### PR TITLE
Gui: Fix copying elements in the tree view by holding CTRL key

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -620,7 +620,6 @@ TreeWidget::TreeWidget(const char* name, QWidget* parent)
 
     this->setDragEnabled(true);
     this->setAcceptDrops(true);
-    this->setDragDropMode(QTreeWidget::InternalMove);
     this->setColumnCount(3);
     this->setItemDelegate(new TreeWidgetItemDelegate(this));
     this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);


### PR DESCRIPTION
In older versions it was possible to copy elements with drag and drop by holding the CTRL key. Since v0.20 or v0.21 this wasn't possible any more so that elements are always moved.

Note: Copying is only allowed for elements that have a parent object.