### PR TITLE
BOM generation bugfix: Columns are persistent and .doCommandEval dependency circumvented

### DIFF
--- a/src/Mod/Assembly/CommandCreateBom.py
+++ b/src/Mod/Assembly/CommandCreateBom.py
@@ -160,6 +160,7 @@ class TaskAssemblyCreateBom(QtCore.QObject):
         self.updateColumnList()
 
     def accept(self):
+        self.updateColumnList()
         self.deactivate()
         App.closeActiveTransaction()
 

--- a/src/Mod/Assembly/CommandCreateBom.py
+++ b/src/Mod/Assembly/CommandCreateBom.py
@@ -335,7 +335,7 @@ class TaskAssemblyCreateBom(QtCore.QObject):
         else:
             commands = 'bomObj = App.activeDocument().addObject("Assembly::BomObject", "Bill of Materials")'
         Gui.doCommand(commands)
-        
+
         bom_objects = [
             obj for obj in App.ActiveDocument.Objects if obj.TypeId == "Assembly::BomObject"
         ]

--- a/src/Mod/Assembly/CommandCreateBom.py
+++ b/src/Mod/Assembly/CommandCreateBom.py
@@ -335,7 +335,11 @@ class TaskAssemblyCreateBom(QtCore.QObject):
         else:
             commands = 'bomObj = App.activeDocument().addObject("Assembly::BomObject", "Bill of Materials")'
         Gui.doCommand(commands)
-        self.bomObj = Gui.doCommandEval("bomObj")
+        
+        bom_objects = [
+            obj for obj in App.ActiveDocument.Objects if obj.TypeId == "Assembly::BomObject"
+        ]
+        self.bomObj = bom_objects[-1]
 
     def export(self):
         self.bomObj.recompute()


### PR DESCRIPTION
The BOM generation does not work properly as described in #18053.

Behaviour: Only index column visible after clicking "OK" no matter the selected columns to add to the BOM). 
![Aufzeichnung 2024-12-19 123855](https://github.com/user-attachments/assets/2146ccf7-09d3-47a0-ad2f-e167137802f8)

Only chance for me to add columns was to add them via the according property but that's not desirable. So:
First commit: Updated the `accept(self)` method with an additional `self.updateColumnList()` which led to the desired behaviour:

![Aufzeichnung 2024-12-19 124615](https://github.com/user-attachments/assets/24a407a9-b6c0-40dc-82af-5b79e2773c65)

Still there is the error from `self.bomObj = Gui.doCommandEval("bomObj")` in `createBomObject(self)` method. 

Second commit: Fixed it with a workaround by using the last created BOM obj as `self.bomObj`. This actually makes the first commit obsolete - yet I think it still makes the code more robust so I kept it.

Behaviour as intended, here shown with multiple BOMs and updating them. 
![Aufzeichnung 2024-12-19 135158](https://github.com/user-attachments/assets/c582369c-6d93-49f9-80d8-8215b5a0d016)
