### PR TITLE
fix(PD): size should be enabled if profile is not none

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -81,7 +81,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
         ui->ThreadSize->addItem(tr(it.c_str()));
     }
     ui->ThreadSize->setCurrentIndex(pcHole->ThreadSize.getValue());
-    ui->ThreadSize->setEnabled(!pcHole->Threaded.getValue() && pcHole->ThreadType.getValue() != 0L);
+    ui->ThreadSize->setEnabled(pcHole->ThreadType.getValue() != 0L);
 
     ui->ThreadClass->clear();
     cursor = pcHole->ThreadClass.getEnumVector();


### PR DESCRIPTION
ThreadSize can be enabled when Threaded and when not threaded(clearance hole)