### PR TITLE
Fix SketchObjectPy::addExternal

### DIFF
--- a/src/Mod/Sketcher/App/SketchObjectPy.xml
+++ b/src/Mod/Sketcher/App/SketchObjectPy.xml
@@ -253,7 +253,7 @@ carbonCopy(objName:str, asConstruction=True)
         <UserDocu>
 Add a link to an external geometry.
 
-addExternal(objName:str, subName:str, bool:defining, bool:intersection)
+addExternal(objName:str, subName:str, defining:bool=False, intersection:bool=False)
 
     Args:
         objName: The name of the document object to reference.

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -555,38 +555,23 @@ PyObject* SketchObjectPy::carbonCopy(PyObject* args)
 
 PyObject* SketchObjectPy::addExternal(PyObject* args)
 {
-    char* ObjectName;
-    char* SubName;
-    PyObject* defining;      // this is an optional argument default false
-    PyObject* intersection;  // this is an optional argument default false
-    bool isDefining;
-    bool isIntersection;
+    char* ObjectName = nullptr;
+    char* SubName = nullptr;
+    PyObject* defining = Py_False;
+    PyObject* intersection = Py_False;
     if (!PyArg_ParseTuple(args,
-                          "ssO!O!",
+                          "ss|O!O!",
                           &ObjectName,
                           &SubName,
                           &PyBool_Type,
                           &defining,
                           &PyBool_Type,
                           &intersection)) {
-        if (!PyArg_ParseTuple(args, "ssO!", &ObjectName, &SubName, &PyBool_Type, &defining)) {
-            PyErr_Clear();
-            if (!PyArg_ParseTuple(args, "ss", &ObjectName, &SubName)) {
-                return nullptr;
-            }
-            else {
-                isDefining = false;
-            }
-        }
-        else {
-            isDefining = Base::asBoolean(defining);
-        }
-        isIntersection = false;
+        return nullptr;
     }
-    else {
-        isDefining = Base::asBoolean(defining);
-        isIntersection = Base::asBoolean(intersection);
-    }
+
+    bool isDefining = Base::asBoolean(defining);
+    bool isIntersection = Base::asBoolean(intersection);
 
     // get the target object for the external link
     Sketcher::SketchObject* skObj = this->getSketchObjectPtr();


### PR DESCRIPTION
* The syntax of type hints in Python is 'argument name: argument type'.
    For more details see: https://docs.python.org/3/library/typing.html
* Use PyArg_ParseTuple's support of optional arguments than doing it with several calls of PyArg_ParseTuple
    with different arguments.
    This is error-prone, leads to convoluted code logic and may even fail because once the error indicator is set
    PyArg_ParseTuple may unexpectedly fail.
