### PR TITLE
Draft: allow point for Trimex extrusion to be co-planar with the face

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -261,6 +261,9 @@ class Trimex(gui_base_original.Modifier):
         dvec = self.point.sub(self.newpoint)
         if not shift:
             delta = DraftVecUtils.project(dvec, self.normal)
+            if delta.Length < 1e-7:
+                # Use the normal if self.newpoint is coplanar with the face:
+                delta = self.normal * dvec.Length
         else:
             delta = dvec
         if self.force and delta.Length:
@@ -420,7 +423,7 @@ class Trimex(gui_base_original.Modifier):
 
         if self.extrudeMode:
             delta = self.extrude(self.shift, real=True)
-            # print("delta", delta)
+            #print("delta", delta)
             self.doc.openTransaction("Extrude")
             Gui.addModule("Draft")
             obj = Draft.extrude(self.obj, delta, solid=True)


### PR DESCRIPTION
Fixes #14826.

If the point for the extrusion height is co-planar with the face, the normal of the face is used for the direction of the extrusion. The user can then enter a positive or negative value in the task panel. It is probably not the ideal solution, but better than what we have now I think.