### PR TITLE
[Gui] Load Structure and View toolbar items based on CMake build options

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -44,6 +44,14 @@ if (BUILD_ADDONMGR)
     add_definitions(-DBUILD_ADDONMGR )
 endif(BUILD_ADDONMGR)
 
+if (BUILD_PART)
+    add_definitions(-DBUILD_PART )
+endif(BUILD_PART)
+
+if (BUILD_MEASURE)
+    add_definitions(-DBUILD_MEASURE )
+endif(BUILD_MEASURE)
+
 include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -803,7 +803,14 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     auto view = new ToolBarItem( root );
     view->setCommand("View");
     *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_ViewGroup" << "Std_AlignToSelection"
-          << "Separator" << "Std_DrawStyle" << "Std_TreeViewActions";
+          << "Separator" << "Std_DrawStyle";
+#ifdef BUILD_PART
+    *view << "Part_SelectFilter";
+#endif
+    *view << "Std_TreeViewActions";
+#ifdef BUILD_MEASURE
+    *view << "Std_Measure";
+#endif
 
     // Individual views
     auto individualViews = new ToolBarItem(root, ToolBarItem::DefaultVisibility::Hidden);
@@ -819,7 +826,11 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     // Structure
     auto structure = new ToolBarItem( root );
     structure->setCommand("Structure");
-    *structure << "Std_Part" << "Std_Group" << "Std_LinkActions" << "Std_VarSet";
+    *structure << "Std_Part";
+#ifdef BUILD_PART
+    *structure << "Part_Datums";
+#endif
+    *structure << "Std_Group" << "Std_LinkActions" << "Std_VarSet";
 
     // Help
     auto help = new ToolBarItem( root );

--- a/src/Mod/Measure/Gui/WorkbenchManipulator.cpp
+++ b/src/Mod/Measure/Gui/WorkbenchManipulator.cpp
@@ -38,14 +38,6 @@ void WorkbenchManipulator::modifyMenuBar([[maybe_unused]] Gui::MenuItem* menuBar
     menuTools->appendItem(itemMeasure);
 }
 
-void WorkbenchManipulator::modifyToolBars(Gui::ToolBarItem* toolBar)
+void WorkbenchManipulator::modifyToolBars([[maybe_unused]] Gui::ToolBarItem* toolBar)
 {
-    auto tbView = toolBar->findItem("View");
-    if (!tbView) {
-        return;
-    }
-
-    auto itemMeasure = new Gui::ToolBarItem();
-    itemMeasure->setCommand("Std_Measure");
-    tbView->appendItem(itemMeasure);
 }

--- a/src/Mod/Measure/Gui/WorkbenchManipulator.cpp
+++ b/src/Mod/Measure/Gui/WorkbenchManipulator.cpp
@@ -39,5 +39,4 @@ void WorkbenchManipulator::modifyMenuBar([[maybe_unused]] Gui::MenuItem* menuBar
 }
 
 void WorkbenchManipulator::modifyToolBars([[maybe_unused]] Gui::ToolBarItem* toolBar)
-{
-}
+{}

--- a/src/Mod/Measure/Gui/WorkbenchManipulator.h
+++ b/src/Mod/Measure/Gui/WorkbenchManipulator.h
@@ -32,7 +32,7 @@ class WorkbenchManipulator: public Gui::WorkbenchManipulator
 {
 protected:
     void modifyMenuBar(Gui::MenuItem* menuBar) override;
-    void modifyToolBars(Gui::ToolBarItem* toolBar) override;
+    void modifyToolBars([[maybe_unused]] Gui::ToolBarItem* toolBar) override;
 };
 
 }  // namespace MeasureGui

--- a/src/Mod/Part/Gui/WorkbenchManipulator.cpp
+++ b/src/Mod/Part/Gui/WorkbenchManipulator.cpp
@@ -34,10 +34,8 @@ void WorkbenchManipulator::modifyMenuBar([[maybe_unused]] Gui::MenuItem* menuBar
     addSectionCut(menuBar);
 }
 
-void WorkbenchManipulator::modifyToolBars(Gui::ToolBarItem* toolBar)
+void WorkbenchManipulator::modifyToolBars([[maybe_unused]] Gui::ToolBarItem* toolBar)
 {
-    addSelectionFilter(toolBar);
-    addDatums(toolBar);
 }
 
 void WorkbenchManipulator::modifyDockWindows([[maybe_unused]] Gui::DockWindowItems* dockWindow)
@@ -55,35 +53,5 @@ void WorkbenchManipulator::addSectionCut(Gui::MenuItem* menuBar)
         auto add = new Gui::MenuItem(); // NOLINT
         add->setCommand("Part_SectionCut");
         par->insertItem(item, add);
-    }
-}
-
-void WorkbenchManipulator::addSelectionFilter(Gui::ToolBarItem* toolBar)
-{
-    if (auto view = toolBar->findItem("View")) {
-        auto add = new Gui::ToolBarItem(); // NOLINT
-        add->setCommand("Part_SelectFilter");
-        auto item = view->findItem("Std_TreeViewActions");
-        if (item) {
-            view->insertItem(item, add);
-        }
-        else {
-            view->appendItem(add);
-        }
-    }
-}
-
-void WorkbenchManipulator::addDatums(Gui::ToolBarItem* toolBar)
-{
-    if (auto view = toolBar->findItem("Structure")) {
-        auto add = new Gui::ToolBarItem(); // NOLINT
-        add->setCommand("Part_Datums");
-        auto item = view->findItem("Std_Group");
-        if (item) {
-            view->insertItem(item, add);
-        }
-        else {
-            view->appendItem(add);
-        }
     }
 }

--- a/src/Mod/Part/Gui/WorkbenchManipulator.h
+++ b/src/Mod/Part/Gui/WorkbenchManipulator.h
@@ -53,8 +53,6 @@ protected:
 
 private:
     static void addSectionCut(Gui::MenuItem* menuBar);
-    static void addSelectionFilter(Gui::ToolBarItem* toolBar);
-    static void addDatums(Gui::ToolBarItem* toolBar);
 };
 
 } // namespace PartGui


### PR DESCRIPTION
There is no difference to the UI when a normal Release build is generated only that the Structure and View toolbars are populated based on options set at compilation time.

Fixes: #18647 