### PR TITLE
Draft: comment out 3 test files with only dummy tests

### DIFF
--- a/src/Mod/Draft/TestDraft.py
+++ b/src/Mod/Draft/TestDraft.py
@@ -105,9 +105,9 @@ from drafttests.test_modification import DraftModification as DraftTest03
 from drafttests.test_draftgeomutils import TestDraftGeomUtils as DraftTest04
 
 # Handling of file formats tests
-from drafttests.test_svg import DraftSVG as DraftTest05
-from drafttests.test_dxf import DraftDXF as DraftTest06
-from drafttests.test_dwg import DraftDWG as DraftTest07
+# from drafttests.test_svg import DraftSVG as DraftTest05
+# from drafttests.test_dxf import DraftDXF as DraftTest06
+# from drafttests.test_dwg import DraftDWG as DraftTest07
 # from drafttests.test_oca import DraftOCA as DraftTest08
 # from drafttests.test_airfoildat import DraftAirfoilDAT as DraftTest09
 from drafttests.test_array import DraftArray as DraftTest10
@@ -117,9 +117,9 @@ True if DraftTest01 else False
 True if DraftTest02 else False
 True if DraftTest03 else False
 True if DraftTest04 else False
-True if DraftTest05 else False
-True if DraftTest06 else False
-True if DraftTest07 else False
+# True if DraftTest05 else False
+# True if DraftTest06 else False
+# True if DraftTest07 else False
 # True if DraftTest08 else False
 # True if DraftTest09 else False
 True if DraftTest10 else False


### PR DESCRIPTION
Some Draft test files contain only dummy tests (`aux.fake_function`). Running them will just open a new file and then immediately close it. This can result in issues with code that is called with a delay. See #18679. Disabling these tests by commenting them out avoids this.
