### PR TITLE
TechDraw: Component Drawing as default document type

### DIFF
--- a/src/Mod/TechDraw/Templates/A0_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/A0_Landscape_ISO5457_advanced.svg
@@ -252,7 +252,7 @@
     <text id="responsible_department_data_field" x="1140" y="816.2" freecad:editable="responsible_department"><tspan>RD</tspan></text>
     <text id="approval_person_data_field" x="1080" y="804.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="1080" y="792.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="1000" y="816.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="1000" y="816.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="document_status_data_field" x="1000" y="828.2" freecad:editable="document_status"><tspan>In preparation</tspan></text>
     <text id="sheet_scale_data_field" x="1129" y="780.2" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="1080" y="780.2" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>

--- a/src/Mod/TechDraw/Templates/A0_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/A0_Landscape_ISO5457_minimal.svg
@@ -245,7 +245,7 @@
     <text id="title_data_field" x="1000" y="804.2" freecad:editable="title" freecad:autofill="title"><tspan>ISO 5457 template</tspan></text>
     <text id="approval_person_data_field" x="1080" y="816.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="1080" y="804.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="1000" y="816.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="1000" y="816.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="sheet_scale_data_field" x="1129" y="792.2" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="1080" y="792.2" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>
     <text id="part_material_data_field" x="1000" y="792.2" freecad:editable="part_material"><tspan>Stainless steel Mat.No. 1.4301</tspan></text>

--- a/src/Mod/TechDraw/Templates/A1_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/A1_Landscape_ISO5457_advanced.svg
@@ -204,7 +204,7 @@
     <text id="responsible_department_data_field" x="792" y="569.2" freecad:editable="responsible_department"><tspan>RD</tspan></text>
     <text id="approval_person_data_field" x="732" y="557.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="732" y="545.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="652" y="569.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="652" y="569.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="document_status_data_field" x="652" y="581.2" freecad:editable="document_status"><tspan>In preparation</tspan></text>
     <text id="sheet_scale_data_field" x="781" y="533.2" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="732" y="533.2" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>

--- a/src/Mod/TechDraw/Templates/A1_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/A1_Landscape_ISO5457_minimal.svg
@@ -198,7 +198,7 @@
     <text id="title_data_field" x="652" y="557.2" freecad:editable="title" freecad:autofill="title"><tspan>ISO 5457 template</tspan></text>
     <text id="approval_person_data_field" x="732" y="569.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="732" y="557.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="652" y="569.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="652" y="569.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="sheet_scale_data_field" x="781" y="545.2" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="732" y="545.2" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>
     <text id="part_material_data_field" x="652" y="545.2" freecad:editable="part_material"><tspan>Stainless steel Mat.No. 1.4301</tspan></text>

--- a/src/Mod/TechDraw/Templates/A2_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/A2_Landscape_ISO5457_advanced.svg
@@ -172,7 +172,7 @@
     <text id="responsible_department_data_field" x="545" y="395.2" freecad:editable="responsible_department"><tspan>RD</tspan></text>
     <text id="approval_person_data_field" x="485" y="383.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="485" y="371.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="405" y="395.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="405" y="395.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="document_status_data_field" x="405" y="407.2" freecad:editable="document_status"><tspan>In preparation</tspan></text>
     <text id="sheet_scale_data_field" x="534" y="359.2" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="485" y="359.2" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>

--- a/src/Mod/TechDraw/Templates/A2_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/A2_Landscape_ISO5457_minimal.svg
@@ -165,7 +165,7 @@
     <text id="title_data_field" x="405" y="383.2" freecad:editable="title" freecad:autofill="title"><tspan>ISO 5457 template</tspan></text>
     <text id="approval_person_data_field" x="485" y="395.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="485" y="383.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="405" y="395.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="405" y="395.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="sheet_scale_data_field" x="534" y="371.2" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="485" y="371.2" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>
     <text id="part_material_data_field" x="405" y="371.2" freecad:editable="part_material"><tspan>Stainless steel Mat.No. 1.4301</tspan></text>

--- a/src/Mod/TechDraw/Templates/A3_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/A3_Landscape_ISO5457_advanced.svg
@@ -148,7 +148,7 @@
     <text id="responsible_department_data_field" x="371" y="272.2" freecad:editable="responsible_department"><tspan>RD</tspan></text>
     <text id="approval_person_data_field" x="311" y="260.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="311" y="248.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="231" y="272.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="231" y="272.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="document_status_data_field" x="231" y="284.2" freecad:editable="document_status"><tspan>In preparation</tspan></text>
     <text id="sheet_scale_data_field" x="360" y="236.2" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="311" y="236.2" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>

--- a/src/Mod/TechDraw/Templates/A3_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/A3_Landscape_ISO5457_minimal.svg
@@ -141,7 +141,7 @@
     <text id="title_data_field" x="231" y="260.2" freecad:editable="title" freecad:autofill="title"><tspan>ISO 5457 template</tspan></text>
     <text id="approval_person_data_field" x="311" y="272.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="311" y="260.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="231" y="272.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="231" y="272.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="sheet_scale_data_field" x="360" y="248.2" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="311" y="248.2" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>
     <text id="part_material_data_field" x="231" y="248.2" freecad:editable="part_material"><tspan>Stainless steel Mat.No. 1.4301</tspan></text>

