### PR TITLE
Add spacenavd motion event support to Placement dialog that allows for object rotation and translation

### DIFF
--- a/src/Gui/Placement.cpp
+++ b/src/Gui/Placement.cpp
@@ -49,6 +49,11 @@
 #include "Placement.h"
 #include "ui_Placement.h"
 
+#include <Gui/MainWindow.h>
+#include <Gui/View3DInventor.h>
+#include <Inventor/SbVec3f.h>
+#include <Gui/SpaceballEvent.h>
+#include <Base/DualQuaternion.h>
 
 using namespace Gui::Dialog;
 namespace sp = std::placeholders;
@@ -462,10 +467,12 @@ Placement::Placement(QWidget* parent, Qt::WindowFlags fl)
     setupUnits();
     setupSignalMapper();
     setupRotationMethod();
+    setupEventFilter();
 }
 
 Placement::~Placement()
 {
+    if (qApp!=NULL) qApp->removeEventFilter(this);
     delete ui;
 }
 
@@ -547,6 +554,12 @@ void Placement::setupRotationMethod()
     ui->stackedWidget->setCurrentIndex(index);
 }
 
+
+void Placement::setupEventFilter()
+{
+    if (qApp!=NULL) qApp->installEventFilter(this);
+}
+
 void Placement::showDefaultButtons(bool ok)
 {
     ui->buttonBox->setVisible(ok);
@@ -557,6 +570,83 @@ void Placement::showDefaultButtons(bool ok)
     else {
         ui->buttonBoxLayout->removeItem(ui->buttonBoxSpacer);
     }
+}
+
+bool Placement::eventFilter(QObject*, QEvent* ev) {
+    //handle spacenav daemon motion events in placement window
+    if (//event->type() == Spaceball::ButtonEvent::ButtonEventType ||
+        ev->type() == Spaceball::MotionEvent::MotionEventType){
+                Spaceball::MotionEvent *motionEvent = dynamic_cast<Spaceball::MotionEvent*>(ev);
+                if (!motionEvent) {
+                    Base::Console().Log("invalid spaceball motion event in bool Placement::eventFilter(QObject*, QEvent* ev)\n");
+                    return false;
+                    }
+                motionEvent->setHandled(true);
+
+                static double translationConstant(.001f);
+                double xTrans = static_cast<double>(motionEvent->translationX())*translationConstant;
+                double yTrans = static_cast<double>(motionEvent->translationY())*translationConstant;
+                double zTrans = static_cast<double>(motionEvent->translationZ())*translationConstant;
+
+                static double rotationConstant(.001f);
+                double dY=static_cast<double>(motionEvent->rotationZ()) * rotationConstant;
+                double dP=static_cast<double>(motionEvent->rotationY()) * rotationConstant;
+                double dR=static_cast<double>(motionEvent->rotationX()) * rotationConstant;
+
+                if(xTrans == 0 && yTrans == 0 && zTrans == 0 && dY ==0 && dP ==0 && dR ==0 ) return false;
+                signalMapper->blockSignals(true);
+//                printf("\nSpaceball Placement Event\t(x,y,z)=(%f,%f,%f)\t(Rx,Ry,Rz)=(%f,%f,%f);\n",xTrans,yTrans,zTrans,dR,dP,dY  );
+
+                Base::Vector3d dTrans(xTrans,yTrans,zTrans);
+                Base::Vector3d rotationCenter=this->getCenterData();
+                Base::Placement old_placement(getPositionData(),getRotationData());
+                // Code below allows for seamles rotation around axes without blocking on roll, pitch, yaw range ends.
+                Base::Matrix4D new_placement_mat;
+                new_placement_mat = old_placement.toMatrix();
+                new_placement_mat.move(-rotationCenter);
+                if(dY!=0) new_placement_mat.rotZ(Base::toRadians(dY));
+                if(dP!=0) new_placement_mat.rotY(Base::toRadians(dP));
+                if(dR!=0) new_placement_mat.rotX(Base::toRadians(dR));
+                new_placement_mat.move(rotationCenter);
+                new_placement_mat.move(dTrans);
+                Base::Placement new_placement(new_placement_mat);
+                new_placement.setPosition(old_placement.getPosition()+dTrans);
+                //setPlacementData(new_placement);//Does not work properly because of problems with euler angles. Angle values need to be adjusted below to fit into proper range.
+
+                ui->xPos->setValue(new_placement.getPosition().x);
+                ui->yPos->setValue(new_placement.getPosition().y);
+                ui->zPos->setValue(new_placement.getPosition().z);
+
+                Base::Vector3d new_dir_vect;
+                double angle;
+                new_placement.getRotation().getValue(new_dir_vect,angle);
+
+                // bug seen in freecad-0.21.2+dfsg1 (from debian source package) and in github master 20240708
+                // If there are issues with precision when rotating (360 deg rotation arround axis does not return to the same orientation) increase decimal places in Preferences (stored values in Gui::QuantitySpinBox are rounded and result in precision loss after multiple iterations of rotation)
+                // bug presence may be tested by uncomenting printf with "eventFilter-C" and "eventFilter-D" they will return different (RotXYZ) values when bug is present (D line will have visibly rounded values).
+                //printf("eventFilter-C\t(x,y,z)=(%f,%f,%f)\t(RotXYZ)=(%f,%f,%f)\t(RotAngle)=(%f)\n",new_placement.getPosition().x,new_placement.getPosition().y,new_placement.getPosition().z,new_dir_vect.x, new_dir_vect.y, new_dir_vect.z, Base::toDegrees<double>(angle));
+
+                ui->xAxis->setValue(new_dir_vect.x);
+                ui->yAxis->setValue(new_dir_vect.y);
+                ui->zAxis->setValue(new_dir_vect.z);
+                ui->angle->setValue(Base::toDegrees<double>(angle));
+                //printf("eventFilter-D\t(x,y,z)=(%f,%f,%f)\t(RotXYZ)=(%f,%f,%f)\t(RotAngle)=(%f)\n\n",ui->xPos->value().getValue(),ui->yPos->value().getValue(),ui->zPos->value().getValue(),ui->xAxis->value().getValue(),ui->yAxis->value().getValue(),ui->zAxis->value().getValue(),ui->angle->value().getValue());
+
+                // Euler angles (XY'Z'')
+                double Y,P,R;
+                new_placement.getRotation().getYawPitchRoll(Y,P,R);
+                if(R>180) R-=360; else if(R<-180) R+=360;
+                if(P>90) P-=180; else if(P<-90) R+=180;
+                if(Y>180) Y-=360; else if(Y<-180) Y+=360;
+                ui->yawAngle->setValue(Y);
+                ui->pitchAngle->setValue(P);
+                ui->rollAngle->setValue(R);
+
+                signalMapper->blockSignals(false);
+                onPlacementChanged(0);
+                return true;
+                };
+    return false;
 }
 
 void Placement::open()

