### PR TITLE
TechDraw: Ensure tolerance font size is > 0

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -466,7 +466,7 @@ void QGIDatumLabel::setFont(QFont font)
     QFont tFont(font);
     double fontSize = font.pixelSize();
     double tolAdj = getTolAdjust();
-    tFont.setPixelSize((int)(fontSize * tolAdj));
+    tFont.setPixelSize(std::max(1, (int)(fontSize * tolAdj)));
     m_tolTextOver->setFont(tFont);
     m_tolTextUnder->setFont(tFont);
     updateFrameRect();


### PR DESCRIPTION
When `TolSizeAdjust` user preference set to small value, font size could be rounded down to zero flooding log with thousands
```
QFont::setPixelSize: Pixel size <= 0 (0)
```
so set minimal font height to 1.