### PR TITLE
Addon Manager: Arch->BIM in list of known internal WBs

### DIFF
--- a/src/Mod/AddonManager/Addon.py
+++ b/src/Mod/AddonManager/Addon.py
@@ -49,7 +49,7 @@ translate = fci.translate
 
 #  A list of internal workbenches that can be used as a dependency of an Addon
 INTERNAL_WORKBENCHES = {
-    "arch": "Arch",
+    "bim": "BIM",
     "assembly": "Assembly",
     "draft": "Draft",
     "fem": "FEM",

--- a/src/Mod/AddonManager/AddonManagerTest/data/depends_on_all_workbenches.xml
+++ b/src/Mod/AddonManager/AddonManagerTest/data/depends_on_all_workbenches.xml
@@ -13,7 +13,7 @@
 		<workbench>
 			<classname>MyFirstWorkbench</classname>
 			<icon>Resources/icons/PackageIcon.svg</icon>
-			<depend>Arch</depend>
+			<depend>BIM</depend>
 			<depend>Assembly</depend>
 			<depend>DraftWB</depend>
 			<depend>FEM WB</depend>


### PR DESCRIPTION
Update name that Addon authors can use to assert a dependency on an internal WB.