### PR TITLE
Pixi improvements

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -75,6 +75,7 @@ sed = "*"
 sysroot_linux-64 = "*"
 xorg-x11-server-common-cos6-x86_64 = "*"
 xorg-x11-server-xvfb-cos6-x86_64 = "*"
+xorg-xorgproto = "*"
 
 ## Linux Dependencies (aarch64)
 [target.linux-aarch64.dependencies]
@@ -108,6 +109,7 @@ sed = "*"
 sysroot_linux-aarch64 = "*"
 xorg-x11-server-common-cos7-aarch64 = "*"
 xorg-x11-server-xvfb-cos7-aarch64 = "*"
+xorg-xorgproto = "*"
 
 ## macOS Dependencies (Intel)
 [target.osx-64.dependencies]


### PR DESCRIPTION
I have noticed that a pixi.toml was added recently, very nice! I have been using pixi for some time already. My local pixi.toml was overwritten by the one from the repo and then I got CMake errors..

I am not using `pixi run configure` and `pixi run build`. I have been using CLion with a toolchain to a script containing this to make CLion detect the pixi packages:
```
#!/bin/bash
cd /home/bas/src/FreeCAD && eval "$(pixi shell-hook)"
```

The first error is a missing X11_X11_INCLUDE_PATH. This only occurred after removing the build folder and either removing pixi.lock or running `pixi update`. It works now because xorg-xorgproto is included in the pixi.lock file but when running `pixi update` it is removed. Adding it explicitly fixes this.

`pixi run build` successfully started building after adding xorg-xorgproto. However, in CLion I got more errors which are also reproducible by temporarily changing the linux64 configure task to:
`configure = { cmd = [ "cmake", "-B", "build" ], depends-on = ["initialize"]}` and running `pixi run configure`.

The second error is "med.h not found". Adding libmed to pixi.toml fixes this but downgrades hfd5 to 1.14.3

Finally I got a CMake boost error:
```
Could not find a package configuration file provided by "boost_python"
  (requested version 1.86.0) with any of the following names:

    boost_pythonConfig.cmake
    boost_python-config.cmake

  Add the installation prefix of "boost_python" to CMAKE_PREFIX_PATH or set
  "boost_python_DIR" to a directory containing one of the above files.  If
  "boost_python" provides a separate development package or SDK, be sure it
  has been installed.
```
  Adding libboost-python-devel fixed this.

Going forward I would like to use the pixi.toml from the repository but it needs these changes to work for me.

@oursland, @looooo, could one of you review please.
