### PR TITLE
[PartDesign] Hole: restore missing call to FeatureAddSub::refineShapeIfActive()

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1950,6 +1950,7 @@ App::DocumentObjectExecReturn* Hole::execute()
             }
             result = base;
         }
+        result = refineShapeIfActive(result);
 
         if (!isSingleSolidRuleSatisfied(result.getShape())) {
             return new App::DocumentObjectExecReturn(

--- a/src/Mod/PartDesign/PartDesignTests/TestHole.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestHole.py
@@ -116,6 +116,84 @@ class TestHole(unittest.TestCase):
         self.Doc.recompute()
         self.assertAlmostEqual(self.Hole.Shape.Volume, 10**3 - pi * 3**2 * 10 - 24.7400421)
 
+    def testNoRefineHole(self):
+        # Add a second box to get a shape with more faces
+        self.Box2 = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+        self.Box2.Length=10
+        self.Box2.Width=10
+        self.Box2.Height=10
+        self.Box2.AttacherEngine = u"Engine 3D"
+        self.Box2.AttachmentOffset = App.Placement(
+            App.Vector(1.0000000000, 0.0000000000, 0.0000000000),
+            App.Rotation(0.0000000000, 0.0000000000, 0.0000000000),
+        )
+        self.Box2.MapReversed = False
+        self.Box2.AttachmentSupport = self.Doc.getObject('XY_Plane')
+        self.Box2.MapPathParameter = 0.000000
+        self.Box2.MapMode = 'FlatFace'
+
+        # Set the Refine option to False, otherwise adding the second box would be useless
+        self.Box2.Refine = False
+        self.Body.addObject(self.Box2)
+        self.Doc.recompute()
+
+        # Move the Hole on top of the Body
+        self.Body.removeObject(self.Hole)
+        self.Body.insertObject(self.Hole,self.Box2, True)
+        self.Body.Tip = self.Hole
+        self.Hole.Diameter = 6
+        self.Hole.Depth = 10
+        self.Hole.ThreadType = 0
+        self.Hole.HoleCutType = 0
+        self.Hole.DepthType = 0
+        self.Hole.DrillPoint = 0
+        self.Hole.Tapered = 0
+        self.Hole.Visibility = True
+
+        # Test the number of faces with the Refine option set to False
+        self.Hole.Refine = False
+        self.Doc.recompute()
+        self.assertEqual(len(self.Hole.Shape.Faces), 15)
+
+    def testRefineHole(self):
+        # Add a second box to get a shape with more faces
+        self.Box2 = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+        self.Box2.Length=10
+        self.Box2.Width=10
+        self.Box2.Height=10
+        self.Box2.AttacherEngine = u"Engine 3D"
+        self.Box2.AttachmentOffset = App.Placement(
+            App.Vector(1.0000000000, 0.0000000000, 0.0000000000),
+            App.Rotation(0.0000000000, 0.0000000000, 0.0000000000),
+        )
+        self.Box2.MapReversed = False
+        self.Box2.AttachmentSupport = self.Doc.getObject('XY_Plane')
+        self.Box2.MapPathParameter = 0.000000
+        self.Box2.MapMode = 'FlatFace'
+
+        # Set the Refine option to False, otherwise adding the second box would be useless
+        self.Box2.Refine = False
+        self.Body.addObject(self.Box2)
+        self.Doc.recompute()
+
+        # Move the Hole on top of the Body
+        self.Body.removeObject(self.Hole)
+        self.Body.insertObject(self.Hole,self.Box2, True)
+        self.Body.Tip = self.Hole
+        self.Hole.Diameter = 6
+        self.Hole.Depth = 10
+        self.Hole.ThreadType = 0
+        self.Hole.HoleCutType = 0
+        self.Hole.DepthType = 0
+        self.Hole.DrillPoint = 0
+        self.Hole.Tapered = 0
+        self.Hole.Visibility = True
+
+        # Test the number of faces with the Refine option set to True
+        self.Hole.Refine = True
+        self.Doc.recompute()
+        self.assertEqual(len(self.Hole.Shape.Faces), 7)
+
     def tearDown(self):
         #closing doc
         FreeCAD.closeDocument("PartDesignTestHole")

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
@@ -520,22 +520,23 @@ class TestSketcherSolver(unittest.TestCase):
         hole.DrillForDepth = 0
         hole.Tapered = 0
         self.Doc.recompute()
-        self.assertEqual(len(hole.Shape.Edges), 13)
+        self.assertEqual(len(hole.Shape.Edges), 12)
         hole.Threaded = True
         hole.ModelThread = True
-        body.addObject(hole)
+        # body.addObject(hole) # Commented out as this is a duplicate
+        # (already performed after hole = self.Doc.addObject("PartDesign::Hole", "Hole"))
         #
         sketch2 = self.Doc.addObject("Sketcher::SketchObject", "Sketch2")
         CreateRectangleSketch(sketch2, (0, 0), (3, 3))
         body.addObject(sketch2)
         self.Doc.recompute()
         sketch2.addExternal("Hole", "Edge29")  # Edge29 will disappear when we stop modeling threads
-        self.assertEqual(len(hole.Shape.Edges), 38)
+        self.assertEqual(len(hole.Shape.Edges), 32)
         hole.ModelThread = False
         hole.Refine = True
         self.Doc.recompute()
-        self.assertEqual(len(hole.Shape.Edges), 38)
-        self.assertEqual(len(sketch2.ExternalGeometry), 1)
+        self.assertEqual(len(hole.Shape.Edges), 12)
+        self.assertEqual(len(sketch2.ExternalGeometry), 0)
 
     def testSaveLoadWithExternalGeometryReference(self):
         # Arrange


### PR DESCRIPTION
related to #17124

During the import of the Toponaming code, the call to `FeatureAddSub::refineShapeIfActive()` in `PartDesign::Hole::execute()` was accidentally removed as it isn't present in https://github.com/realthunder/FreeCAD/blob/a9810d509a6f112b5ac03d4d4831b67e6bffd5b7/src/Mod/PartDesign/App/FeatureHole.cpp#L1971 but was present in https://github.com/FreeCAD/FreeCAD/blob/b9bfa5c5507506e4515816414cd27f4851d00489/src/Mod/PartDesign/App/FeatureHole.cpp#L1901

Acorrding to https://github.com/FreeCAD/FreeCAD/issues/17124#issuecomment-2517662019 this modification helps fixing one of the case files of that issue, together with other code imported from LS3 that will be added in a future PR.

Regardless for that, as for my https://github.com/FreeCAD/FreeCAD/issues/17124#issuecomment-2525716196, this PR's purpose is to restore the correct behavior of `PartDesign::Hole::execute()`