### PR TITLE
MeshPart: Remove unused INCLUDE_DIRS

### DIFF
--- a/src/Mod/MeshPart/App/CMakeLists.txt
+++ b/src/Mod/MeshPart/App/CMakeLists.txt
@@ -14,10 +14,8 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
-    ${ZLIB_INCLUDE_DIR}
     ${PYTHON_INCLUDE_DIRS}
     ${SMESH_INCLUDE_DIR}
-    ${VTK_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIR}
     ${pybind11_INCLUDE_DIR}
 )

--- a/src/Mod/MeshPart/Gui/CMakeLists.txt
+++ b/src/Mod/MeshPart/Gui/CMakeLists.txt
@@ -16,7 +16,6 @@ include_directories(
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${COIN3D_INCLUDE_DIRS}
-    ${ZLIB_INCLUDE_DIR}
     ${PYTHON_INCLUDE_DIRS}
 )
 


### PR DESCRIPTION
Not the most consequential change but for myself when packaging I use `grep` quite a bit and invalid hits can be misleading.
