### PR TITLE
Add proper PDF creator metadata

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -37,6 +37,7 @@
 # include <boost/date_time/posix_time/posix_time.hpp>
 # include <chrono>
 # include <random>
+# include <fmt/format.h>
 #endif
 
 #ifdef FC_OS_WIN32
@@ -1140,6 +1141,17 @@ std::string Application::getHomePath()
 std::string Application::getExecutableName()
 {
     return mConfig["ExeName"];
+}
+
+std::string Application::getNameWithVersion()
+{
+    auto appname = QCoreApplication::applicationName().toStdString();
+    auto config = App::Application::Config();
+    auto major = config["BuildVersionMajor"];
+    auto minor = config["BuildVersionMinor"];
+    auto point = config["BuildVersionPoint"];
+    auto suffix = config["BuildVersionSuffix"];
+    return fmt::format("{} {}.{}.{}{}", appname, major, minor, point, suffix);
 }
 
 std::string Application::getTempPath()

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -409,6 +409,7 @@ public:
     //@{
     static std::string getHomePath();
     static std::string getExecutableName();
+    static std::string getNameWithVersion();
     /*!
      Returns the temporary directory. By default, this is set to the
      system's temporary directory but can be customized by the user.

--- a/src/App/PreCompiled.h
+++ b/src/App/PreCompiled.h
@@ -101,6 +101,8 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 
+#include <fmt/format.h>
+
 #endif  //_PreComp_
 
 #endif  // APP_PRECOMPILED_H

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -36,7 +36,6 @@
 
 #include <boost/regex.hpp>
 
-#include <App/Application.h>
 #include <App/DocumentObjectPy.h>
 #include <App/DocumentPy.h>
 #include <App/PropertyFile.h>
@@ -774,19 +773,11 @@ PyObject* ApplicationPy::sExport(PyObject * /*self*/, PyObject *args)
                         view3d->viewAll();
                     }
                     QPrinter printer(QPrinter::ScreenResolution);
-                    // setPdfVersion sets the printied PDF Version to comply with PDF/A-1b, more details under: https://www.kdab.com/creating-pdfa-documents-qt/
+                    // setPdfVersion sets the printed PDF Version to comply with PDF/A-1b, more details under: https://www.kdab.com/creating-pdfa-documents-qt/
                     printer.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
                     printer.setOutputFormat(QPrinter::PdfFormat);
                     printer.setOutputFileName(fileName);
-
-                    QString appname = QCoreApplication::applicationName();
-                    auto config = App::Application::Config();
-                    QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
-                    QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
-                    QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
-                    QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
-                    printer.setCreator(QString::fromUtf8("%1 %2.%3.%4%5").arg(appname, major, minor, point, suffix));
-
+                    printer.setCreator(QString::fromStdString(App::Application::getNameWithVersion()));
                     view->print(&printer);
                 }
             }

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -36,6 +36,7 @@
 
 #include <boost/regex.hpp>
 
+#include <App/Application.h>
 #include <App/DocumentObjectPy.h>
 #include <App/DocumentPy.h>
 #include <App/PropertyFile.h>
@@ -777,6 +778,15 @@ PyObject* ApplicationPy::sExport(PyObject * /*self*/, PyObject *args)
                     printer.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
                     printer.setOutputFormat(QPrinter::PdfFormat);
                     printer.setOutputFileName(fileName);
+
+                    QString appname = QCoreApplication::applicationName();
+                    auto config = App::Application::Config();
+                    QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
+                    QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
+                    QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
+                    QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
+                    printer.setCreator(QString::fromUtf8("%1 %2.%3.%4%5").arg(appname, major, minor, point, suffix));
+
                     view->print(&printer);
                 }
             }

--- a/src/Gui/EditorView.cpp
+++ b/src/Gui/EditorView.cpp
@@ -56,6 +56,7 @@
 #include <Base/Exception.h>
 #include <Base/Interpreter.h>
 #include <Base/Parameter.h>
+#include <App/Application.h>
 
 
 using namespace Gui;
