### PR TITLE
[ArchStairs] Regression-fix : EnsureBase prevent creation

### DIFF
--- a/src/Mod/BIM/ArchStairs.py
+++ b/src/Mod/BIM/ArchStairs.py
@@ -267,8 +267,11 @@ class _Stairs(ArchComponent.Component):
 
         if self.clone(obj):
             return
-        if not self.ensureBase(obj):
-            return
+
+        # Stairs can do without Base.  Base validity is tested in code below.
+        # Remarked out ensureBase() below
+        #if not self.ensureBase(obj):
+        #    return
 
         self.steps = []
         self.risers = []


### PR DESCRIPTION
Stairs can do without Base.  Base validity is tested in code.

EnsureBase() is remarked out.