### PR TITLE
Draft: props_changed_placement_only should ignore material props

### DIFF
--- a/src/Mod/Draft/draftobjects/base.py
+++ b/src/Mod/Draft/draftobjects/base.py
@@ -183,8 +183,9 @@ class DraftObject(object):
             delattr(self, "props_changed")
 
     def props_changed_placement_only(self, obj=None):
-        """Return `True` if the self.props_changed list, after removing `Shape`
-        and `_LinkTouched` items, only contains `Placement` items.
+        """Return `True` if the self.props_changed list, after removing
+        `_LinkTouched`, `Shape`, `Density`, `Volume` and `Mass` items,
+        only contains `Placement` items.
 
         Parameters
         ----------
@@ -205,10 +206,9 @@ class DraftObject(object):
             return False
 
         props = set(self.props_changed)
-        if "Shape" in props:
-            props.remove("Shape")
-        if "_LinkTouched" in props:
-            props.remove("_LinkTouched")
+        for prop in ("_LinkTouched", "Shape", "Density", "Volume", "Mass"):
+            if prop in props:
+                props.remove(prop)
         return props == {"Placement"}
 
 


### PR DESCRIPTION
The new material related properties (Density, Volume and Mass) must be ignored by the `props_changed_placement_only` function.

Without this moving a Draft_Point will fail for example.
