### PR TITLE
fix MSVC build, do not use designated initializers and 'near' name for variables

### DIFF
--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -788,17 +788,17 @@ RayPickInfo View3DInventor::getObjInfoRay(Base::Vector3d* startvec, Base::Vector
     vdy = dirvec->y;
     vdz = dirvec->z;
     // near plane clipping is required to avoid false intersections
-    float near = 0.1;
+    float nearPlane = 0.1;
 
-    RayPickInfo ret = {.isValid = false,
-                       .point = Base::Vector3d(),
-                       .document = "",
-                       .object = "",
-                       .parentObject = std::nullopt,
-                       .component = std::nullopt,
-                       .subName = std::nullopt};
+    RayPickInfo ret = {false, // isValid
+                       Base::Vector3d(), // point
+                       "", // document
+                       "", // object
+                       std::nullopt, // parentObject
+                       std::nullopt, // component
+                       std::nullopt}; // subName
     SoRayPickAction action(getViewer()->getSoRenderManager()->getViewportRegion());
-    action.setRay(SbVec3f(vsx, vsy, vsz), SbVec3f(vdx, vdy, vdz), near);
+    action.setRay(SbVec3f(vsx, vsy, vsz), SbVec3f(vdx, vdy, vdz), nearPlane);
     action.apply(getViewer()->getSoRenderManager()->getSceneGraph());
     SoPickedPoint* Point = action.getPickedPoint();
 


### PR DESCRIPTION
Fixes Windows build issue introduced in https://github.com/FreeCAD/FreeCAD/pull/16789#issuecomment-2542095089
