### PR TITLE
Draft: fix focus behavior of radius input

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -758,8 +758,7 @@ class DraftToolBar:
         self.z = 0
         self.pointButton.show()
         if rel: self.isRelative.show()
-        todo.delay(self.setFocus,None)
-        self.xValue.selectAll()
+        todo.delay(self.setFocus, None)
 
     def labelUi(self,title=translate("draft","Label"),callback=None):
         w = QtWidgets.QWidget()
@@ -787,8 +786,7 @@ class DraftToolBar:
         self.labelRadius.setText(translate("draft","Distance"))
         self.radiusValue.setToolTip(translate("draft", "Offset distance"))
         self.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
-        todo.delay(self.radiusValue.setFocus,None)
-        self.radiusValue.selectAll()
+        todo.delay(self.setFocus, "radius")
 
     def offUi(self):
         todo.delay(FreeCADGui.Control.closeDialog,None)
@@ -805,8 +803,7 @@ class DraftToolBar:
         self.labelRadius.setText(translate("draft","Distance"))
         self.radiusValue.setToolTip(translate("draft", "Offset distance"))
         self.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
-        todo.delay(self.radiusValue.setFocus,None)
-        self.radiusValue.selectAll()
+        todo.delay(self.setFocus, "radius")
 
     def radiusUi(self):
         self.hideXYZ()
@@ -815,8 +812,7 @@ class DraftToolBar:
         self.labelRadius.show()
         self.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
         self.radiusValue.show()
-        todo.delay(self.radiusValue.setFocus,None)
-        self.radiusValue.selectAll()
+        todo.delay(self.setFocus, "radius")
 
     def textUi(self):
         self.hideXYZ()
@@ -1466,7 +1462,7 @@ class DraftToolBar:
             print("Error: setRadiusValue called for number without Dimension")
             t = display_external(val,None, None)
         self.radiusValue.setText(t)
-        self.radiusValue.setFocus()
+        self.setFocus("radius")
 
     def runAutoGroup(self):
         FreeCADGui.runCommand("Draft_AutoGroup")

--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -212,8 +212,7 @@ class Offset(gui_base_original.Modifier):
                 self.constrainSeg = None
                 self.linetrack.off()
                 self.ui.radiusValue.setText("off")
-            self.ui.radiusValue.setFocus()
-            self.ui.radiusValue.selectAll()
+            self.ui.setFocus("radius")
             if self.extendedCopy:
                 if not gui_tool_utils.hasMod(arg, gui_tool_utils.get_mod_alt_key()):
                     self.finish()

--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -238,8 +238,7 @@ class Trimex(gui_base_original.Modifier):
                 # situation. Setting 0 with no unit will show "0 ??" and not
                 # compute any value
                 self.ui.setRadiusValue(0)
-            self.ui.radiusValue.setFocus()
-            self.ui.radiusValue.selectAll()
+            self.ui.setFocus("radius")
             gui_tool_utils.redraw3DView()
 
         elif arg["Type"] == "SoMouseButtonEvent":


### PR DESCRIPTION
Fixes #16249.

The input did receive the focus, but the existing value was not selected.

The circle, arc, trim and offset tools had a related issue. The whole radius/distance value, including the unit string, was selected, instead of just the numerical portion.
