### PR TITLE
Base: Add Services and ServiceProvider

### DIFF
--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -256,6 +256,7 @@ SET(FreeCADBase_CPP_SRCS
     Rotation.cpp
     RotationPyImp.cpp
     Sequencer.cpp
+    ServiceProvider.cpp
     SmartPtrPy.cpp
     Stream.cpp
     Swap.cpp
@@ -319,6 +320,7 @@ SET(FreeCADBase_HPP_SRCS
     QtTools.h
     Reader.h
     Rotation.h
+    ServiceProvider.h
     Sequencer.h
     SmartPtrPy.h
     Stream.h
@@ -356,7 +358,7 @@ IF (MSVC)
         ${FreeCADBase_SRCS}
         StackWalker.cpp
         StackWalker.h
-)
+    )
 ENDIF(MSVC)
 
 # Use external zipios++ if specified.

--- a/src/Base/ServiceProvider.cpp
+++ b/src/Base/ServiceProvider.cpp
@@ -1,0 +1,31 @@
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2024 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "ServiceProvider.h"
+
+Base::ServiceProvider& Base::ServiceProvider::get()
+{
+    static Base::ServiceProvider instance;
+    return instance;
+}

--- a/src/Base/ServiceProvider.h
+++ b/src/Base/ServiceProvider.h
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2024 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#ifndef APP_SERVICE_PROVIDER_H
+#define APP_SERVICE_PROVIDER_H
+
+#include <FCGlobal.h>
+
+#include <algorithm>
+#include <deque>
+#include <map>
+#include <string>
+#include <any>
+#include <list>
+
+namespace Base
+{
+
+class BaseExport ServiceProvider
+{
+    struct ServiceDescriptor
+    {
+        std::string name;
+        std::any instance;
+
+        template<typename T>
+        T* get() const
+        {
+            return std::any_cast<T*>(instance);
+        }
+    };
+
+public:
+    ServiceProvider() = default;
+
+    /**
+     * Returns most recent implementation of service specified as T param.
+     *
+     * @tparam T Service interface
+     */
+    template<typename T>
+    T* provide() const
+    {
+        if (auto it = _implementations.find(typeid(T).name()); it != _implementations.end()) {
+            auto descriptors = it->second;
+
+            if (descriptors.empty()) {
+                return nullptr;
+            }
+
+            return descriptors.front().get<T>();
+        }
+
+        return nullptr;
+    }
+
+    /**
+     * Returns all implementations of service specified as T param.
+     *
+     * @tparam T Service interface
+     */
+    template<typename T>
+    std::list<T*> all() const
+    {
+        if (auto it = _implementations.find(typeid(T).name()); it != _implementations.end()) {
+            auto source = it->second;
+
+            std::list<T*> result(source.size());
+
+            std::transform(source.begin(),
+                           source.end(),
+                           result.begin(),
+                           [](const ServiceDescriptor& descriptor) {
+                               return descriptor.get<T>();
+                           });
+
+            return result;
+        }
+
+        return {};
+    }
+
+    /**
+     * Adds new implementation of service T.
+     *
+     * @tparam T Service interface
+     */
+    template<typename T>
+    void implement(T* contract)
+    {
+        ServiceDescriptor descriptor {typeid(T).name(), contract};
+
+        _implementations[typeid(T).name()].push_front(descriptor);
+    }
+
+    static ServiceProvider& get();
+
+private:
+    std::map<const char*, std::deque<ServiceDescriptor>> _implementations;
+};
+
+template<typename T>
+T* provideImplementation()
+{
+    return ServiceProvider::get().provide<T>();
+}
+
+template<typename T>
+std::list<T*> provideAllImplementations()
+{
+    return ServiceProvider::get().all<T>();
+}
+
+template<typename T>
+void implementContract(T* implementation)
+{
+    ServiceProvider::get().implement<T>(implementation);
+}
+
+}  // namespace Base
+
+
+#endif  // APP_SERVICE_PROVIDER_H

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(
             ${CMAKE_CURRENT_SOURCE_DIR}/Quantity.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Reader.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Rotation.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/ServiceProvider.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Stream.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/TimeInfo.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Tools.cpp

--- a/tests/src/Base/ServiceProvider.cpp
+++ b/tests/src/Base/ServiceProvider.cpp
@@ -1,0 +1,110 @@
+#include <gtest/gtest.h>
+#include <Base/ServiceProvider.h>
+
+class SimpleService
+{
+public:
+    virtual ~SimpleService() = default;
+    virtual std::string foo() = 0;
+
+    SimpleService() = default;
+
+    SimpleService(const SimpleService& other) = delete;
+    SimpleService(SimpleService&& other) noexcept = delete;
+    SimpleService& operator=(const SimpleService& other) = delete;
+    SimpleService& operator=(SimpleService&& other) noexcept = delete;
+};
+
+class FirstServiceImplementation final: public SimpleService
+{
+public:
+    std::string foo() override
+    {
+        return "first";
+    }
+};
+
+class SecondServiceImplementation final: public SimpleService
+{
+public:
+    std::string foo() override
+    {
+        return "second";
+    }
+};
+
+TEST(ServiceProvider, provideEmptyImplementation)
+{
+    // Arrange
+    Base::ServiceProvider serviceProvider;
+
+    // Act
+    auto implementation = serviceProvider.provide<SimpleService>();
+
+    // Assert
+    EXPECT_EQ(implementation, nullptr);
+}
+
+TEST(ServiceProvider, provideEmptyImplementationList)
+{
+    // Arrange
+    Base::ServiceProvider serviceProvider;
+
+    // Act
+    const auto implementations = serviceProvider.all<SimpleService>();
+
+    // Assert
+    EXPECT_EQ(implementations.size(), 0);
+}
+
+TEST(ServiceProvider, provideImplementation)
+{
+    // Arrange
+    Base::ServiceProvider serviceProvider;
+
+    serviceProvider.implement<SimpleService>(new FirstServiceImplementation);
+
+    // Act
+    auto implementation = serviceProvider.provide<SimpleService>();
+
+    // Assert
+    EXPECT_NE(implementation, nullptr);
+    EXPECT_EQ(implementation->foo(), "first");
+}
+
+TEST(ServiceProvider, provideLatestImplementation)
+{
+    // Arrange
+    Base::ServiceProvider serviceProvider;
+
+    serviceProvider.implement<SimpleService>(new FirstServiceImplementation);
+    serviceProvider.implement<SimpleService>(new SecondServiceImplementation);
+
+    // Act
+    auto implementation = serviceProvider.provide<SimpleService>();
+
+    // Assert
+    EXPECT_NE(implementation, nullptr);
+    EXPECT_EQ(implementation->foo(), "second");
+}
+
+TEST(ServiceProvider, provideAllImplementations)
+{
+    // Arrange
+    Base::ServiceProvider serviceProvider;
+
+    serviceProvider.implement<SimpleService>(new FirstServiceImplementation);
+    serviceProvider.implement<SimpleService>(new SecondServiceImplementation);
+
+    // Act
+    auto implementations = serviceProvider.all<SimpleService>();
+    auto it = implementations.begin();
+
+    // Assert
+    // Implementations should be available in order from the most recent one
+    EXPECT_EQ((*it)->foo(), "second");
+    ++it;
+    EXPECT_EQ((*it)->foo(), "first");
+    ++it;
+    EXPECT_EQ(it, implementations.end());
+}


### PR DESCRIPTION
This PR introduces the concept of `Services` (if you have a better name - please go ahead and suggest one!). `Services` are meant to be small, well-defined interfaces that provide some functionality.

This is intended to be used for inter-module communication. Modules can specify service interfaces that are then implemented by other modules. This way, we can use features from, for example, the Part module in Core without relying on the Part module explicitly.

Base does provide Service interface  – which is basically an abstract class with pure virtual methods. This service then can be implemented in other modules and accessed at runtime via the `ServiceProvider` class that stores all implementations.

`ServiceProvider` does store multiple implementations so, in theory, it is possible to use it to provide granular implementations. For example, the part can provide a CenterOfMass service implementation that provides the center of mass for part features, the mesh can implement another one for meshes, and then we can iterate over all implementations and find one that can provide the center of.

Example use comes from https://github.com/FreeCAD/FreeCAD/pull/17564 PR. This PR defines a new transform dialog, which aims to provide the ability to re-align the dragger placement based on user selection. To achieve that, the dialog must have the ability to calculate placement based on selection. Such a calculation is, however, possible only by depending on the Part module.

In this case, we can define SubObjectPlacementService:
```c++
class SubObjectPlacementService
{
public:
    virtual ~SubObjectPlacementService() = default;

    virtual Base::Placement getPlacement(SubObjectT object, Base::Placement basePlacement) const = 0;
};
```
In the dialog, we can specify dependency on the service implementation:
```c++
App::SubObjectPlacementService* subObjectPlacementProvider = Base::provideImplementation<App::SubObjectPlacementService>();
```
The App module has no idea about the implementation – it should be provided by other modules. Implementation is optional, so nullptr can be returned here, which should be handled by the developer. std::optional<...> would be better, but it does not play well with references or pointers.

In Part, we can then define the implementation for this service:
```c++
// Part/App/Services.h
class AttacherSubObjectPlacement final: public App::SubObjectPlacementService
{
public:
    AttacherSubObjectPlacement();

    Base::Placement getPlacement(App::SubObjectT object,
                                 Base::Placement basePlacement) const override;

private:
    std::unique_ptr<Attacher::AttachEngine3D> attacher;
};

// Part/App/Services.cpp
AttacherSubObjectPlacement::AttacherSubObjectPlacement()
    : attacher(std::make_unique<Attacher::AttachEngine3D>())
{
    attacher->setUp({}, Attacher::mmMidpoint);
}

Base::Placement AttacherSubObjectPlacement::getPlacement(App::SubObjectT object,
                                                         Base::Placement basePlacement) const
{
    attacher->setReferences({object});
    return attacher->calculateAttachedPlacement(basePlacement);
}

// Part/AppPart.cpp
Base::implementService<App::SubObjectPlacementService>(new AttacherSubObjectPlacement);
```

This is essentially the implementation of a runtime dependency injection container. It is quite similar to Factory classes, which have a similar goal, but it does not aim to create new objects; rather, it provides existing ones.
