### PR TITLE
Always update the element map version if it's not valid or unknown

### DIFF
--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -271,11 +271,14 @@ void PropertyPartShape::Save (Base::Writer &writer) const
     }
     std::string version;
     // If exporting, do not export mapped element name, but still make a mark
-    if(owner) {
-        if(!owner->isExporting())
-            version = _Ver.size()?_Ver:owner->getElementMapVersion(this);
-    }else
-        version = _Ver.size()?_Ver:_Shape.getElementMapVersion();
+    auto const version_valid = _Ver.size() && (_Ver != "?");
+    if (owner) {
+        if (!owner->isExporting()) {
+            version = version_valid ? _Ver : owner->getElementMapVersion(this);
+        }
+    } else {
+        version = version_valid ? _Ver : _Shape.getElementMapVersion();
+    }
     writer.Stream() << " ElementMap=\"" << version << '"';
 
     bool binary = writer.getMode("BinaryBrep");


### PR DESCRIPTION
`_Ver` can contain "?" after loading and in some circumstances this is not cleared (often by `setValue()`) before saving (`MultiPattern` children or empty `Part::Feature`). When saved the same "?" is then written again to the file causing the recomputing dialog to pop up again and again.

This not only checks for an empty `_Ver` but also explicitly for "?" and then regenerating the version if necessary.

Fixes #16958 for the provided test file and the mentioned MultiPattern case.
This should be reviewed by someone with knowledge about the element maps. 
This should also be backported to 1.0 as this seems to be triggered by older files, most likely from dev versions.