### PR TITLE
Placement::tostring Fix fmt expression

### DIFF
--- a/src/Base/Placement.cpp
+++ b/src/Base/Placement.cpp
@@ -221,7 +221,7 @@ std::string Placement::toString()
     double angle;
     rot.getRawValue(axis, angle);
 
-    return fmt::format("position ({.1f}, {.1f}, {.1f}), axis ({.1f}, {.1f}, {.1f}), angle {.1f}\n",
+    return fmt::format("position ({:.1f}, {:.1f}, {:.1f}), axis ({:.1f}, {:.1f}, {:.1f}), angle {:.1f}\n",
                        pos.x,
                        pos.y,
                        pos.z,


### PR DESCRIPTION
The recent placement toString function had a fmt formating issue, which is making build failing on some machines. (cf https://forum.freecad.org/viewtopic.php?p=798145#p798145)

@chennes we probably want to get this in as soon as possible since it's breaking build.