### PR TITLE
Sketcher: Add an option to always add ext. geometry as reference

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -39,6 +39,7 @@
 #include <Gui/SelectionFilter.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
+#include <Gui/Window.h>
 #include <Mod/Part/App/DatumFeature.h>
 #include <Mod/Part/App/Geometry2d.h>
 #include <Mod/Sketcher/App/Constraint.h>
@@ -1515,7 +1516,11 @@ CONSTRUCTION_UPDATE_ACTION(CmdSketcherProjection, "Sketcher_Projection")
 void CmdSketcherProjection::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    ActivateHandler(getActiveGuiDocument(), std::make_unique<DrawSketchHandlerExternal>());
+    bool extGeoRef = Gui::WindowParameter::getDefaultParameter()
+                         ->GetGroup("Mod/Sketcher/General")
+                         ->GetBool("AlwaysExtGeoReference", false);
+    ActivateHandler(getActiveGuiDocument(),
+                    std::make_unique<DrawSketchHandlerExternal>(extGeoRef, false));
 }
 
 bool CmdSketcherProjection::isActive()
@@ -1546,12 +1551,17 @@ CmdSketcherIntersection::CmdSketcherIntersection()
 
 CONSTRUCTION_UPDATE_ACTION(CmdSketcherIntersection, "Sketcher_Intersection")
 
-void CmdSketcherIntersection::activated(int)
+void CmdSketcherIntersection::activated(int iMsg)
 {
-    ActivateHandler(getActiveGuiDocument(), std::make_unique<DrawSketchHandlerExternal>(true));
+    Q_UNUSED(iMsg);
+    bool extGeoRef = Gui::WindowParameter::getDefaultParameter()
+                         ->GetGroup("Mod/Sketcher/General")
+                         ->GetBool("AlwaysExtGeoReference", false);
+    ActivateHandler(getActiveGuiDocument(),
+                    std::make_unique<DrawSketchHandlerExternal>(extGeoRef, true));
 }
 
-bool CmdSketcherIntersection::isActive(void)
+bool CmdSketcherIntersection::isActive()
 {
     return isCommandActive(getActiveGuiDocument());
 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
@@ -116,8 +116,9 @@ public:
 class DrawSketchHandlerExternal: public DrawSketchHandler
 {
 public:
-    DrawSketchHandlerExternal(bool intersection = false)
-        : intersection(intersection)
+    DrawSketchHandlerExternal(bool alwaysReference, bool intersection)
+        : alwaysReference {alwaysReference}
+        , intersection {intersection}
     {}
     ~DrawSketchHandlerExternal() override
     {
@@ -168,7 +169,8 @@ public:
                                           "addExternal(\"%s\",\"%s\", %s, %s)",
                                           msg.pObjectName,
                                           msg.pSubName,
-                                          isConstructionMode() ? "False" : "True",
+                                          alwaysReference || isConstructionMode() ? "False"
+                                                                                  : "True",
                                           intersection ? "True" : "False");
 
                     Gui::Command::commitCommand();
@@ -229,6 +231,7 @@ private:
         setAxisPickStyle(true);
     }
 
+    bool alwaysReference;
     bool intersection;
 };
 

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -112,6 +112,7 @@ void SketcherSettings::saveSettings()
     ui->checkBoxAutoRemoveRedundants->onSave();
     ui->checkBoxUnifiedCoincident->onSave();
     ui->checkBoxHorVerAuto->onSave();
+    ui->checkBoxAddExtGeo->onSave();
 
     enum
     {
@@ -186,6 +187,7 @@ void SketcherSettings::loadSettings()
     setProperty("checkBoxUnifiedCoincident", ui->checkBoxUnifiedCoincident->isChecked());
     ui->checkBoxHorVerAuto->onRestore();
     setProperty("checkBoxHorVerAuto", ui->checkBoxHorVerAuto->isChecked());
+    ui->checkBoxAddExtGeo->onRestore();
 
     // Dimensioning constraints mode
     ui->dimensioningMode->clear();

--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -216,6 +216,25 @@ Requires to re-enter edit mode to take effect.</string>
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBoxAddExtGeo">
+        <property name="toolTip">
+         <string>If checked then external geometry is always added as reference, otherwise it's added according to the current construction mode.</string>
+        </property>
+        <property name="text">
+         <string>Always add external geometry as reference</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>AlwaysExtGeoReference</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Sketcher/General</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
There are many complaints about the new behaviour to add ext. geometry according to the current construction mode.
In the past the default was to always add it as reference.

With this option the user can restore the old behaviour.