### PR TITLE
Gui: Fix Blender and Revit navigation issues with shift key in sketcher

### DIFF
--- a/src/Gui/BlenderNavigationStyle.cpp
+++ b/src/Gui/BlenderNavigationStyle.cpp
@@ -197,13 +197,11 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent * const ev)
         const auto * const event = (const SoLocation2Event *) ev;
         if (this->currentmode == NavigationStyle::ZOOMING) {
             this->zoomByCursor(posn, prevnormalized);
-            newmode = NavigationStyle::SELECTION;
             processed = true;
         }
         else if (this->currentmode == NavigationStyle::PANNING) {
             float ratio = vp.getViewportAspectRatio();
             panCamera(viewer->getSoRenderManager()->getCamera(), ratio, this->panningplane, posn, prevnormalized);
-            newmode = NavigationStyle::SELECTION;
             processed = true;
         }
         else if (this->currentmode == NavigationStyle::DRAGGING) {
@@ -277,6 +275,13 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent * const ev)
         break;
 
     default:
+        // Reset mode to IDLE when button 3 is released
+        // This stops the PANNING when button 3 is released but SHIFT is still pressed
+        // This stops the ZOOMING when button 3 is released but CTRL is still pressed
+        if ((curmode == NavigationStyle::PANNING || curmode == NavigationStyle::ZOOMING)
+            && !this->button3down) {
+            newmode = NavigationStyle::IDLE;
+        }
         break;
     }
 

--- a/src/Gui/RevitNavigationStyle.cpp
+++ b/src/Gui/RevitNavigationStyle.cpp
@@ -272,12 +272,12 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent * const ev)
         break;
 
     default:
-        // Reset mode to SELECTION when button 3 is released
+        // Reset mode to IDLE when button 3 is released
         // This stops the DRAGGING when button 3 is released but SHIFT is still pressed
         // This stops the ZOOMING when button 3 is released but CTRL is still pressed
         if ((curmode == NavigationStyle::DRAGGING || curmode == NavigationStyle::ZOOMING)
             && !this->button3down) {
-            newmode = NavigationStyle::SELECTION;
+            newmode = NavigationStyle::IDLE;
         }
         break;
     }


### PR DESCRIPTION
Fixes #18202.

Setting the `newmode` to IDLE when middle mouse button is released after DRAGGING, ZOOMING or PANNING seems to fix the issue. It doesn't make much sense to me why it went to SELECTION mode after releasing MMB.

This should probably also be back ported to 1.0.