### PR TITLE
Gui: Rename variable to eliminate macro conflict

### DIFF
--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -788,7 +788,7 @@ RayPickInfo View3DInventor::getObjInfoRay(Base::Vector3d* startvec, Base::Vector
     vdy = dirvec->y;
     vdz = dirvec->z;
     // near plane clipping is required to avoid false intersections
-    float near = 0.1;
+    float nearClippingPlane = 0.1;
 
     RayPickInfo ret = {.isValid = false,
                        .point = Base::Vector3d(),
@@ -798,7 +798,7 @@ RayPickInfo View3DInventor::getObjInfoRay(Base::Vector3d* startvec, Base::Vector
                        .component = std::nullopt,
                        .subName = std::nullopt};
     SoRayPickAction action(getViewer()->getSoRenderManager()->getViewportRegion());
-    action.setRay(SbVec3f(vsx, vsy, vsz), SbVec3f(vdx, vdy, vdz), near);
+    action.setRay(SbVec3f(vsx, vsy, vsz), SbVec3f(vdx, vdy, vdz), nearClippingPlane);
     action.apply(getViewer()->getSoRenderManager()->getSceneGraph());
     SoPickedPoint* Point = action.getPickedPoint();
 


### PR DESCRIPTION
Windows.h defines 'near' and 'far' macros, and they are actually used in the Inventor codebase (so we can't just undefine them).