### PR TITLE
GUI: cleanup Privacy Policy formatting

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -4,10 +4,7 @@ The FreeCAD application does not collect, transmit, share or use any Personal Da
 
 FreeCAD is community-developed Free Software. The community does not condone the unauthorized usage of private data, so our software does not gather or send personal data.
 
-The FreeCAD website is mostly static, it does not contain any trackers, neither ours nor third-party.  The website uses cookies to remember logged in status, timezone and other
-data related to navigating the site.
-
-The website does not contain advertisements.
+The FreeCAD website is mostly static, it does not contain any trackers, neither ours nor third-party. The website uses cookies to remember logged in status, timezone and other data related to navigating the site. The website does not contain advertisements.
 
 The software does not contain advertisements or trackers either.
 
@@ -15,9 +12,9 @@ The software does not contain advertisements or trackers either.
 
 FreeCAD is able to load or save files to/from remote servers (for some protocols and platforms). If you choose to load or save a remote file, your IP or other private data might be shared as part of the normal connection flow for the given protocol. This is out of our control and it is up to you to decide whether you trust a remote host.
 
-The FreeCAD eco system includes user developed workbenches.  These workbenches can be installed/updated using the Add-on Manager.  The Add-on Manager retrieves workbenches from remote servers across the internet.  Add-on workbenches are not checked for malicious content.  It is your responsibility to decide whether you trust an add-on workbench.
+The FreeCAD eco system includes user developed workbenches. These workbenches can be installed/updated using the Add-on Manager. The Add-on Manager retrieves workbenches from remote servers across the internet. Add-on workbenches are not checked for malicious content. It is your responsibility to decide whether you trust an add-on workbench.
 
-FreeCAD is meant to manipulate CAD files which may contain metadata. It is your responsibility to verify the metadata contained in your files before you share them with others.   These files may contain local directory paths which could reveal user names if the user name forms part of the path - as in “C:\MrsCAD\Documents\myFreeCADFile.FCstd”.
+FreeCAD is meant to manipulate CAD files which may contain metadata. It is your responsibility to verify the metadata contained in your files before you share them with others. These files may contain local directory paths which could reveal user names if the user name forms part of the path - as in “C:\MrsCAD\Documents\myFreeCADFile.FCstd”.
 
 FreeCAD can also be used to create and run macros. These are Python scripts that can perform any action that the user can perform on a system. When running a macro from an outside source, it is your responsibility to ensure you trust the author.
 
@@ -28,5 +25,4 @@ When reading the online version of the User Manual within FreeCAD, manual conten
 FreeCAD is Free Software and therefore may be packaged by other people, who may include additional software or modify the source code. We do not vouch for these third-party packages and cannot tell you what they contain and what they do regarding your privacy. The official packages are explicitly listed in our download page.
 
 
- - [based on the GIMP privacy policy](https://www.gimp.org/about/privacy.html)
-
+*The above privacy policy is based on the [GIMP privacy policy](https://www.gimp.org/about/privacy.html).*


### PR DESCRIPTION
Small formatting cleanup (whitespaces, italic for reference instead of list bullet) of the Privacy Policy, accessible from the menu Help > About FreeCAD > Privacy Policy.

<details><summary>Before</summary>

![PP-before](https://github.com/user-attachments/assets/2a47415d-6da3-4d1a-bf55-d75b35fbde84)

</details>

<details><summary>After</summary>

![PP-after](https://github.com/user-attachments/assets/70d7f1b5-fe23-4833-ae28-007e476c9ab0)

</details>