### PR TITLE
[Gui] Tree, set FontSize on start of application

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -748,6 +748,7 @@ TreeWidget::TreeWidget(const char* name, QWidget* parent)
     setColumnHidden(1, TreeParams::getHideColumn());
     setColumnHidden(2, TreeParams::getHideInternalNames());
     header()->setVisible(!TreeParams::getHideColumn() || !TreeParams::getHideInternalNames());
+    TreeParams::onFontSizeChanged();
 }
 
 TreeWidget::~TreeWidget()


### PR DESCRIPTION
Currently setting the tree font size only applies to that current session even though it is written to the user.cfg. this PR loads the setting on initialization.

Fixes https://github.com/FreeCAD/FreeCAD-Bundle/issues/343

IMHO this should be backported to the 1.0 branch.