### PR TITLE
CMake: Issue a non-fatal error when module dependency is not found.

### DIFF
--- a/cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake
+++ b/cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake
@@ -8,7 +8,7 @@ macro(CheckInterModuleDependencies)
         if(${dependent})
             foreach(prerequisite IN LISTS ARGN)
                 if(NOT ${prerequisite})
-                    message(STATUS "${dependent} requires ${prerequisite} to be ON, but it"
+                    message(SEND_ERROR "${dependent} requires ${prerequisite} to be ON, but it"
                                    " is \"${${prerequisite}}\"")
                     set(${dependent} OFF PARENT_SCOPE)
                     break()


### PR DESCRIPTION
This makes it much easier to notice the error, previously it was just printed as a regular message and lost in the output.