### PR TITLE
[TD}Fix crash on no mdi (fix #16672)

### DIFF
--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -651,3 +651,8 @@ void Preferences::setBalloonDragModifiers(Qt::KeyboardModifiers newModifiers)
 }
 
 
+//! if true, automatically switch to TD workbench when a Page is set in edit (double click)
+bool Preferences::switchOnClick()
+{
+    return getPreferenceGroup("General")->GetBool("SwitchToWB", true);
+}

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -150,6 +150,8 @@ public:
 
     static Qt::KeyboardModifiers balloonDragModifiers();
     static void setBalloonDragModifiers(Qt::KeyboardModifiers newModifiers);
+
+    static bool switchOnClick();
 };
 
 

--- a/src/Mod/TechDraw/Gui/AppTechDrawGuiPy.cpp
+++ b/src/Mod/TechDraw/Gui/AppTechDrawGuiPy.cpp
@@ -37,7 +37,6 @@
 #include <Mod/TechDraw/App/DrawPagePy.h>
 #include <Mod/TechDraw/App/DrawViewPy.h>  // generated from DrawViewPy.xml
 
-#include "MDIViewPage.h"
 #include "QGIView.h"
 #include "QGSPage.h"
 #include "ViewProviderPage.h"
@@ -131,25 +130,30 @@ private:
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             PyObject* item = (*it).ptr();
             if (PyObject_TypeCheck(item, &(App::DocumentObjectPy::Type))) {
-                App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(item)->getDocumentObjectPtr();
+                App::DocumentObject* obj =
+                    static_cast<App::DocumentObjectPy*>(item)->getDocumentObjectPtr();
                 if (obj->isDerivedFrom<TechDraw::DrawPage>()) {
                     page = static_cast<TechDraw::DrawPage*>(obj);
-                    Gui::Document* activeGui = Gui::Application::Instance->getDocument(page->getDocument());
+                    Gui::Document* activeGui =
+                        Gui::Application::Instance->getDocument(page->getDocument());
                     Gui::ViewProvider* vp = activeGui->getViewProvider(obj);
-                    ViewProviderPage* dvp = dynamic_cast<ViewProviderPage*>(vp);
-                    if ( !(dvp  && dvp->getMDIViewPage()) ) {
+                    ViewProviderPage* vpPage = dynamic_cast<ViewProviderPage*>(vp);
+                    if (!vpPage) {
                         throw Py::TypeError("TechDraw can not find Page");
                     }
 
                     Base::FileInfo fi_out(EncodedName.c_str());
 
                     if (fi_out.hasExtension("svg")) {
-                        dvp->getMDIViewPage()->saveSVG(EncodedName);
-                    } else if (fi_out.hasExtension("dxf")) {
-                        dvp->getMDIViewPage()->saveDXF(EncodedName);
-                    } else if (fi_out.hasExtension("pdf")) {
-                        dvp->getMDIViewPage()->savePDF(EncodedName);
-                    } else {
+                        PagePrinter::saveSVG(vpPage, EncodedName);
+                    }
+                    else if (fi_out.hasExtension("dxf")) {
+                        PagePrinter::saveDXF(vpPage, EncodedName);
+                    }
+                    else if (fi_out.hasExtension("pdf")) {
+                        PagePrinter::savePDF(vpPage, EncodedName);
+                    }
+                    else {
                         throw Py::TypeError("TechDraw can not export this file format");
                     }
                 }
@@ -175,30 +179,22 @@ private:
         PyMem_Free(name);
 
         try {
-           App::DocumentObject* obj = nullptr;
-           Gui::ViewProvider* vp = nullptr;
-           MDIViewPage* mdi = nullptr;
-           if (PyObject_TypeCheck(pageObj, &(App::DocumentObjectPy::Type))) {
-               obj = static_cast<App::DocumentObjectPy*>(pageObj)->getDocumentObjectPtr();
-               vp = Gui::Application::Instance->getViewProvider(obj);
-               if (vp) {
-                   TechDrawGui::ViewProviderPage* vpp = dynamic_cast<TechDrawGui::ViewProviderPage*>(vp);
-                   if (vpp) {
-                       mdi = vpp->getMDIViewPage();
-                       if (mdi) {
-                           mdi->savePDF(filePath);
-                       } else {
-                           vpp->showMDIViewPage();
-                           mdi = vpp->getMDIViewPage();
-                           if (mdi) {
-                               mdi->savePDF(filePath);
-                           } else {
-                               throw Py::TypeError("Page not available! Is it Hidden?");
-                           }
-                       }
-                   }
-               }
-           }
+            App::DocumentObject* obj = nullptr;
+            Gui::ViewProvider* vp = nullptr;
+            if (PyObject_TypeCheck(pageObj, &(App::DocumentObjectPy::Type))) {
+                obj = static_cast<App::DocumentObjectPy*>(pageObj)->getDocumentObjectPtr();
+                vp = Gui::Application::Instance->getViewProvider(obj);
+                if (vp) {
+                    TechDrawGui::ViewProviderPage* vpPage =
+                        dynamic_cast<TechDrawGui::ViewProviderPage*>(vp);
+                    if (vpPage) {
+                        PagePrinter::savePDF(vpPage, filePath);
+                    }
+                    else {
+                        throw Py::TypeError("Page not available! Is it Hidden?");
+                    }
+                }
+            }
         }
         catch (Base::Exception &e) {
             e.setPyException();
@@ -221,30 +217,22 @@ private:
         PyMem_Free(name);
 
         try {
-           App::DocumentObject* obj = nullptr;
-           Gui::ViewProvider* vp = nullptr;
-           MDIViewPage* mdi = nullptr;
-           if (PyObject_TypeCheck(pageObj, &(App::DocumentObjectPy::Type))) {
-               obj = static_cast<App::DocumentObjectPy*>(pageObj)->getDocumentObjectPtr();
-               vp = Gui::Application::Instance->getViewProvider(obj);
-               if (vp) {
-                   TechDrawGui::ViewProviderPage* vpp = dynamic_cast<TechDrawGui::ViewProviderPage*>(vp);
-                   if (vpp) {
-                       mdi = vpp->getMDIViewPage();
-                       if (mdi) {
-                           mdi->saveSVG(filePath);
-                       } else {
-                           vpp->showMDIViewPage();
-                           mdi = vpp->getMDIViewPage();
-                           if (mdi) {
-                               mdi->saveSVG(filePath);
-                           } else {
-                               throw Py::TypeError("Page not available! Is it Hidden?");
-                           }
-                       }
-                   }
-               }
-           }
+            App::DocumentObject* obj = nullptr;
+            Gui::ViewProvider* vp = nullptr;
+            if (PyObject_TypeCheck(pageObj, &(App::DocumentObjectPy::Type))) {
+                obj = static_cast<App::DocumentObjectPy*>(pageObj)->getDocumentObjectPtr();
+                vp = Gui::Application::Instance->getViewProvider(obj);
+                if (vp) {
+                    TechDrawGui::ViewProviderPage* vpPage =
+                        dynamic_cast<TechDrawGui::ViewProviderPage*>(vp);
+                    if (vpPage) {
+                        PagePrinter::saveSVG(vpPage, filePath);
+                    }
+                    else {
+                        throw Py::TypeError("Page not available! Is it Hidden?");
+                    }
+                }
+            }
         }
         catch (Base::Exception &e) {
             e.setPyException();

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -323,7 +323,7 @@ void CmdTechDrawView::activated(int iMsg)
     auto* vpp = dynamic_cast<ViewProviderPage*>
         (Gui::Application::Instance->getViewProvider(page));
     if (vpp) {
-        vpp->switchToMdiViewPage();
+        vpp->show();
     }
 
 
@@ -1793,14 +1793,16 @@ void CmdTechDrawExportPageSVG::activated(int iMsg)
 
     Gui::Document* activeGui = Gui::Application::Instance->getDocument(page->getDocument());
     Gui::ViewProvider* vp = activeGui->getViewProvider(page);
-    ViewProviderPage* dvp = dynamic_cast<ViewProviderPage*>(vp);
+    ViewProviderPage* vpPage = dynamic_cast<ViewProviderPage*>(vp);
 
-    if (dvp && dvp->getMDIViewPage()) {
-        dvp->getMDIViewPage()->saveSVG();
+    if (vpPage) {
+        vpPage->show();  // make sure a mdi will be available
+        vpPage->getMDIViewPage()->saveSVG();
     }
     else {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("No Drawing View"),
-                             QObject::tr("Open Drawing View before attempting export to SVG."));
+        QMessageBox::warning(Gui::getMainWindow(),
+                             QObject::tr("No Drawing Page"),
+                             QObject::tr("FreeCAD could not find a page to export"));
         return;
     }
 }

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
@@ -28,27 +28,99 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout" columnstretch="1,0,0">
-        <item row="2" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbFuseBeforeSection">
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Overlap Edges Scrub Passes</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbCrazyEdges">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
           <property name="toolTip">
-           <string>Perform a fuse operation on input shape(s) before Section view processing</string>
+           <string>Include edges with unexpected geometry (zero length etc.) in results</string>
           </property>
           <property name="text">
-           <string>Fuse Before Section</string>
+           <string>Allow Crazy Edges</string>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>SectionFuseFirst</cstring>
+           <cstring>allowCrazyEdge</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/debug</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="2">
+         <widget class="Gui::PrefSpinBox" name="sbMaxTiles">
+          <property name="toolTip">
+           <string>Limit of 64x64 pixel SVG tiles used to hatch a single face.
+For large scalings you might get an error about too many SVG tiles.
+Then you need to increase the tile limit.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignRight</set>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>1000000</number>
+          </property>
+          <property name="singleStep">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>10000</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>MaxSVGTile</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="pdsbMarkFuzz">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>174</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Selection area around center marks
+Each unit is approx. 0.1 mm wide</string>
+          </property>
+          <property name="statusTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>MarkFuzz</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/General</cstring>
@@ -77,110 +149,29 @@
           </property>
          </widget>
         </item>
-        <item row="7" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="pdsbEdgeFuzz">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>174</width>
-            <height>0</height>
-           </size>
-          </property>
+        <item row="1" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbNewFaceFinder">
           <property name="toolTip">
-           <string>Size of selection area around edges
-Each unit is approx. 0.1 mm wide</string>
+           <string>If checked, FreeCAD will use the new face finder algorithm.  If not checked, FreeCAD will use the original face finder.</string>
           </property>
-          <property name="statusTip">
-           <string/>
+          <property name="text">
+           <string>Use New Face Finder Algorithm</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>10.000000000000000</double>
+          <property name="checked">
+           <bool>true</bool>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>EdgeFuzz</cstring>
+           <cstring>NewFaceFinder</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/General</cstring>
           </property>
          </widget>
         </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Edge Fuzz</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbCrazyEdges">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Include edges with unexpected geometry (zero length etc.) in results</string>
-          </property>
-          <property name="text">
-           <string>Allow Crazy Edges</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>allowCrazyEdge</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/debug</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="2">
-         <widget class="Gui::PrefSpinBox" name="sbMaxPat">
-          <property name="toolTip">
-           <string>Maximum hatch line segments to use
-when hatching a face with a PAT pattern</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight</set>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>1000000</number>
-          </property>
-          <property name="singleStep">
-           <number>100</number>
-          </property>
-          <property name="value">
-           <number>10000</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>MaxSeg</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/PAT</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Mark Fuzz</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
+        <item row="6" column="1">
          <spacer name="horizontalSpacer">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -190,97 +181,40 @@ when hatching a face with a PAT pattern</string>
           </property>
          </spacer>
         </item>
-        <item row="8" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="pdsbMarkFuzz">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>174</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Selection area around center marks
-Each unit is approx. 0.1 mm wide</string>
-          </property>
-          <property name="statusTip">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>5.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>MarkFuzz</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0">
+        <item row="10" column="0">
          <widget class="QLabel" name="label">
           <property name="text">
            <string>Max SVG Hatch Tiles</string>
           </property>
          </widget>
         </item>
-        <item row="9" column="2">
-         <widget class="Gui::PrefSpinBox" name="sbMaxTiles">
+        <item row="0" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbReportProgress">
           <property name="toolTip">
-           <string>Limit of 64x64 pixel SVG tiles used to hatch a single face.
-For large scalings you might get an error about too many SVG tiles.
-Then you need to increase the tile limit.</string>
+           <string>Issue progress messages while building View geometry</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight</set>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>1000000</number>
-          </property>
-          <property name="singleStep">
-           <number>100</number>
-          </property>
-          <property name="value">
-           <number>10000</number>
+          <property name="text">
+           <string>Report Progress</string>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>MaxSVGTile</cstring>
+           <cstring>ReportProgress</cstring>
           </property>
           <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
+           <cstring>/Mod/TechDraw/General</cstring>
           </property>
          </widget>
         </item>
-        <item row="4" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbDebugDetail">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Dump intermediate results during Detail view processing</string>
-          </property>
+        <item row="8" column="0">
+         <widget class="QLabel" name="label_5">
           <property name="text">
-           <string>Debug Detail</string>
+           <string>Edge Fuzz</string>
           </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>debugDetail</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/debug</cstring>
+         </widget>
+        </item>
+        <item row="9" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Mark Fuzz</string>
           </property>
          </widget>
         </item>
@@ -309,38 +243,32 @@ Then you need to increase the tile limit.</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbReportProgress">
+        <item row="11" column="2">
+         <widget class="Gui::PrefSpinBox" name="sbMaxPat">
           <property name="toolTip">
-           <string>Issue progress messages while building View geometry</string>
+           <string>Maximum hatch line segments to use
+when hatching a face with a PAT pattern</string>
           </property>
-          <property name="text">
-           <string>Report Progress</string>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignRight</set>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>1000000</number>
+          </property>
+          <property name="singleStep">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>10000</number>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>ReportProgress</cstring>
+           <cstring>MaxSeg</cstring>
           </property>
           <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbNewFaceFinder">
-          <property name="toolTip">
-           <string>If checked, FreeCAD will use the new face finder algorithm.  If not checked, FreeCAD will use the original face finder.</string>
-          </property>
-          <property name="text">
-           <string>Use New Face Finder Algorithm</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>NewFaceFinder</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
+           <cstring>Mod/TechDraw/PAT</cstring>
           </property>
          </widget>
         </item>
@@ -363,6 +291,93 @@ Then you need to increase the tile limit.</string>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="pdsbEdgeFuzz">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>174</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Size of selection area around edges
+Each unit is approx. 0.1 mm wide</string>
+          </property>
+          <property name="statusTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>EdgeFuzz</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbFuseBeforeSection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Perform a fuse operation on input shape(s) before Section view processing</string>
+          </property>
+          <property name="text">
+           <string>Fuse Before Section</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SectionFuseFirst</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="2">
+         <widget class="Gui::PrefSpinBox" name="sbScrubCount">
+          <property name="toolTip">
+           <string>The number of times FreeCAD should try to remove overlapping edges returned by the Hidden Line Removal algorithm. A value of 0 indicates no scrubbing, 1 indicates a single pass and 2 indicates a second pass should be performed. Values above 2 are generally not productive. Each pass adds to the time required to produce the drawing.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+          </property>
+          <property name="suffix">
+           <string/>
+          </property>
+          <property name="prefix">
+           <string/>
+          </property>
+          <property name="value">
+           <number>1</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ScrubCount</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
           </property>
          </widget>
         </item>
@@ -394,44 +409,48 @@ can be a performance penalty in complex models.</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
+        <item row="4" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbDebugDetail">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Dump intermediate results during Detail view processing</string>
           </property>
           <property name="text">
-           <string>Overlap Edges Scrub Passes</string>
+           <string>Debug Detail</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>debugDetail</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/debug</cstring>
           </property>
          </widget>
         </item>
-        <item row="10" column="0">
+        <item row="11" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
            <string>Max PAT Hatch Segments</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="2">
-         <widget class="Gui::PrefSpinBox" name="sbScrubCount">
+        <item row="5" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbSwitchWB">
           <property name="toolTip">
-           <string>The number of times FreeCAD should try to remove overlapping edges returned by the Hidden Line Removal algorithm. A value of 0 indicates no scrubbing, 1 indicates a single pass and 2 indicates a second pass should be performed. Values above 2 are generally not productive. Each pass adds to the time required to produce the drawing.</string>
+           <string>If this box is checked, double clicking on a page in the tree will automatically switch to TechDraw and the page will be made visible.</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <property name="text">
+           <string>Switch Workbench on Click</string>
           </property>
-          <property name="suffix">
-           <string/>
-          </property>
-          <property name="prefix">
-           <string/>
-          </property>
-          <property name="value">
-           <number>1</number>
+          <property name="checked">
+           <bool>true</bool>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>ScrubCount</cstring>
+           <cstring>SwitchToWB</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/General</cstring>
@@ -538,7 +557,7 @@ can be a performance penalty in complex models.</string>
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="textFormat">
-      <enum>Qt::RichText</enum>
+      <enum>Qt::TextFormat::RichText</enum>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -548,7 +567,7 @@ can be a performance penalty in complex models.</string>
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvancedImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvancedImp.cpp
@@ -64,6 +64,8 @@ void DlgPrefsTechDrawAdvancedImp::saveSettings()
     ui->sbScrubCount->onSave();
 
     saveBalloonOverride();
+
+    ui->cbSwitchWB->onSave();
 }
 
 
@@ -114,6 +116,8 @@ void DlgPrefsTechDrawAdvancedImp::loadSettings()
     ui->sbScrubCount->onRestore();
 
     loadBalloonOverride();
+
+    ui->cbSwitchWB->onRestore();
 }
 
 void DlgPrefsTechDrawAdvancedImp::loadBalloonOverride()

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -119,14 +119,11 @@ MDIViewPage::MDIViewPage(ViewProviderPage* pageVp, Gui::Document* doc, QWidget* 
     connectDeletedObject = appDoc->signalDeletedObject.connect(bnd);
     //NOLINTEND
 
-    // m_pagePrinter = new PagePrinter(m_vpPage);
-    // m_pagePrinter->setOwner(this);
 }
 
 MDIViewPage::~MDIViewPage()
 {
     connectDeletedObject.disconnect();
-    // delete m_pagePrinter;
 }
 
 void MDIViewPage::setScene(QGSPage* scene, QGVPage* viewWidget)
@@ -134,9 +131,6 @@ void MDIViewPage::setScene(QGSPage* scene, QGVPage* viewWidget)
     m_scene = scene;
     setCentralWidget(viewWidget);//this makes viewWidget a Qt child of MDIViewPage
     QObject::connect(scene, &QGSPage::selectionChanged, this, &MDIViewPage::sceneSelectionChanged);
-    // if (m_pagePrinter) {
-    //     m_pagePrinter->setScene(m_scene);
-    // }
 }
 
 void MDIViewPage::setDocumentObject(const std::string& name)
