### PR TITLE
CI: Add run of PartDesign CLI tests with AllowCompound

### DIFF
--- a/.github/workflows/actions/runPythonTests/action.yml
+++ b/.github/workflows/actions/runPythonTests/action.yml
@@ -46,7 +46,9 @@ runs:
       shell: bash -l {0}
       run: |
         set -o pipefail
-        ${{ inputs.testCommand }} | sed -Ee "/[[:blank:]]*\([[:digit:]]{1,3} %\)[[:blank:]]*/d" | tee -a ${{ inputs.logFile }}
+        {
+        ${{ inputs.testCommand }}
+        } | sed -Ee "/[[:blank:]]*\([[:digit:]]{1,3} %\)[[:blank:]]*/d" | tee -a ${{ inputs.logFile }}
     - name: Write report
       shell: bash -l {0}
       if: always()

--- a/.github/workflows/sub_buildUbuntu2004.yml
+++ b/.github/workflows/sub_buildUbuntu2004.yml
@@ -223,6 +223,20 @@ jobs:
           testCommand: FreeCADCmd -t 0
           logFile: ${{ env.logdir }}TestCLIInstall.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+      - name: FreeCAD CLI PD tests on install with AllowCompound enabled
+        timeout-minutes: 5
+        uses: ./.github/workflows/actions/runPythonTests
+        with:
+          testDescription: "CLI PD tests on install with AllowCompound enabled"
+          testCommand: |
+            cat > /tmp/enable_pd_compound.py <<EOF
+            import FreeCAD
+            pd_params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/PartDesign")
+            pd_params.SetBool("AllowCompoundDefault", True)
+            EOF
+            FreeCADCmd --safe-mode --run-test TestPartDesignApp /tmp/enable_pd_compound.py
+          logFile: ${{ env.logdir }}TestCLIPDInstall.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: FreeCAD GUI tests on install
         timeout-minutes: 15
         uses: ./.github/workflows/actions/runPythonTests


### PR DESCRIPTION
Since #13960 have an experimental setting to allow multiple solids within a PartDesign Body. This PR extends the CI to run the PartDesign tests with this setting enabled as well -- in addition to the tests with the default (aka without support multiple solids).
This should help preventing issues like #17363 in the future.