### PR TITLE
GDB/LLDB debugger pretty printers w/QString support and vscode launch config

### DIFF
--- a/contrib/.vscode/launch.json
+++ b/contrib/.vscode/launch.json
@@ -16,10 +16,30 @@
       ],
       "linux": {
         "MIMode": "gdb",
-        "miDebuggerPath": "/usr/bin/gdb"
+        "miDebuggerPath": "/usr/bin/gdb",
+        "setupCommands": [
+          {
+            "description": "Load QT pretty-printers for GDB",
+            "text": "python import sys; sys.path.append('${workspaceFolder}/contrib/debugger'); from qt_pretty_printers_gdb import register_qt_printers; register_qt_printers()",
+            "ignoreFailures": false
+          },
+          {
+            "description": "Enable pretty-printing for GDB",
+            "text": "-enable-pretty-printing",
+            "ignoreFailures": true
+          },
+          {
+            "description": "Set Disassembly Flavor to Intel",
+            "text": "-gdb-set disassembly-flavor intel",
+            "ignoreFailures": true
+          }
+        ]
       },
       "osx": {
-        "MIMode": "lldb"
+        "MIMode": "lldb",
+        "preRunCommands": [
+          "command script import ${workspaceFolder}/contrib/debugger/qt_pretty_printers_lldb.py"
+        ]
       },
       "stopAtEntry": false,
       "externalConsole": false,
@@ -47,10 +67,30 @@
       ],
       "linux": {
         "MIMode": "gdb",
-        "miDebuggerPath": "/usr/bin/gdb"
+        "miDebuggerPath": "/usr/bin/gdb",
+        "setupCommands": [
+          {
+            "description": "Load QT pretty-printers for GDB",
+            "text": "python import sys; sys.path.append('${workspaceFolder}/contrib/debugger'); from qt_pretty_printers_gdb import register_qt_printers; register_qt_printers()",
+            "ignoreFailures": false
+          },
+          {
+            "description": "Enable pretty-printing for GDB",
+            "text": "-enable-pretty-printing",
+            "ignoreFailures": true
+          },
+          {
+            "description": "Set Disassembly Flavor to Intel",
+            "text": "-gdb-set disassembly-flavor intel",
+            "ignoreFailures": true
+          }
+        ]
       },
       "osx": {
-        "MIMode": "lldb"
+        "MIMode": "lldb",
+        "preRunCommands": [
+          "command script import ${workspaceFolder}/contrib/debugger/qt_pretty_printers_lldb.py"
+        ]
       },
       "stopAtEntry": false,
       "externalConsole": false,

--- a/contrib/debugger/qt_pretty_printers_gdb.py
+++ b/contrib/debugger/qt_pretty_printers_gdb.py
@@ -122,4 +122,3 @@ def register_qt_printers(objfile=None):
         print("QT pretty-printer script loaded.")
         gdb.pretty_printers.append(lookup_function)
         print("QT pretty-printer registered.")
-        

--- a/contrib/debugger/qt_pretty_printers_gdb.py
+++ b/contrib/debugger/qt_pretty_printers_gdb.py
@@ -63,7 +63,7 @@
  }
 
 
