### PR TITLE
CMake: Improve Pivy Coin3D version mismatch checking.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ if(NOT FREECAD_LIBPACK_USE OR FREECAD_LIBPACK_CHECKFILE_CLBUNDLER OR FREECAD_LIB
 
     if(BUILD_GUI)
         SetupCoin3D()
+        SetupPivy()
         SetupSpaceball()
         SetupShibokenAndPyside()
         SetupMatplotlib()

--- a/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
+++ b/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
@@ -27,6 +27,10 @@ macro(SetupCoin3D)
         set(COIN3D_MICRO_VERSION "${CMAKE_MATCH_1}")
         set(COIN3D_VERSION "${COIN3D_MAJOR_VERSION}.${COIN3D_MINOR_VERSION}.${COIN3D_MICRO_VERSION}")
     ENDIF ()
+endmacro(SetupCoin3D)
+
+macro(SetupPivy)
+    # -------------------------------- Pivy --------------------------------
 
     IF (NOT PIVY_VERSION)
         message(STATUS "Checking Pivy version by importing it in a Python program...")
@@ -41,4 +45,30 @@ macro(SetupCoin3D)
         endif ()
     ENDIF ()
 
-endmacro(SetupCoin3D)
+    message(STATUS "Checking Pivy Coin3D version by importing it in a Python program...")
+    execute_process(
+            COMMAND ${Python3_EXECUTABLE} -c "import pivy as p; print(p.SoDB.getVersion(),end='')"
+            OUTPUT_VARIABLE PIVY_COIN_VERSION
+            RESULT_VARIABLE RETURN_CODE)
+    if (RETURN_CODE EQUAL 0)
+        message(STATUS "Found Pivy Coin3D ${PIVY_COIN_VERSION}")
+    else ()
+        message(ERROR "Failed to get Pivy Coin3D version using ${Python3_EXECUTABLE}")
+    endif ()
+
+    if (${PIVY_COIN_VERSION} MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+        set(PIVY_COIN_MAJOR_VERSION ${CMAKE_MATCH_1})
+        set(PIVY_COIN_MINOR_VERSION ${CMAKE_MATCH_2})
+        set(PIVY_COIN_MICRO_VERSION ${CMAKE_MATCH_3})
+        set(PIVY_COIN_VERSION "${PIVY_COIN_MAJOR_VERSION}.${PIVY_COIN_MINOR_VERSION}.${PIVY_COIN_MICRO_VERSION}")
+    else ()
+        message(FATAL_ERROR "Failed to match Pivy Coin3D version string output")
+    endif ()
+
+    if (NOT (
+        (${COIN3D_MAJOR_VERSION} EQUAL ${PIVY_COIN_MAJOR_VERSION}) AND
+        (${COIN3D_MINOR_VERSION} EQUAL ${PIVY_COIN_MINOR_VERSION}) AND
+        (${COIN3D_MICRO_VERSION} EQUAL ${PIVY_COIN_MICRO_VERSION})))
+        message(FATAL_ERROR "Coin3D version ${COIN3D_VERSION} mismatches Pivy Coin3D ${PIVY_COIN_VERSION}.")
+    endif ()
+endmacro(SetupPivy)


### PR DESCRIPTION
When working with a custom Coin3D build, it's very easy to end up with a mismatched Pivy version being picked up from the system.

Prevent this by catching for mismatched versions at CMake configuration time.