### PR TITLE
CI: Remove readability-identifier-length check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 Checks:          'clang-diagnostic-*,clang-analyzer-*,boost-*,bugprone-*,
 performance-*,readability-*,portability-*,modernize-*,cppcoreguidelines-*,google-explicit-constructor,
-concurrency-*,-modernize-use-trailing-return-type, -modernize-use-nodiscard,
+concurrency-*,-modernize-use-trailing-return-type, -modernize-use-nodiscard,-readability-identifier-length,
 -readability-redundant-access-specifiers,-readability-qualified-auto,
 -cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,
 -readability-convert-member-functions-to-static,-bugprone-easily-swappable-parameters,
@@ -150,8 +150,6 @@ CheckOptions:
     value:           '0'
   - key:             concurrency-mt-unsafe.FunctionSet
     value:           any
-  - key:             readability-identifier-length.IgnoredExceptionVariableNames
-    value:           '^[e]$'
   - key:             google-readability-braces-around-statements.ShortStatementLines
     value:           '1'
   - key:             bugprone-reserved-identifier.AllowedIdentifiers


### PR DESCRIPTION
As discussed in the PR Review Meeting this morning, this removes the `readability-identifier-length` automated check, which creates more noise than it is worth. We plan to instead rely on code reviewers to encourage good variable naming, which will often (though not always) include using longer names.