### PR TITLE
Sketch: Drop restriction to disallow using non-driving constraints in…

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -9777,16 +9777,6 @@ std::string SketchObject::validateExpression(const App::ObjectIdentifier& path,
     auto deps = expr->getDeps();
     auto it = deps.find(this);
     if (it != deps.end()) {
-        auto it2 = it->second.find("Constraints");
-        if (it2 != it->second.end()) {
-            for (auto& oid : it2->second) {
-                const Constraint* constraint = Constraints.getConstraint(oid);
-
-                if (!constraint->isDriving)
-                    return "Reference constraint from this sketch cannot be used in this "
-                           "expression.";
-            }
-        }
         geoMap.clear();
         const auto &vals = getInternalGeometry();
         for(long i=0;i<(long)vals.size();++i) {


### PR DESCRIPTION
… an expression

In the German sub-forum there is an issue reported where using non-driving constraints in expressions is not allowed any more: https://forum.freecad.org/viewtopic.php?t=92181

The function that prints the error message already exists since 2015 ([67800ec8c4286c](http://github.com/FreeCAD/FreeCAD/commit/67800ec8c4286c)) and it's not clear why it has ever worked in older versions to use non-driving constraints in expressions. At least since v1.0 it doesn't work any more.

The other question is why this restriction even exists. When I drop it then things work again as in older versions.