### PR TITLE
CAM: Add missing docstring to Path/Geom.py

### DIFF
--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -252,6 +252,8 @@ def xy(point):
 
 
 def speedBetweenPoints(p0, p1, hSpeed, vSpeed):
+    """speedBetweenPoints(p0, p1, hSpeed, vSpeed)
+    TODO: Needs docstring description here."""
     if isRoughly(hSpeed, vSpeed):
         return hSpeed
 


### PR DESCRIPTION
Help make CAM source easier to understand and limit the docstring lint warnings.

Note: This PR needs feedback before merge. Specifically it needs a suggested docstring.