### PR TITLE
Draft: avoid listing status bar widgets in toolbar area context menu

### DIFF
--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -151,8 +151,8 @@ class DraftWorkbench(FreeCADGui.Workbench):
             FreeCADGui.draftToolBar.Activated()
         if hasattr(FreeCADGui, "Snapper"):
             FreeCADGui.Snapper.show()
-            import draftutils.init_draft_statusbar as dsb
-            dsb.show_draft_statusbar()
+            from draftutils import init_draft_statusbar
+            init_draft_statusbar.show_draft_statusbar()
         import WorkingPlane
         WorkingPlane._view_observer_start()  # Updates the draftToolBar when switching views.
         from draftutils import grid_observer
@@ -165,8 +165,12 @@ class DraftWorkbench(FreeCADGui.Workbench):
             FreeCADGui.draftToolBar.Deactivated()
         if hasattr(FreeCADGui, "Snapper"):
             FreeCADGui.Snapper.hide()
-            import draftutils.init_draft_statusbar as dsb
-            dsb.hide_draft_statusbar()
+            from PySide import QtCore
+            from draftutils import init_draft_statusbar
+            # Delay required in case the Draft WB is preloaded,
+            # else show_draft_statusbar will not yet be done:
+            t = QtCore.QTimer()
+            t.singleShot(500, init_draft_statusbar.hide_draft_statusbar)
         import WorkingPlane
         WorkingPlane._view_observer_stop()
         from draftutils import grid_observer

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -170,7 +170,7 @@ class DraftWorkbench(FreeCADGui.Workbench):
             # Delay required in case the Draft WB is preloaded,
             # else show_draft_statusbar will not yet be done:
             t = QtCore.QTimer()
-            t.singleShot(500, init_draft_statusbar.hide_draft_statusbar)
+            t.singleShot(700, init_draft_statusbar.hide_draft_statusbar)
         import WorkingPlane
         WorkingPlane._view_observer_stop()
         from draftutils import grid_observer

--- a/src/Mod/Draft/draftutils/init_draft_statusbar.py
+++ b/src/Mod/Draft/draftutils/init_draft_statusbar.py
@@ -181,7 +181,11 @@ def init_draft_statusbar_scale():
     sb = mw.statusBar()
 
     scale_widget = QtWidgets.QToolBar()
+    # prevent the widget from showing up in the toolbar area context menu:
+    scale_widget.toggleViewAction().setVisible(False)
     scale_widget.setObjectName("draft_scale_widget")
+    # WindowTitle is just in case, should not be visble in the GUI.
+    scale_widget.setWindowTitle(translate("draft", "Draft scale widget"))
 
     # get scales list according to system units
     draft_scales = get_scales()
@@ -238,7 +242,11 @@ def init_draft_statusbar_snap():
 
     # snap widget:
     snap_widget = QtWidgets.QToolBar()
+    # prevent the widget from showing up in the toolbar area context menu:
+    snap_widget.toggleViewAction().setVisible(False)
     snap_widget.setObjectName("draft_snap_widget")
+    # WindowTitle is just in case, should not be visble in the GUI.
+    snap_widget.setWindowTitle(translate("draft", "Draft snap widget"))
     snap_widget.setOrientation(QtCore.Qt.Orientation.Horizontal)
     snap_widget.setIconSize(QtCore.QSize(16, 16))
     sb.insertPermanentWidget(2, snap_widget)
@@ -330,9 +338,6 @@ def hide_draft_statusbar():
         scale_widget = mw.findChild(QtWidgets.QToolBar, "draft_scale_widget")
     if scale_widget:
         scale_widget.hide()
-        # prevent the widget from showing up as a blank item in the toolbar
-        # area context menu after switching to a different workbench:
-        scale_widget.toggleViewAction().setVisible(False)
 
     # hide snap widget
     snap_widget = sb.findChild(QtWidgets.QToolBar,"draft_snap_widget")
@@ -342,8 +347,5 @@ def hide_draft_statusbar():
         snap_widget = mw.findChild(QtWidgets.QToolBar,"draft_snap_widget")
     if snap_widget:
         snap_widget.hide()
-        # prevent the widget from showing up as a blank item in the toolbar
-        # area context menu after switching to a different workbench:
-        snap_widget.toggleViewAction().setVisible(False)
 
 ## @}


### PR DESCRIPTION
Fixes #16832.

In V1.0 the two Draft status bar widgets appear as checkboxes without label in the toolbar area context menu. They should not be listed in that menu, as was the case in V0.21. Their visibility is controlled via preferences.

Additionally, in case the Draft WB is only preloaded, the widgets would display in another workbench. This is prevented by using a delay.
