### PR TITLE
Show menu icons on macOS on Qt6.7.3+

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2282,6 +2282,10 @@ void Application::runApplication()
     MainWindow mw;
     mw.setProperty("QuitOnClosed", true);
 
+    // https://forum.freecad.org/viewtopic.php?f=3&t=15540
+    // Needs to be set after app is created to override platform defaults (qt commit a2aa1f81a81)
+    QApplication::setAttribute(Qt::AA_DontShowIconsInMenus, false);
+
 #ifdef FC_DEBUG  // redirect Coin messages to FreeCAD
     SoDebugError::setHandlerCallback(messageHandlerCoin, 0);
 #endif

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -107,8 +107,6 @@ void StartupProcess::setupApplication()
     // compression for tablet events here to solve that.
     QCoreApplication::setAttribute(Qt::AA_CompressTabletEvents);
 #endif
-    // https://forum.freecad.org/viewtopic.php?f=3&t=15540
-    QApplication::setAttribute(Qt::AA_DontShowIconsInMenus, false);
 }
 
 void StartupProcess::execute()


### PR DESCRIPTION
[Qt 6.7.3 changed default based on platform](https://github.com/qt/qtbase/commit/a2aa1f81a81) which made macOS hide all icons. This as Apple's guidelines says that menus shouldn't include icons.

We already set this attribute (`AA_DontShowMenuIcons`) to `false` in bootup, but this is reset when application is loaded as Qt sets it in [init_platform](https://github.com/qt/qtbase/commit/a2aa1f81a81#diff-6ce1c6c83aa4b5db78a6748c8a9eec19620a10a2e2a495fd9053fdf391a9863aR1360). To fix this, I've moved the old workaround for linux from `StartupProcess::setupApplication()` to `Application::runApplication()`.