### PR TITLE
Core: Allow exposing properties

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3194,7 +3194,7 @@ int Document::recompute(const std::vector<App::DocumentObject*>& objs,
                     signalRecomputedObject(*obj);
                     obj->purgeTouched();
                     // set all dependent object touched to force recompute
-                    for (auto inObjIt : obj->getInList()) {
+                    for (auto inObjIt : obj->getInListWithoutExposed()) {
                         inObjIt->enforceRecompute();
                     }
                 }

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include <App/DocumentObjectPy.h>
+#include <App/Expression.h>
 #include <Base/Console.h>
 #include <Base/Matrix.h>
 #include <Base/Tools.h>
@@ -428,12 +429,25 @@ void DocumentObject::getOutList(int options, std::vector<DocumentObject*>& res) 
     std::size_t size = res.size();
     for (auto prop : props) {
         auto link = dynamic_cast<PropertyLinkBase*>(prop);
-        if (link) {
+        if (link && strcmp(link->getName(), "ExpressionEngine") != 0) {
             link->getLinks(res, noHidden);
         }
     }
     if (!(options & OutListNoExpression)) {
-        ExpressionEngine.getLinks(res);
+        //ExpressionEngine.getLinks(res);
+        auto expressions = ExpressionEngine.getExpressions();
+        for (const auto& pair : expressions) {
+            const App::Expression* exp = pair.second;
+            for (const auto& id : exp->getIdentifiers()) {
+                Property* prop = id.first.getProperty();
+                if (prop) {
+                    DocumentObject* obj = dynamic_cast<DocumentObject*>(prop->getContainer());
+                    if (obj && !obj->isExposed(prop)) {
+                        res.push_back(obj);
+                    }
+                }
+            }
+        }
     }
 
     if (options & OutListNoXLinked) {
@@ -921,13 +935,22 @@ void DocumentObject::onChanged(const Property* prop)
     // set object touched if it is an input property
     if (!testStatus(ObjectStatus::NoTouch) && !(prop->getType() & Prop_Output)
         && !prop->testStatus(Property::Output)) {
-        if (!StatusBits.test(ObjectStatus::Touch)) {
-            FC_TRACE("touch '" << getFullName() << "' on change of '" << prop->getName() << "'");
-            StatusBits.set(ObjectStatus::Touch);
+        if (isExposed(prop)) {
+            // The property is exposed: Do not touch this object but the ones
+            // that depend on it.
+            for (auto obj : getInList()) {
+                obj->touch(false);
+            }
         }
-        // must execute on document recompute
-        if (!(prop->getType() & Prop_NoRecompute)) {
-            StatusBits.set(ObjectStatus::Enforce);
+        else {
+            if (!StatusBits.test(ObjectStatus::Touch)) {
+                FC_TRACE("touch '" << getFullName() << "' on change of '" << prop->getName() << "'");
+                StatusBits.set(ObjectStatus::Touch);
+            }
+            // must execute on document recompute
+            if (!(prop->getType() & Prop_NoRecompute)) {
+                StatusBits.set(ObjectStatus::Enforce);
+            }
         }
     }
 

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -734,6 +734,19 @@ bool DocumentObject::testIfLinkDAGCompatible(PropertyLinkSub& linkTo) const
     return this->testIfLinkDAGCompatible(linkTo_in_vector);
 }
 
+bool DocumentObject::isExposed(const Property* prop) const
+{
+    return prop->testStatus(Property::Exposed);
+}
+
+bool DocumentObject::isExposed() const
+{
+    std::vector<Property*> allProps;
+    getPropertyList(allProps);
+    return std::any_of(allProps.begin(), allProps.end(),
+                       [this](Property* prop) { return isExposed(prop); });
+}
+
 void DocumentObject::onLostLinkToObject(DocumentObject*)
 {}
 

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -311,6 +311,7 @@ public:
      * @param recursive [in]: whether to obtain recursive in list
      */
     std::set<App::DocumentObject*> getInListEx(bool recursive) const;
+    std::set<App::DocumentObject*> getInListWithoutExposed() const;
 
     /// get group if object is part of a group, otherwise 0 is returned
     DocumentObjectGroup* getGroup() const;
@@ -761,6 +762,7 @@ protected:
 
 private:
     void printInvalidLinks() const;
+    bool onlyReferencedByExposedIn(const App::DocumentObject* obj) const;
 
     /// python object of this class and all descendent
 protected:  // attributes

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -344,6 +344,12 @@ public:
     bool testIfLinkDAGCompatible(App::PropertyLinkSubList& linksTo) const;
     bool testIfLinkDAGCompatible(App::PropertyLinkSub& linkTo) const;
 
+    /// check if the property is exposed
+    bool isExposed(const Property* prop) const;
+    /// check whether any of the properties in the container are exposed
+    bool isExposed() const;
+
+
     /** Return the element map version of the geometry data stored in the given property
      *
      * @param prop: the geometry property to query for element map version

--- a/src/App/Expression.h
+++ b/src/App/Expression.h
@@ -146,8 +146,11 @@ public:
     void getDeps(ExpressionDeps &deps, int option=DepNormal) const;
     ExpressionDeps getDeps(int option=DepNormal) const;
 
-    std::map<App::DocumentObject*,bool> getDepObjects(std::vector<std::string> *labels=nullptr) const;
-    void getDepObjects(std::map<App::DocumentObject*,bool> &, std::vector<std::string> *labels=nullptr) const;
+    std::map<App::DocumentObject*,bool> getDepObjects(std::vector<std::string> *labels=nullptr,
+                                                      bool excludeExposed=false) const;
+    void getDepObjects(std::map<App::DocumentObject*,bool> &,
+                       std::vector<std::string> *labels=nullptr,
+                       bool excludeExposed=false) const;
 
     ExpressionPtr importSubNames(const std::map<std::string,std::string> &nameMap) const;
 

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -97,10 +97,11 @@ public:
         PropOutput = 27,       // corresponding to Prop_Output
         PropStaticEnd = 28,
 
-        User1 = 28,  // user-defined status
-        User2 = 29,  // user-defined status
-        User3 = 30,  // user-defined status
-        User4 = 31   // user-defined status
+        User1 = 28,    // user-defined status
+        User2 = 29,    // user-defined status
+        User3 = 30,    // user-defined status
+        Exposed = 31,  // user-defined status
+
     };
 
     Property();

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -46,6 +46,8 @@ TYPESYSTEM_SOURCE_ABSTRACT(App::PropertyExpressionContainer, App::PropertyXLinkC
 
 static std::set<PropertyExpressionContainer*> _ExprContainers;
 
+const bool EXCLUDE_EXPOSED = true;
+
 PropertyExpressionContainer::PropertyExpressionContainer()
 {
     static bool inited;
@@ -871,7 +873,7 @@ PropertyExpressionEngine::validateExpression(const ObjectIdentifier& path,
     assert(pathDocObj);
 
     auto inList = pathDocObj->getInListEx(true);
-    for (auto& v : expr->getDepObjects()) {
+    for(auto& v : expr->getDepObjects(nullptr, EXCLUDE_EXPOSED)) {
         auto docObj = v.first;
         if (!v.second && inList.count(docObj)) {
             std::stringstream ss;

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -709,6 +709,7 @@ enum MenuAction
     MA_Touched,
     MA_EvalOnRestore,
     MA_CopyOnChange,
+    MA_Exposed,
 };
 
 void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
@@ -824,6 +825,7 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
         _ACTION_SETUP(Touched);
         _ACTION_SETUP(EvalOnRestore);
         _ACTION_SETUP(CopyOnChange);
+        _ACTION_SETUP(Exposed);
 
         menu.addMenu(subMenu);
     }
@@ -859,6 +861,7 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
             ACTION_CHECK(Hidden);
             ACTION_CHECK(EvalOnRestore);
             ACTION_CHECK(CopyOnChange);
+            ACTION_CHECK(Exposed);
         case MA_Touched:
             for (auto prop : props) {
                 if (action->isChecked()) {


### PR DESCRIPTION
Resolves #18389.

Adds an exposed flag to properties. Marking a property as exposed allows referencing the property in child objects without triggering cyclic dependencies. See the issue and forum posts for more information.

Note that this is a proof-of-concept implementation that uses the strategy to make minimal changes to the existing dependency checking logic. The ideas behind it are described in [this forum post](https://forum.freecad.org/viewtopic.php?p=795527#p795527) and beyond.

The functionality to expose properties is used in https://github.com/FreeCAD/FreeCAD/pull/19735.