### PR TITLE
Update for 3Dconnexion NavLib integration

### DIFF
--- a/src/Gui/3Dconnexion/navlib/NavlibInterface.h
+++ b/src/Gui/3Dconnexion/navlib/NavlibInterface.h
@@ -161,5 +161,7 @@ private:
     mutable std::array<SbVec2f, hitTestingResolution> hitTestPattern;
     mutable bool patternInitialized;
     std::vector<std::string> exportedCommandSets;
+    mutable bool wasPointerPick = false;
+    mutable double orthoNearDistance = 0.0;
 };
 #endif

--- a/src/Gui/3Dconnexion/navlib/NavlibInterface.h
+++ b/src/Gui/3Dconnexion/navlib/NavlibInterface.h
@@ -162,6 +162,6 @@ private:
     mutable bool patternInitialized;
     std::vector<std::string> exportedCommandSets;
     mutable bool wasPointerPick = false;
-    mutable double orthoNearDistance = 0.0;
+    double orthoNearDistance = 0.0;
 };
 #endif

--- a/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
@@ -107,7 +107,6 @@ long NavlibInterface::GetPointerPosition(navlib::point_t& position) const
 
         SbVec3f worldPosition =
             inventorViewer->getPointOnFocalPlane(SbVec2s(viewPoint.x(), viewPoint.y()));
-        
         std::copy(worldPosition.getValue(), worldPosition.getValue() + 3, &position.x);
 
         wasPointerPick = true;

--- a/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
@@ -97,19 +97,23 @@ long NavlibInterface::GetPointerPosition(navlib::point_t& position) const
     if (is3DView()) {
         const Gui::View3DInventorViewer* const inventorViewer = currentView.pView3d->getViewer();
         if (inventorViewer == nullptr)
-                return navlib::make_result_code(navlib::navlib_errc::no_data_available);
+            return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
-            QPoint viewPoint = currentView.pView3d->mapFromGlobal(QCursor::pos());
-            viewPoint.setY(currentView.pView3d->height() - viewPoint.y());
-            SbVec3f worldPosition =
-                inventorViewer->getPointOnFocalPlane(SbVec2s(viewPoint.x(), viewPoint.y()));
+        QPoint viewPoint = currentView.pView3d->mapFromGlobal(QCursor::pos());
+        viewPoint.setY(currentView.pView3d->height() - viewPoint.y());
 
-            std::copy(worldPosition.getValue(), worldPosition.getValue() + 3, &position.x);
+        double scaling = inventorViewer->devicePixelRatio();
+        viewPoint *= scaling;
 
-            wasPointerPick = true;
+        SbVec3f worldPosition =
+            inventorViewer->getPointOnFocalPlane(SbVec2s(viewPoint.x(), viewPoint.y()));
+        
+        std::copy(worldPosition.getValue(), worldPosition.getValue() + 3, &position.x);
 
-            return 0;
-        }
+        wasPointerPick = true;
+
+        return 0;
+    }
     return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 }
 
@@ -324,9 +328,9 @@ long NavlibInterface::GetViewExtents(navlib::box_t& extents) const
         return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
     const SbViewVolume viewVolume = pCamera->getViewVolume(pCamera->aspectRatio.getValue());
-    const float halfHeight = viewVolume.getHeight() / 2.0f;
-    const float halfWidth = viewVolume.getWidth() / 2.0f;
-    const float halfDepth = 1e8;
+    const double halfHeight = static_cast<double>(viewVolume.getHeight() / 2.0f);
+    const double halfWidth = static_cast<double>(viewVolume.getWidth() / 2.0f);
+    const double halfDepth = 1.0e8;
 
     extents = {-halfWidth,
                -halfHeight,

--- a/src/Gui/3Dconnexion/navlib/NavlibPivot.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibPivot.cpp
@@ -260,9 +260,8 @@ long NavlibInterface::SetHitLookFrom(const navlib::point_t& eye)
 
         SbVec3f position = pCamera->position.getValue();
         ray.origin = position + orthoNearDistance * ray.direction;
-
-        return 0;
     }
