### PR TITLE
Patch: use sensible defaults for length units

### DIFF
--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -59,19 +59,23 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, QStr
             unitString = QString::fromLatin1("nm");
             factor = 1e-6;
         }
-        else if (UnitValue < 0.1) {
+        else if (UnitValue < 1) {
             unitString = QString::fromUtf8("\xC2\xB5m");
             factor = 1e-3;
         }
-        else if (UnitValue < 1e4) {
+        else if (UnitValue < 10) {
             unitString = QString::fromLatin1("mm");
             factor = 1.0;
         }
-        else if (UnitValue < 1e7) {
+        else if (UnitValue < 1e3) {
+            unitString = QString::fromLatin1("cm");
+            factor = 10;
+        }
+        else if (UnitValue < 1e6) {
             unitString = QString::fromLatin1("m");
             factor = 1e3;
         }
-        else if (UnitValue < 1e10) {
+        else if (UnitValue < 1e9) {
             unitString = QString::fromLatin1("km");
             factor = 1e6;
         }


### PR DESCRIPTION
In our standard unit schema I am missing centimeters and the threshold values are all over the place.

In this patch I added centimeters to our length units and use reasonable threshold values (like we all learned in school at some point):
- less than 1 mm -> use μm
- more than 10 mm -> use cm
- more than 100 cm -> use m
- more than 1000 m -> use km