### PR TITLE
[Python console] add Execute in console context menu item

### DIFF
--- a/src/Gui/PythonEditor.cpp
+++ b/src/Gui/PythonEditor.cpp
@@ -25,11 +25,13 @@
 # include <QContextMenuEvent>
 # include <QMenu>
 # include <QPainter>
+# include <QRegularExpression>
 # include <QShortcut>
 # include <QTextCursor>
 #endif
 
 #include <Base/Parameter.h>
+#include <Gui/Command.h>
 
 #include "PythonEditor.h"
 #include "Application.h"
@@ -77,8 +79,12 @@ PythonEditor::PythonEditor(QWidget* parent)
     auto uncomment = new QShortcut(this);
     uncomment->setKey(QKeySequence(QString::fromLatin1("ALT+U")));
 
+    auto execInConsole = new QShortcut(this);
+    execInConsole->setKey(QKeySequence(QString::fromLatin1("ALT+SHIFT+P")));
+
     connect(comment, &QShortcut::activated, this, &PythonEditor::onComment);
     connect(uncomment, &QShortcut::activated, this, &PythonEditor::onUncomment);
+    connect(execInConsole, &QShortcut::activated, this, &PythonEditor::onExecuteInConsole);
 }
 
 /** Destroys the object and frees any allocated resources */
@@ -153,6 +159,9 @@ void PythonEditor::contextMenuEvent ( QContextMenuEvent * e )
         comment->setShortcut(QKeySequence(QString::fromLatin1("ALT+C")));
         QAction* uncomment = menu->addAction( tr("Uncomment"), this, &PythonEditor::onUncomment);
         uncomment->setShortcut(QKeySequence(QString::fromLatin1("ALT+U")));
+        QAction* execInConsole = menu->addAction( tr("Execute in console"),
+                                                  this, &PythonEditor::onExecuteInConsole);
+        execInConsole->setShortcut(QKeySequence(QString::fromLatin1("ALT+Shift+P")));
     }
 
     menu->exec(e->globalPos());
@@ -254,6 +263,69 @@ void PythonEditor::onUncomment()
     }
 
     cursor.endEditBlock();
+}
+
+void PythonEditor::onExecuteInConsole()
+{
+    QTextCursor cursor = textCursor();
+    int selStart = cursor.selectionStart();
+    int selEnd = cursor.selectionEnd();
+    QTextBlock block;
+    QString selectedCode;
+
+    for (block = document()->begin(); block.isValid(); block = block.next()) {
+        int pos = block.position();
+        int off = block.length() - 1;
+        if (pos >= selStart || pos + off >= selStart) {
+            if (pos + 1 > selEnd)
+                break;
+
+            QString lineText = block.text();
+            selectedCode.append(lineText + QLatin1String("\n"));
+        }
+    }
+
+    if (!selectedCode.isEmpty()) {
+
+        /** Dedent the block of code so that the first selected
+         *  line has no indentation, but the remaining lines
+         *  keep their indentation relative to that first line.
+         */
+
+        // get the leading whitespace of the first line
+        QStringList lines = selectedCode.split(QLatin1Char('\n'));
+        QString firstLineIndent;
+        for (const QString& line : lines) {
+            if (!line.isEmpty()) {
+                int leadingWhitespace = line.indexOf(QRegularExpression(QLatin1String("\\S")));
+                if (leadingWhitespace > 0) {
+                    firstLineIndent = line.left(leadingWhitespace);
+                }
+                break;
+            }
+        }
+
+        // remove that first line whitespace from all the lines
+        for (QString& line : lines) {
+            if (!line.isEmpty() && line.startsWith(firstLineIndent)) {
+                line.remove(0, firstLineIndent.length());
+            }
+        }
+
+        // join the lines into a single QString so we can execute as a single block
+        QString dedentedCode = lines.join(QLatin1Char('\n'));
+
+        if (!dedentedCode.isEmpty()) {
+            try {
+                Gui::Command::doCommand(Gui::Command::Doc, dedentedCode.toStdString().c_str());
+            } catch (const Base::Exception& e) {
+                QString errorMessage = QString::fromStdString(e.what());
+                Base::Console().Error("Error executing Python code:\n%s\n", errorMessage.toUtf8().constData());
+            } catch (...) {
+                Base::Console().Error("An unknown error occurred while executing Python code.\n");
+            }
+        }
+    }
 }
 
 // ------------------------------------------------------------------------

--- a/src/Gui/PythonEditor.cpp
+++ b/src/Gui/PythonEditor.cpp
@@ -277,8 +277,9 @@ void PythonEditor::onExecuteInConsole()
         int pos = block.position();
         int off = block.length() - 1;
         if (pos >= selStart || pos + off >= selStart) {
-            if (pos + 1 > selEnd)
+            if (pos + 1 > selEnd) {
                 break;
+            }
 
             QString lineText = block.text();
             selectedCode.append(lineText + QLatin1String("\n"));

--- a/src/Gui/PythonEditor.h
+++ b/src/Gui/PythonEditor.h
@@ -59,6 +59,7 @@ public Q_SLOTS:
      * this line is skipped.
      */
     void onUncomment();
+    void onExecuteInConsole();
     void setFileName(const QString&);
     void startDebug();
 


### PR DESCRIPTION
This PR adds the ability to send selected code from the python editor to be executed in the python console.  Usage: select a block of code in the python editor, press Alt+Shift+P (or select Execute in console from the context menu).  Selected block of code will be executed in the python console.

Often there is an issue with indentation, for example, if we wish to execute a block of code that is within a function definition or class definition.  This PR will attempt to normalize the indentation level so that it can be executed in the console.  The method used is to find the leading whitespace of the first selected line, and then remove that leading whitespace from all the lines in the selected block, thus preserving the indentation relative to the first selected line.

Note that the selected shortcut is similar to the shortcut for sending selected objects to the python console (Ctrl+Shift+P).