### PR TITLE
Draft: Introduce base classes for Draft tests

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -48,22 +48,23 @@ SET (Draft_geoutils
 
 SET(Draft_tests
     drafttests/__init__.py
+    drafttests/README.md
     drafttests/auxiliary.py
+    drafttests/draft_test_objects.py
+    drafttests/test_airfoildat.py
+    drafttests/test_array.py
+    drafttests/test_base.py
+    drafttests/test_creation.py
+    drafttests/test_draftgeomutils.py
+    drafttests/test_dwg.py
+    drafttests/test_dxf.py
     drafttests/test_import.py
     drafttests/test_import_gui.py
     drafttests/test_import_tools.py
-    drafttests/test_pivy.py
-    drafttests/test_array.py
-    drafttests/test_creation.py
     drafttests/test_modification.py
-    drafttests/test_svg.py
-    drafttests/test_dxf.py
-    drafttests/test_dwg.py
     drafttests/test_oca.py
-    drafttests/test_airfoildat.py
-    drafttests/test_draftgeomutils.py
-    drafttests/draft_test_objects.py
-    drafttests/README.md
+    drafttests/test_pivy.py
+    drafttests/test_svg.py
 )
 
 SET(Draft_utilities

--- a/src/Mod/Draft/drafttests/test_airfoildat.py
+++ b/src/Mod/Draft/drafttests/test_airfoildat.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2025 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -29,34 +30,17 @@
 ## \addtogroup drafttests
 # @{
 import os
-import unittest
 
 import FreeCAD as App
 import Draft
 import drafttests.auxiliary as aux
 
 from draftutils.messages import _msg
+from drafttests import test_base
 
 
-class DraftAirfoilDAT(unittest.TestCase):
+class DraftAirfoilDAT(test_base.DraftTestCaseDoc):
     """Test reading and writing of AirfoilDAT with Draft."""
-
-    def setUp(self):
-        """Set up a new document to hold the tests.
-
-        This is executed before every test, so we create a document
-        to hold the objects.
-        """
-        aux.draw_header()
-        self.doc_name = self.__class__.__name__
-        if App.ActiveDocument:
-            if App.ActiveDocument.Name != self.doc_name:
-                App.newDocument(self.doc_name)
-        else:
-            App.newDocument(self.doc_name)
-        App.setActiveDocument(self.doc_name)
-        self.doc = App.ActiveDocument
-        _msg("  Temporary document '{}'".format(self.doc_name))
 
     def test_read_airfoildat(self):
         """Read an airfoil DAT file and import its elements as objects."""
@@ -86,12 +70,5 @@ class DraftAirfoilDAT(unittest.TestCase):
         Draft.export_airfoildat = aux.fake_function
         obj = Draft.export_airfoildat(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
-
-    def tearDown(self):
-        """Finish the test.
-
-        This is executed after each test, so we close the document.
-        """
-        App.closeDocument(self.doc_name)
 
 ## @}

--- a/src/Mod/Draft/drafttests/test_base.py
+++ b/src/Mod/Draft/drafttests/test_base.py
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
-# *   Copyright (c) 2023 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+# *                                                                         *
 # *   Copyright (c) 2025 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of FreeCAD.                                         *
@@ -19,51 +20,37 @@
 # *   <https://www.gnu.org/licenses/>.                                      *
 # *                                                                         *
 # ***************************************************************************
-"""Unit tests for the Draft Workbench, array tests."""
-## @package test_array
-# \ingroup drafttests
-# \brief Unit tests for the Draft Workbench, array tests.
 
-## \addtogroup drafttests
-# @{
-import math
+import unittest
 
 import FreeCAD as App
-import Draft
-
-from FreeCAD import Vector
+from drafttests import auxiliary as aux
 from draftutils.messages import _msg
-from drafttests import test_base
+from draftutils.todo import ToDo
 
 
-class DraftArray(test_base.DraftTestCaseDoc):
-    """Test Draft array functions."""
+class DraftTestCaseDoc(unittest.TestCase):
+    """Base class for Draft tests that require a document."""
 
-    def test_link_array(self):
-        """Create a link array."""
-        box = self.doc.addObject("Part::Box","Box")
-        box.Label = "Box"
-        self.doc.recompute()
+    def setUp(self):
+        """Set up a new document for each test."""
+        aux.draw_header()
+        # name = self.__class__.__name__
+        name = "___".join(self.id().split(".")[2:])  # unique name for each test
+        if not name in App.listDocuments():
+            App.newDocument(name)
+        App.setActiveDocument(name)
+        self.doc = App.ActiveDocument
+        _msg("  Temporary document '{}'".format(self.doc.Name))
 
-        array = Draft.make_ortho_array(box, v_x=App.Vector(100.0, 0.0, 0.0),
-                                            v_y=App.Vector(0.0, 100.0, 0.0),
-                                            v_z=App.Vector(0.0, 0.0, 100.0),
-                                            n_x=12, n_y=1, n_z=1, use_link=True)
+    def tearDown(self):
+        """Close the document after each test."""
+        App.closeDocument(self.doc.Name)
 
-        Draft.autogroup(array)
-        array.ExpandArray = True
-        array.Fuse = False
-        self.doc.recompute(None,True,True)
 
-        array.NumberX = 6
-        self.doc.recompute(None,True,True)
-        self.assertEqual(array.Count, array.NumberX)
+class DraftTestCaseNoDoc(unittest.TestCase):
+    """Base class for Draft tests that do not require a document."""
 
-        array.NumberX = 24
-        self.doc.recompute(None,True,True)
-        self.assertEqual(array.Count, array.NumberX)
-
-        self.doc.recompute(None,True,True)
-        self.assertEqual(array.Count, array.NumberX)
-
-## @}
+    def setUp(self):
+        """Draw the header."""
+        aux.draw_header()

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2025 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -28,7 +29,6 @@
 
 ## \addtogroup drafttests
 # @{
-import unittest
 import math
 
 import FreeCAD as App
@@ -37,27 +37,11 @@ import drafttests.auxiliary as aux
 
 from FreeCAD import Vector
 from draftutils.messages import _msg
+from drafttests import test_base
 
 
-class DraftCreation(unittest.TestCase):
+class DraftCreation(test_base.DraftTestCaseDoc):
     """Test Draft creation functions."""
-
-    def setUp(self):
-        """Set up a new document to hold the tests.
-
-        This is executed before every test, so we create a document
-        to hold the objects.
-        """
-        aux.draw_header()
-        doc_name = self.__class__.__name__
-        if App.ActiveDocument:
-            if App.ActiveDocument.Name != doc_name:
-                App.newDocument(doc_name)
-        else:
-            App.newDocument(doc_name)
-        App.setActiveDocument(doc_name)
-        self.doc = App.ActiveDocument
-        _msg("  Temporary document '{}'".format(self.doc.Name))
 
     def test_line(self):
         """Create a line."""
@@ -282,7 +266,7 @@ class DraftCreation(unittest.TestCase):
         _msg("  or an App::PropertyLinkSubList")
 
         _msg("  Box")
-        box = App.ActiveDocument.addObject("Part::Box")
+        box = self.doc.addObject("Part::Box")
         self.doc.recompute()
         # The facebinder function accepts a Gui selection set,
         # or a 'PropertyLinkSubList'
@@ -378,14 +362,14 @@ class DraftCreation(unittest.TestCase):
         _msg("  length={0}, width={1}".format(length, width))
         rect = Draft.make_rectangle(length, width)
         rect.MakeFace = True
-        App.ActiveDocument.recompute()
+        self.doc.recompute()
 
         patfile = App.getResourceDir() + "Mod/TechDraw/PAT/FCPAT.pat"
         patname = "Horizontal5"
         _msg("  patfile='{0}'".format(patfile))
         _msg("  patname='{0}'".format(patname))
         obj = Draft.make_hatch(rect, patfile, patname, scale=1, rotation=45)
-        App.ActiveDocument.recompute()
+        self.doc.recompute()
 
         box = obj.Shape.BoundBox
         # A rather high tolerance is required.
@@ -393,12 +377,5 @@ class DraftCreation(unittest.TestCase):
                       and math.isclose(box.XLength, length, rel_tol=0, abs_tol=1e-6)
                       and math.isclose(box.YLength, width, rel_tol=0, abs_tol=1e-6))
         self.assertTrue(obj_is_ok, "'{}' failed".format(operation))
-
-    def tearDown(self):
-        """Finish the test.
-
-        This is executed after each test, so we close the document.
-        """
-        App.closeDocument(self.doc.Name)
 
 ## @}

--- a/src/Mod/Draft/drafttests/test_draftgeomutils.py
+++ b/src/Mod/Draft/drafttests/test_draftgeomutils.py
@@ -1,5 +1,6 @@
 # ***************************************************************************
 # *   Copyright (c) 2020 Antoine Lafr                                       *
+# *   Copyright (c) 2025 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -22,19 +23,15 @@
 # ***************************************************************************
 """Unit test for the DraftGeomUtils module."""
 
-import unittest
 import FreeCAD
 import Part
 import DraftGeomUtils
 import drafttests.auxiliary as aux
 from draftutils.messages import _msg
+from drafttests import test_base
 
-class TestDraftGeomUtils(unittest.TestCase):
+class TestDraftGeomUtils(test_base.DraftTestCaseNoDoc):
     """Testing the functions in the file DraftGeomUtils.py"""
-
-    def setUp(self):
-        """Prepare the test. Nothing to do here, DraftGeomUtils doesn't need a document."""
-        aux.draw_header()
 
     def check_wire(self, wire):
         offset_values = (2000.0, 0.0, -1000, -2000, -3000, -5500)
@@ -214,10 +211,6 @@ class TestDraftGeomUtils(unittest.TestCase):
         wire = Part.Wire(edges)
         wire.Orientation = "Reversed"
         self.check_wire(wire)
-
-    def tearDown(self):
-        """Finish the test. Nothing to do here, DraftGeomUtils doesn't need a document."""
-        pass
 
 # suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestDraftGeomUtils)
 # unittest.TextTestRunner().run(suite)

--- a/src/Mod/Draft/drafttests/test_dwg.py
+++ b/src/Mod/Draft/drafttests/test_dwg.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2025 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -29,7 +30,6 @@
 ## \addtogroup drafttests
 # @{
 import os
-import unittest
 
 import FreeCAD as App
 import Draft
@@ -38,25 +38,8 @@ import drafttests.auxiliary as aux
 from draftutils.messages import _msg
 
 
-class DraftDWG(unittest.TestCase):
+class DraftDWG(test_base.DraftTestCaseDoc):
     """Test reading and writing of DWG files with Draft."""
-
-    def setUp(self):
-        """Set up a new document to hold the tests.
-
-        This is executed before every test, so we create a document
-        to hold the objects.
-        """
-        aux.draw_header()
-        self.doc_name = self.__class__.__name__
-        if App.ActiveDocument:
-            if App.ActiveDocument.Name != self.doc_name:
-                App.newDocument(self.doc_name)
-        else:
-            App.newDocument(self.doc_name)
-        App.setActiveDocument(self.doc_name)
-        self.doc = App.ActiveDocument
-        _msg("  Temporary document '{}'".format(self.doc_name))
 
     def test_read_dwg(self):
         """Read a DWG file and import its elements as Draft objects."""
@@ -86,12 +69,5 @@ class DraftDWG(unittest.TestCase):
         Draft.export_dwg = aux.fake_function
         obj = Draft.export_dwg(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
-
-    def tearDown(self):
-        """Finish the test.
-
-        This is executed after each test, so we close the document.
-        """
-        App.closeDocument(self.doc_name)
 
 ## @}

--- a/src/Mod/Draft/drafttests/test_dwg.py
+++ b/src/Mod/Draft/drafttests/test_dwg.py
@@ -36,6 +36,7 @@ import Draft
 import drafttests.auxiliary as aux
 
 from draftutils.messages import _msg
+from drafttests import test_base
 
 
 class DraftDWG(test_base.DraftTestCaseDoc):

--- a/src/Mod/Draft/drafttests/test_dxf.py
+++ b/src/Mod/Draft/drafttests/test_dxf.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2025 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -29,34 +30,17 @@
 ## \addtogroup drafttests
 # @{
 import os
-import unittest
 
 import FreeCAD as App
 import Draft
 import drafttests.auxiliary as aux
 
 from draftutils.messages import _msg
+from drafttests import test_base
 
 
-class DraftDXF(unittest.TestCase):
+class DraftDXF(test_base.DraftTestCaseDoc):
     """Test reading and writing of DXF files with Draft."""
-
-    def setUp(self):
-        """Set up a new document to hold the tests.
-
-        This is executed before every test, so we create a document
-        to hold the objects.
-        """
-        aux.draw_header()
-        self.doc_name = self.__class__.__name__
-        if App.ActiveDocument:
-            if App.ActiveDocument.Name != self.doc_name:
-                App.newDocument(self.doc_name)
-        else:
-            App.newDocument(self.doc_name)
-        App.setActiveDocument(self.doc_name)
-        self.doc = App.ActiveDocument
-        _msg("  Temporary document '{}'".format(self.doc_name))
 
     def test_read_dxf(self):
         """Read a DXF file and import its elements as Draft objects."""
@@ -86,12 +70,5 @@ class DraftDXF(unittest.TestCase):
         Draft.export_dxf = aux.fake_function
         obj = Draft.export_dxf(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
-
-    def tearDown(self):
-        """Finish the test.
-
-        This is executed after each test, so we close the document.
-        """
-        App.closeDocument(self.doc_name)
 
 ## @}

--- a/src/Mod/Draft/drafttests/test_import.py
+++ b/src/Mod/Draft/drafttests/test_import.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2025 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -28,22 +29,12 @@
 
 ## \addtogroup drafttests
 # @{
-import unittest
-
 import drafttests.auxiliary as aux
+from drafttests import test_base
 
 
-class DraftImport(unittest.TestCase):
+class DraftImport(test_base.DraftTestCaseNoDoc):
     """Import the Draft modules."""
-
-    def setUp(self):
-        """Draw the header.
-
-        This is executed before every test.
-        No document is needed to test the import of modules so no document
-        is created, and `tearDown` isn't defined.
-        """
-        aux.draw_header()
 
     def test_import_draft(self):
         """Import the Draft module."""

--- a/src/Mod/Draft/drafttests/test_import_gui.py
+++ b/src/Mod/Draft/drafttests/test_import_gui.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2025 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -28,22 +29,12 @@
 
 ## \addtogroup drafttests
 # @{
-import unittest
-
 import drafttests.auxiliary as aux
+from drafttests import test_base
 
 
-class DraftGuiImport(unittest.TestCase):
+class DraftGuiImport(test_base.DraftTestCaseNoDoc):
     """Import the Draft graphical modules."""
-
-    def setUp(self):
-        """Draw the header.
-
-        This is executed before every test.
-        No document is needed to test the import of modules so no document
-        is created, and `tearDown` isn't defined.
-        """
-        aux.draw_header()
 
     def test_import_gui_draftgui(self):
         """Import Draft TaskView GUI tools."""

--- a/src/Mod/Draft/drafttests/test_import_tools.py
+++ b/src/Mod/Draft/drafttests/test_import_tools.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2025 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -28,22 +29,12 @@
 
 ## \addtogroup drafttests
 # @{
-import unittest
-
 import drafttests.auxiliary as aux
+from drafttests import test_base
 
 
-class DraftImportTools(unittest.TestCase):
+class DraftImportTools(test_base.DraftTestCaseNoDoc):
     """Test for each individual module that defines a tool."""
-
-    def setUp(self):
-        """Draw the header.
-
-        This is executed before every test.
-        No document is needed to test the import of modules so no document
-        is created, and `tearDown` isn't defined.
-        """
-        aux.draw_header()
 
     def test_import_gui_draftedit(self):
         """Import Draft Edit."""

--- a/src/Mod/Draft/drafttests/test_oca.py
+++ b/src/Mod/Draft/drafttests/test_oca.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2025 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -29,34 +30,17 @@
 ## \addtogroup drafttests
 # @{
 import os
-import unittest
 
 import FreeCAD as App
 import Draft
 import drafttests.auxiliary as aux
 
 from draftutils.messages import _msg
+from drafttests import test_base
 
 
-class DraftOCA(unittest.TestCase):
+class DraftOCA(test_base.DraftTestCaseDoc):
     """Test reading and writing of OCA files with Draft."""
-
-    def setUp(self):
-        """Set up a new document to hold the tests.
-
-        This is executed before every test, so we create a document
-        to hold the objects.
-        """
-        aux.draw_header()
-        self.doc_name = self.__class__.__name__
-        if App.ActiveDocument:
-            if App.ActiveDocument.Name != self.doc_name:
-                App.newDocument(self.doc_name)
-        else:
-            App.newDocument(self.doc_name)
-        App.setActiveDocument(self.doc_name)
-        self.doc = App.ActiveDocument
-        _msg("  Temporary document '{}'".format(self.doc_name))
 
     def test_read_oca(self):
         """Read an OCA file and import its elements as Draft objects."""
@@ -86,12 +70,5 @@ class DraftOCA(unittest.TestCase):
         Draft.export_oca = aux.fake_function
         obj = Draft.export_oca(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
-
-    def tearDown(self):
-        """Finish the test.
-
-        This is executed after each test, so we close the document.
-        """
-        App.closeDocument(self.doc_name)
 
 ## @}

--- a/src/Mod/Draft/drafttests/test_pivy.py
+++ b/src/Mod/Draft/drafttests/test_pivy.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2025 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -28,34 +29,15 @@
 
 ## \addtogroup drafttests
 # @{
-import unittest
-
-import FreeCAD as App
 import FreeCADGui as Gui
 import drafttests.auxiliary as aux
 
 from draftutils.messages import _msg
+from drafttests import test_base
 
 
-class DraftPivy(unittest.TestCase):
+class DraftPivy(test_base.DraftTestCaseDoc):
     """Test for the presence of Pivy and that it works with Coin3D."""
-
-    def setUp(self):
-        """Set up a new document to hold the tests.
-
-        This is executed before every test, so we create a document
-        to hold the objects.
-        """
-        aux.draw_header()
-        self.doc_name = self.__class__.__name__
-        if App.ActiveDocument:
-            if App.ActiveDocument.Name != self.doc_name:
-                App.newDocument(self.doc_name)
-        else:
-            App.newDocument(self.doc_name)
-        App.setActiveDocument(self.doc_name)
-        self.doc = App.ActiveDocument
-        _msg("  Temporary document '{}'".format(self.doc_name))
 
     def test_pivy_import(self):
         """Import Coin (Pivy)."""
@@ -68,15 +50,8 @@ class DraftPivy(unittest.TestCase):
         import pivy.coin as coin
         cube = coin.SoCube()
         _msg("  Draw cube")
-        Gui.ActiveDocument.ActiveView.getSceneGraph().addChild(cube)
+        Gui.getDocument(self.doc).ActiveView.getSceneGraph().addChild(cube)
         _msg("  Adding cube to the active view scene")
         self.assertTrue(cube, "Pivy is not working properly.")
-
-    def tearDown(self):
-        """Finish the test.
-
-        This is executed after each test, so we close the document.
-        """
-        App.closeDocument(self.doc_name)
 
 ## @}

--- a/src/Mod/Draft/drafttests/test_svg.py
+++ b/src/Mod/Draft/drafttests/test_svg.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2025 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -29,13 +30,13 @@
 ## \addtogroup drafttests
 # @{
 import os
-import unittest
 
 import FreeCAD as App
 import Draft
 import drafttests.auxiliary as aux
 
 from draftutils.messages import _msg
+from drafttests import test_base
 
 try:
     import Arch
@@ -45,25 +46,8 @@ else:
     have_arch = True
 
 
-class DraftSVG(unittest.TestCase):
+class DraftSVG(test_base.DraftTestCaseDoc):
     """Test reading and writing of SVGs with Draft."""
-
-    def setUp(self):
-        """Set up a new document to hold the tests.
-
-        This is executed before every test, so we create a document
-        to hold the objects.
-        """
-        aux.draw_header()
-        self.doc_name = self.__class__.__name__
-        if App.ActiveDocument:
-            if App.ActiveDocument.Name != self.doc_name:
-                App.newDocument(self.doc_name)
-        else:
-            App.newDocument(self.doc_name)
-        App.setActiveDocument(self.doc_name)
-        self.doc = App.ActiveDocument
-        _msg("  Temporary document '{}'".format(self.doc_name))
 
     def test_read_svg(self):
         """Read an SVG file and import its elements as Draft objects."""
@@ -101,11 +85,11 @@ class DraftSVG(unittest.TestCase):
         import Draft
 
         sb = Part.makeBox(1,1,1)
-        b = App.ActiveDocument.addObject('Part::Feature','Box')
+        b = self.doc.addObject('Part::Feature','Box')
         b.Shape = sb
 
         s = Arch.makeSpace(b)
-        App.ActiveDocument.recompute()
+        self.doc.recompute()
 
         try:
             Draft.get_svg(s, direction=App.Vector(0,0,0))
@@ -115,12 +99,5 @@ class DraftSVG(unittest.TestCase):
             App.Console.PrintLog("Exception thrown, OK: {}".format(err))
         else:
             self.fail("no exception thrown")
-
-    def tearDown(self):
-        """Finish the test.
-
-        This is executed after each test, so we close the document.
-        """
-        App.closeDocument(self.doc_name)
 
 ## @}

--- a/src/Mod/Draft/drafttests/test_svg.py
+++ b/src/Mod/Draft/drafttests/test_svg.py
@@ -30,6 +30,7 @@
 ## \addtogroup drafttests
 # @{
 import os
+import unittest
 
 import FreeCAD as App
 import Draft


### PR DESCRIPTION
To avoid code duplication.
