### PR TITLE
Clang-Tidy: Remove AnalyzeTemporaryDtors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,7 +8,6 @@ concurrency-*,-modernize-use-trailing-return-type, -modernize-use-nodiscard,-rea
 -cppcoreguidelines-pro-type-static-cast-downcast'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     file
 User:            florians
 CheckOptions:


### PR DESCRIPTION
Deprecated in clang-tidy 16 and removed in clang-tidy 18.