### PR TITLE
Assembly: Joint creation presolve: fix #18369

### DIFF
--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -706,31 +706,10 @@ class Joint:
             part2Connected = assembly.isPartConnected(part2)
             joint.Activated = True
         else:
-            part1Connected = False
-            part2Connected = True
+            part1Connected = True
+            part2Connected = False
 
-        if not part2Connected:
-            if savePlc:
-                self.partMovedByPresolved = part2
-                self.presolveBackupPlc = part2.Placement
-
-            globalJcsPlc1 = UtilsAssembly.getJcsGlobalPlc(joint.Placement1, joint.Reference1)
-            jcsPlc2 = UtilsAssembly.getJcsPlcRelativeToPart(
-                assembly, joint.Placement2, joint.Reference2
-            )
-            if not sameDir:
-                jcsPlc2 = UtilsAssembly.flipPlacement(jcsPlc2)
-
-            # For link groups and sub-assemblies we have to take into account
-            # the parent placement (ie the linkgroup plc) as the linkgroup is not the moving part
-            # But instead of doing as follow, we rather enforce identity placement for linkgroups.
-            # parentPlc = UtilsAssembly.getParentPlacementIfNeeded(part2)
-            # part2.Placement = globalJcsPlc1 * jcsPlc2.inverse() * parentPlc.inverse()
-
-            part2.Placement = globalJcsPlc1 * jcsPlc2.inverse()
-            return True
-
-        elif not part1Connected:
+        if not part1Connected:
             if savePlc:
                 self.partMovedByPresolved = part1
                 self.presolveBackupPlc = part1.Placement
@@ -742,7 +721,28 @@ class Joint:
             if not sameDir:
                 jcsPlc1 = UtilsAssembly.flipPlacement(jcsPlc1)
 
+            # For link groups and sub-assemblies we have to take into account
+            # the parent placement (ie the linkgroup plc) as the linkgroup is not the moving part
+            # But instead of doing as follow, we rather enforce identity placement for linkgroups.
+            # parentPlc = UtilsAssembly.getParentPlacementIfNeeded(part2)
+            # part2.Placement = globalJcsPlc1 * jcsPlc2.inverse() * parentPlc.inverse()
+
             part1.Placement = globalJcsPlc2 * jcsPlc1.inverse()
+            return True
+
+        elif not part2Connected:
+            if savePlc:
+                self.partMovedByPresolved = part2
+                self.presolveBackupPlc = part2.Placement
+
+            globalJcsPlc1 = UtilsAssembly.getJcsGlobalPlc(joint.Placement1, joint.Reference1)
+            jcsPlc2 = UtilsAssembly.getJcsPlcRelativeToPart(
+                assembly, joint.Placement2, joint.Reference2
+            )
+            if not sameDir:
+                jcsPlc2 = UtilsAssembly.flipPlacement(jcsPlc2)
+
+            part2.Placement = globalJcsPlc1 * jcsPlc2.inverse()
             return True
         return False
 


### PR DESCRIPTION
Assembly: Joint creation presolve: move part2 rather than part1 when both are unconnected.

Fix https://github.com/FreeCAD/FreeCAD/issues/18369