### PR TITLE
[TD]Symbol scaling (fix #14400)

### DIFF
--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -676,3 +676,9 @@ bool Preferences::switchOnClick()
 {
     return getPreferenceGroup("General")->GetBool("SwitchToWB", true);
 }
+
+//! if true, svg symbols will use the old scaling logic.
+bool Preferences::useLegacySvgScaling()
+{
+    return getPreferenceGroup("General")->GetBool("LegacySvgScaling", false);
+}

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -157,6 +157,8 @@ public:
     static bool checkShapesBeforeUse();
     static bool debugBadShape();
 
+    static bool useLegacySvgScaling();
+
 };
 
 

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.h
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.h
@@ -59,6 +59,8 @@ public:
 protected:
     virtual void drawSvg();
     void symbolToSvg(QByteArray qba);
+    double legacyScaler(TechDraw::DrawViewSymbol* feature) const;
+    double symbolScaler(TechDraw::DrawViewSymbol* feature) const;
 
     QGDisplayArea* m_displayArea;
     QGCustomSvg *m_svgItem;


### PR DESCRIPTION
This PR implements a fix for issue #14400.  Previously, Svg symbols inserted onto a  page were scaled incorrect.  This fix sets 1 Svg px = 1 scene unit (0.1mm) on the page and 1 Svg mm to 1 mm on the page.

The original behaviour is available by setting General/LegacySvgScaling to true.  The is no Gui update for this parameter, as it will only be changed in rare circumstances.