### PR TITLE
Materials: Check if m_uuid is empty before adding to recents

### DIFF
--- a/src/Mod/Material/Gui/MaterialTreeWidget.cpp
+++ b/src/Mod/Material/Gui/MaterialTreeWidget.cpp
@@ -482,6 +482,9 @@ void MaterialTreeWidget::saveRecents()
 
 void MaterialTreeWidget::addRecent(const QString& uuid)
 {
+    if (uuid.isEmpty()) {
+        return;
+    }
     // Ensure it is a material. New, unsaved materials will not be
     try {
         auto material = _materialManager.getMaterial(uuid);


### PR DESCRIPTION
This fixes #18168 