@@ -420,7 +414,7 @@ void MDIViewPage::print(QPrinter* printer)
     PagePrinter::print(getViewProviderPage(), printer);
 }
 
-//static routine to print all pages in a document
+// static routine to print all pages in a document.  Used by PrintAll command in Command.cpp
 void MDIViewPage::printAll(QPrinter* printer, App::Document* doc)
 {
     PagePrinter::printAll(printer, doc);

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -119,14 +119,14 @@ MDIViewPage::MDIViewPage(ViewProviderPage* pageVp, Gui::Document* doc, QWidget* 
     connectDeletedObject = appDoc->signalDeletedObject.connect(bnd);
     //NOLINTEND
 
-    m_pagePrinter = new PagePrinter(m_vpPage);
-    m_pagePrinter->setOwner(this);
+    // m_pagePrinter = new PagePrinter(m_vpPage);
+    // m_pagePrinter->setOwner(this);
 }
 
 MDIViewPage::~MDIViewPage()
 {
     connectDeletedObject.disconnect();
-    delete m_pagePrinter;
+    // delete m_pagePrinter;
 }
 
 void MDIViewPage::setScene(QGSPage* scene, QGVPage* viewWidget)
@@ -134,9 +134,9 @@ void MDIViewPage::setScene(QGSPage* scene, QGVPage* viewWidget)
     m_scene = scene;
     setCentralWidget(viewWidget);//this makes viewWidget a Qt child of MDIViewPage
     QObject::connect(scene, &QGSPage::selectionChanged, this, &MDIViewPage::sceneSelectionChanged);
-    if (m_pagePrinter) {
-        m_pagePrinter->setScene(m_scene);
-    }
+    // if (m_pagePrinter) {
+    //     m_pagePrinter->setScene(m_scene);
+    // }
 }
 
 void MDIViewPage::setDocumentObject(const std::string& name)