- Note: There may be variances between different operating systems and/or build configurations 
+ Note: There may be variances between different operating systems and/or build configurations
        in how QString data is stored internally.  This was tested on debian12/amd64. @BootsSiR
 """
 # pylint: enable=line-too-long
@@ -122,4 +122,3 @@ def register_qt_printers(objfile=None):
         print("QT pretty-printer script loaded.")
         gdb.pretty_printers.append(lookup_function)
         print("QT pretty-printer registered.")
-        

--- a/contrib/debugger/qt_pretty_printers_gdb.py
+++ b/contrib/debugger/qt_pretty_printers_gdb.py
@@ -1,0 +1,120 @@
+
+# QT Pretty Printer for GDB 
+#
+# Currently supports displaying the following QT types in the debugger
+#     * QString
+#
+#
+# Can be used from GDB via:
+#
+# (gdb) python
+# >import sys
+# >sys.path.insert(0, '{Your FreeCAD source dir}/contrib/debugger')
+# >from qt_pretty_printers_gdb import register_qt_printers
+# >register_qt_printers()
+# >end
+# QT pretty-printer script loaded.
+# QT pretty-printer registered.
+# (gdb) run
+# *breakpoint*
+# (gdb) p testString
+# $1 = This is a QString in the debugger!
+# (gdb)
+
+#
+#
+# Can be used in VSCode via launch.json
+#
+# {
+#     "version": "0.2.0",
+#     "configurations": [        
+#         {
+#             "name": "(gdb) Launch",
+#             "type": "cppdbg",
+#             "request": "launch",
+#             "program": "${workspaceFolder}/build/bin/FreeCAD",
+#             "args": [],
+#             "stopAtEntry": true,
+#             "cwd": "${workspaceFolder}/build",
+#             "environment": [],
+#             "externalConsole": false,
+#             "MIMode": "gdb",
+#             "setupCommands": [
+#                 {
+#                     "description": "Load QT pretty-printers for GDB",
+#                     "text": "python import sys; sys.path.append('${workspaceFolder}/contrib/debugger'); from qt_pretty_printers_gdb import register_qt_printers; register_qt_printers()",
+#                     "ignoreFailures": false
+#                 },                
+#                 {
+#                     "description": "Enable pretty-printing for gdb",
+#                     "text": "-enable-pretty-printing",
+#                     "ignoreFailures": true
+#                 },
+#                 {
+#                     "description": "Set Disassembly Flavor to Intel",
+#                     "text": "-gdb-set disassembly-flavor intel",
+#                     "ignoreFailures": true
+#                 }
+#             ],
+#             "miDebuggerPath": "/usr/bin/gdb"            
+#         }
+#     ]
+# }
+#
+#
+# Note: There may be variances between different operating systems and/or build configurations in how QString
+#       data is stored internally.  This was tested on x86_64. @BootsSiR
+
+import gdb
+
+class QStringPrinter:
+    """Pretty-printer for QString objects in GDB."""
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        try:
+            d = self.val["d"]
+            if d == 0:
+                return 'null'
+
+            offset = int(d["offset"])
+            data_ptr = d.cast(gdb.lookup_type("char").pointer()) + offset
+            char16_t_ptr = data_ptr.cast(gdb.lookup_type("char16_t").pointer())
+
+            string_data = []
+            i = 0
+            while char16_t_ptr[i] != 0:
+                string_data.append(chr(char16_t_ptr[i]))
+                i += 1            
+
+            return "".join(string_data)
+        except gdb.error as e:
+            if "Cannot access memory at address" in str(e):
+                return "<uninitialized>"
+            return f"<error: {str(e)}>"
+        except Exception as e:
+            return f"<unexpected error: {str(e)}>"
+
+
+def lookup_function(val):
+    try:
+        qstring_type = gdb.lookup_type("QString")
+        if val.type.strip_typedefs() == qstring_type:
+            return QStringPrinter(val)
+        return None
+    except gdb.error:
+        return None
+
+
+def register_qt_printers(objfile=None):
+    """Register the QString pretty-printer with GDB."""
+    if objfile is None:
+        objfile = gdb.current_objfile()
+
+    # Check if the printer is already registered
+    if not any(printer == lookup_function for printer in gdb.pretty_printers):            
+        print("QT pretty-printer script loaded.")
+        gdb.pretty_printers.append(lookup_function)
+        print("QT pretty-printer registered.")
+        

--- a/contrib/debugger/qt_pretty_printers_gdb.py
+++ b/contrib/debugger/qt_pretty_printers_gdb.py
@@ -122,3 +122,4 @@ def register_qt_printers(objfile=None):
         print("QT pretty-printer script loaded.")
         gdb.pretty_printers.append(lookup_function)
         print("QT pretty-printer registered.")
+        

--- a/contrib/debugger/qt_pretty_printers_gdb.py
+++ b/contrib/debugger/qt_pretty_printers_gdb.py
@@ -1,78 +1,82 @@
+# pylint: disable=line-too-long
+"""
+ QT Pretty Printer for GDB
 
