### PR TITLE
Fem: Add smoothing filter extension to contours filter

### DIFF
--- a/src/Mod/Fem/App/AppFem.cpp
+++ b/src/Mod/Fem/App/AppFem.cpp
@@ -181,6 +181,8 @@ PyMOD_INIT_FUNC(Fem)
     Fem::FemSolverObjectPython                ::init();
 
 #ifdef FC_USE_VTK
+    Fem::FemPostSmoothFilterExtension         ::init();
+
     Fem::FemPostObject                        ::init();
     Fem::FemPostPipeline                      ::init();
     Fem::FemPostFilter                        ::init();

--- a/src/Mod/Fem/App/FemPostFilter.cpp
+++ b/src/Mod/Fem/App/FemPostFilter.cpp
@@ -516,6 +516,104 @@ DocumentObjectExecReturn* FemPostClipFilter::execute()
 }
 
 // ***************************************************************************
+// smoothing filter extension
+const App::PropertyQuantityConstraint::Constraints FemPostSmoothFilterExtension::angleRange = {
+    0.0,
+    180.0,
+    1.0};
+const App::PropertyIntegerConstraint::Constraints FemPostSmoothFilterExtension::iterationRange = {
+    0,
+    VTK_INT_MAX,
+    1};
+const App::PropertyFloatConstraint::Constraints FemPostSmoothFilterExtension::relaxationRange = {
+    0,
+    1.0,
+    0.01};
+
+EXTENSION_PROPERTY_SOURCE(Fem::FemPostSmoothFilterExtension, App::DocumentObjectExtension)
+
+FemPostSmoothFilterExtension::FemPostSmoothFilterExtension()
+{
+    EXTENSION_ADD_PROPERTY_TYPE(BoundarySmoothing,
+                                (true),
+                                "Smoothing",
+                                App::Prop_None,
+                                "Smooth vertices on the boundary");
+    EXTENSION_ADD_PROPERTY_TYPE(EdgeAngle,
+                                (15),
+                                "Smoothing",
+                                App::Prop_None,
+                                "Angle to control smoothing along edges");
+    EXTENSION_ADD_PROPERTY_TYPE(EnableSmoothing,
+                                (false),
+                                "Smoothing",
+                                App::Prop_None,
+                                "Enable Laplacian smoothing");
+    EXTENSION_ADD_PROPERTY_TYPE(FeatureAngle,
+                                (45),
+                                "Smoothing",
+                                App::Prop_None,
+                                "Angle for sharp edge identification");
+    EXTENSION_ADD_PROPERTY_TYPE(EdgeSmoothing,
+                                (false),
+                                "Smoothing",
+                                App::Prop_None,
+                                "Smooth aling sharp interior edges");
+    EXTENSION_ADD_PROPERTY_TYPE(RelaxationFactor,
+                                (0.05),
+                                "Smoothing",
+                                App::Prop_None,
+                                "Factor to control vertex displacement");
+    EXTENSION_ADD_PROPERTY_TYPE(Iterations,
+                                (20),
+                                "Smoothing",
+                                App::Prop_None,
+                                "Number of smoothing iterations");
+
+    EdgeAngle.setConstraints(&angleRange);
+    FeatureAngle.setConstraints(&angleRange);
+    Iterations.setConstraints(&iterationRange);
+    RelaxationFactor.setConstraints(&relaxationRange);
+
+    m_smooth = vtkSmartPointer<vtkSmoothPolyDataFilter>::New();
+    // override default VTK values
+    m_smooth->SetNumberOfIterations(EnableSmoothing.getValue() ? Iterations.getValue() : 0);
+    m_smooth->SetBoundarySmoothing(BoundarySmoothing.getValue());
+    m_smooth->SetEdgeAngle(EdgeAngle.getValue());
+    m_smooth->SetFeatureAngle(FeatureAngle.getValue());
+    m_smooth->SetFeatureEdgeSmoothing(EdgeSmoothing.getValue());
+    m_smooth->SetRelaxationFactor(RelaxationFactor.getValue());
+
+    initExtensionType(FemPostSmoothFilterExtension::getExtensionClassTypeId());
+}
+
+void FemPostSmoothFilterExtension::extensionOnChanged(const App::Property* prop)
+{
+    if (prop == &EnableSmoothing || prop == &Iterations) {
+        // if disabled, set iterations to zero to do nothing
+        m_smooth->SetNumberOfIterations(EnableSmoothing.getValue() ? Iterations.getValue() : 0);
+    }
+    else if (prop == &BoundarySmoothing) {
+        m_smooth->SetBoundarySmoothing(static_cast<const App::PropertyBool*>(prop)->getValue());
+    }
+    else if (prop == &EdgeAngle) {
+        m_smooth->SetEdgeAngle(static_cast<const App::PropertyAngle*>(prop)->getValue());
+    }
+    else if (prop == &FeatureAngle) {
+        m_smooth->SetFeatureAngle(static_cast<const App::PropertyAngle*>(prop)->getValue());
+    }
+    else if (prop == &EdgeSmoothing) {
+        m_smooth->SetFeatureEdgeSmoothing(static_cast<const App::PropertyBool*>(prop)->getValue());
+    }
+    else if (prop == &RelaxationFactor) {
+        m_smooth->SetRelaxationFactor(static_cast<const App::PropertyFloat*>(prop)->getValue());
+    }
+    else {
+        DocumentObjectExtension::extensionOnChanged(prop);
+    }
+}
+
+// ***************************************************************************
 // contours filter
 PROPERTY_SOURCE(Fem::FemPostContoursFilter, Fem::FemPostFilter)
 