@@ -309,35 +309,6 @@ void MDIViewPage::fixSceneDependencies()
 /// as file name selection and error messages
 /// PagePrinter handles the actual printing mechanics.
 
-/// save the page state so it can be restore after printing
-void MDIViewPage::savePageExportState(ViewProviderPage* page)
-{
-    auto guiDoc = page->getDocument();
-    if (!guiDoc) {
-        return;
-    }
-    m_docModStateBeforePrint = guiDoc->isModified();
-}
-/// ensure that the page reverts to its normal state after any changes made for printing.
-void MDIViewPage::resetPageExportState(ViewProviderPage* page) const
-{
-    auto pageFeature  = page->getDrawPage();
-    if (!pageFeature) {
-        // how did this happen?
-        return;
-    }
-
-    auto guiDoc = page->getDocument();
-    if (!guiDoc) {
-        return;
-    }
-    auto scene = page->getQGSPage();
-    scene->setExportingPdf(false);
-    scene->setExportingSvg(false);
-    guiDoc->setModified(m_docModStateBeforePrint);
-    pageFeature->redrawCommand();
-}
-
 
 /// overrides of MDIView print methods so that they print the QGraphicsScene instead
 /// of the COIN3d scenegraph.
@@ -354,72 +325,46 @@ void MDIViewPage::printPdf()
     }
 
     Gui::WaitCursor wc;
