### PR TITLE
Gui: allow LineEdit to grow with text - fixes #17747

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -549,9 +549,11 @@ public:
     {
         QSize size = QLineEdit::sizeHint(); 
         QFontMetrics fm(font());
-        int availableWidth = parentWidget()->width() - geometry().x() - 20; // Calculate available width
-        size.setWidth(std::min(fm.horizontalAdvance(text()) + 30, availableWidth)); // Add some padding and max width
-        Base::Console().Warning("sizeHint %d %d\n", size.width(), size.height());
+        int availableWidth = parentWidget()->width() - geometry().x(); // Calculate available width
+        int margin = 2 * (style()->pixelMetric(QStyle::PM_FocusFrameHMargin) + 1)
+                    + 2 * style()->pixelMetric(QStyle::PM_LayoutHorizontalSpacing)
+                    + TreeParams::getItemBackgroundPadding();
+        size.setWidth(std::min(fm.horizontalAdvance(text()) + margin , availableWidth));
         return size;
     }
 
@@ -561,7 +563,6 @@ public:
         ExpLineEdit::keyPressEvent(event);
         setMinimumWidth(sizeHint().width());
     }
-    
 
 };
 

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -540,6 +540,31 @@ void TreeWidgetItemDelegate::initStyleOption(QStyleOptionViewItem *option,
     }
 }
 
+class DynamicQLineEdit : public ExpLineEdit
+{
+public:
+    DynamicQLineEdit(QWidget *parent = nullptr) : ExpLineEdit(parent) {}
+
+    QSize sizeHint() const override
+    {
+        QSize size = QLineEdit::sizeHint(); 
+        QFontMetrics fm(font());
+        int availableWidth = parentWidget()->width() - geometry().x() - 20; // Calculate available width
+        size.setWidth(std::min(fm.horizontalAdvance(text()) + 30, availableWidth)); // Add some padding and max width
+        Base::Console().Warning("sizeHint %d %d\n", size.width(), size.height());
+        return size;
+    }
+
+    // resize on key presses
+    void keyPressEvent(QKeyEvent *event) override
+    {
+        ExpLineEdit::keyPressEvent(event);
+        setMinimumWidth(sizeHint().width());
+    }
+    
+
+};
+
 QWidget* TreeWidgetItemDelegate::createEditor(
         QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index) const
 {
@@ -555,15 +580,15 @@ QWidget* TreeWidgetItemDelegate::createEditor(
     App::GetApplication().setActiveTransaction(str.str().c_str());
     FC_LOG("create editor transaction " << App::GetApplication().getActiveTransaction());
 
-    QLineEdit *editor;
+    DynamicQLineEdit *editor;
     if(TreeParams::getLabelExpression()) {
-        ExpLineEdit *le = new ExpLineEdit(parent);
+        DynamicQLineEdit *le = new DynamicQLineEdit(parent);
         le->setAutoApply(true);
         le->setFrame(false);
         le->bind(App::ObjectIdentifier(prop));
         editor = le;
     } else {
-        editor = new QLineEdit(parent);
+        editor = new DynamicQLineEdit(parent);
     }
     editor->setReadOnly(prop.isReadOnly());
     return editor;


### PR DESCRIPTION
This adds a `DynamicQLineEdit` dynamic class for the model Tree so that the edit field can grow with what is being typed during renaming. This fixes #17747 .

https://github.com/user-attachments/assets/615bcedf-70ba-4437-a2b3-51b77f897d21

I am not sure if this merits an new class or if it should have been added to `ExpLineEdit`.  (I didn't want to disturb the existing class).