@@ -543,10 +641,13 @@ FemPostContoursFilter::FemPostContoursFilter()
     FilterPipeline contours;
     m_contours = vtkSmartPointer<vtkContourFilter>::New();
     m_contours->ComputeScalarsOn();
+    smoothExtension.getFilter()->SetInputConnection(m_contours->GetOutputPort());
     contours.source = m_contours;
-    contours.target = m_contours;
+    contours.target = smoothExtension.getFilter();
     addFilterPipeline(contours, "contours");
     setActiveFilterPipeline("contours");
+
+    smoothExtension.initExtension(this);
 }
 
 FemPostContoursFilter::~FemPostContoursFilter() = default;

--- a/src/Mod/Fem/App/FemPostFilter.cpp
+++ b/src/Mod/Fem/App/FemPostFilter.cpp
@@ -558,7 +558,7 @@ FemPostSmoothFilterExtension::FemPostSmoothFilterExtension()
                                 (false),
                                 "Smoothing",
                                 App::Prop_None,
-                                "Smooth aling sharp interior edges");
+                                "Smooth align sharp interior edges");
     EXTENSION_ADD_PROPERTY_TYPE(RelaxationFactor,
                                 (0.05),
                                 "Smoothing",

--- a/src/Mod/Fem/Gui/TaskPostBoxes.h
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.h
@@ -412,6 +412,8 @@ private:
     void onVectorModeChanged(int idx);
     void onNumberOfContoursChanged(int number);
     void onNoColorChanged(bool state);
+    void onSmoothingChanged(bool state);
+    void onRelaxationChanged(double v);
 
 private:
     QWidget* proxy;

--- a/src/Mod/Fem/Gui/TaskPostContours.ui
+++ b/src/Mod/Fem/Gui/TaskPostContours.ui
@@ -58,7 +58,7 @@
         </size>
        </property>
        <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <set>Qt::AlignLeft|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
        <property name="keyboardTracking">
         <bool>false</bool>
@@ -71,17 +71,53 @@
        </property>
       </widget>
      </item>
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="ckb_smoothing">
+       <property name="toolTip">
+        <string>Enable Laplacian smoothing</string>
+       </property>
+       <property name="text">
+        <string>Smoothing</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="lbl_relaxation">
+       <property name="text">
+        <string notr="true">Relaxation Factor:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QDoubleSpinBox" name="dsb_relaxation">
+       <property name="alignment">
+        <set>Qt::AlignLeft|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="toolTip">
+        <string>Factor to control vertex displacement</string>
+       </property>
+       <property name="minimum">
+        <double>0.00000000000</double>
+       </property>
+       <property name="maximum">
+        <double>1.00000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.01000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QCheckBox" name="noColorCB">
+       <property name="toolTip">
+        <string>Contour lines will not be colored</string>
+       </property>
+       <property name="text">
+        <string>No Color</string>
+       </property>
+      </widget>
+     </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="noColorCB">
-     <property name="toolTip">
-      <string>Contour lines will not be colored</string>
-     </property>
-     <property name="text">
-      <string>No color</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Add an optional Laplacian smoothing filter to the contour filter, to get a smoother result when the generated isosurfaces are too coarse.
Below are two example images with filter disabled and filter enabled, respectively.
![image](https://github.com/user-attachments/assets/b359fe5d-7936-4617-9ec7-c964c303377d)
![image](https://github.com/user-attachments/assets/42e7292c-05cc-4408-b25e-1d49b9979d9e)

@FEA-eng