### PR TITLE
PartDesign: revert c09ef94 and a3c4f4b to fix 17949

### DIFF
--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -89,12 +89,14 @@ bool setEdit(App::DocumentObject *obj, PartDesign::Body *body) {
         return false;
     App::DocumentObject *parent = nullptr;
     std::string subname;
-    auto activeBody = activeView->getActiveObject<PartDesign::Body*>(PDBODYKEY);
+    auto activeBody = activeView->getActiveObject<PartDesign::Body*>(PDBODYKEY, &parent, &subname);
     if (activeBody != body) {
         parent = obj;
+        subname.clear();
     }
     else {
-        parent = getParent(obj, subname);
+        subname += obj->getNameInDocument();
+        subname += '.';
     }
 
     Gui::cmdGuiDocument(parent, std::ostringstream() << "setEdit("


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/17949

by reverting :
1 - https://github.com/FreeCAD/FreeCAD/commit/c09ef943f76a9693af6a045220070f685847e458 by @adrianinsaval
2 - https://github.com/FreeCAD/FreeCAD/commit/a3c4f4bb01f5201daf666852444a8f9c5adbda8d by @wwmayer

https://github.com/FreeCAD/FreeCAD/commit/c09ef943f76a9693af6a045220070f685847e458 was fixing a bug introduced by https://github.com/FreeCAD/FreeCAD/commit/a3c4f4bb01f5201daf666852444a8f9c5adbda8d which was fixing the bug https://github.com/FreeCAD/FreeCAD/issues/9538

However after reverting both commits, the issue https://github.com/FreeCAD/FreeCAD/issues/9538 cannot be reproduced anymore. So it must have been fixed by something else since.