### PR TITLE
Macros: Save last used debugger

### DIFF
--- a/src/Gui/RemoteDebugger.py
+++ b/src/Gui/RemoteDebugger.py
@@ -34,9 +34,14 @@ class RemoteDebugger():
         self.dialog.buttonBox.accepted.connect(self.accept)
         self.dialog.buttonBox.rejected.connect(self.reject)
 
+        self.prefs = App.ParamGet("User parameter:BaseApp/Macro/Debugger")
+        index = self.prefs.GetInt("TabIndex", 0)
+        self.dialog.tabWidget.setCurrentIndex(index)
+
     def accept(self):
         try:
             index = self.dialog.tabWidget.currentIndex()
+            self.prefs.SetInt("TabIndex", index)
 
             if index == 0: # winpdb
                 passwd = self.dialog.lineEditPassword.text()

--- a/src/Gui/RemoteDebugger.py
+++ b/src/Gui/RemoteDebugger.py
@@ -37,6 +37,10 @@ class RemoteDebugger():
         self.prefs = App.ParamGet("User parameter:BaseApp/Macro/Debugger")
         index = self.prefs.GetInt("TabIndex", 0)
         self.dialog.tabWidget.setCurrentIndex(index)
+        address = self.prefs.GetString("VSCodeAddress", "localhost")
+        port = self.prefs.GetInt("VSCodePort", 5678)
+        self.dialog.lineEditAddress.setText(address)
+        self.dialog.spinBoxPort.setValue(port)
 
     def accept(self):
         try:
@@ -52,6 +56,8 @@ class RemoteDebugger():
             elif index == 1: # VS code
                 address = self.dialog.lineEditAddress.text()
                 port = self.dialog.spinBoxPort.value()
+                self.prefs.SetString("VSCodeAddress", address)
+                self.prefs.SetInt("VSCodePort", port)
 
                 import debugpy
 


### PR DESCRIPTION
Typically users use the same debugger repeatedly. The current dialog required users to change tabs each time the debugger is launched. This change saves the last used debugger tab and sets that as the selected tab when relaunching the debugger.