### PR TITLE
[Draft Gui_Stretch] Improve Stretch Rectangle Behaviour

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_stretch.py
+++ b/src/Mod/Draft/draftguitools/gui_stretch.py
@@ -346,7 +346,7 @@ class Stretch(gui_base_original.Modifier):
                         #       " - ", ops[1],
                         #       " - ", self.displacement)
                         done = False
-                        if optype > 0 and optype < 5:
+                        if 0 < optype < 5:
                             v1 = ops[0].Placement.multVec(p2).sub(ops[0].Placement.multVec(p1))
                             a1 = round(self.displacement.getAngle(v1), 4)
                             v2 = ops[0].Placement.multVec(p4).sub(ops[0].Placement.multVec(p1))
@@ -445,7 +445,7 @@ class Stretch(gui_base_original.Modifier):
                                     commitops.append(_cmd)
                                     commitops.append(_pl)
                                     done = True
-                        if optype == 5:
+                        elif optype == 5:
                             _pl = _doc + ops[0].Name
                             _pl += ".Placement.Base=FreeCAD."
                             _pl += str(ops[0].Placement.Base.add(self.displacement))

--- a/src/Mod/Draft/draftguitools/gui_stretch.py
+++ b/src/Mod/Draft/draftguitools/gui_stretch.py
@@ -337,6 +337,8 @@ class Stretch(gui_base_original.Modifier):
                             optype = 3
                         elif ops[1] == [True, True, False, False]:
                             optype = 4
+                        elif ops[1] == [True, True, True, True]:
+                            optype = 5
                         else:
                             optype = 0
                         # print("length:", ops[0].Length,
@@ -344,7 +346,7 @@ class Stretch(gui_base_original.Modifier):
                         #       " - ", ops[1],
                         #       " - ", self.displacement)
                         done = False
-                        if optype > 0:
+                        if optype > 0 and optype < 5:
                             v1 = ops[0].Placement.multVec(p2).sub(ops[0].Placement.multVec(p1))
                             a1 = round(self.displacement.getAngle(v1), 4)
                             v2 = ops[0].Placement.multVec(p4).sub(ops[0].Placement.multVec(p1))
@@ -443,6 +445,12 @@ class Stretch(gui_base_original.Modifier):
                                     commitops.append(_cmd)
                                     commitops.append(_pl)
                                     done = True
+                        if optype == 5:
+                            _pl = _doc + ops[0].Name
+                            _pl += ".Placement.Base=FreeCAD."
+                            _pl += str(ops[0].Placement.Base.add(self.displacement))
+                            commitops.append(_pl)
+                            done = True
                         if not done:
                             # otherwise create a wire copy and stretch it instead
                             _msg(translate("draft", "Turning one Rectangle into a Wire"))


### PR DESCRIPTION
Feature Improvement discussed at FreeCAD Forum :
- https://forum.freecad.org/viewtopic.php?t=92124#p792118  (Draft_Stretching the whole rectangle creates a new wire)


Currently, 3 cases in general, proposed PR improve Case 3 below :

1. The original object is a Rectangle, if after stretching it is no longer a rectangle, it makes a copy turning it into a Wire which reflect the result of stretching.
   - Current behanviour is good for user, no change.
2. If after stretching it is still a rectangle, the code just resize the original.
   - Current behanviour is good for user, no change.
3. **Now, if the user 'stretch' the whole rectangle, the code creates a copy as DWire in the 'stretched location'.**  
   - *** **Users find this not intuitive, better just move the whole rectangle**.