### PR TITLE
[ArchSpace]  Improve Space Creation and ensureBase

### DIFF
--- a/src/Mod/BIM/ArchSpace.py
+++ b/src/Mod/BIM/ArchSpace.py
@@ -262,8 +262,11 @@ class _Space(ArchComponent.Component):
 
         if self.clone(obj):
             return
-        if not self.ensureBase(obj):
-            return
+
+        # Space can do without Base.  Base validity is tested in getShape() code below.
+        # Remarked out ensureBase() below
+        #if not self.ensureBase(obj):
+        #    return
         self.getShape(obj)
 
     def onChanged(self,obj,prop):
@@ -324,11 +327,11 @@ class _Space(ArchComponent.Component):
         #print("starting compute")
 
         # 1: if we have a base shape, we use it
-        if obj.Base:
-            if hasattr(obj.Base,'Shape'):
-                if obj.Base.Shape.Solids:
-                    shape = obj.Base.Shape.copy()
-                    shape = shape.removeSplitter()
+        # Check if there is obj.Base and its validity to proceed
+        if self.ensureBase(obj):
+            if obj.Base.Shape.Solids:
+                shape = obj.Base.Shape.copy()
+                shape = shape.removeSplitter()
 
         # 2: if not, add all bounding boxes of considered objects and build a first shape
         if shape:


### PR DESCRIPTION
Refer to discussion at -
https://github.com/FreeCAD/FreeCAD/issues/18917

Like Wall and Stairs, Space should do without Base. Base validity tested in execute() prevented the desired and documented behaviour.

EnsureBase() is remarked out in execute() and to be run in getShape(). With this improvement, if there is no Base, or Base is not valid, Space would be created if it could be defined by obj.Boundaries.