### PR TITLE
Fix compilation issue if KuKa files have been removed.

### DIFF
--- a/src/Mod/Robot/CMakeLists.txt
+++ b/src/Mod/Robot/CMakeLists.txt
@@ -44,10 +44,12 @@ fc_target_copy_resource(RobotScripts
     ${CMAKE_BINARY_DIR}/Mod/Robot
     ${Robot_Scripts})
 
+if (DEFINED Robot_Resources)
 fc_target_copy_resource(RobotScripts
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Robot
     ${Robot_Resources})
+endif()
 
 INSTALL(
     FILES
@@ -56,6 +58,7 @@ INSTALL(
         Mod/Robot
 )
 
+if (DEFINED Robot_Resources)
 INSTALL(
     DIRECTORY
         Lib
@@ -65,3 +68,4 @@ INSTALL(
     PATTERN "*.pdf" EXCLUDE
     PATTERN "testprog.*" EXCLUDE
 )
+endif()


### PR DESCRIPTION
(Background is issue #18622)

CMake errors out when the Kuka files are removed with:

```
CMake Error at cMake/FreeCadMacros.cmake:79 (ADD_CUSTOM_COMMAND):
  ADD_CUSTOM_COMMAND called with wrong number of arguments.
Call Stack (most recent call first):
  src/Mod/Robot/CMakeLists.txt:47 (fc_target_copy_resource)
```

The problem is that while the CMake code checks whether /src/Mod/Robot/Lib/Kuka is there befor setting Robot_Resources, but then later still uses the variable, even if it hasn't been set.

The patch just guards the failing fc_target_copy_resource with another if that checks whether the variable has been defined.

CMake install would also fail when Lib is empty, so another guard is required for the `INSTALL( DIRECTORY Lib` … section.