### PR TITLE
[Techdraw] Import SVG files with UTF-8 encoding

### DIFF
--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -193,6 +193,7 @@ SET(TDTestFile_SRCS
     TDTest/TestHatch.svg
     TDTest/TestImage.png
     TDTest/TestSymbol.svg
+    TDTest/TestNonAsciiSymbol.svg
     TDTest/TestTemplate.svg
 )
 

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -455,16 +455,25 @@ void CmdTechDrawView::activated(int iMsg)
                     filename = Base::Tools::escapeEncodeFilename(filename);
                     auto filespec = DU::cleanFilespecBackslash(filename.toStdString());
                     openCommand(QT_TRANSLATE_NOOP("Command", "Create Symbol"));
-                    doCommand(Doc, "f = open(\"%s\", 'r')", filespec.c_str());
+                    doCommand(Doc, "import codecs");
+                    doCommand(Doc,
+                              "f = codecs.open(\"%s\", 'r', encoding=\"utf-8\")",
+                              filespec.c_str());
                     doCommand(Doc, "svg = f.read()");
                     doCommand(Doc, "f.close()");
-                    doCommand(Doc, "App.activeDocument().addObject('TechDraw::DrawViewSymbol', '%s')",
+                    doCommand(Doc,
+                              "App.activeDocument().addObject('TechDraw::DrawViewSymbol', '%s')",
+                              FeatName.c_str());
+                    doCommand(
+                        Doc,
+                        "App.activeDocument().%s.translateLabel('DrawViewSymbol', 'Symbol', '%s')",
+                        FeatName.c_str(),
                         FeatName.c_str());
-                    doCommand(Doc, "App.activeDocument().%s.translateLabel('DrawViewSymbol', 'Symbol', '%s')",
-                        FeatName.c_str(), FeatName.c_str());
                     doCommand(Doc, "App.activeDocument().%s.Symbol = svg", FeatName.c_str());
-                    doCommand(Doc, "App.activeDocument().%s.addView(App.activeDocument().%s)", PageName.c_str(),
-                        FeatName.c_str());
+                    doCommand(Doc,
+                              "App.activeDocument().%s.addView(App.activeDocument().%s)",
+                              PageName.c_str(),
+                              FeatName.c_str());
                 }
                 else {
                     std::string FeatName = getUniqueObjectName("Image");
@@ -1550,7 +1559,8 @@ void CmdTechDrawSymbol::activated(int iMsg)
         filename = Base::Tools::escapeEncodeFilename(filename);
         auto filespec = DU::cleanFilespecBackslash(filename.toStdString());
         openCommand(QT_TRANSLATE_NOOP("Command", "Create Symbol"));
-        doCommand(Doc, "f = open(\"%s\", 'r')", (const char*)filespec.c_str());
+        doCommand(Doc, "import codecs");
+        doCommand(Doc, "f = codecs.open(\"%s\", 'r', encoding=\"utf-8\")",  filespec.c_str());
         doCommand(Doc, "svg = f.read()");
         doCommand(Doc, "f.close()");
         doCommand(Doc, "App.activeDocument().addObject('TechDraw::DrawViewSymbol', '%s')",

--- a/src/Mod/TechDraw/TDTest/DrawViewSymbolTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawViewSymbolTest.py
@@ -21,7 +21,8 @@ class DrawViewSymbolTest(unittest.TestCase):
         sym = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewSymbol", "TestSymbol")
         path = os.path.dirname(os.path.abspath(__file__))
         symbolFileSpec = path + "/TestSymbol.svg"
-        f = open(symbolFileSpec, "r")
+        import codecs
+        f = codecs.open(symbolFileSpec, "r", encoding="utf-8")
         svg = f.read()
         f.close()
         sym.Symbol = svg
@@ -32,6 +33,26 @@ class DrawViewSymbolTest(unittest.TestCase):
         FreeCAD.ActiveDocument.recompute()
 
         self.assertTrue("Up-to-date" in sym.State)
+
+    def testNonAsciiSymbol(self):
+        """Tests if a Non-Ascii symbol can be added to page"""
+        print("Running Non Ascii Symbol Test")
+        sym = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewSymbol", "NonAsciiSymbol")
+        path = os.path.dirname(os.path.abspath(__file__))
+        symbolFileSpec = path + "/TestNonAsciiSymbol.svg"
+        import codecs
+        f = codecs.open(symbolFileSpec, "r", encoding="utf-8")
+        svg = f.read()
+        f.close()
+        sym.Symbol = svg
+        self.page.addView(sym)
+        sym.X = 220.0
+        sym.Y = 150.0
+
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertTrue("Up-to-date" in sym.State)
+
 
 
 if __name__ == "__main__":

--- a/src/Mod/TechDraw/TDTest/TestNonAsciiSymbol.svg
+++ b/src/Mod/TechDraw/TDTest/TestNonAsciiSymbol.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg" version="1.1"
+  xmlns:freecad="http://www.freecad.org/wiki/index.php?title=Svg_Namespace"
+  width ="57.0mm"
+  height="10mm"
+  viewBox="0 0 57.0 10">
+    <g id="first-frame"
+      style="fill:#fff;fill-opacity:1;stroke:#000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;font-size:5.0;text-anchor:middle;font-family:osifont">
+        <rect width="56.5" height="9.5" x="0.25" y="0.25" />
+        <circle cx="5.0" cy="5.0" r="1.75" />
+        <path d="m 2 5 h 6  m -3 -3 v 6 " />
+        <path d="m 9.75 0.25 v 9.5 " />
+        <text freecad:editable="Value1" x="20.0" y="7" fill="#000"> <tspan>⌀ 0,01</tspan> </text>
+        <path d="m 28.25 0.25 v 9.5 " />
+        <text freecad:editable="Value2" x="34.0" y="7" fill="#000"> <tspan>Ä</tspan> </text>
+        <path d="m 37.75 0.25 v 9.5 " />
+        <text freecad:editable="Value3" x="43.5" y="7" fill="#000"> <tspan>Ö</tspan> </text>
+        <path d="m 47.25 0.25 v 9.5 " />
+        <text freecad:editable="Value4" x="53.0" y="7" fill="#000"> <tspan>Ü</tspan> </text>
+    </g>
+</svg>


### PR DESCRIPTION
Fixes #18794 

Includes a new test for non-Ascii SVG file