@@ -511,6 +512,15 @@ void EditorView::printPdf()
         printer.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
         printer.setOutputFormat(QPrinter::PdfFormat);
         printer.setOutputFileName(filename);
+
+        QString appname = QCoreApplication::applicationName();
+        auto config = App::Application::Config();
+        QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
+        QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
+        QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
+        QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
+        printer.setCreator(QString::fromUtf8("%1 %2.%3.%4%5").arg(appname, major, minor, point, suffix));
+
         d->textEdit->document()->print(&printer);
     }
 }

--- a/src/Gui/EditorView.cpp
+++ b/src/Gui/EditorView.cpp
@@ -56,7 +56,6 @@
 #include <Base/Exception.h>
 #include <Base/Interpreter.h>
 #include <Base/Parameter.h>
-#include <App/Application.h>
 
 
 using namespace Gui;
@@ -512,15 +511,7 @@ void EditorView::printPdf()
         printer.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
         printer.setOutputFormat(QPrinter::PdfFormat);
         printer.setOutputFileName(filename);
-
-        QString appname = QCoreApplication::applicationName();
-        auto config = App::Application::Config();
-        QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
-        QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
-        QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
-        QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
-        printer.setCreator(QString::fromUtf8("%1 %2.%3.%4%5").arg(appname, major, minor, point, suffix));
-
+        printer.setCreator(QString::fromStdString(App::Application::getNameWithVersion()));
         d->textEdit->document()->print(&printer);
     }
 }

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -39,6 +39,7 @@
 
 #include <Base/Interpreter.h>
 #include <App/Document.h>
+#include <App/Application.h>
 
 #include "MDIView.h"
 #include "MDIViewPy.h"
@@ -264,6 +265,15 @@ void MDIView::printPdf()
         printer.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
         printer.setOutputFormat(QPrinter::PdfFormat);
         printer.setOutputFileName(filename);
+
+        QString appname = QCoreApplication::applicationName();
+        auto config = App::Application::Config();
+        QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
+        QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
+        QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
+        QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
+        printer.setCreator(QString::fromUtf8("%1 %2.%3.%4%5").arg(appname, major, minor, point, suffix));
+
         print(&printer);
     }
 }

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -265,15 +265,7 @@ void MDIView::printPdf()
         printer.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
         printer.setOutputFormat(QPrinter::PdfFormat);
         printer.setOutputFileName(filename);
-
-        QString appname = QCoreApplication::applicationName();
-        auto config = App::Application::Config();
-        QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
-        QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
-        QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
-        QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
-        printer.setCreator(QString::fromUtf8("%1 %2.%3.%4%5").arg(appname, major, minor, point, suffix));
-
+        printer.setCreator(QString::fromStdString(App::Application::getNameWithVersion()));
         print(&printer);
     }
 }

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2303,12 +2303,7 @@ void MainWindow::setWindowTitle(const QString& string)
 
     if (showVersion) {
         // set main window title with FreeCAD Version
-        auto config = App::Application::Config();
-        QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
-        QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
-        QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
-        QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
-        title = QString::fromUtf8("%1 %2.%3.%4%5").arg(appname, major, minor, point, suffix);
+        title = QString::fromStdString(App::Application::getNameWithVersion());
     }
     else {
         title = appname;

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -259,15 +259,7 @@ void View3DInventor::printPdf()
         printer.setOutputFormat(QPrinter::PdfFormat);
         printer.setPageOrientation(QPageLayout::Landscape);
         printer.setOutputFileName(filename);
-
-        QString appname = QCoreApplication::applicationName();
-        auto config = App::Application::Config();
-        QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
-        QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
-        QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
-        QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
-        printer.setCreator(QString::fromUtf8("%1 %2.%3.%4%5").arg(appname, major, minor, point, suffix));
-
+        printer.setCreator(QString::fromStdString(App::Application::getNameWithVersion()));
         print(&printer);
     }
 }

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -50,6 +50,8 @@
 # include <Inventor/SoPickedPoint.h>
 #endif
 
+
+#include <App/Application.h>
 #include <App/Document.h>
 #include <App/GeoFeature.h>
 #include <Base/Builder3D.h>
