### PR TITLE
Gui: Move Python functions from Application to ApplicationPy

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -60,6 +60,7 @@
 #include <Quarter/Quarter.h>
 
 #include "Application.h"
+#include "ApplicationPy.h"
 #include "AxisOriginPy.h"
 #include "BitmapFactory.h"
 #include "Command.h"
@@ -436,7 +437,7 @@ Application::Application(bool GUIenabled)
                                                              "FreeCADGui",
                                                              FreeCADGui_doc,
                                                              -1,
-                                                             Application::Methods,
+                                                             ApplicationPy::Methods,
                                                              nullptr,
                                                              nullptr,
                                                              nullptr,
@@ -447,7 +448,7 @@ Application::Application(bool GUIenabled)
         }
         else {
             // extend the method list
-            PyModule_AddFunctions(module, Application::Methods);
+            PyModule_AddFunctions(module, ApplicationPy::Methods);
         }
         Py::Module(module).setAttr(std::string("ActiveDocument"), Py::None());
         Py::Module(module).setAttr(std::string("HasQtBug_129596"),

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -39,6 +39,7 @@ class SoNode;
 class NavlibInterface;
 
 namespace Gui{
+class ApplicationPy;
 class BaseView;
 class CommandManager;
 class Document;
@@ -293,89 +294,13 @@ public:
     bool setUserEditMode(const std::string &mode);
     //@}
 
-public:
-    //---------------------------------------------------------------------
-    // python exports goes here +++++++++++++++++++++++++++++++++++++++++++
-    //---------------------------------------------------------------------
-    // static python wrapper of the exported functions
-    static PyObject* sActivateWorkbenchHandler (PyObject *self,PyObject *args); // activates a workbench object
-    static PyObject* sAddWorkbenchHandler      (PyObject *self,PyObject *args); // adds a new workbench handler to a list
-    static PyObject* sRemoveWorkbenchHandler   (PyObject *self,PyObject *args); // removes a workbench handler from the list
-    static PyObject* sGetWorkbenchHandler      (PyObject *self,PyObject *args); // retrieves the workbench handler
-    static PyObject* sListWorkbenchHandlers    (PyObject *self,PyObject *args); // retrieves a list of all workbench handlers
-    static PyObject* sActiveWorkbenchHandler   (PyObject *self,PyObject *args); // retrieves the active workbench object
-    static PyObject* sAddResPath               (PyObject *self,PyObject *args); // adds a path where to find resources
-    static PyObject* sAddLangPath              (PyObject *self,PyObject *args); // adds a path to a qm file
-    static PyObject* sAddIconPath              (PyObject *self,PyObject *args); // adds a path to an icon file
-    static PyObject* sAddIcon                  (PyObject *self,PyObject *args); // adds an icon to the cache
-    static PyObject* sGetIcon                  (PyObject *self,PyObject *args); // get an icon from the cache
-    static PyObject* sIsIconCached             (PyObject *self,PyObject *args); // check if an icon is cached
-
-    static PyObject* sSendActiveView           (PyObject *self,PyObject *args);
-    static PyObject* sSendFocusView            (PyObject *self,PyObject *args);
-
-    static PyObject* sGetMainWindow            (PyObject *self,PyObject *args);
-    static PyObject* sUpdateGui                (PyObject *self,PyObject *args);
-    static PyObject* sUpdateLocale             (PyObject *self,PyObject *args);
-    static PyObject* sGetLocale                (PyObject *self,PyObject *args);
-    static PyObject* sSetLocale                (PyObject *self,PyObject *args);
-    static PyObject* sSupportedLocales         (PyObject *self,PyObject *args);
-    static PyObject* sCreateDialog             (PyObject *self,PyObject *args);
-    static PyObject* sAddPreferencePage        (PyObject *self,PyObject *args);
-
-    static PyObject* sRunCommand               (PyObject *self,PyObject *args);
-    static PyObject* sAddCommand               (PyObject *self,PyObject *args);
-
-    static PyObject* sHide                     (PyObject *self,PyObject *args); // deprecated
-    static PyObject* sShow                     (PyObject *self,PyObject *args); // deprecated
-    static PyObject* sHideObject               (PyObject *self,PyObject *args); // hide view provider object
-    static PyObject* sShowObject               (PyObject *self,PyObject *args); // show view provider object
-
-    static PyObject* sOpen                     (PyObject *self,PyObject *args); // open Python scripts
-    static PyObject* sInsert                   (PyObject *self,PyObject *args); // open Python scripts
-    static PyObject* sExport                   (PyObject *self,PyObject *args);
-    static PyObject* sReload                   (PyObject *self,PyObject *args); // reload FCStd file
-    static PyObject* sLoadFile                 (PyObject *self,PyObject *args); // open all types of files
-
-    static PyObject* sCoinRemoveAllChildren    (PyObject *self,PyObject *args);
-
-    static PyObject* sActiveDocument           (PyObject *self,PyObject *args);
-    static PyObject* sSetActiveDocument        (PyObject *self,PyObject *args);
-    static PyObject* sActiveView               (PyObject *self,PyObject *args);
-    static PyObject* sActivateView             (PyObject *self,PyObject *args);
-    static PyObject* sGetDocument              (PyObject *self,PyObject *args);
-    static PyObject* sEditDocument             (PyObject *self,PyObject *args);
-
-    static PyObject* sDoCommand                (PyObject *self,PyObject *args);
-    static PyObject* sDoCommandGui             (PyObject *self,PyObject *args);
-    static PyObject* sDoCommandEval            (PyObject *self,PyObject *args);
-    static PyObject* sDoCommandSkip            (PyObject *self,PyObject *args);
-    static PyObject* sAddModule                (PyObject *self,PyObject *args);
-
-    static PyObject* sShowDownloads            (PyObject *self,PyObject *args);
-    static PyObject* sShowPreferences          (PyObject *self,PyObject *args);
-    static PyObject* sShowPreferencesByName    (PyObject *self,PyObject *args);
-
-    static PyObject* sCreateViewer             (PyObject *self,PyObject *args);
-    static PyObject* sGetMarkerIndex           (PyObject *self,PyObject *args);
-
-    static PyObject* sAddDocObserver           (PyObject *self,PyObject *args);
-    static PyObject* sRemoveDocObserver        (PyObject *self,PyObject *args);
-
-    static PyObject* sAddWbManipulator         (PyObject *self,PyObject *args);
-    static PyObject* sRemoveWbManipulator      (PyObject *self,PyObject *args);
-
-    static PyObject* sListUserEditModes        (PyObject *self,PyObject *args);
-    static PyObject* sGetUserEditMode          (PyObject *self,PyObject *args);
-    static PyObject* sSetUserEditMode          (PyObject *self,PyObject *args);
-
-    static PyMethodDef    Methods[];
-
 private:
     struct ApplicationP* d;
     /// workbench python dictionary
-    PyObject*             _pcWorkbenchDictionary;
+    PyObject* _pcWorkbenchDictionary;
     NavlibInterface* pNavlibInterface;
+
+    friend class ApplicationPy;
 };
 
 } //namespace Gui

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -45,6 +45,7 @@
 #include <CXX/Objects.hxx>
 
 #include "Application.h"
+#include "ApplicationPy.h"
 #include "BitmapFactory.h"
 #include "Command.h"
 #include "DlgPreferencesImp.h"
@@ -74,15 +75,15 @@
 using namespace Gui;
 
 // Application methods structure