+    return 0;
 }
 
 long NavlibInterface::SetHitSelectionOnly(bool hitSelection)

--- a/src/Gui/3Dconnexion/navlib/NavlibPivot.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibPivot.cpp
@@ -136,35 +136,61 @@ long NavlibInterface::GetHitLookAt(navlib::point_t& position) const
 
     pCamera->orientation.getValue().getValue(cameraMatrix);
 
-    // Initialize the samples array if it wasn't done before
+     // Initialize the samples array if it wasn't done before
     initializePattern();
 
+    navlib::bool_t isPerspective;
+    GetIsViewPerspective(isPerspective);
+
     for (uint32_t i = 0; i < hitTestingResolution; i++) {
-        // Scale the sample like it was defined in camera space (placed on XY plane)
-        SbVec3f transform(
-            hitTestPattern[i][0] * ray.radius, hitTestPattern[i][1] * ray.radius, 0.0f);
 
-        // Apply the model-view transform to a sample (only the rotation)
-        cameraMatrix.multVecMatrix(transform, transform);
+        SbVec3f origin;
 
-        // Calculate origin of current hit-testing ray
-        SbVec3f newOrigin = ray.origin + transform;
+        if (wasPointerPick) {
+            origin = ray.origin;
+        }
+        else {
+            // Scale the sample like it was defined in camera space (placed on XY plane)
+            SbVec3f transform(hitTestPattern[i][0] * ray.radius,
+                              hitTestPattern[i][1] * ray.radius,
+                              0.0f);
+
+            // Apply the model-view transform to a sample (only the rotation)
+            cameraMatrix.multVecMatrix(transform, transform);
+
+            // Calculate origin of current hit-testing ray
+            origin = ray.origin + transform;
+        }
 
         // Perform the hit-test
-        rayPickAction.setRay(newOrigin, ray.direction);
+        if (isPerspective) {
+            rayPickAction.setRay(origin,
+                                 ray.direction,
+                                 pCamera->nearDistance.getValue(),
+                                 pCamera->farDistance.getValue());
+        }
+        else {
+            rayPickAction.setRay(origin, ray.direction);
+        }
+
         rayPickAction.apply(pSceneGraph);
         SoPickedPoint* pickedPoint = rayPickAction.getPickedPoint();
 
         // Check if there was a hit
         if (pickedPoint != nullptr) {
             SbVec3f hitPoint = pickedPoint->getPoint();
-            float distance = (newOrigin - hitPoint).length();
+            float distance = (origin - hitPoint).length();
 
             // Save hit of the lowest depth
             if (distance < minLength) {
                 minLength = distance;
                 closestHitPoint = hitPoint;
             }
+        }
+
+        if (wasPointerPick) {
+            wasPointerPick = false;
+            break;
         }
     }
 
@@ -219,8 +245,24 @@ long NavlibInterface::SetHitDirection(const navlib::vector_t& direction)
 
 long NavlibInterface::SetHitLookFrom(const navlib::point_t& eye)
 {
-    ray.origin.setValue(eye.x, eye.y, eye.z);
-    return 0;
+    navlib::bool_t isPerspective;
+
+    GetIsViewPerspective(isPerspective);
+
+    if (isPerspective) {
+        ray.origin.setValue(eye.x, eye.y, eye.z);
+    }
+    else {
+        auto pCamera = getCamera<SoCamera*>();
+        if (pCamera == nullptr) {
+            return navlib::make_result_code(navlib::navlib_errc::no_data_available);
+        }
+
+        SbVec3f position = pCamera->position.getValue();
+        ray.origin = position + orthoNearDistance * ray.direction;
+
+        return 0;
+    }
 }
 
 long NavlibInterface::SetHitSelectionOnly(bool hitSelection)


### PR DESCRIPTION
Hello,

The following changes address some issues with the new integration, which were recently found:

- Fixed an crash occuring if QuickZoom is used on geometry clipped by the view volume,
- Fixed a bug causing an center of rotation stop updating it's position in ortho view,
- Fixed QuickZoom for high DPI screens (support for variable scaling)