### PR TITLE
FEM: ResultsPurge - delete all results objects including pipelines and filters

### DIFF
--- a/src/Mod/Fem/femcommands/commands.py
+++ b/src/Mod/Fem/femcommands/commands.py
@@ -893,7 +893,7 @@ class _ResultsPurge(CommandManager):
         self.tooltip = Qt.QT_TRANSLATE_NOOP(
             "FEM_ResultsPurge", "Purges all results from active analysis"
         )
-        self.is_active = "with_results"
+        self.is_active = "with_analysis"
 
     def Activated(self):
         import femresult.resulttools as resulttools

--- a/src/Mod/Fem/femresult/resulttools.py
+++ b/src/Mod/Fem/femresult/resulttools.py
@@ -78,6 +78,7 @@ def purge_results(analysis):
             analysis.Document.removeObject(m.Name)
     analysis.Document.recompute()
 
+
 def reset_mesh_deformation(resultobj):
     """Resets result mesh deformation.
 

--- a/src/Mod/Fem/femresult/resulttools.py
+++ b/src/Mod/Fem/femresult/resulttools.py
@@ -62,9 +62,10 @@ def purge_results(analysis):
             analysis.Document.removeObject(m.Name)
     analysis.Document.recompute()
 
-    # dat text object
+    # output text object
     for m in analysis.Group:
-        if is_of_type(m, "App::TextDocument") and m.Name.startswith("ccx_dat_file"):
+        if is_of_type(m, "App::TextDocument") and (m.Name.startswith("ccx_dat_file") or 
+        m.Name.startswith("SolverElmerOutput")):
             analysis.Document.removeObject(m.Name)
     analysis.Document.recompute()
 

--- a/src/Mod/Fem/femresult/resulttools.py
+++ b/src/Mod/Fem/femresult/resulttools.py
@@ -62,11 +62,9 @@ def purge_results(analysis):
             analysis.Document.removeObject(m.Name)
     analysis.Document.recompute()
 
-    # output text object
+    # text object
     for m in analysis.Group:
-        if is_of_type(m, "App::TextDocument") and (
-            m.Name.startswith("ccx_dat_file") or m.Name.startswith("SolverElmerOutput")
-        ):
+        if is_of_type(m, "App::TextDocument"):
             analysis.Document.removeObject(m.Name)
     analysis.Document.recompute()
 

--- a/src/Mod/Fem/femresult/resulttools.py
+++ b/src/Mod/Fem/femresult/resulttools.py
@@ -64,8 +64,9 @@ def purge_results(analysis):
 
     # output text object
     for m in analysis.Group:
-        if is_of_type(m, "App::TextDocument") and (m.Name.startswith("ccx_dat_file") or 
-        m.Name.startswith("SolverElmerOutput")):
+        if is_of_type(m, "App::TextDocument") and (
+            m.Name.startswith("ccx_dat_file") or m.Name.startswith("SolverElmerOutput")
+        ):
             analysis.Document.removeObject(m.Name)
     analysis.Document.recompute()
 

--- a/src/Mod/Fem/femresult/resulttools.py
+++ b/src/Mod/Fem/femresult/resulttools.py
@@ -43,7 +43,7 @@ def purge_results(analysis):
         analysis group as a container for all  objects needed for the analysis
     """
 
-    # if analysis typ check is used result mesh
+    # if analysis type check is used, result mesh
     # without result obj is created in the analysis
     # we could run into trouble in one loop because
     # we will delete objects and try to access them later
@@ -68,6 +68,15 @@ def purge_results(analysis):
             analysis.Document.removeObject(m.Name)
     analysis.Document.recompute()
 
+    # result pipeline and filter
+    for m in analysis.Group:
+        if is_of_type(m, "Fem::FemPostPipeline"):
+            # delete associated filters
+            for filter_obj in m.Filter:
+                analysis.Document.removeObject(filter_obj.Name)
+            # delete the pipeline itself
+            analysis.Document.removeObject(m.Name)
+    analysis.Document.recompute()
 
 def reset_mesh_deformation(resultobj):
     """Resets result mesh deformation.


### PR DESCRIPTION
fixes #13889 - quite annoying issue where one cannot easily delete all the results because pipelines and their filters are not affected by the ResultsPurge tool

@marioalexis84 FYI