### PR TITLE
App: Fix encoding of Datums.cpp

### DIFF
--- a/src/App/Datums.cpp
+++ b/src/App/Datums.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2015 Stefan Tröger <stefantroeger@gmx.net>              *
+ *   Copyright (c) 2015 Stefan TrÃ¶ger <stefantroeger@gmx.net>              *
  *   Copyright (c) 2015 Alexander Golubev (Fat-Zer) <fatzer2@gmail.com>    *
  *   Copyright (c) 2024 Ondsel (PL Boyer) <development@ondsel.com>         *
  *                                                                         *


### PR DESCRIPTION
The encoding was not UTF-8, so Stefan Tröger was mis-rendered in some editors (and the compiler complained).