### PR TITLE
Tests: On Windows place test exes in bin

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,5 +148,10 @@ include(GoogleTest)
 set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST)
 
 foreach (exe ${TestExecutables})
+    if(WIN32)
+        # On Windows, everything has to be in the same directory so the tests can find the DLLs
+        set_target_properties(${exe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+        set_target_properties(${exe} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+    endif()
     gtest_discover_tests(${exe})
 endforeach()


### PR DESCRIPTION
To ensure that the test executables can find the FreeCAD DLL files, all exe files must be in the same directory as those DLLs. I was doing this by hand before, but I believe this is the normal way to make cmake do it automatically. @wwmayer can you verify that this is correct, or let me know a better way? This works on my system, at any rate.