@@ -257,6 +259,15 @@ void View3DInventor::printPdf()
         printer.setOutputFormat(QPrinter::PdfFormat);
         printer.setPageOrientation(QPageLayout::Landscape);
         printer.setOutputFileName(filename);
+
+        QString appname = QCoreApplication::applicationName();
+        auto config = App::Application::Config();
+        QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
+        QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
+        QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
+        QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
+        printer.setCreator(QString::fromUtf8("%1 %2.%3.%4%5").arg(appname, major, minor, point, suffix));
+
         print(&printer);
     }
 }

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -529,16 +529,7 @@ void DrawingView::printPdf()
         printer.setFullPage(true);
         printer.setOutputFormat(QPrinter::PdfFormat);
         printer.setOutputFileName(filename);
-
-        QString appname = QCoreApplication::applicationName();
-        auto config = App::Application::Config();
-        QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
-        QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
-        QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
-        QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
-        printer.setCreator(
-            QString::fromUtf8("%1 Drawing %2.%3.%4%5").arg(appname, major, minor, point, suffix));
-
+        printer.setCreator(QString::fromStdString(App::Application::getNameWithVersion()));
         printer.setPageOrientation(m_orientation);
         QList<QListWidgetItem*> items = listWidget->selectedItems();
         if (items.size() == 1) {

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -529,6 +529,15 @@ void DrawingView::printPdf()
         printer.setFullPage(true);
         printer.setOutputFormat(QPrinter::PdfFormat);
         printer.setOutputFileName(filename);
+
+        QString appname = QCoreApplication::applicationName();
+        auto config = App::Application::Config();
+        QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
+        QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
+        QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
+        QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
+        printer.setCreator(QString::fromUtf8("%1 Drawing %2.%3.%4%5").arg(appname, major, minor, point, suffix));
+
         printer.setPageOrientation(m_orientation);
         QList<QListWidgetItem*> items = listWidget->selectedItems();
         if (items.size() == 1) {

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -536,7 +536,8 @@ void DrawingView::printPdf()
         QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
         QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
         QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
-        printer.setCreator(QString::fromUtf8("%1 Drawing %2.%3.%4%5").arg(appname, major, minor, point, suffix));
+        printer.setCreator(
+            QString::fromUtf8("%1 Drawing %2.%3.%4%5").arg(appname, major, minor, point, suffix));
 
         printer.setPageOrientation(m_orientation);
         QList<QListWidgetItem*> items = listWidget->selectedItems();

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -23,6 +23,7 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
+#include <QApplication>
 #include <QPalette>
 #include <QPrintDialog>
 #include <QPrintPreviewDialog>
@@ -30,6 +31,7 @@
 #include <QTextDocument>
 #endif
 
+#include <App/Application.h>
 #include <App/DocumentObject.h>
 #include <App/Range.h>
 #include <Base/Tools.h>
@@ -307,6 +309,15 @@ void SheetView::printPdf()
         printer.setPageOrientation(QPageLayout::Landscape);
         printer.setOutputFormat(QPrinter::PdfFormat);
         printer.setOutputFileName(filename);
+
+        QString appname = QCoreApplication::applicationName();
+        auto config = App::Application::Config();
+        QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
+        QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
+        QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
+        QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
+        printer.setCreator(QString::fromUtf8("%1 Spreadsheet %2.%3.%4%5").arg(appname, major, minor, point, suffix));
+
         print(&printer);
     }
 }

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -23,7 +23,6 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-#include <QApplication>
 #include <QPalette>
 #include <QPrintDialog>
 #include <QPrintPreviewDialog>
@@ -309,16 +308,7 @@ void SheetView::printPdf()
         printer.setPageOrientation(QPageLayout::Landscape);
         printer.setOutputFormat(QPrinter::PdfFormat);
         printer.setOutputFileName(filename);
