### PR TITLE
SH3DImporter: Removing IFC project by default

### DIFF
--- a/src/Mod/BIM/Resources/ui/preferences-sh3d-import.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-sh3d-import.ui
@@ -290,6 +290,22 @@
                 </property>
               </widget>
             </item>
+            <item>
+              <widget class="Gui::PrefCheckBox" name="checkBox_12">
+                <property name="toolTip">
+                  <string>Create a default IFC project with the newly created Site.</string>
+                </property>
+                <property name="text">
+                  <string>Create IFC Project</string>
+                </property>
+                <property name="prefEntry" stdset="0">
+                  <cstring>sh3dCreateIFCProject</cstring>
+                </property>
+                <property name="prefPath" stdset="0">
+                  <cstring>Mod/Arch</cstring>
+                </property>
+              </widget>
+            </item>
           </layout>
         </widget>
       </item>

--- a/src/Mod/BIM/TestArch.py
+++ b/src/Mod/BIM/TestArch.py
@@ -767,7 +767,6 @@ class ArchTest(unittest.TestCase):
         import BIM.importers.importSH3DHelper
         importer = BIM.importers.importSH3DHelper.SH3DImporter(None)
         importer.import_sh3d_from_string(SH3D_HOME)
-        assert App.ActiveDocument.Project
         assert App.ActiveDocument.Site
         assert App.ActiveDocument.BuildingPart.Label == "Building"
         assert App.ActiveDocument.BuildingPart001.Label == "Level"
@@ -793,7 +792,7 @@ class ArchTest(unittest.TestCase):
         level = Arch.makeFloor()
         level.addObjects([wall, column])
         App.ActiveDocument.recompute()
-        
+
         # Create a drawing view
         section = Arch.makeSectionPlane(level)
         drawing = Arch.make2DDrawing()
@@ -803,7 +802,7 @@ class ArchTest(unittest.TestCase):
         cut.ProjectionMode = "Cutfaces"
         drawing.addObjects([view, cut])
         App.ActiveDocument.recompute()
-        
+
         # Create a TD page
         tpath = os.path.join(App.getResourceDir(),"Mod","TechDraw","Templates","A3_Landscape_blank.svg")
         page = App.ActiveDocument.addObject("TechDraw::DrawPage", "Page")

--- a/src/Mod/BIM/importers/importSH3DHelper.py
+++ b/src/Mod/BIM/importers/importSH3DHelper.py
@@ -277,10 +277,10 @@ class SH3DImporter:
             self._import_elements(home, 'camera')
             self._refresh()
 
-        if self.preferences["CREATE_RENDER_PROJECT"] and self.project:
+        if self.preferences["CREATE_RENDER_PROJECT"] and self.site:
             Project.create(doc, renderer="Povray", template="povray_standard.pov")
             Gui.Selection.clearSelection()
-            Gui.Selection.addSelection(self.project)
+            Gui.Selection.addSelection(self.site)
             Gui.runCommand('Render_View', 0)
             self._refresh()
 
@@ -308,6 +308,7 @@ class SH3DImporter:
             'JOIN_ARCH_WALL': get_param_arch("sh3dJoinArchWall"),
             'CREATE_RENDER_PROJECT': get_param_arch("sh3dCreateRenderProject") and RENDER_IS_AVAILABLE,
             'FIT_VIEW': get_param_arch("sh3dFitView"),
+            'CREATE_IFC_PROJECT': get_param_arch("sh3dCreateIFCProject"),
             'DEFAULT_FLOOR_COLOR': color_fc2sh(get_param_arch("sh3dDefaultFloorColor")),
             'DEFAULT_CEILING_COLOR': color_fc2sh(get_param_arch("sh3dDefaultCeilingColor")),
         }
@@ -449,7 +450,7 @@ class SH3DImporter:
         """
         if 'Project' in self.fc_objects:
             self.project = self.fc_objects.get('Project')
-        else:
+        elif self.preferences["CREATE_IFC_PROJECT"]:
             self.project = self._create_project()
         if 'Site' in self.fc_objects:
             self.site = self.fc_objects.get('Site')
@@ -459,7 +460,10 @@ class SH3DImporter:
             self.building = self.fc_objects.get(elm.get('name'))
         else:
             self.building = self._create_building(elm)
-        self.project.addObject(self.site)
+
+        if self.preferences["CREATE_IFC_PROJECT"]:
+            self.project.addObject(self.site)
+
         self.site.addObject(self.building)
 
     def _create_project(self):


### PR DESCRIPTION
As suggested in https://github.com/FreeCAD/FreeCAD/pull/17165#issuecomment-2551291883 the IFC project created by default during import is not used in BIM and only make sense when working with IFC files.

This PR aims to remove that element, while letting the user import it if he/she so wishes.