### PR TITLE
CAM:  converted the refactored* postprocessors to the new (more object-oriented) API

### DIFF
--- a/src/Mod/CAM/CAMTests/TestRefactoredCentroidPost.py
+++ b/src/Mod/CAM/CAMTests/TestRefactoredCentroidPost.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2022 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
+# *   Copyright (c) 2022 - 2025 Larry Woestman <LarryWoestman2@gmail.com>   *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -21,13 +21,11 @@
 # *                                                                         *
 # ***************************************************************************
 
-from importlib import reload
-
 import FreeCAD
 
 import Path
 import CAMTests.PathTestUtils as PathTestUtils
-from Path.Post.scripts import refactored_centroid_post as postprocessor
+from Path.Post.Processor import PostProcessorFactory
 
 
 Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -35,9 +33,12 @@ Path.Log.trackModule(Path.Log.thisModule())
 
 
 class TestRefactoredCentroidPost(PathTestUtils.PathTestBase):
+    """Test the refactored_centroid_post.py postprocessor."""
+
     @classmethod
     def setUpClass(cls):
         """setUpClass()...
+
         This method is called upon instantiation of this test class.  Add code
         and objects here that are needed for the duration of the test() methods
         in this class.  In other words, set up the 'global' test environment
@@ -46,63 +47,108 @@ class TestRefactoredCentroidPost(PathTestUtils.PathTestBase):
         is able to call static methods within this same class.
         """
 
-        # Open existing FreeCAD document with test geometry
-        FreeCAD.newDocument("Unnamed")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
+        cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/CAMTests/boxtest.fcstd")
+        cls.job = cls.doc.getObject("Job")
+        cls.post = PostProcessorFactory.get_post_processor(cls.job, "refactored_centroid")
+        # locate the operation named "Profile"
+        for op in cls.job.Operations.Group:
+            if op.Label == "Profile":
+                # remember the "Profile" operation
+                cls.profile_op = op
+                return
 
     @classmethod
     def tearDownClass(cls):
         """tearDownClass()...
+
         This method is called prior to destruction of this test class.  Add
         code and objects here that cleanup the test environment after the
         test() methods in this class have been executed.  This method does not
         have access to the class `self` reference.  This method is able to
         call static methods within this same class.
         """
-        # Close geometry document without saving
-        FreeCAD.closeDocument(FreeCAD.ActiveDocument.Name)
+        FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     # Setup and tear down methods called before and after each unit test
+
     def setUp(self):
         """setUp()...
+
         This method is called prior to each `test()` method.  Add code and
         objects here that are needed for multiple `test()` methods.
         """
-        self.doc = FreeCAD.ActiveDocument
-        self.con = FreeCAD.Console
-        self.docobj = FreeCAD.ActiveDocument.addObject("Path::Feature", "testpath")
-        reload(
-            postprocessor
-        )  # technical debt.  This shouldn't be necessary but here to bypass a bug
+        # allow a full length "diff" if an error occurs
+        self.maxDiff = None
+        # reinitialize the postprocessor data structures between tests
+        self.post.reinitialize()
 
     def tearDown(self):
         """tearDown()...
+
         This method is called after each test() method. Add cleanup instructions here.
         Such cleanup instructions will likely undo those in the setUp() method.
         """
-        FreeCAD.ActiveDocument.removeObject("testpath")
+        pass
+
+    def single_compare(self, path, expected, args, debug=False):
+        """Perform a test with a single line of gcode comparison."""
+        nl = "\n"
+        self.job.PostProcessorArgs = args
+        # replace the original path (that came with the job and operation) with our path
+        self.profile_op.Path = Path.Path(path)
+        # the gcode is in the first section for this particular job and operation
+        gcode = self.post.export()[0][1]
+        if debug:
+            print(f"--------{nl}{gcode}--------{nl}")
+        # there are 4 lines of "other stuff" before the line we are interested in
+        self.assertEqual(gcode.splitlines()[4], expected)
+
+    def multi_compare(self, path, expected, args, debug=False):
+        """Perform a test with multiple lines of gcode comparison."""
+        nl = "\n"
+        self.job.PostProcessorArgs = args
+        # replace the original path (that came with the job and operation) with our path
+        self.profile_op.Path = Path.Path(path)
+        # the gcode is in the first section for this particular job and operation
+        gcode = self.post.export()[0][1]
+        if debug:
+            print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode, expected)
 
     def test000(self):
         """Test Output Generation.
         Empty path.  Produces only the preamble and postable.
         """
+        nl = "\n"
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
         # Test generating with header
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
-        args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertTrue(len(gcode.splitlines()) == 16)
+        self.job.PostProcessorArgs = "--no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertTrue(len(gcode.splitlines()) == 25)
 
         # Test without header
         expected = """G90 G80 G40 G49
+;T1=TC__Default_Tool
 ;Begin preamble
 G53 G00 G17
 G21
 ;Begin operation
-;End operation: testpath
+G54
+;End operation: Fixture
+;Begin operation
+;TC: Default Tool
+;Begin toolchange
+M6 T1
+;End operation: TC: Default Tool
+;Begin operation
+;End operation: Profile
 ;Begin postamble
 M5
 M25
@@ -111,17 +157,17 @@ G90 G80 G40 G49
 M99
 """
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
 
         # test without comments
         expected = """G90 G80 G40 G49
 G53 G00 G17
 G21
+G54
+M6 T1
 M5
 M25
 G49 H0
@@ -129,29 +175,33 @@ G90 G80 G40 G49
 M99
 """
 
-        args = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = "--no-header --no-comments --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
 
     def test010(self):
         """Test command Generation.
         Test Precision
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[14]
         expected = "G0 X10.0000 Y20.0000 Z30.0000"
         self.assertEqual(result, expected)
 
-        args = "--no-header --axis-precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --axis-precision=2 --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[14]
         expected = "G0 X10.00 Y20.00 Z30.00"
         self.assertEqual(result, expected)
 
@@ -159,27 +209,32 @@ M99
         """
         Test Line Numbers
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
-        expected = "N150 G0 X10.0000 Y20.0000 Z30.0000"
+        self.job.PostProcessorArgs = "--no-header --line-numbers --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[14]
+        expected = "N240 G0 X10.0000 Y20.0000 Z30.0000"
         self.assertEqual(result, expected)
 
     def test030(self):
         """
         Test Pre-amble
         """
+        nl = "\n"
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
-        args = "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = (
+            "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
+        )
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         result = gcode.splitlines()[1]
         self.assertEqual(result, "G18 G55")
 
@@ -187,10 +242,15 @@ M99
         """
         Test Post-amble
         """
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-        args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        nl = "\n"
+
+        self.profile_op.Path = Path.Path([])
+
+        self.job.PostProcessorArgs = (
+            "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
+        )
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         result = gcode.splitlines()[-2]
         self.assertEqual(result, "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -199,22 +259,25 @@ M99
         """
         Test inches
         """
+        nl = "\n"
 
         c = Path.Command("G0 X10 Y20 Z30")
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
 
-        args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertEqual(gcode.splitlines()[3], "G20")
+        self.profile_op.Path = Path.Path([c])
 
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --inches --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[4], "G20")
+
+        result = gcode.splitlines()[14]
         expected = "G0 X0.3937 Y0.7874 Z1.1811"
         self.assertEqual(result, expected)
 
-        args = "--no-header --inches --axis-precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --inches --axis-precision=2 --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[14]
         expected = "G0 X0.39 Y0.79 Z1.18"
         self.assertEqual(result, expected)
 
@@ -223,15 +286,17 @@ M99
         Test test modal
         Suppress the command name if the same as previous
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
         c1 = Path.Command("G0 X10 Y30 Z30")
 
-        self.docobj.Path = Path.Path([c, c1])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c, c1])
 
-        args = "--no-header --modal --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[6]
+        self.job.PostProcessorArgs = "--no-header --modal --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[15]
         expected = "X10.0000 Y30.0000 Z30.0000"
         self.assertEqual(result, expected)
 
@@ -240,15 +305,17 @@ M99
         Test axis modal
         Suppress the axis coordinate if the same as previous
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
         c1 = Path.Command("G0 X10 Y30 Z30")
 
-        self.docobj.Path = Path.Path([c, c1])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c, c1])
 
-        args = "--no-header --axis-modal --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[6]
+        self.job.PostProcessorArgs = "--no-header --axis-modal --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[15]
         expected = "G0 Y30.0000"
         self.assertEqual(result, expected)
 
@@ -256,33 +323,38 @@ M99
         """
         Test tool change
         """
+        nl = "\n"
+
         c = Path.Command("M6 T2")
         c2 = Path.Command("M3 S3000")
-        self.docobj.Path = Path.Path([c, c2])
-        postables = [self.docobj]
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertEqual(gcode.splitlines()[6], "M6 T2")
-        self.assertEqual(gcode.splitlines()[7], "M3 S3000")
+        self.profile_op.Path = Path.Path([c, c2])
+
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[15], "M6 T2")
+        self.assertEqual(gcode.splitlines()[16], "M3 S3000")
 
         # suppress TLO
-        args = "--no-header --no-tlo --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertEqual(gcode.splitlines()[7], "M3 S3000")
+        self.job.PostProcessorArgs = "--no-header --no-tlo --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[16], "M3 S3000")
 
     def test090(self):
         """
         Test comment
         """
+        nl = "\n"
 
         c = Path.Command("(comment)")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[14]
         expected = ";comment"
         self.assertEqual(result, expected)

--- a/src/Mod/CAM/CAMTests/TestRefactoredGrblPost.py
+++ b/src/Mod/CAM/CAMTests/TestRefactoredGrblPost.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2022 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
+# *   Copyright (c) 2022 - 2025 Larry Woestman <LarryWoestman2@gmail.com>   *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -21,13 +21,11 @@
 # *                                                                         *
 # ***************************************************************************
 
-from importlib import reload
-
 import FreeCAD
 
 import Path
 import CAMTests.PathTestUtils as PathTestUtils
-from Path.Post.scripts import refactored_grbl_post as postprocessor
+from Path.Post.Processor import PostProcessorFactory
 
 
 Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -35,9 +33,12 @@ Path.Log.trackModule(Path.Log.thisModule())
 
 
 class TestRefactoredGrblPost(PathTestUtils.PathTestBase):
+    """Test the refactored_grbl_post.py postprocessor."""
+
     @classmethod
     def setUpClass(cls):
         """setUpClass()...
+
         This method is called upon instantiation of this test class.  Add code
         and objects here that are needed for the duration of the test() methods
         in this class.  In other words, set up the 'global' test environment
@@ -46,108 +47,135 @@ class TestRefactoredGrblPost(PathTestUtils.PathTestBase):
         is able to call static methods within this same class.
         """
 
-        # Open existing FreeCAD document with test geometry
-        FreeCAD.newDocument("Unnamed")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
+        cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/CAMTests/boxtest.fcstd")
+        cls.job = cls.doc.getObject("Job")
+        cls.post = PostProcessorFactory.get_post_processor(cls.job, "refactored_grbl")
+        # locate the operation named "Profile"
+        for op in cls.job.Operations.Group:
+            if op.Label == "Profile":
+                # remember the "Profile" operation
+                cls.profile_op = op
+                return
 
     @classmethod
     def tearDownClass(cls):
         """tearDownClass()...
+
         This method is called prior to destruction of this test class.  Add
         code and objects here that cleanup the test environment after the
         test() methods in this class have been executed.  This method does not
         have access to the class `self` reference.  This method
         is able to call static methods within this same class.
         """
-        # Close geometry document without saving
-        FreeCAD.closeDocument(FreeCAD.ActiveDocument.Name)
+        FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     # Setup and tear down methods called before and after each unit test
+    
     def setUp(self):
         """setUp()...
+
         This method is called prior to each `test()` method.  Add code and
         objects here that are needed for multiple `test()` methods.
         """
-        self.doc = FreeCAD.ActiveDocument
-        self.con = FreeCAD.Console
-        self.docobj = FreeCAD.ActiveDocument.addObject("Path::Feature", "testpath")
-        reload(
-            postprocessor
-        )  # technical debt.  This shouldn't be necessary but here to bypass a bug
+        # allow a full length "diff" if an error occurs
+        self.maxDiff = None
+        # reinitialize the postprocessor data structures between tests
+        self.post.reinitialize()
 
     def tearDown(self):
         """tearDown()...
+
         This method is called after each test() method. Add cleanup instructions here.
         Such cleanup instructions will likely undo those in the setUp() method.
         """
-        FreeCAD.ActiveDocument.removeObject("testpath")
+        pass
 
     def test000(self):
         """Test Output Generation.
         Empty path.  Produces only the preamble and postable.
         """
+        nl = "\n"
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
         # Test generating with header
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
-        args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertTrue(len(gcode.splitlines()) == 14)
+        self.job.PostProcessorArgs = "--no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertTrue(len(gcode.splitlines()) == 24)
 
         # Test without header
         expected = """(Begin preamble)
 G17 G90
 G21
-(Begin operation: testpath)
-(Path: testpath)
-(Finish operation: testpath)
+(Begin operation: Fixture)
+(Path: Fixture)
+G54
+(Finish operation: Fixture)
+(Begin operation: TC: Default Tool)
+(Path: TC: Default Tool)
+(TC: Default Tool)
+(Begin toolchange)
+( M6 T1 )
+(Finish operation: TC: Default Tool)
+(Begin operation: Profile)
+(Path: Profile)
+(Finish operation: Profile)
 (Begin postamble)
 M5
 G17 G90
 M2
 """
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
-        args = "--no-header --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
 
         # test without comments
         expected = """G17 G90
 G21
+G54
+M6 T1
 M5
 G17 G90
 M2
 """
 
-        args = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = "--no-header --no-comments --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
 
     def test010(self):
         """Test command Generation.
         Test Precision
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[15]
         expected = "G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
-        args = "--no-header --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --precision=2 --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[15]
         expected = "G0 X10.00 Y20.00 Z30.00"
         self.assertEqual(result, expected)
 
@@ -155,27 +183,32 @@ M2
         """
         Test Line Numbers
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
-        expected = "N150 G0 X10.000 Y20.000 Z30.000"
+        self.job.PostProcessorArgs = "--no-header --line-numbers --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[15]
+        expected = "N250 G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
     def test030(self):
         """
         Test Pre-amble
         """
+        nl = "\n"
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
-        args = "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = (
+            "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
+        )
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         result = gcode.splitlines()[0]
         self.assertEqual(result, "G18 G55")
 
@@ -183,10 +216,15 @@ M2
         """
         Test Post-amble
         """
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-        args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        nl = "\n"
+
+        self.profile_op.Path = Path.Path([])
+
+        self.job.PostProcessorArgs = (
+            "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
+        )
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         result = gcode.splitlines()[-2]
         self.assertEqual(result, "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -195,22 +233,25 @@ M2
         """
         Test inches
         """
+        nl = "\n"
 
         c = Path.Command("G0 X10 Y20 Z30")
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
 
-        args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        self.profile_op.Path = Path.Path([c])
+
+        self.job.PostProcessorArgs = "--no-header --inches --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[2], "G20")
 
-        result = gcode.splitlines()[5]
+        result = gcode.splitlines()[15]
         expected = "G0 X0.3937 Y0.7874 Z1.1811"
         self.assertEqual(result, expected)
 
-        args = "--no-header --inches --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --inches --precision=2 --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[15]
         expected = "G0 X0.39 Y0.79 Z1.18"
         self.assertEqual(result, expected)
 
@@ -219,15 +260,17 @@ M2
         Test test modal
         Suppress the command name if the same as previous
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
         c1 = Path.Command("G0 X10 Y30 Z30")
 
-        self.docobj.Path = Path.Path([c, c1])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c, c1])
 
-        args = "--no-header --modal --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[6]
+        self.job.PostProcessorArgs = "--no-header --modal --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[16]
         expected = "X10.000 Y30.000 Z30.000"
         self.assertEqual(result, expected)
 
@@ -236,15 +279,17 @@ M2
         Test axis modal
         Suppress the axis coordinate if the same as previous
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
         c1 = Path.Command("G0 X10 Y30 Z30")
 
-        self.docobj.Path = Path.Path([c, c1])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c, c1])
 
-        args = "--no-header --axis-modal --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[6]
+        self.job.PostProcessorArgs = "--no-header --axis-modal --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[16]
         expected = "G0 Y30.000"
         self.assertEqual(result, expected)
 
@@ -252,33 +297,38 @@ M2
         """
         Test tool change
         """
+        nl = "\n"
+
         c = Path.Command("M6 T2")
         c2 = Path.Command("M3 S3000")
-        self.docobj.Path = Path.Path([c, c2])
-        postables = [self.docobj]
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertEqual(gcode.splitlines()[6], "( M6 T2 )")
-        self.assertEqual(gcode.splitlines()[7], "M3 S3000")
+        self.profile_op.Path = Path.Path([c, c2])
+
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[16], "( M6 T2 )")
+        self.assertEqual(gcode.splitlines()[17], "M3 S3000")
 
         # suppress TLO
-        args = "--no-header --no-tlo --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertEqual(gcode.splitlines()[7], "M3 S3000")
+        self.job.PostProcessorArgs = "--no-header --no-tlo --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[17], "M3 S3000")
 
     def test090(self):
         """
         Test comment
         """
+        nl = "\n"
 
         c = Path.Command("(comment)")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[15]
         expected = "(comment)"
         self.assertEqual(result, expected)

--- a/src/Mod/CAM/CAMTests/TestRefactoredLinuxCNCPost.py
+++ b/src/Mod/CAM/CAMTests/TestRefactoredLinuxCNCPost.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2022 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
+# *   Copyright (c) 2022 - 2025 Larry Woestman <LarryWoestman2@gmail.com>   *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -21,13 +21,11 @@
 # *                                                                         *
 # ***************************************************************************
 
-from importlib import reload
-
 import FreeCAD
 
 import Path
 import CAMTests.PathTestUtils as PathTestUtils
-from Path.Post.scripts import refactored_linuxcnc_post as postprocessor
+from Path.Post.Processor import PostProcessorFactory
 
 
 Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -35,9 +33,12 @@ Path.Log.trackModule(Path.Log.thisModule())
 
 
 class TestRefactoredLinuxCNCPost(PathTestUtils.PathTestBase):
+    """Test the refactored_linuxcnc_post.py postprocessor."""
+
     @classmethod
     def setUpClass(cls):
         """setUpClass()...
+
         This method is called upon instantiation of this test class.  Add code
         and objects here that are needed for the duration of the test() methods
         in this class.  In other words, set up the 'global' test environment
@@ -46,108 +47,139 @@ class TestRefactoredLinuxCNCPost(PathTestUtils.PathTestBase):
         is able to call static methods within this same class.
         """
 
-        # Open existing FreeCAD document with test geometry
-        FreeCAD.newDocument("Unnamed")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
+        cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/CAMTests/boxtest.fcstd")
+        cls.job = cls.doc.getObject("Job")
+        cls.post = PostProcessorFactory.get_post_processor(cls.job, "refactored_linuxcnc")
+        # locate the operation named "Profile"
+        for op in cls.job.Operations.Group:
+            if op.Label == "Profile":
+                # remember the "Profile" operation
+                cls.profile_op = op
+                return
 
     @classmethod
     def tearDownClass(cls):
         """tearDownClass()...
+
         This method is called prior to destruction of this test class.  Add
         code and objects here that cleanup the test environment after the
         test() methods in this class have been executed.  This method does not
         have access to the class `self` reference.  This method
         is able to call static methods within this same class.
         """
-        # Close geometry document without saving
-        FreeCAD.closeDocument(FreeCAD.ActiveDocument.Name)
+        FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     # Setup and tear down methods called before and after each unit test
+
     def setUp(self):
         """setUp()...
+
         This method is called prior to each `test()` method.  Add code and
         objects here that are needed for multiple `test()` methods.
         """
-        self.doc = FreeCAD.ActiveDocument
-        self.con = FreeCAD.Console
-        self.docobj = FreeCAD.ActiveDocument.addObject("Path::Feature", "testpath")
-        reload(
-            postprocessor
-        )  # technical debt.  This shouldn't be necessary but here to bypass a bug
+        # allow a full length "diff" if an error occurs
+        self.maxDiff = None
+        # reinitialize the postprocessor data structures between tests
+        self.post.reinitialize()
 
     def tearDown(self):
         """tearDown()...
+
         This method is called after each test() method. Add cleanup instructions here.
         Such cleanup instructions will likely undo those in the setUp() method.
         """
-        FreeCAD.ActiveDocument.removeObject("testpath")
+        pass
 
     def test000(self):
         """Test Output Generation.
         Empty path.  Produces only the preamble and postable.
         """
+        nl = "\n"
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
         # Test generating with header
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
-        args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertTrue(len(gcode.splitlines()) == 14)
+        self.job.PostProcessorArgs = "--no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertTrue(len(gcode.splitlines()) == 26)
 
         # Test without header
         expected = """(Begin preamble)
 G17 G54 G40 G49 G80 G90
 G21
-(Begin operation: testpath)
+(Begin operation: Fixture)
 (Machine units: mm/min)
-(Finish operation: testpath)
+G54
+(Finish operation: Fixture)
+(Begin operation: TC: Default Tool)
+(Machine units: mm/min)
+(TC: Default Tool)
+(Begin toolchange)
+M5
+M6 T1
+G43 H1
+(Finish operation: TC: Default Tool)
+(Begin operation: Profile)
+(Machine units: mm/min)
+(Finish operation: Profile)
 (Begin postamble)
 M05
 G17 G54 G90 G80 G40
 M2
 """
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
-        args = "--no-header --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
 
         # test without comments
         expected = """G17 G54 G40 G49 G80 G90
 G21
+G54
+M5
+M6 T1
+G43 H1
 M05
 G17 G54 G90 G80 G40
 M2
 """
 
-        args = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = "--no-header --no-comments --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
 
     def test010(self):
         """Test command Generation.
         Test Precision
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
         expected = "G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
-        args = "--no-header --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --precision=2 --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
         expected = "G0 X10.00 Y20.00 Z30.00"
         self.assertEqual(result, expected)
 
@@ -155,27 +187,32 @@ M2
         """
         Test Line Numbers
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
-        expected = "N150 G0 X10.000 Y20.000 Z30.000"
+        self.job.PostProcessorArgs = "--no-header --line-numbers --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
+        expected = "N270 G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
     def test030(self):
         """
         Test Pre-amble
         """
+        nl = "\n"
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
-        args = "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = (
+            "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
+        )
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         result = gcode.splitlines()[0]
         self.assertEqual(result, "G18 G55")
 
