### PR TITLE
Draft: Closed corners for extruded Facebinders

### DIFF
--- a/src/Mod/Draft/draftobjects/base.py
+++ b/src/Mod/Draft/draftobjects/base.py
@@ -183,8 +183,9 @@ class DraftObject(object):
             delattr(self, "props_changed")
 
     def props_changed_placement_only(self, obj=None):
-        """Return `True` if the self.props_changed list, after removing `Shape`
-        and `_LinkTouched` items, only contains `Placement` items.
+        """Return `True` if the self.props_changed list, after removing
+        `_LinkTouched`, `Shape`, `Density`, `Volume` and `Mass` items,
+        only contains `Placement` items.
 
         Parameters
         ----------
@@ -205,10 +206,9 @@ class DraftObject(object):
             return False
 
         props = set(self.props_changed)
-        if "Shape" in props:
-            props.remove("Shape")
-        if "_LinkTouched" in props:
-            props.remove("_LinkTouched")
+        for prop in ("_LinkTouched", "Shape", "Density", "Volume", "Mass"):
+            if prop in props:
+                props.remove(prop)
         return props == {"Placement"}
 
 

--- a/src/Mod/Draft/draftobjects/base.py
+++ b/src/Mod/Draft/draftobjects/base.py
@@ -183,9 +183,8 @@ class DraftObject(object):
             delattr(self, "props_changed")
 
     def props_changed_placement_only(self, obj=None):
-        """Return `True` if the self.props_changed list, after removing
-        `_LinkTouched`, `Shape`, `Density`, `Volume` and `Mass` items,
-        only contains `Placement` items.
+        """Return `True` if the self.props_changed list, after removing `Shape`
+        and `_LinkTouched` items, only contains `Placement` items.
 
         Parameters
         ----------
@@ -206,9 +205,10 @@ class DraftObject(object):
             return False
 
         props = set(self.props_changed)
-        for prop in ("_LinkTouched", "Shape", "Density", "Volume", "Mass"):
-            if prop in props:
-                props.remove(prop)
+        if "Shape" in props:
+            props.remove("Shape")
+        if "_LinkTouched" in props:
+            props.remove("_LinkTouched")
         return props == {"Placement"}
 
 


### PR DESCRIPTION
Fixes #13816.

The `makeOffsetShape` method that creates the extruded shape is quite picky. For example, it will work for a pyramidal shell (4 triangles) with a square floorplan, but not if the floorplan is slightly rectangular. To get closed corners the `Sew` property of the Facebinder must be set to `True`. If extruding does not work properly, the code will retry with `Sew` disabled.

There is also some code that tries to convert flat B-spline faces created between the main offset faces into planar faces. In some cases that code will fail (the results of `makeOffsetShape` can already contain errors). If that is the case the original shape created by `makeOffsetShape` is used.