### PR TITLE
Main: Avoid Popups in Console Mode

### DIFF
--- a/src/App/PreCompiled.h
+++ b/src/App/PreCompiled.h
@@ -100,6 +100,7 @@
 #include <boost/filesystem/exception.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
+#include <boost/scope_exit.hpp>
 
 #endif  //_PreComp_
 

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -95,6 +95,35 @@ private:
     FILE* file;
 };
 
+static void DisplayInfo(const QString& msg, bool preformatted = true)
+{
+    if (App::Application::Config()["Console"] == "1") {
+        std::cout << msg.toStdString();
+        return;
+    }
+
+    QString appName = QString::fromStdString(App::Application::Config()["ExeName"]);
+    QMessageBox msgBox;
+    msgBox.setIcon(QMessageBox::Information);
+    msgBox.setWindowTitle(appName);
+    msgBox.setDetailedText(msg);
+    msgBox.setText(preformatted ? QStringLiteral("<pre>%1</pre>").arg(msg) : msg);
+    msgBox.exec();
+}
+
+static void DisplayCritical(const QString& msg, bool preformatted = true)
+{
+    if (App::Application::Config()["Console"] == "1") {
+        std::cerr << msg.toStdString();
+        return;
+    }
+
+    QString appName = QString::fromStdString(App::Application::Config()["ExeName"]);
+    QString title = QObject::tr("Initialization of %1 failed").arg(appName);
+    QString text = preformatted ? QStringLiteral("<pre>%1</pre>").arg(msg) : msg;
+    QMessageBox::critical(nullptr, title, text);
+}
+
 int main(int argc, char** argv)
 {
 #if defined(FC_OS_LINUX) || defined(FC_OS_BSD)
@@ -214,24 +243,14 @@ int main(int argc, char** argv)
     }
     catch (const Base::UnknownProgramOption& e) {
         QApplication app(argc, argv);
-        QString appName = QString::fromLatin1(App::Application::Config()["ExeName"].c_str());
         QString msg = QString::fromLatin1(e.what());
-        QString s = QLatin1String("<pre>") + msg + QLatin1String("</pre>");
-        QMessageBox::critical(nullptr, appName, s);
+        DisplayCritical(msg);
         exit(1);
     }
     catch (const Base::ProgramInformation& e) {
         QApplication app(argc, argv);
-        QString appName = QString::fromLatin1(App::Application::Config()["ExeName"].c_str());
         QString msg = QString::fromUtf8(e.what());
-        QString s = QLatin1String("<pre>") + msg + QLatin1String("</pre>");
-
-        QMessageBox msgBox;
-        msgBox.setIcon(QMessageBox::Information);
-        msgBox.setWindowTitle(appName);
-        msgBox.setDetailedText(msg);
-        msgBox.setText(s);
-        msgBox.exec();
+        DisplayInfo(msg);
         exit(0);
     }
     catch (const Base::Exception& e) {
@@ -258,9 +277,7 @@ int main(int argc, char** argv)
                 "\nPlease contact the application's support team for more information.\n\n");
         }
 
-        QMessageBox::critical(nullptr,
-                              QObject::tr("Initialization of %1 failed").arg(appName),
-                              msg);
+        DisplayCritical(msg, false);
         exit(100);
     }
     catch (...) {
@@ -271,9 +288,7 @@ int main(int argc, char** argv)
             QObject::tr("Unknown runtime error occurred while initializing %1.\n\n"
                         "Please contact the application's support team for more information.\n\n")
                 .arg(appName);
-        QMessageBox::critical(nullptr,
-                              QObject::tr("Initialization of %1 failed").arg(appName),
-                              msg);
+        DisplayCritical(msg, false);
         exit(101);
     }
 


### PR DESCRIPTION
When in console mode, some messages from CLI interaction still resulted in popup dialogs. This is becasue those information are communicated via exceptions and those exceptions prevented the console mode from being properly set. By using a scope guard the console mode flag is now evaluated in all cases. The code to display those messages got refactored into dedicated methods which now also take care of console mode.

The change does not cover all cases, though: When encountering unknown or invalid arguments, the parser itself throws and in this case the console mode flag is not propagated. However, for regular use, e.g. the for `--help`, `--dump-config` or `--version`, the output is now placed in the console when `--console` was specified.

I also noted a wild mix of `toLatin1`/`fromLatin1` and `toUtf8`/`fromUtf8` when converting between `char*` and `QString`. When only dealing with english text it probably doesn't matter. Here we now place translated text into stdout. Do we have any guidelines on "what is right" here?