### PR TITLE
Auto scroll to constraint on click

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1371,6 +1371,8 @@ void TaskSketcherConstraints::onSelectionChanged(const Gui::SelectionChanges& ms
                                 auto tmpBlock = ui->listWidgetConstraints->blockSignals(true);
                                 item->setSelected(select);
                                 ui->listWidgetConstraints->blockSignals(tmpBlock);
+                                QModelIndex index = ui->listWidgetConstraints->model()->index(i, 0);
+                                ui->listWidgetConstraints->scrollTo(index, QAbstractItemView::PositionAtCenter);
                                 break;
                             }
                         }

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1371,8 +1371,10 @@ void TaskSketcherConstraints::onSelectionChanged(const Gui::SelectionChanges& ms
                                 auto tmpBlock = ui->listWidgetConstraints->blockSignals(true);
                                 item->setSelected(select);
                                 ui->listWidgetConstraints->blockSignals(tmpBlock);
-                                QModelIndex index = ui->listWidgetConstraints->model()->index(i, 0);
-                                ui->listWidgetConstraints->scrollTo(index, QAbstractItemView::PositionAtCenter);
+                                if (ui->listWidgetConstraints->model()) {
+                                    QModelIndex index = ui->listWidgetConstraints->model()->index(i, 0);
+                                    ui->listWidgetConstraints->scrollTo(index, QAbstractItemView::PositionAtCenter);
+                                }
                                 break;
                             }
                         }

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1371,7 +1371,7 @@ void TaskSketcherConstraints::onSelectionChanged(const Gui::SelectionChanges& ms
                                 auto tmpBlock = ui->listWidgetConstraints->blockSignals(true);
                                 item->setSelected(select);
                                 ui->listWidgetConstraints->blockSignals(tmpBlock);
-                                if (ui->listWidgetConstraints->model()) {
+                                if (select && ui->listWidgetConstraints->model()) { // scrollTo only on select, not de-select
                                     QModelIndex index = ui->listWidgetConstraints->model()->index(i, 0);
                                     ui->listWidgetConstraints->scrollTo(index, QAbstractItemView::PositionAtCenter);
                                 }


### PR DESCRIPTION
When clicking on a constraint in Sketcher, that constraint is now automatically scrolled to in the Constraints listview. If selecting multiple constraints, the last one is scrolled to. Closes #17361