### PR TITLE
Materials: Change display of Quantity values

### DIFF
--- a/src/App/PropertyUnits.cpp
+++ b/src/App/PropertyUnits.cpp
@@ -48,7 +48,9 @@ TYPESYSTEM_SOURCE(App::PropertyQuantity, App::PropertyFloat)
 
 Base::Quantity PropertyQuantity::getQuantityValue() const
 {
-    return Quantity(_dValue, _Unit);
+    Quantity quantity(_dValue, _Unit);
+    quantity.setFormat(_Format);
+    return quantity;
 }
 
 const char* PropertyQuantity::getEditorName() const
@@ -129,7 +131,9 @@ void PropertyQuantity::setPathValue(const ObjectIdentifier& /*path*/, const boos
 
 const boost::any PropertyQuantity::getPathValue(const ObjectIdentifier& /*path*/) const
 {
-    return Quantity(_dValue, _Unit);
+    Quantity quantity(_dValue, _Unit);
+    quantity.setFormat(_Format);
+    return quantity;
 }
 
 //**************************************************************************

--- a/src/App/PropertyUnits.h
+++ b/src/App/PropertyUnits.h
@@ -73,6 +73,15 @@ public:
         return PropertyFloat::getValue();
     }
 
+    const Base::QuantityFormat& getFormat() const
+    {
+        return _Format;
+    }
+    void setFormat(const Base::QuantityFormat& fmt)
+    {
+        _Format = fmt;
+    }
+
     void setPathValue(const App::ObjectIdentifier& path, const boost::any& value) override;
     const boost::any getPathValue(const App::ObjectIdentifier& path) const override;
 
@@ -89,6 +98,7 @@ public:
 protected:
     Base::Quantity createQuantityFromPy(PyObject* value);
     Base::Unit _Unit;
