### PR TITLE
Address the poor performance of the existing unique-name generation

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -450,24 +450,31 @@ void Application::renameDocument(const char *OldName, const char *NewName)
     throw Base::RuntimeError("Renaming document internal name is no longer allowed!");
 }
 
-Document* Application::newDocument(const char * Name, const char * UserName, bool createView, bool tempDoc)
+Document* Application::newDocument(const char * proposedName, const char * proposedLabel, bool createView, bool tempDoc)
 {
     std::string name;
-    bool defaultName = (!Name || Name[0] == '\0');
+    bool useDefaultName = (!proposedName || proposedName[0] == '\0');
     // get a valid name anyway!
-    if (defaultName) {
-        name = "Unnamed";
-    }
-    else {
-        name = Name;
+    if (useDefaultName) {
+        proposedName = "Unnamed";
     }
 
-    std::string userName;
-    if (UserName && UserName[0] != '\0') {
-        userName = UserName;
+    name = getUniqueDocumentName(proposedName, tempDoc);
+
+    // return the temporary document if it exists
+    if (tempDoc) {
+        auto it = DocMap.find(name);
+        if (it != DocMap.end() && it->second->testStatus(Document::TempDoc))
+            return it->second;
+    }
+
+    // Determine the document's Label
+    std::string label;
+    if (proposedLabel && proposedLabel[0] != '\0') {
+        label = proposedLabel;
     }
     else {
-        userName = defaultName ? QObject::tr("Unnamed").toStdString() : Name;
+        label = useDefaultName ? QObject::tr("Unnamed").toStdString() : proposedName;
 
         if (!DocMap.empty()) {
             // The assumption here is that there are not many documents and
@@ -478,65 +485,48 @@ Document* Application::newDocument(const char * Name, const char * UserName, boo
                 names.addExactName(pos.second->Label.getValue());
             }
 
-            userName = names.makeUniqueName(userName);
+            label = names.makeUniqueName(label);
         }
     }
-    name = getUniqueDocumentName(name.c_str(), tempDoc);
-
-    // return the temporary document if it exists
-    if (tempDoc) {
-        auto it = DocMap.find(name);
-        if (it != DocMap.end() && it->second->testStatus(Document::TempDoc))
-            return it->second;
-        }
-
     // create the FreeCAD document
-    std::unique_ptr<Document> newDoc(new Document(name.c_str()));
-    newDoc->setStatus(Document::TempDoc, tempDoc);
-
-    auto oldActiveDoc = _pActiveDoc;
-    auto doc = newDoc.release(); // now owned by the Application
+    Document* doc = new Document(name.c_str());
+    doc->setStatus(Document::TempDoc, tempDoc);
 
     // add the document to the internal list
     DocMap[name] = doc;
-    _pActiveDoc = doc;
 
     //NOLINTBEGIN
     // clang-format off
     // connect the signals to the application for the new document
-    _pActiveDoc->signalBeforeChange.connect(std::bind(&App::Application::slotBeforeChangeDocument, this, sp::_1, sp::_2));
-    _pActiveDoc->signalChanged.connect(std::bind(&App::Application::slotChangedDocument, this, sp::_1, sp::_2));
-    _pActiveDoc->signalNewObject.connect(std::bind(&App::Application::slotNewObject, this, sp::_1));
-    _pActiveDoc->signalDeletedObject.connect(std::bind(&App::Application::slotDeletedObject, this, sp::_1));
-    _pActiveDoc->signalBeforeChangeObject.connect(std::bind(&App::Application::slotBeforeChangeObject, this, sp::_1, sp::_2));
-    _pActiveDoc->signalChangedObject.connect(std::bind(&App::Application::slotChangedObject, this, sp::_1, sp::_2));
-    _pActiveDoc->signalRelabelObject.connect(std::bind(&App::Application::slotRelabelObject, this, sp::_1));
-    _pActiveDoc->signalActivatedObject.connect(std::bind(&App::Application::slotActivatedObject, this, sp::_1));
-    _pActiveDoc->signalUndo.connect(std::bind(&App::Application::slotUndoDocument, this, sp::_1));
-    _pActiveDoc->signalRedo.connect(std::bind(&App::Application::slotRedoDocument, this, sp::_1));
-    _pActiveDoc->signalRecomputedObject.connect(std::bind(&App::Application::slotRecomputedObject, this, sp::_1));
-    _pActiveDoc->signalRecomputed.connect(std::bind(&App::Application::slotRecomputed, this, sp::_1));
-    _pActiveDoc->signalBeforeRecompute.connect(std::bind(&App::Application::slotBeforeRecompute, this, sp::_1));
-    _pActiveDoc->signalOpenTransaction.connect(std::bind(&App::Application::slotOpenTransaction, this, sp::_1, sp::_2));
-    _pActiveDoc->signalCommitTransaction.connect(std::bind(&App::Application::slotCommitTransaction, this, sp::_1));
-    _pActiveDoc->signalAbortTransaction.connect(std::bind(&App::Application::slotAbortTransaction, this, sp::_1));
-    _pActiveDoc->signalStartSave.connect(std::bind(&App::Application::slotStartSaveDocument, this, sp::_1, sp::_2));
-    _pActiveDoc->signalFinishSave.connect(std::bind(&App::Application::slotFinishSaveDocument, this, sp::_1, sp::_2));
-    _pActiveDoc->signalChangePropertyEditor.connect(std::bind(&App::Application::slotChangePropertyEditor, this, sp::_1, sp::_2));
+    doc->signalBeforeChange.connect(std::bind(&App::Application::slotBeforeChangeDocument, this, sp::_1, sp::_2));
+    doc->signalChanged.connect(std::bind(&App::Application::slotChangedDocument, this, sp::_1, sp::_2));
+    doc->signalNewObject.connect(std::bind(&App::Application::slotNewObject, this, sp::_1));
+    doc->signalDeletedObject.connect(std::bind(&App::Application::slotDeletedObject, this, sp::_1));
+    doc->signalBeforeChangeObject.connect(std::bind(&App::Application::slotBeforeChangeObject, this, sp::_1, sp::_2));
+    doc->signalChangedObject.connect(std::bind(&App::Application::slotChangedObject, this, sp::_1, sp::_2));
+    doc->signalRelabelObject.connect(std::bind(&App::Application::slotRelabelObject, this, sp::_1));
+    doc->signalActivatedObject.connect(std::bind(&App::Application::slotActivatedObject, this, sp::_1));
+    doc->signalUndo.connect(std::bind(&App::Application::slotUndoDocument, this, sp::_1));
+    doc->signalRedo.connect(std::bind(&App::Application::slotRedoDocument, this, sp::_1));
+    doc->signalRecomputedObject.connect(std::bind(&App::Application::slotRecomputedObject, this, sp::_1));
+    doc->signalRecomputed.connect(std::bind(&App::Application::slotRecomputed, this, sp::_1));
+    doc->signalBeforeRecompute.connect(std::bind(&App::Application::slotBeforeRecompute, this, sp::_1));
+    doc->signalOpenTransaction.connect(std::bind(&App::Application::slotOpenTransaction, this, sp::_1, sp::_2));
+    doc->signalCommitTransaction.connect(std::bind(&App::Application::slotCommitTransaction, this, sp::_1));
+    doc->signalAbortTransaction.connect(std::bind(&App::Application::slotAbortTransaction, this, sp::_1));
+    doc->signalStartSave.connect(std::bind(&App::Application::slotStartSaveDocument, this, sp::_1, sp::_2));
+    doc->signalFinishSave.connect(std::bind(&App::Application::slotFinishSaveDocument, this, sp::_1, sp::_2));
+    doc->signalChangePropertyEditor.connect(std::bind(&App::Application::slotChangePropertyEditor, this, sp::_1, sp::_2));
     // clang-format on
     //NOLINTEND
 
-    // make sure that the active document is set in case no GUI is up
-    {
-        Base::PyGILStateLocker lock;
-        Py::Object active(_pActiveDoc->getPyObject(), true);
-        Py::Module("FreeCAD").setAttr(std::string("ActiveDocument"), active);
-    }
+    // (temporarily) make this the active document for the upcoming notifications.
+    // Signal NewDocument rather than ActiveDocument
+    auto oldActiveDoc = _pActiveDoc;
+    setActiveDocumentNoSignal(doc);
+    signalNewDocument(*doc, createView);
 
-    signalNewDocument(*_pActiveDoc, createView);
-
-    // set the UserName after notifying all observers
-    _pActiveDoc->Label.setValue(userName);
+    doc->Label.setValue(label);
 
     // set the old document active again if the new is temporary
     if (tempDoc && oldActiveDoc)
@@ -1055,24 +1045,29 @@ Document* Application::getActiveDocument() const
 
 void Application::setActiveDocument(Document* pDoc)
 {
+    setActiveDocumentNoSignal(pDoc);
+
+    if (pDoc)
+        signalActiveDocument(*pDoc);
+}
+
+void Application::setActiveDocumentNoSignal(Document* pDoc)
+{
     _pActiveDoc = pDoc;
 
     // make sure that the active document is set in case no GUI is up
     if (pDoc) {
         Base::PyGILStateLocker lock;
         Py::Object active(pDoc->getPyObject(), true);
-        Py::Module("FreeCAD").setAttr(std::string("ActiveDocument"),active);
+        Py::Module("FreeCAD").setAttr(std::string("ActiveDocument"), active);
     }
     else {
         Base::PyGILStateLocker lock;
-        Py::Module("FreeCAD").setAttr(std::string("ActiveDocument"),Py::None());
+        Py::Module("FreeCAD").setAttr(std::string("ActiveDocument"), Py::None());
     }
-
-    if (pDoc)
-        signalActiveDocument(*pDoc);
 }
 
-void Application::setActiveDocument(const char *Name)
+void Application::setActiveDocument(const char* Name)
 {
     // If no active document is set, resort to a default.
     if (*Name == '\0') {

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -160,7 +160,7 @@ public:
     std::vector<App::Document*> getDocuments() const;
     /// Set the active document
     void setActiveDocument(App::Document* pDoc);
-    void setActiveDocument(const char *Name);
+    void setActiveDocument(const char* Name);
     /// close all documents (without saving)
     void closeAllDocuments();
     /// Add pending document to open together with the current opening document
@@ -504,6 +504,8 @@ private:
     virtual ~Application();
 
     static void cleanupUnits();
+
+    void setActiveDocumentNoSignal(App::Document* pDoc);
 
     /** @name member for parameter */
     //@{

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -4065,9 +4065,9 @@ void Document::_removeObject(DocumentObject* pcObject)
     pcObject->setStatus(ObjectStatus::Remove, false);  // Unset the bit to be on the safe side
     d->objectIdMap.erase(pcObject->_Id);
     d->objectNameManager.removeExactName(pos->first);
+    unregisterLabel(pos->second->Label.getStrValue());
     d->objectMap.erase(pos);
 
-    unregisterLabel(pos->second->Label.getStrValue());
     for (std::vector<DocumentObject*>::iterator it = d->objectArray.begin();
          it != d->objectArray.end();
          ++it) {

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -287,6 +287,10 @@ public:
      */
     void addObject(DocumentObject*, const char* pObjectName = nullptr);
 
+    /// returns whether this is actually contains the DocumentObject.
+    /// Testing the DocumentObject's pDoc pointer is not sufficient because the object
+    /// removeObject and _removeObject leave _pDoc unchanged
+    bool containsObject(const DocumentObject*) const;
 
     /** Copy objects from another document to this document
      *
@@ -318,11 +322,14 @@ public:
     /// Returns true if the DocumentObject is contained in this document
     bool isIn(const DocumentObject* pFeat) const;
     /// Returns a Name of an Object or 0
-    const char* getObjectName(DocumentObject* pFeat) const;
-    /// Returns a Name of an Object or 0
-    std::string getUniqueObjectName(const char* Name) const;
-    /// Returns a name of the form prefix_number. d specifies the number of digits.
-    std::string getStandardObjectName(const char* Name, int d) const;
+    const char *getObjectName(DocumentObject* pFeat) const;
+    /// Returns a Name for a new Object or empty if proposedName is null or empty.
+    std::string getUniqueObjectName(const char* proposedName) const;
+    /// Returns a name different from any of the Labels of any objects in this document, based on the given modelName.
+    std::string getStandardObjectLabel(const char* modelName, int d) const;
+    /// Break an object Name or Label into its base parts, returning tuple(digitCount, digitsValue)
+    std::tuple<uint, uint>
+    decomposeName(const std::string& name, std::string& baseName, std::string& nameExtension);
     /// Returns a list of document's objects including the dependencies
     std::vector<DocumentObject*> getDependingObjects() const;
     /// Returns a list of all Objects
@@ -566,6 +573,11 @@ public:
 
     /// Indicate if there is any document restoring/importing
     static bool isAnyRestoring();
+
+    void registerLabel(const std ::string& newLabel);
+    void unregisterLabel(const std::string& oldLabel);
+    bool containsLabel(const std::string& label);
+    std::string makeUniqueLabel(const std::string& modelLabel);
 
     friend class Application;
     /// because of transaction handling

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -814,6 +814,74 @@ void DocumentObject::onBeforeChange(const Property* prop)
     signalBeforeChange(*this, *prop);
 }
 
+std::vector<std::pair<Property*, std::unique_ptr<Property>>>
+DocumentObject::onProposedLabelChange(std::string& newLabel)
+{
+    // Note that this work can't be done in onBeforeChangeLabel because FeaturePython overrides this
+    // method and does not initially base-call it.
+
+    // We re only called if the new label differs from the old one, and our code to check duplicates
+    // may not work if this is not the case.
+    std::string oldLabel = Label.getStrValue();
+    assert(newLabel != oldLabel);
+    std::string label;
+    if (!isAttachedToDocument()
+        || (getDocument()->testStatus(App::Document::Restoring)
+            && !getDocument()->testStatus(App::Document::Importing))
+        || getDocument()->isPerformingTransaction()) {
+        return {};
+    }
+    static ParameterGrp::handle _hPGrp;
+    if (!_hPGrp) {
+        _hPGrp = GetApplication().GetUserParameter().GetGroup("BaseApp");
+        _hPGrp = _hPGrp->GetGroup("Preferences")->GetGroup("Document");
+    }
+    App::Document* doc = getDocument();
+    if (doc && newLabel.size() > 0 && !_hPGrp->GetBool("DuplicateLabels") && !allowDuplicateLabel()
+        && doc->containsLabel(newLabel)) {
+        // We must ensure the Label is unique in the document (well, sort of...).
+        // If the base name of the proposed label equals the base name of the object Name, we use
+        // the (uniquefied) object Name, which could actually be identical to another object's Label,
+        // but probably isn't.
+        // Otherwise we generate a unique Label using newLabel as a prototype name. In doing so,
+        // we must also act as if the current value of the property is not an existing Label entry.
+        std::string objName = getNameInDocument();
+        std::string objBaseName;
+        std::string objSuffix;
+        doc->decomposeName(objName, objBaseName, objSuffix);
+        std::string newBaseName;
+        std::string newSuffix;
+        doc->decomposeName(newLabel, newBaseName, newSuffix);
+        if (newBaseName == objBaseName && newSuffix == objSuffix) {
+            newLabel = objName;
+        }
+        else {
+            // We deregister the old label so it does not interfere with making the new label,
+            // and re-register it after. This is probably a bit less efficient that having a special
+            // make-unique-label-as-if-this-one-did-not-exist method, but such a method would be a real
+            // ugly wart.
+            doc->unregisterLabel(oldLabel);
+            newLabel = doc->makeUniqueLabel(newLabel);
+            doc->registerLabel(oldLabel);
+        }
+    }
+
+    // Despite our efforts to make a unique label, onBeforeLabelChange can change it.
+    onBeforeChangeLabel(newLabel);
+
+    if (oldLabel != newLabel && !getDocument()->testStatus(App::Document::Restoring)) {
+        // Only update label reference if we are not restoring. When
+        // importing (which also counts as restoring), it is possible the
+        // new object changes its label. However, we cannot update label
+        // references here, because object restoring is not based on
+        // dependency order. It can only be done in afterRestore().
+        //
+        // See PropertyLinkBase::restoreLabelReference() for more details.
+        return PropertyLinkBase::updateLabelReferences(this, newLabel.c_str());
+    }
+    return {};
+}
+
 void DocumentObject::onEarlyChange(const Property* prop)
 {
     if (GetApplication().isClosingAll()) {
@@ -836,6 +904,11 @@ void DocumentObject::onEarlyChange(const Property* prop)
 /// get called by the container when a Property was changed
 void DocumentObject::onChanged(const Property* prop)
 {
+    if (prop == &Label && _pDoc && _pDoc->containsObject(this) && oldLabel != Label.getStrValue()) {
+        _pDoc->unregisterLabel(oldLabel);
+        _pDoc->registerLabel(Label.getStrValue());
+    }
+
     if (isFreezed() && prop != &Visibility) {
         return;
     }

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -869,17 +869,17 @@ DocumentObject::onProposedLabelChange(std::string& newLabel)
     // Despite our efforts to make a unique label, onBeforeLabelChange can change it.
     onBeforeChangeLabel(newLabel);
 
-    if (oldLabel != newLabel && !getDocument()->testStatus(App::Document::Restoring)) {
-        // Only update label reference if we are not restoring. When
-        // importing (which also counts as restoring), it is possible the
+    if (oldLabel == newLabel || getDocument()->testStatus(App::Document::Restoring)) {
+        // Don't update label reference if we are restoring or if the label is unchanged.
+        // When importing (which also counts as restoring), it is possible the
         // new object changes its label. However, we cannot update label
-        // references here, because object restoring is not based on
+        // references here, because object being restored is not based on
         // dependency order. It can only be done in afterRestore().
         //
         // See PropertyLinkBase::restoreLabelReference() for more details.
-        return PropertyLinkBase::updateLabelReferences(this, newLabel.c_str());
+        return {};
     }
-    return {};
+    return PropertyLinkBase::updateLabelReferences(this, newLabel.c_str());
 }
 
 void DocumentObject::onEarlyChange(const Property* prop)

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -513,7 +513,12 @@ public:
     {
         return false;
     }
-
+    /// Handle Label changes, including forcing unique label values,
+    /// signalling OnBeforeLabelChange, and arranging to update linked references,
+    /// on the assumption that after returning the label will indeed be changed to
+    /// the (altered) value of newLabel.
+    /// Returns a vector of referenging (linking) properties as produced by
+    /// PropertyLinkBase::updateLabelReferences which is needed for undo/redo purposes.
     std::vector<std::pair<Property*, std::unique_ptr<Property>>>
     onProposedLabelChange(std::string& newLabel);
     /*** Called to let object itself control relabeling

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -514,6 +514,8 @@ public:
         return false;
     }
 
+    std::vector<std::pair<Property*, std::unique_ptr<Property>>>
+    onProposedLabelChange(std::string& newLabel);
     /*** Called to let object itself control relabeling
      *
      * @param newLabel: input as the new label, which can be modified by object itself
@@ -765,10 +767,10 @@ protected:  // attributes
     /// Old label; used for renaming expressions
     std::string oldLabel;
 
+private:
     // pointer to the document name string (for performance)
     const std::string* pcNameInDocument {nullptr};
 
-private:
     // accessed by App::Document to record and restore the correct view provider type
     std::string _pcViewProviderName;
 

--- a/src/App/DynamicProperty.h
+++ b/src/App/DynamicProperty.h
@@ -87,7 +87,7 @@ public:
     void getPropertyList(std::vector<Property*>& List) const;
     /// get all properties with their names
     void getPropertyNamedList(std::vector<std::pair<const char*, Property*>>& List) const;
-    // See PropertyContainer::visitProperties for semantics
+    /// See PropertyContainer::visitProperties for semantics
     void visitProperties(std::function<void(Property*)> visitor) const;
     /// Get all properties of the class (including parent)
     void getPropertyMap(std::map<std::string, Property*>& Map) const;

--- a/src/App/DynamicProperty.h
+++ b/src/App/DynamicProperty.h
@@ -87,9 +87,8 @@ public:
     void getPropertyList(std::vector<Property*>& List) const;
     /// get all properties with their names
     void getPropertyNamedList(std::vector<std::pair<const char*, Property*>>& List) const;
-    // Call the given visitor for each property, stops and returns false if the visitor returns
-    // false This is undefined if the collection of Properties is changed
-    bool visitProperties(std::function<bool(Property*)> visitor) const;
+    // See PropertyContainer::visitProperties for semantics
+    void visitProperties(std::function<void(Property*)> visitor) const;
     /// Get all properties of the class (including parent)
     void getPropertyMap(std::map<std::string, Property*>& Map) const;
     /// Find a dynamic property by its name

--- a/src/App/DynamicProperty.h
+++ b/src/App/DynamicProperty.h
@@ -87,6 +87,9 @@ public:
     void getPropertyList(std::vector<Property*>& List) const;
     /// get all properties with their names
     void getPropertyNamedList(std::vector<std::pair<const char*, Property*>>& List) const;
+    // Call the given visitor for each property, stops and returns false if the visitor returns
+    // false This is undefined if the collection of Properties is changed
+    bool visitProperties(std::function<bool(Property*)> visitor) const;
     /// Get all properties of the class (including parent)
     void getPropertyMap(std::map<std::string, Property*>& Map) const;
     /// Find a dynamic property by its name

--- a/src/App/Extension.cpp
+++ b/src/App/Extension.cpp
@@ -181,9 +181,9 @@ void Extension::extensionGetPropertyMap(std::map<std::string, Property*>& Map) c
     extensionGetPropertyData().getPropertyMap(this, Map);
 }
 
-bool Extension::extensionVisitProperties(std::function<bool(Property*)> visitor) const
+void Extension::extensionVisitProperties(std::function<void(Property*)> visitor) const
 {
-    return extensionGetPropertyData().visitProperties(this, visitor);
+    extensionGetPropertyData().visitProperties(this, visitor);
 }
 void Extension::initExtensionSubclass(Base::Type& toInit,
                                       const char* ClassName,

--- a/src/App/Extension.cpp
+++ b/src/App/Extension.cpp
@@ -181,6 +181,10 @@ void Extension::extensionGetPropertyMap(std::map<std::string, Property*>& Map) c
     extensionGetPropertyData().getPropertyMap(this, Map);
 }
 
+bool Extension::extensionVisitProperties(std::function<bool(Property*)> visitor) const
+{
+    return extensionGetPropertyData().visitProperties(this, visitor);
+}
 void Extension::initExtensionSubclass(Base::Type& toInit,
                                       const char* ClassName,
                                       const char* ParentName,

--- a/src/App/Extension.h
+++ b/src/App/Extension.h
@@ -254,6 +254,7 @@ public:
     virtual const char* extensionGetPropertyName(const Property* prop) const;
     /// get all properties of the class (including properties of the parent)
     virtual void extensionGetPropertyMap(std::map<std::string,Property*> &Map) const;
+    virtual bool extensionVisitProperties(std::function<bool(Property*)> visitor) const;
     /// get all properties of the class (including properties of the parent)
     virtual void extensionGetPropertyList(std::vector<Property*> &List) const;
 

--- a/src/App/Extension.h
+++ b/src/App/Extension.h
@@ -254,7 +254,7 @@ public:
     virtual const char* extensionGetPropertyName(const Property* prop) const;
     /// get all properties of the class (including properties of the parent)
     virtual void extensionGetPropertyMap(std::map<std::string,Property*> &Map) const;
-    // See PropertyContainer::visitProperties for semantics
+    /// See PropertyContainer::visitProperties for semantics
     virtual void extensionVisitProperties(std::function<void(Property*)> visitor) const;
     /// get all properties of the class (including properties of the parent)
     virtual void extensionGetPropertyList(std::vector<Property*> &List) const;

--- a/src/App/Extension.h
+++ b/src/App/Extension.h
@@ -254,7 +254,8 @@ public:
     virtual const char* extensionGetPropertyName(const Property* prop) const;
     /// get all properties of the class (including properties of the parent)
     virtual void extensionGetPropertyMap(std::map<std::string,Property*> &Map) const;
-    virtual bool extensionVisitProperties(std::function<bool(Property*)> visitor) const;
+    // See PropertyContainer::visitProperties for semantics
+    virtual void extensionVisitProperties(std::function<void(Property*)> visitor) const;
     /// get all properties of the class (including properties of the parent)
     virtual void extensionGetPropertyList(std::vector<Property*> &List) const;
 

--- a/src/App/ExtensionContainer.cpp
+++ b/src/App/ExtensionContainer.cpp
@@ -176,17 +176,12 @@ void ExtensionContainer::getPropertyMap(std::map<std::string, Property*>& Map) c
         entry.second->extensionGetPropertyMap(Map);
     }
 }
-bool ExtensionContainer::visitProperties(std::function<bool(Property*)> visitor) const
+void ExtensionContainer::visitProperties(std::function<void(Property*)> visitor) const
 {
-    if (!App::PropertyContainer::visitProperties(visitor)) {
-        return false;
-    }
-    for (const auto& entry : _extensions) {
-        if (!entry.second->extensionVisitProperties(visitor)) {
-            return false;
-        }
-    }
-    return true;
+    App::PropertyContainer::visitProperties(visitor);
+    for(const auto &entry : _extensions) {
+        entry.second->extensionVisitProperties(visitor);
+    };
 }
 
 Property* ExtensionContainer::getPropertyByName(const char* name) const

--- a/src/App/ExtensionContainer.cpp
+++ b/src/App/ExtensionContainer.cpp
@@ -176,6 +176,18 @@ void ExtensionContainer::getPropertyMap(std::map<std::string, Property*>& Map) c
         entry.second->extensionGetPropertyMap(Map);
     }
 }
+bool ExtensionContainer::visitProperties(std::function<bool(Property*)> visitor) const
+{
+    if (!App::PropertyContainer::visitProperties(visitor)) {
+        return false;
+    }
+    for (const auto& entry : _extensions) {
+        if (!entry.second->extensionVisitProperties(visitor)) {
+            return false;
+        }
+    }
+    return true;
+}
 
 Property* ExtensionContainer::getPropertyByName(const char* name) const
 {

--- a/src/App/ExtensionContainer.h
+++ b/src/App/ExtensionContainer.h
@@ -182,6 +182,7 @@ public:
     const char* getPropertyName(const Property* prop) const override;
     /// get all properties of the class (including properties of the parent)
     void getPropertyMap(std::map<std::string, Property*>& Map) const override;
+    bool visitProperties(std::function<bool(Property*)> visitor) const;
     /// get all properties of the class (including properties of the parent)
     void getPropertyList(std::vector<Property*>& List) const override;
 

--- a/src/App/ExtensionContainer.h
+++ b/src/App/ExtensionContainer.h
@@ -182,7 +182,7 @@ public:
     const char* getPropertyName(const Property* prop) const override;
     /// get all properties of the class (including properties of the parent)
     void getPropertyMap(std::map<std::string, Property*>& Map) const override;
-    // See PropertyContainer::visitProperties for semantics
+    /// See PropertyContainer::visitProperties for semantics
     void visitProperties(std::function<void(Property*)> visitor) const override;
     /// get all properties of the class (including properties of the parent)
     void getPropertyList(std::vector<Property*>& List) const override;

--- a/src/App/ExtensionContainer.h
+++ b/src/App/ExtensionContainer.h
@@ -182,7 +182,8 @@ public:
     const char* getPropertyName(const Property* prop) const override;
     /// get all properties of the class (including properties of the parent)
     void getPropertyMap(std::map<std::string, Property*>& Map) const override;
-    bool visitProperties(std::function<bool(Property*)> visitor) const;
+    // See PropertyContainer::visitProperties for semantics
+    void visitProperties(std::function<void(Property*)> visitor) const override;
     /// get all properties of the class (including properties of the parent)
     void getPropertyList(std::vector<Property*>& List) const override;
 

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -92,12 +92,10 @@ void PropertyContainer::getPropertyList(std::vector<Property*> &List) const
     getPropertyData().getPropertyList(this,List);
 }
 
-bool PropertyContainer::visitProperties(std::function<bool(Property *)> visitor) const
+void PropertyContainer::visitProperties(std::function<void(Property *)> visitor) const
 {
-    if (!dynamicProps.visitProperties(visitor)) {
-        return false;
-    }
-    return getPropertyData().visitProperties(this, visitor);
+    dynamicProps.visitProperties(visitor);
+    getPropertyData().visitProperties(this, visitor);
 }
 
 void PropertyContainer::getPropertyNamedList(std::vector<std::pair<const char*, Property*> > &List) const
@@ -627,16 +625,14 @@ void PropertyData::getPropertyNamedList(OffsetBase offsetBase,
     }
 }
 
-bool PropertyData::visitProperties(OffsetBase offsetBase,
-                                   std::function<bool(Property*)> visitor) const
+void PropertyData::visitProperties(OffsetBase offsetBase,
+                                   std::function<void(Property*)> visitor) const
 {
     merge();
-    for (auto& spec : propertyData.get<0>()) {
-        if (!visitor(reinterpret_cast<Property*>(spec.Offset + offsetBase.getOffset()))) {
-            return false;
-        }
-    }
-    return true;
+    char* offset = offsetBase.getOffset();
+    for (const auto& spec : propertyData.get<0>()) {
+        visitor(reinterpret_cast<Property*>(spec.Offset + offset));
+    };
 }
 
 /** \defgroup PropFrame Property framework

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -92,6 +92,14 @@ void PropertyContainer::getPropertyList(std::vector<Property*> &List) const
     getPropertyData().getPropertyList(this,List);
 }
 
+bool PropertyContainer::visitProperties(std::function<bool(Property *)> visitor) const
+{
+    if (!dynamicProps.visitProperties(visitor)) {
+        return false;
+    }
+    return getPropertyData().visitProperties(this, visitor);
+}
+
 void PropertyContainer::getPropertyNamedList(std::vector<std::pair<const char*, Property*> > &List) const
 {
     dynamicProps.getPropertyNamedList(List);
@@ -619,7 +627,17 @@ void PropertyData::getPropertyNamedList(OffsetBase offsetBase,
     }
 }
 
-
+bool PropertyData::visitProperties(OffsetBase offsetBase,
+                                   std::function<bool(Property*)> visitor) const
+{
+    merge();
+    for (auto& spec : propertyData.get<0>()) {
+        if (!visitor(reinterpret_cast<Property*>(spec.Offset + offsetBase.getOffset()))) {
+            return false;
+        }
+    }
+    return true;
+}
 
 /** \defgroup PropFrame Property framework
     \ingroup APP

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -134,7 +134,7 @@ struct AppExport PropertyData
   void getPropertyMap(OffsetBase offsetBase,std::map<std::string,Property*> &Map) const;
   void getPropertyList(OffsetBase offsetBase,std::vector<Property*> &List) const;
   void getPropertyNamedList(OffsetBase offsetBase, std::vector<std::pair<const char*,Property*> > &List) const;
-  // See PropertyContainer::visitProperties for semantics
+  /// See PropertyContainer::visitProperties for semantics
   void visitProperties(OffsetBase offsetBase, std::function<void(Property*)> visitor) const;
 
   void merge(PropertyData *other=nullptr) const;
@@ -174,10 +174,10 @@ public:
   virtual void getPropertyMap(std::map<std::string,Property*> &Map) const;
   /// get all properties of the class (including properties of the parent)
   virtual void getPropertyList(std::vector<Property*> &List) const;
-  // Call the given visitor for each property. The visiting order is undefined.
-  // This method is necessary because PropertyContainer has no begin and end methods
-  // and it is not practical to implement these.
-  // What gets visited is undefined if the collection of Properties is changed during this call.
+  /// Call the given visitor for each property. The visiting order is undefined.
+  /// This method is necessary because PropertyContainer has no begin and end methods
+  /// and it is not practical to implement these.
+  /// What gets visited is undefined if the collection of Properties is changed during this call.
   virtual void visitProperties(std::function<void(Property*)> visitor) const;
   /// get all properties with their names, may contain duplicates and aliases
   virtual void getPropertyNamedList(std::vector<std::pair<const char*,Property*> > &List) const;

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -134,7 +134,8 @@ struct AppExport PropertyData
   void getPropertyMap(OffsetBase offsetBase,std::map<std::string,Property*> &Map) const;
   void getPropertyList(OffsetBase offsetBase,std::vector<Property*> &List) const;
   void getPropertyNamedList(OffsetBase offsetBase, std::vector<std::pair<const char*,Property*> > &List) const;
-  bool visitProperties(OffsetBase offsetBase, std::function<bool(Property*)> visitor) const;
+  // See PropertyContainer::visitProperties for semantics
+  void visitProperties(OffsetBase offsetBase, std::function<void(Property*)> visitor) const;
 
   void merge(PropertyData *other=nullptr) const;
   void split(PropertyData *other);
@@ -173,9 +174,11 @@ public:
   virtual void getPropertyMap(std::map<std::string,Property*> &Map) const;
   /// get all properties of the class (including properties of the parent)
   virtual void getPropertyList(std::vector<Property*> &List) const;
-  // Call the given visitor for each property, stopping and returning false if the visitor returns false
-  // This is undefined if the collection of Properties is changed
-  virtual bool visitProperties(std::function<bool(Property*)> visitor) const;
+  // Call the given visitor for each property. The visiting order is undefined.
+  // This method is necessary because PropertyContainer has no begin and end methods
+  // and it is not practical to implement these.
+  // What gets visited is undefined if the collection of Properties is changed during this call.
+  virtual void visitProperties(std::function<void(Property*)> visitor) const;
   /// get all properties with their names, may contain duplicates and aliases
   virtual void getPropertyNamedList(std::vector<std::pair<const char*,Property*> > &List) const;
   /// set the Status bit of all properties at once

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -134,6 +134,7 @@ struct AppExport PropertyData
   void getPropertyMap(OffsetBase offsetBase,std::map<std::string,Property*> &Map) const;
   void getPropertyList(OffsetBase offsetBase,std::vector<Property*> &List) const;
   void getPropertyNamedList(OffsetBase offsetBase, std::vector<std::pair<const char*,Property*> > &List) const;
+  bool visitProperties(OffsetBase offsetBase, std::function<bool(Property*)> visitor) const;
 
   void merge(PropertyData *other=nullptr) const;
   void split(PropertyData *other);
@@ -172,6 +173,9 @@ public:
   virtual void getPropertyMap(std::map<std::string,Property*> &Map) const;
   /// get all properties of the class (including properties of the parent)
   virtual void getPropertyList(std::vector<Property*> &List) const;
+  // Call the given visitor for each property, stopping and returning false if the visitor returns false
+  // This is undefined if the collection of Properties is changed
+  virtual bool visitProperties(std::function<bool(Property*)> visitor) const;
   /// get all properties with their names, may contain duplicates and aliases
   virtual void getPropertyNamedList(std::vector<std::pair<const char*,Property*> > &List) const;
   /// set the Status bit of all properties at once

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1385,101 +1385,13 @@ void PropertyString::setValue(const char* newLabel)
         return;
     }
 
-    std::string _newLabel;
-
     std::vector<std::pair<Property*, std::unique_ptr<Property>>> propChanges;
-    std::string label;
+    std::string label = newLabel;
     auto obj = dynamic_cast<DocumentObject*>(getContainer());
     bool commit = false;
 
-    if (obj && obj->isAttachedToDocument() && this == &obj->Label
-        && (!obj->getDocument()->testStatus(App::Document::Restoring)
-            || obj->getDocument()->testStatus(App::Document::Importing))
-        && !obj->getDocument()->isPerformingTransaction()) {
-        // allow object to control label change
-
-        static ParameterGrp::handle _hPGrp;
-        if (!_hPGrp) {
-            _hPGrp = GetApplication().GetUserParameter().GetGroup("BaseApp");
-            _hPGrp = _hPGrp->GetGroup("Preferences")->GetGroup("Document");
-        }
-        App::Document* doc = obj->getDocument();
-        if (doc && !_hPGrp->GetBool("DuplicateLabels") && !obj->allowDuplicateLabel()) {
-            std::vector<std::string> objectLabels;
-            std::vector<App::DocumentObject*>::const_iterator it;
-            std::vector<App::DocumentObject*> objs = doc->getObjects();
-            bool match = false;
-            for (it = objs.begin(); it != objs.end(); ++it) {
-                if (*it == obj) {
-                    continue;  // don't compare object with itself
-                }
-                std::string objLabel = (*it)->Label.getValue();
-                if (!match && objLabel == newLabel) {
-                    match = true;
-                }
-                objectLabels.push_back(objLabel);
-            }
-
-            // make sure that there is a name conflict otherwise we don't have to do anything
-            if (match && *newLabel) {
-                label = newLabel;
-                // remove number from end to avoid lengthy names
-                size_t lastpos = label.length() - 1;
-                while (label[lastpos] >= 48 && label[lastpos] <= 57) {
-                    // if 'lastpos' becomes 0 then all characters are digits. In this case we use
-                    // the complete label again
-                    if (lastpos == 0) {
-                        lastpos = label.length() - 1;
-                        break;
-                    }
-                    lastpos--;
-                }
-
-                bool changed = false;
-                label = label.substr(0, lastpos + 1);
-                if (label != obj->getNameInDocument()
-                    && boost::starts_with(obj->getNameInDocument(), label)) {
-                    // In case the label has the same base name as object's
-                    // internal name, use it as the label instead.
-                    const char* objName = obj->getNameInDocument();
-                    const char* c = &objName[lastpos + 1];
-                    for (; *c; ++c) {
-                        if (*c < 48 || *c > 57) {
-                            break;
-                        }
-                    }
-                    if (*c == 0
-                        && std::find(objectLabels.begin(),
-                                     objectLabels.end(),
-                                     obj->getNameInDocument())
-                            == objectLabels.end()) {
-                        label = obj->getNameInDocument();
-                        changed = true;
-                    }
-                }
-                if (!changed) {
-                    label = Base::Tools::getUniqueName(label, objectLabels, 3);
-                }
-            }
-        }
-
-        if (label.empty()) {
-            label = newLabel;
-        }
-        obj->onBeforeChangeLabel(label);
-        newLabel = label.c_str();
-
-        if (!obj->getDocument()->testStatus(App::Document::Restoring)) {
-            // Only update label reference if we are not restoring. When
-            // importing (which also counts as restoring), it is possible the
-            // new object changes its label. However, we cannot update label
-            // references here, because object restoring is not based on
-            // dependency order. It can only be done in afterRestore().
-            //
-            // See PropertyLinkBase::restoreLabelReference() for more details.
-            propChanges = PropertyLinkBase::updateLabelReferences(obj, newLabel);
-        }
-
+    if (obj && this == &obj->Label) {
+        propChanges = obj->onProposedLabelChange(label);
         if (!propChanges.empty() && !GetApplication().getActiveTransaction()) {
             commit = true;
             std::ostringstream str;
@@ -1489,7 +1401,7 @@ void PropertyString::setValue(const char* newLabel)
     }
 
     aboutToSetValue();
-    _cValue = newLabel;
+    _cValue = label;
     hasSetValue();
 
     for (auto& change : propChanges) {

--- a/src/App/private/DocumentP.h
+++ b/src/App/private/DocumentP.h
@@ -30,6 +30,7 @@
 #include <App/DocumentObject.h>
 #include <App/DocumentObserver.h>
 #include <App/StringHasher.h>
+#include <base/Tools.h>
 #include <CXX/Objects.hxx>
 #include <boost/bimap.hpp>
 #include <boost/graph/adjacency_list.hpp>
@@ -65,6 +66,9 @@ struct DocumentP
     std::vector<DocumentObject*> objectArray;
     std::unordered_set<App::DocumentObject*> touchedObjs;
     std::unordered_map<std::string, DocumentObject*> objectMap;
+    Base::UniqueNameManager objectNameManager;
+    Base::UniqueNameManager objectLabelManager;
+    std::unordered_map<std::string, int> objectLabelCounts;
     std::unordered_map<long, DocumentObject*> objectIdMap;
     std::unordered_map<std::string, bool> partialLoadObjects;
     std::vector<DocumentObjectT> pendingRemove;
@@ -129,6 +133,8 @@ struct DocumentP
 
     void clearDocument()
     {
+        objectLabelCounts.clear();
+        objectLabelManager.clear();
         objectArray.clear();
         for (auto& v : objectMap) {
             v.second->setStatus(ObjectStatus::Destroy, true);
@@ -136,6 +142,7 @@ struct DocumentP
             v.second = nullptr;
         }
         objectMap.clear();
+        objectNameManager.clear();
         objectIdMap.clear();
     }
 

--- a/src/App/private/DocumentP.h
+++ b/src/App/private/DocumentP.h
@@ -30,7 +30,7 @@
 #include <App/DocumentObject.h>
 #include <App/DocumentObserver.h>
 #include <App/StringHasher.h>
-#include <base/Tools.h>
+#include <Base/Tools.h>
 #include <CXX/Objects.hxx>
 #include <boost/bimap.hpp>
 #include <boost/graph/adjacency_list.hpp>

--- a/src/Base/Reader.cpp
+++ b/src/Base/Reader.cpp
@@ -463,14 +463,13 @@ const char* Base::XMLReader::addFile(const char* Name, Base::Persistence* Object
     temp.Object = Object;
 
     FileList.push_back(temp);
-    FileNames.push_back(temp.FileName);
 
     return Name;
 }
 
-const std::vector<std::string>& Base::XMLReader::getFilenames() const
+bool Base::XMLReader::hasFilenames() const
 {
-    return FileNames;
+    return FileList.size() > 0;
 }
 
 bool Base::XMLReader::hasReadFailed(const std::string& filename) const

--- a/src/Base/Reader.h
+++ b/src/Base/Reader.h
@@ -251,8 +251,8 @@ public:
     const char* addFile(const char* Name, Base::Persistence* Object);
     /// process the requested file writes
     void readFiles(zipios::ZipInputStream& zipstream) const;
-    /// get all registered file names
-    const std::vector<std::string>& getFilenames() const;
+    /// Returns whether reader has any registered filenames
+    bool hasFilenames() const;
     /// returns true if reading the file \a filename has failed
     bool hasReadFailed(const std::string& filename) const;
     bool isRegistered(Base::Persistence* Object) const;
@@ -364,7 +364,6 @@ public:
     std::vector<FileEntry> FileList;
 
 private:
-    std::vector<std::string> FileNames;
     mutable std::vector<std::string> FailedFiles;
 
     std::bitset<32> StatusBits;

--- a/src/Base/Tools.cpp
+++ b/src/Base/Tools.cpp
@@ -188,8 +188,6 @@ std::string Base::UniqueNameManager::makeUniqueName(const std::string& modelName
     return namePrefix + digits + nameSuffix;
 }
 
-// Remove a rgistered name so it can be generated again.
-// Nothing happens if you try to remove a non-registered name.
 void Base::UniqueNameManager::removeExactName(const std::string& name)
 {
     std::string baseName;

--- a/src/Base/Tools.cpp
+++ b/src/Base/Tools.cpp
@@ -33,130 +33,217 @@
 #include "Interpreter.h"
 #include "Tools.h"
 
-namespace Base
+void Base::UniqueNameManager::PiecewiseSparseIntegerSet::Add(uint value)
 {
-struct string_comp
+    etype newSpan(value, 1);
+    iterator above = Spans.lower_bound(newSpan);
+    if (above != Spans.end() && above->first <= value) {
+        // The found span includes value so there is nothing to do as it is already in the set.
+        return;
+    }
+
+    // Set below to the next span down, if any
+    iterator below;
+    if (above == Spans.begin()) {
+        below = Spans.end();
+    }
+    else {
+        below = above;
+        --below;
+    }
+
+    if (above != Spans.end() && below != Spans.end()
+        && above->first - below->first + 1 == below->second) {
+        // below and above have a gap of exactly one between them, and this must be value
+        // so we coalesce the two spans (and the gap) into one.
+        newSpan = etype(below->first, below->second + above->second + 1);
+        Spans.erase(above);
+        above = Spans.erase(below);
+    }
+    if (below != Spans.end() && value - below->first == below->second) {
+        // value is adjacent to the end of below, so just expand below by one
+        newSpan = etype(below->first, below->second + 1);
+        above = Spans.erase(below);
+    }
+    else if (above != Spans.end() && above->first - value == 1) {
+        // value is adjacent to the start of above, so juse expand above down by one
+        newSpan = etype(above->first - 1, above->second + 1);
+        above = Spans.erase(above);
+    }
+    // else  value is not adjacent to any existing span, so just make anew span for it
+    Spans.insert(above, newSpan);
+}
+void Base::UniqueNameManager::PiecewiseSparseIntegerSet::Remove(uint value)
 {
-    // s1 and s2 must be numbers represented as string
-    bool operator()(const std::string& s1, const std::string& s2)
-    {
-        if (s1.size() < s2.size()) {
-            return true;
-        }
-        if (s1.size() > s2.size()) {
-            return false;
-        }
-
-        return s1 < s2;
+    etype newSpan(value, 1);
+    iterator at = Spans.lower_bound(newSpan);
+    if (at == Spans.end() || at->first > value) {
+        // The found span does not include value so there is nothing to do, as it is already not in
+        // the set.
+        return;
     }
-    static std::string increment(const std::string& s)
-    {
-        std::string n = s;
-        int addcarry = 1;
-        for (std::string::reverse_iterator it = n.rbegin(); it != n.rend(); ++it) {
-            if (addcarry == 0) {
-                break;
-            }
-            int d = *it - 48;
-            d = d + addcarry;
-            *it = ((d % 10) + 48);
-            addcarry = d / 10;
-        }
-        if (addcarry > 0) {
-            std::string b;
-            b.resize(1);
-            b[0] = addcarry + 48;
-            n = b + n;
-        }
-
-        return n;
+    if (at->second == 1) {
+        // value is the only in this span, just remove the span
+        Spans.erase(at);
     }
-};
-
-class unique_name
+    else if (at->first == value) {
+        // value is the first in this span, trim the lower end
+        etype replacement(at->first + 1, at->second - 1);
+        Spans.insert(Spans.erase(at), replacement);
+    }
+    else if (value - at->first == at->second - 1) {
+        // value is the last in this span, trim the upper end
+        etype replacement(at->first, at->second - 1);
+        Spans.insert(Spans.erase(at), replacement);
+    }
+    else {
+        // value is in the moddle of the span, so we must split it.
+        etype firstReplacement(at->first, value - at->first);
+        etype secondReplacement(value + 1, at->second - ((value + 1) - at->first));
+        // Because erase returns the iterator after the erased element, and insert returns the
+        // iterator for the inserted item, we want to insert secondReplacement first.
+        Spans.insert(Spans.insert(Spans.erase(at), secondReplacement), firstReplacement);
+    }
+}
+bool Base::UniqueNameManager::PiecewiseSparseIntegerSet::Contains(uint value) const
 {
-public:
-    unique_name(std::string name, const std::vector<std::string>& names, int padding)
-        : base_name {std::move(name)}
-        , padding {padding}
-    {
-        removeDigitsFromEnd();
-        findHighestSuffix(names);
-    }
-
-    std::string get() const
-    {
-        return appendSuffix();
-    }
-
-private:
-    void removeDigitsFromEnd()
-    {
-        std::string::size_type pos = base_name.find_last_not_of("0123456789");
-        if (pos != std::string::npos && (pos + 1) < base_name.size()) {
-            num_suffix = base_name.substr(pos + 1);
-            base_name.erase(pos + 1);
-        }
-    }
-
-    void findHighestSuffix(const std::vector<std::string>& names)
-    {
-        for (const auto& name : names) {
-            if (name.substr(0, base_name.length()) == base_name) {  // same prefix
-                std::string suffix(name.substr(base_name.length()));
-                if (!suffix.empty()) {
-                    std::string::size_type pos = suffix.find_first_not_of("0123456789");
-                    if (pos == std::string::npos) {
-                        num_suffix = std::max<std::string>(num_suffix, suffix, Base::string_comp());
-                    }
-                }
-            }
-        }
-    }
-
-    std::string appendSuffix() const
-    {
-        std::stringstream str;
-        str << base_name;
-        if (padding > 0) {
-            str.fill('0');
-            str.width(padding);
-        }
-        str << Base::string_comp::increment(num_suffix);
-        return str.str();
-    }
-
-private:
-    std::string num_suffix;
-    std::string base_name;
-    int padding;
-};
-
-}  // namespace Base
-
-std::string
-Base::Tools::getUniqueName(const std::string& name, const std::vector<std::string>& names, int pad)
-{
-    if (names.empty()) {
-        return name;
-    }
-
-    Base::unique_name unique(name, names, pad);
-    return unique.get();
+    iterator at = Spans.lower_bound(etype(value, 1));
+    return at != Spans.end() && at->first <= value;
 }
 
-std::string Base::Tools::addNumber(const std::string& name, unsigned int num, int d)
+std::tuple<uint, uint> Base::UniqueNameManager::decomposeName(const std::string& name,
+                                                              std::string& baseNameOut,
+                                                              std::string& nameSuffixOut) const
 {
-    std::stringstream str;
-    str << name;
-    if (d > 0) {
-        str.fill('0');
-        str.width(d);
+    std::string::const_iterator suffixStart = GetNameSuffixStartPosition(name);
+    nameSuffixOut = name.substr(suffixStart - name.cbegin());
+    std::string::const_iterator digitsStart = suffixStart;
+    while (digitsStart > name.cbegin() && isdigit(digitsStart[-1])) {
+        --digitsStart;
     }
-    str << num;
-    return str.str();
+    baseNameOut = name.substr(0, digitsStart - name.cbegin());
+    uint digitCount = suffixStart - digitsStart;
+    if (digitCount == 0) {
+        // No digits in name
+        return std::tuple<uint, uint> {0, 0};
+    }
+    else {
+        return std::tuple<uint, uint> {
+            digitCount,
+            std::stol(name.substr(digitsStart - name.cbegin(), digitCount))};
+    }
+}
+void Base::UniqueNameManager::addExactName(const std::string& name)
+{
+    std::string baseName;
+    std::string nameSuffix;
+    uint digitCount;
+    uint digitsValue;
+    std::tie(digitCount, digitsValue) = decomposeName(name, baseName, nameSuffix);
+    baseName += nameSuffix;
+    auto baseNameEntry = UniqueSeeds.find(baseName);
+    if (baseNameEntry == UniqueSeeds.end()) {
+        // First use of baseName
+        baseNameEntry = UniqueSeeds
+                            .insert(std::pair<std::string, std::vector<PiecewiseSparseIntegerSet>>(
+                                baseName,
+                                std::vector<PiecewiseSparseIntegerSet>()))
+                            .first;
+    }
+    if (digitCount >= baseNameEntry->second.size()) {
+        // First use of this digitCount
+        baseNameEntry->second.resize(digitCount + 1);
+    }
+    PiecewiseSparseIntegerSet& baseNameAndDigitCountEntry = baseNameEntry->second[digitCount];
+    // Name should not already be there
+    assert(!baseNameAndDigitCountEntry.Contains(digitsValue));
+    baseNameAndDigitCountEntry.Add(digitsValue);
+}
+std::string Base::UniqueNameManager::makeUniqueName(const std::string& modelName,
+                                                    int minDigits) const
+{
+    std::string namePrefix;
+    std::string nameSuffix;
+    decomposeName(modelName, namePrefix, nameSuffix);
+    std::string baseName = namePrefix + nameSuffix;
+    auto baseNameEntry = UniqueSeeds.find(baseName);
+    if (baseNameEntry == UniqueSeeds.end()) {
+        // First use of baseName, just return it with no unique digits
+        return baseName;
+    }
+    // We don't care about the digit count of the suggested name, we always use at least the most
+    // digits ever used before.
+    int digitCount = baseNameEntry->second.size() - 1;
+    uint digitsValue;
+    if (digitCount < minDigits) {
+        // Caller is asking for more digits than we have in any registered name.
+        // We start the longer digit string at 000...0001 even though we might have shorter strings
+        // with larger numeric values.
+        digitCount = minDigits;
+        digitsValue = 1;
+    }
+    else {
+        digitsValue = baseNameEntry->second[digitCount].Next();
+    }
+    std::string digits = std::to_string(digitsValue);
+    if (digitCount > digits.size()) {
+        namePrefix += std::string(digitCount - digits.size(), '0');
+    }
+    return namePrefix + digits + nameSuffix;
 }
 
+// Remove a rgistered name so it can be generated again.
+// Nothing happens if you try to remove a non-registered name.
+void Base::UniqueNameManager::removeExactName(const std::string& name)
+{
+    std::string baseName;
+    std::string nameSuffix;
+    uint digitCount;
+    uint digitsValue;
+    std::tie(digitCount, digitsValue) = decomposeName(name, baseName, nameSuffix);
+    baseName += nameSuffix;
+    auto baseNameEntry = UniqueSeeds.find(baseName);
+    if (baseNameEntry == UniqueSeeds.end()) {
+        // name must not be registered, so nothing to do.
+        return;
+    }
+    int maxDigitCount = baseNameEntry->second.size();
+    if (digitCount >= maxDigitCount) {
+        // First use of this digitCount, name must not be registered, so nothing to do.
+        return;
+    }
+    PiecewiseSparseIntegerSet& baseNameAndDigitCountEntry = baseNameEntry->second[digitCount];
+    baseNameAndDigitCountEntry.Remove(digitsValue);
+    // Prune empty vector entries
+    while (--maxDigitCount >= 0 && !baseNameEntry->second[maxDigitCount].Any())
+        ;
+    if (maxDigitCount < 0) {
+        UniqueSeeds.erase(baseName);
+    }
+    else {
+        baseNameEntry->second.resize(maxDigitCount + 1);
+    }
+}
+
+bool Base::UniqueNameManager::containsName(const std::string& name) const
+{
+    std::string baseName;
+    std::string nameSuffix;
+    uint digitCount;
+    uint digitsValue;
+    std::tie(digitCount, digitsValue) = decomposeName(name, baseName, nameSuffix);
+    baseName += nameSuffix;
+    auto baseNameEntry = UniqueSeeds.find(baseName);
+    if (baseNameEntry == UniqueSeeds.end()) {
+        // base name is not registered
+        return false;
+    }
+    if (digitCount >= baseNameEntry->second.size()) {
+        // First use of this digitCount, name must not be registered, so not in collection
+        return false;
+    }
+    return baseNameEntry->second[digitCount].Contains(digitsValue);
+}
 std::string Base::Tools::getIdentifier(const std::string& name)
 {
     if (name.empty()) {

--- a/src/Base/Tools.cpp
+++ b/src/Base/Tools.cpp
@@ -211,11 +211,10 @@ void Base::UniqueNameManager::removeExactName(const std::string& name)
     digitValueSets[digitCount].Remove(digitsValue);
     // an element of digitValueSets may now be newly empty and so may other elements below it
     // Prune off all such trailing empty entries.
-    auto lastNonemptyEntry = std::find_if(digitValueSets.crbegin(),
-                                          digitValueSets.crend(),
-                                          [](auto& it) {
-                                              return it.Any();
-                                          });
+    auto lastNonemptyEntry =
+        std::find_if(digitValueSets.crbegin(), digitValueSets.crend(), [](auto& it) {
+            return it.Any();
+        });
     if (lastNonemptyEntry == digitValueSets.crend()) {
         // All entries are empty, so the entire baseName can be forgotten.
         UniqueSeeds.erase(baseName);

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include <set>
 #include <boost_signals2.hpp>
 #include <QString>
 
@@ -264,11 +265,100 @@ public:
 
 // ----------------------------------------------------------------------------
 
+
+class BaseExport UniqueNameManager
+{
+protected:
+    // This method returns the position of the start of the suffix (or name.cend() if no
+    // suffix). It must return the same suffix lentgh (name.size() - returnValue) for both
+    // unique names (one containing digits) and the corresponding base name (with no digits).
+    virtual std::string::const_iterator GetNameSuffixStartPosition(const std::string& name) const
+    {
+        return name.cend();
+    }
+
+private:
+    class PiecewiseSparseIntegerSet
+    {
+    public:
+        PiecewiseSparseIntegerSet()
+        {}
+
+    private:
+        // Each pair being <lowest, count> represents the span of integers from lowest to
+        // (lowest+count-1) inclusive
+        using etype = std::pair<uint, uint>;
+        // This span comparer class is analogous to std::less and treats overlapping spans as being
+        // neither greater nor less than each other
+        class comparer
+        {
+        public:
+            bool operator()(const etype& lhs, const etype& rhs) const
+            {
+                // The equality case here is when lhs is below and directly adjacent to rhs.
+                return rhs.first - lhs.first >= lhs.second;
+            }
+        };
+        // Spans is the set of spans. Adjacent spans are coalesced so there are always gaps between
+        // the entries.
+        std::set<etype, comparer> Spans;
+        using iterator = typename std::set<etype, comparer>::iterator;
+        using const_iterator = typename std::set<etype, comparer>::const_iterator;
+
+    public:
+        void Add(uint value);
+        void Remove(uint value);
+        bool Contains(uint value) const;
+        bool Any() const
+        {
+            return Spans.size() != 0;
+        }
+        void Clear()
+        {
+            Spans.clear();
+        }
+        uint Next() const
+        {
+            if (Spans.size() == 0) {
+                return 0;
+            }
+            iterator last = Spans.end();
+            --last;
+            return last->first + last->second;
+        }
+    };
+    // Keyed as UniqueSeeds[baseName][digitCount][digitValue] iff that seed is taken.
+    // We need the double-indexing so that Name01 and Name001 can both be indexed, although we only
+    // ever allocate off the longest for each name i.e. UniqueSeeds[baseName].size()-1 digits.
+    std::map<std::string, std::vector<PiecewiseSparseIntegerSet>> UniqueSeeds;
+
+public:
+    std::tuple<uint, uint> decomposeName(const std::string& name,
+                                         std::string& baseNameOut,
+                                         std::string& nameSuffixOut) const;
+
+    UniqueNameManager()
+    {}
+
+    // Register a name in the collection. It is an error (detected only by assertions) to register a
+    // name more than once. The effect if undetected is that the second registration will have no
+    // effect
+    void addExactName(const std::string& name);
+    std::string makeUniqueName(const std::string& modelName, int minDigits = 0) const;
+
+    // Remove a rgistered name so it can be generated again.
+    // Nothing happens if you try to remove a non-registered name.
+    void removeExactName(const std::string& name);
+
+    bool containsName(const std::string& name) const;
+
+    void clear()
+    {
+        UniqueSeeds.clear();
+    }
+};
 struct BaseExport Tools
 {
-    static std::string
-    getUniqueName(const std::string&, const std::vector<std::string>&, int d = 0);
-    static std::string addNumber(const std::string&, unsigned int, int d = 0);
     static std::string getIdentifier(const std::string&);
     static std::wstring widen(const std::string& str);
     static std::string narrow(const std::wstring& str);

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -346,7 +346,7 @@ public:
     void addExactName(const std::string& name);
     std::string makeUniqueName(const std::string& modelName, int minDigits = 0) const;
 
-    // Remove a rgistered name so it can be generated again.
+    // Remove a registered name so it can be generated again.
     // Nothing happens if you try to remove a non-registered name.
     void removeExactName(const std::string& name);
 

--- a/src/Base/Writer.cpp
+++ b/src/Base/Writer.cpp
@@ -247,54 +247,17 @@ std::string Writer::addFile(const char* Name, const Base::Persistence* Object)
     assert(!isForceXML());
 
     FileEntry temp;
-    temp.FileName = getUniqueFileName(Name);
+    temp.FileName = Name ? Name : "";
+    if (FileNameManager.containsName(temp.FileName)) {
+        temp.FileName = FileNameManager.makeUniqueName(temp.FileName);
+    }
     temp.Object = Object;
 
     FileList.push_back(temp);
-
-    FileNames.push_back(temp.FileName);
+    FileNameManager.addExactName(temp.FileName);
 
     // return the unique file name
     return temp.FileName;
-}
-
-std::string Writer::getUniqueFileName(const char* Name)
-{
-    // name in use?
-    std::string CleanName = (Name ? Name : "");
-    std::vector<std::string>::const_iterator pos;
-    pos = find(FileNames.begin(), FileNames.end(), CleanName);
-
-    if (pos == FileNames.end()) {
-        // if not, name is OK
-        return CleanName;
-    }
-
-    std::vector<std::string> names;
-    names.reserve(FileNames.size());
-    FileInfo fi(CleanName);
-    CleanName = fi.fileNamePure();
-    std::string ext = fi.extension();
-    for (pos = FileNames.begin(); pos != FileNames.end(); ++pos) {
-        fi.setFile(*pos);
-        std::string FileName = fi.fileNamePure();
-        if (fi.extension() == ext) {
-            names.push_back(FileName);
-        }
-    }
-
-    std::stringstream str;
-    str << Base::Tools::getUniqueName(CleanName, names);
-    if (!ext.empty()) {
-        str << "." << ext;
-    }
-
-    return str.str();
-}
-
-const std::vector<std::string>& Writer::getFilenames() const
-{
-    return FileNames;
 }
 
 void Writer::incInd()

--- a/src/Base/Writer.h
+++ b/src/Base/Writer.h
@@ -39,6 +39,8 @@
 #include <zipios++/zipoutputstream.h>
 #include <zipios++/meta-iostreams.h>
 
+#include <Base/Tools.h>
+
 #include "FileInfo.h"
 
 
@@ -56,6 +58,24 @@ class Persistence;
  */
 class BaseExport Writer
 {
+private:
+    // This overrides UniqueNameManager's suffix-locating function so thet the last '.' and
+    // everything after it is considered suffix.
+    class UniqueFileNameManager: public UniqueNameManager
+    {
+    protected:
+        virtual std::string::const_iterator
+        GetNameSuffixStartPosition(const std::string& name) const override
+        {
+            // This is an awkward way to do this, because the FileInfo class only yields pieces of
+            // the path, not delimiter positions. We can't just use fi.extension().size() because
+            // both "xyz" and "xyz." would yield three; we need the length of the extension
+            // *including its delimiter* so we use the length difference between the fileName and
+            // fileNamePure.
+            FileInfo fi(name);
+            return name.end() - (fi.fileName().size() - fi.fileNamePure().size());
+        }
+    };
 
 public:
     Writer();
@@ -84,8 +104,6 @@ public:
     std::string addFile(const char* Name, const Base::Persistence* Object);
     /// process the requested file storing
     virtual void writeFiles() = 0;
-    /// get all registered file names
-    const std::vector<std::string>& getFilenames() const;
     /// Set mode
     void setMode(const std::string& mode);
     /// Set modes
@@ -151,14 +169,13 @@ public:
     std::string ObjectName;
 
 protected:
-    std::string getUniqueFileName(const char* Name);
     struct FileEntry
     {
         std::string FileName;
         const Base::Persistence* Object;
     };
     std::vector<FileEntry> FileList;
-    std::vector<std::string> FileNames;
+    UniqueFileNameManager FileNameManager;
     std::vector<std::string> Errors;
     std::set<std::string> Modes;
 

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1938,7 +1938,7 @@ void Document::importObjects(const std::vector<App::DocumentObject*>& obj, Base:
     localreader->readEndElement("Document");
 
     // In the file GuiDocument.xml new data files might be added
-    if (!localreader->getFilenames().empty())
+    if (localreader->hasFilenames())
         reader.initLocalReader(localreader);
 }
 

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -3408,7 +3408,16 @@ void ViewProviderLink::getPropertyMap(std::map<std::string,App::Property*> &Map)
     }
 }
 
-void ViewProviderLink::getPropertyList(std::vector<App::Property*> &List) const {
+bool ViewProviderLink::visitProperties(std::function<bool(App::Property*)> visitor) const
+{
+    if (!inherited::visitProperties(visitor)) {
+        return false;
+    }
+    return !childVp || childVp->visitProperties(visitor);
+}
+
+void ViewProviderLink::getPropertyList(std::vector<App::Property*>& List) const
+{
     std::map<std::string,App::Property*> Map;
     getPropertyMap(Map);
     List.reserve(List.size()+Map.size());

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -3408,12 +3408,12 @@ void ViewProviderLink::getPropertyMap(std::map<std::string,App::Property*> &Map)
     }
 }
 
-bool ViewProviderLink::visitProperties(std::function<bool(App::Property*)> visitor) const
+void ViewProviderLink::visitProperties(std::function<void(App::Property*)> visitor) const
 {
-    if (!inherited::visitProperties(visitor)) {
-        return false;
+    inherited::visitProperties(visitor);
+    if (childVp != nullptr) {
+        childVp->visitProperties(visitor);
     }
-    return !childVp || childVp->visitProperties(visitor);
 }
 
 void ViewProviderLink::getPropertyList(std::vector<App::Property*>& List) const

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -265,7 +265,8 @@ public:
 
     App::Property *getPropertyByName(const char* name) const override;
     void getPropertyMap(std::map<std::string,App::Property*> &Map) const override;
-    bool visitProperties(std::function<bool(App::Property*)> visitor) const override;
+    // See PropertyContainer::visitProperties for semantics
+    void visitProperties(std::function<void(App::Property*)> visitor) const override;
     void getPropertyList(std::vector<App::Property*>& List) const override;
 
     ViewProviderDocumentObject *getLinkedViewProvider(

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -265,7 +265,7 @@ public:
 
     App::Property *getPropertyByName(const char* name) const override;
     void getPropertyMap(std::map<std::string,App::Property*> &Map) const override;
-    // See PropertyContainer::visitProperties for semantics
+    /// See PropertyContainer::visitProperties for semantics
     void visitProperties(std::function<void(App::Property*)> visitor) const override;
     void getPropertyList(std::vector<App::Property*>& List) const override;
 

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -265,7 +265,8 @@ public:
 
     App::Property *getPropertyByName(const char* name) const override;
     void getPropertyMap(std::map<std::string,App::Property*> &Map) const override;
-    void getPropertyList(std::vector<App::Property*> &List) const override;
+    bool visitProperties(std::function<bool(App::Property*)> visitor) const override;
+    void getPropertyList(std::vector<App::Property*>& List) const override;
 
     ViewProviderDocumentObject *getLinkedViewProvider(
             std::string *subname=nullptr, bool recursive=false) const override;

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -872,6 +872,20 @@ void Sheet::getPropertyNamedList(std::vector<std::pair<const char*, Property*>>&
     }
 }
 
+bool Sheet::visitProperties(std::function<bool(App::Property*)> visitor) const
+{
+    if (!DocumentObject::visitProperties(visitor)) {
+        return false;
+    }
+    for (auto& v : cells.aliasProp) {
+        auto prop = getProperty(v.first);
+        if (prop && !visitor(prop)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void Sheet::touchCells(Range range)
 {
     do {
@@ -1134,7 +1148,7 @@ DocumentObjectExecReturn* Sheet::execute()
             catch (std::exception&) {  // TODO: evaluate using a more specific exception (not_a_dag)
                 // Cycle detected; flag all with errors
                 Base::Console().Error("Cyclic dependency detected in spreadsheet : %s\n",
-                                      *pcNameInDocument);
+                                      getNameInDocument());
                 std::ostringstream ss;
                 ss << "Cyclic dependency";
                 int count = 0;

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -872,18 +872,15 @@ void Sheet::getPropertyNamedList(std::vector<std::pair<const char*, Property*>>&
     }
 }
 
-bool Sheet::visitProperties(std::function<bool(App::Property*)> visitor) const
+void Sheet::visitProperties(std::function<void(App::Property*)> visitor) const
 {
-    if (!DocumentObject::visitProperties(visitor)) {
-        return false;
-    }
-    for (auto& v : cells.aliasProp) {
+    DocumentObject::visitProperties(visitor);
+    for (const auto& v : cells.aliasProp) {
         auto prop = getProperty(v.first);
-        if (prop && !visitor(prop)) {
-            return false;
+        if (prop != nullptr) {
+            visitor(prop);
         }
-    }
-    return true;
+    };
 }
 
 void Sheet::touchCells(Range range)

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -189,7 +189,7 @@ public:
     void
     getPropertyNamedList(std::vector<std::pair<const char*, App::Property*>>& List) const override;
 
-    // See PropertyContainer::visitProperties for semantics
+    /// See PropertyContainer::visitProperties for semantics
     void visitProperties(std::function<void(App::Property*)> visitor) const override;
 
     short mustExecute() const override;

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -189,6 +189,8 @@ public:
     void
     getPropertyNamedList(std::vector<std::pair<const char*, App::Property*>>& List) const override;
 
+    bool visitProperties(std::function<bool(App::Property*)> visitor) const override;
+
     short mustExecute() const override;
 
     App::DocumentObjectExecReturn* execute() override;

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -189,7 +189,8 @@ public:
     void
     getPropertyNamedList(std::vector<std::pair<const char*, App::Property*>>& List) const override;
 
-    bool visitProperties(std::function<bool(App::Property*)> visitor) const override;
+    // See PropertyContainer::visitProperties for semantics
+    void visitProperties(std::function<void(App::Property*)> visitor) const override;
 
     short mustExecute() const override;
 

--- a/tests/src/Base/Tools.cpp
+++ b/tests/src/Base/Tools.cpp
@@ -5,42 +5,58 @@
 // NOLINTBEGIN(cppcoreguidelines-*,readability-*)
 TEST(BaseToolsSuite, TestUniqueName1)
 {
-    EXPECT_EQ(Base::Tools::getUniqueName("Body", {}), "Body");
+    EXPECT_EQ(Base::UniqueNameManager().makeUniqueName("Body"), "Body");
 }
 
 TEST(BaseToolsSuite, TestUniqueName2)
 {
-    EXPECT_EQ(Base::Tools::getUniqueName("Body", {"Body"}, 1), "Body1");
+    Base::UniqueNameManager manager;
+    manager.addExactName("Body");
+    EXPECT_EQ(manager.makeUniqueName("Body", 1), "Body1");
 }
 
 TEST(BaseToolsSuite, TestUniqueName3)
 {
-    EXPECT_EQ(Base::Tools::getUniqueName("Body", {"Body"}, 3), "Body001");
+    Base::UniqueNameManager manager;
+    manager.addExactName("Body");
+    EXPECT_EQ(manager.makeUniqueName("Body", 3), "Body001");
 }
 
 TEST(BaseToolsSuite, TestUniqueName4)
 {
-    EXPECT_EQ(Base::Tools::getUniqueName("Body", {"Body001"}, 3), "Body002");
+    Base::UniqueNameManager manager;
+    manager.addExactName("Body001");
+    EXPECT_EQ(manager.makeUniqueName("Body", 3), "Body002");
 }
 
 TEST(BaseToolsSuite, TestUniqueName5)
 {
-    EXPECT_EQ(Base::Tools::getUniqueName("Body", {"Body", "Body001"}, 3), "Body002");
+    Base::UniqueNameManager manager;
+    manager.addExactName("Body");
+    manager.addExactName("Body001");
+    EXPECT_EQ(manager.makeUniqueName("Body", 3), "Body002");
 }
 
 TEST(BaseToolsSuite, TestUniqueName6)
 {
-    EXPECT_EQ(Base::Tools::getUniqueName("Body001", {"Body", "Body001"}, 3), "Body002");
+    Base::UniqueNameManager manager;
+    manager.addExactName("Body");
+    manager.addExactName("Body001");
+    EXPECT_EQ(manager.makeUniqueName("Body001", 3), "Body002");
 }
 
 TEST(BaseToolsSuite, TestUniqueName7)
 {
-    EXPECT_EQ(Base::Tools::getUniqueName("Body001", {"Body"}, 3), "Body002");
+    Base::UniqueNameManager manager;
+    manager.addExactName("Body");
+    EXPECT_EQ(manager.makeUniqueName("Body001", 3), "Body001");
 }
 
 TEST(BaseToolsSuite, TestUniqueName8)
 {
-    EXPECT_EQ(Base::Tools::getUniqueName("Body12345", {"Body"}, 3), "Body12346");
+    Base::UniqueNameManager manager;
+    manager.addExactName("Body");
+    EXPECT_EQ(manager.makeUniqueName("Body12345", 3), "Body001");
 }
 
 TEST(Tools, TestIota)


### PR DESCRIPTION
As described in #16849, the existing Tools::getUniqueName method requires calling code to form a vector of existing names to be avoided.

This leads to poor performance both in the O(n) cost of building such a vector and also getUniqueName's O(n) algorithm for actually generating the unique name (where 'n' is the number of pre-existing names).

This has particularly noticeable cost in documents with large numbers of DocumentObjects because generating both Names and Labels for each new object incurs this cost. During an operation such as importing this results in an O(n^2) time spent generating names.

The other major cost is in the saving of the temporary backup file, which uses name generation for the "files" embedded in the Zip file. Documents can easily need several such "files" for each object in the document.
