### PR TITLE
Addon Manager: Correct run_interruptable_subprocess

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -58,7 +58,7 @@ from composite_view import CompositeView
 from Widgets.addonmanager_widget_global_buttons import WidgetGlobalButtonBar
 from package_list import PackageListItemModel
 from Addon import Addon
-from manage_python_dependencies import (
+from addonmanager_python_deps_gui import (
     PythonPackageManager,
 )
 from addonmanager_cache import local_cache_needs_update

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_utilities.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_utilities.py
@@ -22,16 +22,26 @@
 # ***************************************************************************
 
 import unittest
+from unittest.mock import MagicMock, patch
 import os
-import FreeCAD
+import sys
+import subprocess
 
-from Addon import Addon
+try:
+    import FreeCAD
+except ImportError:
+    FreeCAD = None
+
+sys.path.append("../..")
+
+from AddonManagerTest.app.mocks import MockAddon as Addon
 
 from addonmanager_utilities import (
     recognized_git_location,
     get_readme_url,
     get_assigned_string_literal,
     get_macro_version_from_file,
+    run_interruptable_subprocess,
 )
 
 
@@ -40,9 +50,7 @@ class TestUtilities(unittest.TestCase):
     MODULE = "test_utilities"  # file name without extension
 
     def setUp(self):
-        self.test_dir = os.path.join(
-            FreeCAD.getHomePath(), "Mod", "AddonManager", "AddonManagerTest", "data"
-        )
+        pass
 
     @classmethod
     def tearDownClass(cls):
@@ -59,7 +67,7 @@ class TestUtilities(unittest.TestCase):
             "https://salsa.debian.org/science-team/freecad",
         ]
         for url in recognized_urls:
-            repo = Addon("Test Repo", url, Addon.Status.NOT_INSTALLED, "branch")
+            repo = Addon("Test Repo", url, "Addon.Status.NOT_INSTALLED", "branch")
             self.assertTrue(recognized_git_location(repo), f"{url} was unexpectedly not recognized")
 
         unrecognized_urls = [
@@ -69,7 +77,7 @@ class TestUtilities(unittest.TestCase):
             "https://github.com.malware.com/",
         ]
         for url in unrecognized_urls:
-            repo = Addon("Test Repo", url, Addon.Status.NOT_INSTALLED, "branch")
+            repo = Addon("Test Repo", url, "Addon.Status.NOT_INSTALLED", "branch")
             self.assertFalse(recognized_git_location(repo), f"{url} was unexpectedly recognized")
 
     def test_get_readme_url(self):
@@ -90,14 +98,14 @@ class TestUtilities(unittest.TestCase):
         for url in github_urls:
             branch = "branchname"
             expected_result = f"{url}/raw/{branch}/README.md"
-            repo = Addon("Test Repo", url, Addon.Status.NOT_INSTALLED, branch)
+            repo = Addon("Test Repo", url, "Addon.Status.NOT_INSTALLED", branch)
             actual_result = get_readme_url(repo)
             self.assertEqual(actual_result, expected_result)
 
         for url in gitlab_urls:
             branch = "branchname"
             expected_result = f"{url}/-/raw/{branch}/README.md"
-            repo = Addon("Test Repo", url, Addon.Status.NOT_INSTALLED, branch)
+            repo = Addon("Test Repo", url, "Addon.Status.NOT_INSTALLED", branch)
             actual_result = get_readme_url(repo)
             self.assertEqual(actual_result, expected_result)
 
@@ -125,14 +133,88 @@ class TestUtilities(unittest.TestCase):
             self.assertIsNone(result)
 
     def test_get_macro_version_from_file(self):
-        good_file = os.path.join(self.test_dir, "good_macro_metadata.FCStd")
-        version = get_macro_version_from_file(good_file)
-        self.assertEqual(version, "1.2.3")
+        if FreeCAD:
+            test_dir = os.path.join(
+                FreeCAD.getHomePath(), "Mod", "AddonManager", "AddonManagerTest", "data"
+            )
+            good_file = os.path.join(test_dir, "good_macro_metadata.FCStd")
+            version = get_macro_version_from_file(good_file)
+            self.assertEqual(version, "1.2.3")
 
