### PR TITLE
CAM: Maintain tool name when editing tool bits

### DIFF
--- a/src/Mod/CAM/Path/Tool/Bit.py
+++ b/src/Mod/CAM/Path/Tool/Bit.py
@@ -437,7 +437,7 @@ class ToolBit(object):
     def templateAttrs(self, obj):
         attrs = {}
         attrs["version"] = 2
-        attrs["name"] = obj.Label
+        attrs["name"] = obj.Label2
         if Path.Preferences.toolsStoreAbsolutePaths():
             attrs["shape"] = obj.BitShape
         else:
@@ -467,6 +467,7 @@ class ToolBitFactory(object):
         Path.Log.track(attrs, path)
         obj = Factory.Create(name, attrs["shape"], path)
         obj.Label = attrs["name"]
+        obj.Label2 = attrs["name"]
         params = attrs["parameter"]
         for prop in params:
             PathUtil.setProperty(obj, prop, params[prop])

--- a/src/Mod/CAM/Path/Tool/Gui/BitEdit.py
+++ b/src/Mod/CAM/Path/Tool/Gui/BitEdit.py
@@ -202,7 +202,7 @@ class ToolBitEditor(object):
 
     def updateUI(self):
         Path.Log.track()
-        self.form.toolName.setText(self.tool.Label)
+        self.form.toolName.setText(self.tool.Label2)
         self.form.shapePath.setText(self.tool.BitShape)
 
         for lbl, qsb, editor in self.widgets:
@@ -218,7 +218,7 @@ class ToolBitEditor(object):
                 editor.attachTo(self.tool, "File")
             self.tool.BitShape = shapePath
             self.setupTool(self.tool)
-            self.form.toolName.setText(self.tool.Label)
+            self.form.toolName.setText(self.tool.Label2)
             if self.tool.BitBody and self.tool.BitBody.ViewObject:
                 if not self.tool.BitBody.ViewObject.Visibility:
                     self.tool.BitBody.ViewObject.Visibility = True
@@ -239,8 +239,8 @@ class ToolBitEditor(object):
 
         label = str(self.form.toolName.text())
         shape = str(self.form.shapePath.text())
-        if self.tool.Label != label:
-            self.tool.Label = label
+        if self.tool.Label2 != label:
+            self.tool.Label2 = label
         self._updateBitShape(shape)
 
         for lbl, qsb, editor in self.widgets:


### PR DESCRIPTION
When editing tools an edit tool object is created in the document. If the same tool is already used in the document the edit tool label will be incremented i.e myTool > myTool001

The edit tool label is used to write the tool data back to the library, using the new tool name. 

This PR makes changes to use the edit tools Label2 property as Label2 is not automatically incremented. 

Before this PR:

https://github.com/user-attachments/assets/0d7a0673-c10b-48cd-b2da-fbf2e4db758c

After this PR:

https://github.com/user-attachments/assets/0ed53780-4aab-4ce5-a8c5-1bf85df28797

Fixes: #12823 