### PR TITLE
Fixing OfflineRenderingUtils.guidata on BIMExample.FCstd

### DIFF
--- a/src/Mod/BIM/OfflineRenderingUtils.py
+++ b/src/Mod/BIM/OfflineRenderingUtils.py
@@ -220,6 +220,8 @@ def getGuiData(filename):
                 if isinstance(properties,dict):
                     for propname in properties.keys():
                         if properties[propname]["type"] == "App::PropertyColorList":
+                            if not guidata[key][propname]["value"]:
+                                continue
                             df = zdoc.open(guidata[key][propname]["value"])
                             buf = df.read()
                             df.close()


### PR DESCRIPTION
Trying to run `OfflineRenderingUtils.getGuiData("./examples/BIMExample.FCStd")` on the example file fails with:

```trace
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[10], line 1
----> 1 OfflineRenderingUtils.getGuiData("./examples/BIMExample.FCStd")

File ~/micromamba/envs/jupytercad-freecad/Mod/BIM/OfflineRenderingUtils.py:223, in getGuiData(filename)
    221 for propname in properties.keys():
    222     if properties[propname]["type"] == "App::PropertyColorList":
--> 223         df = zdoc.open(guidata[key][propname]["value"])
    224         buf = df.read()
    225         df.close()

File ~/micromamba/envs/jupytercad-freecad/lib/python3.9/zipfile.py:1519, in ZipFile.open(self, name, mode, pwd, force_zip64)
   1516     zinfo._compresslevel = self.compresslevel
   1517 else:
   1518     # Get info object for name
-> 1519     zinfo = self.getinfo(name)
   1521 if mode == 'w':
   1522     return self._open_to_write(zinfo, force_zip64=force_zip64)

File ~/micromamba/envs/jupytercad-freecad/lib/python3.9/zipfile.py:1446, in ZipFile.getinfo(self, name)
   1444 info = self.NameToInfo.get(name)
   1445 if info is None:
-> 1446     raise KeyError(
   1447         'There is no item named %r in the archive' % name)
   1449 return info

KeyError: "There is no item named '' in the archive"
```

This PR adds a check for the property value before trying to read it