-        bad_file = os.path.join(self.test_dir, "bad_macro_metadata.FCStd")
-        version = get_macro_version_from_file(bad_file)
-        self.assertEqual(version, "", "Bad version did not yield empty string")
+            bad_file = os.path.join(test_dir, "bad_macro_metadata.FCStd")
+            version = get_macro_version_from_file(bad_file)
+            self.assertEqual(version, "", "Bad version did not yield empty string")
 
-        empty_file = os.path.join(self.test_dir, "missing_macro_metadata.FCStd")
-        version = get_macro_version_from_file(empty_file)
-        self.assertEqual(version, "", "Missing version did not yield empty string")
+            empty_file = os.path.join(test_dir, "missing_macro_metadata.FCStd")
+            version = get_macro_version_from_file(empty_file)
+            self.assertEqual(version, "", "Missing version did not yield empty string")
+
+    @patch("subprocess.Popen")
+    def test_run_interruptable_subprocess_success_instant_return(self, mock_popen):
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = ("Mocked stdout", "Mocked stderr")
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        completed_process = run_interruptable_subprocess(["arg0", "arg1"])
+
+        self.assertEqual(completed_process.returncode, 0)
+        self.assertEqual(completed_process.stdout, "Mocked stdout")
+        self.assertEqual(completed_process.stderr, "Mocked stderr")
+
+    @patch("subprocess.Popen")
+    def test_run_interruptable_subprocess_returns_nonzero(self, mock_popen):
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = ("Mocked stdout", "Mocked stderr")
+        mock_process.returncode = 1
+        mock_popen.return_value = mock_process
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            run_interruptable_subprocess(["arg0", "arg1"])
+
+    @patch("subprocess.Popen")
+    def test_run_interruptable_subprocess_timeout_five_times(self, mock_popen):
+        """Five times is below the limit for an error to be raised"""
+
+        def raises_first_five_times(timeout):
+            raises_first_five_times.counter += 1
+            if raises_first_five_times.counter <= 5:
+                raise subprocess.TimeoutExpired("Test", timeout)
+            return "Mocked stdout", None
+
+        raises_first_five_times.counter = 0
+
+        mock_process = MagicMock()
+        mock_process.communicate = raises_first_five_times
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        result = run_interruptable_subprocess(["arg0", "arg1"], 10)
+
+        self.assertEqual(result.returncode, 0)
+
+    @patch("subprocess.Popen")
+    def test_run_interruptable_subprocess_timeout_ten_times(self, mock_popen):
+        """Ten times is the limit for an error to be raised (e.g. the real timeout is ten seconds)"""
+
+        def raises_first_ten_times(timeout=0):
+            raises_first_ten_times.counter += 1
+            if not raises_first_ten_times.mock_access.kill.called:
+                if raises_first_ten_times.counter <= 10:
+                    raise subprocess.TimeoutExpired("Test", timeout)
+            return "Mocked stdout", "Mocked stderr"
+
+        raises_first_ten_times.counter = 0
+
+        mock_process = MagicMock()
+        mock_process.communicate = raises_first_ten_times
+        raises_first_ten_times.mock_access = mock_process
+        mock_process.returncode = None
+        mock_popen.return_value = mock_process
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            run_interruptable_subprocess(["arg0", "arg1"], 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/AddonManager/AddonManagerTest/gui/gui_mocks.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/gui_mocks.py
@@ -21,7 +21,17 @@
 # *                                                                         *
 # ***************************************************************************
 
-from PySide import QtCore, QtWidgets
+import sys
+
+try:
+    from PySide import QtCore, QtWidgets
+except ImportError:
+    try:
+        from PySide6 import QtCore, QtWidgets
+    except ImportError:
+        from PySide2 import QtCore, QtWidgets
+
+sys.path.append("../../")  # For running in standalone mode during testing
 
 from AddonManagerTest.app.mocks import SignalCatcher
 

--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_python_deps_gui.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_python_deps_gui.py
@@ -1,0 +1,139 @@
+import logging
+import subprocess
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+try:
+    import FreeCAD
+    import FreeCADGui
+except ImportError:
+    try:
+        from PySide6 import QtCore, QtWidgets
+    except ImportError:
+        from PySide2 import QtCore, QtWidgets
+
+sys.path.append(
+    "../.."
+)  # So that when run standalone, the Addon Manager classes imported below are available
+
+from addonmanager_python_deps_gui import (
+    PythonPackageManager,
+    call_pip,
+    PipFailed,
+    python_package_updates_are_available,
+    parse_pip_list_output,
+)
+from AddonManagerTest.gui.gui_mocks import DialogInteractor, DialogWatcher
+
+
+class TestPythonPackageManager(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.manager = PythonPackageManager([])
+
+    def tearDown(self) -> None:
+        if self.manager.worker_thread:
+            self.manager.worker_thread.terminate()
+            self.manager.worker_thread.wait()
+
+    @patch("addonmanager_python_deps_gui.PythonPackageManager._create_list_from_pip")
+    def test_show(self, patched_create_list_from_pip):
+        dialog_watcher = DialogWatcher("Manage Python Dependencies")
+        self.manager.show()
+        self.assertTrue(dialog_watcher.dialog_found, "Failed to find the expected dialog box")
+
+
+class TestPythonDepsStandaloneFunctions(unittest.TestCase):
+
+    @patch("addonmanager_utilities.run_interruptable_subprocess")
+    def test_call_pip(self, mock_run_subprocess: MagicMock):
+        call_pip(["arg1", "arg2", "arg3"])
+        mock_run_subprocess.assert_called()
+        args = mock_run_subprocess.call_args[0][0]
+        self.assertTrue("pip" in args)
+
+    @patch("addonmanager_python_deps_gui.get_python_exe")
+    def test_call_pip_no_python(self, mock_get_python_exe: MagicMock):
+        mock_get_python_exe.return_value = None
+        with self.assertRaises(PipFailed):
+            call_pip(["arg1", "arg2", "arg3"])
+
+    @patch("addonmanager_utilities.run_interruptable_subprocess")
+    def test_call_pip_exception_raised(self, mock_run_subprocess: MagicMock):
+        mock_run_subprocess.side_effect = subprocess.CalledProcessError(
+            -1, "dummy_command", "Fake contents of stdout", "Fake contents of stderr"
+        )
+        with self.assertRaises(PipFailed):
+            call_pip(["arg1", "arg2", "arg3"])
+
+    @patch("addonmanager_utilities.run_interruptable_subprocess")
+    def test_call_pip_splits_results(self, mock_run_subprocess: MagicMock):
+        result_mock = MagicMock()
+        result_mock.stdout = "\n".join(["Value 1", "Value 2", "Value 3"])
+        mock_run_subprocess.return_value = result_mock
+        result = call_pip(["arg1", "arg2", "arg3"])
+        self.assertEqual(len(result), 3)
+
+    @patch("addonmanager_python_deps_gui.call_pip")
+    def test_python_package_updates_are_available(self, mock_call_pip: MagicMock):
+        mock_call_pip.return_value = "Some result"
+        result = python_package_updates_are_available()
+        self.assertEqual(result, True)
+
+    @patch("addonmanager_python_deps_gui.call_pip")
+    def test_python_package_updates_are_available_no_results(self, mock_call_pip: MagicMock):
+        """An empty string is an indication that no updates are available"""
+        mock_call_pip.return_value = ""
+        result = python_package_updates_are_available()
+        self.assertEqual(result, False)
+
+    @patch("addonmanager_python_deps_gui.call_pip")
+    def test_python_package_updates_are_available_pip_failure(self, mock_call_pip: MagicMock):
+        logging.disable()
+        mock_call_pip.side_effect = PipFailed("Test error message")
+        logging.disable()  # A logging error message is expected here, but not desirable during test runs
+        result = python_package_updates_are_available()
+        self.assertEqual(result, False)
+        logging.disable(logging.NOTSET)
+
+    def test_parse_pip_list_output_no_input(self):
+        results_dict = parse_pip_list_output("", "")
+        self.assertEqual(len(results_dict), 0)
+
+    def test_parse_pip_list_output_all_packages_no_updates(self):
+        results_dict = parse_pip_list_output(
+            ["Package    Version", "---------- -------", "gitdb      4.0.9", "setuptools 41.2.0"],
+            [],
+        )
+        self.assertEqual(len(results_dict), 2)
+        self.assertTrue("gitdb" in results_dict)
+        self.assertTrue("setuptools" in results_dict)
+        self.assertEqual(results_dict["gitdb"]["installed_version"], "4.0.9")
+        self.assertEqual(results_dict["gitdb"]["available_version"], "")
+        self.assertEqual(results_dict["setuptools"]["installed_version"], "41.2.0")
+        self.assertEqual(results_dict["setuptools"]["available_version"], "")
+
+    def test_parse_pip_list_output_all_packages_with_updates(self):
+        results_dict = parse_pip_list_output(
+            [],
+            [
+                "Package    Version Latest Type",
+                "---------- ------- ------ -----",
+                "pip        21.0.1  22.1.2 wheel",
+                "setuptools 41.2.0  63.2.0 wheel",
+            ],
+        )
+        self.assertEqual(len(results_dict), 2)
+        self.assertTrue("pip" in results_dict)
+        self.assertTrue("setuptools" in results_dict)
+        self.assertEqual(results_dict["pip"]["installed_version"], "21.0.1")
+        self.assertEqual(results_dict["pip"]["available_version"], "22.1.2")
+        self.assertEqual(results_dict["setuptools"]["installed_version"], "41.2.0")
+        self.assertEqual(results_dict["setuptools"]["available_version"], "63.2.0")
+
+
+if __name__ == "__main__":
+    app = QtWidgets.QApplication(sys.argv)
+    QtCore.QTimer.singleShot(0, unittest.main)
+    app.exec()

--- a/src/Mod/AddonManager/CMakeLists.txt
+++ b/src/Mod/AddonManager/CMakeLists.txt
@@ -4,11 +4,20 @@ IF (BUILD_GUI)
 ENDIF (BUILD_GUI)
 
 SET(AddonManager_SRCS
-    add_toolbar_button_dialog.ui
+    ALLOWED_PYTHON_PACKAGES.txt
     Addon.py
-    AddonStats.py
     AddonManager.py
     AddonManager.ui
+    AddonManagerOptions.py
+    AddonManagerOptions.ui
+    AddonManagerOptions_AddCustomRepository.ui
+    AddonStats.py
+    Init.py
+    InitGui.py
+    NetworkManager.py
+    PythonDependencyUpdateDialog.ui
+    TestAddonManagerApp.py
+    add_toolbar_button_dialog.ui
     addonmanager_cache.py
     addonmanager_connection_checker.py
     addonmanager_dependency_installer.py
@@ -17,8 +26,8 @@ SET(AddonManager_SRCS
     addonmanager_devmode_license_selector.py
     addonmanager_devmode_licenses_table.py
     addonmanager_devmode_metadata_checker.py
-    addonmanager_devmode_person_editor.py
     addonmanager_devmode_people_table.py
+    addonmanager_devmode_person_editor.py
     addonmanager_devmode_predictor.py
     addonmanager_devmode_validators.py
     addonmanager_firstrun.py
@@ -33,18 +42,15 @@ SET(AddonManager_SRCS
     addonmanager_package_details_controller.py
     addonmanager_preferences_defaults.json
     addonmanager_pyside_interface.py
+    addonmanager_python_deps_gui.py
     addonmanager_readme_controller.py
-    addonmanager_update_all_gui.py
     addonmanager_uninstaller.py
     addonmanager_uninstaller_gui.py
+    addonmanager_update_all_gui.py
     addonmanager_utilities.py
     addonmanager_workers_installation.py
     addonmanager_workers_startup.py
     addonmanager_workers_utility.py
-    AddonManagerOptions.ui
-    AddonManagerOptions_AddCustomRepository.ui
-    AddonManagerOptions.py
-    ALLOWED_PYTHON_PACKAGES.txt
     change_branch.py
     change_branch.ui
     compact_view.py
@@ -65,16 +71,10 @@ SET(AddonManager_SRCS
     developer_mode_tags.ui
     expanded_view.py
     first_run.ui
-    Init.py
-    InitGui.py
     install_to_toolbar.py
     loading.html
-    manage_python_dependencies.py
-    NetworkManager.py
     package_list.py
-    PythonDependencyUpdateDialog.ui
     select_toolbar_dialog.ui
-    TestAddonManagerApp.py
     update_all.ui
 )
 IF (BUILD_GUI)


### PR DESCRIPTION
Two refactorings and a bug fix:

1) `communicate()` has to be called after a final `kill()` to get the output. Also adds unit tests for the function. Related to #18380.
2) Renames and starts a refactoring/testing pass on the Python dependencies GUI. This needs considerably more refactoring, but this is a start.