### PR TITLE
Part: Fix segmentation fault in Feature::getExportElementName

### DIFF
--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -365,7 +365,7 @@ App::ElementNamePair Feature::getExportElementName(TopoShape shape,
                     // find it by matching either planes for faces or lines for edges.
                     auto searchShape = this->Shape.getShape();
                     // If we're still out at a Shell, Solid, CompSolid, or Compound drill in
-                    while (searchShape.getShape().ShapeType() < TopAbs_FACE ) {
+                    while (!searchShape.getShape().IsNull() && searchShape.getShape().ShapeType() < TopAbs_FACE ) {
                         auto shapes = searchShape.getSubTopoShapes();
                         if ( shapes.empty() ) // No more subshapes, so don't continue
                             break;


### PR DESCRIPTION
Calling ShapeType() on a null shape is not allowed and causes a segmentation fault. So, check beforehand if the shape is not null.

Fixes #18537