-# QT Pretty Printer for GDB 
-#
-# Currently supports displaying the following QT types in the debugger
-#     * QString
-#
-#
-# Can be used from GDB via:
-#
-# (gdb) python
-# >import sys
-# >sys.path.insert(0, '{Your FreeCAD source dir}/contrib/debugger')
-# >from qt_pretty_printers_gdb import register_qt_printers
-# >register_qt_printers()
-# >end
-# QT pretty-printer script loaded.
-# QT pretty-printer registered.
-# (gdb) run
-# *breakpoint*
-# (gdb) p testString
-# $1 = This is a QString in the debugger!
-# (gdb)
+ Currently supports displaying the following QT types in the debugger
+     * QString
 
-#
-#
-# Can be used in VSCode via launch.json
-#
-# {
-#     "version": "0.2.0",
-#     "configurations": [        
-#         {
-#             "name": "(gdb) Launch",
-#             "type": "cppdbg",
-#             "request": "launch",
-#             "program": "${workspaceFolder}/build/bin/FreeCAD",
-#             "args": [],
-#             "stopAtEntry": true,
-#             "cwd": "${workspaceFolder}/build",
-#             "environment": [],
-#             "externalConsole": false,
-#             "MIMode": "gdb",
-#             "setupCommands": [
-#                 {
-#                     "description": "Load QT pretty-printers for GDB",
-#                     "text": "python import sys; sys.path.append('${workspaceFolder}/contrib/debugger'); from qt_pretty_printers_gdb import register_qt_printers; register_qt_printers()",
-#                     "ignoreFailures": false
-#                 },                
-#                 {
-#                     "description": "Enable pretty-printing for gdb",
-#                     "text": "-enable-pretty-printing",
-#                     "ignoreFailures": true
-#                 },
-#                 {
-#                     "description": "Set Disassembly Flavor to Intel",
-#                     "text": "-gdb-set disassembly-flavor intel",
-#                     "ignoreFailures": true
-#                 }
-#             ],
-#             "miDebuggerPath": "/usr/bin/gdb"            
-#         }
-#     ]
-# }
-#
-#
-# Note: There may be variances between different operating systems and/or build configurations in how QString
-#       data is stored internally.  This was tested on x86_64. @BootsSiR
+
+ Can be used from GDB via:
+
+ (gdb) python
+ >import sys
+ >sys.path.insert(0, '{Your FreeCAD source dir}/contrib/debugger')
+ >from qt_pretty_printers_gdb import register_qt_printers
+ >register_qt_printers()
+ >end
+ QT pretty-printer script loaded.
+ QT pretty-printer registered.
+ (gdb) run
+ *breakpoint*
+ (gdb) p testString
+ $1 = This is a QString in the debugger!
+ (gdb)
+
+
+
+ Can be used in VSCode via launch.json
+
+ {
+     "version": "0.2.0",
+     "configurations": [
+         {
+             "name": "(gdb) Launch",
+             "type": "cppdbg",
+             "request": "launch",
+             "program": "${workspaceFolder}/build/bin/FreeCAD",
+             "args": [],
+             "stopAtEntry": true,
+             "cwd": "${workspaceFolder}/build",
+             "environment": [],
+             "externalConsole": false,
+             "MIMode": "gdb",
+             "setupCommands": [
+                 {
+                     "description": "Load QT pretty-printers for GDB",
+                     "text": "python import sys; sys.path.append('${workspaceFolder}/contrib/debugger'); from qt_pretty_printers_gdb import register_qt_printers; register_qt_printers()",
+                     "ignoreFailures": false
+                 },
+                 {
+                     "description": "Enable pretty-printing for gdb",
+                     "text": "-enable-pretty-printing",
+                     "ignoreFailures": true
+                 },
+                 {
+                     "description": "Set Disassembly Flavor to Intel",
+                     "text": "-gdb-set disassembly-flavor intel",
+                     "ignoreFailures": true
+                 }
+             ],
+             "miDebuggerPath": "/usr/bin/gdb"
+         }
+     ]
+ }
+
+
+ Note: There may be variances between different operating systems and/or build configurations 
+       in how QString data is stored internally.  This was tested on debian12/amd64. @BootsSiR
+"""
+# pylint: enable=line-too-long
 
 import gdb
 
 class QStringPrinter:
-    """Pretty-printer for QString objects in GDB."""
+    """Pretty-printer class for QString objects in GDB."""
     def __init__(self, val):
         self.val = val
 
     def to_string(self):
+        """Pretty-printer function for QString objects in LLDB."""
         try:
             d = self.val["d"]
             if d == 0:
@@ -86,18 +90,19 @@ class QStringPrinter:
             i = 0
             while char16_t_ptr[i] != 0:
                 string_data.append(chr(char16_t_ptr[i]))
-                i += 1            
+                i += 1
 
             return "".join(string_data)
         except gdb.error as e:
             if "Cannot access memory at address" in str(e):
                 return "<uninitialized>"
             return f"<error: {str(e)}>"
-        except Exception as e:
+        except Exception as e: # pylint: disable=broad-except
             return f"<unexpected error: {str(e)}>"
 
 
 def lookup_function(val):
+    """Maps a type to the appropriate pretty printer"""
     try:
         qstring_type = gdb.lookup_type("QString")
         if val.type.strip_typedefs() == qstring_type:
@@ -113,7 +118,7 @@ def register_qt_printers(objfile=None):
         objfile = gdb.current_objfile()
 
     # Check if the printer is already registered
-    if not any(printer == lookup_function for printer in gdb.pretty_printers):            
+    if not any(printer == lookup_function for printer in gdb.pretty_printers): # pylint: disable=comparison-with-callable
         print("QT pretty-printer script loaded.")
         gdb.pretty_printers.append(lookup_function)
         print("QT pretty-printer registered.")

--- a/contrib/debugger/qt_pretty_printers_lldb.py
+++ b/contrib/debugger/qt_pretty_printers_lldb.py
@@ -1,0 +1,99 @@
+
+# QT Pretty Printer for LLDB 
+#
+# Currently supports displaying the following QT types in the debugger
+#     * QString
+#
+#
+# Can be used from LLDB via:
+#
+# (lldb) command script import {Your FreeCAD source dir}/contrib/debugger/qt_pretty_printers_lldb.py
+#
+# (lldb) frame variable test
+# (QString) test = "This is a test string." 
+# (lldb)
+#
+#
+# Can be used in VSCode via launch.json (tested with CodeLLDB extension)
+#
+# {
+#     "version": "0.2.0",
+#     "configurations": [
+#         {
+#             "type": "lldb",
+#             "request": "launch",
+#             "name": "Debug LLDB",
+#             "stopOnEntry": false,
+#             "program": "${workspaceFolder}/build/bin/FreeCAD",
+#             "args": [],
+#             "cwd": "${workspaceFolder}/build/",            
+#             "preLaunchTask": "CMake: build",         
+#             "preRunCommands": [
+#                 "command script import ${workspaceFolder}/contrib/debugger/qt_pretty_printers_lldb.py"
+#             ]
+#         }
+#     ]
+# }
+#
+#
+# Note: There may be variances between different operating systems and/or build configurations in how QString
+#       data is stored internally.  This was tested on x86_64 and macOS/arm64. @BootsSiR
+
+
+import lldb
+
+def QStringPrinter(val, internal_dict):
+    """Pretty-printer for QString objects in LLDB."""
+    try:
+        # Access the 'd' member of QString
+        d = val.GetChildMemberWithName("d")
+        if not d.IsValid():
+            return 'null'
+
+        # some machines have a different object layout (macOS? arm64?)
+        ptr_field = d.GetChildMemberWithName("ptr")
+
+        # if the ptr field isn't valid, use the offset method
+        if not ptr_field.IsValid():
+            # Address of the QString::Data
+            d_address = d.GetValueAsUnsigned()
+
+            # Assume the string data starts immediately after the first 24 bytes
+            data_base_address = d_address + 24
+        else:
+            # use the ptr value
+            data_base_address = ptr_field.GetValueAsUnsigned()
+            if data_base_address == 0:
+                return "null"
+
+        # Initialize variables for memory reading
+        process = val.GetTarget().GetProcess()
+        error = lldb.SBError()
+        chunk_size = 256  # Size of each memory chunk to read
+        string_data = []
+        offset = 0
+
+        # Read memory in chunks until null-terminator is found
+        while True:
+            raw_data = process.ReadMemory(data_base_address + offset, chunk_size, error)
+            if not error.Success():
+                return f"<error: unable to read memory: {error.GetCString()}>"
+
+            # Parse UTF-16 data from the chunk
+            for i in range(0, len(raw_data), 2):  # char16_t is 2 bytes
+                char16_val = int.from_bytes(raw_data[i:i+2], byteorder='little')
+                if char16_val == 0:  # Null-terminator found
+                    return f'"{ "".join(string_data) }"'
+                string_data.append(chr(char16_val))
+
+            # Increase the offset for the next chunk
+            offset += chunk_size
+
+    except Exception as e:
+        return f"<error: {str(e)}>"
+
+def __lldb_init_module(debugger, internal_dict):
+    """Register the QString pretty-printer with LLDB."""
+    print("QT pretty-printer script loaded.")
+    debugger.HandleCommand('type summary add QString -F qt_pretty_printers_lldb.QStringPrinter')
+    print("QT pretty-printer registered.")

--- a/contrib/debugger/qt_pretty_printers_lldb.py
+++ b/contrib/debugger/qt_pretty_printers_lldb.py
@@ -1,6 +1,6 @@
 # pylint: disable=line-too-long
 """
