### PR TITLE
Units rework II

### DIFF
--- a/src/App/FeatureTest.cpp
+++ b/src/App/FeatureTest.cpp
@@ -31,6 +31,7 @@
 #include <Base/Exception.h>
 #include <Base/Interpreter.h>
 #include <Base/Unit.h>
+#include "Base/Units.h"
 #include <CXX/Objects.hxx>
 
 #include "FeatureTest.h"
@@ -142,11 +143,10 @@ FeatureTest::FeatureTest()
                       (App::PropertyType)(Prop_Output | Prop_ReadOnly | Prop_Hidden),
                       "An example property which has the types 'Output', 'ReadOnly' and 'Hidden'");
 
-    ADD_PROPERTY(QuantityLength, (1.0));
-    QuantityLength.setUnit(Base::Unit::Length);
-    ADD_PROPERTY(QuantityOther, (5.0));
-    QuantityOther.setUnit(Base::Unit(-3, 1));
-    // clang-format on
+  ADD_PROPERTY(QuantityLength,(1.0));
+  QuantityLength.setUnit(Base::Units::Length);
+  ADD_PROPERTY(QuantityOther,(5.0));
+  QuantityOther.setUnit(Base::Units::Density);
 }
 
 FeatureTest::~FeatureTest() = default;

--- a/src/App/PropertyGeo.cpp
+++ b/src/App/PropertyGeo.cpp
@@ -35,6 +35,7 @@
 #include <Base/Tools.h>
 #include <Base/VectorPy.h>
 #include <Base/Writer.h>
+#include "Base/Units.h"
 
 #include "ComplexGeoData.h"
 #include "Document.h"
@@ -193,8 +194,8 @@ void PropertyVector::getPaths(std::vector<ObjectIdentifier>& paths) const
 
 const boost::any PropertyVector::getPathValue(const ObjectIdentifier& path) const
 {
-    Base::Unit unit = getUnit();
-    if (!unit.isEmpty()) {
+    const Unit unit = getUnit();
+    if (unit != Units::NullUnit) {
         std::string p = path.getSubPathStr();
         if (p == ".x" || p == ".y" || p == ".z") {
             // Convert double to quantity
@@ -206,8 +207,8 @@ const boost::any PropertyVector::getPathValue(const ObjectIdentifier& path) cons
 
 bool PropertyVector::getPyPathValue(const ObjectIdentifier& path, Py::Object& res) const
 {
-    Base::Unit unit = getUnit();
-    if (unit.isEmpty()) {
+    const Unit unit = getUnit();
+    if (unit == Units::NullUnit) {
         return false;
     }
 
@@ -716,11 +717,11 @@ const boost::any PropertyPlacement::getPathValue(const ObjectIdentifier& path) c
         // Convert angle to degrees
         return Base::Quantity(
             Base::toDegrees(boost::any_cast<double>(Property::getPathValue(path))),
-            Unit::Angle);
+            Units::Angle);
     }
     else if (p == ".Base.x" || p == ".Base.y" || p == ".Base.z") {
         // Convert double to quantity
-        return Base::Quantity(boost::any_cast<double>(Property::getPathValue(path)), Unit::Length);
+        return Base::Quantity(boost::any_cast<double>(Property::getPathValue(path)), Units::Length);
     }
     else if (p == ".Rotation.Axis.x") {
         return getAxis(_cPos).x;
@@ -767,19 +768,19 @@ bool PropertyPlacement::getPyPathValue(const ObjectIdentifier& path, Py::Object&
         Base::Vector3d axis;
         double angle;
         _cPos.getRotation().getValue(axis, angle);
-        res = Py::asObject(new QuantityPy(new Quantity(Base::toDegrees(angle), Unit::Angle)));
+        res = Py::asObject(new QuantityPy(new Quantity(Base::toDegrees(angle), Units::Angle)));
         return true;
     }
     else if (p == ".Base.x") {
-        res = Py::asObject(new QuantityPy(new Quantity(_cPos.getPosition().x, Unit::Length)));
+        res = Py::asObject(new QuantityPy(new Quantity(_cPos.getPosition().x, Units::Length)));
         return true;
     }
     else if (p == ".Base.y") {
-        res = Py::asObject(new QuantityPy(new Quantity(_cPos.getPosition().y, Unit::Length)));
+        res = Py::asObject(new QuantityPy(new Quantity(_cPos.getPosition().y, Units::Length)));
         return true;
     }
     else if (p == ".Base.z") {
-        res = Py::asObject(new QuantityPy(new Quantity(_cPos.getPosition().z, Unit::Length)));
+        res = Py::asObject(new QuantityPy(new Quantity(_cPos.getPosition().z, Units::Length)));
         return true;
     }
     else if (p == ".Rotation.Axis.x") {
@@ -1166,7 +1167,7 @@ const boost::any PropertyRotation::getPathValue(const ObjectIdentifier& path) co
         // Convert angle to degrees
         return Base::Quantity(
             Base::toDegrees(boost::any_cast<double>(Property::getPathValue(path))),
-            Unit::Angle);
+            Units::Angle);
     }
     else if (p == ".Axis.x") {
         return getAxis(_rot).x;
@@ -1196,7 +1197,7 @@ bool PropertyRotation::getPyPathValue(const ObjectIdentifier& path, Py::Object& 
         Base::Vector3d axis;
         double angle;
         _rot.getValue(axis, angle);
-        res = Py::asObject(new QuantityPy(new Quantity(Base::toDegrees(angle), Unit::Angle)));
+        res = Py::asObject(new QuantityPy(new Quantity(Base::toDegrees(angle), Units::Angle)));
         return true;
     }
     else if (p == ".Axis.x") {

--- a/src/App/PropertyGeo.h
+++ b/src/App/PropertyGeo.h
@@ -28,6 +28,7 @@
 #include <Base/Matrix.h>
 #include <Base/Placement.h>
 #include <Base/Unit.h>
+#include <Base/Units.h>
 #include <Base/Vector3D.h>
 
 #include "PropertyLinks.h"
@@ -103,9 +104,8 @@ public:
 
     bool getPyPathValue(const ObjectIdentifier& path, Py::Object& res) const override;
 
-    virtual Base::Unit getUnit() const
-    {
-        return {};
+    virtual Base::Unit getUnit() const {
+        return Base::Units::NullUnit;
     }
 
     bool isSame(const Property& other) const override
@@ -139,9 +139,8 @@ public:
      */
     ~PropertyVectorDistance() override;
 
-    Base::Unit getUnit() const override
-    {
-        return Base::Unit::Length;
+    Base::Unit getUnit() const override {
+        return Base::Units::Length;
     }
 
     const char* getEditorName() const override
@@ -167,9 +166,8 @@ public:
      */
     ~PropertyPosition() override;
 
-    Base::Unit getUnit() const override
-    {
-        return Base::Unit::Length;
+    Base::Unit getUnit() const override {
+        return Base::Units::Length;
     }
 
     const char* getEditorName() const override
@@ -195,9 +193,8 @@ public:
      */
     ~PropertyDirection() override;
 
-    Base::Unit getUnit() const override
-    {
-        return Base::Unit::Length;
+    Base::Unit getUnit() const override {
+        return Base::Units::Length;
     }
 
     const char* getEditorName() const override

--- a/src/App/PropertyUnits.cpp
+++ b/src/App/PropertyUnits.cpp
@@ -27,6 +27,7 @@
 
 #include <Base/QuantityPy.h>
 #include <Base/UnitPy.h>
+#include "Base/Units.h"
 
 #include "PropertyUnits.h"
 #include "Expression.h"
@@ -46,7 +47,7 @@ const PropertyQuantityConstraint::Constraints AngleStandard = {-360, 360, 1.0};
 
 TYPESYSTEM_SOURCE(App::PropertyQuantity, App::PropertyFloat)
 
-Base::Quantity PropertyQuantity::getQuantityValue() const
+Quantity PropertyQuantity::getQuantityValue() const
 {
     Quantity quantity(_dValue, _Unit);
     quantity.setFormat(_Format);
@@ -63,9 +64,9 @@ PyObject* PropertyQuantity::getPyObject()
     return new QuantityPy(new Quantity(_dValue, _Unit));
 }
 
-Base::Quantity PropertyQuantity::createQuantityFromPy(PyObject* value)
+Quantity PropertyQuantity::createQuantityFromPy(PyObject* value)
 {
-    Base::Quantity quant;
+    Quantity quant;
 
     if (PyUnicode_Check(value)) {
         quant = Quantity::parse(PyUnicode_AsUTF8(value));
@@ -77,13 +78,13 @@ Base::Quantity PropertyQuantity::createQuantityFromPy(PyObject* value)
         quant = Quantity(double(PyLong_AsLong(value)), _Unit);
     }
     else if (PyObject_TypeCheck(value, &(QuantityPy::Type))) {
-        Base::QuantityPy* pcObject = static_cast<Base::QuantityPy*>(value);
+        QuantityPy* pcObject = static_cast<QuantityPy*>(value);
         quant = *(pcObject->getQuantityPtr());
     }
     else {
         std::string error = std::string("wrong type as quantity: ");
         error += value->ob_type->tp_name;
-        throw Base::TypeError(error);
+        throw TypeError(error);
     }
 
     return quant;
@@ -95,34 +96,33 @@ void PropertyQuantity::setPyObject(PyObject* value)
     // and set the value
 
     if (PyObject_TypeCheck(value, &(UnitPy::Type))) {
-        Base::UnitPy* pcObject = static_cast<Base::UnitPy*>(value);
-        Base::Unit unit = *(pcObject->getUnitPtr());
+        const auto* pcObject = static_cast<UnitPy*>(value);
+        const Unit unit = *pcObject->getUnitPtr();
         aboutToSetValue();
         _Unit = unit;
         hasSetValue();
+        return;
     }
-    else {
-        Base::Quantity quant = createQuantityFromPy(value);
+    const Quantity quant = createQuantityFromPy(value);
 
-        Unit unit = quant.getUnit();
-        if (unit.isEmpty()) {
-            PropertyFloat::setValue(quant.getValue());
-            return;
-        }
-
-        if (unit != _Unit) {
-            throw Base::UnitsMismatchError("Not matching Unit!");
-        }
-
+    const Unit unit = quant.getUnit();
+    if (unit == Units::NullUnit) {
         PropertyFloat::setValue(quant.getValue());
+        return;
     }
+
+    if (unit != _Unit) {
+        throw UnitsMismatchError("Not matching Unit!");
+    }
+
+    PropertyFloat::setValue(quant.getValue());
 }
 
 void PropertyQuantity::setPathValue(const ObjectIdentifier& /*path*/, const boost::any& value)
 {
-    auto q = App::anyToQuantity(value);
+    const auto q = anyToQuantity(value);
     aboutToSetValue();
-    if (!q.getUnit().isEmpty()) {
+    if (q.getUnit() != Units::NullUnit) {
         _Unit = q.getUnit();
     }
     _dValue = q.getValue();
@@ -184,9 +184,9 @@ double PropertyQuantityConstraint::getStepSize() const
 
 void PropertyQuantityConstraint::setPyObject(PyObject* value)
 {
-    Base::Quantity quant = createQuantityFromPy(value);
+    Quantity quant = createQuantityFromPy(value);
 
-    Unit unit = quant.getUnit();
+    const Unit unit = quant.getUnit();
     double temp = quant.getValue();
     if (_ConstStruct) {
         if (temp > _ConstStruct->UpperBound) {
@@ -198,13 +198,13 @@ void PropertyQuantityConstraint::setPyObject(PyObject* value)
     }
     quant.setValue(temp);
 
-    if (unit.isEmpty()) {
+    if (unit == Units::NullUnit) {
         PropertyFloat::setValue(quant.getValue());  // clazy:exclude=skipped-base-method
         return;
     }
 
     if (unit != _Unit) {
-        throw Base::UnitsMismatchError("Not matching Unit!");
+        throw UnitsMismatchError("Not matching Unit!");
     }
 
     PropertyFloat::setValue(quant.getValue());  // clazy:exclude=skipped-base-method
@@ -222,7 +222,7 @@ TYPESYSTEM_SOURCE(App::PropertyAcceleration, App::PropertyQuantity)
 
 PropertyAcceleration::PropertyAcceleration()
 {
-    setUnit(Base::Unit::Acceleration);
+    setUnit(Units::Acceleration);
 }
 
 //**************************************************************************
@@ -233,7 +233,7 @@ TYPESYSTEM_SOURCE(App::PropertyAmountOfSubstance, App::PropertyQuantity)
 
 PropertyAmountOfSubstance::PropertyAmountOfSubstance()
 {
-    setUnit(Base::Unit::AmountOfSubstance);
+    setUnit(Units::AmountOfSubstance);
 }
 
 //**************************************************************************
@@ -244,7 +244,7 @@ TYPESYSTEM_SOURCE(App::PropertyAngle, App::PropertyQuantityConstraint)
 
 PropertyAngle::PropertyAngle()
 {
-    setUnit(Base::Unit::Angle);
+    setUnit(Units::Angle);
     setConstraints(&AngleStandard);
 }
 
@@ -256,7 +256,7 @@ TYPESYSTEM_SOURCE(App::PropertyArea, App::PropertyQuantityConstraint)
 
 PropertyArea::PropertyArea()
 {
-    setUnit(Base::Unit::Area);
+    setUnit(Units::Area);
     setConstraints(&LengthStandard);
 }
 
@@ -268,7 +268,7 @@ TYPESYSTEM_SOURCE(App::PropertyCompressiveStrength, App::PropertyQuantity)
 
 PropertyCompressiveStrength::PropertyCompressiveStrength()
 {
-    setUnit(Base::Unit::CompressiveStrength);
+    setUnit(Units::CompressiveStrength);
 }
 
 //**************************************************************************
@@ -279,7 +279,7 @@ TYPESYSTEM_SOURCE(App::PropertyCurrentDensity, App::PropertyQuantity)
 
 PropertyCurrentDensity::PropertyCurrentDensity()
 {
-    setUnit(Base::Unit::CurrentDensity);
+    setUnit(Units::CurrentDensity);
 }
 
 //**************************************************************************
@@ -290,7 +290,7 @@ TYPESYSTEM_SOURCE(App::PropertyDensity, App::PropertyQuantity)
 
 PropertyDensity::PropertyDensity()
 {
-    setUnit(Base::Unit::Density);
+    setUnit(Units::Density);
 }
 
 //**************************************************************************
@@ -301,7 +301,7 @@ TYPESYSTEM_SOURCE(App::PropertyDissipationRate, App::PropertyQuantity)
 
 PropertyDissipationRate::PropertyDissipationRate()
 {
-    setUnit(Base::Unit::DissipationRate);
+    setUnit(Units::DissipationRate);
 }
 
 //**************************************************************************
@@ -312,7 +312,7 @@ TYPESYSTEM_SOURCE(App::PropertyDistance, App::PropertyQuantity)
 
 PropertyDistance::PropertyDistance()
 {
-    setUnit(Base::Unit::Length);
+    setUnit(Units::Length);
 }
 
 //**************************************************************************
@@ -323,7 +323,7 @@ TYPESYSTEM_SOURCE(App::PropertyDynamicViscosity, App::PropertyQuantity)
 
 PropertyDynamicViscosity::PropertyDynamicViscosity()
 {
-    setUnit(Base::Unit::DynamicViscosity);
+    setUnit(Units::DynamicViscosity);
 }
 
 //**************************************************************************
@@ -334,7 +334,7 @@ TYPESYSTEM_SOURCE(App::PropertyElectricalCapacitance, App::PropertyQuantity)
 
 PropertyElectricalCapacitance::PropertyElectricalCapacitance()
 {
-    setUnit(Base::Unit::ElectricalCapacitance);
+    setUnit(Units::ElectricalCapacitance);
 }
 
 //**************************************************************************
@@ -345,7 +345,7 @@ TYPESYSTEM_SOURCE(App::PropertyElectricalInductance, App::PropertyQuantity)
 
 PropertyElectricalInductance::PropertyElectricalInductance()
 {
-    setUnit(Base::Unit::ElectricalInductance);
+    setUnit(Units::ElectricalInductance);
 }
 
 //**************************************************************************
@@ -356,7 +356,7 @@ TYPESYSTEM_SOURCE(App::PropertyElectricalConductance, App::PropertyQuantity)
 
 PropertyElectricalConductance::PropertyElectricalConductance()
 {
-    setUnit(Base::Unit::ElectricalConductance);
+    setUnit(Units::ElectricalConductance);
 }
 
 //**************************************************************************
@@ -367,7 +367,7 @@ TYPESYSTEM_SOURCE(App::PropertyElectricalConductivity, App::PropertyQuantity)
 
 PropertyElectricalConductivity::PropertyElectricalConductivity()
 {
-    setUnit(Base::Unit::ElectricalConductivity);
+    setUnit(Units::ElectricalConductivity);
 }
 
 //**************************************************************************
@@ -378,7 +378,7 @@ TYPESYSTEM_SOURCE(App::PropertyElectricalResistance, App::PropertyQuantity)
 
 PropertyElectricalResistance::PropertyElectricalResistance()
 {
-    setUnit(Base::Unit::ElectricalResistance);
+    setUnit(Units::ElectricalResistance);
 }
 
 //**************************************************************************
@@ -389,7 +389,7 @@ TYPESYSTEM_SOURCE(App::PropertyElectricCharge, App::PropertyQuantity)
 
 PropertyElectricCharge::PropertyElectricCharge()
 {
-    setUnit(Base::Unit::ElectricCharge);
+    setUnit(Units::ElectricCharge);
 }
 
 //**************************************************************************
@@ -400,7 +400,7 @@ TYPESYSTEM_SOURCE(App::PropertyElectricCurrent, App::PropertyQuantity)
 
 PropertyElectricCurrent::PropertyElectricCurrent()
 {
-    setUnit(Base::Unit::ElectricCurrent);
+    setUnit(Units::ElectricCurrent);
 }
 
 //**************************************************************************
@@ -411,7 +411,7 @@ TYPESYSTEM_SOURCE(App::PropertyElectricPotential, App::PropertyQuantity)
 
 PropertyElectricPotential::PropertyElectricPotential()
 {
-    setUnit(Base::Unit::ElectricPotential);
+    setUnit(Units::ElectricPotential);
 }
 
 //**************************************************************************
@@ -422,7 +422,7 @@ TYPESYSTEM_SOURCE(App::PropertyFrequency, App::PropertyQuantity)
 
 PropertyFrequency::PropertyFrequency()
 {
-    setUnit(Base::Unit::Frequency);
+    setUnit(Units::Frequency);
 }
 
 //**************************************************************************
@@ -433,7 +433,7 @@ TYPESYSTEM_SOURCE(App::PropertyForce, App::PropertyQuantity)
 
 PropertyForce::PropertyForce()
 {
-    setUnit(Base::Unit::Force);
+    setUnit(Units::Force);
 }
 
 //**************************************************************************
@@ -444,7 +444,7 @@ TYPESYSTEM_SOURCE(App::PropertyHeatFlux, App::PropertyQuantity)
 
 PropertyHeatFlux::PropertyHeatFlux()
 {
-    setUnit(Base::Unit::HeatFlux);
+    setUnit(Units::HeatFlux);
 }
 
 //**************************************************************************
@@ -455,7 +455,7 @@ TYPESYSTEM_SOURCE(App::PropertyInverseArea, App::PropertyQuantity)
 
 PropertyInverseArea::PropertyInverseArea()
 {
-    setUnit(Base::Unit::InverseArea);
+    setUnit(Units::InverseArea);
 }
 
 //**************************************************************************
@@ -466,7 +466,7 @@ TYPESYSTEM_SOURCE(App::PropertyInverseLength, App::PropertyQuantity)
 
 PropertyInverseLength::PropertyInverseLength()
 {
-    setUnit(Base::Unit::InverseLength);
+    setUnit(Units::InverseLength);
 }
 
 //**************************************************************************
@@ -477,7 +477,7 @@ TYPESYSTEM_SOURCE(App::PropertyInverseVolume, App::PropertyQuantity)
 
 PropertyInverseVolume::PropertyInverseVolume()
 {
-    setUnit(Base::Unit::InverseVolume);
+    setUnit(Units::InverseVolume);
 }
 
 //**************************************************************************
@@ -488,7 +488,7 @@ TYPESYSTEM_SOURCE(App::PropertyKinematicViscosity, App::PropertyQuantity)
 
 PropertyKinematicViscosity::PropertyKinematicViscosity()
 {
-    setUnit(Base::Unit::KinematicViscosity);
+    setUnit(Units::KinematicViscosity);
 }
 
 //**************************************************************************
@@ -499,7 +499,7 @@ TYPESYSTEM_SOURCE(App::PropertyLength, App::PropertyQuantityConstraint)
 
 PropertyLength::PropertyLength()
 {
-    setUnit(Base::Unit::Length);
+    setUnit(Units::Length);
     setConstraints(&LengthStandard);
 }
 
@@ -511,7 +511,7 @@ TYPESYSTEM_SOURCE(App::PropertyLuminousIntensity, App::PropertyQuantity)
 
 PropertyLuminousIntensity::PropertyLuminousIntensity()
 {
-    setUnit(Base::Unit::LuminousIntensity);
+    setUnit(Units::LuminousIntensity);
 }
 
 //**************************************************************************
@@ -522,7 +522,7 @@ TYPESYSTEM_SOURCE(App::PropertyMagneticFieldStrength, App::PropertyQuantity)
 
 PropertyMagneticFieldStrength::PropertyMagneticFieldStrength()
 {
-    setUnit(Base::Unit::MagneticFieldStrength);
+    setUnit(Units::MagneticFieldStrength);
 }
 
 //**************************************************************************
@@ -533,7 +533,7 @@ TYPESYSTEM_SOURCE(App::PropertyMagneticFlux, App::PropertyQuantity)
 
 PropertyMagneticFlux::PropertyMagneticFlux()
 {
-    setUnit(Base::Unit::MagneticFlux);
+    setUnit(Units::MagneticFlux);
 }
 
 //**************************************************************************
@@ -544,7 +544,7 @@ TYPESYSTEM_SOURCE(App::PropertyMagneticFluxDensity, App::PropertyQuantity)
 
 PropertyMagneticFluxDensity::PropertyMagneticFluxDensity()
 {
-    setUnit(Base::Unit::MagneticFluxDensity);
+    setUnit(Units::MagneticFluxDensity);
 }
 
 //**************************************************************************
@@ -555,7 +555,7 @@ TYPESYSTEM_SOURCE(App::PropertyMagnetization, App::PropertyQuantity)
 
 PropertyMagnetization::PropertyMagnetization()
 {
-    setUnit(Base::Unit::Magnetization);
+    setUnit(Units::Magnetization);
 }
 
 //**************************************************************************
@@ -566,7 +566,7 @@ TYPESYSTEM_SOURCE(App::PropertyElectromagneticPotential, App::PropertyQuantity)
 
 PropertyElectromagneticPotential::PropertyElectromagneticPotential()
 {
-    setUnit(Base::Unit::ElectromagneticPotential);
+    setUnit(Units::ElectromagneticPotential);
 }
 
 //**************************************************************************
@@ -577,7 +577,7 @@ TYPESYSTEM_SOURCE(App::PropertyMass, App::PropertyQuantity)
 
 PropertyMass::PropertyMass()
 {
-    setUnit(Base::Unit::Mass);
+    setUnit(Units::Mass);
 }
 
 //**************************************************************************
@@ -588,7 +588,7 @@ TYPESYSTEM_SOURCE(App::PropertyMoment, App::PropertyQuantity)
 
 PropertyMoment::PropertyMoment()
 {
-    setUnit(Base::Unit::Moment);
+    setUnit(Units::Moment);
 }
 
 //**************************************************************************
@@ -599,7 +599,7 @@ TYPESYSTEM_SOURCE(App::PropertyPressure, App::PropertyQuantity)
 
 PropertyPressure::PropertyPressure()
 {
-    setUnit(Base::Unit::Pressure);
+    setUnit(Units::Pressure);
 }
 
 //**************************************************************************
@@ -610,7 +610,7 @@ TYPESYSTEM_SOURCE(App::PropertyPower, App::PropertyQuantity)
 
 PropertyPower::PropertyPower()
 {
-    setUnit(Base::Unit::Power);
+    setUnit(Units::Power);
 }
 
 //**************************************************************************
@@ -621,7 +621,7 @@ TYPESYSTEM_SOURCE(App::PropertySpecificEnergy, App::PropertyQuantity)
 
 PropertySpecificEnergy::PropertySpecificEnergy()
 {
-    setUnit(Base::Unit::SpecificEnergy);
+    setUnit(Units::SpecificEnergy);
 }
 
 //**************************************************************************
@@ -632,7 +632,7 @@ TYPESYSTEM_SOURCE(App::PropertySpecificHeat, App::PropertyQuantity)
 
 PropertySpecificHeat::PropertySpecificHeat()
 {
-    setUnit(Base::Unit::SpecificHeat);
+    setUnit(Units::SpecificHeat);
 }
 
 //**************************************************************************
@@ -643,7 +643,7 @@ TYPESYSTEM_SOURCE(App::PropertySpeed, App::PropertyQuantity)
 
 PropertySpeed::PropertySpeed()
 {
-    setUnit(Base::Unit::Velocity);
+    setUnit(Units::Velocity);
 }
 
 //**************************************************************************
@@ -654,7 +654,7 @@ TYPESYSTEM_SOURCE(App::PropertyStiffness, App::PropertyQuantity)
 
 PropertyStiffness::PropertyStiffness()
 {
-    setUnit(Base::Unit::Stiffness);
+    setUnit(Units::Stiffness);
 }
 
 //**************************************************************************
@@ -665,7 +665,7 @@ TYPESYSTEM_SOURCE(App::PropertyStiffnessDensity, App::PropertyQuantity)
 
 PropertyStiffnessDensity::PropertyStiffnessDensity()
 {
-    setUnit(Base::Unit::StiffnessDensity);
+    setUnit(Units::StiffnessDensity);
 }
 
 //**************************************************************************
@@ -676,7 +676,7 @@ TYPESYSTEM_SOURCE(App::PropertyTemperature, App::PropertyQuantity)
 
 PropertyTemperature::PropertyTemperature()
 {
-    setUnit(Base::Unit::Temperature);
+    setUnit(Units::Temperature);
 }
 
 //**************************************************************************
@@ -687,7 +687,7 @@ TYPESYSTEM_SOURCE(App::PropertyThermalConductivity, App::PropertyQuantity)
 
 PropertyThermalConductivity::PropertyThermalConductivity()
 {
-    setUnit(Base::Unit::ThermalConductivity);
+    setUnit(Units::ThermalConductivity);
 }
 
 //**************************************************************************
@@ -698,7 +698,7 @@ TYPESYSTEM_SOURCE(App::PropertyThermalExpansionCoefficient, App::PropertyQuantit
 
 PropertyThermalExpansionCoefficient::PropertyThermalExpansionCoefficient()
 {
-    setUnit(Base::Unit::ThermalExpansionCoefficient);
+    setUnit(Units::ThermalExpansionCoefficient);
 }
 
 
@@ -710,7 +710,7 @@ TYPESYSTEM_SOURCE(App::PropertyThermalTransferCoefficient, App::PropertyQuantity
 
 PropertyThermalTransferCoefficient::PropertyThermalTransferCoefficient()
 {
-    setUnit(Base::Unit::ThermalTransferCoefficient);
+    setUnit(Units::ThermalTransferCoefficient);
 }
 
 //**************************************************************************
@@ -721,7 +721,7 @@ TYPESYSTEM_SOURCE(App::PropertyTime, App::PropertyQuantity)
 
 PropertyTime::PropertyTime()
 {
-    setUnit(Base::Unit::TimeSpan);
+    setUnit(Units::TimeSpan);
 }
 
 //**************************************************************************
@@ -732,7 +732,7 @@ TYPESYSTEM_SOURCE(App::PropertyShearModulus, App::PropertyQuantity)
 
 PropertyShearModulus::PropertyShearModulus()
 {
-    setUnit(Base::Unit::ShearModulus);
+    setUnit(Units::ShearModulus);
 }
 
 //**************************************************************************
@@ -743,7 +743,7 @@ TYPESYSTEM_SOURCE(App::PropertyStress, App::PropertyQuantity)
 
 PropertyStress::PropertyStress()
 {
-    setUnit(Base::Unit::Stress);
+    setUnit(Units::Stress);
 }
 
 //**************************************************************************
@@ -754,7 +754,7 @@ TYPESYSTEM_SOURCE(App::PropertyUltimateTensileStrength, App::PropertyQuantity)
 
 PropertyUltimateTensileStrength::PropertyUltimateTensileStrength()
 {
-    setUnit(Base::Unit::UltimateTensileStrength);
+    setUnit(Units::UltimateTensileStrength);
 }
 
 //**************************************************************************
@@ -765,7 +765,7 @@ TYPESYSTEM_SOURCE(App::PropertyVacuumPermittivity, App::PropertyQuantity)
 
 PropertyVacuumPermittivity::PropertyVacuumPermittivity()
 {
-    setUnit(Base::Unit::VacuumPermittivity);
+    setUnit(Units::VacuumPermittivity);
 }
 
 //**************************************************************************
@@ -776,7 +776,7 @@ TYPESYSTEM_SOURCE(App::PropertyVelocity, App::PropertyQuantity)
 
 PropertyVelocity::PropertyVelocity()
 {
-    setUnit(Base::Unit::Velocity);
+    setUnit(Units::Velocity);
 }
 
 //**************************************************************************
@@ -787,7 +787,7 @@ TYPESYSTEM_SOURCE(App::PropertyVolume, App::PropertyQuantityConstraint)
 
 PropertyVolume::PropertyVolume()
 {
-    setUnit(Base::Unit::Volume);
+    setUnit(Units::Volume);
     setConstraints(&LengthStandard);
 }
 
@@ -799,7 +799,7 @@ TYPESYSTEM_SOURCE(App::PropertyVolumeFlowRate, App::PropertyQuantity)
 
 PropertyVolumeFlowRate::PropertyVolumeFlowRate()
 {
-    setUnit(Base::Unit::VolumeFlowRate);
+    setUnit(Units::VolumeFlowRate);
 }
 
 //**************************************************************************
@@ -810,7 +810,7 @@ TYPESYSTEM_SOURCE(App::PropertyVolumetricThermalExpansionCoefficient, App::Prope
 
 PropertyVolumetricThermalExpansionCoefficient::PropertyVolumetricThermalExpansionCoefficient()
 {
-    setUnit(Base::Unit::VolumetricThermalExpansionCoefficient);
+    setUnit(Units::VolumetricThermalExpansionCoefficient);
 }
 
 //**************************************************************************
@@ -821,7 +821,7 @@ TYPESYSTEM_SOURCE(App::PropertyWork, App::PropertyQuantity)
 
 PropertyWork::PropertyWork()
 {
-    setUnit(Base::Unit::Work);
+    setUnit(Units::Work);
 }
 
 //**************************************************************************
@@ -832,7 +832,7 @@ TYPESYSTEM_SOURCE(App::PropertyYieldStrength, App::PropertyQuantity)
 
 PropertyYieldStrength::PropertyYieldStrength()
 {
-    setUnit(Base::Unit::YieldStrength);
+    setUnit(Units::YieldStrength);
 }
 
 //**************************************************************************
@@ -843,5 +843,5 @@ TYPESYSTEM_SOURCE(App::PropertyYoungsModulus, App::PropertyQuantity)
 
 PropertyYoungsModulus::PropertyYoungsModulus()
 {
-    setUnit(Base::Unit::YoungsModulus);
+    setUnit(Units::YoungsModulus);
 }

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -203,6 +203,7 @@ SET(FreeCADBase_UNITAPI_SRCS
     QuantityParser.y
     Unit.h
     Unit.cpp
+    Units.h
     UnitPyImp.cpp
 )
 SOURCE_GROUP("Units" FILES ${FreeCADBase_UNITAPI_SRCS})

--- a/src/Base/MatrixPyImp.cpp
+++ b/src/Base/MatrixPyImp.cpp
@@ -30,7 +30,7 @@
 #include "QuantityPy.h"
 #include "MatrixPy.h"
 #include "MatrixPy.cpp"
-
+#include "Base/Units.h"
 
 using namespace Base;
 
@@ -550,7 +550,7 @@ PyObject* MatrixPy::rotateX(PyObject* args)
         PyObject* object {};
         if (PyArg_ParseTuple(args, "O!", &(Base::QuantityPy::Type), &object)) {
             Quantity* q = static_cast<Base::QuantityPy*>(object)->getQuantityPtr();
-            if (q->getUnit() == Base::Unit::Angle) {
+            if (q->getUnit() == Base::Units::Angle) {
                 angle = q->getValueAs(Base::Quantity::Radian);
                 break;
             }
@@ -580,7 +580,7 @@ PyObject* MatrixPy::rotateY(PyObject* args)
         PyObject* object {};
         if (PyArg_ParseTuple(args, "O!", &(Base::QuantityPy::Type), &object)) {
             Quantity* q = static_cast<Base::QuantityPy*>(object)->getQuantityPtr();
-            if (q->getUnit() == Base::Unit::Angle) {
+            if (q->getUnit() == Base::Units::Angle) {
                 angle = q->getValueAs(Base::Quantity::Radian);
                 break;
             }
@@ -610,7 +610,7 @@ PyObject* MatrixPy::rotateZ(PyObject* args)
         PyObject* object {};
         if (PyArg_ParseTuple(args, "O!", &(Base::QuantityPy::Type), &object)) {
             Quantity* q = static_cast<Base::QuantityPy*>(object)->getQuantityPtr();
-            if (q->getUnit() == Base::Unit::Angle) {
+            if (q->getUnit() == Base::Units::Angle) {
                 angle = q->getValueAs(Base::Quantity::Radian);
                 break;
             }

--- a/src/Base/Quantity.cpp
+++ b/src/Base/Quantity.cpp
@@ -33,6 +33,7 @@
 #include "Exception.h"
 #include "Quantity.h"
 #include "UnitsApi.h"
+#include "Units.h"
 
 /** \defgroup Units Units system
     \ingroup BASE
@@ -178,7 +179,7 @@ Quantity Quantity::operator/(double factor) const
 
 Quantity Quantity::pow(const Quantity& other) const
 {
-    if (!other.myUnit.isEmpty()) {
+    if (other.myUnit != Units::NullUnit) {
         throw Base::UnitsMismatchError("Quantity::pow(): exponent must not have a unit");
     }
 
@@ -263,7 +264,7 @@ std::string Quantity::getSafeUserString() const
 /// true if it has a number without a unit
 bool Quantity::isDimensionless() const
 {
-    return isValid() && myUnit.isEmpty();
+    return isValid() && myUnit == Units::NullUnit;
 }
 
 /// true if it has a specific unit or no dimension.
@@ -275,7 +276,7 @@ bool Quantity::isDimensionlessOrUnit(const Unit& unit) const
 // true if it has a number and a valid unit
 bool Quantity::isQuantity() const
 {
-    return isValid() && !myUnit.isEmpty();
+    return isValid() && myUnit != Units::NullUnit;
 }
 
 // true if it has a number with or without a unit
@@ -290,162 +291,154 @@ void Quantity::setInvalid()
 }
 
 // === Predefined types =====================================================
-
-const Quantity Quantity::NanoMetre(1.0e-6, Unit(1));
-const Quantity Quantity::MicroMetre(1.0e-3, Unit(1));
-const Quantity Quantity::MilliMetre(1.0, Unit(1));
-const Quantity Quantity::CentiMetre(10.0, Unit(1));
-const Quantity Quantity::DeciMetre(100.0, Unit(1));
-const Quantity Quantity::Metre(1.0e3, Unit(1));
-const Quantity Quantity::KiloMetre(1.0e6, Unit(1));
-
-const Quantity Quantity::MilliLiter(1000.0, Unit(3));
-const Quantity Quantity::Liter(1.0e6, Unit(3));
-
-const Quantity Quantity::Hertz(1.0, Unit(0, 0, -1));
-const Quantity Quantity::KiloHertz(1.0e3, Unit(0, 0, -1));
-const Quantity Quantity::MegaHertz(1.0e6, Unit(0, 0, -1));
-const Quantity Quantity::GigaHertz(1.0e9, Unit(0, 0, -1));
-const Quantity Quantity::TeraHertz(1.0e12, Unit(0, 0, -1));
-
-const Quantity Quantity::MicroGram(1.0e-9, Unit(0, 1));
-const Quantity Quantity::MilliGram(1.0e-6, Unit(0, 1));
-const Quantity Quantity::Gram(1.0e-3, Unit(0, 1));
-const Quantity Quantity::KiloGram(1.0, Unit(0, 1));
-const Quantity Quantity::Ton(1.0e3, Unit(0, 1));
-
-const Quantity Quantity::Second(1.0, Unit(0, 0, 1));
-const Quantity Quantity::Minute(60.0, Unit(0, 0, 1));
-const Quantity Quantity::Hour(3600.0, Unit(0, 0, 1));
-
-const Quantity Quantity::Ampere(1.0, Unit(0, 0, 0, 1));
-const Quantity Quantity::MilliAmpere(0.001, Unit(0, 0, 0, 1));
-const Quantity Quantity::KiloAmpere(1000.0, Unit(0, 0, 0, 1));
-const Quantity Quantity::MegaAmpere(1.0e6, Unit(0, 0, 0, 1));
-
-const Quantity Quantity::Kelvin(1.0, Unit(0, 0, 0, 0, 1));
-const Quantity Quantity::MilliKelvin(0.001, Unit(0, 0, 0, 0, 1));
-const Quantity Quantity::MicroKelvin(0.000001, Unit(0, 0, 0, 0, 1));
-
-const Quantity Quantity::MilliMole(0.001, Unit(0, 0, 0, 0, 0, 1));
-const Quantity Quantity::Mole(1.0, Unit(0, 0, 0, 0, 0, 1));
-
-const Quantity Quantity::Candela(1.0, Unit(0, 0, 0, 0, 0, 0, 1));
-
-const Quantity Quantity::Inch(25.4, Unit(1));
-const Quantity Quantity::Foot(304.8, Unit(1));
-const Quantity Quantity::Thou(0.0254, Unit(1));
-const Quantity Quantity::Yard(914.4, Unit(1));
-const Quantity Quantity::Mile(1609344.0, Unit(1));
-
-const Quantity Quantity::MilePerHour(447.04, Unit(1, 0, -1));
-const Quantity Quantity::SquareFoot(92903.04, Unit(2));
-const Quantity Quantity::CubicFoot(28316846.592, Unit(3));
-
-const Quantity Quantity::Pound(0.45359237, Unit(0, 1));
-const Quantity Quantity::Ounce(0.0283495231, Unit(0, 1));
-const Quantity Quantity::Stone(6.35029318, Unit(0, 1));
-const Quantity Quantity::Hundredweights(50.80234544, Unit(0, 1));
-
-const Quantity Quantity::PoundForce(4448.22, Unit(1, 1, -2));  // lbf are ~= 4.44822 Newton
-
-const Quantity Quantity::Newton(1000.0, Unit(1, 1, -2));  // Newton (kg*m/s^2)
-const Quantity Quantity::MilliNewton(1.0, Unit(1, 1, -2));
-const Quantity Quantity::KiloNewton(1e+6, Unit(1, 1, -2));
-const Quantity Quantity::MegaNewton(1e+9, Unit(1, 1, -2));
-
-const Quantity Quantity::NewtonPerMeter(1.00, Unit(0, 1, -2));  // Newton per meter (N/m or kg/s^2)
-const Quantity Quantity::MilliNewtonPerMeter(1e-3, Unit(0, 1, -2));
-const Quantity Quantity::KiloNewtonPerMeter(1e3, Unit(0, 1, -2));
-const Quantity Quantity::MegaNewtonPerMeter(1e6, Unit(0, 1, -2));
-
-const Quantity Quantity::Pascal(0.001, Unit(-1, 1, -2));  // Pascal (kg/m/s^2 or N/m^2)
-const Quantity Quantity::KiloPascal(1.00, Unit(-1, 1, -2));
-const Quantity Quantity::MegaPascal(1000.0, Unit(-1, 1, -2));
-const Quantity Quantity::GigaPascal(1e+6, Unit(-1, 1, -2));
-
-const Quantity Quantity::MilliBar(0.1, Unit(-1, 1, -2));
-const Quantity Quantity::Bar(100.0, Unit(-1, 1, -2));  // 1 bar = 100 kPa
-
-const Quantity
-    Quantity::Torr(101.325 / 760.0,
-                   Unit(-1, 1, -2));  // Torr is a defined fraction of Pascal (kg/m/s^2 or N/m^2)
-const Quantity
-    Quantity::mTorr(0.101325 / 760.0,
-                    Unit(-1, 1, -2));  // Torr is a defined fraction of Pascal (kg/m/s^2 or N/m^2)
-const Quantity
-    Quantity::yTorr(0.000101325 / 760.0,
-                    Unit(-1, 1, -2));  // Torr is a defined fraction of Pascal (kg/m/s^2 or N/m^2)
-
-const Quantity Quantity::PSI(6.894744825494, Unit(-1, 1, -2));   // pounds/in^2
-const Quantity Quantity::KSI(6894.744825494, Unit(-1, 1, -2));   // 1000 x pounds/in^2
-const Quantity Quantity::MPSI(6894744.825494, Unit(-1, 1, -2));  // 1000 ksi
-
-const Quantity Quantity::Watt(1e+6, Unit(2, 1, -3));  // Watt (kg*m^2/s^3)
-const Quantity Quantity::MilliWatt(1e+3, Unit(2, 1, -3));
-const Quantity Quantity::KiloWatt(1e+9, Unit(2, 1, -3));
-const Quantity Quantity::VoltAmpere(1e+6, Unit(2, 1, -3));  // VoltAmpere (kg*m^2/s^3)
-
-const Quantity Quantity::Volt(1e+6, Unit(2, 1, -3, -1));  // Volt (kg*m^2/A/s^3)
-const Quantity Quantity::MilliVolt(1e+3, Unit(2, 1, -3, -1));
-const Quantity Quantity::KiloVolt(1e+9, Unit(2, 1, -3, -1));
-
-const Quantity Quantity::MegaSiemens(1.0, Unit(-2, -1, 3, 2));
-const Quantity Quantity::KiloSiemens(1e-3, Unit(-2, -1, 3, 2));
-const Quantity Quantity::Siemens(1e-6, Unit(-2, -1, 3, 2));  // Siemens (A^2*s^3/kg/m^2)
-const Quantity Quantity::MilliSiemens(1e-9, Unit(-2, -1, 3, 2));
-const Quantity Quantity::MicroSiemens(1e-12, Unit(-2, -1, 3, 2));
-
-const Quantity Quantity::Ohm(1e+6, Unit(2, 1, -3, -2));  // Ohm (kg*m^2/A^2/s^3)
-const Quantity Quantity::KiloOhm(1e+9, Unit(2, 1, -3, -2));
-const Quantity Quantity::MegaOhm(1e+12, Unit(2, 1, -3, -2));
-
-const Quantity Quantity::Coulomb(1.0, Unit(0, 0, 1, 1));  // Coulomb (A*s)
-
-const Quantity Quantity::Tesla(1.0, Unit(0, 1, -2, -1));   // Tesla (kg/s^2/A)
-const Quantity Quantity::Gauss(1e-4, Unit(0, 1, -2, -1));  // 1 G = 1e-4 T
-
-const Quantity Quantity::Weber(1e6, Unit(2, 1, -2, -1));  // Weber (kg*m^2/s^2/A)
-
 // disable Oersted because people need to input e.g. a field strength of
 // 1 ampere per meter -> 1 A/m and not get the recalculation to Oersted
-// const Quantity Quantity::Oersted(0.07957747, Unit(-1, 0, 0, 1));// Oersted (A/m)
+// const Quantity Quantity::Oersted(0.07957747, Units::-1, 0, 0, 1));// Oersted (A/m)
 
-const Quantity Quantity::PicoFarad(1e-18, Unit(-2, -1, 4, 2));
-const Quantity Quantity::NanoFarad(1e-15, Unit(-2, -1, 4, 2));
-const Quantity Quantity::MicroFarad(1e-12, Unit(-2, -1, 4, 2));
-const Quantity Quantity::MilliFarad(1e-9, Unit(-2, -1, 4, 2));
-const Quantity Quantity::Farad(1e-6, Unit(-2, -1, 4, 2));  // Farad (s^4*A^2/m^2/kg)
+// clang-format off
+const Quantity Quantity::NanoMetre           ( 1.0e-6              , Units::Length                );
+const Quantity Quantity::MicroMetre          ( 1.0e-3              , Units::Length                );
+const Quantity Quantity::MilliMetre          ( 1.0                 , Units::Length                );
+const Quantity Quantity::CentiMetre          ( 10.0                , Units::Length                );
+const Quantity Quantity::DeciMetre           ( 100.0               , Units::Length                );
+const Quantity Quantity::Metre               ( 1.0e3               , Units::Length                );
+const Quantity Quantity::KiloMetre           ( 1.0e6               , Units::Length                );
 
-const Quantity Quantity::NanoHenry(1e-3, Unit(2, 1, -2, -2));
-const Quantity Quantity::MicroHenry(1.0, Unit(2, 1, -2, -2));
-const Quantity Quantity::MilliHenry(1e+3, Unit(2, 1, -2, -2));
-const Quantity Quantity::Henry(1e+6, Unit(2, 1, -2, -2));  // Henry (kg*m^2/s^2/A^2)
+const Quantity Quantity::MilliLiter          ( 1000.0              , Units::Volume                );
+const Quantity Quantity::Liter               ( 1.0e6               , Units::Volume                );
 
-const Quantity Quantity::Joule(1e+6, Unit(2, 1, -2));  // Joule (kg*m^2/s^2)
-const Quantity Quantity::MilliJoule(1e+3, Unit(2, 1, -2));
-const Quantity Quantity::KiloJoule(1e+9, Unit(2, 1, -2));
-const Quantity Quantity::NewtonMeter(1e+6, Unit(2, 1, -2));              // Joule (kg*m^2/s^2)
-const Quantity Quantity::VoltAmpereSecond(1e+6, Unit(2, 1, -2));         // Joule (kg*m^2/s^2)
-const Quantity Quantity::WattSecond(1e+6, Unit(2, 1, -2));               // Joule (kg*m^2/s^2)
-const Quantity Quantity::KiloWattHour(3.6e+12, Unit(2, 1, -2));          // 1 kWh = 3.6e6 J
-const Quantity Quantity::ElectronVolt(1.602176634e-13, Unit(2, 1, -2));  // 1 eV = 1.602176634e-19 J
-const Quantity Quantity::KiloElectronVolt(1.602176634e-10, Unit(2, 1, -2));
-const Quantity Quantity::MegaElectronVolt(1.602176634e-7, Unit(2, 1, -2));
-const Quantity Quantity::Calorie(4.1868e+6, Unit(2, 1, -2));  // 1 cal = 4.1868 J
-const Quantity Quantity::KiloCalorie(4.1868e+9, Unit(2, 1, -2));
+const Quantity Quantity::Hertz               ( 1.0                 , Units::Frequency             );
+const Quantity Quantity::KiloHertz           ( 1.0e3               , Units::Frequency             );
+const Quantity Quantity::MegaHertz           ( 1.0e6               , Units::Frequency             );
+const Quantity Quantity::GigaHertz           ( 1.0e9               , Units::Frequency             );
+const Quantity Quantity::TeraHertz           ( 1.0e12              , Units::Frequency             );
 
-const Quantity Quantity::KMH(277.778, Unit(1, 0, -1));  // km/h
-const Quantity Quantity::MPH(447.04, Unit(1, 0, -1));   // Mile/h
+const Quantity Quantity::MicroGram           ( 1.0e-9              , Units::Mass                  );
+const Quantity Quantity::MilliGram           ( 1.0e-6              , Units::Mass                  );
+const Quantity Quantity::Gram                ( 1.0e-3              , Units::Mass                  );
+const Quantity Quantity::KiloGram            ( 1.0                 , Units::Mass                  );
+const Quantity Quantity::Ton                 ( 1.0e3               , Units::Mass                  );
 
-const Quantity Quantity::AngMinute(1.0 / 60.0, Unit(0, 0, 0, 0, 0, 0, 0, 1));    // angular minute
-const Quantity Quantity::AngSecond(1.0 / 3600.0, Unit(0, 0, 0, 0, 0, 0, 0, 1));  // angular second
-const Quantity
-    Quantity::Degree(1.0,
-                     Unit(0, 0, 0, 0, 0, 0, 0, 1));  // degree         (internal standard angle)
-const Quantity Quantity::Radian(180 / M_PI, Unit(0, 0, 0, 0, 0, 0, 0, 1));  // radian
-const Quantity Quantity::Gon(360.0 / 400.0, Unit(0, 0, 0, 0, 0, 0, 0, 1));  // gon
+const Quantity Quantity::Second              ( 1.0                 , Units::TimeSpan              );
+const Quantity Quantity::Minute              ( 60.0                , Units::TimeSpan              );
+const Quantity Quantity::Hour                ( 3600.0              , Units::TimeSpan              );
 
+const Quantity Quantity::Ampere              ( 1.0                 , Units::ElectricCurrent       );
+const Quantity Quantity::MilliAmpere         ( 0.001               , Units::ElectricCurrent       );
+const Quantity Quantity::KiloAmpere          ( 1000.0              , Units::ElectricCurrent       );
+const Quantity Quantity::MegaAmpere          ( 1.0e6               , Units::ElectricCurrent       );
+
+const Quantity Quantity::Kelvin              ( 1.0                 , Units::Temperature           );
+const Quantity Quantity::MilliKelvin         ( 0.001               , Units::Temperature           );
+const Quantity Quantity::MicroKelvin         ( 0.000001            , Units::Temperature           );
+
+const Quantity Quantity::MilliMole           ( 0.001               , Units::AmountOfSubstance     );
+const Quantity Quantity::Mole                ( 1.0                 , Units::AmountOfSubstance     );
+
+const Quantity Quantity::Candela             ( 1.0                 , Units::LuminousIntensity     );
+
+const Quantity Quantity::Inch                ( 25.4                , Units::Length                );
+const Quantity Quantity::Foot                ( 304.8               , Units::Length                );
+const Quantity Quantity::Thou                ( 0.0254              , Units::Length                );
+const Quantity Quantity::Yard                ( 914.4               , Units::Length                );
+const Quantity Quantity::Mile                ( 1609344.0           , Units::Length                );
+
+const Quantity Quantity::MilePerHour         ( 447.04              , Units::Velocity              );
+const Quantity Quantity::SquareFoot          ( 92903.04            , Units::Area                  );
+const Quantity Quantity::CubicFoot           ( 28316846.592        , Units::Volume                );
+
+const Quantity Quantity::Pound               ( 0.45359237          , Units::Mass                  );
+const Quantity Quantity::Ounce               ( 0.0283495231        , Units::Mass                  );
+const Quantity Quantity::Stone               ( 6.35029318          , Units::Mass                  );
+const Quantity Quantity::Hundredweights      ( 50.80234544         , Units::Mass                  );
+
+const Quantity Quantity::PoundForce          ( 4448.22             , Units::Force                 );  // lbf are ~= 4.44822 Newton
+
+const Quantity Quantity::Newton              ( 1000.0              , Units::Force                 );  // Newton (kg*m/s^2)
+const Quantity Quantity::MilliNewton         ( 1.0                 , Units::Force                 );
+const Quantity Quantity::KiloNewton          ( 1e+6                , Units::Force                 );
+const Quantity Quantity::MegaNewton          ( 1e+9                , Units::Force                 );
+
+const Quantity Quantity::NewtonPerMeter      ( 1.00                , Units::Stiffness             );  // Newton per meter (N/m or kg/s^2)
+const Quantity Quantity::MilliNewtonPerMeter ( 1e-3                , Units::Stiffness             );
+const Quantity Quantity::KiloNewtonPerMeter  ( 1e3                 , Units::Stiffness             );
+const Quantity Quantity::MegaNewtonPerMeter  ( 1e6                 , Units::Stiffness             );
+
+const Quantity Quantity::Pascal              ( 0.001               , Units::CompressiveStrength   );  // Pascal (kg/m/s^2 or N/m^2)
+const Quantity Quantity::KiloPascal          ( 1.00                , Units::CompressiveStrength   );
+const Quantity Quantity::MegaPascal          ( 1000.0              , Units::CompressiveStrength   );
+const Quantity Quantity::GigaPascal          ( 1e+6                , Units::CompressiveStrength   );
+
+const Quantity Quantity::MilliBar            ( 0.1                 , Units::CompressiveStrength   );
+const Quantity Quantity::Bar                 ( 100.0               , Units::CompressiveStrength   );  // 1 bar = 100 kPa
+
+const Quantity Quantity::Torr                ( 101.325 / 760.0     , Units::CompressiveStrength   );  // Torr is a defined fraction of Pascal (kg/m/s^2 or N/m^2)
+const Quantity Quantity::mTorr               ( 0.101325 / 760.0    , Units::CompressiveStrength   );  // Torr is a defined fraction of Pascal (kg/m/s^2 or N/m^2)
+const Quantity Quantity::yTorr               ( 0.000101325 / 760.0 , Units::CompressiveStrength   );  // Torr is a defined fraction of Pascal (kg/m/s^2 or N/m^2)
+
+const Quantity Quantity::PSI                 ( 6.894744825494      , Units::CompressiveStrength   );   // pounds/in^2
+const Quantity Quantity::KSI                 ( 6894.744825494      , Units::CompressiveStrength   );   // 1000 x pounds/in^2
+const Quantity Quantity::MPSI                ( 6894744.825494      , Units::CompressiveStrength   );  // 1000 ksi
+
+const Quantity Quantity::Watt                ( 1e+6                , Units::Power                 );  // Watt (kg*m^2/s^3)
+const Quantity Quantity::MilliWatt           ( 1e+3                , Units::Power                 );
+const Quantity Quantity::KiloWatt            ( 1e+9                , Units::Power                 );
+const Quantity Quantity::VoltAmpere          ( 1e+6                , Units::Power                 );  // VoltAmpere (kg*m^2/s^3)
+
+const Quantity Quantity::Volt                ( 1e+6                , Units::ElectricPotential     );  // Volt (kg*m^2/A/s^3)
+const Quantity Quantity::MilliVolt           ( 1e+3                , Units::ElectricPotential     );
+const Quantity Quantity::KiloVolt            ( 1e+9                , Units::ElectricPotential     );
+
+const Quantity Quantity::MegaSiemens         ( 1.0                 , Units::ElectricalConductance );
+const Quantity Quantity::KiloSiemens         ( 1e-3                , Units::ElectricalConductance );
+const Quantity Quantity::Siemens             ( 1e-6                , Units::ElectricalConductance );  // Siemens (A^2*s^3/kg/m^2)
+const Quantity Quantity::MilliSiemens        ( 1e-9                , Units::ElectricalConductance );
+const Quantity Quantity::MicroSiemens        ( 1e-12               , Units::ElectricalConductance );
+
+const Quantity Quantity::Ohm                 ( 1e+6                , Units::ElectricalResistance  );  // Ohm (kg*m^2/A^2/s^3)
+const Quantity Quantity::KiloOhm             ( 1e+9                , Units::ElectricalResistance  );
+const Quantity Quantity::MegaOhm             ( 1e+12               , Units::ElectricalResistance  );
+
+const Quantity Quantity::Coulomb             ( 1.0                 , Units::ElectricCharge        );  // Coulomb (A*s)
+
+const Quantity Quantity::Tesla               ( 1.0                 , Units::MagneticFluxDensity   );   // Tesla (kg/s^2/A)
+const Quantity Quantity::Gauss               ( 1e-4                , Units::MagneticFluxDensity   );  // 1 G = 1e-4 T
+
+const Quantity Quantity::Weber               ( 1e6                 , Units::MagneticFlux          );  // Weber (kg*m^2/s^2/A)
+
+const Quantity Quantity::PicoFarad           ( 1e-18               , Units::ElectricalCapacitance );
+const Quantity Quantity::NanoFarad           ( 1e-15               , Units::ElectricalCapacitance );
+const Quantity Quantity::MicroFarad          ( 1e-12               , Units::ElectricalCapacitance );
+const Quantity Quantity::MilliFarad          ( 1e-9                , Units::ElectricalCapacitance );
+const Quantity Quantity::Farad               ( 1e-6                , Units::ElectricalCapacitance );  // Farad (s^4*A^2/m^2/kg)
+
+const Quantity Quantity::NanoHenry           ( 1e-3                , Units::ElectricalInductance  );
+const Quantity Quantity::MicroHenry          ( 1.0                 , Units::ElectricalInductance  );
+const Quantity Quantity::MilliHenry          ( 1e+3                , Units::ElectricalInductance  );
+const Quantity Quantity::Henry               ( 1e+6                , Units::ElectricalInductance  );  // Henry (kg*m^2/s^2/A^2)
+
+const Quantity Quantity::Joule               ( 1e+6                , Units::Moment                );  // Joule (kg*m^2/s^2)
+const Quantity Quantity::MilliJoule          ( 1e+3                , Units::Moment                );
+const Quantity Quantity::KiloJoule           ( 1e+9                , Units::Moment                );
+const Quantity Quantity::NewtonMeter         ( 1e+6                , Units::Moment                );              // Joule (kg*m^2/s^2)
+const Quantity Quantity::VoltAmpereSecond    ( 1e+6                , Units::Moment                );         // Joule (kg*m^2/s^2)
+const Quantity Quantity::WattSecond          ( 1e+6                , Units::Moment                );               // Joule (kg*m^2/s^2)
+const Quantity Quantity::KiloWattHour        ( 3.6e+12             , Units::Moment                );          // 1 kWh = 3.6e6 J
+const Quantity Quantity::ElectronVolt        ( 1.602176634e-13     , Units::Moment                );  // 1 eV = 1.602176634e-19 J
+const Quantity Quantity::KiloElectronVolt    ( 1.602176634e-10     , Units::Moment                );
+const Quantity Quantity::MegaElectronVolt    ( 1.602176634e-7      , Units::Moment                );
+const Quantity Quantity::Calorie             ( 4.1868e+6           , Units::Moment                );  // 1 cal = 4.1868 J
+const Quantity Quantity::KiloCalorie         ( 4.1868e+9           , Units::Moment                );
+
+const Quantity Quantity::KMH                 ( 277.778             , Units::Velocity              );  // km/h
+const Quantity Quantity::MPH                 ( 447.04              , Units::Velocity              );   // Mile/h
+
+const Quantity Quantity::AngMinute           ( 1.0 / 60.0          , Units::Angle                 );    // angular minute
+const Quantity Quantity::AngSecond           ( 1.0 / 3600.0        , Units::Angle                 );  // angular second
+const Quantity Quantity::Degree              ( 1.0                 , Units::Angle                 );  // degree         (internal standard angle)
+const Quantity Quantity::Radian              ( 180 / M_PI          , Units::Angle                 );  // radian
+const Quantity Quantity::Gon                 ( 360.0 / 400.0       , Units::Angle                 );  // gon
+// clamg-format on
 
 // === Parser & Scanner stuff ===============================================
 

--- a/src/Base/Unit.cpp
+++ b/src/Base/Unit.cpp
@@ -21,698 +21,172 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
+
 #ifndef _PreComp_
 #include <algorithm>
 #include <array>
 #include <cmath>
 #include <limits>
-#include <sstream>
-#include <utility>
 #endif
 
+#include <vector>
+#include "fmt/format.h"
+#include "fmt/ranges.h"
 #include "Unit.h"
 #include "Exception.h"
-#include "Quantity.h"
-
 
 using namespace Base;
 
-// clang-format off
-constexpr int UnitSignatureLengthBits                   = 4;
-constexpr int UnitSignatureMassBits                     = 4;
-constexpr int UnitSignatureTimeBits                     = 4;
-constexpr int UnitSignatureElectricCurrentBits          = 4;
-constexpr int UnitSignatureThermodynamicTemperatureBits = 4;
-constexpr int UnitSignatureAmountOfSubstanceBits        = 4;
-constexpr int UnitSignatureLuminousIntensityBits        = 4;
-constexpr int UnitSignatureAngleBits                    = 4;
 
-struct UnitSignature {
-    int32_t Length: UnitSignatureLengthBits;
-    int32_t Mass: UnitSignatureMassBits;
-    int32_t Time: UnitSignatureTimeBits;
-    int32_t ElectricCurrent: UnitSignatureElectricCurrentBits;
-    int32_t ThermodynamicTemperature: UnitSignatureThermodynamicTemperatureBits;
-    int32_t AmountOfSubstance: UnitSignatureAmountOfSubstanceBits;
-    int32_t LuminousIntensity: UnitSignatureLuminousIntensityBits;
-    int32_t Angle: UnitSignatureAngleBits;
-};
-
-static inline uint32_t sigVal(const std::string &op,
-                              int length, int mass, int time, int electricCurrent,
-                              int thermodynamicTemperature, int amountOfSubstance, int luminousIntensity, int angle)
+bool Unit::operator==(const Unit& that) const
 {
-    if ( ( length                   >=  (1 << (UnitSignatureLengthBits                   - 1)) ) ||
-         ( mass                     >=  (1 << (UnitSignatureMassBits                     - 1)) ) ||
-         ( time                     >=  (1 << (UnitSignatureTimeBits                     - 1)) ) ||
-         ( electricCurrent          >=  (1 << (UnitSignatureElectricCurrentBits          - 1)) ) ||
-         ( thermodynamicTemperature >=  (1 << (UnitSignatureThermodynamicTemperatureBits - 1)) ) ||
-         ( amountOfSubstance        >=  (1 << (UnitSignatureAmountOfSubstanceBits        - 1)) ) ||
-         ( luminousIntensity        >=  (1 << (UnitSignatureLuminousIntensityBits        - 1)) ) ||
-         ( angle                    >=  (1 << (UnitSignatureAngleBits                    - 1)) ) ) {
-        throw Base::OverflowError(("Unit overflow in " + op).c_str());
-    }
-    if ( ( length                   <  -(1 << (UnitSignatureLengthBits                   - 1)) ) ||
-         ( mass                     <  -(1 << (UnitSignatureMassBits                     - 1)) ) ||
-         ( time                     <  -(1 << (UnitSignatureTimeBits                     - 1)) ) ||
-         ( electricCurrent          <  -(1 << (UnitSignatureElectricCurrentBits          - 1)) ) ||
-         ( thermodynamicTemperature <  -(1 << (UnitSignatureThermodynamicTemperatureBits - 1)) ) ||
-         ( amountOfSubstance        <  -(1 << (UnitSignatureAmountOfSubstanceBits        - 1)) ) ||
-         ( luminousIntensity        <  -(1 << (UnitSignatureLuminousIntensityBits        - 1)) ) ||
-         ( angle                    <  -(1 << (UnitSignatureAngleBits                    - 1)) ) ) {
-        throw Base::UnderflowError(("Unit underflow in " + op).c_str());
-    }
-
-    UnitSignature Sig;
-    Sig.Length                   = length;
-    Sig.Mass                     = mass;
-    Sig.Time                     = time;
-    Sig.ElectricCurrent          = electricCurrent;
-    Sig.ThermodynamicTemperature = thermodynamicTemperature;
-    Sig.AmountOfSubstance        = amountOfSubstance;
-    Sig.LuminousIntensity        = luminousIntensity;
-    Sig.Angle                    = angle;
-
-    uint32_t ret;
-    memcpy(&ret, &Sig, sizeof(ret));
-    return ret;
+    return vals == that.vals;
 }
 
-
-Unit::Unit(int8_t Length, //NOLINT
-           int8_t Mass,
-           int8_t Time,
-           int8_t ElectricCurrent,
-           int8_t ThermodynamicTemperature,
-           int8_t AmountOfSubstance,
-           int8_t LuminousIntensity,
-           int8_t Angle)
+bool Unit::operator!=(const Unit& that) const
 {
-    Val = sigVal("unit",
-                 Length,
-                 Mass,
-                 Time,
-                 ElectricCurrent,
-                 ThermodynamicTemperature,
-                 AmountOfSubstance,
-                 LuminousIntensity,
-                 Angle);
+    return vals != that.vals;
 }
 
-
-Unit::Unit() //NOLINT
+Unit& Unit::operator*=(const Unit& that)
 {
-    Val = 0;
+    *this = *this * that;
+    return *this;
 }
 
-Unit::Unit(const std::string& expr)  // NOLINT
+Unit& Unit::operator/=(const Unit& that)
 {
-    try {
-        *this = Quantity::parse(expr).getUnit();
-    }
-    catch (const Base::ParserError&) {
-        Val = 0;
-    }
+    *this = *this / that;
+    return *this;
 }
 
-Unit Unit::pow(double exp) const
+std::array<int8_t, unitNumVals> Unit::getVals() const
 {
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
-    auto isInt = [](double value) {
-        return std::fabs(std::round(value) - value) < std::numeric_limits<double>::epsilon();
-    };
-    if (!isInt(sig.Length                   * exp) ||
-        !isInt(sig.Mass                     * exp) ||
-        !isInt(sig.Time                     * exp) ||
-        !isInt(sig.ElectricCurrent          * exp) ||
-        !isInt(sig.ThermodynamicTemperature * exp) ||
-        !isInt(sig.AmountOfSubstance        * exp) ||
-        !isInt(sig.LuminousIntensity        * exp) ||
-        !isInt(sig.Angle                    * exp))
-        throw Base::UnitsMismatchError("pow() of unit not possible");
-
-    Unit result;
-    result.Val = sigVal("pow()",
-               sig.Length                   * exp,
-               sig.Mass                     * exp,
-               sig.Time                     * exp,
-               sig.ElectricCurrent          * exp,
-               sig.ThermodynamicTemperature * exp,
-               sig.AmountOfSubstance        * exp,
-               sig.LuminousIntensity        * exp,
-               sig.Angle                    * exp);
-
-    return result;
-}
-
-Unit Unit::sqrt() const
-{
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
-    // All components of unit must be either zero or dividable by 2
-    if (!((sig.Length                   % 2) == 0) &&
-         ((sig.Mass                     % 2) == 0) &&
-         ((sig.Time                     % 2) == 0) &&
-         ((sig.ElectricCurrent          % 2) == 0) &&
-         ((sig.ThermodynamicTemperature % 2) == 0) &&
-         ((sig.AmountOfSubstance        % 2) == 0) &&
-         ((sig.LuminousIntensity        % 2) == 0) &&
-         ((sig.Angle                    % 2) == 0))
-        throw Base::UnitsMismatchError("sqrt() needs even dimensions");
-
-    Unit result;
-    result.Val = sigVal("sqrt()",
-          sig.Length                   >> 1,
-          sig.Mass                     >> 1,
-          sig.Time                     >> 1,
-          sig.ElectricCurrent          >> 1,
-          sig.ThermodynamicTemperature >> 1,
-          sig.AmountOfSubstance        >> 1,
-          sig.LuminousIntensity        >> 1,
-          sig.Angle                    >> 1);
-
-    return result;
-}
-
-Unit Unit::cbrt() const
-{
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
-    // All components of unit must be either zero or dividable by 3
-    if (!((sig.Length                   % 3) == 0) &&
-         ((sig.Mass                     % 3) == 0) &&
-         ((sig.Time                     % 3) == 0) &&
-         ((sig.ElectricCurrent          % 3) == 0) &&
-         ((sig.ThermodynamicTemperature % 3) == 0) &&
-         ((sig.AmountOfSubstance        % 3) == 0) &&
-         ((sig.LuminousIntensity        % 3) == 0) &&
-         ((sig.Angle                    % 3) == 0))
-        throw Base::UnitsMismatchError("cbrt() needs dimensions to be multiples of 3");
-
-    Unit result;
-    result.Val = sigVal("cbrt()",
-          sig.Length                   / 3,
-          sig.Mass                     / 3,
-          sig.Time                     / 3,
-          sig.ElectricCurrent          / 3,
-          sig.ThermodynamicTemperature / 3,
-          sig.AmountOfSubstance        / 3,
-          sig.LuminousIntensity        / 3,
-          sig.Angle                    / 3);
-
-    return result;
-}
-
-int Unit::length() const
-{
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
-    return sig.Length;
-}
-
-int Unit::mass() const
-{
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
-    return sig.Mass;
-}
-
-
-int Unit::time() const
-{
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
-    return sig.Time;
-}
-
-int Unit::electricCurrent() const
-{
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
-    return sig.ElectricCurrent;
-}
-
-int Unit::thermodynamicTemperature() const
-{
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
-    return sig.ThermodynamicTemperature;
-}
-
-int Unit::amountOfSubstance() const
-{
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
-    return sig.AmountOfSubstance;
-}
-
-int Unit::luminousIntensity() const
-{
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
-    return sig.LuminousIntensity;
-}
-
-int Unit::angle() const
-{
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
-    return sig.Angle;
-}
-
-bool Unit::isEmpty() const
-{
-    return Val == 0;
-}
-
-int Unit::operator [](int index) const
-{
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
-
-    switch (index) {
-       case 0:
-          return sig.Length;
-       case 1:
-          return sig.Mass;
-       case 2:
-          return sig.Time;
-       case 3:
-          return sig.ElectricCurrent;
-       case 4:
-          return sig.ThermodynamicTemperature;
-       case 5:
-          return sig.AmountOfSubstance;
-       case 6:
-          return sig.LuminousIntensity;
-       case 7:
-          return sig.Angle;
-       default:
-          throw Base::IndexError("Unknown Unit element");
-    }
-}
-
-bool Unit::operator ==(const Unit& that) const
-{
-    return Val == that.Val;
-}
-
-Unit Unit::operator *(const Unit &right) const
-{
-    Unit result;
-    UnitSignature sig, rsig;
-
-    memcpy(&sig, &Val, sizeof(Val));
-    memcpy(&rsig, &right.Val, sizeof(right.Val));
-    result.Val = sigVal("* operator",
-                        sig.Length                   + rsig.Length,
-                        sig.Mass                     + rsig.Mass,
-                        sig.Time                     + rsig.Time,
-                        sig.ElectricCurrent          + rsig.ElectricCurrent,
-                        sig.ThermodynamicTemperature + rsig.ThermodynamicTemperature,
-                        sig.AmountOfSubstance        + rsig.AmountOfSubstance,
-                        sig.LuminousIntensity        + rsig.LuminousIntensity,
-                        sig.Angle                    + rsig.Angle);
-
-    return result;
-}
-
-Unit Unit::operator /(const Unit &right) const
-{
-    Unit result;
-    UnitSignature sig, rsig;
-
-    memcpy(&sig, &Val, sizeof(Val));
-    memcpy(&rsig, &right.Val, sizeof(right.Val));
-    result.Val = sigVal("/ operator",
-                        sig.Length                   - rsig.Length,
-                        sig.Mass                     - rsig.Mass,
-                        sig.Time                     - rsig.Time,
-                        sig.ElectricCurrent          - rsig.ElectricCurrent,
-                        sig.ThermodynamicTemperature - rsig.ThermodynamicTemperature,
-                        sig.AmountOfSubstance        - rsig.AmountOfSubstance,
-                        sig.LuminousIntensity        - rsig.LuminousIntensity,
-                        sig.Angle                    - rsig.Angle);
-
-    return result;
+    return vals;
 }
 
 std::string Unit::getString() const
 {
-    if (isEmpty()) {
-        return {};
+    auto buildSubStr = [&](auto index) {
+        const std::string unitStrString {valNames.at(index)};
+        const auto absol {abs(vals.at(index))};
+
+        return absol <= 1 ? unitStrString
+                          : fmt::format("{}^{}", unitStrString, std::to_string(absol));
+    };
+
+    auto buildStr = [&](auto indexes) {
+        std::vector<std::string> subStrings {};
+        std::transform(indexes.begin(), indexes.end(), std::back_inserter(subStrings), buildSubStr);
+
+        return format("{}", fmt::join(subStrings, "*"));
+    };
+
+    //------------------------------------------------------------------------------
+
+    auto [posValIndexes, negValIndexes] = nonZeroValsIndexes();
+    auto numeratorStr = buildStr(posValIndexes);
+    if (negValIndexes.empty()) {
+        return numeratorStr;
     }
 
-    std::stringstream ret;
-    UnitSignature sig;
-    memcpy(&sig, &Val, sizeof(Val));
+    auto denominatorStr = buildStr(negValIndexes);
 
-    if (sig.Length                   > 0 ||
-        sig.Mass                     > 0 ||
-        sig.Time                     > 0 ||
-        sig.ElectricCurrent          > 0 ||
-        sig.ThermodynamicTemperature > 0 ||
-        sig.AmountOfSubstance        > 0 ||
-        sig.LuminousIntensity        > 0 ||
-        sig.Angle                    > 0 ) {
+    return fmt::format("{}/{}",
+                       numeratorStr.empty() ? "1" : numeratorStr,
+                       negValIndexes.size() > 1 ? fmt::format("({})", denominatorStr)
+                                                : denominatorStr);
+}
 
-        bool mult = false;
-        if (sig.Length > 0) {
-            mult = true;
-            ret << "mm";
-            if (sig.Length > 1) {
-                ret << "^" << sig.Length;
-            }
+Unit Unit::root(const uint8_t num) const
+{
+    auto apply = [&](auto val) {
+        if (val % num != 0) {
+            throw UnitsMismatchError("unit values must be divisible by root");
         }
+        return static_cast<int8_t>(val / num);
+    };
 
-        if (sig.Mass > 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "kg";
-            if (sig.Mass > 1) {
-                ret << "^" << sig.Mass;
-            }
-        }
-
-        if (sig.Time > 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "s";
-            if (sig.Time > 1) {
-                ret << "^" << sig.Time;
-            }
-        }
-
-        if (sig.ElectricCurrent > 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "A";
-            if (sig.ElectricCurrent > 1) {
-                ret << "^" << sig.ElectricCurrent;
-            }
-        }
-
-        if (sig.ThermodynamicTemperature > 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "K";
-            if (sig.ThermodynamicTemperature > 1) {
-                ret << "^" << sig.ThermodynamicTemperature;
-            }
-        }
-
-        if (sig.AmountOfSubstance > 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "mol";
-            if (sig.AmountOfSubstance > 1) {
-                ret << "^" << sig.AmountOfSubstance;
-            }
-        }
-
-        if (sig.LuminousIntensity > 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "cd";
-            if (sig.LuminousIntensity > 1) {
-                ret << "^" << sig.LuminousIntensity;
-            }
-        }
-
-        if (sig.Angle > 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "deg";
-            if (sig.Angle > 1) {
-                ret << "^" << sig.Angle;
-            }
-        }
-    }
-    else {
-        ret << "1";
+    if (num < 1) {
+        throw UnitsMismatchError("root must be > 0");
     }
 
-    if (sig.Length                   < 0 ||
-        sig.Mass                     < 0 ||
-        sig.Time                     < 0 ||
-        sig.ElectricCurrent          < 0 ||
-        sig.ThermodynamicTemperature < 0 ||
-        sig.AmountOfSubstance        < 0 ||
-        sig.LuminousIntensity        < 0 ||
-        sig.Angle                    < 0 ) {
-        ret << "/";
+    std::array<int8_t, unitNumVals> res {};
+    std::transform(vals.begin(), vals.end(), res.begin(), apply);
 
-        int nnom = 0;
-        nnom += sig.Length                   < 0 ? 1 : 0;
-        nnom += sig.Mass                     < 0 ? 1 : 0;
-        nnom += sig.Time                     < 0 ? 1 : 0;
-        nnom += sig.ElectricCurrent          < 0 ? 1 : 0;
-        nnom += sig.ThermodynamicTemperature < 0 ? 1 : 0;
-        nnom += sig.AmountOfSubstance        < 0 ? 1 : 0;
-        nnom += sig.LuminousIntensity        < 0 ? 1 : 0;
-        nnom += sig.Angle                    < 0 ? 1 : 0;
+    return Unit {res};
+}
 
-        if (nnom > 1) {
-            ret << '(';
+int Unit::getLength() const
+{
+    return vals[0];
+}
+
+std::string Unit::representation() const
+{
+    auto inParen = format("Unit: {} ({})", getString(), fmt::join(vals, ","));
+    return name.empty() ? inParen : fmt::format("{} [{}]", inParen, name);
+}
+
+Unit Unit::pow(const double exp) const
+{
+    auto apply = [&](const auto val) {
+        const auto num {val * exp};
+        if (std::fabs(std::round(num) - num) >= std::numeric_limits<double>::epsilon()) {
+            throw UnitsMismatchError("pow() of unit not possible");
         }
 
-        bool mult = false;
-        if (sig.Length < 0) {
-            ret << "mm";
-            mult = true;
-            if (sig.Length < -1) {
-                ret << "^" << abs(sig.Length);
-            }
-        }
+        return static_cast<int>(val * exp);
+    };
 
-        if (sig.Mass < 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "kg";
-            if (sig.Mass < -1) {
-                ret << "^" << abs(sig.Mass);
-            }
-        }
+    UnitVals res {};
+    std::transform(vals.begin(), vals.end(), res.begin(), apply);
 
-        if (sig.Time < 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "s";
-            if (sig.Time < -1) {
-                ret << "^" << abs(sig.Time);
-            }
-        }
+    return Unit {res};
+}
 
-        if (sig.ElectricCurrent < 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "A";
-            if (sig.ElectricCurrent < -1) {
-                ret << "^" << abs(sig.ElectricCurrent);
-            }
-        }
+Unit Unit::operator*(const Unit& right) const
+{
+    auto add = [&](auto leftVal, auto rightVal) {
+        return leftVal + rightVal;
+    };
 
-        if (sig.ThermodynamicTemperature < 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "K";
-            if (sig.ThermodynamicTemperature < -1) {
-                ret << "^" << abs(sig.ThermodynamicTemperature);
-            }
-        }
+    UnitVals res {};
+    std::transform(vals.begin(), vals.end(), right.vals.begin(), res.begin(), add);
 
-        if (sig.AmountOfSubstance < 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "mol";
-            if (sig.AmountOfSubstance < -1) {
-                ret << "^" << abs(sig.AmountOfSubstance);
-            }
-        }
+    return Unit {res};
+}
 
-        if (sig.LuminousIntensity < 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "cd";
-            if (sig.LuminousIntensity < -1) {
-                ret << "^" << abs(sig.LuminousIntensity);
-            }
-        }
+Unit Unit::operator/(const Unit& right) const
+{
+    auto div = [&](auto leftVal, auto rightVal) mutable {
+        return leftVal - rightVal;
+    };
 
-        if (sig.Angle < 0) {
-            if (mult) {
-                ret << '*';
-            }
-            mult = true;
-            ret << "deg";
-            if (sig.Angle < -1) {
-                ret << "^" << abs(sig.Angle);
-            }
-        }
+    UnitVals res {};
+    std::transform(vals.begin(), vals.end(), right.vals.begin(), res.begin(), div);
 
-        if (nnom > 1) {
-            ret << ')';
-        }
-    }
-
-    return ret.str();
+    return Unit {res};
 }
 
 std::string Unit::getTypeString() const
 {
-    static std::array<std::pair<Unit, std::string>, 55> unitSpecs {{
-        { Unit::Acceleration, "Acceleration" },
-        { Unit::AmountOfSubstance, "AmountOfSubstance" },
-        { Unit::Angle, "Angle" },
-        { Unit::AngleOfFriction, "AngleOfFriction" },
-        { Unit::Area, "Area" },
-        { Unit::CurrentDensity, "CurrentDensity" },
-        { Unit::Density, "Density" },
-        { Unit::DissipationRate, "DissipationRate" },
-        { Unit::DynamicViscosity, "DynamicViscosity" },
-        { Unit::ElectricalCapacitance, "ElectricalCapacitance" },
-        { Unit::ElectricalConductance, "ElectricalConductance" },
-        { Unit::ElectricalConductivity, "ElectricalConductivity" },
-        { Unit::ElectricalInductance, "ElectricalInductance" },
-        { Unit::ElectricalResistance, "ElectricalResistance" },
-        { Unit::ElectricCharge, "ElectricCharge" },
-        { Unit::ElectricCurrent, "ElectricCurrent" },
-        { Unit::ElectricPotential, "ElectricPotential" },
-        { Unit::ElectromagneticPotential, "ElectromagneticPotential" },
-        { Unit::Frequency, "Frequency" },
-        { Unit::Force, "Force" },
-        { Unit::HeatFlux, "HeatFlux" },
-        { Unit::InverseArea, "InverseArea" },
-        { Unit::InverseLength, "InverseLength" },
-        { Unit::InverseVolume, "InverseVolume" },
-        { Unit::KinematicViscosity, "KinematicViscosity" },
-        { Unit::Length, "Length" },
-        { Unit::LuminousIntensity, "LuminousIntensity" },
-        { Unit::MagneticFieldStrength, "MagneticFieldStrength" },
-        { Unit::MagneticFlux, "MagneticFlux" },
-        { Unit::MagneticFluxDensity, "MagneticFluxDensity" },
-        { Unit::Magnetization, "Magnetization" },
-        { Unit::Mass, "Mass" },
-        { Unit::Pressure, "Pressure" },
-        { Unit::Power, "Power" },
-        { Unit::ShearModulus, "ShearModulus" },
-        { Unit::SpecificEnergy, "SpecificEnergy" },
-        { Unit::SpecificHeat, "SpecificHeat" },
-        { Unit::Stiffness, "Stiffness" },
-        { Unit::StiffnessDensity, "StiffnessDensity" },
-        { Unit::Stress, "Stress" },
-        { Unit::Temperature, "Temperature" },
-        { Unit::ThermalConductivity, "ThermalConductivity" },
-        { Unit::ThermalExpansionCoefficient, "ThermalExpansionCoefficient" },
-        { Unit::ThermalTransferCoefficient, "ThermalTransferCoefficient" },
-        { Unit::TimeSpan, "TimeSpan" },
-        { Unit::UltimateTensileStrength, "UltimateTensileStrength" },
-        { Unit::VacuumPermittivity, "VacuumPermittivity" },
-        { Unit::Velocity, "Velocity" },
-        { Unit::Volume, "Volume" },
-        { Unit::VolumeFlowRate, "VolumeFlowRate" },
-        { Unit::VolumetricThermalExpansionCoefficient, "VolumetricThermalExpansionCoefficient" },
-        { Unit::Work, "Work" },
-        { Unit::YieldStrength, "YieldStrength" },
-        { Unit::YoungsModulus, "YoungsModulus" },
-        { Unit::Moment, "Moment" },
-    }};
-
-    const auto spec =
-        std::find_if(unitSpecs.begin(), unitSpecs.end(), [&](const auto& pair) {
-            return pair.first == *this;
-        });
-
-    if (spec == std::end(unitSpecs))
-        return "";
-
-    return spec->second;
+    return std::string {name.data(), name.size()};
 }
 
-// SI base units
-const Unit Unit::AmountOfSubstance          (0, 0, 0, 0, 0, 1);
-const Unit Unit::ElectricCurrent            (0, 0, 0, 1);
-const Unit Unit::Length                     (1);
-const Unit Unit::LuminousIntensity          (0, 0, 0, 0, 0, 0, 1);
-const Unit Unit::Mass                       (0, 1);
-const Unit Unit::Temperature                (0, 0, 0, 0, 1);
-const Unit Unit::TimeSpan                   (0, 0, 1);
+std::pair<std::vector<size_t>, std::vector<size_t>> Unit::nonZeroValsIndexes() const
+{
+    std::vector<size_t> pos {};
+    std::vector<size_t> neg {};
 
-// all other units
-const Unit Unit::Acceleration               (1, 0, -2);
-const Unit Unit::Angle                      (0, 0, 0, 0, 0, 0, 0, 1);
-const Unit Unit::AngleOfFriction            (0, 0, 0, 0, 0, 0, 0, 1);
-const Unit Unit::Area                       (2);
-const Unit Unit::CompressiveStrength        (-1, 1, -2);
-const Unit Unit::CurrentDensity             (-2, 0, 0, 1);
-const Unit Unit::Density                    (-3, 1);
-const Unit Unit::DissipationRate   (2, 0, -3); // https://cfd-online.com/Wiki/Turbulence_dissipation_rate
-const Unit Unit::DynamicViscosity           (-1, 1, -1);
-const Unit Unit::ElectricalCapacitance      (-2, -1, 4, 2);
-const Unit Unit::ElectricalConductance      (-2, -1, 3, 2);
-const Unit Unit::ElectricalConductivity     (-3, -1, 3, 2);
-const Unit Unit::ElectricalInductance       (2, 1, -2, -2);
-const Unit Unit::ElectricalResistance       (2, 1, -3, -2);
-const Unit Unit::ElectricCharge             (0, 0, 1, 1);
-const Unit Unit::ElectricPotential          (2, 1, -3, -1);
-const Unit Unit::ElectromagneticPotential   (1, 1, -2, -1);
-const Unit Unit::Force                      (1, 1, -2);
-const Unit Unit::Frequency                  (0, 0, -1);
-const Unit Unit::HeatFlux                   (0, 1, -3, 0, 0);
-const Unit Unit::InverseArea                (-2, 0, 0);
-const Unit Unit::InverseLength              (-1, 0, 0);
-const Unit Unit::InverseVolume              (-3, 0, 0);
-const Unit Unit::KinematicViscosity         (2, 0, -1);
-const Unit Unit::MagneticFieldStrength      (-1,0,0,1);
-const Unit Unit::MagneticFlux               (2,1,-2,-1);
-const Unit Unit::MagneticFluxDensity        (0,1,-2,-1);
-const Unit Unit::Magnetization              (-1,0,0,1);
-const Unit Unit::Moment                     (2, 1, -2);
-const Unit Unit::Pressure                   (-1,1,-2);
-const Unit Unit::Power                      (2, 1, -3);
-const Unit Unit::ShearModulus               (-1,1,-2);
-const Unit Unit::SpecificEnergy             (2, 0, -2);
-const Unit Unit::SpecificHeat               (2, 0, -2, 0, -1);
-const Unit Unit::Stiffness                  (0, 1, -2);
-const Unit Unit::StiffnessDensity           (-2, 1, -2);
-const Unit Unit::Stress                     (-1,1,-2);
-const Unit Unit::ThermalConductivity        (1, 1, -3, 0, -1);
-const Unit Unit::ThermalExpansionCoefficient(0, 0, 0, 0, -1);
-const Unit Unit::ThermalTransferCoefficient (0, 1, -3, 0, -1);
-const Unit Unit::UltimateTensileStrength    (-1,1,-2);
-const Unit Unit::VacuumPermittivity         (-3, -1, 4,  2);
-const Unit Unit::Velocity                   (1, 0, -1);
-const Unit Unit::Volume                     (3);
-const Unit Unit::VolumeFlowRate             (3, 0, -1);
-const Unit Unit::VolumetricThermalExpansionCoefficient(0, 0, 0, 0, -1);
-const Unit Unit::Work                       (2, 1, -2);
-const Unit Unit::YieldStrength              (-1,1,-2);
-const Unit Unit::YoungsModulus              (-1,1,-2);
-// clang-format on
+    auto posNeg = [&, index {0}](auto val) mutable {
+        if (val != 0) {
+            (val > 0 ? pos : neg).push_back(index);
+        }
+        ++index;
+    };
+
+    std::for_each(vals.begin(), vals.end(), posNeg);
+
+    return {pos, neg};
+}

--- a/src/Base/Units.h
+++ b/src/Base/Units.h
@@ -1,0 +1,207 @@
+/***************************************************************************
+ *   Copyright (c) 2013 Jürgen Riegel <juergen.riegel@web.de>              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef UNITS_H
+#define UNITS_H
+
+#include <algorithm>
+#include <stdexcept>
+#include "Unit.h"
+
+namespace Base::Units
+{
+
+
+struct UnitSpec
+{
+    std::string_view name;
+    UnitVals vals;
+};
+
+constexpr auto numUnitSpecs {57};
+constexpr std::array<std::pair<std::string_view, UnitVals>, numUnitSpecs> unitSpecs {{
+    // clang-format off
+    //                                             Length
+    //                                             .   Mass
+    //                                             .   .   Time
+    //                                             .   .   .   ElectricCurrent
+    //                                             .   .   .   .   ThermodynamicTemperature
+    //                                             .   .   .   .   .   AmountOfSubstance
+    //                                             .   .   .   .   .   .   LuminousIntensity
+    //                                             .   .   .   .   .   .   .   Angle
+    { "NullUnit"                              , {  0,  0,  0,  0,  0,  0,  0,  0 } },
+    { "AmountOfSubstance"                     , {  0,  0,  0,  0,  0,  1         } },
+    { "ElectricCurrent"                       , {  0,  0,  0,  1                 } },
+    { "Length"                                , {  1                             } },
+    { "LuminousIntensity"                     , {  0,  0,  0,  0,  0,  0,  1     } },
+    { "Mass"                                  , {  0,  1                         } },
+    { "Temperature"                           , {  0,  0,  0,  0,  1             } },
+    { "TimeSpan"                              , {  0,  0,  1                     } },
+    { "Acceleration"                          , {  1,  0, -2                     } },
+    { "Angle"                                 , {  0,  0,  0,  0,  0,  0,  0,  1 } },
+    { "AngleOfFriction"                       , {  0,  0,  0,  0,  0,  0,  0,  1 } },
+    { "Area"                                  , {  2                             } },
+    { "CompressiveStrength"                   , { -1,  1, -2                     } },
+    { "CurrentDensity"                        , { -2,  0,  0,  1                 } },
+    { "Density"                               , { -3,  1                         } },
+    { "DissipationRate"                       , {  2,  0, -3                     } },
+    { "DynamicViscosity"                      , { -1,  1, -1                     } },
+    { "ElectricalCapacitance"                 , { -2, -1,  4,  2                 } },
+    { "ElectricalConductance"                 , { -2, -1,  3,  2                 } },
+    { "ElectricalConductivity"                , { -3, -1,  3,  2                 } },
+    { "ElectricalInductance"                  , {  2,  1, -2, -2                 } },
+    { "ElectricalResistance"                  , {  2,  1, -3, -2                 } },
+    { "ElectricCharge"                        , {  0,  0,  1,  1                 } },
+    { "ElectricPotential"                     , {  2,  1, -3, -1                 } },
+    { "ElectromagneticPotential"              , {  1,  1, -2, -1                 } },
+    { "Force"                                 , {  1,  1, -2                     } },
+    { "Frequency"                             , {  0,  0, -1                     } },
+    { "HeatFlux"                              , {  0,  1, -3                     } },
+    { "InverseArea"                           , { -2                             } },
+    { "InverseLength"                         , { -1                             } },
+    { "InverseVolume"                         , { -3                             } },
+    { "KinematicViscosity"                    , {  2,  0, -1                     } },
+    { "MagneticFieldStrength"                 , { -1,  0,  0,  1                 } },
+    { "MagneticFlux"                          , {  2,  1, -2, -1                 } },
+    { "MagneticFluxDensity"                   , {  0,  1, -2, -1                 } },
+    { "Magnetization"                         , { -1,  0,  0,  1                 } },
+    { "Moment"                                , {  2,  1, -2                     } },
+    { "Pressure"                              , { -1,  1, -2                     } },
+    { "Power"                                 , {  2,  1, -3                     } },
+    { "ShearModulus"                          , { -1,  1, -2                     } },
+    { "SpecificEnergy"                        , {  2,  0, -2                     } },
+    { "SpecificHeat"                          , {  2,  0, -2,  0, -1             } },
+    { "Stiffness"                             , {  0,  1, -2                     } },
+    { "StiffnessDensity"                      , { -2,  1, -2                     } },
+    { "Stress"                                , { -1,  1, -2                     } },
+    { "ThermalConductivity"                   , {  1,  1, -3,  0, -1             } },
+    { "ThermalExpansionCoefficient"           , {  0,  0,  0,  0, -1             } },
+    { "ThermalTransferCoefficient"            , {  0,  1, -3,  0, -1             } },
+    { "UltimateTensileStrength"               , { -1,  1, -2                     } },
+    { "VacuumPermittivity"                    , { -3, -1,  4,  2                 } },
+    { "Velocity"                              , {  1,  0, -1                     } },
+    { "Volume"                                , {  3                             } },
+    { "VolumeFlowRate"                        , {  3,  0, -1                     } },
+    { "VolumetricThermalExpansionCoefficient" , {  0,  0,  0,  0, -1             } },
+    { "Work"                                  , {  2,  1, -2                     } },
+    { "YieldStrength"                         , { -1,  1, -2                     } },
+    { "YoungsModulus"                         , { -1,  1, -2                     } },
+}};  // clang-format on
+
+constexpr Unit makeFromSpec(const std::pair<std::string_view, UnitVals>& unitSpec)
+{
+    return Unit {unitSpec.second, unitSpec.first};
+}
+
+constexpr Unit make(const std::string_view name = "NullUnit")
+{
+    for (const auto& spec : unitSpecs) {  // algorithms not constexpr until C++20
+        if (spec.first == name) {
+            return makeFromSpec(spec);
+        }
+    }
+    throw std::invalid_argument("Invalid unit name");
+}
+
+inline bool isUnitName(const std::string_view str)
+{
+    auto match = [&](const std::pair<std::string_view, UnitVals>& pair) {
+        return pair.first == str;
+    };
+
+    const auto found = std::find_if(unitSpecs.begin(), unitSpecs.end(), match);
+    return found != unitSpecs.end();
+}
+
+inline std::string getString(const UnitVals vals)
+{
+    auto match = [&](const std::pair<std::string_view, UnitVals>& pair) {
+        return pair.second == vals;
+    };
+
+    const auto found = std::find_if(unitSpecs.begin(), unitSpecs.end(), match);
+    return std::string(found == unitSpecs.end() ? "" : found->first);
+}
+
+// clang-format off
+constexpr Unit NullUnit                              = make("NullUnit"                    );
+constexpr Unit AmountOfSubstance                     = make("AmountOfSubstance"           );
+constexpr Unit ElectricCurrent                       = make("ElectricCurrent"             );
+constexpr Unit Length                                = make("Length"                      );
+constexpr Unit LuminousIntensity                     = make("LuminousIntensity"           );
+constexpr Unit Mass                                  = make("Mass"                        );
+constexpr Unit Temperature                           = make("Temperature"                 );
+constexpr Unit TimeSpan                              = make("TimeSpan"                    );
+constexpr Unit Acceleration                          = make("Acceleration"                );
+constexpr Unit Angle                                 = make("Angle"                       );
+constexpr Unit AngleOfFriction                       = make("Angle"                       );
+constexpr Unit Area                                  = make("Area"                        );
+constexpr Unit CompressiveStrength                   = make("CompressiveStrength"         );
+constexpr Unit CurrentDensity                        = make("CurrentDensity"              );
+constexpr Unit Density                               = make("Density"                     );
+constexpr Unit DissipationRate                       = make("DissipationRate"             );
+constexpr Unit DynamicViscosity                      = make("DynamicViscosity"            );
+constexpr Unit ElectricalCapacitance                 = make("ElectricalCapacitance"       );
+constexpr Unit ElectricalConductance                 = make("ElectricalConductance"       );
+constexpr Unit ElectricalConductivity                = make("ElectricalConductivity"      );
+constexpr Unit ElectricalInductance                  = make("ElectricalInductance"        );
+constexpr Unit ElectricalResistance                  = make("ElectricalResistance"        );
+constexpr Unit ElectricCharge                        = make("ElectricCharge"              );
+constexpr Unit ElectricPotential                     = make("ElectricPotential"           );
+constexpr Unit ElectromagneticPotential              = make("ElectromagneticPotential"    );
+constexpr Unit Force                                 = make("Force"                       );
+constexpr Unit Frequency                             = make("Frequency"                   );
+constexpr Unit HeatFlux                              = make("HeatFlux"                    );
+constexpr Unit InverseArea                           = make("InverseArea"                 );
+constexpr Unit InverseLength                         = make("InverseLength"               );
+constexpr Unit InverseVolume                         = make("InverseVolume"               );
+constexpr Unit KinematicViscosity                    = make("KinematicViscosity"          );
+constexpr Unit MagneticFieldStrength                 = make("Magnetization"               );
+constexpr Unit MagneticFlux                          = make("MagneticFlux"                );
+constexpr Unit MagneticFluxDensity                   = make("MagneticFluxDensity"         );
+constexpr Unit Magnetization                         = make("MagneticFieldStrength"       );
+constexpr Unit Moment                                = make("Moment"                      );
+constexpr Unit Pressure                              = make("Pressure"                    );
+constexpr Unit Power                                 = make("Power"                       );
+constexpr Unit ShearModulus                          = make("Pressure"                    );
+constexpr Unit SpecificEnergy                        = make("SpecificEnergy"              );
+constexpr Unit SpecificHeat                          = make("SpecificHeat"                );
+constexpr Unit Stiffness                             = make("Stiffness"                   );
+constexpr Unit StiffnessDensity                      = make("StiffnessDensity"            );
+constexpr Unit Stress                                = make("Pressure"                    );
+constexpr Unit ThermalConductivity                   = make("ThermalConductivity"         );
+constexpr Unit ThermalExpansionCoefficient           = make("ThermalExpansionCoefficient" );
+constexpr Unit ThermalTransferCoefficient            = make("ThermalTransferCoefficient"  );
+constexpr Unit UltimateTensileStrength               = make("Pressure"                    );
+constexpr Unit VacuumPermittivity                    = make("VacuumPermittivity"          );
+constexpr Unit Velocity                              = make("Velocity"                    );
+constexpr Unit Volume                                = make("Volume"                      );
+constexpr Unit VolumeFlowRate                        = make("VolumeFlowRate"              );
+constexpr Unit VolumetricThermalExpansionCoefficient = make("ThermalExpansionCoefficient" );
+constexpr Unit Work                                  = make("Work"                        );
+constexpr Unit YieldStrength                         = make("Pressure"                    );
+constexpr Unit YoungsModulus                         = make("Pressure"                    );
+// clang-format on
+
+
+}  // namespace Base::Units
+#endif  // UNITS_H

--- a/src/Base/UnitsApi.h
+++ b/src/Base/UnitsApi.h
@@ -29,6 +29,7 @@
 #include <QCoreApplication>
 #include "UnitsSchema.h"
 #include "Quantity.h"
+#include "Base/Units.h"
 
 using PyObject = struct _object;
 using PyMethodDef = struct PyMethodDef;
@@ -91,9 +92,9 @@ public:
                                 const QuantityFormat& f = QuantityFormat(QuantityFormat::Default));
 
     /// generate a value for a quantity with default user preferred system
-    static double toDouble(PyObject* args, const Base::Unit& u = Base::Unit());
+    static double toDouble(PyObject* args, const Base::Unit& u = Units::NullUnit);
     /// generate a value for a quantity with default user preferred system
-    static Quantity toQuantity(PyObject* args, const Base::Unit& u = Base::Unit());
+    static Quantity toQuantity(PyObject* args, const Base::Unit& u = Base::Units::NullUnit);
 
     // set the number of decimals
     static void setDecimals(int);

--- a/src/Base/UnitsSchemaCentimeters.cpp
+++ b/src/Base/UnitsSchemaCentimeters.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include "UnitsSchemaCentimeters.h"
+#include "Units.h"
 
 using namespace Base;
 
@@ -37,13 +38,13 @@ std::string UnitsSchemaCentimeters::schemaTranslate(const Base::Quantity& quant,
                                                     std::string& unitString)
 {
     static std::array<std::pair<Unit, std::pair<std::string, double>>, 7> unitSpecs {{
-        {Unit::Length, {"cm", 10.0}},
-        {Unit::Area, {"m^2", 1000000.0}},
-        {Unit::Volume, {"m^3", 1000000000.0}},
-        {Unit::Power, {"W", 1000000.0}},
-        {Unit::ElectricPotential, {"V", 1000000.0}},
-        {Unit::HeatFlux, {"W/m^2", 1.0}},
-        {Unit::Velocity, {"mm/min", 1.0 / 60}},
+        {Units::Length, {"cm", 10.0}},
+        {Units::Area, {"m^2", 1000000.0}},
+        {Units::Volume, {"m^3", 1000000000.0}},
+        {Units::Power, {"W", 1000000.0}},
+        {Units::ElectricPotential, {"V", 1000000.0}},
+        {Units::HeatFlux, {"W/m^2", 1.0}},
+        {Units::Velocity, {"mm/min", 1.0 / 60}},
     }};
 
     const auto unit = quant.getUnit();

--- a/src/Base/UnitsSchemaFemMilliMeterNewton.cpp
+++ b/src/Base/UnitsSchemaFemMilliMeterNewton.cpp
@@ -30,6 +30,7 @@
 #endif
 
 #include "UnitsSchemaFemMilliMeterNewton.h"
+#include "Units.h"
 
 using namespace Base;
 
@@ -38,8 +39,8 @@ std::string UnitsSchemaFemMilliMeterNewton::schemaTranslate(const Quantity& quan
                                                             std::string& unitString)
 {
     static std::array<std::pair<Unit, std::pair<std::string, double>>, 2> unitSpecs {{
-        {Unit::Length, {"mm", 1.0}},
-        {Unit::Mass, {"t", 1e3}},
+        {Units::Length, {"mm", 1.0}},
+        {Units::Mass, {"t", 1e3}},
     }};
 
     const auto unit = quant.getUnit();

--- a/src/Base/UnitsSchemaImperial1.cpp
+++ b/src/Base/UnitsSchemaImperial1.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include "UnitsSchemaImperial1.h"
+#include "Units.h"
 
 using namespace Base;
 
@@ -44,7 +45,7 @@ std::string UnitsSchemaImperial1::schemaTranslate(const Quantity& quant,
     // mm/kg/s. And all combined units have to be calculated from there!
 
     // now do special treatment on all cases seems necessary:
-    if (unit == Unit::Length) {        // Length handling ============================
+    if (unit == Units::Length) {       // Length handling ============================
         if (UnitValue < 0.00000254) {  // smaller then 0.001 thou -> inch and scientific notation
             unitString = "in";
             factor = 25.4;
@@ -74,29 +75,29 @@ std::string UnitsSchemaImperial1::schemaTranslate(const Quantity& quant,
             factor = 25.4;
         }
     }
-    else if (unit == Unit::Angle) {
+    else if (unit == Units::Angle) {
         unitString = "\xC2\xB0";
         factor = 1.0;
     }
-    else if (unit == Unit::Area) {
+    else if (unit == Units::Area) {
         // TODO: Cascade for the Areas
         // default action for all cases without special treatment:
         unitString = "in^2";
         factor = 645.16;
     }
-    else if (unit == Unit::Volume) {
+    else if (unit == Units::Volume) {
         // TODO: Cascade for the Volume
         // default action for all cases without special treatment:
         unitString = "in^3";
         factor = 16387.064;
     }
-    else if (unit == Unit::Mass) {
+    else if (unit == Units::Mass) {
         // TODO: Cascade for the weights
         // default action for all cases without special treatment:
         unitString = "lb";
         factor = 0.45359237;
     }
-    else if (unit == Unit::Pressure) {
+    else if (unit == Units::Pressure) {
         if (UnitValue < 6894.744) {  // psi is the smallest
             unitString = "psi";
             factor = 6.894744825494;
@@ -110,11 +111,11 @@ std::string UnitsSchemaImperial1::schemaTranslate(const Quantity& quant,
             factor = 6.894744825494;
         }
     }
-    else if (unit == Unit::Stiffness) {  // Conversion to lbf/in
+    else if (unit == Units::Stiffness) {  // Conversion to lbf/in
         unitString = "lbf/in";
         factor = 4.448222 / 0.0254;
     }
-    else if (unit == Unit::Velocity) {
+    else if (unit == Units::Velocity) {
         unitString = "in/min";
         factor = 25.4 / 60;
     }
@@ -136,45 +137,45 @@ std::string UnitsSchemaImperialDecimal::schemaTranslate(const Base::Quantity& qu
     // mm/kg/s. And all combined units have to be calculated from there!
 
     // now do special treatment on all cases seems necessary:
-    if (unit == Unit::Length) {  // Length handling ============================
+    if (unit == Units::Length) {  // Length handling ============================
         unitString = "in";
         factor = 25.4;
     }
-    else if (unit == Unit::Angle) {
+    else if (unit == Units::Angle) {
         unitString = "\xC2\xB0";
         factor = 1.0;
     }
-    else if (unit == Unit::Area) {
+    else if (unit == Units::Area) {
         // TODO: Cascade for the Areas
         // default action for all cases without special treatment:
         unitString = "in^2";
         factor = 645.16;
     }
-    else if (unit == Unit::Volume) {
+    else if (unit == Units::Volume) {
         // TODO: Cascade for the Volume
         // default action for all cases without special treatment:
         unitString = "in^3";
         factor = 16387.064;
     }
-    else if (unit == Unit::Mass) {
+    else if (unit == Units::Mass) {
         // TODO: Cascade for the weights
         // default action for all cases without special treatment:
         unitString = "lb";
         factor = 0.45359237;
     }
-    else if (unit == Unit::Pressure) {
+    else if (unit == Units::Pressure) {
         unitString = "psi";
         factor = 6.894744825494;
     }
-    else if (unit == Unit::Stiffness) {
+    else if (unit == Units::Stiffness) {
         unitString = "lbf/in";
         factor = 4.448222 / 0.0254;
     }
-    else if (unit == Unit::Velocity) {
+    else if (unit == Units::Velocity) {
         unitString = "in/min";
         factor = 25.4 / 60;
     }
-    else if (unit == Unit::Acceleration) {
+    else if (unit == Units::Acceleration) {
         unitString = "in/min^2";
         factor = 25.4 / 3600;
     }
@@ -194,7 +195,7 @@ std::string UnitsSchemaImperialBuilding::schemaTranslate(const Quantity& quant,
     // this schema expresses distances in feet + inches + fractions
     // ex: 3'- 4 1/4" with proper rounding
     Unit unit = quant.getUnit();
-    if (unit == Unit::Length) {
+    if (unit == Units::Length) {
         unitString = "in";
         factor = 25.4;
 
@@ -291,19 +292,19 @@ std::string UnitsSchemaImperialBuilding::schemaTranslate(const Quantity& quant,
         // Done!
         return output.str();
     }
-    else if (unit == Unit::Angle) {
+    else if (unit == Units::Angle) {
         unitString = "\xC2\xB0";
         factor = 1.0;
     }
-    else if (unit == Unit::Area) {
+    else if (unit == Units::Area) {
         unitString = "sqft";
         factor = 92903.04;
     }
-    else if (unit == Unit::Volume) {
+    else if (unit == Units::Volume) {
         unitString = "cft";
         factor = 28316846.592;
     }
-    else if (unit == Unit::Velocity) {
+    else if (unit == Units::Velocity) {
         unitString = "in/min";
         factor = 25.4 / 60;
     }
@@ -324,36 +325,36 @@ std::string UnitsSchemaImperialCivil::schemaTranslate(const Base::Quantity& quan
     // mm/kg/s. And all combined units have to be calculated from there!
 
     // now do special treatment on all cases seems necessary:
-    if (unit == Unit::Length) {  // Length handling ============================
-        unitString = "ft";       // always ft
-        factor = 304.8;          // 12 * 25.4
+    if (unit == Units::Length) {  // Length handling ============================
+        unitString = "ft";        // always ft
+        factor = 304.8;           // 12 * 25.4
     }
-    else if (unit == Unit::Area) {
+    else if (unit == Units::Area) {
         unitString = "ft^2";  // always sq.ft
         factor = 92903.04;
     }
-    else if (unit == Unit::Volume) {
+    else if (unit == Units::Volume) {
         unitString = "ft^3";  // always cu. ft
         factor = 28316846.592;
     }
-    else if (unit == Unit::Mass) {
+    else if (unit == Units::Mass) {
         unitString = "lb";  // always lbs.
         factor = 0.45359237;
     }
-    else if (unit == Unit::Pressure) {
+    else if (unit == Units::Pressure) {
         unitString = "psi";
         factor = 6.894744825494;
     }
-    else if (unit == Unit::Stiffness) {
+    else if (unit == Units::Stiffness) {
         unitString = "lbf/in";
         factor = 4.448222 / 0.0254;
     }
-    else if (unit == Unit::Velocity) {
+    else if (unit == Units::Velocity) {
         unitString = "mph";
         factor = 447.04;  // 1mm/sec => mph
     }
     // this schema expresses angles in degrees + minutes + seconds
-    else if (unit == Unit::Angle) {
+    else if (unit == Units::Angle) {
         unitString = "deg";
         std::string degreeString = "\xC2\xB0";      // degree symbol
         std::string minuteString = "\xE2\x80\xB2";  // prime symbol

--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include "UnitsSchemaInternal.h"
+#include "Units.h"
 #include <cmath>
 
 using namespace Base;
@@ -46,8 +47,8 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
     // = 10e6 * kg*mm/s^3/K
 
     // now do special treatment on all cases seems necessary:
-    if (unit == Unit::Length) {  // Length handling ============================
-        if (UnitValue < 1e-6) {  // smaller than 0.001 nm -> scientific notation
+    if (unit == Units::Length) {  // Length handling ============================
+        if (UnitValue < 1e-6) {   // smaller than 0.001 nm -> scientific notation
             unitString = "mm";
             factor = 1.0;
         }
@@ -76,7 +77,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e3;
         }
     }
-    else if (unit == Unit::Area) {
+    else if (unit == Units::Area) {
         if (UnitValue < 100) {
             unitString = "mm^2";
             factor = 1.0;
@@ -94,7 +95,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e12;
         }
     }
-    else if (unit == Unit::Volume) {
+    else if (unit == Units::Volume) {
         if (UnitValue < 1e3) {  // smaller than 1 ul
             unitString = "mm^3";
             factor = 1.0;
@@ -112,13 +113,13 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e9;
         }
     }
-    else if (unit == Unit::Angle) {
+    else if (unit == Units::Angle) {
         // TODO: Cascade for the Areas
         // default action for all cases without special treatment:
         unitString = "\xC2\xB0";
         factor = 1.0;
     }
-    else if (unit == Unit::Mass) {
+    else if (unit == Units::Mass) {
         if (UnitValue < 1e-6) {
             unitString = "\xC2\xB5g";
             factor = 1e-9;
@@ -140,7 +141,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e3;
         }
     }
-    else if (unit == Unit::Density) {
+    else if (unit == Units::Density) {
         if (UnitValue < 0.0001) {
             unitString = "kg/m^3";
             factor = 1e-9;
@@ -154,7 +155,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1.0;
         }
     }
-    else if (unit == Unit::ThermalConductivity) {
+    else if (unit == Units::ThermalConductivity) {
         if (UnitValue > 1e6) {
             unitString = "W/mm/K";
             factor = 1e6;
@@ -164,7 +165,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1000.0;
         }
     }
-    else if (unit == Unit::ThermalExpansionCoefficient) {
+    else if (unit == Units::ThermalExpansionCoefficient) {
         if (UnitValue < 0.001) {
             unitString = "\xC2\xB5m/m/K";  // micro-meter/meter/K
             factor = 1e-6;
@@ -174,7 +175,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1.0;
         }
     }
-    else if (unit == Unit::VolumetricThermalExpansionCoefficient) {
+    else if (unit == Units::VolumetricThermalExpansionCoefficient) {
         if (UnitValue < 0.001) {
             unitString = "mm^3/m^3/K";
             factor = 1e-9;
@@ -184,15 +185,15 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1.0;
         }
     }
-    else if (unit == Unit::SpecificHeat) {
+    else if (unit == Units::SpecificHeat) {
         unitString = "J/kg/K";
         factor = 1e6;
     }
-    else if (unit == Unit::ThermalTransferCoefficient) {
+    else if (unit == Units::ThermalTransferCoefficient) {
         unitString = "W/m^2/K";
         factor = 1.0;
     }
-    else if ((unit == Unit::Pressure) || (unit == Unit::Stress)) {
+    else if ((unit == Units::Pressure) || (unit == Units::Stress)) {
         if (UnitValue < 10.0) {  // Pa is the smallest
             unitString = "Pa";
             factor = 0.001;
@@ -214,7 +215,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 0.001;
         }
     }
-    else if ((unit == Unit::Stiffness)) {
+    else if ((unit == Units::Stiffness)) {
         if (UnitValue < 1) {  // mN/m is the smallest
             unitString = "mN/m";
             factor = 1e-3;
@@ -232,7 +233,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e6;
         }
     }
-    else if ((unit == Unit::StiffnessDensity)) {
+    else if ((unit == Units::StiffnessDensity)) {
         if (UnitValue < 1e-3) {
             unitString = "Pa/m";
             factor = 1e-6;
@@ -250,7 +251,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e3;
         }
     }
-    else if (unit == Unit::Force) {
+    else if (unit == Units::Force) {
         if (UnitValue < 1e3) {
             unitString = "mN";
             factor = 1.0;
@@ -268,7 +269,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e9;
         }
     }
-    //    else if (unit == Unit::Moment) {
+    //    else if (unit == Units::Moment) {
     //        if (UnitValue < 1e6) {
     //            unitString = "mNm";
     //            factor = 1e3;
@@ -286,7 +287,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
     //            factor = 1e12;
     //        }
     //    }
-    else if (unit == Unit::Power) {
+    else if (unit == Units::Power) {
         if (UnitValue < 1e6) {
             unitString = "mW";
             factor = 1e3;
@@ -300,7 +301,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e9;
         }
     }
-    else if (unit == Unit::ElectricPotential) {
+    else if (unit == Units::ElectricPotential) {
         if (UnitValue < 1e6) {
             unitString = "mV";
             factor = 1e3;
@@ -318,7 +319,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e6;
         }
     }
-    else if (unit == Unit::Work) {
+    else if (unit == Units::Work) {
         if (UnitValue < 1.602176634e-10) {
             unitString = "eV";
             factor = 1.602176634e-13;
@@ -352,19 +353,19 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e6;
         }
     }
-    else if (unit == Unit::SpecificEnergy) {
+    else if (unit == Units::SpecificEnergy) {
         unitString = "m^2/s^2";
         factor = 1e6;
     }
-    else if (unit == Unit::HeatFlux) {
+    else if (unit == Units::HeatFlux) {
         unitString = "W/m^2";
         factor = 1;  //  unit signature (0,1,-3,0,0) is length independent
     }
-    else if (unit == Unit::ElectricCharge) {
+    else if (unit == Units::ElectricCharge) {
         unitString = "C";
         factor = 1.0;
     }
-    else if (unit == Unit::CurrentDensity) {
+    else if (unit == Units::CurrentDensity) {
         if (UnitValue <= 1e3) {
             unitString = "A/m^2";
             factor = 1e-6;
@@ -374,7 +375,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1;
         }
     }
-    else if (unit == Unit::MagneticFluxDensity) {
+    else if (unit == Units::MagneticFluxDensity) {
         if (UnitValue <= 1e-3) {
             unitString = "G";
             factor = 1e-4;
@@ -384,23 +385,23 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1.0;
         }
     }
-    else if (unit == Unit::MagneticFieldStrength) {
+    else if (unit == Units::MagneticFieldStrength) {
         unitString = "A/m";
         factor = 1e-3;
     }
-    else if (unit == Unit::MagneticFlux) {
+    else if (unit == Units::MagneticFlux) {
         unitString = "Wb";
         factor = 1e6;
     }
-    else if (unit == Unit::Magnetization) {
+    else if (unit == Units::Magnetization) {
         unitString = "A/m";
         factor = 1e-3;
     }
-    else if (unit == Unit::ElectromagneticPotential) {
+    else if (unit == Units::ElectromagneticPotential) {
         unitString = "Wb/m";
         factor = 1e3;
     }
-    else if (unit == Unit::ElectricalConductance) {
+    else if (unit == Units::ElectricalConductance) {
         if (UnitValue < 1e-9) {
             unitString = "\xC2\xB5S";
             factor = 1e-12;
@@ -414,7 +415,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e-6;
         }
     }
-    else if (unit == Unit::ElectricalResistance) {
+    else if (unit == Units::ElectricalResistance) {
         if (UnitValue < 1e9) {
             unitString = "Ohm";
             factor = 1e6;
@@ -428,7 +429,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e12;
         }
     }
-    else if (unit == Unit::ElectricalConductivity) {
+    else if (unit == Units::ElectricalConductivity) {
         if (UnitValue < 1e-3) {
             unitString = "mS/m";
             factor = 1e-12;
@@ -446,7 +447,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e-3;
         }
     }
-    else if (unit == Unit::ElectricalCapacitance) {
+    else if (unit == Units::ElectricalCapacitance) {
         if (UnitValue < 1e-15) {
             unitString = "pF";
             factor = 1e-18;
@@ -470,7 +471,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e-6;
         }
     }
-    else if (unit == Unit::ElectricalInductance) {
+    else if (unit == Units::ElectricalInductance) {
         if (UnitValue < 1.0) {
             unitString = "nH";
             factor = 1e-3;
@@ -488,11 +489,11 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e6;
         }
     }
-    else if (unit == Unit::VacuumPermittivity) {
+    else if (unit == Units::VacuumPermittivity) {
         unitString = "F/m";
         factor = 1e-9;
     }
-    else if (unit == Unit::Frequency) {
+    else if (unit == Units::Frequency) {
         if (UnitValue < 1e3) {
             unitString = "Hz";
             factor = 1.0;
@@ -514,15 +515,15 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e12;
         }
     }
-    else if (unit == Unit::Velocity) {
+    else if (unit == Units::Velocity) {
         unitString = "mm/s";
         factor = 1.0;
     }
-    else if (unit == Unit::DynamicViscosity) {
+    else if (unit == Units::DynamicViscosity) {
         unitString = "Pa*s";
         factor = 0.001;
     }
-    else if (unit == Unit::KinematicViscosity) {
+    else if (unit == Units::KinematicViscosity) {
         if (UnitValue < 1e3) {
             unitString = "mm^2/s";
             factor = 1.0;
@@ -532,7 +533,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e6;
         }
     }
-    else if (unit == Unit::VolumeFlowRate) {
+    else if (unit == Units::VolumeFlowRate) {
         if (UnitValue < 1e3) {
             unitString = "mm^3/s";
             factor = 1.0;
@@ -550,11 +551,11 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e9;
         }
     }
-    else if (unit == Unit::DissipationRate) {
+    else if (unit == Units::DissipationRate) {
         unitString = "W/kg";
         factor = 1e6;
     }
-    else if (unit == Unit::InverseLength) {
+    else if (unit == Units::InverseLength) {
         if (UnitValue < 1e-6) {  // smaller than 0.001 1/km -> scientific notation
             unitString = "1/m";
             factor = 1e-3;
@@ -584,7 +585,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1e-3;
         }
     }
-    else if (unit == Unit::InverseArea) {
+    else if (unit == Units::InverseArea) {
         if (UnitValue < 1e-12) {  // smaller than 0.001 1/km^2 -> scientific notation
             unitString = "1/m^2";
             factor = 1e-6;
@@ -606,7 +607,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std:
             factor = 1.0;
         }
     }
-    else if (unit == Unit::InverseVolume) {
+    else if (unit == Units::InverseVolume) {
         if (UnitValue < 1e-6) {
             unitString = "1/m^3";
             factor = 1e-9;

--- a/src/Base/UnitsSchemaMKS.cpp
+++ b/src/Base/UnitsSchemaMKS.cpp
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #endif
 
+#include "Units.h"
 #include "UnitsSchemaMKS.h"
 #include <cmath>
 
@@ -38,8 +39,8 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
     Unit unit = quant.getUnit();
 
     // now do special treatment on all cases seems necessary:
-    if (unit == Unit::Length) {  // Length handling ============================
-        if (UnitValue < 1e-6) {  // smaller than 0.001 nm -> scientific notation
+    if (unit == Units::Length) {  // Length handling ============================
+        if (UnitValue < 1e-6) {   // smaller than 0.001 nm -> scientific notation
             unitString = "mm";
             factor = 1.0;
         }
@@ -68,7 +69,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e3;
         }
     }
-    else if (unit == Unit::Area) {
+    else if (unit == Units::Area) {
         if (UnitValue < 100) {
             unitString = "mm^2";
             factor = 1.0;
@@ -86,7 +87,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e12;
         }
     }
-    else if (unit == Unit::Volume) {
+    else if (unit == Units::Volume) {
         if (UnitValue < 1e3) {  // smaller than 1 ul
             unitString = "mm^3";
             factor = 1.0;
@@ -104,7 +105,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e9;
         }
     }
-    else if (unit == Unit::Mass) {
+    else if (unit == Units::Mass) {
         if (UnitValue < 1e-6) {
             unitString = "\xC2\xB5g";
             factor = 1e-9;
@@ -126,7 +127,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e3;
         }
     }
-    else if (unit == Unit::Density) {
+    else if (unit == Units::Density) {
         if (UnitValue < 0.0001) {
             unitString = "kg/m^3";
             factor = 0.000000001;
@@ -140,11 +141,11 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1.0;
         }
     }
-    else if (unit == Unit::Acceleration) {
+    else if (unit == Units::Acceleration) {
         unitString = "m/s^2";
         factor = 1000.0;
     }
-    else if ((unit == Unit::Pressure) || (unit == Unit::Stress)) {
+    else if ((unit == Units::Pressure) || (unit == Units::Stress)) {
         if (UnitValue < 10.0) {  // Pa is the smallest
             unitString = "Pa";
             factor = 0.001;
@@ -166,7 +167,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 0.001;
         }
     }
-    else if ((unit == Unit::Stiffness)) {
+    else if ((unit == Units::Stiffness)) {
         if (UnitValue < 1) {  // mN/m is the smallest
             unitString = "mN/m";
             factor = 1e-3;
@@ -184,7 +185,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e6;
         }
     }
-    else if ((unit == Unit::StiffnessDensity)) {
+    else if ((unit == Units::StiffnessDensity)) {
         if (UnitValue < 1e-3) {
             unitString = "Pa/m";
             factor = 1e-6;
@@ -202,7 +203,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e3;
         }
     }
-    else if (unit == Unit::ThermalConductivity) {
+    else if (unit == Units::ThermalConductivity) {
         if (UnitValue > 1000000) {
             unitString = "W/mm/K";
             factor = 1000000.0;
@@ -212,7 +213,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1000.0;
         }
     }
-    else if (unit == Unit::ThermalExpansionCoefficient) {
+    else if (unit == Units::ThermalExpansionCoefficient) {
         if (UnitValue < 0.001) {
             unitString = "\xC2\xB5m/m/K";
             factor = 0.000001;
@@ -222,7 +223,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1.0;
         }
     }
-    else if (unit == Unit::VolumetricThermalExpansionCoefficient) {
+    else if (unit == Units::VolumetricThermalExpansionCoefficient) {
         if (UnitValue < 0.001) {
             unitString = "mm^3/m^3/K";
             factor = 1e-9;
@@ -232,15 +233,15 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1.0;
         }
     }
-    else if (unit == Unit::SpecificHeat) {
+    else if (unit == Units::SpecificHeat) {
         unitString = "J/kg/K";
         factor = 1000000.0;
     }
-    else if (unit == Unit::ThermalTransferCoefficient) {
+    else if (unit == Units::ThermalTransferCoefficient) {
         unitString = "W/m^2/K";
         factor = 1.0;
     }
-    else if (unit == Unit::Force) {
+    else if (unit == Units::Force) {
         if (UnitValue < 1e3) {
             unitString = "mN";
             factor = 1.0;
@@ -258,7 +259,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e9;
         }
     }
-    //    else if (unit == Unit::Moment) {
+    //    else if (unit == Units::Moment) {
     //        if (UnitValue < 1e6) {
     //            unitString = "mNm";
     //            factor = 1e3;
@@ -276,7 +277,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
     //            factor = 1e12;
     //        }
     //    }
-    else if (unit == Unit::Power) {
+    else if (unit == Units::Power) {
         if (UnitValue < 1e6) {
             unitString = "mW";
             factor = 1e3;
@@ -290,7 +291,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e9;
         }
     }
-    else if (unit == Unit::ElectricPotential) {
+    else if (unit == Units::ElectricPotential) {
         if (UnitValue < 1e6) {
             unitString = "mV";
             factor = 1e3;
@@ -308,11 +309,11 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e6;
         }
     }
-    else if (unit == Unit::ElectricCharge) {
+    else if (unit == Units::ElectricCharge) {
         unitString = "C";
         factor = 1.0;
     }
-    else if (unit == Unit::CurrentDensity) {
+    else if (unit == Units::CurrentDensity) {
         if (UnitValue <= 1e3) {
             unitString = "A/m^2";
             factor = 1e-6;
@@ -322,7 +323,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1;
         }
     }
-    else if (unit == Unit::MagneticFluxDensity) {
+    else if (unit == Units::MagneticFluxDensity) {
         if (UnitValue <= 1e-3) {
             unitString = "G";
             factor = 1e-4;
@@ -332,23 +333,23 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1.0;
         }
     }
-    else if (unit == Unit::MagneticFieldStrength) {
+    else if (unit == Units::MagneticFieldStrength) {
         unitString = "A/m";
         factor = 1e-3;
     }
-    else if (unit == Unit::MagneticFlux) {
+    else if (unit == Units::MagneticFlux) {
         unitString = "Wb";
         factor = 1e6;
     }
-    else if (unit == Unit::Magnetization) {
+    else if (unit == Units::Magnetization) {
         unitString = "A/m";
         factor = 1e-3;
     }
-    else if (unit == Unit::ElectromagneticPotential) {
+    else if (unit == Units::ElectromagneticPotential) {
         unitString = "Wb/m";
         factor = 1e3;
     }
-    else if (unit == Unit::ElectricalConductance) {
+    else if (unit == Units::ElectricalConductance) {
         if (UnitValue < 1e-9) {
             unitString = "\xC2\xB5S";
             factor = 1e-12;
@@ -362,7 +363,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e-6;
         }
     }
-    else if (unit == Unit::ElectricalResistance) {
+    else if (unit == Units::ElectricalResistance) {
         if (UnitValue < 1e9) {
             unitString = "Ohm";
             factor = 1e6;
@@ -376,7 +377,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e12;
         }
     }
-    else if (unit == Unit::ElectricalConductivity) {
+    else if (unit == Units::ElectricalConductivity) {
         if (UnitValue < 1e-3) {
             unitString = "mS/m";
             factor = 1e-12;
@@ -394,7 +395,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e-3;
         }
     }
-    else if (unit == Unit::ElectricalCapacitance) {
+    else if (unit == Units::ElectricalCapacitance) {
         if (UnitValue < 1e-15) {
             unitString = "pF";
             factor = 1e-18;
@@ -418,7 +419,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e-6;
         }
     }
-    else if (unit == Unit::ElectricalInductance) {
+    else if (unit == Units::ElectricalInductance) {
         if (UnitValue < 1e-6) {
             unitString = "nH";
             factor = 1e-3;
@@ -436,11 +437,11 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e6;
         }
     }
-    else if (unit == Unit::VacuumPermittivity) {
+    else if (unit == Units::VacuumPermittivity) {
         unitString = "F/m";
         factor = 1e-9;
     }
-    else if (unit == Unit::Work) {
+    else if (unit == Units::Work) {
         if (UnitValue < 1.602176634e-10) {
             unitString = "eV";
             factor = 1.602176634e-13;
@@ -474,15 +475,15 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e6;
         }
     }
-    else if (unit == Unit::SpecificEnergy) {
+    else if (unit == Units::SpecificEnergy) {
         unitString = "m^2/s^2";
         factor = 1000000;
     }
-    else if (unit == Unit::HeatFlux) {
+    else if (unit == Units::HeatFlux) {
         unitString = "W/m^2";
         factor = 1.0;
     }
-    else if (unit == Unit::Frequency) {
+    else if (unit == Units::Frequency) {
         if (UnitValue < 1e3) {
             unitString = "Hz";
             factor = 1.0;
@@ -504,19 +505,19 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e12;
         }
     }
-    else if (unit == Unit::Velocity) {
+    else if (unit == Units::Velocity) {
         unitString = "m/s";
         factor = 1000.0;
     }
-    else if (unit == Unit::DynamicViscosity) {
+    else if (unit == Units::DynamicViscosity) {
         unitString = "Pa*s";
         factor = 0.001;
     }
-    else if (unit == Unit::KinematicViscosity) {
+    else if (unit == Units::KinematicViscosity) {
         unitString = "m^2/s";
         factor = 1e6;
     }
-    else if (unit == Unit::VolumeFlowRate) {
+    else if (unit == Units::VolumeFlowRate) {
         if (UnitValue < 1e-3) {  // smaller than 0.001 mm^3/s -> scientific notation
             unitString = "m^3/s";
             factor = 1e9;
@@ -538,11 +539,11 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e9;
         }
     }
-    else if (unit == Unit::DissipationRate) {
+    else if (unit == Units::DissipationRate) {
         unitString = "W/kg";
         factor = 1e6;
     }
-    else if (unit == Unit::InverseLength) {
+    else if (unit == Units::InverseLength) {
         if (UnitValue < 1e-6) {  // smaller than 0.001 1/km -> scientific notation
             unitString = "1/m";
             factor = 1e-3;
@@ -572,7 +573,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1e-3;
         }
     }
-    else if (unit == Unit::InverseArea) {
+    else if (unit == Units::InverseArea) {
         if (UnitValue < 1e-12) {  // smaller than 0.001 1/km^2 -> scientific notation
             unitString = "1/m^2";
             factor = 1e-6;
@@ -594,7 +595,7 @@ UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::stri
             factor = 1.0;
         }
     }
-    else if (unit == Unit::InverseVolume) {
+    else if (unit == Units::InverseVolume) {
         if (UnitValue < 1e-6) {
             unitString = "1/m^3";
             factor = 1e-9;

--- a/src/Base/UnitsSchemaMeterDecimal.cpp
+++ b/src/Base/UnitsSchemaMeterDecimal.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include "UnitsSchemaMeterDecimal.h"
+#include "Units.h"
 
 using namespace Base;
 
@@ -44,13 +45,13 @@ std::string UnitsSchemaMeterDecimal::schemaTranslate(const Base::Quantity& quant
                                                      std::string& unitString)
 {
     static std::array<std::pair<Unit, std::pair<std::string, double>>, 7> unitSpecs {{
-        {Unit::Length, {"m", 1e0}},
-        {Unit::Area, {"m^2", 1e6}},
-        {Unit::Volume, {"m^3", 1e9}},
-        {Unit::Power, {"W", 1000000}},
-        {Unit::ElectricPotential, {"V", 1000000}},
-        {Unit::HeatFlux, {"W/m^2", 1.0}},
-        {Unit::Velocity, {"m/s", 1e3}},
+        {Units::Length, {"m", 1e0}},
+        {Units::Area, {"m^2", 1e6}},
+        {Units::Volume, {"m^3", 1e9}},
+        {Units::Power, {"W", 1000000}},
+        {Units::ElectricPotential, {"V", 1000000}},
+        {Units::HeatFlux, {"W/m^2", 1.0}},
+        {Units::Velocity, {"m/s", 1e3}},
     }};
 
     const auto unit = quant.getUnit();

--- a/src/Base/UnitsSchemaMmMin.cpp
+++ b/src/Base/UnitsSchemaMmMin.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include "UnitsSchemaMmMin.h"
+#include "Units.h"
 
 using namespace Base;
 
@@ -36,9 +37,9 @@ std::string
 UnitsSchemaMmMin::schemaTranslate(const Quantity& quant, double& factor, std::string& unitString)
 {
     static std::array<std::pair<Unit, std::pair<std::string, double>>, 3> unitSpecs {{
-        {Unit::Length, {"mm", 1.0}},
-        {Unit::Angle, {"\xC2\xB0", 1.0}},
-        {Unit::Velocity, {"mm/min", 1.0 / 60.0}},
+        {Units::Length, {"mm", 1.0}},
+        {Units::Angle, {"\xC2\xB0", 1.0}},
+        {Units::Velocity, {"mm/min", 1.0 / 60.0}},
     }};
 
     const auto unit = quant.getUnit();

--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -45,6 +45,7 @@
 #include "ExpressionBinding.h"
 #include "BitmapFactory.h"
 #include "ViewProviderDocumentObject.h"
+#include "Base/Units.h"
 
 using namespace App;
 using namespace Gui::Dialog;
@@ -294,14 +295,15 @@ void DlgExpressionInput::checkExpression(const QString& text)
                 }
 
                 auto msg = value.getUserString();
-                if (!impliedUnit.isEmpty()) {
-                    if (!value.getUnit().isEmpty() && value.getUnit() != impliedUnit)
+                if (impliedUnit != Base::Units::NullUnit) {
+                    const Base::Unit unit = value.getUnit();
+                    if (unit != Base::Units::NullUnit && unit != impliedUnit)
                         throw Base::UnitsMismatchError("Unit mismatch between result and required unit");
 
                     value.setUnit(impliedUnit);
 
                 }
-                else if (!value.getUnit().isEmpty()) {
+                else if (value.getUnit() != Base::Units::NullUnit) {
                     msg += " (Warning: unit discarded)";
 
                     QPalette p(ui->msg->palette());

--- a/src/Gui/DlgUnitsCalculatorImp.cpp
+++ b/src/Gui/DlgUnitsCalculatorImp.cpp
@@ -31,6 +31,7 @@
 #include "DlgUnitsCalculatorImp.h"
 #include "ui_DlgUnitsCalculator.h"
 #include <Base/UnitsApi.h>
+#include "Base/Units.h"
 
 using namespace Gui::Dialog;
 
@@ -86,24 +87,24 @@ DlgUnitsCalculator::DlgUnitsCalculator(QWidget* parent, Qt::WindowFlags fl)
     ui->ValueInput->setText(QString::fromLatin1("1 cm"));
     ui->UnitInput->setText(QString::fromLatin1("in"));
 
-    units << Base::Unit::Acceleration << Base::Unit::AmountOfSubstance << Base::Unit::Angle
-          << Base::Unit::Area << Base::Unit::Density << Base::Unit::CurrentDensity
-          << Base::Unit::DissipationRate << Base::Unit::DynamicViscosity
-          << Base::Unit::ElectricalCapacitance << Base::Unit::ElectricalInductance
-          << Base::Unit::ElectricalConductance << Base::Unit::ElectricalResistance
-          << Base::Unit::ElectricalConductivity << Base::Unit::ElectricCharge
-          << Base::Unit::ElectricCurrent << Base::Unit::ElectricPotential << Base::Unit::Force
-          << Base::Unit::Frequency << Base::Unit::HeatFlux << Base::Unit::InverseArea
-          << Base::Unit::InverseLength << Base::Unit::InverseVolume
-          << Base::Unit::KinematicViscosity << Base::Unit::Length << Base::Unit::LuminousIntensity
-          << Base::Unit::Mass << Base::Unit::MagneticFieldStrength << Base::Unit::MagneticFlux
-          << Base::Unit::MagneticFluxDensity << Base::Unit::Magnetization << Base::Unit::Power
-          << Base::Unit::Pressure << Base::Unit::SpecificEnergy << Base::Unit::SpecificHeat
-          << Base::Unit::Stiffness << Base::Unit::Temperature << Base::Unit::ThermalConductivity
-          << Base::Unit::ThermalExpansionCoefficient << Base::Unit::ThermalTransferCoefficient
-          << Base::Unit::TimeSpan << Base::Unit::VacuumPermittivity << Base::Unit::Velocity
-          << Base::Unit::Volume << Base::Unit::VolumeFlowRate
-          << Base::Unit::VolumetricThermalExpansionCoefficient << Base::Unit::Work;
+    units << Base::Units::Acceleration << Base::Units::AmountOfSubstance << Base::Units::Angle
+          << Base::Units::Area << Base::Units::Density << Base::Units::CurrentDensity
+          << Base::Units::DissipationRate << Base::Units::DynamicViscosity
+          << Base::Units::ElectricalCapacitance << Base::Units::ElectricalInductance
+          << Base::Units::ElectricalConductance << Base::Units::ElectricalResistance
+          << Base::Units::ElectricalConductivity << Base::Units::ElectricCharge
+          << Base::Units::ElectricCurrent << Base::Units::ElectricPotential << Base::Units::Force
+          << Base::Units::Frequency << Base::Units::HeatFlux << Base::Units::InverseArea
+          << Base::Units::InverseLength << Base::Units::InverseVolume
+          << Base::Units::KinematicViscosity << Base::Units::Length << Base::Units::LuminousIntensity
+          << Base::Units::Mass << Base::Units::MagneticFieldStrength << Base::Units::MagneticFlux
+          << Base::Units::MagneticFluxDensity << Base::Units::Magnetization << Base::Units::Power
+          << Base::Units::Pressure << Base::Units::SpecificEnergy << Base::Units::SpecificHeat
+          << Base::Units::Stiffness << Base::Units::Temperature << Base::Units::ThermalConductivity
+          << Base::Units::ThermalExpansionCoefficient << Base::Units::ThermalTransferCoefficient
+          << Base::Units::TimeSpan << Base::Units::VacuumPermittivity << Base::Units::Velocity
+          << Base::Units::Volume << Base::Units::VolumeFlowRate
+          << Base::Units::VolumetricThermalExpansionCoefficient << Base::Units::Work;
     for (const Base::Unit& it : units) {
         ui->unitsBox->addItem(QString::fromStdString(it.getTypeString()));
     }
@@ -138,15 +139,14 @@ void DlgUnitsCalculator::valueChanged(const Base::Quantity& quant)
     // explicitly check for "ee" like in "eeV" because this would trigger an exception in Base::Unit
     // since it expects then a scientific notation number like "1e3"
     if ((ui->UnitInput->text().mid(0, 2) == QString::fromLatin1("ee"))
-        || Base::Unit(ui->UnitInput->text().toStdString()).getTypeString().empty()) {
+        || Base::Units::isUnitName(ui->UnitInput->text().toStdString())) {
         ui->ValueOutput->setText(
             QString::fromLatin1("%1 %2").arg(tr("unknown unit:"), ui->UnitInput->text()));
         ui->pushButton_Copy->setEnabled(false);
     }
     else {  // the unit is valid
         // we can only convert units of the same type, thus check
-        if (Base::Unit(ui->UnitInput->text().toStdString()).getTypeString()
-            != quant.getUnit().getTypeString()) {
+        if (ui->UnitInput->text().toStdString() != quant.getUnit().getTypeString()) {
             ui->ValueOutput->setText(tr("unit mismatch"));
             ui->pushButton_Copy->setEnabled(false);
         }
@@ -202,11 +202,11 @@ void DlgUnitsCalculator::onUnitsBoxActivated(int index)
     // SI units use [m], not [mm] for lengths
     //
     Base::Quantity q = ui->quantitySpinBox->value();
-    int32_t old = q.getUnit().length();
+    int32_t old = q.getUnit().getLength();
     double value = q.getValue();
 
     Base::Unit unit = units[index];
-    int32_t len = unit.length();
+    int32_t len = unit.getLength();
     ui->quantitySpinBox->setValue(Base::Quantity(value * std::pow(10.0, 3 * (len - old)), unit));
 }
 

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -109,7 +109,7 @@ struct DocumentP
     std::map<SoSeparator *,ViewProviderDocumentObject*> _CoinMap;
     std::map<std::string,ViewProvider*> _ViewProviderMapAnnotation;
     std::list<ViewProviderDocumentObject*> _redoViewProviders;
-    
+
     using Connection = boost::signals2::connection;
     Connection connectNewObject;
     Connection connectDelObject;
@@ -2773,7 +2773,7 @@ void Document::toggleInSceneGraph(ViewProvider *vp)
 }
 
 void Document::slotChangePropertyEditor(const App::Document &doc, const App::Property &Prop) {
-    if(getDocument() == &doc) {
+    if (getDocument() == &doc) {
         FC_LOG(Prop.getFullName() << " editor changed");
         setModified(true);
         getMainWindow()->setUserSchema(doc.UnitSystem.getValue());

--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -145,7 +145,7 @@ void EditableDatumLabel::startEdit(double val, QObject* eventFilteringObj, bool 
     label->string = " ";
 
     spinBox = new QuantitySpinBox(mdi);
-    spinBox->setUnit(Base::Unit::Length);
+    spinBox->setUnit(Base::Units::Length);
     spinBox->setMinimum(-INT_MAX);
     spinBox->setMaximum(INT_MAX);
     spinBox->setButtonSymbols(QAbstractSpinBox::NoButtons);

--- a/src/Gui/EditableDatumLabel.h
+++ b/src/Gui/EditableDatumLabel.h
@@ -29,6 +29,7 @@
 #include <Gui/QuantitySpinBox.h>
 
 #include "SoDatumLabel.h"
+#include "Base/Units.h"
 
 #include <FCGlobal.h>
 
@@ -63,7 +64,7 @@ public:
     bool isActive() const;
     bool isInEdit() const;
     double getValue() const;
-    void setSpinboxValue(double val, const Base::Unit& unit = Base::Unit::Length);
+    void setSpinboxValue(double val, const Base::Unit& unit = Base::Units::Length);
     void setPlacement(const Base::Placement& plc);
     void setColor(SbColor color);
     void setFocus();

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -40,6 +40,7 @@
 #include "InputField.h"
 #include "BitmapFactory.h"
 #include "Command.h"
+#include "Base/Units.h"
 #include "QuantitySpinBox_p.h"
 
 
@@ -267,11 +268,11 @@ void InputField::newInput(const QString & text)
         return;
     }
 
-    if (res.getUnit().isEmpty())
+    if (res.getUnit() == Units::NullUnit)
         res.setUnit(this->actUnit);
 
     // check if unit fits!
-    if(!actUnit.isEmpty() && !res.getUnit().isEmpty() && actUnit != res.getUnit()){
+    if(actUnit != Units::NullUnit && res.getUnit() != Units::NullUnit && actUnit != res.getUnit()) {
         QPixmap pixmap = getValidationIcon(":/icons/button_invalid.svg", QSize(sizeHint().height(),sizeHint().height()));
         iconLabel->setPixmap(pixmap);
         Q_EMIT parseError(QString::fromLatin1("Wrong unit"));
@@ -632,7 +633,7 @@ void InputField::focusInEvent(QFocusEvent *event)
 void InputField::focusOutEvent(QFocusEvent *event)
 {
     try {
-        if (Quantity::parse(this->text().toStdString()).getUnit().isEmpty()) {
+        if (Quantity::parse(this->text().toStdString()).getUnit() == Units::NullUnit) {
             // if user didn't enter a unit, we virtually compensate
             // the multiplication factor induced by user unit system
             double factor;

--- a/src/Gui/InputVector.cpp
+++ b/src/Gui/InputVector.cpp
@@ -28,6 +28,7 @@
 
 #include <Base/UnitsApi.h>
 
+#include "Base/Units.h"
 #include "InputVector.h"
 #include "ui_InputVector.h"
 #include "QuantitySpinBox.h"
@@ -67,9 +68,9 @@ LocationWidget::LocationWidget (QWidget * parent)
     box->addWidget(dLabel, 3, 0, 1, 1);
     box->addWidget(dValue, 3, 1, 1, 1);
 
-    xValue->setUnit(Base::Unit::Length);
-    yValue->setUnit(Base::Unit::Length);
-    zValue->setUnit(Base::Unit::Length);
+    xValue->setUnit(Base::Units::Length);
+    yValue->setUnit(Base::Units::Length);
+    zValue->setUnit(Base::Units::Length);
 
     auto gridLayout = new QGridLayout(this);
     gridLayout->addLayout(box, 0, 0, 1, 2);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -175,7 +175,7 @@ public:
         setText(qApp->translate("Gui::MainWindow", "Dimension"));
         setMinimumWidth(120);
 
-        //create the action buttons
+        // create the action buttons
         auto* menu = new QMenu(this);
         auto* actionGrp = new QActionGroup(menu);
         int num = static_cast<int>(Base::UnitSystem::NumUnitSystemTypes);

--- a/src/Gui/Placement.cpp
+++ b/src/Gui/Placement.cpp
@@ -495,25 +495,25 @@ void Placement::setupConnections()
 
 void Placement::setupUnits()
 {
-    ui->xPos->setUnit(Base::Unit::Length);
-    ui->yPos->setUnit(Base::Unit::Length);
-    ui->zPos->setUnit(Base::Unit::Length);
-    ui->axialPos->setUnit(Base::Unit::Length);
-    ui->xCnt->setValue(Base::Quantity(0, Base::Unit::Length));
-    ui->yCnt->setValue(Base::Quantity(0, Base::Unit::Length));
-    ui->zCnt->setValue(Base::Quantity(0, Base::Unit::Length));
-    ui->angle->setUnit(Base::Unit::Angle);
+    ui->xPos->setUnit(Base::Units::Length);
+    ui->yPos->setUnit(Base::Units::Length);
+    ui->zPos->setUnit(Base::Units::Length);
+    ui->axialPos->setUnit(Base::Units::Length);
+    ui->xCnt->setValue(Base::Quantity(0, Base::Units::Length));
+    ui->yCnt->setValue(Base::Quantity(0, Base::Units::Length));
+    ui->zCnt->setValue(Base::Quantity(0, Base::Units::Length));
+    ui->angle->setUnit(Base::Units::Angle);
     ui->yawAngle->setMaximum(180.0F);
     ui->yawAngle->setMinimum(-180.0F);
-    ui->yawAngle->setUnit(Base::Unit::Angle);
+    ui->yawAngle->setUnit(Base::Units::Angle);
     ui->yawAngle->checkRangeInExpression(true);
     ui->pitchAngle->setMaximum(90.0F);
     ui->pitchAngle->setMinimum(-90.0F);
-    ui->pitchAngle->setUnit(Base::Unit::Angle);
+    ui->pitchAngle->setUnit(Base::Units::Angle);
     ui->pitchAngle->checkRangeInExpression(true);
     ui->rollAngle->setMaximum(180.0F);
     ui->rollAngle->setMinimum(-180.0F);
-    ui->rollAngle->setUnit(Base::Unit::Angle);
+    ui->rollAngle->setUnit(Base::Units::Angle);
     ui->rollAngle->checkRangeInExpression(true);
 }
 
@@ -743,9 +743,9 @@ void Placement::onApplyAxialClicked()
     else {
         newPos = Base::Vector3d(curPos.x+(axis.x*axPos),curPos.y+(axis.y*axPos),curPos.z+(axis.z*axPos));
     }
-    ui->xPos->setValue(Base::Quantity(newPos.x,Base::Unit::Length));
-    ui->yPos->setValue(Base::Quantity(newPos.y,Base::Unit::Length));
-    ui->zPos->setValue(Base::Quantity(newPos.z,Base::Unit::Length));
+    ui->xPos->setValue(Base::Quantity(newPos.x,Base::Units::Length));
+    ui->yPos->setValue(Base::Quantity(newPos.y,Base::Units::Length));
+    ui->zPos->setValue(Base::Quantity(newPos.z,Base::Units::Length));
     signalMapper->blockSignals(false);
     onPlacementChanged(0);
 }
@@ -954,15 +954,15 @@ void Placement::setPlacement(const Base::Placement& p)
 void Placement::setPlacementData(const Base::Placement& p)
 {
     QSignalBlocker block(signalMapper);
-    ui->xPos->setValue(Base::Quantity(p.getPosition().x, Base::Unit::Length));
-    ui->yPos->setValue(Base::Quantity(p.getPosition().y, Base::Unit::Length));
-    ui->zPos->setValue(Base::Quantity(p.getPosition().z, Base::Unit::Length));
+    ui->xPos->setValue(Base::Quantity(p.getPosition().x, Base::Units::Length));
+    ui->yPos->setValue(Base::Quantity(p.getPosition().y, Base::Units::Length));
+    ui->zPos->setValue(Base::Quantity(p.getPosition().z, Base::Units::Length));
 
     double Y,P,R;
     p.getRotation().getYawPitchRoll(Y,P,R);
-    ui->yawAngle->setValue(Base::Quantity(Y, Base::Unit::Angle));
-    ui->pitchAngle->setValue(Base::Quantity(P, Base::Unit::Angle));
-    ui->rollAngle->setValue(Base::Quantity(R, Base::Unit::Angle));
+    ui->yawAngle->setValue(Base::Quantity(Y, Base::Units::Angle));
+    ui->pitchAngle->setValue(Base::Quantity(P, Base::Units::Angle));
+    ui->rollAngle->setValue(Base::Quantity(R, Base::Units::Angle));
 
     double angle;
     Base::Vector3d axis;
@@ -970,7 +970,7 @@ void Placement::setPlacementData(const Base::Placement& p)
     ui->xAxis->setValue(axis.x);
     ui->yAxis->setValue(axis.y);
     ui->zAxis->setValue(axis.z);
-    ui->angle->setValue(Base::Quantity(Base::toDegrees(angle), Base::Unit::Angle));
+    ui->angle->setValue(Base::Quantity(Base::toDegrees(angle), Base::Units::Angle));
 }
 
 Base::Placement Placement::getPlacement() const

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -232,7 +232,7 @@ void DlgSettingsGeneral::saveUnitSystemSettings()
         // currently selected View System (unit system)
         int viewSystemIndex = ui->comboBox_UnitSystem->currentIndex();
         UnitsApi::setSchema(static_cast<UnitSystem>(viewSystemIndex));
-    }
+        }
     else if (App::Document* doc = App::GetApplication().getActiveDocument()) {
         UnitsApi::setSchema(static_cast<UnitSystem>(doc->UnitSystem.getValue()));
     }
@@ -771,7 +771,7 @@ void DlgSettingsGeneral::onLoadPreferencePackClicked(const std::string& packName
 void DlgSettingsGeneral::onUnitSystemIndexChanged(int index)
 {
     if (index < 0)
-        return; // happens when clearing the combo box in retranslateUi()
+        return;  // happens when clearing the combo box in retranslateUi()
 
     // Enable/disable the fractional inch option depending on system
     if (static_cast<UnitSystem>(index) == UnitSystem::ImperialBuilding)
@@ -803,7 +803,7 @@ void DlgSettingsGeneral::onLinkActivated(const QString& link)
     // This is a quick and dirty way to open Addon Manager with only themes.
     auto pref = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Addons");
     pref->SetInt("PackageTypeSelection", 3); // 3 stands for Preference Packs
-    pref->SetInt("StatusSelection", 0);      // 0 stands for any installation status 
+    pref->SetInt("StatusSelection", 0);      // 0 stands for any installation status
 
     Gui::Application::Instance->commandManager().runCommandByName("Std_AddonMgr");
 }

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -44,6 +44,7 @@
 #include <Base/Exception.h>
 #include <Base/UnitsApi.h>
 #include <Base/Tools.h>
+#include "Base/Units.h"
 
 #include "QuantitySpinBox.h"
 #include "QuantitySpinBox_p.h"
@@ -221,7 +222,7 @@ public:
         ok = parseString(copy, res, value, path);
 
         // If result does not have unit: add default unit
-        if (res.getUnit().isEmpty()){
+        if (res.getUnit() == Units::NullUnit){
             res.setUnit(unit);
         }
 

--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -50,6 +50,7 @@
 #endif
 
 #include <Base/Quantity.h>
+#include "Base/Units.h"
 
 #include "SoFCCSysDragger.h"
 #include "Inventor/So3DAnnotation.h"
@@ -354,7 +355,7 @@ void TDragger::drag()
 
     Base::Quantity quantity(static_cast<double>(translationIncrementCount.getValue())
                                 * translationIncrement.getValue(),
-                            Base::Unit::Length);
+                            Base::Units::Length);
 
     QString message =
         QString::fromLatin1("%1 %2").arg(QObject::tr("Translation:"), QString::fromStdString(quantity.getUserString()));
@@ -637,10 +638,10 @@ void TPlanarDragger::drag()
 
     Base::Quantity quantityX(static_cast<double>(translationIncrementXCount.getValue())
                                  * translationIncrement.getValue(),
-                             Base::Unit::Length);
+                             Base::Units::Length);
     Base::Quantity quantityY(static_cast<double>(translationIncrementYCount.getValue())
                                  * translationIncrement.getValue(),
-                             Base::Unit::Length);
+                             Base::Units::Length);
 
     QString message = QString::fromLatin1("%1 %2, %3")
                           .arg(QObject::tr("Translation XY:"),
@@ -967,7 +968,7 @@ void RDragger::drag()
 
     Base::Quantity quantity(static_cast<double>(rotationIncrementCount.getValue()) * (180.0 / M_PI)
                                 * rotationIncrement.getValue(),
-                            Base::Unit::Angle);
+                            Base::Units::Angle);
 
     QString message =
         QString::fromLatin1("%1 %2").arg(QObject::tr("Rotation:"), QString::fromStdString(quantity.getUserString()));

--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -175,7 +175,7 @@ void ExpressionSpinBox::openFormulaDialog()
 {
     Q_ASSERT(isBound());
 
-    auto * qprop = freecad_dynamic_cast<PropertyQuantity>(getPath().getProperty());
+    auto *qprop = freecad_dynamic_cast<PropertyQuantity>(getPath().getProperty());
     Unit unit;
 
     if (qprop)

--- a/src/Gui/TaskCSysDragger.cpp
+++ b/src/Gui/TaskCSysDragger.cpp
@@ -45,6 +45,7 @@
 #include "SoFCCSysDragger.h"
 #include "ViewProviderDragger.h"
 #include "TaskView/TaskView.h"
+#include "Base/Units.h"
 
 #include "TaskCSysDragger.h"
 #include "ui_TaskCSysDragger.h"
@@ -204,14 +205,14 @@ void TaskTransform::setupGui()
                                  ui->xPositionSpinBox,
                                  ui->yPositionSpinBox,
                                  ui->zPositionSpinBox}) {
-        positionSpinBox->setUnit(Base::Unit::Length);
+        positionSpinBox->setUnit(Base::Units::Length);
     }
 
     for (auto rotationSpinBox : {ui->rotationIncrementSpinBox,
                                  ui->xRotationSpinBox,
                                  ui->yRotationSpinBox,
                                  ui->zRotationSpinBox}) {
-        rotationSpinBox->setUnit(Base::Unit::Angle);
+        rotationSpinBox->setUnit(Base::Units::Angle);
     }
 
     connect(ui->translationIncrementSpinBox,

--- a/src/Gui/TaskView/TaskImage.cpp
+++ b/src/Gui/TaskView/TaskImage.cpp
@@ -530,7 +530,7 @@ void InteractiveScale::setDistance(const SbVec3f& pos3d)
 {
     Base::Quantity quantity;
     quantity.setValue(getDistance(pos3d));
-    quantity.setUnit(Base::Unit::Length);
+    quantity.setUnit(Base::Units::Length);
 
     // Update the displayed distance
     double factor {};

--- a/src/Gui/Transform.cpp
+++ b/src/Gui/Transform.cpp
@@ -323,9 +323,9 @@ void Transform::setTransformStrategy(TransformStrategy* ts)
         delete strategy;
     strategy = ts;
     Base::Vector3d cnt = strategy->getRotationCenter();
-    ui->xCnt->setValue(Base::Quantity(cnt.x, Base::Unit::Length));
-    ui->yCnt->setValue(Base::Quantity(cnt.y, Base::Unit::Length));
-    ui->zCnt->setValue(Base::Quantity(cnt.z, Base::Unit::Length));
+    ui->xCnt->setValue(Base::Quantity(cnt.x, Base::Units::Length));
+    ui->yCnt->setValue(Base::Quantity(cnt.y, Base::Units::Length));
+    ui->zCnt->setValue(Base::Quantity(cnt.z, Base::Units::Length));
     this->setDisabled(strategy->transformObjects().empty());
 }
 
@@ -368,9 +368,9 @@ void Transform::onApplyButtonClicked()
     }
 
     Base::Vector3d cnt = strategy->getRotationCenter();
-    ui->xCnt->setValue(Base::Quantity(cnt.x, Base::Unit::Length));
-    ui->yCnt->setValue(Base::Quantity(cnt.y, Base::Unit::Length));
-    ui->zCnt->setValue(Base::Quantity(cnt.z, Base::Unit::Length));
+    ui->xCnt->setValue(Base::Quantity(cnt.x, Base::Units::Length));
+    ui->yCnt->setValue(Base::Quantity(cnt.y, Base::Units::Length));
+    ui->zCnt->setValue(Base::Quantity(cnt.z, Base::Units::Length));
 }
 
 Base::Vector3d Transform::getDirection() const

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -42,6 +42,7 @@
 
 #include <Base/Exception.h>
 #include <Base/Interpreter.h>
+#include "Base/Units.h"
 #include <App/ExpressionParser.h>
 #include <App/Material.h>
 
@@ -860,7 +861,7 @@ UrlLabel::UrlLabel(QWidget* parent, Qt::WindowFlags f)
     , _url (QStringLiteral("http://localhost"))
     , _launchExternal(true)
 {
-    setToolTip(this->_url);    
+    setToolTip(this->_url);
     setCursor(Qt::PointingHandCursor);
     if (qApp->styleSheet().isEmpty())
         setStyleSheet(QStringLiteral("Gui--UrlLabel {color: #0000FF;text-decoration: underline;}"));
@@ -925,9 +926,9 @@ void StatefulLabel::setParameterGroup(const std::string& groupName)
 {
     if (_parameterGroup.isValid())
         _parameterGroup->Detach(this);
-        
+
     // Attach to the Parametergroup so we know when it changes
-    _parameterGroup = App::GetApplication().GetParameterGroupByPath(groupName.c_str());    
+    _parameterGroup = App::GetApplication().GetParameterGroupByPath(groupName.c_str());
     if (_parameterGroup.isValid())
         _parameterGroup->Attach(this);
 }
@@ -1671,7 +1672,7 @@ void ExpLineEdit::openFormulaDialog()
     Q_ASSERT(isBound());
 
     auto box = new Gui::Dialog::DlgExpressionInput(
-            getPath(), getExpression(),Unit(), this);
+            getPath(), getExpression(), Units::NullUnit, this);
     connect(box, &Dialog::DlgExpressionInput::finished, this, &ExpLineEdit::finishFormulaDialog);
     box->show();
 

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -1769,9 +1769,9 @@ QVariant PropertyVectorDistanceItem::toString(const QVariant& prop) const
 {
     const Base::Vector3d& value = prop.value<Base::Vector3d>();
     std::string str = fmt::format("[{} {} {}]",
-                                  Base::Quantity(value.x, Base::Unit::Length).getUserString(),
-                                  Base::Quantity(value.y, Base::Unit::Length).getUserString(),
-                                  Base::Quantity(value.z, Base::Unit::Length).getUserString());
+                                  Base::Quantity(value.x, Base::Units::Length).getUserString(),
+                                  Base::Quantity(value.y, Base::Units::Length).getUserString(),
+                                  Base::Quantity(value.z, Base::Units::Length).getUserString());
     if (hasExpression()) {
         str += fmt::format("  ( {} )", getExpressionString());
     }
@@ -1794,9 +1794,9 @@ void PropertyVectorDistanceItem::setValue(const QVariant& variant)
     }
     const Base::Vector3d& value = variant.value<Base::Vector3d>();
 
-    Base::Quantity x = Base::Quantity(value.x, Base::Unit::Length);
-    Base::Quantity y = Base::Quantity(value.y, Base::Unit::Length);
-    Base::Quantity z = Base::Quantity(value.z, Base::Unit::Length);
+    Base::Quantity x = Base::Quantity(value.x, Base::Units::Length);
+    Base::Quantity y = Base::Quantity(value.y, Base::Units::Length);
+    Base::Quantity z = Base::Quantity(value.z, Base::Units::Length);
 
     Base::QuantityFormat format(Base::QuantityFormat::Default, highPrec);
     std::string val = fmt::format("({}, {}, {})",
@@ -1836,7 +1836,7 @@ QVariant PropertyVectorDistanceItem::editorData(QWidget* editor) const
 
 Base::Quantity PropertyVectorDistanceItem::x() const
 {
-    return Base::Quantity(data(1, Qt::EditRole).value<Base::Vector3d>().x, Base::Unit::Length);
+    return Base::Quantity(data(1, Qt::EditRole).value<Base::Vector3d>().x, Base::Units::Length);
 }
 
 void PropertyVectorDistanceItem::setX(Base::Quantity x)
@@ -1846,7 +1846,7 @@ void PropertyVectorDistanceItem::setX(Base::Quantity x)
 
 Base::Quantity PropertyVectorDistanceItem::y() const
 {
-    return Base::Quantity(data(1, Qt::EditRole).value<Base::Vector3d>().y, Base::Unit::Length);
+    return Base::Quantity(data(1, Qt::EditRole).value<Base::Vector3d>().y, Base::Units::Length);
 }
 
 void PropertyVectorDistanceItem::setY(Base::Quantity y)
@@ -1856,7 +1856,7 @@ void PropertyVectorDistanceItem::setY(Base::Quantity y)
 
 Base::Quantity PropertyVectorDistanceItem::z() const
 {
-    return Base::Quantity(data(1, Qt::EditRole).value<Base::Vector3d>().z, Base::Unit::Length);
+    return Base::Quantity(data(1, Qt::EditRole).value<Base::Vector3d>().z, Base::Units::Length);
 }
 
 void PropertyVectorDistanceItem::setZ(Base::Quantity z)
@@ -2424,7 +2424,7 @@ Base::Quantity PropertyRotationItem::getAngle() const
 
     const Base::Rotation& val = value.value<Base::Rotation>();
     double angle = h.getAngle(val);
-    return Base::Quantity(Base::toDegrees<double>(angle), Base::Unit::Angle);
+    return Base::Quantity(Base::toDegrees<double>(angle), Base::Units::Angle);
 }
 
 void PropertyRotationItem::setAngle(Base::Quantity angle)
@@ -2520,7 +2520,7 @@ QVariant PropertyRotationItem::toolTip(const App::Property* prop) const
             .arg(loc.toString(dir.x, 'f', decimals()),
                  loc.toString(dir.y, 'f', decimals()),
                  loc.toString(dir.z, 'f', decimals()),
-                 QString::fromStdString(Base::Quantity(angle, Base::Unit::Angle).getUserString()));
+                 QString::fromStdString(Base::Quantity(angle, Base::Units::Angle).getUserString()));
     return {data};
 }
 
@@ -2538,7 +2538,7 @@ QVariant PropertyRotationItem::toString(const QVariant& prop) const
             .arg(loc.toString(dir.x, 'f', lowPrec),
                  loc.toString(dir.y, 'f', lowPrec),
                  loc.toString(dir.z, 'f', lowPrec),
-                 QString::fromStdString(Base::Quantity(angle, Base::Unit::Angle).getUserString()));
+                 QString::fromStdString(Base::Quantity(angle, Base::Units::Angle).getUserString()));
     return {data};
 }
 
@@ -2699,7 +2699,7 @@ Base::Quantity PropertyPlacementItem::getAngle() const
 
     const Base::Placement& val = value.value<Base::Placement>();
     double angle = h.getAngle(val.getRotation());
-    return Base::Quantity(Base::toDegrees<double>(angle), Base::Unit::Angle);
+    return Base::Quantity(Base::toDegrees<double>(angle), Base::Units::Angle);
 }
 
 void PropertyPlacementItem::setAngle(Base::Quantity angle)
@@ -2822,13 +2822,14 @@ QVariant PropertyPlacementItem::toolTip(const App::Property* prop) const
         QString::fromUtf8("Axis: (%1 %2 %3)\n"
                           "Angle: %4\n"
                           "Position: (%5  %6  %7)")
-            .arg(loc.toString(dir.x, 'f', decimals()),
-                 loc.toString(dir.y, 'f', decimals()),
-                 loc.toString(dir.z, 'f', decimals()),
-                 QString::fromStdString(Base::Quantity(angle, Base::Unit::Angle).getUserString()),
-                 QString::fromStdString(Base::Quantity(pos.x, Base::Unit::Length).getUserString()),
-                 QString::fromStdString(Base::Quantity(pos.y, Base::Unit::Length).getUserString()),
-                 QString::fromStdString(Base::Quantity(pos.z, Base::Unit::Length).getUserString()));
+            .arg(
+                loc.toString(dir.x, 'f', decimals()),
+                loc.toString(dir.y, 'f', decimals()),
+                loc.toString(dir.z, 'f', decimals()),
+                QString::fromStdString(Base::Quantity(angle, Base::Units::Angle).getUserString()),
+                QString::fromStdString(Base::Quantity(pos.x, Base::Units::Length).getUserString()),
+                QString::fromStdString(Base::Quantity(pos.y, Base::Units::Length).getUserString()),
+                QString::fromStdString(Base::Quantity(pos.z, Base::Units::Length).getUserString()));
     return {data};
 }
 
@@ -2845,13 +2846,14 @@ QVariant PropertyPlacementItem::toString(const QVariant& prop) const
     QLocale loc;
     QString data =
         QString::fromUtf8("[(%1 %2 %3); %4; (%5  %6  %7)]")
-            .arg(loc.toString(dir.x, 'f', lowPrec),
-                 loc.toString(dir.y, 'f', lowPrec),
-                 loc.toString(dir.z, 'f', lowPrec),
-                 QString::fromStdString(Base::Quantity(angle, Base::Unit::Angle).getUserString()),
-                 QString::fromStdString(Base::Quantity(pos.x, Base::Unit::Length).getUserString()),
-                 QString::fromStdString(Base::Quantity(pos.y, Base::Unit::Length).getUserString()),
-                 QString::fromStdString(Base::Quantity(pos.z, Base::Unit::Length).getUserString()));
+            .arg(
+                loc.toString(dir.x, 'f', lowPrec),
+                loc.toString(dir.y, 'f', lowPrec),
+                loc.toString(dir.z, 'f', lowPrec),
+                QString::fromStdString(Base::Quantity(angle, Base::Units::Angle).getUserString()),
+                QString::fromStdString(Base::Quantity(pos.x, Base::Units::Length).getUserString()),
+                QString::fromStdString(Base::Quantity(pos.y, Base::Units::Length).getUserString()),
+                QString::fromStdString(Base::Quantity(pos.z, Base::Units::Length).getUserString()));
     return {data};
 }
 

--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -68,6 +68,7 @@
 #include <Base/Stream.h>
 #include <Base/TimeInfo.h>
 #include <Base/Writer.h>
+#include "Base/Units.h"
 #include <Mod/Mesh/App/Core/Iterator.h>
 
 #include "FemMesh.h"
@@ -2616,7 +2617,7 @@ Base::Quantity FemMesh::getVolume() const
             1.0 / 6.0 * fabs((a_b_product.x * c.x) + (a_b_product.y * c.y) + (a_b_product.z * c.z));
     }
 
-    return Base::Quantity(volume, Unit::Volume);
+    return Base::Quantity(volume, Units::Volume);
 }
 
 int FemMesh::addGroup(const std::string TypeString, const std::string Name, const int theId)

--- a/src/Mod/Inspection/Gui/VisualInspection.cpp
+++ b/src/Mod/Inspection/Gui/VisualInspection.cpp
@@ -34,6 +34,8 @@
 #include <Gui/PrefWidgets.h>
 #include <Gui/ViewProvider.h>
 
+#include "Base/Units.h"
+
 #include "VisualInspection.h"
 #include "ui_VisualInspection.h"
 
@@ -99,9 +101,9 @@ VisualInspection::VisualInspection(QWidget* parent, Qt::WindowFlags fl)
     // FIXME: Not used yet
     ui->textLabel2->hide();
     ui->thickness->hide();
-    ui->searchRadius->setUnit(Base::Unit::Length);
+    ui->searchRadius->setUnit(Base::Units::Length);
     ui->searchRadius->setRange(0, DBL_MAX);
-    ui->thickness->setUnit(Base::Unit::Length);
+    ui->thickness->setUnit(Base::Units::Length);
     ui->thickness->setRange(0, DBL_MAX);
 
     App::Document* doc = App::GetApplication().getActiveDocument();

--- a/src/Mod/Material/Gui/ArrayDelegate.cpp
+++ b/src/Mod/Material/Gui/ArrayDelegate.cpp
@@ -80,7 +80,7 @@ void ArrayDelegate::paint(QPainter* painter,
         }
         painter->drawText(option.rect, 0, text);
         painter->restore();
-    }
+}
     else {
         QStyledItemDelegate::paint(painter, option, index);
     }

--- a/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/src/Mod/Measure/App/MeasureAngle.cpp
@@ -59,7 +59,7 @@ MeasureAngle::MeasureAngle()
                       "Measurement",
                       App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
                       "Angle between the two elements");
-    Angle.setUnit(Base::Unit::Angle);
+    Angle.setUnit(Base::Units::Angle);
 }
 
 MeasureAngle::~MeasureAngle() = default;

--- a/src/Mod/Measure/App/MeasureDistance.cpp
+++ b/src/Mod/Measure/App/MeasureDistance.cpp
@@ -66,26 +66,26 @@ MeasureDistance::MeasureDistance()
                       "Measurement",
                       App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
                       "Distance between the two elements");
-    Distance.setUnit(Base::Unit::Length);
+    Distance.setUnit(Base::Units::Length);
 
     ADD_PROPERTY_TYPE(DistanceX,
                       (0.0),
                       "Measurement",
                       App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
                       "Distance in X direction");
-    DistanceX.setUnit(Base::Unit::Length);
+    DistanceX.setUnit(Base::Units::Length);
     ADD_PROPERTY_TYPE(DistanceY,
                       (0.0),
                       "Measurement",
                       App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
                       "Distance in Y direction");
-    DistanceY.setUnit(Base::Unit::Length);
+    DistanceY.setUnit(Base::Units::Length);
     ADD_PROPERTY_TYPE(DistanceZ,
                       (0.0),
                       "Measurement",
                       App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
                       "Distance in Z direction");
-    DistanceZ.setUnit(Base::Unit::Length);
+    DistanceZ.setUnit(Base::Units::Length);
 
     ADD_PROPERTY_TYPE(Position1,
                       (Base::Vector3d(0.0, 0.0, 0.0)),
@@ -327,26 +327,26 @@ MeasureDistanceDetached::MeasureDistanceDetached()
                       "Measurement",
                       App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
                       "Distance between the two elements");
-    Distance.setUnit(Base::Unit::Length);
+    Distance.setUnit(Base::Units::Length);
 
     ADD_PROPERTY_TYPE(DistanceX,
                       (0.0),
                       "Measurement",
                       App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
                       "Distance in X direction");
-    DistanceX.setUnit(Base::Unit::Length);
+    DistanceX.setUnit(Base::Units::Length);
     ADD_PROPERTY_TYPE(DistanceY,
                       (0.0),
                       "Measurement",
                       App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
                       "Distance in Y direction");
-    DistanceY.setUnit(Base::Unit::Length);
+    DistanceY.setUnit(Base::Units::Length);
     ADD_PROPERTY_TYPE(DistanceZ,
                       (0.0),
                       "Measurement",
                       App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
                       "Distance in Z direction");
-    DistanceZ.setUnit(Base::Unit::Length);
+    DistanceZ.setUnit(Base::Units::Length);
 
     ADD_PROPERTY_TYPE(Position1,
                       (Base::Vector3d(0.0, 0.0, 0.0)),

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -181,13 +181,13 @@ void QuickMeasure::addSelectionToMeasurement()
 
 static QString areaStr(double value)
 {
-    Base::Quantity area(value, Base::Unit::Area);
+    const Base::Quantity area(value, Base::Units::Area);
     return QString::fromStdString(area.getUserString());
 }
 
 static QString lenghtStr(double value)
 {
-    Base::Quantity dist(value, Base::Unit::Length);
+    const Base::Quantity dist(value, Base::Units::Length);
     return QString::fromStdString(dist.getUserString());
 }
 
@@ -200,8 +200,8 @@ void QuickMeasure::printResult()
     /* deactivated because computing the volumes/area of solids makes a significant
     slow down in selection of complex solids.
     else if (mtype == MeasureType::Volumes) {
-        Base::Quantity area(measurement->area(), Base::Unit::Area);
-        Base::Quantity vol(measurement->volume(), Base::Unit::Volume);
+        Base::Quantity area(measurement->area(), Base::Units::Area);
+        Base::Quantity vol(measurement->volume(), Base::Units::Volume);
         print(tr("Volume: %1, Area:
     %2").arg(vol.getSafeUserString()).arg(area.getSafeUserString()));
     }*/

--- a/src/Mod/MeshPart/Gui/CrossSections.cpp
+++ b/src/Mod/MeshPart/Gui/CrossSections.cpp
@@ -180,9 +180,9 @@ CrossSections::CrossSections(const Base::BoundBox3d& bb, QWidget* parent, Qt::Wi
     setupConnections();
 
     ui->position->setRange(-DBL_MAX, DBL_MAX);
-    ui->position->setUnit(Base::Unit::Length);
+    ui->position->setUnit(Base::Units::Length);
     ui->distance->setRange(0, DBL_MAX);
-    ui->distance->setUnit(Base::Unit::Length);
+    ui->distance->setUnit(Base::Units::Length);
     ui->spinEpsilon->setMinimum(0.0001);
     vp = new ViewProviderCrossSections();
 

--- a/src/Mod/Part/App/PartFeatures.cpp
+++ b/src/Mod/Part/App/PartFeatures.cpp
@@ -370,7 +370,7 @@ Thickness::Thickness()
     ADD_PROPERTY_TYPE(SelfIntersection, (false), "Thickness", App::Prop_None, "Self Intersection");
 
     // Value should have length as unit
-    Value.setUnit(Base::Unit::Length);
+    Value.setUnit(Base::Units::Length);
 }
 
 short Thickness::mustExecute() const

--- a/src/Mod/Part/Gui/CrossSections.cpp
+++ b/src/Mod/Part/Gui/CrossSections.cpp
@@ -127,9 +127,9 @@ CrossSections::CrossSections(const Base::BoundBox3d& bb, QWidget* parent, Qt::Wi
     setupConnections();
 
     ui->position->setRange(-DBL_MAX, DBL_MAX);
-    ui->position->setUnit(Base::Unit::Length);
+    ui->position->setUnit(Base::Units::Length);
     ui->distance->setRange(0, DBL_MAX);
-    ui->distance->setUnit(Base::Unit::Length);
+    ui->distance->setUnit(Base::Units::Length);
     vp = new ViewProviderCrossSections();
 
     Base::Vector3d c = bbox.GetCenter();

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -106,11 +106,11 @@ DlgExtrusion::DlgExtrusion(QWidget* parent, Qt::WindowFlags fl)
     ui->dirX->setDecimals(Base::UnitsApi::getDecimals());
     ui->dirY->setDecimals(Base::UnitsApi::getDecimals());
     ui->dirZ->setDecimals(Base::UnitsApi::getDecimals());
-    ui->spinLenFwd->setUnit(Base::Unit::Length);
+    ui->spinLenFwd->setUnit(Base::Units::Length);
     ui->spinLenFwd->setValue(10.0);
-    ui->spinLenRev->setUnit(Base::Unit::Length);
-    ui->spinTaperAngle->setUnit(Base::Unit::Angle);
-    ui->spinTaperAngle->setUnit(Base::Unit::Angle);
+    ui->spinLenRev->setUnit(Base::Units::Length);
+    ui->spinTaperAngle->setUnit(Base::Units::Angle);
+    ui->spinTaperAngle->setUnit(Base::Units::Angle);
     findShapes();
 
     Gui::ItemViewSelection sel(ui->treeWidget);

--- a/src/Mod/Part/Gui/DlgFilletEdges.cpp
+++ b/src/Mod/Part/Gui/DlgFilletEdges.cpp
@@ -86,7 +86,7 @@ QWidget *FilletRadiusDelegate::createEditor(QWidget *parent, const QStyleOptionV
         return nullptr;
 
     Gui::QuantitySpinBox *editor = new Gui::QuantitySpinBox(parent);
-    editor->setUnit(Base::Unit::Length);
+    editor->setUnit(Base::Units::Length);
     editor->setMinimum(0.0);
     editor->setMaximum(INT_MAX);
     editor->setSingleStep(0.1);
@@ -235,11 +235,11 @@ DlgFilletEdges::DlgFilletEdges(FilletType type, Part::FilletBase* fillet, QWidge
 
     ui->filletStartRadius->setMaximum(INT_MAX);
     ui->filletStartRadius->setMinimum(0);
-    ui->filletStartRadius->setUnit(Base::Unit::Length);
+    ui->filletStartRadius->setUnit(Base::Units::Length);
 
     ui->filletEndRadius->setMaximum(INT_MAX);
     ui->filletEndRadius->setMinimum(0);
-    ui->filletEndRadius->setUnit(Base::Unit::Length);
+    ui->filletEndRadius->setUnit(Base::Units::Length);
 
     d->object = nullptr;
     d->selection = new EdgeFaceSelection(d->object);
@@ -667,8 +667,8 @@ void DlgFilletEdges::setupFillet(const std::vector<App::DocumentObject*>& objs)
                 model->setData(model->index(index, 0), Qt::Checked, Qt::CheckStateRole);
                 //model->setData(model->index(index, 1), QVariant(QLocale().toString(et->radius1,'f',Base::UnitsApi::getDecimals())));
                 //model->setData(model->index(index, 2), QVariant(QLocale().toString(et->radius2,'f',Base::UnitsApi::getDecimals())));
-                model->setData(model->index(index, 1), QVariant::fromValue<Base::Quantity>(Base::Quantity(et.radius1, Base::Unit::Length)));
-                model->setData(model->index(index, 2), QVariant::fromValue<Base::Quantity>(Base::Quantity(et.radius2, Base::Unit::Length)));
+                model->setData(model->index(index, 1), QVariant::fromValue<Base::Quantity>(Base::Quantity(et.radius1, Base::Units::Length)));
+                model->setData(model->index(index, 2), QVariant::fromValue<Base::Quantity>(Base::Quantity(et.radius2, Base::Units::Length)));
 
                 startRadius = et.radius1;
                 endRadius = et.radius2;
@@ -824,8 +824,8 @@ void DlgFilletEdges::onShapeObjectActivated(int itemPos)
             model->setData(model->index(index, 0), QVariant(id), Qt::UserRole);
           //model->setData(model->index(index, 1), QVariant(QLocale().toString(1.0,'f',Base::UnitsApi::getDecimals())));
           //model->setData(model->index(index, 2), QVariant(QLocale().toString(1.0,'f',Base::UnitsApi::getDecimals())));
-            model->setData(model->index(index, 1), QVariant::fromValue<Base::Quantity>(Base::Quantity(1.0,Base::Unit::Length)));
-            model->setData(model->index(index, 2), QVariant::fromValue<Base::Quantity>(Base::Quantity(1.0,Base::Unit::Length)));
+            model->setData(model->index(index, 1), QVariant::fromValue<Base::Quantity>(Base::Quantity(1.0,Base::Units::Length)));
+            model->setData(model->index(index, 2), QVariant::fromValue<Base::Quantity>(Base::Quantity(1.0,Base::Units::Length)));
             std::stringstream element;
             element << "Edge" << id;
             if (Gui::Selection().isSelected(part, element.str().c_str()))

--- a/src/Mod/Part/Gui/DlgPrimitives.cpp
+++ b/src/Mod/Part/Gui/DlgPrimitives.cpp
@@ -1994,10 +1994,10 @@ Location::Location(QWidget* parent, Part::Feature* feature)
     connect(ui->viewPositionButton, &QPushButton::clicked,
             this, &Location::onViewPositionButton);
 
-    ui->XPositionQSB->setUnit(Base::Unit::Length);
-    ui->YPositionQSB->setUnit(Base::Unit::Length);
-    ui->ZPositionQSB->setUnit(Base::Unit::Length);
-    ui->AngleQSB->setUnit(Base::Unit::Angle);
+    ui->XPositionQSB->setUnit(Base::Units::Length);
+    ui->YPositionQSB->setUnit(Base::Units::Length);
+    ui->ZPositionQSB->setUnit(Base::Units::Length);
+    ui->AngleQSB->setUnit(Base::Units::Angle);
 
     // fill location widget if object already exists
     if (feature) {

--- a/src/Mod/Part/Gui/DlgRevolution.cpp
+++ b/src/Mod/Part/Gui/DlgRevolution.cpp
@@ -105,19 +105,19 @@ DlgRevolution::DlgRevolution(QWidget* parent, Qt::WindowFlags fl)
     ui->xPos->setRange(-DBL_MAX,DBL_MAX);
     ui->yPos->setRange(-DBL_MAX,DBL_MAX);
     ui->zPos->setRange(-DBL_MAX,DBL_MAX);
-    ui->xPos->setUnit(Base::Unit::Length);
-    ui->yPos->setUnit(Base::Unit::Length);
-    ui->zPos->setUnit(Base::Unit::Length);
+    ui->xPos->setUnit(Base::Units::Length);
+    ui->yPos->setUnit(Base::Units::Length);
+    ui->zPos->setUnit(Base::Units::Length);
 
     ui->xDir->setRange(-DBL_MAX,DBL_MAX);
     ui->yDir->setRange(-DBL_MAX,DBL_MAX);
     ui->zDir->setRange(-DBL_MAX,DBL_MAX);
-    ui->xDir->setUnit(Base::Unit());
-    ui->yDir->setUnit(Base::Unit());
-    ui->zDir->setUnit(Base::Unit());
+    ui->xDir->setUnit(Base::Units::NullUnit);
+    ui->yDir->setUnit(Base::Units::NullUnit);
+    ui->zDir->setUnit(Base::Units::NullUnit);
     ui->zDir->setValue(1.0);
 
-    ui->angle->setUnit(Base::Unit::Angle);
+    ui->angle->setUnit(Base::Units::Angle);
     ui->angle->setValue(360.0);
     findShapes();
 

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -185,9 +185,9 @@ Mirroring::Mirroring(QWidget* parent)
     ui->baseX->setRange(-DBL_MAX, DBL_MAX);
     ui->baseY->setRange(-DBL_MAX, DBL_MAX);
     ui->baseZ->setRange(-DBL_MAX, DBL_MAX);
-    ui->baseX->setUnit(Base::Unit::Length);
-    ui->baseY->setUnit(Base::Unit::Length);
-    ui->baseZ->setUnit(Base::Unit::Length);
+    ui->baseX->setUnit(Base::Units::Length);
+    ui->baseY->setUnit(Base::Units::Length);
+    ui->baseZ->setUnit(Base::Units::Length);
     findShapes();
 
     Gui::ItemViewSelection sel(ui->shapes);

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -72,7 +72,7 @@ const QString makeRefString(const App::DocumentObject* obj, const std::string& s
         return QString::fromLatin1(obj->getNameInDocument());
     }
 
-    // Hide the TNP string from the user. ie show "Body.Pad.Face6"  and not : 
+    // Hide the TNP string from the user. ie show "Body.Pad.Face6"  and not :
     // "Body.Pad.;#a:1;:G0;XTR;:Hc94:8,F.Face6"
     App::ElementNamePair el;
     App::GeoFeature::resolveElement(obj, sub.c_str(), el, true);
@@ -441,7 +441,7 @@ void TaskAttacher::findCorrectObjAndSubInThisContext(App::DocumentObject*& rootO
         }
 
         // In case the attaching object is in a link to a part.
-        // For instance : 
+        // For instance :
         // - Part1
         // - - LinkToPart2
         // - - - Cube
@@ -454,7 +454,7 @@ void TaskAttacher::findCorrectObjAndSubInThisContext(App::DocumentObject*& rootO
     }
 
     // if we reach this point it means that attaching object's group is outside of
-    // the scope of the attached object. For instance: 
+    // the scope of the attached object. For instance:
     // - Part1
     // - - Part2
     // - - - Cube
@@ -906,9 +906,9 @@ void TaskAttacher::updateAttachmentOffsetUI()
     ui->attachmentOffsetPitch->blockSignals(bBlock);
     ui->attachmentOffsetRoll->blockSignals(bBlock);
 
-    ui->attachmentOffsetX->setValue(Base::Quantity(pos.x, Base::Unit::Length));
-    ui->attachmentOffsetY->setValue(Base::Quantity(pos.y, Base::Unit::Length));
-    ui->attachmentOffsetZ->setValue(Base::Quantity(pos.z, Base::Unit::Length));
+    ui->attachmentOffsetX->setValue(Base::Quantity(pos.x,Base::Units::Length));
+    ui->attachmentOffsetY->setValue(Base::Quantity(pos.y,Base::Units::Length));
+    ui->attachmentOffsetZ->setValue(Base::Quantity(pos.z,Base::Units::Length));
     ui->attachmentOffsetYaw->setValue(yaw);
     ui->attachmentOffsetPitch->setValue(pitch);
     ui->attachmentOffsetRoll->setValue(roll);

--- a/src/Mod/Part/Gui/TaskOffset.cpp
+++ b/src/Mod/Part/Gui/TaskOffset.cpp
@@ -62,7 +62,7 @@ OffsetWidget::OffsetWidget(Part::Offset* offset, QWidget* parent)
     d->ui.setupUi(this);
     setupConnections();
 
-    d->ui.spinOffset->setUnit(Base::Unit::Length);
+    d->ui.spinOffset->setUnit(Base::Units::Length);
     d->ui.spinOffset->setRange(-INT_MAX, INT_MAX);
     d->ui.spinOffset->setSingleStep(0.1);
     d->ui.facesButton->hide();

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -60,15 +60,15 @@ Chamfer::Chamfer()
     ChamferType.setEnums(ChamferTypeEnums);
 
     ADD_PROPERTY_TYPE(Size, (1.0), "Chamfer", App::Prop_None, "Size of chamfer");
-    Size.setUnit(Base::Unit::Length);
+    Size.setUnit(Base::Units::Length);
     Size.setConstraints(&floatSize);
 
     ADD_PROPERTY_TYPE(Size2, (1.0), "Chamfer", App::Prop_None, "Second size of chamfer");
-    Size2.setUnit(Base::Unit::Length);
+    Size2.setUnit(Base::Units::Length);
     Size2.setConstraints(&floatSize);
 
     ADD_PROPERTY_TYPE(Angle, (45.0), "Chamfer", App::Prop_None, "Angle of chamfer");
-    Angle.setUnit(Base::Unit::Angle);
+    Angle.setUnit(Base::Units::Angle);
     Angle.setConstraints(&floatAngle);
 
     ADD_PROPERTY_TYPE(FlipDirection, (false), "Chamfer", App::Prop_None, "Flip direction");

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -49,7 +49,7 @@ const App::PropertyQuantityConstraint::Constraints floatRadius = {0.0,FLT_MAX,0.
 Fillet::Fillet()
 {
     ADD_PROPERTY_TYPE(Radius, (1.0), "Fillet", App::Prop_None, "Fillet radius.");
-    Radius.setUnit(Base::Unit::Length);
+    Radius.setUnit(Base::Units::Length);
     Radius.setConstraints(&floatRadius);
     ADD_PROPERTY_TYPE(UseAllEdges, (false), "Fillet", App::Prop_None,
       "Fillet all edges if true, else use only those edges in Base property.\n"

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -122,18 +122,18 @@ void TaskChamferParameters::setUpUI(PartDesign::Chamfer* pcChamfer)
     ui->flipDirection->setEnabled(index != 0);  // Enable if type is not "Equal distance"
     ui->flipDirection->setChecked(pcChamfer->FlipDirection.getValue());
 
-    ui->chamferSize->setUnit(Base::Unit::Length);
+    ui->chamferSize->setUnit(Base::Units::Length);
     ui->chamferSize->setMinimum(0);
     ui->chamferSize->setValue(pcChamfer->Size.getValue());
     ui->chamferSize->bind(pcChamfer->Size);
     ui->chamferSize->selectNumber();
 
-    ui->chamferSize2->setUnit(Base::Unit::Length);
+    ui->chamferSize2->setUnit(Base::Units::Length);
     ui->chamferSize2->setMinimum(0);
     ui->chamferSize2->setValue(pcChamfer->Size2.getValue());
     ui->chamferSize2->bind(pcChamfer->Size2);
 
-    ui->chamferAngle->setUnit(Base::Unit::Angle);
+    ui->chamferAngle->setUnit(Base::Units::Angle);
     ui->chamferAngle->setMinimum(pcChamfer->Angle.getMinimum());
     ui->chamferAngle->setMaximum(pcChamfer->Angle.getMaximum());
     ui->chamferAngle->setValue(pcChamfer->Angle.getValue());

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -61,7 +61,7 @@ TaskFilletParameters::TaskFilletParameters(ViewProviderDressUp* DressUpView, QWi
     ui->listWidgetReferences->setEnabled(!useAllEdges);
     double r = pcFillet->Radius.getValue();
 
-    ui->filletRadius->setUnit(Base::Unit::Length);
+    ui->filletRadius->setUnit(Base::Units::Length);
     ui->filletRadius->setValue(r);
     ui->filletRadius->setMinimum(0);
     ui->filletRadius->selectNumber();

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -87,11 +87,11 @@ void TaskLinearPatternParameters::setupParameterUI(QWidget* widget)
     ui->comboMode->setEnabled(true);
     ui->spinLength->blockSignals(true);
     ui->spinLength->setEnabled(true);
-    ui->spinLength->setUnit(Base::Unit::Length);
+    ui->spinLength->setUnit(Base::Units::Length);
     ui->spinLength->blockSignals(false);
     ui->spinOffset->blockSignals(true);
     ui->spinOffset->setEnabled(true);
-    ui->spinOffset->setUnit(Base::Unit::Length);
+    ui->spinOffset->setUnit(Base::Units::Length);
     ui->spinOffset->blockSignals(false);
     ui->spinOccurrences->setEnabled(true);
 

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -92,7 +92,7 @@ void TaskPadParameters::onModeChanged(int index)
     case Mode::Dimension:
         pcPad->Type.setValue("Length");
         // Avoid error message
-        if (ui->lengthEdit->value() < Base::Quantity(Precision::Confusion(), Base::Unit::Length))
+        if (ui->lengthEdit->value() < Base::Quantity(Precision::Confusion(), Base::Units::Length))
             ui->lengthEdit->setValue(5.0);
         break;
     case Mode::ToLast:

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -915,8 +915,8 @@ bool TaskBoxPrimitives::setPrimitive(App::DocumentObject* obj)
                     QMessageBox::warning(Gui::getMainWindow(),
                                          tr("Invalid wedge parameters"),
                                          tr("X min must not be equal to X max!"));
-                    return false;
-                }
+            return false;
+        }
                 else if (ui->wedgeYmin->value().getValue() == ui->wedgeYmax->value().getValue()) {
                     QMessageBox::warning(Gui::getMainWindow(),
                                          tr("Invalid wedge parameters"),

--- a/src/Mod/Robot/App/WaypointPyImp.cpp
+++ b/src/Mod/Robot/App/WaypointPyImp.cpp
@@ -25,6 +25,7 @@
 #include <Base/PlacementPy.h>
 #include <Base/PyWrapParseTupleAndKeywords.h>
 #include <Base/UnitsApi.h>
+#include "Base/Units.h"
 
 // clang-format off
 // inclusion of the generated files (generated out of WaypointPy.xml)
@@ -153,7 +154,7 @@ int WaypointPy::PyInit(PyObject* args, PyObject* kwd)
         }
     }
     else {
-        getWaypointPtr()->Velocity = Base::UnitsApi::toDouble(vel, Base::Unit::Velocity);
+        getWaypointPtr()->Velocity = Base::UnitsApi::toDouble(vel, Base::Units::Velocity);
     }
     getWaypointPtr()->Cont = cont ? true : false;
     getWaypointPtr()->Tool = tool;
@@ -162,7 +163,7 @@ int WaypointPy::PyInit(PyObject* args, PyObject* kwd)
         getWaypointPtr()->Acceleration = 100;
     }
     else {
-        getWaypointPtr()->Acceleration = Base::UnitsApi::toDouble(acc, Base::Unit::Acceleration);
+        getWaypointPtr()->Acceleration = Base::UnitsApi::toDouble(acc, Base::Units::Acceleration);
     }
 
     return 0;

--- a/src/Mod/Sketcher/App/Constraint.cpp
+++ b/src/Mod/Sketcher/App/Constraint.cpp
@@ -30,6 +30,7 @@
 #include <Base/Reader.h>
 #include <Base/Tools.h>
 #include <Base/Writer.h>
+#include <Base/Units.h>
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
@@ -121,11 +122,11 @@ Quantity Constraint::getPresentationValue() const
         case DistanceX:
         case DistanceY:
             quantity.setValue(Value);
-            quantity.setUnit(Unit::Length);
+            quantity.setUnit(Units::Length);
             break;
         case Angle:
             quantity.setValue(toDegrees<double>(Value));
-            quantity.setUnit(Unit::Angle);
+            quantity.setUnit(Units::Angle);
             break;
         case SnellsLaw:
         case Weight:

--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #include <Base/QuantityPy.h>
+#include "Base/Units.h"
 
 #include "ConstraintPy.h"
 
@@ -169,7 +170,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 if (PyObject_TypeCheck(index_or_value, &(Base::QuantityPy::Type))) {
                     Base::Quantity q =
                         *(static_cast<Base::QuantityPy*>(index_or_value)->getQuantityPtr());
-                    if (q.getUnit() == Base::Unit::Angle) {
+                    if (q.getUnit() == Base::Units::Angle) {
                         Value = q.getValueAs(Base::Quantity::Radian);
                     }
                 }
@@ -304,7 +305,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 if (PyObject_TypeCheck(index_or_value, &(Base::QuantityPy::Type))) {
                     Base::Quantity q =
                         *(static_cast<Base::QuantityPy*>(index_or_value)->getQuantityPtr());
-                    if (q.getUnit() == Base::Unit::Angle) {
+                    if (q.getUnit() == Base::Units::Angle) {
                         Value = q.getValueAs(Base::Quantity::Radian);
                     }
                 }
@@ -555,7 +556,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 if (PyObject_TypeCheck(oNumArg5, &(Base::QuantityPy::Type))) {
                     Base::Quantity q =
                         *(static_cast<Base::QuantityPy*>(oNumArg5)->getQuantityPtr());
-                    if (q.getUnit() == Base::Unit::Angle) {
+                    if (q.getUnit() == Base::Units::Angle) {
                         Value = q.getValueAs(Base::Quantity::Radian);
                     }
                 }
@@ -565,7 +566,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 if (PyObject_TypeCheck(oNumArg5, &(Base::QuantityPy::Type))) {
                     Base::Quantity q =
                         *(static_cast<Base::QuantityPy*>(oNumArg5)->getQuantityPtr());
-                    if (q.getUnit() == Base::Unit::Angle) {
+                    if (q.getUnit() == Base::Units::Angle) {
                         Value = q.getValueAs(Base::Quantity::Radian);
                     }
                 }

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -671,7 +671,7 @@ PyObject* SketchObjectPy::setDatum(PyObject* args)
         // handle (int,Quantity)
         if (PyArg_ParseTuple(args, "iO!", &Index, &(Base::QuantityPy::Type), &object)) {
             Quantity = *(static_cast<Base::QuantityPy*>(object)->getQuantityPtr());
-            if (Quantity.getUnit() == Base::Unit::Angle) {
+            if (Quantity.getUnit() == Base::Units::Angle) {
                 Datum = Base::toRadians<double>(Quantity.getValue());
                 break;
             }
@@ -693,7 +693,7 @@ PyObject* SketchObjectPy::setDatum(PyObject* args)
         PyErr_Clear();
         if (PyArg_ParseTuple(args, "sO!", &constrName, &(Base::QuantityPy::Type), &object)) {
             Quantity = *(static_cast<Base::QuantityPy*>(object)->getQuantityPtr());
-            if (Quantity.getUnit() == Base::Unit::Angle) {
+            if (Quantity.getUnit() == Base::Units::Angle) {
                 Datum = Base::toRadians<double>(Quantity.getValue());
             }
             else {
@@ -844,10 +844,10 @@ PyObject* SketchObjectPy::getDatum(PyObject* args)
     datum.setValue(constr->getValue());
     if (type == Angle) {
         datum.setValue(Base::toDegrees<double>(datum.getValue()));
-        datum.setUnit(Base::Unit::Angle);
+        datum.setUnit(Base::Units::Angle);
     }
     else {
-        datum.setUnit(Base::Unit::Length);
+        datum.setUnit(Base::Units::Length);
     }
 
     return new Base::QuantityPy(new Base::Quantity(datum));

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -9825,7 +9825,7 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
     dlg.setWindowTitle(EditDatumDialog::tr("Refractive index ratio"));
     ui_Datum.label->setText(EditDatumDialog::tr("Ratio n2/n1:"));
     Base::Quantity init_val;
-    init_val.setUnit(Base::Unit());
+    init_val.setUnit(Base::Units::NullUnit);
     init_val.setValue(0.0);
 
     ui_Datum.labelEdit->setValue(init_val);

--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -514,7 +514,7 @@ public:
 
     void drawDoubleAtCursor(const Base::Vector2d& position,
                             const double radius,
-                            Base::Unit unit = Base::Unit::Length)
+                            Base::Unit unit = Base::Units::Length)
     {
         if (shouldDrawDimensionsAtCursor()) {
             handler->drawDoubleAtCursor(position, radius, unit);
@@ -635,9 +635,9 @@ protected:
 
     void setOnViewParameterValue(OnViewParameter index,
                                  double val,
-                                 const Base::Unit& unit = Base::Unit::Length)
+                                 const Base::Unit& unit = Base::Units::Length)
     {
-        bool visible = isOnViewParameterVisible(index);
+        const bool visible = isOnViewParameterVisible(index);
 
         if (visible) {
             onViewParameters[index]->setSpinboxValue(val, unit);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -1009,7 +1009,7 @@ void DrawSketchHandler::drawDoubleAtCursor(const Base::Vector2d& position,
     }
 
     SbString text;
-    std::string doubleString = unit == Base::Unit::Length
+    const std::string doubleString = unit == Base::Units::Length
         ? lengthToDisplayFormat(val, 1)
         : angleToDisplayFormat(val * 180.0 / M_PI, 1);
     text.sprintf(" (%s)", doubleString.c_str());

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -30,6 +30,8 @@
 
 #include <Base/Parameter.h>
 #include <Base/Tools2D.h>
+#include "Base/Units.h"
+
 #include <Gui/Selection.h>
 #include <Gui/ToolHandler.h>
 #include <Mod/Part/App/Geometry.h>
@@ -257,7 +259,7 @@ protected:
     drawWidthHeightAtCursor(const Base::Vector2d& position, const double val1, const double val2);
     void drawDoubleAtCursor(const Base::Vector2d& position,
                             const double radius,
-                            Base::Unit unit = Base::Unit::Length);
+                            Base::Unit unit = Base::Units::Length);
 
     int getPreselectPoint() const;
     int getPreselectCurve() const;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -194,7 +194,7 @@ private:
                 }
 
                 if (constructionMethod() == ConstructionMethod::Center) {
-                    toolWidgetManager.drawDoubleAtCursor(onSketchPos, arcAngle, Base::Unit::Angle);
+                    toolWidgetManager.drawDoubleAtCursor(onSketchPos, arcAngle, Base::Units::Angle);
                     seekAndRenderAutoConstraint(sugConstraints[2],
                                                 onSketchPos,
                                                 Base::Vector2d(0.0, 0.0));
@@ -618,7 +618,7 @@ void DSHArcController::adaptParameters(Base::Vector2d onSketchPos)
                 }
                 double range = Base::toDegrees(handler->startAngle);
                 if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
+                    setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Units::Angle);
                 }
 
                 Base::Vector3d start = toVector3d(handler->centerPoint);
@@ -651,7 +651,7 @@ void DSHArcController::adaptParameters(Base::Vector2d onSketchPos)
                 double range = Base::toDegrees(handler->arcAngle);
 
                 if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fifth, range, Base::Unit::Angle);
+                    setOnViewParameterValue(OnViewParameter::Fifth, range, Base::Units::Angle);
                 }
 
                 Base::Vector3d start = toVector3d(handler->centerPoint);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
@@ -140,7 +140,7 @@ private:
 
                 CreateAndDrawShapeGeometry();
 
-                toolWidgetManager.drawDoubleAtCursor(onSketchPos, arcAngle, Base::Unit::Angle);
+                toolWidgetManager.drawDoubleAtCursor(onSketchPos, arcAngle, Base::Units::Angle);
 
                 seekAndRenderAutoConstraint(sugConstraints[2],
                                             onSketchPos,
@@ -695,7 +695,7 @@ void DSHArcSlotController::adaptParameters(Base::Vector2d onSketchPos)
             }
             double range = Base::toDegrees(handler->startAngle);
             if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
+                setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Units::Angle);
             }
 
             Base::Vector3d start = toVector3d(handler->centerPoint);
@@ -709,7 +709,7 @@ void DSHArcSlotController::adaptParameters(Base::Vector2d onSketchPos)
             double range = Base::toDegrees(handler->arcAngle);
 
             if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Fifth, range, Base::Unit::Angle);
+                setOnViewParameterValue(OnViewParameter::Fifth, range, Base::Units::Angle);
             }
 
             Base::Vector3d start = toVector3d(handler->centerPoint);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -888,7 +888,7 @@ void DSHBSplineController::configureToolWidget()
         toolWidget->setParameterLabel(
             WParameter::First,
             QApplication::translate("ToolWidgetManager_p4", "Degree (+'U'/ -'J')"));
-        toolWidget->configureParameterUnit(WParameter::First, Base::Unit());
+        toolWidget->configureParameterUnit(WParameter::First, Base::Units::NullUnit);
         toolWidget->configureParameterMin(WParameter::First, 1.0);  // NOLINT
         toolWidget->configureParameterMax(WParameter::First, Geom_BSplineCurve::MaxDegree());
         toolWidget->configureParameterDecimals(WParameter::First, 0);
@@ -1041,7 +1041,7 @@ void DSHBSplineController::adaptParameters(Base::Vector2d onSketchPos)
             if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
                 setOnViewParameterValue(OnViewParameter::Fourth,
                                         Base::toDegrees(range),
-                                        Base::Unit::Angle);
+                                        Base::Units::Angle);
             }
 
             onViewParameters[OnViewParameter::Third]->setPoints(start, end);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -598,7 +598,7 @@ void DSHEllipseController::adaptParameters(Base::Vector2d onSketchPos)
 
                 if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
                     double angle = vec.Length() > 0 ? Base::toDegrees(vec.Angle()) : 0;
-                    setOnViewParameterValue(OnViewParameter::Fourth, angle, Base::Unit::Angle);
+                    setOnViewParameterValue(OnViewParameter::Fourth, angle, Base::Units::Angle);
                 }
 
                 Base::Vector3d start = toVector3d(handler->centerPoint);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -490,7 +490,7 @@ void DSHLineController::adaptParameters(Base::Vector2d onSketchPos)
                 if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
                     setOnViewParameterValue(OnViewParameter::Fourth,
                                             Base::toDegrees(range),
-                                            Base::Unit::Angle);
+                                            Base::Units::Angle);
                 }
 
                 onViewParameters[OnViewParameter::Third]->setPoints(start, end);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -304,7 +304,7 @@ void DSHPolygonController::configureToolWidget()
         QApplication::translate("ToolWidgetManager_p4", "Sides (+'U'/ -'J')"));
     toolWidget->setParameter(WParameter::First,
                              handler->numberOfCorners);  // unconditionally set
-    toolWidget->configureParameterUnit(WParameter::First, Base::Unit());
+    toolWidget->configureParameterUnit(WParameter::First, Base::Units::NullUnit);
     toolWidget->configureParameterMin(WParameter::First, 3.0);  // NOLINT
     // We set a reasonable max to avoid the spinbox from being very large
     toolWidget->configureParameterMax(WParameter::First, 9999.0);  // NOLINT
@@ -406,7 +406,7 @@ void DSHPolygonController::adaptParameters(Base::Vector2d onSketchPos)
             if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
                 setOnViewParameterValue(OnViewParameter::Fourth,
                                         Base::toDegrees(range),
-                                        Base::Unit::Angle);
+                                        Base::Units::Angle);
             }
 
             onViewParameters[OnViewParameter::Third]->setPoints(start, end);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -2139,7 +2139,7 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
                 if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
                     setOnViewParameterValue(OnViewParameter::Fourth,
                                             Base::toDegrees(handler->angle),
-                                            Base::Unit::Angle);
+                                            Base::Units::Angle);
                 }
 
                 onViewParameters[OnViewParameter::Fourth]->setPoints(toVector3d(handler->corner1),
@@ -2214,7 +2214,7 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
 
                 if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
                     double val = Base::toDegrees(handler->angle123);
-                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
+                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Units::Angle);
                 }
 
                 onViewParameters[OnViewParameter::Sixth]->setPoints(
@@ -2242,7 +2242,7 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
 
                 if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
                     double val = Base::toDegrees(handler->angle412);
-                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
+                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Units::Angle);
                 }
 
                 onViewParameters[OnViewParameter::Sixth]->setPoints(toVector3d(handler->corner1),

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -522,7 +522,7 @@ void DSHRotateController::configureToolWidget()
         WParameter::First,
         QApplication::translate("TaskSketcherTool_p4_rotate", "Copies (+'U'/ -'J')"));
     toolWidget->setParameter(OnViewParameter::First, 0.0);
-    toolWidget->configureParameterUnit(OnViewParameter::First, Base::Unit());
+    toolWidget->configureParameterUnit(OnViewParameter::First, Base::Units::NullUnit);
     toolWidget->configureParameterMin(OnViewParameter::First, 0.0);     // NOLINT
     toolWidget->configureParameterMax(OnViewParameter::First, 9999.0);  // NOLINT
     toolWidget->configureParameterDecimals(OnViewParameter::First, 0);
@@ -618,7 +618,7 @@ void DSHRotateController::adaptParameters(Base::Vector2d onSketchPos)
         case SelectMode::SeekSecond: {
             double range = Base::toDegrees(handler->startAngle);
             if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Third, range, Base::Unit::Angle);
+                setOnViewParameterValue(OnViewParameter::Third, range, Base::Units::Angle);
             }
 
             Base::Vector3d start = toVector3d(handler->centerPoint);
@@ -630,7 +630,7 @@ void DSHRotateController::adaptParameters(Base::Vector2d onSketchPos)
             double range = Base::toDegrees(handler->totalAngle);
 
             if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
+                setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Units::Angle);
             }
 
             Base::Vector3d start = toVector3d(handler->centerPoint);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
@@ -473,7 +473,9 @@ void DSHScaleController::adaptParameters(Base::Vector2d onSketchPos)
         } break;
         case SelectMode::SeekThird: {
             if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Third, handler->scaleFactor, Base::Unit());
+                setOnViewParameterValue(OnViewParameter::Third,
+                                        handler->scaleFactor,
+                                        Base::Units::NullUnit);
             }
 
             Base::Vector3d start = toVector3d(handler->referencePoint);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
@@ -466,7 +466,7 @@ void DSHSlotController::adaptParameters(Base::Vector2d onSketchPos)
             if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
                 setOnViewParameterValue(OnViewParameter::Fourth,
                                         Base::toDegrees(range),
-                                        Base::Unit::Angle);
+                                        Base::Units::Angle);
             }
 
             onViewParameters[OnViewParameter::Third]->setPoints(start, end);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
@@ -520,8 +520,8 @@ void DSHTranslateController::configureToolWidget()
 
     toolWidget->setParameter(OnViewParameter::First, 0.0);
     toolWidget->setParameter(OnViewParameter::Second, 1.0);
-    toolWidget->configureParameterUnit(OnViewParameter::First, Base::Unit());
-    toolWidget->configureParameterUnit(OnViewParameter::Second, Base::Unit());
+    toolWidget->configureParameterUnit(OnViewParameter::First, Base::Units::NullUnit);
+    toolWidget->configureParameterUnit(OnViewParameter::Second, Base::Units::NullUnit);
     toolWidget->configureParameterMin(OnViewParameter::First, 0.0);      // NOLINT
     toolWidget->configureParameterMin(OnViewParameter::Second, 0.0);     // NOLINT
     toolWidget->configureParameterMax(OnViewParameter::First, 9999.0);   // NOLINT
@@ -650,7 +650,7 @@ void DSHTranslateController::adaptParameters(Base::Vector2d onSketchPos)
             double range = angle * 180 / M_PI;
 
             if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
+                setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Units::Angle);
             }
 
             Base::Vector3d start = toVector3d(handler->referencePoint);
@@ -672,7 +672,7 @@ void DSHTranslateController::adaptParameters(Base::Vector2d onSketchPos)
             double range = angle * 180 / M_PI;
 
             if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Sixth, range, Base::Unit::Angle);
+                setOnViewParameterValue(OnViewParameter::Sixth, range, Base::Units::Angle);
             }
 
             Base::Vector3d start = toVector3d(handler->referencePoint);

--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -96,21 +96,21 @@ int EditDatumDialog::exec(bool atCursor)
         if (Constr->Type == Sketcher::Angle) {
             datum = Base::toDegrees<double>(datum);
             dlg.setWindowTitle(tr("Insert angle"));
-            init_val.setUnit(Base::Unit::Angle);
+            init_val.setUnit(Base::Units::Angle);
             ui_ins_datum->label->setText(tr("Angle:"));
             ui_ins_datum->labelEdit->setParamGrpPath(
                 QByteArray("User parameter:BaseApp/History/SketcherAngle"));
         }
         else if (Constr->Type == Sketcher::Radius) {
             dlg.setWindowTitle(tr("Insert radius"));
-            init_val.setUnit(Base::Unit::Length);
+            init_val.setUnit(Base::Units::Length);
             ui_ins_datum->label->setText(tr("Radius:"));
             ui_ins_datum->labelEdit->setParamGrpPath(
                 QByteArray("User parameter:BaseApp/History/SketcherLength"));
         }
         else if (Constr->Type == Sketcher::Diameter) {
             dlg.setWindowTitle(tr("Insert diameter"));
-            init_val.setUnit(Base::Unit::Length);
+            init_val.setUnit(Base::Units::Length);
             ui_ins_datum->label->setText(tr("Diameter:"));
             ui_ins_datum->labelEdit->setParamGrpPath(
                 QByteArray("User parameter:BaseApp/History/SketcherLength"));
@@ -130,7 +130,7 @@ int EditDatumDialog::exec(bool atCursor)
         }
         else {
             dlg.setWindowTitle(tr("Insert length"));
-            init_val.setUnit(Base::Unit::Length);
+            init_val.setUnit(Base::Units::Length);
             ui_ins_datum->label->setText(tr("Length:"));
             ui_ins_datum->labelEdit->setParamGrpPath(
                 QByteArray("User parameter:BaseApp/History/SketcherLength"));

--- a/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
+++ b/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include <Base/Tools.h>
+#include "Base/Units.h"
 #include <Mod/Sketcher/App/PropertyConstraintList.h>
 
 #include "PropertyConstraintListItem.h"
@@ -261,11 +262,11 @@ QVariant PropertyConstraintListItem::value(const App::Property* prop) const
             Base::Quantity quant;
             if ((*it)->Type == Sketcher::Angle) {
                 double datum = Base::toDegrees<double>((*it)->getValue());
-                quant.setUnit(Base::Unit::Angle);
+                quant.setUnit(Base::Units::Angle);
                 quant.setValue(datum);
             }
             else {
-                quant.setUnit(Base::Unit::Length);
+                quant.setUnit(Base::Units::Length);
                 quant.setValue((*it)->getValue());
             }
 

--- a/src/Mod/Sketcher/Gui/SketcherToolDefaultWidget.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherToolDefaultWidget.cpp
@@ -355,7 +355,7 @@ void SketcherToolDefaultWidget::configureParameterInitialValue(int parameterinde
 void SketcherToolDefaultWidget::configureParameterUnit(int parameterindex, const Base::Unit& unit)
 {
     // For reference unit can be changed with :
-    // setUnit(Base::Unit::Length); Base::Unit::Angle
+    // setUnit(Base::Units::Length); Base::Units::Angle
     Base::StateLocker lock(blockParameterSlots, true);
     if (parameterindex < nParameters) {
         getParameterSpinBox(parameterindex)->setUnit(unit);

--- a/src/Mod/Sketcher/Gui/SketcherToolDefaultWidget.h
+++ b/src/Mod/Sketcher/Gui/SketcherToolDefaultWidget.h
@@ -117,7 +117,7 @@ public:
     double getParameter(int parameterindex);
     bool isParameterSet(int parameterindex);
     void
-    updateVisualValue(int parameterindex, double val, const Base::Unit& unit = Base::Unit::Length);
+    updateVisualValue(int parameterindex, double val, const Base::Unit& unit = Base::Units::Length);
 
     void setParameterEnabled(int parameterindex, bool active = true);
     void setParameterFocus(int parameterindex);

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -711,8 +711,8 @@ std::string SketcherGui::lengthToDisplayFormat(double value, int digits)
 {
     Base::Quantity asQuantity;
     asQuantity.setValue(value);
-    asQuantity.setUnit(Base::Unit::Length);
-    std::string userString = asQuantity.getUserString();
+    asQuantity.setUnit(Base::Units::Length);
+    const std::string userString = asQuantity.getUserString();
     if (Base::UnitsApi::isMultiUnitLength() || (!hideUnits() && useSystemDecimals())) {
         // just return the user string
         return userString;
@@ -771,7 +771,7 @@ std::string SketcherGui::angleToDisplayFormat(double value, int digits)
 {
     Base::Quantity asQuantity;
     asQuantity.setValue(value);
-    asQuantity.setUnit(Base::Unit::Angle);
+    asQuantity.setUnit(Base::Units::Angle);
     QString qUserString = QString::fromStdString(asQuantity.getUserString());
     if (Base::UnitsApi::isMultiUnitAngle()) {
         // just return the user string

--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -611,7 +611,7 @@ void Cell::setComputedUnit(const Base::Unit& unit)
     PropertySheet::AtomicPropertyChange signaller(*owner);
 
     computedUnit = unit;
-    setUsed(COMPUTED_UNIT_SET, !computedUnit.isEmpty());
+    setUsed(COMPUTED_UNIT_SET, computedUnit != Units::NullUnit);
     setDirty();
 
     signaller.tryInvoke();
@@ -1106,7 +1106,7 @@ std::string Cell::getFormattedQuantity()
         const Base::Unit& computedUnit = floatProp->getUnit();
         qFormatted = QLocale().toString(rawVal, 'f', Base::UnitsApi::getDecimals());
         if (hasDisplayUnit) {
-            if (computedUnit.isEmpty() || computedUnit == du.unit) {
+            if (computedUnit == Units::NullUnit || computedUnit == du.unit) {
                 QString number =
                     QLocale().toString(rawVal / duScale, 'f', Base::UnitsApi::getDecimals());
                 qFormatted = number + QString::fromStdString(" " + displayUnit.stringRep);

--- a/src/Mod/Spreadsheet/App/DisplayUnit.h
+++ b/src/Mod/Spreadsheet/App/DisplayUnit.h
@@ -24,6 +24,7 @@
 #define DISPLAYUNIT_H
 
 #include <Base/Unit.h>
+#include <Base/Units.h>
 #include <string>
 
 namespace Spreadsheet
@@ -37,7 +38,7 @@ public:
     double scaler;
 
     explicit DisplayUnit(const std::string _stringRep = "",
-                         const Base::Unit _unit = Base::Unit(),
+                         const Base::Unit _unit = Base::Units::NullUnit,
                          double _scaler = 0.0)
         : stringRep(_stringRep)
         , unit(_unit)

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -782,12 +782,12 @@ void Sheet::updateProperty(CellAddress key)
         auto number = freecad_dynamic_cast<NumberExpression>(output.get());
         if (number) {
             long l;
-            auto constant = freecad_dynamic_cast<ConstantExpression>(output.get());
+            const auto constant = freecad_dynamic_cast<ConstantExpression>(output.get());
             if (constant && !constant->isNumber()) {
-                Base::PyGILStateLocker lock;
+                PyGILStateLocker lock;
                 setObjectProperty(key, constant->getPyValue());
             }
-            else if (!number->getUnit().isEmpty()) {
+            else if (number->getUnit() != Units::NullUnit) {
                 setQuantityProperty(key, number->getValue(), number->getUnit());
             }
             else if (number->isInteger(&l)) {

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -360,7 +360,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
 
                 // Display locale specific decimal separator (#0003875,#0003876)
                 if (cell->getDisplayUnit(displayUnit)) {
-                    if (computedUnit.isEmpty() || computedUnit == displayUnit.unit) {
+                    if (computedUnit == Base::Units::NullUnit || computedUnit == displayUnit.unit) {
                         QString number =
                             QLocale().toString(floatProp->getValue() / displayUnit.scaler,
                                                'f',

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -33,354 +33,561 @@ from FreeCAD import Units
 
 v = Base.Vector
 
+
 # ----------------------------------------------------------------------------------
-# define the functions to test the FreeCAD Spreadsheet module and expression engine
+# Test Spreadsheet module and expression engine
 # ----------------------------------------------------------------------------------
 
 
-class SpreadsheetCases(unittest.TestCase):
-    def setUp(self):
-        self.doc = FreeCAD.newDocument()
-        self.TempPath = tempfile.gettempdir()
-        FreeCAD.Console.PrintLog("  Using temp path: " + self.TempPath + "\n")
+#############################################################################################
+class SpreadsheetAggregates(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = FreeCAD.newDocument()
+        cls.TempPath = tempfile.gettempdir()
+        FreeCAD.Console.PrintLog("  Using temp path: " + cls.TempPath + "\n")
+        cls.sheet = cls.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
 
-    def testAggregates(self):
-        """Test all aggregate functions"""
-        sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
-        sheet.set("B13", "4")
-        sheet.set("B14", "5")
-        sheet.set("B15", "6")
-        sheet.set("C13", "4mm")
-        sheet.set("C14", "5mm")
-        sheet.set("C15", "6mm")
-        sheet.set("C16", "6")
+        cls.sheet.set("B13", "4")
+        cls.sheet.set("B14", "5")
+        cls.sheet.set("B15", "6")
+        cls.sheet.set("C13", "4mm")
+        cls.sheet.set("C14", "5mm")
+        cls.sheet.set("C15", "6mm")
+        cls.sheet.set("C16", "6")
 
-        sheet.set("A1", "=sum(1)")
-        sheet.set("A2", "=sum(1;2)")
-        sheet.set("A3", "=sum(1;2;3)")
-        sheet.set("A4", "=sum(1;2;3;B13)")
-        sheet.set("A5", "=sum(1;2;3;B13:B15)")
+        cls.sheet.set("A1", "=sum(1)")
+        cls.sheet.set("A2", "=sum(1;2)")
+        cls.sheet.set("A3", "=sum(1;2;3)")
+        cls.sheet.set("A4", "=sum(1;2;3;B13)")
+        cls.sheet.set("A5", "=sum(1;2;3;B13:B15)")
 
-        sheet.set("B1", "=min(1)")
-        sheet.set("B2", "=min(1;2)")
-        sheet.set("B3", "=min(1;2;3)")
-        sheet.set("B4", "=min(1;2;3;B13)")
-        sheet.set("B5", "=min(1;2;3;B13:B15)")
+        cls.sheet.set("B1", "=min(1)")
+        cls.sheet.set("B2", "=min(1;2)")
+        cls.sheet.set("B3", "=min(1;2;3)")
+        cls.sheet.set("B4", "=min(1;2;3;B13)")
+        cls.sheet.set("B5", "=min(1;2;3;B13:B15)")
 
-        sheet.set("C1", "=max(1)")
-        sheet.set("C2", "=max(1;2)")
-        sheet.set("C3", "=max(1;2;3)")
-        sheet.set("C4", "=max(1;2;3;B13)")
-        sheet.set("C5", "=max(1;2;3;B13:B15)")
+        cls.sheet.set("C1", "=max(1)")
+        cls.sheet.set("C2", "=max(1;2)")
+        cls.sheet.set("C3", "=max(1;2;3)")
+        cls.sheet.set("C4", "=max(1;2;3;B13)")
+        cls.sheet.set("C5", "=max(1;2;3;B13:B15)")
 
-        sheet.set("D1", "=stddev(1)")
-        sheet.set("D2", "=stddev(1;2)")
-        sheet.set("D3", "=stddev(1;2;3)")
-        sheet.set("D4", "=stddev(1;2;3;B13)")
-        sheet.set("D5", "=stddev(1;2;3;B13:B15)")
+        cls.sheet.set("D1", "=stddev(1)")
+        cls.sheet.set("D2", "=stddev(1;2)")
+        cls.sheet.set("D3", "=stddev(1;2;3)")
+        cls.sheet.set("D4", "=stddev(1;2;3;B13)")
+        cls.sheet.set("D5", "=stddev(1;2;3;B13:B15)")
 
-        sheet.set("E1", "=count(1)")
-        sheet.set("E2", "=count(1;2)")
-        sheet.set("E3", "=count(1;2;3)")
-        sheet.set("E4", "=count(1;2;3;B13)")
-        sheet.set("E5", "=count(1;2;3;B13:B15)")
+        cls.sheet.set("E1", "=count(1)")
+        cls.sheet.set("E2", "=count(1;2)")
+        cls.sheet.set("E3", "=count(1;2;3)")
+        cls.sheet.set("E4", "=count(1;2;3;B13)")
+        cls.sheet.set("E5", "=count(1;2;3;B13:B15)")
 
-        sheet.set("F1", "=average(1)")
-        sheet.set("F2", "=average(1;2)")
-        sheet.set("F3", "=average(1;2;3)")
-        sheet.set("F4", "=average(1;2;3;B13)")
-        sheet.set("F5", "=average(1;2;3;B13:B15)")
+        cls.sheet.set("F1", "=average(1)")
+        cls.sheet.set("F2", "=average(1;2)")
+        cls.sheet.set("F3", "=average(1;2;3)")
+        cls.sheet.set("F4", "=average(1;2;3;B13)")
+        cls.sheet.set("F5", "=average(1;2;3;B13:B15)")
 
-        sheet.set("G1", "=average(C13:C15)")
-        sheet.set("G2", "=min(C13:C15)")
-        sheet.set("G3", "=max(C13:C15)")
-        sheet.set("G4", "=count(C13:C15)")
-        sheet.set("G5", "=stddev(C13:C15)")
-        sheet.set("G6", "=sum(C13:C15)")
+        cls.sheet.set("G1", "=average(C13:C15)")
+        cls.sheet.set("G2", "=min(C13:C15)")
+        cls.sheet.set("G3", "=max(C13:C15)")
+        cls.sheet.set("G4", "=count(C13:C15)")
+        cls.sheet.set("G5", "=stddev(C13:C15)")
+        cls.sheet.set("G6", "=sum(C13:C15)")
 
-        sheet.set("H1", "=average(C13:C16)")
-        sheet.set("H2", "=min(C13:C16)")
-        sheet.set("H3", "=max(C13:C16)")
-        sheet.set("H4", "=count(C13:C16)")
-        sheet.set("H5", "=stddev(C13:C16)")
-        sheet.set("H6", "=sum(C13:C16)")
+        cls.sheet.set("H1", "=average(C13:C16)")
+        cls.sheet.set("H2", "=min(C13:C16)")
+        cls.sheet.set("H3", "=max(C13:C16)")
+        cls.sheet.set("H4", "=count(C13:C16)")
+        cls.sheet.set("H5", "=stddev(C13:C16)")
+        cls.sheet.set("H6", "=sum(C13:C16)")
 
-        self.doc.recompute()
-        self.assertEqual(sheet.A1, 1)
-        self.assertEqual(sheet.A2, 3)
-        self.assertEqual(sheet.A3, 6)
-        self.assertEqual(sheet.A4, 10)
-        self.assertEqual(sheet.A5, 21)
+        cls.doc.recompute()
 
-        self.assertEqual(sheet.B1, 1)
-        self.assertEqual(sheet.B2, 1)
-        self.assertEqual(sheet.B3, 1)
-        self.assertEqual(sheet.B4, 1)
-        self.assertEqual(sheet.B5, 1)
+    @classmethod
+    def tearDownClass(cls):
+        FreeCAD.closeDocument(cls.doc.Name)
 
-        self.assertEqual(sheet.C1, 1)
-        self.assertEqual(sheet.C2, 2)
-        self.assertEqual(sheet.C3, 3)
-        self.assertEqual(sheet.C4, 4)
-        self.assertEqual(sheet.C5, 6)
+    def test_values(self):
+        self.assertEqual(self.sheet.A1, 1)
+        self.assertEqual(self.sheet.A2, 3)
+        self.assertEqual(self.sheet.A3, 6)
+        self.assertEqual(self.sheet.A4, 10)
+        self.assertEqual(self.sheet.A5, 21)
 
+    def test_sum(self):
+        self.assertEqual(self.sheet.B1, 1)
+        self.assertEqual(self.sheet.B2, 1)
+        self.assertEqual(self.sheet.B3, 1)
+        self.assertEqual(self.sheet.B4, 1)
+        self.assertEqual(self.sheet.B5, 1)
+
+    def test_min(self):
+        self.assertEqual(self.sheet.C1, 1)
+        self.assertEqual(self.sheet.C2, 2)
+        self.assertEqual(self.sheet.C3, 3)
+        self.assertEqual(self.sheet.C4, 4)
+        self.assertEqual(self.sheet.C5, 6)
+
+    def test_max(self):
         self.assertTrue(
-            sheet.D1.startswith("ERR: Invalid number of entries: at least two required.")
+            self.sheet.D1.startswith("ERR: Invalid number of entries: at least two required.")
         )
-        self.assertEqual(sheet.D2, 0.7071067811865476)
-        self.assertEqual(sheet.D3, 1.0)
-        self.assertEqual(sheet.D4, 1.2909944487358056)
-        self.assertEqual(sheet.D5, 1.8708286933869707)
 
-        self.assertEqual(sheet.E1, 1)
-        self.assertEqual(sheet.E2, 2)
-        self.assertEqual(sheet.E3, 3)
-        self.assertEqual(sheet.E4, 4)
-        self.assertEqual(sheet.E5, 6)
+    def test_stddev(self):
+        self.assertEqual(self.sheet.D2, 0.7071067811865476)
+        self.assertEqual(self.sheet.D3, 1.0)
+        self.assertEqual(self.sheet.D4, 1.2909944487358056)
+        self.assertEqual(self.sheet.D5, 1.8708286933869707)
 
-        self.assertEqual(sheet.F1, 1)
-        self.assertEqual(sheet.F2, (1.0 + 2.0) / 2.0)
-        self.assertEqual(sheet.F3, (1.0 + 2 + 3) / 3)
-        self.assertEqual(sheet.F4, (1.0 + 2 + 3 + 4) / 4)
-        self.assertEqual(sheet.F5, (1.0 + 2 + 3 + 4 + 5 + 6) / 6)
+    def test_count(self):
+        self.assertEqual(self.sheet.E1, 1)
+        self.assertEqual(self.sheet.E2, 2)
+        self.assertEqual(self.sheet.E3, 3)
+        self.assertEqual(self.sheet.E4, 4)
+        self.assertEqual(self.sheet.E5, 6)
 
-        self.assertEqual(sheet.G1, Units.Quantity("5 mm"))
-        self.assertEqual(sheet.G2, Units.Quantity("4 mm"))
-        self.assertEqual(sheet.G3, Units.Quantity("6 mm"))
-        self.assertEqual(sheet.G4, 3)
-        self.assertEqual(sheet.G5, Units.Quantity("1 mm"))
-        self.assertEqual(sheet.G6, Units.Quantity("15 mm"))
+    def test_average(self):
+        self.assertEqual(self.sheet.F1, 1)
+        self.assertEqual(self.sheet.F2, (1.0 + 2.0) / 2.0)
+        self.assertEqual(self.sheet.F3, (1.0 + 2 + 3) / 3)
+        self.assertEqual(self.sheet.F4, (1.0 + 2 + 3 + 4) / 4)
+        self.assertEqual(self.sheet.F5, (1.0 + 2 + 3 + 4 + 5 + 6) / 6)
 
+    def test_range(self):
+        self.assertEqual(self.sheet.G1, Units.Quantity("5 mm"))
+        self.assertEqual(self.sheet.G2, Units.Quantity("4 mm"))
+        self.assertEqual(self.sheet.G3, Units.Quantity("6 mm"))
+        self.assertEqual(self.sheet.G4, 3)
+        self.assertEqual(self.sheet.G5, Units.Quantity("1 mm"))
+        self.assertEqual(self.sheet.G6, Units.Quantity("15 mm"))
+
+    def test_range_invalid(self):
         self.assertTrue(
-            sheet.H1.startswith("ERR: Quantity::operator +=(): Unit mismatch in plus operation")
+            self.sheet.H1.startswith(
+                "ERR: Quantity::operator +=(): Unit mismatch in plus operation"
+            )
         )
         self.assertTrue(
-            sheet.H2.startswith(
+            self.sheet.H2.startswith(
                 "ERR: Quantity::operator <(): quantities need to have same unit to compare"
             )
         )
         self.assertTrue(
-            sheet.H3.startswith(
+            self.sheet.H3.startswith(
                 "ERR: Quantity::operator >(): quantities need to have same unit to compare"
             )
         )
-        self.assertEqual(sheet.H4, 4)
+        self.assertEqual(self.sheet.H4, 4)
         self.assertTrue(
-            sheet.H5.startswith("ERR: Quantity::operator -(): Unit mismatch in minus operation")
+            self.sheet.H5.startswith(
+                "ERR: Quantity::operator -(): Unit mismatch in minus operation"
+            )
         )
         self.assertTrue(
-            sheet.H6.startswith("ERR: Quantity::operator +=(): Unit mismatch in plus operation")
+            self.sheet.H6.startswith(
+                "ERR: Quantity::operator +=(): Unit mismatch in plus operation"
+            )
         )
+
+
+#############################################################################################
+class SpreadsheetFunction(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = FreeCAD.newDocument()
+        cls.sheet = cls.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
+
+        cls.sheet.set("A1", "=cos(60)")  # Cos
+        cls.sheet.set("B1", "=cos(60deg)")
+        cls.sheet.set("C1", "=cos(pi / 2 * 1rad)")
+        cls.sheet.set("A2", "=sin(30)")  # Sin
+        cls.sheet.set("B2", "=sin(30deg)")
+        cls.sheet.set("C2", "=sin(pi / 6 * 1rad)")
+        cls.sheet.set("A3", "=tan(45)")  # Tan
+        cls.sheet.set("B3", "=tan(45deg)")
+        cls.sheet.set("C3", "=tan(pi / 4 * 1rad)")
+        cls.sheet.set("A4", "=abs(3)")  # Abs
+        cls.sheet.set("B4", "=abs(-3)")
+        cls.sheet.set("C4", "=abs(-3mm)")
+        cls.sheet.set("A5", "=exp(3)")  # Exp
+        cls.sheet.set("B5", "=exp(-3)")
+        cls.sheet.set("C5", "=exp(-3mm)")
+        cls.sheet.set("A6", "=log(3)")  # Log
+        cls.sheet.set("B6", "=log(-3)")
+        cls.sheet.set("C6", "=log(-3mm)")
+        cls.sheet.set("A7", "=log10(10)")  # Log10
+        cls.sheet.set("B7", "=log10(-3)")
+        cls.sheet.set("C7", "=log10(-3mm)")
+        cls.sheet.set("A8", "=round(3.4)")  # Round
+        cls.sheet.set("B8", "=round(3.6)")
+        cls.sheet.set("C8", "=round(-3.4)")
+        cls.sheet.set("D8", "=round(-3.6)")
+        cls.sheet.set("E8", "=round(3.4mm)")
+        cls.sheet.set("F8", "=round(3.6mm)")
+        cls.sheet.set("G8", "=round(-3.4mm)")
+        cls.sheet.set("H8", "=round(-3.6mm)")
+        cls.sheet.set("A9", "=trunc(3.4)")  # Trunc
+        cls.sheet.set("B9", "=trunc(3.6)")
+        cls.sheet.set("C9", "=trunc(-3.4)")
+        cls.sheet.set("D9", "=trunc(-3.6)")
+        cls.sheet.set("E9", "=trunc(3.4mm)")
+        cls.sheet.set("F9", "=trunc(3.6mm)")
+        cls.sheet.set("G9", "=trunc(-3.4mm)")
+        cls.sheet.set("H9", "=trunc(-3.6mm)")
+        cls.sheet.set("A10", "=ceil(3.4)")  # Ceil
+        cls.sheet.set("B10", "=ceil(3.6)")
+        cls.sheet.set("C10", "=ceil(-3.4)")
+        cls.sheet.set("D10", "=ceil(-3.6)")
+        cls.sheet.set("E10", "=ceil(3.4mm)")
+        cls.sheet.set("F10", "=ceil(3.6mm)")
+        cls.sheet.set("G10", "=ceil(-3.4mm)")
+        cls.sheet.set("H10", "=ceil(-3.6mm)")
+        cls.sheet.set("A11", "=floor(3.4)")  # Floor
+        cls.sheet.set("B11", "=floor(3.6)")
+        cls.sheet.set("C11", "=floor(-3.4)")
+        cls.sheet.set("D11", "=floor(-3.6)")
+        cls.sheet.set("E11", "=floor(3.4mm)")
+        cls.sheet.set("F11", "=floor(3.6mm)")
+        cls.sheet.set("G11", "=floor(-3.4mm)")
+        cls.sheet.set("H11", "=floor(-3.6mm)")
+        cls.sheet.set("A12", "=asin(0.5)")  # Asin
+        cls.sheet.set("B12", "=asin(0.5mm)")
+        cls.sheet.set("A13", "=acos(0.5)")  # Acos
+        cls.sheet.set("B13", "=acos(0.5mm)")
+        cls.sheet.set("A14", "=atan(sqrt(3))")  # Atan
+        cls.sheet.set("B14", "=atan(0.5mm)")
+        cls.sheet.set("A15", "=sinh(0.5)")  # Sinh
+        cls.sheet.set("B15", "=sinh(0.5mm)")
+        cls.sheet.set("A16", "=cosh(0.5)")  # Cosh
+        cls.sheet.set("B16", "=cosh(0.5mm)")
+        cls.sheet.set("A17", "=tanh(0.5)")  # Tanh
+        cls.sheet.set("B17", "=tanh(0.5mm)")
+        cls.sheet.set("A18", "=sqrt(4)")  # Sqrt
+        cls.sheet.set("B18", "=sqrt(4mm^2)")
+        cls.sheet.set("A19", "=mod(7; 4)")  # Mod
+        cls.sheet.set("B19", "=mod(-7; 4)")
+        cls.sheet.set("C19", "=mod(7mm; 4)")
+        cls.sheet.set("D19", "=mod(7mm; 4mm)")
+        cls.sheet.set("A20", "=atan2(3; 3)")  # Atan2
+        cls.sheet.set("B20", "=atan2(-3; 3)")
+        cls.sheet.set("C20", "=atan2(3mm; 3)")
+        cls.sheet.set("D20", "=atan2(3mm; 3mm)")
+        cls.sheet.set("A21", "=pow(7; 4)")  # Pow
+        cls.sheet.set("B21", "=pow(-7; 4)")
+        cls.sheet.set("C21", "=pow(7mm; 4)")
+        cls.sheet.set("D21", "=pow(7mm; 4mm)")
+        cls.sheet.set("A23", "=hypot(3; 4)")  # Hypot
+        cls.sheet.set("B23", "=hypot(-3; 4)")
+        cls.sheet.set("C23", "=hypot(3mm; 4)")
+        cls.sheet.set("D23", "=hypot(3mm; 4mm)")
+        cls.sheet.set("A24", "=hypot(3; 4; 5)")  # Hypot
+        cls.sheet.set("B24", "=hypot(-3; 4; 5)")
+        cls.sheet.set("C24", "=hypot(3mm; 4; 5)")
+        cls.sheet.set("D24", "=hypot(3mm; 4mm; 5mm)")
+        cls.sheet.set("A26", "=cath(5; 3)")  # Cath
+        cls.sheet.set("B26", "=cath(-5; 3)")
+        cls.sheet.set("C26", "=cath(5mm; 3)")
+        cls.sheet.set("D26", "=cath(5mm; 3mm)")
+
+        l = math.sqrt(5 * 5 + 4 * 4 + 3 * 3)
+        cls.sheet.set("A27", "=cath(%0.15f; 5; 4)" % l)  # Cath
+        cls.sheet.set("B27", "=cath(%0.15f; -5; 4)" % l)
+        cls.sheet.set("C27", "=cath(%0.15f mm; 5mm; 4)" % l)
+        cls.sheet.set("D27", "=cath(%0.15f mm; 5mm; 4mm)" % l)
+
+        cls.doc.recompute()
+
+    @classmethod
+    def tearDownClass(cls):
+        FreeCAD.closeDocument(cls.doc.Name)
 
     def assertMostlyEqual(self, a, b):
         if type(a) is Units.Quantity:
             self.assertTrue(math.fabs(a.Value - b.Value) < 1e-14)
             self.assertTrue(a.Unit == b.Unit)
         else:
+            self.assertNotIsInstance(a, str)
+            self.assertNotIsInstance(b, str)
+            self.assertTrue(
+                math.fabs(a - b) < 1e-14,
+                "Values are not equal: %s != %s" % (a, b),
+            )
             self.assertTrue(math.fabs(a - b) < 1e-14)
 
-    def testFunctions(self):
-        """Test all built-in simple functions"""
-        sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
-        sheet.set("A1", "=cos(60)")  # Cos
-        sheet.set("B1", "=cos(60deg)")
-        sheet.set("C1", "=cos(pi / 2 * 1rad)")
-        sheet.set("A2", "=sin(30)")  # Sin
-        sheet.set("B2", "=sin(30deg)")
-        sheet.set("C2", "=sin(pi / 6 * 1rad)")
-        sheet.set("A3", "=tan(45)")  # Tan
-        sheet.set("B3", "=tan(45deg)")
-        sheet.set("C3", "=tan(pi / 4 * 1rad)")
-        sheet.set("A4", "=abs(3)")  # Abs
-        sheet.set("B4", "=abs(-3)")
-        sheet.set("C4", "=abs(-3mm)")
-        sheet.set("A5", "=exp(3)")  # Exp
-        sheet.set("B5", "=exp(-3)")
-        sheet.set("C5", "=exp(-3mm)")
-        sheet.set("A6", "=log(3)")  # Log
-        sheet.set("B6", "=log(-3)")
-        sheet.set("C6", "=log(-3mm)")
-        sheet.set("A7", "=log10(10)")  # Log10
-        sheet.set("B7", "=log10(-3)")
-        sheet.set("C7", "=log10(-3mm)")
-        sheet.set("A8", "=round(3.4)")  # Round
-        sheet.set("B8", "=round(3.6)")
-        sheet.set("C8", "=round(-3.4)")
-        sheet.set("D8", "=round(-3.6)")
-        sheet.set("E8", "=round(3.4mm)")
-        sheet.set("F8", "=round(3.6mm)")
-        sheet.set("G8", "=round(-3.4mm)")
-        sheet.set("H8", "=round(-3.6mm)")
-        sheet.set("A9", "=trunc(3.4)")  # Trunc
-        sheet.set("B9", "=trunc(3.6)")
-        sheet.set("C9", "=trunc(-3.4)")
-        sheet.set("D9", "=trunc(-3.6)")
-        sheet.set("E9", "=trunc(3.4mm)")
-        sheet.set("F9", "=trunc(3.6mm)")
-        sheet.set("G9", "=trunc(-3.4mm)")
-        sheet.set("H9", "=trunc(-3.6mm)")
-        sheet.set("A10", "=ceil(3.4)")  # Ceil
-        sheet.set("B10", "=ceil(3.6)")
-        sheet.set("C10", "=ceil(-3.4)")
-        sheet.set("D10", "=ceil(-3.6)")
-        sheet.set("E10", "=ceil(3.4mm)")
-        sheet.set("F10", "=ceil(3.6mm)")
-        sheet.set("G10", "=ceil(-3.4mm)")
-        sheet.set("H10", "=ceil(-3.6mm)")
-        sheet.set("A11", "=floor(3.4)")  # Floor
-        sheet.set("B11", "=floor(3.6)")
-        sheet.set("C11", "=floor(-3.4)")
-        sheet.set("D11", "=floor(-3.6)")
-        sheet.set("E11", "=floor(3.4mm)")
-        sheet.set("F11", "=floor(3.6mm)")
-        sheet.set("G11", "=floor(-3.4mm)")
-        sheet.set("H11", "=floor(-3.6mm)")
-        sheet.set("A12", "=asin(0.5)")  # Asin
-        sheet.set("B12", "=asin(0.5mm)")
-        sheet.set("A13", "=acos(0.5)")  # Acos
-        sheet.set("B13", "=acos(0.5mm)")
-        sheet.set("A14", "=atan(sqrt(3))")  # Atan
-        sheet.set("B14", "=atan(0.5mm)")
-        sheet.set("A15", "=sinh(0.5)")  # Sinh
-        sheet.set("B15", "=sinh(0.5mm)")
-        sheet.set("A16", "=cosh(0.5)")  # Cosh
-        sheet.set("B16", "=cosh(0.5mm)")
-        sheet.set("A17", "=tanh(0.5)")  # Tanh
-        sheet.set("B17", "=tanh(0.5mm)")
-        sheet.set("A18", "=sqrt(4)")  # Sqrt
-        sheet.set("B18", "=sqrt(4mm^2)")
-        sheet.set("A19", "=mod(7; 4)")  # Mod
-        sheet.set("B19", "=mod(-7; 4)")
-        sheet.set("C19", "=mod(7mm; 4)")
-        sheet.set("D19", "=mod(7mm; 4mm)")
-        sheet.set("A20", "=atan2(3; 3)")  # Atan2
-        sheet.set("B20", "=atan2(-3; 3)")
-        sheet.set("C20", "=atan2(3mm; 3)")
-        sheet.set("D20", "=atan2(3mm; 3mm)")
-        sheet.set("A21", "=pow(7; 4)")  # Pow
-        sheet.set("B21", "=pow(-7; 4)")
-        sheet.set("C21", "=pow(7mm; 4)")
-        sheet.set("D21", "=pow(7mm; 4mm)")
-        sheet.set("A23", "=hypot(3; 4)")  # Hypot
-        sheet.set("B23", "=hypot(-3; 4)")
-        sheet.set("C23", "=hypot(3mm; 4)")
-        sheet.set("D23", "=hypot(3mm; 4mm)")
-        sheet.set("A24", "=hypot(3; 4; 5)")  # Hypot
-        sheet.set("B24", "=hypot(-3; 4; 5)")
-        sheet.set("C24", "=hypot(3mm; 4; 5)")
-        sheet.set("D24", "=hypot(3mm; 4mm; 5mm)")
-        sheet.set("A26", "=cath(5; 3)")  # Cath
-        sheet.set("B26", "=cath(-5; 3)")
-        sheet.set("C26", "=cath(5mm; 3)")
-        sheet.set("D26", "=cath(5mm; 3mm)")
+    def test_cos_num(self):
+        self.assertMostlyEqual(self.sheet.A1, 0.5)
 
-        l = math.sqrt(5 * 5 + 4 * 4 + 3 * 3)
-        sheet.set("A27", "=cath(%0.15f; 5; 4)" % l)  # Cath
-        sheet.set("B27", "=cath(%0.15f; -5; 4)" % l)
-        sheet.set("C27", "=cath(%0.15f mm; 5mm; 4)" % l)
-        sheet.set("D27", "=cath(%0.15f mm; 5mm; 4mm)" % l)
+    def test_cos_str(self):
+        self.assertMostlyEqual(self.sheet.B1, 0.5)
 
-        self.doc.recompute()
-        self.assertMostlyEqual(sheet.A1, 0.5)  # Cos
-        self.assertMostlyEqual(sheet.B1, 0.5)
-        self.assertMostlyEqual(sheet.C1, 0)
-        self.assertMostlyEqual(sheet.A2, 0.5)  # Sin
-        self.assertMostlyEqual(sheet.B2, 0.5)
-        self.assertMostlyEqual(sheet.C2, 0.5)
-        self.assertMostlyEqual(sheet.A3, 1)  # Tan
-        self.assertMostlyEqual(sheet.B3, 1)
-        self.assertMostlyEqual(sheet.C3, 1)
-        self.assertMostlyEqual(sheet.A4, 3)  # Abs
-        self.assertMostlyEqual(sheet.B4, 3)
-        self.assertMostlyEqual(sheet.C4, Units.Quantity("3 mm"))
-        self.assertMostlyEqual(sheet.A5, math.exp(3))  # Exp
-        self.assertMostlyEqual(sheet.B5, math.exp(-3))
-        self.assertTrue(sheet.C5.startswith("ERR: Unit must be empty."))
-        self.assertMostlyEqual(sheet.A6, math.log(3))  # Log
-        self.assertTrue(math.isnan(sheet.B6))
-        self.assertTrue(sheet.C6.startswith("ERR: Unit must be empty."))
-        self.assertMostlyEqual(sheet.A7, math.log10(10))  # Log10
-        self.assertTrue(math.isnan(sheet.B7))
-        self.assertTrue(sheet.C7.startswith("ERR: Unit must be empty."))
-        self.assertMostlyEqual(sheet.A8, 3)  # Round
-        self.assertMostlyEqual(sheet.B8, 4)
-        self.assertMostlyEqual(sheet.C8, -3)
-        self.assertMostlyEqual(sheet.D8, -4)
-        self.assertEqual(sheet.E8, Units.Quantity("3 mm"))
-        self.assertEqual(sheet.F8, Units.Quantity("4 mm"))
-        self.assertEqual(sheet.G8, Units.Quantity("-3 mm"))
-        self.assertEqual(sheet.H8, Units.Quantity("-4 mm"))
-        self.assertMostlyEqual(sheet.A9, 3)  # Trunc
-        self.assertMostlyEqual(sheet.B9, 3)
-        self.assertMostlyEqual(sheet.C9, -3)
-        self.assertMostlyEqual(sheet.D9, -3)
-        self.assertEqual(sheet.E9, Units.Quantity("3 mm"))
-        self.assertEqual(sheet.F9, Units.Quantity("3 mm"))
-        self.assertEqual(sheet.G9, Units.Quantity("-3 mm"))
-        self.assertEqual(sheet.H9, Units.Quantity("-3 mm"))
-        self.assertMostlyEqual(sheet.A10, 4)  # Ceil
-        self.assertMostlyEqual(sheet.B10, 4)
-        self.assertMostlyEqual(sheet.C10, -3)
-        self.assertMostlyEqual(sheet.D10, -3)
-        self.assertMostlyEqual(sheet.E10, Units.Quantity("4 mm"))
-        self.assertMostlyEqual(sheet.F10, Units.Quantity("4 mm"))
-        self.assertMostlyEqual(sheet.G10, Units.Quantity("-3 mm"))
-        self.assertMostlyEqual(sheet.H10, Units.Quantity("-3 mm"))
-        self.assertMostlyEqual(sheet.A11, 3)  # Floor
-        self.assertMostlyEqual(sheet.B11, 3)
-        self.assertMostlyEqual(sheet.C11, -4)
-        self.assertMostlyEqual(sheet.D11, -4)
-        self.assertMostlyEqual(sheet.E11, Units.Quantity("3 mm"))
-        self.assertMostlyEqual(sheet.F11, Units.Quantity("3 mm"))
-        self.assertMostlyEqual(sheet.G11, Units.Quantity("-4 mm"))
-        self.assertMostlyEqual(sheet.H11, Units.Quantity("-4 mm"))
-        self.assertMostlyEqual(sheet.A12, Units.Quantity("30 deg"))  # Asin
-        self.assertTrue(sheet.B12.startswith("ERR: Unit must be empty."))
-        self.assertMostlyEqual(sheet.A13, Units.Quantity("60 deg"))  # Acos
-        self.assertTrue(sheet.B13.startswith("ERR: Unit must be empty."))
-        self.assertMostlyEqual(sheet.A14, Units.Quantity("60 deg"))  # Atan
-        self.assertTrue(sheet.B14.startswith("ERR: Unit must be empty."))
-        self.assertMostlyEqual(sheet.A15, math.sinh(0.5))  # Sinh
-        self.assertTrue(sheet.B15.startswith("ERR: Unit must be empty."))
-        self.assertMostlyEqual(sheet.A16, math.cosh(0.5))  # Cosh
-        self.assertTrue(sheet.B16.startswith("ERR: Unit must be empty."))
-        self.assertMostlyEqual(sheet.A17, math.tanh(0.5))  # Tanh
-        self.assertTrue(sheet.B17.startswith("ERR: Unit must be empty."))
-        self.assertMostlyEqual(sheet.A18, 2)  # Sqrt
-        self.assertMostlyEqual(sheet.B18, Units.Quantity("2 mm"))
-        self.assertMostlyEqual(sheet.A19, 3)  # Mod
-        self.assertMostlyEqual(sheet.B19, -3)
-        self.assertMostlyEqual(sheet.C19, Units.Quantity("3 mm"))
-        self.assertEqual(sheet.D19, 3)
-        self.assertMostlyEqual(sheet.A20, Units.Quantity("45 deg"))  # Atan2
-        self.assertMostlyEqual(sheet.B20, Units.Quantity("-45 deg"))
-        self.assertTrue(sheet.C20.startswith("ERR: Units must be equal"))
-        self.assertMostlyEqual(sheet.D20, Units.Quantity("45 deg"))
-        self.assertMostlyEqual(sheet.A21, 2401)  # Pow
-        self.assertMostlyEqual(sheet.B21, 2401)
-        self.assertMostlyEqual(sheet.C21, Units.Quantity("2401mm^4"))
-        self.assertTrue(sheet.D21.startswith("ERR: Exponent is not allowed to have a unit."))
-        self.assertMostlyEqual(sheet.A23, 5)  # Hypot
-        self.assertMostlyEqual(sheet.B23, 5)
-        self.assertTrue(sheet.C23.startswith("ERR: Units must be equal"))
-        self.assertMostlyEqual(sheet.D23, Units.Quantity("5mm"))
+    def test_cos_form(self):
+        self.assertMostlyEqual(self.sheet.C1, 0)
 
+    def test_sin_num(self):
+        self.assertMostlyEqual(self.sheet.A2, 0.5)
+
+    def test_sin_str(self):
+        self.assertMostlyEqual(self.sheet.B2, 0.5)
+
+    def test_sin_form(self):
+        self.assertMostlyEqual(self.sheet.C2, 0.5)
+
+    def test_tan_num(self):
+        self.assertMostlyEqual(self.sheet.A3, 1)
+
+    def test_tan_str(self):
+        self.assertMostlyEqual(self.sheet.B3, 1)
+
+    def test_tan_form(self):
+        self.assertMostlyEqual(self.sheet.C3, 1)
+
+    def test_abs_pos(self):
+        self.assertMostlyEqual(self.sheet.A4, 3)
+
+    def test_abs_neg(self):
+        self.assertMostlyEqual(self.sheet.B4, 3)
+
+    def test_abs_quant(self):
+        self.assertMostlyEqual(self.sheet.C4, Units.Quantity("3 mm"))
+
+    def test_exp_pos(self):
+        self.assertMostlyEqual(self.sheet.A5, math.exp(3))
+
+    def test_exp_neg(self):
+        self.assertMostlyEqual(self.sheet.B5, math.exp(-3))
+
+    def test_exp_error(self):
+        self.assertTrue(self.sheet.C5.startswith("ERR: Unit must be empty."))
+
+    def test_log(self):
+        self.assertMostlyEqual(self.sheet.A6, math.log(3))
+
+    def test_log_nan(self):
+        self.assertTrue(math.isnan(self.sheet.B6))
+
+    def test_log_error(self):
+        self.assertTrue(self.sheet.C6.startswith("ERR: Unit must be empty."))
+
+    def test_log10(self):
+        self.assertMostlyEqual(self.sheet.A7, math.log10(10))
+
+    def test_log10_nan(self):
+        self.assertTrue(math.isnan(self.sheet.B7))
+
+    def test_log10_error(self):
+        self.assertTrue(self.sheet.C7.startswith("ERR: Unit must be empty."))
+
+    def test_round_pos_num(self):
+        self.assertMostlyEqual(self.sheet.A8, 3)
+        self.assertMostlyEqual(self.sheet.B8, 4)
+
+    def test_round_neg_num(self):
+        self.assertMostlyEqual(self.sheet.C8, -3)
+        self.assertMostlyEqual(self.sheet.D8, -4)
+
+    def test_round_pos_quant(self):
+        self.assertEqual(self.sheet.E8, Units.Quantity("3 mm"))
+        self.assertEqual(self.sheet.F8, Units.Quantity("4 mm"))
+
+    def test_round_neg_quant(self):
+        self.assertEqual(self.sheet.G8, Units.Quantity("-3 mm"))
+        self.assertEqual(self.sheet.H8, Units.Quantity("-4 mm"))
+
+    def test_trunc_pos_num(self):
+        self.assertMostlyEqual(self.sheet.A9, 3)
+        self.assertMostlyEqual(self.sheet.B9, 3)
+
+    def test_trunc_neg_num(self):
+        self.assertMostlyEqual(self.sheet.C9, -3)
+        self.assertMostlyEqual(self.sheet.D9, -3)
+
+    def test_trunc_pos_quant(self):
+        self.assertEqual(self.sheet.E9, Units.Quantity("3 mm"))
+        self.assertEqual(self.sheet.F9, Units.Quantity("3 mm"))
+
+    def test_trunc_neg_quant(self):
+        self.assertEqual(self.sheet.G9, Units.Quantity("-3 mm"))
+        self.assertEqual(self.sheet.H9, Units.Quantity("-3 mm"))
+
+    def test_ceil_pos(self):
+        self.assertMostlyEqual(self.sheet.A10, 4)
+        self.assertMostlyEqual(self.sheet.B10, 4)
+
+    def test_ceil_neg(self):
+        self.assertMostlyEqual(self.sheet.C10, -3)
+        self.assertMostlyEqual(self.sheet.D10, -3)
+
+    def test_ceil_quant_pos(self):
+        self.assertMostlyEqual(self.sheet.E10, Units.Quantity("4 mm"))
+        self.assertMostlyEqual(self.sheet.F10, Units.Quantity("4 mm"))
+
+    def test_ceil_quant_neg(self):
+        self.assertMostlyEqual(self.sheet.G10, Units.Quantity("-3 mm"))
+        self.assertMostlyEqual(self.sheet.H10, Units.Quantity("-3 mm"))
+
+    def test_floor_pos_num(self):
+        self.assertMostlyEqual(self.sheet.A11, 3)
+        self.assertMostlyEqual(self.sheet.B11, 3)
+
+    def test_floor_neg_num(self):
+        self.assertMostlyEqual(self.sheet.C11, -4)
+        self.assertMostlyEqual(self.sheet.D11, -4)
+
+    def test_floor_pos_quant(self):
+        self.assertMostlyEqual(self.sheet.E11, Units.Quantity("3 mm"))
+        self.assertMostlyEqual(self.sheet.F11, Units.Quantity("3 mm"))
+
+    def test_floor_neg_quant(self):
+        self.assertMostlyEqual(self.sheet.G11, Units.Quantity("-4 mm"))
+        self.assertMostlyEqual(self.sheet.H11, Units.Quantity("-4 mm"))
+
+    def test_asin(self):
+        self.assertMostlyEqual(self.sheet.A12, Units.Quantity("30 deg"))
+
+    def test_asin_error(self):
+        self.assertTrue(self.sheet.B12.startswith("ERR: Unit must be empty."))
+
+    def test_acos(self):
+        self.assertMostlyEqual(self.sheet.A13, Units.Quantity("60 deg"))
+
+    def test_acos_error(self):
+        self.assertTrue(self.sheet.B13.startswith("ERR: Unit must be empty."))
+
+    def test_atan(self):
+        self.assertMostlyEqual(self.sheet.A14, Units.Quantity("60 deg"))  # "=atan(sqrt(3))"
+
+    def test_atan_error(self):
+        self.assertTrue(self.sheet.B14.startswith("ERR: Unit must be empty."))
+
+    def test_sinh(self):
+        self.assertMostlyEqual(self.sheet.A15, math.sinh(0.5))
+
+    def test_sinh_error(self):
+        self.assertTrue(self.sheet.B15.startswith("ERR: Unit must be empty."))
+
+    def test_cosh(self):
+        self.assertMostlyEqual(self.sheet.A16, math.cosh(0.5))
+
+    def test_cosh_error(self):
+        self.assertTrue(self.sheet.B16.startswith("ERR: Unit must be empty."))
+
+    def test_tanh(self):
+        self.assertMostlyEqual(self.sheet.A17, math.tanh(0.5))
+
+    def test_tanh_error(self):
+        self.assertTrue(self.sheet.B17.startswith("ERR: Unit must be empty."))
+
+    def test_sqrt_number(self):
+        self.assertMostlyEqual(self.sheet.A18, 2)  # "=sqrt(4)"
+
+    def test_sqrt_quantity(self):
+        self.assertMostlyEqual(self.sheet.B18, Units.Quantity("2 mm"))
+
+    def test_mod_pos(self):
+        self.assertMostlyEqual(self.sheet.A19, 3)
+
+    def test_mod_neg(self):
+        self.assertMostlyEqual(self.sheet.B19, -3)
+
+    def test_mod_error(self):
+        self.assertMostlyEqual(self.sheet.C19, Units.Quantity("3 mm"))
+
+    def test_mod_(self):
+        self.assertEqual(self.sheet.D19, 3)
+
+    def test_atan2_pos(self):
+        self.assertMostlyEqual(self.sheet.A20, Units.Quantity("45 deg"))
+
+    def test_atan2_neg(self):
+        self.assertMostlyEqual(self.sheet.B20, Units.Quantity("-45 deg"))
+
+    def test_atan2_error(self):
+        self.assertTrue(self.sheet.C20.startswith("ERR: Units must be equal"))
+
+    def test_atan2_quant(self):
+        self.assertMostlyEqual(self.sheet.D20, Units.Quantity("45 deg"))
+
+    def test_pow_pos(self):
+        self.assertMostlyEqual(self.sheet.A21, 2401)
+
+    def test_pow_neg(self):
+        self.assertMostlyEqual(self.sheet.B21, 2401)
+
+    def test_pow_error(self):
+        self.assertMostlyEqual(self.sheet.C21, Units.Quantity("2401mm^4"))
+
+    def test_pow_quant(self):
+        self.assertTrue(self.sheet.D21.startswith("ERR: Exponent is not allowed to have a unit."))
+
+    def test_hypot_pos(self):
+        self.assertMostlyEqual(self.sheet.A23, 5)
+
+    def test_hypot_neg(self):
+        self.assertMostlyEqual(self.sheet.B23, 5)
+
+    def test_hypot_error(self):
+        self.assertTrue(self.sheet.C23.startswith("ERR: Units must be equal"))
+
+    def test_hypot_quant(self):
+        self.assertMostlyEqual(self.sheet.D23, Units.Quantity("5mm"))
+
+    def test_hypot2_pos(self):
         l = math.sqrt(3 * 3 + 4 * 4 + 5 * 5)
-        self.assertMostlyEqual(sheet.A24, l)  # Hypot
-        self.assertMostlyEqual(sheet.B24, l)
-        self.assertTrue(sheet.C24.startswith("ERR: Units must be equal"))
-        self.assertMostlyEqual(sheet.D24, Units.Quantity("7.07106781186548 mm"))
-        self.assertMostlyEqual(sheet.A26, 4)  # Cath
-        self.assertMostlyEqual(sheet.B26, 4)
-        self.assertTrue(sheet.C26.startswith("ERR: Units must be equal"))
-        self.assertMostlyEqual(sheet.D26, Units.Quantity("4mm"))
+        self.assertMostlyEqual(self.sheet.A24, l)
 
+    def test_hypot2_neg(self):
+        l = math.sqrt(3 * 3 + 4 * 4 + 5 * 5)
+        self.assertMostlyEqual(self.sheet.B24, l)
+
+    def test_hypot2_error(self):
+        self.assertTrue(self.sheet.C24.startswith("ERR: Units must be equal"))
+
+    def test_hypot2_quant(self):
+        self.assertMostlyEqual(self.sheet.D24, Units.Quantity("7.07106781186548 mm"))
+
+    def test_cath_pos(self):
+        self.assertMostlyEqual(self.sheet.A26, 4)
+
+    def test_cath_neg(self):
+        self.assertMostlyEqual(self.sheet.B26, 4)
+
+    def test_cath_error(self):
+        self.assertTrue(self.sheet.C26.startswith("ERR: Units must be equal"))
+
+    def test_cath_quant(self):
+        self.assertMostlyEqual(self.sheet.D26, Units.Quantity("4mm"))
+
+    def test_cath2_pos(self):
         l = math.sqrt(5 * 5 + 4 * 4 + 3 * 3)
-        l = math.sqrt(l * l - 5 * 5 - 4 * 4)
-        self.assertMostlyEqual(sheet.A27, l)  # Cath
-        self.assertMostlyEqual(sheet.B27, l)
-        self.assertTrue(sheet.C27.startswith("ERR: Units must be equal"))
-        self.assertMostlyEqual(sheet.D27, Units.Quantity("3 mm"))
+        ll = math.sqrt(l * l - 5 * 5 - 4 * 4)
+        self.assertMostlyEqual(self.sheet.A27, ll)
+
+    def test_cath2_neg(self):
+        l = math.sqrt(5 * 5 + 4 * 4 + 3 * 3)
+        ll = math.sqrt(l * l - 5 * 5 - 4 * 4)
+        self.assertMostlyEqual(self.sheet.B27, ll)
+
+    def test_cath2_error(self):
+        self.assertTrue(self.sheet.C27.startswith("ERR: Units must be equal"))
+
+    def test_cath2_quant(self):
+        self.assertMostlyEqual(self.sheet.D27, Units.Quantity("3 mm"))
+
+
+#############################################################################################
+class SpreadsheetCases(unittest.TestCase):
+    def setUp(self):
+        self.doc = FreeCAD.newDocument()
+        self.TempPath = tempfile.gettempdir()
+        FreeCAD.Console.PrintLog("  Using temp path: " + self.TempPath + "\n")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.doc.Name)
 
     def testRelationalOperators(self):
         """Test relational operators"""
@@ -412,6 +619,7 @@ class SpreadsheetCases(unittest.TestCase):
         sheet.set("A24", "=1 != 1.0000000000000001 ? 0 : 1")
 
         self.doc.recompute()
+
         self.assertEqual(sheet.A1, 1)
         self.assertEqual(sheet.A2, 1)
         self.assertEqual(sheet.A3, 1)
@@ -446,13 +654,15 @@ class SpreadsheetCases(unittest.TestCase):
         sheet.set("A4", "=4mm / 2mm")
         sheet.set("A5", "=(4mm)^2")
         sheet.set("A6", "=5(mm^2)")
-        sheet.set("A7", "=5mm^2")  #  ^2 operates on whole number
+        sheet.set("A7", "=5mm^2")  # ^2 operates on whole number
         sheet.set("A8", "=5")
         sheet.set("A9", "=5*1/K")  # Currently fails
         sheet.set("A10", "=5 K^-1")  # Currently fails
         sheet.set("A11", "=9.8 m/s^2")  # Currently fails
         sheet.setDisplayUnit("A8", "1/K")
+
         self.doc.recompute()
+
         self.assertEqual(sheet.A1, Units.Quantity("5mm"))
         self.assertEqual(sheet.A2, Units.Quantity("-1 mm"))
         self.assertEqual(sheet.A3, Units.Quantity("6 mm^2"))
@@ -538,6 +748,7 @@ class SpreadsheetCases(unittest.TestCase):
         sheet.set("A54", '=-(Cylinder.Radius + Box.Length - 1"/2)')
 
         self.doc.recompute()
+
         self.assertEqual(sheet.getContents("A1"), "=1 < 2 ? 3 : 4")
         self.assertEqual(sheet.getContents("A2"), "=1 + 2 < 3 + 4 ? 5 + 6 : 7 + 8")
         self.assertEqual(
@@ -670,7 +881,9 @@ class SpreadsheetCases(unittest.TestCase):
         sheet.set("A16", "1/1")
         sheet.set("A17", "1/2")
         sheet.set("A18", "2/4")
+
         self.doc.recompute()
+
         self.assertEqual(sheet.A1, 1)
         self.assertEqual(sheet.A2, 1.5)
         self.assertEqual(sheet.A3, 0.5)
@@ -699,7 +912,9 @@ class SpreadsheetCases(unittest.TestCase):
         sheet.set("A4", "2/mm")
         sheet.set("A5", "4/2mm")
         sheet.set("A6", "6mm/3s")
+
         self.doc.recompute()
+
         self.assertEqual(sheet.A1, Units.Quantity("1 mm"))
         self.assertEqual(sheet.A2, 0.5)
         self.assertEqual(sheet.A3, Units.Quantity("2 mm"))
@@ -902,7 +1117,7 @@ class SpreadsheetCases(unittest.TestCase):
             qpair = zip(plm1.Rotation.Q, plm2.Rotation.Q)
             qdiff1 = sqrt(sum([(v1 - v2) ** 2 for v1, v2 in qpair]))
             qdiff2 = sqrt(sum([(v1 + v2) ** 2 for v1, v2 in qpair]))
-            return (plm1.Base - plm2.Base).Length < 1e-7 and (qdiff1 < 1e-12 or dqiff2 < 1e-12)
+            return (plm1.Base - plm2.Base).Length < 1e-7 and (qdiff1 < 1e-12 or qdiff2 < 1e-12)
 
         sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
 
@@ -1217,7 +1432,7 @@ class SpreadsheetCases(unittest.TestCase):
         self.doc.recompute()
         sheet.setAlias("C3", "test")
 
-    def testCrossLinkEmptyPropertyName(self):
+    def test_cross_link_empty_property_name(self):
         # https://forum.freecad.org/viewtopic.php?f=3&t=58603
         base = FreeCAD.newDocument("base")
         sheet = base.addObject("Spreadsheet::Sheet", "Spreadsheet")
@@ -1234,10 +1449,10 @@ class SpreadsheetCases(unittest.TestCase):
         box.Height = 10.00
         square.recompute()
 
-        basePath = self.TempPath + os.sep + "base.FCStd"
-        base.saveAs(basePath)
-        squarePath = self.TempPath + os.sep + "square.FCStd"
-        square.saveAs(squarePath)
+        base_path = self.TempPath + os.sep + "base.FCStd"
+        base.saveAs(base_path)
+        square_path = self.TempPath + os.sep + "square.FCStd"
+        square.saveAs(square_path)
 
         base.save()
         square.save()
@@ -1247,8 +1462,8 @@ class SpreadsheetCases(unittest.TestCase):
 
         ##
         ## preparation done
-        base = FreeCAD.openDocument(basePath)
-        square = FreeCAD.openDocument(squarePath)
+        base = FreeCAD.openDocument(base_path)
+        square = FreeCAD.openDocument(square_path)
 
         square.Box.setExpression("Length", "base#Spreadsheet.x")
         square.recompute()
@@ -1258,7 +1473,7 @@ class SpreadsheetCases(unittest.TestCase):
         FreeCAD.closeDocument(square.Name)
         FreeCAD.closeDocument(base.Name)
 
-    def testExpressionWithAlias(self):
+    def test_expression_with_alias(self):
         # https://forum.freecad.org/viewtopic.php?p=564502#p564502
         ss1 = self.doc.addObject("Spreadsheet::Sheet", "Input")
         ss1.setAlias("A1", "one")
@@ -1571,7 +1786,3 @@ class SpreadsheetCases(unittest.TestCase):
         self.assertLess(sheet.F3.distanceToPoint(FreeCAD.Vector(0.28, 0.04, -0.2)), tolerance)
         self.assertLess(abs(sheet.F4.Value - -1.6971), 0.0001)
         self.assertEqual(sheet.F5, FreeCAD.Vector(1.72, 2.96, 4.2))
-
-    def tearDown(self):
-        # closing doc
-        FreeCAD.closeDocument(self.doc.Name)

--- a/src/Mod/Start/Gui/GeneralSettingsWidget.cpp
+++ b/src/Mod/Start/Gui/GeneralSettingsWidget.cpp
@@ -37,6 +37,7 @@
 #include <gsl/pointers>
 #include <App/Application.h>
 #include <Base/Parameter.h>
+#include <Base/Units.h>
 #include <Base/UnitsApi.h>
 #include <Gui/Language/Translator.h>
 #include <Gui/NavigationStyle.h>

--- a/src/Mod/TechDraw/App/DimensionFormatter.cpp
+++ b/src/Mod/TechDraw/App/DimensionFormatter.cpp
@@ -69,13 +69,13 @@ std::string DimensionFormatter::formatValue(const qreal value,
     Base::Quantity asQuantity;
     asQuantity.setValue(value);
     if (angularMeasure) {
-        asQuantity.setUnit(Base::Unit::Angle);
+        asQuantity.setUnit(Base::Units::Angle);
     }
     else if (areaMeasure) {
-        asQuantity.setUnit(Base::Unit::Area);
+        asQuantity.setUnit(Base::Units::Area);
     }
     else {
-        asQuantity.setUnit(Base::Unit::Length);
+        asQuantity.setUnit(Base::Units::Length);
     }
 
     // this handles mm to inch/km/parsec etc and decimal positions but

--- a/src/Mod/TechDraw/App/DrawSVGTemplate.cpp
+++ b/src/Mod/TechDraw/App/DrawSVGTemplate.cpp
@@ -183,13 +183,13 @@ void DrawSVGTemplate::extractTemplateAttributes(QDomDocument& templateDocument)
     // Obtain the width
     QString str = docElement.attribute(QString::fromLatin1("width"));
     quantity = Base::Quantity::parse(str.toStdString());
-    quantity.setUnit(Base::Unit::Length);
+    quantity.setUnit(Base::Units::Length);
 
     Width.setValue(quantity.getValue());
 
     str = docElement.attribute(QString::fromLatin1("height"));
     quantity = Base::Quantity::parse(str.toStdString());
-    quantity.setUnit(Base::Unit::Length);
+    quantity.setUnit(Base::Units::Length);
 
     Height.setValue(quantity.getValue());
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -170,7 +170,7 @@ DrawViewDimension::DrawViewDimension()
                       App::Prop_Output,
                       "Overtolerance value\nIf 'Equal Tolerance' is true this is also\nthe negated "
                       "value for 'Under Tolerance'");
-    OverTolerance.setUnit(Base::Unit::Length);
+    OverTolerance.setUnit(Base::Units::Length);
     OverTolerance.setConstraints(&ToleranceConstraint);
     ADD_PROPERTY_TYPE(UnderTolerance,
                       (0.0),
@@ -178,7 +178,7 @@ DrawViewDimension::DrawViewDimension()
                       App::Prop_Output,
                       "Undertolerance value\nIf 'Equal Tolerance' is true it will be replaced\nby "
                       "negative value of 'Over Tolerance'");
-    UnderTolerance.setUnit(Base::Unit::Length);
+    UnderTolerance.setUnit(Base::Units::Length);
     UnderTolerance.setConstraints(&ToleranceConstraint);
     ADD_PROPERTY_TYPE(Inverted,
                       (false),
@@ -321,12 +321,12 @@ void DrawViewDimension::onChanged(const App::Property* prop)
         FormatSpec.setValue(getDefaultFormatSpec().c_str());
         auto type = static_cast<DimensionType>(Type.getValue());
         if (type == DimensionType::Angle || type == DimensionType::Angle3Pt) {
-            OverTolerance.setUnit(Base::Unit::Angle);
-            UnderTolerance.setUnit(Base::Unit::Angle);
+            OverTolerance.setUnit(Base::Units::Angle);
+            UnderTolerance.setUnit(Base::Units::Angle);
         }
         else {
-            OverTolerance.setUnit(Base::Unit::Length);
-            UnderTolerance.setUnit(Base::Unit::Length);
+            OverTolerance.setUnit(Base::Units::Length);
+            UnderTolerance.setUnit(Base::Units::Length);
         }
     }
     else if (prop == &TheoreticalExact) {
@@ -412,8 +412,8 @@ void DrawViewDimension::onDocumentRestored()
 
     auto type = static_cast<DimensionType>(Type.getValue());
     if (type == DimensionType::Angle || type == DimensionType::Angle3Pt) {
-        OverTolerance.setUnit(Base::Unit::Angle);
-        UnderTolerance.setUnit(Base::Unit::Angle);
+        OverTolerance.setUnit(Base::Units::Angle);
+        UnderTolerance.setUnit(Base::Units::Angle);
     }
 }
 

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -1838,7 +1838,7 @@ void CmdTechDrawExtensionAreaAnnotation::activated(int iMsg)
     //make area unit-aware
     Base::Quantity asQuantity;
     asQuantity.setValue(totalArea);
-    asQuantity.setUnit(Base::Unit::Area);
+    asQuantity.setUnit(Base::Units::Area);
 
     QString qUserString = QString::fromStdString(asQuantity.getUserString());
     if (qUserString.endsWith(QString::fromUtf8("^2"))) {

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include <Base/Tools.h>
+#include "Base/Units.h"
 
 #include <Mod/TechDraw/App/LineGroup.h>
 #include <Mod/TechDraw/App/Preferences.h>
@@ -46,7 +47,7 @@ DlgPrefsTechDrawAnnotationImp::DlgPrefsTechDrawAnnotationImp(QWidget* parent)
     , ui(new Ui_DlgPrefsTechDrawAnnotationImp)
 {
     ui->setupUi(this);
-    ui->pdsbBalloonKink->setUnit(Base::Unit::Length);
+    ui->pdsbBalloonKink->setUnit(Base::Units::Length);
     ui->pdsbBalloonKink->setMinimum(0);
 
     // stylesheet override to defeat behaviour of non-editable combobox to ignore

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensionsImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensionsImp.cpp
@@ -25,6 +25,7 @@
 #include "PreCompiled.h"
 
 #include <App/Application.h>
+#include "Base/Units.h"
 
 #include "DlgPrefsTechDrawDimensionsImp.h"
 #include "ui_DlgPrefsTechDrawDimensions.h"
@@ -41,9 +42,9 @@ DlgPrefsTechDrawDimensionsImp::DlgPrefsTechDrawDimensionsImp( QWidget* parent )
   , ui(new Ui_DlgPrefsTechDrawDimensionsImp)
 {
     ui->setupUi(this);
-    ui->plsb_FontSize->setUnit(Base::Unit::Length);
+    ui->plsb_FontSize->setUnit(Base::Units::Length);
     ui->plsb_FontSize->setMinimum(0);
-    ui->plsb_ArrowSize->setUnit(Base::Unit::Length);
+    ui->plsb_ArrowSize->setUnit(Base::Units::Length);
     ui->plsb_ArrowSize->setMinimum(0);
 }
 

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
@@ -28,6 +28,7 @@
 #include "ui_DlgPrefsTechDrawGeneral.h"
 #include "PreferencesGui.h"
 #include "DrawGuiUtil.h"
+#include "Base/Units.h"
 
 
 using namespace TechDrawGui;
@@ -38,10 +39,10 @@ DlgPrefsTechDrawGeneralImp::DlgPrefsTechDrawGeneralImp( QWidget* parent )
   , ui(new Ui_DlgPrefsTechDrawGeneralImp)
 {
     ui->setupUi(this);
-    ui->plsb_LabelSize->setUnit(Base::Unit::Length);
+    ui->plsb_LabelSize->setUnit(Base::Units::Length);
     ui->plsb_LabelSize->setMinimum(0);
 
-    ui->psb_GridSpacing->setUnit(Base::Unit::Length);
+    ui->psb_GridSpacing->setUnit(Base::Units::Length);
     ui->psb_GridSpacing->setMinimum(0);
 }
 

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScaleImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScaleImp.cpp
@@ -26,6 +26,7 @@
 
 #include "DlgPrefsTechDrawScaleImp.h"
 #include "ui_DlgPrefsTechDrawScale.h"
+#include "Base/Units.h"
 
 
 using namespace TechDrawGui;
@@ -36,7 +37,7 @@ DlgPrefsTechDrawScaleImp::DlgPrefsTechDrawScaleImp( QWidget* parent )
 {
     ui->setupUi(this);
 
-    ui->pdsbTemplateMark->setUnit(Base::Unit::Length);
+    ui->pdsbTemplateMark->setUnit(Base::Units::Length);
     ui->pdsbTemplateMark->setMinimum(0);
 
     connect(ui->cbViewScaleType, qOverload<int>(&QComboBox::currentIndexChanged),

--- a/src/Mod/TechDraw/Gui/TaskActiveView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskActiveView.cpp
@@ -63,8 +63,8 @@ TaskActiveView::TaskActiveView(TechDraw::DrawPage* pageFeat)
 {
     ui->setupUi(this);
 
-    ui->qsbWidth->setUnit(Base::Unit::Length);
-    ui->qsbHeight->setUnit(Base::Unit::Length);
+    ui->qsbWidth->setUnit(Base::Units::Length);
+    ui->qsbHeight->setUnit(Base::Units::Length);
 
     setUiPrimary();
     connect(ui->cbCrop, &QCheckBox::clicked, this, &TaskActiveView::onCropChanged);

--- a/src/Mod/TechDraw/Gui/TaskBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.cpp
@@ -78,15 +78,15 @@ TaskBalloon::TaskBalloon(QGIViewBalloon *parent, ViewProviderBalloon *balloonVP)
     ui->comboBubbleShape->setCurrentIndex(i);
     connect(ui->comboBubbleShape, qOverload<int>(&QComboBox::currentIndexChanged), this, &TaskBalloon::onBubbleShapeChanged);
 
-    ui->qsbFontSize->setUnit(Base::Unit::Length);
+    ui->qsbFontSize->setUnit(Base::Units::Length);
     ui->qsbFontSize->setMinimum(0);
 
-    ui->qsbLineWidth->setUnit(Base::Unit::Length);
+    ui->qsbLineWidth->setUnit(Base::Units::Length);
     ui->qsbLineWidth->setSingleStep(0.100);
     ui->qsbLineWidth->setMinimum(0);
 
     // negative kink length is allowed, thus no minimum
-    ui->qsbKinkLength->setUnit(Base::Unit::Length);
+    ui->qsbKinkLength->setUnit(Base::Units::Length);
 
     if (balloonVP) {
         ui->textColor->setColor(balloonVP->Color.getValue().asValue<QColor>());

--- a/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
@@ -183,15 +183,15 @@ void TaskCenterLine::setUiPrimary()
         ui->cboxStyle->setCurrentIndex(Preferences::CenterLineStyle() - 1);
     }
 
-    ui->qsbVertShift->setUnit(Base::Unit::Length);
-    ui->qsbHorizShift->setUnit(Base::Unit::Length);
+    ui->qsbVertShift->setUnit(Base::Units::Length);
+    ui->qsbHorizShift->setUnit(Base::Units::Length);
     Base::Quantity qVal;
-    qVal.setUnit(Base::Unit::Length);
+    qVal.setUnit(Base::Units::Length);
     qVal.setValue(getExtendBy());
     ui->qsbExtend->setValue(qVal);
 
     Base::Quantity qAngle;
-    qAngle.setUnit(Base::Unit::Angle);
+    qAngle.setUnit(Base::Units::Angle);
     ui->qsbRotate->setValue(qAngle);
     int precision = Base::UnitsApi::getDecimals();
     ui->qsbRotate->setDecimals(precision);
@@ -234,7 +234,7 @@ void TaskCenterLine::setUiEdit()
         ui->rbAligned->setChecked(true);
 
     Base::Quantity qVal;
-    qVal.setUnit(Base::Unit::Length);
+    qVal.setUnit(Base::Units::Length);
     qVal.setValue(m_cl->m_vShift);
     ui->qsbVertShift->setValue(qVal);
     qVal.setValue(m_cl->m_hShift);
@@ -243,7 +243,7 @@ void TaskCenterLine::setUiEdit()
     ui->qsbExtend->setValue(qVal);
 
     Base::Quantity qAngle;
-    qAngle.setUnit(Base::Unit::Angle);
+    qAngle.setUnit(Base::Units::Angle);
     ui->qsbRotate->setValue(qAngle);
     int precision = Base::UnitsApi::getDecimals();
     ui->qsbRotate->setDecimals(precision);

--- a/src/Mod/TechDraw/Gui/TaskCosVertex.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCosVertex.cpp
@@ -118,8 +118,8 @@ void TaskCosVertex::setUiPrimary()
     int decimals = Base::UnitsApi::getDecimals();
     ui->dsbX->setDecimals(decimals);
     ui->dsbY->setDecimals(decimals);
-    ui->dsbX->setUnit(Base::Unit::Length);
-    ui->dsbY->setUnit(Base::Unit::Length);
+    ui->dsbX->setUnit(Base::Units::Length);
+    ui->dsbY->setUnit(Base::Units::Length);
 }
 
 // set the ui x,y to apparent coords (ie invertY)

--- a/src/Mod/TechDraw/Gui/TaskCosmeticCircle.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCosmeticCircle.cpp
@@ -144,11 +144,11 @@ void TaskCosmeticCircle::setUiPrimary()
         displayCenter = DU::invertY(displayCenter);
     }
 
-    ui->qsbCenterX->setUnit(Base::Unit::Length);
+    ui->qsbCenterX->setUnit(Base::Units::Length);
     ui->qsbCenterX->setValue(displayCenter.x);
-    ui->qsbCenterY->setUnit(Base::Unit::Length);
+    ui->qsbCenterY->setUnit(Base::Units::Length);
     ui->qsbCenterY->setValue(displayCenter.y);
-    ui->qsbCenterY->setUnit(Base::Unit::Length);
+    ui->qsbCenterY->setUnit(Base::Units::Length);
     ui->qsbCenterZ->setValue(displayCenter.z);
 
     double radius = (mathPoints[1] - mathPoints[0]).Length() / m_partFeat->getScale();

--- a/src/Mod/TechDraw/Gui/TaskCosmeticLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCosmeticLine.cpp
@@ -135,18 +135,18 @@ void TaskCosmeticLine::setUiPrimary()
     ui->rb2d1->setChecked(true);
     ui->rb3d1->setChecked(false);
 
-    ui->qsbx1->setUnit(Base::Unit::Length);
+    ui->qsbx1->setUnit(Base::Units::Length);
     ui->qsbx1->setValue(p1.x);
-    ui->qsby1->setUnit(Base::Unit::Length);
+    ui->qsby1->setUnit(Base::Units::Length);
     ui->qsby1->setValue(-p1.y);
-    ui->qsby1->setUnit(Base::Unit::Length);
+    ui->qsby1->setUnit(Base::Units::Length);
     ui->qsbz1->setValue(p1.z);
 
-    ui->qsbx2->setUnit(Base::Unit::Length);
+    ui->qsbx2->setUnit(Base::Units::Length);
     ui->qsbx2->setValue(p2.x);
-    ui->qsby2->setUnit(Base::Unit::Length);
+    ui->qsby2->setUnit(Base::Units::Length);
     ui->qsby2->setValue(-p2.y);
-    ui->qsbz2->setUnit(Base::Unit::Length);
+    ui->qsbz2->setUnit(Base::Units::Length);
     ui->qsbz2->setValue(p2.z);
 }
 

--- a/src/Mod/TechDraw/Gui/TaskDetail.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDetail.cpp
@@ -260,14 +260,14 @@ void TaskDetail::setUiFromFeat()
     ui->pbDragger->setText(tr("Drag Highlight"));
     ui->pbDragger->setEnabled(true);
     int decimals = Base::UnitsApi::getDecimals();
-    ui->qsbX->setUnit(Base::Unit::Length);
+    ui->qsbX->setUnit(Base::Units::Length);
     ui->qsbX->setDecimals(decimals);
     ui->qsbX->setValue(anchor.x);
-    ui->qsbY->setUnit(Base::Unit::Length);
+    ui->qsbY->setUnit(Base::Units::Length);
     ui->qsbY->setDecimals(decimals);
     ui->qsbY->setValue(anchor.y);
     ui->qsbRadius->setDecimals(decimals);
-    ui->qsbRadius->setUnit(Base::Unit::Length);
+    ui->qsbRadius->setUnit(Base::Units::Length);
     ui->qsbRadius->setValue(radius);
     ui->qsbScale->setDecimals(decimals);
     ui->cbScaleType->setCurrentIndex(ScaleType);

--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -71,12 +71,12 @@ TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *di
         ui->qsbOvertolerance->setMinimum(0.0);
     if ((parent->getDimFeat()->Type.isValue("Angle")) ||
         (parent->getDimFeat()->Type.isValue("Angle3Pt"))) {
-        ui->qsbOvertolerance->setUnit(Base::Unit::Angle);
-        ui->qsbUndertolerance->setUnit(Base::Unit::Angle);
+        ui->qsbOvertolerance->setUnit(Base::Units::Angle);
+        ui->qsbUndertolerance->setUnit(Base::Units::Angle);
     }
     else {
-        ui->qsbOvertolerance->setUnit(Base::Unit::Length);
-        ui->qsbUndertolerance->setUnit(Base::Unit::Length);
+        ui->qsbOvertolerance->setUnit(Base::Units::Length);
+        ui->qsbUndertolerance->setUnit(Base::Units::Length);
     }
     ui->qsbOvertolerance->setValue(parent->getDimFeat()->OverTolerance.getValue());
     ui->qsbUndertolerance->setValue(parent->getDimFeat()->UnderTolerance.getValue());
@@ -113,7 +113,7 @@ TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *di
         ui->dimensionColor->setColor(dimensionVP->Color.getValue().asValue<QColor>());
         connect(ui->dimensionColor, &ColorButton::changed, this, &TaskDimension::onColorChanged);
         ui->qsbFontSize->setValue(dimensionVP->Fontsize.getValue());
-        ui->qsbFontSize->setUnit(Base::Unit::Length);
+        ui->qsbFontSize->setUnit(Base::Units::Length);
         ui->qsbFontSize->setMinimum(0);
         connect(ui->qsbFontSize, qOverload<double>(&QuantitySpinBox::valueChanged), this, &TaskDimension::onFontsizeChanged);
         ui->comboDrawingStyle->setCurrentIndex(dimensionVP->StandardAndStyle.getValue());

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
@@ -239,7 +239,7 @@ void TaskLeaderLine::setUiPrimary()
     DrawGuiUtil::loadArrowBox(ui->cboxEndSym);
     ui->cboxEndSym->setCurrentIndex(TechDraw::ArrowType::NONE);
 
-    ui->dsbWeight->setUnit(Base::Unit::Length);
+    ui->dsbWeight->setUnit(Base::Units::Length);
     ui->dsbWeight->setMinimum(0);
     ui->dsbWeight->setValue(TechDraw::LineGroup::getDefaultWidth("Graphic"));
 

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -162,8 +162,8 @@ void TaskProjGroup::initializeUi()
     // Initially toggle view checkboxes if needed
     setupViewCheckboxes(true);
 
-    ui->sbXSpacing->setUnit(Base::Unit::Length);
-    ui->sbYSpacing->setUnit(Base::Unit::Length);
+    ui->sbXSpacing->setUnit(Base::Units::Length);
+    ui->sbYSpacing->setUnit(Base::Units::Length);
 
     if (Preferences::useCameraDirection()) {
         ui->butCam->setChecked(true);
@@ -959,7 +959,7 @@ void DirectionEditDialog::createUI() {
     auto* xLayout = new QHBoxLayout;
     auto* xLabel = new QLabel(QStringLiteral("X: "));
     xSpinBox = new Gui::QuantitySpinBox;
-    xSpinBox->setUnit(Base::Unit::Length);
+    xSpinBox->setUnit(Base::Units::Length);
     xLayout->addWidget(xLabel);
     xLayout->addWidget(xSpinBox);
 
@@ -967,7 +967,7 @@ void DirectionEditDialog::createUI() {
     auto* yLayout = new QHBoxLayout;
     auto* yLabel = new QLabel(QStringLiteral("Y: "));
     ySpinBox = new Gui::QuantitySpinBox;
-    ySpinBox->setUnit(Base::Unit::Length);
+    ySpinBox->setUnit(Base::Units::Length);
     yLayout->addWidget(yLabel);
     yLayout->addWidget(ySpinBox);
 
@@ -975,7 +975,7 @@ void DirectionEditDialog::createUI() {
     auto* zLayout = new QHBoxLayout;
     auto* zLabel = new QLabel(QStringLiteral("Z: "));
     zSpinBox = new Gui::QuantitySpinBox;
-    zSpinBox->setUnit(Base::Unit::Length);
+    zSpinBox->setUnit(Base::Units::Length);
     zLayout->addWidget(zLabel);
     zLayout->addWidget(zSpinBox);
 
@@ -986,7 +986,7 @@ void DirectionEditDialog::createUI() {
     directionGroup->setLayout(directionLayout);
 
     angleSpinBox = new Gui::QuantitySpinBox;
-    angleSpinBox->setUnit(Base::Unit::Angle);
+    angleSpinBox->setUnit(Base::Units::Angle);
 
     auto* buttonsLayout = new QHBoxLayout;
     auto* okButton = new QPushButton(tr("OK"));

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
@@ -168,7 +168,7 @@ void TaskRichAnno::setUiPrimary()
         std::string baseName = m_baseFeat->getNameInDocument();
         ui->leBaseView->setText(QString::fromStdString(baseName));
     }
-    ui->dsbWidth->setUnit(Base::Unit::Length);
+    ui->dsbWidth->setUnit(Base::Units::Length);
     ui->dsbWidth->setMinimum(0);
     ui->dsbWidth->setValue(prefWeight());
 

--- a/src/Mod/TechDraw/Gui/TaskSectionView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.cpp
@@ -190,11 +190,11 @@ void TaskSectionView::setUiCommon(Base::Vector3d origin)
     QString qTemp = QString::fromStdString(temp);
     ui->leBaseView->setText(qTemp);
 
-    ui->sbOrgX->setUnit(Base::Unit::Length);
+    ui->sbOrgX->setUnit(Base::Units::Length);
     ui->sbOrgX->setValue(origin.x);
-    ui->sbOrgY->setUnit(Base::Unit::Length);
+    ui->sbOrgY->setUnit(Base::Units::Length);
     ui->sbOrgY->setValue(origin.y);
-    ui->sbOrgZ->setUnit(Base::Unit::Length);
+    ui->sbOrgZ->setUnit(Base::Units::Length);
     ui->sbOrgZ->setValue(origin.z);
 
     enableAll(false);

--- a/tests/src/App/ExpressionParser.cpp
+++ b/tests/src/App/ExpressionParser.cpp
@@ -37,16 +37,12 @@ protected:
     App::DocumentObject* this_obj() { return _this_obj; }
 
     Base::Quantity parse_expression_text_as_quantity(const char* expression_text) {
-        auto expression = App::ExpressionParser::parse(this_obj(), expression_text);
-        auto expression_value = expression->getValueAsAny();
-        auto quantity_result = App::any_cast<Base::Quantity>(expression_value);
-        return quantity_result;
+        const auto expression = App::ExpressionParser::parse(this_obj(), expression_text);
+        return App::any_cast<Base::Quantity>(expression->getValueAsAny());
     }
 
     Base::Quantity parse_quantity_text_as_quantity(const char* quantity_text) {
-        auto quantity_str = std::string(quantity_text);
-        auto quantity_result = Base::Quantity::parse(quantity_str);
-        return quantity_result;
+        return Base::Quantity::parse(quantity_text);
     }
 
 private:

--- a/tests/src/Base/Quantity.cpp
+++ b/tests/src/Base/Quantity.cpp
@@ -2,6 +2,7 @@
 #include <Base/Exception.h>
 #include <Base/Quantity.h>
 #include <Base/UnitsApi.h>
+#include "Base/Units.h"
 #include <Base/UnitsSchemaImperial1.h>
 #include <QLocale>
 #include <boost/core/ignore_unused.hpp>
@@ -9,8 +10,8 @@
 // NOLINTBEGIN
 TEST(BaseQuantity, TestValid)
 {
-    Base::Quantity q1 {1.0, Base::Unit::Length};
-    Base::Quantity q2 {1.0, Base::Unit::Area};
+    Base::Quantity q1 {1.0, Base::Units::Length};
+    Base::Quantity q2 {1.0, Base::Units::Area};
     q2.setInvalid();
 
     EXPECT_EQ(q1.isValid(), true);
@@ -21,13 +22,13 @@ TEST(BaseQuantity, TestParse)
 {
     Base::Quantity q1 = Base::Quantity::parse("1,234 kg");
 
-    EXPECT_EQ(q1, Base::Quantity(1.2340, Base::Unit::Mass));
+    EXPECT_EQ(q1, Base::Quantity(1.2340, Base::Units::Mass));
     EXPECT_THROW(boost::ignore_unused(Base::Quantity::parse("1,234,500.12 kg")), Base::ParserError);
 }
 
 TEST(BaseQuantity, TestDim)
 {
-    Base::Quantity q1 {0, Base::Unit::Area};
+    Base::Quantity q1 {0, Base::Units::Area};
 
     EXPECT_EQ(q1.isQuantity(), true);
 }
@@ -42,53 +43,53 @@ TEST(BaseQuantity, TestNoDim)
 
 TEST(BaseQuantity, TestPowEQ1)
 {
-    Base::Quantity q1 {2, Base::Unit::Area};
-    EXPECT_EQ(q1.pow(1), Base::Quantity(2, Base::Unit::Area));
+    Base::Quantity q1 {2, Base::Units::Area};
+    EXPECT_EQ(q1.pow(1), Base::Quantity(2, Base::Units::Area));
 }
 
 TEST(BaseQuantity, TestPowEQ0)
 {
-    Base::Quantity q1 {2, Base::Unit::Area};
+    Base::Quantity q1 {2, Base::Units::Area};
     EXPECT_EQ(q1.pow(0), Base::Quantity {1});
 }
 
 TEST(BaseQuantity, TestPowGT1)
 {
-    Base::Quantity q1 {2, Base::Unit::Length};
-    EXPECT_EQ(q1.pow(2), Base::Quantity(4, Base::Unit::Area));
+    Base::Quantity q1 {2, Base::Units::Length};
+    EXPECT_EQ(q1.pow(2), Base::Quantity(4, Base::Units::Area));
 }
 
 TEST(BaseQuantity, TestPowLT1)
 {
-    Base::Quantity q1 {8, Base::Unit::Volume};
-    EXPECT_EQ(q1.pow(1.0 / 3.0), Base::Quantity(2, Base::Unit::Length));
+    Base::Quantity q1 {8, Base::Units::Volume};
+    EXPECT_EQ(q1.pow(1.0 / 3.0), Base::Quantity(2, Base::Units::Length));
 }
 
 TEST(BaseQuantity, TestPow3DIV2)
 {
-    Base::Quantity unit {8, Base::Unit::Volume};
+    Base::Quantity unit {8, Base::Units::Volume};
     EXPECT_THROW(unit.pow(3.0 / 2.0), Base::UnitsMismatchError);
 }
 
 TEST(BaseQuantity, TestString)
 {
     Base::Quantity q1 {2, "kg*m/s^2"};
-    EXPECT_EQ(q1.getUnit(), Base::Unit::Force);
+    EXPECT_EQ(q1.getUnit(), Base::Units::Force);
 
     Base::Quantity q2 {2, "kg*m^2/s^2"};
-    EXPECT_EQ(q2.getUnit(), Base::Unit::Work);
+    EXPECT_EQ(q2.getUnit(), Base::Units::Work);
 }
 
 TEST(BaseQuantity, TestCopy)
 {
-    Base::Quantity q1 {1.0, Base::Unit::Length};
+    Base::Quantity q1 {1.0, Base::Units::Length};
 
     EXPECT_EQ(Base::Quantity {q1}, q1);
 }
 
 TEST(BaseQuantity, TestEqual)
 {
-    Base::Quantity q1 {1.0, Base::Unit::Force};
+    Base::Quantity q1 {1.0, Base::Units::Force};
     Base::Quantity q2 {1.0, "kg*mm/s^2"};
 
     EXPECT_EQ(q1 == q1, true);
@@ -97,9 +98,9 @@ TEST(BaseQuantity, TestEqual)
 
 TEST(BaseQuantity, TestNotEqual)
 {
-    Base::Quantity q1 {1.0, Base::Unit::Force};
+    Base::Quantity q1 {1.0, Base::Units::Force};
     Base::Quantity q2 {2.0, "kg*m/s^2"};
-    Base::Quantity q3 {1.0, Base::Unit::Work};
+    Base::Quantity q3 {1.0, Base::Units::Work};
 
     EXPECT_EQ(q1 != q2, true);
     EXPECT_EQ(q1 != q3, true);
@@ -107,9 +108,9 @@ TEST(BaseQuantity, TestNotEqual)
 
 TEST(BaseQuantity, TestLessOrGreater)
 {
-    Base::Quantity q1 {1.0, Base::Unit::Force};
+    Base::Quantity q1 {1.0, Base::Units::Force};
     Base::Quantity q2 {2.0, "kg*m/s^2"};
-    Base::Quantity q3 {2.0, Base::Unit::Work};
+    Base::Quantity q3 {2.0, Base::Units::Work};
 
     EXPECT_EQ(q1 < q2, true);
     EXPECT_EQ(q1 > q2, false);
@@ -123,53 +124,53 @@ TEST(BaseQuantity, TestLessOrGreater)
 
 TEST(BaseQuantity, TestAdd)
 {
-    Base::Quantity q1 {1.0, Base::Unit::Length};
-    Base::Quantity q2 {1.0, Base::Unit::Area};
+    Base::Quantity q1 {1.0, Base::Units::Length};
+    Base::Quantity q2 {1.0, Base::Units::Area};
     EXPECT_THROW(q1 + q2, Base::UnitsMismatchError);
     EXPECT_THROW(q1 += q2, Base::UnitsMismatchError);
-    EXPECT_EQ(q1 + q1, Base::Quantity(2, Base::Unit::Length));
-    EXPECT_EQ(q1 += q1, Base::Quantity(2, Base::Unit::Length));
+    EXPECT_EQ(q1 + q1, Base::Quantity(2, Base::Units::Length));
+    EXPECT_EQ(q1 += q1, Base::Quantity(2, Base::Units::Length));
 }
 
 TEST(BaseQuantity, TestSub)
 {
-    Base::Quantity q1 {1.0, Base::Unit::Length};
-    Base::Quantity q2 {1.0, Base::Unit::Area};
+    Base::Quantity q1 {1.0, Base::Units::Length};
+    Base::Quantity q2 {1.0, Base::Units::Area};
     EXPECT_THROW(q1 - q2, Base::UnitsMismatchError);
     EXPECT_THROW(q1 -= q2, Base::UnitsMismatchError);
-    EXPECT_EQ(q1 - q1, Base::Quantity(0, Base::Unit::Length));
-    EXPECT_EQ(q1 -= q1, Base::Quantity(0, Base::Unit::Length));
+    EXPECT_EQ(q1 - q1, Base::Quantity(0, Base::Units::Length));
+    EXPECT_EQ(q1 -= q1, Base::Quantity(0, Base::Units::Length));
 }
 
 TEST(BaseQuantity, TestNeg)
 {
-    Base::Quantity q1 {1.0, Base::Unit::Length};
-    EXPECT_EQ(-q1, Base::Quantity(-1.0, Base::Unit::Length));
+    Base::Quantity q1 {1.0, Base::Units::Length};
+    EXPECT_EQ(-q1, Base::Quantity(-1.0, Base::Units::Length));
 }
 
 TEST(BaseQuantity, TestMult)
 {
-    Base::Quantity q1 {1.0, Base::Unit::Length};
-    Base::Quantity q2 {1.0, Base::Unit::Area};
-    EXPECT_EQ(q1 * q2, Base::Quantity(1.0, Base::Unit::Volume));
-    EXPECT_EQ(q1 * 2.0, Base::Quantity(2.0, Base::Unit::Length));
+    Base::Quantity q1 {1.0, Base::Units::Length};
+    Base::Quantity q2 {1.0, Base::Units::Area};
+    EXPECT_EQ(q1 * q2, Base::Quantity(1.0, Base::Units::Volume));
+    EXPECT_EQ(q1 * 2.0, Base::Quantity(2.0, Base::Units::Length));
 }
 
 TEST(BaseQuantity, TestDiv)
 {
-    Base::Quantity q1 {1.0, Base::Unit::Length};
-    Base::Quantity q2 {1.0, Base::Unit::Area};
-    EXPECT_EQ(q1 / q2, Base::Quantity(1.0, Base::Unit::InverseLength));
-    EXPECT_EQ(q1 / 2.0, Base::Quantity(0.5, Base::Unit::Length));
+    Base::Quantity q1 {1.0, Base::Units::Length};
+    Base::Quantity q2 {1.0, Base::Units::Area};
+    EXPECT_EQ(q1 / q2, Base::Quantity(1.0, Base::Units::InverseLength));
+    EXPECT_EQ(q1 / 2.0, Base::Quantity(0.5, Base::Units::Length));
 }
 
 TEST(BaseQuantity, TestPow)
 {
-    Base::Quantity q1 {2.0, Base::Unit::Length};
-    Base::Quantity q2 {2.0, Base::Unit::Area};
+    Base::Quantity q1 {2.0, Base::Units::Length};
+    Base::Quantity q2 {2.0, Base::Units::Area};
     Base::Quantity q3 {0.0};
     EXPECT_EQ(q1.pow(q3), Base::Quantity {1});
-    EXPECT_EQ(q1.pow(2.0), Base::Quantity(4, Base::Unit::Area));
+    EXPECT_EQ(q1.pow(2.0), Base::Quantity(4, Base::Units::Area));
     EXPECT_THROW(q1.pow(q2), Base::UnitsMismatchError);
 }
 
@@ -187,7 +188,7 @@ protected:
 
 TEST_F(Quantity, TestSchemeImperialTwo)
 {
-    Base::Quantity quantity {1.0, Base::Unit::Length};
+    Base::Quantity quantity {1.0, Base::Units::Length};
 
     double factor {};
     std::string unitString;
@@ -198,7 +199,7 @@ TEST_F(Quantity, TestSchemeImperialTwo)
 
 TEST_F(Quantity, TestSchemeImperialOne)
 {
-    Base::Quantity quantity {1.0, Base::Unit::Length};
+    Base::Quantity quantity {1.0, Base::Units::Length};
 
     Base::QuantityFormat format = quantity.getFormat();
     format.precision = 1;
@@ -216,7 +217,7 @@ TEST_F(Quantity, TestSafeUserString)
 {
     Base::UnitsApi::setSchema(Base::UnitSystem::ImperialDecimal);
 
-    Base::Quantity quantity {1.0, Base::Unit::Length};
+    Base::Quantity quantity {1.0, Base::Units::Length};
     Base::QuantityFormat format = quantity.getFormat();
     format.precision = 1;
     quantity.setFormat(format);
@@ -227,14 +228,14 @@ TEST_F(Quantity, TestSafeUserString)
 
     Base::UnitsApi::setSchema(Base::UnitSystem::Imperial1);
 
-    quantity = Base::Quantity {304.8, Base::Unit::Length};
+    quantity = Base::Quantity {304.8, Base::Units::Length};
     quantity.setFormat(format);
 
     result = quantity.getSafeUserString();
 
     EXPECT_EQ(result, "1.0 \\'");
 
-    quantity = Base::Quantity {25.4, Base::Unit::Length};
+    quantity = Base::Quantity {25.4, Base::Units::Length};
     quantity.setFormat(format);
 
     result = quantity.getSafeUserString();

--- a/tests/src/Base/Unit.cpp
+++ b/tests/src/Base/Unit.cpp
@@ -1,193 +1,172 @@
 #include "Base/Unit.h"
+#include "Base/Units.h"
 #include <gtest/gtest.h>
 #include <Base/Exception.h>
 
-// NOLINTBEGIN
-TEST(Unit, TestString)
+using namespace Base;
+using namespace Units;
+
+TEST(Unit, string_nullUnit)
 {
-    auto toString = [](const Base::Unit& unit) {
-        return unit.getString();
-    };
-    EXPECT_EQ(toString(Base::Unit(0, 0, 0, 0, 0, 0, 0, 0)), "");
-    EXPECT_EQ(toString(Base::Unit(1, 0, 0, 0, 0, 0, 0, 0)), "mm");
-    EXPECT_EQ(toString(Base::Unit(0, 1, 0, 0, 0, 0, 0, 0)), "kg");
-    EXPECT_EQ(toString(Base::Unit(0, 0, 1, 0, 0, 0, 0, 0)), "s");
-    EXPECT_EQ(toString(Base::Unit(0, 0, 0, 1, 0, 0, 0, 0)), "A");
-    EXPECT_EQ(toString(Base::Unit(0, 0, 0, 0, 1, 0, 0, 0)), "K");
-    EXPECT_EQ(toString(Base::Unit(0, 0, 0, 0, 0, 1, 0, 0)), "mol");
-    EXPECT_EQ(toString(Base::Unit(0, 0, 0, 0, 0, 0, 1, 0)), "cd");
-    EXPECT_EQ(toString(Base::Unit(0, 0, 0, 0, 0, 0, 0, 1)), "deg");
-    EXPECT_EQ(toString(Base::Unit(2, 0, 0, 0, 0, 0, 0, 0)), "mm^2");
-    EXPECT_EQ(toString(Base::Unit(1, 1, -2, 0, 0, 0, 0, 0)), "mm*kg/s^2");
+    EXPECT_EQ(NullUnit.getString(), "");
 }
 
-TEST(Unit, TestTypeString)
+TEST(Unit, string_simple_numerator_no_denominator)
 {
-    auto toString = [](const Base::Unit& unit) {
-        return unit.getTypeString();
-    };
-    EXPECT_EQ(toString(Base::Unit::Acceleration), "Acceleration");
-    EXPECT_EQ(toString(Base::Unit::AmountOfSubstance), "AmountOfSubstance");
-    EXPECT_EQ(toString(Base::Unit::Angle), "Angle");
-    EXPECT_EQ(toString(Base::Unit::AngleOfFriction), "Angle");  // same unit as Angle
-    EXPECT_EQ(toString(Base::Unit::Area), "Area");
-    EXPECT_EQ(toString(Base::Unit::CurrentDensity), "CurrentDensity");
-    EXPECT_EQ(toString(Base::Unit::Density), "Density");
-    EXPECT_EQ(toString(Base::Unit::DissipationRate), "DissipationRate");
-    EXPECT_EQ(toString(Base::Unit::DynamicViscosity), "DynamicViscosity");
-    EXPECT_EQ(toString(Base::Unit::ElectricalCapacitance), "ElectricalCapacitance");
-    EXPECT_EQ(toString(Base::Unit::ElectricalConductance), "ElectricalConductance");
-    EXPECT_EQ(toString(Base::Unit::ElectricalConductivity), "ElectricalConductivity");
-    EXPECT_EQ(toString(Base::Unit::ElectricalInductance), "ElectricalInductance");
-    EXPECT_EQ(toString(Base::Unit::ElectricalResistance), "ElectricalResistance");
-    EXPECT_EQ(toString(Base::Unit::ElectricCharge), "ElectricCharge");
-    EXPECT_EQ(toString(Base::Unit::ElectricCurrent), "ElectricCurrent");
-    EXPECT_EQ(toString(Base::Unit::ElectricPotential), "ElectricPotential");
-    EXPECT_EQ(toString(Base::Unit::Frequency), "Frequency");
-    EXPECT_EQ(toString(Base::Unit::Force), "Force");
-    EXPECT_EQ(toString(Base::Unit::HeatFlux), "HeatFlux");
-    EXPECT_EQ(toString(Base::Unit::InverseArea), "InverseArea");
-    EXPECT_EQ(toString(Base::Unit::InverseLength), "InverseLength");
-    EXPECT_EQ(toString(Base::Unit::InverseVolume), "InverseVolume");
-    EXPECT_EQ(toString(Base::Unit::KinematicViscosity), "KinematicViscosity");
-    EXPECT_EQ(toString(Base::Unit::Length), "Length");
-    EXPECT_EQ(toString(Base::Unit::LuminousIntensity), "LuminousIntensity");
-    EXPECT_EQ(toString(Base::Unit::MagneticFieldStrength), "MagneticFieldStrength");
-    EXPECT_EQ(toString(Base::Unit::MagneticFlux), "MagneticFlux");
-    EXPECT_EQ(toString(Base::Unit::MagneticFluxDensity), "MagneticFluxDensity");
-    EXPECT_EQ(toString(Base::Unit::Magnetization),
-              "MagneticFieldStrength");  // same as MagneticFieldStrength
-    EXPECT_EQ(toString(Base::Unit::Mass), "Mass");
-    EXPECT_EQ(toString(Base::Unit::Pressure), "Pressure");
-    EXPECT_EQ(toString(Base::Unit::Power), "Power");
-    EXPECT_EQ(toString(Base::Unit::ShearModulus), "Pressure");  // same as Pressure
-    EXPECT_EQ(toString(Base::Unit::SpecificEnergy), "SpecificEnergy");
-    EXPECT_EQ(toString(Base::Unit::SpecificHeat), "SpecificHeat");
-    EXPECT_EQ(toString(Base::Unit::Stiffness), "Stiffness");
-    EXPECT_EQ(toString(Base::Unit::Stress), "Pressure");  // same as Pressure
-    EXPECT_EQ(toString(Base::Unit::Temperature), "Temperature");
-    EXPECT_EQ(toString(Base::Unit::ThermalConductivity), "ThermalConductivity");
-    EXPECT_EQ(toString(Base::Unit::ThermalExpansionCoefficient), "ThermalExpansionCoefficient");
-    EXPECT_EQ(toString(Base::Unit::ThermalTransferCoefficient), "ThermalTransferCoefficient");
-    EXPECT_EQ(toString(Base::Unit::TimeSpan), "TimeSpan");
-    EXPECT_EQ(toString(Base::Unit::UltimateTensileStrength), "Pressure");  // same as Pressure
-    EXPECT_EQ(toString(Base::Unit::VacuumPermittivity), "VacuumPermittivity");
-    EXPECT_EQ(toString(Base::Unit::Velocity), "Velocity");
-    EXPECT_EQ(toString(Base::Unit::Volume), "Volume");
-    EXPECT_EQ(toString(Base::Unit::VolumeFlowRate), "VolumeFlowRate");
-    EXPECT_EQ(toString(Base::Unit::VolumetricThermalExpansionCoefficient),
-              "ThermalExpansionCoefficient");
-    EXPECT_EQ(toString(Base::Unit::Work), "Work");
-    EXPECT_EQ(toString(Base::Unit::YieldStrength), "Pressure");  // same as Pressure
-    EXPECT_EQ(toString(Base::Unit::YoungsModulus), "Pressure");  // same unit as Pressure
+    EXPECT_EQ(Length.getString(), "mm");
 }
-TEST(Unit, strings)
+
+TEST(Unit, string_complex_numerator_no_denominator)
 {
-    EXPECT_STREQ(Base::Unit::Acceleration.getString().c_str(), "mm/s^2");
-    EXPECT_STREQ(Base::Unit::AmountOfSubstance.getString().c_str(), "mol");
-    EXPECT_STREQ(Base::Unit::Angle.getString().c_str(), "deg");
-    EXPECT_STREQ(Base::Unit::AngleOfFriction.getString().c_str(), "deg");
-    EXPECT_STREQ(Base::Unit::Area.getString().c_str(), "mm^2");
-    EXPECT_STREQ(Base::Unit::CurrentDensity.getString().c_str(), "A/mm^2");
-    EXPECT_STREQ(Base::Unit::Density.getString().c_str(), "kg/mm^3");
-    EXPECT_STREQ(Base::Unit::DissipationRate.getString().c_str(), "mm^2/s^3");
+    EXPECT_EQ(Area.getString(), "mm^2");
+}
+
+TEST(Unit, string_complex_single_denominator)
+{
+    EXPECT_EQ(DissipationRate.getString(), "mm^2/s^3");
+}
+
+TEST(Unit, string_no_numerator)
+{
+    EXPECT_EQ(InverseArea.getString(), "1/mm^2");
+}
+
+TEST(Unit, string_complex_multi_denominator)
+{
+    EXPECT_EQ(MagneticFlux.getString(), "mm^2*kg/(s^2*A)");
+}
+
+TEST(Unit, type_string_null)
+{
+    EXPECT_EQ(NullUnit.getTypeString(), "NullUnit");
+}
+
+TEST(Unit, type_string_not_null)
+{
+    EXPECT_EQ(MagneticFlux.getTypeString(), "MagneticFlux");
 }
 
 TEST(Unit, TestEqual)
 {
-    Base::Unit unit {1};
-    EXPECT_EQ(unit.pow(2) == Base::Unit {2}, true);
+    EXPECT_TRUE(Length == Length);
 }
 
 TEST(Unit, TestNotEqual)
 {
-    Base::Unit unit {1};
-    EXPECT_EQ(unit.pow(2) != Base::Unit {1}, true);
+    EXPECT_TRUE(Length != Area);
+}
+
+TEST(Unit, multipy_nullUnits_is_nullUnit)
+{
+    EXPECT_EQ(NullUnit * NullUnit, NullUnit);
 }
 
 TEST(Unit, TestMult)
 {
-    EXPECT_EQ(Base::Unit {} * Base::Unit {}, Base::Unit {});
-    EXPECT_EQ(Base::Unit(0, 1) * Base::Unit(1, 0), Base::Unit(1, 1));
+    constexpr std::array<int8_t, 8> arr {1, 1, 0, 0, 0, 0, 0, 0};
+    EXPECT_EQ(Mass * Length, Unit {arr});
 }
 
-TEST(Unit, TestDiv)
+TEST(Unit, mult_nullUnit_is_nullUnit)
 {
-    EXPECT_EQ(Base::Unit {} * Base::Unit {}, Base::Unit {});
-    EXPECT_EQ(Base::Unit(0, 1) / Base::Unit(1, 0), Base::Unit(-1, 1));
+    EXPECT_EQ(NullUnit * NullUnit, NullUnit);
 }
 
-TEST(Unit, TestPowNoDim)
+TEST(Unit, div)
 {
-    Base::Unit unit {};
-    EXPECT_EQ(unit.pow(2), Base::Unit {0});
-    EXPECT_EQ(unit.isEmpty(), true);
+    EXPECT_EQ(Area / Length, Length);
 }
 
-TEST(Unit, TestPowEQ1)
+TEST(Unit, div_by_nullUnit_does_nothing)
 {
-    Base::Unit unit {2};
-    EXPECT_EQ(unit.pow(1), Base::Unit {2});
+    EXPECT_EQ(Area / NullUnit, Area);
 }
 
-TEST(Unit, TestPowEQ0)
+TEST(Unit, pow_0_is_null_unit)
 {
-    Base::Unit unit {2};
-    EXPECT_EQ(unit.pow(0), Base::Unit {0});
+    EXPECT_EQ(Area.pow(0), NullUnit);
 }
 
-TEST(Unit, TestPowGT1)
+TEST(Unit, pow_1_leaves_unit_unchanged)
 {
-    Base::Unit unit {2};
-    EXPECT_EQ(unit.pow(2), Base::Unit {4});
+    EXPECT_EQ(Area.pow(1), Area);
 }
 
-TEST(Unit, TestPowLT1)
+TEST(Unit, pow_2_is_squared)
 {
-    Base::Unit unit {3};
-    EXPECT_EQ(unit.pow(1.0 / 3.0), Base::Unit {1});
+    EXPECT_EQ(Length.pow(2), Area);
+}
+
+TEST(Unit, pow_3_is_cubed)
+{
+    EXPECT_EQ(Length.pow(3), Volume);
+}
+
+TEST(Unit, pow_less_then_one)
+{
+    EXPECT_EQ(Volume.pow(1.0 / 3.0), Length);
+}
+
+TEST(Unit, null_unit_still_null_after_pow)
+{
+    EXPECT_EQ(NullUnit.pow(2), NullUnit);
+}
+
+TEST(Unit, square_root)
+{
+    EXPECT_EQ(Area.root(2), Length);
+}
+
+TEST(Unit, cube_root)
+{
+    EXPECT_EQ(Volume.root(3), Length);
+}
+
+TEST(Unit, zero_root)
+{
+    EXPECT_THROW([[maybe_unused]] auto res = Area.root(0), UnitsMismatchError);
+}
+
+TEST(Unit, one_root)
+{
+    EXPECT_EQ(Area.root(1), Area);
 }
 
 TEST(Unit, TestPow3DIV2)
 {
-    Base::Unit unit {3};
-    EXPECT_THROW(unit.pow(3.0 / 2.0), Base::UnitsMismatchError);
+    EXPECT_THROW([[maybe_unused]] auto res = Volume.pow(3.0 / 2.0), UnitsMismatchError);
 }
 
-TEST(Unit, TestOverflow)
+TEST(Unit, overflow)
 {
-    // this tests _that_ the expected exception is thrown
-    EXPECT_THROW(
-        {
-            try {
-                Base::Unit unit {3};
-                unit.pow(10000);
-            }
-            catch (const Base::OverflowError& e) {
-                // and this tests that it has the correct message
-                EXPECT_STREQ("Unit overflow in pow()", e.what());
-                throw;
-            }
-        },
-        Base::OverflowError);
+    constexpr UnitVals arr {99, 0, 0, 0, 0, 0, 0, 0};
+    EXPECT_EQ(Unit {arr}, NullUnit);
 }
 
-TEST(Unit, TestUnderflow)
+TEST(Unit, underflow)
 {
-    // this tests _that_ the expected exception is thrown
-    EXPECT_THROW(
-        {
-            try {
-                Base::Unit unit {3};
-                unit.pow(-10000);
-            }
-            catch (const Base::UnderflowError& e) {
-                // and this tests that it has the correct message
-                EXPECT_STREQ("Unit underflow in pow()", e.what());
-                throw;
-            }
-        },
-        Base::UnderflowError);
+    constexpr UnitVals arr {-99, 0, 0, 0, 0, 0, 0, 0};
+    EXPECT_EQ(Unit {arr}, NullUnit);
 }
 
-// NOLINTEND
+TEST(Unit, representation_simple)
+{
+    const std::string expect {"Unit: mm (1,0,0,0,0,0,0,0) [Length]"};
+    const auto actual = Length.representation();
+    EXPECT_EQ(actual, expect);
+}
+
+TEST(Unit, representation_complex)
+{
+    const std::string expect {"Unit: mm^2*kg/(s^2*A) (2,1,-2,-1,0,0,0,0) [MagneticFlux]"};
+    const auto actual = MagneticFlux.representation();
+    EXPECT_EQ(actual, expect);
+}
+
+TEST(Unit, representation_no_name)
+{
+    constexpr Unit unit {{1, 1}};
+    const std::string expect {"Unit: mm*kg (1,1,0,0,0,0,0,0)"};
+    const auto actual = unit.representation();
+    EXPECT_EQ(actual, expect);
+}


### PR DESCRIPTION
Continues on from the work of @3x380V 
Make constexpr.
Make immutable.
Separate data from code.
Move units setup to namespace Units in Base/Units.h. Prefer algorithms to raw loops.
Cover more behaviors in unit tests.
Reduce repetition.