### PR TITLE
Gui: Add Show Plane utility to 2D Objects

### DIFF
--- a/src/Mod/Part/Gui/ViewProvider2DObject.h
+++ b/src/Mod/Part/Gui/ViewProvider2DObject.h
@@ -41,13 +41,28 @@ class PartGuiExport ViewProvider2DObject : public PartGui::ViewProviderPart
 {
     PROPERTY_HEADER_WITH_OVERRIDE(PartGui::ViewProvider2DObject);
 
+    static constexpr float horizontalPlanePadding = 8;
+    static constexpr float verticalPlanePadding = 5;
+
 public:
     /// constructor
     ViewProvider2DObject();
     /// destructor
     ~ViewProvider2DObject() override;
+
+    App::PropertyBool ShowPlane;
+
+    void attach(App::DocumentObject*) override;
+    void updateData(const App::Property *) override;
+    void onChanged(const App::Property *) override;
+
     std::vector<std::string> getDisplayModes() const override;
     const char* getDefaultDisplayMode() const override;
+
+protected:
+    void updatePlane();
+
+    Gui::CoinPtr<SoSwitch> plane;
 };
 
 class PartGuiExport ViewProvider2DObjectGrid : public ViewProvider2DObject

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2923,8 +2923,7 @@ void ViewProviderSketch::onChanged(const App::Property* prop)
         return;
     }
 
-    // call father
-    ViewProviderPart::onChanged(prop);
+    ViewProvider2DObject::onChanged(prop);
 }
 
 void SketcherGui::ViewProviderSketch::startRestoring()
@@ -2960,14 +2959,14 @@ void SketcherGui::ViewProviderSketch::finishRestoring()
 
 void ViewProviderSketch::attach(App::DocumentObject* pcFeat)
 {
-    ViewProviderPart::attach(pcFeat);
+    ViewProvider2DObject::attach(pcFeat);
 }
 
 void ViewProviderSketch::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {
     menu->addAction(tr("Edit sketch"), receiver, member);
     // Call the extensions
-    Gui::ViewProvider::setupContextMenu(menu, receiver, member);
+    ViewProvider::setupContextMenu(menu, receiver, member);
 }
 
 bool ViewProviderSketch::setEdit(int ModNum)


### PR DESCRIPTION
This adds utility that allows users to see plane that sketch is based on. For now it is enabled only explicitly via view property but in the future we should enable it automatically when:

 - User edits attachment of 2D object
 - User transforms 2D object
 - As preference when sketch is selected
 - As preference when sketch is preselected
 - maybe other scenarios

![image](https://github.com/user-attachments/assets/a72ce287-4571-46ef-9b20-c0a5ad39a002)