### PR TITLE
Fixes to Mesh: WildMagic4 to build on Windows MSVC++

### DIFF
--- a/src/Mod/Mesh/App/WildMagic4/Wm4TRational.inl
+++ b/src/Mod/Mesh/App/WildMagic4/Wm4TRational.inl
@@ -652,11 +652,11 @@ TRational<N>::TRational (double dValue)
     // multiply by 2^exponent
     TRational kMultiplier;
     TInteger<N> kPower(2);
-    int i, iDelay = 0;
+    int iDelay = 0;
     if (uiExponent & 0x400)
     {
         kMultiplier = 2;
-        for (i = 0; i <= 9; i++, uiExponent >>= 1, iDelay++)
+        for (int i = 0; i <= 9; i++, uiExponent >>= 1, iDelay++)
         {
             if (uiExponent & 1)
             {
@@ -673,7 +673,7 @@ TRational<N>::TRational (double dValue)
     else
     {
         kMultiplier = 1;
-        for (i = 0; i <= 9; i++, uiExponent >>= 1, iDelay++)
+        for (int i = 0; i <= 9; i++, uiExponent >>= 1, iDelay++)
         {
             if (!(uiExponent & 1))
             {

--- a/src/Mod/Mesh/App/WildMagic4/Wm4TRational.inl
+++ b/src/Mod/Mesh/App/WildMagic4/Wm4TRational.inl
@@ -174,7 +174,7 @@ bool TRational<N>::operator> (const TRational& rkR) const
 template <int N>
 TRational<N> TRational<N>::operator+ (const TRational& rkR) const
 {
-    TRational kSum;
+    TRational<N> kSum;
     kSum.m_kNumer = m_kNumer*rkR.m_kDenom + m_kDenom*rkR.m_kNumer;
     kSum.m_kDenom = m_kDenom*rkR.m_kDenom;
     kSum.EliminatePowersOfTwo();
@@ -184,7 +184,7 @@ TRational<N> TRational<N>::operator+ (const TRational& rkR) const
 template <int N>
 TRational<N> TRational<N>::operator- (const TRational& rkR) const
 {
-    TRational kDiff;
+    TRational<N> kDiff;
     kDiff.m_kNumer = m_kNumer*rkR.m_kDenom - m_kDenom*rkR.m_kNumer;
     kDiff.m_kDenom = m_kDenom*rkR.m_kDenom;
     kDiff.EliminatePowersOfTwo();
@@ -194,7 +194,7 @@ TRational<N> TRational<N>::operator- (const TRational& rkR) const
 template <int N>
 TRational<N> TRational<N>::operator* (const TRational& rkR) const
 {
-    TRational kProd;
+    TRational<N> kProd;
     kProd.m_kNumer = m_kNumer*rkR.m_kNumer;
     kProd.m_kDenom = m_kDenom*rkR.m_kDenom;
     kProd.EliminatePowersOfTwo();
@@ -204,7 +204,7 @@ TRational<N> TRational<N>::operator* (const TRational& rkR) const
 template <int N>
 TRational<N> TRational<N>::operator/ (const TRational& rkR) const
 {
-    TRational kQuot;
+    TRational<N> kQuot;
     kQuot.m_kNumer = m_kNumer*rkR.m_kDenom;
     kQuot.m_kDenom = m_kDenom*rkR.m_kNumer;
     kQuot.EliminatePowersOfTwo();
@@ -214,7 +214,7 @@ TRational<N> TRational<N>::operator/ (const TRational& rkR) const
 template <int N>
 TRational<N> TRational<N>::operator- () const
 {
-    TRational kNeg;
+    TRational<N> kNeg;
     kNeg.m_kNumer = -m_kNumer;
     kNeg.m_kDenom = m_kDenom;
     return kNeg;
@@ -350,7 +350,7 @@ TRational<N>::TRational (float fValue)
     unsigned int uiMantissa = (0x007FFFFF & uiBits);
 
     // create 1.mantissa
-    TRational kFraction(1,2);
+    TRational<N> kFraction(1,2);
     TInteger<N> kTwo(2);
     m_kNumer = kOne;
     unsigned int uiMask;
@@ -363,7 +363,7 @@ TRational<N>::TRational (float fValue)
     }
 
     // multiply by 2^exponent
-    TRational kMultiplier;
+    TRational<N> kMultiplier;
     TInteger<N> kPower(2);
     int i, iDelay = 0;
     if (uiExponent & 0x00000080)
@@ -630,7 +630,7 @@ TRational<N>::TRational (double dValue)
     unsigned int uiMantissaLo = auiBits[0];
 
     // create 1.mantissa
-    TRational kFraction(1,2);
+    TRational<N> kFraction(1,2);
     TInteger<N> kTwo(2);
     m_kNumer = kOne;
     unsigned int uiMask;
@@ -650,7 +650,7 @@ TRational<N>::TRational (double dValue)
     }
 
     // multiply by 2^exponent
-    TRational kMultiplier;
+    TRational<N> kMultiplier;
     TInteger<N> kPower(2);
     int iDelay = 0;
     if (uiExponent & 0x400)


### PR DESCRIPTION
Qt6 adds the `/permissive-` option to the MSVC++ command line, resulting in build failures due to WM4.  These changes bring the code into compliance and permit building for Windows with Qt6.