+    Base::QuantityFormat _Format;
 };
 
 /** Float with Unit property

--- a/src/Mod/Material/App/MaterialLoader.cpp
+++ b/src/Mod/Material/App/MaterialLoader.cpp
@@ -117,6 +117,7 @@ std::shared_ptr<Material2DArray> MaterialYamlEntry::read2DArray(const YAML::Node
             for (std::size_t j = 0; j < yamlRow.size(); j++) {
                 Base::Quantity qq =
                     Base::Quantity::parse(QString::fromStdString(yamlRow[j].as<std::string>()));
+                qq.setFormat(MaterialValue::getQuantityFormat());
                 row->push_back(QVariant::fromValue(qq));
             }
             array2d->addRow(row);
@@ -143,6 +144,7 @@ std::shared_ptr<Material3DArray> MaterialYamlEntry::read3DArray(const YAML::Node
             for (auto it = yamlDepth.begin(); it != yamlDepth.end(); it++) {
                 auto depthValue =
                     Base::Quantity::parse(QString::fromStdString(it->first.as<std::string>()));
+                depthValue.setFormat(MaterialValue::getQuantityFormat());
 
                 array3d->addDepth(depth, depthValue);
 
@@ -152,8 +154,10 @@ std::shared_ptr<Material3DArray> MaterialYamlEntry::read3DArray(const YAML::Node
 
                     auto row = std::make_shared<QList<Base::Quantity>>();
                     for (std::size_t j = 0; j < yamlRow.size(); j++) {
-                        row->push_back(Base::Quantity::parse(
-                            QString::fromStdString(yamlRow[j].as<std::string>())));
+                        auto qq = Base::Quantity::parse(
+                            QString::fromStdString(yamlRow[j].as<std::string>()));
+                        qq.setFormat(MaterialValue::getQuantityFormat());
+                        row->push_back(qq);
                     }
                     array3d->addRow(depth, row);
                 }

--- a/src/Mod/Material/App/MaterialValue.cpp
+++ b/src/Mod/Material/App/MaterialValue.cpp
@@ -311,6 +311,11 @@ QString MaterialValue::getYAMLString() const
     return yaml;
 }
 
+const Base::QuantityFormat MaterialValue::getQuantityFormat()
+{
+    return Base::QuantityFormat(Base::QuantityFormat::NumberFormat::Default, PRECISION);
+}
+
 //===
 
 TYPESYSTEM_SOURCE(Materials::Material2DArray, Materials::MaterialValue)

--- a/src/Mod/Material/App/MaterialValue.h
+++ b/src/Mod/Material/App/MaterialValue.h
@@ -107,6 +107,11 @@ public:
     static QString escapeString(const QString& source);
     static ValueType mapType(const QString& stringType);
 
+    static const Base::QuantityFormat getQuantityFormat();
+
+    // The precision is based on the value from the original materials editor
+    static const int PRECISION = 6;
+
 protected:
     MaterialValue(ValueType type, ValueType inherited);
 

--- a/src/Mod/Material/App/Materials.cpp
+++ b/src/Mod/Material/App/Materials.cpp
@@ -43,8 +43,6 @@ using namespace Materials;
 
 TYPESYSTEM_SOURCE(Materials::MaterialProperty, Materials::ModelProperty)
 
-int const MaterialProperty::PRECISION = 6;
-
 MaterialProperty::MaterialProperty()
 {
     _valuePtr = std::make_shared<MaterialValue>(MaterialValue::None);
@@ -134,7 +132,7 @@ QString MaterialProperty::getString() const
         if (value.isNull()) {
             return {};
         }
-        return QString(QLatin1String("%L1")).arg(value.toFloat(), 0, 'g', PRECISION);
+        return QString(QLatin1String("%L1")).arg(value.toFloat(), 0, 'g', MaterialValue::PRECISION);
     }
     return getValue().toString();
 }
@@ -180,7 +178,7 @@ QString MaterialProperty::getDictionaryString() const
     if (getType() == MaterialValue::Quantity) {
         auto quantity = getValue().value<Base::Quantity>();
         auto string = QString(QLatin1String("%1 %2"))
-                          .arg(quantity.getValue(), 0, 'g', PRECISION)
+                          .arg(quantity.getValue(), 0, 'g', MaterialValue::PRECISION)
                           .arg(quantity.getUnit().getString());
         return string;
     }
@@ -189,7 +187,7 @@ QString MaterialProperty::getDictionaryString() const
         if (value.isNull()) {
             return {};
         }
-        return QString(QLatin1String("%1")).arg(value.toFloat(), 0, 'g', PRECISION);
+        return QString(QLatin1String("%1")).arg(value.toFloat(), 0, 'g', MaterialValue::PRECISION);
     }
     return getValue().toString();
 }
@@ -387,7 +385,9 @@ void MaterialProperty::setFloat(const QString& value)
 
 void MaterialProperty::setQuantity(const Base::Quantity& value)
 {
-    _valuePtr->setValue(QVariant(QVariant::fromValue(value)));
+    auto quantity = value;
+    quantity.setFormat(MaterialValue::getQuantityFormat());
+    _valuePtr->setValue(QVariant(QVariant::fromValue(quantity)));
 }
 
 void MaterialProperty::setQuantity(double value, const QString& units)
@@ -1046,7 +1046,7 @@ Material::getValueString(const std::map<QString, std::shared_ptr<MaterialPropert
                 return {};
             }
             return QString(QLatin1String("%L1"))
-                .arg(value.toFloat(), 0, 'g', MaterialProperty::PRECISION);
+                .arg(value.toFloat(), 0, 'g', MaterialValue::PRECISION);
         }
         return property->getValue().toString();
     }

--- a/src/Mod/Material/App/Materials.h
+++ b/src/Mod/Material/App/Materials.h
@@ -140,11 +140,6 @@ public:
         return !operator==(other);
     }
 
-    // void save(QTextStream& stream);
-
-    // Define precision for displaying floating point values
-    static int const PRECISION;
-
 protected:
     void setType(const QString& type);
     // void setType(MaterialValue::ValueType type) { _valueType = type; }

--- a/src/Mod/Material/Gui/ArrayModel.cpp
+++ b/src/Mod/Material/Gui/ArrayModel.cpp
@@ -94,6 +94,7 @@ QVariant Array2DModel::data(const QModelIndex& index, int role) const
             auto column = _property->getColumnType(index.column());
             if (column == Materials::MaterialValue::Quantity) {
                 Base::Quantity qq = Base::Quantity(0, _property->getColumnUnits(index.column()));
+                qq.setFormat(Materials::MaterialValue::getQuantityFormat());
                 return QVariant::fromValue(qq);
             }
         }
@@ -237,6 +238,7 @@ QVariant Array3DDepthModel::data(const QModelIndex& index, int role) const
 
         try {
             Base::Quantity qq = Base::Quantity(0, _property->getColumnUnits(0));
+            qq.setFormat(Materials::MaterialValue::getQuantityFormat());
             return QVariant::fromValue(qq);
         }
         catch (const Materials::InvalidIndex&) {
@@ -291,7 +293,9 @@ bool Array3DDepthModel::insertRows(int row, int count, const QModelIndex& parent
     beginInsertRows(parent, row, row + count - 1);
 
     for (int i = 0; i < count; i++) {
-        _value->addDepth(row, Base::Quantity(0, _property->getColumnUnits(0)));
+        auto qq = Base::Quantity(0, _property->getColumnUnits(0));
+        qq.setFormat(Materials::MaterialValue::getQuantityFormat());
+        _value->addDepth(row, qq);
     }
 
     endInsertRows();
@@ -392,6 +396,7 @@ QVariant Array3DModel::data(const QModelIndex& index, int role) const
 
         try {
             Base::Quantity qq = Base::Quantity(0, _property->getColumnUnits(index.column() + 1));
+            qq.setFormat(Materials::MaterialValue::getQuantityFormat());
             return QVariant::fromValue(qq);
         }
         catch (const Materials::InvalidIndex&) {

--- a/src/Mod/Material/materialtests/TestMaterialCreation.py
+++ b/src/Mod/Material/materialtests/TestMaterialCreation.py
@@ -67,6 +67,12 @@ class MaterialCreationTestCases(unittest.TestCase):
         self.assertEqual(len(material.Parent), 0)
         self.assertEqual(len(material.Tags), 0)
 
+    def getQuantity(self, value):
+        quantity = parseQuantity(value)
+        quantity.Format = { "NumberFormat" : "g",
+                            "Precision" : 6 }
+        return quantity
+
     def testCreateMaterial(self):
         """ Create a material with properties """
         material = Materials.Material()
@@ -125,7 +131,8 @@ class MaterialCreationTestCases(unittest.TestCase):
 
         # Quantity properties require units
         material.setPhysicalValue("Density", "99.9 kg/m^3")
-        self.assertEqual(material.getPhysicalValue("Density").UserString, parseQuantity("99.90 kg/m^3").UserString)
+        self.assertEqual(material.getPhysicalValue("Density").Format["NumberFormat"], "g")
+        self.assertEqual(material.getPhysicalValue("Density").UserString, self.getQuantity("99.90 kg/m^3").UserString)
 
         # MaterialManager is unaware of the material until it is saved
         #

--- a/src/Mod/Material/materialtests/TestMaterials.py
+++ b/src/Mod/Material/materialtests/TestMaterials.py
@@ -46,6 +46,12 @@ class MaterialTestCases(unittest.TestCase):
         self.assertIn("MaterialLibraries", dir(self.MaterialManager))
         self.assertIn("Materials", dir(self.MaterialManager))
 
+    def getQuantity(self, value):
+        quantity = parseQuantity(value)
+        quantity.Format = { "NumberFormat" : "g",
+                            "Precision" : 6 }
+        return quantity
+
     def testCalculiXSteel(self):
         """
         Test a representative material card for CalculX Steel
@@ -175,27 +181,27 @@ class MaterialTestCases(unittest.TestCase):
         self.assertTrue(len(properties["SpecularColor"]) > 0)
         self.assertTrue(len(properties["Transparency"]) > 0)
 
-        self.assertEqual(parseQuantity(properties["Density"]).UserString,
-                         parseQuantity("7900.00 kg/m^3").UserString)
+        self.assertEqual(self.getQuantity(properties["Density"]).UserString,
+                         self.getQuantity("7900.00 kg/m^3").UserString)
         # self.assertEqual(properties["BulkModulus"], "")
-        self.assertAlmostEqual(parseQuantity(properties["PoissonRatio"]).Value,
-                               parseQuantity("0.3").Value)
-        self.assertEqual(parseQuantity(properties["YoungsModulus"]).UserString,
-                         parseQuantity("210.00 GPa").UserString)
+        self.assertAlmostEqual(self.getQuantity(properties["PoissonRatio"]).Value,
+                               self.getQuantity("0.3").Value)
+        self.assertEqual(self.getQuantity(properties["YoungsModulus"]).UserString,
+                         self.getQuantity("210.00 GPa").UserString)
         # self.assertEqual(properties["ShearModulus"], "")
-        self.assertEqual(parseQuantity(properties["SpecificHeat"]).UserString,
-                         parseQuantity("590.00 J/kg/K").UserString)
-        self.assertEqual(parseQuantity(properties["ThermalConductivity"]).UserString,
-                         parseQuantity("43.00 W/m/K").UserString)
-        self.assertEqual(parseQuantity(properties["ThermalExpansionCoefficient"]).UserString,
-                         parseQuantity("12.00 µm/m/K").UserString)
+        self.assertEqual(self.getQuantity(properties["SpecificHeat"]).UserString,
+                         self.getQuantity("590.00 J/kg/K").UserString)
+        self.assertEqual(self.getQuantity(properties["ThermalConductivity"]).UserString,
+                         self.getQuantity("43.00 W/m/K").UserString)
+        self.assertEqual(self.getQuantity(properties["ThermalExpansionCoefficient"]).UserString,
+                         self.getQuantity("12.00 µm/m/K").UserString)
         self.assertEqual(properties["AmbientColor"], "(0.0020, 0.0020, 0.0020, 1.0)")
         self.assertEqual(properties["DiffuseColor"], "(0.0000, 0.0000, 0.0000, 1.0)")
         self.assertEqual(properties["EmissiveColor"], "(0.0000, 0.0000, 0.0000, 1.0)")
-        self.assertAlmostEqual(parseQuantity(properties["Shininess"]).Value, parseQuantity("0.06").Value)
+        self.assertAlmostEqual(self.getQuantity(properties["Shininess"]).Value, self.getQuantity("0.06").Value)
         self.assertEqual(properties["SpecularColor"], "(0.9800, 0.9800, 0.9800, 1.0)")
-        self.assertAlmostEqual(parseQuantity(properties["Transparency"]).Value,
-                               parseQuantity("0").Value)
+        self.assertAlmostEqual(self.getQuantity(properties["Transparency"]).Value,
+                               self.getQuantity("0").Value)
 
         print("Density " + steel.getPhysicalValue("Density").UserString)
         # print("BulkModulus " + properties["BulkModulus"])
@@ -225,6 +231,12 @@ class MaterialTestCases(unittest.TestCase):
         self.assertAlmostEqual(steel.getAppearanceValue("Shininess"), 0.06)
         self.assertEqual(steel.getAppearanceValue("SpecularColor"), "(0.9800, 0.9800, 0.9800, 1.0)")
         self.assertAlmostEqual(steel.getAppearanceValue("Transparency"), 0.0)
+
+        self.assertEqual(steel.getPhysicalValue("Density").Format["NumberFormat"], "g")
+        self.assertEqual(steel.getPhysicalValue("YoungsModulus").Format["NumberFormat"], "g")
+        self.assertEqual(steel.getPhysicalValue("SpecificHeat").Format["NumberFormat"], "g")
+        self.assertEqual(steel.getPhysicalValue("ThermalConductivity").Format["NumberFormat"], "g")
+        self.assertEqual(steel.getPhysicalValue("ThermalExpansionCoefficient").Format["NumberFormat"], "g")
 
     def testMaterialsWithModel(self):
         """
@@ -325,12 +337,19 @@ class MaterialTestCases(unittest.TestCase):
         self.assertEqual(len(arrayData[1]), 2)
         self.assertEqual(len(arrayData[2]), 2)
 
-        self.assertEqual(arrayData[0][0].UserString, parseQuantity("10.00 C").UserString)
-        self.assertEqual(arrayData[0][1].UserString, parseQuantity("10.00 kg/m^3").UserString)
-        self.assertEqual(arrayData[1][0].UserString, parseQuantity("20.00 C").UserString)
-        self.assertEqual(arrayData[1][1].UserString, parseQuantity("20.00 kg/m^3").UserString)
-        self.assertEqual(arrayData[2][0].UserString, parseQuantity("30.00 C").UserString)
-        self.assertEqual(arrayData[2][1].UserString, parseQuantity("30.00 kg/m^3").UserString)
+        self.assertEqual(arrayData[0][0].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[0][1].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[1][0].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[1][1].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[2][0].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[2][1].Format["NumberFormat"], "g")
+
+        self.assertEqual(arrayData[0][0].UserString, self.getQuantity("10.00 C").UserString)
+        self.assertEqual(arrayData[0][1].UserString, self.getQuantity("10.00 kg/m^3").UserString)
+        self.assertEqual(arrayData[1][0].UserString, self.getQuantity("20.00 C").UserString)
+        self.assertEqual(arrayData[1][1].UserString, self.getQuantity("20.00 kg/m^3").UserString)
+        self.assertEqual(arrayData[2][0].UserString, self.getQuantity("30.00 C").UserString)
+        self.assertEqual(arrayData[2][1].UserString, self.getQuantity("30.00 kg/m^3").UserString)
 
         self.assertAlmostEqual(arrayData[0][0].Value, 10.0)
         self.assertAlmostEqual(arrayData[0][1].Value, 1e-8)
@@ -346,12 +365,19 @@ class MaterialTestCases(unittest.TestCase):
         with self.assertRaises(IndexError):
             self.assertAlmostEqual(arrayData[0][2].Value, 10.0)
 
-        self.assertEqual(array.getValue(0,0).UserString, parseQuantity("10.00 C").UserString)
-        self.assertEqual(array.getValue(0,1).UserString, parseQuantity("10.00 kg/m^3").UserString)
-        self.assertEqual(array.getValue(1,0).UserString, parseQuantity("20.00 C").UserString)
-        self.assertEqual(array.getValue(1,1).UserString, parseQuantity("20.00 kg/m^3").UserString)
-        self.assertEqual(array.getValue(2,0).UserString, parseQuantity("30.00 C").UserString)
-        self.assertEqual(array.getValue(2,1).UserString, parseQuantity("30.00 kg/m^3").UserString)
+        self.assertEqual(array.getValue(0,0).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(0,1).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(1,0).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(1,1).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(2,0).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(2,1).Format["NumberFormat"], "g")
+
+        self.assertEqual(array.getValue(0,0).UserString, self.getQuantity("10.00 C").UserString)
+        self.assertEqual(array.getValue(0,1).UserString, self.getQuantity("10.00 kg/m^3").UserString)
+        self.assertEqual(array.getValue(1,0).UserString, self.getQuantity("20.00 C").UserString)
+        self.assertEqual(array.getValue(1,1).UserString, self.getQuantity("20.00 kg/m^3").UserString)
+        self.assertEqual(array.getValue(2,0).UserString, self.getQuantity("30.00 C").UserString)
+        self.assertEqual(array.getValue(2,1).UserString, self.getQuantity("30.00 kg/m^3").UserString)
 
         self.assertAlmostEqual(array.getValue(0,0).Value, 10.0)
         self.assertAlmostEqual(array.getValue(0,1).Value, 1e-8)
@@ -410,69 +436,91 @@ class MaterialTestCases(unittest.TestCase):
         self.assertEqual(len(arrayData[1]), 0)
         self.assertEqual(len(arrayData[2]), 3)
 
-        self.assertEqual(arrayData[0][0][0].UserString, parseQuantity("11.00 Pa").UserString)
-        self.assertEqual(arrayData[0][0][1].UserString, parseQuantity("12.00 Pa").UserString)
-        self.assertEqual(arrayData[0][1][0].UserString, parseQuantity("21.00 Pa").UserString)
-        self.assertEqual(arrayData[0][1][1].UserString, parseQuantity("22.00 Pa").UserString)
-        self.assertEqual(arrayData[2][0][0].UserString, parseQuantity("10.00 Pa").UserString)
-        self.assertEqual(arrayData[2][0][1].UserString, parseQuantity("11.00 Pa").UserString)
-        self.assertEqual(arrayData[2][1][0].UserString, parseQuantity("20.00 Pa").UserString)
-        self.assertEqual(arrayData[2][1][1].UserString, parseQuantity("21.00 Pa").UserString)
-        self.assertEqual(arrayData[2][2][0].UserString, parseQuantity("30.00 Pa").UserString)
-        self.assertEqual(arrayData[2][2][1].UserString, parseQuantity("31.00 Pa").UserString)
+        self.assertEqual(arrayData[0][0][0].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[0][0][1].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[0][1][0].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[0][1][1].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[2][0][0].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[2][0][1].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[2][1][0].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[2][1][1].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[2][2][0].Format["NumberFormat"], "g")
+        self.assertEqual(arrayData[2][2][1].Format["NumberFormat"], "g")
 
-        self.assertEqual(array.getDepthValue(0).UserString, parseQuantity("10.00 C").UserString)
-        self.assertEqual(array.getDepthValue(1).UserString, parseQuantity("20.00 C").UserString)
-        self.assertEqual(array.getDepthValue(2).UserString, parseQuantity("30.00 C").UserString)
+        self.assertEqual(arrayData[0][0][0].UserString, self.getQuantity("11.00 Pa").UserString)
+        self.assertEqual(arrayData[0][0][1].UserString, self.getQuantity("12.00 Pa").UserString)
+        self.assertEqual(arrayData[0][1][0].UserString, self.getQuantity("21.00 Pa").UserString)
+        self.assertEqual(arrayData[0][1][1].UserString, self.getQuantity("22.00 Pa").UserString)
+        self.assertEqual(arrayData[2][0][0].UserString, self.getQuantity("10.00 Pa").UserString)
+        self.assertEqual(arrayData[2][0][1].UserString, self.getQuantity("11.00 Pa").UserString)
+        self.assertEqual(arrayData[2][1][0].UserString, self.getQuantity("20.00 Pa").UserString)
+        self.assertEqual(arrayData[2][1][1].UserString, self.getQuantity("21.00 Pa").UserString)
+        self.assertEqual(arrayData[2][2][0].UserString, self.getQuantity("30.00 Pa").UserString)
+        self.assertEqual(arrayData[2][2][1].UserString, self.getQuantity("31.00 Pa").UserString)
 
-        self.assertEqual(arrayData[0][0][-1].UserString, parseQuantity("12.00 Pa").UserString)
+        self.assertEqual(array.getDepthValue(0).UserString, self.getQuantity("10.00 C").UserString)
+        self.assertEqual(array.getDepthValue(1).UserString, self.getQuantity("20.00 C").UserString)
+        self.assertEqual(array.getDepthValue(2).UserString, self.getQuantity("30.00 C").UserString)
+
+        self.assertEqual(arrayData[0][0][-1].UserString, self.getQuantity("12.00 Pa").UserString)
         with self.assertRaises(IndexError):
-            self.assertEqual(arrayData[0][0][2].UserString, parseQuantity("11.00 Pa").UserString)
-        self.assertEqual(arrayData[0][-1][0].UserString, parseQuantity("21.00 Pa").UserString)
+            self.assertEqual(arrayData[0][0][2].UserString, self.getQuantity("11.00 Pa").UserString)
+        self.assertEqual(arrayData[0][-1][0].UserString, self.getQuantity("21.00 Pa").UserString)
         with self.assertRaises(IndexError):
-            self.assertEqual(arrayData[0][2][0].UserString, parseQuantity("11.00 Pa").UserString)
+            self.assertEqual(arrayData[0][2][0].UserString, self.getQuantity("11.00 Pa").UserString)
         with self.assertRaises(IndexError):
-            self.assertEqual(arrayData[1][0][0].UserString, parseQuantity("11.00 Pa").UserString)
-        self.assertEqual(arrayData[-1][0][0].UserString, parseQuantity("10.00 Pa").UserString)
+            self.assertEqual(arrayData[1][0][0].UserString, self.getQuantity("11.00 Pa").UserString)
+        self.assertEqual(arrayData[-1][0][0].UserString, self.getQuantity("10.00 Pa").UserString)
         with self.assertRaises(IndexError):
-            self.assertEqual(arrayData[3][0][0].UserString, parseQuantity("11.00 Pa").UserString)
+            self.assertEqual(arrayData[3][0][0].UserString, self.getQuantity("11.00 Pa").UserString)
 
         with self.assertRaises(IndexError):
             self.assertEqual(array.getDepthValue(-1).UserString,
-                             parseQuantity("10.00 C").UserString)
+                             self.getQuantity("10.00 C").UserString)
         with self.assertRaises(IndexError):
             self.assertEqual(array.getDepthValue(3).UserString,
-                             parseQuantity("10.00 C").UserString)
+                             self.getQuantity("10.00 C").UserString)
 
-        self.assertEqual(array.getValue(0,0,0).UserString, parseQuantity("11.00 Pa").UserString)
-        self.assertEqual(array.getValue(0,0,1).UserString, parseQuantity("12.00 Pa").UserString)
-        self.assertEqual(array.getValue(0,1,0).UserString, parseQuantity("21.00 Pa").UserString)
-        self.assertEqual(array.getValue(0,1,1).UserString, parseQuantity("22.00 Pa").UserString)
-        self.assertEqual(array.getValue(2,0,0).UserString, parseQuantity("10.00 Pa").UserString)
-        self.assertEqual(array.getValue(2,0,1).UserString, parseQuantity("11.00 Pa").UserString)
-        self.assertEqual(array.getValue(2,1,0).UserString, parseQuantity("20.00 Pa").UserString)
-        self.assertEqual(array.getValue(2,1,1).UserString, parseQuantity("21.00 Pa").UserString)
-        self.assertEqual(array.getValue(2,2,0).UserString, parseQuantity("30.00 Pa").UserString)
-        self.assertEqual(array.getValue(2,2,1).UserString, parseQuantity("31.00 Pa").UserString)
+        self.assertEqual(array.getValue(0,0,0).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(0,0,1).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(0,1,0).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(0,1,1).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(2,0,0).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(2,0,1).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(2,1,0).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(2,1,1).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(2,2,0).Format["NumberFormat"], "g")
+        self.assertEqual(array.getValue(2,2,1).Format["NumberFormat"], "g")
+
+        self.assertEqual(array.getValue(0,0,0).UserString, self.getQuantity("11.00 Pa").UserString)
+        self.assertEqual(array.getValue(0,0,1).UserString, self.getQuantity("12.00 Pa").UserString)
+        self.assertEqual(array.getValue(0,1,0).UserString, self.getQuantity("21.00 Pa").UserString)
+        self.assertEqual(array.getValue(0,1,1).UserString, self.getQuantity("22.00 Pa").UserString)
+        self.assertEqual(array.getValue(2,0,0).UserString, self.getQuantity("10.00 Pa").UserString)
+        self.assertEqual(array.getValue(2,0,1).UserString, self.getQuantity("11.00 Pa").UserString)
+        self.assertEqual(array.getValue(2,1,0).UserString, self.getQuantity("20.00 Pa").UserString)
+        self.assertEqual(array.getValue(2,1,1).UserString, self.getQuantity("21.00 Pa").UserString)
+        self.assertEqual(array.getValue(2,2,0).UserString, self.getQuantity("30.00 Pa").UserString)
+        self.assertEqual(array.getValue(2,2,1).UserString, self.getQuantity("31.00 Pa").UserString)
 
         with self.assertRaises(IndexError):
             self.assertEqual(array.getValue(0,0,-1).UserString,
-                             parseQuantity("11.00 Pa").UserString)
+                             self.getQuantity("11.00 Pa").UserString)
         with self.assertRaises(IndexError):
             self.assertEqual(array.getValue(0,0,2).UserString,
-                             parseQuantity("11.00 Pa").UserString)
+                             self.getQuantity("11.00 Pa").UserString)
         with self.assertRaises(IndexError):
             self.assertEqual(array.getValue(0,-1,0).UserString,
-                             parseQuantity("11.00 Pa").UserString)
+                             self.getQuantity("11.00 Pa").UserString)
         with self.assertRaises(IndexError):
             self.assertEqual(array.getValue(0,2,0).UserString,
-                             parseQuantity("11.00 Pa").UserString)
+                             self.getQuantity("11.00 Pa").UserString)
         with self.assertRaises(IndexError):
             self.assertEqual(array.getValue(1,0,0).UserString,
-                             parseQuantity("11.00 Pa").UserString)
+                             self.getQuantity("11.00 Pa").UserString)
         with self.assertRaises(IndexError):
             self.assertEqual(array.getValue(-1,0,0).UserString,
-                             parseQuantity("11.00 Pa").UserString)
+                             self.getQuantity("11.00 Pa").UserString)
         with self.assertRaises(IndexError):
             self.assertEqual(array.getValue(3,0,0).UserString,
-                             parseQuantity("11.00 Pa").UserString)
+                             self.getQuantity("11.00 Pa").UserString)

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -81,6 +81,8 @@
 using namespace Part;
 namespace sp = std::placeholders;
 
+constexpr const int MaterialPrecision = 6;
+
 FC_LOG_LEVEL_INIT("Part",true,true)
 
 PROPERTY_SOURCE(Part::Feature, App::GeoFeature)
@@ -106,18 +108,24 @@ Feature::Feature()
                       static_cast<App::PropertyType>(App::Prop_ReadOnly | App::Prop_Output
                                                      | App::Prop_NoRecompute | App::Prop_NoPersist),
                       "Feature density");
+    Density.setFormat(
+        Base::QuantityFormat(Base::QuantityFormat::NumberFormat::Default, MaterialPrecision));
     ADD_PROPERTY_TYPE(Mass,
                       (0.0),
                       group,
                       static_cast<App::PropertyType>(App::Prop_ReadOnly | App::Prop_Output
                                                      | App::Prop_NoRecompute | App::Prop_NoPersist),
                       "Feature mass");
+    Mass.setFormat(
+        Base::QuantityFormat(Base::QuantityFormat::NumberFormat::Default, MaterialPrecision));
     ADD_PROPERTY_TYPE(Volume,
                       (1.0),
                       group,
                       static_cast<App::PropertyType>(App::Prop_ReadOnly | App::Prop_Output
                                                      | App::Prop_NoRecompute | App::Prop_NoPersist),
                       "Feature volume");
+    Volume.setFormat(
+        Base::QuantityFormat(Base::QuantityFormat::NumberFormat::Default, MaterialPrecision));
 }
 
 Feature::~Feature() = default;
@@ -1552,7 +1560,6 @@ void Feature::updatePhysicalProperties()
         Mass.setValue(Volume.getValue() * Density.getValue());
     } else {
         // No shape
-        Base::Console().Log("No shape defined\n");
         Volume.setValue(0.0);
         Mass.setValue(0.0);
     }

--- a/tests/src/Mod/Material/App/TestMaterials.cpp
+++ b/tests/src/Mod/Material/App/TestMaterials.cpp
@@ -37,6 +37,7 @@
 #include <src/App/InitApplication.h>
 
 #include <Mod/Material/App/MaterialManager.h>
+#include <Mod/Material/App/MaterialValue.h>
 #include <Mod/Material/App/Model.h>
 #include <Mod/Material/App/ModelManager.h>
 #include <Mod/Material/App/ModelUuids.h>
@@ -223,7 +224,9 @@ TEST_F(TestMaterial, TestAddAppearanceModel)
 QString parseQuantity(const char *string)
 {
     QString value = QString::fromStdString(string);
-    return Base::Quantity::parse(value).getUserString();
+    auto quantity = Base::Quantity::parse(value);
+    quantity.setFormat(Materials::MaterialValue::getQuantityFormat());
+    return quantity.getUserString();
 }
 
 TEST_F(TestMaterial, TestCalculiXSteel)


### PR DESCRIPTION
The default display type of quantity objects is fixed point resulting in insufficient accuracy when changing unit systems, or when the values are small. This fix changes the default format from 'Fixed' to the more apt 'Default' format. This allows the displayed values to scale as appropriate.

Fixes #18149 