### PR TITLE
Draft: Fix finish behavior of commands on doc close

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_circulararray.py
+++ b/src/Mod/Draft/draftguitools/gui_circulararray.py
@@ -124,11 +124,15 @@ class CircularArray(gui_base.GuiCommandBase):
         We should remove the callbacks that were added to the 3D view
         and then close the task panel.
         """
-        self.view.removeEventCallbackPivy(self.location,
-                                          self.callback_move)
-        self.view.removeEventCallbackPivy(self.mouse_event,
-                                          self.callback_click)
-        gui_utils.end_all_events()
+        try:
+            self.view.removeEventCallbackPivy(self.location, self.callback_move)
+            self.view.removeEventCallbackPivy(self.mouse_event, self.callback_click)
+            gui_utils.end_all_events()
+        except RuntimeError:
+            # the view has been deleted already
+            pass
+        self.callback_move = None
+        self.callback_click = None
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
             self.finish()

--- a/src/Mod/Draft/draftguitools/gui_orthoarray.py
+++ b/src/Mod/Draft/draftguitools/gui_orthoarray.py
@@ -111,11 +111,13 @@ class OrthoArray(gui_base.GuiCommandBase):
         We should remove the callbacks that were added to the 3D view
         and then close the task panel.
         """
-        # self.view.removeEventCallbackPivy(self.location,
-        #                                   self.callback_move)
-        self.view.removeEventCallbackPivy(self.mouse_event,
-                                          self.callback_click)
-        gui_utils.end_all_events()
+        try:
+            self.view.removeEventCallbackPivy(self.mouse_event, self.callback_click)
+            gui_utils.end_all_events()
+        except RuntimeError:
+            # the view has been deleted already
+            pass
+        self.callback_click = None
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
             self.finish()

--- a/src/Mod/Draft/draftguitools/gui_points.py
+++ b/src/Mod/Draft/draftguitools/gui_points.py
@@ -143,13 +143,17 @@ class Point(gui_base_original.Creator):
             Restart (continue) the command if `True`, or if `None` and
             `ui.continueMode` is `True`.
         """
-        if self.callbackClick:
-            self.view.removeEventCallbackPivy(coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick)
-        if self.callbackMove:
-            self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(), self.callbackMove)
-        if self.callbackClick or self.callbackMove:
-            # Next line fixes https://github.com/FreeCAD/FreeCAD/issues/10469:
-            gui_utils.end_all_events()
+        try:
+            if self.callbackClick:
+                self.view.removeEventCallbackPivy(coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick)
+            if self.callbackMove:
+                self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(), self.callbackMove)
+            if self.callbackClick or self.callbackMove:
+                # Next line fixes https://github.com/FreeCAD/FreeCAD/issues/10469:
+                gui_utils.end_all_events()
+        except RuntimeError:
+            # the view has been deleted already
+            pass
         self.callbackClick = None
         self.callbackMove = None
         super().finish()

--- a/src/Mod/Draft/draftguitools/gui_polararray.py
+++ b/src/Mod/Draft/draftguitools/gui_polararray.py
@@ -124,11 +124,15 @@ class PolarArray(gui_base.GuiCommandBase):
         We should remove the callbacks that were added to the 3D view
         and then close the task panel.
         """
-        self.view.removeEventCallbackPivy(self.location,
-                                          self.callback_move)
-        self.view.removeEventCallbackPivy(self.mouse_event,
-                                          self.callback_click)
-        gui_utils.end_all_events()
+        try:
+            self.view.removeEventCallbackPivy(self.location, self.callback_move)
+            self.view.removeEventCallbackPivy(self.mouse_event, self.callback_click)
+            gui_utils.end_all_events()
+        except RuntimeError:
+            # the view has been deleted already
+            pass
+        self.callback_move = None
+        self.callback_click = None
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
             self.finish()

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -1385,13 +1385,17 @@ class Snapper:
         self.view = Draft.get3DView()
 
         # remove any previous leftover callbacks