@@ -183,10 +220,15 @@ M2
         """
         Test Post-amble
         """
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-        args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        nl = "\n"
+
+        self.profile_op.Path = Path.Path([])
+
+        self.job.PostProcessorArgs = (
+            "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
+        )
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         result = gcode.splitlines()[-2]
         self.assertEqual(result, "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -195,22 +237,25 @@ M2
         """
         Test inches
         """
+        nl = "\n"
 
         c = Path.Command("G0 X10 Y20 Z30")
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
 
-        args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        self.profile_op.Path = Path.Path([c])
+
+        self.job.PostProcessorArgs = "--no-header --inches --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[2], "G20")
 
-        result = gcode.splitlines()[5]
+        result = gcode.splitlines()[17]
         expected = "G0 X0.3937 Y0.7874 Z1.1811"
         self.assertEqual(result, expected)
 
-        args = "--no-header --inches --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --inches --precision=2 --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
         expected = "G0 X0.39 Y0.79 Z1.18"
         self.assertEqual(result, expected)
 
@@ -219,15 +264,17 @@ M2
         Test test modal
         Suppress the command name if the same as previous
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
         c1 = Path.Command("G0 X10 Y30 Z30")
 
-        self.docobj.Path = Path.Path([c, c1])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c, c1])
 
-        args = "--no-header --modal --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[6]
+        self.job.PostProcessorArgs = "--no-header --modal --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[18]
         expected = "X10.000 Y30.000 Z30.000"
         self.assertEqual(result, expected)
 
@@ -236,15 +283,17 @@ M2
         Test axis modal
         Suppress the axis coordinate if the same as previous
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
         c1 = Path.Command("G0 X10 Y30 Z30")
 
-        self.docobj.Path = Path.Path([c, c1])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c, c1])
 
-        args = "--no-header --axis-modal --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[6]
+        self.job.PostProcessorArgs = "--no-header --axis-modal --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[18]
         expected = "G0 Y30.000"
         self.assertEqual(result, expected)
 
@@ -252,35 +301,41 @@ M2
         """
         Test tool change
         """
+        nl = "\n"
+
         c = Path.Command("M6 T2")
         c2 = Path.Command("M3 S3000")
-        self.docobj.Path = Path.Path([c, c2])
-        postables = [self.docobj]
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertEqual(gcode.splitlines()[6], "M5")
-        self.assertEqual(gcode.splitlines()[7], "M6 T2")
-        self.assertEqual(gcode.splitlines()[8], "G43 H2")
-        self.assertEqual(gcode.splitlines()[9], "M3 S3000")
+        self.profile_op.Path = Path.Path([c, c2])
+
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        split_gcode = gcode.splitlines()
+        self.assertEqual(split_gcode[18], "M5")
+        self.assertEqual(split_gcode[19], "M6 T2")
+        self.assertEqual(split_gcode[20], "G43 H2")
+        self.assertEqual(split_gcode[21], "M3 S3000")
 
         # suppress TLO
-        args = "--no-header --no-tlo --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertEqual(gcode.splitlines()[8], "M3 S3000")
+        self.job.PostProcessorArgs = "--no-header --no-tlo --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[19], "M3 S3000")
 
     def test090(self):
         """
         Test comment
         """
+        nl = "\n"
 
         c = Path.Command("(comment)")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
         expected = "(comment)"
         self.assertEqual(result, expected)

--- a/src/Mod/CAM/CAMTests/TestRefactoredMach3Mach4Post.py
+++ b/src/Mod/CAM/CAMTests/TestRefactoredMach3Mach4Post.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2022 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
+# *   Copyright (c) 2022 - 2025 Larry Woestman <LarryWoestman2@gmail.com>   *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -21,22 +21,24 @@
 # *                                                                         *
 # ***************************************************************************
 
-from importlib import reload
-
 import FreeCAD
 
 import Path
 import CAMTests.PathTestUtils as PathTestUtils
-from Path.Post.scripts import refactored_mach3_mach4_post as postprocessor
+from Path.Post.Processor import PostProcessorFactory
+
 
 Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
 Path.Log.trackModule(Path.Log.thisModule())
 
 
 class TestRefactoredMach3Mach4Post(PathTestUtils.PathTestBase):
+    """Test the refactored_mach3_mach4_post.py postprocessor."""
+
     @classmethod
     def setUpClass(cls) -> None:
         """setUpClass()...
+
         This method is called upon instantiation of this test class.  Add code
         and objects here that are needed for the duration of the test() methods
         in this class.  In other words, set up the 'global' test environment
@@ -45,108 +47,162 @@ class TestRefactoredMach3Mach4Post(PathTestUtils.PathTestBase):
         is able to call static methods within this same class.
         """
 
-        # Open existing FreeCAD document with test geometry
-        FreeCAD.newDocument("Unnamed")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
+        cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/CAMTests/boxtest.fcstd")
+        cls.job = cls.doc.getObject("Job")
+        cls.post = PostProcessorFactory.get_post_processor(cls.job, "refactored_mach3_mach4")
+        # locate the operation named "Profile"
+        for op in cls.job.Operations.Group:
+            if op.Label == "Profile":
+                # remember the "Profile" operation
+                cls.profile_op = op
+                return
 
     @classmethod
     def tearDownClass(cls) -> None:
         """tearDownClass()...
+
         This method is called prior to destruction of this test class.  Add
         code and objects here that cleanup the test environment after the
         test() methods in this class have been executed.  This method does not
         have access to the class `self` reference.  This method is able to
         call static methods within this same class.
         """
-        # Close geometry document without saving
-        FreeCAD.closeDocument(FreeCAD.ActiveDocument.Name)
+        FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     # Setup and tear down methods called before and after each unit test
+
     def setUp(self) -> None:
         """setUp()...
+
         This method is called prior to each `test()` method.  Add code and
         objects here that are needed for multiple `test()` methods.
         """
-        self.doc = FreeCAD.ActiveDocument
-        self.con = FreeCAD.Console
-        self.docobj = FreeCAD.ActiveDocument.addObject("Path::Feature", "testpath")
-        reload(
-            postprocessor
-        )  # technical debt.  This shouldn't be necessary but here to bypass a bug
+        # allow a full length "diff" if an error occurs
+        self.maxDiff = None
+        # reinitialize the postprocessor data structures between tests
+        self.post.reinitialize()
 
     def tearDown(self) -> None:
         """tearDown()...
+
         This method is called after each test() method. Add cleanup instructions here.
         Such cleanup instructions will likely undo those in the setUp() method.
         """
-        FreeCAD.ActiveDocument.removeObject("testpath")
+        pass
+
+    def single_compare(self, path, expected, args, debug=False):
+        """Perform a test with a single line of gcode comparison."""
+        nl = "\n"
+        self.job.PostProcessorArgs = args
+        # replace the original path (that came with the job and operation) with our path
+        self.profile_op.Path = Path.Path(path)
+        # the gcode is in the first section for this particular job and operation
+        gcode = self.post.export()[0][1]
+        if debug:
+            print(f"--------{nl}{gcode}--------{nl}")
+        # there are 4 lines of "other stuff" before the line we are interested in
+        self.assertEqual(gcode.splitlines()[4], expected)
+
+    def multi_compare(self, path, expected, args, debug=False):
+        """Perform a test with multiple lines of gcode comparison."""
+        nl = "\n"
+        self.job.PostProcessorArgs = args
+        # replace the original path (that came with the job and operation) with our path
+        self.profile_op.Path = Path.Path(path)
+        # the gcode is in the first section for this particular job and operation
+        gcode = self.post.export()[0][1]
+        if debug:
+            print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode, expected)
 
     def test000(self) -> None:
         """Test Output Generation.
         Empty path.  Produces only the preamble and postable.
         """
+        nl = "\n"
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
         # Test generating with header
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
-        args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertTrue(len(gcode.splitlines()) == 14)
+        self.job.PostProcessorArgs = "--no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertTrue(len(gcode.splitlines()) == 26)
 
         # Test without header
         expected = """(Begin preamble)
 G17 G54 G40 G49 G80 G90
 G21
-(Begin operation: testpath)
+(Begin operation: Fixture)
 (Machine: mach3_4, mm/min)
-(Finish operation: testpath)
+G54
+(Finish operation: Fixture)
+(Begin operation: TC: Default Tool)
+(Machine: mach3_4, mm/min)
+(TC: Default Tool)
+(Begin toolchange)
+M5
+M6 T1
+G43 H1
+(Finish operation: TC: Default Tool)
+(Begin operation: Profile)
+(Machine: mach3_4, mm/min)
+(Finish operation: Profile)
 (Begin postamble)
 M05
 G17 G54 G90 G80 G40
 M2
 """
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-
-        args = "--no-header --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
 
         # test without comments
         expected = """G17 G54 G40 G49 G80 G90
 G21
+G54
+M5
+M6 T1
+G43 H1
 M05
 G17 G54 G90 G80 G40
 M2
 """
 
-        args = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = "--no-header --no-comments --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
 
     def test010(self):
         """Test command Generation.
         Test Precision
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
         expected = "G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
-        args = "--no-header --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --precision=2 --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
         expected = "G0 X10.00 Y20.00 Z30.00"
         self.assertEqual(result, expected)
 
@@ -154,27 +210,32 @@ M2
         """
         Test Line Numbers
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
-        expected = "N150 G0 X10.000 Y20.000 Z30.000"
+        self.job.PostProcessorArgs = "--no-header --line-numbers --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
+        expected = "N270 G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
     def test030(self):
         """
         Test Pre-amble
         """
+        nl = "\n"
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
-        args = "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = (
+            "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
+        )
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         result = gcode.splitlines()[0]
         self.assertEqual(result, "G18 G55")
 
@@ -182,10 +243,15 @@ M2
         """
         Test Post-amble
         """
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-        args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        nl = "\n"
+
+        self.profile_op.Path = Path.Path([])
+
+        self.job.PostProcessorArgs = (
+            "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
+        )
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         result = gcode.splitlines()[-2]
         self.assertEqual(result, "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -194,22 +260,25 @@ M2
         """
         Test inches
         """
+        nl = "\n"
 
         c = Path.Command("G0 X10 Y20 Z30")
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
 
-        args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        self.profile_op.Path = Path.Path([c])
+
+        self.job.PostProcessorArgs = "--no-header --inches --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[2], "G20")
 
-        result = gcode.splitlines()[5]
+        result = gcode.splitlines()[17]
         expected = "G0 X0.3937 Y0.7874 Z1.1811"
         self.assertEqual(result, expected)
 
-        args = "--no-header --inches --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --inches --precision=2 --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
         expected = "G0 X0.39 Y0.79 Z1.18"
         self.assertEqual(result, expected)
 
@@ -218,15 +287,17 @@ M2
         Test test modal
         Suppress the command name if the same as previous
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
         c1 = Path.Command("G0 X10 Y30 Z30")
 
-        self.docobj.Path = Path.Path([c, c1])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c, c1])
 
-        args = "--no-header --modal --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[6]
+        self.job.PostProcessorArgs = "--no-header --modal --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[18]
         expected = "X10.000 Y30.000 Z30.000"
         self.assertEqual(result, expected)
 
@@ -235,15 +306,17 @@ M2
         Test axis modal
         Suppress the axis coordinate if the same as previous
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
         c1 = Path.Command("G0 X10 Y30 Z30")
 
-        self.docobj.Path = Path.Path([c, c1])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c, c1])
 
-        args = "--no-header --axis-modal --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[6]
+        self.job.PostProcessorArgs = "--no-header --axis-modal --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[18]
         expected = "G0 Y30.000"
         self.assertEqual(result, expected)
 
@@ -251,35 +324,41 @@ M2
         """
         Test tool change
         """
+        nl = "\n"
+
         c = Path.Command("M6 T2")
         c2 = Path.Command("M3 S3000")
-        self.docobj.Path = Path.Path([c, c2])
-        postables = [self.docobj]
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertEqual(gcode.splitlines()[6], "M5")
-        self.assertEqual(gcode.splitlines()[7], "M6 T2")
-        self.assertEqual(gcode.splitlines()[8], "G43 H2")
-        self.assertEqual(gcode.splitlines()[9], "M3 S3000")
+        self.profile_op.Path = Path.Path([c, c2])
+
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        split_gcode = gcode.splitlines()
+        self.assertEqual(split_gcode[18], "M5")
+        self.assertEqual(split_gcode[19], "M6 T2")
+        self.assertEqual(split_gcode[20], "G43 H2")
+        self.assertEqual(split_gcode[21], "M3 S3000")
 
         # suppress TLO
-        args = "--no-header --no-tlo --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertEqual(gcode.splitlines()[8], "M3 S3000")
+        self.job.PostProcessorArgs = "--no-header --no-tlo --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[19], "M3 S3000")
 
     def test090(self):
         """
         Test comment
         """
+        nl = "\n"
 
         c = Path.Command("(comment)")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
         expected = "(comment)"
         self.assertEqual(result, expected)

--- a/src/Mod/CAM/CAMTests/TestRefactoredTestPost.py
+++ b/src/Mod/CAM/CAMTests/TestRefactoredTestPost.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2022 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022-2023 Larry Woestman <LarryWoestman2@gmail.com>     *
+# *   Copyright (c) 2022-2025 Larry Woestman <LarryWoestman2@gmail.com>     *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -25,7 +25,7 @@ import FreeCAD
 
 import Path
 import CAMTests.PathTestUtils as PathTestUtils
-from Path.Post.scripts import refactored_test_post as postprocessor
+from Path.Post.Processor import PostProcessorFactory
 
 
 Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -33,6 +33,8 @@ Path.Log.trackModule(Path.Log.thisModule())
 
 
 class TestRefactoredTestPost(PathTestUtils.PathTestBase):
+    """Test the refactored_test_post.py postprocessor command line arguments."""
+
     @classmethod
     def setUpClass(cls):
         """setUpClass()...
@@ -44,8 +46,16 @@ class TestRefactoredTestPost(PathTestUtils.PathTestBase):
         This method does not have access to the class `self` reference, but it
         is able to call static methods within this same class.
         """
-        # Open existing FreeCAD document with test geometry
-        FreeCAD.newDocument("Unnamed")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
+        cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/CAMTests/boxtest.fcstd")
+        cls.job = cls.doc.getObject("Job")
+        cls.post = PostProcessorFactory.get_post_processor(cls.job, "refactored_test")
+        # locate the operation named "Profile"
+        for op in cls.job.Operations.Group:
+            if op.Label == "Profile":
+                # remember the "Profile" operation
+                cls.profile_op = op
+                return
 
     @classmethod
     def tearDownClass(cls):
@@ -57,8 +67,8 @@ class TestRefactoredTestPost(PathTestUtils.PathTestBase):
         not have access to the class `self` reference.  This method is able
         to call static methods within this same class.
         """
-        # Close geometry document without saving
-        FreeCAD.closeDocument(FreeCAD.ActiveDocument.Name)
+        FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     # Setup and tear down methods called before and after each unit test
 
@@ -68,15 +78,12 @@ class TestRefactoredTestPost(PathTestUtils.PathTestBase):
         This method is called prior to each `test()` method.  Add code and
         objects here that are needed for multiple `test()` methods.
         """
+        # allow a full length "diff" if an error occurs
         self.maxDiff = None
-        self.doc = FreeCAD.ActiveDocument
-        self.con = FreeCAD.Console
-        self.docobj = FreeCAD.ActiveDocument.addObject("Path::Feature", "testpath")
         #
-        # Re-initialize all of the values before doing a test.
+        # reinitialize the postprocessor data structures between tests
         #
-        postprocessor.UNITS = "G21"
-        postprocessor.init_values(postprocessor.global_values)
+        self.post.reinitialize()
 
     def tearDown(self):
         """tearDown()...
@@ -84,39 +91,42 @@ class TestRefactoredTestPost(PathTestUtils.PathTestBase):
         This method is called after each test() method. Add cleanup instructions here.
         Such cleanup instructions will likely undo those in the setUp() method.
         """
-        FreeCAD.ActiveDocument.removeObject("testpath")
+        pass
 
     def single_compare(self, path, expected, args, debug=False):
-        """Perform a test with a single comparison."""
+        """Perform a test with a single line of gcode comparison."""
         nl = "\n"
-        self.docobj.Path = Path.Path(path)
-        postables = [self.docobj]
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = args
+        # replace the original path (that came with the job and operation) with our path
+        self.profile_op.Path = Path.Path(path)
+        # the gcode is in the first section for this particular job and operation
+        gcode = self.post.export()[0][1]
+        if debug:
+            print(f"--------{nl}{gcode}--------{nl}")
+        # there are 4 lines of "other stuff" before the line we are interested in
+        self.assertEqual(gcode.splitlines()[4], expected)
+
+    def multi_compare(self, path, expected, args, debug=False):
+        """Perform a test with multiple lines of gcode comparison."""
+        nl = "\n"
+        self.job.PostProcessorArgs = args
+        # replace the original path (that came with the job and operation) with our path
+        self.profile_op.Path = Path.Path(path)
+        # the gcode is in the first section for this particular job and operation
+        gcode = self.post.export()[0][1]
         if debug:
             print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
-
-    def compare_third_line(self, path_string, expected, args, debug=False):
-        """Perform a test with a single comparison to the third line of the output."""
-        nl = "\n"
-        if path_string:
-            self.docobj.Path = Path.Path([Path.Command(path_string)])
-        else:
-            self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-        gcode = postprocessor.export(postables, "-", args)
-        if debug:
-            print(f"--------{nl}{gcode}--------{nl}")
-        self.assertEqual(gcode.splitlines()[2], expected)
 
     #############################################################################
     #
     # The tests are organized into groups:
     #
     #   00000 - 00099  tests that don't fit any other category
-    #   00100 - 00999  tests for all of the various arguments/options
-    #   01000 - 01999  tests for the various G codes at 1000 + 10 * g_code_value
-    #   02000 - 02999  tests for the various M codes at 2000 + 10 * m_code_value
+    #   00100 - 09999  tests for all of the various arguments/options
+    #   10000 - 18999  tests for the various G codes at 10000 + 10 * g_code_value
+    #   19000 - 19999  tests for the A, B, and C axis outputs
+    #   20000 - 29999  tests for the various M codes at 20000 + 10 * m_code_value
     #
     #############################################################################
 
@@ -125,37 +135,45 @@ class TestRefactoredTestPost(PathTestUtils.PathTestBase):
 
         Suppress the axis coordinate if the same as previous
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
         c1 = Path.Command("G0 X10 Y30 Z30")
+        self.profile_op.Path = Path.Path([c, c1])
 
-        self.docobj.Path = Path.Path([c, c1])
-        postables = [self.docobj]
+        self.job.PostProcessorArgs = "--axis-modal"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[5], "G0 Y30.000")
 
-        args = "--axis-modal"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[3], "G0 Y30.000")
-
-        args = "--no-axis-modal"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[3], "G0 X10.000 Y30.000 Z30.000")
+        self.job.PostProcessorArgs = "--no-axis-modal"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[5], "G0 X10.000 Y30.000 Z30.000")
 
     #############################################################################
 
     def test00110(self):
         """Test axis-precision."""
-        self.compare_third_line("G0 X10 Y20 Z30", "G0 X10.00 Y20.00 Z30.00", "--axis-precision=2")
+        self.single_compare("G0 X10 Y20 Z30", "G0 X10.00 Y20.00 Z30.00", "--axis-precision=2")
 
     #############################################################################
 
     def test00120(self):
         """Test bcnc."""
-        self.single_compare(
+        self.multi_compare(
             [],
             """G90
 G21
-(Block-name: testpath)
+(Block-name: Fixture)
+(Block-expand: 0)
+(Block-enable: 1)
+G54
+(Block-name: TC: Default Tool)
+(Block-expand: 0)
+(Block-enable: 1)
+M6 T1
+(Block-name: Profile)
 (Block-expand: 0)
 (Block-enable: 1)
 (Block-name: post_amble)
@@ -164,10 +182,12 @@ G21
 """,
             "--bcnc",
         )
-        self.single_compare(
+        self.multi_compare(
             [],
             """G90
 G21
+G54
+M6 T1
 """,
             "--no-bcnc",
         )
@@ -176,37 +196,38 @@ G21
 
     def test00130(self):
         """Test comments."""
+        nl = "\n"
+
         c = Path.Command("(comment)")
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
-        args = "--comments"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[4], "(comment)")
+        self.profile_op.Path = Path.Path([c])
+
+        self.job.PostProcessorArgs = "--comments"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[12], "(comment)")
 
     #############################################################################
 
     def test00140(self):
         """Test feed-precision."""
-        #
+        nl = "\n"
+
         c = Path.Command("G1 X10 Y20 Z30 F123.123456")
+        self.profile_op.Path = Path.Path([c])
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
-
-        args = ""
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
+        self.job.PostProcessorArgs = ""
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         # Note:  The "internal" F speed is in mm/s,
         #        while the output F speed is in mm/min.
-        self.assertEqual(gcode.splitlines()[2], "G1 X10.000 Y20.000 Z30.000 F7387.407")
+        self.assertEqual(gcode.splitlines()[4], "G1 X10.000 Y20.000 Z30.000 F7387.407")
 
-        args = "--feed-precision=2"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
+        self.job.PostProcessorArgs = "--feed-precision=2"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         # Note:  The "internal" F speed is in mm/s,
         #        while the output F speed is in mm/min.
-        self.assertEqual(gcode.splitlines()[2], "G1 X10.000 Y20.000 Z30.000 F7387.41")
+        self.assertEqual(gcode.splitlines()[4], "G1 X10.000 Y20.000 Z30.000 F7387.41")
 
     #############################################################################
 
@@ -215,90 +236,107 @@ G21
 
         Also tests the interactions between --comments and --header.
         """
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        nl = "\n"
+
+        self.profile_op.Path = Path.Path([])
 
         # Test generating with comments and header.
+        self.job.PostProcessorArgs = "--comments --header"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        split_gcode = gcode.splitlines()
+        self.assertEqual(split_gcode[0], "(Exported by FreeCAD)")
+        self.assertEqual(split_gcode[1], "(Post Processor: refactored_test_post)")
+        self.assertEqual(split_gcode[2], "(Cam File: boxtest.fcstd)")
         # The header contains a time stamp that messes up unit testing.
         # Only test the length of the line that contains the time.
-        args = "--comments --header"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[0], "(Exported by FreeCAD)")
-        self.assertEqual(
-            gcode.splitlines()[1],
-            "(Post Processor: Path.Post.scripts.refactored_test_post)",
-        )
-        self.assertEqual(gcode.splitlines()[2], "(Cam File: )")
-        self.assertIn("(Output Time: ", gcode.splitlines()[3])
-        self.assertTrue(len(gcode.splitlines()[3]) == 41)
-        self.assertEqual(gcode.splitlines()[4], "(Begin preamble)")
-        self.assertEqual(gcode.splitlines()[5], "G90")
-        self.assertEqual(gcode.splitlines()[6], "G21")
-        self.assertEqual(gcode.splitlines()[7], "(Begin operation)")
-        self.assertEqual(gcode.splitlines()[8], "(Finish operation: testpath)")
-        self.assertEqual(gcode.splitlines()[9], "(Begin postamble)")
+        self.assertIn("(Output Time: ", split_gcode[3])
+        self.assertTrue(len(split_gcode[3]) == 41)
+        self.assertEqual(split_gcode[4], "(Begin preamble)")
+        self.assertEqual(split_gcode[5], "G90")
+        self.assertEqual(split_gcode[6], "G21")
+        self.assertEqual(split_gcode[7], "(Begin operation)")
+        self.assertEqual(split_gcode[8], "G54")
+        self.assertEqual(split_gcode[9], "(Finish operation: Fixture)")
+        self.assertEqual(split_gcode[10], "(Begin operation)")
+        self.assertEqual(split_gcode[11], "(TC: Default Tool)")
+        self.assertEqual(split_gcode[12], "(Begin toolchange)")
+        self.assertEqual(split_gcode[13], "( M6 T1 )")
+        self.assertEqual(split_gcode[14], "(Finish operation: TC: Default Tool)")
+        self.assertEqual(split_gcode[15], "(Begin operation)")
+        self.assertEqual(split_gcode[16], "(Finish operation: Profile)")
+        self.assertEqual(split_gcode[17], "(Begin postamble)")
 
         # Test with comments without header.
         expected = """(Begin preamble)
 G90
 G21
 (Begin operation)