--- a/src/Gui/Placement.h
+++ b/src/Gui/Placement.h
@@ -131,6 +131,8 @@ public:
     Base::Placement getPlacement() const;
     void showDefaultButtons(bool);
 
+    bool eventFilter(QObject *, QEvent *ev);
+
 protected:
     void changeEvent(QEvent *e) override;
     void keyPressEvent(QKeyEvent*) override;
@@ -153,6 +155,7 @@ private:
     void setupSignalMapper();
     void setupRotationMethod();
     void bindProperty(const App::DocumentObject* obj, const std::string& propertyName);
+    void setupEventFilter();
 
     bool onApply();
     void setPlacementData(const Base::Placement&);


### PR DESCRIPTION
This commit adds spacemouse/spacenavd support to Placement dialog that allows for moving of objects (rotation and translation with 6-axis controller) instead of rotating the view.
It allows for smooth changing of object`s pitch/yaw/roll despite the range limits set in ui spinboxes (object rotation does not stop when reaching the spinbox limit).
When one of the angles exceeds limits set in spinbox all angles are corrected in such a way that the actual direction is still accurate.
Rotation and translation is relative to the main coordinate system (not the current camera view position).

Because this commit is using the Gui::QuantitySpinBox as data storage for object Placement it is susceptible to errors introduced by rounding (inherent to Gui::QuantitySpinBox and configured by decimal places setting).
Rounding errors accumulation is especially visible when using "Rotation axis with angle" in Placement dialog during consecutive calls to "Placement::eventFilter(QObject*, QEvent* ev)". This issue can be circumvented by increasing the decimal places setting in Edit->Preferences->General->Units->Number of decimals.
This can be tested by orienting object in such a way that x/y/z part of direction vector is non zero and then rotating it by 360degrees around any axis - the object does not return to the same, starting orientation when the rounding issue is present.

Code was tested and was working in dev version of freecad:
OS: Debian GNU/Linux 12 (bookworm) (X-Cinnamon/lightdm-xsession/xcb)
Architecture: x86_64
Version: 1.1.0dev.39290 (Git)
Build type: Unknown
Branch: main
Hash: 0a2e78be3872e92f9aa3a280d35ecff469d9fc42
Python 3.11.2, Qt 5.15.8, Coin 4.0.0, Vtk 9.1.0, OCC 7.6.3
Locale: English/United States (en_US)
Stylesheet/Theme/QtStyle: unset/unset/Qt default
Installed mods: 
  * A2plus 0.4.61
  * CurvedShapes 1.0.5
  * DynamicData 2.59.0
  * Pyramids-and-Polyhedrons
  * Plot 2022.4.17
  * Assembly4 0.50.6
  * parts_library
  * SelectorToolbar
  * pcb 6.2023.0
  * Manipulator 1.5.0
  * toSketch 1.0.1
  * ThreadProfile 1.89.0
  * slic3r-tools
  * fasteners 0.4.74
  * lattice2 1.0.0
  * sheetmetal 0.5.6
  * kicadStepUpMod 10.22.1
  * ExplodedAssembly
  * MnesarcoUtils 0.2.5
  * CubeMenu
  * Estimate 0.1.2
  * freecad.gears 1.1.0
  * Silk 0.1.5
  * offline-documentation 1.0.0-alpha
  * QuickMeasure 2022.10.28
  * dodo 1.0.0
  * Defeaturing 1.2.1

This is a copy of #15375 that was unintentionally closed.
