### PR TITLE
Gui: Add spinning enabled option to `NavigationStyle`.

### DIFF
--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -224,6 +224,7 @@ void NavigationStyle::initialize()
     this->currentmode = NavigationStyle::IDLE;
     this->animationEnabled = true;
     this->spinningAnimationEnabled = false;
+    this->spinningEnabled = true;
     this->spinsamplecounter = 0;
     this->spinincrement = SbRotation::identity();
     this->rotationCenterFound = false;
@@ -865,6 +866,10 @@ SbVec3f NavigationStyle::getFocalPoint() const
  */
 void NavigationStyle::spin(const SbVec2f & pointerpos)
 {
+    if (!isSpinningEnabled()) {
+        return;
+    }
+
     if (this->log.historysize < 2)
         return;
     assert(this->spinprojector);
@@ -1217,6 +1222,22 @@ SbBool NavigationStyle::isAnimating() const
 SbBool NavigationStyle::isSpinning() const
 {
     return currentmode == NavigationStyle::SPINNING;
+}
+
+/**
+ * @return Whether or not spinning is enabled
+ */
+SbBool NavigationStyle::isSpinningEnabled() const
+{
+    return spinningEnabled;
+}
+
+/**
+ * @brief Decide if it should be possible to start a spinning action
+ */
+void NavigationStyle::setSpinningEnabled(const SbBool enable)
+{
+    spinningEnabled = enable;
 }
 
 void NavigationStyle::startAnimating(const std::shared_ptr<NavigationAnimation>& animation, bool wait) const

--- a/src/Gui/NavigationStyle.h
+++ b/src/Gui/NavigationStyle.h
@@ -128,6 +128,9 @@ public:
     SbBool isSpinningAnimationEnabled() const;
     SbBool isAnimating() const;
     SbBool isSpinning() const;
+    SbBool isSpinningEnabled() const;
+    void setSpinningEnabled(SbBool enable);
+
     void startAnimating(const std::shared_ptr<NavigationAnimation>& animation, bool wait = false) const;
     void stopAnimating() const;
 
@@ -276,6 +279,7 @@ protected:
     /** @name Spinning data */
     //@{
     SbBool spinningAnimationEnabled;
+    SbBool spinningEnabled;
     int spinsamplecounter;
     SbRotation spinincrement;
     SbSphereSheetProjector * spinprojector;

--- a/src/Gui/NavigationStylePy.xml
+++ b/src/Gui/NavigationStylePy.xml
@@ -13,6 +13,11 @@
       <Author Licence="LGPL" Name="Werner Mayer" EMail="wmayer@users.sourceforge.net" />
       <UserDocu>This is the base class for navigation styles</UserDocu>
     </Documentation>
+    <Methode Name="setSpinningEnabled">
+      <Documentation>
+        <UserDocu>Sets if spinning is enabled</UserDocu>
+      </Documentation>
+    </Methode>
     <CustomAttributes />
   </PythonExport>
 </GenerateModel>

--- a/src/Gui/NavigationStylePyImp.cpp
+++ b/src/Gui/NavigationStylePyImp.cpp
@@ -40,6 +40,19 @@ std::string NavigationStylePy::representation() const
     return {"<NavigationStyle object>"};
 }
 
+/** Sets the spinning enabled state */
+PyObject* NavigationStylePy::setSpinningEnabled(PyObject *args)
+{
+    PY_TRY {
+        int pEnabled;
+        if (!PyArg_ParseTuple(args, "p", &pEnabled))
+            return nullptr;
+
+        getNavigationStylePtr()->setSpinningEnabled(pEnabled);
+        Py_Return;
+    } PY_CATCH;
+}
+
 PyObject* NavigationStylePy::getCustomAttributes(const char* /*attr*/) const
 {
     return nullptr;


### PR DESCRIPTION
This adds a new option to `NavigationStyle` to prevent the spinning of the view, useful to restrict a viewer to a locked orientation.

Built upon https://github.com/FreeCAD/FreeCAD/pull/19038 for Python bindings.
