### PR TITLE
Spreadsheet: Alias tab first in Cell properties

### DIFF
--- a/src/Mod/Spreadsheet/Gui/PropertiesDialog.cpp
+++ b/src/Mod/Spreadsheet/Gui/PropertiesDialog.cpp
@@ -326,7 +326,7 @@ void PropertiesDialog::apply()
 
 void PropertiesDialog::selectAlias()
 {
-    ui->tabWidget->setCurrentIndex(4);
+    ui->tabWidget->setCurrentIndex(0);
     ui->alias->setFocus();
 }
 

--- a/src/Mod/Spreadsheet/Gui/PropertiesDialog.ui
+++ b/src/Mod/Spreadsheet/Gui/PropertiesDialog.ui
@@ -22,7 +22,37 @@
      <property name="usesScrollButtons">
       <bool>false</bool>
      </property>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="tab_0">
+      <attribute name="title">
+       <string>A&amp;lias</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_6">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Alias for this cell</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="alias"/>
+       </item>
+       <item row="1" column="0">
+        <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_1">
       <attribute name="title">
        <string>&amp;Color</string>
       </attribute>
@@ -257,36 +287,6 @@
         </spacer>
        </item>
        </layout>
-     </widget>
-     <widget class="QWidget" name="tab_5">
-      <attribute name="title">
-       <string>A&amp;lias</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_6">
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>Alias for this cell</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLineEdit" name="alias"/>
-       </item>
-       <item row="1" column="0">
-        <spacer name="verticalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
      </widget>
     </widget>
    </item>


### PR DESCRIPTION
I have strong suspicion the Alias tab is the most used feature of the Cell properties dialog. However the Alias tab is the last one, which seems a bit odd from a usability perspective.

This moves the Alias tab to be the first one (and thus default active).