### PR TITLE
Fix: Ensure IFC context menu actions are displayed correctly

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_viewproviders.py
+++ b/src/Mod/BIM/nativeifc/ifc_viewproviders.py
@@ -111,17 +111,17 @@ class ifc_vp_object:
                 FreeCADGui.ActiveDocument.ActiveView.getActiveObject("NativeIFC")
                 == vobj.Object
             ):
-                action_activate = QtGui.QAction(icon, "Deactivate container")
+                action_activate = QtGui.QAction(icon, "Deactivate container",menu)
             else:
-                action_activate = QtGui.QAction(icon, "Make active container")
+                action_activate = QtGui.QAction(icon, "Make active container",menu)
             action_activate.triggered.connect(self.activate)
             menu.addAction(action_activate)
         if self.hasChildren(vobj.Object):
-            action_expand = QtGui.QAction(icon, "Expand children")
+            action_expand = QtGui.QAction(icon, "Expand children",menu)
             action_expand.triggered.connect(self.expandChildren)
             actions.append(action_expand)
         if vobj.Object.Group:
-            action_shrink = QtGui.QAction(icon, "Collapse children")
+            action_shrink = QtGui.QAction(icon, "Collapse children",menu)
             action_shrink.triggered.connect(self.collapseChildren)
             actions.append(action_shrink)
         if vobj.Object.ShapeMode == "Shape":
@@ -132,22 +132,22 @@ class ifc_vp_object:
         action_shape.triggered.connect(self.switchShape)
         actions.append(action_shape)
         if vobj.Object.ShapeMode == "None":
-            action_coin = QtGui.QAction(icon, "Load representation")
+            action_coin = QtGui.QAction(icon, "Load representation",menu)
             action_coin.triggered.connect(self.switchCoin)
             actions.append(action_coin)
         if element and ifc_tools.has_representation(element):
-            action_geom = QtGui.QAction(icon, "Add geometry properties")
+            action_geom = QtGui.QAction(icon, "Add geometry properties",menu)
             action_geom.triggered.connect(self.addGeometryProperties)
             actions.append(action_geom)
-        action_tree = QtGui.QAction(icon, "Show geometry tree")
+        action_tree = QtGui.QAction(icon, "Show geometry tree",menu)
         action_tree.triggered.connect(self.showTree)
         actions.append(action_tree)
         if ifc_psets.has_psets(self.Object):
-            action_props = QtGui.QAction(icon, "Expand property sets")
+            action_props = QtGui.QAction(icon, "Expand property sets",menu)
             action_props.triggered.connect(self.showProps)
             actions.append(action_props)
         if ifc_materials.get_material(self.Object):
-            action_material = QtGui.QAction(icon, "Load material")
+            action_material = QtGui.QAction(icon, "Load material",menu)
             action_material.triggered.connect(self.addMaterial)
             actions.append(action_material)
         if actions:
@@ -159,7 +159,7 @@ class ifc_vp_object:
 
         # generic actions
         ficon = QtGui.QIcon.fromTheme("folder", QtGui.QIcon(":/icons/folder.svg"))
-        action_group = QtGui.QAction(ficon, "Create group...")
+        action_group = QtGui.QAction(ficon, "Create group...",menu)
         action_group.triggered.connect(self.createGroup)
         menu.addAction(action_group)
 


### PR DESCRIPTION
Cause of the Issue
In the setupContextMenu function (ifc_viewproviders.py), the QAction objects were being created without specifying the menu as their parent. Without an explicit parent, the actions were not correctly linked to the menu, which caused them to be omitted from the context menu.

Proposed Fix
Updated the setupContextMenu function to include the menu parameter as the parent for all QAction objects.
Ensured consistency across all action creation to avoid similar issues in the future.