### PR TITLE
Gui: Fix crash on scrolling workbench tab bar in Qt < 5.15.6

### DIFF
--- a/src/Gui/WorkbenchSelector.h
+++ b/src/Gui/WorkbenchSelector.h
@@ -110,14 +110,13 @@ class GuiExport WorkbenchTabWidget : public QWidget
         {
             // Qt does not expose any way to programmatically control scroll of QTabBar hence
             // we need to use a bit hacky solution of simulating clicks on the scroll buttons
+            const auto buttonToClickName = wheelEvent->angleDelta().y() < 0
+                ? QStringLiteral("ScrollLeftButton")
+                : QStringLiteral("ScrollRightButton");
 
-            auto left = findChild<QAbstractButton*>(QString::fromUtf8("ScrollLeftButton"));
-            auto right = findChild<QAbstractButton*>(QString::fromUtf8("ScrollRightButton"));
-
-            if (wheelEvent->angleDelta().y() > 0) {
-                right->click();
-            } else {
-                left->click();
+            // Qt introduces named buttons in Qt 6.3 and 5.15.6, before that they are not available
+            if (const auto button = findChild<QAbstractButton*>(buttonToClickName)) {
+                button->click();
             }
         }
 


### PR DESCRIPTION
As explained in https://github.com/FreeCAD/FreeCAD/issues/18484#issuecomment-2572430803 named buttons were introduced only for newer versions of Qt. I am not aware about any other method that allows us to scroll it programmatically so this simply prevents the crash.

Fixes #18484 