### PR TITLE
Start: Implement Thumbnail Managing Standard

### DIFF
--- a/src/Mod/Start/App/DisplayedFilesModel.cpp
+++ b/src/Mod/Start/App/DisplayedFilesModel.cpp
@@ -30,6 +30,8 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QStandardPaths>
+#include <QUrl>
 #endif
 
 #include "DisplayedFilesModel.h"
@@ -93,12 +95,16 @@ std::string getThumbnailsImage()
 
 QString getThumbnailsName()
 {
+#if defined(Q_OS_LINUX)
+    return QString::fromLatin1("thumbnails/normal");
+#else
     return QString::fromLatin1("FreeCADStartThumbnails");
+#endif
 }
 
 QDir getThumnailsParentDir()
 {
-    return QDir::temp();
+    return {QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation)};
 }
 
 QString getThumbnailsDir()
@@ -116,22 +122,23 @@ void createThumbnailsDir()
     }
 }
 
-QString getSha1Hash(const std::string& path)
+QString getMD5Hash(const std::string& path)
 {
-    QCryptographicHash hash(QCryptographicHash::Sha1);
-    hash.addData(path.c_str(), static_cast<int>(path.size()));
-    QByteArray ba1 = hash.result().toHex();
-    hash.reset();
-    hash.addData(ba1);
-    QByteArray ba2 = hash.result().toHex();
-    return QString::fromLatin1(ba2);
+    // Use MD5 hash as specified here:
+    // https://specifications.freedesktop.org/thumbnail-spec/0.8.0/thumbsave.html
+    QUrl url(QString::fromStdString(path));
+    url.setScheme(QString::fromLatin1("file"));
+    QCryptographicHash hash(QCryptographicHash::Md5);
+    hash.addData(url.toEncoded());
+    QByteArray ba = hash.result().toHex();
+    return QString::fromLatin1(ba);
 }
 
 QString getUniquePNG(const std::string& path)
 {
     QDir dir = getThumbnailsDir();
-    QString sha1 = getSha1Hash(path) + QLatin1String(".png");
-    return dir.absoluteFilePath(sha1);
+    QString md5 = getMD5Hash(path) + QLatin1String(".png");
+    return dir.absoluteFilePath(md5);
 }
 
 bool useCachedPNG(const std::string& image, const std::string& project)

--- a/src/Mod/Start/App/PreCompiled.h
+++ b/src/Mod/Start/App/PreCompiled.h
@@ -52,6 +52,8 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QStandardPaths>
+#include <QUrl>
 
 #endif  // _PreComp_
 #endif  // START_PRECOMPILED_H


### PR DESCRIPTION
as specified here: https://specifications.freedesktop.org/thumbnail-spec/0.8.0/

The changes are:
* use MD5 as hashing algorithm
* write thumbnails to ~/.cache/thumbnails/normal