### PR TITLE
[Spreadsheet] fix isValidAlias()

### DIFF
--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -129,20 +129,16 @@ const Cell* PropertySheet::getValueFromAlias(const std::string& alias) const
 
 bool PropertySheet::isValidCellAddressName(const std::string& candidate)
 {
-    static const boost::regex gen("^[A-Za-z][_A-Za-z0-9]*$");
+    /* Check if it matches a cell reference */
+    static const boost::regex e("\\${0,1}([A-Z]{1,2})\\${0,1}([0-9]{1,5})");
     boost::cmatch cm;
 
-    /* Check if it matches a cell reference */
-    if (boost::regex_match(candidate.c_str(), cm, gen)) {
-        static const boost::regex e("\\${0,1}([A-Z]{1,2})\\${0,1}([0-9]{1,5})");
+    if (boost::regex_match(candidate.c_str(), cm, e)) {
+        const boost::sub_match<const char*> colstr = cm[1];
+        const boost::sub_match<const char*> rowstr = cm[2];
 
-        if (boost::regex_match(candidate.c_str(), cm, e)) {
-            const boost::sub_match<const char*> colstr = cm[1];
-            const boost::sub_match<const char*> rowstr = cm[2];
-
-            if (App::validRow(rowstr.str()) >= 0 && App::validColumn(colstr.str())) {
-                return true;
-            }
+        if (App::validRow(rowstr.str()) >= 0 && App::validColumn(colstr.str())) {
+            return true;
         }
     }
     return false;

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -150,13 +150,19 @@ bool PropertySheet::isValidCellAddressName(const std::string& candidate)
 
 bool PropertySheet::isValidAlias(const std::string& candidate)
 {
+    /* Ensure it only contains allowed characters */
+    static const boost::regex gen("^[A-Za-z][_A-Za-z0-9]*$");
+    boost::cmatch cm;
+    if (!boost::regex_match(candidate.c_str(), cm, gen)) {
+        return false;
+    }
 
     /* Check if it is used before */
     if (getValueFromAlias(candidate)) {
         return false;
     }
 
-    /* check if it would be a valid cell address name, e.g. "A2" or "C3" */
+    /* Check if it would be a valid cell address name, e.g. "A2" or "C3" */
     if (isValidCellAddressName(candidate)) {
         return false;
     }

--- a/tests/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/tests/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -76,7 +76,11 @@ TEST_F(PropertySheetTest, validAliases)  // NOLINT
 
 TEST_F(PropertySheetTest, invalidAliases)  // NOLINT
 {
-    std::vector<std::string> invalidAliases {"A1", "ZZ1234", "mm", "no spaces allowed", "\'NoLeadingQuotes"};
+    std::vector<std::string> invalidAliases {"A1",
+                                             "ZZ1234",
+                                             "mm",
+                                             "no spaces allowed",
+                                             "\'NoLeadingQuotes"};
     for (const auto& name : invalidAliases) {
         EXPECT_FALSE(propertySheet()->isValidAlias(name))
             << "\"" << name << "\" was accepted as an alias name, and should not be";

--- a/tests/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/tests/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -81,6 +81,7 @@ TEST_F(PropertySheetTest, invalidAliases)  // NOLINT
                                              "mm",
                                              "no spaces allowed",
                                              "\'NoLeadingQuotes"};
+
     for (const auto& name : invalidAliases) {
         EXPECT_FALSE(propertySheet()->isValidAlias(name))
             << "\"" << name << "\" was accepted as an alias name, and should not be";

--- a/tests/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/tests/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -76,7 +76,7 @@ TEST_F(PropertySheetTest, validAliases)  // NOLINT
 
 TEST_F(PropertySheetTest, invalidAliases)  // NOLINT
 {
-    std::vector<std::string> invalidAliases {"A1", "ZZ1234", "mm"};
+    std::vector<std::string> invalidAliases {"A1", "ZZ1234", "mm", "no spaces allowed", "\'NoLeadingQuotes"};
     for (const auto& name : invalidAliases) {
         EXPECT_FALSE(propertySheet()->isValidAlias(name))
             << "\"" << name << "\" was accepted as an alias name, and should not be";


### PR DESCRIPTION
Alias validation was broken in one of my previous PR's.  This fixes the issue introduced in https://github.com/FreeCAD/FreeCAD/pull/17315

Incorrectly, I previously thought the re matching was only looking for valid address strings, but it was also looking for invalid characters, such as spaces or quote characters in the alias name.  The relevant re search was moved back into isValidAlias().

I also added an alias named with spaces and another with a leading single quote character to the unit tests.  I am not entirely sure these tests are actually being run. @chennes can you have a look?  I tried adding one of the invalid names to the valid names list, but it did not trigger the expected test failure.  Instead, all tests passed when that one should have failed.  Method to run was from the linux terminal in the build folder:

`./bin/FreeCAD -t0`

As a sidenote there appear to be lots of exceptions getting thrown in the unit tests, but they aren't triggering test failures.

What lead me back here was this post on the forum: 

https://forum.freecad.org/viewtopic.php?t=92952

It seems when copying the contents of a cell that has a string in it the leading singlequote is also copied, and when this is simply pasted into the Alias QLineEdit widget it can lead to a crash.  This should resolve that crash because now the alias name with the leading quote is flagged as an invalid alias and so setAlias() isn't being called on it.  I considered automatically removing the leading single quote, but then upon investigating found this bug that this PR is fixing.