### PR TITLE
AddonManager: Render different addon documents on a tabbed group

### DIFF
--- a/src/Mod/AddonManager/Widgets/addonmanager_widget_package_details_view.py
+++ b/src/Mod/AddonManager/Widgets/addonmanager_widget_package_details_view.py
@@ -106,17 +106,28 @@ class PackageDetailsView(QtWidgets.QWidget):
     def _setup_ui(self):
         self.vertical_layout = QtWidgets.QVBoxLayout(self)
         self.button_bar = WidgetAddonButtons(self)
-        self.readme_browser = WidgetReadmeBrowser(self)
         self.message_label = QtWidgets.QLabel(self)
         self.location_label = QtWidgets.QLabel(self)
         self.url_label = QtWidgets.QLabel(self)
         self.url_label.setOpenExternalLinks(True)
         self.location_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+
+        self.tab_widget = QtWidgets.QTabWidget(self)
+        self.readme_browser = WidgetReadmeBrowser(self)
+        self.changelog_browser = WidgetReadmeBrowser(self)
+        self.contrib_browser = WidgetReadmeBrowser(self)
+        self.license_browser = WidgetReadmeBrowser(self)
+
+        self.tab_widget.addTab(self.readme_browser, translate("AddonsInstaller", "README"))
+        self.tab_widget.addTab(self.changelog_browser, translate("AddonsInstaller", "CHANGELOG"))
+        self.tab_widget.addTab(self.contrib_browser, translate("AddonsInstaller", "CONTRIBUTING"))
+        self.tab_widget.addTab(self.license_browser, translate("AddonsInstaller", "LICENSE"))
+
         self.vertical_layout.addWidget(self.button_bar)
         self.vertical_layout.addWidget(self.message_label)
         self.vertical_layout.addWidget(self.location_label)
         self.vertical_layout.addWidget(self.url_label)
-        self.vertical_layout.addWidget(self.readme_browser)
+        self.vertical_layout.addWidget(self.tab_widget)
         self.button_bar.hide()  # Start with no bar
 
     def set_location(self, location: Optional[str]):

--- a/src/Mod/AddonManager/addonmanager_package_details_controller.py
+++ b/src/Mod/AddonManager/addonmanager_package_details_controller.py
@@ -61,6 +61,9 @@ class PackageDetailsController(QtCore.QObject):
         super().__init__()
         self.ui = widget
         self.readme_controller = ReadmeController(self.ui.readme_browser)
+        self.changelog_controller = ReadmeController(self.ui.changelog_browser)
+        self.contrib_controller = ReadmeController(self.ui.contrib_browser)
+        self.license_controller = ReadmeController(self.ui.license_browser)
         self.worker = None
         self.addon = None
         self.update_check_thread = None
@@ -85,7 +88,10 @@ class PackageDetailsController(QtCore.QObject):
         """The main entry point for this class, shows the package details and related buttons
         for the provided repo."""
         self.addon = repo
-        self.readme_controller.set_addon(repo)
+        self.readme_controller.set_addon(repo, 0)
+        self.changelog_controller.set_addon(repo, 1)
+        self.contrib_controller.set_addon(repo, 2)
+        self.license_controller.set_addon(repo, 3)
         self.original_disabled_state = self.addon.is_disabled()
         if repo is not None:
             self.ui.button_bar.show()

--- a/src/Mod/AddonManager/addonmanager_readme_controller.py
+++ b/src/Mod/AddonManager/addonmanager_readme_controller.py
@@ -64,7 +64,7 @@ class ReadmeController(QtCore.QObject):
         self.widget.load_resource.connect(self.loadResource)
         self.widget.follow_link.connect(self.follow_link)
 
-    def set_addon(self, repo: Addon):
+    def set_addon(self, repo: Addon, document: int):
         """Set which Addon's information is displayed"""
 
         self.addon = repo
@@ -83,7 +83,15 @@ class ReadmeController(QtCore.QObject):
                 )
                 return
         else:
-            self.url = utils.get_readme_url(repo)
+            if document == 0:  # README
+                self.url = utils.get_readme_url(repo)
+            elif document == 1:  # CHANGELOG
+                self.url = utils.get_changelog_url(repo)
+            elif document == 2:  # CONTRIBUTING
+                self.url = utils.get_contrib_url(repo)
+            elif document == 3:  # LICENSE
+                self.url = utils.get_license_url(repo)
+
         self.widget.setUrl(self.url)
 
         self.widget.setText(

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -45,7 +45,6 @@ except ImportError:
 import addonmanager_freecad_interface as fci
 
 if fci.FreeCADGui:
-
     # If the GUI is up, we can use the NetworkManager to handle our downloads. If there is no event
     # loop running this is not possible, so fall back to requests (if available), or the native
     # Python urllib.request (if requests is not available).
@@ -211,6 +210,24 @@ def get_readme_url(repo):
     """Returns the location of a readme file"""
 
     return construct_git_url(repo, "README.md")
+
+
+def get_changelog_url(repo):
+    """Returns the location of a changelog file"""
+
+    return construct_git_url(repo, "CHANGELOG.md")
+
+
+def get_contrib_url(repo):
+    """Returns the location of a contributing file"""
+
+    return construct_git_url(repo, "CONTRIBUTING.md")
+
+
+def get_license_url(repo):
+    """Returns the location of a license file"""
+
+    return construct_git_url(repo, "LICENSE")
 
 
 def get_metadata_url(url):


### PR DESCRIPTION
Works as expected but probably it's better to tweak a little the code. Are plans to update the package metadata format? Not sure if it really interesting to h ave the license.

>[!IMPORTANT]
>As of now documents URL are hardcoded, probably is better to only hardcode the `package.xml` URL and then from it parse all needed URLS, but as of now contributing or changelog are not in the specification.

- [ ] Hide when showing macros
- [ ] Heading with link is downgraded to text
- [ ] Emojis from changelog don't appear :sob: 

![image](https://github.com/user-attachments/assets/3fe6e02b-4c8e-4062-b48d-6b1bff1fb78b)


Fix #12968 