### PR TITLE
Draft: Draft_Split: apply original view props to split off object

### DIFF
--- a/src/Mod/Draft/draftfunctions/split.py
+++ b/src/Mod/Draft/draftfunctions/split.py
@@ -33,22 +33,22 @@ import draftmake.make_wire as make_wire
 
 def split(wire, newPoint, edgeIndex):
     if utils.get_type(wire) != "Wire":
-        return
-    elif wire.Closed:
-        split_closed_wire(wire, edgeIndex)
-    else:
-        split_open_wire(wire, newPoint, edgeIndex)
+        return None
+    if wire.Closed:
+        return split_closed_wire(wire, edgeIndex)
+    return split_open_wire(wire, newPoint, edgeIndex)
 
 
 def split_closed_wire(wire, edgeIndex):
     wire.Closed = False
     if edgeIndex == len(wire.Points):
-        make_wire.make_wire([wire.Placement.multVec(wire.Points[0]),
+        new = make_wire.make_wire([wire.Placement.multVec(wire.Points[0]),
             wire.Placement.multVec(wire.Points[-1])], placement=wire.Placement)
     else:
-        make_wire.make_wire([wire.Placement.multVec(wire.Points[edgeIndex-1]),
+        new = make_wire.make_wire([wire.Placement.multVec(wire.Points[edgeIndex-1]),
             wire.Placement.multVec(wire.Points[edgeIndex])], placement=wire.Placement)
         wire.Points = list(reversed(wire.Points[0:edgeIndex])) + list(reversed(wire.Points[edgeIndex:]))
+    return new
 
 
 splitClosedWire = split_closed_wire
@@ -67,7 +67,7 @@ def split_open_wire(wire, newPoint, edgeIndex):
         elif index > edgeIndex:
             wire2Points.append(wire.Placement.multVec(point))
     wire.Points = wire1Points
-    make_wire.make_wire(wire2Points, placement=wire.Placement)
+    return make_wire.make_wire(wire2Points, placement=wire.Placement)
 
 
 splitOpenWire = split_open_wire

--- a/src/Mod/Draft/draftguitools/gui_split.py
+++ b/src/Mod/Draft/draftguitools/gui_split.py
@@ -87,22 +87,19 @@ class Split(gui_base_original.Modifier):
     def proceed(self, info):
         """Proceed with execution of the command after click on an edge."""
         self.end_callbacks(self.call)
-        wire = App.ActiveDocument.getObject(info["Object"])
-        edge_index = int(info["Component"][4:])
+        wire = info["Object"]
+        index = info["Component"][4:]
+        point = DraftVecUtils.toString(self.point)
 
         Gui.addModule("Draft")
-        _cmd = "Draft.split"
-        _cmd += "("
-        _cmd += "FreeCAD.ActiveDocument." + wire.Name + ", "
-        _cmd += DraftVecUtils.toString(self.point) + ", "
-        _cmd += str(edge_index)
-        _cmd += ")"
-        _cmd_list = ["s = " + _cmd,
-                     "FreeCAD.ActiveDocument.recompute()"]
+        cmd_list = [
+            "obj = FreeCAD.ActiveDocument." + wire,
+            "new = Draft.split(obj, " + point + ", " + index + ")",
+            "Draft.format_object(new, obj)",
+            "FreeCAD.ActiveDocument.recompute()"
+        ]
 
-        self.commit(translate("draft", "Split line"),
-                    _cmd_list)
-
+        self.commit(translate("draft", "Split line"), cmd_list)
         self.finish()
 
     def finish(self, cont=False):


### PR DESCRIPTION
Fixes #16210.

Note that `Draft.format_object` is called from gui_split.py (in the commit). This is not consistent with other tools where this is handled in the `make_*` functions. In this case the new object is formatted twice. The 1st time by the `make_wire` code which (wrongly) applies the current default props.