-PyMethodDef Application::Methods[] = {
-  {"activateWorkbench",(PyCFunction) Application::sActivateWorkbenchHandler, METH_VARARGS,
+PyMethodDef ApplicationPy::Methods[] = {
+  {"activateWorkbench",(PyCFunction) ApplicationPy::sActivateWorkbenchHandler, METH_VARARGS,
    "activateWorkbench(name) -> bool\n"
     "\n"
    "Activate workbench by its name. Return False if the workbench is\n"
    "already active.\n"
     "\n"
     "name : str\n    Name of the workbench to activate."},
-  {"addWorkbench",     (PyCFunction) Application::sAddWorkbenchHandler, METH_VARARGS,
+  {"addWorkbench",     (PyCFunction) ApplicationPy::sAddWorkbenchHandler, METH_VARARGS,
    "addWorkbench(workbench) -> None\n"
     "\n"
    "Add a workbench.\n"
@@ -90,46 +91,46 @@ PyMethodDef Application::Methods[] = {
     "workbench : Workbench, Workbench type\n"
     "    Instance of a Workbench subclass or subclass of the\n"
     "    Workbench class."},
-  {"removeWorkbench",  (PyCFunction) Application::sRemoveWorkbenchHandler, METH_VARARGS,
+  {"removeWorkbench",  (PyCFunction) ApplicationPy::sRemoveWorkbenchHandler, METH_VARARGS,
    "removeWorkbench(name) -> None\n"
    "\n"
    "Remove a workbench.\n"
    "\n"
    "name : str\n    Name of the workbench to remove."},
-  {"getWorkbench",     (PyCFunction) Application::sGetWorkbenchHandler, METH_VARARGS,
+  {"getWorkbench",     (PyCFunction) ApplicationPy::sGetWorkbenchHandler, METH_VARARGS,
    "getWorkbench(name) -> Workbench\n"
    "\n"
    "Get the workbench by its name.\n"
    "\n"
    "name : str\n    Name of the workbench to return."},
-  {"listWorkbenches",   (PyCFunction) Application::sListWorkbenchHandlers, METH_VARARGS,
+  {"listWorkbenches",   (PyCFunction) ApplicationPy::sListWorkbenchHandlers, METH_VARARGS,
    "listWorkbenches() -> dict\n"
    "\n"
    "Get a dictionary with all workbenches."},
-  {"activeWorkbench", (PyCFunction) Application::sActiveWorkbenchHandler, METH_VARARGS,
+  {"activeWorkbench", (PyCFunction) ApplicationPy::sActiveWorkbenchHandler, METH_VARARGS,
    "activeWorkbench() -> Workbench\n"
    "\n"
    "Return the active workbench object."},
-  {"addResourcePath",             (PyCFunction) Application::sAddResPath, METH_VARARGS,
+  {"addResourcePath",             (PyCFunction) ApplicationPy::sAddResPath, METH_VARARGS,
    "addResourcePath(path) -> None\n"
    "\n"
    "Add a new path to the system where to find resource files\n"
    "like icons or localization files.\n"
    "\n"
    "path : str, bytes, bytearray\n    Path to resource files."},
-  {"addLanguagePath",             (PyCFunction) Application::sAddLangPath, METH_VARARGS,
+  {"addLanguagePath",             (PyCFunction) ApplicationPy::sAddLangPath, METH_VARARGS,
    "addLanguagePath(path) -> None\n"
    "\n"
    "Add a new path to the system where to find language files.\n"
    "\n"
    "path : str, bytes, bytearray\n    Path to language files."},
-  {"addIconPath",             (PyCFunction) Application::sAddIconPath, METH_VARARGS,
+  {"addIconPath",             (PyCFunction) ApplicationPy::sAddIconPath, METH_VARARGS,
    "addIconPath(path) -> None\n"
    "\n"
    "Add a new path to the system where to find icon files.\n"
    "\n"
    "path : str, bytes, bytearray\n    Path to icon files."},
-  {"addIcon",                 (PyCFunction) Application::sAddIcon, METH_VARARGS,
+  {"addIcon",                 (PyCFunction) ApplicationPy::sAddIcon, METH_VARARGS,
    "addIcon(name, content, format='XPM') -> None\n"
    "\n"
    "Add an icon to the system.\n"
@@ -137,53 +138,53 @@ PyMethodDef Application::Methods[] = {
    "name : str\n    Name of the icon.\n"
    "content : str, bytes-like\n    Content of the icon.\n"
    "format : str\n    Format of the icon."},
-  {"getIcon",                 (PyCFunction) Application::sGetIcon, METH_VARARGS,
+  {"getIcon",                 (PyCFunction) ApplicationPy::sGetIcon, METH_VARARGS,
    "getIcon(name) -> QIcon or None\n"
    "\n"
    "Get an icon in the system. If the pixmap is null, return None.\n"
    "\n"
    "name : str\n    Name of the icon."},
-  {"isIconCached",           (PyCFunction) Application::sIsIconCached, METH_VARARGS,
+  {"isIconCached",           (PyCFunction) ApplicationPy::sIsIconCached, METH_VARARGS,
    "isIconCached(name) -> Bool\n"
    "\n"
    "Check if an icon with the given name is cached.\n"
    "\n"
    "name : str\n    Name of the icon."},
-  {"getMainWindow",           (PyCFunction) Application::sGetMainWindow, METH_VARARGS,
+  {"getMainWindow",           (PyCFunction) ApplicationPy::sGetMainWindow, METH_VARARGS,
    "getMainWindow() -> QMainWindow\n"
    "\n"
    "Return the main window instance."},
-  {"updateGui",               (PyCFunction) Application::sUpdateGui, METH_VARARGS,
+  {"updateGui",               (PyCFunction) ApplicationPy::sUpdateGui, METH_VARARGS,
    "updateGui() -> None\n"
    "\n"
    "Update the main window and all its windows."},
-  {"updateLocale",            (PyCFunction) Application::sUpdateLocale, METH_VARARGS,
+  {"updateLocale",            (PyCFunction) ApplicationPy::sUpdateLocale, METH_VARARGS,
    "updateLocale() -> None\n"
    "\n"
    "Update the localization."},
-  {"getLocale",            (PyCFunction) Application::sGetLocale, METH_VARARGS,
+  {"getLocale",            (PyCFunction) ApplicationPy::sGetLocale, METH_VARARGS,
    "getLocale() -> str\n"
    "\n"
    "Returns the locale currently used by FreeCAD."},
-  {"setLocale",            (PyCFunction) Application::sSetLocale, METH_VARARGS,
+  {"setLocale",            (PyCFunction) ApplicationPy::sSetLocale, METH_VARARGS,
    "setLocale(name) -> None\n"
    "\n"
    "Sets the locale used by FreeCAD. Can be set by top-level\n"
    "domain (e.g. \"de\") or the language name (e.g. \"German\").\n"
    "\n"
    "name : str\n    Locale name."},
-  {"supportedLocales", (PyCFunction) Application::sSupportedLocales, METH_VARARGS,
+  {"supportedLocales", (PyCFunction) ApplicationPy::sSupportedLocales, METH_VARARGS,
    "supportedLocales() -> dict\n"
    "\n"
    "Returns a dict of all supported locales. The keys are the language\n"
    "names and the values the top-level domains."},
-  {"createDialog",            (PyCFunction) Application::sCreateDialog, METH_VARARGS,
+  {"createDialog",            (PyCFunction) ApplicationPy::sCreateDialog, METH_VARARGS,
    "createDialog(path) -> PyResource\n"
    "\n"
    "Open a UI file.\n"
    "\n"
    "path : str\n    UI file path."},
-  {"addPreferencePage",       (PyCFunction) Application::sAddPreferencePage, METH_VARARGS,
+  {"addPreferencePage",       (PyCFunction) ApplicationPy::sAddPreferencePage, METH_VARARGS,
    "addPreferencePage(path, group) -> None\n"
    "addPreferencePage(dialog, group) -> None\n"
    "\n"
@@ -192,7 +193,7 @@ PyMethodDef Application::Methods[] = {
    "path : str\n    UI file path.\n"
    "group : str\n    Group name.\n"
    "dialog : type\n    Preference page."},
-  {"addCommand",              (PyCFunction) Application::sAddCommand, METH_VARARGS,
+  {"addCommand",              (PyCFunction) ApplicationPy::sAddCommand, METH_VARARGS,
    "addCommand(name, cmd, activation) -> None\n"
    "\n"
    "Add a command object.\n"
@@ -200,58 +201,58 @@ PyMethodDef Application::Methods[] = {
    "name : str\n    Name of the command.\n"
    "cmd : object\n    Command instance.\n"
    "activation : str\n    Activation sequence. Optional."},
-  {"runCommand",              (PyCFunction) Application::sRunCommand, METH_VARARGS,
+  {"runCommand",              (PyCFunction) ApplicationPy::sRunCommand, METH_VARARGS,
    "runCommand(name, index=0) -> None\n"
    "\n"
    "Run command by its name.\n"
    "\n"
    "name : str\n    Name of the command.\n"
    "index : int\n    Index of the child command."},
-  {"SendMsgToActiveView",     (PyCFunction) Application::sSendActiveView, METH_VARARGS,
+  {"SendMsgToActiveView",     (PyCFunction) ApplicationPy::sSendActiveView, METH_VARARGS,
    "SendMsgToActiveView(name, suppress=False) -> str or None\n"
    "\n"
    "Send message to the active view. Deprecated, use class View.\n"
    "\n"
    "name : str\n    Name of the view command.\n"
    "suppress : bool\n    If the sent message fail, suppress warning message."},
-  {"sendMsgToFocusView",     (PyCFunction) Application::sSendFocusView, METH_VARARGS,
+  {"sendMsgToFocusView",     (PyCFunction) ApplicationPy::sSendFocusView, METH_VARARGS,
    "sendMsgToFocusView(name, suppress=False) -> str or None\n"
    "\n"
    "Send message to the focused view.\n"
    "\n"
    "name : str\n    Name of the view command.\n"
    "suppress : bool\n    If send message fail, suppress warning message."},
-  {"hide",                    (PyCFunction) Application::sHide, METH_VARARGS,
+  {"hide",                    (PyCFunction) ApplicationPy::sHide, METH_VARARGS,
    "hide(name) -> None\n"
    "\n"
    "Hide the given feature. Deprecated.\n"
    "\n"
    "name : str\n    Feature name."},
-  {"show",                    (PyCFunction) Application::sShow, METH_VARARGS,
+  {"show",                    (PyCFunction) ApplicationPy::sShow, METH_VARARGS,
    "show(name) -> None\n"
    "\n"
    "Show the given feature. Deprecated.\n"
    "\n"
    "name : str\n    Feature name."},
-  {"hideObject",              (PyCFunction) Application::sHideObject, METH_VARARGS,
+  {"hideObject",              (PyCFunction) ApplicationPy::sHideObject, METH_VARARGS,
    "hideObject(obj) -> None\n"
    "\n"
    "Hide the view provider of the given object.\n"
    "\n"
    "obj : App.DocumentObject"},
-  {"showObject",              (PyCFunction) Application::sShowObject, METH_VARARGS,
+  {"showObject",              (PyCFunction) ApplicationPy::sShowObject, METH_VARARGS,
    "showObject(obj) -> None\n"
    "\n"
    "Show the view provider of the given object.\n"
    "\n"
    "obj : App.DocumentObject"},
-  {"open",                    (PyCFunction) Application::sOpen, METH_VARARGS,
+  {"open",                    (PyCFunction) ApplicationPy::sOpen, METH_VARARGS,
    "open(fileName) -> None\n"
    "\n"
    "Open a macro, Inventor or VRML file.\n"
    "\n"
    "fileName : str, bytes, bytearray\n    File name."},
-  {"insert",                  (PyCFunction) Application::sInsert, METH_VARARGS,
+  {"insert",                  (PyCFunction) ApplicationPy::sInsert, METH_VARARGS,
    "insert(fileName, docName) -> None\n"
    "\n"
    "Insert a macro, Inventor or VRML file. If no document name\n"
@@ -259,31 +260,31 @@ PyMethodDef Application::Methods[] = {
    "\n"
    "fileName : str, bytes, bytearray\n    File name.\n"
    "docName : str\n    Document name."},
-  {"export",                  (PyCFunction) Application::sExport, METH_VARARGS,
+  {"export",                  (PyCFunction) ApplicationPy::sExport, METH_VARARGS,
    "export(objs, fileName) -> None\n"
    "\n"
    "Save scene to Inventor or VRML file.\n"
    "\n"
    "objs : sequence of App.DocumentObject\n    Sequence of objects to save.\n"
    "fileName : str, bytes, bytearray\n    File name."},
-  {"activeDocument",          (PyCFunction) Application::sActiveDocument, METH_VARARGS,
+  {"activeDocument",          (PyCFunction) ApplicationPy::sActiveDocument, METH_VARARGS,
    "activeDocument() -> Gui.Document or None\n"
    "\n"
    "Return the active document. If no one exists, return None."},
-  {"setActiveDocument",       (PyCFunction) Application::sSetActiveDocument, METH_VARARGS,
+  {"setActiveDocument",       (PyCFunction) ApplicationPy::sSetActiveDocument, METH_VARARGS,
    "setActiveDocument(doc) -> None\n"
    "\n"
    "Activate the specified document.\n"
    "\n"
    "doc : str, App.Document\n    Document to activate."},
-  {"activeView", (PyCFunction)Application::sActiveView, METH_VARARGS,
+  {"activeView", (PyCFunction)ApplicationPy::sActiveView, METH_VARARGS,
    "activeView(typeName) -> object or None\n"
    "\n"
    "Return the active view of the active document. If no one\n"
    "exists, return None.\n"
    "\n"
    "typeName : str\n    Type name."},
-  {"activateView", (PyCFunction)Application::sActivateView, METH_VARARGS,
+  {"activateView", (PyCFunction)ApplicationPy::sActivateView, METH_VARARGS,
    "activateView(typeName, create=False) -> None\n"
    "\n"
    "Activate a view of the given type in the active document.\n"
@@ -292,126 +293,126 @@ PyMethodDef Application::Methods[] = {
    "\n"
    "type : str\n    Type name.\n"
    "create : bool"},
-  {"editDocument", (PyCFunction)Application::sEditDocument, METH_VARARGS,
+  {"editDocument", (PyCFunction)ApplicationPy::sEditDocument, METH_VARARGS,
    "editDocument() -> Gui.Document or None\n"
    "\n"
    "Return the current editing document. If no one exists,\n"
    "return None."},
-  {"getDocument",             (PyCFunction) Application::sGetDocument, METH_VARARGS,
+  {"getDocument",             (PyCFunction) ApplicationPy::sGetDocument, METH_VARARGS,
    "getDocument(doc) -> Gui.Document\n"
    "\n"
    "Get a document.\n"
    "\n"
    "doc : str, App.Document\n    `App.Document` name or `App.Document` object."},
-  {"doCommand",               (PyCFunction) Application::sDoCommand, METH_VARARGS,
+  {"doCommand",               (PyCFunction) ApplicationPy::sDoCommand, METH_VARARGS,
    "doCommand(cmd) -> None\n"
    "\n"
    "Prints the given string in the python console and runs it.\n"
    "\n"
    "cmd : str"},
-  {"doCommandGui",               (PyCFunction) Application::sDoCommandGui, METH_VARARGS,
+  {"doCommandGui",               (PyCFunction) ApplicationPy::sDoCommandGui, METH_VARARGS,
    "doCommandGui(cmd) -> None\n"
    "\n"
    "Prints the given string in the python console and runs it\n"
    "but doesn't record it in macros.\n"
    "\n"
    "cmd : str"},
-  {"doCommandEval",               (PyCFunction) Application::sDoCommandEval, METH_VARARGS,
+  {"doCommandEval",               (PyCFunction) ApplicationPy::sDoCommandEval, METH_VARARGS,
           "doCommandEval(cmd) -> PyObject\n"
           "\n"
           "Runs the given string without showing in the python console or recording in\n"
           "macros, and returns the result.\n"
           "\n"
           "cmd : str"},
-  {"doCommandSkip",               (PyCFunction) Application::sDoCommandSkip, METH_VARARGS,
+  {"doCommandSkip",               (PyCFunction) ApplicationPy::sDoCommandSkip, METH_VARARGS,
           "doCommandSkip(cmd) -> None\n"
           "\n"
           "Record the given string in the Macro but comment it out in the console\n"
           "\n"
           "cmd : str"},
-  {"addModule",               (PyCFunction) Application::sAddModule, METH_VARARGS,
+  {"addModule",               (PyCFunction) ApplicationPy::sAddModule, METH_VARARGS,
    "addModule(mod) -> None\n"
    "\n"
    "Prints the given module import only once in the macro recording.\n"
    "\n"
    "mod : str"},
-  {"showDownloads",               (PyCFunction) Application::sShowDownloads, METH_VARARGS,
+  {"showDownloads",               (PyCFunction) ApplicationPy::sShowDownloads, METH_VARARGS,
    "showDownloads() -> None\n\n"
    "Show the downloads manager window."},
-  {"showPreferences",               (PyCFunction) Application::sShowPreferences, METH_VARARGS,
+  {"showPreferences",               (PyCFunction) ApplicationPy::sShowPreferences, METH_VARARGS,
    "showPreferences(grp, index=0) -> None\n"
    "\n"
    "Show the preferences window.\n"
    "\n"
    "grp: str\n    Group to show.\n"
    "index : int\n    Page index."},
-  {"showPreferencesByName",       (PyCFunction) Application::sShowPreferencesByName, METH_VARARGS,
+  {"showPreferencesByName",       (PyCFunction) ApplicationPy::sShowPreferencesByName, METH_VARARGS,
    "showPreferencesByName(grp, pagename) -> None\n"
    "\n"
    "Show the preferences window.\n"
    "\n"
    "grp: str\n    Group to show.\n"
    "pagename : str\n    Page to show."},
-  {"createViewer",               (PyCFunction) Application::sCreateViewer, METH_VARARGS,
+  {"createViewer",               (PyCFunction) ApplicationPy::sCreateViewer, METH_VARARGS,
    "createViewer(views=1, name) -> View3DInventorPy or AbstractSplitViewPy\n"
    "\n"
    "Show and returns a viewer.\n"
    "\n"
    "views : int\n    If > 1 a `AbstractSplitViewPy` object is returned.\n"
    "name : str\n    Viewer title."},
-  {"getMarkerIndex", (PyCFunction) Application::sGetMarkerIndex, METH_VARARGS,
+  {"getMarkerIndex", (PyCFunction) ApplicationPy::sGetMarkerIndex, METH_VARARGS,
    "getMarkerIndex(marker, size=9) -> int\n"
    "\n"
    "Get marker index according to marker name and size.\n"
    "\n"
    "marker : str\n    Marker style name.\n"
    "size : int\n    Marker size."},
-  {"addDocumentObserver",  (PyCFunction) Application::sAddDocObserver, METH_VARARGS,
+  {"addDocumentObserver",  (PyCFunction) ApplicationPy::sAddDocObserver, METH_VARARGS,
    "addDocumentObserver(obj) -> None\n"
    "\n"
    "Add an observer to get notifications about changes on documents.\n"
    "\n"
    "obj : object"},
-  {"removeDocumentObserver",  (PyCFunction) Application::sRemoveDocObserver, METH_VARARGS,
+  {"removeDocumentObserver",  (PyCFunction) ApplicationPy::sRemoveDocObserver, METH_VARARGS,
    "removeDocumentObserver(obj) -> None\n"
    "\n"
    "Remove an added document observer.\n"
    "\n"
    "obj : object"},
-  {"addWorkbenchManipulator",  (PyCFunction) Application::sAddWbManipulator, METH_VARARGS,
+  {"addWorkbenchManipulator",  (PyCFunction) ApplicationPy::sAddWbManipulator, METH_VARARGS,
    "addWorkbenchManipulator(obj) -> None\n"
    "\n"
    "Add a workbench manipulator to modify a workbench when it is activated.\n"
    "\n"
    "obj : object"},
-  {"removeWorkbenchManipulator",  (PyCFunction) Application::sRemoveWbManipulator, METH_VARARGS,
+  {"removeWorkbenchManipulator",  (PyCFunction) ApplicationPy::sRemoveWbManipulator, METH_VARARGS,
    "removeWorkbenchManipulator(obj) -> None\n"
    "\n"
    "Remove an added workbench manipulator.\n"
    "\n"
    "obj : object"},
-  {"listUserEditModes", (PyCFunction) Application::sListUserEditModes, METH_VARARGS,
+  {"listUserEditModes", (PyCFunction) ApplicationPy::sListUserEditModes, METH_VARARGS,
    "listUserEditModes() -> list\n"
    "\n"
    "List available user edit modes."},
-  {"getUserEditMode", (PyCFunction) Application::sGetUserEditMode, METH_VARARGS,
+  {"getUserEditMode", (PyCFunction) ApplicationPy::sGetUserEditMode, METH_VARARGS,
    "getUserEditMode() -> str\n"
    "\n"
    "Get current user edit mode."},
-  {"setUserEditMode", (PyCFunction) Application::sSetUserEditMode, METH_VARARGS,
+  {"setUserEditMode", (PyCFunction) ApplicationPy::sSetUserEditMode, METH_VARARGS,
    "setUserEditMode(mode) -> bool\n"
    "\n"
    "Set user edit mode. Returns True if exists, False otherwise.\n"
    "\n"
    "mode : str"},
-  {"reload",                    (PyCFunction) Application::sReload, METH_VARARGS,
+  {"reload",                    (PyCFunction) ApplicationPy::sReload, METH_VARARGS,
    "reload(name) -> App.Document or None\n"
    "\n"
    "Reload a partial opened document. If the document is not open,\n"
    "return None.\n"
    "\n"
    "name : str\n    `App.Document` name."},
-  {"loadFile",       (PyCFunction) Application::sLoadFile, METH_VARARGS,
+  {"loadFile",       (PyCFunction) ApplicationPy::sLoadFile, METH_VARARGS,
    "loadFile(fileName, module) -> None\n"
    "\n"
    "Loads an arbitrary file by delegating to the given Python module.\n"
@@ -421,7 +422,7 @@ PyMethodDef Application::Methods[] = {
    "\n"
    "fileName : str\n"
    "module : str"},
-  {"coinRemoveAllChildren",     (PyCFunction) Application::sCoinRemoveAllChildren, METH_VARARGS,
+  {"coinRemoveAllChildren",     (PyCFunction) ApplicationPy::sCoinRemoveAllChildren, METH_VARARGS,
    "coinRemoveAllChildren(node) -> None\n"
    "\n"
    "Remove all children from a group node.\n"
@@ -430,59 +431,67 @@ PyMethodDef Application::Methods[] = {
   {nullptr, nullptr, 0, nullptr}    /* Sentinel */
 };
 
-PyObject* Gui::Application::sEditDocument(PyObject * /*self*/, PyObject *args)
+PyObject* Gui::ApplicationPy::sEditDocument(PyObject * /*self*/, PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, ""))
+    if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
+    }
 
-    Document *pcDoc = Instance->editDocument();
-    if (pcDoc)
+    Document *pcDoc = Application::Instance->editDocument();
+    if (pcDoc) {
         return pcDoc->getPyObject();
-    else
-        Py_Return;
+    }
+
+    Py_Return;
 }
 
-PyObject* Gui::Application::sActiveDocument(PyObject * /*self*/, PyObject *args)
+PyObject* Gui::ApplicationPy::sActiveDocument(PyObject * /*self*/, PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, ""))
+    if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
+    }
 
-    Document *pcDoc = Instance->activeDocument();
-    if (pcDoc)
+    Document *pcDoc = Application::Instance->activeDocument();
+    if (pcDoc) {
         return pcDoc->getPyObject();
-    else
-        Py_Return;
+    }
+
+    Py_Return;
 }
 
-PyObject* Gui::Application::sActiveView(PyObject * /*self*/, PyObject *args)
+PyObject* Gui::ApplicationPy::sActiveView(PyObject * /*self*/, PyObject *args)
 {
     const char *typeName = nullptr;
-    if (!PyArg_ParseTuple(args, "|s", &typeName))
+    if (!PyArg_ParseTuple(args, "|s", &typeName)) {
         return nullptr;
+    }
 
     PY_TRY {
         Base::Type type;
-        if(typeName) {
+        if (typeName) {
             type = Base::Type::fromName(typeName);
-            if(type.isBad()) {
+            if (type.isBad()) {
                 PyErr_Format(PyExc_TypeError, "Invalid type '%s'", typeName);
                 return nullptr;
             }
         }
 
-        Gui::MDIView* mdiView = Instance->activeView();
+        Gui::MDIView* mdiView = Application::Instance->activeView();
         if (mdiView && (type.isBad() || mdiView->isDerivedFrom(type))) {
             auto res = Py::asObject(mdiView->getPyObject());
-            if(!res.isNone() || !type.isBad())
+            if(!res.isNone() || !type.isBad()) {
                 return Py::new_reference_to(res);
+            }
         }
 
-        if(type.isBad())
+        if (type.isBad()) {
             type = Gui::View3DInventor::getClassTypeId();
-        Instance->activateView(type, true);
-        mdiView = Instance->activeView();
-        if (mdiView)
+        }
+        Application::Instance->activateView(type, true);
+        mdiView = Application::Instance->activeView();
+        if (mdiView) {
             return mdiView->getPyObject();
+        }
 
         Py_Return;
 
@@ -490,27 +499,29 @@ PyObject* Gui::Application::sActiveView(PyObject * /*self*/, PyObject *args)
     PY_CATCH
 }
 
-PyObject* Gui::Application::sActivateView(PyObject * /*self*/, PyObject *args)
+PyObject* Gui::ApplicationPy::sActivateView(PyObject * /*self*/, PyObject *args)
 {
-    char* typeStr;
+    char* typeStr = nullptr;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
     PyObject *create = Py_False;
-    if (!PyArg_ParseTuple(args, "sO!", &typeStr, &PyBool_Type, &create))
+    if (!PyArg_ParseTuple(args, "sO!", &typeStr, &PyBool_Type, &create)) {
         return nullptr;
+    }
 
     Base::Type type = Base::Type::fromName(typeStr);
-    Instance->activateView(type, Base::asBoolean(create));
+    Application::Instance->activateView(type, Base::asBoolean(create));
 
     Py_Return;
 }
 
-PyObject* Gui::Application::sSetActiveDocument(PyObject * /*self*/, PyObject *args)
+PyObject* Gui::ApplicationPy::sSetActiveDocument(PyObject * /*self*/, PyObject *args)
 {
     Document *pcDoc = nullptr;
 
     do {
         char *pstr = nullptr;
         if (PyArg_ParseTuple(args, "s", &pstr)) {
-            pcDoc = Instance->getDocument(pstr);
+            pcDoc = Application::Instance->getDocument(pstr);
             if (!pcDoc) {
                 PyErr_Format(PyExc_NameError, "Unknown document '%s'", pstr);
                 return nullptr;
@@ -519,9 +530,10 @@ PyObject* Gui::Application::sSetActiveDocument(PyObject * /*self*/, PyObject *ar
         }
 
         PyErr_Clear();
-        PyObject* doc;
+        PyObject* doc = nullptr;
         if (PyArg_ParseTuple(args, "O!", &(App::DocumentPy::Type), &doc)) {
-            pcDoc = Instance->getDocument(static_cast<App::DocumentPy*>(doc)->getDocumentPtr());
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+            pcDoc = Application::Instance->getDocument(static_cast<App::DocumentPy*>(doc)->getDocumentPtr());
             if (!pcDoc) {
                 PyErr_Format(PyExc_KeyError, "Unknown document instance");
                 return nullptr;
@@ -536,7 +548,7 @@ PyObject* Gui::Application::sSetActiveDocument(PyObject * /*self*/, PyObject *ar
         return nullptr;
     }
 
-    if (Instance->activeDocument() != pcDoc) {
+    if (Application::Instance->activeDocument() != pcDoc) {
         Gui::MDIView* view = pcDoc->getActiveView();
         getMainWindow()->setActiveWindow(view);
     }
@@ -544,11 +556,11 @@ PyObject* Gui::Application::sSetActiveDocument(PyObject * /*self*/, PyObject *ar
     Py_Return;
 }
 
-PyObject* Application::sGetDocument(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sGetDocument(PyObject * /*self*/, PyObject *args)
 {
     char *pstr = nullptr;
     if (PyArg_ParseTuple(args, "s", &pstr)) {
-        Document *pcDoc = Instance->getDocument(pstr);
+        Document *pcDoc = Application::Instance->getDocument(pstr);
         if (!pcDoc) {
             PyErr_Format(PyExc_NameError, "Unknown document '%s'", pstr);
             return nullptr;
@@ -557,9 +569,10 @@ PyObject* Application::sGetDocument(PyObject * /*self*/, PyObject *args)
     }
 
     PyErr_Clear();
-    PyObject* doc;
+    PyObject* doc = nullptr;
     if (PyArg_ParseTuple(args, "O!", &(App::DocumentPy::Type), &doc)) {
-        Document *pcDoc = Instance->getDocument(static_cast<App::DocumentPy*>(doc)->getDocumentPtr());
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        Document *pcDoc = Application::Instance->getDocument(static_cast<App::DocumentPy*>(doc)->getDocumentPtr());
         if (!pcDoc) {
             PyErr_Format(PyExc_KeyError, "Unknown document instance");
             return nullptr;
@@ -571,64 +584,73 @@ PyObject* Application::sGetDocument(PyObject * /*self*/, PyObject *args)
     return nullptr;
 }
 
-PyObject* Application::sHide(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sHide(PyObject * /*self*/, PyObject *args)
 {
-    char *psFeatStr;
-    if (!PyArg_ParseTuple(args, "s;Name of the object to hide has to be given!",&psFeatStr))
+    char *psFeatStr = nullptr;
+    if (!PyArg_ParseTuple(args, "s;Name of the object to hide has to be given!",&psFeatStr)) {
         return nullptr;
+    }
 
-    Document *pcDoc = Instance->activeDocument();
+    Document *pcDoc = Application::Instance->activeDocument();
 
-    if (pcDoc)
+    if (pcDoc) {
         pcDoc->setHide(psFeatStr);
+    }
 
     Py_Return;
 }
 
-PyObject* Application::sShow(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sShow(PyObject * /*self*/, PyObject *args)
 {
-    char *psFeatStr;
-    if (!PyArg_ParseTuple(args, "s;Name of the object to show has to be given!",&psFeatStr))
+    char *psFeatStr = nullptr;
+    if (!PyArg_ParseTuple(args, "s;Name of the object to show has to be given!",&psFeatStr)) {
         return nullptr;
+    }
 
-    Document *pcDoc = Instance->activeDocument();
+    Document *pcDoc = Application::Instance->activeDocument();
 
-    if (pcDoc)
+    if (pcDoc) {
         pcDoc->setShow(psFeatStr);
+    }
 
     Py_Return;
 }
 
-PyObject* Application::sHideObject(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sHideObject(PyObject * /*self*/, PyObject *args)
 {
-    PyObject *object;
-    if (!PyArg_ParseTuple(args, "O!",&(App::DocumentObjectPy::Type),&object))
+    PyObject *object = nullptr;
+    if (!PyArg_ParseTuple(args, "O!",&(App::DocumentObjectPy::Type),&object)) {
         return nullptr;
+    }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(object)->getDocumentObjectPtr();
-    Instance->hideViewProvider(obj);
+    Application::Instance->hideViewProvider(obj);
 
     Py_Return;
 }
 
-PyObject* Application::sShowObject(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sShowObject(PyObject * /*self*/, PyObject *args)
 {
-    PyObject *object;
-    if (!PyArg_ParseTuple(args, "O!",&(App::DocumentObjectPy::Type),&object))
+    PyObject *object = nullptr;
+    if (!PyArg_ParseTuple(args, "O!",&(App::DocumentObjectPy::Type),&object)) {
         return nullptr;
+    }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(object)->getDocumentObjectPtr();
-    Instance->showViewProvider(obj);
+    Application::Instance->showViewProvider(obj);
 
     Py_Return;
 }
 
-PyObject* Application::sOpen(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sOpen(PyObject * /*self*/, PyObject *args)
 {
     // only used to open Python files
-    char* Name;
-    if (!PyArg_ParseTuple(args, "et","utf-8",&Name))
+    char* Name = nullptr;
+    if (!PyArg_ParseTuple(args, "et","utf-8",&Name)) {
         return nullptr;
+    }
 
     std::string Utf8Name = std::string(Name);
     PyMem_Free(Name);
@@ -645,12 +667,13 @@ PyObject* Application::sOpen(PyObject * /*self*/, PyObject *args)
     Py_Return;
 }
 
-PyObject* Application::sInsert(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sInsert(PyObject * /*self*/, PyObject *args)
 {
-    char* Name;
+    char* Name = nullptr;
     char* DocName = nullptr;
-    if (!PyArg_ParseTuple(args, "et|s","utf-8",&Name,&DocName))
+    if (!PyArg_ParseTuple(args, "et|s","utf-8",&Name,&DocName)) {
         return nullptr;
+    }
 
     std::string Utf8Name = std::string(Name);
     PyMem_Free(Name);
@@ -667,12 +690,13 @@ PyObject* Application::sInsert(PyObject * /*self*/, PyObject *args)
     Py_Return;
 }
 
-PyObject* Application::sExport(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sExport(PyObject * /*self*/, PyObject *args)
 {
-    PyObject* object;
-    char* Name;
-    if (!PyArg_ParseTuple(args, "Oet",&object,"utf-8",&Name))
+    PyObject* object = nullptr;
+    char* Name = nullptr;
+    if (!PyArg_ParseTuple(args, "Oet",&object,"utf-8",&Name)) {
         return nullptr;
+    }
 
     std::string Utf8Name = std::string(Name);
     PyMem_Free(Name);
@@ -683,6 +707,7 @@ PyObject* Application::sExport(PyObject * /*self*/, PyObject *args)
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             PyObject* item = (*it).ptr();
             if (PyObject_TypeCheck(item, &(App::DocumentObjectPy::Type))) {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
                 App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(item)->getDocumentObjectPtr();
                 doc = obj->getDocument();
                 break;
@@ -708,6 +733,7 @@ PyObject* Application::sExport(PyObject * /*self*/, PyObject *args)
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 PyObject* item = (*it).ptr();
                 if (PyObject_TypeCheck(item, &(App::DocumentObjectPy::Type))) {
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
                     App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(item)->getDocumentObjectPtr();
 
                     Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider(obj);
@@ -722,11 +748,16 @@ PyObject* Application::sExport(PyObject * /*self*/, PyObject *args)
             action.setCanApproximate(true);
             action.apply(sep);
 
+            constexpr const int triangleLimit = 100000;
+            constexpr const int pointLimit = 30000;
+            constexpr const int lineLimit = 10000;
+
             bool binary = false;
-            if (action.getTriangleCount() > 100000 ||
-                action.getPointCount() > 30000 ||
-                action.getLineCount() > 10000)
+            if (action.getTriangleCount() > triangleLimit ||
+                action.getPointCount() > pointLimit ||
+                action.getLineCount() > lineLimit) {
                 binary = true;
+            }
 
             SoFCDB::writeToFile(sep, Utf8Name.c_str(), binary);
             sep->unref();
@@ -738,8 +769,9 @@ PyObject* Application::sExport(PyObject * /*self*/, PyObject *args)
                 Gui::MDIView* view = gui_doc->getActiveView();
                 if (view) {
                     auto view3d = qobject_cast<View3DInventor*>(view);
-                    if (view3d)
+                    if (view3d) {
                         view3d->viewAll();
+                    }
                     QPrinter printer(QPrinter::ScreenResolution);
                     // setPdfVersion sets the printied PDF Version to comply with PDF/A-1b, more details under: https://www.kdab.com/creating-pdfa-documents-qt/
                     printer.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
@@ -757,17 +789,20 @@ PyObject* Application::sExport(PyObject * /*self*/, PyObject *args)
     Py_Return;
 }
 
-PyObject* Application::sSendActiveView(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sSendActiveView(PyObject * /*self*/, PyObject *args)
 {
-    char *psCommandStr;
-    PyObject *suppress=Py_False;
-    if (!PyArg_ParseTuple(args, "s|O!",&psCommandStr,&PyBool_Type,&suppress))
+    char *psCommandStr = nullptr;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    PyObject *suppress = Py_False;
+    if (!PyArg_ParseTuple(args, "s|O!",&psCommandStr,&PyBool_Type,&suppress)) {
         return nullptr;
+    }
 
     const char* ppReturn = nullptr;
-    if (!Instance->sendMsgToActiveView(psCommandStr,&ppReturn)) {
-        if (!Base::asBoolean(suppress))
+    if (!Application::Instance->sendMsgToActiveView(psCommandStr,&ppReturn)) {
+        if (!Base::asBoolean(suppress)) {
             Base::Console().Warning("Unknown view command: %s\n",psCommandStr);
+        }
     }
 
     // Print the return value to the output
@@ -778,17 +813,20 @@ PyObject* Application::sSendActiveView(PyObject * /*self*/, PyObject *args)
     Py_Return;
 }
 
-PyObject* Application::sSendFocusView(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sSendFocusView(PyObject * /*self*/, PyObject *args)
 {
-    char *psCommandStr;
-    PyObject *suppress=Py_False;
-    if (!PyArg_ParseTuple(args, "s|O!",&psCommandStr,&PyBool_Type,&suppress))
+    char *psCommandStr = nullptr;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    PyObject *suppress = Py_False;
+    if (!PyArg_ParseTuple(args, "s|O!",&psCommandStr,&PyBool_Type,&suppress)) {
         return nullptr;
+    }
 
     const char* ppReturn = nullptr;
-    if (!Instance->sendMsgToFocusView(psCommandStr,&ppReturn)) {
-        if (!Base::asBoolean(suppress))
+    if (!Application::Instance->sendMsgToFocusView(psCommandStr,&ppReturn)) {
+        if (!Base::asBoolean(suppress)) {
             Base::Console().Warning("Unknown view command: %s\n",psCommandStr);
+        }
     }
 
     // Print the return value to the output
@@ -799,10 +837,11 @@ PyObject* Application::sSendFocusView(PyObject * /*self*/, PyObject *args)
     Py_Return;
 }
 
-PyObject* Application::sGetMainWindow(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sGetMainWindow(PyObject * /*self*/, PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, ""))
+    if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
+    }
 
     try {
         return Py::new_reference_to(MainWindowPy::createWrapper(Gui::getMainWindow()));
@@ -812,40 +851,44 @@ PyObject* Application::sGetMainWindow(PyObject * /*self*/, PyObject *args)
     }
 }
 
-PyObject* Application::sUpdateGui(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sUpdateGui(PyObject * /*self*/, PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, ""))
+    if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
+    }
 
     qApp->processEvents();
 
     Py_Return;
 }
 
-PyObject* Application::sUpdateLocale(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sUpdateLocale(PyObject * /*self*/, PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, ""))
+    if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
+    }
 
     Translator::instance()->refresh();
 
     Py_Return;
 }
 
-PyObject* Application::sGetLocale(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sGetLocale(PyObject * /*self*/, PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, ""))
+    if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
+    }
 
     std::string locale = Translator::instance()->activeLanguage();
     return PyUnicode_FromString(locale.c_str());
 }
 
-PyObject* Application::sSetLocale(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sSetLocale(PyObject * /*self*/, PyObject *args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    char* name = nullptr;
+    if (!PyArg_ParseTuple(args, "s", &name)) {
         return nullptr;
+    }
 
     std::string cname(name);
     TStringMap map = Translator::instance()->supportedLocales();
@@ -860,10 +903,11 @@ PyObject* Application::sSetLocale(PyObject * /*self*/, PyObject *args)
     Py_Return;
 }
 
-PyObject* Application::sSupportedLocales(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sSupportedLocales(PyObject * /*self*/, PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, ""))
+    if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
+    }
 
     TStringMap map = Translator::instance()->supportedLocales();
     Py::Dict dict;
@@ -876,15 +920,17 @@ PyObject* Application::sSupportedLocales(PyObject * /*self*/, PyObject *args)
     return Py::new_reference_to(dict);
 }
 
-PyObject* Application::sCreateDialog(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sCreateDialog(PyObject * /*self*/, PyObject *args)
 {
     char* fn = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &fn))
+    if (!PyArg_ParseTuple(args, "s", &fn)) {
         return nullptr;
+    }
 
     PyObject* pPyResource = nullptr;
     try{
         pPyResource = new PyResource();
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
         static_cast<PyResource*>(pPyResource)->load(fn);
     }
     catch (const Base::Exception& e) {
@@ -895,9 +941,10 @@ PyObject* Application::sCreateDialog(PyObject * /*self*/, PyObject *args)
     return pPyResource;
 }
 
-PyObject* Application::sAddPreferencePage(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sAddPreferencePage(PyObject * /*self*/, PyObject *args)
 {
-    char *fn, *grp;
+    char* fn = nullptr;
+    char* grp = nullptr;
     if (PyArg_ParseTuple(args, "ss", &fn,&grp)) {
         QFileInfo fi(QString::fromUtf8(fn));
         if (!fi.exists()) {
@@ -911,7 +958,7 @@ PyObject* Application::sAddPreferencePage(PyObject * /*self*/, PyObject *args)
     }
 
     PyErr_Clear();
-    PyObject* dlg;
+    PyObject* dlg = nullptr;
     // new style classes
     if (PyArg_ParseTuple(args, "O!s", &PyType_Type, &dlg, &grp)) {
         // add to the preferences dialog
@@ -922,21 +969,22 @@ PyObject* Application::sAddPreferencePage(PyObject * /*self*/, PyObject *args)
     return nullptr;
 }
 
-PyObject* Application::sActivateWorkbenchHandler(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sActivateWorkbenchHandler(PyObject * /*self*/, PyObject *args)
 {
-    char* psKey;
-    if (!PyArg_ParseTuple(args, "s", &psKey))
+    char* psKey = nullptr;
+    if (!PyArg_ParseTuple(args, "s", &psKey)) {
         return nullptr;
+    }
 
     // search for workbench handler from the dictionary
-    PyObject* pcWorkbench = PyDict_GetItemString(Instance->_pcWorkbenchDictionary, psKey);
+    PyObject* pcWorkbench = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary, psKey);
     if (!pcWorkbench) {
         PyErr_Format(PyExc_KeyError, "No such workbench '%s'", psKey);
         return nullptr;
     }
 
     try {
-        bool ok = Instance->activateWorkbench(psKey);
+        bool ok = Application::Instance->activateWorkbench(psKey);
         return Py::new_reference_to(Py::Boolean(ok));
     }
     catch (const Base::Exception& e) {
@@ -965,11 +1013,12 @@ PyObject* Application::sActivateWorkbenchHandler(PyObject * /*self*/, PyObject *
     }
 }
 
-PyObject* Application::sAddWorkbenchHandler(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sAddWorkbenchHandler(PyObject * /*self*/, PyObject *args)
 {
-    PyObject* pcObject;
-    if (!PyArg_ParseTuple(args, "O", &pcObject))
+    PyObject* pcObject = nullptr;
+    if (!PyArg_ParseTuple(args, "O", &pcObject)) {
         return nullptr;
+    }
 
     try {
         // get the class object 'Workbench' from the main module that is expected
@@ -1000,19 +1049,21 @@ PyObject* Application::sAddWorkbenchHandler(PyObject * /*self*/, PyObject *args)
             return nullptr;
         }
 
+        // NOLINTBEGIN(bugprone-unused-raii)
         // Search for some methods and members without invoking them
         Py::Callable(object.getAttr(std::string("Initialize")));
         Py::Callable(object.getAttr(std::string("GetClassName")));
-        std::string item = name.as_std_string("ascii");
+        // NOLINTEND(bugprone-unused-raii)
 
-        PyObject* wb = PyDict_GetItemString(Instance->_pcWorkbenchDictionary,item.c_str());
+        std::string item = name.as_std_string("ascii");
+        PyObject* wb = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary,item.c_str());
         if (wb) {
             PyErr_Format(PyExc_KeyError, "'%s' already exists.", item.c_str());
             return nullptr;
         }
 
-        PyDict_SetItemString(Instance->_pcWorkbenchDictionary,item.c_str(),object.ptr());
-        Instance->signalRefreshWorkbenches();
+        PyDict_SetItemString(Application::Instance->_pcWorkbenchDictionary,item.c_str(),object.ptr());
+        Application::Instance->signalRefreshWorkbenches();
     }
     catch (const Py::Exception&) {
         return nullptr;
@@ -1021,33 +1072,35 @@ PyObject* Application::sAddWorkbenchHandler(PyObject * /*self*/, PyObject *args)
     Py_Return;
 }
 
-PyObject* Application::sRemoveWorkbenchHandler(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sRemoveWorkbenchHandler(PyObject * /*self*/, PyObject *args)
 {
-    char* psKey;
-    if (!PyArg_ParseTuple(args, "s", &psKey))
+    char* psKey = nullptr;
+    if (!PyArg_ParseTuple(args, "s", &psKey)) {
         return nullptr;
+    }
 
-    PyObject* wb = PyDict_GetItemString(Instance->_pcWorkbenchDictionary,psKey);
+    PyObject* wb = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary,psKey);
     if (!wb) {
         PyErr_Format(PyExc_KeyError, "No such workbench '%s'", psKey);
         return nullptr;
     }
 
     WorkbenchManager::instance()->removeWorkbench(psKey);
-    PyDict_DelItemString(Instance->_pcWorkbenchDictionary,psKey);
-    Instance->signalRefreshWorkbenches();
+    PyDict_DelItemString(Application::Instance->_pcWorkbenchDictionary,psKey);
+    Application::Instance->signalRefreshWorkbenches();
 
     Py_Return;
 }
 
-PyObject* Application::sGetWorkbenchHandler(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sGetWorkbenchHandler(PyObject * /*self*/, PyObject *args)
 {
-    char* psKey;
-    if (!PyArg_ParseTuple(args, "s", &psKey))
+    char* psKey = nullptr;
+    if (!PyArg_ParseTuple(args, "s", &psKey)) {
         return nullptr;
+    }
 
     // get the python workbench object from the dictionary
-    PyObject* pcWorkbench = PyDict_GetItemString(Instance->_pcWorkbenchDictionary, psKey);
+    PyObject* pcWorkbench = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary, psKey);
     if (!pcWorkbench) {
         PyErr_Format(PyExc_KeyError, "No such workbench '%s'", psKey);
         return nullptr;
@@ -1057,19 +1110,21 @@ PyObject* Application::sGetWorkbenchHandler(PyObject * /*self*/, PyObject *args)
     return pcWorkbench;
 }
 
-PyObject* Application::sListWorkbenchHandlers(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sListWorkbenchHandlers(PyObject * /*self*/, PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, ""))
+    if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
+    }
 
-    Py_INCREF(Instance->_pcWorkbenchDictionary);
-    return Instance->_pcWorkbenchDictionary;
+    Py_INCREF(Application::Instance->_pcWorkbenchDictionary);
+    return Application::Instance->_pcWorkbenchDictionary;
 }
 
-PyObject* Application::sActiveWorkbenchHandler(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sActiveWorkbenchHandler(PyObject * /*self*/, PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, ""))
+    if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
+    }
 
     Workbench* actWb = WorkbenchManager::instance()->active();
     if (!actWb) {
@@ -1079,7 +1134,7 @@ PyObject* Application::sActiveWorkbenchHandler(PyObject * /*self*/, PyObject *ar
 
     // get the python workbench object from the dictionary
     std::string key = actWb->name();
-    PyObject* pcWorkbench = PyDict_GetItemString(Instance->_pcWorkbenchDictionary, key.c_str());
+    PyObject* pcWorkbench = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary, key.c_str());
     if (!pcWorkbench) {
         PyErr_Format(PyExc_KeyError, "No such workbench '%s'", key.c_str());
         return nullptr;
@@ -1090,11 +1145,12 @@ PyObject* Application::sActiveWorkbenchHandler(PyObject * /*self*/, PyObject *ar
     return pcWorkbench;
 }
 
-PyObject* Application::sAddResPath(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sAddResPath(PyObject * /*self*/, PyObject *args)
 {
-    char* filePath;
-    if (!PyArg_ParseTuple(args, "et", "utf-8", &filePath))
+    char* filePath = nullptr;
+    if (!PyArg_ParseTuple(args, "et", "utf-8", &filePath)) {
         return nullptr;
+    }
 
     QString path = QString::fromUtf8(filePath);
     PyMem_Free(filePath);
@@ -1110,11 +1166,12 @@ PyObject* Application::sAddResPath(PyObject * /*self*/, PyObject *args)
     Py_Return;
 }
 
-PyObject* Application::sAddLangPath(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sAddLangPath(PyObject * /*self*/, PyObject *args)
 {
-    char* filePath;
-    if (!PyArg_ParseTuple(args, "et", "utf-8", &filePath))
+    char* filePath = nullptr;
+    if (!PyArg_ParseTuple(args, "et", "utf-8", &filePath)) {
         return nullptr;
+    }
 
     QString path = QString::fromUtf8(filePath);
     PyMem_Free(filePath);
@@ -1129,11 +1186,12 @@ PyObject* Application::sAddLangPath(PyObject * /*self*/, PyObject *args)
     Py_Return;
 }
 
-PyObject* Application::sAddIconPath(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sAddIconPath(PyObject * /*self*/, PyObject *args)
 {
-    char* filePath;
-    if (!PyArg_ParseTuple(args, "et", "utf-8", &filePath))
+    char* filePath = nullptr;
+    if (!PyArg_ParseTuple(args, "et", "utf-8", &filePath)) {
         return nullptr;
+    }
 
     QString path = QString::fromUtf8(filePath);
     PyMem_Free(filePath);
@@ -1148,13 +1206,14 @@ PyObject* Application::sAddIconPath(PyObject * /*self*/, PyObject *args)
     Py_Return;
 }
 
-PyObject* Application::sAddIcon(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sAddIcon(PyObject * /*self*/, PyObject *args)
 {
-    const char *iconName;
+    const char *iconName = nullptr;
     Py_buffer content;
     const char *format = "XPM";
-    if (!PyArg_ParseTuple(args, "ss*|s", &iconName, &content, &format))
+    if (!PyArg_ParseTuple(args, "ss*|s", &iconName, &content, &format)) {
         return nullptr;
+    }
 
     QPixmap icon;
     if (BitmapFactory().findPixmapInCache(iconName, icon)) {
@@ -1164,11 +1223,11 @@ PyObject* Application::sAddIcon(PyObject * /*self*/, PyObject *args)
     }
 
     const char* contentStr = static_cast<const char*>(content.buf);
-    QByteArray ary(contentStr, content.len);
+    QByteArray ary(contentStr, static_cast<int>(content.len));
     icon.loadFromData(ary, format);
 
     if (icon.isNull()){
-        QString file = QString::fromUtf8(contentStr, content.len);
+        QString file = QString::fromUtf8(contentStr, static_cast<int>(content.len));
         icon.load(file);
     }
 
@@ -1184,44 +1243,49 @@ PyObject* Application::sAddIcon(PyObject * /*self*/, PyObject *args)
     Py_Return;
 }
 
-PyObject* Application::sGetIcon(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sGetIcon(PyObject * /*self*/, PyObject *args)
 {
-    char *iconName;
-    if (!PyArg_ParseTuple(args, "s", &iconName))
+    char *iconName = nullptr;
+    if (!PyArg_ParseTuple(args, "s", &iconName)) {
         return nullptr;
+    }
 
     PythonWrapper wrap;
     wrap.loadGuiModule();
     wrap.loadWidgetsModule();
     auto pixmap = BitmapFactory().pixmap(iconName);
-    if(!pixmap.isNull())
+    if(!pixmap.isNull()) {
         return Py::new_reference_to(wrap.fromQIcon(new QIcon(pixmap)));
+    }
 
     Py_Return;
 }
 
-PyObject* Application::sIsIconCached(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sIsIconCached(PyObject * /*self*/, PyObject *args)
 {
-    char *iconName;
-    if (!PyArg_ParseTuple(args, "s", &iconName))
+    char *iconName = nullptr;
+    if (!PyArg_ParseTuple(args, "s", &iconName)) {
         return nullptr;
+    }
 
     QPixmap icon;
 
     return Py::new_reference_to(Py::Boolean(BitmapFactory().findPixmapInCache(iconName, icon)));
 }
 
-PyObject* Application::sAddCommand(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sAddCommand(PyObject * /*self*/, PyObject *args)
 {
-    char* pName;
+    char* pName = nullptr;
     char* pSource = nullptr;
-    PyObject* pcCmdObj;
-    if (!PyArg_ParseTuple(args, "sO|s", &pName,&pcCmdObj,&pSource))
+    PyObject* pcCmdObj = nullptr;
+    if (!PyArg_ParseTuple(args, "sO|s", &pName,&pcCmdObj,&pSource)) {
         return nullptr;
+    }
 
     // get the call stack to find the Python module name
     //
-    std::string module, group;
+    std::string module;
+    std::string group;
     try {
         Base::PyGILStateLocker lock;
         Py::Module mod(PyImport_ImportModule("inspect"), true);
@@ -1236,8 +1300,9 @@ PyObject* Application::sAddCommand(PyObject * /*self*/, PyObject *args)
         // usually this is the file name of the calling script
         Py::Object info = list.getItem(0);
         PyObject *pyfile = PyStructSequence_GET_ITEM(*info,1);
-        if(!pyfile)
+        if(!pyfile) {
             throw Py::Exception();
+        }
 
         file = Py::Object(pyfile).as_string();
         Base::FileInfo fi(file);
@@ -1253,10 +1318,11 @@ PyObject* Application::sAddCommand(PyObject * /*self*/, PyObject *args)
         }
         else {
             boost::regex rx("/Ext/freecad/(\\w+)/");
-            if (boost::regex_search(file, what, rx))
+            if (boost::regex_search(file, what, rx)) {
                 group = what[1];
-            else
+            } else {
                 group = module;
+            }
         }
     }
     catch (Py::Exception& e) {
@@ -1292,19 +1358,20 @@ PyObject* Application::sAddCommand(PyObject * /*self*/, PyObject *args)
         return nullptr;
     }
     catch (...) {
-        PyErr_SetString(Base::PyExc_FC_GeneralError, "Unknown C++ exception raised in Application::sAddCommand()");
+        PyErr_SetString(Base::PyExc_FC_GeneralError, "Unknown C++ exception raised in ApplicationPy::sAddCommand()");
         return nullptr;
     }
 
     Py_Return;
 }
 
-PyObject* Application::sRunCommand(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sRunCommand(PyObject * /*self*/, PyObject *args)
 {
-    char* pName;
+    char* pName = nullptr;
     int item = 0;
-    if (!PyArg_ParseTuple(args, "s|i", &pName, &item))
+    if (!PyArg_ParseTuple(args, "s|i", &pName, &item)) {
         return nullptr;
+    }
 
     Gui::Command::LogDisabler d1;
     Gui::SelectionLogDisabler d2;
@@ -1314,17 +1381,17 @@ PyObject* Application::sRunCommand(PyObject * /*self*/, PyObject *args)
         cmd->invoke(item);
         Py_Return;
     }
-    else {
-        PyErr_Format(Base::PyExc_FC_GeneralError, "No such command '%s'", pName);
-        return nullptr;
-    }
+
+    PyErr_Format(Base::PyExc_FC_GeneralError, "No such command '%s'", pName);
+    return nullptr;
 }
 
-PyObject* Application::sDoCommand(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sDoCommand(PyObject * /*self*/, PyObject *args)
 {
     char *sCmd = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &sCmd))
+    if (!PyArg_ParseTuple(args, "s", &sCmd)) {
         return nullptr;
+    }
 
     Gui::Command::LogDisabler d1;
     Gui::SelectionLogDisabler d2;
@@ -1332,25 +1399,29 @@ PyObject* Application::sDoCommand(PyObject * /*self*/, PyObject *args)
     Gui::Command::printPyCaller();
     Gui::Application::Instance->macroManager()->addLine(MacroManager::App, sCmd);
 
-    PyObject *module, *dict;
+    PyObject* module = nullptr;
+    PyObject* dict = nullptr;
 
     Base::PyGILStateLocker locker;
     module = PyImport_AddModule("__main__");
-    if (!module)
+    if (!module) {
         return nullptr;
+    }
 
     dict = PyModule_GetDict(module);
-    if (!dict)
+    if (!dict) {
         return nullptr;
+    }
 
     return PyRun_String(sCmd, Py_file_input, dict, dict);
 }
 
-PyObject* Application::sDoCommandGui(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sDoCommandGui(PyObject * /*self*/, PyObject *args)
 {
     char *sCmd = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &sCmd))
+    if (!PyArg_ParseTuple(args, "s", &sCmd)) {
         return nullptr;
+    }
 
     Gui::Command::LogDisabler d1;
     Gui::SelectionLogDisabler d2;
@@ -1358,48 +1429,56 @@ PyObject* Application::sDoCommandGui(PyObject * /*self*/, PyObject *args)
     Gui::Command::printPyCaller();
     Gui::Application::Instance->macroManager()->addLine(MacroManager::Gui, sCmd);
 
-    PyObject *module, *dict;
+    PyObject* module = nullptr;
+    PyObject* dict = nullptr;
 
     Base::PyGILStateLocker locker;
     module = PyImport_AddModule("__main__");
-    if (!module)
+    if (!module) {
         return nullptr;
+    }
 
     dict = PyModule_GetDict(module);
-    if (!dict)
+    if (!dict) {
         return nullptr;
+    }
 
     return PyRun_String(sCmd, Py_file_input, dict, dict);
 }
 
-PyObject* Application::sDoCommandEval(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sDoCommandEval(PyObject * /*self*/, PyObject *args)
 {
     char *sCmd = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &sCmd))
+    if (!PyArg_ParseTuple(args, "s", &sCmd)) {
         return nullptr;
+    }
 
     Gui::Command::LogDisabler d1;
     Gui::SelectionLogDisabler d2;
 
-    PyObject *module, *dict;
+    PyObject* module = nullptr;
+    PyObject* dict = nullptr;
 
     Base::PyGILStateLocker locker;
     module = PyImport_AddModule("__main__");
-    if (!module)
+    if (!module) {
         return nullptr;
+}
 
     dict = PyModule_GetDict(module);
-    if (!dict)
+    if (!dict) {
         return nullptr;
+    }
 
     return PyRun_String(sCmd, Py_eval_input, dict, dict);
 }
 
-PyObject* Application::sDoCommandSkip(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sDoCommandSkip(PyObject * /*self*/, PyObject *args)
 {
     char *sCmd = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &sCmd))
+    if (!PyArg_ParseTuple(args, "s", &sCmd)) {
         return nullptr;
+    }
 
     Gui::Command::LogDisabler d1;
     Gui::SelectionLogDisabler d2;
@@ -1409,11 +1488,12 @@ PyObject* Application::sDoCommandSkip(PyObject * /*self*/, PyObject *args)
     return Py::None().ptr();
 }
 
-PyObject* Application::sAddModule(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sAddModule(PyObject * /*self*/, PyObject *args)
 {
-    char *pstr;
-    if (!PyArg_ParseTuple(args, "s", &pstr))
+    char *pstr = nullptr;
+    if (!PyArg_ParseTuple(args, "s", &pstr)) {
         return nullptr;
+    }
 
     try {
         Command::addModule(Command::Doc,pstr);
@@ -1425,17 +1505,18 @@ PyObject* Application::sAddModule(PyObject * /*self*/, PyObject *args)
     }
 }
 
-PyObject* Application::sShowDownloads(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sShowDownloads(PyObject * /*self*/, PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, ""))
+    if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
+    }
 
     Gui::Dialog::DownloadManager::getInstance();
 
     Py_Return;
 }
 
-PyObject* Application::sShowPreferences(PyObject* /*self*/, PyObject* args)
+PyObject* ApplicationPy::sShowPreferences(PyObject* /*self*/, PyObject* args)
 {
     char* pstr = nullptr;
     int idx = 0;
@@ -1456,7 +1537,7 @@ PyObject* Application::sShowPreferences(PyObject* /*self*/, PyObject* args)
     Py_Return;
 }
 
-PyObject* Application::sShowPreferencesByName(PyObject* /*self*/, PyObject* args)
+PyObject* ApplicationPy::sShowPreferencesByName(PyObject* /*self*/, PyObject* args)
 {
     char* pstr = nullptr;
     const char* prefType = "";
@@ -1477,40 +1558,45 @@ PyObject* Application::sShowPreferencesByName(PyObject* /*self*/, PyObject* args
     Py_Return;
 }
 
-PyObject* Application::sCreateViewer(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sCreateViewer(PyObject * /*self*/, PyObject *args)
 {
     int num_of_views = 1;
     char* title = nullptr;
     // if one argument (int) is given
-    if (!PyArg_ParseTuple(args, "|is", &num_of_views, &title))
+    if (!PyArg_ParseTuple(args, "|is", &num_of_views, &title)) {
         return nullptr;
+    }
 
     if (num_of_views <= 0) {
         PyErr_Format(PyExc_ValueError, "views must be > 0");
         return nullptr;
     }
-    else if (num_of_views == 1) {
+    if (num_of_views == 1) {
         auto viewer = new View3DInventor(nullptr, nullptr);
-        if (title)
+        if (title) {
             viewer->setWindowTitle(QString::fromUtf8(title));
+        }
         Gui::getMainWindow()->addWindow(viewer);
         return viewer->getPyObject();
     }
     else {
         auto viewer = new SplitView3DInventor(num_of_views, nullptr, nullptr);
-        if (title)
+        if (title) {
             viewer->setWindowTitle(QString::fromUtf8(title));
+        }
         Gui::getMainWindow()->addWindow(viewer);
         return viewer->getPyObject();
     }
 }
 
-PyObject* Application::sGetMarkerIndex(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sGetMarkerIndex(PyObject * /*self*/, PyObject *args)
 {
+    constexpr const int defaultSize = 9;
     char *pstr {};
-    int  defSize = 9;
-    if (!PyArg_ParseTuple(args, "s|i", &pstr, &defSize))
+    int  defSize = defaultSize;
+    if (!PyArg_ParseTuple(args, "s|i", &pstr, &defSize)) {
         return nullptr;
+    }
 
     PY_TRY {
         ParameterGrp::handle const hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
@@ -1539,35 +1625,39 @@ PyObject* Application::sGetMarkerIndex(PyObject * /*self*/, PyObject *args)
         //get the marker size
         auto sizeList = Gui::Inventor::MarkerBitmaps::getSupportedSizes(marker_arg);
 
-        if (std::find(std::begin(sizeList), std::end(sizeList), defSize) == std::end(sizeList))
-            defSize = 9;
+        if (std::find(std::begin(sizeList), std::end(sizeList), defSize) == std::end(sizeList)) {
+            defSize = defaultSize;
+        }
 
         return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex(marker_arg, defSize));
     }
     PY_CATCH;
 }
 
-PyObject* Application::sReload(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sReload(PyObject * /*self*/, PyObject *args)
 {
-    const char *name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    const char *name = nullptr;
+    if (!PyArg_ParseTuple(args, "s", &name)) {
         return nullptr;
+    }
 
     PY_TRY {
         auto doc = Application::Instance->reopen(App::GetApplication().getDocument(name));
-        if(doc)
+        if(doc) {
             return doc->getPyObject();
+        }
         Py_Return;
     }
     PY_CATCH;
 }
 
-PyObject* Application::sLoadFile(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sLoadFile(PyObject * /*self*/, PyObject *args)
 {
     const char *path = "";
     const char *mod = "";
-    if (!PyArg_ParseTuple(args, "s|s", &path, &mod))
+    if (!PyArg_ParseTuple(args, "s|s", &path, &mod)) {
         return nullptr;
+    }
 
     PY_TRY {
         Base::FileInfo fi(path);
@@ -1584,9 +1674,8 @@ PyObject* Application::sLoadFile(PyObject * /*self*/, PyObject *args)
                 PyErr_Format(PyExc_IOError, "Filetype %s is not supported.", ext.c_str());
                 return nullptr;
             }
-            else {
-                module = modules.front();
-            }
+
+            module = modules.front();
         }
 
         Application::Instance->open(path,module.c_str());
@@ -1596,11 +1685,12 @@ PyObject* Application::sLoadFile(PyObject * /*self*/, PyObject *args)
     PY_CATCH
 }
 
-PyObject* Application::sAddDocObserver(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sAddDocObserver(PyObject * /*self*/, PyObject *args)
 {
-    PyObject* o;
-    if (!PyArg_ParseTuple(args, "O",&o))
+    PyObject* o = nullptr;
+    if (!PyArg_ParseTuple(args, "O",&o)) {
         return nullptr;
+    }
 
     PY_TRY {
         DocumentObserverPython::addObserver(Py::Object(o));
@@ -1609,11 +1699,12 @@ PyObject* Application::sAddDocObserver(PyObject * /*self*/, PyObject *args)
     PY_CATCH;
 }
 
-PyObject* Application::sRemoveDocObserver(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sRemoveDocObserver(PyObject * /*self*/, PyObject *args)
 {
-    PyObject* o;
-    if (!PyArg_ParseTuple(args, "O",&o))
+    PyObject* o = nullptr;
+    if (!PyArg_ParseTuple(args, "O",&o)) {
         return nullptr;
+    }
 
     PY_TRY {
         DocumentObserverPython::removeObserver(Py::Object(o));
@@ -1622,11 +1713,12 @@ PyObject* Application::sRemoveDocObserver(PyObject * /*self*/, PyObject *args)
     PY_CATCH;
 }
 
-PyObject* Application::sAddWbManipulator(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sAddWbManipulator(PyObject * /*self*/, PyObject *args)
 {
-    PyObject* o;
-    if (!PyArg_ParseTuple(args, "O",&o))
+    PyObject* o = nullptr;
+    if (!PyArg_ParseTuple(args, "O",&o)) {
         return nullptr;
+    }
 
     PY_TRY {
         WorkbenchManipulatorPython::installManipulator(Py::Object(o));
@@ -1635,11 +1727,12 @@ PyObject* Application::sAddWbManipulator(PyObject * /*self*/, PyObject *args)
     PY_CATCH;
 }
 
-PyObject* Application::sRemoveWbManipulator(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sRemoveWbManipulator(PyObject * /*self*/, PyObject *args)
 {
-    PyObject* o;
-    if (!PyArg_ParseTuple(args, "O",&o))
+    PyObject* o = nullptr;
+    if (!PyArg_ParseTuple(args, "O",&o)) {
         return nullptr;
+    }
 
     PY_TRY {
         WorkbenchManipulatorPython::removeManipulator(Py::Object(o));
@@ -1648,11 +1741,12 @@ PyObject* Application::sRemoveWbManipulator(PyObject * /*self*/, PyObject *args)
     PY_CATCH;
 }
 
-PyObject* Application::sCoinRemoveAllChildren(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sCoinRemoveAllChildren(PyObject * /*self*/, PyObject *args)
 {
-    PyObject *pynode;
-    if (!PyArg_ParseTuple(args, "O", &pynode))
+    PyObject *pynode = nullptr;
+    if (!PyArg_ParseTuple(args, "O", &pynode)) {
         return nullptr;
+    }
 
     PY_TRY {
         void* ptr = nullptr;
@@ -1668,34 +1762,37 @@ PyObject* Application::sCoinRemoveAllChildren(PyObject * /*self*/, PyObject *arg
     PY_CATCH;
 }
 
-PyObject* Application::sListUserEditModes(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sListUserEditModes(PyObject * /*self*/, PyObject *args)
 {
     Py::List ret;
-    if (!PyArg_ParseTuple(args, ""))
+    if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
+    }
 
-    for (auto const &uem : Instance->listUserEditModes()) {
+    for (auto const &uem : Application::Instance->listUserEditModes()) {
         ret.append(Py::String(uem.second.first));
     }
 
     return Py::new_reference_to(ret);
 }
 
-PyObject* Application::sGetUserEditMode(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sGetUserEditMode(PyObject * /*self*/, PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, ""))
+    if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
+    }
 
-    return Py::new_reference_to(Py::String(Instance->getUserEditModeUIStrings().first));
+    return Py::new_reference_to(Py::String(Application::Instance->getUserEditModeUIStrings().first));
 }
 
-PyObject* Application::sSetUserEditMode(PyObject * /*self*/, PyObject *args)
+PyObject* ApplicationPy::sSetUserEditMode(PyObject * /*self*/, PyObject *args)
 {
     const char *mode = "";
-    if (!PyArg_ParseTuple(args, "s", &mode))
+    if (!PyArg_ParseTuple(args, "s", &mode)) {
         return nullptr;
+    }
 
-    bool ok = Instance->setUserEditMode(std::string(mode));
+    bool ok = Application::Instance->setUserEditMode(std::string(mode));
 
     return Py::new_reference_to(Py::Boolean(ok));
 }

--- a/src/Gui/ApplicationPy.h
+++ b/src/Gui/ApplicationPy.h
@@ -1,0 +1,120 @@
+/***************************************************************************
+ *   Copyright (c) 2004 Jürgen Riegel <juergen.riegel@web.de>              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef GUI_APPLICATIONPY_H
+#define GUI_APPLICATIONPY_H
+
+#include <Base/PyObjectBase.h>
+
+namespace Gui{
+
+/** The ApplicationPy class
+ * This is the Python wrapper class of Application.
+ * @author Jürgen Riegel, Werner Mayer
+ */
+class GuiExport ApplicationPy
+{
+public:
+    // clang-format off
+    //---------------------------------------------------------------------
+    // python exports goes here +++++++++++++++++++++++++++++++++++++++++++
+    //---------------------------------------------------------------------
+    // static python wrapper of the exported functions
+    static PyObject* sActivateWorkbenchHandler (PyObject *self,PyObject *args); // activates a workbench object
+    static PyObject* sAddWorkbenchHandler      (PyObject *self,PyObject *args); // adds a new workbench handler to a list
+    static PyObject* sRemoveWorkbenchHandler   (PyObject *self,PyObject *args); // removes a workbench handler from the list
+    static PyObject* sGetWorkbenchHandler      (PyObject *self,PyObject *args); // retrieves the workbench handler
+    static PyObject* sListWorkbenchHandlers    (PyObject *self,PyObject *args); // retrieves a list of all workbench handlers
+    static PyObject* sActiveWorkbenchHandler   (PyObject *self,PyObject *args); // retrieves the active workbench object
+    static PyObject* sAddResPath               (PyObject *self,PyObject *args); // adds a path where to find resources
+    static PyObject* sAddLangPath              (PyObject *self,PyObject *args); // adds a path to a qm file
+    static PyObject* sAddIconPath              (PyObject *self,PyObject *args); // adds a path to an icon file
+    static PyObject* sAddIcon                  (PyObject *self,PyObject *args); // adds an icon to the cache
+    static PyObject* sGetIcon                  (PyObject *self,PyObject *args); // get an icon from the cache
+    static PyObject* sIsIconCached             (PyObject *self,PyObject *args); // check if an icon is cached
+
+    static PyObject* sSendActiveView           (PyObject *self,PyObject *args);
+    static PyObject* sSendFocusView            (PyObject *self,PyObject *args);
+
+    static PyObject* sGetMainWindow            (PyObject *self,PyObject *args);
+    static PyObject* sUpdateGui                (PyObject *self,PyObject *args);
+    static PyObject* sUpdateLocale             (PyObject *self,PyObject *args);
+    static PyObject* sGetLocale                (PyObject *self,PyObject *args);
+    static PyObject* sSetLocale                (PyObject *self,PyObject *args);
+    static PyObject* sSupportedLocales         (PyObject *self,PyObject *args);
+    static PyObject* sCreateDialog             (PyObject *self,PyObject *args);
+    static PyObject* sAddPreferencePage        (PyObject *self,PyObject *args);
+
+    static PyObject* sRunCommand               (PyObject *self,PyObject *args);
+    static PyObject* sAddCommand               (PyObject *self,PyObject *args);
+
+    static PyObject* sHide                     (PyObject *self,PyObject *args); // deprecated
+    static PyObject* sShow                     (PyObject *self,PyObject *args); // deprecated
+    static PyObject* sHideObject               (PyObject *self,PyObject *args); // hide view provider object
+    static PyObject* sShowObject               (PyObject *self,PyObject *args); // show view provider object
+
+    static PyObject* sOpen                     (PyObject *self,PyObject *args); // open Python scripts
+    static PyObject* sInsert                   (PyObject *self,PyObject *args); // open Python scripts
+    static PyObject* sExport                   (PyObject *self,PyObject *args);
+    static PyObject* sReload                   (PyObject *self,PyObject *args); // reload FCStd file
+    static PyObject* sLoadFile                 (PyObject *self,PyObject *args); // open all types of files
+
+    static PyObject* sCoinRemoveAllChildren    (PyObject *self,PyObject *args);
+
+    static PyObject* sActiveDocument           (PyObject *self,PyObject *args);
+    static PyObject* sSetActiveDocument        (PyObject *self,PyObject *args);
+    static PyObject* sActiveView               (PyObject *self,PyObject *args);
+    static PyObject* sActivateView             (PyObject *self,PyObject *args);
+    static PyObject* sGetDocument              (PyObject *self,PyObject *args);
+    static PyObject* sEditDocument             (PyObject *self,PyObject *args);
+
+    static PyObject* sDoCommand                (PyObject *self,PyObject *args);
+    static PyObject* sDoCommandGui             (PyObject *self,PyObject *args);
+    static PyObject* sDoCommandEval            (PyObject *self,PyObject *args);
+    static PyObject* sDoCommandSkip            (PyObject *self,PyObject *args);
+    static PyObject* sAddModule                (PyObject *self,PyObject *args);
+
+    static PyObject* sShowDownloads            (PyObject *self,PyObject *args);
+    static PyObject* sShowPreferences          (PyObject *self,PyObject *args);
+    static PyObject* sShowPreferencesByName    (PyObject *self,PyObject *args);
+
+    static PyObject* sCreateViewer             (PyObject *self,PyObject *args);
+    static PyObject* sGetMarkerIndex           (PyObject *self,PyObject *args);
+
+    static PyObject* sAddDocObserver           (PyObject *self,PyObject *args);
+    static PyObject* sRemoveDocObserver        (PyObject *self,PyObject *args);
+
+    static PyObject* sAddWbManipulator         (PyObject *self,PyObject *args);
+    static PyObject* sRemoveWbManipulator      (PyObject *self,PyObject *args);
+
+    static PyObject* sListUserEditModes        (PyObject *self,PyObject *args);
+    static PyObject* sGetUserEditMode          (PyObject *self,PyObject *args);
+    static PyObject* sSetUserEditMode          (PyObject *self,PyObject *args);
+
+    static PyMethodDef    Methods[];
+    // clang-format on
+};
+
+} //namespace Gui
+
+#endif


### PR DESCRIPTION
This reduces build time when adding new Python functions because only one file must be compiled. Handles also many linter warnings.