### PR TITLE
Gui: Mark mouse move action handled to skip digging nodes

### DIFF
--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -762,6 +762,7 @@ SoFCUnifiedSelection::handleEvent(SoHandleEventAction * action)
                     this->touch();
                 }
             }
+            action->setHandled();
         }
     }
     // mouse press events for (de)selection


### PR DESCRIPTION
I'm not sure this is suitable modification but, `SoNode::traversal` is bottle neck of mouse hover operation in importing DXF, like following.

![image](https://github.com/user-attachments/assets/0317ed0a-b614-4167-a26b-681bbc81a031)

As you can see the worst bottle neck is digging down `SoNode` tree, but I think that digging down does nothing since the selection is already done by `SoFCUnifiedSelection::handleEvent` (similar to selection). If so, mark the action handled to skip digging down and performance bottle neck is moving to ray pick action like this.

![image](https://github.com/user-attachments/assets/13915a51-fa85-4ef2-820d-a6813b476525)

I opened this PR as draft because I'm not familiar with FreeCAD and Coin3D. Please tell me if the modification will break any feature.

rel: #17185
sa: https://github.com/coin3d/coin/issues/542 (ray pick action performance)