### PR TITLE
FEM: Add accuracy parameter for CalculiX buckling analysis

### DIFF
--- a/src/Mod/Fem/femsolver/calculix/solver.py
+++ b/src/Mod/Fem/femsolver/calculix/solver.py
@@ -317,8 +317,14 @@ class _BaseSolverCalculix:
             obj.ThermoMechType = thermomech_types
 
         if not hasattr(obj, "BucklingAccuracy"):
-            obj.addProperty("App::PropertyFloatConstraint", "BucklingAccuracy", "Fem", "Accuracy for buckling analysis")
+            obj.addProperty(
+                "App::PropertyFloatConstraint",
+                "BucklingAccuracy",
+                "Fem",
+                "Accuracy for buckling analysis",
+            )
             obj.BucklingAccuracy = 0.01
+
 
 class Proxy(solverbase.Proxy, _BaseSolverCalculix):
     """The Fem::FemSolver's Proxy python type, add solver specific properties"""

--- a/src/Mod/Fem/femsolver/calculix/solver.py
+++ b/src/Mod/Fem/femsolver/calculix/solver.py
@@ -316,6 +316,9 @@ class _BaseSolverCalculix:
             )
             obj.ThermoMechType = thermomech_types
 
+        if not hasattr(obj, "BucklingAccuracy"):
+            obj.addProperty("App::PropertyFloatConstraint", "BucklingAccuracy", "Fem", "Accuracy for buckling analysis")
+            obj.BucklingAccuracy = 0.01
 
 class Proxy(solverbase.Proxy, _BaseSolverCalculix):
     """The Fem::FemSolver's Proxy python type, add solver specific properties"""

--- a/src/Mod/Fem/femsolver/calculix/write_step_equation.py
+++ b/src/Mod/Fem/femsolver/calculix/write_step_equation.py
@@ -154,7 +154,10 @@ def write_step_equation(f, ccxwriter):
             ccxwriter.solver_obj.TimeMaximumStep,
         )
     elif ccxwriter.analysis_type == "buckling":
-        analysis_parameter = f"{ccxwriter.solver_obj.BucklingFactors}\n"
+        analysis_parameter = "{},{}".format(
+            ccxwriter.solver_obj.BucklingFactors,
+            ccxwriter.solver_obj.BucklingAccuracy,
+        )
 
     # write analysis type line, analysis parameter line
     f.write(analysis_type + "\n")


### PR DESCRIPTION
Adds _BucklingAccuracy_ parameter - in some cases, it might be necessary to lower this default value: https://github.com/Dhondtguido/CalculiX/issues/57

@marioalexis84 FYI