### PR TITLE
Macro: Ability to conviently 'send selection to console' from the Macro Editor context menu.

### DIFF
--- a/src/Gui/PythonEditor.h
+++ b/src/Gui/PythonEditor.h
@@ -31,6 +31,7 @@ namespace Gui {
 
 class PythonSyntaxHighlighter;
 class PythonSyntaxHighlighterP;
+class PythonConsole;
 
 /**
  * Python text editor with syntax highlighting.
@@ -61,6 +62,7 @@ public Q_SLOTS:
     void onUncomment();
     /** Executes the selected code in python console. */
     void onExecuteSelection();
+    PythonConsole* getPythonConsole() const;
     void setFileName(const QString&);
     void startDebug();
 
@@ -73,6 +75,7 @@ protected:
 private:
     //PythonSyntaxHighlighter* pythonSyntax;
     struct PythonEditorP* d;
+    mutable PythonConsole* pyConsole {nullptr};  // link to the python console
 };
 
 /**

--- a/src/Gui/PythonEditor.h
+++ b/src/Gui/PythonEditor.h
@@ -59,6 +59,8 @@ public Q_SLOTS:
      * this line is skipped.
      */
     void onUncomment();
+    /** Executes the selected code in python console. */
+    void onExecuteSelection();
     void setFileName(const QString&);
     void startDebug();
 


### PR DESCRIPTION
Adds a feature requested on issue #18422

Adds an ability to execute selected line(s) directly from Macro Editor's (Python Editor) context menu or with keyboard shortcut: `Ctrl+Shift+E`
Executes the line that the cursor is on, if there is no selection (for speed).

Uses
`Base::Interpreter().runInteractiveString();`
for single-line selection, to get interactive messages such as:

> AttributeError: module 'FreeCADGui' has no attribute 'getWindow'. Did you mean: 'getMainWindow'?

and
`Base::Interpreter().runString();`
for the ability to run multiline selections (multiple statements).


The output (print messages, errors, etc.) goes to the Report View. Therefore, the following settings need to be enabled:
### Record View
Output
- [x] Record normal messages
- [x] Record log messages
- [x] Record warnings
- [x]  Record error messages

Python interpreter
- [x] Redirect internal Python output to report view
- [x] Redirect internal Python errors to report view

### Update

Fixed indentation issue and and added `printStatement` to print the executed code in the console.
Credits to @mwganson  for providing the solution for handling indentation. PR #18716

> Often there is an issue with indentation, for example, if we wish to execute a block of code that is within a function definition or class definition. This PR will attempt to normalize the indentation level so that it can be executed in the console. The method used is to find the leading whitespace of the first selected line, and then remove that leading whitespace from all the lines in the selected block, thus preserving the indentation relative to the first selected line.