### PR TITLE
Fix incorrect displayed default compression level in preferences

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsDocument.ui
+++ b/src/Gui/PreferencePages/DlgSettingsDocument.ui
@@ -88,7 +88,7 @@
          <widget class="QLabel" name="textLabel1">
           <property name="text">
            <string>Document save compression level
-(0 = none, 9 = highest, 3 = default)</string>
+(0 = none, 9 = highest, 7 = default)</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Default compression level was changed a year ago by [this commit](https://github.com/FreeCAD/FreeCAD/commit/f1a6a9e3a6ff61d716bc7f8415a0a7bb8e5456e5) but the text still says "default=3"

The following issue should be closed as "no compression" is already implemented and seem to be working. 
https://github.com/FreeCAD/FreeCAD/issues/9432 