### PR TITLE
Sketcher: Fix double RMB to quit polyline after closed shape

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -554,6 +554,7 @@ public:
                         static_cast<int>(lastEndPosId),
                         firstCurve,
                         static_cast<int>(firstPosId));
+                    firstsegment = true;
                 }
                 Gui::Command::commitCommand();
 


### PR DESCRIPTION
This fixes #13939 where two right mouse buttons were needed to exit the polyline tool after the creation of a closed shape.