### PR TITLE
Refactor countObjectsOfType in selection and document

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -4407,6 +4407,12 @@ int Document::countObjectsOfType(const Base::Type& typeId) const
     return ct;
 }
 
+int Document::countObjectsOfType(const char* typeName) const
+{
+    Base::Type type = Base::Type::fromName(typeName);
+    return type.isBad() ? 0 : countObjectsOfType(type);
+}
+
 PyObject* Document::getPyObject()
 {
     return Py::new_reference_to(d->DocumentPythonObject);

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -4397,14 +4397,9 @@ Document::findObjects(const Base::Type& typeId, const char* objname, const char*
 
 int Document::countObjectsOfType(const Base::Type& typeId) const
 {
-    int ct = 0;
-    for (const auto& it : d->objectMap) {
-        if (it.second->getTypeId().isDerivedFrom(typeId)) {
-            ct++;
-        }
-    }
-
-    return ct;
+    return std::count_if(d->objectMap.begin(), d->objectMap.end(), [&](const auto& it) {
+        return it.second->getTypeId().isDerivedFrom(typeId);
+    });
 }
 
 int Document::countObjectsOfType(const char* typeName) const

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -339,6 +339,9 @@ public:
     template<typename T>
     inline std::vector<T*> getObjectsOfType() const;
     int countObjectsOfType(const Base::Type& typeId) const;
+    template<typename T>
+    inline int countObjectsOfType() const;
+    int countObjectsOfType(const char* typeName) const;
     /// get the number of objects in the document
     int countObjects() const;
     //@}
@@ -649,6 +652,14 @@ inline std::vector<T*> Document::getObjectsOfType() const
         type.push_back(static_cast<T*>(it));
     }
     return type;
+}
+
+template<typename T>
+inline int Document::countObjectsOfType() const
+{
+    static_assert(std::is_base_of<App::DocumentObject, T>::value,
+                  "T must be derived from App::DocumentObject");
+    return this->countObjectsOfType(T::getClassTypeId());
 }
 
 

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -338,7 +338,6 @@ public:
     /// Returns an array with the correct types already.
     template<typename T>
     inline std::vector<T*> getObjectsOfType() const;
-    int countObjectsOfType(const Base::Type& typeId) const;
     template<typename T>
     inline int countObjectsOfType() const;
     int countObjectsOfType(const char* typeName) const;
@@ -593,6 +592,7 @@ protected:
     std::vector<App::DocumentObject*> readObjects(Base::XMLReader& reader);
     void writeObjects(const std::vector<App::DocumentObject*>&, Base::Writer& writer) const;
     bool saveToFile(const char* filename) const;
+    int countObjectsOfType(const Base::Type& typeId) const;
 
     void onBeforeChange(const Property* prop) override;
     void onChanged(const Property* prop) override;

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1698,7 +1698,7 @@ bool StdCmdAlignment::isActive()
 {
     if (ManualAlignment::hasInstance())
         return false;
-    return Gui::Selection().countObjectsOfType(App::GeoFeature::getClassTypeId()) == 2;
+    return Gui::Selection().countObjectsOfType<App::GeoFeature>() == 2;
 }
 
 //===========================================================================

--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -526,7 +526,6 @@ std::vector<App::DocumentObject*> SelectionSingleton::getObjectsOfType(const cha
 
 unsigned int SelectionSingleton::countObjectsOfType(const Base::Type& typeId, const char* pDocName, ResolveMode resolve) const
 {
-    unsigned int iNbr=0;
     App::Document *pcDoc = nullptr;
     if(!pDocName || strcmp(pDocName,"*") != 0) {
         pcDoc = getDocument(pDocName);
@@ -534,12 +533,9 @@ unsigned int SelectionSingleton::countObjectsOfType(const Base::Type& typeId, co
             return 0;
     }
 
-    for (auto &sel : _SelList) {
-        if((!pcDoc||pcDoc==sel.pDoc) && getObjectOfType(sel, typeId, resolve))
-            iNbr++;
-    }
-
-    return iNbr;
+    return std::count_if(_SelList.begin(), _SelList.end(), [&](auto& sel) {
+        return (!pcDoc || pcDoc == sel.pDoc) && getObjectOfType(sel, typeId, resolve);
+    });
 }
 
 unsigned int SelectionSingleton::countObjectsOfType(const char* typeName, const char* pDocName, ResolveMode resolve) const

--- a/src/Gui/Selection.h
+++ b/src/Gui/Selection.h
@@ -387,14 +387,9 @@ public:
      * If no document name is given the active document is assumed.
      *
      * Set 'resolve' to true to resolve any sub object inside selection SubName
-     * field
-     */
-    unsigned int countObjectsOfType(const Base::Type& typeId=App::DocumentObject::getClassTypeId(),
-            const char* pDocName=nullptr, ResolveMode resolve = ResolveMode::OldStyleElement) const;
-
-    /**
-     * A convenience template-based method that returns the number of objects of the given type.
-     * \a T must be based on Base::BaseClass, otherwise 0 is returned.
+     * field.
+     * 
+     * The typename T must be based on App::DocumentObject.
      */
     template<typename T> inline unsigned int countObjectsOfType(
             const char* pDocName=nullptr, ResolveMode resolve = ResolveMode::OldStyleElement) const;
@@ -714,6 +709,9 @@ protected:
 
     static App::DocumentObject *getObjectOfType(_SelObj &sel, Base::Type type,
             ResolveMode resolve, const char **subelement=nullptr);
+
+    unsigned int countObjectsOfType(const Base::Type& typeId=App::DocumentObject::getClassTypeId(),
+            const char* pDocName=nullptr, ResolveMode resolve = ResolveMode::OldStyleElement) const;
 
     static SelectionSingleton* _pcSingleton;
 

--- a/src/Gui/Selection.h
+++ b/src/Gui/Selection.h
@@ -393,6 +393,13 @@ public:
             const char* pDocName=nullptr, ResolveMode resolve = ResolveMode::OldStyleElement) const;
 
     /**
+     * A convenience template-based method that returns the number of objects of the given type.
+     * \a T must be based on Base::BaseClass, otherwise 0 is returned.
+     */
+    template<typename T> inline unsigned int countObjectsOfType(
+            const char* pDocName=nullptr, ResolveMode resolve = ResolveMode::OldStyleElement) const;
+
+    /**
      * Does basically the same as the method above unless that it accepts a string literal as first argument.
      * \a typeName must be a registered type, otherwise 0 is returned.
      */
@@ -723,6 +730,15 @@ protected:
 
     SelectionStyle selectionStyle;
 };
