### PR TITLE
App: Fix GeoFeature::getGlobalPlacement when rootObj is Link

### DIFF
--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -316,6 +316,11 @@ Base::Placement GeoFeature::getGlobalPlacement(App::DocumentObject* targetObj,
         return plc;
     }
 
+    if (rootObj->isLink()) {
+        // Update doc in case its an external link.
+        doc = rootObj->getLinkedObject()->getDocument();
+    }
+
     for (auto& name : names) {
         App::DocumentObject* obj = doc->getObject(name.c_str());
         if (!obj) {


### PR DESCRIPTION
This fixes a case when in case of rootObj being Link placement was not calculated correctly due to not changing of the document. While for original use it was fine as this was mostly used in case where there was defined non-link root for general case Links can be root objects of the document.

partial fix for https://github.com/FreeCAD/FreeCAD/issues/18093

@PaddleStroke FYI

This could use backport.