### PR TITLE
Sketch: Fix possible crash in BSpline::splineValue

### DIFF
--- a/src/Mod/Sketcher/App/planegcs/Geo.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Geo.cpp
@@ -1141,7 +1141,7 @@ double BSpline::splineValue(double x, size_t k, unsigned int p, VEC_D& d, const 
         }
     }
 
-    return d[p];
+    return p < d.size() ? d[p] : 0.0;
 }
 
 void BSpline::setupFlattenedKnots()


### PR DESCRIPTION
There is an underflow of an unsigned int in the calling instance that sets the parameter 'p' to 2**32-1. But the size of the passed vector is 0. To fix the crash first check if p is less then the size of the vector.

See: https://forum.freecad.org/viewtopic.php?t=92815