### PR TITLE
Add libyaml-cpp-dev to Docker ubuntu.sh dependencies

### DIFF
--- a/tools/build/Docker/ubuntu.sh
+++ b/tools/build/Docker/ubuntu.sh
@@ -10,7 +10,7 @@ apt-get install --no-install-recommends --yes build-essential cmake doxygen git 
     libopencv-dev libproj-dev libpyside2-dev libqt5svg5-dev\
     libshiboken2-dev libvtk9-dev libvtk9-qt-dev \
     libvtk-dicom-dev libx11-dev libxerces-c-dev libxmu-dev libxmuu-dev \
-    libzipios++-dev netgen netgen-headers pyside2-tools python3-dev \
+    libyaml-cpp-dev libzipios++-dev netgen netgen-headers pyside2-tools python3-dev \
     python3-matplotlib python3-pivy python3-ply python3-pyside2.qtsvg \
     python3-pyside2.qtuitools qtchooser qttools5-dev shiboken2 swig \
     qtwayland5


### PR DESCRIPTION
Add libyaml-cpp-dev to Docker ubuntu.sh dependencies

I tried following the [tools/build/Docker/README.rst](https://github.com/FreeCAD/FreeCAD/blob/main/tools/build/Docker/README.rst) instructions for building a Ubuntu Docker image with FreeCAD, but it fails due to a missing dependency on `libyaml-cpp-dev`. This PR adds  libyaml-cpp-dev to the dependencies script `ubuntu.sh`, to fix this.