+
+/**
+ * A convenience template-based method that returns the number of objects of the given type.
+ */
+template<typename T>
+inline unsigned int SelectionSingleton::countObjectsOfType(const char* pDocName, ResolveMode resolve) const {
+    static_assert(std::is_base_of<App::DocumentObject, T>::value, "Template parameter T must be derived from App::DocumentObject");
+    return this->countObjectsOfType(T::getClassTypeId(), pDocName, resolve);
+}
 
 /**
  * A convenience template-based method that returns an array with the correct types already.

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -594,7 +594,7 @@ void StdWorkbench::setupContextMenu(const char* recipient, MenuItem* item) const
               << StdViews << "Separator"
               << "Std_ViewDockUndockFullscreen";
 
-        if (Gui::Selection().countObjectsOfType(App::DocumentObject::getClassTypeId()) > 0) {
+        if (Gui::Selection().countObjectsOfType<App::DocumentObject>() > 0) {
             *item << "Separator" << "Std_ToggleVisibility"
                   << "Std_ToggleSelectability" << "Std_TreeSelection"
                   << "Std_RandomColor" << "Std_ToggleTransparency" << "Separator" << "Std_Delete"
@@ -603,7 +603,7 @@ void StdWorkbench::setupContextMenu(const char* recipient, MenuItem* item) const
     }
     else if (strcmp(recipient,"Tree") == 0)
     {
-        if (Gui::Selection().countObjectsOfType(App::DocumentObject::getClassTypeId()) > 0) {
+        if (Gui::Selection().countObjectsOfType<App::DocumentObject>() > 0) {
             *item  << "Std_ToggleFreeze" << "Separator"
                   << "Std_Placement" << "Std_ToggleVisibility" << "Std_ShowSelection" << "Std_HideSelection"
                   << "Std_ToggleSelectability" << "Std_TreeSelectAllInstances" << "Separator"

--- a/src/Mod/Drawing/Gui/Command.cpp
+++ b/src/Mod/Drawing/Gui/Command.cpp
@@ -479,7 +479,7 @@ CmdDrawingOpenBrowserView::CmdDrawingOpenBrowserView()
 void CmdDrawingOpenBrowserView::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    unsigned int n = getSelection().countObjectsOfType(Drawing::FeaturePage::getClassTypeId());
+    unsigned int n = getSelection().countObjectsOfType<Drawing::FeaturePage>();
     if (n != 1) {
         QMessageBox::warning(Gui::getMainWindow(),
                              QObject::tr("Wrong selection"),
@@ -691,7 +691,7 @@ CmdDrawingExportPage::CmdDrawingExportPage()
 void CmdDrawingExportPage::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    unsigned int n = getSelection().countObjectsOfType(Drawing::FeaturePage::getClassTypeId());
+    unsigned int n = getSelection().countObjectsOfType<Drawing::FeaturePage>();
     if (n != 1) {
         QMessageBox::warning(Gui::getMainWindow(),
                              QObject::tr("Wrong selection"),
@@ -757,7 +757,7 @@ void CmdDrawingProjectShape::activated(int iMsg)
 
 bool CmdDrawingProjectShape::isActive(void)
 {
-    int ct = Gui::Selection().countObjectsOfType(Part::Feature::getClassTypeId());
+    int ct = Gui::Selection().countObjectsOfType<Part::Feature>();
     return (ct > 0 && !Gui::Control().activeDialog());
 }
 

--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -223,8 +223,7 @@ bool CmdFemAddPart::isActive(void)
 {
     if (Gui::Control().activeDialog())
         return false;
-    Base::Type type = Base::Type::fromName("Part::Feature");
-    return Gui::Selection().countObjectsOfType(type) > 0;
+    return Gui::Selection().countObjectsOfType<Part::Feature>(type) > 0;
 }
 */
 
