### PR TITLE
BIM: Fix ArchReference problem caused by TNP code

### DIFF
--- a/src/Mod/BIM/ArchReference.py
+++ b/src/Mod/BIM/ArchReference.py
@@ -402,7 +402,7 @@ class ArchReference:
                         writemode = False
                 elif "<Property name=\"Shape\" type=\"Part::PropertyPartShape\"" in line:
                     writemode = True
-                elif writemode and "<Part file=" in line:
+                elif writemode and "<Part" in line and "file=" in line:
                     n = re.findall(r'file=\"(.*?)\"',line)
                     if n:
                         part = n[0]


### PR DESCRIPTION
Due to TNP code Document.xml can contain (for example)` <Part ElementMap="0.4" file="Box001.Shape.brp"/>` instead of `<Part file="Box001.Shape.brp"/>`.
