### PR TITLE
Assembly: migrationScript2 and migrationScript4 improved and refactored

### DIFF
--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -148,6 +148,20 @@ def solveIfAllowed(assembly, storePrev=False):
         assembly.solve(storePrev)
 
 
+def getContext(obj):
+    """Fetch the context of an object."""
+    context = []
+    current = obj
+
+    while current:
+        # Add the object's Label at the beginning or the Name if label is empty
+        context.insert(0, current.Label if current.Label else current.Name)
+        # Get the immediate parent object
+        parents = getattr(current, "InList", [])
+        current = parents[0] if parents else None
+    return ".".join(context)
+
+
 # The joint object consists of 2 JCS (joint coordinate systems) and a Joint Type.
 # A JCS is a placement that is computed (unless it is detached) from references (PropertyXLinkSubHidden) that links to :
 # - An object: this can be any Part::Feature solid. Or a PartDesign Body. Or a App::Link to those.
@@ -432,54 +446,43 @@ class Joint:
             joint.Object2 = [obj2, [el2, vtx2]]
 
     def migrationScript2(self, joint):
-        if hasattr(joint, "Object1"):
-            joint.addProperty(
-                "App::PropertyXLinkSubHidden",
-                "Reference1",
-                "Joint Connector 1",
-                QT_TRANSLATE_NOOP("App::Property", "The first reference of the joint"),
-            )
+        def processObject(object_attr, reference_attr, part_attr, connector_label, order):
+            try:
+                if hasattr(joint, object_attr):
+                    joint.addProperty(
+                        "App::PropertyXLinkSubHidden",
+                        reference_attr,
+                        connector_label,
+                        QT_TRANSLATE_NOOP("App::Property", f"The {order} reference of the joint"),
+                    )
 
-            if joint.Object1 is not None:
-                obj = joint.Object1[0]
-                part = joint.Part1
-                elt = joint.Object1[1][0]
-                vtx = joint.Object1[1][1]
+                    obj = getattr(joint, object_attr)
 
-                # now we need to get the 'selection-root-obj' and the global path
-                rootObj, path = UtilsAssembly.getRootPath(obj, part)
-                obj = rootObj
-                elt = path + elt
-                vtx = path + vtx
+                    base_obj = obj[0]
+                    part = getattr(joint, part_attr)
+                    elt = obj[1][0]
+                    vtx = obj[1][1]
 
-                joint.Reference1 = [obj, [elt, vtx]]
+                    # Get the 'selection-root-obj' and the global path
+                    root_obj, path = UtilsAssembly.getRootPath(base_obj, part)
+                    base_obj = root_obj
+                    elt = path + elt
+                    vtx = path + vtx
 
-            joint.removeProperty("Object1")
-            joint.removeProperty("Part1")
+                    setattr(joint, reference_attr, [base_obj, [elt, vtx]])
 
-        if hasattr(joint, "Object2"):
-            joint.addProperty(
-                "App::PropertyXLinkSubHidden",
-                "Reference2",
-                "Joint Connector 2",
-                QT_TRANSLATE_NOOP("App::Property", "The second reference of the joint"),
-            )
+                    joint.removeProperty(object_attr)
+                    joint.removeProperty(part_attr)
 
-            if joint.Object2 is not None:
-                obj = joint.Object2[0]
-                part = joint.Part2
-                elt = joint.Object2[1][0]
-                vtx = joint.Object2[1][1]
+            except (AttributeError, IndexError, TypeError) as e:
+                App.Console.PrintWarning(
+                    f"{translate('Assembly', 'Assembly joint')} '{getContext(joint)}' "
+                    f"{translate('Assembly', 'has an invalid')} '{object_attr}' "
+                    f"{translate('Assembly', 'or related attributes')}. {str(e)}\n"
+                )
 
-                rootObj, path = UtilsAssembly.getRootPath(obj, part)
-                obj = rootObj
-                elt = path + elt
-                vtx = path + vtx
-
-                joint.Reference2 = [obj, [elt, vtx]]
-
-            joint.removeProperty("Object2")
-            joint.removeProperty("Part2")
+        processObject("Object1", "Reference1", "Part1", "Joint Connector 1", "first")
+        processObject("Object2", "Reference2", "Part2", "Joint Connector 2", "second")
 
     def migrationScript3(self, joint):
         if hasattr(joint, "Offset"):
@@ -512,33 +515,27 @@ class Joint:
             joint.Offset2 = App.Placement(current_offset, App.Rotation(current_rotation, 0, 0))
 
     def migrationScript4(self, joint):
-        if (
-            hasattr(joint, "Reference1")
-            and isinstance(joint.Reference1, Sequence)
-            and joint.Reference1[0] is not None
-        ):
-            doc_name = joint.Reference1[0].Document.Name
-            sub1 = joint.Reference1[1][0]
-            sub1 = UtilsAssembly.fixBodyExtraFeatureInSub(doc_name, sub1)
-            sub2 = joint.Reference1[1][1]
-            sub2 = UtilsAssembly.fixBodyExtraFeatureInSub(doc_name, sub2)
+        def processReference(reference_attr):
+            try:
+                if hasattr(joint, reference_attr):
+                    ref = getattr(joint, reference_attr)
 
