### PR TITLE
Draft: fix color of arrays

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_array.py
+++ b/src/Mod/Draft/draftviewproviders/view_array.py
@@ -56,7 +56,9 @@ class ViewProviderDraftArray(ViewProviderDraft):
         obj = vobj.Object
         if obj.Base is not None:
             colors = gui_utils.get_diffuse_color(obj.Base)
-            if colors:
+            if not colors:
+                return
+            if len(colors) > 1:
                 n = 1
                 if hasattr(obj, "ArrayType"):
                     if obj.ArrayType == "ortho":
@@ -68,7 +70,7 @@ class ViewProviderDraftArray(ViewProviderDraft):
                 elif hasattr(obj, "Count"):
                     n = obj.Count
                 colors = colors * n
-                vobj.DiffuseColor = colors
+            vobj.DiffuseColor = colors
 
 
 # Alias for compatibility with v0.18 and earlier


### PR DESCRIPTION
If `get_diffuse_color` returned a list with a single color, the list was wrongly multiplied. Regression introduced in V0.21, but in that version the error was masked by how Core handled the diffuse color.

Fixes #17052.