@@ -1165,7 +1164,7 @@ void CmdFemDefineNodesSet::activated(int)
 bool CmdFemDefineNodesSet::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    if (getSelection().countObjectsOfType(Fem::FemMeshObject::getClassTypeId()) != 1) {
+    if (getSelection().countObjectsOfType<Fem::FemMeshObject>() != 1) {
         return false;
     }
 
@@ -1314,7 +1313,7 @@ void CmdFemDefineElementsSet::activated(int)
 bool CmdFemDefineElementsSet::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    if (getSelection().countObjectsOfType(Fem::FemMeshObject::getClassTypeId()) != 1) {
+    if (getSelection().countObjectsOfType<Fem::FemMeshObject>() != 1) {
         return false;
     }
 
@@ -2028,25 +2027,25 @@ bool CmdFemPostClipFilter::isActive()
         return false;
     }
     // only activate if a result is either a post pipeline or a possible filter
-    if (getSelection().getObjectsOfType<Fem::FemPostPipeline>().size() == 1) {
+    if (getSelection().countObjectsOfType<Fem::FemPostPipeline>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostClipFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostDataAlongLineFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostDataAlongLineFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostScalarClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostScalarClipFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostContoursFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostContoursFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostCutFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostCutFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostWarpVectorFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostWarpVectorFilter>() == 1) {
         return true;
     }
     return false;
@@ -2080,25 +2079,25 @@ bool CmdFemPostCutFilter::isActive()
         return false;
     }
     // only activate if a result is either a post pipeline or a possible filter
-    if (getSelection().getObjectsOfType<Fem::FemPostPipeline>().size() == 1) {
+    if (getSelection().countObjectsOfType<Fem::FemPostPipeline>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostClipFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostContoursFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostContoursFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostCutFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostCutFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostScalarClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostScalarClipFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostDataAlongLineFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostDataAlongLineFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostWarpVectorFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostWarpVectorFilter>() == 1) {
         return true;
     }
     return false;
@@ -2132,22 +2131,22 @@ bool CmdFemPostDataAlongLineFilter::isActive()
         return false;
     }
     // only activate if a result is either a post pipeline or a possible filter
-    if (getSelection().getObjectsOfType<Fem::FemPostPipeline>().size() == 1) {
+    if (getSelection().countObjectsOfType<Fem::FemPostPipeline>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostClipFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostContoursFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostContoursFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostCutFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostCutFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostScalarClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostScalarClipFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostWarpVectorFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostWarpVectorFilter>() == 1) {
         return true;
     }
     return false;
@@ -2182,22 +2181,22 @@ bool CmdFemPostDataAtPointFilter::isActive()
         return false;
     }
     // only activate if a result is either a post pipeline or a possible filter
-    if (getSelection().getObjectsOfType<Fem::FemPostPipeline>().size() == 1) {
+    if (getSelection().countObjectsOfType<Fem::FemPostPipeline>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostClipFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostCutFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostCutFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostDataAlongLineFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostDataAlongLineFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostScalarClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostScalarClipFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostWarpVectorFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostWarpVectorFilter>() == 1) {
         return true;
     }
     return false;
@@ -2307,22 +2306,22 @@ bool CmdFemPostScalarClipFilter::isActive()
         return false;
     }
     // only activate if a result is either a post pipeline or a possible other filter
-    if (getSelection().getObjectsOfType<Fem::FemPostPipeline>().size() == 1) {
+    if (getSelection().countObjectsOfType<Fem::FemPostPipeline>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostClipFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostContoursFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostContoursFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostCutFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostCutFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostDataAlongLineFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostDataAlongLineFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostWarpVectorFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostWarpVectorFilter>() == 1) {
         return true;
     }
     return false;
@@ -2356,22 +2355,22 @@ bool CmdFemPostWarpVectorFilter::isActive()
         return false;
     }
     // only activate if a result is either a post pipeline or a possible other filter
-    if (getSelection().getObjectsOfType<Fem::FemPostPipeline>().size() == 1) {
+    if (getSelection().countObjectsOfType<Fem::FemPostPipeline>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostClipFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostCutFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostCutFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostContoursFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostContoursFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostDataAlongLineFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostDataAlongLineFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostScalarClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostScalarClipFilter>() == 1) {
         return true;
     }
     return false;
@@ -2405,22 +2404,22 @@ bool CmdFemPostContoursFilter::isActive()
         return false;
     }
     // only activate if a result is either a post pipeline or a possible other filter
-    if (getSelection().getObjectsOfType<Fem::FemPostPipeline>().size() == 1) {
+    if (getSelection().countObjectsOfType<Fem::FemPostPipeline>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostClipFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostCutFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostCutFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostDataAlongLineFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostDataAlongLineFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostScalarClipFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostScalarClipFilter>() == 1) {
         return true;
     }
-    else if (getSelection().getObjectsOfType<Fem::FemPostWarpVectorFilter>().size() == 1) {
+    else if (getSelection().countObjectsOfType<Fem::FemPostWarpVectorFilter>() == 1) {
         return true;
     }
     return false;

--- a/src/Mod/Inspection/Gui/Command.cpp
+++ b/src/Mod/Inspection/Gui/Command.cpp
@@ -99,7 +99,7 @@ void CmdInspectElement::activated(int)
 bool CmdInspectElement::isActive()
 {
     App::Document* doc = App::GetApplication().getActiveDocument();
-    if (!doc || doc->countObjectsOfType(Inspection::Feature::getClassTypeId()) == 0) {
+    if (!doc || doc->countObjectsOfType<Inspection::Feature>() == 0) {
         return false;
     }
 

--- a/src/Mod/Measure/Gui/Command.cpp
+++ b/src/Mod/Measure/Gui/Command.cpp
@@ -64,7 +64,7 @@ void StdCmdMeasure::activated(int iMsg)
 bool StdCmdMeasure::isActive()
 {
     App::Document* doc = App::GetApplication().getActiveDocument();
-    if (!doc || doc->countObjectsOfType(App::GeoFeature::getClassTypeId()) == 0) {
+    if (!doc || doc->countObjectsOfType<App::GeoFeature>() == 0) {
         return false;
     }
 

--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -151,7 +151,7 @@ void CmdMeshUnion::activated(int)
 
 bool CmdMeshUnion::isActive()
 {
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 2;
+    return getSelection().countObjectsOfType<Mesh::Feature>() == 2;
 }
 
 //--------------------------------------------------------------------------------------
@@ -230,7 +230,7 @@ void CmdMeshDifference::activated(int)
 
 bool CmdMeshDifference::isActive()
 {
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 2;
+    return getSelection().countObjectsOfType<Mesh::Feature>() == 2;
 }
 
 //--------------------------------------------------------------------------------------
@@ -309,7 +309,7 @@ void CmdMeshIntersection::activated(int)
 
 bool CmdMeshIntersection::isActive()
 {
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 2;
+    return getSelection().countObjectsOfType<Mesh::Feature>() == 2;
 }
 
 //--------------------------------------------------------------------------------------
@@ -445,7 +445,7 @@ void CmdMeshExport::activated(int)
 
 bool CmdMeshExport::isActive()
 {
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 1;
+    return getSelection().countObjectsOfType<Mesh::Feature>() == 1;
 }
 
 //--------------------------------------------------------------------------------------
@@ -516,7 +516,7 @@ bool CmdMeshFromGeometry::isActive()
     if (!doc) {
         return false;
     }
-    return getSelection().countObjectsOfType(App::GeoFeature::getClassTypeId()) >= 1;
+    return getSelection().countObjectsOfType<App::GeoFeature>() >= 1;
 }
 
 //===========================================================================
@@ -598,7 +598,7 @@ void CmdMeshVertexCurvature::activated(int)
 bool CmdMeshVertexCurvature::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0;
+    return getSelection().countObjectsOfType<Mesh::Feature>() > 0;
 }
 
 //--------------------------------------------------------------------------------------
@@ -696,7 +696,7 @@ void CmdMeshPolySegm::activated(int)
 bool CmdMeshPolySegm::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 0) {
+    if (getSelection().countObjectsOfType<Mesh::Feature>() == 0) {
         return false;
     }
 
@@ -744,7 +744,7 @@ void CmdMeshAddFacet::activated(int)
 bool CmdMeshAddFacet::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) != 1) {
+    if (getSelection().countObjectsOfType<Mesh::Feature>() != 1) {
         return false;
     }
 
@@ -809,7 +809,7 @@ void CmdMeshPolyCut::activated(int)
 bool CmdMeshPolyCut::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 0) {
+    if (getSelection().countObjectsOfType<Mesh::Feature>() == 0) {
         return false;
     }
 
@@ -874,7 +874,7 @@ void CmdMeshPolyTrim::activated(int)
 bool CmdMeshPolyTrim::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 0) {
+    if (getSelection().countObjectsOfType<Mesh::Feature>() == 0) {
         return false;
     }
 
@@ -913,11 +913,7 @@ void CmdMeshTrimByPlane::activated(int)
 bool CmdMeshTrimByPlane::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) != 1) {
-        return false;
-    }
-
-    return true;
+    return getSelection().countObjectsOfType<Mesh::Feature>() == 1;
 }
 
 //--------------------------------------------------------------------------------------
@@ -946,11 +942,7 @@ void CmdMeshSectionByPlane::activated(int)
 bool CmdMeshSectionByPlane::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) != 1) {
-        return false;
-    }
-
-    return true;
+    return getSelection().countObjectsOfType<Mesh::Feature>() == 1;
 }
 
 //--------------------------------------------------------------------------------------
