### PR TITLE
Remove unused ifndefs for GL_MULTISAMPLE

### DIFF
--- a/src/Mod/Sandbox/Gui/GLGraphicsView.cpp
+++ b/src/Mod/Sandbox/Gui/GLGraphicsView.cpp
@@ -66,10 +66,6 @@
 
 using namespace Gui;
 
-#ifndef GL_MULTISAMPLE
-#define GL_MULTISAMPLE  0x809D
-#endif
-
 // http://doc.qt.digia.com/qq/qq26-openglcanvas.html
 
 GraphicsView::GraphicsView()

--- a/src/Mod/Sandbox/Gui/Overlay.cpp
+++ b/src/Mod/Sandbox/Gui/Overlay.cpp
@@ -69,9 +69,6 @@ public:
 
         view->getSoRenderManager()->scheduleRedraw();
     }
- #ifndef GL_MULTISAMPLE
- #define GL_MULTISAMPLE  0x809D
- #endif
     void paintGL()
     {
     const SbViewportRegion vp = view->getSoRenderManager()->getViewportRegion();


### PR DESCRIPTION
(found while searching for the build error on armhf/armel on Debian buildds, once resolved will make an additional PR for that.)

$grep -r GL_MULTISAMPLE src/
yields:

 src/Mod/Sandbox/Gui/Overlay.cpp: #ifndef GL_MULTISAMPLE
 src/Mod/Sandbox/Gui/Overlay.cpp: #define GL_MULTISAMPLE  0x809D
 src/Mod/Sandbox/Gui/GLGraphicsView.cpp:#ifndef GL_MULTISAMPLE
 src/Mod/Sandbox/Gui/GLGraphicsView.cpp:#define GL_MULTISAMPLE  0x809D

-> The defines are defined, but never used in the compilation unit