-
-        QString appname = QCoreApplication::applicationName();
-        auto config = App::Application::Config();
-        QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
-        QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
-        QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
-        QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
-        printer.setCreator(QString::fromUtf8("%1 Spreadsheet %2.%3.%4%5")
-                               .arg(appname, major, minor, point, suffix));
-
+        printer.setCreator(QString::fromStdString(App::Application::getNameWithVersion()));
         print(&printer);
     }
 }

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -316,7 +316,8 @@ void SheetView::printPdf()
         QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
         QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
         QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
-        printer.setCreator(QString::fromUtf8("%1 Spreadsheet %2.%3.%4%5").arg(appname, major, minor, point, suffix));
+        printer.setCreator(QString::fromUtf8("%1 Spreadsheet %2.%3.%4%5")
+                               .arg(appname, major, minor, point, suffix));
 
         print(&printer);
     }

--- a/src/Mod/TechDraw/Gui/PagePrinter.cpp
+++ b/src/Mod/TechDraw/Gui/PagePrinter.cpp
@@ -188,14 +188,8 @@ void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
     pdfWriter.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
 
     pdfWriter.setTitle(documentName);
-
-    QString appname = QCoreApplication::applicationName();
-    auto config = App::Application::Config();
-    QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
-    QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
-    QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
-    QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
-    pdfWriter.setCreator(QString::fromUtf8("%1 TechDraw %2.%3.%4%5").arg(appname, major, minor, point, suffix));
+    pdfWriter.setCreator(QString::fromStdString(App::Application::getNameWithVersion())
+                       + QLatin1String(" TechDraw"));
 
     pdfWriter.setResolution(printer->resolution());
     QPageLayout pageLayout = printer->pageLayout();
@@ -365,13 +359,8 @@ void PagePrinter::printPdf(ViewProviderPage* vpPage, const std::string& file)
     pdfWriter.setTitle(documentName);
     // default pdfWriter dpi is 1200.
 
-    QString appname = QCoreApplication::applicationName();
-    auto config = App::Application::Config();
-    QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
-    QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
-    QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
-    QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
-    pdfWriter.setCreator(QString::fromUtf8("%1 TechDraw %2.%3.%4%5").arg(appname, major, minor, point, suffix));
+    pdfWriter.setCreator(QString::fromStdString(App::Application::getNameWithVersion())
+                       + QLatin1String(" TechDraw"));
 
     // set up the page layout
     auto dPage = vpPage->getDrawPage();

--- a/src/Mod/TechDraw/Gui/PagePrinter.cpp
+++ b/src/Mod/TechDraw/Gui/PagePrinter.cpp
@@ -188,6 +188,15 @@ void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
     pdfWriter.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
 
     pdfWriter.setTitle(documentName);
+
+    QString appname = QCoreApplication::applicationName();
+    auto config = App::Application::Config();
+    QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
+    QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
+    QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
+    QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
+    pdfWriter.setCreator(QString::fromUtf8("%1 TechDraw %2.%3.%4%5").arg(appname, major, minor, point, suffix));
+
     pdfWriter.setResolution(printer->resolution());
     QPageLayout pageLayout = printer->pageLayout();
     // we want to set the layout for the first page before we make the painter(&pdfWriter) or the layout for the first page will
@@ -355,6 +364,14 @@ void PagePrinter::printPdf(ViewProviderPage* vpPage, const std::string& file)
     QString documentName = QString::fromUtf8(vpPage->getDrawPage()->getNameInDocument());
     pdfWriter.setTitle(documentName);
     // default pdfWriter dpi is 1200.
+
+    QString appname = QCoreApplication::applicationName();
+    auto config = App::Application::Config();
+    QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
+    QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
+    QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
+    QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
+    pdfWriter.setCreator(QString::fromUtf8("%1 TechDraw %2.%3.%4%5").arg(appname, major, minor, point, suffix));
 
     // set up the page layout
     auto dPage = vpPage->getDrawPage();


### PR DESCRIPTION
Currently FreeCAD does not set a PDF creator tag. And (almost) all PDF generating applications do set this tag.

Practically speaking, it can be useful for debugging being able to see which version of FreeCAD generated a particular PDF, without being dependent on a user remembering/reporting it correctly.
