### PR TITLE
GitHub: add actions/stale to keep the GitHub backlog tidy

### DIFF
--- a/.github/stale_issues
+++ b/.github/stale_issues
@@ -1,0 +1,82 @@
+# This workflow warns and then closes issues that have had no activity for a
+# specified amount of time. You can adjust the behavior by modifying this file.
+# For more information, see:
+#   https://github.com/marketplace/actions/close-stale-issues
+#   https://github.com/actions/stale/blob/master/action.yml
+#   https://github.com/actions/stale
+---
+name: 'Stale Issues'
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '0 0 * * *'  # Run at 00:00 UTC every day
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write  # for actions/stale to close stale issues
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: '🧹 Tag & close stale issues'
+        id: stale_issues
+        uses: actions/stale@v9.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 90
+          days-before-close: 20
+          operations-per-run: 100  # max num of ops per run
+          stale-issue-label: 'Status: Stale'
+          close-issue-label: 'Status: Auto-closing'
+          # trunk-ignore(yamllint/line-length)
+          exempt-issue-labels: 'Status: Confirmed', 'Priority: High', 'Priority: Critical', 'Blocker', 'Type: Feature'
+          remove-stale-when-updated: true
+          stale-issue-message: |
+            Hi! This issue hasn’t seen activity in a while. If it’s still relevant, please update to the latest FreeCAD weekly build [download here](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds) to see if the problem is resolved.
+
+            If the issue persists, let us know by adding a comment with any updates or details. Otherwise, we’ll close this issue automatically in 20 days to keep our backlog tidy. Feel free to comment anytime to keep it open. Closed issues can always be reopened.
+            Thanks for helping improve FreeCAD!
+
+            Access additional [FreeCAD](https://freecad.org) resources:
+              - **Forum**: https://forum.freecad.org
+              - **Blog**: https://blog.freecad.org
+              - **Wiki**: https://wiki.freecad.org
+
+      - name: 'Print outputs'
+        run: |
+          for key in steps.stale_issues.outputs
+            do
+              printf '%s: %s\n' "${key}" "${steps.stale_issues.outputs[key]}"
+            done
+
+      - name: '🧹 Close stale requested feedback issues'
+        id: awaiting_issues
+        uses: actions/stale@v9.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 20
+          days-before-close: 20
+          operations-per-run: 30  # max num of ops per run
+          stale-issue-label: 'Status: Stale'
+          close-issue-label: 'Status: Auto-closing'
+          only-labels: 'Status: Needs feedback', 'Status: Needs test on dev version', 'Status: Needs steps to reproduce'
+          remove-stale-when-updated: true
+          stale-issue-message: |
+            Hi! This issue hasn’t seen activity in a while despite the need for further feedback.
+            If it’s still relevant, please update to the latest FreeCAD weekly build [download here](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds) to see if the problem is resolved.
+
+            If the issue persists, let us know by adding a comment with any updates or details. Otherwise, we’ll close this issue automatically in 20 days to keep our backlog tidy. Feel free to comment anytime to keep it open. Closed issues can always be reopened.
+            Thanks for helping improve FreeCAD!
+
+            Access additional [FreeCAD](https://freecad.org) resources:
+              - **Forum**: https://forum.freecad.org
+              - **Blog**: https://blog.freecad.org
+              - **Wiki**: https://wiki.freecad.org
+
+      - name: 'Print outputs'
+        run: |
+          for key in steps.awaiting_issues.outputs
+            do
+              printf '%s: %s\n' "${key}" "${steps.awaiting_issues.outputs[key]}"
+            done


### PR DESCRIPTION
Adding the actions/stale to help keep the GitHub repository organized and automatically identify/close stale issues.

Two actions to be implemented:
1. Check for issues without any feedback (comment) in the last **90 days** (confirmed bugs, high priority issues and feature requests are not touched by this) to check for relevance. 
This checks all issues but not the ones with the labels https://github.com/FreeCAD/FreeCAD/labels/Status%3A%20Confirmed, https://github.com/FreeCAD/FreeCAD/labels/Priority%3A%20High, https://github.com/FreeCAD/FreeCAD/labels/Priority%3A%20Critical, https://github.com/FreeCAD/FreeCAD/labels/Blocker, https://github.com/FreeCAD/FreeCAD/labels/Type%3A%20Feature

2. Check for issues where feedback was requested but no feedback was provided in the last **20 days**
This only checks on issues with the tags: https://github.com/FreeCAD/FreeCAD/labels/Status%3A%20Needs%20feedback, https://github.com/FreeCAD/FreeCAD/labels/Status%3A%20Needs%20test%20on%20dev%20version, https://github.com/FreeCAD/FreeCAD/labels/Status%3A%20Needs%20steps%20to%20reproduce

In both cases if an issue is considered stale it is automatically tagged https://github.com/FreeCAD/FreeCAD/labels/Status%3A%20Stale and a comment is added asking for further feedback.

> Hi! This issue hasn’t seen activity in a while. If it’s still relevant, please update to the latest FreeCAD weekly build [download here](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds) to see if the problem is resolved.
> 
> If the issue persists, let us know by adding a comment with any updates or details. Otherwise, we’ll close this issue automatically in 20 days to keep our backlog tidy. Feel free to comment anytime to keep it open. Closed issues can always be reopened.
> Thanks for helping improve FreeCAD!
> 
> Access additional [FreeCAD](https://freecad.org) resources:
> - **Forum**: https://forum.freecad.org
> - **Blog**: https://blog.freecad.org
> - **Wiki**: https://wiki.freecad.org

If no follow up comment is provided in the following **20 days**, the issue is automatically closed.
The action runs every day.

We could add other actions later on too.