### PR TITLE
Arrange clipboard commands horizontally in context menu

### DIFF
--- a/src/Gui/MenuManager.h
+++ b/src/Gui/MenuManager.h
@@ -52,6 +52,9 @@ public:
     MenuItem* copy() const;
     uint count() const;
 
+    bool isHorizontal(void);
+    void setHorizontal(bool isHorizontal);
+
     void appendItem(MenuItem*);
     bool insertItem(MenuItem*, MenuItem*);
     MenuItem* afterItem(MenuItem*) const;
@@ -65,6 +68,8 @@ public:
 private:
     std::string _name;
     QList<MenuItem*> _items;
+
+    bool horizontal = false;
 };
 
 /**

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -604,12 +604,16 @@ void StdWorkbench::setupContextMenu(const char* recipient, MenuItem* item) const
     else if (strcmp(recipient,"Tree") == 0)
     {
         if (Gui::Selection().countObjectsOfType<App::DocumentObject>() > 0) {
+            auto clipboard_cmds = new MenuItem();
+            clipboard_cmds->setHorizontal(true);
+            clipboard_cmds->setCommand("Clipboard thingies");
+            *clipboard_cmds << "Std_Cut" << "Std_Copy" << "Std_Paste" << "Std_Delete" << "Std_SendToPythonConsole";
+
             *item  << "Std_ToggleFreeze" << "Separator"
                   << "Std_Placement" << "Std_ToggleVisibility" << "Std_ShowSelection" << "Std_HideSelection"
                   << "Std_ToggleSelectability" << "Std_TreeSelectAllInstances" << "Separator"
                   << "Std_RandomColor" << "Std_ToggleTransparency" << "Separator"
-                  << "Std_Cut" << "Std_Copy" << "Std_Paste" << "Std_Delete"
-                  << "Std_SendToPythonConsole" << "Separator";
+                  << clipboard_cmds;
         }
     }
 }


### PR DESCRIPTION
The context menu contains too many items. I think that the solution is to place some items horizontally, as implemented in _MS Word_ or _MS Explorer_. This commit arranges clipboard commands horizontally, placing them at the top of the context menu.



<details> <summary> The menu now looks like this. </summary>


![Безымянный](https://github.com/user-attachments/assets/dc9b2cb8-81b6-4f04-a6c5-16d348fe21ee)


</details>


Other items in the context menu can be arranged horizontally as well. 


Related to #13194.