--- a/src/Mod/TechDraw/Templates/A4_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/A4_Landscape_ISO5457_advanced.svg
@@ -123,7 +123,7 @@
     <text id="responsible_department_data_field" x="248" y="185.2" freecad:editable="responsible_department"><tspan>RD</tspan></text>
     <text id="approval_person_data_field" x="188" y="173.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="188" y="161.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="108" y="185.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="108" y="185.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="document_status_data_field" x="108" y="197.2" freecad:editable="document_status"><tspan>In preparation</tspan></text>
     <text id="sheet_scale_data_field" x="237" y="149.2" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="188" y="149.2" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>

--- a/src/Mod/TechDraw/Templates/A4_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/A4_Landscape_ISO5457_minimal.svg
@@ -116,7 +116,7 @@
     <text id="title_data_field" x="108" y="173.2" freecad:editable="title" freecad:autofill="title"><tspan>ISO 5457 template</tspan></text>
     <text id="approval_person_data_field" x="188" y="185.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="188" y="173.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="108" y="185.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="108" y="185.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="sheet_scale_data_field" x="237" y="161.2" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="188" y="161.2" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>
     <text id="part_material_data_field" x="108" y="161.2" freecad:editable="part_material"><tspan>Stainless steel Mat.No. 1.4301</tspan></text>

--- a/src/Mod/TechDraw/Templates/A4_Portrait_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/A4_Portrait_ISO5457_advanced.svg
@@ -123,7 +123,7 @@
     <text id="responsible_department_data_field" x="161" y="272.2" freecad:editable="responsible_department"><tspan>RD</tspan></text>
     <text id="approval_person_data_field" x="101" y="260.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="101" y="248.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="21" y="272.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="21" y="272.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="document_status_data_field" x="21" y="284.2" freecad:editable="document_status"><tspan>In preparation</tspan></text>
     <text id="sheet_scale_data_field" x="150" y="236.2" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="101" y="236.2" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>

--- a/src/Mod/TechDraw/Templates/A4_Portrait_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/A4_Portrait_ISO5457_minimal.svg
@@ -116,7 +116,7 @@
     <text id="title_data_field" x="21" y="260.2" freecad:editable="title" freecad:autofill="title"><tspan>ISO 5457 template</tspan></text>
     <text id="approval_person_data_field" x="101" y="272.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="101" y="260.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="21" y="272.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="21" y="272.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="sheet_scale_data_field" x="150" y="248.2" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="101" y="248.2" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>
     <text id="part_material_data_field" x="21" y="248.2" freecad:editable="part_material"><tspan>Stainless steel Mat.No. 1.4301</tspan></text>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_1_minimal.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_1_minimal.svg
@@ -72,7 +72,7 @@
     <text id="title_data_field" x="1" y="9.2" freecad:editable="title" freecad:autofill="title"><tspan>ISO 5457 template</tspan></text>
     <text id="approval_person_data_field" x="81" y="21.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="81" y="9.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="1" y="21.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="1" y="21.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="sheet_scale_data_field" x="130" y="-2.8" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="81" y="-2.8" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>
     <text id="part_material_data_field" x="1" y="-2.8" freecad:editable="part_material"><tspan>Stainless steel Mat.No. 1.4301</tspan></text>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_2.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_2.svg
@@ -69,6 +69,6 @@
     <text id="responsible_department_data_field" x="141" y="33.2" freecad:editable="responsible_department"><tspan>RD</tspan></text>
     <text id="approval_person_data_field" x="81" y="21.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="81" y="9.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="1" y="21.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="1" y="21.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_3_advanced.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_3_advanced.svg
@@ -79,7 +79,7 @@
     <text id="responsible_department_data_field" x="141" y="33.2" freecad:editable="responsible_department"><tspan>RD</tspan></text>
     <text id="approval_person_data_field" x="81" y="21.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="81" y="9.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="1" y="33.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="1" y="33.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="document_status_data_field" x="1" y="45.2" freecad:editable="document_status"><tspan>In preparation</tspan></text>
     <text id="sheet_scale_data_field" x="130" y="-2.8" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
     <text id="general_tolerances_data_field" x="81" y="-2.8" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_4.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_4.svg
@@ -78,7 +78,7 @@
     <text id="responsible_department_data_field" x="141" y="33" freecad:editable="responsible_department"><tspan>RD</tspan></text>
     <text id="approval_person_data_field" x="81" y="21.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="81" y="9.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="1" y="33.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="1" y="33.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="document_status_data_field" x="1" y="45.2" freecad:editable="document_status"><tspan>In preparation</tspan></text>
     <text id="paper_size_data_field" x="90" y="45.2" style="text-align:center;text-anchor:middle">A3</text>
   </g>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_5_maximal.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_5_maximal.svg
@@ -90,7 +90,7 @@
     <text id="technical_reference_data_field" x="81" y="33.2" freecad:editable="technical_reference"><tspan>C. Kali</tspan></text>
     <text id="approval_person_data_field" x="81" y="21.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
     <text id="creator_data_field" x="81" y="9.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="1" y="33.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+    <text id="document_type_data_field" x="1" y="33.2" freecad:editable="document_type"><tspan>Component Drawing</tspan></text>
     <text id="key_words_data_field" x="1" y="45.2" freecad:editable="key_words"><tspan>KW</tspan></text>
     <text id="document_status_data_field" x="1" y="57.2" freecad:editable="document_status"><tspan>In preparation</tspan></text>
     <text id="page_number_data_field" x="170" y="45.2" freecad:editable="page_number" style="text-align:center;text-anchor:middle"><tspan>X / Y</tspan></text>


### PR DESCRIPTION
Presumably Component Drawings are more common as opposed to Assembly Drawing's therefore FreeCAD's default should reflect this.

find src/Mod/TechDraw/Templates -iname "*.svg" -exec sed -i 's#Assembly Drawing#Component Drawing#g' "{}" \;