### PR TITLE
TechDraw: Fix finding outlines consisting of a single closed edge

### DIFF
--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -270,6 +270,8 @@ private:
 
         std::vector<TopoDS_Edge> closedEdges;
         edgeList = DrawProjectSplit::scrubEdges(edgeList, closedEdges);
+        // Need to also check closed edges- those are valid wires
+        edgeList.insert( edgeList.end(), closedEdges.begin(), closedEdges.end() );
 
         std::vector<TopoDS_Wire> sortedWires;
         try {
@@ -326,6 +328,8 @@ private:
 
         std::vector<TopoDS_Edge> closedEdges;
         edgeList = DrawProjectSplit::scrubEdges(edgeList, closedEdges);
+        // Need to also check closed edges, since that may be the outline
+        edgeList.insert( edgeList.end(), closedEdges.begin(), closedEdges.end() );
 
         PyObject* outerWire = nullptr;
         std::vector<TopoDS_Wire> sortedWires;
@@ -389,6 +393,8 @@ private:
 
         std::vector<TopoDS_Edge> closedEdges;
         edgeList = DrawProjectSplit::scrubEdges(edgeList, closedEdges);
+        // Need to also check closed edges, since that may be the outline
+        edgeList.insert( edgeList.end(), closedEdges.begin(), closedEdges.end() );
 
         PyObject* outerWire = nullptr;
         std::vector<TopoDS_Wire> sortedWires;


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/12601

Basically a few TechDraw operations fail to account for single-edge wires, which either fails to find an outline when one should exist, or finds the wrong outline if there are any other closed wires provided. I found 3 functions that had this issue, though it's possible there are some I missed.

Somebody who knows better what's going on here should check if this is more a bandage than a proper fix- eg, if the call to `DrawProjectSplit::scrubEdges` is actually the root problem or something.

Test case showing the issue (works correctly with the pull request applied):
```
# Tests for single-edge issues in TechDraw
# No command should raise an exception, and all BoundBox outputs should be for the circle:
# BoundBox (-1, -1, 0, 1, 1, 0) #Correct
# BoundBox (-0.5, -0.5, 0, 0.5, 0.5, 0) #Incorrect

import TechDraw

r = Part.makePolygon([(-0.5,-0.5,0), (0.5,-0.5,0), (0.5,0.5,0), (-0.5,0.5,0), (-0.5,-0.5,0)])
c = Part.makeCircle(1)
f = Part.makeFace([r,c])

# This fails outright (ValueError: EdgeWalker has no edges to load)
w = TechDraw.findShapeOutline(c, 1, FreeCAD.Vector(0, 0, 1))
w.BoundBox

# This fails by finding the square in the face
w = TechDraw.findShapeOutline(f, 1, FreeCAD.Vector(0, 0, 1))
w.BoundBox

#This also fails outright (ValueError: EdgeWalker has no edges to load)
w = TechDraw.findOuterWire(c.Edges)
w.BoundBox

# This fails by finding the square in the face
w = TechDraw.findOuterWire(f.Edges)
w.BoundBox

#This also fails outright (ValueError: EdgeWalker has no edges to load)
w = TechDraw.edgeWalker(c.Edges)
w[0].BoundBox

# This fails by finding the square in the face
w = TechDraw.edgeWalker(f.Edges)
w[0].BoundBox
```

This is a prerequisite for https://github.com/FreeCAD/FreeCAD/pull/17155 to be merged.