-    auto vpp = getViewProviderPage();
-    if (!vpp) {
-        // how did this happen?
-        return;
-    }
-
-    savePageExportState(vpp);
 
     std::string utf8Content = fn.toUtf8().constData();
-    if (m_pagePrinter) {
-        m_pagePrinter->printPdf(utf8Content);
-        resetPageExportState(vpp);
-    }
+    PagePrinter::printPdf(getViewProviderPage(), utf8Content);
 }
 
 void MDIViewPage::print()
 {
-    if (!m_pagePrinter) {
-        return;
-    }
-
-    auto vpp = getViewProviderPage();
-    if (!vpp) {
-        // how did this happen?
-        return;
-    }
-
-    savePageExportState(vpp);
-
-    m_pagePrinter->getPaperAttributes();
+    auto pageAttr = PagePrinter::getPaperAttributes(getViewProviderPage());
 
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
-    if (m_pagePrinter->getPaperSize() == QPageSize::Custom) {
-        printer.setPageSize(QPageSize(QSizeF(m_pagePrinter->getPageWidth(), m_pagePrinter->getPageHeight()), QPageSize::Millimeter));
+    if (pageAttr.pageSize() == QPageSize::Custom) {
+        printer.setPageSize(
+            QPageSize(QSizeF(pageAttr.pageWidth(), pageAttr.pageHeight()), QPageSize::Millimeter));
     }
     else {
-        printer.setPageSize(QPageSize(m_pagePrinter->getPaperSize()));
+        printer.setPageSize(QPageSize(pageAttr.pageSize()));
     }
-    printer.setPageOrientation(m_pagePrinter->getOrientation());
+    printer.setPageOrientation(pageAttr.orientation());
 
     QPrintDialog dlg(&printer, this);
     if (dlg.exec() == QDialog::Accepted) {
         print(&printer);
-        resetPageExportState(vpp);
     }
 }
 
 void MDIViewPage::printPreview()
 {
-//    Base::Console().Message("MDIVP::printPreview()\n");
-
-    if (!m_pagePrinter) {
-        return;
-    }
-    m_pagePrinter->getPaperAttributes();
+    auto pageAttr = PagePrinter::getPaperAttributes(getViewProviderPage());
 
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
-    if (m_pagePrinter->getPaperSize() == QPageSize::Custom) {
-        printer.setPageSize(QPageSize(QSizeF(m_pagePrinter->getPageWidth(), m_pagePrinter->getPageHeight()), QPageSize::Millimeter));
+    if (pageAttr.pageSize() == QPageSize::Custom) {
+        printer.setPageSize(
+            QPageSize(QSizeF(pageAttr.pageWidth(), pageAttr.pageHeight()), QPageSize::Millimeter));
     }
     else {
-        printer.setPageSize(QPageSize(m_pagePrinter->getPaperSize()));
+        printer.setPageSize(QPageSize(pageAttr.pageSize()));
     }
-    printer.setPageOrientation(m_pagePrinter->getOrientation());
+    printer.setPageOrientation(pageAttr.orientation());
 
     QPrintPreviewDialog dlg(&printer, this);
     connect(&dlg, &QPrintPreviewDialog::paintRequested, this, qOverload<QPrinter*>(&MDIViewPage::print));
@@ -429,18 +374,6 @@ void MDIViewPage::printPreview()
 
 void MDIViewPage::print(QPrinter* printer)
 {
-    // Base::Console().Message("MDIVP::print(printer)\n");
-    if (!m_pagePrinter) {
-        return;
-    }
-    auto vpp = getViewProviderPage();
-    if (!vpp) {
-        // how did this happen?
-        return;
-    }
-    savePageExportState(vpp);
-
-    m_pagePrinter->getPaperAttributes();
     // As size of the render area paperRect() should be used. When performing a real
     // print pageRect() may also work but the output is cropped at the bottom part.
     // So, independent whether pageRect() or paperRect() is used there is no scaling effect.
@@ -452,7 +385,9 @@ void MDIViewPage::print(QPrinter* printer)
     //
     // When showing the preview of a print paperRect() must be used because with pageRect()
     // a certain scaling effect can be observed and the content becomes smaller.
+
     QPaintEngine::Type paintType = printer->paintEngine()->type();
+    auto pageAttr = PagePrinter::getPaperAttributes(getViewProviderPage());
     if (printer->outputFormat() == QPrinter::NativeFormat) {
         QPageSize::PageSizeId psPrtSetting = printer->pageLayout().pageSize().id();
 
@@ -460,7 +395,7 @@ void MDIViewPage::print(QPrinter* printer)
         // care if it uses wrong printer settings
         bool doPrint = paintType != QPaintEngine::Picture;
 
-        if (doPrint && printer->pageLayout().orientation() != m_pagePrinter->getOrientation()) {
+        if (doPrint && printer->pageLayout().orientation() != pageAttr.orientation()) {
             int ret = QMessageBox::warning(
                 this, tr("Different orientation"),
                 tr("The printer uses a different orientation  than the drawing.\n"
@@ -470,7 +405,7 @@ void MDIViewPage::print(QPrinter* printer)
                 return;
             }
         }
-        if (doPrint && psPrtSetting != m_pagePrinter->getPaperSize()) {
+        if (doPrint && psPrtSetting != pageAttr.pageSize()) {
             int ret = QMessageBox::warning(
                 this, tr("Different paper size"),
                 tr("The printer uses a different paper size than the drawing.\n"
@@ -482,17 +417,12 @@ void MDIViewPage::print(QPrinter* printer)
         }
     }
 
-    if (m_pagePrinter) {
-        m_pagePrinter->print(printer);
-        resetPageExportState(vpp);
-    }
-
+    PagePrinter::print(getViewProviderPage(), printer);
 }
 
 //static routine to print all pages in a document
 void MDIViewPage::printAll(QPrinter* printer, App::Document* doc)
 {
-    // Base::Console().Message("MDIVP::printAll()\n");
     PagePrinter::printAll(printer, doc);
 }
 
@@ -538,14 +468,9 @@ void MDIViewPage::saveSVG(std::string filename)
 {
     auto vpp = getViewProviderPage();
     if (!vpp) {
-        // how did this happen?
         return;
     }
-    savePageExportState(vpp);
-    if (m_pagePrinter) {
-        m_pagePrinter->saveSVG(filename);
-        resetPageExportState(vpp);
-    }
+    PagePrinter::saveSVG(vpp, filename);
 }
 
 
@@ -567,9 +492,7 @@ void MDIViewPage::saveSVG()
 
 void MDIViewPage::saveDXF(std::string filename)
 {
-    if (m_pagePrinter) {
-        m_pagePrinter->saveDXF(filename);
-    }
+    PagePrinter::saveDXF(getViewProviderPage(), filename);
 }
 
 void MDIViewPage::saveDXF()
@@ -590,14 +513,9 @@ void MDIViewPage::savePDF(std::string filename)
 {
     auto vpp = getViewProviderPage();
     if (!vpp) {
-        // how did this happen?
         return;
     }
-    savePageExportState(vpp);
-    if (m_pagePrinter) {
-        m_pagePrinter->savePDF(filename);
-        resetPageExportState(vpp);
-    }
+    PagePrinter::savePDF(vpp, filename);
 }
 
 void MDIViewPage::savePDF()
@@ -614,7 +532,7 @@ void MDIViewPage::savePDF()
     savePDF(sFileName);
 }
 
-/// a slot for printing all the pages
+/// a slot for printing all the pages. just redirects to printAllPages
 void MDIViewPage::printAll()
 {
     MDIViewPage::printAllPages();

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -100,8 +100,6 @@ public:
     PyObject* getPyObject() override;
     TechDraw::DrawPage * getPage() { return m_vpPage->getDrawPage(); }
     ViewProviderPage* getViewProviderPage() {return m_vpPage;}
-    void savePageExportState(ViewProviderPage* page);
-    void resetPageExportState(ViewProviderPage* page) const;
 
     void setTabText(std::string tabText);
 
@@ -158,11 +156,6 @@ private:
     ViewProviderPage* m_vpPage;
 
     QList<QGraphicsItem*> m_orderedSceneSelection;        //items in selection order
-
-    void getPaperAttributes();
-    PagePrinter* m_pagePrinter;
-
-    bool m_docModStateBeforePrint{false};
 
 };
 

--- a/src/Mod/TechDraw/Gui/PagePrinter.cpp
+++ b/src/Mod/TechDraw/Gui/PagePrinter.cpp
@@ -56,7 +56,6 @@
 #include "QGSPage.h"
 #include "Rez.h"
 #include "ViewProviderPage.h"
-#include "MDIViewPage.h"
 
 using namespace TechDrawGui;
 using namespace TechDraw;
@@ -70,19 +69,6 @@ constexpr double mmPerInch = 25.4;
 /* TRANSLATOR TechDrawGui::PagePrinter */
 
 //TYPESYSTEM_SOURCE_ABSTRACT(TechDrawGui::PagePrinter)
-
-PagePrinter::PagePrinter(ViewProviderPage* pageVp)
-    : m_vpPage(pageVp), m_orientation(QPageLayout::Landscape),
-      m_paperSize(QPageSize::A4), m_pagewidth(0.0), m_pageheight(0.0)
-{
-}
-
-void PagePrinter::setScene(QGSPage* scene)
-{
-    m_scene = scene;
-}
-
-void PagePrinter::setDocumentName(const std::string& name) { m_documentName = name; }
 
 
 //! retrieve the attributes of a DrawPage and its Template
@@ -99,144 +85,78 @@ PaperAttributes PagePrinter::getPaperAttributes(TechDraw::DrawPage* dPage)
         width = pageTemplate->Width.getValue();
         height = pageTemplate->Height.getValue();
     }
-    result.pagewidth = width;
-    result.pageheight = height;
+    // result.m_pagewidth = width;
+    // result.m_pageheight = height;
 
     //Qt's page size determination assumes Portrait orientation. To get the right paper size
     //we need to ask in the proper form.
     QPageSize::PageSizeId paperSizeID =
         QPageSize::id(QSizeF(std::min(width, height), std::max(width, height)),
                       QPageSize::Millimeter, QPageSize::FuzzyOrientationMatch);
-    result.paperSize =  paperSizeID;
+    auto paperSize = paperSizeID;
 
-    result.orientation = (QPageLayout::Orientation)dPage->getOrientation();
-    if (result.paperSize == QPageSize::Ledger) {
+    auto orientation = (QPageLayout::Orientation)dPage->getOrientation();
+    if (paperSize == QPageSize::Ledger) {
         // Ledger size paper orientation is reversed inside Qt
-        result.orientation =(QPageLayout::Orientation)(1 - result.orientation);
+        orientation = (QPageLayout::Orientation)(1 - orientation);
     }
 
-    return result;
+    return {orientation, paperSize, width, height};
 }
 
-void PagePrinter::getPaperAttributes()
+//! retrieve the attributes of a DrawPage by its viewProvider
+PaperAttributes PagePrinter::getPaperAttributes(ViewProviderPage* vpPage)
 {
-    PaperAttributes attr = getPaperAttributes(m_vpPage->getDrawPage());
-    m_pagewidth = attr.pagewidth;
-    m_pageheight = attr.pageheight;
-    m_paperSize = attr.paperSize;
-    m_orientation = attr.orientation;
+    auto page = vpPage->getDrawPage();
+    return getPaperAttributes(page);
 }
+
 
 //! construct a page layout object that reflects the characteristics of a DrawPage
-//static
 void PagePrinter::makePageLayout(TechDraw::DrawPage* dPage, QPageLayout& pageLayout, double& width,
                                 double& height)
 {
     PaperAttributes attr = getPaperAttributes(dPage);
-    width = attr.pagewidth;
-    height = attr.pageheight;
-    pageLayout.setPageSize(QPageSize(attr.paperSize));
-    pageLayout.setOrientation(attr.orientation);
+    width = attr.pageWidth();
+    height = attr.pageHeight();
+    pageLayout.setPageSize(QPageSize(attr.pageSize()));
+    pageLayout.setOrientation(attr.orientation());
     pageLayout.setMode(QPageLayout::FullPageMode);
     pageLayout.setMargins(QMarginsF());
 }
 
-/// print the Page associated with the parent MDIViewPage as a Pdf file
-void PagePrinter::printPdf(std::string file)
-{
-    // Base::Console().Message("PP::printPdf(%s)\n", file.c_str());
-    if (file.empty()) {
-        Base::Console().Warning("PagePrinter - no file specified\n");
-        return;
-    }
 
-    // set up the pdfwriter
-    auto filespec = Base::Tools::escapeEncodeFilename(file);
-    filespec = DU::cleanFilespecBackslash(filespec);
-    QString outputFile = Base::Tools::fromStdString(filespec);
-    QPdfWriter pdfWriter(outputFile);
-    QPageLayout pageLayout = pdfWriter.pageLayout();
-    auto marginsdb = pageLayout.margins(QPageLayout::Millimeter);
-    QString documentName = QString::fromUtf8(m_vpPage->getDrawPage()->getNameInDocument());
-    pdfWriter.setTitle(documentName);
-    // default pdfWriter dpi is 1200.
-
-    // set up the page layout
-    auto dPage = m_vpPage->getDrawPage();
-    double width = A4Heightmm;//default to A4 Landscape 297 x 210
-    double height = A4Widthmm;
-    makePageLayout(dPage, pageLayout, width, height);
-    pdfWriter.setPageLayout(pageLayout);
-    marginsdb = pageLayout.margins(QPageLayout::Millimeter);
-
-    // first page does not respect page layout unless painter is created after
-    // pdfWriter layout is established.
-    QPainter painter(&pdfWriter);
-
-    // render the page
-    m_scene->setExportingPdf(true);
-    QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
-    double dpmm = pdfWriter.resolution() / mmPerInch;
-    int twide = int(std::round(width * dpmm));
-    int thigh = int(std::round(height * dpmm));
-    QRect targetRect(0, 0, twide, thigh);
-    renderPage(m_vpPage, painter, sourceRect, targetRect);
-    m_scene->setExportingPdf(false);
-}
-
-
-/// print the Page associated with the parent MDIViewPage
-void PagePrinter::print(QPrinter* printer)
-{
-//    Base::Console().Message("PP::print(printer)\n");
-    QPageLayout pageLayout = printer->pageLayout();
-
-    TechDraw::DrawPage* dp = m_vpPage->getDrawPage();
-    double width = A4Heightmm;//default to A4 Landscape 297 x 210
-    double height = A4Widthmm;
-    makePageLayout(dp, pageLayout, width, height);
-    printer->setPageLayout(pageLayout);
-
-    QPainter painter(printer);
-
-    QRect targetRect = printer->pageLayout().fullRectPixels(printer->resolution());
-    QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
-    renderPage(m_vpPage, painter, sourceRect, targetRect);
-}
-
-//static routine to print all pages in a document
+//! print all pages in a document
 void PagePrinter::printAll(QPrinter* printer, App::Document* doc)
 {
-    Base::Console().Message("PP::printAll()\n");
-
     QPageLayout pageLayout = printer->pageLayout();
     std::vector<App::DocumentObject*> docObjs =
         doc->getObjectsOfType(TechDraw::DrawPage::getClassTypeId());
     auto firstPage = docObjs.front();
 
     auto dPage = static_cast<TechDraw::DrawPage*>(firstPage);
-    double width = A4Heightmm;//default to A4 Landscape 297 x 210
+    double width = A4Heightmm;  // default to A4 Landscape 297 x 210
     double height = A4Widthmm;
     makePageLayout(dPage, pageLayout, width, height);
     printer->setPageLayout(pageLayout);
     QPainter painter(printer);
 
+    auto ourDoc = Gui::Application::Instance->getDocument(doc);
+    auto docModifiedState = ourDoc->isModified();
+
     bool firstTime = true;
     for (auto& obj : docObjs) {
         Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider(obj);
         if (!vp) {
-            continue;// can't print this one
+            continue;  // can't print this one
         }
         auto* vpp = dynamic_cast<TechDrawGui::ViewProviderPage*>(vp);
         if (!vpp) {
-            continue;// can't print this one
+            continue;  // can't print this one
         }
-        // is there always a mdi when printAll is called?
-        auto mdi = vpp->getMDIViewPage();
-        mdi->savePageExportState(vpp);
 
         auto dPage = static_cast<TechDraw::DrawPage*>(obj);
-        double width = A4Heightmm;//default to A4 Landscape 297 x 210
+        double width = A4Heightmm;  // default to A4 Landscape 297 x 210
         double height = A4Widthmm;
         makePageLayout(dPage, pageLayout, width, height);
         printer->setPageLayout(pageLayout);
@@ -247,25 +167,27 @@ void PagePrinter::printAll(QPrinter* printer, App::Document* doc)
         firstTime = false;
         QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
         QRect targetRect = printer->pageLayout().fullRectPixels(printer->resolution());
-
         renderPage(vpp, painter, sourceRect, targetRect);
-        mdi->resetPageExportState(vpp);
+        dPage->redrawCommand();
     }
+
+    ourDoc->setModified(docModifiedState);
 }
 
-//static routine to print all pages in a document to pdf
+//! print all pages in a document to pdf
 void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
 {
-    // Base::Console().Message("PP::printAllPdf()\n");
     double dpmm = printer->resolution() / mmPerInch;
 
     QString outputFile = printer->outputFileName();
     QString documentName = QString::fromUtf8(doc->getName());
     QPdfWriter pdfWriter(outputFile);
-    // setPdfVersion sets the printed PDF Version to comply with PDF/A-1b, more details under: https://www.kdab.com/creating-pdfa-documents-qt/
-    // but this is not working as of Qt 5.12
-    //printer->setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
-    //pdfWriter.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
+
+    // setPdfVersion sets the printed PDF Version to comply with PDF/A-1b, more details under:
+    // https://www.kdab.com/creating-pdfa-documents-qt/ but this is not working as of Qt 5.12
+    // printer->setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
+    // pdfWriter.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
+
     pdfWriter.setTitle(documentName);
     pdfWriter.setResolution(printer->resolution());
     QPageLayout pageLayout = printer->pageLayout();
@@ -285,6 +207,9 @@ void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
     // start() or end() until all the pages are printed.
     QPainter painter(&pdfWriter);
 
+    auto ourDoc = Gui::Application::Instance->getDocument(doc);
+    auto docModifiedState = ourDoc->isModified();
+
     bool firstTime = true;
     for (auto& obj : docObjs) {
         Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider(obj);
@@ -295,12 +220,9 @@ void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
         if (!vpp) {
             continue;// can't print this one
         }
-        // is there always a mdi when printAll is called?
-        auto mdi = vpp->getMDIViewPage();
-        mdi->savePageExportState(vpp);
 
-        auto scene = vpp->getQGSPage();
-        scene->setExportingPdf(true);
+        auto ourScene = vpp->getQGSPage();
+        ourScene->setExportingPdf(true);
 
         auto dPage = static_cast<TechDraw::DrawPage*>(obj);
         double width{0};
@@ -315,13 +237,16 @@ void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
         QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
         QRect targetRect(0, 0, width * dpmm, height * dpmm);
         renderPage(vpp, painter, sourceRect, targetRect);
-        mdi->resetPageExportState(vpp);
+        dPage->redrawCommand();
 
+        ourScene->setExportingPdf(true);
     }
+
+    ourDoc->setModified(docModifiedState);
 }
 
-//static
-//! we don't need the banner page any more
+
+//! we don't need the banner page any more, but it might become useful again in the future.
 void PagePrinter::printBannerPage(QPrinter* printer, QPainter& painter, QPageLayout& pageLayout,
                                   App::Document* doc, std::vector<App::DocumentObject*>& docObjs)
 {
@@ -353,11 +278,10 @@ void PagePrinter::printBannerPage(QPrinter* printer, QPainter& painter, QPageLay
     painter.setFont(savePainterFont);//restore the original font
 }
 
-//static
+
 void PagePrinter::renderPage(ViewProviderPage* vpp, QPainter& painter, QRectF& sourceRect,
                              QRect& targetRect)
 {
-//    Base::Console().Message("PP::renderPage()\n");
     //turn off view frames for print
     bool saveState = vpp->getFrameState();
     vpp->setFrameState(false);
@@ -381,7 +305,90 @@ void PagePrinter::renderPage(ViewProviderPage* vpp, QPainter& painter, QRectF& s
     vpp->getQGSPage()->refreshViews();
 }
 
-void PagePrinter::saveSVG(std::string file)
+
+/// print the Page associated with the view provider
+void PagePrinter::print(ViewProviderPage* vpPage, QPrinter* printer)
+{
+    QPageLayout pageLayout = printer->pageLayout();
+
+    TechDraw::DrawPage* dPage = vpPage->getDrawPage();
+    double width = A4Heightmm;  // default to A4 Landscape 297 x 210
+    double height = A4Widthmm;
+    makePageLayout(dPage, pageLayout, width, height);
+    printer->setPageLayout(pageLayout);
+
+    QPainter painter(printer);
+
+    auto ourScene = vpPage->getQGSPage();
+    if (!printer->outputFileName().isEmpty()) {
+        ourScene->setExportingPdf(true);
+    }
+    auto ourDoc = Gui::Application::Instance->getDocument(dPage->getDocument());
+    auto docModifiedState = ourDoc->isModified();
+
+    QRect targetRect = printer->pageLayout().fullRectPixels(printer->resolution());
+    QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
+    renderPage(vpPage, painter, sourceRect, targetRect);
+
+    ourScene->setExportingPdf(false);  // doesn't hurt if not pdf
+    ourDoc->setModified(docModifiedState);
+    dPage->redrawCommand();
+}
+
+
+/// print the Page associated with the ViewProvider as a Pdf file
+void PagePrinter::printPdf(ViewProviderPage* vpPage, const std::string& file)
+{
+    if (file.empty()) {
+        Base::Console().Warning("PagePrinter - no file specified\n");
+        return;
+    }
+
+    auto filespec = Base::Tools::escapeEncodeFilename(file);
+    filespec = DU::cleanFilespecBackslash(filespec);
+
+    // set up the pdfwriter
+    QString outputFile = Base::Tools::fromStdString(filespec);
+    QPdfWriter pdfWriter(outputFile);
+    QPageLayout pageLayout = pdfWriter.pageLayout();
+    auto marginsdb = pageLayout.margins(QPageLayout::Millimeter);
+    QString documentName = QString::fromUtf8(vpPage->getDrawPage()->getNameInDocument());
+    pdfWriter.setTitle(documentName);
+    // default pdfWriter dpi is 1200.
+
+    // set up the page layout
+    auto dPage = vpPage->getDrawPage();
+    double width = A4Heightmm;  // default to A4 Landscape 297 x 210
+    double height = A4Widthmm;
+    makePageLayout(dPage, pageLayout, width, height);
+    pdfWriter.setPageLayout(pageLayout);
+    marginsdb = pageLayout.margins(QPageLayout::Millimeter);
+
+    // first page does not respect page layout unless painter is created after
+    // pdfWriter layout is established.
+    QPainter painter(&pdfWriter);
+
+    auto ourScene = vpPage->getQGSPage();
+    ourScene->setExportingPdf(true);
+    auto ourDoc = Gui::Application::Instance->getDocument(dPage->getDocument());
+    auto docModifiedState = ourDoc->isModified();
+
+    // render the page
+    QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
+    double dpmm = pdfWriter.resolution() / mmPerInch;
+    int twide = int(std::round(width * dpmm));
+    int thigh = int(std::round(height * dpmm));
+    QRect targetRect(0, 0, twide, thigh);
+    renderPage(vpPage, painter, sourceRect, targetRect);
+
+    ourScene->setExportingPdf(false);
+    ourDoc->setModified(docModifiedState);
+    dPage->redrawCommand();
+}
+
+
+//! save the page associated with the view provider as an svg file
+void PagePrinter::saveSVG(ViewProviderPage* vpPage, const std::string& file)
 {
     if (file.empty()) {
         Base::Console().Warning("PagePrinter - no file specified\n");
@@ -390,14 +397,24 @@ void PagePrinter::saveSVG(std::string file)
     auto filespec = Base::Tools::escapeEncodeFilename(file);
     filespec = DU::cleanFilespecBackslash(file);
     QString filename = Base::Tools::fromStdString(filespec);
-    if (m_scene) {
-        m_scene->saveSvg(filename);
-    }
+
+    auto ourScene = vpPage->getQGSPage();
+    ourScene->setExportingSvg(true);
+    auto ourDoc = vpPage->getDocument();
+    auto docModifiedState = ourDoc->isModified();
+
+    ourScene->saveSvg(filename);
+
+    ourScene->setExportingSvg(false);
+    ourDoc->setModified(docModifiedState);
 }
 
-void PagePrinter::saveDXF(std::string inFileName)
+
+//! save the page associated with the view provider as an svg file
+// Note: the dxf exporter does not modify the page, so we do not need to reset the modified flag
+void PagePrinter::saveDXF(ViewProviderPage* vpPage, const std::string& inFileName)
 {
-    TechDraw::DrawPage* page = m_vpPage->getDrawPage();
+    TechDraw::DrawPage* page = vpPage->getDrawPage();
     std::string PageName = page->getNameInDocument();
     auto filespec = Base::Tools::escapeEncodeFilename(inFileName);
     filespec = DU::cleanFilespecBackslash(filespec);
@@ -405,21 +422,23 @@ void PagePrinter::saveDXF(std::string inFileName)
     Gui::Command::doCommand(Gui::Command::Doc, "import TechDraw");
     Gui::Command::doCommand(Gui::Command::Doc,
                             "TechDraw.writeDXFPage(App.activeDocument().%s, u\"%s\")",
-                            PageName.c_str(), filespec.c_str());
+                            PageName.c_str(),
+                            filespec.c_str());
     Gui::Command::commitCommand();
 }
 
-void PagePrinter::savePDF(std::string file)
+// this one is somewhat superfluous (just a redirect).
+void PagePrinter::savePDF(ViewProviderPage* vpPage, const std::string& file)
 {
-//    Base::Console().Message("PP::savePDF(%s)\n", file.c_str());
-    printPdf(file);
+    printPdf(vpPage, file);
 }
+
 
 PaperAttributes::PaperAttributes()
 {
     // set default values to A4 Landscape
-    orientation = QPageLayout::Orientation::Landscape;
-    paperSize = QPageSize::A4;
-    pagewidth = A4Heightmm;
-    pageheight = A4Widthmm;
+    m_orientation = QPageLayout::Orientation::Landscape;
+    m_paperSize = QPageSize::A4;
+    m_pagewidth = A4Heightmm;
+    m_pageheight = A4Widthmm;
 }

--- a/src/Mod/TechDraw/Gui/PagePrinter.h
+++ b/src/Mod/TechDraw/Gui/PagePrinter.h
@@ -51,34 +51,49 @@ class TechDrawGuiExport PaperAttributes
 {
 public:
     PaperAttributes();
-//    ~PaperAttributes() = default;
+    PaperAttributes(QPageLayout::Orientation orientation,
+                    QPageSize::PageSizeId paperSize,
+                    double pageWidth,
+                    double pageHeight)
+        : m_orientation(orientation)
+        , m_paperSize(paperSize)
+        , m_pagewidth(pageWidth)
+        , m_pageheight(pageHeight)
+    {}
 
-    QPageLayout::Orientation orientation;
-    QPageSize::PageSizeId paperSize;
-    double pagewidth;
-    double pageheight;
+    QPageLayout::Orientation orientation() const
+    {
+        return m_orientation;
+    }
+    QPageSize::PageSizeId pageSize() const
+    {
+        return m_paperSize;
+    }
+    double pageWidth() const
+    {
+        return m_pagewidth;
+    }
+    double pageHeight() const
+    {
+        return m_pageheight;
+    }
+
+private:
+    QPageLayout::Orientation m_orientation;
+    QPageSize::PageSizeId m_paperSize;
+    double m_pagewidth;
+    double m_pageheight;
 };
 
 class TechDrawGuiExport PagePrinter
 {
 public:
-    explicit PagePrinter(ViewProviderPage *page);
-
-    void print(QPrinter* printer);
-    void printPdf();
-    void printPdf(std::string file);
-    void printPreview();
-    static void printAllPages();
-    static void printAll(QPrinter* printer,
-                         App::Document* doc);
-    static void printAllPdf(QPrinter* printer,
-                            App::Document* doc);
-
     // print banner page is no longer used
     static void printBannerPage(QPrinter* printer, QPainter& painter,
                                 QPageLayout& pageLayout,
                                 App::Document* doc,
                                 std::vector<App::DocumentObject*>& docObjs);
+
     static void renderPage(ViewProviderPage* vpp,
                            QPainter& painter,
                            QRectF& sourceRect,
@@ -87,45 +102,20 @@ public:
                                QPageLayout& pageLayout,
                               double& width, double& height);
 
-    void saveSVG(std::string file);
-    void saveDXF(std::string file);
-    void savePDF(std::string file);
-
-    void setDocumentName(const std::string&);
-    void setScene(QGSPage* scene, QGVPage* view);
-    void setOwner(MDIViewPage* owner) { m_owner = owner; }
-    void setScene(QGSPage* scene);
-
-
-    TechDraw::DrawPage * getPage() { return m_vpPage->getDrawPage(); }
-
-    ViewProviderPage* getViewProviderPage() {return m_vpPage;}
-
     static PaperAttributes getPaperAttributes(TechDraw::DrawPage* pageObject);
-    void getPaperAttributes();
-    QPageLayout::Orientation getOrientation() const { return m_orientation; }
-    QPageSize::PageSizeId getPaperSize() const { return m_paperSize; }
-    double getPageWidth() const { return m_pagewidth; }
-    double getPageHeight() const { return m_pageheight; }
+    static PaperAttributes getPaperAttributes(ViewProviderPage* vpPage);
 
-private:
-    std::string m_objectName;
-    std::string m_documentName;
-    QPointer<QGSPage> m_scene;
+    static void print(ViewProviderPage* vpPage, QPrinter* printer);
+    static void printPdf(ViewProviderPage* vpPage, const std::string& file);
+    static void printAll(QPrinter* printer, App::Document* doc);
+    static void printAllPdf(QPrinter* printer, App::Document* doc);
 
-    QString m_currentPath;
-    ViewProviderPage* m_vpPage;
-
-    QPageLayout::Orientation m_orientation;
-    QPageSize::PageSizeId m_paperSize;
-    double m_pagewidth, m_pageheight;
-
-    MDIViewPage* m_owner;
-
+    static void saveSVG(ViewProviderPage* vpPage, const std::string& file);
+    static void saveDXF(ViewProviderPage* vpPage, const std::string& file);
+    static void savePDF(ViewProviderPage* vpPage, const std::string& file);
 };
 
-
-} // namespace PagePrinterGui
+}  // namespace TechDrawGui
 
 #endif // TECHDRAWGUI_PAGEPRINTER_H
 

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -263,20 +263,11 @@ void ViewProviderPage::unsetEdit(int ModNum)
 
 bool ViewProviderPage::doubleClicked(void)
 {
-    // assure the TechDraw workbench
-    if (App::GetApplication()
-        .GetUserParameter()
-        .GetGroup("BaseApp")
-        ->GetGroup("Preferences")
-        ->GetGroup("Mod/TechDraw")
-        ->GetBool("SwitchToWB", true)) {
+    if (Preferences::switchOnClick()) {
         Gui::Command::assureWorkbench("TechDrawWorkbench");
+        show();
     }
 
-    show();
-    if (m_mdiView) {
-        switchToMdiViewPage();
-    }
     return true;
 }
 
@@ -289,7 +280,7 @@ void ViewProviderPage::show(void)
 void ViewProviderPage::hide(void)
 {
     if (getMDIView()) {
-        getMDIView()->hide();//this doesn't remove the mdiViewPage from the mainWindow
+        getMDIView()->hide();  // this doesn't remove the mdiViewPage from the mainWindow
         removeMDIView();
     }
     ViewProviderDocumentObject::hide();
@@ -339,12 +330,11 @@ void ViewProviderPage::createMDIViewPage()
     m_mdiView->setWindowTitle(tabTitle + QString::fromLatin1("[*]"));
     m_mdiView->setWindowIcon(Gui::BitmapFactory().pixmap("TechDraw_TreePage"));
     Gui::getMainWindow()->addWindow(m_mdiView);
-    switchToMdiViewPage();
 }
 
 void ViewProviderPage::switchToMdiViewPage()
 {
-    Gui::getMainWindow()->setActiveWindow(m_mdiView);
+    show();
     m_graphicsView->setFocus();
 }
 
@@ -407,8 +397,10 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
     // Collect any child views
     // for Page, valid children are any View except: DrawViewDimension
     //                                               DrawViewBalloon
-    //                                               any FeatuerView in a DrawViewClip
+    //                                               any FeatureView in a DrawViewClip
     //                                               DrawHatch
+    //                                               DrawGeomHatch
+    //  ?? leaders?
 
     try {
         for (auto* obj : getDrawPage()->Views.getValues()) {
@@ -422,11 +414,14 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
             // Don't collect if dimension, balloon, hatch or member of ClipGroup as these should be grouped elsewhere
             if (obj->isDerivedFrom<TechDraw::DrawViewDimension>()
                 || obj->isDerivedFrom<TechDraw::DrawHatch>()
+                || obj->isDerivedFrom<TechDraw::DrawGeomHatch>()
                 || obj->isDerivedFrom<TechDraw::DrawViewBalloon>()
-                || (featView && featView->isInClip()))
+                || (featView && featView->isInClip())) {
                 continue;
-            else
+            }
+            else {
                 temp.push_back(obj);
+            }
         }
         return temp;
     }
@@ -578,4 +573,13 @@ void ViewProviderPage::fixSceneDependencies()
         vpvp->fixSceneDependencies();
     }
 
+}
+
+//! convenient way to ask feature to redraw everything
+void  ViewProviderPage::redrawPage() const
+{
+    auto feature = getDrawPage();
+    if (feature) {
+        feature->redrawCommand();
+    }
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -43,6 +43,7 @@
 #include <Gui/MainWindow.h>
 #include <Gui/ViewProviderDocumentObject.h>
 #include <Mod/TechDraw/App/DrawHatch.h>
+#include <Mod/TechDraw/App/DrawGeomHatch.h>
 #include <Mod/TechDraw/App/DrawPage.h>
 #include <Mod/TechDraw/App/DrawProjGroupItem.h>
 #include <Mod/TechDraw/App/DrawTemplate.h>
@@ -50,6 +51,7 @@
 #include <Mod/TechDraw/App/DrawViewBalloon.h>
 #include <Mod/TechDraw/App/DrawViewDimension.h>
 #include <Mod/TechDraw/App/DrawWeldSymbol.h>
+#include <Mod/TechDraw/App/Preferences.h>
 
 #include "ViewProviderPage.h"
 #include "MDIViewPage.h"

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.h
@@ -120,8 +120,8 @@ public:
 
     void setGrid();
 
-    QGSPage* getQGSPage(void) { return m_graphicsScene; }
-    QGVPage* getQGVPage(void) { return m_graphicsView; }
+    QGSPage* getQGSPage(void) const { return m_graphicsScene; }
+    QGVPage* getQGVPage(void) const { return m_graphicsView; }
 
     ViewProviderPageExtension* getVPPExtension() const;
 
@@ -129,6 +129,7 @@ public:
 
     void fixSceneDependencies();
 
+    void redrawPage() const;
 
 protected:
     bool setEdit(int ModNum) override;


### PR DESCRIPTION
This PR implements a fix for issue #16672.

Background
Issue #16672 is caused by use of stale pointer to switch to a closed/hidden tab in the Ui.
Similar problem affects static printAll function when it attempts to use a closed tab.

Known Issues to be solved
TechDraw: Insert view > Segfault #16672 

Replaces PR #17688
Corrects PR #17488

Solution
Remove print and context-switch behaviour with dependencies on MDIViewPage since it is not always available.
MDIViewPage will continue to handle tree selection, message dispatch and widget functions.

Access printing functions through the view provider, since it is always available when the gui is up and 
knows about the QGraphicsScene already.

Change context-switch behaviour to use standard show() method instead of manipulating the mdiview directly.

Add preference for forced WB switch on change of tabs.

Change exporter to not rely on MDIViewPage.
change Commandxxxx reliance on MDIViewPage.
