### PR TITLE
Core / Assembly: Add a way for vp edit modes to be restored.

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -84,8 +84,12 @@ struct DocumentP
     bool       _isModified;
     bool       _isTransacting;
     bool       _changeViewTouchDocument;
+    bool                        _editWantsRestore;
+    bool                        _editWantsRestorePrevious;
     int                         _editMode;
+    int                         _editModePrevious;
     ViewProvider*               _editViewProvider;
+    ViewProvider*               _editViewProviderPrevious;
     App::DocumentObject*        _editingObject;
     ViewProviderDocumentObject* _editViewProviderParent;
     std::string                 _editSubname;
@@ -426,10 +430,14 @@ Document::Document(App::Document* pcDocument,Application * app)
     d->_pcAppWnd = app;
     d->_pcDocument = pcDocument;
     d->_editViewProvider = nullptr;
+    d->_editViewProviderPrevious = nullptr;
     d->_editingObject = nullptr;
     d->_editViewProviderParent = nullptr;
     d->_editingViewer = nullptr;
     d->_editMode = 0;
+    d->_editModePrevious = 0;
+    d->_editWantsRestore = false;
+    d->_editWantsRestorePrevious = false;
 
     //NOLINTBEGIN
     // Setup the connections
@@ -644,7 +652,16 @@ void Document::setEditingTransform(const Base::Matrix4D &mat) {
 }
 
 void Document::resetEdit() {
+    bool vpIsNotNull = d->_editViewProvider != nullptr;
+    int modeToRestore = d->_editModePrevious;
+    Gui::ViewProvider* vpToRestore = d->_editViewProviderPrevious;
+    bool shouldRestorePrevious = d->_editWantsRestorePrevious;
+
     Application::Instance->setEditDocument(nullptr);
+
+    if (vpIsNotNull && shouldRestorePrevious) {
+        setEdit(vpToRestore, modeToRestore);
+    }
 }
 
 void Document::_resetEdit()
@@ -658,6 +675,11 @@ void Document::_resetEdit()
         }
 
         d->_editViewProvider->finishEditing();
+
+        d->_editViewProviderPrevious = d->_editViewProvider;
+        d->_editModePrevious = d->_editMode;
+        d->_editWantsRestorePrevious = d->_editWantsRestore;
+        d->_editWantsRestore = false;
 
         // Have to check d->_editViewProvider below, because there is a chance
         // the editing object gets deleted inside the above call to
@@ -680,8 +702,9 @@ void Document::_resetEdit()
     d->_editingViewer = nullptr;
     d->_editObjs.clear();
     d->_editingObject = nullptr;
-    if(Application::Instance->editDocument() == this)
+    if (Application::Instance->editDocument() == this) {
         Application::Instance->setEditDocument(nullptr);
+    }
 }
 
 ViewProvider *Document::getInEdit(ViewProviderDocumentObject **parentVp,
@@ -727,6 +750,11 @@ void Document::setAnnotationViewProvider(const char* name, ViewProvider *pcProvi
         if (activeView)
             activeView->getViewer()->addViewProvider(pcProvider);
     }
+}
+
+void Document::setEditRestore(bool askRestore)
+{
+    d->_editWantsRestore = askRestore;
 }
 
 ViewProvider * Document::getAnnotationViewProvider(const char* name) const

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -255,6 +255,8 @@ public:
     void resetEdit();
     /// reset edit of this document
     void _resetEdit();
+    /// set if the edit asks for restore or not.
+    void setEditRestore(bool val);
     /// get the in edit ViewProvider or NULL
     ViewProvider *getInEdit(ViewProviderDocumentObject **parentVp=nullptr,
             std::string *subname=nullptr, int *mode=nullptr, std::string *subElement=nullptr) const;

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -217,6 +217,9 @@ bool ViewProviderAssembly::canDragObjectToTarget(App::DocumentObject* obj,
 bool ViewProviderAssembly::setEdit(int mode)
 {
     if (mode == ViewProvider::Default) {
+        // Ask that this edit mode be restored. For example if it is quit to edit a sketch.
+        getDocument()->setEditRestore(true);
+
         // Set the part as 'Activated' ie bold in the tree.
         Gui::Command::doCommand(Gui::Command::Gui,
                                 "appDoc = App.getDocument('%s')\n"


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/17948
Fix https://github.com/FreeCAD/FreeCAD/issues/16238

When you start editing a sketch from an assembly, it unset the assembly edit. Which is very annoying for assembly top-down design.

The proposed solution is to add the possibility for VP to ask for restore. If a VP does this, and is unset by another vp setting, then when this other vp unset, it set back the previous vp.

This has the advantage of also solving the same when user use the transform tool. After transform is finish the assembly is reactivated.

https://github.com/user-attachments/assets/be8431ed-0a6b-49c2-8e81-ab9721d0b960

@wwmayer please comment if this solution seems acceptable to you.