### PR TITLE
Fix various typos

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathHelix.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelix.py
@@ -140,7 +140,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
                     )
 
     def testPathDirection(self):
-        """Verify that the generated paths obays the given parameters"""
+        """Verify that the generated paths obeys the given parameters"""
         helix = PathHelix.Create("Helix")
 
         def check(start_side, cut_mode, expected_direction):

--- a/src/Mod/Draft/draftgeoutils/circles.py
+++ b/src/Mod/Draft/draftgeoutils/circles.py
@@ -359,7 +359,7 @@ def findHomotheticCenterOfCircles(circle1, circle2):
     cenDir = vec(cen1_cen2)
     cenDir.normalize()
 
-    # Get the perpedicular vector.
+    # Get the perpendicular vector.
     perpCenDir = cenDir.cross(App.Vector(0, 0, 1))
     perpCenDir.normalize()
 
@@ -427,7 +427,7 @@ def findRadicalAxis(circle1, circle2):
     cenDir = cen1.sub(circle2.Curve.Center)
     cenDir.normalize()
 
-    # Get the perpedicular vector.
+    # Get the perpendicular vector.
     perpCenDir = cenDir.cross(App.Vector(0, 0, 1))
     perpCenDir.normalize()
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3512,7 +3512,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
                                                                     Constraint* constr) {
         // TODO: Move code currently later in this method (that does as per the following description) here.
         /* It is possible that the trimming entity has both a PointOnObject constraint to the
-         * trimmed entity, and a simple Tangent contstraint to the trimmed entity. In this case we
+         * trimmed entity, and a simple Tangent constraint to the trimmed entity. In this case we
          * want to change to a single end-to-end tangency, i.e we want to ensure that constrType1 is
          * set to Sketcher::Tangent, that the secondPos1 is captured from the PointOnObject, and
          * also make sure that the PointOnObject constraint is deleted. The below loop ensures this,


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,addmin,ake,aline,alle,alledges,alocation,als,ang,anid,anormal,aply,apoints,ba,beginn,behaviour,bloaded,bottome,brushin,bu,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childrens,childs,colour,colours,commen,connexion,currenty,documentin,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,findn,fle,freez,graphin,hist,iff,incrementin,indexin,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,itsel,kilometre,leadin,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oce,oder,ontop,orgin,orginx,orginy,ot,pard,parm,parms,pres,programm,que,rady,recurrance,renderin,rin,ro,rougly,sectionin,seperator,serie,shs,sinc,siz,som,strack,substraction,te,technic,thist,thru,tread,tru,ue,uint,unter,uptodate,vas,vertexes,vew,wallthickness,whitespaces -S "./.git,*.po,*.ts,*.pdf,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./src/Base/StackWalker.cpp,./build/doc/SourceDoc,./tools/build/WindowsInstaller/lang,./src/Mod/TechDraw/Templates/locale"`