### PR TITLE
App: Use mapping protocol in App::PropertyMap and add the protocol to Materials.Material objects

### DIFF
--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1926,17 +1926,14 @@ PyObject* PropertyMap::getPyObject()
 
 void PropertyMap::setPyObject(PyObject* value)
 {
-    if (PyDict_Check(value)) {
-
+    if (PyMapping_Check(value)) {
         std::map<std::string, std::string> values;
         // get key and item list
-        PyObject* keyList = PyDict_Keys(value);
-
-        PyObject* itemList = PyDict_Values(value);
+        PyObject* keyList = PyMapping_Keys(value);
+        PyObject* itemList = PyMapping_Values(value);
         Py_ssize_t nSize = PyList_Size(keyList);
 
         for (Py_ssize_t i = 0; i < nSize; ++i) {
-
             // check on the key:
             std::string keyStr;
             PyObject* key = PyList_GetItem(keyList, i);
@@ -1944,7 +1941,7 @@ void PropertyMap::setPyObject(PyObject* value)
                 keyStr = PyUnicode_AsUTF8(key);
             }
             else {
-                std::string error("type of the key need to be unicode or string, not");
+                std::string error("type of the key need to be string, not ");
                 error += key->ob_type->tp_name;
                 throw Base::TypeError(error);
             }
@@ -1955,16 +1952,19 @@ void PropertyMap::setPyObject(PyObject* value)
                 values[keyStr] = PyUnicode_AsUTF8(item);
             }
             else {
-                std::string error("type in list must be string or unicode, not ");
+                std::string error("type in values must be string, not ");
                 error += item->ob_type->tp_name;
                 throw Base::TypeError(error);
             }
         }
 
+        Py_XDECREF(itemList);
+        Py_XDECREF(keyList);
+
         setValues(values);
     }
     else {
-        std::string error("type must be a dict object");
+        std::string error("type must be a dict or object with mapping protocol, not ");
         error += value->ob_type->tp_name;
         throw Base::TypeError(error);
     }

--- a/src/Mod/Material/App/MaterialPy.xml
+++ b/src/Mod/Material/App/MaterialPy.xml
@@ -210,5 +210,21 @@
         <UserDocu>Set the value associated with the property</UserDocu>
       </Documentation>
     </Methode>
+    <Methode Name="keys" NoArgs="true">
+      <Documentation>
+        <UserDocu>Property keys</UserDocu>
+      </Documentation>
+    </Methode>
+    <Methode Name="values" NoArgs="true">
+      <Documentation>
+        <UserDocu>Property values</UserDocu>
+      </Documentation>
+    </Methode>
+    <Sequence
+        sq_length="true"
+        sq_item="true"
+        sq_contains="true"
+        mp_subscript="true">
+    </Sequence>
   </PythonExport>
 </GenerateModel>

--- a/src/Mod/Material/App/MaterialPyImp.cpp
+++ b/src/Mod/Material/App/MaterialPyImp.cpp
@@ -553,3 +553,35 @@ PyObject* MaterialPy::setAppearanceValue(PyObject* args)
     Py_INCREF(Py_None);
     return Py_None;
 }
+
+PyObject* MaterialPy::keys()
+{
+    return Py::new_reference_to(this->getProperties().keys());
+}
+
+PyObject* MaterialPy::values()
+{
+    return Py::new_reference_to(this->getProperties().values());
+}
+
+Py_ssize_t MaterialPy::sequence_length(PyObject *self)
+{
+    return static_cast<MaterialPy*>(self)->getProperties().size();
+}
+
+PyObject* MaterialPy::sequence_item(PyObject* self, Py_ssize_t item)
+{
+    Py::List keys = static_cast<MaterialPy*>(self)->getProperties().keys();
+    return Py::new_reference_to(keys.getItem(item));
+}
+
+int MaterialPy::sequence_contains(PyObject* self, PyObject* key)
+{
+    return PyDict_Contains(static_cast<MaterialPy*>(self)->getProperties().ptr(), key);
+}
+
+PyObject* MaterialPy::mapping_subscript(PyObject* self, PyObject* key)
+{
+    Py::Dict dict = static_cast<MaterialPy*>(self)->getProperties();
+    return Py::new_reference_to(dict.getItem(Py::Object(key)));
+}


### PR DESCRIPTION
The first commit generalizes how to set the Python object for `App::PropertyMap` properties by using objects with mapping protocol (basically objects that behave like a dictionary with key-value pairs).

The second commit adds support for sequence and mapping protocol to `Material::MaterialPy` class, so Python `Materials.Material` objects behave like a dict using material properties:
```
# get some material
import Materials
mat = Materials.MaterialManager().getMaterial("90bbd8ef-8623-4d78-b3bf-e0bdb9b74dd3")

for key in mat:
  mat[key] --> get properties values

mat["Name"] --> get "Name" property

"Density" in mat --> True/False 

dict(mat) --> get dict of properties from the material
```
This changes adds backwards compatibility with `App::MaterialObject` and simplifies the code in cases where it is necessary to migrate objects with a `App::PropertyMap` property to  `Materials::PropertyMaterial` property:
```
obj = App.ActiveDocument.addObject("App::MaterialObject")
obj.Material = mat --> Material property (App::PropertyMap) set to dict created from properties of Materials.Material object.
```

@davesrocketshop 