### PR TITLE
Materials: Physical properties reversion

### DIFF
--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -93,39 +93,6 @@ Feature::Feature()
     ADD_PROPERTY(Shape, (TopoDS_Shape()));
     auto mat = Materials::MaterialManager::defaultMaterial();
     ADD_PROPERTY(ShapeMaterial, (*mat));
-
-    // Read only properties based on the material
-    static const char* group = "PhysicalProperties";
-    ADD_PROPERTY_TYPE(MaterialName,
-                      (""),
-                      group,
-                      static_cast<App::PropertyType>(App::Prop_ReadOnly | App::Prop_Output
-                                                     | App::Prop_NoRecompute | App::Prop_NoPersist),
-                      "Feature material");
-    ADD_PROPERTY_TYPE(Density,
-                      (0.0),
-                      group,
-                      static_cast<App::PropertyType>(App::Prop_ReadOnly | App::Prop_Output
-                                                     | App::Prop_NoRecompute | App::Prop_NoPersist),
-                      "Feature density");
-    Density.setFormat(
-        Base::QuantityFormat(Base::QuantityFormat::NumberFormat::Default, MaterialPrecision));
-    ADD_PROPERTY_TYPE(Mass,
-                      (0.0),
-                      group,
-                      static_cast<App::PropertyType>(App::Prop_ReadOnly | App::Prop_Output
-                                                     | App::Prop_NoRecompute | App::Prop_NoPersist),
-                      "Feature mass");
-    Mass.setFormat(
-        Base::QuantityFormat(Base::QuantityFormat::NumberFormat::Default, MaterialPrecision));
-    ADD_PROPERTY_TYPE(Volume,
-                      (1.0),
-                      group,
-                      static_cast<App::PropertyType>(App::Prop_ReadOnly | App::Prop_Output
-                                                     | App::Prop_NoRecompute | App::Prop_NoPersist),
-                      "Feature volume");
-    Volume.setFormat(
-        Base::QuantityFormat(Base::QuantityFormat::NumberFormat::Default, MaterialPrecision));
 }
 
 Feature::~Feature() = default;
@@ -1533,39 +1500,10 @@ void Feature::onChanged(const App::Property* prop)
                 }
             }
         }
-        updatePhysicalProperties();
-    } else if (prop == &this->ShapeMaterial) {
-        updatePhysicalProperties();
     }
 
     GeoFeature::onChanged(prop);
 }
-
-void Feature::updatePhysicalProperties()
-{
-    MaterialName.setValue(ShapeMaterial.getValue().getName().toStdString());
-    if (ShapeMaterial.getValue().hasPhysicalProperty(QString::fromLatin1("Density"))) {
-        Density.setValue(ShapeMaterial.getValue()
-                             .getPhysicalQuantity(QString::fromLatin1("Density"))
-                             .getValue());
-    } else {
-        Base::Console().Log("Density is undefined\n");
-        Density.setValue(0.0);
-    }
-
-    auto topoShape = Shape.getValue();
-    if (!topoShape.IsNull()) {
-        GProp_GProps props;
-        BRepGProp::VolumeProperties(topoShape, props);
-        Volume.setValue(props.Mass());
-        Mass.setValue(Volume.getValue() * Density.getValue());
-    } else {
-        // No shape
-        Volume.setValue(0.0);
-        Mass.setValue(0.0);
-    }
-}
-
 
 const std::vector<std::string>& Feature::searchElementCache(const std::string& element,
                                                             Data::SearchOptions options,

--- a/src/Mod/Part/App/PartFeature.h
+++ b/src/Mod/Part/App/PartFeature.h
@@ -25,7 +25,6 @@
 
 #include <App/FeaturePython.h>
 #include <App/GeoFeature.h>
-#include <App/PropertyUnits.h>
 #include <Mod/Material/App/PropertyMaterial.h>
 #include <Mod/Part/PartGlobal.h>
 
@@ -60,12 +59,6 @@ public:
 
     PropertyPartShape Shape;
     Materials::PropertyMaterial ShapeMaterial;
-
-    // Convenience properties set when material or shape changes
-    App::PropertyString MaterialName;
-    App::PropertyDensity Density;
-    App::PropertyMass Mass;
-    App::PropertyVolume Volume;
 
     /** @name methods override feature */
     //@{
@@ -178,9 +171,6 @@ protected:
 
     void copyMaterial(Feature* feature);
     void copyMaterial(App::DocumentObject* link);
-
-    /// Update the mass and volume properties
-    void updatePhysicalProperties();
 
     void registerElementCache(const std::string &prefix, PropertyPartShape *prop);
 


### PR DESCRIPTION
Reverts PR #17438

The PR experienced sever performance issues when the file contained objects with errors. This PR removes the physical properties attributes and its associated calculations.

It retains changes to the material filter funtions which were not affected by the errors.