### PR TITLE
PD: Fix error "duplicate command PartDesign_InvoluteGear"

### DIFF
--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -451,14 +451,12 @@ Gui::MenuItem* Workbench::setupMenuBar() const
           << "Separator"
           << "Part_CheckGeometry"
           << "Separator"
+          << "PartDesign_InvoluteGear"
           << "PartDesign_Sprocket";
 
     // For 0.13 a couple of python packages like numpy, matplotlib and others
     // are not deployed with the installer on Windows. Thus, the WizardShaft is
     // not deployed either hence the check for the existence of the command.
-    if (Gui::Application::Instance->commandManager().getCommandByName("PartDesign_InvoluteGear")) {
-        *part << "PartDesign_InvoluteGear";
-    }
     if (Gui::Application::Instance->commandManager().getCommandByName("PartDesign_WizardShaft")) {
         *part << "Separator" << "PartDesign_WizardShaft";
     }

--- a/src/Mod/PartDesign/InitGui.py
+++ b/src/Mod/PartDesign/InitGui.py
@@ -50,15 +50,12 @@ class PartDesignWorkbench ( Workbench ):
 
         import PartDesignGui
         import PartDesign
-        try:
-            from PartDesign import InvoluteGearFeature
-            from PartDesign import SprocketFeature
-        except ImportError:
-            print("Involute gear module cannot be loaded")
-            #try:
-            #    from FeatureHole import HoleGui
-            #except:
-            #    pass
+
+        from PartDesign.InvoluteGearFeature import CommandInvoluteGear
+        Gui.addCommand('PartDesign_InvoluteGear', CommandInvoluteGear())
+
+        from PartDesign.SprocketFeature import CommandSprocket
+        FreeCADGui.addCommand('PartDesign_Sprocket', CommandSprocket())
 
     def GetClassName(self):
         return "PartDesignGui::Workbench"

--- a/src/Mod/PartDesign/InvoluteGearFeature.py
+++ b/src/Mod/PartDesign/InvoluteGearFeature.py
@@ -51,7 +51,7 @@ def makeInvoluteGear(name):
     return obj
 
 
-class _CommandInvoluteGear:
+class CommandInvoluteGear:
     "GUI command to create an InvoluteGear"
     def GetResources(self):
         return {'Pixmap'  : 'PartDesign_InternalExternalGear',
@@ -277,7 +277,3 @@ class _InvoluteGearTaskPanel:
     def reject(self):
         FreeCADGui.ActiveDocument.resetEdit()
         FreeCAD.ActiveDocument.abortTransaction()
-
-
-if FreeCAD.GuiUp:
-    FreeCADGui.addCommand('PartDesign_InvoluteGear',_CommandInvoluteGear())

--- a/src/Mod/PartDesign/SprocketFeature.py
+++ b/src/Mod/PartDesign/SprocketFeature.py
@@ -332,7 +332,3 @@ class SprocketTaskPanel:
         FreeCAD.ActiveDocument.recompute()
         FreeCADGui.ActiveDocument.resetEdit()
         FreeCAD.ActiveDocument.abortTransaction()
-
-
-if FreeCAD.GuiUp:
-    FreeCADGui.addCommand('PartDesign_Sprocket', CommandSprocket())


### PR DESCRIPTION
Every time the InvoluteGearFeature python module was imported, and we're in GUI context, the command "PartDesign_InvoluteGear" was registered. On the 2nd (3rd, ...) time, this was reported as an error in the console, like "error: Command.cpp(1841): duplicate command PartDesign_InvoluteGear"

The first import happens when the PartDesign FreeCAD Module is loaded, via `InitGui.py`. Subsequent imports may happen when e.g. executing the involute gear command or when running it's tests via FC's Test WB.

This change now registers the command only then the PartDesign WB is set up in InitGui, not when importing the python module. The same fix is applied for sprocket, where the same pattern for command registration was used.

In addition, the import error catch was removed, which seems to be a copy paste left-over from the ShaftWizard. In contrast to ShaftWizard, involute gear and sprocket only use modules from the Python standard lib, so I think this precaution is not worth the additional complexity, just for hiding actual errors.