@@ -978,7 +970,7 @@ void CmdMeshCrossSections::activated(int)
 
 bool CmdMeshCrossSections::isActive()
 {
-    return (Gui::Selection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0
+    return (Gui::Selection().countObjectsOfType<Mesh::Feature>() > 0
             && !Gui::Control().activeDialog());
 }
 
@@ -1026,7 +1018,7 @@ void CmdMeshPolySplit::activated(int)
 bool CmdMeshPolySplit::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 0) {
+    if (getSelection().countObjectsOfType<Mesh::Feature>() == 0) {
         return false;
     }
 
@@ -1209,7 +1201,7 @@ void CmdMeshRemeshGmsh::activated(int)
 
 bool CmdMeshRemeshGmsh::isActive()
 {
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 1;
+    return getSelection().countObjectsOfType<Mesh::Feature>() == 1;
 }
 
 //--------------------------------------------------------------------------------------
@@ -1297,7 +1289,7 @@ void CmdMeshEvaluateSolid::activated(int)
 bool CmdMeshEvaluateSolid::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 1;
+    return getSelection().countObjectsOfType<Mesh::Feature>() == 1;
 }
 
 //--------------------------------------------------------------------------------------
@@ -1326,7 +1318,7 @@ bool CmdMeshSmoothing::isActive()
     if (Gui::Control().activeDialog()) {
         return false;
     }
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0;
+    return getSelection().countObjectsOfType<Mesh::Feature>() > 0;
 }
 
 //--------------------------------------------------------------------------------------
@@ -1358,7 +1350,7 @@ bool CmdMeshDecimating::isActive()
     }
 #endif
     // Check for the selected mesh feature (all Mesh types)
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0;
+    return getSelection().countObjectsOfType<Mesh::Feature>() > 0;
 }
 
 //--------------------------------------------------------------------------------------
@@ -1394,7 +1386,7 @@ void CmdMeshHarmonizeNormals::activated(int)
 bool CmdMeshHarmonizeNormals::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0;
+    return getSelection().countObjectsOfType<Mesh::Feature>() > 0;
 }
 
 //--------------------------------------------------------------------------------------
@@ -1430,7 +1422,7 @@ void CmdMeshFlipNormals::activated(int)
 bool CmdMeshFlipNormals::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0;
+    return getSelection().countObjectsOfType<Mesh::Feature>() > 0;
 }
 
 //--------------------------------------------------------------------------------------
@@ -1482,7 +1474,7 @@ void CmdMeshBoundingBox::activated(int)
 bool CmdMeshBoundingBox::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 1;
+    return getSelection().countObjectsOfType<Mesh::Feature>() == 1;
 }
 
 //--------------------------------------------------------------------------------------
@@ -1565,7 +1557,7 @@ void CmdMeshFillupHoles::activated(int)
 bool CmdMeshFillupHoles::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0;
+    return getSelection().countObjectsOfType<Mesh::Feature>() > 0;
 }
 
 //--------------------------------------------------------------------------------------
@@ -1648,7 +1640,7 @@ bool CmdMeshSegmentation::isActive()
     if (Gui::Control().activeDialog()) {
         return false;
     }
-    return Gui::Selection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 1;
+    return Gui::Selection().countObjectsOfType<Mesh::Feature>() == 1;
 }
 
 //--------------------------------------------------------------------------------------
@@ -1684,7 +1676,7 @@ bool CmdMeshSegmentationBestFit::isActive()
     if (Gui::Control().activeDialog()) {
         return false;
     }
-    return Gui::Selection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 1;
+    return Gui::Selection().countObjectsOfType<Mesh::Feature>() == 1;
 }
 
 //--------------------------------------------------------------------------------------
@@ -1730,7 +1722,7 @@ void CmdMeshMerge::activated(int)
 
 bool CmdMeshMerge::isActive()
 {
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) >= 2;
+    return getSelection().countObjectsOfType<Mesh::Feature>() >= 2;
 }
 
 //--------------------------------------------------------------------------------------
@@ -1779,7 +1771,7 @@ void CmdMeshSplitComponents::activated(int)
 
 bool CmdMeshSplitComponents::isActive()
 {
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 1;
+    return getSelection().countObjectsOfType<Mesh::Feature>() == 1;
 }
 
 //--------------------------------------------------------------------------------------
@@ -1837,7 +1829,7 @@ void CmdMeshScale::activated(int)
 
 bool CmdMeshScale::isActive()
 {
-    return getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0;
+    return getSelection().countObjectsOfType<Mesh::Feature>() > 0;
 }
 
 