- QT Pretty Printer for LLDB 
+ QT Pretty Printer for LLDB
 
  Currently supports displaying the following QT types in the debugger
      * QString
@@ -11,7 +11,7 @@
  (lldb) command script import {Your FreeCAD source dir}/contrib/debugger/qt_pretty_printers_lldb.py
 
  (lldb) frame variable test
- (QString) test = "This is a test string." 
+ (QString) test = "This is a test string."
  (lldb)
 
 
@@ -27,8 +27,8 @@
              "stopOnEntry": false,
              "program": "${workspaceFolder}/build/bin/FreeCAD",
              "args": [],
-             "cwd": "${workspaceFolder}/build/",            
-             "preLaunchTask": "CMake: build",         
+             "cwd": "${workspaceFolder}/build/",
+             "preLaunchTask": "CMake: build",      
              "preRunCommands": [
                  "command script import ${workspaceFolder}/contrib/debugger/qt_pretty_printers_lldb.py"
              ]
@@ -37,8 +37,8 @@
  }
 
 
- Note: There may be variances between different operating systems and/or build configurations 
-       in how QString data is stored internally.  This was tested on debian12/amd64 and 
+ Note: There may be variances between different operating systems and/or build configurations
+       in how QString data is stored internally.  This was tested on debian12/amd64 and
        macOS/arm64. @BootsSiR
 """
 # pylint: enable=line-too-long

--- a/contrib/debugger/qt_pretty_printers_lldb.py
+++ b/contrib/debugger/qt_pretty_printers_lldb.py
@@ -1,48 +1,51 @@
+# pylint: disable=line-too-long
+"""
+ QT Pretty Printer for LLDB 
 