-        if self.callbackClick:
-            self.view.removeEventCallbackPivy(coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick)
-        if self.callbackMove:
-            self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(), self.callbackMove)
-        if self.callbackClick or self.callbackMove:
-            # Next line fixes https://github.com/FreeCAD/FreeCAD/issues/10469:
-            gui_utils.end_all_events()
+        try:
+            if self.callbackClick:
+                self.view.removeEventCallbackPivy(coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick)
+            if self.callbackMove:
+                self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(), self.callbackMove)
+            if self.callbackClick or self.callbackMove:
+                # Next line fixes https://github.com/FreeCAD/FreeCAD/issues/10469:
+                gui_utils.end_all_events()
+        except RuntimeError:
+            # the view has been deleted already
+            pass
         self.callbackClick = None
         self.callbackMove = None
 
@@ -1428,13 +1432,17 @@ class Snapper:
                     accept()
 
         def accept():
-            if self.callbackClick:
-                self.view.removeEventCallbackPivy(coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick)
-            if self.callbackMove:
-                self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(), self.callbackMove)
-            if self.callbackClick or self.callbackMove:
-                # Next line fixes https://github.com/FreeCAD/FreeCAD/issues/10469:
-                gui_utils.end_all_events()
+            try:
+                if self.callbackClick:
+                    self.view.removeEventCallbackPivy(coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick)
+                if self.callbackMove:
+                    self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(), self.callbackMove)
+                if self.callbackClick or self.callbackMove:
+                    # Next line fixes https://github.com/FreeCAD/FreeCAD/issues/10469:
+                    gui_utils.end_all_events()
+            except RuntimeError:
+                # the view has been deleted already
+                pass
             self.callbackClick = None
             self.callbackMove = None
             Gui.Snapper.off()
@@ -1450,13 +1458,17 @@ class Snapper:
             self.pt = None
 
         def cancel():
-            if self.callbackClick:
-                self.view.removeEventCallbackPivy(coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick)
-            if self.callbackMove:
-                self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(), self.callbackMove)
-            if self.callbackClick or self.callbackMove:
-                # Next line fixes https://github.com/FreeCAD/FreeCAD/issues/10469:
-                gui_utils.end_all_events()
+            try:
+                if self.callbackClick:
+                    self.view.removeEventCallbackPivy(coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick)
+                if self.callbackMove:
+                    self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(), self.callbackMove)
+                if self.callbackClick or self.callbackMove:
+                    # Next line fixes https://github.com/FreeCAD/FreeCAD/issues/10469:
+                    gui_utils.end_all_events()
+            except RuntimeError:
+                # the view has been deleted already
+                pass
             self.callbackClick = None
             self.callbackMove = None
             Gui.Snapper.off()

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -478,7 +478,8 @@ class TaskPanelCircularArray:
         the delayed functions, and perform cleanup.
         """
         # App.ActiveDocument.commitTransaction()
-        Gui.ActiveDocument.resetEdit()
+        if Gui.ActiveDocument is not None:
+            Gui.ActiveDocument.resetEdit()
         # Runs the parent command to complete the call
         self.source_command.completed()
 

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -386,7 +386,8 @@ class TaskPanelOrthoArray:
         the delayed functions, and perform cleanup.
         """
         # App.ActiveDocument.commitTransaction()
-        Gui.ActiveDocument.resetEdit()
+        if Gui.ActiveDocument is not None:
+            Gui.ActiveDocument.resetEdit()
         # Runs the parent command to complete the call
         self.source_command.completed()
 

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -431,7 +431,8 @@ class TaskPanelPolarArray:
         the delayed functions, and perform cleanup.
         """
         # App.ActiveDocument.commitTransaction()
-        Gui.ActiveDocument.resetEdit()
+        if Gui.ActiveDocument is not None:
+            Gui.ActiveDocument.resetEdit()
         # Runs the parent command to complete the call
         self.source_command.completed()
 


### PR DESCRIPTION
Forum topic:
https://forum.freecad.org/viewtopic.php?p=794746#p794746

This PR (after the 2nd commit) also improves several issues reported in #17952. But the task panel of most commands (except Draft_Edit) stays open when the document is closed during a command.