### PR TITLE
Disable external zipios usage for Debian builds

### DIFF
--- a/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
+++ b/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
@@ -178,7 +178,10 @@ macro(InitializeFreeCADBuildOptions)
 
     # if this is set override some options
     if (FREECAD_BUILD_DEBIAN)
-        set(FREECAD_USE_EXTERNAL_ZIPIOS ON )
+        # Disable it until the upstream package has been fixed. See
+        # https://github.com/FreeCAD/FreeCAD/issues/13676#issuecomment-2539978468
+        # https://github.com/FreeCAD/FreeCAD/issues/13676#issuecomment-2541513308
+        set(FREECAD_USE_EXTERNAL_ZIPIOS OFF )
         # A Debian package for SMESH doesn't exist
         #set(FREECAD_USE_EXTERNAL_SMESH ON )
     endif (FREECAD_BUILD_DEBIAN)


### PR DESCRIPTION
As per comment on https://github.com/FreeCAD/FreeCAD/issues/13676#issuecomment-2539978468 and https://github.com/FreeCAD/FreeCAD/issues/13676#issuecomment-2541325750

In summary, the Debian package version of zipios++ seems to contain a bug when used in FreeCAD to write thumbnails. For Debian packages, this change enables building the zipios sources bundled with FreeCAD.

The snap package has been fixed via https://github.com/FreeCAD/FreeCAD-snap/pull/139 and has been tested to work.

Fixes https://github.com/FreeCAD/FreeCAD/issues/13676