### PR TITLE
fixed loading of bim tutorial images

### DIFF
--- a/src/Mod/BIM/bimcommands/BimTutorial.py
+++ b/src/Mod/BIM/bimcommands/BimTutorial.py
@@ -175,7 +175,6 @@ class BIM_Tutorial:
                     except:
                         print("unparsable image path:", path)
                     else:
-                        name = name[-1]
                         storename = os.path.join(store, name)
                         if not os.path.exists(storename):
                             if path.startswith("/images"):


### PR DESCRIPTION
Loading the images into the BIM tutorial is still broken. This patch fixes this issue.