### PR TITLE
Draft: Remove unnecessary CamelCase names

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -79,9 +79,7 @@ from draftutils.utils import (get_real_name,
                               compareObjects,
                               shapify,
                               filter_objects_for_modifiers,
-                              filterObjectsForModifiers,
-                              is_closed_edge,
-                              isClosedEdge)
+                              is_closed_edge)
 
 from draftutils.utils import (string_encode_coin,
                               stringencodecoin,
@@ -155,27 +153,21 @@ from draftfunctions.heal import heal
 
 from draftfunctions.move import (move,
                                  move_vertex,
-                                 moveVertex,
                                  move_edge,
-                                 moveEdge,
-                                 copy_moved_edges,
-                                 copyMovedEdges)
+                                 copy_moved_edge,
+                                 copy_moved_edges)
 
 from draftfunctions.rotate import (rotate,
                                    rotate_vertex,
-                                   rotateVertex,
                                    rotate_edge,
-                                   rotateEdge,
-                                   copy_rotated_edges,
-                                   copyRotatedEdges)
+                                   copy_rotated_edge,
+                                   copy_rotated_edges)
 
 from draftfunctions.scale import (scale,
                                   scale_vertex,
-                                  scaleVertex,
                                   scale_edge,
-                                  scaleEdge,
-                                  copy_scaled_edges,
-                                  copyScaledEdges)
+                                  copy_scaled_edge,
+                                  copy_scaled_edges)
 
 from draftfunctions.join import (join_wires,
                                  joinWires,

--- a/src/Mod/Draft/draftfunctions/move.py
+++ b/src/Mod/Draft/draftfunctions/move.py
@@ -176,22 +176,16 @@ def move_vertex(object, vertex_index, vector):
     object.Points = points
 
 
-moveVertex = move_vertex
-
-
 def move_edge(object, edge_index, vector):
     """
     Needed for SubObjects modifiers.
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
     move_vertex(object, edge_index, vector)
-    if utils.isClosedEdge(edge_index, object):
+    if utils.is_closed_edge(edge_index, object):
         move_vertex(object, 0, vector)
     else:
         move_vertex(object, edge_index+1, vector)
-
-
-moveEdge = move_edge
 
 
 def copy_moved_edges(arguments):
@@ -205,16 +199,13 @@ def copy_moved_edges(arguments):
     join.join_wires(copied_edges)
 
 
-copyMovedEdges = copy_moved_edges
-
-
 def copy_moved_edge(object, edge_index, vector):
     """
     Needed for SubObjects modifiers.
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
     vertex1 = object.getGlobalPlacement().multVec(object.Points[edge_index]).add(vector)
-    if utils.isClosedEdge(edge_index, object):
+    if utils.is_closed_edge(edge_index, object):
         vertex2 = object.getGlobalPlacement().multVec(object.Points[0]).add(vector)
     else:
         vertex2 = object.getGlobalPlacement().multVec(object.Points[edge_index+1]).add(vector)

--- a/src/Mod/Draft/draftfunctions/rotate.py
+++ b/src/Mod/Draft/draftfunctions/rotate.py
@@ -182,9 +182,6 @@ def rotate_vertex(object, vertex_index, angle, center, axis):
     object.Points = points
 
 
-rotateVertex = rotate_vertex
-
-
 def rotate_vector_from_center(vector, angle, axis, center):
     """
     Needed for SubObjects modifiers.
@@ -195,22 +192,16 @@ def rotate_vector_from_center(vector, angle, axis, center):
     return center.add(rv)
 
 
-rotateVectorFromCenter = rotate_vector_from_center
-
-
 def rotate_edge(object, edge_index, angle, center, axis):
     """
     Needed for SubObjects modifiers.
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
     rotate_vertex(object, edge_index, angle, center, axis)
-    if utils.isClosedEdge(edge_index, object):
+    if utils.is_closed_edge(edge_index, object):
         rotate_vertex(object, 0, angle, center, axis)
     else:
         rotate_vertex(object, edge_index+1, angle, center, axis)
-
-
-rotateEdge = rotate_edge
 
 
 def copy_rotated_edges(arguments):
@@ -225,9 +216,6 @@ def copy_rotated_edges(arguments):
     join.join_wires(copied_edges)
 
 
-copyRotatedEdges = copy_rotated_edges
-
-
 def copy_rotated_edge(object, edge_index, angle, center, axis):
     """
     Needed for SubObjects modifiers.
@@ -236,7 +224,7 @@ def copy_rotated_edge(object, edge_index, angle, center, axis):
     vertex1 = rotate_vector_from_center(
         object.getGlobalPlacement().multVec(object.Points[edge_index]),
         angle, axis, center)
-    if utils.isClosedEdge(edge_index, object):
+    if utils.is_closed_edge(edge_index, object):
         vertex2 = rotate_vector_from_center(
             object.getGlobalPlacement().multVec(object.Points[0]),
             angle, axis, center)

--- a/src/Mod/Draft/draftfunctions/scale.py
+++ b/src/Mod/Draft/draftfunctions/scale.py
@@ -155,18 +155,12 @@ def scale_vertex(obj, vertex_index, scale, center):
     obj.Points = points
 
 
-scaleVertex = scale_vertex
-
-
 def scale_vector_from_center(vector, scale, center):
     """
     Needed for SubObjects modifiers.
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
     return vector.sub(center).scale(scale.x, scale.y, scale.z).add(center)
-
-
-scaleVectorFromCenter = scale_vector_from_center
 
 
 def scale_edge(obj, edge_index, scale, center):
@@ -179,9 +173,6 @@ def scale_edge(obj, edge_index, scale, center):
         scale_vertex(obj, 0, scale, center)
     else:
         scale_vertex(obj, edge_index+1, scale, center)
-
-
-scaleEdge = scale_edge
 
 
 def copy_scaled_edge(obj, edge_index, scale, center):
@@ -203,9 +194,6 @@ def copy_scaled_edge(obj, edge_index, scale, center):
     return make_line.make_line(vertex1, vertex2)
 
 
-copyScaledEdge = copy_scaled_edge
-
-
 def copy_scaled_edges(arguments):
     """
     Needed for SubObjects modifiers.
@@ -216,8 +204,5 @@ def copy_scaled_edges(arguments):
         copied_edges.append(copy_scaled_edge(argument[0], argument[1],
             argument[2], argument[3]))
     join.join_wires(copied_edges)
-
-
-copyScaledEdges = copy_scaled_edges
 
 ## @}

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -906,14 +906,8 @@ def filter_objects_for_modifiers(objects, isCopied=False):
     return filteredObjects
 
 
-filterObjectsForModifiers = filter_objects_for_modifiers
-
-
 def is_closed_edge(edge_index, object):
     return edge_index + 1 >= len(object.Points)
-
-
-isClosedEdge = is_closed_edge
 
 
 def utf8_decode(text):


### PR DESCRIPTION
The related functions were introduced in V0.19. They should not be also available under CamelCase names.