-# QT Pretty Printer for LLDB 
-#
-# Currently supports displaying the following QT types in the debugger
-#     * QString
-#
-#
-# Can be used from LLDB via:
-#
-# (lldb) command script import {Your FreeCAD source dir}/contrib/debugger/qt_pretty_printers_lldb.py
-#
-# (lldb) frame variable test
-# (QString) test = "This is a test string." 
-# (lldb)
-#
-#
-# Can be used in VSCode via launch.json (tested with CodeLLDB extension)
-#
-# {
-#     "version": "0.2.0",
-#     "configurations": [
-#         {
-#             "type": "lldb",
-#             "request": "launch",
-#             "name": "Debug LLDB",
-#             "stopOnEntry": false,
-#             "program": "${workspaceFolder}/build/bin/FreeCAD",
-#             "args": [],
-#             "cwd": "${workspaceFolder}/build/",            
-#             "preLaunchTask": "CMake: build",         
-#             "preRunCommands": [
-#                 "command script import ${workspaceFolder}/contrib/debugger/qt_pretty_printers_lldb.py"
-#             ]
-#         }
-#     ]
-# }
-#
-#
-# Note: There may be variances between different operating systems and/or build configurations in how QString
-#       data is stored internally.  This was tested on x86_64 and macOS/arm64. @BootsSiR
+ Currently supports displaying the following QT types in the debugger
+     * QString
 
