### PR TITLE
[TD]Fix transparent area in pdf (fix #18443)

### DIFF
--- a/src/Mod/TechDraw/Gui/PagePrinter.cpp
+++ b/src/Mod/TechDraw/Gui/PagePrinter.cpp
@@ -183,10 +183,9 @@ void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
     QString documentName = QString::fromUtf8(doc->getName());
     QPdfWriter pdfWriter(outputFile);
 
-    // setPdfVersion sets the printed PDF Version to comply with PDF/A-1b, more details under:
-    // https://www.kdab.com/creating-pdfa-documents-qt/ but this is not working as of Qt 5.12
-    // printer->setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
-    // pdfWriter.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
+    // set the printed PDF Version to comply with PDF/A-1b, more details under:
+    // https://www.kdab.com/creating-pdfa-documents-qt/
+    pdfWriter.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
 
     pdfWriter.setTitle(documentName);
     pdfWriter.setResolution(printer->resolution());
@@ -350,6 +349,7 @@ void PagePrinter::printPdf(ViewProviderPage* vpPage, const std::string& file)
     // set up the pdfwriter
     QString outputFile = QString::fromStdString(filespec);
     QPdfWriter pdfWriter(outputFile);
+    pdfWriter.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
     QPageLayout pageLayout = pdfWriter.pageLayout();
     auto marginsdb = pageLayout.margins(QPageLayout::Millimeter);
     QString documentName = QString::fromUtf8(vpPage->getDrawPage()->getNameInDocument());

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -925,6 +925,7 @@ void QGIViewBalloon::setPens(void)
 {
     balloonLines->setWidth(m_lineWidth);
     balloonShape->setWidth(m_lineWidth);
+    balloonShape->setFillColor(PreferencesGui::pageQColor());
     arrow->setWidth(m_lineWidth);
 }
 


### PR DESCRIPTION
This PR implements a fix for #18443.  It also restores the use of PDF/A-1b format for pdf in TechDraw which was removed due to issues in Qt which now appear to be fixed,