### PR TITLE
BIM: Fixed shape loading

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_viewproviders.py
+++ b/src/Mod/BIM/nativeifc/ifc_viewproviders.py
@@ -245,7 +245,7 @@ class ifc_vp_object:
             import Part  # lazy loading
 
             self.Object.Shape = Part.Shape()
-        elif self.Object.ShapeMode == "Coin":
+        else:
             self.Object.ShapeMode = "Shape"
         self.Object.Document.recompute()
         self.Object.ViewObject.DiffuseColor = self.Object.ViewObject.DiffuseColor


### PR DESCRIPTION
NativeIFC objects shape would not load when ShapeType is None

Fixes #18391 