### PR TITLE
CAM: Fix finishing pass

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathVcarve.py
+++ b/src/Mod/CAM/CAMTests/TestPathVcarve.py
@@ -53,7 +53,7 @@ class TestPathVcarve(PathTestBase):
     def testFinishingPass(self):
         self.doc = FreeCAD.newDocument()
         part = FreeCAD.ActiveDocument.addObject("Part::Feature", "TestShape")
-        rect = Part.makePolygon([(0,0,0), (5,0,0), (5,10,0), (0,10,0), (0,0,0)])
+        rect = Part.makePolygon([(0, 0, 0), (5, 0, 0), (5, 10, 0), (0, 10, 0), (0, 0, 0)])
         part.Shape = Part.makeFace(rect, "Part::FaceMakerSimple")
         job = PathJob.Create("Job", [part])
         tool_file = PathToolBit.findToolBit("60degree_Vbit.fctb")

--- a/src/Mod/CAM/CAMTests/TestPathVcarve.py
+++ b/src/Mod/CAM/CAMTests/TestPathVcarve.py
@@ -21,6 +21,8 @@
 # ***************************************************************************
 
 import FreeCAD
+import Part
+import Path.Main.Job as PathJob
 import Path.Op.Vcarve as PathVcarve
 import Path.Tool.Bit as PathToolBit
 import math
@@ -43,6 +45,34 @@ Scale60 = math.sqrt(3)
 
 class TestPathVcarve(PathTestBase):
     """Test Vcarve milling basics."""
+
+    def tearDown(self):
+        if hasattr(self, "doc"):
+            FreeCAD.closeDocument(self.doc.Name)
+
+    def testFinishingPass(self):
+        self.doc = FreeCAD.newDocument()
+        part = FreeCAD.ActiveDocument.addObject("Part::Feature", "TestShape")
+        rect = Part.makePolygon([(0,0,0), (5,0,0), (5,10,0), (0,10,0), (0,0,0)])
+        part.Shape = Part.makeFace(rect, "Part::FaceMakerSimple")
+        job = PathJob.Create("Job", [part])
+        tool_file = PathToolBit.findToolBit("60degree_Vbit.fctb")
+        job.Tools.Group[0].Tool = PathToolBit.Factory.CreateFrom(tool_file)
+
+        op = PathVcarve.Create("TestVCarve")
+        op.Base = job.Model.Group[0]
+
+        op.FinishingPass = False
+        op.Proxy.execute(op)
+        min_z_no_finish = op.Path.BoundBox.ZMin
+
+        finishing_offset = -0.1
+        op.FinishingPass = True
+        op.FinishingPassZOffset = finishing_offset
+        op.Proxy.execute(op)
+        min_z_with_finish = op.Path.BoundBox.ZMin
+
+        self.assertRoughly(min_z_with_finish - min_z_no_finish, finishing_offset)
 
     def test00(self):
         """Verify 90 deg depth calculation"""

--- a/src/Mod/CAM/Path/Op/Vcarve.py
+++ b/src/Mod/CAM/Path/Op/Vcarve.py
@@ -507,13 +507,10 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
 
         # add finishing pass if enabled
 
-        #   if obj.FinishingPass:
-        #       geom.offset = obj.FinishingPassZOffset.Value
+            if obj.FinishingPass:
+               geom.offset = obj.FinishingPassZOffset.Value
 
-        #       for w in wires:
-        #           pWire = self._getPartEdges(obj, w, geom)
-        #           if pWire:
-        #               pathlist.extend(cutWire(pWire))
+               cutWires(wires, pathlist, obj.OptimizeMovements)
 
         self.commandlist = pathlist
 

--- a/src/Mod/Sketcher/App/GeometryFacade.cpp
+++ b/src/Mod/Sketcher/App/GeometryFacade.cpp
@@ -155,7 +155,7 @@ int GeometryFacade::getId(const Part::Geometry* geometry)
 void GeometryFacade::setId(Part::Geometry* geometry, int id)
 {
     auto gf = GeometryFacade::getFacade(geometry);
-    return gf->setId(id);
+    gf->setId(id);
 }
 
 bool GeometryFacade::getConstruction(const Part::Geometry* geometry)
@@ -171,7 +171,7 @@ void GeometryFacade::setConstruction(Part::Geometry* geometry, bool construction
     throwOnNullPtr(geometry);
 
     auto gf = GeometryFacade::getFacade(geometry);
-    return gf->setConstruction(construction);
+    gf->setConstruction(construction);
 }
 
 bool GeometryFacade::isInternalType(const Part::Geometry* geometry, InternalType::InternalType type)


### PR DESCRIPTION
Finishing pass logic for Vcarve operation was commented by mistake as it was using old cutting API. Reworked and enabled again.