### PR TITLE
Update stale_issues.yml

### DIFF
--- a/.github/workflows/auto-close_stale_issues_and_pull-requests.yml
+++ b/.github/workflows/auto-close_stale_issues_and_pull-requests.yml
@@ -14,12 +14,13 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   issues: write  # for actions/stale to close stale issues
+  pull-requests: write # for actions/stale to close stale pull requests
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - name: '🧹 Tag & close stale issues'
+      - name: '🧹 Tag & close stale unconfirmed bugs'
         id: stale_issues
         uses: actions/stale@v9.0.0
         with:
@@ -32,6 +33,7 @@ jobs:
           # trunk-ignore(yamllint/line-length)
           exempt-issue-labels: 'Status: Confirmed,Priority: High,Priority: Critical,Blocker,Type: Feature'
           remove-stale-when-updated: true
+          ascending: true
           stale-issue-message: |
             Hi! This issue hasn’t seen activity in a while. If it’s still relevant, please update to the latest FreeCAD weekly build [download here](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds) to see if the problem is resolved.
 
@@ -55,6 +57,7 @@ jobs:
           close-issue-label: 'Status: Auto-closing'
           only-labels: 'Status: Needs feedback,Status: Needs test on dev version,Status: Needs steps to reproduce'
           remove-stale-when-updated: true
+          ascending: true
           stale-issue-message: |
             Hi! This issue hasn’t seen activity in a while despite the need for further feedback.
             If it’s still relevant, please update to the latest FreeCAD weekly build [download here](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds) to see if the problem is resolved.
@@ -66,3 +69,54 @@ jobs:
               - **Forum**: https://forum.freecad.org
               - **Blog**: https://blog.freecad.org
               - **Wiki**: https://wiki.freecad.org
+
+      - name: '🧹 Tag & close inactive issues'
+        id: inactive_issues
+        uses: actions/stale@v9.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 190
+          days-before-close: 60
+          operations-per-run: 30  # max num of ops per run
+          stale-issue-label: 'Status: Stale'
+          close-issue-label: 'Status: Auto-closing'
+          exempt-issue-labels: 'Priority: High,Priority: Critical,Blocker'
+          remove-stale-when-updated: true
+          ascending: true
+          stale-issue-message: |
+            Hi! This issue hasn’t seen activity in a while. We automatically check each issue after 190 days without activity to keep the backlog tidy.
+            If it’s still relevant, please update to the latest FreeCAD weekly build [download here](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds) to see if the issue is already resolved.
+
+            If the issue is still relevant, let us know by adding a comment.
+            Otherwise, we’ll close this issue automatically in 60 days.
+
+            Feel free to comment anytime to keep it open. Closed issues can always be reopened.
+            Thanks for helping improve FreeCAD!
+
+            Access additional [FreeCAD](https://freecad.org) resources:
+              - **Forum**: https://forum.freecad.org
+              - **Blog**: https://blog.freecad.org
+              - **Wiki**: https://wiki.freecad.org
+
+      - name: '🧹 Tag & close inactive PRs'
+        id: inactive_pr
+        uses: actions/stale@v9.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-pr-stale: 150
+          days-before-close: 90
+          operations-per-run: 30  # max num of ops per run
+          stale-pr-label: 'Status: Stale'
+          close-pr-label: 'Status: Auto-closing'
+          exempt-pr-labels: 'Needs backport,✋ On hold,Priority: High, Priority: Critical'
+          remove-stale-when-updated: true
+          ascending: true
+          stale-pr-message: |
+            Thanks for helping improve FreeCAD!
+            This pull request hasn’t seen activity in a while. We automatically check each PR after 160 days without activity to keep the repository tidy.
+
+            If the PR is still relevant, let us know by adding a comment.
+            Otherwise, we’ll close this PR automatically in 90 days.
+
+            If you would like to keep working on this pull request, we advice to rebase it on current main branch, ask feedback from users or maintainers and engage with the community to get it forward.
+


### PR DESCRIPTION
Added actions/stale for old, inactive issues and inactive PRs.

Adds two actions:
1. Checks all old, inactive **issues** (including features and confirmed bugs) and marks them https://github.com/FreeCAD/FreeCAD/labels/Status%3A%20Stale if there was no activity (comment) for **190 days**. It comments and asks if the issue is still relevant. If there is no feedback (comment) the issue will be closed automatically after additional **60 days**.
Issues with the labels https://github.com/FreeCAD/FreeCAD/labels/Priority%3A%20High, https://github.com/FreeCAD/FreeCAD/labels/Priority%3A%20Critical, https://github.com/FreeCAD/FreeCAD/labels/Blocker are excluded.
2. Checks all inactive **PRs** and marks them https://github.com/FreeCAD/FreeCAD/labels/Status%3A%20Stale if there was no activity (comment) for **150 days**. It comments and asks if the PR is still relevant. If there is no feedback (comment) the PR will be closed automatically after additional **90 days**. 
PRs with the label  https://github.com/FreeCAD/FreeCAD/labels/Needs%20backport, https://github.com/FreeCAD/FreeCAD/labels/%E2%9C%8B%20On%20hold, https://github.com/FreeCAD/FreeCAD/labels/Priority%3A%20High, https://github.com/FreeCAD/FreeCAD/labels/Priority%3A%20Critical are excluded

Automatically closed issues/PRs will have the https://github.com/FreeCAD/FreeCAD/labels/Status%3A%20Auto-closing tag.
