### PR TITLE
Fix the crash in the interface for managing preference packs

### DIFF
--- a/src/Gui/DlgPreferencePackManagementImp.cpp
+++ b/src/Gui/DlgPreferencePackManagementImp.cpp
@@ -46,9 +46,11 @@ DlgPreferencePackManagementImp::DlgPreferencePackManagementImp(QWidget* parent)
 {
     ui->setupUi(this);
     connect(ui->pushButtonOpenAddonManager, &QPushButton::clicked, this, &DlgPreferencePackManagementImp::showAddonManager);
+    connect(this, &DlgPreferencePackManagementImp::packVisibilityChanged, this, &DlgPreferencePackManagementImp::updateTree);
+    updateTree();
 }
 
-void DlgPreferencePackManagementImp::showEvent(QShowEvent* event)
+void DlgPreferencePackManagementImp::updateTree(void)
 {
     // Separate out user-saved packs from installed packs: we can remove individual user-saved packs,
     // but can only disable individual installed packs (though we can completely uninstall the pack's
@@ -97,8 +99,6 @@ void DlgPreferencePackManagementImp::showEvent(QShowEvent* event)
     for (const auto& installedPack : installedPacks) {
         addTreeNode(installedPack.first, installedPack.second, TreeWidgetType::ADDON);
     }
-
-    QDialog::showEvent(event);
 }
 
 void DlgPreferencePackManagementImp::addTreeNode(const std::string &name, const std::vector<std::string> &contents, TreeWidgetType twt)
@@ -159,7 +159,6 @@ void DlgPreferencePackManagementImp::deleteUserPack(const std::string& name)
         QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
     if (result == QMessageBox::Yes) {
         Application::Instance->prefPackManager()->deleteUserPack(name);
-        showEvent(nullptr);
         Q_EMIT packVisibilityChanged();
     }
 }
@@ -167,14 +166,12 @@ void DlgPreferencePackManagementImp::deleteUserPack(const std::string& name)
 void DlgPreferencePackManagementImp::hideBuiltInPack(const std::string& prefPackName)
 {
     Application::Instance->prefPackManager()->toggleVisibility("##BUILT_IN##", prefPackName);
-    showEvent(nullptr);
     Q_EMIT packVisibilityChanged();
 }
 
 void DlgPreferencePackManagementImp::hideInstalledPack(const std::string& addonName, const std::string& prefPackName)
 {
     Application::Instance->prefPackManager()->toggleVisibility(addonName, prefPackName);
-    showEvent(nullptr);
     Q_EMIT packVisibilityChanged();
 }
 

--- a/src/Gui/DlgPreferencePackManagementImp.cpp
+++ b/src/Gui/DlgPreferencePackManagementImp.cpp
@@ -50,7 +50,7 @@ DlgPreferencePackManagementImp::DlgPreferencePackManagementImp(QWidget* parent)
     updateTree();
 }
 
-void DlgPreferencePackManagementImp::updateTree(void)
+void DlgPreferencePackManagementImp::updateTree()
 {
     // Separate out user-saved packs from installed packs: we can remove individual user-saved packs,
     // but can only disable individual installed packs (though we can completely uninstall the pack's

--- a/src/Gui/DlgPreferencePackManagementImp.h
+++ b/src/Gui/DlgPreferencePackManagementImp.h
@@ -62,8 +62,6 @@ protected Q_SLOTS:
     void deleteUserPack(const std::string & prefPackName);
     void hideBuiltInPack(const std::string& prefPackName);
     void hideInstalledPack(const std::string& addonName, const std::string& prefPackName);
-
-    void showEvent(QShowEvent* event) override;
     void showAddonManager();
 
 private:
@@ -77,6 +75,7 @@ private:
     std::unique_ptr<Ui_DlgPreferencePackManagement> ui;
 
     void addTreeNode(const std::string& name, const std::vector<std::string>& contents, TreeWidgetType twt);
+    void updateTree(void);
 };
 
 } // namespace Dialog

--- a/src/Gui/DlgPreferencePackManagementImp.h
+++ b/src/Gui/DlgPreferencePackManagementImp.h
@@ -75,7 +75,7 @@ private:
     std::unique_ptr<Ui_DlgPreferencePackManagement> ui;
 
     void addTreeNode(const std::string& name, const std::vector<std::string>& contents, TreeWidgetType twt);
-    void updateTree(void);
+    void updateTree();
 };
 
 } // namespace Dialog


### PR DESCRIPTION
Closes #18725. The cause of the crash is a direct invocation of `QDialog::showEvent(QShowEvent *event)` with `nullptr`, leading to the segmentation fault. [^1] Simple minuscule refactoring fixes it.



[^1]: https://github.com/qt/qtbase/blob/d89cef439f5c1a58aeff879a12d9a33292764b7f/src/widgets/dialogs/qdialog.cpp#L851-L860
