### PR TITLE
PD: Make InvoluteGearTests independent of "single solid" setting

### DIFF
--- a/src/Mod/PartDesign/PartDesignTests/TestInvoluteGear.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestInvoluteGear.py
@@ -254,7 +254,6 @@ class TestInvoluteGear(unittest.TestCase):
         profile.HighPrecision = False
         profile.NumberOfTeeth = 8
         body = self.Doc.addObject('PartDesign::Body','GearBody')
-        body.AllowCompound = False
         body.addObject(profile)
         cylinder = body.newObject('PartDesign::AdditiveCylinder','GearCylinder')
         default_dedendum = 1.25
@@ -325,7 +324,9 @@ class TestInvoluteGear(unittest.TestCase):
         return distance < Precision.intersection()
 
     def assertSolid(self, shape, msg=None):
-        self.assertEqual(shape.ShapeType, 'Solid', msg=msg)
+        # we don't check shape.ShapeType for 'Solid' as with body.AllowCompound==True
+        # we get, also in the good case, our solid wrapped in a compound.
+        self.assertEqual(len(shape.Solids), 1, msg=msg)
 
 
 def inv(a):


### PR DESCRIPTION
When enabling the experimental "Allow multiple solids in Part Design Body by default" some involute gear tests broke. As a quick measure, `AllowCompound` was disabled for the respective body; see #17364. This commit now makes the tests independent of this setting and removes the workaround.