### PR TITLE
[VectorListEditor] Set precision to 12 digits when copying table data

### DIFF
--- a/src/Gui/VectorListEditor.cpp
+++ b/src/Gui/VectorListEditor.cpp
@@ -26,6 +26,7 @@
 #include "ui_VectorListEditor.h"
 #include "QuantitySpinBox.h"
 
+#include <App/Application.h>
 #include <Base/Console.h>
 
 #include <QClipboard>
@@ -142,11 +143,14 @@ void Gui::VectorTableModel::copyToClipboard() const
 {
     QString clipboardText;
     QTextStream stream(&clipboardText);
+    int precision = App::GetApplication()
+                         .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Units")
+                         ->GetInt("PropertyVectorListCopyPrecision", 16);
 
     for (const auto& vector : vectors) {
-        stream << QString::number(vector.x, 'f', decimals) << '\t'
-               << QString::number(vector.y, 'f', decimals) << '\t'
-               << QString::number(vector.z, 'f', decimals) << '\n';
+        stream << QString::number(vector.x, 'f', precision) << '\t'
+               << QString::number(vector.y, 'f', precision) << '\t'
+               << QString::number(vector.z, 'f', precision) << '\n';
     }
 
     QApplication::clipboard()->setText(clipboardText);


### PR DESCRIPTION
See https://github.com/FreeCAD/FreeCAD/pull/17851

That PR added the copy table and paste table functionality to the table context menu for the vector list property editor.  It was noted that some precision was being list during the copy to clipboard process, since the precision was based on the user decimals preference (default:2).  This sets the precision to be used to the greater of decimals or 12.  I decided on 12 because as a test I exported a draft wire as a step file and examined the file to find 12 was the highest number of digits to the right of the decimal being used.

Note that if the user requires more precision then he can set decimals = 15, for example, and then the precision of 15 would be used.