### PR TITLE
[PythonEditor] Make converting tabs to spaces the default

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsEditor.ui
+++ b/src/Gui/PreferencePages/DlgSettingsEditor.ui
@@ -205,7 +205,7 @@
          <string>Keep tabs</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>Tabs</cstring>
@@ -225,6 +225,9 @@
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>Spaces</cstring>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Editor</cstring>

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -435,7 +435,7 @@ void InteractiveInterpreter::clearBuffer()
  *  Constructs a PythonConsole which is a child of 'parent'.
  */
 PythonConsole::PythonConsole(QWidget *parent)
-  : TextEdit(parent), WindowParameter( "Editor" ), _sourceDrain(nullptr)
+  : PythonTextEditor(parent), _sourceDrain(nullptr)
 {
     d = new PythonConsoleP();
     d->interactive = false;
@@ -467,7 +467,6 @@ PythonConsole::PythonConsole(QWidget *parent)
 
     // set colors and font from settings
     ParameterGrp::handle hPrefGrp = getWindowParameter();
-    hPrefGrp->Attach(this);
     hPrefGrp->NotifyAll();
 
     d->hGrpSettings = WindowParameter::getDefaultParameter()->GetGroup("PythonConsole");
@@ -512,7 +511,6 @@ PythonConsole::~PythonConsole()
     saveHistory();
     Base::PyGILStateLocker lock;
     d->hGrpSettings->Detach(this);
-    getWindowParameter()->Detach(this);
     delete pythonSyntax;
     Py_XDECREF(d->_stdoutPy);
     Py_XDECREF(d->_stderrPy);
@@ -613,13 +611,13 @@ void PythonConsole::keyPressEvent(QKeyEvent * e)
               if (e->text().isEmpty() ||
                   e->matches(QKeySequence::Copy) ||
                   e->matches(QKeySequence::SelectAll)) {
-                  TextEdit::keyPressEvent(e);
+                  PythonTextEditor::keyPressEvent(e);
               }
               else if (!e->text().isEmpty() &&
                   (e->modifiers() == Qt::NoModifier ||
                    e->modifiers() == Qt::ShiftModifier)) {
                   this->moveCursor(QTextCursor::End);
-                  TextEdit::keyPressEvent(e);
+                  PythonTextEditor::keyPressEvent(e);
               }
               break;
         }
@@ -671,11 +669,11 @@ void PythonConsole::keyPressEvent(QKeyEvent * e)
               if (e->text() == QLatin1String(".")) {
                   // analyse context and show available call tips
                   int contextLength = cursor.position() - inputLineBegin.position();
-                  TextEdit::keyPressEvent(e);
+                  PythonTextEditor::keyPressEvent(e);
                   d->callTipsList->showTips( inputStrg.left( contextLength ) );
               }
               else {
-                  TextEdit::keyPressEvent(e);
+                  PythonTextEditor::keyPressEvent(e);
               }
           }   break;
 
@@ -707,25 +705,25 @@ void PythonConsole::keyPressEvent(QKeyEvent * e)
           case Qt::Key_Left:
           {
               if (cursor > inputLineBegin)
-                  { TextEdit::keyPressEvent(e); }
+                  { PythonTextEditor::keyPressEvent(e); }
               restartHistory = false;
           }   break;
 
           case Qt::Key_Right:
           {
-              TextEdit::keyPressEvent(e);
+              PythonTextEditor::keyPressEvent(e);
               restartHistory = false;
           }   break;
 
           case Qt::Key_Backspace:
           {
               if (cursorBeyond( cursor, inputLineBegin, +1 ))
-                  { TextEdit::keyPressEvent(e); }
+                  { PythonTextEditor::keyPressEvent(e); }
           }   break;
 
           default:
           {
-              TextEdit::keyPressEvent(e);
+              PythonTextEditor::keyPressEvent(e);
           }   break;
         }
         // This can't be done in CallTipsList::eventFilter() because we must first perform

--- a/src/Gui/PythonConsole.h
+++ b/src/Gui/PythonConsole.h
@@ -97,7 +97,7 @@ private:
  * @author Werner Mayer
  */
 class PythonConsoleHighlighter;
-class GuiExport PythonConsole : public TextEdit, public WindowParameter
+class GuiExport PythonConsole : public PythonTextEditor
 {
     Q_OBJECT
 

--- a/src/Gui/PythonEditor.cpp
+++ b/src/Gui/PythonEditor.cpp
@@ -65,7 +65,7 @@ struct PythonEditorP
  *  syntax highlighting for the Python language.
  */
 PythonEditor::PythonEditor(QWidget* parent)
-  : TextEditor(parent)
+    : PythonTextEditor(parent)
 {
     d = new PythonEditorP();
     this->setSyntaxHighlighter(new PythonSyntaxHighlighter(this));
@@ -205,7 +205,7 @@ void PythonEditor::keyPressEvent(QKeyEvent* e)
         setTextCursor(cursor);
         return; //skip default handler
     }
-    TextEditor::keyPressEvent(e); //wasn't enter key, so let base class handle it
+    PythonTextEditor::keyPressEvent(e); //wasn't enter key, so let base class handle it
 }
 
 void PythonEditor::onComment()

--- a/src/Gui/PythonEditor.h
+++ b/src/Gui/PythonEditor.h
@@ -36,7 +36,7 @@ class PythonSyntaxHighlighterP;
  * Python text editor with syntax highlighting.
  * \author Werner Mayer
  */
-class GuiExport PythonEditor : public TextEditor
+class GuiExport PythonEditor : public PythonTextEditor
 {
     Q_OBJECT
 

--- a/src/Gui/TextEdit.h
+++ b/src/Gui/TextEdit.h
@@ -118,6 +118,22 @@ private:
     friend class SyntaxHighlighter;
 };
 
+/** subclass of TextEditor that serves as base class for the
+ *  python editor and the python console where we handle
+ *  the tab key conversion to spaces, depending on user settings
+ */
+class GuiExport PythonTextEditor : public TextEditor
+{
+    Q_OBJECT
+public:
+    explicit PythonTextEditor(QWidget *parent = nullptr);
+    ~PythonTextEditor() override;
+protected:
+    void keyPressEvent(QKeyEvent *) override;
+
+};
+
+
 class LineMarker : public QWidget
 {
     Q_OBJECT


### PR DESCRIPTION
Since migrating to python3, which does not tolerate mixing spaces and tabs, the default should now be set to convert tabs into spaces for this editor.