-(Finish operation: testpath)
+G54
+(Finish operation: Fixture)
+(Begin operation)
+(TC: Default Tool)
+(Begin toolchange)
+( M6 T1 )
+(Finish operation: TC: Default Tool)
+(Begin operation)
+(Finish operation: Profile)
 (Begin postamble)
 """
-        args = "--comments --no-header"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
+        self.job.PostProcessorArgs = "--comments --no-header"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
 
         # Test without comments with header.
-        args = "--no-comments --header"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[0], "(Exported by FreeCAD)")
-        self.assertEqual(
-            gcode.splitlines()[1],
-            "(Post Processor: Path.Post.scripts.refactored_test_post)",
-        )
-        self.assertEqual(gcode.splitlines()[2], "(Cam File: )")
-        self.assertIn("(Output Time: ", gcode.splitlines()[3])
-        self.assertTrue(len(gcode.splitlines()[3]) == 41)
-        self.assertEqual(gcode.splitlines()[4], "G90")
-        self.assertEqual(gcode.splitlines()[5], "G21")
+        self.job.PostProcessorArgs = "--no-comments --header"
+        gcode = self.post.export()[0][1]
+        split_gcode = gcode.splitlines()
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(split_gcode[0], "(Exported by FreeCAD)")
+        self.assertEqual(split_gcode[1], "(Post Processor: refactored_test_post)")
+        self.assertEqual(split_gcode[2], "(Cam File: boxtest.fcstd)")
+        # The header contains a time stamp that messes up unit testing.
+        # Only test the length of the line that contains the time.
+        self.assertIn("(Output Time: ", split_gcode[3])
+        self.assertTrue(len(split_gcode[3]) == 41)
+        self.assertEqual(split_gcode[4], "G90")
+        self.assertEqual(split_gcode[5], "G21")
+        self.assertEqual(split_gcode[6], "G54")
+        self.assertEqual(split_gcode[7], "M6 T1")
 
         # Test without comments or header.
         expected = """G90
 G21
+G54
+M6 T1
 """
-        args = "--no-comments --no-header"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
+        self.job.PostProcessorArgs = "--no-comments --no-header"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
 
     #############################################################################
 
     def test00160(self):
         """Test Line Numbers."""
-        self.compare_third_line(
-            "G0 X10 Y20 Z30", "N120 G0 X10.000 Y20.000 Z30.000", "--line-numbers"
-        )
+        self.single_compare("G0 X10 Y20 Z30", "N140 G0 X10.000 Y20.000 Z30.000", "--line-numbers")
 
     #############################################################################
 
     def test00170(self):
         """Test inches."""
-        #
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30 A10 B20 C30 U10 V20 W30")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
-        args = "--inches"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
+        self.profile_op.Path = Path.Path([c])
+        self.job.PostProcessorArgs = "--inches"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[1], "G20")
         self.assertEqual(
-            gcode.splitlines()[2],
+            gcode.splitlines()[4],
             "G0 X0.3937 Y0.7874 Z1.1811 A10.0000 B20.0000 C30.0000 U0.3937 V0.7874 W1.1811",
         )
 
@@ -309,18 +347,20 @@ G21
 
         Suppress the command name if the same as previous
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
         c1 = Path.Command("G0 X10 Y30 Z30")
-        self.docobj.Path = Path.Path([c, c1])
-        postables = [self.docobj]
-        args = "--modal"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[3], "X10.000 Y30.000 Z30.000")
-        args = "--no-modal"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[3], "G0 X10.000 Y30.000 Z30.000")
+        self.profile_op.Path = Path.Path([c, c1])
+
+        self.job.PostProcessorArgs = "--modal"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[5], "X10.000 Y30.000 Z30.000")
+        self.job.PostProcessorArgs = "--no-modal"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[5], "G0 X10.000 Y30.000 Z30.000")
 
     #############################################################################
 
@@ -329,6 +369,8 @@ G21
 
         Empty path.  Outputs all arguments.
         """
+        nl = "\n"
+
         expected = """Arguments that are commonly used:
   --metric              Convert output for Metric mode (G21) (default)
   --inches              Convert output for US imperial mode (G20)
@@ -390,9 +432,11 @@ G21
   --wait-for-spindle WAIT_FOR_SPINDLE
                         Time to wait (in seconds) after M3, M4 (default = 0.0)
 """
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-        gcode: str = postprocessor.export(postables, "-", "--output_all_arguments")
+        self.profile_op.Path = Path.Path([])
+
+        self.job.PostProcessorArgs = "--output_all_arguments"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         # The argparse help routine turns out to be sensitive to the
         # number of columns in the terminal window that the tests
         # are run from.  This affects the indenting in the output.
@@ -408,41 +452,48 @@ G21
 
         Empty path.  Outputs visible arguments.
         """
-        self.single_compare([], "", "--output_visible_arguments")
+        self.profile_op.Path = Path.Path([])
+        expected = ""
+        self.job.PostProcessorArgs = "--output_visible_arguments"
+        gcode = self.post.export()[0][1]
+        self.assertEqual(gcode, expected)
 
     #############################################################################
 
     def test00210(self):
         """Test Post-amble."""
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-        args = "--postamble='G0 Z50\nM2'"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[-2], "G0 Z50")
-        self.assertEqual(gcode.splitlines()[-1], "M2")
+        nl = "\n"
+
+        self.profile_op.Path = Path.Path([])
+        self.job.PostProcessorArgs = "--postamble='G0 Z50\nM2'"
+        gcode = self.post.export()[0][1]
+        split_gcode = gcode.splitlines()
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(split_gcode[-2], "G0 Z50")
+        self.assertEqual(split_gcode[-1], "M2")
 
     #############################################################################
 
     def test00220(self):
         """Test Pre-amble."""
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-        args = "--preamble='G18 G55'"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
+        nl = "\n"
+
+        self.profile_op.Path = Path.Path([])
+        self.job.PostProcessorArgs = "--preamble='G18 G55'"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[0], "G18 G55")
 
     #############################################################################
 
     def test00230(self):
         """Test precision."""
-        self.compare_third_line(
+        self.single_compare(
             "G1 X10 Y20 Z30 F100",
             "G1 X10.00 Y20.00 Z30.00 F6000.00",
             "--precision=2",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G1 X10 Y20 Z30 F100",
             "G1 X0.39 Y0.79 Z1.18 F236.22",
             "--inches --precision=2",
@@ -452,75 +503,93 @@ G21
 
     def test00240(self):
         """Test return-to."""
-        self.compare_third_line("", "G0 X12 Y34 Z56", "--return-to='12,34,56'")
+        self.single_compare("", "G0 X12 Y34 Z56", "--return-to='12,34,56'")
 
     #############################################################################
 
     def test00250(self):
         """Test tlo."""
+        nl = "\n"
+
         c = Path.Command("M6 T2")
         c2 = Path.Command("M3 S3000")
-        self.docobj.Path = Path.Path([c, c2])
-        postables = [self.docobj]
-        args = "--tlo"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[2], "M6 T2")
-        self.assertEqual(gcode.splitlines()[3], "G43 H2")
-        self.assertEqual(gcode.splitlines()[4], "M3 S3000")
+
+        self.profile_op.Path = Path.Path([c, c2])
+
+        self.job.PostProcessorArgs = "--tlo"
+        gcode = self.post.export()[0][1]
+        split_gcode = gcode.splitlines()
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(split_gcode[5], "M6 T2")
+        self.assertEqual(split_gcode[6], "G43 H2")
+        self.assertEqual(split_gcode[7], "M3 S3000")
+
         # suppress TLO
-        args = "--no-tlo"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[2], "M6 T2")
-        self.assertEqual(gcode.splitlines()[3], "M3 S3000")
+        self.job.PostProcessorArgs = "--no-tlo"
+        gcode = self.post.export()[0][1]
+        split_gcode = gcode.splitlines()
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(split_gcode[4], "M6 T2")
+        self.assertEqual(split_gcode[5], "M3 S3000")
 
     #############################################################################
 
     def test00260(self):
         """Test tool_change."""
+        nl = "\n"
+
         c = Path.Command("M6 T2")
         c2 = Path.Command("M3 S3000")
-        self.docobj.Path = Path.Path([c, c2])
-        postables = [self.docobj]
-        args = "--tool_change"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[2], "M6 T2")
-        self.assertEqual(gcode.splitlines()[3], "M3 S3000")
-        args = "--comments --no-tool_change"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[5], "( M6 T2 )")
-        self.assertEqual(gcode.splitlines()[6], "M3 S3000")
+        self.profile_op.Path = Path.Path([c, c2])
+
+        self.job.PostProcessorArgs = "--tool_change"
+        gcode = self.post.export()[0][1]
+        split_gcode = gcode.splitlines()
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(split_gcode[4], "M6 T2")
+        self.assertEqual(split_gcode[5], "M3 S3000")
+
+        self.job.PostProcessorArgs = "--comments --no-tool_change"
+        gcode = self.post.export()[0][1]
+        split_gcode = gcode.splitlines()
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(split_gcode[13], "( M6 T2 )")
+        self.assertEqual(split_gcode[14], "M3 S3000")
 
     #############################################################################
 
     def test00270(self):
         """Test wait-for-spindle."""
+        nl = "\n"
+
         c = Path.Command("M3 S3000")
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
-        args = ""
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[2], "M3 S3000")
-        args = "--wait-for-spindle=1.23456"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[2], "M3 S3000")
-        self.assertEqual(gcode.splitlines()[3], "G4 P1.23456")
+        self.profile_op.Path = Path.Path([c])
+
+        self.job.PostProcessorArgs = ""
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[4], "M3 S3000")
+
+        self.job.PostProcessorArgs = "--wait-for-spindle=1.23456"
+        gcode = self.post.export()[0][1]
+        split_gcode = gcode.splitlines()
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(split_gcode[4], "M3 S3000")
+        self.assertEqual(split_gcode[5], "G4 P1.23456")
+
         c = Path.Command("M4 S3000")
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
+
         # This also tests that the default for --wait-for-spindle
         # goes back to 0.0 (no wait)
-        args = ""
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[2], "M4 S3000")
-        args = "--wait-for-spindle=1.23456"
-        gcode = postprocessor.export(postables, "-", args)
-        # print("--------\n" + gcode + "--------\n")
-        self.assertEqual(gcode.splitlines()[2], "M4 S3000")
-        self.assertEqual(gcode.splitlines()[3], "G4 P1.23456")
+        self.job.PostProcessorArgs = ""
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[4], "M4 S3000")
+
+        self.job.PostProcessorArgs = "--wait-for-spindle=1.23456"
+        gcode = self.post.export()[0][1]
+        split_gcode = gcode.splitlines()
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(split_gcode[4], "M4 S3000")
+        self.assertEqual(split_gcode[5], "G4 P1.23456")

--- a/src/Mod/CAM/CAMTests/TestRefactoredTestPostGCodes.py
+++ b/src/Mod/CAM/CAMTests/TestRefactoredTestPostGCodes.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2022 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022-2023 Larry Woestman <LarryWoestman2@gmail.com>     *
+# *   Copyright (c) 2022-2025 Larry Woestman <LarryWoestman2@gmail.com>     *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -25,7 +25,7 @@ import FreeCAD
 
 import Path
 import CAMTests.PathTestUtils as PathTestUtils
-from Path.Post.scripts import refactored_test_post as postprocessor
+from Path.Post.Processor import PostProcessorFactory
 
 
 Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -46,8 +46,16 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
         This method does not have access to the class `self` reference, but it
         is able to call static methods within this same class.
         """
-        # Open existing FreeCAD document with test geometry
-        FreeCAD.newDocument("Unnamed")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
+        cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/CAMTests/boxtest.fcstd")
+        cls.job = cls.doc.getObject("Job")
+        cls.post = PostProcessorFactory.get_post_processor(cls.job, "refactored_test")
+        # locate the operation named "Profile"
+        for op in cls.job.Operations.Group:
+            if op.Label == "Profile":
+                # remember the "Profile" operation
+                cls.profile_op = op
+                return
 
     @classmethod
     def tearDownClass(cls):
@@ -59,8 +67,8 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
         not have access to the class `self` reference.  This method is able
         to call static methods within this same class.
         """
-        # Close geometry document without saving
-        FreeCAD.closeDocument(FreeCAD.ActiveDocument.Name)
+        FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     # Setup and tear down methods called before and after each unit test
 
@@ -70,14 +78,12 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
         This method is called prior to each `test()` method.  Add code and
         objects here that are needed for multiple `test()` methods.
         """
-        self.doc = FreeCAD.ActiveDocument
-        self.con = FreeCAD.Console
-        self.docobj = FreeCAD.ActiveDocument.addObject("Path::Feature", "testpath")
+        # allow a full length "diff" if an error occurs
+        self.maxDiff = None
         #
-        # Re-initialize all of the values before doing a test.
+        # reinitialize the postprocessor data structures between tests
         #
-        postprocessor.UNITS = "G21"
-        postprocessor.init_values(postprocessor.global_values)
+        self.post.reinitialize()
 
     def tearDown(self):
         """tearDown()...
@@ -85,30 +91,32 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
         This method is called after each test() method. Add cleanup instructions here.
         Such cleanup instructions will likely undo those in the setUp() method.
         """
-        FreeCAD.ActiveDocument.removeObject("testpath")
+        pass
 
     def single_compare(self, path, expected, args, debug=False):
-        """Perform a test with a single comparison."""
+        """Perform a test with a single line of gcode comparison."""
         nl = "\n"
-        self.docobj.Path = Path.Path(path)
-        postables = [self.docobj]
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = args
+        # replace the original path (that came with the job and operation) with our path
+        self.profile_op.Path = Path.Path(path)
+        # the gcode is in the first section for this particular job and operation
+        gcode = self.post.export()[0][1]
+        if debug:
+            print(f"--------{nl}{gcode}--------{nl}")
+        # there are 4 lines of "other stuff" before the line we are interested in
+        self.assertEqual(gcode.splitlines()[4], expected)
+
+    def multi_compare(self, path, expected, args, debug=False):
+        """Perform a test with multiple lines of gcode comparison."""
+        nl = "\n"
+        self.job.PostProcessorArgs = args
+        # replace the original path (that came with the job and operation) with our path
+        self.profile_op.Path = Path.Path(path)
+        # the gcode is in the first section for this particular job and operation
+        gcode = self.post.export()[0][1]
         if debug:
             print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
-
-    def compare_third_line(self, path_string, expected, args, debug=False):
-        """Perform a test with a single comparison to the third line of the output."""
-        nl = "\n"
-        if path_string:
-            self.docobj.Path = Path.Path([Path.Command(path_string)])
-        else:
-            self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-        gcode = postprocessor.export(postables, "-", args)
-        if debug:
-            print(f"--------{nl}{gcode}--------{nl}")
-        self.assertEqual(gcode.splitlines()[2], expected)
 
     #############################################################################
     #
@@ -124,14 +132,14 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
 
     def test10000(self):
         """Test G0 command Generation."""