+
+ Can be used from LLDB via:
+
+ (lldb) command script import {Your FreeCAD source dir}/contrib/debugger/qt_pretty_printers_lldb.py
+
+ (lldb) frame variable test
+ (QString) test = "This is a test string." 
+ (lldb)
+
+
+ Can be used in VSCode via launch.json (tested with CodeLLDB extension)
+
+ {
+     "version": "0.2.0",
+     "configurations": [
+         {
+             "type": "lldb",
+             "request": "launch",
+             "name": "Debug LLDB",
+             "stopOnEntry": false,
+             "program": "${workspaceFolder}/build/bin/FreeCAD",
+             "args": [],
+             "cwd": "${workspaceFolder}/build/",            
+             "preLaunchTask": "CMake: build",         
+             "preRunCommands": [
+                 "command script import ${workspaceFolder}/contrib/debugger/qt_pretty_printers_lldb.py"
+             ]
+         }
+     ]
+ }
+
+
+ Note: There may be variances between different operating systems and/or build configurations 
+       in how QString data is stored internally.  This was tested on debian12/amd64 and 
+       macOS/arm64. @BootsSiR
+"""
+# pylint: enable=line-too-long
 
 import lldb
 
-def QStringPrinter(val, internal_dict):
+def QStringPrinter(val, _internal_dict):
     """Pretty-printer for QString objects in LLDB."""
     try:
         # Access the 'd' member of QString
@@ -50,21 +53,26 @@ def QStringPrinter(val, internal_dict):
         if not d.IsValid():
             return 'null'
 
-        # some machines have a different object layout (macOS? arm64?)
+        # some machines have a different QString object layout (macOS? arm64?) so
+        # first we must check if a ptr member exists
         ptr_field = d.GetChildMemberWithName("ptr")
 
-        # if the ptr field isn't valid, use the offset method
-        if not ptr_field.IsValid():
-            # Address of the QString::Data
+        # if the ptr member exists, we will use that as the base address for our text data.
+        if ptr_field.IsValid():
+            # use the ptr value
+            data_base_address = ptr_field.GetValueAsUnsigned()
+        else:
+            # we don't have a ptr member, so let's use an offset from the address of the
+            # QString::Data as our base address
             d_address = d.GetValueAsUnsigned()
 
             # Assume the string data starts immediately after the first 24 bytes
             data_base_address = d_address + 24
-        else:
-            # use the ptr value
-            data_base_address = ptr_field.GetValueAsUnsigned()
-            if data_base_address == 0:
-                return "null"
+
+        # if at this point, we don't have a valid data base address
+        # we cannot proceed
+        if data_base_address == 0:
+            return "null"
 
         # Initialize variables for memory reading
         process = val.GetTarget().GetProcess()
@@ -89,10 +97,10 @@ def QStringPrinter(val, internal_dict):
             # Increase the offset for the next chunk
             offset += chunk_size
 
-    except Exception as e:
+    except Exception as e: # pylint: disable=broad-except
         return f"<error: {str(e)}>"
 
-def __lldb_init_module(debugger, internal_dict):
+def __lldb_init_module(debugger, _internal_dict):
     """Register the QString pretty-printer with LLDB."""
     print("QT pretty-printer script loaded.")
     debugger.HandleCommand('type summary add QString -F qt_pretty_printers_lldb.QStringPrinter')

--- a/contrib/debugger/qt_pretty_printers_lldb.py
+++ b/contrib/debugger/qt_pretty_printers_lldb.py
@@ -28,7 +28,7 @@
              "program": "${workspaceFolder}/build/bin/FreeCAD",
              "args": [],
              "cwd": "${workspaceFolder}/build/",
-             "preLaunchTask": "CMake: build",      
+             "preLaunchTask": "CMake: build",
              "preRunCommands": [
                  "command script import ${workspaceFolder}/contrib/debugger/qt_pretty_printers_lldb.py"
              ]


### PR DESCRIPTION
In an attempt to make debugging life easier, I've created QT pretty printers for both GDB and LLDB that will pretty print QString objects in your debugger of choice (future support can be added for other QT types if required.)

Note that there may be variances between different operating systems and/or build configurations in how QString data is stored internally.  I've tried to account for this in the code but we may discover other cases once more people start to use these.  We can fix if and when we encounter any issues.

I've also modified the repositories vscode launch config to incorporate these pretty printers.

QString in GDB Debugger in vscode
![gdb_qstring](https://github.com/user-attachments/assets/c4235466-a7b9-4d0b-b0d9-b1a312d0e00e)

QString in GDB console
```console
x@fcdev:~/freecad-source/build/debug/bin$ gdb ./FreeCAD
GNU gdb (Debian 13.1-3) 13.1
Copyright (C) 2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./FreeCAD...
(gdb) break /home/x/freecad-source/src/Main/MainGui.cpp:103
Breakpoint 1 at 0x2c970: file /home/x/freecad-source/src/Main/MainGui.cpp, line 103.
(gdb) run
Starting program: /home/x/freecad-source/build/debug/bin/FreeCAD 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Breakpoint 1, main (argc=1, argv=0x7fffffffe078) at /home/x/freecad-source/src/Main/MainGui.cpp:103
103	    setlocale(LC_ALL, "");       // use native environment settings
(gdb) p testString
$1 = {d = 0x555555621cc0}
(gdb) python
>sys.path.insert(0, '/home/x/freecad-source/contrib/debugger')
>from qt_pretty_printers_gdb import register_qt_printers
>register_qt_printers()
>end
QT pretty-printer script loaded.
QT pretty-printer registered.
(gdb) p testString
$2 = This is a QString in the debugger!
(gdb) 
```



QString in LLDB Debugger in vscode 
![lldb_qstring](https://github.com/user-attachments/assets/04aeb5b4-f245-41b0-ba3d-4cf805d644e4)

QString in LLDB console
```console
x@fcdev:~/freecad-source/build/debug/bin$ lldb ./FreeCAD
(lldb) target create "./FreeCAD"
Current executable set to '/home/x/freecad-source/build/debug/bin/FreeCAD' (x86_64).
(lldb) b /home/x/freecad-source/src/Main/MainGui.cpp:103
Breakpoint 1: where = FreeCAD`main + 78 at MainGui.cpp:103:14, address = 0x000000000002c970
(lldb) run
Process 307216 launched: '/home/x/freecad-source/build/debug/bin/FreeCAD' (x86_64)
Process 307216 stopped
* thread #1, name = 'FreeCAD', stop reason = breakpoint 1.1
    frame #0: 0x0000555555580970 FreeCAD`main(argc=1, argv=0x00007fffffffe098) at MainGui.cpp:103:14
   100 	    QString testString = QString::fromUtf8("This is a QString in the debugger!");
   101 	    QString nullString;
   102 	#if defined(FC_OS_LINUX) || defined(FC_OS_BSD)
-> 103 	    setlocale(LC_ALL, "");       // use native environment settings
   104 	    setlocale(LC_NUMERIC, "C");  // except for numbers to not break XML import
   105 	    // See https://github.com/FreeCAD/FreeCAD/issues/16724
   106 	
(lldb) frame variable testString
(QString) testString = {
  d = 0x0000555555621cc0
}
(lldb) command script import /home/x/freecad-source/contrib/debugger/qt_pretty_printers_lldb.py
QT pretty-printer script loaded.
QT pretty-printer registered.
(lldb) frame variable testString
(QString) testString = "This is a QString in the debugger!"
(lldb) 
```

Happy debugging!