-            if sub1 != joint.Reference1[1][0] or sub2 != joint.Reference1[1][1]:
-                joint.Reference1 = (joint.Reference1[0], [sub1, sub2])
+                    doc_name = ref[0].Document.Name
+                    sub1 = UtilsAssembly.fixBodyExtraFeatureInSub(doc_name, ref[1][0])
+                    sub2 = UtilsAssembly.fixBodyExtraFeatureInSub(doc_name, ref[1][1])
 
-        if (
-            hasattr(joint, "Reference2")
-            and isinstance(joint.Reference2, Sequence)
-            and joint.Reference2[0] is not None
-        ):
-            doc_name = joint.Reference2[0].Document.Name
-            sub1 = joint.Reference2[1][0]
-            sub1 = UtilsAssembly.fixBodyExtraFeatureInSub(doc_name, sub1)
-            sub2 = joint.Reference2[1][1]
-            sub2 = UtilsAssembly.fixBodyExtraFeatureInSub(doc_name, sub2)
+                    if sub1 != ref[1][0] or sub2 != ref[1][1]:
+                        setattr(joint, reference_attr, (ref[0], [sub1, sub2]))
 
-            if sub1 != joint.Reference2[1][0] or sub2 != joint.Reference2[1][1]:
-                joint.Reference2 = (joint.Reference2[0], [sub1, sub2])
+            except (AttributeError, IndexError, TypeError) as e:
+                App.Console.PrintWarning(
+                    f"{translate('Assembly', 'Assembly joint')} '{getContext(joint)}' "
+                    f"{translate('Assembly', 'has an invalid')} '{reference_attr}' "
+                    f"{translate('Assembly', 'or related attributes')}. {str(e)}\n"
+                )
+
+        processReference("Reference1")
+        processReference("Reference2")
 
     def dumps(self):
         return None


### PR DESCRIPTION
## Description of Defects in migrationScript2 and migrationScript4:

Several additional issues have been identified in the Assembly functions migrationScript4 and migrationScript2, beyond those fixed in patch 71f0104bb2e88670f20b9889148999f8e684461a.

One common problem is that the Joint property Reference1 or Reference2 can be set to an invalid format. For example, user can manually cause this issue by assigning an incorrect reference (e.g., the Z-axis) to these properties via the FreeCAD GUI.  When this happens, internal errors (exceptions and their corresponding Python call stack) are reported in the Report View.  However, such information is not helpful for the user to fix their 3D model.

## Issues with the Current Implementation (Using migrationScript4 as Reference):

- Lack of Type Validation for Reference1 and Reference2:

  The script does not check whether joint.Reference1[1] or joint.Reference2[1] is a sequence. If this condition is not met, statements like:

    sub1 = joint.Reference1[1][0]

  will throw an exception, printing the Python call stack.

- Lack of Length Validation for Sequences:

  The script does not ensure that the sequence length is sufficient for indexing. For example, joint.Reference1 and joint.Reference2 must each have at least two elements to allow:

    joint.Reference1[1][1]
    joint.Reference2[1][1]

  Without validation, such calls can result in exceptions, printing the Python call stack.

- No Feedback on Problematic Joint:

  The user is not informed about which Assembly joint in the object hierarchy has an invalid Reference1 or Reference2. Depending on the size of the 3D model, identifying the defect can be time-consuming and frustrating without proper feedback.

## This patch is focused on:

- Reporting Problematic Joint Path:

  A new function has been added to retrieve the full path to the Assembly joint. The return value (a string) is used to report the issue.

- Improved Exception Handling:

  Instead of adding more conditional checks (see above), exception handling is implemented. AttributeError, IndexError, and TypeError exceptions are caught. The exception message (excluding the call stack) is displayed at the end of a user-friendly warning.

- User-Friendly Warnings in the Report View:

  A single-line warning is now shown in the Report View, containing the following details:

    - Source of Warning:              'Assembly joint'
    - Location in the 3D Model: e.g., 'Assembly_XY.object_XY.joint_XY'
    - Problematic Attribute: e.g.,    'ReferenceXY'
    - Exception Message: e.g.,        'list index out of range'

- Refactoring and Optimization:

  The functions were refactored and optimized at the end of the conversion process.

## Advantages:

- Cleaner Report View: Internal errors (e.g., Python call stacks) are no longer logged in the Report View, as they are not useful for end users. Only the exception message is displayed.

- Improved User Feedback: Users can now identify the problematic Assembly joint in the object hierarchy, saving significant time and effort.

- Robust and Concise Code: The solution simplifies the code while increasing its robustness.