### PR TITLE
Gui: Respect ToolbarIconSize in Workbench TabBar selector

### DIFF
--- a/src/Gui/WorkbenchSelector.cpp
+++ b/src/Gui/WorkbenchSelector.cpp
@@ -141,7 +141,6 @@ WorkbenchTabWidget::WorkbenchTabWidget(WorkbenchGroup* aGroup, QWidget* parent)
     tabBar->setDocumentMode(true);
     tabBar->setUsesScrollButtons(true);
     tabBar->setDrawBase(true);
-    tabBar->setIconSize(QSize(16, 16));
 
     updateWorkbenchList();
 

--- a/src/Gui/WorkbenchSelector.h
+++ b/src/Gui/WorkbenchSelector.h
@@ -71,7 +71,9 @@ class GuiExport WorkbenchTabWidget : public QWidget
 
     class WbTabBar : public QTabBar {
     public:
-        explicit WbTabBar(QWidget* parent) : QTabBar(parent) {}
+        explicit WbTabBar(QWidget* parent) : QTabBar(parent) {
+	    setIconSize(iconSize());
+	}
 
         QSize tabSizeHint(int index) const override {
             auto sizeFromParent = QTabBar::tabSizeHint(index);
@@ -126,6 +128,14 @@ class GuiExport WorkbenchTabWidget : public QWidget
             _itemStyle = itemStyle;
             setProperty("style", QString::fromUtf8(workbenchItemStyleToString(itemStyle)));
         }
+
+        QSize iconSize() const {
+	    auto size = WindowParameter::getDefaultParameter()->GetGroup("General")->GetInt("ToolbarIconSize", 16);
+	    if (size > 16) {
+	      size = size - 8; // do not grow the toolbar height
+	    }
+	    return QSize(size, size);
+	}
 
     private:
         WorkbenchItemStyle _itemStyle{WorkbenchItemStyle::IconAndText};


### PR DESCRIPTION
Respect user's preferred toolbar icon size in the TabBar-style workbench selector instead of hardcoding a fixed pixel size.

This improves upon issue #15533

although currently doesn't update immediately if the preference changes after construction, but requires a restart.