### PR TITLE
App: Create addTranslatableExportType method

### DIFF
--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -372,6 +372,9 @@ public:
     //@{
     /// Register an export filetype and a module name
     void addExportType(const char* Type, const char* ModuleName);
+    void addTranslatableExportType(const char *description,
+                                   const std::vector<std::string> &extensions,
+                                   const char *ModuleName);
     /// Change the module name of a registered filetype
     void changeExportModule(const char* Type, const char* OldModuleName, const char* NewModuleName);
     /// Return a list of modules that support the given filetype.

--- a/tests/src/App/CMakeLists.txt
+++ b/tests/src/App/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
             ${CMAKE_CURRENT_SOURCE_DIR}/MappedElement.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/MappedName.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Metadata.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/ProgramOptionsUtilities.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/ProjectFile.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Property.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/PropertyExpressionEngine.cpp

--- a/tests/src/App/ProgramOptionsUtilities.cpp
+++ b/tests/src/App/ProgramOptionsUtilities.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+#include "App/ProgramOptionsUtilities.h"
+
+using namespace App::Util;
+
+using stringPair = std::pair<std::string, std::string>;
+
+TEST(ProgramOptionsUtilitiesTest, fCustomSyntaxLookup)
+{
+    stringPair res {customSyntax("-display")};
+    stringPair exp {"display", "null"};
+    EXPECT_EQ(res, exp);
+};
+TEST(ProgramOptionsUtilitiesTest, fCustomSyntaxMac)
+{
+    stringPair res {customSyntax("-psn_stuff")};
+    stringPair exp {"psn", "stuff"};
+    EXPECT_EQ(res, exp);
+};
+TEST(ProgramOptionsUtilitiesTest, fCustomSyntaxWidgetCount)
+{
+    stringPair res {customSyntax("-widgetcount")};
+    stringPair exp {"widgetcount", ""};
+    EXPECT_EQ(res, exp);
+}
+TEST(ProgramOptionsUtilitiesTest, fCustomSyntaxNotFound)
+{
+    stringPair res {customSyntax("-displayx")};
+    stringPair exp {"", ""};
+    EXPECT_EQ(res, exp);
+};
+TEST(ProgramOptionsUtilitiesTest, fCustomSyntaxAmpersand)
+{
+    stringPair res {customSyntax("@freddie")};
+    stringPair exp {"response-file", "freddie"};
+    EXPECT_EQ(res, exp);
+};
+TEST(ProgramOptionsUtilitiesTest, fCustomSyntaxEmptyIn)
+{
+    stringPair res {customSyntax("")};
+    stringPair exp {"", ""};
+    EXPECT_EQ(res, exp);
+};


### PR DESCRIPTION
NOTE: This is a work-in-progress, but I am sure there are already some things that could be improved, so I am looking for feedback particularly as regards the C++ aspects of this PR. Especially have a look at the way I've written the two string manipulation functions. I played with `std::transform` and `boost::join`, but I didn't feel like that made the code any clearer, but it definitely feels like there's a better approach (or maybe that's the Python programmer in me...). Suggestions welcome! Pinging @xtemp09, @jbaehr, @hyarion, @kadet1090 , and anyone else interested. Also, @yorikvanhavre does this seem like a reasonable approach to the problem?

--- 

This method aims to solve the problem of untranslatable description strings on file types. Some, but not all, file format description strings contain translatable elements. For example, some languages may translate "FEM mesh formats". Many format descriptions include the words "file," "format," or "mesh" -- these could potentially be replaced with localized versions.

There are two challenges: the first is to prevent translators from accidentally breaking the quite-sensitive formatting of the list of supported extensions. This is achieved by dropping anything that looks like such a list from the string post-translation, and simply recreating it in a known-good format from a list of extensions provided to the new method.

The second challenge is to support retranslation during a single run of the program (e.g. changing the language of the UI while it is running). To achieve this, a caching system is used. Every call to the new method is cached, and when the language changes those calls will be "replayed" both to remove the original entry, and to add the entry in the new language.

This commit implements the Export method and cache, but does not add either the corresponding Input method and cache, the replay of the cache, or the actual code update needed to call this method when a translation is possible.

Unit tests for the new method are added, and some refactoring of a small set of existing tests is included as part of the reorganization of the Application class tests.