### PR TITLE
[TD]Dimension font clipping (fix #11452)

### DIFF
--- a/src/Mod/TechDraw/Gui/QGCustomText.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomText.cpp
@@ -183,17 +183,6 @@ void QGCustomText::paint ( QPainter * painter, const QStyleOptionGraphicsItem * 
     QGraphicsTextItem::paint (painter, &myOption, widget);
 }
 
-QRectF QGCustomText::boundingRect() const
-{
-    if (toPlainText().isEmpty()) {
-        return QRectF();
-    } else if (tightBounding) {
-        return tightBoundingRect();
-    } else {
-        return QGraphicsTextItem::boundingRect();
-    }
-}
-
 QRectF QGCustomText::tightBoundingRect() const
 {
     QFontMetrics qfm(font());
@@ -204,9 +193,22 @@ QRectF QGCustomText::tightBoundingRect() const
 
     // Adjust the bounding box 50% towards the Qt tightBoundingRect(),
     // except chomp some extra empty space above the font (1.75*y_adj)
+    // wf: this does not work with all fonts.  it depends on where the glyph is located within
+    //     the em square.  see https://github.com/FreeCAD/FreeCAD/issues/11452
+    // TODO: how to know where the glyph is going to be placed?
     result.adjust(x_adj, 1.75*y_adj, -x_adj, -y_adj);
 
     return result;
+}
+
+//! a boundingRect for text alignment, that does not adversely affect rendering.
+QRectF QGCustomText::alignmentRect() const
+{
+    if (tightBounding) {
+        return tightBoundingRect();
+    } else {
+        return boundingRect();
+    }
 }
 
 // Calculate the amount of difference between tight and relaxed bounding boxes

--- a/src/Mod/TechDraw/Gui/QGCustomText.h
+++ b/src/Mod/TechDraw/Gui/QGCustomText.h
@@ -49,12 +49,11 @@ public:
     enum {Type = QGraphicsItem::UserType + 130};
     int type() const override { return Type;}
     void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = nullptr ) override;
-    QRectF boundingRect() const override;
+
     QRectF tightBoundingRect() const;
+    QRectF alignmentRect() const;
     QPointF tightBoundingAdjust() const;
-    // void setPos(const QPointF &pos);
-    // void setPos(qreal x, qreal y);
-    // QPointF pos() const;
+
 
     void setHighlighted(bool state);
     virtual void setPrettyNormal();

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -418,21 +418,21 @@ void QGIDatumLabel::setPosFromCenter(const double& xCenter, const double& yCente
         m_unitText->setPlainText(QString());
     }
 
-    QRectF labelBox = m_dimText->boundingRect();
+    QRectF labelBox = m_dimText->alignmentRect();
     double right = labelBox.right();
     double top = labelBox.top();
     double bottom = labelBox.bottom();
     double middle = (top + bottom) / 2.0;
 
     //set unit position
-    QRectF unitBox = m_unitText->boundingRect();
+    QRectF unitBox = m_unitText->alignmentRect();
     double unitWidth = unitBox.width();
     double unitRight = right + unitWidth;
     // Set the m_unitText font *baseline* at same height as the m_dimText font baseline
     m_unitText->setPos(right, 0.0);
 
     //set tolerance position
-    QRectF overBox = m_tolTextOver->boundingRect();
+    QRectF overBox = m_tolTextOver->alignmentRect();
     double tolLeft  = unitRight;
 
     // Adjust for difference in tight and original bounding box sizes, note the y-coord down system


### PR DESCRIPTION
This PR implements a fix for the clipping problems raised in issue #11452.

The problems of glyph placement within the text bounding rectangle will have to be addressed in another PR, likely one that addresses issue #16975.