### PR TITLE
[TD]use transformShape instead of transformGeometry

### DIFF
--- a/src/Mod/Measure/App/ShapeFinder.cpp
+++ b/src/Mod/Measure/App/ShapeFinder.cpp
@@ -194,7 +194,7 @@ TopoDS_Shape ShapeFinder::transformShape(TopoDS_Shape& inShape,
         return {};
     }
 
-    tshape.transformGeometry(scaler);
+    tshape.transformShape(scaler, true, true);
     tshape.setPlacement(placement);
 
     return tshape.getShape();


### PR DESCRIPTION
This PR is an alternative to PR #19007.  

This PR corrects the slow transform in ShapeFinder.

PR #19007 reverts the TD changes for handling long form sub element names in dimension references from  PR #18641.