### PR TITLE
Gui: Rename ViewProviderDatum::getRoot() to ViewProviderDatum::getDat…

### DIFF
--- a/src/Gui/ViewProviderDatum.h
+++ b/src/Gui/ViewProviderDatum.h
@@ -44,10 +44,10 @@ namespace Gui
         ~ViewProviderDatum() override;
 
         /// Get point derived classes will add their specific stuff
-        SoSeparator* getRoot() { return pRoot; }
+        SoSeparator* getDatumRoot() const { return pRoot; }
 
         /// Get pointer to the text label associated with the feature
-        SoText2* getLabel() { return pLabel; }
+        SoText2* getLabel() const { return pLabel; }
 
         void attach(App::DocumentObject*) override;
         std::vector<std::string> getDisplayModes() const override;

--- a/src/Gui/ViewProviderLine.cpp
+++ b/src/Gui/ViewProviderLine.cpp
@@ -94,7 +94,7 @@ void ViewProviderLine::attach(App::DocumentObject *obj) {
     // indexes used to create the edges
     static const int32_t lines[4] = { 0, 1, -1 };
 
-    SoSeparator *sep = getRoot();
+    SoSeparator *sep = getDatumRoot();
 
     auto pCoords = new SoCoordinate3 ();
     pCoords->point.setNum (2);

--- a/src/Gui/ViewProviderPlane.cpp
+++ b/src/Gui/ViewProviderPlane.cpp
@@ -114,7 +114,7 @@ void ViewProviderPlane::attach(App::DocumentObject * obj) {
     // indexes used to create the edges
     static const int32_t lines[6] = { 0, 1, 2, 3, 0, -1 };
 
-    SoSeparator* sep = getRoot();
+    SoSeparator* sep = getDatumRoot();
 
     auto pCoords = new SoCoordinate3();
     pCoords->point.setNum(4);

--- a/src/Gui/ViewProviderPoint.cpp
+++ b/src/Gui/ViewProviderPoint.cpp
@@ -52,7 +52,7 @@ void ViewProviderPoint::attach(App::DocumentObject * obj) {
     // The coordinates for the point (single vertex at the origin)
     static const SbVec3f point = SbVec3f(0, 0, 0);
 
-    SoSeparator* sep = getRoot();
+    SoSeparator* sep = getDatumRoot();
 
     auto pCoords = new SoCoordinate3();
     pCoords->point.setNum(1);


### PR DESCRIPTION
…umRoot()

Before the change the compiler raised the warning: 'Gui::ViewProviderDatum::getRoot' hides overloaded virtual function [-Werror,-Woverloaded-virtual] In the base class the method getRoot() is declared as const while in ViewProviderDatum it's not and that's why it's considered as an overloaded method. However, this signature causes two problems:
1. In the client code it's not clear which version of getRoot() should be called
2. It violates const-correctness

So, trying to declare the method ViewProviderDatum::getRoot() as const it now overrides the method of the base class (and fixes the warning) but this doesn't lead to the expected result: See https://forum.freecad.org/viewtopic.php?p=796064#p796064

So, the other option is to rename the method. And this gives the expected result now.