### PR TITLE
[ArchStairs]  Improve Stairs Creation and ensureBase

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -832,7 +832,6 @@ def makeStairs(baseobj=None,length=None,width=None,height=None,steps=None,name=N
             stair.Label = label
             ArchStairs._Stairs(stair)
             stairs.append(stair)
-            stairs[0].Label = label
             i = 1
         else:
             i = 0
@@ -841,17 +840,12 @@ def makeStairs(baseobj=None,length=None,width=None,height=None,steps=None,name=N
             stair.Label = label
             ArchStairs._Stairs(stair)
             stairs.append(stair)
-            stairs[i].Label = label
             stairs[i].Base = baseobjI
-
-            if len(baseobjI.Shape.Edges) > 1:
-                stepsI = 1                              #'landing' if 'multi-edges' currently
-            elif steps:
+            if steps:
                 stepsI = steps
             else:
                 stepsI = 20
             setProperty(stairs[i],None,width,height,stepsI)
-
             if i > 1:
                 additions.append(stairs[i])
                 stairs[i].LastSegment = stairs[i-1]

--- a/src/Mod/BIM/ArchStairs.py
+++ b/src/Mod/BIM/ArchStairs.py
@@ -287,11 +287,11 @@ class _Stairs(ArchComponent.Component):
             if hasattr(obj.Base,"Shape"):
                 if obj.Base.Shape:
                     if obj.Base.Shape.Solids:
-                        base = obj.Base.Shape.copy()
-
+                        base = Part.Shape(obj.Base.Shape)
         # special case NumberOfSteps = 1 : multi-edges landing
         if (not base) and obj.Width.Value and obj.Height.Value and (obj.NumberOfSteps > 0):
-            if obj.Base:
+            # Check if there is obj.Base and its validity to proceed
+            if self.ensureBase(obj):
                 if not hasattr(obj.Base,'Shape'):
                     return
                 if obj.Base.Shape.Solids:
@@ -334,6 +334,7 @@ class _Stairs(ArchComponent.Component):
                     ## TODO - Found Part.sortEdges() occasionally return less edges then 'input'
                     edges = Part.sortEdges(obj.Base.Shape.Edges)[0]
                     self.makeMultiEdgesLanding(obj,edges)
+            # Build Stairs if there is no obj.Base or even obj.Base is not valid
             else:
                 if not obj.Length.Value:
                     return

--- a/src/Mod/BIM/bimcommands/BimStairs.py
+++ b/src/Mod/BIM/bimcommands/BimStairs.py
@@ -54,18 +54,24 @@ class Arch_Stairs:
         from draftutils import params
         FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Stairs"))
         FreeCADGui.addModule("Arch")
-        if FreeCADGui.Selection.getSelection():
+        sel = FreeCADGui.Selection.getSelection()
+        if sel:
             n = []
             nStr = ""
-            for obj in FreeCADGui.Selection.getSelection():
+            for obj in sel:
                 if nStr != "":
                     nStr += ","
                 nStr += "FreeCAD.ActiveDocument." + obj.Name
-            FreeCADGui.doCommand("obj = Arch.makeStairs(baseobj=["+nStr+"])")
+            #'obj' in GUI not the same as obj in script,
+            # make it 'stairs' to distinguish one from another
+            #Create Stairs object with steps numbers in user preference
+            FreeCADGui.doCommand("stairs = Arch.makeStairs(baseobj=["+nStr+"],steps="+str(params.get_param_arch("StairsSteps"))+")")
+            FreeCADGui.Selection.clearSelection()
+            FreeCADGui.doCommand("FreeCADGui.Selection.addSelection(stairs)")
         else:
-            FreeCADGui.doCommand("obj = Arch.makeStairs(steps="+str(params.get_param_arch("StairsSteps"))+")")
+            FreeCADGui.doCommand("stairs = Arch.makeStairs(steps="+str(params.get_param_arch("StairsSteps"))+")")
         FreeCADGui.addModule("Draft")
-        FreeCADGui.doCommand("Draft.autogroup(obj)")
+        FreeCADGui.doCommand("Draft.autogroup(stairs)")
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()
 


### PR DESCRIPTION
Refer to discussion at -
https://github.com/FreeCAD/FreeCAD/pull/18864
https://github.com/FreeCAD/FreeCAD/pull/18651
https://github.com/FreeCAD/FreeCAD/issues/16409

Like Wall, Stairs should do without Base. Base validity tested in execute() prevented the desired and documented behaviour.

With this improvement, EnsureBase() is now only to be run when there is Base. If there is no Base, or Base is not valid, Stairs would be created as declared.