### PR TITLE
Base: Improved FindElement performance by reducing call of transcode

### DIFF
--- a/src/App/Metadata.cpp
+++ b/src/App/Metadata.cpp
@@ -158,7 +158,7 @@ void Metadata::loadFromInputSource(const InputSource& source)
         throw Base::XMLBaseException(
             "Malformed package.xml document: Root <package> group not found");
     }
-    auto formatVersion = XMLString::parseInt(_dom->getAttribute(XUTF8Str("format").unicodeForm()));
+    auto formatVersion = XMLString::parseInt(_dom->getAttribute(XUTF8StrLiteral("format").unicodeForm()));
     switch (formatVersion) {
         case 1:
             parseVersion1(_dom);
@@ -560,10 +560,10 @@ void addAttribute(DOMElement* node, const std::string& key, const std::string& v
 void addAttribute(DOMElement* node, const std::string& key, bool value)
 {
     if (value) {
-        node->setAttribute(XUTF8Str(key.c_str()).unicodeForm(), XUTF8Str("True").unicodeForm());
+        node->setAttribute(XUTF8Str(key.c_str()).unicodeForm(), XUTF8StrLiteral("True").unicodeForm());
     }
     else {
-        node->setAttribute(XUTF8Str(key.c_str()).unicodeForm(), XUTF8Str("False").unicodeForm());
+        node->setAttribute(XUTF8Str(key.c_str()).unicodeForm(), XUTF8StrLiteral("False").unicodeForm());
     }
 }
 
@@ -608,13 +608,13 @@ void addDependencyNode(DOMElement* root, const std::string& name, const Meta::De
 void Metadata::write(const fs::path& file) const
 {
     DOMImplementation* impl =
-        DOMImplementationRegistry::getDOMImplementation(XUTF8Str("Core LS").unicodeForm());
+        DOMImplementationRegistry::getDOMImplementation(XUTF8StrLiteral("Core LS").unicodeForm());
 
-    DOMDocument* doc = impl->createDocument(nullptr, XUTF8Str("package").unicodeForm(), nullptr);
+    DOMDocument* doc = impl->createDocument(nullptr, XUTF8StrLiteral("package").unicodeForm(), nullptr);
     DOMElement* root = doc->getDocumentElement();
-    root->setAttribute(XUTF8Str("format").unicodeForm(), XUTF8Str("1").unicodeForm());
-    root->setAttribute(XUTF8Str("xmlns").unicodeForm(),
-                       XUTF8Str("https://wiki.freecad.org/Package_Metadata").unicodeForm());
+    root->setAttribute(XUTF8StrLiteral("format").unicodeForm(), XUTF8StrLiteral("1").unicodeForm());
+    root->setAttribute(XUTF8StrLiteral("xmlns").unicodeForm(),
+                       XUTF8StrLiteral("https://wiki.freecad.org/Package_Metadata").unicodeForm());
 
     appendToElement(root);
 
@@ -852,7 +852,7 @@ void Metadata::appendToElement(DOMElement* root) const
 
     if (!_content.empty()) {
         auto doc = root->getOwnerDocument();
-        DOMElement* contentRootElement = doc->createElement(XUTF8Str("content").unicodeForm());
+        DOMElement* contentRootElement = doc->createElement(XUTF8StrLiteral("content").unicodeForm());
         root->appendChild(contentRootElement);
         for (const auto& content : _content) {
             DOMElement* contentElement =
@@ -982,7 +982,7 @@ Meta::Contact::Contact(const XERCES_CPP_NAMESPACE::DOMElement* elem)
     if (!elem) {
         return;
     }
-    auto emailAttribute = elem->getAttribute(XUTF8Str("email").unicodeForm());
+    auto emailAttribute = elem->getAttribute(XUTF8StrLiteral("email").unicodeForm());
     name = StrXUTF8(elem->getTextContent()).str;
     email = StrXUTF8(emailAttribute).str;
 }
@@ -1004,7 +1004,7 @@ Meta::License::License(const XERCES_CPP_NAMESPACE::DOMElement* elem)
     if (!elem) {
         return;
     }
-    auto fileAttribute = elem->getAttribute(XUTF8Str("file").unicodeForm());
+    auto fileAttribute = elem->getAttribute(XUTF8StrLiteral("file").unicodeForm());
     if (XMLString::stringLen(fileAttribute) > 0) {
         file = fs::path(StrXUTF8(fileAttribute).str);
     }
@@ -1033,7 +1033,7 @@ Meta::Url::Url(const XERCES_CPP_NAMESPACE::DOMElement* elem)
     if (!elem) {
         return;
     }
-    auto typeAttribute = StrXUTF8(elem->getAttribute(XUTF8Str("type").unicodeForm())).str;
+    auto typeAttribute = StrXUTF8(elem->getAttribute(XUTF8StrLiteral("type").unicodeForm())).str;
     if (typeAttribute.empty() || typeAttribute == "website") {
         type = UrlType::website;
     }
@@ -1057,7 +1057,7 @@ Meta::Url::Url(const XERCES_CPP_NAMESPACE::DOMElement* elem)
     }
 
     if (type == UrlType::repository) {
-        branch = StrXUTF8(elem->getAttribute(XUTF8Str("branch").unicodeForm())).str;
+        branch = StrXUTF8(elem->getAttribute(XUTF8StrLiteral("branch").unicodeForm())).str;
     }
     location = StrXUTF8(elem->getTextContent()).str;
 }
@@ -1083,13 +1083,13 @@ App::Meta::Dependency::Dependency(std::string pkg)
 
 Meta::Dependency::Dependency(const XERCES_CPP_NAMESPACE::DOMElement* elem)
 {
-    version_lt = StrXUTF8(elem->getAttribute(XUTF8Str("version_lt").unicodeForm())).str;
-    version_lte = StrXUTF8(elem->getAttribute(XUTF8Str("version_lte").unicodeForm())).str;
-    version_eq = StrXUTF8(elem->getAttribute(XUTF8Str("version_eq").unicodeForm())).str;
-    version_gte = StrXUTF8(elem->getAttribute(XUTF8Str("version_gte").unicodeForm())).str;
-    version_gt = StrXUTF8(elem->getAttribute(XUTF8Str("version_gt").unicodeForm())).str;
-    condition = StrXUTF8(elem->getAttribute(XUTF8Str("condition").unicodeForm())).str;
-    std::string opt_string = StrXUTF8(elem->getAttribute(XUTF8Str("optional").unicodeForm())).str;
+    version_lt = StrXUTF8(elem->getAttribute(XUTF8StrLiteral("version_lt").unicodeForm())).str;
+    version_lte = StrXUTF8(elem->getAttribute(XUTF8StrLiteral("version_lte").unicodeForm())).str;
+    version_eq = StrXUTF8(elem->getAttribute(XUTF8StrLiteral("version_eq").unicodeForm())).str;
+    version_gte = StrXUTF8(elem->getAttribute(XUTF8StrLiteral("version_gte").unicodeForm())).str;
+    version_gt = StrXUTF8(elem->getAttribute(XUTF8StrLiteral("version_gt").unicodeForm())).str;
+    condition = StrXUTF8(elem->getAttribute(XUTF8StrLiteral("condition").unicodeForm())).str;
+    std::string opt_string = StrXUTF8(elem->getAttribute(XUTF8StrLiteral("optional").unicodeForm())).str;
     if (opt_string == "true"
         || opt_string == "True") {  // Support Python capitalization in this one case...
         optional = true;
@@ -1097,7 +1097,7 @@ Meta::Dependency::Dependency(const XERCES_CPP_NAMESPACE::DOMElement* elem)
     else {
         optional = false;
     }
-    std::string type_string = StrXUTF8(elem->getAttribute(XUTF8Str("type").unicodeForm())).str;
+    std::string type_string = StrXUTF8(elem->getAttribute(XUTF8StrLiteral("type").unicodeForm())).str;
     if (type_string == "automatic" || type_string.empty()) {
         dependencyType = Meta::DependencyType::automatic;
     }

--- a/src/App/ProjectFile.cpp
+++ b/src/App/ProjectFile.cpp
@@ -84,12 +84,12 @@ public:
 
         std::map<std::string, std::string> propMap = initMap();
 
-        DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStr("Properties").unicodeForm());
+        DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStrLiteral("Properties").unicodeForm());
         for (XMLSize_t i = 0; i < nodes->getLength(); i++) {
             DOMNode* node = nodes->item(i);
             if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
                 auto elem = static_cast<DOMElement*>(node);  // NOLINT
-                DOMNodeList* propList = elem->getElementsByTagName(XStr("Property").unicodeForm());
+                DOMNodeList* propList = elem->getElementsByTagName(XStrLiteral("Property").unicodeForm());
                 for (XMLSize_t j = 0; j < propList->getLength(); j++) {
                     DOMNode* propNode = propList->item(j);
                     readProperty(propNode, propMap);
@@ -105,12 +105,12 @@ private:
     void readProgramVersion()
     {
         if (DOMNodeList* nodes =
-                xmlDocument->getElementsByTagName(XStr("Document").unicodeForm())) {
+                xmlDocument->getElementsByTagName(XStrLiteral("Document").unicodeForm())) {
             for (XMLSize_t i = 0; i < nodes->getLength(); i++) {
                 DOMNode* node = nodes->item(i);
                 if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
                     DOMNode* nameAttr =
-                        node->getAttributes()->getNamedItem(XStr("ProgramVersion").unicodeForm());
+                        node->getAttributes()->getNamedItem(XStrLiteral("ProgramVersion").unicodeForm());
                     if (nameAttr) {
                         std::string value = StrX(nameAttr->getNodeValue()).c_str();
                         metadata.programVersion = value;
@@ -153,7 +153,7 @@ private:
 
     static void readProperty(DOMNode* propNode, std::map<std::string, std::string>& propMap)
     {
-        DOMNode* nameAttr = propNode->getAttributes()->getNamedItem(XStr("name").unicodeForm());
+        DOMNode* nameAttr = propNode->getAttributes()->getNamedItem(XStrLiteral("name").unicodeForm());
         if (nameAttr) {
             std::string name = StrX(nameAttr->getNodeValue()).c_str();
             auto it = propMap.find(name);
@@ -169,7 +169,7 @@ private:
             if (DOMElement* child =
                     static_cast<DOMElement*>(node)->getFirstElementChild()) {  // NOLINT
                 if (DOMNode* nameAttr =
-                        child->getAttributes()->getNamedItem(XStr("value").unicodeForm())) {
+                        child->getAttributes()->getNamedItem(XStrLiteral("value").unicodeForm())) {
                     std::string value = StrX(nameAttr->getNodeValue()).c_str();
                     return value;
                 }
@@ -260,18 +260,18 @@ std::list<ProjectFile::Object> ProjectFile::getObjects() const
         return names;
     }
 
-    DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStr("Objects").unicodeForm());
+    DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStrLiteral("Objects").unicodeForm());
     for (XMLSize_t i = 0; i < nodes->getLength(); i++) {
         DOMNode* node = nodes->item(i);
         if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
             DOMNodeList* objectList = static_cast<DOMElement*>(node)->getElementsByTagName(
-                XStr("Object").unicodeForm());  // NOLINT
+                XStrLiteral("Object").unicodeForm());  // NOLINT
             for (XMLSize_t j = 0; j < objectList->getLength(); j++) {
                 DOMNode* objectNode = objectList->item(j);
                 DOMNode* typeAttr =
-                    objectNode->getAttributes()->getNamedItem(XStr("type").unicodeForm());
+                    objectNode->getAttributes()->getNamedItem(XStrLiteral("type").unicodeForm());
                 DOMNode* nameAttr =
-                    objectNode->getAttributes()->getNamedItem(XStr("name").unicodeForm());
+                    objectNode->getAttributes()->getNamedItem(XStrLiteral("name").unicodeForm());
                 if (typeAttr && nameAttr) {
                     Object obj;
                     obj.name = StrX(nameAttr->getNodeValue()).c_str();
@@ -292,18 +292,18 @@ std::list<std::string> ProjectFile::getObjectsOfType(const Base::Type& typeId) c
         return names;
     }
 
-    DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStr("Objects").unicodeForm());
+    DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStrLiteral("Objects").unicodeForm());
     for (XMLSize_t i = 0; i < nodes->getLength(); i++) {
         DOMNode* node = nodes->item(i);
         if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
             DOMNodeList* objectList = static_cast<DOMElement*>(node)->getElementsByTagName(
-                XStr("Object").unicodeForm());  // NOLINT
+                XStrLiteral("Object").unicodeForm());  // NOLINT
             for (XMLSize_t j = 0; j < objectList->getLength(); j++) {
                 DOMNode* objectNode = objectList->item(j);
                 DOMNode* typeAttr =
-                    objectNode->getAttributes()->getNamedItem(XStr("type").unicodeForm());
+                    objectNode->getAttributes()->getNamedItem(XStrLiteral("type").unicodeForm());
                 DOMNode* nameAttr =
-                    objectNode->getAttributes()->getNamedItem(XStr("name").unicodeForm());
+                    objectNode->getAttributes()->getNamedItem(XStrLiteral("name").unicodeForm());
                 if (typeAttr && nameAttr) {
                     if (Base::Type::fromName(StrX(typeAttr->getNodeValue()).c_str()) == typeId) {
                         names.emplace_back(StrX(nameAttr->getNodeValue()).c_str());
@@ -366,18 +366,18 @@ Base::Type ProjectFile::getTypeId(const std::string& name) const
         return Base::Type::badType();
     }
 
-    DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStr("Objects").unicodeForm());
+    DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStrLiteral("Objects").unicodeForm());
     for (XMLSize_t i = 0; i < nodes->getLength(); i++) {
         DOMNode* node = nodes->item(i);
         if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
             DOMNodeList* objectList = static_cast<DOMElement*>(node)->getElementsByTagName(
-                XStr("Object").unicodeForm());  // NOLINT
+                XStrLiteral("Object").unicodeForm());  // NOLINT
             for (XMLSize_t j = 0; j < objectList->getLength(); j++) {
                 DOMNode* objectNode = objectList->item(j);
                 DOMNode* typeAttr =
-                    objectNode->getAttributes()->getNamedItem(XStr("type").unicodeForm());
+                    objectNode->getAttributes()->getNamedItem(XStrLiteral("type").unicodeForm());
                 DOMNode* nameAttr =
-                    objectNode->getAttributes()->getNamedItem(XStr("name").unicodeForm());
+                    objectNode->getAttributes()->getNamedItem(XStrLiteral("name").unicodeForm());
                 if (typeAttr && nameAttr) {
                     if (strcmp(name.c_str(), StrX(nameAttr->getNodeValue()).c_str()) == 0) {
                         std::string typeId = StrX(typeAttr->getNodeValue()).c_str();
@@ -407,16 +407,16 @@ std::list<ProjectFile::PropertyFile> ProjectFile::getPropertyFiles(const std::st
     }
 
     std::list<PropertyFile> files;
-    DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStr("ObjectData").unicodeForm());
+    DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStrLiteral("ObjectData").unicodeForm());
     for (XMLSize_t i = 0; i < nodes->getLength(); i++) {
         DOMNode* node = nodes->item(i);
         if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
             DOMNodeList* objectList = static_cast<DOMElement*>(node)->getElementsByTagName(
-                XStr("Object").unicodeForm());  // NOLINT
+                XStrLiteral("Object").unicodeForm());  // NOLINT
             for (XMLSize_t j = 0; j < objectList->getLength(); j++) {
                 DOMNode* objectNode = objectList->item(j);
                 DOMNode* nameAttr =
-                    objectNode->getAttributes()->getNamedItem(XStr("name").unicodeForm());
+                    objectNode->getAttributes()->getNamedItem(XStrLiteral("name").unicodeForm());
                 if (nameAttr && strcmp(name.c_str(), StrX(nameAttr->getNodeValue()).c_str()) == 0) {
                     // now go recursively through the sub-tree (i.e. the properties) and collect
                     // every file attribute
@@ -434,18 +434,18 @@ void ProjectFile::findFiles(XERCES_CPP_NAMESPACE_QUALIFIER DOMNode* node,
 {
     if (node->hasAttributes()) {
         ProjectFile::PropertyFile prop;
-        DOMNode* fileAttr = node->getAttributes()->getNamedItem(XStr("file").unicodeForm());
+        DOMNode* fileAttr = node->getAttributes()->getNamedItem(XStrLiteral("file").unicodeForm());
         if (fileAttr) {
             DOMNode* parentNode = node->getParentNode();
             if (parentNode) {
                 DOMNode* nameAttr =
-                    parentNode->getAttributes()->getNamedItem(XStr("name").unicodeForm());
+                    parentNode->getAttributes()->getNamedItem(XStrLiteral("name").unicodeForm());
                 if (nameAttr) {
                     prop.name = StrX(nameAttr->getNodeValue()).c_str();
                 }
 
                 DOMNode* typeAttr =
-                    parentNode->getAttributes()->getNamedItem(XStr("type").unicodeForm());
+                    parentNode->getAttributes()->getNamedItem(XStrLiteral("type").unicodeForm());
                 if (typeAttr) {
                     prop.type = Base::Type::fromName(StrX(typeAttr->getNodeValue()).c_str());
                 }
@@ -486,16 +486,16 @@ std::list<std::string> ProjectFile::getInputFiles(const std::string& name) const
     }
 
     std::list<std::string> files;
-    DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStr("ObjectData").unicodeForm());
+    DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStrLiteral("ObjectData").unicodeForm());
     for (XMLSize_t i = 0; i < nodes->getLength(); i++) {
         DOMNode* node = nodes->item(i);
         if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
             DOMNodeList* objectList = static_cast<DOMElement*>(node)->getElementsByTagName(
-                XStr("Object").unicodeForm());  // NOLINT
+                XStrLiteral("Object").unicodeForm());  // NOLINT
             for (XMLSize_t j = 0; j < objectList->getLength(); j++) {
                 DOMNode* objectNode = objectList->item(j);
                 DOMNode* nameAttr =
-                    objectNode->getAttributes()->getNamedItem(XStr("name").unicodeForm());
+                    objectNode->getAttributes()->getNamedItem(XStrLiteral("name").unicodeForm());
                 if (nameAttr && strcmp(name.c_str(), StrX(nameAttr->getNodeValue()).c_str()) == 0) {
                     // now go recursively through the sub-tree (i.e. the properties) and collect
                     // every file attribute
@@ -512,7 +512,7 @@ void ProjectFile::findFiles(XERCES_CPP_NAMESPACE_QUALIFIER DOMNode* node,
                             std::list<std::string>& files) const
 {
     if (node->hasAttributes()) {
-        DOMNode* fileAttr = node->getAttributes()->getNamedItem(XStr("file").unicodeForm());
+        DOMNode* fileAttr = node->getAttributes()->getNamedItem(XStrLiteral("file").unicodeForm());
         if (fileAttr) {
             files.emplace_back(StrX(fileAttr->getNodeValue()).c_str());
         }

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -362,8 +362,9 @@ ParameterGrp::CreateElement(XERCES_CPP_NAMESPACE_QUALIFIER DOMElement* Start,
                             const char* Type,
                             const char* Name)
 {
-    if (XMLString::compareString(Start->getNodeName(), XStr("FCParamGroup").unicodeForm()) != 0
-        && XMLString::compareString(Start->getNodeName(), XStr("FCParameters").unicodeForm())
+    if (XMLString::compareString(Start->getNodeName(), XStrLiteral("FCParamGroup").unicodeForm())
+            != 0
+        && XMLString::compareString(Start->getNodeName(), XStrLiteral("FCParameters").unicodeForm())
             != 0) {
         Base::Console().Warning("CreateElement: %s cannot have the element %s of type %s\n",
                                 StrX(Start->getNodeName()).c_str(),
@@ -380,7 +381,7 @@ ParameterGrp::CreateElement(XERCES_CPP_NAMESPACE_QUALIFIER DOMElement* Start,
     XERCES_CPP_NAMESPACE_QUALIFIER DOMDocument* pDocument = Start->getOwnerDocument();
 
     auto pcElem = pDocument->createElement(XStr(Type).unicodeForm());
-    pcElem->setAttribute(XStr("Name").unicodeForm(), XStr(Name).unicodeForm());
+    pcElem->setAttribute(XStrLiteral("Name").unicodeForm(), XStr(Name).unicodeForm());
     Start->appendChild(pcElem);
 
     return pcElem;
@@ -488,9 +489,10 @@ std::vector<Base::Reference<ParameterGrp>> ParameterGrp::GetGroups()
 
     DOMElement* pcTemp = FindElement(_pGroupNode, "FCParamGroup");
     while (pcTemp) {
-        Name =
-            StrX(pcTemp->getAttributes()->getNamedItem(XStr("Name").unicodeForm())->getNodeValue())
-                .c_str();
+        Name = StrX(pcTemp->getAttributes()
+                        ->getNamedItem(XStrLiteral("Name").unicodeForm())
+                        ->getNodeValue())
+                   .c_str();
         // already created?
         if (!(rParamGrp = _GroupMap[Name]).isValid()) {
             rParamGrp = Base::Reference<ParameterGrp>(new ParameterGrp(pcTemp, Name.c_str(), this));
@@ -630,7 +632,7 @@ const char* ParameterGrp::GetAttribute(ParamType Type,
         Value = GetASCII(Name, Default);
     }
     else if (Type != ParamType::FCGroup) {
-        Value = StrX(pcElem->getAttribute(XStr("Value").unicodeForm())).c_str();
+        Value = StrX(pcElem->getAttribute(XStrLiteral("Value").unicodeForm())).c_str();
     }
     return Value.c_str();
 }
@@ -654,7 +656,7 @@ ParameterGrp::GetAttributeMap(ParamType Type, const char* sFilter) const
     while (pcTemp) {
         Name = StrX(static_cast<DOMElement*>(pcTemp)
                         ->getAttributes()
-                        ->getNamedItem(XStr("Name").unicodeForm())
+                        ->getNamedItem(XStrLiteral("Name").unicodeForm())
                         ->getNodeValue())
                    .c_str();
         // check on filter condition
@@ -665,7 +667,7 @@ ParameterGrp::GetAttributeMap(ParamType Type, const char* sFilter) const
             else {
                 res.emplace_back(Name,
                                  StrX(static_cast<DOMElement*>(pcTemp)->getAttribute(
-                                          XStr("Value").unicodeForm()))
+                                          XStrLiteral("Value").unicodeForm()))
                                      .c_str());
             }
         }
@@ -731,7 +733,8 @@ bool ParameterGrp::GetBool(const char* Name, bool bPreset) const
     }
 
     // if yes check the value and return
-    return (strcmp(StrX(pcElem->getAttribute(XStr("Value").unicodeForm())).c_str(), "1") == 0);
+    return (strcmp(StrX(pcElem->getAttribute(XStrLiteral("Value").unicodeForm())).c_str(), "1")
+            == 0);
 }
 
 void ParameterGrp::SetBool(const char* Name, bool bValue)
@@ -750,10 +753,11 @@ std::vector<bool> ParameterGrp::GetBools(const char* sFilter) const
 
     DOMElement* pcTemp = FindElement(_pGroupNode, "FCBool");
     while (pcTemp) {
-        Name = StrX(pcTemp->getAttribute(XStr("Name").unicodeForm())).c_str();
+        Name = StrX(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
         if (!sFilter || Name.find(sFilter) != std::string::npos) {
-            if (strcmp(StrX(pcTemp->getAttribute(XStr("Value").unicodeForm())).c_str(), "1") != 0) {
+            if (strcmp(StrX(pcTemp->getAttribute(XStrLiteral("Value").unicodeForm())).c_str(), "1")
+                != 0) {
                 vrValues.push_back(false);
             }
             else {
@@ -777,10 +781,11 @@ std::vector<std::pair<std::string, bool>> ParameterGrp::GetBoolMap(const char* s
 
     DOMElement* pcTemp = FindElement(_pGroupNode, "FCBool");
     while (pcTemp) {
-        Name = StrX(pcTemp->getAttribute(XStr("Name").unicodeForm())).c_str();
+        Name = StrX(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
         if (!sFilter || Name.find(sFilter) != std::string::npos) {
-            if (strcmp(StrX(pcTemp->getAttribute(XStr("Value").unicodeForm())).c_str(), "1") != 0) {
+            if (strcmp(StrX(pcTemp->getAttribute(XStrLiteral("Value").unicodeForm())).c_str(), "1")
+                != 0) {
                 vrValues.emplace_back(Name, false);
             }
             else {
@@ -806,7 +811,7 @@ long ParameterGrp::GetInt(const char* Name, long lPreset) const
         return lPreset;
     }
     // if yes check the value and return
-    return atol(StrX(pcElem->getAttribute(XStr("Value").unicodeForm())).c_str());
+    return atol(StrX(pcElem->getAttribute(XStrLiteral("Value").unicodeForm())).c_str());
 }
 
 void ParameterGrp::SetInt(const char* Name, long lValue)
@@ -826,11 +831,11 @@ std::vector<long> ParameterGrp::GetInts(const char* sFilter) const
 
     DOMElement* pcTemp = FindElement(_pGroupNode, "FCInt");
     while (pcTemp) {
-        Name = StrX(pcTemp->getAttribute(XStr("Name").unicodeForm())).c_str();
+        Name = StrX(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
         if (!sFilter || Name.find(sFilter) != std::string::npos) {
             vrValues.push_back(
-                atol(StrX(pcTemp->getAttribute(XStr("Value").unicodeForm())).c_str()));
+                atol(StrX(pcTemp->getAttribute(XStrLiteral("Value").unicodeForm())).c_str()));
         }
         pcTemp = FindNextElement(pcTemp, "FCInt");
     }
@@ -849,12 +854,12 @@ std::vector<std::pair<std::string, long>> ParameterGrp::GetIntMap(const char* sF
 
     DOMElement* pcTemp = FindElement(_pGroupNode, "FCInt");
     while (pcTemp) {
-        Name = StrX(pcTemp->getAttribute(XStr("Name").unicodeForm())).c_str();
+        Name = StrX(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
         if (!sFilter || Name.find(sFilter) != std::string::npos) {
             vrValues.emplace_back(
                 Name,
-                (atol(StrX(pcTemp->getAttribute(XStr("Value").unicodeForm())).c_str())));
+                (atol(StrX(pcTemp->getAttribute(XStrLiteral("Value").unicodeForm())).c_str())));
         }
         pcTemp = FindNextElement(pcTemp, "FCInt");
     }
@@ -877,7 +882,9 @@ unsigned long ParameterGrp::GetUnsigned(const char* Name, unsigned long lPreset)
 
     // if yes check the value and return
     const int base = 10;
-    return strtoul(StrX(pcElem->getAttribute(XStr("Value").unicodeForm())).c_str(), nullptr, base);
+    return strtoul(StrX(pcElem->getAttribute(XStrLiteral("Value").unicodeForm())).c_str(),
+                   nullptr,
+                   base);
 }
 
 void ParameterGrp::SetUnsigned(const char* Name, unsigned long lValue)
@@ -898,11 +905,11 @@ std::vector<unsigned long> ParameterGrp::GetUnsigneds(const char* sFilter) const
 
     DOMElement* pcTemp = FindElement(_pGroupNode, "FCUInt");
     while (pcTemp) {
-        Name = StrX(pcTemp->getAttribute(XStr("Name").unicodeForm())).c_str();
+        Name = StrX(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
         if (!sFilter || Name.find(sFilter) != std::string::npos) {
             vrValues.push_back(
-                strtoul(StrX(pcTemp->getAttribute(XStr("Value").unicodeForm())).c_str(),
+                strtoul(StrX(pcTemp->getAttribute(XStrLiteral("Value").unicodeForm())).c_str(),
                         nullptr,
                         base));
         }
@@ -925,12 +932,12 @@ ParameterGrp::GetUnsignedMap(const char* sFilter) const
 
     DOMElement* pcTemp = FindElement(_pGroupNode, "FCUInt");
     while (pcTemp) {
-        Name = StrX(pcTemp->getAttribute(XStr("Name").unicodeForm())).c_str();
+        Name = StrX(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
         if (!sFilter || Name.find(sFilter) != std::string::npos) {
             vrValues.emplace_back(
                 Name,
-                (strtoul(StrX(pcTemp->getAttribute(XStr("Value").unicodeForm())).c_str(),
+                (strtoul(StrX(pcTemp->getAttribute(XStrLiteral("Value").unicodeForm())).c_str(),
                          nullptr,
                          base)));
         }
@@ -953,7 +960,7 @@ double ParameterGrp::GetFloat(const char* Name, double dPreset) const
         return dPreset;
     }
     // if yes check the value and return
-    return atof(StrX(pcElem->getAttribute(XStr("Value").unicodeForm())).c_str());
+    return atof(StrX(pcElem->getAttribute(XStrLiteral("Value").unicodeForm())).c_str());
 }
 
 void ParameterGrp::SetFloat(const char* Name, double dValue)
@@ -974,11 +981,11 @@ std::vector<double> ParameterGrp::GetFloats(const char* sFilter) const
 
     DOMElement* pcTemp = FindElement(_pGroupNode, "FCFloat");
     while (pcTemp) {
-        Name = StrX(pcTemp->getAttribute(XStr("Name").unicodeForm())).c_str();
+        Name = StrX(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
         if (!sFilter || Name.find(sFilter) != std::string::npos) {
             vrValues.push_back(
-                atof(StrX(pcTemp->getAttribute(XStr("Value").unicodeForm())).c_str()));
+                atof(StrX(pcTemp->getAttribute(XStrLiteral("Value").unicodeForm())).c_str()));
         }
         pcTemp = FindNextElement(pcTemp, "FCFloat");
     }
@@ -997,12 +1004,12 @@ std::vector<std::pair<std::string, double>> ParameterGrp::GetFloatMap(const char
 
     DOMElement* pcTemp = FindElement(_pGroupNode, "FCFloat");
     while (pcTemp) {
-        Name = StrX(pcTemp->getAttribute(XStr("Name").unicodeForm())).c_str();
+        Name = StrX(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
         if (!sFilter || Name.find(sFilter) != std::string::npos) {
             vrValues.emplace_back(
                 Name,
-                (atof(StrX(pcTemp->getAttribute(XStr("Value").unicodeForm())).c_str())));
+                (atof(StrX(pcTemp->getAttribute(XStrLiteral("Value").unicodeForm())).c_str())));
         }
         pcTemp = FindNextElement(pcTemp, "FCFloat");
     }
@@ -1086,7 +1093,7 @@ std::vector<std::string> ParameterGrp::GetASCIIs(const char* sFilter) const
 
     DOMElement* pcTemp = FindElement(_pGroupNode, "FCText");
     while (pcTemp) {
-        Name = StrXUTF8(pcTemp->getAttribute(XStr("Name").unicodeForm())).c_str();
+        Name = StrXUTF8(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
         if (!sFilter || Name.find(sFilter) != std::string::npos) {
             // retrieve the text element
@@ -1116,7 +1123,7 @@ ParameterGrp::GetASCIIMap(const char* sFilter) const
 
     DOMElement* pcTemp = FindElement(_pGroupNode, "FCText");
     while (pcTemp) {
-        Name = StrXUTF8(pcTemp->getAttribute(XStr("Name").unicodeForm())).c_str();
+        Name = StrXUTF8(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
         if (!sFilter || Name.find(sFilter) != std::string::npos) {
             // retrieve the text element
@@ -1299,7 +1306,7 @@ bool ParameterGrp::RenameGrp(const char* OldName, const char* NewName)
     // check if Element in group
     DOMElement* pcElem = FindElement(_pGroupNode, "FCParamGroup", OldName);
     if (pcElem) {
-        pcElem->setAttribute(XStr("Name").unicodeForm(), XStr(NewName).unicodeForm());
+        pcElem->setAttribute(XStrLiteral("Name").unicodeForm(), XStr(NewName).unicodeForm());
     }
 
     _Notify(ParamType::FCGroup, NewName, OldName);
@@ -1349,7 +1356,7 @@ void ParameterGrp::Clear(bool notify)
         if (type != ParamType::FCInvalid && type != ParamType::FCGroup) {
             params.emplace_back(type,
                                 StrX(child->getAttributes()
-                                         ->getNamedItem(XStr("Name").unicodeForm())
+                                         ->getNamedItem(XStrLiteral("Name").unicodeForm())
                                          ->getNodeValue())
                                     .c_str());
         }
@@ -1387,8 +1394,9 @@ ParameterGrp::FindElement(XERCES_CPP_NAMESPACE_QUALIFIER DOMElement* Start,
                           const char* Type,
                           const char* Name) const
 {
-    if (XMLString::compareString(Start->getNodeName(), XStr("FCParamGroup").unicodeForm()) != 0
-        && XMLString::compareString(Start->getNodeName(), XStr("FCParameters").unicodeForm())
+    if (XMLString::compareString(Start->getNodeName(), XStrLiteral("FCParamGroup").unicodeForm())
+            != 0
+        && XMLString::compareString(Start->getNodeName(), XStrLiteral("FCParameters").unicodeForm())
             != 0) {
         Base::Console().Warning("FindElement: %s cannot have the element %s of type %s\n",
                                 StrX(Start->getNodeName()).c_str(),
@@ -1484,7 +1492,7 @@ ParameterGrp::GetParameterNames(const char* sFilter) const
             if (Type != ParamType::FCInvalid && Type != ParamType::FCGroup) {
                 if (clChild->getAttributes()->getLength() > 0) {
                     StrX name(clChild->getAttributes()
-                                  ->getNamedItem(XStr("Name").unicodeForm())
+                                  ->getNamedItem(XStrLiteral("Name").unicodeForm())
                                   ->getNodeValue());
                     if (!sFilter || strstr(name.c_str(), sFilter)) {
                         res.emplace_back(Type, name.c_str());
@@ -1975,16 +1983,17 @@ void ParameterManager::CreateDocument()
 {
     // creating a document from screatch
     DOMImplementation* impl =
-        DOMImplementationRegistry::getDOMImplementation(XStr("Core").unicodeForm());
+        DOMImplementationRegistry::getDOMImplementation(XStrLiteral("Core").unicodeForm());
     delete _pDocument;
-    _pDocument = impl->createDocument(nullptr,  // root element namespace URI.
-                                      XStr("FCParameters").unicodeForm(),  // root element name
-                                      nullptr);  // document type object (DTD).
+    _pDocument =
+        impl->createDocument(nullptr,  // root element namespace URI.
+                             XStrLiteral("FCParameters").unicodeForm(),  // root element name
+                             nullptr);  // document type object (DTD).
 
     // creating the node for the root group
     DOMElement* rootElem = _pDocument->getDocumentElement();
-    _pGroupNode = _pDocument->createElement(XStr("FCParamGroup").unicodeForm());
-    _pGroupNode->setAttribute(XStr("Name").unicodeForm(), XStr("Root").unicodeForm());
+    _pGroupNode = _pDocument->createElement(XStrLiteral("FCParamGroup").unicodeForm());
+    _pGroupNode->setAttribute(XStrLiteral("Name").unicodeForm(), XStrLiteral("Root").unicodeForm());
     rootElem->appendChild(_pGroupNode);
 }
 
@@ -2095,14 +2104,15 @@ DOMPrintFilter::DOMPrintFilter(ShowType whatToShow)
 
 DOMPrintFilter::FilterAction DOMPrintFilter::acceptNode(const DOMNode* node) const
 {
-    if (XMLString::compareString(node->getNodeName(), XStr("FCParameters").unicodeForm()) == 0) {
+    if (XMLString::compareString(node->getNodeName(), XStrLiteral("FCParameters").unicodeForm())
+        == 0) {
         // This node is supposed to have a single FCParamGroup and two text nodes.
         // Over time it can happen that the text nodes collect extra newlines.
         const DOMNodeList* children = node->getChildNodes();
         for (XMLSize_t i = 0; i < children->getLength(); i++) {
             DOMNode* child = children->item(i);
             if (child->getNodeType() == DOMNode::TEXT_NODE) {
-                child->setNodeValue(XStr("\n").unicodeForm());
+                child->setNodeValue(XStrLiteral("\n").unicodeForm());
             }
         }
     }
@@ -2115,7 +2125,7 @@ DOMPrintFilter::FilterAction DOMPrintFilter::acceptNode(const DOMNode* node) con
             // there.
             auto parent = node->getParentNode();
             if (parent && XMLString::compareString(parent->getNodeName(),
-                                                   XStr("FCParamGroup").unicodeForm()) == 0) {
+                                                   XStrLiteral("FCParamGroup").unicodeForm()) == 0) {
                 return DOMNodeFilter::FILTER_REJECT;
             }
             return DOMNodeFilter::FILTER_ACCEPT;

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -1411,9 +1411,10 @@ ParameterGrp::FindElement(XERCES_CPP_NAMESPACE_QUALIFIER DOMElement* Start,
         if (clChild->getNodeType() == DOMNode::ELEMENT_NODE) {
             // the right node Type
             if (!XMLString::compareString(xType.unicodeForm(), clChild->getNodeName())) {
-                if (clChild->getAttributes()->getLength() > 0) {
+                auto attrs = clChild->getAttributes();
+                if (attrs->getLength() > 0) {
                     if (Name) {
-                        DOMNode* attr = FindAttribute(clChild, "Name");
+                        DOMNode* attr = attrs->getNamedItem(XStrLiteral("Name").unicodeForm());
                         if (attr
                             && !XMLString::compareString(xName.unicodeForm(),
                                                          attr->getNodeValue())) {

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -1396,15 +1396,19 @@ ParameterGrp::FindElement(XERCES_CPP_NAMESPACE_QUALIFIER DOMElement* Start,
                                 Type);
         return nullptr;
     }
+    const XStr xType(Type);
+    const XStr xName(Name);
     for (DOMNode* clChild = Start->getFirstChild(); clChild != nullptr;
          clChild = clChild->getNextSibling()) {
         if (clChild->getNodeType() == DOMNode::ELEMENT_NODE) {
             // the right node Type
-            if (!strcmp(Type, StrX(clChild->getNodeName()).c_str())) {
+            if (!XMLString::compareString(xType.unicodeForm(), clChild->getNodeName())) {
                 if (clChild->getAttributes()->getLength() > 0) {
                     if (Name) {
                         DOMNode* attr = FindAttribute(clChild, "Name");
-                        if (attr && !strcmp(Name, StrX(attr->getNodeValue()).c_str())) {
+                        if (attr
+                            && !XMLString::compareString(xName.unicodeForm(),
+                                                         attr->getNodeValue())) {
                             return dynamic_cast<DOMElement*>(clChild);
                         }
                     }
@@ -1426,10 +1430,11 @@ ParameterGrp::FindNextElement(XERCES_CPP_NAMESPACE_QUALIFIER DOMNode* Prev, cons
         return nullptr;
     }
 
+    const XStr xType(Type);
     while ((clChild = clChild->getNextSibling()) != nullptr) {
         if (clChild->getNodeType() == DOMNode::ELEMENT_NODE) {
             // the right node Type
-            if (!strcmp(Type, StrX(clChild->getNodeName()).c_str())) {
+            if (!XMLString::compareString(xType.unicodeForm(), clChild->getNodeName())) {
                 return dynamic_cast<DOMElement*>(clChild);
             }
         }

--- a/src/Base/XMLTools.h
+++ b/src/Base/XMLTools.h
@@ -174,6 +174,9 @@ inline XStr::~XStr()
     XERCES_CPP_NAMESPACE_QUALIFIER XMLString::release(&fUnicodeForm);
 }
 
+// Uses the compiler to create a cache of transcoded string literals so that each subsequent call
+// can re-use the data from the lambda's initial creation. Permits the same usage as 
+// XStr("literal").unicodeForm()
 #define XStrLiteral(literal)                                                                       \
     ([]() -> const XStr& {                                                                         \
         static const XStr str {literal};                                                           \
@@ -216,6 +219,9 @@ inline XUTF8Str::XUTF8Str(const char* const fromTranscode)
 
 inline XUTF8Str::~XUTF8Str() = default;
 
+// Uses the compiler to create a cache of transcoded string literals so that each subsequent call
+// can re-use the data from the lambda's initial creation. Permits the same usage as 
+// XStr("literal").unicodeForm()
 #define XUTF8StrLiteral(literal)                                                                   \
     ([]() -> const XUTF8Str& {                                                                     \
         static const XUTF8Str str {literal};                                                       \

--- a/src/Base/XMLTools.h
+++ b/src/Base/XMLTools.h
@@ -174,6 +174,12 @@ inline XStr::~XStr()
     XERCES_CPP_NAMESPACE_QUALIFIER XMLString::release(&fUnicodeForm);
 }
 
+#define XStrLiteral(literal)                                                                       \
+    ([]() -> const XStr& {                                                                         \
+        static const XStr str {literal};                                                           \
+        return str;                                                                                \
+    }())
+
 
 // -----------------------------------------------------------------------
 //  Getter methods
@@ -210,6 +216,11 @@ inline XUTF8Str::XUTF8Str(const char* const fromTranscode)
 
 inline XUTF8Str::~XUTF8Str() = default;
 
+#define XUTF8StrLiteral(literal)                                                                   \
+    ([]() -> const XUTF8Str& {                                                                     \
+        static const XUTF8Str str {literal};                                                       \
+        return str;                                                                                \
+    }())
 
 // -----------------------------------------------------------------------
 //  Getter methods

--- a/src/Base/XMLTools.h
+++ b/src/Base/XMLTools.h
@@ -175,7 +175,7 @@ inline XStr::~XStr()
 }
 
 // Uses the compiler to create a cache of transcoded string literals so that each subsequent call
-// can re-use the data from the lambda's initial creation. Permits the same usage as 
+// can re-use the data from the lambda's initial creation. Permits the same usage as
 // XStr("literal").unicodeForm()
 #define XStrLiteral(literal)                                                                       \
     ([]() -> const XStr& {                                                                         \
@@ -220,7 +220,7 @@ inline XUTF8Str::XUTF8Str(const char* const fromTranscode)
 inline XUTF8Str::~XUTF8Str() = default;
 
 // Uses the compiler to create a cache of transcoded string literals so that each subsequent call
-// can re-use the data from the lambda's initial creation. Permits the same usage as 
+// can re-use the data from the lambda's initial creation. Permits the same usage as
 // XStr("literal").unicodeForm()
 #define XUTF8StrLiteral(literal)                                                                   \
     ([]() -> const XUTF8Str& {                                                                     \

--- a/src/Mod/Mesh/App/Core/IO/Reader3MF.cpp
+++ b/src/Mod/Mesh/App/Core/IO/Reader3MF.cpp
@@ -138,7 +138,7 @@ bool Reader3MF::TryLoadModel(std::istream& str, const Component& comp)
 
 bool Reader3MF::LoadModel(DOMDocument& xmlDocument, const Component& comp)
 {
-    DOMNodeList* nodes = xmlDocument.getElementsByTagName(XStr("model").unicodeForm());
+    DOMNodeList* nodes = xmlDocument.getElementsByTagName(XStrLiteral("model").unicodeForm());
     for (XMLSize_t i = 0; i < nodes->getLength(); i++) {
         DOMNode* node = nodes->item(i);
         if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
@@ -152,8 +152,8 @@ bool Reader3MF::LoadModel(DOMDocument& xmlDocument, const Component& comp)
 bool Reader3MF::LoadResourcesAndBuild(DOMElement* node, const Component& comp)
 {
     bool resource =
-        LoadResources(node->getElementsByTagName(XStr("resources").unicodeForm()), comp);
-    bool build = LoadBuild(node->getElementsByTagName(XStr("build").unicodeForm()));
+        LoadResources(node->getElementsByTagName(XStrLiteral("resources").unicodeForm()), comp);
+    bool build = LoadBuild(node->getElementsByTagName(XStrLiteral("build").unicodeForm()));
     return (resource && build);
 }
 
@@ -167,7 +167,8 @@ bool Reader3MF::LoadResources(DOMNodeList* nodes, const Component& comp)
         DOMNode* node = nodes->item(i);
         if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
             auto elem = static_cast<DOMElement*>(node);
-            DOMNodeList* objectList = elem->getElementsByTagName(XStr("object").unicodeForm());
+            DOMNodeList* objectList =
+                elem->getElementsByTagName(XStrLiteral("object").unicodeForm());
             return LoadObject(objectList, comp);
         }
     }
@@ -185,7 +186,7 @@ bool Reader3MF::LoadBuild(DOMNodeList* nodes)
         DOMNode* node = nodes->item(i);
         if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
             auto elem = static_cast<DOMElement*>(node);
-            DOMNodeList* objectList = elem->getElementsByTagName(XStr("item").unicodeForm());
+            DOMNodeList* objectList = elem->getElementsByTagName(XStrLiteral("item").unicodeForm());
             return LoadItems(objectList);
         }
     }
@@ -210,12 +211,12 @@ bool Reader3MF::LoadItems(DOMNodeList* nodes)
 
 void Reader3MF::LoadItem(DOMNamedNodeMap* nodeMap)
 {
-    DOMNode* idAttr = nodeMap->getNamedItem(XStr("objectid").unicodeForm());
+    DOMNode* idAttr = nodeMap->getNamedItem(XStrLiteral("objectid").unicodeForm());
     if (idAttr) {
         std::string id = StrX(idAttr->getNodeValue()).c_str();
         int idValue = std::stoi(id);
 
-        DOMNode* transformAttr = nodeMap->getNamedItem(XStr("transform").unicodeForm());
+        DOMNode* transformAttr = nodeMap->getNamedItem(XStrLiteral("transform").unicodeForm());
         if (transformAttr) {
             std::optional<Base::Matrix4D> mat = ReadTransform(transformAttr);
             if (mat) {
@@ -280,17 +281,19 @@ bool Reader3MF::LoadObject(DOMNodeList* nodes, const Component& comp)
     for (XMLSize_t i = 0; i < nodes->getLength(); i++) {
         DOMNode* objectNode = nodes->item(i);
         if (objectNode->getNodeType() == DOMNode::ELEMENT_NODE) {
-            DOMNode* idAttr = objectNode->getAttributes()->getNamedItem(XStr("id").unicodeForm());
+            DOMNode* idAttr =
+                objectNode->getAttributes()->getNamedItem(XStrLiteral("id").unicodeForm());
             auto elem = static_cast<DOMElement*>(objectNode);
             if (idAttr) {
                 int id = std::stoi(StrX(idAttr->getNodeValue()).c_str());
-                DOMNodeList* meshNode = elem->getElementsByTagName(XStr("mesh").unicodeForm());
+                DOMNodeList* meshNode =
+                    elem->getElementsByTagName(XStrLiteral("mesh").unicodeForm());
                 if (meshNode->getLength() > 0) {
                     LoadMesh(meshNode, id, comp);
                 }
                 else {
                     DOMNodeList* compNode =
-                        elem->getElementsByTagName(XStr("components").unicodeForm());
+                        elem->getElementsByTagName(XStrLiteral("components").unicodeForm());
                     LoadComponents(compNode, id);
                 }
             }
@@ -321,7 +324,8 @@ void Reader3MF::LoadComponents(DOMNodeList* nodes, int id)
         DOMNode* objectNode = nodes->item(i);
         if (objectNode->getNodeType() == DOMNode::ELEMENT_NODE) {
             auto elem = static_cast<DOMElement*>(objectNode);
-            DOMNodeList* compNode = elem->getElementsByTagName(XStr("component").unicodeForm());
+            DOMNodeList* compNode =
+                elem->getElementsByTagName(XStrLiteral("component").unicodeForm());
             if (compNode->getLength() > 0) {
                 LoadComponent(compNode, id);
             }
@@ -353,13 +357,13 @@ void Reader3MF::LoadComponent(DOMNamedNodeMap* attr, int id)
 
     Component component;
     component.id = id;
-    if (DOMNode* pathAttr = attr->getNamedItem(XStr("p:path").unicodeForm())) {
+    if (DOMNode* pathAttr = attr->getNamedItem(XStrLiteral("p:path").unicodeForm())) {
         component.path = StrX(pathAttr->getNodeValue()).c_str();
     }
-    if (DOMNode* idAttr = attr->getNamedItem(XStr("objectid").unicodeForm())) {
+    if (DOMNode* idAttr = attr->getNamedItem(XStrLiteral("objectid").unicodeForm())) {
         component.objectId = std::stoi(StrX(idAttr->getNodeValue()).c_str());
     }
-    if (DOMNode* transformAttr = attr->getNamedItem(XStr("transform").unicodeForm())) {
+    if (DOMNode* transformAttr = attr->getNamedItem(XStrLiteral("transform").unicodeForm())) {
         std::optional<Base::Matrix4D> mat = ReadTransform(transformAttr);
         if (mat) {
             component.transform = mat.value();
@@ -382,8 +386,9 @@ void Reader3MF::LoadMesh(DOMNodeList* nodes, int id, const Component& comp)
             auto elem = static_cast<DOMElement*>(node);
             MeshPointArray points;
             MeshFacetArray facets;
-            LoadVertices(elem->getElementsByTagName(XStr("vertices").unicodeForm()), points);
-            LoadTriangles(elem->getElementsByTagName(XStr("triangles").unicodeForm()), facets);
+            LoadVertices(elem->getElementsByTagName(XStrLiteral("vertices").unicodeForm()), points);
+            LoadTriangles(elem->getElementsByTagName(XStrLiteral("triangles").unicodeForm()),
+                          facets);
 
             MeshCleanup meshCleanup(points, facets);
             meshCleanup.RemoveInvalids();
@@ -408,7 +413,8 @@ void Reader3MF::LoadVertices(DOMNodeList* nodes, MeshPointArray& points)
         DOMNode* node = nodes->item(i);
         if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
             auto elem = static_cast<DOMElement*>(node);
-            DOMNodeList* vertexList = elem->getElementsByTagName(XStr("vertex").unicodeForm());
+            DOMNodeList* vertexList =
+                elem->getElementsByTagName(XStrLiteral("vertex").unicodeForm());
             if (vertexList) {
                 ReadVertices(vertexList, points);
             }
@@ -424,9 +430,9 @@ void Reader3MF::ReadVertices(DOMNodeList* vertexList, MeshPointArray& points)
         DOMNode* vertexNode = vertexList->item(j);
         DOMNamedNodeMap* attr = vertexNode->getAttributes();
         if (attr) {
-            DOMNode* xAttr = attr->getNamedItem(XStr("x").unicodeForm());
-            DOMNode* yAttr = attr->getNamedItem(XStr("y").unicodeForm());
-            DOMNode* zAttr = attr->getNamedItem(XStr("z").unicodeForm());
+            DOMNode* xAttr = attr->getNamedItem(XStrLiteral("x").unicodeForm());
+            DOMNode* yAttr = attr->getNamedItem(XStrLiteral("y").unicodeForm());
+            DOMNode* zAttr = attr->getNamedItem(XStrLiteral("z").unicodeForm());
             if (xAttr && yAttr && zAttr) {
                 // NOLINTBEGIN
                 float x = std::stof(StrX(xAttr->getNodeValue()).c_str());
@@ -449,7 +455,8 @@ void Reader3MF::LoadTriangles(DOMNodeList* nodes, MeshFacetArray& facets)
         DOMNode* node = nodes->item(i);
         if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
             auto elem = static_cast<DOMElement*>(node);
-            DOMNodeList* triangleList = elem->getElementsByTagName(XStr("triangle").unicodeForm());
+            DOMNodeList* triangleList =
+                elem->getElementsByTagName(XStrLiteral("triangle").unicodeForm());
             if (triangleList) {
                 ReadTriangles(triangleList, facets);
             }
@@ -465,9 +472,9 @@ void Reader3MF::ReadTriangles(DOMNodeList* triangleList, MeshFacetArray& facets)
         DOMNode* triangleNode = triangleList->item(j);
         DOMNamedNodeMap* attr = triangleNode->getAttributes();
         if (attr) {
-            DOMNode* v1Attr = attr->getNamedItem(XStr("v1").unicodeForm());
-            DOMNode* v2Attr = attr->getNamedItem(XStr("v2").unicodeForm());
-            DOMNode* v3Attr = attr->getNamedItem(XStr("v3").unicodeForm());
+            DOMNode* v1Attr = attr->getNamedItem(XStrLiteral("v1").unicodeForm());
+            DOMNode* v2Attr = attr->getNamedItem(XStrLiteral("v2").unicodeForm());
+            DOMNode* v3Attr = attr->getNamedItem(XStrLiteral("v3").unicodeForm());
             if (v1Attr && v2Attr && v3Attr) {
                 PointIndex v1 = std::stoul(StrX(v1Attr->getNodeValue()).c_str());
                 PointIndex v2 = std::stoul(StrX(v2Attr->getNodeValue()).c_str());


### PR DESCRIPTION
This PR improves DXF import performance; in my case it improves 5% of execution time (sorry I cannot provide dxf data due to confidential project).
This PR minimize call of `XMLString::transcode` by comparing string in `xercesc` space; it reduces conversion cost since `Name` and `Type` are invariant during iteration in contrast of converting node name/value in each iteration.

I profiled with perf(1); just D&D dxf file and close FreeCAD:

baseline
```
$ perf report --symbol-filter FindElement
# To display the perf.data header info, please use --header/--header-only options.                                                                                                                                                            
#                                                                                                                      
#                                                                                                                      
# Total Lost Samples: 0                                                                                                
#                                                                                                                      
# Samples: 368K of event 'cycles:Pu'                                                                                   
# Event count (approx.): 418601183645                                                                                  
#                                                                                                                      
# Children      Self  Command  Shared Object      Symbol                                                                                                                                                                                      
# ........  ........  .......  .................  .......................................................................................
#                                                                                                                      
     6.06%     0.06%  FreeCAD  libFreeCADBase.so  [.] ParameterGrp::FindElement(xercesc_3_2::DOMElement*, char const*, char const*) const
            |                                                                                                          
             --6.00%--ParameterGrp::FindElement(xercesc_3_2::DOMElement*, char const*, char const*) const
                       |                                                                                                                                                                                                                      
                        --5.55%--xercesc_3_2::IconvGNULCPTranscoder::transcode(char16_t const*, xercesc_3_2::MemoryManager*)             
                                  |          
                                  |--2.79%--xercesc_3_2::IconvGNULCPTranscoder::calcRequiredSize(char16_t const*, xercesc_3_2::MemoryManager*)
                                  |          |          
                                  |           --2.05%--xercesc_3_2::IconvGNUWrapper::iconvTo(char const*, unsigned long*, char**, unsigned long)
                                  |                     |                                                                                                                                                                                     
                                  |                      --1.99%--iconv
                                  |                                |          
                                  |                                 --1.80%--__gconv
                                  |                                           |          
                                  |                                            --1.33%--gconv
                                  |                                                      |          
                                  |                                                       --0.77%--__gconv_transform_internal_utf8
                                  |          
                                  |--1.46%--xercesc_3_2::IconvGNUWrapper::iconvTo(char const*, unsigned long*, char**, unsigned long)
                                  |          |          
                                  |           --1.40%--iconv
                                  |                     |           
                                  |                      --1.22%--__gconv
                                  |                                |          
                                  |                                 --1.01%--gconv
                                  |                                           |          
                                  |                                            --0.64%--__gconv_transform_internal_utf8 
                                  |          
                                   --0.64%--xercesc_3_2::XMLPlatformUtils::lockMutex(void*)
                                             |          
                                              --0.58%--pthread_mutex_lock@@GLIBC_2.2.5
```

This PR
```
$ perf report --symbol-filter FindElement
# To display the perf.data header info, please use --header/--header-only options.                                     
#                                                                                                                      
#                                                                                                                      
# Total Lost Samples: 0                                                                                                                                                                                                                       
#                                                                                                                                                                                                                                             
# Samples: 362K of event 'cycles:Pu'                                                                                   
# Event count (approx.): 417397065338                                                                                                                                                                                                         
#                                                                                                                      
# Children      Self  Command  Shared Object      Symbol                                                                                  
# ........  ........  .......  .................  .......................................................................................                                                                                                     
#                                                                                                                                                                                                                                             
     0.92%     0.26%  FreeCAD  libFreeCADBase.so  [.] ParameterGrp::FindElement(xercesc_3_2::DOMElement*, char const*, char const*) const
            |                                                                                                                                                                                                                                 
             --0.66%--ParameterGrp::FindElement(xercesc_3_2::DOMElement*, char const*, char const*) const
                       |                                                                                                                                                                                                                      
                        --0.52%--xercesc_3_2::IconvGNULCPTranscoder::transcode(char const*, xercesc_3_2::MemoryManager*)                                                                                                                      
```