### PR TITLE
Center text in spreadsheet vertical headers

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -182,6 +182,7 @@ SheetTableView::SheetTableView(QWidget* parent)
     horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
     verticalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
 
+    verticalHeader()->setDefaultAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
 
     contextMenu.addAction(actionProperties);
     connect(actionProperties, &QAction::triggered, this, &SheetTableView::cellProperties);


### PR DESCRIPTION
There seem to be a de facto standard in spreadsheet applications to center text both in column and row headers, however in qt, default seem to be to left align row header text.

This PR changes the alignment so it matches other spreadsheet applications such as google sheets, excel, numbers, excel, open office (even lotus 1-2-3 for windows).

As mentioned in [this other PR comment](https://github.com/FreeCAD/FreeCAD/pull/18719#issuecomment-2561970566), centering text needs to be done in code rather than in style sheets. By doing it in code, it is also fixes it in Classic.

Before (classic 1.0):
<img width="364" alt="image" src="https://github.com/user-attachments/assets/9cd2cce8-c743-43aa-b169-ef5c8d0ceee0" />

Before (classic 1.1.0dev head+qt6-this modification):
<img width="361" alt="image" src="https://github.com/user-attachments/assets/9f2f5942-ea1b-4ef9-a141-506d29b8428c" />

After (classic 1.1.0dev head+qt6+this modification):
<img width="361" alt="image" src="https://github.com/user-attachments/assets/eb415aad-363a-4d10-b7e5-11252c944db8" />