-        self.compare_third_line(
+        self.single_compare(
             "G0 X10 Y20 Z30 A40 B50 C60 U70 V80 W90",
-            ("G0 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 " "U70.000 V80.000 W90.000"),
+            ("G0 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 U70.000 V80.000 W90.000"),
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G00 X10 Y20 Z30 A40 B50 C60 U70 V80 W90",
-            ("G00 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 " "U70.000 V80.000 W90.000"),
+            ("G00 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 U70.000 V80.000 W90.000"),
             "",
         )
 
@@ -139,7 +147,7 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
 
     def test10010(self):
         """Test G1 command Generation."""
-        self.compare_third_line(
+        self.single_compare(
             "G1 X10 Y20 Z30 A40 B50 C60 U70 V80 W90 F1.23456",
             (
                 "G1 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 "
@@ -147,7 +155,7 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             ),
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G01 X10 Y20 Z30 A40 B50 C60 U70 V80 W90 F1.23456",
             (
                 "G01 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 "
@@ -156,7 +164,7 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             "",
         )
         # Test argument order
-        self.compare_third_line(
+        self.single_compare(
             "G1 F1.23456 Z30 V80 C60 W90 X10 B50 U70 Y20 A40",
             (
                 "G1 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 "
@@ -164,7 +172,7 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             ),
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G1 X10 Y20 Z30 A40 B50 C60 U70 V80 W90 F1.23456",
             (
                 "G1 X0.3937 Y0.7874 Z1.1811 A40.0000 B50.0000 C60.0000 "
@@ -178,27 +186,27 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
     def test10020(self):
         """Test G2 command Generation."""
         #
-        self.compare_third_line(
+        self.single_compare(
             "G2 X10 Y20 Z30 I40 J50 P60 F1.23456",
             "G2 X10.000 Y20.000 Z30.000 I40.000 J50.000 P60 F74.074",
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G02 X10 Y20 Z30 I40 J50 P60 F1.23456",
             "G02 X10.000 Y20.000 Z30.000 I40.000 J50.000 P60 F74.074",
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G2 X10 Y20 Z30 R40 P60 F1.23456",
             "G2 X10.000 Y20.000 Z30.000 R40.000 P60 F74.074",
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G2 X10 Y20 Z30 I40 J50 P60 F1.23456",
             "G2 X0.3937 Y0.7874 Z1.1811 I1.5748 J1.9685 P60 F2.9163",
             "--inches",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G2 X10 Y20 Z30 R40 P60 F1.23456",
             "G2 X0.3937 Y0.7874 Z1.1811 R1.5748 P60 F2.9163",
             "--inches",
@@ -208,27 +216,27 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
 
     def test10030(self):
         """Test G3 command Generation."""
-        self.compare_third_line(
+        self.single_compare(
             "G3 X10 Y20 Z30 I40 J50 P60 F1.23456",
             "G3 X10.000 Y20.000 Z30.000 I40.000 J50.000 P60 F74.074",
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G03 X10 Y20 Z30 I40 J50 P60 F1.23456",
             "G03 X10.000 Y20.000 Z30.000 I40.000 J50.000 P60 F74.074",
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G3 X10 Y20 Z30 R40 P60 F1.23456",
             "G3 X10.000 Y20.000 Z30.000 R40.000 P60 F74.074",
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G3 X10 Y20 Z30 I40 J50 P60 F1.23456",
             "G3 X0.3937 Y0.7874 Z1.1811 I1.5748 J1.9685 P60 F2.9163",
             "--inches",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G3 X10 Y20 Z30 R40 P60 F1.23456",
             "G3 X0.3937 Y0.7874 Z1.1811 R1.5748 P60 F2.9163",
             "--inches",
@@ -243,59 +251,59 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
         # The P parameter indicates "time to wait" where a 0.001 would
         # be a millisecond wait, so more than 3 or 4 digits of precision
         # might be useful.
-        self.compare_third_line("G4 P1.23456", "G4 P1.23456", "")
-        self.compare_third_line("G04 P1.23456", "G04 P1.23456", "")
-        self.compare_third_line("G4 P1.23456", "G4 P1.23456", "--inches")
+        self.single_compare("G4 P1.23456", "G4 P1.23456", "")
+        self.single_compare("G04 P1.23456", "G04 P1.23456", "")
+        self.single_compare("G4 P1.23456", "G4 P1.23456", "--inches")
 
     #############################################################################
 
     def test10070(self):
         """Test G7 command Generation."""
-        self.compare_third_line("G7", "G7", "")
+        self.single_compare("G7", "G7", "")
 
     #############################################################################
 
     def test10080(self):
         """Test G8 command Generation."""
-        self.compare_third_line("G8", "G8", "")
+        self.single_compare("G8", "G8", "")
 
     #############################################################################
 
     def test10100(self):
         """Test G10 command Generation."""
-        self.compare_third_line("G10 L1 P2 Z1.23456", "G10 L1 Z1.235 P2", "")
-        self.compare_third_line(
+        self.single_compare("G10 L1 P2 Z1.23456", "G10 L1 Z1.235 P2", "")
+        self.single_compare(
             "G10 L1 P2 R1.23456 I2.34567 J3.456789 Q3",
             "G10 L1 I2.346 J3.457 R1.235 P2 Q3",
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G10 L2 P3 X1.23456 Y2.34567 Z3.456789",
             "G10 L2 X1.235 Y2.346 Z3.457 P3",
             "",
         )
-        self.compare_third_line("G10 L2 P0 X0 Y0 Z0", "G10 L2 X0.000 Y0.000 Z0.000 P0", "")
-        self.compare_third_line(
+        self.single_compare("G10 L2 P0 X0 Y0 Z0", "G10 L2 X0.000 Y0.000 Z0.000 P0", "")
+        self.single_compare(
             "G10 L10 P1 X1.23456 Y2.34567 Z3.456789",
             "G10 L10 X1.235 Y2.346 Z3.457 P1",
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G10 L10 P2 R1.23456 I2.34567 J3.456789 Q3",
             "G10 L10 I2.346 J3.457 R1.235 P2 Q3",
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G10 L11 P1 X1.23456 Y2.34567 Z3.456789",
             "G10 L11 X1.235 Y2.346 Z3.457 P1",
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G10 L11 P2 R1.23456 I2.34567 J3.456789 Q3",
             "G10 L11 I2.346 J3.457 R1.235 P2 Q3",
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             "G10 L20 P9 X1.23456 Y2.34567 Z3.456789",
             "G10 L20 X1.235 Y2.346 Z3.457 P9",
             "",
@@ -305,58 +313,62 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
 
     def test10170(self):
         """Test G17 command Generation."""
-        self.compare_third_line("G17", "G17", "")
+        self.single_compare("G17", "G17", "")
 
     #############################################################################
 
     def test10171(self):
         """Test G17.1 command Generation."""
-        self.compare_third_line("G17.1", "G17.1", "")
+        self.single_compare("G17.1", "G17.1", "")
 
     #############################################################################
 
     def test10180(self):
         """Test G18 command Generation."""
-        self.compare_third_line("G18", "G18", "")
+        self.single_compare("G18", "G18", "")
 
     #############################################################################
 
     def test10181(self):
         """Test G18.1 command Generation."""
-        self.compare_third_line("G18.1", "G18.1", "")
+        self.single_compare("G18.1", "G18.1", "")
 
     #############################################################################
 
     def test10190(self):
         """Test G19 command Generation."""
-        self.compare_third_line("G19", "G19", "")
+        self.single_compare("G19", "G19", "")
 
     #############################################################################
 
     def test10191(self):
         """Test G19.1 command Generation."""
-        self.compare_third_line("G19.1", "G19.1", "")
+        self.single_compare("G19.1", "G19.1", "")
 
     #############################################################################
 
     def test10200(self):
         """Test G20 command Generation."""
-        self.compare_third_line("G20", "G20", "")
+        # for some reason, Path.Path("G20") doesn't do the same thing
+        # as Path.Path([Path.Command("G20")])
+        self.single_compare([Path.Command("G20")], "G20", "")
 
     #############################################################################
 
     def test10210(self):
         """Test G21 command Generation."""
-        self.compare_third_line("G21", "G21", "")
+        # for some reason, Path.Path("G21") doesn't do the same thing
+        # as Path.Path([Path.Command("G21")])
+        self.single_compare([Path.Command("G21")], "G21", "")
 
     #############################################################################
 
     def test10280(self):
         """Test G28 command Generation."""
-        self.compare_third_line("G28", "G28", "")
-        self.compare_third_line(
+        self.single_compare("G28", "G28", "")
+        self.single_compare(
             "G28 X10 Y20 Z30 A40 B50 C60 U70 V80 W90",
-            ("G28 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 " "U70.000 V80.000 W90.000"),
+            ("G28 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 U70.000 V80.000 W90.000"),
             "",
         )
 
@@ -364,16 +376,16 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
 
     def test10281(self):
         """Test G28.1 command Generation."""
-        self.compare_third_line("G28.1", "G28.1", "")
+        self.single_compare("G28.1", "G28.1", "")
 
     #############################################################################
 
     def test10300(self):
         """Test G30 command Generation."""
-        self.compare_third_line("G30", "G30", "")
-        self.compare_third_line(
+        self.single_compare("G30", "G30", "")
+        self.single_compare(
             "G30 X10 Y20 Z30 A40 B50 C60 U70 V80 W90",
-            ("G30 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 " "U70.000 V80.000 W90.000"),
+            ("G30 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 U70.000 V80.000 W90.000"),
             "",
         )
 
@@ -381,7 +393,7 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
 
     def test10382(self):
         """Test G38.2 command Generation."""
-        self.compare_third_line(
+        self.single_compare(
             "G38.2 X10 Y20 Z30 A40 B50 C60 U70 V80 W90 F123",
             (
                 "G38.2 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 "
@@ -394,7 +406,7 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
 
     def test10383(self):
         """Test G38.3 command Generation."""
-        self.compare_third_line(
+        self.single_compare(
             "G38.3 X10 Y20 Z30 A40 B50 C60 U70 V80 W90 F123",
             (
                 "G38.3 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 "
@@ -407,7 +419,7 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
 
     def test10384(self):
         """Test G38.4 command Generation."""
-        self.compare_third_line(
+        self.single_compare(
             "G38.4 X10 Y20 Z30 A40 B50 C60 U70 V80 W90 F123",
             (
                 "G38.4 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 "
@@ -420,7 +432,7 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
 
     def test10385(self):
         """Test G38.5 command Generation."""
-        self.compare_third_line(
+        self.single_compare(
             "G38.5 X10 Y20 Z30 A40 B50 C60 U70 V80 W90 F123",
             (
                 "G38.5 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 "
@@ -433,59 +445,59 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
 
     def test10301(self):
         """Test G30.1 command Generation."""
-        self.compare_third_line("G30.1", "G30.1", "")
+        self.single_compare("G30.1", "G30.1", "")
 
     #############################################################################
 
     def test10400(self):
         """Test G40 command Generation."""
-        self.compare_third_line("G40", "G40", "")
-        self.compare_third_line("G40", "G40", "--inches")
+        self.single_compare("G40", "G40", "")
+        self.single_compare("G40", "G40", "--inches")
 
     #############################################################################
 
     def test10410(self):
         """Test G41 command Generation."""
-        self.compare_third_line("G41 D1.23456", "G41 D1", "")
-        self.compare_third_line("G41 D0", "G41 D0", "")
-        self.compare_third_line("G41 D1.23456", "G41 D1", "--inches")
+        self.single_compare("G41 D1.23456", "G41 D1", "")
+        self.single_compare("G41 D0", "G41 D0", "")
+        self.single_compare("G41 D1.23456", "G41 D1", "--inches")
 
     #############################################################################
 
     def test10411(self):
         """Test G41.1 command Generation."""
-        self.compare_third_line("G41.1 D1.23456 L3", "G41.1 D1.235 L3", "")
-        self.compare_third_line("G41.1 D1.23456 L3", "G41.1 D0.0486 L3", "--inches")
+        self.single_compare("G41.1 D1.23456 L3", "G41.1 D1.235 L3", "")
+        self.single_compare("G41.1 D1.23456 L3", "G41.1 D0.0486 L3", "--inches")
 
     #############################################################################
 
     def test10420(self):
         """Test G42 command Generation."""
-        self.compare_third_line("G42 D1.23456", "G42 D1", "")
-        self.compare_third_line("G42 D0", "G42 D0", "")
-        self.compare_third_line("G42 D1.23456", "G42 D1", "--inches")
+        self.single_compare("G42 D1.23456", "G42 D1", "")
+        self.single_compare("G42 D0", "G42 D0", "")
+        self.single_compare("G42 D1.23456", "G42 D1", "--inches")
 
     #############################################################################
 
     def test10421(self):
         """Test G42.1 command Generation."""
-        self.compare_third_line("G42.1 D1.23456 L3", "G42.1 D1.235 L3", "")
-        self.compare_third_line("G42.1 D1.23456 L3", "G42.1 D0.0486 L3", "--inches")
+        self.single_compare("G42.1 D1.23456 L3", "G42.1 D1.235 L3", "")
+        self.single_compare("G42.1 D1.23456 L3", "G42.1 D0.0486 L3", "--inches")
 
     #############################################################################
 
     def test10430(self):
         """Test G43 command Generation."""
-        self.compare_third_line("G43", "G43", "")
-        self.compare_third_line("G43 H1.23456", "G43 H1", "")
-        self.compare_third_line("G43 H0", "G43 H0", "")
-        self.compare_third_line("G43 H1.23456", "G43 H1", "--inches")
+        self.single_compare("G43", "G43", "")
+        self.single_compare("G43 H1.23456", "G43 H1", "")
+        self.single_compare("G43 H0", "G43 H0", "")
+        self.single_compare("G43 H1.23456", "G43 H1", "--inches")
 
     #############################################################################
 
     def test10431(self):
         """Test G43.1 command Generation."""
-        self.compare_third_line(
+        self.single_compare(
             (
                 "G43.1 X1.234567 Y2.345678 Z3.456789 A4.567891 B5.678912 C6.789123 "
                 "U7.891234 V8.912345 W9.123456"
@@ -493,12 +505,12 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             "G43.1 X1.235 Y2.346 Z3.457 A4.568 B5.679 C6.789 U7.891 V8.912 W9.123",
             "",
         )
-        self.compare_third_line(
+        self.single_compare(
             (
                 "G43.1 X1.234567 Y2.345678 Z3.456789 A4.567891 B5.678912 C6.789123 "
                 "U7.891234 V8.912345 W9.123456"
             ),
-            ("G43.1 X0.0486 Y0.0923 Z0.1361 A4.5679 B5.6789 C6.7891 " "U0.3107 V0.3509 W0.3592"),
+            ("G43.1 X0.0486 Y0.0923 Z0.1361 A4.5679 B5.6789 C6.7891 U0.3107 V0.3509 W0.3592"),
             "--inches",
         )
 
@@ -506,50 +518,38 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
 
     def test10432(self):
         """Test G43.2 command Generation."""
-        self.compare_third_line("G43.2 H1.23456", "G43.2 H1", "")
+        self.single_compare("G43.2 H1.23456", "G43.2 H1", "")
 
     #############################################################################
 
     def test10490(self):
         """Test G49 command Generation."""
-        self.compare_third_line("G49", "G49", "")
+        self.single_compare("G49", "G49", "")
 
     #############################################################################
 
     def test10520(self):
         """Test G52 command Generation."""
         self.single_compare(
-            [
-                Path.Command(
-                    (
-                        "G52 X1.234567 Y2.345678 Z3.456789 A4.567891 B5.678912 "
-                        "C6.789123 U7.891234 V8.912345 W9.123456"
-                    )
-                ),
-                Path.Command("G52 X0 Y0.0 Z0.00 A0.000 B0.0000 C0.00000 U0.000000 V0 W0"),
-            ],
-            """G90
-G21
-G52 X1.235 Y2.346 Z3.457 A4.568 B5.679 C6.789 U7.891 V8.912 W9.123
-G52 X0.000 Y0.000 Z0.000 A0.000 B0.000 C0.000 U0.000 V0.000 W0.000
-""",
+            "G52 X1.234567 Y2.345678 Z3.456789 A4.567891 B5.678912 C6.789123 "
+            "U7.891234 V8.912345 W9.123456",
+            "G52 X1.235 Y2.346 Z3.457 A4.568 B5.679 C6.789 U7.891 V8.912 W9.123",
             "",
         )
         self.single_compare(
-            [
-                Path.Command(
-                    (
-                        "G52 X1.234567 Y2.345678 Z3.456789 A4.567891 B5.678912 "
-                        "C6.789123 U7.891234 V8.912345 W9.123456"
-                    )
-                ),
-                Path.Command("G52 X0 Y0.0 Z0.00 A0.000 B0.0000 C0.00000 U0.000000 V0 W0"),
-            ],
-            """G90
-G20
-G52 X0.0486 Y0.0923 Z0.1361 A4.5679 B5.6789 C6.7891 U0.3107 V0.3509 W0.3592
-G52 X0.0000 Y0.0000 Z0.0000 A0.0000 B0.0000 C0.0000 U0.0000 V0.0000 W0.0000
-""",
+            "G52 X0 Y0.0 Z0.00 A0.000 B0.0000 C0.00000 U0.000000 V0 W0",
+            "G52 X0.000 Y0.000 Z0.000 A0.000 B0.000 C0.000 U0.000 V0.000 W0.000",
+            "",
+        )
+        self.single_compare(
+            "G52 X1.234567 Y2.345678 Z3.456789 A4.567891 B5.678912 C6.789123 "
+            "U7.891234 V8.912345 W9.123456",
+            "G52 X0.0486 Y0.0923 Z0.1361 A4.5679 B5.6789 C6.7891 U0.3107 V0.3509 W0.3592",
+            "--inches",
+        )
+        self.single_compare(
+            "G52 X0 Y0.0 Z0.00 A0.000 B0.0000 C0.00000 U0.000000 V0 W0",
+            "G52 X0.0000 Y0.0000 Z0.0000 A0.0000 B0.0000 C0.0000 U0.0000 V0.0000 W0.0000",
             "--inches",
         )
 
@@ -585,7 +585,7 @@ G52 X0.0000 Y0.0000 Z0.0000 A0.0000 B0.0000 C0.0000 U0.0000 V0.0000 W0.0000
 
     def test10540(self):
         """Test G54 command Generation."""
-        self.compare_third_line("G54", "G54", "")
+        self.single_compare("G54", "G54", "")
 
     #############################################################################
 
@@ -595,118 +595,118 @@ G52 X0.0000 Y0.0000 Z0.0000 A0.0000 B0.0000 C0.0000 U0.0000 V0.0000 W0.0000
         # Some gcode interpreters use G54.1 P- to select additional
         # work coordinate systems.
         #
-        self.compare_third_line("G54.1 P2.34567", "G54.1 P2", "")
+        self.single_compare("G54.1 P2.34567", "G54.1 P2", "")
 
     #############################################################################
 
     def test10550(self):
         """Test G55 command Generation."""
-        self.compare_third_line("G55", "G55", "")
+        self.single_compare("G55", "G55", "")
 
     #############################################################################
 
     def test10560(self):
         """Test G56 command Generation."""
-        self.compare_third_line("G56", "G56", "")
+        self.single_compare("G56", "G56", "")
 
     #############################################################################
 
     def test10570(self):
         """Test G57 command Generation."""
-        self.compare_third_line("G57", "G57", "")
+        self.single_compare("G57", "G57", "")
 
     #############################################################################
 
     def test10580(self):
         """Test G58 command Generation."""
-        self.compare_third_line("G58", "G58", "")
+        self.single_compare("G58", "G58", "")
 
     #############################################################################
 
     def test10590(self):
         """Test G59 command Generation."""
-        self.compare_third_line("G59", "G59", "")
+        self.single_compare("G59", "G59", "")
         #
         # Some gcode interpreters use G59 P- to select additional
         # work coordinate systems.  This is considered somewhat
         # obsolete and is being replaced by G54.1 P- instead.
         #
-        self.compare_third_line("G59 P2.34567", "G59 P2", "")
+        self.single_compare("G59 P2.34567", "G59 P2", "")
 
     #############################################################################
 
     def test10591(self):
         """Test G59.1 command Generation."""
-        self.compare_third_line("G59.1", "G59.1", "")
+        self.single_compare("G59.1", "G59.1", "")
 
     #############################################################################
 
     def test10592(self):
         """Test G59.2 command Generation."""
-        self.compare_third_line("G59.2", "G59.2", "")
+        self.single_compare("G59.2", "G59.2", "")
 
     #############################################################################
 
     def test10593(self):
         """Test G59.3 command Generation."""
-        self.compare_third_line("G59.3", "G59.3", "")
+        self.single_compare("G59.3", "G59.3", "")
 
     #############################################################################
 
     def test10594(self):
         """Test G59.4 command Generation."""
-        self.compare_third_line("G59.4", "G59.4", "")
+        self.single_compare("G59.4", "G59.4", "")
 
     #############################################################################
 
     def test10595(self):
         """Test G59.5 command Generation."""
-        self.compare_third_line("G59.5", "G59.5", "")
+        self.single_compare("G59.5", "G59.5", "")
 
     #############################################################################
 
     def test10596(self):
         """Test G59.6 command Generation."""
-        self.compare_third_line("G59.6", "G59.6", "")
+        self.single_compare("G59.6", "G59.6", "")
 
     #############################################################################
 
     def test10597(self):
         """Test G59.7 command Generation."""
-        self.compare_third_line("G59.7", "G59.7", "")
+        self.single_compare("G59.7", "G59.7", "")
 
     #############################################################################
 
     def test10598(self):
         """Test G59.8 command Generation."""
-        self.compare_third_line("G59.8", "G59.8", "")
+        self.single_compare("G59.8", "G59.8", "")
 
     #############################################################################
 
     def test10599(self):
         """Test G59.9 command Generation."""
-        self.compare_third_line("G59.9", "G59.9", "")
+        self.single_compare("G59.9", "G59.9", "")
 
     #############################################################################
 
     def test10610(self):
         """Test G61 command Generation."""
-        self.compare_third_line("G61", "G61", "")
+        self.single_compare("G61", "G61", "")
 
     #############################################################################
 
     def test10611(self):
         """Test G61.1 command Generation."""
-        self.compare_third_line("G61.1", "G61.1", "")
+        self.single_compare("G61.1", "G61.1", "")
 
     #############################################################################
 
     def test10640(self):
         """Test G64 command Generation."""
-        self.compare_third_line("G64", "G64", "")
-        self.compare_third_line("G64 P3.456789", "G64 P3.457", "")
-        self.compare_third_line("G64 P3.456789 Q4.567891", "G64 P3.457 Q4.568", "")
-        self.compare_third_line("G64 P3.456789 Q4.567891", "G64 P0.1361 Q0.1798", "--inches")
+        self.single_compare("G64", "G64", "")
+        self.single_compare("G64 P3.456789", "G64 P3.457", "")
+        self.single_compare("G64 P3.456789 Q4.567891", "G64 P3.457 Q4.568", "")
+        self.single_compare("G64 P3.456789 Q4.567891", "G64 P0.1361 Q0.1798", "--inches")
 
     #############################################################################
 
@@ -721,10 +721,12 @@ G52 X0.0000 Y0.0000 Z0.0000 A0.0000 B0.0000 C0.0000 U0.0000 V0.0000 W0.0000
             Path.Command("G80"),
             Path.Command("G90"),
         ]
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G90
@@ -735,10 +737,12 @@ G90
 """,
             "",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G90
@@ -759,11 +763,19 @@ G90
 """,
             "--translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """(Begin preamble)
 G90
 G21
+(Begin operation)
+G54
+(Finish operation: Fixture)
+(Begin operation)
+(TC: Default Tool)
+(Begin toolchange)
+( M6 T1 )
+(Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
@@ -785,18 +797,18 @@ G1 Z0.000 F7380.000
 G0 Z5.000
 ( G80 )
 G90
-(Finish operation: testpath)
+(Finish operation: Profile)
 (Begin postamble)
 """,
             "--comments --translate_drill",
         )
         #
-        # Re-initialize all of the values before doing more tests.
+        # reinitialize the postprocessor data structures before doing more tests
         #
-        postprocessor.UNITS = "G21"
-        postprocessor.init_values(postprocessor.global_values)
+        self.post.reinitialize()
         #
-        # Test translate_drill with G83 and G91.
+        # Test translate_drill with G73 and G91.
+        #
         path = [
             Path.Command("G0 X1 Y2"),
             Path.Command("G0 Z8"),
@@ -806,10 +818,12 @@ G90
             Path.Command("G80"),
             Path.Command("G90"),
         ]
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G91
@@ -820,10 +834,12 @@ G90
 """,
             "--no-comments --no-translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G91
@@ -846,11 +862,19 @@ G90
 """,
             "--translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """(Begin preamble)
 G90
 G21
+(Begin operation)
+G54
+(Finish operation: Fixture)
+(Begin operation)
+(TC: Default Tool)
+(Begin toolchange)
+( M6 T1 )
+(Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
@@ -874,7 +898,7 @@ G0 Z13.000
 G91
 ( G80 )
 G90
-(Finish operation: testpath)
+(Finish operation: Profile)
 (Begin postamble)
 """,
             "--comments --translate_drill",
@@ -893,10 +917,12 @@ G90
             Path.Command("G80"),
             Path.Command("G90"),
         ]
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G90
@@ -905,12 +931,14 @@ G81 X1.000 Y2.000 Z0.000 R5.000 F7380.000
 G80
 G90
 """,
-            "",
+            "--no-translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G90
@@ -922,11 +950,19 @@ G90
 """,
             "--translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """(Begin preamble)
 G90
 G21
+(Begin operation)
+G54
+(Finish operation: Fixture)
+(Begin operation)
+(TC: Default Tool)
+(Begin toolchange)
+( M6 T1 )
+(Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
@@ -939,18 +975,18 @@ G1 Z0.000 F7380.000
 G0 Z5.000
 ( G80 )
 G90
-(Finish operation: testpath)
+(Finish operation: Profile)
 (Begin postamble)
 """,
             "--comments --translate_drill",
         )
         #
-        # Re-initialize all of the values before doing more tests.
+        # reinitialize the postprocessor data structures before doing more tests
         #
-        postprocessor.UNITS = "G21"
-        postprocessor.init_values(postprocessor.global_values)
+        self.post.reinitialize()
         #
         # Test translate_drill with G81 and G91.
+        #
         path = [
             Path.Command("G0 X1 Y2"),
             Path.Command("G0 Z8"),
@@ -960,10 +996,12 @@ G90
             Path.Command("G80"),
             Path.Command("G90"),
         ]
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G91
@@ -972,12 +1010,14 @@ G81 X1.000 Y2.000 Z0.000 R5.000 F7380.000
 G80
 G90
 """,
-            "--no-comments --no-translate_drill",
+            "--no-translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G91
@@ -991,11 +1031,19 @@ G90
 """,
             "--translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """(Begin preamble)
 G90
 G21
+(Begin operation)
+G54
+(Finish operation: Fixture)
+(Begin operation)
+(TC: Default Tool)
+(Begin toolchange)
+( M6 T1 )
+(Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
@@ -1010,7 +1058,7 @@ G0 Z13.000
 G91
 ( G80 )
 G90
-(Finish operation: testpath)
+(Finish operation: Profile)
 (Begin postamble)
 """,
             "--comments --translate_drill",
@@ -1029,10 +1077,12 @@ G90
             Path.Command("G80"),
             Path.Command("G90"),
         ]
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G90
@@ -1041,12 +1091,14 @@ G82 X1.000 Y2.000 Z0.000 R5.000 P1.23456 F7380.000
 G80
 G90
 """,
-            "",
+            "--no-translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G90
@@ -1059,11 +1111,19 @@ G90
 """,
             "--translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """(Begin preamble)
 G90
 G21
+(Begin operation)
+G54
+(Finish operation: Fixture)
+(Begin operation)
+(TC: Default Tool)
+(Begin toolchange)
+( M6 T1 )
+(Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
@@ -1077,18 +1137,18 @@ G4 P1.23456
 G0 Z5.000
 ( G80 )
 G90
-(Finish operation: testpath)
+(Finish operation: Profile)
 (Begin postamble)
 """,
             "--comments --translate_drill",
         )
         #
-        # Re-initialize all of the values before doing more tests.
+        # reinitialize the postprocessor data structures before doing more tests
         #
-        postprocessor.UNITS = "G21"
-        postprocessor.init_values(postprocessor.global_values)
+        self.post.reinitialize()
         #
         # Test translate_drill with G82 and G91.
+        #
         path = [
             Path.Command("G0 X1 Y2"),
             Path.Command("G0 Z8"),
@@ -1098,10 +1158,12 @@ G90
             Path.Command("G80"),
             Path.Command("G90"),
         ]
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G91
@@ -1110,12 +1172,14 @@ G82 X1.000 Y2.000 Z0.000 R5.000 P1.23456 F7380.000
 G80
 G90
 """,
-            "--no-comments --no-translate_drill",
+            "--no-translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G91
@@ -1130,11 +1194,19 @@ G90
 """,
             "--translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """(Begin preamble)
 G90
 G21
+(Begin operation)
+G54
+(Finish operation: Fixture)
+(Begin operation)
+(TC: Default Tool)
+(Begin toolchange)
+( M6 T1 )
+(Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
@@ -1150,7 +1222,7 @@ G0 Z13.000
 G91
 ( G80 )
 G90
-(Finish operation: testpath)
+(Finish operation: Profile)
 (Begin postamble)
 """,
             "--comments --translate_drill",
@@ -1169,10 +1241,12 @@ G90
             Path.Command("G80"),
             Path.Command("G90"),
         ]
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G90
@@ -1181,12 +1255,14 @@ G83 X1.000 Y2.000 Z0.000 R5.000 Q1.500 F7380.000
 G80
 G90
 """,
-            "",
+            "--no-translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G90
@@ -1207,11 +1283,19 @@ G90
 """,
             "--translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """(Begin preamble)
 G90
 G21
+(Begin operation)
+G54
+(Finish operation: Fixture)
+(Begin operation)
+(TC: Default Tool)
+(Begin toolchange)
+( M6 T1 )
+(Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
@@ -1233,18 +1317,18 @@ G1 Z0.000 F7380.000
 G0 Z5.000
 ( G80 )
 G90
-(Finish operation: testpath)
+(Finish operation: Profile)
 (Begin postamble)
 """,
             "--comments --translate_drill",
         )
         #
-        # Re-initialize all of the values before doing more tests.
+        # reinitialize the postprocessor data structures before doing more tests
         #
-        postprocessor.UNITS = "G21"
-        postprocessor.init_values(postprocessor.global_values)
+        self.post.reinitialize()
         #
         # Test translate_drill with G83 and G91.
+        #
         path = [
             Path.Command("G0 X1 Y2"),
             Path.Command("G0 Z8"),
@@ -1254,10 +1338,12 @@ G90
             Path.Command("G80"),
             Path.Command("G90"),
         ]
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G91
@@ -1266,12 +1352,14 @@ G83 X1.000 Y2.000 Z0.000 R5.000 Q1.500 F7380.000
 G80
 G90
 """,
-            "--no-comments --no-translate_drill",
+            "--no-translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """G90
 G21
+G54
+M6 T1
 G0 X1.000 Y2.000
 G0 Z8.000
 G91
@@ -1294,11 +1382,19 @@ G90
 """,
             "--translate_drill",
         )
-        self.single_compare(
+        self.multi_compare(
             path,
             """(Begin preamble)
 G90
 G21
+(Begin operation)
+G54
+(Finish operation: Fixture)
+(Begin operation)
+(TC: Default Tool)
+(Begin toolchange)
+( M6 T1 )
+(Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
@@ -1322,7 +1418,7 @@ G0 Z13.000
 G91
 ( G80 )
 G90
-(Finish operation: testpath)
+(Finish operation: Profile)
 (Begin postamble)
 """,
             "--comments --translate_drill",
@@ -1332,33 +1428,37 @@ G90
 
     def test10900(self):
         """Test G90 command Generation."""
-        self.compare_third_line("G90", "G90", "")
+        # specifying no arguments ("") doesn't set all of the arguments
+        # back to defaults any more, so tests are more order dependent
+        # This test works when run by itself but fails when run after
+        # test10830 because comments are being generated.
+        self.single_compare("G90", "G90", "--no-comments")
 
     #############################################################################
 
     def test10901(self):
         """Test G90.1 command Generation."""
-        self.compare_third_line("G90.1", "G90.1", "")
+        self.single_compare("G90.1", "G90.1", "")
 
     #############################################################################
 
     def test10910(self):
         """Test G91 command Generation."""
-        self.compare_third_line("G91", "G91", "")
+        self.single_compare("G91", "G91", "")
 
     #############################################################################
 
     def test10911(self):
         """Test G91.1 command Generation."""
-        self.compare_third_line("G91.1", "G91.1", "")
+        self.single_compare("G91.1", "G91.1", "")
 
     #############################################################################
 
     def test10920(self):
         """Test G92 command Generation."""
-        self.compare_third_line(
+        self.single_compare(
             "G92 X10 Y20 Z30 A40 B50 C60 U70 V80 W90",
-            ("G92 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 " "U70.000 V80.000 W90.000"),
+            ("G92 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 U70.000 V80.000 W90.000"),
             "",
         )
 
@@ -1366,49 +1466,49 @@ G90
 
     def test10921(self):
         """Test G92.1 command Generation."""
-        self.compare_third_line("G92.1", "G92.1", "")
+        self.single_compare("G92.1", "G92.1", "")
 
     #############################################################################
 
     def test10922(self):
         """Test G92.2 command Generation."""
-        self.compare_third_line("G92.2", "G92.2", "")
+        self.single_compare("G92.2", "G92.2", "")
 
     #############################################################################
 
     def test10923(self):
         """Test G92.3 command Generation."""
-        self.compare_third_line("G92.3", "G92.3", "")
+        self.single_compare("G92.3", "G92.3", "")
 
     #############################################################################
 
     def test10930(self):
         """Test G93 command Generation."""
-        self.compare_third_line("G93", "G93", "")
+        self.single_compare("G93", "G93", "")
 
     #############################################################################
 
     def test10940(self):
         """Test G94 command Generation."""
-        self.compare_third_line("G94", "G94", "")
+        self.single_compare("G94", "G94", "")
 
     #############################################################################
 
     def test10950(self):
         """Test G95 command Generation."""
-        self.compare_third_line("G95", "G95", "")
+        self.single_compare("G95", "G95", "")
 
     #############################################################################
 
     def test10980(self):
         """Test G98 command Generation."""
-        self.compare_third_line("G98", "G98", "")
+        self.single_compare("G98", "G98", "")
 
     #############################################################################
 
     def test10990(self):
         """Test G99 command Generation."""
-        self.compare_third_line("G99", "G99", "")
+        self.single_compare("G99", "G99", "")
 
     #############################################################################
     #############################################################################
@@ -1457,15 +1557,15 @@ G90
                 with self.subTest(
                     "individual axis test", axis_name=axis_name, input_value=input_value
                 ):
-                    self.compare_third_line(
+                    self.single_compare(
                         f"G1 X10 Y20 Z30 {axis_name}{input_value}",
                         f"G1 X10.000 Y20.000 Z30.000 {axis_name}{metric_output_expected}",
-                        "",
+                        "--no-comments",
                     )
-                    self.compare_third_line(
+                    self.single_compare(
                         f"G1 X10 Y20 Z30 {axis_name}{input_value}",
                         f"G1 X0.3937 Y0.7874 Z1.1811 {axis_name}{inches_output_expected}",
-                        "--inches",
+                        "--no-comments --inches",
                     )
 
     #############################################################################
@@ -1659,13 +1759,13 @@ G90
                 b_input_value=b_input_value,
                 c_input_value=c_input_value,
             ):
-                self.compare_third_line(
+                self.single_compare(
                     f"G1 X10 Y20 Z30 A{a_input_value} B{b_input_value} C{c_input_value}",
                     f"G1 X10.000 Y20.000 Z30.000 A{a_metric_output_expected} "
                     f"B{b_metric_output_expected} C{c_metric_output_expected}",
                     "",
                 )
-                self.compare_third_line(
+                self.single_compare(
                     f"G1 X10 Y20 Z30 A{a_input_value} B{b_input_value} C{c_input_value}",
                     f"G1 X0.3937 Y0.7874 Z1.1811 A{a_inches_output_expected} "
                     f"B{b_inches_output_expected} C{c_inches_output_expected}",

--- a/src/Mod/CAM/CAMTests/TestRefactoredTestPostMCodes.py
+++ b/src/Mod/CAM/CAMTests/TestRefactoredTestPostMCodes.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2022 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022-2023 Larry Woestman <LarryWoestman2@gmail.com>     *
+# *   Copyright (c) 2022-2025 Larry Woestman <LarryWoestman2@gmail.com>     *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -25,7 +25,7 @@ import FreeCAD
 
 import Path
 import CAMTests.PathTestUtils as PathTestUtils
-from Path.Post.scripts import refactored_test_post as postprocessor
+from Path.Post.Processor import PostProcessorFactory
 
 
 Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -46,8 +46,16 @@ class TestRefactoredTestPostMCodes(PathTestUtils.PathTestBase):
         This method does not have access to the class `self` reference, but it
         is able to call static methods within this same class.
         """
-        # Open existing FreeCAD document with test geometry
-        FreeCAD.newDocument("Unnamed")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
+        cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/CAMTests/boxtest.fcstd")
+        cls.job = cls.doc.getObject("Job")
+        cls.post = PostProcessorFactory.get_post_processor(cls.job, "refactored_test")
+        # locate the operation named "Profile"
+        for op in cls.job.Operations.Group:
+            if op.Label == "Profile":
+                # remember the "Profile" operation
+                cls.profile_op = op
+                return
 
     @classmethod
     def tearDownClass(cls):
@@ -59,8 +67,8 @@ class TestRefactoredTestPostMCodes(PathTestUtils.PathTestBase):
         not have access to the class `self` reference.  This method is able
         to call static methods within this same class.
         """
-        # Close geometry document without saving
-        FreeCAD.closeDocument(FreeCAD.ActiveDocument.Name)
+        FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     # Setup and tear down methods called before and after each unit test
 
@@ -70,14 +78,12 @@ class TestRefactoredTestPostMCodes(PathTestUtils.PathTestBase):
         This method is called prior to each `test()` method.  Add code and
         objects here that are needed for multiple `test()` methods.
         """
-        self.doc = FreeCAD.ActiveDocument
-        self.con = FreeCAD.Console
-        self.docobj = FreeCAD.ActiveDocument.addObject("Path::Feature", "testpath")
+        # allow a full length "diff" if an error occurs
+        self.maxDiff = None
         #
-        # Re-initialize all of the values before doing a test.
+        # reinitialize the postprocessor data structures between tests
         #
-        postprocessor.UNITS = "G21"
-        postprocessor.init_values(postprocessor.global_values)
+        self.post.reinitialize()
 
     def tearDown(self):
         """tearDown()...
@@ -85,30 +91,20 @@ class TestRefactoredTestPostMCodes(PathTestUtils.PathTestBase):
         This method is called after each test() method. Add cleanup instructions here.
         Such cleanup instructions will likely undo those in the setUp() method.
         """
-        FreeCAD.ActiveDocument.removeObject("testpath")
+        pass
 
     def single_compare(self, path, expected, args, debug=False):
         """Perform a test with a single comparison."""
         nl = "\n"
-        self.docobj.Path = Path.Path(path)
-        postables = [self.docobj]
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = args
+        # replace the original path (that came with the job and operation) with our path
+        self.profile_op.Path = Path.Path(path)
+        # the gcode is in the first section for this particular job and operation
+        gcode = self.post.export()[0][1]
         if debug:
             print(f"--------{nl}{gcode}--------{nl}")
-        self.assertEqual(gcode, expected)
-
-    def compare_third_line(self, path_string, expected, args, debug=False):
-        """Perform a test with a single comparison to the third line of the output."""
-        nl = "\n"
-        if path_string:
-            self.docobj.Path = Path.Path([Path.Command(path_string)])
-        else:
-            self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-        gcode = postprocessor.export(postables, "-", args)
-        if debug:
-            print(f"--------{nl}{gcode}--------{nl}")
-        self.assertEqual(gcode.splitlines()[2], expected)
+        # there are 4 lines of "other stuff" before the line we are interested in
+        self.assertEqual(gcode.splitlines()[4], expected)
 
     #############################################################################
     #
@@ -116,99 +112,100 @@ class TestRefactoredTestPostMCodes(PathTestUtils.PathTestBase):
     #
     #   00000 - 00099  tests that don't fit any other category
     #   00100 - 09999  tests for all of the various arguments/options
-    #   10000 - 19999  tests for the various G codes at 10000 + 10 * g_code_value
+    #   10000 - 18999  tests for the various G codes at 10000 + 10 * g_code_value
+    #   19000 - 19999  tests for the A, B, and C axis outputs
     #   20000 - 29999  tests for the various M codes at 20000 + 10 * m_code_value
     #
     #############################################################################
 
     def test20000(self):
         """Test M0 command Generation."""
-        self.compare_third_line("M0", "M0", "")
-        self.compare_third_line("M00", "M00", "")
+        self.single_compare("M0", "M0", "")
+        self.single_compare("M00", "M00", "")
 
     #############################################################################
 
     def test20010(self):
         """Test M1 command Generation."""
-        self.compare_third_line("M1", "M1", "")
-        self.compare_third_line("M01", "M01", "")
+        self.single_compare("M1", "M1", "")
+        self.single_compare("M01", "M01", "")
 
     #############################################################################
 
     def test20020(self):
         """Test M2 command Generation."""
-        self.compare_third_line("M2", "M2", "")
-        self.compare_third_line("M02", "M02", "")
+        self.single_compare("M2", "M2", "")
+        self.single_compare("M02", "M02", "")
 
     #############################################################################
 
     def test20030(self):
         """Test M3 command Generation."""
-        self.compare_third_line("M3", "M3", "")
-        self.compare_third_line("M03", "M03", "")
+        self.single_compare("M3", "M3", "")
+        self.single_compare("M03", "M03", "")
 
     #############################################################################
 
     def test20040(self):
         """Test M4 command Generation."""
-        self.compare_third_line("M4", "M4", "")
-        self.compare_third_line("M04", "M04", "")
+        self.single_compare("M4", "M4", "")
+        self.single_compare("M04", "M04", "")
 
     #############################################################################
 
     def test20050(self):
         """Test M5 command Generation."""
-        self.compare_third_line("M5", "M5", "")
-        self.compare_third_line("M05", "M05", "")
+        self.single_compare("M5", "M5", "")
+        self.single_compare("M05", "M05", "")
 
     #############################################################################
 
     def test20060(self):
         """Test M6 command Generation."""
-        self.compare_third_line("M6", "M6", "")
-        self.compare_third_line("M06", "M06", "")
+        self.single_compare("M6", "M6", "")
+        self.single_compare("M06", "M06", "")
 
     #############################################################################
 
     def test20070(self):
         """Test M7 command Generation."""
-        self.compare_third_line("M7", "M7", "")
-        self.compare_third_line("M07", "M07", "")
+        self.single_compare("M7", "M7", "")
+        self.single_compare("M07", "M07", "")
 
     #############################################################################
 
     def test20080(self):
         """Test M8 command Generation."""
-        self.compare_third_line("M8", "M8", "")
-        self.compare_third_line("M08", "M08", "")
+        self.single_compare("M8", "M8", "")
+        self.single_compare("M08", "M08", "")
 
     #############################################################################
 
     def test20090(self):
         """Test M9 command Generation."""
-        self.compare_third_line("M9", "M9", "")
-        self.compare_third_line("M09", "M09", "")
+        self.single_compare("M9", "M9", "")
+        self.single_compare("M09", "M09", "")
 
     #############################################################################
 
     def test20300(self):
         """Test M30 command Generation."""
-        self.compare_third_line("M30", "M30", "")
+        self.single_compare("M30", "M30", "")
 
     #############################################################################
 
     def test20480(self):
         """Test M48 command Generation."""
-        self.compare_third_line("M48", "M48", "")
+        self.single_compare("M48", "M48", "")
 
     #############################################################################
 
     def test20490(self):
         """Test M49 command Generation."""
-        self.compare_third_line("M49", "M49", "")
+        self.single_compare("M49", "M49", "")
 
     #############################################################################
 
     def test20600(self):
         """Test M60 command Generation."""
-        self.compare_third_line("M60", "M60", "")
+        self.single_compare("M60", "M60", "")

--- a/src/Mod/CAM/Path/Post/scripts/refactored_centroid_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/refactored_centroid_post.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # ***************************************************************************
-# *   Copyright (c) 2015 Dan Falck <ddfalck@gmail.com>                      *
-# *   Copyright (c) 2020 Schildkroet                                        *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
+# *   Copyright (c) 2014 sliptonic <shopinthewoods@gmail.com>               *
+# *   Copyright (c) 2022 - 2025 Larry Woestman <LarryWoestman2@gmail.com>   *
+# *   Copyright (c) 2024 Ondsel <development@ondsel.com>                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -24,259 +23,317 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 import argparse
 
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Tuple, Union
 
+from Path.Post.Processor import PostProcessor
 import Path.Post.UtilsArguments as PostUtilsArguments
 import Path.Post.UtilsExport as PostUtilsExport
 
+import Path
+import FreeCAD
+
+translate = FreeCAD.Qt.translate
+
+DEBUG = False
+if DEBUG:
+    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+    Path.Log.trackModule(Path.Log.thisModule())
+else:
+    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
 # Define some types that are used throughout this file
+Defaults = Dict[str, bool]
+FormatHelp = str
+GCodeSections = List[Tuple[str, str]]
 Parser = argparse.ArgumentParser
+ParserArgs = Union[str, argparse.Namespace]
+Postables = Union[List, List[Tuple[str, List]]]
+Section = Tuple[str, List]
+Sublist = List
+Units = str
 Values = Dict[str, Any]
-
-#
-# The following variables need to be global variables
-# to keep the PathPostProcessor.load method happy:
-#
-#    TOOLTIP
-#    TOOLTIP_ARGS
-#    UNITS
-#
-#    The "argument_defaults", "arguments_visible", and the "values" hashes
-#    need to be defined before the "init_shared_arguments" routine can be
-#    called to create TOOLTIP_ARGS, so they also end up having to be globals.
-#    TOOLTIP_ARGS can be defined, so they end up being global variables also.
-#
-TOOLTIP: str = """
-This is a postprocessor file for the Path workbench. It is used to
-take a pseudo-G-code fragment outputted by a Path object, and output
-real G-code suitable for a centroid 3 axis mill. This postprocessor, once placed
-in the appropriate PathScripts folder, can be used directly from inside
-FreeCAD, via the GUI importer or via python scripts with:
-
-import refactored_centroid_post
-refactored_centroid_post.export(object,"/path/to/file.ncc","")
-"""
-#
-# Default to metric mode
-#
-UNITS: str = "G21"
+Visible = Dict[str, bool]
 
 
-def init_values(values: Values) -> None:
-    """Initialize values that are used throughout the postprocessor."""
-    #
-    PostUtilsArguments.init_shared_values(values)
-    #
-    # Set any values here that need to override the default values set
-    # in the init_shared_values routine.
-    #
-    # Use 4 digits for axis precision by default.
-    #
-    values["AXIS_PRECISION"] = 4
-    values["DEFAULT_AXIS_PRECISION"] = 4
-    values["DEFAULT_INCH_AXIS_PRECISION"] = 4
-    #
-    # Use ";" as the comment symbol
-    #
-    values["COMMENT_SYMBOL"] = ";"
-    #
-    # Use 1 digit for feed precision by default.
-    #
-    values["FEED_PRECISION"] = 1
-    values["DEFAULT_FEED_PRECISION"] = 1
-    values["DEFAULT_INCH_FEED_PRECISION"] = 1
-    #
-    # This value usually shows up in the post_op comment as "Finish operation:".
-    # Change it to "End" to produce "End operation:".
-    #
-    values["FINISH_LABEL"] = "End"
-    #
-    # If this value is True, then a list of tool numbers
-    # with their labels are output just before the preamble.
-    #
-    values["LIST_TOOLS_IN_PREAMBLE"] = True
-    #
-    # Used in the argparser code as the "name" of the postprocessor program.
-    # This would normally show up in the usage message in the TOOLTIP_ARGS,
-    # but we are suppressing the usage message, so it doesn't show up after all.
-    #
-    values["MACHINE_NAME"] = "Centroid"
-    #
-    # This list controls the order of parameters in a line during output.
-    # centroid doesn't want K properties on XY plane; Arcs need work.
-    #
-    values["PARAMETER_ORDER"] = [
-        "X",
-        "Y",
-        "Z",
-        "A",
-        "B",
-        "I",
-        "J",
-        "F",
-        "S",
-        "T",
-        "Q",
-        "R",
-        "L",
-        "H",
-    ]
-    #
-    # Any commands in this value will be output as the last commands
-    # in the G-code file.
-    #
-    values["POSTAMBLE"] = """M99"""
-    values["POSTPROCESSOR_FILE_NAME"] = __name__
-    #
-    # Any commands in this value will be output after the header and
-    # safety block at the beginning of the G-code file.
-    #
-    values["PREAMBLE"] = """G53 G00 G17"""
-    #
-    # Output any messages.
-    #
-    values["REMOVE_MESSAGES"] = False
-    #
-    # Any commands in this value are output after the header but before the preamble,
-    # then again after the TOOLRETURN but before the POSTAMBLE.
-    #
-    values["SAFETYBLOCK"] = """G90 G80 G40 G49"""
-    #
-    # Do not show the current machine units just before the PRE_OPERATION.
-    #
-    values["SHOW_MACHINE_UNITS"] = False
-    #
-    # Do not show the current operation label just before the PRE_OPERATION.
-    #
-    values["SHOW_OPERATION_LABELS"] = False
-    #
-    # Do not output an M5 command to stop the spindle for tool changes.
-    #
-    values["STOP_SPINDLE_FOR_TOOL_CHANGE"] = False
-    #
-    # spindle off, height offset canceled, spindle retracted
-    # (M25 is a centroid command to retract spindle)
-    #
-    values[
-        "TOOLRETURN"
-    ] = """M5
+class Refactored_Centroid(PostProcessor):
+    """The Refactored Centroid post processor class"""
+
+    def __init__(self, job) -> None:
+        super().__init__(
+            job=job,
+            tooltip=translate("CAM", "Refactored Centroid post processor"),
+            tooltipargs=[""],
+            units="Metric",
+        )
+        self.reinitialize()
+        Path.Log.debug("Refactored Centroid post processor initialized")
+
+    def reinitialize(self) -> None:
+        """Initialize or reinitialize the 'core' data structures for the postprocessor"""
+        #
+        # This is also used to reinitialize the data structures between tests
+        #
+        self.values: Values = {}
+        self.init_values(self.values)
+        self.argument_defaults: Defaults = {}
+        self.init_argument_defaults(self.argument_defaults)
+        self.arguments_visible: Visible = {}
+        self.init_arguments_visible(self.arguments_visible)
+        self.parser: Parser = self.init_arguments(
+            self.values, self.argument_defaults, self.arguments_visible
+        )
+        #
+        # Create another parser just to get a list of all possible arguments
+        # that may be output using --output_all_arguments.
+        #
+        self.all_arguments_visible: Visible = {}
+        for k in iter(self.arguments_visible):
+            self.all_arguments_visible[k] = True
+        self.all_visible: Parser = self.init_arguments(
+            self.values, self.argument_defaults, self.all_arguments_visible
+        )
+
+    def init_values(self, values: Values) -> None:
+        """Initialize values that are used throughout the postprocessor."""
+        #
+        PostUtilsArguments.init_shared_values(values)
+        #
+        # Set any values here that need to override the default values set
+        # in the init_shared_values routine.
+        #
+        # Use 4 digits for axis precision by default.
+        #
+        values["AXIS_PRECISION"] = 4
+        values["DEFAULT_AXIS_PRECISION"] = 4
+        values["DEFAULT_INCH_AXIS_PRECISION"] = 4
+        #
+        # Use ";" as the comment symbol
+        #
+        values["COMMENT_SYMBOL"] = ";"
+        #
+        # Use 1 digit for feed precision by default.
+        #
+        values["FEED_PRECISION"] = 1
+        values["DEFAULT_FEED_PRECISION"] = 1
+        values["DEFAULT_INCH_FEED_PRECISION"] = 1
+        #
+        # This value usually shows up in the post_op comment as "Finish operation:".
+        # Change it to "End" to produce "End operation:".
+        #
+        values["FINISH_LABEL"] = "End"
+        #
+        # If this value is True, then a list of tool numbers
+        # with their labels are output just before the preamble.
+        #
+        values["LIST_TOOLS_IN_PREAMBLE"] = True
+        #
+        # Used in the argparser code as the "name" of the postprocessor program.
+        # This would normally show up in the usage message in the TOOLTIP_ARGS.
+        #
+        values["MACHINE_NAME"] = "Centroid"
+        #
+        # This list controls the order of parameters in a line during output.
+        # centroid doesn't want K properties on XY plane; Arcs need work.
+        #
+        values["PARAMETER_ORDER"] = [
+            "X",
+            "Y",
+            "Z",
+            "A",
+            "B",
+            "I",
+            "J",
+            "F",
+            "S",
+            "T",
+            "Q",
+            "R",
+            "L",
+            "H",
+        ]
+        #
+        # Any commands in this value will be output as the last commands
+        # in the G-code file.
+        #
+        values["POSTAMBLE"] = """M99"""
+        values["POSTPROCESSOR_FILE_NAME"] = __name__
+        #
+        # Any commands in this value will be output after the header and
+        # safety block at the beginning of the G-code file.
+        #
+        values["PREAMBLE"] = """G53 G00 G17"""
+        #
+        # Output any messages.
+        #
+        values["REMOVE_MESSAGES"] = False
+        #
+        # Any commands in this value are output after the header but before the preamble,
+        # then again after the TOOLRETURN but before the POSTAMBLE.
+        #
+        values["SAFETYBLOCK"] = """G90 G80 G40 G49"""
+        #
+        # Do not show the current machine units just before the PRE_OPERATION.
+        #
+        values["SHOW_MACHINE_UNITS"] = False
+        #
+        # Do not show the current operation label just before the PRE_OPERATION.
+        #
+        values["SHOW_OPERATION_LABELS"] = False
+        #
+        # Do not output an M5 command to stop the spindle for tool changes.
+        #
+        values["STOP_SPINDLE_FOR_TOOL_CHANGE"] = False
+        #
+        # spindle off, height offset canceled, spindle retracted
+        # (M25 is a centroid command to retract spindle)
+        #
+        values[
+            "TOOLRETURN"
+        ] = """M5
 M25
 G49 H0"""
-    values["UNITS"] = UNITS
-    #
-    # Default to not outputting a G43 following tool changes
-    #
-    values["USE_TLO"] = False
-    #
-    # This was in the original centroid postprocessor file
-    # but does not appear to be used anywhere.
-    #
-    # ZAXISRETURN = """G91 G28 X0 Z0 G90"""
-    #
+        values["UNITS"] = self._units
+        #
+        # Default to not outputting a G43 following tool changes
+        #
+        values["USE_TLO"] = False
+        #
+        # This was in the original centroid postprocessor file
+        # but does not appear to be used anywhere.
+        #
+        # ZAXISRETURN = """G91 G28 X0 Z0 G90"""
+        #
 
+    def init_argument_defaults(self, argument_defaults: Defaults) -> None:
+        """Initialize which arguments (in a pair) are shown as the default argument."""
+        PostUtilsArguments.init_argument_defaults(argument_defaults)
+        #
+        # Modify which argument to show as the default in flag-type arguments here.
+        # If the value is True, the first argument will be shown as the default.
+        # If the value is False, the second argument will be shown as the default.
+        #
+        # For example, if you want to show Metric mode as the default, use:
+        #   argument_defaults["metric_inch"] = True
+        #
+        # If you want to show that "Don't pop up editor for writing output" is
+        # the default, use:
+        #   argument_defaults["show-editor"] = False.
+        #
+        # Note:  You also need to modify the corresponding entries in the "values" hash
+        #        to actually make the default value(s) change to match.
+        #
 
-def init_argument_defaults(argument_defaults: Dict[str, bool]) -> None:
-    """Initialize which arguments (in a pair) are shown as the default argument."""
-    PostUtilsArguments.init_argument_defaults(argument_defaults)
-    #
-    # Modify which argument to show as the default in flag-type arguments here.
-    # If the value is True, the first argument will be shown as the default.
-    # If the value is False, the second argument will be shown as the default.
-    #
-    # For example, if you want to show Metric mode as the default, use:
-    #   argument_defaults["metric_inch"] = True
-    #
-    # If you want to show that "Don't pop up editor for writing output" is
-    # the default, use:
-    #   argument_defaults["show-editor"] = False.
-    #
-    # Note:  You also need to modify the corresponding entries in the "values" hash
-    #        to actually make the default value(s) change to match.
-    #
+    def init_arguments_visible(self, arguments_visible: Visible) -> None:
+        """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
+        PostUtilsArguments.init_arguments_visible(arguments_visible)
+        #
+        # Modify the visibility of any arguments from the defaults here.
+        #
+        arguments_visible["axis-modal"] = False
+        arguments_visible["precision"] = False
+        arguments_visible["tlo"] = False
 
+    def init_arguments(
+        self,
+        values: Values,
+        argument_defaults: Defaults,
+        arguments_visible: Visible,
+    ) -> Parser:
+        """Initialize the shared argument definitions."""
+        _parser: Parser = PostUtilsArguments.init_shared_arguments(
+            values, argument_defaults, arguments_visible
+        )
+        #
+        # Add any argument definitions that are not shared with all other
+        # postprocessors here.
+        #
+        return _parser
 
-def init_arguments_visible(arguments_visible: Dict[str, bool]) -> None:
-    """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
-    PostUtilsArguments.init_arguments_visible(arguments_visible)
-    #
-    # Modify the visibility of any arguments from the defaults here.
-    #
-    arguments_visible["axis-modal"] = False
-    arguments_visible["precision"] = False
-    arguments_visible["tlo"] = False
+    def process_arguments(self) -> Tuple[bool, ParserArgs]:
+        """Process any arguments to the postprocessor."""
+        #
+        # This function is separated out to make it easier to inherit from this postprocessor
+        #
+        args: ParserArgs
+        flag: bool
 
+        (flag, args) = PostUtilsArguments.process_shared_arguments(
+            self.values, self.parser, self._job.PostProcessorArgs, self.all_visible, "-"
+        )
+        #
+        # If the flag is False, then all that is returned is a string
+        # containing the argument list formatted for output
+        #
+        # If the flag is True, then all of the arguments should be processed normally
+        #
+        if flag:
+            #
+            # Process any additional arguments here
+            #
+            #
+            # Update any variables that might have been modified while processing the arguments.
+            #
+            self._units = self.values["UNITS"]
+        return (flag, args)
 
-def init_arguments(
-    values: Values,
-    argument_defaults: Dict[str, bool],
-    arguments_visible: Dict[str, bool],
-) -> Parser:
-    """Initialize the shared argument definitions."""
-    parser: Parser = PostUtilsArguments.init_shared_arguments(
-        values, argument_defaults, arguments_visible
-    )
-    #
-    # Add any argument definitions that are not shared with all other
-    # postprocessors here.
-    #
-    return parser
+    def process_postables(self) -> GCodeSections:
+        """Postprocess the 'postables' in the job to g code sections."""
+        #
+        # This function is separated out to make it easier to inherit from this postprocessor
+        #
+        gcode: str
+        g_code_sections: GCodeSections
+        partname: str
+        postables: Postables
+        section: Section
+        sublist: Sublist
 
+        postables = self._buildPostList()
 
-#
-# Creating global variables and using functions to modify them
-# is useful for being able to test things later.
-#
-global_values: Values = {}
-init_values(global_values)
-global_argument_defaults: Dict[str, bool] = {}
-init_argument_defaults(global_argument_defaults)
-global_arguments_visible: Dict[str, bool] = {}
-init_arguments_visible(global_arguments_visible)
-global_parser: Parser = init_arguments(
-    global_values, global_argument_defaults, global_arguments_visible
-)
-#
-# The TOOLTIP_ARGS value is created from the help information about the arguments.
-#
-TOOLTIP_ARGS: str = global_parser.format_help()
-#
-# Create another parser just to get a list of all possible arguments
-# that may be output using --output_all_arguments.
-#
-global_all_arguments_visible: Dict[str, bool] = {}
-k: str
-for k in iter(global_arguments_visible):
-    global_all_arguments_visible[k] = True
-global_all_visible: Parser = init_arguments(
-    global_values, global_argument_defaults, global_all_arguments_visible
-)
+        Path.Log.debug(f"postables count: {len(postables)}")
 
+        g_code_sections = []
+        for _, section in enumerate(postables):
+            partname, sublist = section
+            gcode = PostUtilsExport.export_common(self.values, sublist, "-")
+            g_code_sections.append((partname, gcode))
 
-def export(objectslist, filename: str, argstring: str) -> str:
-    """Postprocess the objects in objectslist to filename."""
-    args: Union[str, argparse.Namespace]
-    flag: bool
+        return g_code_sections
 
-    global UNITS  # pylint: disable=global-statement
+    def export(self) -> GCodeSections:
+        """Process the parser arguments, then postprocess the 'postables'."""
+        args: ParserArgs
+        flag: bool
 
-    # print(parser.format_help())
+        Path.Log.debug("Exporting the job")
 
-    (flag, args) = PostUtilsArguments.process_shared_arguments(
-        global_values, global_parser, argstring, global_all_visible, filename
-    )
-    if not flag:
-        return args  # type: ignore
-    #
-    # Process any additional arguments here
-    #
+        (flag, args) = self.process_arguments()
+        #
+        # If the flag is True, then continue postprocessing the 'postables'
+        #
+        if flag:
+            return self.process_postables()
+        #
+        # If the flag is False, then all that is returned is a string
+        # containing the argument list formatted for output
+        #
+        return [("allitems", args)]  # type: ignore
 
-    #
-    # Update the global variables that might have been modified
-    # while processing the arguments.
-    #
-    UNITS = global_values["UNITS"]
+    @property
+    def tooltip(self):
+        tooltip: str = """
+        This is a postprocessor file for the CAM workbench.
+        It is used to take a pseudo-gcode fragment from a CAM object
+        and output 'real' GCode suitable for a centroid 3 axis mill.
+        """
+        return tooltip
 
-    return PostUtilsExport.export_common(global_values, objectslist, filename)
+    @property
+    def tooltipArgs(self) -> FormatHelp:
+        return self.parser.format_help()
+
+    @property
+    def units(self) -> Units:
+        return self._units

--- a/src/Mod/CAM/Path/Post/scripts/refactored_grbl_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/refactored_grbl_post.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2014 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2018, 2019 Gauthier Briere                              *
-# *   Copyright (c) 2019, 2020 Schildkroet                                  *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
+# *   Copyright (c) 2022 - 2025 Larry Woestman <LarryWoestman2@gmail.com>   *
+# *   Copyright (c) 2024 Ondsel <development@ondsel.com>                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -25,226 +23,289 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 import argparse
 
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Tuple, Union
 
+from Path.Post.Processor import PostProcessor
 import Path.Post.UtilsArguments as PostUtilsArguments
 import Path.Post.UtilsExport as PostUtilsExport
 
+import Path
+import FreeCAD
+
+translate = FreeCAD.Qt.translate
+
+DEBUG = False
+if DEBUG:
+    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+    Path.Log.trackModule(Path.Log.thisModule())
+else:
+    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
 # Define some types that are used throughout this file
+Defaults = Dict[str, bool]
+FormatHelp = str
+GCodeSections = List[Tuple[str, str]]
 Parser = argparse.ArgumentParser
+ParserArgs = Union[str, argparse.Namespace]
+Postables = Union[List, List[Tuple[str, List]]]
+Section = Tuple[str, List]
+Sublist = List
+Units = str
 Values = Dict[str, Any]
-
-#
-# The following variables need to be global variables
-# to keep the PathPostProcessor.load method happy:
-#
-#    TOOLTIP
-#    TOOLTIP_ARGS
-#    UNITS
-#
-#    The "argument_defaults", "arguments_visible", and the "values" hashes
-#    need to be defined before the "init_shared_arguments" routine can be
-#    called to create TOOLTIP_ARGS, so they also end up having to be globals.
-#
-TOOLTIP: str = """
-Generate g-code from a Path that is compatible with the grbl controller:
-
-import refactored_grbl_post
-refactored_grbl_post.export(object, "/path/to/file.ncc")
-"""
-#
-# Default to metric mode
-#
-UNITS: str = "G21"
+Visible = Dict[str, bool]
 
 
-def init_values(values: Values) -> None:
-    """Initialize values that are used throughout the postprocessor."""
-    #
-    PostUtilsArguments.init_shared_values(values)
-    #
-    # Set any values here that need to override the default values set
-    # in the init_shared_values routine.
-    #
-    #
-    # If this is set to True, then commands that are placed in
-    # comments that look like (MC_RUN_COMMAND: blah) will be output.
-    #
-    values["ENABLE_MACHINE_SPECIFIC_COMMANDS"] = True
-    #
-    # Used in the argparser code as the "name" of the postprocessor program.
-    # This would normally show up in the usage message in the TOOLTIP_ARGS,
-    # but we are suppressing the usage message, so it doesn't show up after all.
-    #
-    values["MACHINE_NAME"] = "Grbl"
-    #
-    # Default to outputting Path labels at the beginning of each Path.
-    #
-    values["OUTPUT_PATH_LABELS"] = True
-    #
-    # Default to not outputting M6 tool changes (comment it) as grbl
-    # currently does not handle it
-    #
-    values["OUTPUT_TOOL_CHANGE"] = False
-    #
-    # The order of the parameters.
-    # Arcs may only work on the XY plane (this needs to be verified).
-    #
-    values["PARAMETER_ORDER"] = [
-        "X",
-        "Y",
-        "Z",
-        "A",
-        "B",
-        "C",
-        "U",
-        "V",
-        "W",
-        "I",
-        "J",
-        "K",
-        "F",
-        "S",
-        "T",
-        "Q",
-        "R",
-        "L",
-        "P",
-    ]
-    #
-    # Any commands in this value will be output as the last commands
-    # in the G-code file.
-    #
-    values[
-        "POSTAMBLE"
-    ] = """M5
+class Refactored_Grbl(PostProcessor):
+    """The Refactored Grbl post processor class"""
+
+    def __init__(self, job) -> None:
+        super().__init__(
+            job=job,
+            tooltip=translate("CAM", "Refactored Grbl post processor"),
+            tooltipargs=[""],
+            units="Metric",
+        )
+        self.reinitialize()
+        Path.Log.debug("Refactored Grbl post processor initialized")
+
+    def reinitialize(self) -> None:
+        """Initialize or reinitialize the 'core' data structures for the postprocessor"""
+        #
+        # This is also used to reinitialize the data structures between tests
+        #
+        self.values: Values = {}
+        self.init_values(self.values)
+        self.argument_defaults: Defaults = {}
+        self.init_argument_defaults(self.argument_defaults)
+        self.arguments_visible: Visible = {}
+        self.init_arguments_visible(self.arguments_visible)
+        self.parser: Parser = self.init_arguments(
+            self.values, self.argument_defaults, self.arguments_visible
+        )
+        #
+        # Create another parser just to get a list of all possible arguments
+        # that may be output using --output_all_arguments.
+        #
+        self.all_arguments_visible: Visible = {}
+        for k in iter(self.arguments_visible):
+            self.all_arguments_visible[k] = True
+        self.all_visible: Parser = self.init_arguments(
+            self.values, self.argument_defaults, self.all_arguments_visible
+        )
+
+    def init_values(self, values: Values) -> None:
+        """Initialize values that are used throughout the postprocessor."""
+        #
+        PostUtilsArguments.init_shared_values(values)
+        #
+        # Set any values here that need to override the default values set
+        # in the init_shared_values routine.
+        #
+        #
+        # If this is set to True, then commands that are placed in
+        # comments that look like (MC_RUN_COMMAND: blah) will be output.
+        #
+        values["ENABLE_MACHINE_SPECIFIC_COMMANDS"] = True
+        #
+        # Used in the argparser code as the "name" of the postprocessor program.
+        # This would normally show up in the usage message in the TOOLTIP_ARGS.
+        #
+        values["MACHINE_NAME"] = "Grbl"
+        #
+        # Default to outputting Path labels at the beginning of each Path.
+        #
+        values["OUTPUT_PATH_LABELS"] = True
+        #
+        # Default to not outputting M6 tool changes (comment it) as grbl
+        # currently does not handle it
+        #
+        values["OUTPUT_TOOL_CHANGE"] = False
+        #
+        # The order of the parameters.
+        # Arcs may only work on the XY plane (this needs to be verified).
+        #
+        values["PARAMETER_ORDER"] = [
+            "X",
+            "Y",
+            "Z",
+            "A",
+            "B",
+            "C",
+            "U",
+            "V",
+            "W",
+            "I",
+            "J",
+            "K",
+            "F",
+            "S",
+            "T",
+            "Q",
+            "R",
+            "L",
+            "P",
+        ]
+        #
+        # Any commands in this value will be output as the last commands
+        # in the G-code file.
+        #
+        values[
+            "POSTAMBLE"
+        ] = """M5
 G17 G90
 M2"""
-    values["POSTPROCESSOR_FILE_NAME"] = __name__
-    #
-    # Any commands in this value will be output after the header and
-    # safety block at the beginning of the G-code file.
-    #
-    values["PREAMBLE"] = """G17 G90"""
-    #
-    # Do not show the current machine units just before the PRE_OPERATION.
-    #
-    values["SHOW_MACHINE_UNITS"] = False
-    values["UNITS"] = UNITS
-    #
-    # Default to not outputting a G43 following tool changes
-    #
-    values["USE_TLO"] = False
+        values["POSTPROCESSOR_FILE_NAME"] = __name__
+        #
+        # Any commands in this value will be output after the header and
+        # safety block at the beginning of the G-code file.
+        #
+        values["PREAMBLE"] = """G17 G90"""
+        #
+        # Do not show the current machine units just before the PRE_OPERATION.
+        #
+        values["SHOW_MACHINE_UNITS"] = False
+        values["UNITS"] = self._units
+        #
+        # Default to not outputting a G43 following tool changes
+        #
+        values["USE_TLO"] = False
 
+    def init_argument_defaults(self, argument_defaults: Defaults) -> None:
+        """Initialize which arguments (in a pair) are shown as the default argument."""
+        PostUtilsArguments.init_argument_defaults(argument_defaults)
+        #
+        # Modify which argument to show as the default in flag-type arguments here.
+        # If the value is True, the first argument will be shown as the default.
+        # If the value is False, the second argument will be shown as the default.
+        #
+        # For example, if you want to show Metric mode as the default, use:
+        #   argument_defaults["metric_inch"] = True
+        #
+        # If you want to show that "Don't pop up editor for writing output" is
+        # the default, use:
+        #   argument_defaults["show-editor"] = False.
+        #
+        # Note:  You also need to modify the corresponding entries in the "values" hash
+        #        to actually make the default value(s) change to match.
+        #
+        argument_defaults["tlo"] = False
+        argument_defaults["tool_change"] = False
 
-def init_argument_defaults(argument_defaults: Dict[str, bool]) -> None:
-    """Initialize which arguments (in a pair) are shown as the default argument."""
-    PostUtilsArguments.init_argument_defaults(argument_defaults)
-    #
-    # Modify which argument to show as the default in flag-type arguments here.
-    # If the value is True, the first argument will be shown as the default.
-    # If the value is False, the second argument will be shown as the default.
-    #
-    # For example, if you want to show Metric mode as the default, use:
-    #   argument_defaults["metric_inch"] = True
-    #
-    # If you want to show that "Don't pop up editor for writing output" is
-    # the default, use:
-    #   argument_defaults["show-editor"] = False.
-    #
-    # Note:  You also need to modify the corresponding entries in the "values" hash
-    #        to actually make the default value(s) change to match.
-    #
-    argument_defaults["tlo"] = False
-    argument_defaults["tool_change"] = False
+    def init_arguments_visible(self, arguments_visible: Visible) -> None:
+        """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
+        PostUtilsArguments.init_arguments_visible(arguments_visible)
+        #
+        # Modify the visibility of any arguments from the defaults here.
+        #
+        arguments_visible["bcnc"] = True
+        arguments_visible["axis-modal"] = False
+        arguments_visible["return-to"] = True
+        arguments_visible["tlo"] = False
+        arguments_visible["tool_change"] = True
+        arguments_visible["translate_drill"] = True
+        arguments_visible["wait-for-spindle"] = True
 
+    def init_arguments(
+        self,
+        values: Values,
+        argument_defaults: Defaults,
+        arguments_visible: Visible,
+    ) -> Parser:
+        """Initialize the shared argument definitions."""
+        _parser: Parser = PostUtilsArguments.init_shared_arguments(
+            values, argument_defaults, arguments_visible
+        )
+        #
+        # Add any argument definitions that are not shared with all other
+        # postprocessors here.
+        #
+        return _parser
 
-def init_arguments_visible(arguments_visible: Dict[str, bool]) -> None:
-    """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
-    PostUtilsArguments.init_arguments_visible(arguments_visible)
-    #
-    # Modify the visibility of any arguments from the defaults here.
-    #
-    arguments_visible["bcnc"] = True
-    arguments_visible["axis-modal"] = False
-    arguments_visible["return-to"] = True
-    arguments_visible["tlo"] = False
-    arguments_visible["tool_change"] = True
-    arguments_visible["translate_drill"] = True
-    arguments_visible["wait-for-spindle"] = True
+    def process_arguments(self) -> Tuple[bool, ParserArgs]:
+        """Process any arguments to the postprocessor."""
+        #
+        # This function is separated out to make it easier to inherit from this postprocessor
+        #
+        args: ParserArgs
+        flag: bool
 
+        (flag, args) = PostUtilsArguments.process_shared_arguments(
+            self.values, self.parser, self._job.PostProcessorArgs, self.all_visible, "-"
+        )
+        #
+        # If the flag is False, then all that is returned is a string
+        # containing the argument list formatted for output
+        #
+        # If the flag is True, then all of the arguments should be processed normally
+        #
+        if flag:
+            #
+            # Process any additional arguments here
+            #
+            #
+            # Update any variables that might have been modified while processing the arguments.
+            #
+            self._units = self.values["UNITS"]
+        return (flag, args)
 
-def init_arguments(
-    values: Values,
-    argument_defaults: Dict[str, bool],
-    arguments_visible: Dict[str, bool],
-) -> Parser:
-    """Initialize the shared argument definitions."""
-    parser: Parser = PostUtilsArguments.init_shared_arguments(
-        values, argument_defaults, arguments_visible
-    )
-    #
-    # Add any argument definitions that are not shared with all other
-    # postprocessors here.
-    #
-    return parser
+    def process_postables(self) -> GCodeSections:
+        """Postprocess the 'postables' in the job to g code sections."""
+        #
+        # This function is separated out to make it easier to inherit from this postprocessor
+        #
+        gcode: str
+        g_code_sections: GCodeSections
+        partname: str
+        postables: Postables
+        section: Section
+        sublist: Sublist
 
+        postables = self._buildPostList()
 
-#
-# Creating global variables and using functions to modify them
-# is useful for being able to test things later.
-#
-global_values: Values = {}
-init_values(global_values)
-global_argument_defaults: Dict[str, bool] = {}
-init_argument_defaults(global_argument_defaults)
-global_arguments_visible: Dict[str, bool] = {}
-init_arguments_visible(global_arguments_visible)
-global_parser: Parser = init_arguments(
-    global_values, global_argument_defaults, global_arguments_visible
-)
-#
-# The TOOLTIP_ARGS value is created from the help information about the arguments.
-#
-TOOLTIP_ARGS: str = global_parser.format_help()
-#
-# Create another parser just to get a list of all possible arguments
-# that may be output using --output_all_arguments.
-#
-global_all_arguments_visible: Dict[str, bool] = {}
-k: str
-for k in iter(global_arguments_visible):
-    global_all_arguments_visible[k] = True
-global_all_visible: Parser = init_arguments(
-    global_values, global_argument_defaults, global_all_arguments_visible
-)
+        Path.Log.debug(f"postables count: {len(postables)}")
 
+        g_code_sections = []
+        for _, section in enumerate(postables):
+            partname, sublist = section
+            gcode = PostUtilsExport.export_common(self.values, sublist, "-")
+            g_code_sections.append((partname, gcode))
 
-def export(objectslist, filename, argstring) -> str:
-    """Postprocess the objects in objectslist to filename."""
-    args: Union[str, argparse.Namespace]
-    flag: bool
+        return g_code_sections
 
-    global UNITS  # pylint: disable=global-statement
+    def export(self) -> GCodeSections:
+        """Process the parser arguments, then postprocess the 'postables'."""
+        args: ParserArgs
+        flag: bool
 
-    # print(parser.format_help())
+        Path.Log.debug("Exporting the job")
 
-    (flag, args) = PostUtilsArguments.process_shared_arguments(
-        global_values, global_parser, argstring, global_all_visible, filename
-    )
-    if not flag:
-        return args  # type: ignore
-    #
-    # Process any additional arguments here
-    #
+        (flag, args) = self.process_arguments()
+        #
+        # If the flag is True, then continue postprocessing the 'postables'
+        #
+        if flag:
+            return self.process_postables()
+        #
+        # If the flag is False, then all that is returned is a string
+        # containing the argument list formatted for output
+        #
+        return [("allitems", args)]  # type: ignore
 
-    #
-    # Update the global variables that might have been modified
-    # while processing the arguments.
-    #
-    UNITS = global_values["UNITS"]
+    @property
+    def tooltip(self):
+        tooltip: str = """
+        This is a postprocessor file for the CAM workbench.
+        It is used to take a pseudo-gcode fragment from a CAM object
+        and output 'real' GCode suitable for a Grbl 3 axis mill.
+        """
+        return tooltip
 
-    return PostUtilsExport.export_common(global_values, objectslist, filename)
+    @property
+    def tooltipArgs(self) -> FormatHelp:
+        return self.parser.format_help()
+
+    @property
+    def units(self) -> Units:
+        return self._units

--- a/src/Mod/CAM/Path/Post/scripts/refactored_linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/refactored_linuxcnc_post.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2014 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
+# *   Copyright (c) 2022 - 2025 Larry Woestman <LarryWoestman2@gmail.com>   *
+# *   Copyright (c) 2024 Ondsel <development@ondsel.com>                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -22,194 +23,254 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 import argparse
 
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Tuple, Union
 
+from Path.Post.Processor import PostProcessor
 import Path.Post.UtilsArguments as PostUtilsArguments
 import Path.Post.UtilsExport as PostUtilsExport
 
+import Path
+import FreeCAD
+
+translate = FreeCAD.Qt.translate
+
+DEBUG = False
+if DEBUG:
+    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+    Path.Log.trackModule(Path.Log.thisModule())
+else:
+    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
 # Define some types that are used throughout this file
+Defaults = Dict[str, bool]
+FormatHelp = str
+GCodeSections = List[Tuple[str, str]]
 Parser = argparse.ArgumentParser
+ParserArgs = Union[str, argparse.Namespace]
+Postables = Union[List, List[Tuple[str, List]]]
+Section = Tuple[str, List]
+Sublist = List
+Units = str
 Values = Dict[str, Any]
-
-#
-# The following variables need to be global variables
-# to keep the PathPostProcessor.load method happy:
-#
-#    TOOLTIP
-#    TOOLTIP_ARGS
-#    UNITS
-#
-#    The "argument_defaults", "arguments_visible", and the "values" hashes
-#    need to be defined before the "init_shared_arguments" routine can be
-#    called to create TOOLTIP_ARGS, so they also end up having to be globals.
-#
-TOOLTIP: str = """This is a postprocessor file for the Path workbench. It is used to
-take a pseudo-gcode fragment outputted by a Path object, and output
-real GCode suitable for a linuxcnc 3 axis mill. This postprocessor, once placed
-in the appropriate PathScripts folder, can be used directly from inside
-FreeCAD, via the GUI importer or via python scripts with:
-
-import refactored_linuxcnc_post
-refactored_linuxcnc_post.export(object,"/path/to/file.ncc","")
-"""
-#
-# Default to metric mode
-#
-UNITS: str = "G21"
+Visible = Dict[str, bool]
 
 
-def init_values(values: Values) -> None:
-    """Initialize values that are used throughout the postprocessor."""
-    #
-    PostUtilsArguments.init_shared_values(values)
-    #
-    # Set any values here that need to override the default values set
-    # in the init_shared_values routine.
-    #
-    values["ENABLE_COOLANT"] = True
-    # the order of parameters
-    # linuxcnc doesn't want K properties on XY plane; Arcs need work.
-    values["PARAMETER_ORDER"] = [
-        "X",
-        "Y",
-        "Z",
-        "A",
-        "B",
-        "C",
-        "I",
-        "J",
-        "F",
-        "S",
-        "T",
-        "Q",
-        "R",
-        "L",
-        "H",
-        "D",
-        "P",
-    ]
-    #
-    # Used in the argparser code as the "name" of the postprocessor program.
-    # This would normally show up in the usage message in the TOOLTIP_ARGS,
-    # but we are suppressing the usage message, so it doesn't show up after all.
-    #
-    values["MACHINE_NAME"] = "LinuxCNC"
-    #
-    # Any commands in this value will be output as the last commands
-    # in the G-code file.
-    #
-    values[
-        "POSTAMBLE"
-    ] = """M05
+class Refactored_Linuxcnc(PostProcessor):
+    """The Refactored LinuxCNC post processor class"""
+
+    def __init__(self, job) -> None:
+        super().__init__(
+            job=job,
+            tooltip=translate("CAM", "Refactored LinuxCNC post processor"),
+            tooltipargs=[""],
+            units="Metric",
+        )
+        self.reinitialize()
+        Path.Log.debug("Refactored LinuxCNC post processor initialized")
+
+    def reinitialize(self) -> None:
+        """Initialize or reinitialize the 'core' data structures for the postprocessor"""
+        #
+        # This is also used to reinitialize the data structures between tests
+        #
+        self.values: Values = {}
+        self.init_values(self.values)
+        self.argument_defaults: Defaults = {}
+        self.init_argument_defaults(self.argument_defaults)
+        self.arguments_visible: Visible = {}
+        self.init_arguments_visible(self.arguments_visible)
+        self.parser: Parser = self.init_arguments(
+            self.values, self.argument_defaults, self.arguments_visible
+        )
+        #
+        # Create another parser just to get a list of all possible arguments
+        # that may be output using --output_all_arguments.
+        #
+        self.all_arguments_visible: Visible = {}
+        for k in iter(self.arguments_visible):
+            self.all_arguments_visible[k] = True
+        self.all_visible: Parser = self.init_arguments(
+            self.values, self.argument_defaults, self.all_arguments_visible
+        )
+
+    def init_values(self, values: Values) -> None:
+        """Initialize values that are used throughout the postprocessor."""
+        #
+        PostUtilsArguments.init_shared_values(values)
+        #
+        # Set any values here that need to override the default values set
+        # in the init_shared_values routine.
+        #
+        values["ENABLE_COOLANT"] = True
+        # the order of parameters
+        # linuxcnc doesn't want K properties on XY plane; Arcs need work.
+        values["PARAMETER_ORDER"] = [
+            "X",
+            "Y",
+            "Z",
+            "A",
+            "B",
+            "C",
+            "I",
+            "J",
+            "F",
+            "S",
+            "T",
+            "Q",
+            "R",
+            "L",
+            "H",
+            "D",
+            "P",
+        ]
+        #
+        # Used in the argparser code as the "name" of the postprocessor program.
+        #
+        values["MACHINE_NAME"] = "Refactored_LinuxCNC"
+        #
+        # Any commands in this value will be output as the last commands
+        # in the G-code file.
+        #
+        values[
+            "POSTAMBLE"
+        ] = """M05
 G17 G54 G90 G80 G40
 M2"""
-    values["POSTPROCESSOR_FILE_NAME"] = __name__
-    #
-    # Any commands in this value will be output after the header and
-    # safety block at the beginning of the G-code file.
-    #
-    values["PREAMBLE"] = """G17 G54 G40 G49 G80 G90"""
-    values["UNITS"] = UNITS
+        values["POSTPROCESSOR_FILE_NAME"] = __name__
+        #
+        # Any commands in this value will be output after the header and
+        # safety block at the beginning of the G-code file.
+        #
+        values["PREAMBLE"] = """G17 G54 G40 G49 G80 G90"""
+        values["UNITS"] = self._units
 
+    def init_argument_defaults(self, argument_defaults: Defaults) -> None:
+        """Initialize which arguments (in a pair) are shown as the default argument."""
+        PostUtilsArguments.init_argument_defaults(argument_defaults)
+        #
+        # Modify which argument to show as the default in flag-type arguments here.
+        # If the value is True, the first argument will be shown as the default.
+        # If the value is False, the second argument will be shown as the default.
+        #
+        # For example, if you want to show Metric mode as the default, use:
+        #   argument_defaults["metric_inch"] = True
+        #
+        # If you want to show that "Don't pop up editor for writing output" is
+        # the default, use:
+        #   argument_defaults["show-editor"] = False.
+        #
+        # Note:  You also need to modify the corresponding entries in the "values" hash
+        #        to actually make the default value(s) change to match.
+        #
 
-def init_argument_defaults(argument_defaults: Dict[str, bool]) -> None:
-    """Initialize which arguments (in a pair) are shown as the default argument."""
-    PostUtilsArguments.init_argument_defaults(argument_defaults)
-    #
-    # Modify which argument to show as the default in flag-type arguments here.
-    # If the value is True, the first argument will be shown as the default.
-    # If the value is False, the second argument will be shown as the default.
-    #
-    # For example, if you want to show Metric mode as the default, use:
-    #   argument_defaults["metric_inch"] = True
-    #
-    # If you want to show that "Don't pop up editor for writing output" is
-    # the default, use:
-    #   argument_defaults["show-editor"] = False.
-    #
-    # Note:  You also need to modify the corresponding entries in the "values" hash
-    #        to actually make the default value(s) change to match.
-    #
+    def init_arguments_visible(self, arguments_visible: Visible) -> None:
+        """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
+        PostUtilsArguments.init_arguments_visible(arguments_visible)
+        #
+        # Modify the visibility of any arguments from the defaults here.
+        #
 
+    def init_arguments(
+        self,
+        values: Values,
+        argument_defaults: Defaults,
+        arguments_visible: Visible,
+    ) -> Parser:
+        """Initialize the shared argument definitions."""
+        _parser: Parser = PostUtilsArguments.init_shared_arguments(
+            values, argument_defaults, arguments_visible
+        )
+        #
+        # Add any argument definitions that are not shared with all other
+        # postprocessors here.
+        #
+        return _parser
 
-def init_arguments_visible(arguments_visible: Dict[str, bool]) -> None:
-    """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
-    PostUtilsArguments.init_arguments_visible(arguments_visible)
-    #
-    # Modify the visibility of any arguments from the defaults here.
-    #
+    def process_arguments(self) -> Tuple[bool, ParserArgs]:
+        """Process any arguments to the postprocessor."""
+        #
+        # This function is separated out to make it easier to inherit from this postprocessor
+        #
+        args: ParserArgs
+        flag: bool
 
+        (flag, args) = PostUtilsArguments.process_shared_arguments(
+            self.values, self.parser, self._job.PostProcessorArgs, self.all_visible, "-"
+        )
+        #
+        # If the flag is False, then all that is returned is a string
+        # containing the argument list formatted for output
+        #
+        # If the flag is True, then all of the arguments should be processed normally
+        #
+        if flag:
+            #
+            # Process any additional arguments here
+            #
+            #
+            # Update any variables that might have been modified while processing the arguments.
+            #
+            self._units = self.values["UNITS"]
+        return (flag, args)
 
-def init_arguments(
-    values: Values,
-    argument_defaults: Dict[str, bool],
-    arguments_visible: Dict[str, bool],
-) -> Parser:
-    """Initialize the shared argument definitions."""
-    parser: Parser = PostUtilsArguments.init_shared_arguments(
-        values, argument_defaults, arguments_visible
-    )
-    #
-    # Add any argument definitions that are not shared with all other
-    # postprocessors here.
-    #
-    return parser
+    def process_postables(self) -> GCodeSections:
+        """Postprocess the 'postables' in the job to g code sections."""
+        #
+        # This function is separated out to make it easier to inherit from this postprocessor
+        #
+        gcode: str
+        g_code_sections: GCodeSections
+        partname: str
+        postables: Postables
+        section: Section
+        sublist: Sublist
 
+        postables = self._buildPostList()
 
-#
-# Creating global variables and using functions to modify them
-# is useful for being able to test things later.
-#
-global_values: Values = {}
-init_values(global_values)
-global_argument_defaults: Dict[str, bool] = {}
-init_argument_defaults(global_argument_defaults)
-global_arguments_visible: Dict[str, bool] = {}
-init_arguments_visible(global_arguments_visible)
-global_parser: Parser = init_arguments(
-    global_values, global_argument_defaults, global_arguments_visible
-)
-#
-# The TOOLTIP_ARGS value is created from the help information about the arguments.
-#
-TOOLTIP_ARGS: str = global_parser.format_help()
-#
-# Create another parser just to get a list of all possible arguments
-# that may be output using --output_all_arguments.
-#
-global_all_arguments_visible: Dict[str, bool] = {}
-for k in iter(global_arguments_visible):
-    global_all_arguments_visible[k] = True
-global_all_visible: Parser = init_arguments(
-    global_values, global_argument_defaults, global_all_arguments_visible
-)
+        Path.Log.debug(f"postables count: {len(postables)}")
 
+        g_code_sections = []
+        for _, section in enumerate(postables):
+            partname, sublist = section
+            gcode = PostUtilsExport.export_common(self.values, sublist, "-")
+            g_code_sections.append((partname, gcode))
 
-def export(objectslist, filename: str, argstring: str) -> str:
-    """Postprocess the objects in objectslist to filename."""
-    args: Union[str, argparse.Namespace]
-    flag: bool
+        return g_code_sections
 
-    global UNITS  # pylint: disable=global-statement
+    def export(self) -> GCodeSections:
+        """Process the parser arguments, then postprocess the 'postables'."""
+        args: ParserArgs
+        flag: bool
 
-    # print(parser.format_help())
+        Path.Log.debug("Exporting the job")
 
-    (flag, args) = PostUtilsArguments.process_shared_arguments(
-        global_values, global_parser, argstring, global_all_visible, filename
-    )
-    if not flag:
-        return args  # type: ignore
-    #
-    # Process any additional arguments here
-    #
+        (flag, args) = self.process_arguments()
+        #
+        # If the flag is True, then continue postprocessing the 'postables'
+        #
+        if flag:
+            return self.process_postables()
+        #
+        # If the flag is False, then all that is returned is a string
+        # containing the argument list formatted for output
+        #
+        return [("allitems", args)]  # type: ignore
 
-    #
-    # Update the global variables that might have been modified
-    # while processing the arguments.
-    #
-    UNITS = global_values["UNITS"]
+    @property
+    def tooltip(self):
+        tooltip: str = """
+        This is a postprocessor file for the CAM workbench.
+        It is used to take a pseudo-gcode fragment from a CAM object
+        and output 'real' GCode suitable for a linuxcnc 3 axis mill.
+        """
+        return tooltip
 
-    return PostUtilsExport.export_common(global_values, objectslist, filename)
+    @property
+    def tooltipArgs(self) -> FormatHelp:
+        return self.parser.format_help()
+
+    @property
+    def units(self) -> Units:
+        return self._units

--- a/src/Mod/CAM/Path/Post/scripts/refactored_mach3_mach4_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/refactored_mach3_mach4_post.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2014 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
+# *   Copyright (c) 2022 - 2025 Larry Woestman <LarryWoestman2@gmail.com>   *
+# *   Copyright (c) 2024 Ondsel <development@ondsel.com>                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -20,205 +21,265 @@
 # *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
 # *   USA                                                                   *
 # *                                                                         *
-# ***************************************************************************/
-
+# ***************************************************************************
 
 import argparse
 
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Tuple, Union
 
+from Path.Post.Processor import PostProcessor
 import Path.Post.UtilsArguments as PostUtilsArguments
 import Path.Post.UtilsExport as PostUtilsExport
 
+import Path
+import FreeCAD
+
+translate = FreeCAD.Qt.translate
+
+DEBUG = False
+if DEBUG:
+    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+    Path.Log.trackModule(Path.Log.thisModule())
+else:
+    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
 # Define some types that are used throughout this file
+Defaults = Dict[str, bool]
+FormatHelp = str
+GCodeSections = List[Tuple[str, str]]
 Parser = argparse.ArgumentParser
+ParserArgs = Union[str, argparse.Namespace]
+Postables = Union[List, List[Tuple[str, List]]]
+Section = Tuple[str, List]
+Sublist = List
+Units = str
 Values = Dict[str, Any]
-
-#
-# The following variables need to be global variables
-# to keep the PathPostProcessor.load method happy:
-#
-#    TOOLTIP
-#    TOOLTIP_ARGS
-#    UNITS
-#
-#    The "argument_defaults", "arguments_visible", and the "values" hashes
-#    need to be defined before the "init_shared_arguments" routine can be
-#    called to create TOOLTIP_ARGS, so they also end up having to be globals.
-#
-TOOLTIP: str = """
-This is a postprocessor file for the Path workbench. It is used to
-take a pseudo-G-code fragment outputted by a Path object, and output
-real G-code suitable for a mach3_4 3 axis mill. This postprocessor, once placed
-in the appropriate PathScripts folder, can be used directly from inside
-FreeCAD, via the GUI importer or via python scripts with:
-
-import mach3_mach4_post
-mach3_mach4_post.export(object,"/path/to/file.ncc","")
-"""
-#
-# Default to metric mode
-#
-UNITS: str = "G21"
+Visible = Dict[str, bool]
 
 
-def init_values(values: Values) -> None:
-    """Initialize values that are used throughout the postprocessor."""
-    #
-    PostUtilsArguments.init_shared_values(values)
-    #
-    # Set any values here that need to override the default values set
-    # in the init_shared_values routine.
-    #
-    values["ENABLE_COOLANT"] = True
-    #
-    # Used in the argparser code as the "name" of the postprocessor program.
-    # This would normally show up in the usage message in the TOOLTIP_ARGS,
-    # but we are suppressing the usage message, so it doesn't show up after all.
-    #
-    values["MACHINE_NAME"] = "mach3_4"
-    # Enable special processing for operations with "Adaptive" in the name
-    values["OUTPUT_ADAPTIVE"] = True
-    # Output the machine name for mach3_mach4 instead of the machine units alone.
-    values["OUTPUT_MACHINE_NAME"] = True
-    # the order of parameters
-    # mach3_mach4 doesn't want K properties on XY plane; Arcs need work.
-    values["PARAMETER_ORDER"] = [
-        "X",
-        "Y",
-        "Z",
-        "A",
-        "B",
-        "C",
-        "I",
-        "J",
-        "F",
-        "S",
-        "T",
-        "Q",
-        "R",
-        "L",
-        "H",
-        "D",
-        "P",
-    ]
-    #
-    # Any commands in this value will be output as the last commands
-    # in the G-code file.
-    #
-    values[
-        "POSTAMBLE"
-    ] = """M05
+class Refactored_Mach3_Mach4(PostProcessor):
+    """The Refactored Mach3_Mach4 post processor class"""
+
+    def __init__(self, job) -> None:
+        super().__init__(
+            job=job,
+            tooltip=translate("CAM", "Refactored Mach3_Mach4 post processor"),
+            tooltipargs=[""],
+            units="Metric",
+        )
+        self.reinitialize()
+        Path.Log.debug("Refactored Mach3_Mach4 post processor initialized")
+
+    def reinitialize(self) -> None:
+        """Initialize or reinitialize the 'core' data structures for the postprocessor"""
+        #
+        # This is also used to reinitialize the data structures between tests
+        #
+        self.values: Values = {}
+        self.init_values(self.values)
+        self.argument_defaults: Defaults = {}
+        self.init_argument_defaults(self.argument_defaults)
+        self.arguments_visible: Visible = {}
+        self.init_arguments_visible(self.arguments_visible)
+        self.parser: Parser = self.init_arguments(
+            self.values, self.argument_defaults, self.arguments_visible
+        )
+        #
+        # Create another parser just to get a list of all possible arguments
+        # that may be output using --output_all_arguments.
+        #
+        self.all_arguments_visible: Visible = {}
+        for k in iter(self.arguments_visible):
+            self.all_arguments_visible[k] = True
+        self.all_visible: Parser = self.init_arguments(
+            self.values, self.argument_defaults, self.all_arguments_visible
+        )
+
+
+    def init_values(self, values: Values) -> None:
+        """Initialize values that are used throughout the postprocessor."""
+        #
+        PostUtilsArguments.init_shared_values(values)
+        #
+        # Set any values here that need to override the default values set
+        # in the init_shared_values routine.
+        #
+        values["ENABLE_COOLANT"] = True
+        #
+        # Used in the argparser code as the "name" of the postprocessor program.
+        # This would normally show up in the usage message in the TOOLTIP_ARGS.
+        #
+        values["MACHINE_NAME"] = "mach3_4"
+        # Enable special processing for operations with "Adaptive" in the name
+        values["OUTPUT_ADAPTIVE"] = True
+        # Output the machine name for mach3_mach4 instead of the machine units alone.
+        values["OUTPUT_MACHINE_NAME"] = True
+        # the order of parameters
+        # mach3_mach4 doesn't want K properties on XY plane; Arcs need work.
+        values["PARAMETER_ORDER"] = [
+            "X",
+            "Y",
+            "Z",
+            "A",
+            "B",
+            "C",
+            "I",
+            "J",
+            "F",
+            "S",
+            "T",
+            "Q",
+            "R",
+            "L",
+            "H",
+            "D",
+            "P",
+        ]
+        #
+        # Any commands in this value will be output as the last commands
+        # in the G-code file.
+        #
+        values[
+            "POSTAMBLE"
+        ] = """M05
 G17 G54 G90 G80 G40
 M2"""
-    values["POSTPROCESSOR_FILE_NAME"] = __name__
-    #
-    # Any commands in this value will be output after the header and
-    # safety block at the beginning of the G-code file.
-    #
-    values["PREAMBLE"] = """G17 G54 G40 G49 G80 G90"""
-    # Output the machine name for mach3_mach4 instead of the machine units alone.
-    values["SHOW_MACHINE_UNITS"] = False
-    values["UNITS"] = UNITS
+        values["POSTPROCESSOR_FILE_NAME"] = __name__
+        #
+        # Any commands in this value will be output after the header and
+        # safety block at the beginning of the G-code file.
+        #
+        values["PREAMBLE"] = """G17 G54 G40 G49 G80 G90"""
+        # Output the machine name for mach3_mach4 instead of the machine units alone.
+        values["SHOW_MACHINE_UNITS"] = False
+        values["UNITS"] = self._units
 
+    def init_argument_defaults(self, argument_defaults: Defaults) -> None:
+        """Initialize which arguments (in a pair) are shown as the default argument."""
+        PostUtilsArguments.init_argument_defaults(argument_defaults)
+        #
+        # Modify which argument to show as the default in flag-type arguments here.
+        # If the value is True, the first argument will be shown as the default.
+        # If the value is False, the second argument will be shown as the default.
+        #
+        # For example, if you want to show Metric mode as the default, use:
+        #   argument_defaults["metric_inch"] = True
+        #
+        # If you want to show that "Don't pop up editor for writing output" is
+        # the default, use:
+        #   argument_defaults["show-editor"] = False.
+        #
+        # Note:  You also need to modify the corresponding entries in the "values" hash
+        #        to actually make the default value(s) change to match.
+        #
 
-def init_argument_defaults(argument_defaults: Dict[str, bool]) -> None:
-    """Initialize which arguments (in a pair) are shown as the default argument."""
-    PostUtilsArguments.init_argument_defaults(argument_defaults)
-    #
-    # Modify which argument to show as the default in flag-type arguments here.
-    # If the value is True, the first argument will be shown as the default.
-    # If the value is False, the second argument will be shown as the default.
-    #
-    # For example, if you want to show Metric mode as the default, use:
-    #   argument_defaults["metric_inch"] = True
-    #
-    # If you want to show that "Don't pop up editor for writing output" is
-    # the default, use:
-    #   argument_defaults["show-editor"] = False.
-    #
-    # Note:  You also need to modify the corresponding entries in the "values" hash
-    #        to actually make the default value(s) change to match.
-    #
+    def init_arguments_visible(self, arguments_visible: Visible) -> None:
+        """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
+        PostUtilsArguments.init_arguments_visible(arguments_visible)
+        #
+        # Modify the visibility of any arguments from the defaults here.
+        #
+        arguments_visible["axis-modal"] = True
 
+    def init_arguments(
+        self,
+        values: Values,
+        argument_defaults: Defaults,
+        arguments_visible: Visible,
+    ) -> Parser:
+        """Initialize the shared argument definitions."""
+        _parser: Parser = PostUtilsArguments.init_shared_arguments(
+            values, argument_defaults, arguments_visible
+        )
+        #
+        # Add any argument definitions that are not shared with all other
+        # postprocessors here.
+        #
+        return _parser
 
-def init_arguments_visible(arguments_visible: Dict[str, bool]) -> None:
-    """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
-    PostUtilsArguments.init_arguments_visible(arguments_visible)
-    #
-    # Modify the visibility of any arguments from the defaults here.
-    #
-    arguments_visible["axis-modal"] = True
+    def process_arguments(self) -> Tuple[bool, ParserArgs]:
+        """Process any arguments to the postprocessor."""
+        #
+        # This function is separated out to make it easier to inherit from this postprocessor
+        #
+        args: ParserArgs
+        flag: bool
 
+        (flag, args) = PostUtilsArguments.process_shared_arguments(
+            self.values, self.parser, self._job.PostProcessorArgs, self.all_visible, "-"
+        )
+        #
+        # If the flag is False, then all that is returned is a string
+        # containing the argument list formatted for output
+        #
+        # If the flag is True, then all of the arguments should be processed normally
+        #
+        if flag:
+            #
+            # Process any additional arguments here
+            #
+            #
+            # Update any variables that might have been modified while processing the arguments.
+            #
+            self._units = self.values["UNITS"]
+        return (flag, args)
 
-def init_arguments(
-    values: Values,
-    argument_defaults: Dict[str, bool],
-    arguments_visible: Dict[str, bool],
-) -> Parser:
-    """Initialize the shared argument definitions."""
-    parser: Parser = PostUtilsArguments.init_shared_arguments(
-        values, argument_defaults, arguments_visible
-    )
-    #
-    # Add any argument definitions that are not shared with all other
-    # postprocessors here.
-    #
-    return parser
+    def process_postables(self) -> GCodeSections:
+        """Postprocess the 'postables' in the job to g code sections."""
+        #
+        # This function is separated out to make it easier to inherit from this postprocessor
+        #
+        gcode: str
+        g_code_sections: GCodeSections
+        partname: str
+        postables: Postables
+        section: Section
+        sublist: Sublist
 
+        postables = self._buildPostList()
 
-#
-# Creating global variables and using functions to modify them
-# is useful for being able to test things later.
-#
-global_values: Values = {}
-init_values(global_values)
-global_argument_defaults: Dict[str, bool] = {}
-init_argument_defaults(global_argument_defaults)
-global_arguments_visible: Dict[str, bool] = {}
-init_arguments_visible(global_arguments_visible)
-global_parser: Parser = init_arguments(
-    global_values, global_argument_defaults, global_arguments_visible
-)
-#
-# The TOOLTIP_ARGS value is created from the help information about the arguments.
-#
-TOOLTIP_ARGS: str = global_parser.format_help()
-#
-# Create another parser just to get a list of all possible arguments
-# that may be output using --output_all_arguments.
-#
-global_all_arguments_visible: Dict[str, bool] = {}
-k: str
-for k in iter(global_arguments_visible):
-    global_all_arguments_visible[k] = True
-global_all_visible: Parser = init_arguments(
-    global_values, global_argument_defaults, global_all_arguments_visible
-)
+        Path.Log.debug(f"postables count: {len(postables)}")
 
+        g_code_sections = []
+        for _, section in enumerate(postables):
+            partname, sublist = section
+            gcode = PostUtilsExport.export_common(self.values, sublist, "-")
+            g_code_sections.append((partname, gcode))
 
-def export(objectslist, filename, argstring) -> str:
-    """Postprocess the objects in objectslist to filename."""
-    args: Union[str, argparse.Namespace]
-    flag: bool
+        return g_code_sections
 
-    global UNITS  # pylint: disable=global-statement
+    def export(self) -> GCodeSections:
+        """Process the parser arguments, then postprocess the 'postables'."""
+        args: ParserArgs
+        flag: bool
 
-    # print(parser.format_help())
+        Path.Log.debug("Exporting the job")
 
-    (flag, args) = PostUtilsArguments.process_shared_arguments(
-        global_values, global_parser, argstring, global_all_visible, filename
-    )
-    if not flag:
-        return args  # type: ignore
-    #
-    # Process any additional arguments here
-    #
+        (flag, args) = self.process_arguments()
+        #
+        # If the flag is True, then continue postprocessing the 'postables'
+        #
+        if flag:
+            return self.process_postables()
+        #
+        # If the flag is False, then all that is returned is a string
+        # containing the argument list formatted for output
+        #
+        return [("allitems", args)]  # type: ignore
 
-    #
-    # Update the global variables that might have been modified
-    # while processing the arguments.
-    #
-    UNITS = global_values["UNITS"]
+    @property
+    def tooltip(self):
+        tooltip: str = """
+        This is a postprocessor file for the CAM workbench.
+        It is used to take a pseudo-gcode fragment from a CAM object
+        and output 'real' GCode suitable for a Mach3_4 3 axis mill.
+        """
+        return tooltip
 
-    return PostUtilsExport.export_common(global_values, objectslist, filename)
+    @property
+    def tooltipArgs(self) -> FormatHelp:
+        return self.parser.format_help()
+
+    @property
+    def units(self) -> Units:
+        return self._units

--- a/src/Mod/CAM/Path/Post/scripts/refactored_test_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/refactored_test_post.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2014 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
+# *   Copyright (c) 2022 - 2025 Larry Woestman <LarryWoestman2@gmail.com>   *
+# *   Copyright (c) 2024 Ondsel <development@ondsel.com>                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -22,200 +23,253 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 import argparse
 
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Tuple, Union
 
-import Path.Post.UtilsArguments as UtilsArguments
-import Path.Post.UtilsExport as UtilsExport
+from Path.Post.Processor import PostProcessor
+import Path.Post.UtilsArguments as PostUtilsArguments
+import Path.Post.UtilsExport as PostUtilsExport
+
+import Path
+import FreeCAD
+
+translate = FreeCAD.Qt.translate
+
+DEBUG = False
+if DEBUG:
+    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+    Path.Log.trackModule(Path.Log.thisModule())
+else:
+    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
 # Define some types that are used throughout this file
+Defaults = Dict[str, bool]
+FormatHelp = str
+GCodeSections = List[Tuple[str, str]]
 Parser = argparse.ArgumentParser
+ParserArgs = Union[str, argparse.Namespace]
+Postables = Union[List, List[Tuple[str, List]]]
+Section = Tuple[str, List]
+Sublist = List
+Units = str
 Values = Dict[str, Any]
-
-#
-# The following variables need to be global variables
-# to keep the PathPostProcessor.load method happy:
-#
-#    TOOLTIP
-#    TOOLTIP_ARGS
-#    UNITS
-#
-#    The "argument_defaults", "arguments_visible", and the "values" hashes
-#    need to be defined before the "init_shared_arguments" routine can be
-#    called to create TOOLTIP_ARGS, so they also end up having to be globals.
-#
-TOOLTIP: str = """This is a postprocessor file for the Path workbench. It is used to
-test the postprocessor code.  It probably isn't useful for "real" gcode.
-
-import refactored_test_post
-refactored_test_post.export(object,"/path/to/file.ncc","")
-"""
-#
-# Default to metric mode
-#
-UNITS: str = "G21"
+Visible = Dict[str, bool]
 
 
-def init_values(values: Values) -> None:
-    """Initialize values that are used throughout the postprocessor."""
-    #
-    global UNITS
+class Refactored_Test(PostProcessor):
+    """The Refactored Test post processor class"""
 
-    UtilsArguments.init_shared_values(values)
-    #
-    # Set any values here that need to override the default values set
-    # in the init_shared_values routine.
-    #
-    # Turn off as much functionality as possible by default.
-    # Then the tests can turn back on the appropriate options as needed.
-    #
-    # Used in the argparser code as the "name" of the postprocessor program.
-    # This would normally show up in the usage message in the TOOLTIP_ARGS,
-    # but we are suppressing the usage message, so it doesn't show up after all.
-    #
-    values["MACHINE_NAME"] = "test"
-    #
-    # Don't output comments by default
-    #
-    values["OUTPUT_COMMENTS"] = False
-    #
-    # Don't output the header by default
-    #
-    values["OUTPUT_HEADER"] = False
-    #
-    # Convert M56 tool change commands to comments,
-    # which are then suppressed by default.
-    #
-    values["OUTPUT_TOOL_CHANGE"] = False
-    values["POSTPROCESSOR_FILE_NAME"] = __name__
-    #
-    # Do not show the editor by default since we are testing.
-    #
-    values["SHOW_EDITOR"] = False
-    #
-    # Don't show the current machine units by default
-    #
-    values["SHOW_MACHINE_UNITS"] = False
-    #
-    # Don't show the current operation label by default.
-    #
-    values["SHOW_OPERATION_LABELS"] = False
-    #
-    # Don't output an M5 command to stop the spindle after an M6 tool change by default.
-    #
-    values["STOP_SPINDLE_FOR_TOOL_CHANGE"] = False
-    #
-    # Don't output a G43 tool length command following tool changes by default.
-    #
-    values["USE_TLO"] = False
-    values["UNITS"] = UNITS
+    def __init__(self, job) -> None:
+        super().__init__(
+            job=job,
+            tooltip=translate("CAM", "Refactored Test post processor"),
+            tooltipargs=[""],
+            units="Metric",
+        )
+        self.reinitialize()
+        Path.Log.debug("Refactored Test post processor initialized")
 
+    def reinitialize(self) -> None:
+        """Initialize or reinitialize the 'core' data structures for the postprocessor"""
+        #
+        # This is also used to reinitialize the data structures between tests
+        #
+        self.values: Values = {}
+        self.init_values(self.values)
+        self.argument_defaults: Defaults = {}
+        self.init_argument_defaults(self.argument_defaults)
+        self.arguments_visible: Visible = {}
+        self.init_arguments_visible(self.arguments_visible)
+        self.parser: Parser = self.init_arguments(
+            self.values, self.argument_defaults, self.arguments_visible
+        )
+        #
+        # Create another parser just to get a list of all possible arguments
+        # that may be output using --output_all_arguments.
+        #
+        self.all_arguments_visible: Visible = {}
+        for k in iter(self.arguments_visible):
+            self.all_arguments_visible[k] = True
+        self.all_visible: Parser = self.init_arguments(
+            self.values, self.argument_defaults, self.all_arguments_visible
+        )
 
-def init_argument_defaults(argument_defaults: Dict[str, bool]) -> None:
-    """Initialize which arguments (in a pair) are shown as the default argument."""
-    UtilsArguments.init_argument_defaults(argument_defaults)
-    #
-    # Modify which argument to show as the default in flag-type arguments here.
-    # If the value is True, the first argument will be shown as the default.
-    # If the value is False, the second argument will be shown as the default.
-    #
-    # For example, if you want to show Metric mode as the default, use:
-    #   argument_defaults["metric_inch"] = True
-    #
-    # If you want to show that "Don't pop up editor for writing output" is
-    # the default, use:
-    #   argument_defaults["show-editor"] = False.
-    #
-    # Note:  You also need to modify the corresponding entries in the "values" hash
-    #        to actually make the default value(s) change to match.
-    #
+    def init_values(self, values: Values) -> None:
+        """Initialize values that are used throughout the postprocessor."""
+        #
+        PostUtilsArguments.init_shared_values(values)
+        #
+        # Set any values here that need to override the default values set
+        # in the init_shared_values routine.
+        #
+        # Used in the argparser code as the "name" of the postprocessor program.
+        #
+        values["MACHINE_NAME"] = "test"
+        #
+        # Don't output comments by default
+        #
+        values["OUTPUT_COMMENTS"] = False
+        #
+        # Don't output the header by default
+        #
+        values["OUTPUT_HEADER"] = False
+        #
+        # Convert M56 tool change commands to comments,
+        # which are then suppressed by default.
+        #
+        values["OUTPUT_TOOL_CHANGE"] = False
+        values["POSTPROCESSOR_FILE_NAME"] = __name__
+        #
+        # Do not show the editor by default since we are testing.
+        #
+        values["SHOW_EDITOR"] = False
+        #
+        # Don't show the current machine units by default
+        #
+        values["SHOW_MACHINE_UNITS"] = False
+        #
+        # Don't show the current operation label by default.
+        #
+        values["SHOW_OPERATION_LABELS"] = False
+        #
+        # Don't output an M5 command to stop the spindle after an M6 tool change by default.
+        #
+        values["STOP_SPINDLE_FOR_TOOL_CHANGE"] = False
+        #
+        # Don't output a G43 tool length command following tool changes by default.
+        #
+        values["USE_TLO"] = False
+        values["UNITS"] = self._units
 
+    def init_argument_defaults(self, argument_defaults: Defaults) -> None:
+        """Initialize which arguments (in a pair) are shown as the default argument."""
+        PostUtilsArguments.init_argument_defaults(argument_defaults)
+        #
+        # Modify which argument to show as the default in flag-type arguments here.
+        # If the value is True, the first argument will be shown as the default.
+        # If the value is False, the second argument will be shown as the default.
+        #
+        # For example, if you want to show Metric mode as the default, use:
+        #   argument_defaults["metric_inch"] = True
+        #
+        # If you want to show that "Don't pop up editor for writing output" is
+        # the default, use:
+        #   argument_defaults["show-editor"] = False.
+        #
+        # Note:  You also need to modify the corresponding entries in the "values" hash
+        #        to actually make the default value(s) change to match.
+        #
 
-def init_arguments_visible(arguments_visible: Dict[str, bool]) -> None:
-    """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
-    key: str
+    def init_arguments_visible(self, arguments_visible: Visible) -> None:
+        """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
+        PostUtilsArguments.init_arguments_visible(arguments_visible)
+        #
+        # Modify the visibility of any arguments from the defaults here.
+        #
+        # Make all arguments invisible by default.
+        #
+        for key in iter(arguments_visible):
+            arguments_visible[key] = False
 
-    UtilsArguments.init_arguments_visible(arguments_visible)
-    #
-    # Modify the visibility of any arguments from the defaults here.
-    #
-    #
-    # Make all arguments invisible by default.
-    #
-    for key in iter(arguments_visible):
-        arguments_visible[key] = False
+    def init_arguments(
+        self,
+        values: Values,
+        argument_defaults: Defaults,
+        arguments_visible: Visible,
+    ) -> Parser:
+        """Initialize the shared argument definitions."""
+        _parser: Parser = PostUtilsArguments.init_shared_arguments(
+            values, argument_defaults, arguments_visible
+        )
+        #
+        # Add any argument definitions that are not shared with all other
+        # postprocessors here.
+        #
+        return _parser
 
+    def process_arguments(self) -> Tuple[bool, ParserArgs]:
+        """Process any arguments to the postprocessor."""
+        #
+        # This function is separated out to make it easier to inherit from this postprocessor
+        #
+        args: ParserArgs
+        flag: bool
 
-def init_arguments(
-    values: Values,
-    argument_defaults: Dict[str, bool],
-    arguments_visible: Dict[str, bool],
-) -> Parser:
-    """Initialize the shared argument definitions."""
-    parser: Parser
+        (flag, args) = PostUtilsArguments.process_shared_arguments(
+            self.values, self.parser, self._job.PostProcessorArgs, self.all_visible, "-"
+        )
+        #
+        # If the flag is False, then all that is returned is a string
+        # containing the argument list formatted for output
+        #
+        # If the flag is True, then all of the arguments should be processed normally
+        #
+        if flag:
+            #
+            # Process any additional arguments here
+            #
+            #
+            # Update any variables that might have been modified while processing the arguments.
+            #
+            self._units = self.values["UNITS"]
+        return (flag, args)
 
-    parser = UtilsArguments.init_shared_arguments(values, argument_defaults, arguments_visible)
-    #
-    # Add any argument definitions that are not shared with all other
-    # postprocessors here.
-    #
-    return parser
+    def process_postables(self) -> GCodeSections:
+        """Postprocess the 'postables' in the job to g code sections."""
+        #
+        # This function is separated out to make it easier to inherit from this postprocessor
+        #
+        gcode: str
+        g_code_sections: GCodeSections
+        partname: str
+        postables: Postables
+        section: Section
+        sublist: Sublist
 
+        postables = self._buildPostList()
 
-#
-# Creating global variables and using functions to modify them
-# is useful for being able to test things later.
-#
-global_values: Values = {}
-init_values(global_values)
-global_argument_defaults: Dict[str, bool] = {}
-init_argument_defaults(global_argument_defaults)
-global_arguments_visible: Dict[str, bool] = {}
-init_arguments_visible(global_arguments_visible)
-global_parser: Parser = init_arguments(
-    global_values, global_argument_defaults, global_arguments_visible
-)
-#
-# The TOOLTIP_ARGS value is created from the help information about the arguments.
-#
-TOOLTIP_ARGS: str = global_parser.format_help()
-#
-# Create another parser just to get a list of all possible arguments
-# that may be output using --output_all_arguments.
-#
-global_all_arguments_visible: Dict[str, bool] = {}
-k: str
-for k in iter(global_arguments_visible):
-    global_all_arguments_visible[k] = True
-global_all_visible: Parser = init_arguments(
-    global_values, global_argument_defaults, global_all_arguments_visible
-)
+        Path.Log.debug(f"postables count: {len(postables)}")
 
+        g_code_sections = []
+        for _, section in enumerate(postables):
+            partname, sublist = section
+            gcode = PostUtilsExport.export_common(self.values, sublist, "-")
+            g_code_sections.append((partname, gcode))
 
-def export(objectslist, filename: str, argstring: str) -> str:
-    """Postprocess the objects in objectslist to filename."""
-    args: Union[str, argparse.Namespace]
-    flag: bool
+        return g_code_sections
 
-    global UNITS  # pylint: disable=global-statement
+    def export(self) -> GCodeSections:
+        """Process the parser arguments, then postprocess the 'postables'."""
+        args: ParserArgs
+        flag: bool
 
-    # print(parser.format_help())
+        Path.Log.debug("Exporting the job")
 
-    (flag, args) = UtilsArguments.process_shared_arguments(
-        global_values, global_parser, argstring, global_all_visible, filename
-    )
-    if not flag:
-        return args  # type: ignore
-    #
-    # Process any additional arguments here
-    #
+        (flag, args) = self.process_arguments()
+        #
+        # If the flag is True, then continue postprocessing the 'postables'
+        #
+        if flag:
+            return self.process_postables()
+        #
+        # If the flag is False, then all that is returned is a string
+        # containing the argument list formatted for output
+        #
+        return [("allitems", args)]  # type: ignore
 
-    #
-    # Update the global variables that might have been modified
-    # while processing the arguments.
-    #
-    UNITS = global_values["UNITS"]
+    @property
+    def tooltip(self):
+        tooltip: str = """
+        This is a postprocessor file for the CAM workbench.  It is used
+        to test the postprocessor code.  It probably isn't useful for "real" gcode.
+        """
+        return tooltip
 
-    return UtilsExport.export_common(global_values, objectslist, filename)
+    @property
+    def tooltipArgs(self) -> FormatHelp:
+        return self.parser.format_help()
+
+    @property
+    def units(self) -> Units:
+        return self._units


### PR DESCRIPTION
Just before the 1.0 release, the way that postprocessors were called from FreeCAD was refactored to be more object oriented as well as better in other ways. The existing postprocessor scripts still work, but the refactored* postprocessors needed to be converted to use the new (more object-oriented) API to be supported and maintained in the future.

This converts the existing refactored* postprocessors to the new API along with the needed changes to the corresponding tests.  This doesn't include the pending Masso refactored postprocessor.

This fixes issue #19004.

