### PR TITLE
App: Improved ParameterString::setValue performance by using std::string_view

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -467,7 +467,7 @@ Document* Application::newDocument(const char * Name, const char * UserName, boo
         else {
             userName = defaultName ? QObject::tr("Unnamed").toStdString() : Name;
 
-            std::vector<std::string> names;
+            std::vector<std::string_view> names;
             names.reserve(DocMap.size());
             for (const auto& pos : DocMap) {
                 names.emplace_back(pos.second->Label.getValue());
@@ -629,7 +629,7 @@ std::string Application::getUniqueDocumentName(const char *Name, bool tempDoc) c
         return CleanName;
     }
     else {
-        std::vector<std::string> names;
+        std::vector<std::string_view> names;
         names.reserve(DocMap.size());
         for (pos = DocMap.begin(); pos != DocMap.end(); ++pos) {
             if (!tempDoc || !pos->second->testStatus(Document::TempDoc))

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3654,7 +3654,7 @@ Document::addObjects(const char* sType, const std::vector<std::string>& objectNa
     }
 
     // get all existing object names
-    std::vector<std::string> reservedNames;
+    std::vector<std::string_view> reservedNames;
     reservedNames.reserve(d->objectMap.size());
     for (const auto& pos : d->objectMap) {
         reservedNames.push_back(pos.first);
@@ -3693,10 +3693,9 @@ Document::addObjects(const char* sType, const std::vector<std::string>& objectNa
             ObjectName = Base::Tools::getUniqueName(ObjectName, reservedNames, 3);
         }
 
-        reservedNames.push_back(ObjectName);
-
         // insert in the name map
-        d->objectMap[ObjectName] = pcObject;
+        auto [itr, _] = d->objectMap.emplace(ObjectName, pcObject);
+        reservedNames.push_back(itr->first);
         // generate object id and add to id map;
         pcObject->_Id = ++d->lastObjectId;
         d->objectIdMap[pcObject->_Id] = pcObject;
@@ -4301,7 +4300,7 @@ std::string Document::getUniqueObjectName(const char* Name) const
             }
         }
 
-        std::vector<std::string> names;
+        std::vector<std::string_view> names;
         names.reserve(d->objectMap.size());
         for (pos = d->objectMap.begin(); pos != d->objectMap.end(); ++pos) {
             names.push_back(pos->first);
@@ -4313,12 +4312,11 @@ std::string Document::getUniqueObjectName(const char* Name) const
 std::string Document::getStandardObjectName(const char* Name, int d) const
 {
     std::vector<App::DocumentObject*> mm = getObjects();
-    std::vector<std::string> labels;
+    std::vector<std::string_view> labels;
     labels.reserve(mm.size());
 
     for (auto it : mm) {
-        std::string label = it->Label.getValue();
-        labels.push_back(label);
+        labels.emplace_back(it->Label.getValue());
     }
     return Base::Tools::getUniqueName(Name, labels, d);
 }

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3694,7 +3694,7 @@ Document::addObjects(const char* sType, const std::vector<std::string>& objectNa
         }
 
         // insert in the name map
-        auto [itr, _] = d->objectMap.emplace(ObjectName, pcObject);
+        auto [itr, _] = d->objectMap.insert_or_assign(ObjectName, pcObject);
         reservedNames.push_back(itr->first);
         // generate object id and add to id map;
         pcObject->_Id = ++d->lastObjectId;

--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -310,7 +310,7 @@ std::string DynamicProperty::getUniquePropertyName(PropertyContainer& pc, const 
         return CleanName;
     }
     else {
-        std::vector<std::string> names;
+        std::vector<std::string_view> names;
         names.reserve(objectProps.size());
         for (pos = objectProps.begin(); pos != objectProps.end(); ++pos) {
             names.push_back(pos->first);

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1385,8 +1385,6 @@ void PropertyString::setValue(const char* newLabel)
         return;
     }
 
-    std::string _newLabel;
-
     std::vector<std::pair<Property*, std::unique_ptr<Property>>> propChanges;
     std::string label;
     auto obj = dynamic_cast<DocumentObject*>(getContainer());

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1403,13 +1403,13 @@ void PropertyString::setValue(const char* newLabel)
         }
         App::Document* doc = obj->getDocument();
         if (doc && !_hPGrp->GetBool("DuplicateLabels") && !obj->allowDuplicateLabel()) {
-            std::vector<std::string> objectLabels;
+            std::vector<std::string_view> objectLabels;
             bool match = false;
             for (const auto& doc_obj : doc->getObjects()) {
                 if (doc_obj == obj) {
                     continue;  // don't compare object with itself
                 }
-                std::string objLabel = doc_obj->Label.getValue();
+                std::string_view objLabel = doc_obj->Label.getValue();
                 if (!match && objLabel == newLabel) {
                     match = true;
                 }

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1404,14 +1404,12 @@ void PropertyString::setValue(const char* newLabel)
         App::Document* doc = obj->getDocument();
         if (doc && !_hPGrp->GetBool("DuplicateLabels") && !obj->allowDuplicateLabel()) {
             std::vector<std::string> objectLabels;
-            std::vector<App::DocumentObject*>::const_iterator it;
-            std::vector<App::DocumentObject*> objs = doc->getObjects();
             bool match = false;
-            for (it = objs.begin(); it != objs.end(); ++it) {
-                if (*it == obj) {
+            for (const auto& doc_obj : doc->getObjects()) {
+                if (doc_obj == obj) {
                     continue;  // don't compare object with itself
                 }
-                std::string objLabel = (*it)->Label.getValue();
+                std::string objLabel = doc_obj->Label.getValue();
                 if (!match && objLabel == newLabel) {
                     match = true;
                 }

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1404,6 +1404,7 @@ void PropertyString::setValue(const char* newLabel)
         App::Document* doc = obj->getDocument();
         if (doc && !_hPGrp->GetBool("DuplicateLabels") && !obj->allowDuplicateLabel()) {
             std::vector<std::string_view> objectLabels;
+            objectLabels.reserve(doc->getObjects().size());
             bool match = false;
             for (const auto& doc_obj : doc->getObjects()) {
                 if (doc_obj == obj) {

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include <string_view>
 #include <boost_signals2.hpp>
 #include <QString>
 
@@ -268,6 +269,11 @@ struct BaseExport Tools
 {
     static std::string
     getUniqueName(const std::string&, const std::vector<std::string>&, int d = 0);
+    // std::reference_wrapper tricks avoiding ambiguous overload resolution with initializer list,
+    // like getUniqueName("name", {"name1"}) in test.
+    static std::string getUniqueName(const std::string&,
+                                     std::reference_wrapper<const std::vector<std::string_view>>,
+                                     int d = 0);
     static std::string addNumber(const std::string&, unsigned int, int d = 0);
     static std::string getIdentifier(const std::string&);
     static std::wstring widen(const std::string& str);


### PR DESCRIPTION
This PR relates #18124. I'm not familiar with parameter management but this PR improves performance by using std::string_view instead std::string: reduces allocating and copying.

I profiled with perf(1); just D&D dxf file and close FreeCAD:

baseline
```
# Children      Self  Command  Shared Object  Symbol                  
# ........  ........  .......  .............  ........................
#
    73.51%     0.00%  FreeCAD  Import.so      [.] CDxfRead::ReadLine()
            |
            ---CDxfRead::ReadLine()
               |          
                --73.28%--Import::ImpExpDxfRead::OnReadLine(Base::Vector3<double> const&, Base::Vector3<double> const&, bool)
                          |          
                           --73.13%--Import::ImpExpDxfRead::DrawingEntityCollector::AddObject(TopoDS_Shape const&, char const*)
                                     |          
                                      --69.58%--App::Document::addObject(char const*, char const*, bool, char const*, bool)
                                                |          
                                                 --19.49%--App::PropertyString::setValue(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
```

This PR
```
# Children      Self  Command  Shared Object  Symbol                  
# ........  ........  .......  .............  ........................
#
    70.35%     0.00%  FreeCAD  Import.so      [.] CDxfRead::ReadLine()
            |          
             --70.34%--CDxfRead::ReadLine()
                       |          
                        --70.06%--Import::ImpExpDxfRead::OnReadLine(Base::Vector3<double> const&, Base::Vector3<double> const&, bool)
                                  |          
                                   --69.84%--Import::ImpExpDxfRead::DrawingEntityCollector::AddObject(TopoDS_Shape const&, char const*)
                                             |          
                                              --65.63%--App::Document::addObject(char const*, char const*, bool, char const*, bool)
                                                        |          
                                                         --10.80%--App::PropertyString::setValue(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
                                                                   App::PropertyString::setValue(char const*)

```