### PR TITLE
PartDesign New sketch : Open attachment dialog

### DIFF
--- a/src/Mod/Part/Gui/TaskAttacher.h
+++ b/src/Mod/Part/Gui/TaskAttacher.h
@@ -160,7 +160,7 @@ class PartGuiExport TaskDlgAttacher : public Gui::TaskView::TaskDialog
     Q_OBJECT
 
 public:
-    explicit TaskDlgAttacher(Gui::ViewProviderDocumentObject *ViewProvider, bool createBox = true);
+    explicit TaskDlgAttacher(Gui::ViewProviderDocumentObject *ViewProvider, bool createBox = true, std::function<void()> onAccept = {}, std::function<void()> onReject = {});
     ~TaskDlgAttacher() override;
 
     Gui::ViewProviderDocumentObject* getViewProvider() const
@@ -188,6 +188,10 @@ protected:
     Gui::ViewProviderDocumentObject   *ViewProvider;
 
     TaskAttacher  *parameter;
+
+    std::function<void()> onAccept;
+    std::function<void()> onReject;
+    bool accepted;
 };
 
 } //namespace PartDesignGui

--- a/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
@@ -111,27 +111,13 @@ void ViewProviderAttachExtension::extensionSetupContextMenu(QMenu* menu, QObject
     }
 }
 
-void ViewProviderAttachExtension::showAttachmentEditor()
+void ViewProviderAttachExtension::showAttachmentEditor(std::function<void()> onAccept, std::function<void()> onReject)
 {
     if (Gui::Control().activeDialog()) {
         Gui::Control().closeDialog();
     }
 
-    // See PropertyEnumAttacherItem::openTask()
-    Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-    TaskDlgAttacher* task;
-    task = qobject_cast<TaskDlgAttacher*>(dlg);
-
-    if (dlg && !task) {
-        // there is already another task dialog which must be closed first
-        Gui::Control().showDialog(dlg);
-        return;
-    }
-
-    if (!task) {
-        task = new TaskDlgAttacher(getExtendedViewProvider());
-    }
-
+    TaskDlgAttacher* task = new TaskDlgAttacher(getExtendedViewProvider(), true, onAccept, onReject);
     Gui::Control().showDialog(task);
 }
 

--- a/src/Mod/Part/Gui/ViewProviderAttachExtension.h
+++ b/src/Mod/Part/Gui/ViewProviderAttachExtension.h
@@ -44,7 +44,7 @@ public:
     void extensionUpdateData(const App::Property*) override;
     void extensionSetupContextMenu(QMenu*, QObject*, const char*) override;
 
-    void showAttachmentEditor();
+    void showAttachmentEditor(std::function<void()> onAccept = {}, std::function<void()> onReject = {});
 };
 
 using ViewProviderAttachExtensionPython = Gui::ViewProviderExtensionPythonT<PartGui::ViewProviderAttachExtension>;


### PR DESCRIPTION
This PR adds a parameter `Preferences/Mod/PartDesign/NewSketchUseAttachmentDialog `
If set to true, the command 'create new sketch' in part design will open the attachment dialog instead of the 'feature pick' dialog.

It is false by default. ie the current workflow is not changed.

The reason it is false is that the workflow with the attachment dialog is not smooth enough to be the default imo. Reasons : 
- In feature pick a single click on a base plane validates. With attachment dialog it needs to select first, then click OK. We could set the attachment dialog to auto-complete on first selection. But then you cannot do more complex attachment (set offset for instance).
- The attachment dialog is not good enough and throws error in all directions.

@pierreporte @maxwxyz 