### PR TITLE
Sketcher: Fixed mapping error when attempting to create a sketch inside a group.

### DIFF
--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -166,7 +166,7 @@ void CmdSketcherNewSketch::activated(int iMsg)
     std::string groupName;
     bool bAttach = false;
     bool groupSelected = false;
-    if (Gui::Selection().countObjectsOfType(App::DocumentObjectGroup::getClassTypeId()) > 0) {
+    if (Gui::Selection().countObjectsOfType<App::DocumentObjectGroup>() > 0) {
         auto selection = Gui::Selection().getSelection();
         if (selection.size() > 1) {
             Gui::TranslatedUserWarning(

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -163,8 +163,23 @@ void CmdSketcherNewSketch::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Attacher::eMapMode mapmode = Attacher::mmDeactivated;
+    std::string groupName;
     bool bAttach = false;
-    if (Gui::Selection().hasSelection()) {
+    bool groupSelected = false;
+    if (Gui::Selection().countObjectsOfType(App::DocumentObjectGroup::getClassTypeId()) > 0) {
+        auto selection = Gui::Selection().getSelection();
+        if (selection.size() > 1) {
+            Gui::TranslatedUserWarning(
+                getActiveGuiDocument(),
+                QObject::tr("Invalid selection"),
+                QObject::tr("Too many objects selected"));
+                return;
+        }
+
+        groupName = selection[0].FeatName;
+        groupSelected = true;
+    }
+    else if (Gui::Selection().hasSelection()) {
         Attacher::SuggestResult::eSuggestResult msgid = Attacher::SuggestResult::srOK;
         QString msg_str;
         std::vector<Attacher::eMapMode> validModes;
@@ -270,9 +285,18 @@ void CmdSketcherNewSketch::activated(int iMsg)
         std::string FeatName = getUniqueObjectName("Sketch");
 
         openCommand(QT_TRANSLATE_NOOP("Command", "Create a new sketch"));
-        doCommand(Doc,
+        if (groupSelected) {
+            doCommand(Doc,
+                    "App.activeDocument().getObject('%s').addObject(App.activeDocument().addObject('Sketcher::SketchObject', '%s'))",
+                    groupName.c_str(),
+                    FeatName.c_str());
+        }
+        else {
+            doCommand(Doc,
                   "App.activeDocument().addObject('Sketcher::SketchObject', '%s')",
                   FeatName.c_str());
+        }
+
         doCommand(Doc,
                   "App.activeDocument().%s.Placement = App.Placement(App.Vector(%f, %f, %f), "
                   "App.Rotation(%f, %f, %f, %f))",


### PR DESCRIPTION
Fix for issue #14603

Fixed an issue in the Sketcher where attempting to create a sketch while a group is selected caused a mapping error. Now, when a sketch is created with a group selected, the sketch will be placed inside the group.

- When the selection contains only a group, the sketch is created inside the group.
- When the selection contains a group and other objects, a warning ("Too many objects selected") is displayed to the user.
- In all other cases, the behavior remains unchanged.