--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -636,7 +636,7 @@ void CmdMeshVertexCurvatureInfo::activated(int)
 bool CmdMeshVertexCurvatureInfo::isActive()
 {
     App::Document* doc = App::GetApplication().getActiveDocument();
-    if (!doc || doc->countObjectsOfType(Mesh::Curvature::getClassTypeId()) == 0) {
+    if (!doc || doc->countObjectsOfType<Mesh::Curvature>() == 0) {
         return false;
     }
 
@@ -1070,7 +1070,7 @@ void CmdMeshEvaluation::activated(int)
 bool CmdMeshEvaluation::isActive()
 {
     App::Document* doc = App::GetApplication().getActiveDocument();
-    if (!doc || doc->countObjectsOfType(Mesh::Feature::getClassTypeId()) == 0) {
+    if (!doc || doc->countObjectsOfType<Mesh::Feature>() == 0) {
         return false;
     }
     return true;
@@ -1109,7 +1109,7 @@ void CmdMeshEvaluateFacet::activated(int)
 bool CmdMeshEvaluateFacet::isActive()
 {
     App::Document* doc = App::GetApplication().getActiveDocument();
-    if (!doc || doc->countObjectsOfType(Mesh::Feature::getClassTypeId()) == 0) {
+    if (!doc || doc->countObjectsOfType<Mesh::Feature>() == 0) {
         return false;
     }
 
@@ -1152,7 +1152,7 @@ bool CmdMeshRemoveComponents::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
     App::Document* doc = getDocument();
-    if (!(doc && doc->countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0)) {
+    if (!(doc && doc->countObjectsOfType<Mesh::Feature>() > 0)) {
         return false;
     }
     Gui::Document* viewDoc = Gui::Application::Instance->getDocument(doc);
@@ -1237,7 +1237,7 @@ void CmdMeshRemoveCompByHand::activated(int)
 bool CmdMeshRemoveCompByHand::isActive()
 {
     App::Document* doc = App::GetApplication().getActiveDocument();
-    if (!doc || doc->countObjectsOfType(Mesh::Feature::getClassTypeId()) == 0) {
+    if (!doc || doc->countObjectsOfType<Mesh::Feature>() == 0) {
         return false;
     }
 
@@ -1596,7 +1596,7 @@ void CmdMeshFillInteractiveHole::activated(int)
 bool CmdMeshFillInteractiveHole::isActive()
 {
     App::Document* doc = App::GetApplication().getActiveDocument();
-    if (!doc || doc->countObjectsOfType(Mesh::Feature::getClassTypeId()) == 0) {
+    if (!doc || doc->countObjectsOfType<Mesh::Feature>() == 0) {
         return false;
     }
 

--- a/src/Mod/Mesh/Gui/Workbench.cpp
+++ b/src/Mod/Mesh/Gui/Workbench.cpp
@@ -158,7 +158,7 @@ void Workbench::deactivated()
 void Workbench::setupContextMenu(const char* recipient, Gui::MenuItem* item) const
 {
     StdWorkbench::setupContextMenu(recipient, item);
-    if (Gui::Selection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0) {
+    if (Gui::Selection().countObjectsOfType<Mesh::Feature>() > 0) {
         *item << "Separator"
               << "Mesh_Import"
               << "Mesh_Export"

--- a/src/Mod/MeshPart/Gui/Command.cpp
+++ b/src/Mod/MeshPart/Gui/Command.cpp
@@ -173,11 +173,7 @@ void CmdMeshPartTrimByPlane::activated(int)
 bool CmdMeshPartTrimByPlane::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) != 1) {
-        return false;
-    }
-
-    return true;
+    return getSelection().countObjectsOfType<Mesh::Feature>() == 1;
 }
 
 //===========================================================================
@@ -262,11 +258,7 @@ void CmdMeshPartSection::activated(int)
 bool CmdMeshPartSection::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) != 1) {
-        return false;
-    }
-
-    return true;
+    return getSelection().countObjectsOfType<Mesh::Feature>() == 1;
 }
 
 //===========================================================================
@@ -304,7 +296,7 @@ void CmdMeshPartCrossSections::activated(int iMsg)
 
 bool CmdMeshPartCrossSections::isActive()
 {
-    return (Gui::Selection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0
+    return (Gui::Selection().countObjectsOfType<Mesh::Feature>() > 0
             && !Gui::Control().activeDialog());
 }
 

--- a/src/Mod/MeshPart/Gui/Command.cpp
+++ b/src/Mod/MeshPart/Gui/Command.cpp
@@ -335,11 +335,7 @@ bool CmdMeshPartCurveOnMesh::isActive()
 
     // Check for the selected mesh feature (all Mesh types)
     App::Document* doc = App::GetApplication().getActiveDocument();
-    if (doc && doc->countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0) {
-        return true;
-    }
-
-    return false;
+    return doc && doc->countObjectsOfType<Mesh::Feature>() > 0;
 }
 
 

--- a/src/Mod/Part/App/FeatureMirroring.h
+++ b/src/Mod/Part/App/FeatureMirroring.h
@@ -31,7 +31,7 @@
 namespace Part
 {
 
-class Mirroring : public Part::Feature
+class PartExport Mirroring : public Part::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::Mirroring);
 

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -344,8 +344,7 @@ void CmdPartCut::activated(int iMsg)
 
 bool CmdPartCut::isActive()
 {
-    return getSelection().countObjectsOfType(
-            App::DocumentObject::getClassTypeId(), nullptr, Gui::ResolveMode::FollowLink)==2;
+    return getSelection().countObjectsOfType<App::DocumentObject>(nullptr, Gui::ResolveMode::FollowLink) == 2;
 }
 
 //===========================================================================
@@ -404,8 +403,7 @@ void CmdPartCommon::activated(int iMsg)
 
 bool CmdPartCommon::isActive()
 {
-    return getSelection().countObjectsOfType(
-            App::DocumentObject::getClassTypeId(), nullptr, Gui::ResolveMode::FollowLink) >= 1;
+    return getSelection().countObjectsOfType<App::DocumentObject>(nullptr, Gui::ResolveMode::FollowLink) >= 1;
 }
 
 //===========================================================================
@@ -483,8 +481,7 @@ void CmdPartFuse::activated(int iMsg)
 
 bool CmdPartFuse::isActive()
 {
-    return getSelection().countObjectsOfType(
-            App::DocumentObject::getClassTypeId(), nullptr, Gui::ResolveMode::FollowLink) >= 1;
+    return getSelection().countObjectsOfType<App::DocumentObject>(nullptr, Gui::ResolveMode::FollowLink) >= 1;
 }
 
 //===========================================================================
@@ -839,8 +836,7 @@ CmdPartCompound::CmdPartCompound()
 void CmdPartCompound::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    unsigned int n = getSelection().countObjectsOfType(
-            App::DocumentObject::getClassTypeId(), nullptr, Gui::ResolveMode::FollowLink);
+    unsigned int n = getSelection().countObjectsOfType<App::DocumentObject>(nullptr, Gui::ResolveMode::FollowLink);
     if (n < 1) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
             QObject::tr("Select one shape or more, please."));
@@ -872,8 +868,7 @@ void CmdPartCompound::activated(int iMsg)
 
 bool CmdPartCompound::isActive()
 {
-    return getSelection().countObjectsOfType(
-            App::DocumentObject::getClassTypeId(), nullptr, Gui::ResolveMode::FollowLink) >= 1;
+    return getSelection().countObjectsOfType<App::DocumentObject>(nullptr, Gui::ResolveMode::FollowLink) >= 1;
 }
 
 //===========================================================================
@@ -921,7 +916,7 @@ void CmdPartSection::activated(int iMsg)
 
 bool CmdPartSection::isActive()
 {
-    return getSelection().countObjectsOfType(App::DocumentObject::getClassTypeId(), nullptr, Gui::ResolveMode::FollowLink) == 2;
+    return getSelection().countObjectsOfType<App::DocumentObject>(nullptr, Gui::ResolveMode::FollowLink) == 2;
 }
 
 //===========================================================================
@@ -1032,7 +1027,7 @@ void CmdPartExport::activated(int iMsg)
 
 bool CmdPartExport::isActive()
 {
-    return Gui::Selection().countObjectsOfType(App::DocumentObject::getClassTypeId(), nullptr, Gui::ResolveMode::FollowLink) > 0;
+    return Gui::Selection().countObjectsOfType<App::DocumentObject>(nullptr, Gui::ResolveMode::FollowLink) > 0;
 }
 
 //===========================================================================
@@ -1360,7 +1355,7 @@ void CmdPartMakeFace::activated(int iMsg)
 
 bool CmdPartMakeFace::isActive()
 {
-    return (Gui::Selection().countObjectsOfType(App::DocumentObject::getClassTypeId(), nullptr, Gui::ResolveMode::FollowLink) > 0 &&
+    return (Gui::Selection().countObjectsOfType<App::DocumentObject>(nullptr, Gui::ResolveMode::FollowLink) > 0 &&
             !Gui::Control().activeDialog());
 }
 

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1153,8 +1153,7 @@ void CmdPartMakeSolid::activated(int iMsg)
 
 bool CmdPartMakeSolid::isActive()
 {
-    return Gui::Selection().countObjectsOfType
-        (App::DocumentObject::getClassTypeId(), nullptr, Gui::ResolveMode::FollowLink) > 0;
+    return Gui::Selection().countObjectsOfType<App::DocumentObject>(nullptr, Gui::ResolveMode::FollowLink) > 0;
 }
 
 //===========================================================================
@@ -1887,8 +1886,7 @@ void CmdPartThickness::activated(int iMsg)
 
 bool CmdPartThickness::isActive()
 {
-    Base::Type partid = Base::Type::fromName("Part::Feature");
-    bool objectsSelected = Gui::Selection().countObjectsOfType(partid, nullptr, Gui::ResolveMode::FollowLink) > 0;
+    bool objectsSelected = Gui::Selection().countObjectsOfType<Part::Feature>(nullptr, Gui::ResolveMode::FollowLink) > 0;
     return (objectsSelected && !Gui::Control().activeDialog());
 }
 
@@ -1918,7 +1916,7 @@ void CmdShapeInfo::activated(int iMsg)
 bool CmdShapeInfo::isActive()
 {
     App::Document* doc = App::GetApplication().getActiveDocument();
-    if (!doc || doc->countObjectsOfType(Part::Feature::getClassTypeId()) == 0)
+    if (!doc || doc->countObjectsOfType<Part::Feature>() == 0)
         return false;
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
@@ -2102,8 +2100,7 @@ void CmdColorPerFace::activated(int iMsg)
 
 bool CmdColorPerFace::isActive()
 {
-    Base::Type partid = Base::Type::fromName("Part::Feature");
-    bool objectSelected = Gui::Selection().countObjectsOfType(partid) == 1;
+    bool objectSelected = Gui::Selection().countObjectsOfType<Part::Feature>() == 1;
     return (hasActiveDocument() && !Gui::Control().activeDialog() && objectSelected);
 }
 

--- a/src/Mod/Part/Gui/CommandSimple.cpp
+++ b/src/Mod/Part/Gui/CommandSimple.cpp
@@ -119,8 +119,7 @@ void CmdPartShapeFromMesh::activated(int iMsg)
 
 bool CmdPartShapeFromMesh::isActive()
 {
-    Base::Type meshid = Base::Type::fromName("Mesh::Feature");
-    return Gui::Selection().countObjectsOfType(meshid) > 0;
+    return Gui::Selection().countObjectsOfType("Mesh::Feature") > 0;
 }
 //===========================================================================
 // Part_PointsFromMesh
@@ -205,8 +204,7 @@ void CmdPartPointsFromMesh::activated(int iMsg)
 
 bool CmdPartPointsFromMesh::isActive()
 {
-    Base::Type meshid = Base::Type::fromName("App::GeoFeature");
-    return Gui::Selection().countObjectsOfType(meshid) > 0;
+    return Gui::Selection().countObjectsOfType<App::GeoFeature>() > 0;
 }
 
 //===========================================================================

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -64,6 +64,7 @@
 #include <Mod/Part/App/PartFeature.h>
 #include <Mod/Part/App/PrimitiveFeature.h>
 #include <Mod/Part/App/DatumFeature.h>
+#include <Mod/Part/App/FeatureMirroring.h>
 #include <App/Datums.h>
 
 #include "Mirroring.h"
@@ -289,7 +290,7 @@ bool Mirroring::accept()
     }
 
     Gui::WaitCursor wc;
-    unsigned int count = activeDoc->countObjectsOfType(Base::Type::fromName("Part::Mirroring"));
+    unsigned int count = activeDoc->countObjectsOfType<Part::Mirroring>();
     activeDoc->openTransaction("Mirroring");
 
     QString shape, label, selectionString;

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -486,7 +486,7 @@ void CmdPartDesignClone::activated(int iMsg)
 
 bool CmdPartDesignClone::isActive()
 {
-    return getSelection().countObjectsOfType(Part::Feature::getClassTypeId()) == 1;
+    return getSelection().countObjectsOfType<Part::Feature>() == 1;
 }
 
 //===========================================================================

--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -707,7 +707,7 @@ std::tuple<bool, PartDesign::Body*> SketchWorkflow::shouldCreateBody()
         pdBody->Placement.setValue(xLink->Placement.getValue());
     }
     if (!pdBody) {
-        if (appdocument->countObjectsOfType(PartDesign::Body::getClassTypeId()) == 0) {
+        if (appdocument->countObjectsOfType<PartDesign::Body>() == 0) {
             shouldMakeBody = true;
         }
         else {

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -121,7 +121,7 @@ PartDesign::Body *getBody(bool messageIfNot, bool autoActivate, bool assertModer
 
     if (activeView) {
         auto doc = activeView->getAppDocument();
-        bool singleBodyDocument = doc->countObjectsOfType(PartDesign::Body::getClassTypeId()) == 1;
+        bool singleBodyDocument = doc->countObjectsOfType<PartDesign::Body>() == 1;
         if (assertModern) {
             activeBody = activeView->getActiveObject<PartDesign::Body*>(PDBODYKEY,topParent,subname);
 

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -132,11 +132,11 @@ void Workbench::setupContextMenu(const char* recipient, Gui::MenuItem* item) con
                 }
             }
 
-            if (Gui::Selection().countObjectsOfType(PartDesign::Transformed::getClassTypeId()) -
-                Gui::Selection().countObjectsOfType(PartDesign::MultiTransform::getClassTypeId()) == 1 )
+            if (Gui::Selection().countObjectsOfType<PartDesign::Transformed>() -
+                Gui::Selection().countObjectsOfType<PartDesign::MultiTransform>() == 1 )
                 *item << "PartDesign_MultiTransform";
 
-            if (Gui::Selection().countObjectsOfType(App::DocumentObject::getClassTypeId()) > 0) {
+            if (Gui::Selection().countObjectsOfType<App::DocumentObject>() > 0) {
                 *item << "Std_Placement"
                       << "Std_ToggleVisibility"
                       << "Std_ShowSelection"

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -101,13 +101,10 @@ void Workbench::setupContextMenu(const char* recipient, Gui::MenuItem* item) con
                     *item   << "Std_ToggleFreeze";
                 }
 
-                bool docHaveBodies = activeView->getAppDocument()->countObjectsOfType (
-                                        PartDesign::Body::getClassTypeId () ) > 0;
-
-                if ( docHaveBodies ) {
+                if (activeView->getAppDocument()->countObjectsOfType<PartDesign::Body>() > 0) {
                     bool addMoveFeature = true;
                     bool addMoveFeatureInTree = (body != nullptr);
-                    for (auto sel: selection) {
+                    for (auto sel : selection) {
                         // if at least one selected feature cannot be moved to a body
                         // disable the entry
                         if ( addMoveFeature && !PartDesign::Body::isAllowed ( sel.pObject ) ) {

--- a/src/Mod/Points/Gui/Command.cpp
+++ b/src/Mod/Points/Gui/Command.cpp
@@ -188,7 +188,7 @@ void CmdPointsExport::activated(int iMsg)
 
 bool CmdPointsExport::isActive()
 {
-    return getSelection().countObjectsOfType(Points::Feature::getClassTypeId()) > 0;
+    return getSelection().countObjectsOfType<Points::Feature>() > 0;
 }
 
 DEF_STD_CMD_A(CmdPointsTransform)
@@ -227,7 +227,7 @@ void CmdPointsTransform::activated(int iMsg)
 
 bool CmdPointsTransform::isActive()
 {
-    return getSelection().countObjectsOfType(Points::Feature::getClassTypeId()) > 0;
+    return getSelection().countObjectsOfType<Points::Feature>() > 0;
 }
 
 DEF_STD_CMD_A(CmdPointsConvert)
@@ -315,7 +315,7 @@ void CmdPointsConvert::activated(int iMsg)
 
 bool CmdPointsConvert::isActive()
 {
-    return getSelection().countObjectsOfType(Base::Type::fromName("App::GeoFeature")) > 0;
+    return getSelection().countObjectsOfType<App::GeoFeature>() > 0;
 }
 
 DEF_STD_CMD_A(CmdPointsPolyCut)
@@ -363,7 +363,7 @@ void CmdPointsPolyCut::activated(int iMsg)
 bool CmdPointsPolyCut::isActive()
 {
     // Check for the selected mesh feature (all Mesh types)
-    return getSelection().countObjectsOfType(Points::Feature::getClassTypeId()) > 0;
+    return getSelection().countObjectsOfType<Points::Feature>() > 0;
 }
 
 DEF_STD_CMD_A(CmdPointsMerge)
@@ -426,7 +426,7 @@ void CmdPointsMerge::activated(int iMsg)
 
 bool CmdPointsMerge::isActive()
 {
-    return getSelection().countObjectsOfType(Points::Feature::getClassTypeId()) > 1;
+    return getSelection().countObjectsOfType<Points::Feature>() > 1;
 }
 
 DEF_STD_CMD_A(CmdPointsStructure)
@@ -537,7 +537,7 @@ void CmdPointsStructure::activated(int iMsg)
 
 bool CmdPointsStructure::isActive()
 {
-    return getSelection().countObjectsOfType(Points::Feature::getClassTypeId()) == 1;
+    return getSelection().countObjectsOfType<Points::Feature>() == 1;
 }
 
 void CreatePointsCommands()

--- a/src/Mod/ReverseEngineering/Gui/Command.cpp
+++ b/src/Mod/ReverseEngineering/Gui/Command.cpp
@@ -233,7 +233,7 @@ void CmdApproxPlane::activated(int)
 
 bool CmdApproxPlane::isActive()
 {
-    if (getSelection().countObjectsOfType(App::GeoFeature::getClassTypeId()) > 0) {
+    if (getSelection().countObjectsOfType<App::GeoFeature>() > 0) {
         return true;
     }
     return false;
@@ -301,7 +301,7 @@ void CmdApproxCylinder::activated(int)
 
 bool CmdApproxCylinder::isActive()
 {
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0) {
+    if (getSelection().countObjectsOfType<Mesh::Feature>() > 0) {
         return true;
     }
     return false;
@@ -349,7 +349,7 @@ void CmdApproxSphere::activated(int)
 
 bool CmdApproxSphere::isActive()
 {
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0) {
+    if (getSelection().countObjectsOfType<Mesh::Feature>() > 0) {
         return true;
     }
     return false;
@@ -407,7 +407,7 @@ void CmdApproxPolynomial::activated(int)
 
 bool CmdApproxPolynomial::isActive()
 {
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0) {
+    if (getSelection().countObjectsOfType<Mesh::Feature>() > 0) {
         return true;
     }
     return false;
@@ -442,7 +442,7 @@ bool CmdSegmentation::isActive()
     if (Gui::Control().activeDialog()) {
         return false;
     }
-    return Gui::Selection().countObjectsOfType(Mesh::Feature::getClassTypeId()) == 1;
+    return Gui::Selection().countObjectsOfType<Mesh::Feature>() == 1;
 }
 
 DEF_STD_CMD_A(CmdSegmentationManual)
@@ -521,7 +521,7 @@ void CmdSegmentationFromComponents::activated(int)
 
 bool CmdSegmentationFromComponents::isActive()
 {
-    if (getSelection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0) {
+    if (getSelection().countObjectsOfType<Mesh::Feature>() > 0) {
         return true;
     }
     return false;
@@ -591,7 +591,7 @@ void CmdMeshBoundary::activated(int)
 
 bool CmdMeshBoundary::isActive()
 {
-    return Gui::Selection().countObjectsOfType(Mesh::Feature::getClassTypeId()) > 0;
+    return Gui::Selection().countObjectsOfType<Mesh::Feature>() > 0;
 }
 
 DEF_STD_CMD_A(CmdPoissonReconstruction)
@@ -676,7 +676,7 @@ void CmdViewTriangulation::activated(int)
 
 bool CmdViewTriangulation::isActive()
 {
-    return (Gui::Selection().countObjectsOfType(Points::Structured::getClassTypeId()) > 0);
+    return (Gui::Selection().countObjectsOfType<Points::Structured>() > 0);
 }
 
 void CreateReverseEngineeringCommands()

--- a/src/Mod/Robot/Gui/CommandExport.cpp
+++ b/src/Mod/Robot/Gui/CommandExport.cpp
@@ -54,8 +54,8 @@ CmdRobotExportKukaCompact::CmdRobotExportKukaCompact()
 
 void CmdRobotExportKukaCompact::activated(int)
 {
-    unsigned int n1 = getSelection().countObjectsOfType(Robot::RobotObject::getClassTypeId());
-    unsigned int n2 = getSelection().countObjectsOfType(Robot::TrajectoryObject::getClassTypeId());
+    unsigned int n1 = getSelection().countObjectsOfType<Robot::RobotObject>();
+    unsigned int n2 = getSelection().countObjectsOfType<Robot::TrajectoryObject>();
 
     if (n1 != 1 || n2 != 1) {
         QMessageBox::warning(Gui::getMainWindow(),
@@ -129,8 +129,8 @@ CmdRobotExportKukaFull::CmdRobotExportKukaFull()
 
 void CmdRobotExportKukaFull::activated(int)
 {
-    unsigned int n1 = getSelection().countObjectsOfType(Robot::RobotObject::getClassTypeId());
-    unsigned int n2 = getSelection().countObjectsOfType(Robot::TrajectoryObject::getClassTypeId());
+    unsigned int n1 = getSelection().countObjectsOfType<Robot::RobotObject>();
+    unsigned int n2 = getSelection().countObjectsOfType<Robot::TrajectoryObject>();
 
     if (n1 != 1 || n2 != 1) {
         QMessageBox::warning(Gui::getMainWindow(),

--- a/src/Mod/Robot/Gui/CommandTrajectory.cpp
+++ b/src/Mod/Robot/Gui/CommandTrajectory.cpp
@@ -98,8 +98,8 @@ CmdRobotInsertWaypoint::CmdRobotInsertWaypoint()
 
 void CmdRobotInsertWaypoint::activated(int)
 {
-    unsigned int n1 = getSelection().countObjectsOfType(Robot::RobotObject::getClassTypeId());
-    unsigned int n2 = getSelection().countObjectsOfType(Robot::TrajectoryObject::getClassTypeId());
+    unsigned int n1 = getSelection().countObjectsOfType<Robot::RobotObject>();
+    unsigned int n2 = getSelection().countObjectsOfType<Robot::TrajectoryObject>();
 
     if (n1 != 1 || n2 != 1) {
         QMessageBox::warning(Gui::getMainWindow(),

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -763,12 +763,8 @@ void CmdSketcherMapSketch::activated(int iMsg)
 bool CmdSketcherMapSketch::isActive()
 {
     App::Document* doc = App::GetApplication().getActiveDocument();
-    Base::Type sketch_type = Base::Type::fromName("Part::Part2DObject");
     std::vector<Gui::SelectionObject> selobjs = Gui::Selection().getSelectionEx();
-    if (doc && doc->countObjectsOfType(sketch_type) > 0 && !selobjs.empty())
-        return true;
-
-    return false;
+    return doc && doc->countObjectsOfType<Part::Part2DObject>() > 0 && !selobjs.empty();
 }
 
 DEF_STD_CMD_A(CmdSketcherViewSketch)

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -328,7 +328,7 @@ void CmdSketcherEditSketch::activated(int iMsg)
 
 bool CmdSketcherEditSketch::isActive()
 {
-    return Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) == 1;
+    return Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() == 1;
 }
 
 DEF_STD_CMD_A(CmdSketcherLeaveSketch)
@@ -539,7 +539,7 @@ void CmdSketcherReorientSketch::activated(int iMsg)
 
 bool CmdSketcherReorientSketch::isActive()
 {
-    return Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) == 1;
+    return Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() == 1;
 }
 
 DEF_STD_CMD_A(CmdSketcherMapSketch)
@@ -843,7 +843,7 @@ bool CmdSketcherValidateSketch::isActive()
 {
     if (Gui::Control().activeDialog())
         return false;
-    return Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) == 1;
+    return Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() == 1;
 }
 
 DEF_STD_CMD_A(CmdSketcherMirrorSketch)
@@ -970,7 +970,7 @@ void CmdSketcherMirrorSketch::activated(int iMsg)
 
 bool CmdSketcherMirrorSketch::isActive()
 {
-    return Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) > 0;
+    return Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() > 0;
 }
 
 DEF_STD_CMD_A(CmdSketcherMergeSketches)
@@ -1059,7 +1059,7 @@ void CmdSketcherMergeSketches::activated(int iMsg)
 
 bool CmdSketcherMergeSketches::isActive()
 {
-    return Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) > 1;
+    return Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() > 1;
 }
 
 // Acknowledgement of idea and original python macro goes to SpritKopf:

--- a/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
+++ b/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
@@ -141,7 +141,7 @@ void CmdSketcherToggleConstruction::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     // Option A: nothing is selected change creation mode from/to construction
-    if (Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) == 0) {
+    if (Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() == 0) {
 
         Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
 

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -81,7 +81,7 @@ bool isCreateConstraintActive(Gui::Document* doc)
             && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
             if (static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit())->getSketchMode()
                 == ViewProviderSketch::STATUS_NONE) {
-                if (Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId())
+                if (Gui::Selection().countObjectsOfType<Sketcher::SketchObject>()
                     > 0) {
                     return true;
                 }
@@ -10013,7 +10013,7 @@ void CmdSketcherToggleDrivingConstraint::activated(int iMsg)
 
     std::vector<Gui::SelectionObject> selection;
 
-    if (Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) > 0) {
+    if (Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() > 0) {
         // Now we check whether we have a constraint selected or not.
 
         // get the selection
@@ -10137,7 +10137,7 @@ void CmdSketcherToggleActiveConstraint::activated(int iMsg)
 
     std::vector<Gui::SelectionObject> selection;
 
-    if (Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) > 0) {
+    if (Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() > 0) {
         // Now we check whether we have a constraint selected or not.
 
         // get the selection

--- a/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp
@@ -61,9 +61,7 @@ bool isSketcherVirtualSpaceActive(Gui::Document* doc, bool actsOnSelection)
                 if (!actsOnSelection) {
                     return true;
                 }
-                else if (Gui::Selection().countObjectsOfType(
-                             Sketcher::SketchObject::getClassTypeId())
-                         > 0) {
+                else if (Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() > 0) {
                     return true;
                 }
             }
@@ -111,7 +109,7 @@ void CmdSketcherSwitchVirtualSpace::activated(int iMsg)
 
     std::vector<Gui::SelectionObject> selection;
 
-    if (Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) > 0) {
+    if (Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() > 0) {
         // Now we check whether we have a constraint selected or not.
         selection = getSelection().getSelectionEx();
 

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -510,10 +510,7 @@ bool SketcherGui::isCommandActive(Gui::Document* doc, bool actsOnSelection)
             if (!actsOnSelection) {
                 return true;
             }
-            else if (Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId())
-                     > 0) {
-                return true;
-            }
+            return Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() > 0;
         }
     }
 
@@ -531,11 +528,7 @@ bool SketcherGui::isSketcherBSplineActive(Gui::Document* doc, bool actsOnSelecti
                 if (!actsOnSelection) {
                     return true;
                 }
-                else if (Gui::Selection().countObjectsOfType(
-                             Sketcher::SketchObject::getClassTypeId())
-                         > 0) {
-                    return true;
-                }
+                return Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() > 0;
             }
         }
     }

--- a/src/Mod/Surface/Gui/Command.cpp
+++ b/src/Mod/Surface/Gui/Command.cpp
@@ -201,13 +201,9 @@ bool CmdSurfaceCurveOnMesh::isActive()
     }
 
     // Check for the selected mesh feature (all Mesh types)
-    Base::Type meshType = Base::Type::fromName("Mesh::Feature");
     App::Document* doc = App::GetApplication().getActiveDocument();
-    if (doc && doc->countObjectsOfType(meshType) > 0) {
-        return true;
-    }
-
-    return false;
+    // Use string based check to avoid linking to Mesh module
+    return doc && doc->countObjectsOfType("Mesh::Feature") > 0;
 }
 
 //===========================================================================

--- a/src/Mod/Surface/Gui/Command.cpp
+++ b/src/Mod/Surface/Gui/Command.cpp
@@ -317,7 +317,7 @@ void CmdSurfaceExtendFace::activated(int)
 
 bool CmdSurfaceExtendFace::isActive()
 {
-    return Gui::Selection().countObjectsOfType(Part::Feature::getClassTypeId()) == 1;
+    return Gui::Selection().countObjectsOfType<Part::Feature>() == 1;
 }
 
 DEF_STD_CMD_A(CmdSurfaceSections)


### PR DESCRIPTION
This creates new template based functions of `countObjectsOfType<T>` in `Gui::SelectionSingleton` and `App::Document`. A string based version has also been added in document which mimics the one in selection. By doing these changes we can:
* create compile time checks that objects to count inherits `DocumentObject`
* simplify code and makes it more declarative
* make the old, less safe, type based checks protected.