### PR TITLE
Gui: Fix render order of datum planes

### DIFF
--- a/src/Gui/Inventor/So3DAnnotation.h
+++ b/src/Gui/Inventor/So3DAnnotation.h
@@ -24,10 +24,47 @@
 
 #include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/elements/SoElement.h>
 #include <FCGlobal.h>
 
 namespace Gui
 {
+
+class GuiExport SoDelayedAnnotationsElement: public SoElement
+{
+    using inherited = SoElement;
+
+    SO_ELEMENT_HEADER(SoDelayedAnnotationsElement);
+
+protected:
+    ~SoDelayedAnnotationsElement() override = default;
+
+    SoDelayedAnnotationsElement& operator=(const SoDelayedAnnotationsElement& other) = default;
+    SoDelayedAnnotationsElement& operator=(SoDelayedAnnotationsElement&& other) noexcept = default;
+
+public:
+    SoDelayedAnnotationsElement(const SoDelayedAnnotationsElement& other) = delete;
+    SoDelayedAnnotationsElement(SoDelayedAnnotationsElement&& other) noexcept = delete;
+
+    void init(SoState* state) override;
+
+    static void initClass();
+
+    static void addDelayedPath(SoState* state, SoPath* path);
+    static SoPathList getDelayedPaths(SoState* state);
+
+    SbBool matches([[maybe_unused]] const SoElement* element) const override
+    {
+        return FALSE;
+    }
+
+    SoElement* copyMatchInfo() const override
+    {
+        return nullptr;
+    }
+
+    SoPathList paths;
+};
 
 /*! @brief 3D Annotation Node - Annotation with depth buffer
  *
@@ -39,21 +76,29 @@ namespace Gui
  */
 class GuiExport So3DAnnotation: public SoSeparator
 {
-    typedef SoSeparator inherited;
+    using inherited = SoSeparator;
 
     SO_NODE_HEADER(So3DAnnotation);
 
 public:
-    static void initClass();
+    static bool render;
+
     So3DAnnotation();
 
-    virtual void GLRender(SoGLRenderAction* action);
-    virtual void GLRenderBelowPath(SoGLRenderAction* action);
-    virtual void GLRenderInPath(SoGLRenderAction* action);
-    virtual void GLRenderOffPath(SoGLRenderAction* action);
+    So3DAnnotation(const So3DAnnotation& other) = delete;
+    So3DAnnotation(So3DAnnotation&& other) noexcept = delete;
+    So3DAnnotation& operator=(const So3DAnnotation& other) = delete;
+    So3DAnnotation& operator=(So3DAnnotation&& other) noexcept = delete;
+
+    static void initClass();
+
+    void GLRender(SoGLRenderAction* action) override;
+    void GLRenderBelowPath(SoGLRenderAction* action) override;
+    void GLRenderInPath(SoGLRenderAction* action) override;
+    void GLRenderOffPath(SoGLRenderAction* action) override;
 
 protected:
-    virtual ~So3DAnnotation() = default;
+    ~So3DAnnotation() override = default;
 };
 
 }  // namespace Gui

--- a/src/Gui/SoFCDB.cpp
+++ b/src/Gui/SoFCDB.cpp
@@ -147,6 +147,7 @@ void Gui::SoFCDB::init()
     SoFCPathAnnotation              ::initClass();
     SoMouseWheelEvent               ::initClass();
     So3DAnnotation                  ::initClass();
+    SoDelayedAnnotationsElement     ::initClass();
 
     PropertyItem                    ::init();
     PropertySeparatorItem           ::init();

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -130,6 +130,8 @@
 #include "NavigationAnimation.h"
 #include "Utilities.h"
 
+#include <Inventor/So3DAnnotation.h>
+
 
 FC_LOG_LEVEL_INIT("3DViewer", true, true)
 
@@ -2379,6 +2381,11 @@ void View3DInventorViewer::renderScene()
     try {
         // Render normal scenegraph.
         inherited::actualRedraw();
+
+        So3DAnnotation::render = true;
+        glClear(GL_DEPTH_BUFFER_BIT);
+        glra->apply(SoDelayedAnnotationsElement::getDelayedPaths(state));
+        So3DAnnotation::render = false;
     }
     catch (const Base::MemoryException&) {
         // FIXME: If this exception appears then the background and camera position get broken somehow. (Werner 2006-02-01)

--- a/src/Gui/ViewProviderDatum.cpp
+++ b/src/Gui/ViewProviderDatum.cpp
@@ -41,6 +41,8 @@
 #include "SoFCSelection.h"
 #include "ViewProviderCoordinateSystem.h"
 
+#include <Inventor/So3DAnnotation.h>
+
 
 using namespace Gui;
 
@@ -111,7 +113,7 @@ void ViewProviderDatum::attach(App::DocumentObject* pcObject)
     visible->addChild(pRoot);
 
     // Hidden features
-    auto hidden = new SoAnnotation();
+    auto hidden = new So3DAnnotation();
 
     // Style for hidden lines
     style = new SoDrawStyle();


### PR DESCRIPTION
This PR Fixes rendering order of datum planes. It achieves it by modifying `So3DAnnotation` to include separate delayed render queue that is rendered after the scene with cleared depth buffer. Depth buffer was previously cleared for every So3DAnnotation instance independently. Basically it introduces ability to draw annotations on separate layer.

This PR does NOT fix picking order - as far as I know it is not possible to do without modifying coin itself as it would require to introduce not only rendering, but also picking layers (or priorities) into SoRayPickAction. 

Someone more knowledgeable in the area (@wwmayer) may know some way - if we would be able to extract all shapes intersected with ray and their priorities we could in theory implement it on our side.

The way that it is implemented is poor, and I am fully aware of it - but without modifying coin code it is hard to implement stuff like that.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/65276f5a-af25-4559-97b7-008927aa38d5) | ![image](https://github.com/user-attachments/assets/baad9ca8-2103-42ce-a60d-122edff805ad) |

@PaddleStroke FYI