### PR TITLE
Fix SPDX Identifier to match license

### DIFF
--- a/src/Mod/Part/App/MeasureInfo.h
+++ b/src/Mod/Part/App/MeasureInfo.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.0-or-later
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /***************************************************************************
  *   Copyright (c) 2024 wandererfan <wandererfan at gmail dot com>         *

--- a/src/Mod/TechDraw/App/DimensionAutoCorrect.cpp
+++ b/src/Mod/TechDraw/App/DimensionAutoCorrect.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: LGPL-2.0-or-later
 /***************************************************************************
  *   Copyright (c) 2023 WandererFan <wandererfan@gmail.com>                *
  *                                                                         *

--- a/src/Mod/TechDraw/App/DimensionAutoCorrect.h
+++ b/src/Mod/TechDraw/App/DimensionAutoCorrect.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: LGPL-2.0-or-later
 /***************************************************************************
  *   Copyright (c) 2023 WandererFan <wandererfan@gmail.com>                *
  *                                                                         *


### PR DESCRIPTION
While preparing the Debian package update, while doing copyright review I've found those three  SPDX headers not aligning to the code.

This MR fixes the SPDX headers, assuming the license comment block  is authoritative.

(@WandererFan FYI)