### PR TITLE
Stylesheet toolbar background

### DIFF
--- a/src/Gui/Stylesheets/FreeCAD Dark.qss
+++ b/src/Gui/Stylesheets/FreeCAD Dark.qss
@@ -104,8 +104,7 @@ Main window
 ==================================================================================================*/
 QMainWindow,
 QDialog,
-QDockWidget,
-QToolBar  {
+QDockWidget {
     background-color: #333333; /* main background color */
 }
 
@@ -881,7 +880,7 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtoolbar
 
 --------------------------------------------------------------------------- */
 QToolBar {
-  background-color: #333333;
+  /* background-color: #333333; */
   /* border: 1px solid #020202; */
   /* font-weight: bold; */
 }

--- a/src/Gui/Stylesheets/FreeCAD Dark.qss
+++ b/src/Gui/Stylesheets/FreeCAD Dark.qss
@@ -885,8 +885,10 @@ QToolBar {
   /* font-weight: bold; */
 }
 
+/* fix background color for toolbars that are the on menubar. */
 QToolBar:only-one {
   background-color: transparent;
+  /* margin-top: -3px; */
 }
 
 QToolBar:horizontal {

--- a/src/Gui/Stylesheets/FreeCAD Dark.qss
+++ b/src/Gui/Stylesheets/FreeCAD Dark.qss
@@ -1877,7 +1877,7 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtabwidget-and-qtabb
 --------------------------------------------------------------------------- */
 QTabBar, QDockWidget QTabBar {
   qproperty-drawBase: 0;
-  background-color: #333333;
+  /* background-color: #333333; */
   /* left: 5px; move to the right by 5px - removed for fix */
 }
 

--- a/src/Gui/Stylesheets/FreeCAD Dark.qss
+++ b/src/Gui/Stylesheets/FreeCAD Dark.qss
@@ -880,9 +880,13 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtoolbar
 
 --------------------------------------------------------------------------- */
 QToolBar {
-  /* background-color: #333333; */
+  background-color: #333333;
   /* border: 1px solid #020202; */
   /* font-weight: bold; */
+}
+
+QToolBar:only-one {
+  background-color: transparent;
 }
 
 QToolBar:horizontal {

--- a/src/Gui/Stylesheets/FreeCAD Light.qss
+++ b/src/Gui/Stylesheets/FreeCAD Light.qss
@@ -885,8 +885,10 @@ QToolBar {
   /* font-weight: bold; */
 }
 
+/* fix background color for toolbars that are the on menubar. */
 QToolBar:only-one {
   background-color: transparent;
+  /* margin-top: -3px; */
 }
 
 QToolBar:horizontal {

--- a/src/Gui/Stylesheets/FreeCAD Light.qss
+++ b/src/Gui/Stylesheets/FreeCAD Light.qss
@@ -1874,7 +1874,7 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtabwidget-and-qtabb
 --------------------------------------------------------------------------- */
 QTabBar, QDockWidget QTabBar {
   qproperty-drawBase: 0;
-  background-color: #f0f0f0;
+  /* background-color: #f0f0f0; */
   /* left: 5px; move to the right by 5px - removed for fix */
 }
 

--- a/src/Gui/Stylesheets/FreeCAD Light.qss
+++ b/src/Gui/Stylesheets/FreeCAD Light.qss
@@ -880,9 +880,13 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtoolbar
 
 --------------------------------------------------------------------------- */
 QToolBar {
-  /* background-color: #f0f0f0; */
+  background-color: #f0f0f0;
   /* border: 1px solid #ababab; */
   /* font-weight: bold; */
+}
+
+QToolBar:only-one {
+  background-color: transparent;
 }
 
 QToolBar:horizontal {

--- a/src/Gui/Stylesheets/FreeCAD Light.qss
+++ b/src/Gui/Stylesheets/FreeCAD Light.qss
@@ -104,8 +104,7 @@ Main window
 ==================================================================================================*/
 QMainWindow,
 QDialog,
-QDockWidget,
-QToolBar  {
+QDockWidget {
     background-color: #f0f0f0; /* main background color */
 }
 
@@ -881,7 +880,7 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtoolbar
 
 --------------------------------------------------------------------------- */
 QToolBar {
-  background-color: #f0f0f0;
+  /* background-color: #f0f0f0; */
   /* border: 1px solid #ababab; */
   /* font-weight: bold; */
 }


### PR DESCRIPTION
When you put a toolbar in the menubar (corner widget), then the background is of the toolbar is light gray (dark theme) and not dark gray like the menu bar.
Removing the color definition for the toolbars fix this it seems.
@MisterMakerNL can you please check?