### PR TITLE
Simplify code by using BaseClass' isDerivedFrom<> and is<>

### DIFF
--- a/src/App/Datums.cpp
+++ b/src/App/Datums.cpp
@@ -156,7 +156,7 @@ App::DatumElement* LocalCoordinateSystem::getDatumElement(const char* role) cons
 {
     const auto& features = OriginFeatures.getValues();
     auto featIt = std::find_if(features.begin(), features.end(), [role](App::DocumentObject* obj) {
-        return obj->isDerivedFrom(App::DatumElement::getClassTypeId())
+        return obj->isDerivedFrom<App::DatumElement>()
             && strcmp(static_cast<App::DatumElement*>(obj)->Role.getValue(), role) == 0;
     });
     if (featIt != features.end()) {
@@ -171,7 +171,7 @@ App::DatumElement* LocalCoordinateSystem::getDatumElement(const char* role) cons
 App::Line* LocalCoordinateSystem::getAxis(const char* role) const
 {
     App::DatumElement* feat = getDatumElement(role);
-    if (feat->isDerivedFrom(App::Line::getClassTypeId())) {
+    if (feat->isDerivedFrom<App::Line>()) {
         return static_cast<App::Line*>(feat);
     }
     std::stringstream err;
@@ -183,7 +183,7 @@ App::Line* LocalCoordinateSystem::getAxis(const char* role) const
 App::Plane* LocalCoordinateSystem::getPlane(const char* role) const
 {
     App::DatumElement* feat = getDatumElement(role);
-    if (feat->isDerivedFrom(App::Plane::getClassTypeId())) {
+    if (feat->isDerivedFrom<App::Plane>()) {
         return static_cast<App::Plane*>(feat);
     }
     std::stringstream err;
@@ -195,7 +195,7 @@ App::Plane* LocalCoordinateSystem::getPlane(const char* role) const
 App::Point* LocalCoordinateSystem::getPoint(const char* role) const
 {
     App::DatumElement* feat = getDatumElement(role);
-    if (feat->isDerivedFrom(App::Point::getClassTypeId())) {
+    if (feat->isDerivedFrom<App::Point>()) {
         return static_cast<App::Point*>(feat);
     }
     std::stringstream err;
@@ -262,7 +262,7 @@ DatumElement* LocalCoordinateSystem::createDatum(const SetupData& data)
     std::string objName = doc->getUniqueObjectName(data.role);
     App::DocumentObject* featureObj = doc->addObject(data.type.getName(), objName.c_str());
 
-    assert(featureObj && featureObj->isDerivedFrom(App::DatumElement::getClassTypeId()));
+    assert(featureObj && featureObj->isDerivedFrom<App::DatumElement>());
 
     QByteArray byteArray = data.label.toUtf8();
     featureObj->Label.setValue(byteArray.constData());

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -835,7 +835,7 @@ void Document::onChanged(const Property* prop)
 
 void Document::onBeforeChangeProperty(const TransactionalObject* Who, const Property* What)
 {
-    if (Who->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+    if (Who->isDerivedFrom<App::DocumentObject>()) {
         signalBeforeChangeObject(*static_cast<const App::DocumentObject*>(Who), *What);
     }
     if (!d->rollback && !globalIsRelabeling) {
@@ -4338,7 +4338,7 @@ std::vector<DocumentObject*> Document::getObjectsOfType(const Base::Type& typeId
 {
     std::vector<DocumentObject*> Objects;
     for (auto it : d->objectArray) {
-        if (it->getTypeId().isDerivedFrom(typeId)) {
+        if (it->isDerivedFrom(typeId)) {
             Objects.push_back(it);
         }
     }
@@ -4376,7 +4376,7 @@ Document::findObjects(const Base::Type& typeId, const char* objname, const char*
     std::vector<DocumentObject*> Objects;
     DocumentObject* found = nullptr;
     for (auto it : d->objectArray) {
-        if (it->getTypeId().isDerivedFrom(typeId)) {
+        if (it->isDerivedFrom(typeId)) {
             found = it;
 
             if (!rx_name.empty() && !boost::regex_search(it->getNameInDocument(), what, rx_name)) {
@@ -4398,7 +4398,7 @@ Document::findObjects(const Base::Type& typeId, const char* objname, const char*
 int Document::countObjectsOfType(const Base::Type& typeId) const
 {
     return std::count_if(d->objectMap.begin(), d->objectMap.end(), [&](const auto& it) {
-        return it.second->getTypeId().isDerivedFrom(typeId);
+        return it.second->isDerivedFrom(typeId);
     });
 }
 

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -759,7 +759,7 @@ bool DocumentObject::removeDynamicProperty(const char* name)
         return false;
     }
 
-    if (prop->isDerivedFrom(PropertyLinkBase::getClassTypeId())) {
+    if (prop->isDerivedFrom<PropertyLinkBase>()) {
         clearOutListCache();
     }
 

--- a/src/App/DocumentObjectExtension.cpp
+++ b/src/App/DocumentObjectExtension.cpp
@@ -76,14 +76,14 @@ PyObject* DocumentObjectExtension::getExtensionPyObject()
 const DocumentObject* DocumentObjectExtension::getExtendedObject() const
 {
 
-    assert(getExtendedContainer()->isDerivedFrom(DocumentObject::getClassTypeId()));
+    assert(getExtendedContainer()->isDerivedFrom<DocumentObject>());
     return static_cast<const DocumentObject*>(getExtendedContainer());
 }
 
 DocumentObject* DocumentObjectExtension::getExtendedObject()
 {
 
-    assert(getExtendedContainer()->isDerivedFrom(DocumentObject::getClassTypeId()));
+    assert(getExtendedContainer()->isDerivedFrom<DocumentObject>());
     return static_cast<DocumentObject*>(getExtendedContainer());
 }
 

--- a/src/App/DocumentObserver.cpp
+++ b/src/App/DocumentObserver.cpp
@@ -177,7 +177,7 @@ void DocumentObjectT::operator=(const DocumentObject* obj)
 void DocumentObjectT::operator=(const Property* prop)
 {
     if (!prop || !prop->hasName() || !prop->getContainer()
-        || !prop->getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        || !prop->getContainer()->isDerivedFrom<App::DocumentObject>()) {
         object.clear();
         label.clear();
         document.clear();

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -2016,7 +2016,7 @@ Py::Object FunctionExpression::evalAggregate(
     }
 
     for (auto &arg : args) {
-        if (arg->isDerivedFrom(RangeExpression::getClassTypeId())) {
+        if (arg->isDerivedFrom<RangeExpression>()) {
             Range range(static_cast<const RangeExpression&>(*arg).getRange());
 
             do {
@@ -2159,7 +2159,7 @@ Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std
 
     switch (f) {
     case LIST: {
-        if (args.size() == 1 && args[0]->isDerivedFrom(RangeExpression::getClassTypeId()))
+        if (args.size() == 1 && args[0]->isDerivedFrom<RangeExpression>())
             return args[0]->getPyValue();
         Py::List list(args.size());
         int i = 0;
@@ -2168,7 +2168,7 @@ Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std
         return list;
     }
     case TUPLE: {
-        if (args.size() == 1 && args[0]->isDerivedFrom(RangeExpression::getClassTypeId()))
+        if (args.size() == 1 && args[0]->isDerivedFrom<RangeExpression>())
             return Py::Tuple(args[0]->getPyValue());
         Py::Tuple tuple(args.size());
         int i = 0;

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -55,7 +55,7 @@ GeoFeatureGroupExtension::~GeoFeatureGroupExtension() = default;
 void GeoFeatureGroupExtension::initExtension(ExtensionContainer* obj)
 {
 
-    if (!obj->isDerivedFrom(App::GeoFeature::getClassTypeId())) {
+    if (!obj->isDerivedFrom<App::GeoFeature>()) {
         throw Base::RuntimeError("GeoFeatureGroupExtension can only be applied to GeoFeatures");
     }
 
@@ -88,7 +88,7 @@ DocumentObject* GeoFeatureGroupExtension::getGroupOfObject(const DocumentObject*
     }
 
     // we will find origins, but not origin features
-    if (obj->isDerivedFrom(App::DatumElement::getClassTypeId())) {
+    if (obj->isDerivedFrom<App::DatumElement>()) {
         return OriginGroupExtension::getGroupOfObject(obj);
     }
 
@@ -307,8 +307,8 @@ void GeoFeatureGroupExtension::getCSOutList(const App::DocumentObject* obj,
 
     //we remove all links to origin features and origins, they belong to a CS too and can't be moved
     result.erase(std::remove_if(result.begin(), result.end(), [](App::DocumentObject* obj)->bool {
-        return (obj->isDerivedFrom(App::DatumElement::getClassTypeId()) ||
-                obj->isDerivedFrom(App::Origin::getClassTypeId()));
+        return (obj->isDerivedFrom<App::DatumElement>() ||
+                obj->isDerivedFrom<App::Origin>());
     }), result.end());
 
     vec.insert(vec.end(), result.begin(), result.end());
@@ -483,7 +483,7 @@ bool GeoFeatureGroupExtension::isLinkValid(App::Property* prop)
     }
 
     // get the object that holds the property
-    if (!prop->getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+    if (!prop->getContainer()->isDerivedFrom<App::DocumentObject>()) {
         return true;  // this link comes not from a document object, scopes are meaningless
     }
     auto obj = static_cast<App::DocumentObject*>(prop->getContainer());

--- a/src/App/Graphviz.cpp
+++ b/src/App/Graphviz.cpp
@@ -301,7 +301,7 @@ void Document::exportGraphviz(std::ostream& out) const
                 if (!sgraph) {
                     auto group = GeoFeatureGroupExtension::getGroupOfObject(docObj);
                     if (group) {
-                        if (docObj->isDerivedFrom(App::DatumElement::getClassTypeId())) {
+                        if (docObj->isDerivedFrom<App::DatumElement>()) {
                             sgraph = GraphList[group->getExtensionByType<OriginGroupExtension>()
                                                    ->Origin.getValue()];
                         }
@@ -311,7 +311,7 @@ void Document::exportGraphviz(std::ostream& out) const
                     }
                 }
                 if (!sgraph) {
-                    if (docObj->isDerivedFrom(DatumElement::getClassTypeId())) {
+                    if (docObj->isDerivedFrom<DatumElement>()) {
                         auto* lcs = static_cast<DatumElement*>(docObj)->getLCS();
                         if (lcs) {
                             sgraph = GraphList[lcs];
@@ -453,7 +453,7 @@ void Document::exportGraphviz(std::ostream& out) const
                     // ignore groups inside other groups, these will be processed in one of the next
                     // recursive calls. App::Origin now has the GeoFeatureGroupExtension but it
                     // should not move its group symbol outside its parent
-                    if (!objectIt->isDerivedFrom(Origin::getClassTypeId())
+                    if (!objectIt->isDerivedFrom<Origin>()
                         && objectIt->hasExtension(
                             GeoFeatureGroupExtension::getExtensionClassTypeId())
                         && GeoFeatureGroupExtension::getGroupOfObject(objectIt) == nullptr) {
@@ -571,7 +571,7 @@ void Document::exportGraphviz(std::ostream& out) const
             // Add edges between document objects
             for (const auto& It : d->objectMap) {
 
-                if (omitGeoFeatureGroups && It.second->isDerivedFrom(Origin::getClassTypeId())) {
+                if (omitGeoFeatureGroups && It.second->isDerivedFrom<Origin>()) {
                     continue;
                 }
 

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -296,7 +296,7 @@ std::vector<DocumentObject*> GroupExtension::getObjectsOfType(const Base::Type& 
     std::vector<DocumentObject*> type;
     const std::vector<DocumentObject*>& grp = Group.getValues();
     for (auto it : grp) {
-        if (it->getTypeId().isDerivedFrom(typeId)) {
+        if (it->isDerivedFrom(typeId)) {
             type.push_back(it);
         }
     }
@@ -309,7 +309,7 @@ int GroupExtension::countObjectsOfType(const Base::Type& typeId) const
     int type = 0;
     const std::vector<DocumentObject*>& grp = Group.getValues();
     for (auto it : grp) {
-        if (it->getTypeId().isDerivedFrom(typeId)) {
+        if (it->isDerivedFrom(typeId)) {
             type++;
         }
     }

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -1167,7 +1167,7 @@ int LinkBaseExtension::extensionIsElementVisible(const char* element)
 const DocumentObject* LinkBaseExtension::getContainer() const
 {
     auto ext = getExtendedContainer();
-    if (!ext || !ext->isDerivedFrom(DocumentObject::getClassTypeId())) {
+    if (!ext || !ext->isDerivedFrom<DocumentObject>()) {
         LINK_THROW(Base::RuntimeError, "Link: container not derived from document object");
     }
     return static_cast<const DocumentObject*>(ext);
@@ -1176,7 +1176,7 @@ const DocumentObject* LinkBaseExtension::getContainer() const
 DocumentObject* LinkBaseExtension::getContainer()
 {
     auto ext = getExtendedContainer();
-    if (!ext || !ext->isDerivedFrom(DocumentObject::getClassTypeId())) {
+    if (!ext || !ext->isDerivedFrom<DocumentObject>()) {
         LINK_THROW(Base::RuntimeError, "Link: container not derived from document object");
     }
     return static_cast<DocumentObject*>(ext);

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -1828,7 +1828,7 @@ ObjectIdentifier::access(const ResolveResults& result, Py::Object* value, Depend
                     auto container = result.resolvedProperty->getContainer();
                     if (container && container != result.resolvedDocumentObject
                         && container != result.resolvedSubObject) {
-                        if (!container->isDerivedFrom(DocumentObject::getClassTypeId())) {
+                        if (!container->isDerivedFrom<DocumentObject>()) {
                             FC_WARN("Invalid property container");
                         }
                         else {

--- a/src/App/OriginGroupExtension.cpp
+++ b/src/App/OriginGroupExtension.cpp
@@ -62,7 +62,7 @@ App::Origin* OriginGroupExtension::getOrigin() const
         err << "Can't find Origin for \"" << getExtendedObject()->getFullName() << "\"";
         throw Base::RuntimeError(err.str().c_str());
     }
-    else if (!originObj->isDerivedFrom(App::Origin::getClassTypeId())) {
+    else if (!originObj->isDerivedFrom<App::Origin>()) {
         std::stringstream err;
         err << "Bad object \"" << originObj->getFullName() << "\"("
             << originObj->getTypeId().getName() << ") linked to the Origin of \""
@@ -114,7 +114,7 @@ App::DocumentObject* OriginGroupExtension::getGroupOfObject(const DocumentObject
         return nullptr;
     }
 
-    bool isOriginFeature = obj->isDerivedFrom(App::DatumElement::getClassTypeId());
+    bool isOriginFeature = obj->isDerivedFrom<App::DatumElement>();
 
     auto list = obj->getInList();
     for (auto o : list) {
@@ -122,7 +122,7 @@ App::DocumentObject* OriginGroupExtension::getGroupOfObject(const DocumentObject
             return o;
         }
         else if (isOriginFeature
-                 && o->isDerivedFrom(App::LocalCoordinateSystem::getClassTypeId())) {
+                 && o->isDerivedFrom<App::LocalCoordinateSystem>()) {
             auto result = getGroupOfObject(o);
             if (result) {
                 return result;
@@ -170,7 +170,7 @@ void OriginGroupExtension::onExtendedSetupObject()
 
     App::DocumentObject* originObj = getLocalizedOrigin(doc);
 
-    assert(originObj && originObj->isDerivedFrom(App::Origin::getClassTypeId()));
+    assert(originObj && originObj->isDerivedFrom<App::Origin>());
     Origin.setValue(originObj);
 
     GeoFeatureGroupExtension::onExtendedSetupObject();

--- a/src/App/Part.cpp
+++ b/src/App/Part.cpp
@@ -75,7 +75,7 @@ static App::Part* _getPartOfObject(const DocumentObject* obj,
         }
         auto group = inObj->getExtensionByType<GeoFeatureGroupExtension>(true);
         if (group && group->hasObject(obj)) {
-            if (inObj->isDerivedFrom(App::Part::getClassTypeId())) {
+            if (inObj->isDerivedFrom<App::Part>()) {
                 return static_cast<App::Part*>(inObj);
             }
             else if (objset) {

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -86,7 +86,7 @@ PyObject* PropertyContainerPy::getPropertyTouchList(PyObject* args)
     }
 
     App::Property* prop = getPropertyContainerPtr()->getPropertyByName(pstr);
-    if (prop && prop->isDerivedFrom(PropertyLists::getClassTypeId())) {
+    if (prop && prop->isDerivedFrom<PropertyLists>()) {
         const auto& touched = static_cast<PropertyLists*>(prop)->getTouchList();
         Py::Tuple ret(touched.size());
         int i = 0;
@@ -647,7 +647,7 @@ PyObject* PropertyContainerPy::getCustomAttributes(const char* attr) const
     }
     /// FIXME: For v0.20: Do not use stuff from Part module here!
     if (Base::streq(attr, "Shape")
-         && getPropertyContainerPtr()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+         && getPropertyContainerPtr()->isDerivedFrom<App::DocumentObject>()) {
         // Special treatment of Shape property
         static PyObject* _getShape = nullptr;
         if (!_getShape) {

--- a/src/App/PropertyFile.cpp
+++ b/src/App/PropertyFile.cpp
@@ -78,7 +78,7 @@ std::string PropertyFileIncluded::getDocTransientPath() const
 {
     std::string path;
     PropertyContainer* co = getContainer();
-    if (co->isDerivedFrom(DocumentObject::getClassTypeId())) {
+    if (co->isDerivedFrom<DocumentObject>()) {
         path = static_cast<DocumentObject*>(co)->getDocument()->TransientDir.getValue();
         std::replace(path.begin(), path.end(), '\\', '/');
     }

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -99,7 +99,7 @@ bool PropertyLinkBase::isSame(const Property& other) const
     if (&other == this) {
         return true;
     }
-    if (other.isDerivedFrom(PropertyLinkBase::getClassTypeId())
+    if (other.isDerivedFrom<PropertyLinkBase>()
         || getScope() != static_cast<const PropertyLinkBase*>(&other)->getScope()) {
         return false;
     }
@@ -692,7 +692,7 @@ void PropertyLink::resetLink()
 #ifndef USE_OLD_DAG
     // maintain the back link in the DocumentObject class if it is from a document object
     if (_pcScope != LinkScope::Hidden && _pcLink && getContainer()
-        && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        && getContainer()->isDerivedFrom<App::DocumentObject>()) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
         // otherwise the backlink contains dangling pointers
@@ -741,7 +741,7 @@ App::DocumentObject* PropertyLink::getValue() const
 
 App::DocumentObject* PropertyLink::getValue(Base::Type t) const
 {
-    return (_pcLink && _pcLink->getTypeId().isDerivedFrom(t)) ? _pcLink : nullptr;
+    return (_pcLink && _pcLink->isDerivedFrom(t)) ? _pcLink : nullptr;
 }
 
 PyObject* PropertyLink::getPyObject()
@@ -817,7 +817,7 @@ Property* PropertyLink::Copy() const
 
 void PropertyLink::Paste(const Property& from)
 {
-    if (!from.isDerivedFrom(PropertyLink::getClassTypeId())) {
+    if (!from.isDerivedFrom<PropertyLink>()) {
         throw Base::TypeError("Incompatible property to paste to");
     }
 
@@ -897,7 +897,7 @@ PropertyLinkList::~PropertyLinkList()
 #ifndef USE_OLD_DAG
     // maintain the back link in the DocumentObject class
     if (_pcScope != LinkScope::Hidden && !_lValueList.empty() && getContainer()
-        && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        && getContainer()->isDerivedFrom<App::DocumentObject>()) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
         // otherwise the backlink contains dangling pointers
@@ -955,7 +955,7 @@ void PropertyLinkList::set1Value(int idx, DocumentObject* const& value)
     _nameMap.clear();
 
 #ifndef USE_OLD_DAG
-    if (getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+    if (getContainer() && getContainer()->isDerivedFrom<App::DocumentObject>()) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
         // otherwise the backlink contains dangling pointers
@@ -1150,7 +1150,7 @@ Property* PropertyLinkList::Copy() const
 
 void PropertyLinkList::Paste(const Property& from)
 {
-    if (!from.isDerivedFrom(PropertyLinkList::getClassTypeId())) {
+    if (!from.isDerivedFrom<PropertyLinkList>()) {
         throw Base::TypeError("Incompatible property to paste to");
     }
 
@@ -1299,7 +1299,7 @@ PropertyLinkSub::~PropertyLinkSub()
     // in case this property is dynamically removed
 #ifndef USE_OLD_DAG
     if (_pcLinkSub && getContainer()
-        && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        && getContainer()->isDerivedFrom<App::DocumentObject>()) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
         // otherwise the backlink contains dangling pointers
@@ -1430,7 +1430,7 @@ std::vector<std::string> PropertyLinkSub::getSubValuesStartsWith(const char* sta
 
 App::DocumentObject* PropertyLinkSub::getValue(Base::Type t) const
 {
-    return (_pcLinkSub && _pcLinkSub->getTypeId().isDerivedFrom(t)) ? _pcLinkSub : nullptr;
+    return (_pcLinkSub && _pcLinkSub->isDerivedFrom(t)) ? _pcLinkSub : nullptr;
 }
 
 PyObject* PropertyLinkSub::getPyObject()
@@ -2054,7 +2054,7 @@ Property* PropertyLinkSub::Copy() const
 
 void PropertyLinkSub::Paste(const Property& from)
 {
-    if (!from.isDerivedFrom(PropertyLinkSub::getClassTypeId())) {
+    if (!from.isDerivedFrom<PropertyLinkSub>()) {
         throw Base::TypeError("Incompatible property to paste to");
     }
     auto& link = static_cast<const PropertyLinkSub&>(from);
@@ -2178,7 +2178,7 @@ PropertyLinkSubList::~PropertyLinkSubList()
 #ifndef USE_OLD_DAG
     // maintain backlinks
     if (!_lValueList.empty() && getContainer()
-        && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        && getContainer()->isDerivedFrom<App::DocumentObject>()) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
         // otherwise the backlink contains dangling pointers
@@ -3112,7 +3112,7 @@ Property* PropertyLinkSubList::Copy() const
 
 void PropertyLinkSubList::Paste(const Property& from)
 {
-    if (!from.isDerivedFrom(PropertyLinkSubList::getClassTypeId())) {
+    if (!from.isDerivedFrom<PropertyLinkSubList>()) {
         throw Base::TypeError("Incompatible property to paste to");
     }
     auto& link = static_cast<const PropertyLinkSubList&>(from);
@@ -4430,7 +4430,7 @@ Property* PropertyXLink::Copy() const
 
 void PropertyXLink::Paste(const Property& from)
 {
-    if (!from.isDerivedFrom(PropertyXLink::getClassTypeId())) {
+    if (!from.isDerivedFrom<PropertyXLink>()) {
         throw Base::TypeError("Incompatible property to paste to");
     }
 
@@ -4461,9 +4461,9 @@ void PropertyXLink::Paste(const Property& from)
 
 bool PropertyXLink::supportXLink(const App::Property* prop)
 {
-    return prop->isDerivedFrom(PropertyXLink::getClassTypeId())
-        || prop->isDerivedFrom(PropertyXLinkSubList::getClassTypeId())
-        || prop->isDerivedFrom(PropertyXLinkContainer::getClassTypeId());
+    return prop->isDerivedFrom<PropertyXLink>()
+        || prop->isDerivedFrom<PropertyXLinkSubList>()
+        || prop->isDerivedFrom<PropertyXLinkContainer>();
 }
 
 bool PropertyXLink::hasXLink(const App::Document* doc)
@@ -5299,7 +5299,7 @@ Property* PropertyXLinkSubList::Copy() const
 
 void PropertyXLinkSubList::Paste(const Property& from)
 {
-    if (!from.isDerivedFrom(PropertyXLinkSubList::getClassTypeId())) {
+    if (!from.isDerivedFrom<PropertyXLinkSubList>()) {
         throw Base::TypeError("Incompatible property to paste to");
     }
 

--- a/src/Base/BaseClass.h
+++ b/src/Base/BaseClass.h
@@ -156,16 +156,10 @@ public:
     }
 
     template<typename T>
-    bool is() const
-    {
-        return getTypeId() == T::getClassTypeId();
-    }
+    bool is() const;
 
     template<typename T>
-    bool isDerivedFrom() const
-    {
-        return getTypeId().isDerivedFrom(T::getClassTypeId());
-    }
+    bool isDerivedFrom() const;
 
 private:
     static Type classTypeId;  // NOLINT
@@ -187,6 +181,20 @@ public:
     virtual ~BaseClass();
 };
 
+template<typename T>
+bool BaseClass::is() const
+{
+    static_assert(std::is_base_of<BaseClass, T>::value, "T must be derived from Base::BaseClass");
+    return getTypeId() == T::getClassTypeId();
+}
+
+template<typename T>
+bool BaseClass::isDerivedFrom() const
+{
+    static_assert(std::is_base_of<BaseClass, T>::value, "T must be derived from Base::BaseClass");
+    return getTypeId().isDerivedFrom(T::getClassTypeId());
+}
+
 /**
  * Template that works just like dynamic_cast, but expects the argument to
  * inherit from Base::BaseClass.
@@ -195,6 +203,8 @@ public:
 template<typename T>
 T* freecad_dynamic_cast(Base::BaseClass* type)
 {
+    static_assert(std::is_base_of<BaseClass, T>::value, "T must be derived from Base::BaseClass");
+
     if (type && type->isDerivedFrom(T::getClassTypeId())) {
         return static_cast<T*>(type);
     }
@@ -210,6 +220,8 @@ T* freecad_dynamic_cast(Base::BaseClass* type)
 template<typename T>
 const T* freecad_dynamic_cast(const Base::BaseClass* type)
 {
+    static_assert(std::is_base_of<BaseClass, T>::value, "T must be derived from Base::BaseClass");
+
     if (type && type->isDerivedFrom(T::getClassTypeId())) {
         return static_cast<const T*>(type);
     }

--- a/src/Gui/AutoSaver.cpp
+++ b/src/Gui/AutoSaver.cpp
@@ -293,13 +293,13 @@ bool RecoveryWriter::shouldWrite(const std::string& name, const Base::Persistenc
 {
     // Property files of a view provider can always be written because
     // these are rather small files.
-    if (object->isDerivedFrom(App::Property::getClassTypeId())) {
+    if (object->isDerivedFrom<App::Property>()) {
         const auto* prop = static_cast<const App::Property*>(object);
         const App::PropertyContainer* parent = prop->getContainer();
-        if (parent && parent->isDerivedFrom(Gui::ViewProvider::getClassTypeId()))
+        if (parent && parent->isDerivedFrom<Gui::ViewProvider>())
             return true;
     }
-    else if (object->isDerivedFrom(Gui::Document::getClassTypeId())) {
+    else if (object->isDerivedFrom<Gui::Document>()) {
         return true;
     }
 
@@ -385,7 +385,7 @@ void RecoveryWriter::writeFiles()
             }
 
             // For properties a copy can be created and then this can be written to disk in a thread
-            if (entry.Object->isDerivedFrom(App::Property::getClassTypeId())) {
+            if (entry.Object->isDerivedFrom<App::Property>()) {
                 const auto* prop = static_cast<const App::Property*>(entry.Object);
                 QThreadPool::globalInstance()->start(new RecoveryRunnable(getModes(), DirName.c_str(), entry.FileName.c_str(), prop));
             }

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -251,7 +251,7 @@ bool Command::isViewOfType(Base::Type t) const
     Gui::BaseView *v = d->getActiveView();
     if (!v)
         return false;
-    if (v->getTypeId().isDerivedFrom(t))
+    if (v->isDerivedFrom(t))
         return true;
     else
         return false;

--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -1117,7 +1117,7 @@ protected: \
     virtual bool isActive(void)\
     {\
         Gui::MDIView* view = Gui::getMainWindow()->activeWindow();\
-        return view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId());\
+        return view && view->isDerivedFrom<Gui::View3DInventor>();\
     }\
 private:\
     X(const X&) = delete;\

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1728,7 +1728,7 @@ void StdCmdEdit::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         if (viewer->isEditingViewProvider()) {
             doCommand(Command::Gui,"Gui.activeDocument().resetEdit()");

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -931,7 +931,7 @@ void StdCmdToggleTransparency::activated(int iMsg)
             App::Document* doc = obj->getDocument();
             Gui::ViewProvider* view = Application::Instance->getDocument(doc)->getViewProvider(obj);
             App::Property* prop = view->getPropertyByName("Transparency");
-            if (prop && prop->getTypeId().isDerivedFrom(App::PropertyInteger::getClassTypeId())) {
+            if (prop && prop->isDerivedFrom<App::PropertyInteger>()) {
                 // To prevent toggling the tip of a PD body (see #11353), we check if the parent has a
                 // Tip prop.
                 const std::vector<App::DocumentObject*> parents = obj->getInList();
@@ -942,7 +942,7 @@ void StdCmdToggleTransparency::activated(int iMsg)
                     if (parentProp) {
                         // Make sure it has a transparency prop too
                         parentProp = parentView->getPropertyByName("Transparency");
-                        if (parentProp && parentProp->getTypeId().isDerivedFrom(App::PropertyInteger::getClassTypeId())) {
+                        if (parentProp && parentProp->isDerivedFrom<App::PropertyInteger>()) {
                             view = parentView;
                         }
                     }
@@ -967,7 +967,7 @@ void StdCmdToggleTransparency::activated(int iMsg)
     bool oneTransparent = false;
     for (auto* view : viewsToToggle) {
         App::Property* prop = view->getPropertyByName("Transparency");
-        if (prop && prop->getTypeId().isDerivedFrom(App::PropertyInteger::getClassTypeId())) {
+        if (prop && prop->isDerivedFrom<App::PropertyInteger>()) {
             auto* transparencyProp = dynamic_cast<App::PropertyInteger*>(prop);
             int transparency = transparencyProp->getValue();
             if (transparency != 0) {
@@ -984,7 +984,7 @@ void StdCmdToggleTransparency::activated(int iMsg)
 
     for (auto* view : viewsToToggle) {
         App::Property* prop = view->getPropertyByName("Transparency");
-        if (prop && prop->getTypeId().isDerivedFrom(App::PropertyInteger::getClassTypeId())) {
+        if (prop && prop->isDerivedFrom<App::PropertyInteger>()) {
             auto* transparencyProp = dynamic_cast<App::PropertyInteger*>(prop);
             transparencyProp->setValue(transparency);
         }
@@ -1033,7 +1033,7 @@ void StdCmdToggleSelectability::activated(int iMsg)
 
         for (const auto & ft : sel) {
             ViewProvider *pr = pcDoc->getViewProviderByName(ft->getNameInDocument());
-            if (pr && pr->isDerivedFrom(ViewProviderGeometryObject::getClassTypeId())){
+            if (pr && pr->isDerivedFrom<ViewProviderGeometryObject>()){
                 if (static_cast<ViewProviderGeometryObject*>(pr)->Selectable.getValue())
                     doCommand(Gui,"Gui.getDocument(\"%s\").getObject(\"%s\").Selectable=False"
                                  , doc->getName(), ft->getNameInDocument());
@@ -2187,7 +2187,7 @@ void StdCmdToggleNavigation::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         SbBool toggle = viewer->isRedirectedToSceneGraph();
         viewer->setRedirectToSceneGraph(!toggle);
@@ -2203,7 +2203,7 @@ bool StdCmdToggleNavigation::isActive()
     if (Gui::Control().activeDialog())
         return false;
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return viewer->isEditing() && viewer->isRedirectToSceneGraphEnabled();
     }
@@ -3203,7 +3203,7 @@ void StdCmdTextureMapping::activated(int iMsg)
 bool StdCmdTextureMapping::isActive()
 {
     Gui::MDIView* view = getMainWindow()->activeWindow();
-    return view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())
+    return view && view->isDerivedFrom<Gui::View3DInventor>()
                 && (!(Gui::Control().activeDialog()));
 }
 

--- a/src/Gui/DAGView/DAGModel.cpp
+++ b/src/Gui/DAGView/DAGModel.cpp
@@ -315,7 +315,7 @@ void Model::slotChangeObject(const ViewProviderDocumentObject &VPDObjectIn, cons
       text->setPlainText(QString::fromUtf8(record.DObject->Label.getValue()));
     }
   }
-  else if (propertyIn.isDerivedFrom(App::PropertyLinkBase::getClassTypeId()))
+  else if (propertyIn.isDerivedFrom<App::PropertyLinkBase>())
   {
     if (hasRecord(&VPDObjectIn, *graphLink))
     {

--- a/src/Gui/DemoMode.cpp
+++ b/src/Gui/DemoMode.cpp
@@ -143,12 +143,8 @@ void DemoMode::hideEvent(QHideEvent*)
 
 Gui::View3DInventor* DemoMode::activeView() const
 {
-    Document* doc = Application::Instance->activeDocument();
-    if (doc) {
-        MDIView* view = doc->getActiveView();
-        if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
-            return static_cast<Gui::View3DInventor*>(view);
-        }
+    if (Document* doc = Application::Instance->activeDocument()) {
+        return Base::freecad_dynamic_cast<Gui::View3DInventor>(doc->getActiveView());
     }
 
     return nullptr;

--- a/src/Gui/Dialogs/DlgPropertyLink.cpp
+++ b/src/Gui/Dialogs/DlgPropertyLink.cpp
@@ -289,15 +289,15 @@ void DlgPropertyLink::init(const App::DocumentObjectT& prop, bool tryFilter)
     std::vector<App::Document*> docs;
 
     singleSelect = false;
-    if (propLink->isDerivedFrom(App::PropertyXLinkSub::getClassTypeId())
-        || propLink->isDerivedFrom(App::PropertyLinkSub::getClassTypeId())) {
+    if (propLink->isDerivedFrom<App::PropertyXLinkSub>()
+        || propLink->isDerivedFrom<App::PropertyLinkSub>()) {
         allowSubObject = true;
         singleParent = true;
     }
-    else if (propLink->isDerivedFrom(App::PropertyLink::getClassTypeId())) {
+    else if (propLink->isDerivedFrom<App::PropertyLink>()) {
         singleSelect = true;
     }
-    else if (propLink->isDerivedFrom(App::PropertyLinkSubList::getClassTypeId())) {
+    else if (propLink->isDerivedFrom<App::PropertyLinkSubList>()) {
         allowSubObject = true;
     }
 
@@ -310,8 +310,8 @@ void DlgPropertyLink::init(const App::DocumentObjectT& prop, bool tryFilter)
     }
 
     bool isLinkList = false;
-    if (propLink->isDerivedFrom(App::PropertyXLinkList::getClassTypeId())
-        || propLink->isDerivedFrom(App::PropertyLinkList::getClassTypeId())) {
+    if (propLink->isDerivedFrom<App::PropertyXLinkList>()
+        || propLink->isDerivedFrom<App::PropertyLinkList>()) {
         isLinkList = true;
         allowSubObject = false;
     }

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -695,7 +695,7 @@ void Document::_resetEdit()
         // the editing object gets deleted inside the above call to
         // 'finishEditing()', which will trigger our slotDeletedObject(), which
         // nullifies _editViewProvider.
-        if (d->_editViewProvider && d->_editViewProvider->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
+        if (d->_editViewProvider && d->_editViewProvider->isDerivedFrom<ViewProviderDocumentObject>()) {
             auto vpd = static_cast<ViewProviderDocumentObject*>(d->_editViewProvider);
             vpd->getDocument()->signalResetEdit(*vpd);
         }
@@ -823,7 +823,7 @@ std::vector<ViewProvider*> Document::getViewProvidersOfType(const Base::Type& ty
     std::vector<ViewProvider*> Objects;
     for (std::map<const App::DocumentObject*,ViewProviderDocumentObject*>::const_iterator it =
          d->_ViewProviderMap.begin(); it != d->_ViewProviderMap.end(); ++it ) {
-        if (it->second->getTypeId().isDerivedFrom(typeId))
+        if (it->second->isDerivedFrom(typeId))
             Objects.push_back(it->second);
     }
     return Objects;
@@ -993,7 +993,7 @@ void Document::slotDeletedObject(const App::DocumentObject& Obj)
 
     handleChildren3D(viewProvider,true);
 
-    if (viewProvider && viewProvider->getTypeId().isDerivedFrom
+    if (viewProvider && viewProvider->isDerivedFrom
         (ViewProviderDocumentObject::getClassTypeId())) {
         // go through the views
         for (vIt = d->baseViews.begin();vIt != d->baseViews.end();++vIt) {
@@ -1034,7 +1034,7 @@ void Document::slotChangedObject(const App::DocumentObject& Obj, const App::Prop
             if(d->_editingViewer
                     && d->_editingObject
                     && d->_editViewProviderParent
-                    && (Prop.isDerivedFrom(App::PropertyPlacement::getClassTypeId())
+                    && (Prop.isDerivedFrom<App::PropertyPlacement>()
                         // Issue ID 0004230 : getName() can return null in which case strstr() crashes
                         || (Prop.getName() && strstr(Prop.getName(),"Scale")))
                     && d->_editObjs.count(&Obj))
@@ -1063,7 +1063,7 @@ void Document::slotChangedObject(const App::DocumentObject& Obj, const App::Prop
 
         handleChildren3D(viewProvider);
 
-        if (viewProvider->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId()))
+        if (viewProvider->isDerivedFrom<ViewProviderDocumentObject>())
             signalChangedObject(static_cast<ViewProviderDocumentObject&>(*viewProvider), Prop);
     }
 
@@ -1079,7 +1079,7 @@ void Document::slotChangedObject(const App::DocumentObject& Obj, const App::Prop
 void Document::slotRelabelObject(const App::DocumentObject& Obj)
 {
     ViewProvider* viewProvider = getViewProvider(&Obj);
-    if (viewProvider && viewProvider->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
+    if (viewProvider && viewProvider->isDerivedFrom<ViewProviderDocumentObject>()) {
         signalRelabelObject(*(static_cast<ViewProviderDocumentObject*>(viewProvider)));
     }
 }
@@ -1087,7 +1087,7 @@ void Document::slotRelabelObject(const App::DocumentObject& Obj)
 void Document::slotTransactionAppend(const App::DocumentObject& obj, App::Transaction* transaction)
 {
     ViewProvider* viewProvider = getViewProvider(&obj);
-    if (viewProvider && viewProvider->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
+    if (viewProvider && viewProvider->isDerivedFrom<ViewProviderDocumentObject>()) {
         transaction->addObjectDel(viewProvider);
     }
 }
@@ -1116,7 +1116,7 @@ void Document::slotTransactionRemove(const App::DocumentObject& obj, App::Transa
 void Document::slotActivatedObject(const App::DocumentObject& Obj)
 {
     ViewProvider* viewProvider = getViewProvider(&Obj);
-    if (viewProvider && viewProvider->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
+    if (viewProvider && viewProvider->isDerivedFrom<ViewProviderDocumentObject>()) {
         signalActivatedObject(*(static_cast<ViewProviderDocumentObject*>(viewProvider)));
     }
 }
@@ -1749,7 +1749,7 @@ void Document::slotFinishRestoreDocument(const App::Document& doc)
     App::DocumentObject* act = doc.getActiveObject();
     if (act) {
         ViewProvider* viewProvider = getViewProvider(act);
-        if (viewProvider && viewProvider->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
+        if (viewProvider && viewProvider->isDerivedFrom<ViewProviderDocumentObject>()) {
             signalActivatedObject(*(static_cast<ViewProviderDocumentObject*>(viewProvider)));
         }
     }
@@ -2389,7 +2389,7 @@ MDIView* Document::getActiveView() const
         // hidden page has view but not in the list. By right, the view will
         // self delete, but not the case for TechDraw, especially during
         // document restore.
-        if(windows.contains(*rit) || (*rit)->isDerivedFrom(View3DInventor::getClassTypeId()))
+        if(windows.contains(*rit) || (*rit)->isDerivedFrom<View3DInventor>())
             return *rit;
     }
     return nullptr;
@@ -2434,7 +2434,7 @@ MDIView *Document::setActiveView(const ViewProviderDocumentObject* vp, Base::Typ
     if (!view || (!typeId.isBad() && !view->isDerivedFrom(typeId))) {
         view = nullptr;
         for (auto *v : d->baseViews) {
-            if (v->isDerivedFrom(MDIView::getClassTypeId()) &&
+            if (v->isDerivedFrom<MDIView>() &&
                (typeId.isBad() || v->isDerivedFrom(typeId))) {
                 view = static_cast<MDIView*>(v);
                 break;

--- a/src/Gui/DocumentModel.cpp
+++ b/src/Gui/DocumentModel.cpp
@@ -575,15 +575,10 @@ const Document* DocumentModel::getDocument(const QModelIndex& index) const
 
 bool DocumentModel::isPropertyLink(const App::Property& prop) const
 {
-    if (prop.isDerivedFrom(App::PropertyLink::getClassTypeId()))
-        return true;
-    if (prop.isDerivedFrom(App::PropertyLinkSub::getClassTypeId()))
-        return true;
-    if (prop.isDerivedFrom(App::PropertyLinkList::getClassTypeId()))
-        return true;
-    if (prop.isDerivedFrom(App::PropertyLinkSubList::getClassTypeId()))
-        return true;
-    return false;
+    return prop.isDerivedFrom<App::PropertyLink>()
+           || prop.isDerivedFrom<App::PropertyLinkSub>()
+           || prop.isDerivedFrom<App::PropertyLinkList>()
+           || prop.isDerivedFrom<App::PropertyLinkSubList>();
 }
 
 std::vector<ViewProviderDocumentObject*>

--- a/src/Gui/ManualAlignment.cpp
+++ b/src/Gui/ManualAlignment.cpp
@@ -136,7 +136,7 @@ void AlignmentGroup::setRandomColor()
         float r = /*(float)rand()/(float)RAND_MAX*/0.0f;
         float g = (float)rand()/(float)RAND_MAX;
         float b = (float)rand()/(float)RAND_MAX;
-        if ((*it)->isDerivedFrom(Gui::ViewProviderGeometryObject::getClassTypeId())) {
+        if ((*it)->isDerivedFrom<Gui::ViewProviderGeometryObject>()) {
             SoSearchAction searchAction;
             searchAction.setType(SoMaterial::getClassTypeId());
             searchAction.setInterest(SoSearchAction::FIRST);
@@ -239,7 +239,7 @@ Base::BoundBox3d AlignmentGroup::getBoundingBox() const
     Base::BoundBox3d box;
     std::vector<Gui::ViewProviderDocumentObject*>::const_iterator it;
     for (it = this->_views.begin(); it != this->_views.end(); ++it) {
-        if ((*it)->isDerivedFrom(Gui::ViewProviderGeometryObject::getClassTypeId())) {
+        if ((*it)->isDerivedFrom<Gui::ViewProviderGeometryObject>()) {
             auto geo = (*it)->getObject<App::GeoFeature>();
             const App::PropertyComplexGeoData* prop = geo->getPropertyOfGeometry();
             if (prop)

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1192,7 +1192,7 @@ void NaviCubeDraggableCmd::activated(int iMsg)
 bool NaviCubeDraggableCmd::isActive()
 {
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         bool check = _pcAction->isChecked();
         auto view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
         bool mode = view->getViewer()->getNaviCube()->isDraggable();

--- a/src/Gui/PropertyView.cpp
+++ b/src/Gui/PropertyView.cpp
@@ -403,7 +403,7 @@ void PropertyView::onTimer()
             continue;
         }
 
-        if(vp->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
+        if(vp->isDerivedFrom<ViewProviderDocumentObject>()) {
             auto cvp = static_cast<ViewProviderDocumentObject*>(vp);
             if(vpLast && cvp!=vpLast)
                 checkLink = false;

--- a/src/Gui/SelectionFilter.cpp
+++ b/src/Gui/SelectionFilter.cpp
@@ -210,7 +210,7 @@ bool SelectionFilter::test(App::DocumentObject*pObj, const char*sSubName)
         return false;
 
     for (const auto& it : Ast->Objects) {
-        if (pObj->getTypeId().isDerivedFrom(it->ObjectType)) {
+        if (pObj->isDerivedFrom(it->ObjectType)) {
             if (!sSubName)
                 return true;
             if (it->SubName.empty())

--- a/src/Gui/SelectionObject.cpp
+++ b/src/Gui/SelectionObject.cpp
@@ -85,7 +85,7 @@ App::DocumentObject * SelectionObject::getObject()
 bool SelectionObject::isObjectTypeOf(const Base::Type& typeId) const
 {
     const App::DocumentObject* obj = getObject();
-    return (obj && obj->getTypeId().isDerivedFrom(typeId));
+    return (obj && obj->isDerivedFrom(typeId));
 }
 
 std::string SelectionObject::getAsPropertyLinkSubString()const

--- a/src/Gui/TextureMapping.cpp
+++ b/src/Gui/TextureMapping.cpp
@@ -143,7 +143,7 @@ void TextureMapping::onFileChooserFileNameSelected(const QString& s)
         Gui::Document* doc = Gui::Application::Instance->activeDocument();
         if (doc) {
             Gui::MDIView* mdi = doc->getActiveView();
-            if (mdi && mdi->isDerivedFrom(View3DInventor::getClassTypeId())) {
+            if (mdi && mdi->isDerivedFrom<View3DInventor>()) {
                 Gui::View3DInventorViewer* view = static_cast<View3DInventor*>(mdi)->getViewer();
                 this->grp = static_cast<SoGroup *>(view->getSceneGraph());
                 this->grp->ref();

--- a/src/Gui/ToolHandler.cpp
+++ b/src/Gui/ToolHandler.cpp
@@ -281,7 +281,7 @@ void ToolHandler::setWidgetCursor(QCursor cursor)
 Gui::View3DInventorViewer* ToolHandler::getViewer()
 {
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         return static_cast<Gui::View3DInventor*>(view)->getViewer();
     }
     return nullptr;

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1075,7 +1075,7 @@ void TreeWidget::contextMenuEvent(QContextMenuEvent* e)
         contextMenu.addAction(this->toggleVisibilityInTreeAction);
 
         if (!acrossDocuments) { // is only sensible for selections within one document
-            if (objitem->object()->getObject()->isDerivedFrom(App::DocumentObjectGroup::getClassTypeId()))
+            if (objitem->object()->getObject()->isDerivedFrom<App::DocumentObjectGroup>())
                 contextMenu.addAction(this->createGroupAction);
             // if there are dependent objects in the selection, add context menu to add them to selection
             if (CheckForDependents())
@@ -2885,7 +2885,7 @@ void TreeWidget::slotRenameDocument(const Gui::Document& Doc)
 void TreeWidget::slotChangedViewObject(const Gui::ViewProvider& vp, const App::Property& prop)
 {
     if (!App::GetApplication().isRestoring()
-        && vp.isDerivedFrom(ViewProviderDocumentObject::getClassTypeId()))
+        && vp.isDerivedFrom<ViewProviderDocumentObject>())
     {
         const auto& vpd = static_cast<const ViewProviderDocumentObject&>(vp);
         if (&prop == &vpd.ShowInTree) {

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -808,7 +808,7 @@ RayPickInfo View3DInventor::getObjInfoRay(Base::Vector3d* startvec, Base::Vector
 
     ret.point = Base::convertTo<Base::Vector3d>(Point->getPoint());
     ViewProvider* vp = getViewer()->getViewProviderByPath(Point->getPath());
-    if (vp && vp->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
+    if (vp && vp->isDerivedFrom<ViewProviderDocumentObject>()) {
         if (!vp->isSelectable()) {
             return ret;
         }

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -1327,7 +1327,7 @@ Py::Object View3DInventorPy::getObjectInfo(const Py::Tuple& args)
             dict.setItem("z", Py::Float(pt[2]));
 
             ViewProvider *vp = getView3DInventorPtr()->getViewer()->getViewProviderByPath(Point->getPath());
-            if (vp && vp->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
+            if (vp && vp->isDerivedFrom<ViewProviderDocumentObject>()) {
                 if (!vp->isSelectable())
                     return ret;
                 auto vpd = static_cast<ViewProviderDocumentObject*>(vp);
@@ -1437,7 +1437,7 @@ Py::Object View3DInventorPy::getObjectsInfo(const Py::Tuple& args)
                 dict.setItem("z", Py::Float(pt[2]));
 
                 ViewProvider *vp = getView3DInventorPtr()->getViewer()->getViewProviderByPath(point->getPath());
-                if(vp && vp->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
+                if(vp && vp->isDerivedFrom<ViewProviderDocumentObject>()) {
                     if(!vp->isSelectable())
                         continue;
                     auto vpd = static_cast<ViewProviderDocumentObject*>(vp);

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -499,12 +499,10 @@ void ViewProviderDocumentObject::setActiveMode()
 
 bool ViewProviderDocumentObject::canDelete(App::DocumentObject* obj) const
 {
-    Q_UNUSED(obj)
-    if (getObject()->hasExtension(App::GroupExtension::getExtensionClassTypeId()))
-        return true;
-    if (getObject()->isDerivedFrom(App::Origin::getClassTypeId()))
-        return true;
-    return false;
+    Q_UNUSED(obj);
+    auto* o = getObject();
+    return o->hasExtension(App::GroupExtension::getExtensionClassTypeId())
+           || o->isDerivedFrom<App::Origin>();
 }
 
 PyObject* ViewProviderDocumentObject::getPyObject()

--- a/src/Gui/ViewProviderDragger.cpp
+++ b/src/Gui/ViewProviderDragger.cpp
@@ -66,7 +66,7 @@ ViewProviderDragger::~ViewProviderDragger() = default;
 
 void ViewProviderDragger::updateData(const App::Property* prop)
 {
-    if (prop->isDerivedFrom(App::PropertyPlacement::getClassTypeId())
+    if (prop->isDerivedFrom<App::PropertyPlacement>()
         && strcmp(prop->getName(), "Placement") == 0) {
         // Note: If R is the rotation, c the rotation center and t the translation
         // vector then Inventor applies the following transformation: R*(x-c)+c+t

--- a/src/Gui/ViewProviderExtension.cpp
+++ b/src/Gui/ViewProviderExtension.cpp
@@ -46,13 +46,13 @@ ViewProviderExtension::~ViewProviderExtension() = default;
 
 const ViewProviderDocumentObject* ViewProviderExtension::getExtendedViewProvider() const{
 
-    assert(getExtendedContainer()->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId()));
+    assert(getExtendedContainer()->isDerivedFrom<ViewProviderDocumentObject>());
     return static_cast<const ViewProviderDocumentObject*>(getExtendedContainer());
 }
 
 ViewProviderDocumentObject* ViewProviderExtension::getExtendedViewProvider() {
 
-    assert(getExtendedContainer()->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId()));
+    assert(getExtendedContainer()->isDerivedFrom<ViewProviderDocumentObject>());
     return static_cast<ViewProviderDocumentObject*>(getExtendedContainer());
 }
 

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -175,13 +175,13 @@ void ViewProviderGeometryObject::attach(App::DocumentObject* pcObj)
 
 void ViewProviderGeometryObject::updateData(const App::Property* prop)
 {
-    if (prop->isDerivedFrom(App::PropertyComplexGeoData::getClassTypeId())) {
+    if (prop->isDerivedFrom<App::PropertyComplexGeoData>()) {
         Base::BoundBox3d box =
             static_cast<const App::PropertyComplexGeoData*>(prop)->getBoundingBox();
         pcBoundingBox->minBounds.setValue(box.MinX, box.MinY, box.MinZ);
         pcBoundingBox->maxBounds.setValue(box.MaxX, box.MaxY, box.MaxZ);
     }
-    else if (prop->isDerivedFrom(App::PropertyPlacement::getClassTypeId())) {
+    else if (prop->isDerivedFrom<App::PropertyPlacement>()) {
         auto geometry = getObject<App::GeoFeature>();
         if (geometry && prop == &geometry->Placement) {
             const App::PropertyComplexGeoData* data = geometry->getPropertyOfGeometry();

--- a/src/Gui/ViewProviderInventorObject.cpp
+++ b/src/Gui/ViewProviderInventorObject.cpp
@@ -124,7 +124,7 @@ void ViewProviderInventorObject::updateData(const App::Property* prop)
             }
         }
     }
-    else if (prop->isDerivedFrom(App::PropertyPlacement::getClassTypeId()) &&
+    else if (prop->isDerivedFrom<App::PropertyPlacement>() &&
              strcmp(prop->getName(), "Placement") == 0) {
         // Note: If R is the rotation, c the rotation center and t the translation
         // vector then Inventor applies the following transformation: R*(x-c)+c+t

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -140,7 +140,7 @@ public:
             Document *pDoc = Application::Instance->getDocument(obj->getDocument());
             if(pDoc) {
                 ViewProvider *vp = pDoc->getViewProvider(obj);
-                if(vp && vp->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId()))
+                if(vp && vp->isDerivedFrom<ViewProviderDocumentObject>())
                     return static_cast<ViewProviderDocumentObject*>(vp);
             }
         }
@@ -1685,7 +1685,7 @@ void ViewProviderLink::attach(App::DocumentObject *pcObj) {
     setDisplayMaskMode("Link");
     inherited::attach(pcObj);
     checkIcon();
-    if(pcObj->isDerivedFrom(App::LinkElement::getClassTypeId()))
+    if(pcObj->isDerivedFrom<App::LinkElement>())
         hide();
     linkView->setOwner(this);
 

--- a/src/Gui/ViewProviderVRMLObject.cpp
+++ b/src/Gui/ViewProviderVRMLObject.cpp
@@ -249,7 +249,7 @@ void ViewProviderVRMLObject::updateData(const App::Property* prop)
             SoInput::removeDirectory(subpath.constData());
         }
     }
-    else if (prop->isDerivedFrom(App::PropertyPlacement::getClassTypeId()) &&
+    else if (prop->isDerivedFrom<App::PropertyPlacement>() &&
              strcmp(prop->getName(), "Placement") == 0) {
         // Note: If R is the rotation, c the rotation center and t the translation
         // vector then Inventor applies the following transformation: R*(x-c)+c+t

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -1603,7 +1603,7 @@ void ExpLineEdit::onChange() {
 
     if (getExpression()) {
         std::unique_ptr<Expression> result(getExpression()->eval());
-        if(result->isDerivedFrom(App::StringExpression::getClassTypeId()))
+        if(result->isDerivedFrom<App::StringExpression>())
             setText(QString::fromUtf8(static_cast<App::StringExpression*>(
                             result.get())->getText().c_str()));
         else

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -643,7 +643,7 @@ void PropertyEditor::buildUp(PropertyModel::PropertyList&& props, bool _checkDoc
                 continue;
             }
             // Include document to get proper handling in PropertyView::slotDeleteDocument()
-            if (checkDocument && container->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+            if (checkDocument && container->isDerivedFrom<App::DocumentObject>()) {
                 propOwners.insert(static_cast<App::DocumentObject*>(container)->getDocument());
             }
             propOwners.insert(container);
@@ -779,7 +779,7 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
     if (props.size() == 1) {
         auto item = static_cast<PropertyItem*>(contextIndex.internalPointer());
         auto prop = *props.begin();
-        if (item->isBound() && !prop->isDerivedFrom(App::PropertyExpressionEngine::getClassTypeId())
+        if (item->isBound() && !prop->isDerivedFrom<App::PropertyExpressionEngine>()
             && !prop->isReadOnly() && !prop->testStatus(App::Property::Immutable)
             && !(prop->getType() & App::Prop_ReadOnly)) {
             contextIndex = propertyModel->buddy(contextIndex);

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -611,17 +611,17 @@ void PropertyItem::setPropertyValue(const std::string& value)
             continue;
         }
 
-        if (parent->isDerivedFrom(App::Document::getClassTypeId())) {
+        if (parent->isDerivedFrom<App::Document>()) {
             auto doc = static_cast<App::Document*>(parent);
             ss << "FreeCAD.getDocument('" << doc->getName() << "').";
         }
-        else if (parent->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        else if (parent->isDerivedFrom<App::DocumentObject>()) {
             auto obj = static_cast<App::DocumentObject*>(parent);
             App::Document* doc = obj->getDocument();
             ss << "FreeCAD.getDocument('" << doc->getName() << "').getObject('"
                << obj->getNameInDocument() << "').";
         }
-        else if (parent->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
+        else if (parent->isDerivedFrom<ViewProviderDocumentObject>()) {
             App::DocumentObject* obj =
                 static_cast<ViewProviderDocumentObject*>(parent)->getObject();
             App::Document* doc = obj->getDocument();

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -160,10 +160,7 @@ bool ViewProviderAssembly::doubleClicked()
 bool ViewProviderAssembly::canDragObject(App::DocumentObject* obj) const
 {
     // The user should not be able to drag the joint group out of the assembly
-    if (!obj || obj->getTypeId() == Assembly::JointGroup::getClassTypeId()) {
-        return false;
-    }
-    return true;
+    return obj && !obj->is<Assembly::JointGroup>();
 }
 
 bool ViewProviderAssembly::canDragObjectToTarget(App::DocumentObject* obj,
@@ -1028,9 +1025,8 @@ bool ViewProviderAssembly::onDelete(const std::vector<std::string>& subNames)
 {
     // Delete the assembly groups when assembly is deleted
     for (auto obj : getObject()->getOutList()) {
-        if (obj->getTypeId() == Assembly::JointGroup::getClassTypeId()
-            || obj->getTypeId() == Assembly::ViewGroup::getClassTypeId()
-            || obj->getTypeId() == Assembly::BomGroup::getClassTypeId()) {
+        if (obj->is<Assembly::JointGroup>() || obj->is<Assembly::ViewGroup>()
+            || obj->is<Assembly::BomGroup>()) {
 
             // Delete the group content first.
             Gui::Command::doCommand(Gui::Command::Doc,

--- a/src/Mod/CAM/App/AppPathPy.cpp
+++ b/src/Mod/CAM/App/AppPathPy.cpp
@@ -178,7 +178,7 @@ private:
         if (PyObject_TypeCheck(pObj, &(App::DocumentObjectPy::Type))) {
             App::DocumentObject* obj =
                 static_cast<App::DocumentObjectPy*>(pObj)->getDocumentObjectPtr();
-            if (obj->getTypeId().isDerivedFrom(Base::Type::fromName("Path::Feature"))) {
+            if (obj->isDerivedFrom<Path::Feature>()) {
                 const Path::Toolpath& path = static_cast<Path::Feature*>(obj)->Path.getValue();
                 std::string gcode = path.toGCode();
                 Base::ofstream ofile(file);

--- a/src/Mod/CAM/App/FeatureArea.cpp
+++ b/src/Mod/CAM/App/FeatureArea.cpp
@@ -82,7 +82,7 @@ App::DocumentObjectExecReturn* FeatureArea::execute()
     }
 
     for (std::vector<App::DocumentObject*>::iterator it = links.begin(); it != links.end(); ++it) {
-        if (!(*it && (*it)->isDerivedFrom(Part::Feature::getClassTypeId()))) {
+        if (!(*it && (*it)->isDerivedFrom<Part::Feature>())) {
             return new App::DocumentObjectExecReturn(
                 "Linked object is not a Part object (has no Shape).");
         }
@@ -202,7 +202,7 @@ std::list<TopoDS_Shape> FeatureAreaView::getShapes()
     if (!pObj) {
         return shapes;
     }
-    if (!pObj->isDerivedFrom(FeatureArea::getClassTypeId())) {
+    if (!pObj->isDerivedFrom<FeatureArea>()) {
         return shapes;
     }
 
@@ -250,7 +250,7 @@ App::DocumentObjectExecReturn* FeatureAreaView::execute()
         return new App::DocumentObjectExecReturn("No shape linked");
     }
 
-    if (!pObj->isDerivedFrom(FeatureArea::getClassTypeId())) {
+    if (!pObj->isDerivedFrom<FeatureArea>()) {
         return new App::DocumentObjectExecReturn("Linked object is not a FeatureArea");
     }
 

--- a/src/Mod/CAM/App/FeaturePathShape.cpp
+++ b/src/Mod/CAM/App/FeaturePathShape.cpp
@@ -66,7 +66,7 @@ App::DocumentObjectExecReturn* FeatureShape::execute()
 
     std::list<TopoDS_Shape> shapes;
     for (std::vector<App::DocumentObject*>::iterator it = links.begin(); it != links.end(); ++it) {
-        if (!(*it && (*it)->isDerivedFrom(Part::Feature::getClassTypeId()))) {
+        if (!(*it && (*it)->isDerivedFrom<Part::Feature>())) {
             continue;
         }
         const TopoDS_Shape& shape = static_cast<Part::Feature*>(*it)->Shape.getShape().getShape();

--- a/src/Mod/CAM/App/PropertyPath.cpp
+++ b/src/Mod/CAM/App/PropertyPath.cpp
@@ -132,7 +132,7 @@ void PropertyPath::RestoreDocFile(Base::Reader& reader)
 {
     App::PropertyContainer* container = getContainer();
     App::DocumentObject* obj = nullptr;
-    if (container->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+    if (container->isDerivedFrom<App::DocumentObject>()) {
         obj = static_cast<App::DocumentObject*>(container);
     }
 

--- a/src/Mod/Drawing/App/FeatureViewSpreadsheet.cpp
+++ b/src/Mod/Drawing/App/FeatureViewSpreadsheet.cpp
@@ -186,14 +186,14 @@ App::DocumentObjectExecReturn* FeatureViewSpreadsheet::execute(void)
             App::Property* prop = sheet->getPropertyByName(address.toString().c_str());
             std::stringstream field;
             if (prop) {
-                if (prop->isDerivedFrom((App::PropertyQuantity::getClassTypeId()))) {
-                    field << static_cast<App::PropertyQuantity*>(prop)->getValue();
+                if (auto* p = Base::freecad_dynamic_cast<App::PropertyQuantity>(prop)) {
+                    field << p->getValue();
                 }
-                else if (prop->isDerivedFrom((App::PropertyFloat::getClassTypeId()))) {
-                    field << static_cast<App::PropertyFloat*>(prop)->getValue();
+                else if (auto p = Base::freecad_dynamic_cast<App::PropertyFloat>(prop)) {
+                    field << p->getValue();
                 }
-                else if (prop->isDerivedFrom((App::PropertyString::getClassTypeId()))) {
-                    field << static_cast<App::PropertyString*>(prop)->getValue();
+                else if (auto p = Base::freecad_dynamic_cast<App::PropertyString>(prop)) {
+                    field << p->getValue();
                 }
                 else {
                     assert(0);

--- a/src/Mod/Fem/App/AppFemPy.cpp
+++ b/src/Mod/Fem/App/AppFemPy.cpp
@@ -203,13 +203,12 @@ private:
             "User parameter:BaseApp/Preferences/Mod/Fem");
 
         Py::Sequence list(object);
-        Base::Type meshId = Base::Type::fromName("Fem::FemMeshObject");
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             PyObject* item = (*it).ptr();
             if (PyObject_TypeCheck(item, &(App::DocumentObjectPy::Type))) {
                 App::DocumentObject* obj =
                     static_cast<App::DocumentObjectPy*>(item)->getDocumentObjectPtr();
-                if (obj->getTypeId().isDerivedFrom(meshId)) {
+                if (obj->isDerivedFrom<Fem::FemMeshObject>()) {
                     auto femMesh = static_cast<FemMeshObject*>(obj)->FemMesh.getValue();
                     if (file.hasExtension({"vtk", "vtu"})) {
                         // get VTK prefs

--- a/src/Mod/Fem/App/FemPostFilter.cpp
+++ b/src/Mod/Fem/App/FemPostFilter.cpp
@@ -468,12 +468,9 @@ void FemPostClipFilter::onChanged(const Property* prop)
 {
     if (prop == &Function) {
 
-        if (Function.getValue()
-            && Function.getValue()->isDerivedFrom(FemPostFunction::getClassTypeId())) {
-            m_clipper->SetClipFunction(
-                static_cast<FemPostFunction*>(Function.getValue())->getImplicitFunction());
-            m_extractor->SetImplicitFunction(
-                static_cast<FemPostFunction*>(Function.getValue())->getImplicitFunction());
+        if (auto* value = Base::freecad_dynamic_cast<FemPostFunction>(Function.getValue())) {
+            m_clipper->SetClipFunction(value->getImplicitFunction());
+            m_extractor->SetImplicitFunction(value->getImplicitFunction());
         }
     }
     else if (prop == &InsideOut) {
@@ -922,10 +919,8 @@ FemPostCutFilter::~FemPostCutFilter() = default;
 void FemPostCutFilter::onChanged(const Property* prop)
 {
     if (prop == &Function) {
-        if (Function.getValue()
-            && Function.getValue()->isDerivedFrom(FemPostFunction::getClassTypeId())) {
-            m_cutter->SetCutFunction(
-                static_cast<FemPostFunction*>(Function.getValue())->getImplicitFunction());
+        if (auto* value = Base::freecad_dynamic_cast<FemPostFunction>(Function.getValue())) {
+            m_cutter->SetCutFunction(value->getImplicitFunction());
         }
     }
 

--- a/src/Mod/Fem/App/FemPostFilter.cpp
+++ b/src/Mod/Fem/App/FemPostFilter.cpp
@@ -91,8 +91,7 @@ DocumentObjectExecReturn* FemPostFilter::execute()
 vtkDataObject* FemPostFilter::getInputData()
 {
     if (Input.getValue()) {
-        if (Input.getValue()->getTypeId().isDerivedFrom(
-                Base::Type::fromName("Fem::FemPostObject"))) {
+        if (Input.getValue()->isDerivedFrom<Fem::FemPostObject>()) {
             return Input.getValue<FemPostObject*>()->Data.getValue();
         }
         else {

--- a/src/Mod/Fem/App/FemPostPipeline.cpp
+++ b/src/Mod/Fem/App/FemPostPipeline.cpp
@@ -225,7 +225,7 @@ void FemPostPipeline::load(FemResultObject* res)
         Base::Console().Log("Result mesh object is empty.\n");
         return;
     }
-    if (!res->Mesh.getValue()->isDerivedFrom(Fem::FemMeshObject::getClassTypeId())) {
+    if (!res->Mesh.getValue()->isDerivedFrom<Fem::FemMeshObject>()) {
         Base::Console().Log("Result mesh object is not derived from Fem::FemMeshObject.\n");
         return;
     }

--- a/src/Mod/Fem/App/FemVTKTools.cpp
+++ b/src/Mod/Fem/App/FemVTKTools.cpp
@@ -550,7 +550,7 @@ App::DocumentObject* getObjectByType(const Base::Type type)
     if (obj->is<FemAnalysis>()) {
         std::vector<App::DocumentObject*> fem = (static_cast<FemAnalysis*>(obj))->Group.getValues();
         for (const auto& it : fem) {
-            if (it->getTypeId().isDerivedFrom(type)) {
+            if (it->isDerivedFrom(type)) {
                 return static_cast<App::DocumentObject*>(it);  // return the first of that type
             }
         }
@@ -891,7 +891,7 @@ void FemVTKTools::exportFreeCADResult(const App::DocumentObject* result,
     // vtk has more points. Vtk does not support point gaps, thus the gaps are
     // filled with points. Then the mapping must be correct)
     App::DocumentObject* meshObj = res->Mesh.getValue();
-    if (!meshObj || !meshObj->isDerivedFrom(FemMeshObject::getClassTypeId())) {
+    if (!meshObj || !meshObj->isDerivedFrom<FemMeshObject>()) {
         Base::Console().Error("Result object does not correctly link to mesh");
         return;
     }

--- a/src/Mod/Fem/App/PropertyPostDataObject.cpp
+++ b/src/Mod/Fem/App/PropertyPostDataObject.cpp
@@ -337,7 +337,7 @@ void PropertyPostDataObject::SaveDocFile(Base::Writer& writer) const
         // We only print an error message but continue writing the next files to the
         // stream...
         App::PropertyContainer* father = this->getContainer();
-        if (father && father->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        if (father && father->isDerivedFrom<App::DocumentObject>()) {
             App::DocumentObject* obj = static_cast<App::DocumentObject*>(father);
             Base::Console().Error("Dataset of '%s' cannot be written to vtk file '%s'\n",
                                   obj->Label.getValue(),
@@ -412,7 +412,7 @@ void PropertyPostDataObject::RestoreDocFile(Base::Reader& reader)
             // We only print an error message but continue reading the next files from the
             // stream...
             App::PropertyContainer* father = this->getContainer();
-            if (father && father->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+            if (father && father->isDerivedFrom<App::DocumentObject>()) {
                 App::DocumentObject* obj = static_cast<App::DocumentObject*>(father);
                 Base::Console().Error("Dataset file '%s' with data of '%s' seems to be empty\n",
                                       fi.filePath().c_str(),

--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -1169,7 +1169,7 @@ bool CmdFemDefineNodesSet::isActive()
     }
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }
@@ -1296,7 +1296,7 @@ void CmdFemDefineElementsSet::activated(int)
         if (it == docObj.begin()) {
             Gui::Document* doc = getActiveGuiDocument();
             Gui::MDIView* view = doc->getActiveView();
-            if (view->getTypeId().isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+            if (view->isDerivedFrom<Gui::View3DInventor>()) {
                 Gui::View3DInventorViewer* viewer = ((Gui::View3DInventor*)view)->getViewer();
                 viewer->setEditing(true);
                 viewer->startSelection(Gui::View3DInventorViewer::Clip);
@@ -1318,7 +1318,7 @@ bool CmdFemDefineElementsSet::isActive()
     }
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }

--- a/src/Mod/Fem/Gui/TaskCreateElementSet.cpp
+++ b/src/Mod/Fem/Gui/TaskCreateElementSet.cpp
@@ -479,7 +479,7 @@ void TaskCreateElementSet::Poly(void)
 {
     Gui::Document* doc = Gui::Application::Instance->activeDocument();
     Gui::MDIView* view = doc->getActiveView();
-    if (view->getTypeId().isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = ((Gui::View3DInventor*)view)->getViewer();
         viewer->setEditing(true);
         viewer->startSelection(Gui::View3DInventorViewer::Clip);

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
@@ -230,38 +230,25 @@ bool ViewProviderFemAnalysis::canDragObject(App::DocumentObject* obj) const
     if (!obj) {
         return false;
     }
-    if (obj->isDerivedFrom<Fem::FemMeshObject>()) {
+
+    // clang-format off: keep line breaks for readability
+    if (obj->isDerivedFrom<Fem::FemMeshObject>()
+        || obj->isDerivedFrom<Fem::FemSolverObject>()
+        || obj->isDerivedFrom<Fem::FemResultObject>()
+        || obj->isDerivedFrom<Fem::Constraint>()
+        || obj->isDerivedFrom<Fem::FemSetObject>()
+        || obj->isDerivedFrom(Base::Type::fromName("Fem::FeaturePython"))
+        || obj->isDerivedFrom<App::MaterialObject>()
+        || obj->isDerivedFrom<App::TextDocument>()) {
         return true;
     }
-    else if (obj->isDerivedFrom<Fem::FemSolverObject>()) {
-        return true;
-    }
-    else if (obj->isDerivedFrom<Fem::FemResultObject>()) {
-        return true;
-    }
-    else if (obj->isDerivedFrom<Fem::Constraint>()) {
-        return true;
-    }
-    else if (obj->isDerivedFrom<Fem::FemSetObject>()) {
-        return true;
-    }
-    else if (obj->getTypeId().isDerivedFrom(Base::Type::fromName("Fem::FeaturePython"))) {
-        return true;
-    }
-    else if (obj->isDerivedFrom<App::MaterialObject>()) {
-        return true;
-    }
-    else if (obj->isDerivedFrom<App::TextDocument>()) {
-        return true;
-    }
+    // clang-format on
 #ifdef FC_USE_VTK
     else if (obj->isDerivedFrom<Fem::FemPostObject>()) {
         return true;
     }
 #endif
-    else {
-        return false;
-    }
+    return false;
 }
 
 void ViewProviderFemAnalysis::dragObject(App::DocumentObject* obj)

--- a/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
@@ -379,7 +379,7 @@ std::vector<std::string> ViewProviderFemMesh::getDisplayModes() const
 
 void ViewProviderFemMesh::updateData(const App::Property* prop)
 {
-    if (prop->isDerivedFrom(Fem::PropertyFemMesh::getClassTypeId())) {
+    if (prop->isDerivedFrom<Fem::PropertyFemMesh>()) {
         ViewProviderFEMMeshBuilder builder;
         resetColorByNodeId();
         resetDisplacementByNodeId();

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
@@ -122,7 +122,7 @@ void ViewProviderFemPostFunctionProvider::updateSize()
 {
     std::vector<App::DocumentObject*> vec = claimChildren();
     for (auto it : vec) {
-        if (!it->isDerivedFrom(Fem::FemPostFunction::getClassTypeId())) {
+        if (!it->isDerivedFrom<Fem::FemPostFunction>()) {
             continue;
         }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -1036,7 +1036,7 @@ void ViewProviderFemPostObject::hide()
     for (auto it : ObjectsList) {
         if (it->isDerivedFrom<Fem::FemPostObject>()) {
             if (!firstVisiblePostObject && it->Visibility.getValue()
-                && !it->isDerivedFrom(Fem::FemPostDataAtPointFilter::getClassTypeId())) {
+                && !it->isDerivedFrom<Fem::FemPostDataAtPointFilter>()) {
                 firstVisiblePostObject = it;
                 break;
             }

--- a/src/Mod/Import/App/ExportOCAF.cpp
+++ b/src/Mod/Import/App/ExportOCAF.cpp
@@ -368,9 +368,7 @@ void ExportOCAF::reallocateFreeShape(std::vector<App::DocumentObject*> hierarchi
     for (std::size_t i = 0; i < n; i++) {
         TDF_Label label = FreeLabels.at(i);
         // hierarchical part does contain only part currently and not node I should add node
-        if (hierarchical_part.at(part_id.at(i))
-                ->getTypeId()
-                .isDerivedFrom(Part::Feature::getClassTypeId())) {
+        if (hierarchical_part.at(part_id.at(i))->isDerivedFrom<Part::Feature>()) {
             Part::Feature* part = static_cast<Part::Feature*>(hierarchical_part.at(part_id.at(i)));
             aShapeTool->SetShape(label, part->Shape.getValue());
             // Add color information

--- a/src/Mod/Import/App/ImportOCAF2.cpp
+++ b/src/Mod/Import/App/ImportOCAF2.cpp
@@ -561,7 +561,7 @@ App::DocumentObject* ImportOCAF2::loadShapes()
     if (ret) {
         ret->recomputeFeature(true);
     }
-    if (options.merge && ret && !ret->isDerivedFrom(Part::Feature::getClassTypeId())) {
+    if (options.merge && ret && !ret->isDerivedFrom<Part::Feature>()) {
         auto shape = Part::Feature::getTopoShape(ret);
         auto feature =
             static_cast<Part::Feature*>(pDocument->addObject("Part::Feature", "Feature"));

--- a/src/Mod/Import/App/SketchExportHelper.cpp
+++ b/src/Mod/Import/App/SketchExportHelper.cpp
@@ -73,14 +73,8 @@ TopoDS_Shape SketchExportHelper::projectShape(const TopoDS_Shape& inShape,
 //! true if obj is a sketch
 bool SketchExportHelper::isSketch(App::DocumentObject* obj)
 {
-    // TODO:: the check for an object being a sketch should be done as in the commented
-    // if statement below. To do this, we need to include Mod/Sketcher/SketchObject.h,
-    // but that makes Import dependent on Eigen libraries which we don't use.  As a
-    // workaround we will inspect the object's class name.
-    //    if (obj->isDerivedFrom(Sketcher::SketchObject::getClassTypeId())) {
-    std::string objTypeName = obj->getTypeId().getName();
-    std::string sketcherToken("Sketcher");
-    return objTypeName.find(sketcherToken) != std::string::npos;
+    // Use name to lookup to avoid dependency on Sketcher module
+    return obj->isDerivedFrom(Base::Type::fromName("Sketcher::SketchObject"));
 }
 
 

--- a/src/Mod/Import/Gui/ExportOCAFGui.cpp
+++ b/src/Mod/Import/Gui/ExportOCAFGui.cpp
@@ -38,7 +38,7 @@ ExportOCAFGui::ExportOCAFGui(Handle(TDocStd_Document) hDoc, bool explicitPlaceme
 void ExportOCAFGui::findColors(Part::Feature* part, std::vector<App::Color>& colors) const
 {
     Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider(part);
-    if (vp && vp->isDerivedFrom(PartGui::ViewProviderPartExt::getClassTypeId())) {
+    if (vp && vp->isDerivedFrom<PartGui::ViewProviderPartExt>()) {
         colors = static_cast<PartGui::ViewProviderPartExt*>(vp)->ShapeAppearance.getDiffuseColors();
     }
 }

--- a/src/Mod/Inspection/Gui/Command.cpp
+++ b/src/Mod/Inspection/Gui/Command.cpp
@@ -104,7 +104,7 @@ bool CmdInspectElement::isActive()
     }
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }

--- a/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
+++ b/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
@@ -385,7 +385,7 @@ void ViewProviderInspection::setDistances()
         SoDebugError::post("ViewProviderInspection::setDistances", "Unknown property 'Distances'");
         return;
     }
-    if (pDistances->getTypeId() != Inspection::PropertyDistanceList::getClassTypeId()) {
+    if (!pDistances->is<Inspection::PropertyDistanceList>()) {
         SoDebugError::post(
             "ViewProviderInspection::setDistances",
             "Property 'Distances' has type %s (Inspection::PropertyDistanceList was expected)",

--- a/src/Mod/Measure/App/MeasureBase.cpp
+++ b/src/Mod/Measure/App/MeasureBase.cpp
@@ -179,7 +179,7 @@ QString MeasureBase::getResultString()
         return QString();
     }
 
-    if (prop->isDerivedFrom(App::PropertyQuantity::getClassTypeId())) {
+    if (prop->isDerivedFrom<App::PropertyQuantity>()) {
         return QString::fromStdString(
             static_cast<App::PropertyQuantity*>(prop)->getQuantityValue().getUserString());
     }

--- a/src/Mod/Measure/Gui/Command.cpp
+++ b/src/Mod/Measure/Gui/Command.cpp
@@ -69,7 +69,7 @@ bool StdCmdMeasure::isActive()
     }
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = dynamic_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -134,7 +134,7 @@ bool QuickMeasure::shouldMeasure(const Gui::SelectionChanges& msg) const
 bool QuickMeasure::isObjAcceptable(App::DocumentObject* obj)
 {
     // only measure shapes
-    if (obj && obj->isDerivedFrom(Part::Feature::getClassTypeId())) {
+    if (obj && obj->isDerivedFrom<Part::Feature>()) {
         return true;
     }
 

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -369,8 +369,7 @@ void TaskMeasure::ensureGroup(Measure::MeasureBase* measurement)
     App::DocumentObject* obj = doc->getObject(measurementGroupName);
 
 
-    if (!obj || !obj->isValid()
-        || !obj->isDerivedFrom(App::DocumentObjectGroup::getClassTypeId())) {
+    if (!obj || !obj->isValid() || !obj->isDerivedFrom<App::DocumentObjectGroup>()) {
         obj = doc->addObject("App::DocumentObjectGroup",
                              measurementGroupName,
                              true,

--- a/src/Mod/Mesh/App/Exporter.cpp
+++ b/src/Mod/Mesh/App/Exporter.cpp
@@ -110,7 +110,7 @@ int Exporter::addObject(App::DocumentObject* obj, float tol)
         auto linked = sobj->getLinkedObject(true, &matrix, false);
         auto it = meshCache.find(linked);
         if (it == meshCache.end()) {
-            if (linked->isDerivedFrom(Mesh::Feature::getClassTypeId())) {
+            if (linked->isDerivedFrom<Mesh::Feature>()) {
                 it = meshCache.emplace(linked, static_cast<Mesh::Feature*>(linked)->Mesh.getValue())
                          .first;
                 it->second.setTransform(matrix);

--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -641,7 +641,7 @@ bool CmdMeshVertexCurvatureInfo::isActive()
     }
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }
@@ -701,7 +701,7 @@ bool CmdMeshPolySegm::isActive()
     }
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }
@@ -749,7 +749,7 @@ bool CmdMeshAddFacet::isActive()
     }
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }
@@ -814,7 +814,7 @@ bool CmdMeshPolyCut::isActive()
     }
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }
@@ -879,7 +879,7 @@ bool CmdMeshPolyTrim::isActive()
     }
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }
@@ -1023,7 +1023,7 @@ bool CmdMeshPolySplit::isActive()
     }
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }
@@ -1114,7 +1114,7 @@ bool CmdMeshEvaluateFacet::isActive()
     }
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }
@@ -1601,7 +1601,7 @@ bool CmdMeshFillInteractiveHole::isActive()
     }
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }

--- a/src/Mod/Mesh/Gui/MeshSelection.cpp
+++ b/src/Mod/Mesh/Gui/MeshSelection.cpp
@@ -136,7 +136,7 @@ std::list<ViewProviderMesh*> MeshSelection::getViewProviders() const
     std::vector<App::DocumentObject*> objs = getObjects();
     std::list<ViewProviderMesh*> vps;
     for (auto obj : objs) {
-        if (obj->isDerivedFrom(Mesh::Feature::getClassTypeId())) {
+        if (obj->isDerivedFrom<Mesh::Feature>()) {
             Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider(obj);
             if (vp->isVisible()) {
                 vps.push_back(static_cast<ViewProviderMesh*>(vp));

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -254,7 +254,7 @@ bool Tessellation::accept()
             shapeObjects.emplace_back(sel.pObject, sel.SubName);
         }
         else if (sel.pObject) {
-            if (sel.pObject->isDerivedFrom(Part::Feature::getClassTypeId())) {
+            if (sel.pObject->isDerivedFrom<Part::Feature>()) {
                 partWithNoFace = true;
             }
             if (auto body = dynamic_cast<Part::BodyBase*>(sel.pObject)) {

--- a/src/Mod/Part/App/FeatureCompound.h
+++ b/src/Mod/Part/App/FeatureCompound.h
@@ -30,7 +30,7 @@
 namespace Part
 {
 
-class Compound : public Part::Feature
+class PartExport Compound : public Part::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::Compound);
 

--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -266,7 +266,7 @@ Base::Vector3d Extrusion::calculateShapeNormal(const App::PropertyLink& shapeLin
         throw Base::ValueError("calculateShapeNormal: link is empty");
 
     //special case for sketches and the like: no matter what shape they have, use their local Z axis.
-    if (docobj->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+    if (docobj->isDerivedFrom<Part::Part2DObject>()) {
         Base::Vector3d OZ(0.0, 0.0, 1.0);
         Base::Vector3d result;
         Base::Rotation(mat).multVec(OZ, result);

--- a/src/Mod/Part/App/FeatureMirroring.cpp
+++ b/src/Mod/Part/App/FeatureMirroring.cpp
@@ -150,8 +150,8 @@ App::DocumentObjectExecReturn *Mirroring::execute()
       Can also be App::Links to such objects
     */
     if (refObject){
-        if (refObject->isDerivedFrom(Part::Plane::getClassTypeId()) || refObject->isDerivedFrom<App::Plane>() || (strstr(refObject->getNameInDocument(), "Plane")
-                                                                                                                  && refObject->isDerivedFrom(Part::Datum::getClassTypeId()))) {
+        if (refObject->isDerivedFrom<Part::Plane>() || refObject->isDerivedFrom<App::Plane>() || (strstr(refObject->getNameInDocument(), "Plane")
+                                                                                                                  && refObject->isDerivedFrom<Part::Datum>())) {
             Part::Feature* plane = static_cast<Part::Feature*>(refObject);
             Base::Vector3d base = plane->Placement.getValue().getPosition();
             axbase = gp_Pnt(base.x, base.y, base.z);

--- a/src/Mod/Part/App/FeaturePartBoolean.h
+++ b/src/Mod/Part/App/FeaturePartBoolean.h
@@ -32,7 +32,7 @@ class FCBRepAlgoAPI_BooleanOperation;
 namespace Part
 {
 
-class Boolean : public Part::Feature
+class PartExport Boolean : public Part::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::Boolean);
 

--- a/src/Mod/Part/App/FeaturePartCommon.h
+++ b/src/Mod/Part/App/FeaturePartCommon.h
@@ -45,7 +45,7 @@ protected:
     //@}
 };
 
-class MultiCommon : public Part::Feature
+class PartExport MultiCommon : public Part::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::MultiCommon);
 

--- a/src/Mod/Part/App/FeaturePartFuse.h
+++ b/src/Mod/Part/App/FeaturePartFuse.h
@@ -45,7 +45,7 @@ protected:
     //@}
 };
 
-class MultiFuse : public Part::Feature
+class PartExport MultiFuse : public Part::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::MultiFuse);
 

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -287,7 +287,7 @@ void Geometry::Save(Base::Writer &writer) const
     // Get the number of persistent extensions
     int counter = 0;
     for(const auto& att : extensions) {
-        if(att->isDerivedFrom(Part::GeometryPersistenceExtension::getClassTypeId()))
+        if(att->isDerivedFrom<Part::GeometryPersistenceExtension>())
             counter++;
     }
 
@@ -296,7 +296,7 @@ void Geometry::Save(Base::Writer &writer) const
     writer.incInd();
 
     for(const auto& att : extensions) {
-        if(att->isDerivedFrom(Part::GeometryPersistenceExtension::getClassTypeId()))
+        if(att->isDerivedFrom<Part::GeometryPersistenceExtension>())
             std::static_pointer_cast<Part::GeometryPersistenceExtension>(att)->Save(writer);
     }
 
@@ -764,7 +764,7 @@ GeomLineSegment* GeomCurve::toLineSegment(KeepTag clone) const
         return nullptr;
 
     Base::Vector3d start, end;
-    if (isDerivedFrom(GeomBoundedCurve::getClassTypeId())) {
+    if (isDerivedFrom<GeomBoundedCurve>()) {
         start = dynamic_cast<const GeomBoundedCurve*>(this)->getStartPoint();
         end = dynamic_cast<const GeomBoundedCurve*>(this)->getEndPoint();
     } else {
@@ -2064,7 +2064,7 @@ PyObject *GeomBSplineCurve::getPyObject()
 bool GeomBSplineCurve::isSame(const Geometry &_other, double tol, double atol) const
 {
     if(_other.getTypeId() != getTypeId()) {
-        if (isLinear() && _other.isDerivedFrom(GeomCurve::getClassTypeId())) {
+        if (isLinear() && _other.isDerivedFrom<GeomCurve>()) {
             std::unique_ptr<Geometry> geo(toLineSegment());
             if (geo)
                 return geo->isSame(_other, tol, atol);
@@ -2256,7 +2256,7 @@ GeomBSplineCurve* GeomConic::toNurbs(double first, double last) const
 
 bool GeomConic::isSame(const Geometry &_other, double tol, double atol) const
 {
-    if(!_other.isDerivedFrom(GeomConic::getClassTypeId()))
+    if(!_other.isDerivedFrom<GeomConic>())
         return false;
 
     auto &other = static_cast<const GeomConic &>(_other);
@@ -4526,7 +4526,7 @@ PyObject *GeomLine::getPyObject()
 bool GeomLine::isSame(const Geometry &_other, double tol, double atol) const
 {
     if(_other.getTypeId() != getTypeId()) {
-        if (_other.isDerivedFrom(GeomCurve::getClassTypeId())) {
+        if (_other.isDerivedFrom<GeomCurve>()) {
             std::unique_ptr<Geometry> geo(dynamic_cast<const GeomCurve&>(_other).toLine());
             if (geo)
                 return isSame(*geo, tol, atol);
@@ -4816,7 +4816,7 @@ bool GeomSurface::isPlanar(const Handle(Geom_Surface) &s, gp_Pln *pln, double to
 
 GeomPlane* GeomSurface::toPlane(bool clone, double tol) const
 {
-    if (isDerivedFrom(GeomPlane::getClassTypeId())) {
+    if (isDerivedFrom<GeomPlane>()) {
         if (clone) {
             return dynamic_cast<GeomPlane*>(this->clone());
         }
@@ -5145,7 +5145,7 @@ PyObject *GeomBSplineSurface::getPyObject()
 bool GeomBSplineSurface::isSame(const Geometry &_other, double tol, double atol) const
 {
     if(_other.getTypeId() != getTypeId()) {
-        if (_other.isDerivedFrom(GeomSurface::getClassTypeId()) && isPlanar()) {
+        if (_other.isDerivedFrom<GeomSurface>() && isPlanar()) {
             std::unique_ptr<Geometry> geo(toPlane());
             if (geo)
                 return geo->isSame(_other, tol, atol);
@@ -5247,7 +5247,7 @@ Base::Vector3d GeomElementarySurface::getYDir(void) const
 
 bool GeomElementarySurface::isSame(const Geometry &_other, double tol, double atol) const
 {
-    if(!_other.isDerivedFrom(GeomElementarySurface::getClassTypeId()))
+    if(!_other.isDerivedFrom<GeomElementarySurface>())
         return false;
 
     auto &other = static_cast<const GeomElementarySurface &>(_other);
@@ -5684,7 +5684,7 @@ PyObject *GeomPlane::getPyObject()
 bool GeomPlane::isSame(const Geometry &_other, double tol, double atol) const
 {
     if(_other.getTypeId() != getTypeId()) {
-        if (_other.isDerivedFrom(GeomSurface::getClassTypeId())) {
+        if (_other.isDerivedFrom<GeomSurface>()) {
             std::unique_ptr<Geometry> geo(static_cast<const GeomSurface&>(_other).toPlane());
             if (geo)
                 return isSame(*geo, tol, atol);
@@ -5940,7 +5940,7 @@ Base::Vector3d GeomSweptSurface::getDir(void) const
 
 bool GeomSweptSurface::isSame(const Geometry &_other, double tol, double atol) const
 {
-    if(!_other.isDerivedFrom(GeomSweptSurface::getClassTypeId()))
+    if(!_other.isDerivedFrom<GeomSweptSurface>())
         return false;
 
     auto &other = static_cast<const GeomSweptSurface &>(_other);

--- a/src/Mod/Part/App/MeasureClient.cpp
+++ b/src/Mod/Part/App/MeasureClient.cpp
@@ -108,7 +108,7 @@ TopoDS_Shape getLocatedShape(const App::SubObjectT& subject, Base::Matrix4D* mat
     shape.setPlacement(placement);
 
     // Don't get the subShape from datum elements
-    if (obj->getTypeId().isDerivedFrom(Part::Datum::getClassTypeId())) {
+    if (obj->isDerivedFrom<Part::Datum>()) {
         return shape.getShape();
     }
 

--- a/src/Mod/Part/App/MeasureClient.cpp
+++ b/src/Mod/Part/App/MeasureClient.cpp
@@ -139,10 +139,8 @@ App::MeasureElementType PartMeasureTypeCb(App::DocumentObject* ob, const char* s
 
             switch (curve.GetType()) {
                 case GeomAbs_Line: {
-                    if (ob->getTypeId().isDerivedFrom(Base::Type::fromName("Part::Datum"))) {
-                        return App::MeasureElementType::LINE;
-                    }
-                    return App::MeasureElementType::LINESEGMENT;
+                    return ob->isDerivedFrom<Part::Datum>() ? App::MeasureElementType::LINE
+                                                            : App::MeasureElementType::LINESEGMENT;
                 }
                 case GeomAbs_Circle: { return App::MeasureElementType::CIRCLE; }
                 case GeomAbs_BezierCurve:

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -521,7 +521,7 @@ static std::vector<std::pair<long, Data::MappedName>> getElementSource(App::Docu
                     break;
                 }
             }
-            if (owner->isDerivedFrom(App::GeoFeature::getClassTypeId())) {
+            if (owner->isDerivedFrom<App::GeoFeature>()) {
                 auto ownerGeoFeature =
                     static_cast<App::GeoFeature*>(owner)->getElementOwner(ret.back().second);
                 if (ownerGeoFeature) {
@@ -624,7 +624,7 @@ std::list<Data::HistoryItem> Feature::getElementHistory(App::DocumentObject* fea
                     break;
                 }
             }
-            if (feature->isDerivedFrom(App::GeoFeature::getClassTypeId())) {
+            if (feature->isDerivedFrom<App::GeoFeature>()) {
                 auto ownerGeoFeature =
                     static_cast<App::GeoFeature*>(feature)->getElementOwner(element);
                 if (ownerGeoFeature) {
@@ -989,7 +989,7 @@ static TopoShape _getTopoShape(const App::DocumentObject* obj,
             }
         }
         else {
-            if (linked->isDerivedFrom(App::Line::getClassTypeId())) {
+            if (linked->isDerivedFrom<App::Line>()) {
                 static TopoDS_Shape _shape;
                 if (_shape.IsNull()) {
                     auto line = static_cast<App::Line*>(linked);
@@ -1000,7 +1000,7 @@ static TopoShape _getTopoShape(const App::DocumentObject* obj,
                 }
                 shape = TopoShape(tag, hasher, _shape);
             }
-            else if (linked->isDerivedFrom(App::Plane::getClassTypeId())) {
+            else if (linked->isDerivedFrom<App::Plane>()) {
                 static TopoDS_Shape _shape;
                 if (_shape.IsNull()) {
                     auto plane = static_cast<App::Plane*>(linked);
@@ -1011,7 +1011,7 @@ static TopoShape _getTopoShape(const App::DocumentObject* obj,
                 }
                 shape = TopoShape(tag, hasher, _shape);
             }
-            else if (linked->isDerivedFrom(App::Point::getClassTypeId())) {
+            else if (linked->isDerivedFrom<App::Point>()) {
                 static TopoDS_Shape _shape;
                 if (_shape.IsNull()) {
                     BRepBuilderAPI_MakeVertex builder(gp_Pnt(0, 0, 0));
@@ -1019,7 +1019,7 @@ static TopoShape _getTopoShape(const App::DocumentObject* obj,
                 }
                 shape = TopoShape(tag, hasher, _shape);
             }
-            else if (linked->isDerivedFrom(App::Placement::getClassTypeId())) {
+            else if (linked->isDerivedFrom<App::Placement>()) {
                 auto element = Data::findElementName(subname);
                 if (element) {
                     if (boost::iequals("x", element) || boost::iequals("x-axis", element)
@@ -1270,7 +1270,7 @@ TopoShape Feature::getTopoShape(const App::DocumentObject* obj,
     // to false. So we manually apply the top level transform if asked.
 
     if (needSubElement && (!pmat || *pmat == Base::Matrix4D())
-        && obj->isDerivedFrom(Part::Feature::getClassTypeId())
+        && obj->isDerivedFrom<Part::Feature>()
         && !obj->hasExtension(App::LinkBaseExtension::getExtensionClassTypeId())) {
         // Some OCC shape making is very sensitive to shape transformation. So
         // check here if a direct sub shape is required, and bypass all extra

--- a/src/Mod/Part/App/PartFeature.h
+++ b/src/Mod/Part/App/PartFeature.h
@@ -201,7 +201,7 @@ private:
     std::vector<std::pair<std::string, PropertyPartShape*>> _elementCachePrefixMap;
 };
 
-class FilletBase : public Part::Feature
+class PartExport FilletBase : public Part::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::FilletBase);
 

--- a/src/Mod/Part/App/PartFeatures.h
+++ b/src/Mod/Part/App/PartFeatures.h
@@ -128,7 +128,7 @@ private:
     static const char* TransitionEnums[];
 };
 
-class Thickness : public Part::Feature
+class PartExport Thickness : public Part::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::Thickness);
 

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -476,7 +476,7 @@ void PropertyPartShape::saveToFile(Base::Writer &writer) const
         // We only print an error message but continue writing the next files to the
         // stream...
         App::PropertyContainer* father = this->getContainer();
-        if (father && father->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        if (father && father->isDerivedFrom<App::DocumentObject>()) {
             App::DocumentObject* obj = static_cast<App::DocumentObject*>(father);
             Base::Console().Error("Shape of '%s' cannot be written to BRep file '%s'\n",
                 obj->Label.getValue(),fi.filePath().c_str());
@@ -528,7 +528,7 @@ void PropertyPartShape::loadFromFile(Base::Reader &reader)
             // We only print an error message but continue reading the next files from the
             // stream...
             App::PropertyContainer* father = this->getContainer();
-            if (father && father->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+            if (father && father->isDerivedFrom<App::DocumentObject>()) {
                 App::DocumentObject* obj = static_cast<App::DocumentObject*>(father);
                 Base::Console().Error("BRep file '%s' with shape of '%s' seems to be empty\n",
                     fi.filePath().c_str(),obj->Label.getValue());

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -474,11 +474,11 @@ std::vector<TopoShape> TopoShape::findSubShapesWithSharedVertex(const TopoShape&
                     return res;
                 }
                 if (shapeType == TopAbs_EDGE) {
-                    isLine = (geom->isDerivedFrom(GeomLine::getClassTypeId())
-                              || geom->isDerivedFrom(GeomLineSegment::getClassTypeId()));
+                    isLine = (geom->isDerivedFrom<GeomLine>()
+                              || geom->isDerivedFrom<GeomLineSegment>());
                 }
                 else {
-                    isPlane = geom->isDerivedFrom(GeomPlane::getClassTypeId());
+                    isPlane = geom->isDerivedFrom<GeomPlane>();
                 }
             }
 
@@ -491,8 +491,8 @@ std::vector<TopoShape> TopoShape::findSubShapesWithSharedVertex(const TopoShape&
                     // For lines, don't compare geometry, just check the
                     // vertices below instead, because the exact same edge
                     // may have different geometrical representation.
-                    if (!g2->isDerivedFrom(GeomLine::getClassTypeId())
-                        && !g2->isDerivedFrom(GeomLineSegment::getClassTypeId())) {
+                    if (!g2->isDerivedFrom<GeomLine>()
+                        && !g2->isDerivedFrom<GeomLineSegment>()) {
                         return false;
                     }
                 }
@@ -500,7 +500,7 @@ std::vector<TopoShape> TopoShape::findSubShapesWithSharedVertex(const TopoShape&
                     // For planes, don't compare geometry either, so that
                     // we don't need to worry about orientation and so on.
                     // Just check the edges.
-                    if (!g2->isDerivedFrom(GeomPlane::getClassTypeId())) {
+                    if (!g2->isDerivedFrom<GeomPlane>()) {
                         return false;
                     }
                 }
@@ -603,8 +603,8 @@ std::vector<TopoShape> TopoShape::findSubShapesWithSharedVertex(const TopoShape&
                             }
                             bool isLine2 = false;
                             gp_Pnt pt1, pt2;
-                            if (geom2->isDerivedFrom(GeomLine::getClassTypeId())
-                                || geom2->isDerivedFrom(GeomLineSegment::getClassTypeId())) {
+                            if (geom2->isDerivedFrom<GeomLine>()
+                                || geom2->isDerivedFrom<GeomLineSegment>()) {
                                 pt1 = BRep_Tool::Pnt(TopExp::FirstVertex(TopoDS::Edge(edge)));
                                 pt2 = BRep_Tool::Pnt(TopExp::LastVertex(TopoDS::Edge(edge)));
                                 isLine2 = true;
@@ -624,8 +624,8 @@ std::vector<TopoShape> TopoShape::findSubShapesWithSharedVertex(const TopoShape&
                                     }
                                 }
                                 if (isLine2) {
-                                    if (g1->isDerivedFrom(GeomLine::getClassTypeId())
-                                        || g1->isDerivedFrom(GeomLineSegment::getClassTypeId())) {
+                                    if (g1->isDerivedFrom<GeomLine>()
+                                        || g1->isDerivedFrom<GeomLineSegment>()) {
                                         auto p1 =
                                             BRep_Tool::Pnt(TopExp::FirstVertex(TopoDS::Edge(e1)));
                                         auto p2 =
@@ -5751,7 +5751,7 @@ TopoShape& TopoShape::makeElementBoolean(const char* maker,
 
 bool TopoShape::isSame(const Data::ComplexGeoData& _other) const
 {
-    if (!_other.isDerivedFrom(TopoShape::getClassTypeId())) {
+    if (!_other.isDerivedFrom<TopoShape>()) {
         return false;
     }
 

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1920,7 +1920,7 @@ bool CmdShapeInfo::isActive()
         return false;
 
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         return !viewer->isEditing();
     }

--- a/src/Mod/Part/Gui/CommandFilter.cpp
+++ b/src/Mod/Part/Gui/CommandFilter.cpp
@@ -157,7 +157,7 @@ void PartCmdSelectFilter::languageChange()
 bool PartCmdSelectFilter::isActive()
 {
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    return view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId());
+    return view && view->isDerivedFrom<Gui::View3DInventor>();
 }
 
 

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -94,8 +94,8 @@ public:
     {
         std::string subString(sSubName);
 
-        if (pObj->isDerivedFrom(Part::Plane::getClassTypeId()) || pObj->isDerivedFrom<App::Plane>()
-                || (strstr(pObj->getNameInDocument(), "Plane") && pObj->isDerivedFrom(Part::Datum::getClassTypeId()))) {
+        if (pObj->isDerivedFrom<Part::Plane>() || pObj->isDerivedFrom<App::Plane>()
+                || (strstr(pObj->getNameInDocument(), "Plane") && pObj->isDerivedFrom<Part::Datum>())) {
             return true;
             // reference is an app::link or a part::feature or some subobject
         } else if (pObj->isDerivedFrom<Part::Feature>() || pObj->isDerivedFrom<App::Link>()) {

--- a/src/Mod/Part/Gui/SectionCutting.cpp
+++ b/src/Mod/Part/Gui/SectionCutting.cpp
@@ -54,11 +54,13 @@
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
 #include <Gui/ViewProviderGeometryObject.h>
+#include <Mod/Part/App/DatumFeature.h>
 #include <Mod/Part/App/FeatureCompound.h>
 #include <Mod/Part/App/FeaturePartBox.h>
 #include <Mod/Part/App/FeaturePartCommon.h>
 #include <Mod/Part/App/FeaturePartCut.h>
 #include <Mod/Part/App/FeaturePartFuse.h>
+#include <Mod/Part/App/Part2DObject.h>
 #include <Mod/Part/App/PartFeatures.h>
 
 #include "SectionCutting.h"
@@ -855,18 +857,13 @@ bool SectionCut::findObjects(std::vector<App::DocumentObject*>& objects)
         }
         // get all shapes that are also Part::Features
         if (object->getPropertyByName("Shape") != nullptr
-            && object->getTypeId().isDerivedFrom(
-                Base::Type::fromName("Part::Feature"))) {
+            && object->isDerivedFrom<Part::Feature>()) {
             // sort out 2D objects, datums, App:Parts, compounds and objects that are
             // part of a PartDesign body
-            if (!object->getTypeId().isDerivedFrom(
-                    Base::Type::fromName("Part::Part2DObject"))
-                && !object->getTypeId().isDerivedFrom(
-                    Base::Type::fromName("Part::Datum"))
-                && !object->getTypeId().isDerivedFrom(
-                    Base::Type::fromName("PartDesign::Feature"))
-                && !object->getTypeId().isDerivedFrom(
-                    Base::Type::fromName("Part::Compound"))
+            if (!object->isDerivedFrom<Part::Part2DObject>()
+                && !object->isDerivedFrom<Part::Datum>()
+                && !object->isDerivedFrom(Base::Type::fromName("PartDesign::Feature"))
+                && !object->isDerivedFrom<Part::Compound>()
                 && object->getTypeId() != Base::Type::fromName("App::Part")) {
                 objects.push_back(object);
             }
@@ -875,7 +872,7 @@ bool SectionCut::findObjects(std::vector<App::DocumentObject*>& objects)
         if (auto pcLink = dynamic_cast<App::Link*>(object)) {
             auto linkedObject = doc->getObject(pcLink->LinkedObject.getObjectName());
             if (linkedObject != nullptr
-                && linkedObject->getTypeId().isDerivedFrom(Base::Type::fromName("Part::Feature"))) {
+                && linkedObject->isDerivedFrom<Part::Feature>()) {
                 objects.push_back(object);
             }
         }
@@ -894,15 +891,11 @@ void SectionCut::filterObjects(std::vector<App::DocumentObject*>& objects)
         if (!object) {
             continue;
         }
-        if (object->getTypeId().isDerivedFrom(Base::Type::fromName("Part::Boolean"))
-            || object->getTypeId().isDerivedFrom(
-                Base::Type::fromName("Part::MultiCommon"))
-            || object->getTypeId().isDerivedFrom(
-                Base::Type::fromName("Part::MultiFuse"))
-            || object->getTypeId().isDerivedFrom(
-                Base::Type::fromName("Part::Thickness"))
-            || object->getTypeId().isDerivedFrom(
-                Base::Type::fromName("Part::FilletBase"))) {
+        if (object->isDerivedFrom<Part::Boolean>()
+            || object->isDerivedFrom<Part::MultiCommon>()
+            || object->isDerivedFrom<Part::MultiFuse>()
+            || object->isDerivedFrom<Part::Thickness>()
+            || object->isDerivedFrom<Part::FilletBase>()) {
             // get possible links
             auto subObjectList = object->getOutList();
             // if there are links, delete them

--- a/src/Mod/Part/Gui/TaskOffset.cpp
+++ b/src/Mod/Part/Gui/TaskOffset.cpp
@@ -67,7 +67,7 @@ OffsetWidget::OffsetWidget(Part::Offset* offset, QWidget* parent)
     d->ui.spinOffset->setSingleStep(0.1);
     d->ui.facesButton->hide();
 
-    bool is_2d = d->offset->isDerivedFrom(Part::Offset2D::getClassTypeId());
+    bool is_2d = d->offset->isDerivedFrom<Part::Offset2D>();
     d->ui.selfIntersection->setVisible(!is_2d);
     if(is_2d)
         d->ui.modeType->removeItem(2);//remove Recto-Verso mode, not supported by 2d offset

--- a/src/Mod/Part/Gui/TaskShapeBuilder.cpp
+++ b/src/Mod/Part/Gui/TaskShapeBuilder.cpp
@@ -67,7 +67,7 @@ namespace PartGui {
         }
         bool allow(App::Document*, App::DocumentObject* obj, const char*sSubName) override
         {
-            if (!obj || !obj->isDerivedFrom(Part::Feature::getClassTypeId()))
+            if (!obj || !obj->isDerivedFrom<Part::Feature>())
                 return false;
             if (!sSubName || sSubName[0] == '\0')
                 return (mode == ALL);

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -255,12 +255,12 @@ std::vector<App::DocumentObject*> Body::addObject(App::DocumentObject *feature)
     }
 
     if(feature->Visibility.getValue()
-        && feature->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
+        && feature->isDerivedFrom<PartDesign::Feature>())
     {
         for(auto obj : Group.getValues()) {
             if(obj->Visibility.getValue()
                     && obj!=feature
-                    && obj->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
+                    && obj->isDerivedFrom<PartDesign::Feature>())
                 obj->Visibility.setValue(false);
         }
     }
@@ -313,7 +313,7 @@ void Body::insertObject(App::DocumentObject* feature, App::DocumentObject* targe
 
     Group.setValues (model);
 
-    if(feature->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
+    if(feature->isDerivedFrom<PartDesign::Feature>())
         static_cast<PartDesign::Feature*>(feature)->_Body.setValue(this);
 
     // Set the BaseFeature property
@@ -399,7 +399,7 @@ App::DocumentObjectExecReturn *Body::execute()
 
     Part::TopoShape tipShape;
     if ( tip ) {
-        if ( !tip->getTypeId().isDerivedFrom ( PartDesign::Feature::getClassTypeId() ) ) {
+        if ( !tip->isDerivedFrom<PartDesign::Feature>() ) {
             return new App::DocumentObjectExecReturn (QT_TRANSLATE_NOOP("Exception", "Linked object is not a PartDesign feature" ));
         }
 
@@ -441,7 +441,7 @@ void Body::onChanged(const App::Property* prop) {
 
             if (BaseFeature.getValue()) {
                 //setup the FeatureBase if needed
-                if (!first || !first->isDerivedFrom(FeatureBase::getClassTypeId())) {
+                if (!first || !first->isDerivedFrom<FeatureBase>()) {
                     bf = static_cast<FeatureBase*>(getDocument()->addObject("PartDesign::FeatureBase", "BaseFeature"));
                     insertObject(bf, first, false);
 
@@ -460,7 +460,7 @@ void Body::onChanged(const App::Property* prop) {
         else if (prop == &Group) {
             //if the FeatureBase was deleted we set the BaseFeature link to nullptr
             if (BaseFeature.getValue() &&
-               (Group.getValues().empty() || !Group.getValues().front()->isDerivedFrom(FeatureBase::getClassTypeId()))) {
+               (Group.getValues().empty() || !Group.getValues().front()->isDerivedFrom<FeatureBase>())) {
                     BaseFeature.setValue(nullptr);
             }
         }
@@ -532,7 +532,7 @@ App::DocumentObject *Body::getSubObject(const char *subname,
             const char* secondDot = strchr(firstDot + 1, '.');
             if (secondDot) {
                 auto firstObj = Group.find(std::string(subname, firstDot).c_str());
-                if (!firstObj || firstObj->isDerivedFrom(PartDesign::Feature::getClassTypeId())) {
+                if (!firstObj || firstObj->isDerivedFrom<PartDesign::Feature>()) {
                     auto secondObj = Group.find(std::string(firstDot + 1, secondDot).c_str());
                     if (secondObj) {
                         // we support only one level of sibling grouping, so no
@@ -564,7 +564,7 @@ App::DocumentObject *Body::getSubObject(const char *subname,
     // We return the shape only if there are feature visible inside
     for(auto obj : Group.getValues()) {
         if(obj->Visibility.getValue() &&
-           obj->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
+           obj->isDerivedFrom<PartDesign::Feature>())
         {
             return Part::BodyBase::getSubObject(subname,pyObj,pmat,transform,depth);
         }
@@ -578,7 +578,7 @@ App::DocumentObject *Body::getSubObject(const char *subname,
 void Body::onDocumentRestored()
 {
     for(auto obj : Group.getValues()) {
-        if(obj->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
+        if(obj->isDerivedFrom<PartDesign::Feature>())
             static_cast<PartDesign::Feature*>(obj)->_Body.setValue(this);
     }
     _GroupTouched.setStatus(App::Property::Output,true);

--- a/src/Mod/PartDesign/App/BodyPyImp.cpp
+++ b/src/Mod/PartDesign/App/BodyPyImp.cpp
@@ -87,7 +87,7 @@ PyObject* BodyPy::insertObject(PyObject *args)
 
 Py::Object BodyPy::getVisibleFeature() const {
     for(auto obj : getBodyPtr()->Group.getValues()) {
-        if(obj->Visibility.getValue() && obj->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
+        if(obj->Visibility.getValue() && obj->isDerivedFrom<PartDesign::Feature>())
             return Py::Object(obj->getPyObject(),true);
     }
     return Py::Object();

--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -285,8 +285,8 @@ const TopoDS_Shape& Feature::getBaseShape() const {
     if (!BaseObject)
         throw Base::ValueError("Base feature's shape is not defined");
 
-    if (BaseObject->isDerivedFrom(PartDesign::ShapeBinder::getClassTypeId())||
-        BaseObject->isDerivedFrom(PartDesign::SubShapeBinder::getClassTypeId()))
+    if (BaseObject->isDerivedFrom<PartDesign::ShapeBinder>()||
+        BaseObject->isDerivedFrom<PartDesign::SubShapeBinder>())
     {
         throw Base::ValueError("Base shape of shape binder cannot be used");
     }
@@ -318,8 +318,8 @@ Part::TopoShape Feature::getBaseTopoShape(bool silent) const
             }
             throw Base::RuntimeError("Missing container body");
         }
-        if (BaseObject->isDerivedFrom(PartDesign::ShapeBinder::getClassTypeId())
-            || BaseObject->isDerivedFrom(PartDesign::SubShapeBinder::getClassTypeId())) {
+        if (BaseObject->isDerivedFrom<PartDesign::ShapeBinder>()
+            || BaseObject->isDerivedFrom<PartDesign::SubShapeBinder>()) {
             if (silent) {
                 return result;
             }
@@ -395,7 +395,7 @@ Body* Feature::getFeatureBody() const {
 
     auto list = getInList();
     for (auto in : list) {
-        if(in->isDerivedFrom(Body::getClassTypeId()) && //is Body?
+        if(in->isDerivedFrom<Body>() && //is Body?
            static_cast<Body*>(in)->hasObject(this)) {    //is part of this Body?
 
                return static_cast<Body*>(in);

--- a/src/Mod/PartDesign/App/FeatureBase.cpp
+++ b/src/Mod/PartDesign/App/FeatureBase.cpp
@@ -64,7 +64,7 @@ App::DocumentObjectExecReturn* FeatureBase::execute()
             QT_TRANSLATE_NOOP("Exception", "BaseFeature link is not set"));
     }
 
-    if (!BaseFeature.getValue()->isDerivedFrom(Part::Feature::getClassTypeId())) {
+    if (!BaseFeature.getValue()->isDerivedFrom<Part::Feature>()) {
         return new App::DocumentObjectExecReturn(
             QT_TRANSLATE_NOOP("Exception", "BaseFeature must be a Part::Feature"));
     }

--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -91,7 +91,7 @@ App::DocumentObjectExecReturn *Boolean::execute()
         baseTopShape = baseFeature->Shape.getShape();
     else {
         auto feature = tools.back();
-        if(!feature->isDerivedFrom(Part::Feature::getClassTypeId()))
+        if(!feature->isDerivedFrom<Part::Feature>())
             return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Cannot do boolean with anything but Part::Feature and its derivatives"));
 
         baseTopShape = static_cast<Part::Feature*>(feature)->Shape.getShape();
@@ -120,7 +120,7 @@ App::DocumentObjectExecReturn *Boolean::execute()
     Base::Placement  bodyPlacement = baseBody->globalPlacement().inverse();
     for (auto tool : tools)
     {
-        if(!tool->isDerivedFrom(Part::Feature::getClassTypeId()))
+        if(!tool->isDerivedFrom<Part::Feature>())
             return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Cannot do boolean with anything but Part::Feature and its derivatives"));
 
         Part::TopoShape toolShape = static_cast<Part::Feature*>(tool)->Shape.getShape();

--- a/src/Mod/PartDesign/App/FeatureDressUp.cpp
+++ b/src/Mod/PartDesign/App/FeatureDressUp.cpp
@@ -86,7 +86,7 @@ Part::Feature *DressUp::getBaseObject(bool silent) const
     const char* err = nullptr;
     App::DocumentObject* base = Base.getValue();
     if (base) {
-        if(base->isDerivedFrom(Part::Feature::getClassTypeId())) {
+        if(base->isDerivedFrom<Part::Feature>()) {
             rv = static_cast<Part::Feature*>(base);
         } else {
             err = "Linked object is not a Part object";
@@ -314,7 +314,7 @@ void DressUp::getAddSubShape(Part::TopoShape &addShape, Part::TopoShape &subShap
                     if(!base)
                         FC_THROWM(Base::CADKernelError,
                                 "Cannot find additive or subtractive support for " << getFullName());
-                    if(!base->isDerivedFrom(DressUp::getClassTypeId()))
+                    if(!base->isDerivedFrom<DressUp>())
                         break;
                 }
             }

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -75,7 +75,7 @@ Loft::getSectionShape(const char *name,
     // Be smart. If part of a sketch is selected, use the entire sketch unless it is a single vertex - 
     // backward compatibility (#16630)
     auto subName = subs.empty() ? "" : subs.front();
-    auto useEntireSketch = obj->isDerivedFrom(Part::Part2DObject::getClassTypeId()) &&  subName.find("Vertex") != 0;
+    auto useEntireSketch = obj->isDerivedFrom<Part::Part2DObject>() &&  subName.find("Vertex") != 0;
     if (subs.empty() || std::find(subs.begin(), subs.end(), std::string()) != subs.end() || useEntireSketch ) {
         shapes.push_back(Part::Feature::getTopoShape(obj));
         if (shapes.back().isNull())

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -112,14 +112,14 @@ App::DocumentObjectExecReturn *Pipe::execute()
 
     auto getSectionShape = [](App::DocumentObject* feature,
                               const std::vector<std::string>& subs) -> TopoDS_Shape {
-        if (!feature || !feature->isDerivedFrom(Part::Feature::getClassTypeId()))
+        if (!feature || !feature->isDerivedFrom<Part::Feature>())
             throw Base::TypeError("Pipe: Invalid profile/section");
 
         auto subName = subs.empty() ? "" : subs.front();
 
         // only take the entire shape when we have a sketch selected, but
         // not a point of the sketch
-        if (feature->isDerivedFrom(Part::Part2DObject::getClassTypeId())
+        if (feature->isDerivedFrom<Part::Part2DObject>()
             && subName.compare(0, 6, "Vertex") != 0)
             return static_cast<Part::Part2DObject*>(feature)->Shape.getValue();
         else {
@@ -237,7 +237,7 @@ App::DocumentObjectExecReturn *Pipe::execute()
             // TODO: we need to order the sections to prevent occ from crashing,
             // as makepipeshell connects the sections in the order of adding
             for (auto& subSet : multisections) {
-                if (!subSet.first->isDerivedFrom(Part::Feature::getClassTypeId()))
+                if (!subSet.first->isDerivedFrom<Part::Feature>())
                     return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
                                                                                "Pipe: All sections need to be part features"));
 

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -104,7 +104,7 @@ void ProfileBased::positionByPrevious()
         //no base. Use either Sketch support's placement, or sketch's placement itself.
         Part::Part2DObject* sketch = getVerifiedSketch();
         App::DocumentObject* support = sketch->AttachmentSupport.getValue();
-        if (support && support->isDerivedFrom(App::GeoFeature::getClassTypeId())) {
+        if (support && support->isDerivedFrom<App::GeoFeature>()) {
             this->Placement.setValue(static_cast<App::GeoFeature*>(support)->Placement.getValue());
         }
         else {
@@ -202,7 +202,7 @@ TopoShape ProfileBased::getTopoShapeVerifiedFace(bool silent,
         }
         else {
             std::string sub;
-            if (!obj->getTypeId().isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+            if (!obj->isDerivedFrom<Part::Part2DObject>()) {
                 if (!subs.empty()) {
                     sub = subs[0];
                 }
@@ -304,7 +304,7 @@ TopoShape ProfileBased::getTopoShapeVerifiedFace(bool silent,
         }
         if (count > 1) {
             if (AllowMultiFace.getValue()
-                || obj->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+                || obj->isDerivedFrom<Part::Part2DObject>()) {
                 return shape;
             }
             FC_WARN("Found more than one face from profile");
@@ -431,11 +431,11 @@ TopoShape ProfileBased::getProfileShape() const
 std::vector<TopoDS_Wire> ProfileBased::getProfileWires() const {
     std::vector<TopoDS_Wire> result;
 
-    if (!Profile.getValue() || !Profile.getValue()->isDerivedFrom(Part::Feature::getClassTypeId()))
+    if (!Profile.getValue() || !Profile.getValue()->isDerivedFrom<Part::Feature>())
         throw Base::TypeError("No valid profile linked");
 
     TopoDS_Shape shape;
-    if (Profile.getValue()->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
+    if (Profile.getValue()->isDerivedFrom<Part::Part2DObject>())
         shape = Profile.getValue<Part::Part2DObject*>()->Shape.getValue();
     else {
         if (Profile.getSubValues().empty())
@@ -613,7 +613,7 @@ Part::Feature* ProfileBased::getBaseObject(bool silent) const
     if (!obj)
         return nullptr;
 
-    if (!obj->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
+    if (!obj->isDerivedFrom<Part::Part2DObject>())
         return obj;
 
     //due to former test we know we have a 2d object
@@ -621,7 +621,7 @@ Part::Feature* ProfileBased::getBaseObject(bool silent) const
     const char* err = nullptr;
     App::DocumentObject* spt = sketch->AttachmentSupport.getValue();
     if (spt) {
-        if (spt->isDerivedFrom(Part::Feature::getClassTypeId())) {
+        if (spt->isDerivedFrom<Part::Feature>()) {
             rv = static_cast<Part::Feature*>(spt);
         }
         else {
@@ -657,7 +657,7 @@ void ProfileBased::getUpToFaceFromLinkSub(TopoShape& upToFace, const App::Proper
         throw Base::ValueError("SketchBased: No face selected");
     }
 
-    if (ref->getTypeId().isDerivedFrom(App::Plane::getClassTypeId())) {
+    if (ref->isDerivedFrom<App::Plane>()) {
         upToFace = makeShapeFromPlane(ref);
         return;
     }
@@ -1397,7 +1397,7 @@ Base::Vector3d ProfileBased::getProfileNormal() const {
         return SketchVector;
 
     // get the Sketch plane
-    if (obj->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+    if (obj->isDerivedFrom<Part::Part2DObject>()) {
         Base::Placement SketchPos = obj->Placement.getValue();
         Base::Rotation SketchOrientation = SketchPos.getRotation();
         SketchOrientation.multVec(SketchVector, SketchVector);

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -838,7 +838,7 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
     for (auto& v : mats) {
         const char* name = cacheName(v.first);
         auto prop = getDynamicPropertyByName(name);
-        if (!prop || !prop->isDerivedFrom(App::PropertyMatrix::getClassTypeId())) {
+        if (!prop || !prop->isDerivedFrom<App::PropertyMatrix>()) {
             if (prop)
                 removeDynamicProperty(name);
             prop = addDynamicProperty("App::PropertyMatrix", name, "Cache", nullptr, 0, false, true);

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -292,7 +292,7 @@ void CmdPartDesignShapeBinder::activated(int iMsg)
 
     bool bEditSelected = false;
     if (support.getSize() == 1 && support.getValue() ){
-        if (support.getValue()->isDerivedFrom(PartDesign::ShapeBinder::getClassTypeId()))
+        if (support.getValue()->isDerivedFrom<PartDesign::ShapeBinder>())
             bEditSelected = true;
     }
 
@@ -766,7 +766,7 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
 {
     auto base_worker = [=](App::DocumentObject *feature, const std::vector<std::string> &subs) {
 
-        if (!feature || !feature->isDerivedFrom(Part::Feature::getClassTypeId()))
+        if (!feature || !feature->isDerivedFrom<Part::Feature>())
             return;
 
         // Related to #0002760: when an operation can't be performed due to a broken
@@ -818,7 +818,7 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
             // `ProfileBased::getProfileShape()` and other methods will return
             // just the sub-shapes if they are set. So when whole sketches are
             // desired, do not set sub-values.
-            if (feature->isDerivedFrom(Part::Part2DObject::getClassTypeId()) &&
+            if (feature->isDerivedFrom<Part::Part2DObject>() &&
                 subName.compare(0, 6, "Vertex") != 0)
                 runProfileCmd();
             else
@@ -853,7 +853,7 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
             // `ProfileBased::getProfileShape()` and other methods will return
             // just the sub-shapes if they are set. So when whole sketches are
             // desired, don't set sub-values.
-            if (feature->isDerivedFrom(Part::Part2DObject::getClassTypeId()) &&
+            if (feature->isDerivedFrom<Part::Part2DObject>() &&
                 subName.compare(0, 6, "Vertex") != 0)
                 runProfileCmd();
             else
@@ -864,7 +864,7 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
             if (selection.size() == 2) { //treat additional selected object as spine
                 std::vector <string> subnames = selection[1].getSubNames();
                 auto objCmdSpine = Gui::Command::getObjectCmd(selection[1].getObject());
-                if (selection[1].getObject()->isDerivedFrom(Part::Part2DObject::getClassTypeId()) && subnames.empty()) {
+                if (selection[1].getObject()->isDerivedFrom<Part::Part2DObject>() && subnames.empty()) {
                     FCMD_OBJ_CMD(Feat,"Spine = " << objCmdSpine);
                 }
                 else {
@@ -1048,7 +1048,7 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
 
 void finishProfileBased(const Gui::Command* cmd, const Part::Feature* sketch, App::DocumentObject *Feat)
 {
-    if (sketch && sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
+    if (sketch && sketch->isDerivedFrom<Part::Part2DObject>())
         FCMD_OBJ_HIDE(sketch);
     finishFeature(cmd, Feat);
 }
@@ -1217,7 +1217,7 @@ void CmdPartDesignRevolution::activated(int iMsg)
         if (!Feat)
             return;
 
-        if (sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+        if (sketch->isDerivedFrom<Part::Part2DObject>()) {
             FCMD_OBJ_CMD(Feat,"ReferenceAxis = (" << getObjectCmd(sketch) << ",['V_Axis'])");
         }
         else {
@@ -1273,7 +1273,7 @@ void CmdPartDesignGroove::activated(int iMsg)
         if (!Feat)
             return;
 
-        if (sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+        if (sketch->isDerivedFrom<Part::Part2DObject>()) {
             FCMD_OBJ_CMD(Feat,"ReferenceAxis = ("<<getObjectCmd(sketch)<<",['V_Axis'])");
         }
         else {
@@ -1537,7 +1537,7 @@ void CmdPartDesignAdditiveHelix::activated(int iMsg)
         // specific parameters for helix
         Gui::Command::updateActive();
 
-        if (sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+        if (sketch->isDerivedFrom<Part::Part2DObject>()) {
             FCMD_OBJ_CMD(Feat,"ReferenceAxis = (" << getObjectCmd(sketch) << ",['V_Axis'])");
         }
         else {
@@ -1605,7 +1605,7 @@ void CmdPartDesignSubtractiveHelix::activated(int iMsg)
         // specific parameters for helix
         Gui::Command::updateActive();
 
-        if (sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+        if (sketch->isDerivedFrom<Part::Part2DObject>()) {
             FCMD_OBJ_CMD(Feat,"ReferenceAxis = (" << getObjectCmd(sketch) << ",['V_Axis'])");
         }
         else {
@@ -2022,7 +2022,7 @@ void CmdPartDesignMirrored::activated(int iMsg)
     Gui::Command* cmd = this;
     auto worker = [cmd, pcActiveBody](App::DocumentObject *Feat, std::vector<App::DocumentObject*> features) {
         bool direction = false;
-        if (!features.empty() && features.front()->isDerivedFrom(PartDesign::ProfileBased::getClassTypeId())) {
+        if (!features.empty() && features.front()->isDerivedFrom<PartDesign::ProfileBased>()) {
             Part::Part2DObject* sketch = (static_cast<PartDesign::ProfileBased*>(features.front()))->getVerifiedSketch(/* silent =*/ true);
             if (sketch) {
                 FCMD_OBJ_CMD(Feat,"MirrorPlane = ("<<getObjectCmd(sketch)<<", ['V_Axis'])");
@@ -2073,7 +2073,7 @@ void CmdPartDesignLinearPattern::activated(int iMsg)
     Gui::Command* cmd = this;
     auto worker = [cmd, pcActiveBody](App::DocumentObject *Feat, std::vector<App::DocumentObject*> features) {
         bool direction = false;
-        if (!features.empty() && features.front()->isDerivedFrom(PartDesign::ProfileBased::getClassTypeId())) {
+        if (!features.empty() && features.front()->isDerivedFrom<PartDesign::ProfileBased>()) {
             Part::Part2DObject *sketch = (static_cast<PartDesign::ProfileBased*>(features.front()))->getVerifiedSketch(/* silent =*/ true);
             if (sketch) {
                 FCMD_OBJ_CMD(Feat,"Direction = ("<<Gui::Command::getObjectCmd(sketch)<<", ['H_Axis'])");
@@ -2127,7 +2127,7 @@ void CmdPartDesignPolarPattern::activated(int iMsg)
     auto worker = [cmd, pcActiveBody](App::DocumentObject *Feat, std::vector<App::DocumentObject*> features) {
 
         bool direction = false;
-        if (!features.empty() && features.front()->isDerivedFrom(PartDesign::ProfileBased::getClassTypeId())) {
+        if (!features.empty() && features.front()->isDerivedFrom<PartDesign::ProfileBased>()) {
             Part::Part2DObject *sketch = (static_cast<PartDesign::ProfileBased*>(features.front()))->getVerifiedSketch(/* silent =*/ true);
             if (sketch) {
                 FCMD_OBJ_CMD(Feat,"Axis = ("<<Gui::Command::getObjectCmd(sketch)<<",['N_Axis'])");

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -134,13 +134,13 @@ void CmdPartDesignBody::activated(int iMsg)
                                          .arg(QString::fromUtf8(baseFeature->Label.getValue())));
                     baseFeature = nullptr;
                 }
-                else if (baseFeature->isDerivedFrom(Sketcher::SketchObject::getClassTypeId())) {
+                else if (baseFeature->isDerivedFrom<Sketcher::SketchObject>()) {
                     // Add sketcher to the body's group property
                     addtogroup = true;
                 }
                 // if a standard Part feature (not a PartDesign feature) is selected then check
                 // the number of solids/shells
-                else if (!baseFeature->isDerivedFrom(PartDesign::Feature::getClassTypeId())) {
+                else if (!baseFeature->isDerivedFrom<PartDesign::Feature>()) {
                     const TopoDS_Shape& shape = static_cast<Part::Feature*>(baseFeature)->Shape.getValue();
                     if (!shape.IsNull()) {
                         int numSolids = 0;
@@ -544,7 +544,7 @@ void CmdPartDesignMoveTip::activated(int iMsg)
 
     if ( features.size() == 1 ) {
         selFeature = features.front();
-        if ( selFeature->getTypeId().isDerivedFrom ( PartDesign::Body::getClassTypeId() ) ) {
+        if ( selFeature->isDerivedFrom<PartDesign::Body>() ) {
             body = static_cast<PartDesign::Body *> ( selFeature );
         } else {
             body = PartDesignGui::getBodyFor ( selFeature, /* messageIfNot =*/ false );
@@ -918,7 +918,7 @@ void CmdPartDesignMoveFeatureInTree::activated(int iMsg)
     std::vector<App::DocumentObject*> bodyFeatures;
     std::map<App::DocumentObject*,size_t> orders;
     for(auto obj : body->Group.getValues()) {
-        if(obj->isDerivedFrom(PartDesign::Feature::getClassTypeId())) {
+        if(obj->isDerivedFrom<PartDesign::Feature>()) {
             orders.emplace(obj,bodyFeatures.size());
             bodyFeatures.push_back(obj);
         }
@@ -928,7 +928,7 @@ void CmdPartDesignMoveFeatureInTree::activated(int iMsg)
     for(size_t i=0;i<bodyFeatures.size();++i) {
         auto feat = bodyFeatures[i];
         for(auto obj : feat->getOutList()) {
-            if(obj->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
+            if(obj->isDerivedFrom<PartDesign::Feature>())
                 continue;
             for(auto dep : App::Document::getDependencyList({obj})) {
                 auto it = orders.find(dep);
@@ -956,7 +956,7 @@ void CmdPartDesignMoveFeatureInTree::activated(int iMsg)
     // user if they want the last object to be the new tip.
     // Only do this for features that can hold a tip (not for e.g. datums)
     if ( lastObject != target && body->Tip.getValue() == target
-        && lastObject->isDerivedFrom(PartDesign::Feature::getClassTypeId()) ) {
+        && lastObject->isDerivedFrom<PartDesign::Feature>() ) {
         QMessageBox msgBox(Gui::getMainWindow());
         msgBox.setIcon(QMessageBox::Question);
         msgBox.setWindowTitle(qApp->translate("PartDesign_MoveFeatureInTree", "Move tip"));

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -301,7 +301,7 @@ bool getReferencedSelection(const App::DocumentObject* thisObj, const Gui::Selec
     //of course only if thisObj is in a body, as otherwise the old workflow would not
     //be supported
     PartDesign::Body* body = PartDesignGui::getBodyFor(thisObj, false);
-    bool originfeature = selObj->isDerivedFrom(App::DatumElement::getClassTypeId());
+    bool originfeature = selObj->isDerivedFrom<App::DatumElement>();
     if (!originfeature && body) {
         PartDesign::Body* selBody = PartDesignGui::getBodyFor(selObj, false);
         if (!selBody || body != selBody) {

--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -105,7 +105,7 @@ public:
         // https://forum.freecad.org/viewtopic.php?f=3&t=37448
         if (object == activeBody) {
             App::DocumentObject* tip = activeBody->Tip.getValue();
-            if (tip && tip->isDerivedFrom(Part::Feature::getClassTypeId()) && elements.size() == 1) {
+            if (tip && tip->isDerivedFrom<Part::Feature>() && elements.size() == 1) {
                 Gui::SelectionChanges msg;
                 msg.pDocName = faceSelection.getDocName();
                 msg.pObjectName = tip->getNameInDocument();

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -61,7 +61,7 @@ TaskDatumParameters::TaskDatumParameters(ViewProviderDatum *ViewProvider,QWidget
 
 TaskDatumParameters::~TaskDatumParameters()
 {
-    if(this->ViewProvider && this->ViewProvider->isDerivedFrom(ViewProviderDatum::getClassTypeId()))
+    if(this->ViewProvider && this->ViewProvider->isDerivedFrom<ViewProviderDatum>())
         static_cast<ViewProviderDatum*>(this->ViewProvider)->setPickable(true);
     Gui::Selection().rmvSelectionGate();
 }

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -137,10 +137,10 @@ TaskFeaturePick::TaskFeaturePick(std::vector<App::DocumentObject*>& objects,
         if (*statusIt != invalidShape && datum) {
             App::Origin* origin = dynamic_cast<App::Origin*>(datum->getLCS());
             if (origin) {
-                if ((*objIt)->isDerivedFrom(App::Plane::getClassTypeId())) {
+                if ((*objIt)->isDerivedFrom<App::Plane>()) {
                     originVisStatus[origin].setFlag(Gui::DatumElement::Planes, true);
                 }
-                else if ((*objIt)->isDerivedFrom(App::Line::getClassTypeId())) {
+                else if ((*objIt)->isDerivedFrom<App::Line>()) {
                     originVisStatus[origin].setFlag(Gui::DatumElement::Axes, true);
                 }
             }
@@ -346,8 +346,8 @@ TaskFeaturePick::makeCopy(App::DocumentObject* obj, std::string sub, bool indepe
         return copy;
     }
     if (independent
-        && (obj->isDerivedFrom(Sketcher::SketchObject::getClassTypeId())
-            || obj->isDerivedFrom(PartDesign::FeaturePrimitive::getClassTypeId()))) {
+        && (obj->isDerivedFrom<Sketcher::SketchObject>()
+            || obj->isDerivedFrom<PartDesign::FeaturePrimitive>())) {
 
         // we do know that the created instance is a document object, as obj is one. But we do not
         // know which exact type
@@ -387,7 +387,7 @@ TaskFeaturePick::makeCopy(App::DocumentObject* obj, std::string sub, bool indepe
 
             // we are a independent copy, therefore no external geometry was copied. WE therefore
             // can delete all constraints
-            if (obj->isDerivedFrom(Sketcher::SketchObject::getClassTypeId())) {
+            if (obj->isDerivedFrom<Sketcher::SketchObject>()) {
                 static_cast<Sketcher::SketchObject*>(copy)->delConstraintsToExternal();
             }
         }
@@ -411,11 +411,11 @@ TaskFeaturePick::makeCopy(App::DocumentObject* obj, std::string sub, bool indepe
         Part::PropertyPartShape* shapeProp = nullptr;
 
         // TODO Replace it with commands (2015-09-11, Fat-Zer)
-        if (obj->isDerivedFrom(Part::Datum::getClassTypeId())) {
+        if (obj->isDerivedFrom<Part::Datum>()) {
             copy = App::GetApplication().getActiveDocument()->addObject(obj->getTypeId().getName(),
                                                                         name.c_str());
 
-            assert(copy->isDerivedFrom(Part::Datum::getClassTypeId()));
+            assert(copy->isDerivedFrom<Part::Datum>());
 
             // we need to reference the individual datums and make again datums. This is important
             // as datum adjust their size dependent on the part size, hence simply copying the shape
@@ -451,7 +451,7 @@ TaskFeaturePick::makeCopy(App::DocumentObject* obj, std::string sub, bool indepe
             }
         }
         else if (obj->is<PartDesign::ShapeBinder>()
-                 || obj->isDerivedFrom(Part::Feature::getClassTypeId())) {
+                 || obj->isDerivedFrom<Part::Feature>()) {
 
             copy = App::GetApplication().getActiveDocument()->addObject("PartDesign::ShapeBinder",
                                                                         name.c_str());
@@ -463,8 +463,8 @@ TaskFeaturePick::makeCopy(App::DocumentObject* obj, std::string sub, bool indepe
                 shapeProp = &static_cast<PartDesign::ShapeBinder*>(copy)->Shape;
             }
         }
-        else if (obj->isDerivedFrom(App::Plane::getClassTypeId())
-                 || obj->isDerivedFrom(App::Line::getClassTypeId())) {
+        else if (obj->isDerivedFrom<App::Plane>()
+                 || obj->isDerivedFrom<App::Line>()) {
 
             copy = App::GetApplication().getActiveDocument()->addObject("PartDesign::ShapeBinder",
                                                                         name.c_str());

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -560,10 +560,10 @@ void TaskRevolutionParameters::onAxisChanged(int num)
             oldSubRefAxis.size() != newSubRefAxis.size() ||
             oldRefName != newRefName) {
             bool reversed = propReversed->getValue();
-            if (pcRevolution->isDerivedFrom(PartDesign::Revolution::getClassTypeId())) {
+            if (pcRevolution->isDerivedFrom<PartDesign::Revolution>()) {
                 reversed = static_cast<PartDesign::Revolution*>(pcRevolution)->suggestReversed();
             }
-            if (pcRevolution->isDerivedFrom(PartDesign::Groove::getClassTypeId())) {
+            if (pcRevolution->isDerivedFrom<PartDesign::Groove>()) {
                 reversed = static_cast<PartDesign::Groove*>(pcRevolution)->suggestReversed();
             }
 

--- a/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
@@ -302,7 +302,7 @@ bool TaskShapeBinder::referenceSelected(const SelectionChanges& msg) const
 
         // get selected object
         auto docObj = vp->getObject()->getDocument()->getObject(msg.pObjectName);
-        if (docObj && docObj->isDerivedFrom(Part::Feature::getClassTypeId())) {
+        if (docObj && docObj->isDerivedFrom<Part::Feature>()) {
             selectedObj = static_cast<Part::Feature*>(docObj);
         }
 

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
@@ -238,7 +238,7 @@ QString TaskSketchBasedParameters::getFaceReference(const QString& obj, const QS
 QString TaskSketchBasedParameters::make2DLabel(const App::DocumentObject* section,
                                                const std::vector<std::string>& subValues)
 {
-    if (section->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+    if (section->isDerivedFrom<Part::Part2DObject>()) {
         return QString::fromUtf8(section->Label.getValue());
     }
     else if (subValues.empty()) {

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -190,7 +190,7 @@ void ViewProvider::onChanged(const App::Property* prop) {
             //hide all features in the body other than this object
             for(App::DocumentObject* obj : body->Group.getValues()) {
 
-                if(obj->isDerivedFrom(PartDesign::Feature::getClassTypeId()) && obj != getObject()) {
+                if(obj->isDerivedFrom<PartDesign::Feature>() && obj != getObject()) {
                    auto vpd = Base::freecad_dynamic_cast<Gui::ViewProviderDocumentObject>(
                            Gui::Application::Instance->getViewProvider(obj));
                    if(vpd && vpd->Visibility.getValue())
@@ -324,7 +324,7 @@ ViewProviderBody* ViewProvider::getBodyViewProvider() {
     auto doc = getDocument();
     if(body && doc) {
         auto vp = doc->getViewProvider(body);
-        if(vp && vp->isDerivedFrom(ViewProviderBody::getClassTypeId()))
+        if(vp && vp->isDerivedFrom<ViewProviderBody>())
            return static_cast<ViewProviderBody*>(vp);
     }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -225,7 +225,7 @@ void ViewProviderBody::updateData(const App::Property* prop)
         // restore icons
         for (auto feature : features) {
             Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider(feature);
-            if (vp && vp->isDerivedFrom(PartDesignGui::ViewProvider::getClassTypeId())) {
+            if (vp && vp->isDerivedFrom<PartDesignGui::ViewProvider>()) {
                 static_cast<PartDesignGui::ViewProvider*>(vp)->setTipIcon(feature == tip);
             }
         }
@@ -300,7 +300,7 @@ void ViewProviderBody::unifyVisualProperty(const App::Property* prop) {
     auto features = body->Group.getValues();
     for (auto feature : features) {
 
-        if (!feature->isDerivedFrom(PartDesign::Feature::getClassTypeId())) {
+        if (!feature->isDerivedFrom<PartDesign::Feature>()) {
             continue;
         }
 
@@ -321,7 +321,7 @@ void ViewProviderBody::setVisualBodyMode(bool bodymode) {
     auto features = body->Group.getValues();
     for(auto feature : features) {
 
-        if(!feature->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
+        if(!feature->isDerivedFrom<PartDesign::Feature>())
             continue;
 
         auto* vp = static_cast<PartDesignGui::ViewProvider*>(gdoc->getViewProvider(feature));
@@ -355,15 +355,15 @@ bool ViewProviderBody::canDropObject(App::DocumentObject* obj) const
     if (obj->isDerivedFrom<App::VarSet>()) {
         return true;
     }
-    else if (obj->isDerivedFrom(App::DatumElement::getClassTypeId())) {
+    else if (obj->isDerivedFrom<App::DatumElement>()) {
         // accept only datums that are not part of a LCS.
         auto* lcs = static_cast<App::DatumElement*>(obj)->getLCS();
         return !lcs;
     }
-    else if (obj->isDerivedFrom(App::LocalCoordinateSystem::getClassTypeId())) {
-        return !obj->isDerivedFrom(App::Origin::getClassTypeId());
+    else if (obj->isDerivedFrom<App::LocalCoordinateSystem>()) {
+        return !obj->isDerivedFrom<App::Origin>();
     }
-    else if (!obj->isDerivedFrom(Part::Feature::getClassTypeId())) {
+    else if (!obj->isDerivedFrom<Part::Feature>()) {
         return false;
     }
     else if (PartDesign::Body::findBodyOf(obj)) {

--- a/src/Mod/PartDesign/Gui/ViewProviderHelix.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHelix.cpp
@@ -89,7 +89,7 @@ void ViewProviderHelix::unsetEdit(int ModNum)
 std::vector<App::DocumentObject*> ViewProviderHelix::claimChildren() const {
     std::vector<App::DocumentObject*> temp;
     App::DocumentObject* sketch = getObject<PartDesign::ProfileBased>()->Profile.getValue();
-    if (sketch && sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
+    if (sketch && sketch->isDerivedFrom<Part::Part2DObject>())
         temp.push_back(sketch);
 
     return temp;

--- a/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
@@ -54,7 +54,7 @@ std::vector<App::DocumentObject*> ViewProviderLoft::claimChildren()const
         temp.push_back(sketch);
 
     for(App::DocumentObject* obj : pcLoft->Sections.getValues()) {
-        if (obj && obj->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
+        if (obj && obj->isDerivedFrom<Part::Part2DObject>())
             temp.push_back(obj);
     }
 
@@ -118,7 +118,7 @@ void ViewProviderLoft::highlightSection(bool on)
         // only take the entire shape when we have a sketch selected, but
         // not a point of the sketch
         auto subName = it.second.empty() ? "" : it.second.front();
-        if (it.first->isDerivedFrom(Part::Part2DObject::getClassTypeId()) && subName.compare(0, 6, "Vertex") != 0) {
+        if (it.first->isDerivedFrom<Part::Part2DObject>() && subName.compare(0, 6, "Vertex") != 0) {
             it.second.clear();
         }
         highlightReferences(dynamic_cast<Part::Feature*>(it.first), it.second, on);

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
@@ -54,16 +54,16 @@ std::vector<App::DocumentObject*> ViewProviderPipe::claimChildren()const
         temp.push_back(sketch);
 
     for(App::DocumentObject* obj : pcPipe->Sections.getValues()) {
-        if (obj && obj->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
+        if (obj && obj->isDerivedFrom<Part::Part2DObject>())
             temp.push_back(obj);
     }
 
     App::DocumentObject* spine = pcPipe->Spine.getValue();
-    if (spine && spine->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
+    if (spine && spine->isDerivedFrom<Part::Part2DObject>())
         temp.push_back(spine);
 
     App::DocumentObject* auxspine = pcPipe->AuxillerySpine.getValue();
-    if (auxspine && auxspine->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
+    if (auxspine && auxspine->isDerivedFrom<Part::Part2DObject>())
         temp.push_back(auxspine);
 
     return temp;

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -138,7 +138,7 @@ void ViewProviderShapeBinder::highlightReferences(bool on)
     App::GeoFeature* obj = nullptr;
     std::vector<std::string> subs;
 
-    if (getObject()->isDerivedFrom(PartDesign::ShapeBinder::getClassTypeId()))
+    if (getObject()->isDerivedFrom<PartDesign::ShapeBinder>())
         PartDesign::ShapeBinder::getFilteredReferences(&getObject<PartDesign::ShapeBinder>()->Support, obj, subs);
     else
         return;

--- a/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
@@ -43,7 +43,7 @@ ViewProviderSketchBased::~ViewProviderSketchBased() = default;
 std::vector<App::DocumentObject*> ViewProviderSketchBased::claimChildren() const {
     std::vector<App::DocumentObject*> temp;
     App::DocumentObject* sketch = getObject<PartDesign::ProfileBased>()->Profile.getValue();
-    if (sketch && !sketch->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
+    if (sketch && !sketch->isDerivedFrom<PartDesign::Feature>())
         temp.push_back(sketch);
 
     return temp;

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -81,7 +81,7 @@ Gui::ViewProvider *ViewProviderTransformed::startEditing(int ModNum) {
     PartDesign::Transformed* pcTransformed = getObject<PartDesign::Transformed>();
     if(!pcTransformed->Originals.getSize()) {
         for(auto obj : pcTransformed->getInList()) {
-            if(obj->isDerivedFrom(PartDesign::MultiTransform::getClassTypeId())) {
+            if(obj->isDerivedFrom<PartDesign::MultiTransform>()) {
                 auto vp = Gui::Application::Instance->getViewProvider(obj);
                 if(vp)
                     return vp->startEditing(ModNum);

--- a/src/Mod/Points/App/AppPointsPy.cpp
+++ b/src/Mod/Points/App/AppPointsPy.cpp
@@ -329,13 +329,12 @@ private:
         }
 
         Py::Sequence list(object);
-        Base::Type pointsId = Base::Type::fromName("Points::Feature");
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             PyObject* item = (*it).ptr();
             if (PyObject_TypeCheck(item, &(App::DocumentObjectPy::Type))) {
                 App::DocumentObject* obj =
                     static_cast<App::DocumentObjectPy*>(item)->getDocumentObjectPtr();
-                if (obj->getTypeId().isDerivedFrom(pointsId)) {
+                if (obj->isDerivedFrom<Points::Feature>()) {
                     // get relative placement
                     Points::Feature* fea = static_cast<Points::Feature*>(obj);
                     Base::Placement globalPlacement = fea->globalPlacement();

--- a/src/Mod/ReverseEngineering/Gui/Command.cpp
+++ b/src/Mod/ReverseEngineering/Gui/Command.cpp
@@ -77,7 +77,7 @@ void CmdApproxCurve::activated(int)
 {
     App::DocumentObjectT objT;
     auto obj = Gui::Selection().getObjectsOfType(App::GeoFeature::getClassTypeId());
-    if (obj.size() != 1 || !(obj.at(0)->isDerivedFrom(Points::Feature::getClassTypeId()))) {
+    if (obj.size() != 1 || !(obj.at(0)->isDerivedFrom<Points::Feature>())) {
         QMessageBox::warning(Gui::getMainWindow(),
                              qApp->translate("Reen_ApproxSurface", "Wrong selection"),
                              qApp->translate("Reen_ApproxSurface", "Please select a point cloud."));
@@ -113,8 +113,8 @@ void CmdApproxSurface::activated(int)
     std::vector<App::DocumentObject*> obj =
         Gui::Selection().getObjectsOfType(App::GeoFeature::getClassTypeId());
     if (obj.size() != 1
-        || !(obj.at(0)->isDerivedFrom(Points::Feature::getClassTypeId())
-             || obj.at(0)->isDerivedFrom(Mesh::Feature::getClassTypeId()))) {
+        || !(obj.at(0)->isDerivedFrom<Points::Feature>()
+             || obj.at(0)->isDerivedFrom<Mesh::Feature>())) {
         QMessageBox::warning(
             Gui::getMainWindow(),
             qApp->translate("Reen_ApproxSurface", "Wrong selection"),

--- a/src/Mod/Robot/Gui/ViewProviderRobotObject.cpp
+++ b/src/Mod/Robot/Gui/ViewProviderRobotObject.cpp
@@ -376,9 +376,7 @@ void ViewProviderRobotObject::updateData(const App::Property* prop)
     else if (prop == &robObj->ToolShape) {
         App::DocumentObject* o = robObj->ToolShape.getValue<App::DocumentObject*>();
 
-        if (o
-            && (o->isDerivedFrom(Part::Feature::getClassTypeId())
-                || o->isDerivedFrom(App::VRMLObject::getClassTypeId()))) {
+        if (o && (o->isDerivedFrom<Part::Feature>() || o->isDerivedFrom<App::VRMLObject>())) {
             // Part::Feature *p = dynamic_cast<Part::Feature *>(o);
             toolShape = Gui::Application::Instance->getViewProvider(o);
             toolShape->setTransformation(

--- a/src/Mod/Sandbox/Gui/AppSandboxGui.cpp
+++ b/src/Mod/Sandbox/Gui/AppSandboxGui.cpp
@@ -73,9 +73,9 @@ private:
                 return;
             Part::Geometry* g1 = items[0];
             Part::Geometry* g2 = items[1];
-            if (!g1 || g1->getTypeId() != Part::GeomArcOfCircle::getClassTypeId())
+            if (!g1 || !g1->is<Part::GeomArcOfCircle>())
                 return;
-            if (!g2 || g2->getTypeId() != Part::GeomLineSegment::getClassTypeId())
+            if (!g2 || !g2->is<Part::GeomLineSegment>())
                 return;
             Part::GeomArcOfCircle* arc = static_cast<Part::GeomArcOfCircle*>(g1);
             Part::GeomLineSegment* seg = static_cast<Part::GeomLineSegment*>(g2);

--- a/src/Mod/Sketcher/App/ExternalGeometryFacadePyImp.cpp
+++ b/src/Mod/Sketcher/App/ExternalGeometryFacadePyImp.cpp
@@ -510,7 +510,7 @@ Py::Boolean ExternalGeometryFacadePy::getConstruction() const
 
 void ExternalGeometryFacadePy::setConstruction(Py::Boolean arg)
 {
-    if (getExternalGeometryFacadePtr()->getTypeId() != Part::GeomPoint::getClassTypeId()) {
+    if (!getExternalGeometryFacadePtr()->is<Part::GeomPoint>()) {
         getExternalGeometryFacadePtr()->setConstruction(arg);
     }
 }

--- a/src/Mod/Sketcher/App/GeometryFacade.h
+++ b/src/Mod/Sketcher/App/GeometryFacade.h
@@ -87,7 +87,7 @@ class GeometryFacadePy;
  *
  *  Part::Geometry* copy = v->copy();
  *
- *  if(construction && copy->getTypeId() != Part::GeomPoint::getClassTypeId()) {
+ *  if(construction && !copy->is<Part::GeomPoint>()) {
  *      GeometryFacade::setConstruction(copy, construction);
  *  }
  *

--- a/src/Mod/Sketcher/App/PythonConverter.cpp
+++ b/src/Mod/Sketcher/App/PythonConverter.cpp
@@ -46,15 +46,16 @@ std::string PythonConverter::convert(const Part::Geometry* geo, Mode mode)
     command = boost::str(boost::format("addGeometry(%s,%s)\n") % sg.creation
                          % (sg.construction ? "True" : "False"));
 
-    if ((geo->getTypeId() != Part::GeomEllipse::getClassTypeId()
-         || geo->getTypeId() != Part::GeomArcOfEllipse::getClassTypeId()
-         || geo->getTypeId() != Part::GeomArcOfHyperbola::getClassTypeId()
-         || geo->getTypeId() != Part::GeomArcOfParabola::getClassTypeId()
-         || geo->getTypeId() != Part::GeomBSplineCurve::getClassTypeId())
-        && mode == Mode::CreateInternalGeometry) {
+    // clang-format off: keep line breaks for readability
+    if ((!geo->is<Part::GeomEllipse>()
+         || !geo->is<Part::GeomArcOfEllipse>()
+         || !geo->is<Part::GeomArcOfHyperbola>()
+         || !geo->is<Part::GeomArcOfParabola>()
+         || !geo->is<Part::GeomBSplineCurve>()) && mode == Mode::CreateInternalGeometry) {
         command +=
             boost::str(boost::format("exposeInternalGeometry(len(ActiveSketch.Geometry))\n"));
     }
+    // clang-format on
 
     return command;
 }
@@ -149,15 +150,17 @@ std::string PythonConverter::convert(const std::string& doc,
     if (mode == Mode::CreateInternalGeometry) {
         for (auto geo : geos) {
             index++;
-            if (geo->getTypeId() != Part::GeomEllipse::getClassTypeId()
-                || geo->getTypeId() != Part::GeomArcOfEllipse::getClassTypeId()
-                || geo->getTypeId() != Part::GeomArcOfHyperbola::getClassTypeId()
-                || geo->getTypeId() != Part::GeomArcOfParabola::getClassTypeId()
-                || geo->getTypeId() != Part::GeomBSplineCurve::getClassTypeId()) {
+            // clang-format off: keep line breaks for readability
+            if (!geo->is<Part::GeomEllipse>()
+                || !geo->is<Part::GeomArcOfEllipse>()
+                || !geo->is<Part::GeomArcOfHyperbola>()
+                || !geo->is<Part::GeomArcOfParabola>()
+                || !geo->is<Part::GeomBSplineCurve>()) {
                 std::string newcommand =
                     boost::str(boost::format("exposeInternalGeometry(lastGeoId + %d)\n") % (index));
                 command += newcommand;
             }
+            // clang-format on
         }
     }
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -2480,8 +2480,8 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
     // TODO: Add support for curved lines.
     const Part::Geometry* geo1 = getGeometry(geoId1);
     const Part::Geometry* geo2 = getGeometry(geoId2);
-    if (geo1->getTypeId() != Part::GeomLineSegment::getClassTypeId()
-        || geo2->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
+    if (!geo1->is<Part::GeomLineSegment>()
+        || !geo2->is<Part::GeomLineSegment>()) {
         delConstraintOnPoint(geoId1, posId1, false);
         delConstraintOnPoint(geoId2, posId2, false);
         return;
@@ -4458,7 +4458,7 @@ bool SketchObject::isCarbonCopyAllowed(App::Document* pDoc, App::DocumentObject*
     std::string sketchArchType ("Sketcher::SketchObjectPython");
 
     // Only applicable to sketches
-    if (pObj->getTypeId() != Sketcher::SketchObject::getClassTypeId()
+    if (!pObj->is<Sketcher::SketchObject>()
         && sketchArchType != pObj->getTypeId().getName()) {
         if (rsn) {
             *rsn = rlNotASketch;
@@ -6913,13 +6913,15 @@ bool SketchObject::increaseBSplineDegree(int GeoId, int degreeincrement /*= 1*/)
     // no need to check input data validity as this is an sketchobject managed operation.
     Base::StateLocker lock(managedoperation, true);
 
-    if (GeoId < 0 || GeoId > getHighestCurveIndex())
+    if (GeoId < 0 || GeoId > getHighestCurveIndex()) {
         return false;
+    }
 
     const Part::Geometry* geo = getGeometry(GeoId);
 
-    if (geo->getTypeId() != Part::GeomBSplineCurve::getClassTypeId())
+    if (!geo->is<Part::GeomBSplineCurve>()) {
         return false;
+    }
 
     const auto* bsp = static_cast<const Part::GeomBSplineCurve*>(geo);
 
@@ -6960,7 +6962,7 @@ bool SketchObject::decreaseBSplineDegree(int GeoId, int degreedecrement /*= 1*/)
 
     const Part::Geometry* geo = getGeometry(GeoId);
 
-    if (geo->getTypeId() != Part::GeomBSplineCurve::getClassTypeId())
+    if (!geo->is<Part::GeomBSplineCurve>())
         return false;
 
     const auto* bsp = static_cast<const Part::GeomBSplineCurve*>(geo);
@@ -7449,7 +7451,7 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
     for (std::vector<Part::Geometry*>::const_iterator it = svals.begin(); it != svals.end(); ++it) {
         Part::Geometry* geoNew = (*it)->copy();
         generateId(geoNew);
-        if (construction && geoNew->getTypeId() != Part::GeomPoint::getClassTypeId()) {
+        if (construction && !geoNew->is<Part::GeomPoint>()) {
             GeometryFacade::setConstruction(geoNew, true);
         }
         newVals.push_back(geoNew);
@@ -10111,7 +10113,7 @@ void SketchObject::onChanged(const App::Property* prop)
 
                     if (ext->testMigrationType(Part::GeometryMigrationExtension::Construction)) {
                         bool oldconstr = ext->getConstruction();
-                        if (geometryValue->getTypeId() == Part::GeomPoint::getClassTypeId()
+                        if (geometryValue->is<Part::GeomPoint>()
                             && !gf->isInternalAligned()) {
                             oldconstr = true;
                         }

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -6841,7 +6841,7 @@ bool SketchObject::convertToNURBS(int GeoId)
     try {
         bspline = geo1->toNurbs(geo1->getFirstParameter(), geo1->getLastParameter());
 
-        if (geo1->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())) {
+        if (geo1->isDerivedFrom<Part::GeomArcOfConic>()) {
             const auto* geoaoc = static_cast<const Part::GeomArcOfConic*>(geo1);
 
             if (geoaoc->isReversed())
@@ -10394,7 +10394,7 @@ void SketchObject::updateGeometryRefs() {
 
         legacyMap[key + Data::oldElementName(sub.c_str())] = i;
 
-        if (!obj->getTypeId().isDerivedFrom(Part::Datum::getClassTypeId())) {
+        if (!obj->isDerivedFrom<Part::Datum>()) {
             key += Data::newElementName(sub.c_str());
         }
         if (!originalRefs.empty() && originalRefs[i] != key) {
@@ -11534,7 +11534,7 @@ Data::IndexedName SketchObject::shapeTypeFromGeoId(int geoId, PointPos posId) co
 
     if (posId == PointPos::none) {
         auto geo = getGeometry(geoId);
-        if (geo && geo->isDerivedFrom(Part::GeomPoint::getClassTypeId())) {
+        if (geo && geo->isDerivedFrom<Part::GeomPoint>()) {
             posId = PointPos::start;
         }
     }

--- a/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
+++ b/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
@@ -49,7 +49,7 @@ bool isAlterGeoActive(Gui::Document* doc)
     if (doc) {
         // checks if a Sketch Viewprovider is in Edit
         if (doc->getInEdit()
-            && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
+            && doc->getInEdit()->isDerivedFrom<SketcherGui::ViewProviderSketch>()) {
             return true;
         }
     }

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -78,7 +78,7 @@ bool isCreateConstraintActive(Gui::Document* doc)
     if (doc) {
         // checks if a Sketch View provider is in Edit and is in no special mode
         if (doc->getInEdit()
-            && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
+            && doc->getInEdit()->isDerivedFrom<SketcherGui::ViewProviderSketch>()) {
             if (static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit())->getSketchMode()
                 == ViewProviderSketch::STATUS_NONE) {
                 if (Gui::Selection().countObjectsOfType<Sketcher::SketchObject>()
@@ -129,7 +129,7 @@ void finishDatumConstraint(Gui::Command* cmd,
     }
 
     if (doc && doc->getInEdit()
-        && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
+        && doc->getInEdit()->isDerivedFrom<SketcherGui::ViewProviderSketch>()) {
         SketcherGui::ViewProviderSketch* vp =
             static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
         scaleFactor = vp->getScaleFactor();

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -54,7 +54,7 @@ void ActivateBSplineHandler(Gui::Document* doc, DrawSketchHandler* handler)
     std::unique_ptr<DrawSketchHandler> ptr(handler);
     if (doc) {
         if (doc->getInEdit()
-            && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
+            && doc->getInEdit()->isDerivedFrom<SketcherGui::ViewProviderSketch>()) {
             SketcherGui::ViewProviderSketch* vp =
                 static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
             vp->purgeHandler();

--- a/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp
@@ -55,7 +55,7 @@ bool isSketcherVirtualSpaceActive(Gui::Document* doc, bool actsOnSelection)
     if (doc) {
         // checks if a Sketch Viewprovider is in Edit and is in no special mode
         if (doc->getInEdit()
-            && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
+            && doc->getInEdit()->isDerivedFrom<SketcherGui::ViewProviderSketch>()) {
             if (static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit())->getSketchMode()
                 == ViewProviderSketch::STATUS_NONE) {
                 if (!actsOnSelection) {
@@ -75,7 +75,7 @@ void ActivateVirtualSpaceHandler(Gui::Document* doc, DrawSketchHandler* handler)
     std::unique_ptr<DrawSketchHandler> ptr(handler);
     if (doc) {
         if (doc->getInEdit()
-            && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
+            && doc->getInEdit()->isDerivedFrom<SketcherGui::ViewProviderSketch>()) {
             SketcherGui::ViewProviderSketch* vp =
                 static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
             vp->purgeHandler();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -194,16 +194,14 @@ std::vector<Base::Vector2d> CurveConverter::toVector2D(const Part::Geometry* geo
 {
     std::vector<Base::Vector2d> vector2d;
 
-    const auto type = geometry->getTypeId();
-
     auto emplaceasvector2d = [&vector2d](const Base::Vector3d& point) {
         vector2d.emplace_back(point.x, point.y);
     };
 
-    auto isconic = type.isDerivedFrom(Part::GeomConic::getClassTypeId());
-    auto isbounded = type.isDerivedFrom(Part::GeomBoundedCurve::getClassTypeId());
+    auto isconic = geometry->isDerivedFrom<Part::GeomConic>();
+    auto isbounded = geometry->isDerivedFrom<Part::GeomBoundedCurve>();
 
-    if (type == Part::GeomLineSegment::getClassTypeId()) {  // add a line
+    if (geometry->is<Part::GeomLineSegment>()) {  // add a line
         auto geo = static_cast<const Part::GeomLineSegment*>(geometry);
 
         emplaceasvector2d(geo->getStartPoint());

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -735,9 +735,8 @@ private:
                                 break;
                             }
                         }
-                        else if (isLineSegment(*geo2)
-                                 || geo2->getTypeId() == Part::GeomArcOfConic::getClassTypeId()
-                                 || isBSplineCurve(*geo2)) {
+                        else if (isLineSegment(*geo2) || isBSplineCurve(*geo2)
+                                 || geo2->is<Part::GeomArcOfConic>()) {
                             // cases where arc is created by arc join mode.
                             Base::Vector3d p2, p3;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -70,7 +70,7 @@ public:
             if (geom->is<Part::GeomLineSegment>()
                 || geom->is<Part::GeomCircle>()
                 || geom->is<Part::GeomEllipse>()
-                || geom->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())
+                || geom->isDerivedFrom<Part::GeomArcOfConic>()
                 || geom->is<Part::GeomBSplineCurve>()) {
                 return true;
             }
@@ -122,7 +122,7 @@ public:
             if (geom->is<Part::GeomLineSegment>()
                 || geom->is<Part::GeomCircle>()
                 || geom->is<Part::GeomEllipse>()
-                || geom->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())
+                || geom->isDerivedFrom<Part::GeomArcOfConic>()
                 || geom->is<Part::GeomBSplineCurve>()) {
                 GeoId = curveGeoId;
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -65,12 +65,16 @@ public:
             int GeoId = std::atoi(element.substr(4, 4000).c_str()) - 1;
             Sketcher::SketchObject* Sketch = static_cast<Sketcher::SketchObject*>(object);
             const Part::Geometry* geom = Sketch->getGeometry(GeoId);
-            if (geom->is<Part::GeomLineSegment>() || geom->is<Part::GeomCircle>()
+
+            // clang-format off: keep line breaks for readability
+            if (geom->is<Part::GeomLineSegment>()
+                || geom->is<Part::GeomCircle>()
                 || geom->is<Part::GeomEllipse>()
                 || geom->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())
                 || geom->is<Part::GeomBSplineCurve>()) {
                 return true;
             }
+            // clang-format on
         }
         else if (element.substr(0, 6) == "Vertex") {
             int VertId = std::atoi(element.substr(6, 4000).c_str()) - 1;
@@ -114,12 +118,15 @@ public:
         int curveGeoId = getPreselectCurve();
         if (curveGeoId >= 0) {
             const Part::Geometry* geom = sketchgui->getSketchObject()->getGeometry(curveGeoId);
-            if (geom->is<Part::GeomLineSegment>() || geom->is<Part::GeomCircle>()
+            // clang-format off: keep line breaks for readability
+            if (geom->is<Part::GeomLineSegment>()
+                || geom->is<Part::GeomCircle>()
                 || geom->is<Part::GeomEllipse>()
                 || geom->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())
                 || geom->is<Part::GeomBSplineCurve>()) {
                 GeoId = curveGeoId;
             }
+            // clang-format on
         }
         else {
             // No curve of interest is pre-selected. Try pre-selected point.

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -182,7 +182,7 @@ bool SketcherGui::ReleaseHandler(Gui::Document* doc)
 {
     if (doc) {
         if (doc->getInEdit()
-            && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
+            && doc->getInEdit()->isDerivedFrom<SketcherGui::ViewProviderSketch>()) {
             SketcherGui::ViewProviderSketch* vp =
                 static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
 
@@ -479,7 +479,7 @@ void SketcherGui::ActivateHandler(Gui::Document* doc, std::unique_ptr<DrawSketch
 {
     if (doc) {
         if (doc->getInEdit()
-            && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
+            && doc->getInEdit()->isDerivedFrom<SketcherGui::ViewProviderSketch>()) {
             SketcherGui::ViewProviderSketch* vp =
                 static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
             vp->purgeHandler();
@@ -522,7 +522,7 @@ bool SketcherGui::isSketcherBSplineActive(Gui::Document* doc, bool actsOnSelecti
     if (doc) {
         // checks if a Sketch Viewprovider is in Edit and is in no special mode
         if (doc->getInEdit()
-            && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
+            && doc->getInEdit()->isDerivedFrom<SketcherGui::ViewProviderSketch>()) {
             if (static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit())->getSketchMode()
                 == ViewProviderSketch::STATUS_NONE) {
                 if (!actsOnSelection) {

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2618,7 +2618,7 @@ float ViewProviderSketch::getScaleFactor() const
     assert(isInEditMode());
     Gui::MDIView* mdi =
         Gui::Application::Instance->editViewOfNode(editCoinManager->getRootEditNode());
-    if (mdi && mdi->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (mdi && mdi->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(mdi)->getViewer();
         SoCamera* camera = viewer->getSoRenderManager()->getCamera();
         float scale = camera->getViewVolume(camera->aspectRatio.getValue())
@@ -2825,7 +2825,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationoverl
     }
 
     Gui::MDIView* mdi = this->getActiveView();
-    if (mdi && mdi->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+    if (mdi && mdi->isDerivedFrom<Gui::View3DInventor>()) {
         static_cast<Gui::View3DInventor*>(mdi)->getViewer()->redraw();
     }
 }
@@ -2889,7 +2889,7 @@ void ViewProviderSketch::slotSolverUpdate()
             + getSketchObject()->getHighestCurveIndex() + 1
         == getSolvedSketch().getGeometrySize()) {
         Gui::MDIView* mdi = Gui::Application::Instance->editDocument()->getActiveView();
-        if (mdi->isDerivedFrom(Gui::View3DInventor::getClassTypeId()))
+        if (mdi->isDerivedFrom<Gui::View3DInventor>())
             draw(false, true);
 
         signalConstraintsChanged();
@@ -3943,7 +3943,7 @@ std::unique_ptr<SoRayPickAction> ViewProviderSketch::getRayPickAction() const
     assert(isInEditMode());
     Gui::MDIView* mdi =
         Gui::Application::Instance->editViewOfNode(editCoinManager->getRootEditNode());
-    if (!(mdi && mdi->isDerivedFrom(Gui::View3DInventor::getClassTypeId())))
+    if (!(mdi && mdi->isDerivedFrom<Gui::View3DInventor>()))
         return nullptr;
     Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(mdi)->getViewer();
 
@@ -4027,7 +4027,7 @@ double ViewProviderSketch::getRotation(SbVec3f pos0, SbVec3f pos1) const
 
     Gui::MDIView* mdi =
         Gui::Application::Instance->editViewOfNode(editCoinManager->getRootEditNode());
-    if (!(mdi && mdi->isDerivedFrom(Gui::View3DInventor::getClassTypeId())))
+    if (!(mdi && mdi->isDerivedFrom<Gui::View3DInventor>()))
         return 0;
     Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(mdi)->getViewer();
     SoCamera* pCam = viewer->getSoRenderManager()->getCamera();

--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -1093,11 +1093,11 @@ std::string Cell::getFormattedQuantity()
     App::CellAddress thisCell = getAddress();
     Property* prop = owner->sheet()->getPropertyByName(thisCell.toString().c_str());
 
-    if (prop->isDerivedFrom(App::PropertyString::getClassTypeId())) {
+    if (prop->isDerivedFrom<App::PropertyString>()) {
         const App::PropertyString* stringProp = static_cast<const App::PropertyString*>(prop);
         qFormatted = QString::fromUtf8(stringProp->getValue());
     }
-    else if (prop->isDerivedFrom(App::PropertyQuantity::getClassTypeId())) {
+    else if (prop->isDerivedFrom<App::PropertyQuantity>()) {
         double rawVal = static_cast<App::PropertyQuantity*>(prop)->getValue();
         const App::PropertyQuantity* floatProp = static_cast<const App::PropertyQuantity*>(prop);
         DisplayUnit du;
@@ -1113,7 +1113,7 @@ std::string Cell::getFormattedQuantity()
             }
         }
     }
-    else if (prop->isDerivedFrom(App::PropertyFloat::getClassTypeId())) {
+    else if (prop->isDerivedFrom<App::PropertyFloat>()) {
         double rawVal = static_cast<const App::PropertyFloat*>(prop)->getValue();
         DisplayUnit du;
         bool hasDisplayUnit = getDisplayUnit(du);
@@ -1125,7 +1125,7 @@ std::string Cell::getFormattedQuantity()
             qFormatted = number + QString::fromStdString(" " + displayUnit.stringRep);
         }
     }
-    else if (prop->isDerivedFrom(App::PropertyInteger::getClassTypeId())) {
+    else if (prop->isDerivedFrom<App::PropertyInteger>()) {
         double rawVal = static_cast<const App::PropertyInteger*>(prop)->getValue();
         DisplayUnit du;
         bool hasDisplayUnit = getDisplayUnit(du);

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -1387,7 +1387,7 @@ void PropertySheet::addDependencies(CellAddress key)
                 cellToPropertyNameMap[key].insert(propName);
 
                 // Also an alias?
-                if (!name.empty() && docObj->isDerivedFrom(Sheet::getClassTypeId())) {
+                if (!name.empty() && docObj->isDerivedFrom<Sheet>()) {
                     auto other = static_cast<Sheet*>(docObj);
                     auto j = other->cells.revAliasProp.find(name);
 
@@ -2063,7 +2063,7 @@ PropertySheet::BindingType PropertySheet::getBinding(const Range& range,
         path << ObjectIdentifier::SimpleComponent(range.from().toString().c_str());
         path << ObjectIdentifier::SimpleComponent(range.to().toString().c_str());
         auto res = owner->getExpression(path);
-        if (res.expression && res.expression->isDerivedFrom(FunctionExpression::getClassTypeId())) {
+        if (res.expression && res.expression->isDerivedFrom<FunctionExpression>()) {
             auto expr = static_cast<FunctionExpression*>(res.expression.get());
             if (href) {
                 if ((expr->getFunction() != FunctionExpression::HIDDENREF

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -573,7 +573,7 @@ Property* Sheet::setFloatProperty(CellAddress key, double value)
     Property* prop = props.getDynamicPropertyByName(name.c_str());
     PropertyFloat* floatProp;
 
-    if (!prop || prop->getTypeId() != PropertyFloat::getClassTypeId()) {
+    if (!prop || !prop->is<PropertyFloat>()) {
         if (prop) {
             this->removeDynamicProperty(name.c_str());
             propAddress.erase(prop);
@@ -601,7 +601,7 @@ Property* Sheet::setIntegerProperty(CellAddress key, long value)
     Property* prop = props.getDynamicPropertyByName(name.c_str());
     PropertyInteger* intProp;
 
-    if (!prop || prop->getTypeId() != PropertyInteger::getClassTypeId()) {
+    if (!prop || !prop->is<PropertyInteger>()) {
         if (prop) {
             this->removeDynamicProperty(name.c_str());
             propAddress.erase(prop);
@@ -641,7 +641,7 @@ Property* Sheet::setQuantityProperty(CellAddress key, double value, const Base::
     Property* prop = props.getDynamicPropertyByName(name.c_str());
     PropertySpreadsheetQuantity* quantityProp;
 
-    if (!prop || prop->getTypeId() != PropertySpreadsheetQuantity::getClassTypeId()) {
+    if (!prop || !prop->is<PropertySpreadsheetQuantity>()) {
         if (prop) {
             this->removeDynamicProperty(name.c_str());
             propAddress.erase(prop);

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -329,17 +329,19 @@ bool Sheet::exportToFile(const std::string& filename,
 
         std::stringstream field;
 
-        if (prop->isDerivedFrom((PropertyQuantity::getClassTypeId()))) {
-            field << static_cast<PropertyQuantity*>(prop)->getValue();
+        using Base::freecad_dynamic_cast;
+
+        if (auto p = freecad_dynamic_cast<PropertyQuantity>(prop)) {
+            field << p->getValue();
         }
-        else if (prop->isDerivedFrom((PropertyFloat::getClassTypeId()))) {
-            field << static_cast<PropertyFloat*>(prop)->getValue();
+        else if (auto p = freecad_dynamic_cast<PropertyFloat>(prop)) {
+            field << p->getValue();
         }
-        else if (prop->isDerivedFrom((PropertyInteger::getClassTypeId()))) {
-            field << static_cast<PropertyInteger*>(prop)->getValue();
+        else if (auto p = freecad_dynamic_cast<PropertyInteger>(prop)) {
+            field << p->getValue();
         }
-        else if (prop->isDerivedFrom((PropertyString::getClassTypeId()))) {
-            field << static_cast<PropertyString*>(prop)->getValue();
+        else if (auto p = freecad_dynamic_cast<PropertyString>(prop)) {
+            field << p->getValue();
         }
         else {
             assert(0);

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -924,7 +924,7 @@ void Sheet::recomputeCell(CellAddress p)
         cellErrors.insert(p);
         cellUpdated(p);
 
-        if (e.isDerivedFrom(Base::AbortException::getClassTypeId())) {
+        if (e.isDerivedFrom<Base::AbortException>()) {
             throw;
         }
     }

--- a/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
@@ -72,14 +72,14 @@ DlgBindSheet::DlgBindSheet(Sheet* sheet, const std::vector<Range>& ranges, QWidg
         ui->lineEditFromEnd->setReadOnly(true);
         ui->checkBoxHREF->setChecked(type == PropertySheet::BindingHiddenRef);
         assert(pStart && pEnd);
-        if (!pStart->hasComponent() && pStart->isDerivedFrom(StringExpression::getClassTypeId())) {
+        if (!pStart->hasComponent() && pStart->isDerivedFrom<StringExpression>()) {
             toStart = static_cast<StringExpression*>(pStart.get())->getText();
         }
         else {
             toStart = "=";
             toStart += pStart->toString();
         }
-        if (!pEnd->hasComponent() && pEnd->isDerivedFrom(StringExpression::getClassTypeId())) {
+        if (!pEnd->hasComponent() && pEnd->isDerivedFrom<StringExpression>()) {
             toEnd = static_cast<StringExpression*>(pEnd.get())->getText();
         }
         else {

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
@@ -130,7 +130,7 @@ App::Property* DlgSheetConf::prepare(CellAddress& from,
         auto prop = path.getProperty(&pseudoType);
         if (pseudoType
             || (prop
-                && (!prop->isDerivedFrom(App::PropertyEnumeration::getClassTypeId())
+                && (!prop->isDerivedFrom<App::PropertyEnumeration>()
                     || !prop->testStatus(App::Property::PropDynamic)))) {
             FC_THROWM(Base::RuntimeError, "Invalid property referenced in: " << expr->toString());
         }
@@ -140,7 +140,7 @@ App::Property* DlgSheetConf::prepare(CellAddress& from,
     Cell* cell = sheet->getCell(from);
     if (cell && cell->getExpression()) {
         auto expr = cell->getExpression();
-        if (expr->isDerivedFrom(FunctionExpression::getClassTypeId())) {
+        if (expr->isDerivedFrom<FunctionExpression>()) {
             auto fexpr = Base::freecad_dynamic_cast<FunctionExpression>(cell->getExpression());
             if (fexpr
                 && (fexpr->getFunction() == FunctionExpression::HREF
@@ -184,7 +184,7 @@ void DlgSheetConf::accept()
             auto cell = sheet->getCell(*r);
             if (cell && cell->getExpression()) {
                 ExpressionPtr expr(cell->getExpression()->eval());
-                if (expr->isDerivedFrom(StringExpression::getClassTypeId())) {
+                if (expr->isDerivedFrom<StringExpression>()) {
                     continue;
                 }
             }

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
@@ -115,8 +115,7 @@ App::Property* DlgSheetConf::prepare(CellAddress& from,
             e.ReportException();
             FC_THROWM(Base::RuntimeError, "Failed to parse expression for property");
         }
-        if (expr->hasComponent()
-            || !expr->isDerivedFrom(App::VariableExpression::getClassTypeId())) {
+        if (expr->hasComponent() || !expr->isDerivedFrom<App::VariableExpression>()) {
             FC_THROWM(Base::RuntimeError, "Invalid property expression: " << expr->toString());
         }
 
@@ -196,8 +195,7 @@ void DlgSheetConf::accept()
 
         std::string exprTxt(ui->lineEditProp->text().trimmed().toUtf8().constData());
         App::ExpressionPtr expr(App::Expression::parse(sheet, exprTxt));
-        if (expr->hasComponent()
-            || !expr->isDerivedFrom(App::VariableExpression::getClassTypeId())) {
+        if (expr->hasComponent() || !expr->isDerivedFrom<App::VariableExpression>()) {
             FC_THROWM(Base::RuntimeError, "Invalid property expression: " << expr->toString());
         }
 

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -286,7 +286,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
                 return {};
         }
     }
-    else if (prop->isDerivedFrom(App::PropertyString::getClassTypeId())) {
+    else if (prop->isDerivedFrom<App::PropertyString>()) {
         /* String */
         const App::PropertyString* stringProp = static_cast<const App::PropertyString*>(prop);
 
@@ -321,7 +321,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
                 return {};
         }
     }
-    else if (prop->isDerivedFrom(App::PropertyQuantity::getClassTypeId())) {
+    else if (prop->isDerivedFrom<App::PropertyQuantity>()) {
         /* Number */
         const App::PropertyQuantity* floatProp = static_cast<const App::PropertyQuantity*>(prop);
 
@@ -386,13 +386,13 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
                 return {};
         }
     }
-    else if (prop->isDerivedFrom(App::PropertyFloat::getClassTypeId())
-             || prop->isDerivedFrom(App::PropertyInteger::getClassTypeId())) {
+    else if (prop->isDerivedFrom<App::PropertyFloat>()
+             || prop->isDerivedFrom<App::PropertyInteger>()) {
         /* Number */
         double d {};
         long l {};
         bool isInteger = false;
-        if (prop->isDerivedFrom(App::PropertyFloat::getClassTypeId())) {
+        if (prop->isDerivedFrom<App::PropertyFloat>()) {
             d = static_cast<const App::PropertyFloat*>(prop)->getValue();
         }
         else {
@@ -454,7 +454,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
                 return {};
         }
     }
-    else if (prop->isDerivedFrom(App::PropertyPythonObject::getClassTypeId())) {
+    else if (prop->isDerivedFrom<App::PropertyPythonObject>()) {
         auto pyProp = static_cast<const App::PropertyPythonObject*>(prop);
 
         switch (role) {

--- a/src/Mod/Surface/Gui/TaskFilling.cpp
+++ b/src/Mod/Surface/Gui/TaskFilling.cpp
@@ -212,7 +212,7 @@ public:
         if (pObj == editedObject) {
             return false;
         }
-        if (!pObj->isDerivedFrom(Part::Feature::getClassTypeId())) {
+        if (!pObj->isDerivedFrom<Part::Feature>()) {
             return false;
         }
 

--- a/src/Mod/Surface/Gui/TaskFillingEdge.cpp
+++ b/src/Mod/Surface/Gui/TaskFillingEdge.cpp
@@ -73,7 +73,7 @@ public:
         if (pObj == editedObject) {
             return false;
         }
-        if (!pObj->isDerivedFrom(Part::Feature::getClassTypeId())) {
+        if (!pObj->isDerivedFrom<Part::Feature>()) {
             return false;
         }
 

--- a/src/Mod/Surface/Gui/TaskFillingVertex.cpp
+++ b/src/Mod/Surface/Gui/TaskFillingVertex.cpp
@@ -65,7 +65,7 @@ public:
         if (pObj == editedObject) {
             return false;
         }
-        if (!pObj->isDerivedFrom(Part::Feature::getClassTypeId())) {
+        if (!pObj->isDerivedFrom<Part::Feature>()) {
             return false;
         }
 

--- a/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
+++ b/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
@@ -168,7 +168,7 @@ bool GeomFillSurface::EdgeSelection::allow(App::Document*,
     if (pObj == editedObject) {
         return false;
     }
-    if (!pObj->isDerivedFrom(Part::Feature::getClassTypeId())) {
+    if (!pObj->isDerivedFrom<Part::Feature>()) {
         return false;
     }
 

--- a/src/Mod/Surface/Gui/TaskSections.cpp
+++ b/src/Mod/Surface/Gui/TaskSections.cpp
@@ -212,7 +212,7 @@ public:
         if (pObj == editedObject) {
             return false;
         }
-        if (!pObj->isDerivedFrom(Part::Feature::getClassTypeId())) {
+        if (!pObj->isDerivedFrom<Part::Feature>()) {
             return false;
         }
 

--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -553,7 +553,7 @@ private:
         TopoDS_Shape shape = ShapeUtils::mirrorShape(gObj->getVisHard());
         double offX = 0.0;
         double offY = 0.0;
-        if (dvp->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())) {
+        if (dvp->isDerivedFrom<TechDraw::DrawProjGroupItem>()) {
             TechDraw::DrawProjGroupItem* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(dvp);
             TechDraw::DrawProjGroup*      dpg = dpgi->getPGroup();
             if (dpg) {
@@ -687,13 +687,13 @@ private:
                 dPage = static_cast<TechDraw::DrawPage*>(obj);
                 auto views = dPage->getAllViews();
                 for (auto& view : views) {
-                    if (view->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+                    if (view->isDerivedFrom<TechDraw::DrawViewPart>()) {
                         TechDraw::DrawViewPart* dvp = static_cast<TechDraw::DrawViewPart*>(view);
                         layerName = dvp->getNameInDocument();
                         writer.setLayerName(layerName);
                         write1ViewDxf(writer, dvp, true);
 
-                    } else if (view->isDerivedFrom(TechDraw::DrawViewAnnotation::getClassTypeId())) {
+                    } else if (view->isDerivedFrom<TechDraw::DrawViewAnnotation>()) {
                         TechDraw::DrawViewAnnotation* dva = static_cast<TechDraw::DrawViewAnnotation*>(view);
                         layerName = dva->getNameInDocument();
                         writer.setLayerName(layerName);
@@ -703,7 +703,7 @@ private:
                         auto lines = dva->Text.getValues();
                         writer.exportText(lines[0].c_str(), loc, loc, height, just);
 
-                    } else if (view->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())) {
+                    } else if (view->isDerivedFrom<TechDraw::DrawViewDimension>()) {
                         DrawViewDimension* dvd = static_cast<TechDraw::DrawViewDimension*>(view);
                         TechDraw::DrawViewPart* dvp = dvd->getViewPart();
                         if (!dvp) {
@@ -711,7 +711,7 @@ private:
                         }
                         double grandParentX = 0.0;
                         double grandParentY = 0.0;
-                        if (dvp->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())) {
+                        if (dvp->isDerivedFrom<TechDraw::DrawProjGroupItem>()) {
                             TechDraw::DrawProjGroupItem* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(dvp);
                             TechDraw::DrawProjGroup* dpg = dpgi->getPGroup();
                             if (!dpg) {

--- a/src/Mod/TechDraw/App/DimensionReferences.cpp
+++ b/src/Mod/TechDraw/App/DimensionReferences.cpp
@@ -108,7 +108,7 @@ TopoDS_Shape ReferenceEntry::getGeometry() const
         return {};
     }
 
-    if ( getObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId()) ) {
+    if ( getObject()->isDerivedFrom<TechDraw::DrawViewPart>() ) {
         // 2d geometry from DrawViewPart will be rotated and scaled
         return getGeometry2d();
     }
@@ -277,14 +277,14 @@ bool ReferenceEntry::isWholeObject() const
 bool ReferenceEntry::is3d() const
 {
     if (getObject() &&
-        getObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId()) &&
+        getObject()->isDerivedFrom<TechDraw::DrawViewPart>() &&
         !getSubName().empty()) {
         // this is a well formed 2d reference
         return false;
     }
 
     if (getObject() &&
-        getObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId()) &&
+        getObject()->isDerivedFrom<TechDraw::DrawViewPart>() &&
         getSubName().empty()) {
         // this is a broken 3d reference, so it should be treated as 3d
         return true;
@@ -302,7 +302,7 @@ bool ReferenceEntry::hasGeometry() const
         return false;
     }
 
-    if ( getObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId()) ) {
+    if ( getObject()->isDerivedFrom<TechDraw::DrawViewPart>() ) {
         // 2d reference
         return hasGeometry2d();
     }

--- a/src/Mod/TechDraw/App/DrawLeaderLine.cpp
+++ b/src/Mod/TechDraw/App/DrawLeaderLine.cpp
@@ -321,7 +321,7 @@ DrawLeaderLine* DrawLeaderLine::makeLeader(DrawViewPart* parent, std::vector<Bas
 
 
     App::DocumentObject* obj = parent->getDocument()->getObject(leaderName.c_str());
-    if (!obj || !obj->isDerivedFrom(TechDraw::DrawLeaderLine::getClassTypeId())) {
+    if (!obj || !obj->isDerivedFrom<TechDraw::DrawLeaderLine>()) {
         throw Base::RuntimeError("DrawLeaderLine::makeLeader - new object not found");
     }
 

--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -173,7 +173,7 @@ bool DrawPage::hasValidTemplate() const
     App::DocumentObject* obj = nullptr;
     obj = Template.getValue();
 
-    if (obj && obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
+    if (obj && obj->isDerivedFrom<TechDraw::DrawTemplate>()) {
         TechDraw::DrawTemplate* templ = static_cast<TechDraw::DrawTemplate*>(obj);
         if (templ->getWidth() > 0. && templ->getHeight() > 0.) {
             return true;
@@ -187,7 +187,7 @@ double DrawPage::getPageWidth() const
 {
     App::DocumentObject* obj = Template.getValue();
 
-    if (obj && obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
+    if (obj && obj->isDerivedFrom<TechDraw::DrawTemplate>()) {
         TechDraw::DrawTemplate* templ = static_cast<TechDraw::DrawTemplate*>(obj);
         return templ->getWidth();
     }
@@ -199,7 +199,7 @@ double DrawPage::getPageHeight() const
 {
     App::DocumentObject* obj = Template.getValue();
 
-    if (obj && obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
+    if (obj && obj->isDerivedFrom<TechDraw::DrawTemplate>()) {
         TechDraw::DrawTemplate* templ = static_cast<TechDraw::DrawTemplate*>(obj);
         return templ->getHeight();
     }
@@ -213,7 +213,7 @@ const char* DrawPage::getPageOrientation() const
     App::DocumentObject* obj;
     obj = Template.getValue();
 
-    if (obj && obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
+    if (obj && obj->isDerivedFrom<TechDraw::DrawTemplate>()) {
         TechDraw::DrawTemplate* templ = static_cast<TechDraw::DrawTemplate*>(obj);
         return templ->Orientation.getValueAsString();
     }
@@ -225,7 +225,7 @@ int DrawPage::getOrientation() const
 {
     App::DocumentObject* obj = Template.getValue();
 
-    if (obj && obj->isDerivedFrom(DrawTemplate::getClassTypeId())) {
+    if (obj && obj->isDerivedFrom<DrawTemplate>()) {
         auto* templ = static_cast<DrawTemplate*>(obj);
         return templ->Orientation.getValue();
     }

--- a/src/Mod/TechDraw/App/DrawPagePyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawPagePyImp.cpp
@@ -88,15 +88,15 @@ PyObject* DrawPagePy::getViews(PyObject* args)
 
     Py::List ret;
     for (auto v: allViews) {
-        if (v->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())) {
+        if (v->isDerivedFrom<TechDraw::DrawProjGroupItem>()) {
             TechDraw::DrawProjGroupItem* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(v);
             ret.append(Py::asObject(new TechDraw::DrawProjGroupItemPy(dpgi)));
         }
-        else if (v->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        else if (v->isDerivedFrom<TechDraw::DrawViewPart>()) {
             TechDraw::DrawViewPart* dvp = static_cast<TechDraw::DrawViewPart*>(v);
             ret.append(Py::asObject(new TechDraw::DrawViewPartPy(dvp)));
         }
-        else if (v->isDerivedFrom(TechDraw::DrawViewAnnotation::getClassTypeId())) {
+        else if (v->isDerivedFrom<TechDraw::DrawViewAnnotation>()) {
             TechDraw::DrawViewAnnotation* dva = static_cast<TechDraw::DrawViewAnnotation*>(v);
             ret.append(Py::asObject(new TechDraw::DrawViewAnnotationPy(dva)));
         }
@@ -120,15 +120,15 @@ PyObject* DrawPagePy::getAllViews(PyObject* args)
 
     Py::List ret;
     for (auto v: allViews) {
-        if (v->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())) {
+        if (v->isDerivedFrom<TechDraw::DrawProjGroupItem>()) {
             TechDraw::DrawProjGroupItem* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(v);
             ret.append(Py::asObject(new TechDraw::DrawProjGroupItemPy(dpgi)));
         }
-        else if (v->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        else if (v->isDerivedFrom<TechDraw::DrawViewPart>()) {
             TechDraw::DrawViewPart* dvp = static_cast<TechDraw::DrawViewPart*>(v);
             ret.append(Py::asObject(new TechDraw::DrawViewPartPy(dvp)));
         }
-        else if (v->isDerivedFrom(TechDraw::DrawViewAnnotation::getClassTypeId())) {
+        else if (v->isDerivedFrom<TechDraw::DrawViewAnnotation>()) {
             TechDraw::DrawViewAnnotation* dva = static_cast<TechDraw::DrawViewAnnotation*>(v);
             ret.append(Py::asObject(new TechDraw::DrawViewAnnotationPy(dva)));
         }

--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -441,7 +441,7 @@ bool DrawProjGroup::canDelete(const char* viewProjType) const
             if (item == this) {
                 continue;
             }
-            if (item->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+            if (item->isDerivedFrom<TechDraw::DrawView>()) {
                 return false;
             }
         }

--- a/src/Mod/TechDraw/App/DrawSVGTemplate.cpp
+++ b/src/Mod/TechDraw/App/DrawSVGTemplate.cpp
@@ -103,7 +103,7 @@ void DrawSVGTemplate::onSettingDocument()
 void DrawSVGTemplate::slotCreatedObject(const App::DocumentObject& obj)
 {
     // Base::Console().Message("DSVGT::slotCreatedObject()\n");
-    if (!obj.isDerivedFrom(TechDraw::DrawPage::getClassTypeId())) {
+    if (!obj.isDerivedFrom<TechDraw::DrawPage>()) {
         // we don't care
         return;
     }
@@ -113,7 +113,7 @@ void DrawSVGTemplate::slotCreatedObject(const App::DocumentObject& obj)
 void DrawSVGTemplate::slotDeletedObject(const App::DocumentObject& obj)
 {
     // Base::Console().Message("DSVGT::slotDeletedObject()\n");
-    if (!obj.isDerivedFrom(TechDraw::DrawPage::getClassTypeId())) {
+    if (!obj.isDerivedFrom<TechDraw::DrawPage>()) {
         // we don't care
         return;
     }

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -573,7 +573,7 @@ void DrawView::handleChangedPropertyType(Base::XMLReader &reader, const char * T
             }
         }
     }
-    else if (prop->isDerivedFrom(App::PropertyLinkList::getClassTypeId())
+    else if (prop->isDerivedFrom<App::PropertyLinkList>()
         && strcmp(prop->getName(), "Source") == 0) {
         App::PropertyLinkGlobal glink;
         App::PropertyLink link;

--- a/src/Mod/TechDraw/App/DrawViewClip.cpp
+++ b/src/Mod/TechDraw/App/DrawViewClip.cpp
@@ -129,11 +129,11 @@ std::vector<App::DocumentObject*> DrawViewClip::getViews() const
     std::vector<App::DocumentObject*> views = Views.getValues();
     std::vector<App::DocumentObject*> allViews;
     for (auto& v : views) {
-        if (v->isDerivedFrom(App::Link::getClassTypeId())) {
+        if (v->isDerivedFrom<App::Link>()) {
             v = static_cast<App::Link*>(v)->getLinkedObject();
         }
 
-        if (!v->isDerivedFrom(DrawView::getClassTypeId())) {
+        if (!v->isDerivedFrom<DrawView>()) {
             continue;
         }
 

--- a/src/Mod/TechDraw/App/DrawViewCollection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewCollection.cpp
@@ -133,11 +133,11 @@ std::vector<App::DocumentObject*> DrawViewCollection::getViews() const
     std::vector<App::DocumentObject*> views = Views.getValues();
     std::vector<App::DocumentObject*> allViews;
     for (auto& v : views) {
-        if (v->isDerivedFrom(App::Link::getClassTypeId())) {
+        if (v->isDerivedFrom<App::Link>()) {
             v = static_cast<App::Link*>(v)->getLinkedObject();
         }
 
-        if (!v->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+        if (!v->isDerivedFrom<TechDraw::DrawView>()) {
             continue;
         }
 

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -157,7 +157,7 @@ App::DocumentObjectExecReturn* DrawViewDetail::execute()
     DrawViewPart* dvp = static_cast<DrawViewPart*>(baseObj);
     TopoDS_Shape shape3d = dvp->getShapeForDetail();
     DrawViewSection* dvs = nullptr;
-    if (dvp->isDerivedFrom(TechDraw::DrawViewSection::getClassTypeId())) {
+    if (dvp->isDerivedFrom<TechDraw::DrawViewSection>()) {
         dvs = static_cast<TechDraw::DrawViewSection*>(dvp);
     }
 

--- a/src/Mod/TechDraw/App/DrawViewDimExtent.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimExtent.cpp
@@ -114,7 +114,7 @@ pointPair DrawViewDimExtent::getPointsExtent(ReferenceVector references)
 //    Base::Console().Message("DVD::getPointsExtent() - %s\n", getNameInDocument());
     App::DocumentObject* refObject = references.front().getObject();
     int direction = DirExtent.getValue();
-    if (refObject->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+    if (refObject->isDerivedFrom<TechDraw::DrawViewPart>()) {
         auto dvp = static_cast<TechDraw::DrawViewPart*>(refObject);
 
         std::vector<std::string> edgeNames;     //empty list means we are using all the edges

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -809,7 +809,7 @@ pointPair DrawViewDimension::getPointsOneEdge(ReferenceVector references)
 {
     App::DocumentObject* refObject = references.front().getObject();
     int iSubelement = DrawUtil::getIndexFromName(references.front().getSubName());
-    if (refObject->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())
+    if (refObject->isDerivedFrom<TechDraw::DrawViewPart>()
         && !references.at(0).getSubName().empty()) {
         // TODO: Notify if not straight line Edge?
         // this is a 2d object (a DVP + subelements)
@@ -850,7 +850,7 @@ pointPair DrawViewDimension::getPointsTwoEdges(ReferenceVector references)
     App::DocumentObject* refObject = references.front().getObject();
     int iSubelement0 = DrawUtil::getIndexFromName(references.at(0).getSubName());
     int iSubelement1 = DrawUtil::getIndexFromName(references.at(1).getSubName());
-    if (refObject->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())
+    if (refObject->isDerivedFrom<TechDraw::DrawViewPart>()
         && !references.at(0).getSubName().empty()) {
         // this is a 2d object (a DVP + subelements)
         TechDraw::BaseGeomPtr geom0 = getViewPart()->getGeomByIndex(iSubelement0);
@@ -882,7 +882,7 @@ pointPair DrawViewDimension::getPointsTwoVerts(ReferenceVector references)
     App::DocumentObject* refObject = references.front().getObject();
     int iSubelement0 = DrawUtil::getIndexFromName(references.at(0).getSubName());
     int iSubelement1 = DrawUtil::getIndexFromName(references.at(1).getSubName());
-    if (refObject->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())
+    if (refObject->isDerivedFrom<TechDraw::DrawViewPart>()
         && !references.at(0).getSubName().empty()) {
         // this is a 2d object (a DVP + subelements)
         TechDraw::VertexPtr v0 = getViewPart()->getProjVertexByIndex(iSubelement0);
@@ -919,7 +919,7 @@ pointPair DrawViewDimension::getPointsEdgeVert(ReferenceVector references)
     App::DocumentObject* refObject = references.front().getObject();
     int iSubelement0 = DrawUtil::getIndexFromName(references.at(0).getSubName());
     int iSubelement1 = DrawUtil::getIndexFromName(references.at(1).getSubName());
-    if (refObject->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())
+    if (refObject->isDerivedFrom<TechDraw::DrawViewPart>()
         && !references.at(0).getSubName().empty()) {
         // this is a 2d object (a DVP + subelements)
         TechDraw::BaseGeomPtr edge;
@@ -975,7 +975,7 @@ arcPoints DrawViewDimension::getArcParameters(ReferenceVector references)
 {
     App::DocumentObject* refObject = references.front().getObject();
     int iSubelement = DrawUtil::getIndexFromName(references.front().getSubName());
-    if (refObject->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())
+    if (refObject->isDerivedFrom<TechDraw::DrawViewPart>()
         && !references.at(0).getSubName().empty()) {
         // this is a 2d object (a DVP + subelements)
         TechDraw::BaseGeomPtr geom = getViewPart()->getGeomByIndex(iSubelement);
@@ -1207,7 +1207,7 @@ anglePoints DrawViewDimension::getAnglePointsTwoEdges(ReferenceVector references
     App::DocumentObject* refObject = references.front().getObject();
     int iSubelement0 = DrawUtil::getIndexFromName(references.at(0).getSubName());
     int iSubelement1 = DrawUtil::getIndexFromName(references.at(1).getSubName());
-    if (refObject->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())
+    if (refObject->isDerivedFrom<TechDraw::DrawViewPart>()
         && !references.at(0).getSubName().empty()) {
         // this is a 2d object (a DVP + subelements)
         TechDraw::BaseGeomPtr geom0 = getViewPart()->getGeomByIndex(iSubelement0);
@@ -1345,7 +1345,7 @@ anglePoints DrawViewDimension::getAnglePointsThreeVerts(ReferenceVector referenc
     int iSubelement0 = DrawUtil::getIndexFromName(references.at(0).getSubName());
     int iSubelement1 = DrawUtil::getIndexFromName(references.at(1).getSubName());
     int iSubelement2 = DrawUtil::getIndexFromName(references.at(2).getSubName());
-    if (refObject->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())
+    if (refObject->isDerivedFrom<TechDraw::DrawViewPart>()
         && !references.at(0).getSubName().empty()) {
         // this is a 2d object (a DVP + subelements)
         TechDraw::VertexPtr vert0 = getViewPart()->getProjVertexByIndex(iSubelement0);

--- a/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
@@ -273,15 +273,15 @@ std::string DrawViewSpreadsheet::getSheetImage()
             App::Property* prop = sheet->getPropertyByName(address.toString().c_str());
             std::stringstream field;
             if (prop && cell) {
-                if (prop->isDerivedFrom(App::PropertyQuantity::getClassTypeId())) {
+                if (prop->isDerivedFrom<App::PropertyQuantity>()) {
                     auto contentAsQuantity = static_cast<App::PropertyQuantity*>(prop)->getQuantityValue();
                     field << contentAsQuantity.getUserString();
-                } else if (prop->isDerivedFrom(App::PropertyFloat::getClassTypeId()) ||
-                           prop->isDerivedFrom(App::PropertyInteger::getClassTypeId())) {
+                } else if (prop->isDerivedFrom<App::PropertyFloat>() ||
+                           prop->isDerivedFrom<App::PropertyInteger>()) {
                     std::string temp = cell->getFormattedQuantity();
                     DrawUtil::encodeXmlSpecialChars(temp);
                     field << temp;
-                } else if (prop->isDerivedFrom(App::PropertyString::getClassTypeId())) {
+                } else if (prop->isDerivedFrom<App::PropertyString>()) {
                     std::string temp = static_cast<App::PropertyString*>(prop)->getValue();
                     DrawUtil::encodeXmlSpecialChars(temp);
                     field << temp;

--- a/src/Mod/TechDraw/App/ShapeExtractor.cpp
+++ b/src/Mod/TechDraw/App/ShapeExtractor.cpp
@@ -69,7 +69,7 @@ std::vector<TopoDS_Shape> ShapeExtractor::getShapes2d(const std::vector<App::Doc
 
     for (auto& l:links) {
         if (is2dObject(l)) {
-            if (l->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())) {
+            if (l->isDerivedFrom<Part::Feature>()) {
                 TopoDS_Shape temp = getLocatedShape(l);
                 // checkShape on 2d objs?
                 if (!temp.IsNull()) {
@@ -118,7 +118,7 @@ TopoDS_Shape ShapeExtractor::getShapes(const std::vector<App::DocumentObject*> l
             }
 
             for (auto* inObj : l->getInList()) {
-                if (inObj->isDerivedFrom(App::Part::getClassTypeId())) {
+                if (inObj->isDerivedFrom<App::Part>()) {
                     // we replace obj by the assembly
                     obj = inObj;
                     break;

--- a/src/Mod/TechDraw/App/ShapeExtractor.cpp
+++ b/src/Mod/TechDraw/App/ShapeExtractor.cpp
@@ -398,31 +398,20 @@ bool ShapeExtractor::is2dObject(const App::DocumentObject* obj)
 bool ShapeExtractor::isEdgeType(const App::DocumentObject* obj)
 {
     Base::Type t = obj->getTypeId();
-    if (t.isDerivedFrom(Part::Line::getClassTypeId()) ) {
-        return true;
-    } else if (t.isDerivedFrom(Part::Circle::getClassTypeId())) {
-        return true;
-    } else if (t.isDerivedFrom(Part::Ellipse::getClassTypeId())) {
-        return true;
-    } else if (t.isDerivedFrom(Part::RegularPolygon::getClassTypeId())) {
-        return true;
-    }
-    return false;
+    return t.isDerivedFrom(Part::Line::getClassTypeId())
+           || t.isDerivedFrom(Part::Circle::getClassTypeId())
+           || t.isDerivedFrom(Part::Ellipse::getClassTypeId())
+           || t.isDerivedFrom(Part::RegularPolygon::getClassTypeId());
 }
 
 bool ShapeExtractor::isPointType(const App::DocumentObject* obj)
 {
-    if (obj) {
-        Base::Type t = obj->getTypeId();
-        if (t.isDerivedFrom(Part::Vertex::getClassTypeId())) {
-            return true;
-        } else if (isDraftPoint(obj)) {
-            return true;
-        } else if (isDatumPoint(obj)) {
-            return true;
-        }
+    if (!obj) {
+        return false;
     }
-    return false;
+    return obj->isDerivedFrom<Part::Vertex>()
+           || isDraftPoint(obj)
+           || isDatumPoint(obj);
 }
 
 bool ShapeExtractor::isDraftPoint(const App::DocumentObject* obj)
@@ -486,17 +475,8 @@ TopoDS_Shape ShapeExtractor::getLocatedShape(const App::DocumentObject* docObj)
 
 bool ShapeExtractor::isSketchObject(const App::DocumentObject* obj)
 {
-// TODO:: the check for an object being a sketch should be done as in the commented
-// if statement below. To do this, we need to include Mod/Sketcher/SketchObject.h,
-// but that makes TechDraw dependent on Eigen libraries which we don't use.  As a
-// workaround we will inspect the object's class name.
-//    if (obj->isDerivedFrom(Sketcher::SketchObject::getClassTypeId())) {
-    std::string objTypeName = obj->getTypeId().getName();
-    std::string sketcherToken("Sketcher");
-    if (objTypeName.find(sketcherToken) != std::string::npos) {
-        return true;
-    }
-    return false;
+    // Use name to lookup to avoid dependency on Sketcher module
+    return obj->isDerivedFrom(Base::Type::fromName("Sketcher::SketchObject"));
 }
 
 

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -377,9 +377,9 @@ void CmdTechDrawView::activated(int iMsg)
             continue;
         }
 
-        if (obj->isDerivedFrom(App::LinkElement::getClassTypeId())
-            || obj->isDerivedFrom(App::LinkGroup::getClassTypeId())
-            || obj->isDerivedFrom(App::Link::getClassTypeId())) {
+        if (obj->isDerivedFrom<App::LinkElement>()
+            || obj->isDerivedFrom<App::LinkGroup>()
+            || obj->isDerivedFrom<App::Link>()) {
             is_linked = true;
         }
         // If parent of the obj is a link to another document, we possibly need to treat non-link obj as linked, too
@@ -392,9 +392,9 @@ void CmdTechDrawView::activated(int iMsg)
                     continue;
                 }
                 // 2nd, do we really have a link to obj?
-                if (parent->isDerivedFrom(App::LinkElement::getClassTypeId())
-                    || parent->isDerivedFrom(App::LinkGroup::getClassTypeId())
-                    || parent->isDerivedFrom(App::Link::getClassTypeId())) {
+                if (parent->isDerivedFrom<App::LinkElement>()
+                    || parent->isDerivedFrom<App::LinkGroup>()
+                    || parent->isDerivedFrom<App::Link>()) {
                     // We have a link chain from this document to obj, and obj is in another document -> it is an XLink target
                     is_linked = true;
                 }
@@ -920,10 +920,10 @@ void execComplexSection(Gui::Command* cmd)
     for (auto& sel : selection) {
         bool is_linked = false;
         auto obj = sel.getObject();
-        if (obj->isDerivedFrom(TechDraw::DrawPage::getClassTypeId())) {
+        if (obj->isDerivedFrom<TechDraw::DrawPage>()) {
             continue;
         }
-        if (obj->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        if (obj->isDerivedFrom<TechDraw::DrawViewPart>()) {
             //use the dvp's Sources as sources for this ComplexSection &
             //check the subelement(s) to see if they can be used as a profile
             baseView = static_cast<TechDraw::DrawViewPart*>(obj);
@@ -934,9 +934,9 @@ void execComplexSection(Gui::Command* cmd)
             }
             continue;
         }
-        if (obj->isDerivedFrom(App::LinkElement::getClassTypeId())
-            || obj->isDerivedFrom(App::LinkGroup::getClassTypeId())
-            || obj->isDerivedFrom(App::Link::getClassTypeId())) {
+        if (obj->isDerivedFrom<App::LinkElement>()
+            || obj->isDerivedFrom<App::LinkGroup>()
+            || obj->isDerivedFrom<App::Link>()) {
             is_linked = true;
         }
         // If parent of the obj is a link to another document, we possibly need to treat non-link obj as linked, too
@@ -949,9 +949,9 @@ void execComplexSection(Gui::Command* cmd)
                     continue;
                 }
                 // 2nd, do we really have a link to obj?
-                if (parent->isDerivedFrom(App::LinkElement::getClassTypeId())
-                    || parent->isDerivedFrom(App::LinkGroup::getClassTypeId())
-                    || parent->isDerivedFrom(App::Link::getClassTypeId())) {
+                if (parent->isDerivedFrom<App::LinkElement>()
+                    || parent->isDerivedFrom<App::LinkGroup>()
+                    || parent->isDerivedFrom<App::Link>()) {
                     // We have a link chain from this document to obj, and obj is in another document -> it is an XLink target
                     is_linked = true;
                 }
@@ -1076,12 +1076,12 @@ void CmdTechDrawProjectionGroup::activated(int iMsg)
     for (auto& sel : selection) {
         bool is_linked = false;
         auto obj = sel.getObject();
-        if (obj->isDerivedFrom(TechDraw::DrawPage::getClassTypeId())) {
+        if (obj->isDerivedFrom<TechDraw::DrawPage>()) {
             continue;
         }
-        if (obj->isDerivedFrom(App::LinkElement::getClassTypeId())
-            || obj->isDerivedFrom(App::LinkGroup::getClassTypeId())
-            || obj->isDerivedFrom(App::Link::getClassTypeId())) {
+        if (obj->isDerivedFrom<App::LinkElement>()
+            || obj->isDerivedFrom<App::LinkGroup>()
+            || obj->isDerivedFrom<App::Link>()) {
             is_linked = true;
         }
         // If parent of the obj is a link to another document, we possibly need to treat non-link obj as linked, too
@@ -1094,9 +1094,9 @@ void CmdTechDrawProjectionGroup::activated(int iMsg)
                     continue;
                 }
                 // 2nd, do we really have a link to obj?
-                if (parent->isDerivedFrom(App::LinkElement::getClassTypeId())
-                    || parent->isDerivedFrom(App::LinkGroup::getClassTypeId())
-                    || parent->isDerivedFrom(App::Link::getClassTypeId())) {
+                if (parent->isDerivedFrom<App::LinkElement>()
+                    || parent->isDerivedFrom<App::LinkGroup>()
+                    || parent->isDerivedFrom<App::Link>()) {
                     // We have a link chain from this document to obj, and obj is in another document -> it is an XLink target
                     is_linked = true;
                 }
@@ -1396,10 +1396,10 @@ void CmdTechDrawClipGroupAdd::activated(int iMsg)
     TechDraw::DrawView* view = nullptr;
     std::vector<Gui::SelectionObject>::iterator itSel = selection.begin();
     for (; itSel != selection.end(); itSel++) {
-        if ((*itSel).getObject()->isDerivedFrom(TechDraw::DrawViewClip::getClassTypeId())) {
+        if ((*itSel).getObject()->isDerivedFrom<TechDraw::DrawViewClip>()) {
             clip = static_cast<TechDraw::DrawViewClip*>((*itSel).getObject());
         }
-        else if ((*itSel).getObject()->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+        else if ((*itSel).getObject()->isDerivedFrom<TechDraw::DrawView>()) {
             view = static_cast<TechDraw::DrawView*>((*itSel).getObject());
         }
     }
@@ -1625,8 +1625,8 @@ void CmdTechDrawDraftView::activated(int iMsg)
 
     std::pair<Base::Vector3d, Base::Vector3d> dirs = DrawGuiUtil::get3DDirAndRot();
     for (auto* obj : objects) {
-         if (obj->isDerivedFrom(TechDraw::DrawPage::getClassTypeId()) ||
-             obj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+         if (obj->isDerivedFrom<TechDraw::DrawPage>() ||
+             obj->isDerivedFrom<TechDraw::DrawView>()) {
             // skip over TechDraw objects as they are not valid subjects for a DraftView
             continue;
         }
@@ -1676,8 +1676,8 @@ void CmdTechDrawArchView::activated(int iMsg)
     App::DocumentObject* archObject = nullptr;
     int archCount = 0;
     for (auto& obj : objects) {
-        if (obj->isDerivedFrom(TechDraw::DrawPage::getClassTypeId()) ||
-            obj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+        if (obj->isDerivedFrom<TechDraw::DrawPage>() ||
+            obj->isDerivedFrom<TechDraw::DrawView>()) {
             // skip over TechDraw objects as they are not valid subjects for a ArchView
             continue;
         }
@@ -1864,7 +1864,7 @@ void CmdTechDrawExportPageDXF::activated(int iMsg)
 
     std::vector<App::DocumentObject*> views = page->getViews();
     for (auto& v : views) {
-        if (v->isDerivedFrom(TechDraw::DrawViewArch::getClassTypeId())) {
+        if (v->isDerivedFrom<TechDraw::DrawViewArch>()) {
             QMessageBox::StandardButton rc = QMessageBox::question(
                 Gui::getMainWindow(), QObject::tr("Can not export selection"),
                 QObject::tr("Page contains DrawViewArch which will not be exported. Continue?"),
@@ -1977,12 +1977,12 @@ void getSelectedShapes(Gui::Command* cmd,
     for (auto& sel : selection) {
         bool is_linked = false;
         auto obj = sel.getObject();
-        if (obj->isDerivedFrom(TechDraw::DrawPage::getClassTypeId())) {
+        if (obj->isDerivedFrom<TechDraw::DrawPage>()) {
             continue;
         }
-        if (obj->isDerivedFrom(App::LinkElement::getClassTypeId())
-            || obj->isDerivedFrom(App::LinkGroup::getClassTypeId())
-            || obj->isDerivedFrom(App::Link::getClassTypeId())) {
+        if (obj->isDerivedFrom<App::LinkElement>()
+            || obj->isDerivedFrom<App::LinkGroup>()
+            || obj->isDerivedFrom<App::Link>()) {
             is_linked = true;
         }
         // If parent of the obj is a link to another document, we possibly need to treat non-link obj as linked, too
@@ -1995,9 +1995,9 @@ void getSelectedShapes(Gui::Command* cmd,
                     continue;
                 }
                 // 2nd, do we really have a link to obj?
-                if (parent->isDerivedFrom(App::LinkElement::getClassTypeId())
-                    || parent->isDerivedFrom(App::LinkGroup::getClassTypeId())
-                    || parent->isDerivedFrom(App::Link::getClassTypeId())) {
+                if (parent->isDerivedFrom<App::LinkElement>()
+                    || parent->isDerivedFrom<App::LinkGroup>()
+                    || parent->isDerivedFrom<App::Link>()) {
                     // We have a link chain from this document to obj, and obj is in another document -> it is an XLink target
                     is_linked = true;
                 }

--- a/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
@@ -737,7 +737,7 @@ void execCenterLine(Gui::Command* cmd)
 
     std::vector<Gui::SelectionObject>::iterator itSel = selection.begin();
     for (; itSel != selection.end(); itSel++)  {
-        if ((*itSel).getObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        if ((*itSel).getObject()->isDerivedFrom<TechDraw::DrawViewPart>()) {
             baseFeat = static_cast<TechDraw::DrawViewPart*> ((*itSel).getObject());
             subNames = (*itSel).getSubNames();
         }
@@ -924,7 +924,7 @@ void exec2PointCenterLine(Gui::Command* cmd)
 
     std::vector<Gui::SelectionObject>::iterator itSel = selection.begin();
     for (; itSel != selection.end(); itSel++)  {
-        if ((*itSel).getObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        if ((*itSel).getObject()->isDerivedFrom<TechDraw::DrawViewPart>()) {
             baseFeat = static_cast<TechDraw::DrawViewPart*> ((*itSel).getObject());
             subNames = (*itSel).getSubNames();
         }
@@ -1030,10 +1030,10 @@ void execLine2Points(Gui::Command* cmd)
     }
 
     for (auto& so: selection) {
-        if (so.getObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        if (so.getObject()->isDerivedFrom<TechDraw::DrawViewPart>()) {
             baseFeat = static_cast<TechDraw::DrawViewPart*> (so.getObject());
             subNames2D = so.getSubNames();
-        } else if (so.getObject()->isDerivedFrom(Part::Feature::getClassTypeId())) {
+        } else if (so.getObject()->isDerivedFrom<Part::Feature>()) {
             std::vector<std::string> subNames3D = so.getSubNames();
             for (auto& sub3D: subNames3D) {
                 std::pair<Part::Feature*, std::string> temp;
@@ -1181,10 +1181,10 @@ void execCosmeticCircle(Gui::Command* cmd)
     }
 
     for (auto& so: selection) {
-        if (so.getObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        if (so.getObject()->isDerivedFrom<TechDraw::DrawViewPart>()) {
             baseFeat = static_cast<TechDraw::DrawViewPart*> (so.getObject());
             subNames2D = so.getSubNames();
-        } else if (so.getObject()->isDerivedFrom(Part::Feature::getClassTypeId())) {
+        } else if (so.getObject()->isDerivedFrom<Part::Feature>()) {
             std::vector<std::string> subNames3D = so.getSubNames();
             for (auto& sub3D: subNames3D) {
                 std::pair<Part::Feature*, std::string> temp;
@@ -1318,7 +1318,7 @@ void CmdTechDrawCosmeticEraser::activated(int iMsg)
 
     for (auto& s: selection) {
         TechDraw::DrawViewPart * objFeat = static_cast<TechDraw::DrawViewPart*> (s.getObject());
-        if (!objFeat->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        if (!objFeat->isDerivedFrom<TechDraw::DrawViewPart>()) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
                             QObject::tr("At least 1 object in selection is not a part view"));
             return;
@@ -1329,7 +1329,7 @@ void CmdTechDrawCosmeticEraser::activated(int iMsg)
     std::vector<std::string> subNames;
     std::vector<Gui::SelectionObject>::iterator itSel = selection.begin();
     for (; itSel != selection.end(); itSel++)  {
-        if ((*itSel).getObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        if ((*itSel).getObject()->isDerivedFrom<TechDraw::DrawViewPart>()) {
             objFeat = static_cast<TechDraw::DrawViewPart*> ((*itSel).getObject());
             subNames = (*itSel).getSubNames();
         }
@@ -1446,7 +1446,7 @@ void CmdTechDrawDecorateLine::activated(int iMsg)
 
     std::vector<Gui::SelectionObject>::iterator itSel = selection.begin();
     for (; itSel != selection.end(); itSel++)  {
-        if ((*itSel).getObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        if ((*itSel).getObject()->isDerivedFrom<TechDraw::DrawViewPart>()) {
             baseFeat = static_cast<TechDraw::DrawViewPart*> ((*itSel).getObject());
             subNames = (*itSel).getSubNames();
         }
@@ -1639,8 +1639,8 @@ void CmdTechDrawSurfaceFinishSymbols::activated(int iMsg)
     else {
         auto objFeat = dynamic_cast<TechDraw::DrawView *>(selection.front().getObject());
         if ( !objFeat ||
-             !(objFeat->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId()) ||
-               objFeat->isDerivedFrom(TechDraw::DrawLeaderLine::getClassTypeId())) ) {
+             !(objFeat->isDerivedFrom<TechDraw::DrawViewPart>() ||
+               objFeat->isDerivedFrom<TechDraw::DrawLeaderLine>()) ) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("SurfaceFinishSymbols"),
                                  QObject::tr("Selected object is not a part view, nor a leader line"));
             return;

--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -136,7 +136,7 @@ void execInsertPrefixChar(Gui::Command* cmd, std::string prefixFormat, const QAc
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Insert Prefix"));
     for (auto selected : selection) {
         auto object = selected.getObject();
-        if (object->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())) {
+        if (object->isDerivedFrom<TechDraw::DrawViewDimension>()) {
             auto dim = static_cast<TechDraw::DrawViewDimension*>(selected.getObject());
             std::string formatSpec = dim->FormatSpec.getStrValue();
             formatSpec = prefixText + formatSpec;
@@ -257,7 +257,7 @@ void execRemovePrefixChar(Gui::Command* cmd) {
     for (auto selected : selection)
     {
         auto object = selected.getObject();
-        if (object->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())) {
+        if (object->isDerivedFrom<TechDraw::DrawViewDimension>()) {
             auto dim = static_cast<TechDraw::DrawViewDimension*>(selected.getObject());
             std::string formatSpec = dim->FormatSpec.getStrValue();
             int pos = formatSpec.find("%.");
@@ -443,7 +443,7 @@ void execIncreaseDecreaseDecimal(Gui::Command* cmd, int delta) {
     std::string numStr;
     for (auto selected : selection) {
         auto object = selected.getObject();
-        if (object->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())) {
+        if (object->isDerivedFrom<TechDraw::DrawViewDimension>()) {
             auto dim = static_cast<TechDraw::DrawViewDimension*>(selected.getObject());
             std::string formatSpec = dim->FormatSpec.getStrValue();
             std::string searchStr("%.");
@@ -2349,8 +2349,8 @@ void CmdTechDrawExtensionCustomizeFormat::activated(int iMsg)
     if (!_checkSelection(this, selected, QT_TRANSLATE_NOOP("QObject","TechDraw Customize Format")))
         return;
     auto object = selected[0].getObject();
-    if (object->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId()) ||
-        object->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId()))
+    if (object->isDerivedFrom<TechDraw::DrawViewDimension>() ||
+        object->isDerivedFrom<TechDraw::DrawViewBalloon>())
         Gui::Control().showDialog(new TaskDlgCustomizeFormat(object));
 }
 
@@ -2521,7 +2521,7 @@ namespace TechDrawGui {
         std::vector<TechDraw::DrawViewDimension*> validDimension;
         for (auto selected : selection) {
             auto object = selected.getObject();
-            if (object->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())) {
+            if (object->isDerivedFrom<TechDraw::DrawViewDimension>()) {
                 auto dim = static_cast<TechDraw::DrawViewDimension*>(selected.getObject());
                 std::string dimType = dim->Type.getValueAsString();
                 if (dimType == needDimType)

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -1480,7 +1480,7 @@ void CmdTechDrawExtensionLockUnlockView::activated(int iMsg)
         return;
     }
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Lock/Unlock View"));
-    if (objFeat->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+    if (objFeat->isDerivedFrom<TechDraw::DrawViewPart>()) {
         bool lockPosition = objFeat->LockPosition.getValue();
         lockPosition = !lockPosition;
         objFeat->LockPosition.setValue(lockPosition);

--- a/src/Mod/TechDraw/Gui/CommandHelpers.cpp
+++ b/src/Mod/TechDraw/Gui/CommandHelpers.cpp
@@ -100,7 +100,7 @@ std::vector<std::string> CommandHelpers::getSelectedSubElements(Gui::Command* cm
     std::vector<Gui::SelectionObject> selection = cmd->getSelection().getSelectionEx();
     std::vector<Gui::SelectionObject>::iterator itSel = selection.begin();
     for (; itSel != selection.end(); itSel++)  {
-        if ((*itSel).getObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        if ((*itSel).getObject()->isDerivedFrom<TechDraw::DrawViewPart>()) {
             dvp = static_cast<TechDraw::DrawViewPart*> ((*itSel).getObject());
             subNames = (*itSel).getSubNames();
             break;
@@ -144,12 +144,12 @@ void CommandHelpers::getSelectedShapes(Gui::Command* cmd,
     for (auto& sel : selection) {
         bool is_linked = false;
         auto obj = sel.getObject();
-        if (obj->isDerivedFrom(TechDraw::DrawPage::getClassTypeId())) {
+        if (obj->isDerivedFrom<TechDraw::DrawPage>()) {
             continue;
         }
-        if (obj->isDerivedFrom(App::LinkElement::getClassTypeId())
-            || obj->isDerivedFrom(App::LinkGroup::getClassTypeId())
-            || obj->isDerivedFrom(App::Link::getClassTypeId())) {
+        if (obj->isDerivedFrom<App::LinkElement>()
+            || obj->isDerivedFrom<App::LinkGroup>()
+            || obj->isDerivedFrom<App::Link>()) {
             is_linked = true;
         }
         // If parent of the obj is a link to another document, we possibly need to treat non-link obj as linked, too
@@ -162,9 +162,9 @@ void CommandHelpers::getSelectedShapes(Gui::Command* cmd,
                     continue;
                 }
                 // 2nd, do we really have a link to obj?
-                if (parent->isDerivedFrom(App::LinkElement::getClassTypeId())
-                    || parent->isDerivedFrom(App::LinkGroup::getClassTypeId())
-                    || parent->isDerivedFrom(App::Link::getClassTypeId())) {
+                if (parent->isDerivedFrom<App::LinkElement>()
+                    || parent->isDerivedFrom<App::LinkGroup>()
+                    || parent->isDerivedFrom<App::Link>()) {
                     // We have a link chain from this document to obj, and obj is in another document -> it is an XLink target
                     is_linked = true;
                 }

--- a/src/Mod/TechDraw/Gui/DimensionValidators.cpp
+++ b/src/Mod/TechDraw/Gui/DimensionValidators.cpp
@@ -54,10 +54,10 @@ TechDraw::DrawViewPart* TechDraw::getReferencesFromSelection(ReferenceVector& re
                                             allowOnlySingle);
 
     for (auto& selItem : selectionAll) {
-        if (selItem.getObject()->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())) {
+        if (selItem.getObject()->isDerivedFrom<TechDraw::DrawViewDimension>()) {
             //we are probably repairing a dimension, but we will check later
             dim = static_cast<TechDraw::DrawViewDimension*>(selItem.getObject());  //NOLINT cppcoreguidelines-pro-type-static-cast-downcast
-        } else if (selItem.getObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        } else if (selItem.getObject()->isDerivedFrom<TechDraw::DrawViewPart>()) {
             //this could be a 2d geometry selection or just a DrawViewPart for context in
             //a 3d selection
             dvp = static_cast<TechDraw::DrawViewPart*>(selItem.getObject());  //NOLINT cppcoreguidelines-pro-type-static-cast-downcast
@@ -75,7 +75,7 @@ TechDraw::DrawViewPart* TechDraw::getReferencesFromSelection(ReferenceVector& re
                 ReferenceEntry ref(dvp, ShapeFinder::getLastTerm(sub));
                 references2d.push_back(ref);
             }
-        } else if (!selItem.getObject()->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+        } else if (!selItem.getObject()->isDerivedFrom<TechDraw::DrawView>()) {
             App::DocumentObject* obj3d = selItem.getObject();
             // this is a regular 3d reference in form obj + long subelement
             for (auto& sub3d : selItem.getSubNames()) {

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -168,7 +168,7 @@ void MDIViewPage::onDeleteObject(const App::DocumentObject& obj)
 {
     //if this page has a QView for this obj, delete it.
     blockSceneSelection(true);
-    if (obj.isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+    if (obj.isDerivedFrom<TechDraw::DrawView>()) {
         (void)m_scene->removeQViewByName(obj.getNameInDocument());
     }
     blockSceneSelection(false);
@@ -657,7 +657,7 @@ void MDIViewPage::onSelectionChanged(const Gui::SelectionChanges& msg)
             std::vector<Gui::SelectionObject> selObjs = Gui::Selection().getSelectionEx(msg.pDocName);
             for (auto &so : selObjs) {
                 App::DocumentObject *docObj = so.getObject();
-                if (docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+                if (docObj->isDerivedFrom<TechDraw::DrawView>()) {
                     selectQGIView(docObj, true, so.getSubNames());
                 }
             }
@@ -665,7 +665,7 @@ void MDIViewPage::onSelectionChanged(const Gui::SelectionChanges& msg)
     }
     else if (msg.Type == Gui::SelectionChanges::AddSelection || msg.Type == Gui::SelectionChanges::RmvSelection) {
         App::DocumentObject *docObj = msg.Object.getSubObject();
-        if (docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+        if (docObj->isDerivedFrom<TechDraw::DrawView>()) {
             bool isSelected = msg.Type != Gui::SelectionChanges::RmvSelection;
             selectQGIView(docObj, isSelected, std::vector(1, std::string(msg.pSubName ? msg.pSubName : "")));
         }
@@ -991,7 +991,7 @@ bool MDIViewPage::compareSelections(std::vector<Gui::SelectionObject> treeSel,
     std::vector<std::string> sceneNames;
 
     for (auto tn : treeSel) {
-        if (tn.getObject()->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+        if (tn.getObject()->isDerivedFrom<TechDraw::DrawView>()) {
             std::string s = tn.getObject()->getNameInDocument();
             treeNames.push_back(s);
             subCount += tn.getSubNames().size();

--- a/src/Mod/TechDraw/Gui/QGIDrawingTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGIDrawingTemplate.cpp
@@ -59,7 +59,7 @@ void QGIDrawingTemplate::clearContents()
 
 TechDraw::DrawParametricTemplate * QGIDrawingTemplate::getParametricTemplate()
 {
-    if(pageTemplate && pageTemplate->isDerivedFrom(TechDraw::DrawParametricTemplate::getClassTypeId()))
+    if(pageTemplate && pageTemplate->isDerivedFrom<TechDraw::DrawParametricTemplate>())
         return static_cast<TechDraw::DrawParametricTemplate *>(pageTemplate);
     else
         return nullptr;

--- a/src/Mod/TechDraw/Gui/QGIEdge.cpp
+++ b/src/Mod/TechDraw/Gui/QGIEdge.cpp
@@ -125,7 +125,7 @@ void QGIEdge::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 {
     Q_UNUSED(event)
     QGIView *parent = dynamic_cast<QGIView *>(parentItem());
-    if (parent && parent->getViewObject() && parent->getViewObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+    if (parent && parent->getViewObject() && parent->getViewObject()->isDerivedFrom<TechDraw::DrawViewPart>()) {
         TechDraw::DrawViewPart *baseFeat = static_cast<TechDraw::DrawViewPart *>(parent->getViewObject());
         std::vector<std::string> edgeName(1, DrawUtil::makeGeomName("Edge", getProjIndex()));
 

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -112,7 +112,7 @@ void QGISVGTemplate::load(const QByteArray& svgCode)
 
 TechDraw::DrawSVGTemplate* QGISVGTemplate::getSVGTemplate()
 {
-    if (pageTemplate && pageTemplate->isDerivedFrom(TechDraw::DrawSVGTemplate::getClassTypeId())) {
+    if (pageTemplate && pageTemplate->isDerivedFrom<TechDraw::DrawSVGTemplate>()) {
         return static_cast<TechDraw::DrawSVGTemplate*>(pageTemplate);
     }
     else {

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -617,7 +617,7 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
 
     TechDraw::DrawViewBalloon* balloon = dynamic_cast<TechDraw::DrawViewBalloon*>(getViewObject());
     if ((!balloon) ||
-        (!balloon->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId()))) {
+        (!balloon->isDerivedFrom<TechDraw::DrawViewBalloon>())) {
         //nothing to draw, don't try
         return;
     }

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -685,7 +685,7 @@ void QGIViewPart::drawAllSectionLines()
     if (vp->ShowSectionLine.getValue()) {
         auto refs = viewPart->getSectionRefs();
         for (auto& r : refs) {
-            if (r->isDerivedFrom(DrawComplexSection::getClassTypeId())) {
+            if (r->isDerivedFrom<DrawComplexSection>()) {
                 drawComplexSectionLine(r, true);
             }
             else {
@@ -1010,7 +1010,7 @@ void QGIViewPart::drawMatting()
 {
     auto viewPart(dynamic_cast<TechDraw::DrawViewPart*>(getViewObject()));
     TechDraw::DrawViewDetail* dvd = nullptr;
-    if (viewPart && viewPart->isDerivedFrom(TechDraw::DrawViewDetail::getClassTypeId())) {
+    if (viewPart && viewPart->isDerivedFrom<TechDraw::DrawViewDetail>()) {
         dvd = static_cast<TechDraw::DrawViewDetail*>(viewPart);
     }
     else {

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
@@ -170,8 +170,8 @@ double QGIViewSymbol::legacyScaler(TechDraw::DrawViewSymbol* feature) const
     //    double pxMm = 3.54;                 //90px/25.4mm ( inkscape value version <= 0.91)
     //some software uses different px/in, so symbol will need Scale adjusted.
     //Arch/Draft views are in px and need to be scaled @ rezfactor px/mm to ensure proper representation
-    if (feature->isDerivedFrom(TechDraw::DrawViewArch::getClassTypeId())
-        || feature->isDerivedFrom(TechDraw::DrawViewDraft::getClassTypeId())) {
+    if (feature->isDerivedFrom<TechDraw::DrawViewArch>()
+        || feature->isDerivedFrom<TechDraw::DrawViewDraft>()) {
         scaling = scaling * rezfactor;
     }
     else {

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -390,57 +390,57 @@ bool QGSPage::addView(const App::DocumentObject* obj)
 bool QGSPage::attachView(App::DocumentObject* obj)
 {
     //    Base::Console().Message("QGSP::attachView(%s)\n", obj->getNameInDocument());
-    QGIView* existing = findQViewForDocObj(obj);
-    if (existing)
+    if (findQViewForDocObj(obj)) {
         return true;
-
-    auto typeId(obj->getTypeId());
+    }
 
     QGIView* qview(nullptr);
 
-    if (typeId.isDerivedFrom(TechDraw::DrawViewSection::getClassTypeId())) {
-        qview = addViewSection(static_cast<TechDraw::DrawViewSection*>(obj));
+    using Base::freecad_dynamic_cast;
+
+    if (auto o = freecad_dynamic_cast<TechDraw::DrawViewSection>(obj)) {
+        qview = addViewSection(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
-        qview = addViewPart(static_cast<TechDraw::DrawViewPart*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawViewPart>(obj)) {
+        qview = addViewPart(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawProjGroup::getClassTypeId())) {
-        qview = addProjectionGroup(static_cast<TechDraw::DrawProjGroup*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawProjGroup>(obj)) {
+        qview = addProjectionGroup(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawViewCollection::getClassTypeId())) {
-        qview = addDrawView(static_cast<TechDraw::DrawViewCollection*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawViewCollection>(obj)) {
+        qview = addDrawView(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())) {
-        qview = addViewDimension(static_cast<TechDraw::DrawViewDimension*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawViewDimension>(obj)) {
+        qview = addViewDimension(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId())) {
-        qview = addViewBalloon(static_cast<TechDraw::DrawViewBalloon*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawViewBalloon>(obj)) {
+        qview = addViewBalloon(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawViewAnnotation::getClassTypeId())) {
-        qview = addAnnotation(static_cast<TechDraw::DrawViewAnnotation*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawViewAnnotation>(obj)) {
+        qview = addAnnotation(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawViewSymbol::getClassTypeId())) {
-        qview = addDrawViewSymbol(static_cast<TechDraw::DrawViewSymbol*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawViewSymbol>(obj)) {
+        qview = addDrawViewSymbol(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawViewClip::getClassTypeId())) {
-        qview = addDrawViewClip(static_cast<TechDraw::DrawViewClip*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawViewClip>(obj)) {
+        qview = addDrawViewClip(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawViewSpreadsheet::getClassTypeId())) {
-        qview = addDrawViewSpreadsheet(static_cast<TechDraw::DrawViewSpreadsheet*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawViewSpreadsheet>(obj)) {
+        qview = addDrawViewSpreadsheet(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawViewImage::getClassTypeId())) {
-        qview = addDrawViewImage(static_cast<TechDraw::DrawViewImage*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawViewImage>(obj)) {
+        qview = addDrawViewImage(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawLeaderLine::getClassTypeId())) {
-        qview = addViewLeader(static_cast<TechDraw::DrawLeaderLine*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawLeaderLine>(obj)) {
+        qview = addViewLeader(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawRichAnno::getClassTypeId())) {
-        qview = addRichAnno(static_cast<TechDraw::DrawRichAnno*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawRichAnno>(obj)) {
+        qview = addRichAnno(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawWeldSymbol::getClassTypeId())) {
-        qview = addWeldSymbol(static_cast<TechDraw::DrawWeldSymbol*>(obj));
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawWeldSymbol>(obj)) {
+        qview = addWeldSymbol(o);
     }
-    else if (typeId.isDerivedFrom(TechDraw::DrawHatch::getClassTypeId())) {
+    else if (auto o = freecad_dynamic_cast<TechDraw::DrawHatch>(obj)) {
         //Hatch is not attached like other Views (since it isn't really a View)
         return true;
     }

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -225,7 +225,7 @@ void QGSPage::updateTemplate(bool forceUpdate)
 
         if (forceUpdate
             || (templObj && templObj->isTouched()
-                && templObj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId()))) {
+                && templObj->isDerivedFrom<TechDraw::DrawTemplate>())) {
 
             QGITemplate* qItemTemplate = getTemplate();
 
@@ -269,10 +269,10 @@ void QGSPage::setPageTemplate(TechDraw::DrawTemplate* templateFeat)
     //    Base::Console().Message("QGSP::setPageTemplate()\n");
     removeTemplate();
 
-    if (templateFeat->isDerivedFrom(TechDraw::DrawParametricTemplate::getClassTypeId())) {
+    if (templateFeat->isDerivedFrom<TechDraw::DrawParametricTemplate>()) {
         pageTemplate = new QGIDrawingTemplate(this);
     }
-    else if (templateFeat->isDerivedFrom(TechDraw::DrawSVGTemplate::getClassTypeId())) {
+    else if (templateFeat->isDerivedFrom<TechDraw::DrawSVGTemplate>()) {
         pageTemplate = new QGISVGTemplate(this);
     }
     pageTemplate->setTemplate(templateFeat);

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -561,7 +561,7 @@ QColor QGVPage::getBackgroundColor()
 double QGVPage::getDevicePixelRatio() const
 {
     for (Gui::MDIView* view : m_vpPage->getDocument()->getMDIViews()) {
-        if (view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+        if (view->isDerivedFrom<Gui::View3DInventor>()) {
             return static_cast<Gui::View3DInventor*>(view)->getViewer()->devicePixelRatio();
         }
     }

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
@@ -282,9 +282,9 @@ void TaskComplexSection::onSectionObjectsUseSelectionClicked()
     std::vector<App::DocumentObject*> newSelection;
     std::vector<App::DocumentObject*> newXSelection;
     for (auto& sel : selection) {
-        if (sel.getObject()->isDerivedFrom(App::LinkElement::getClassTypeId())
-            || sel.getObject()->isDerivedFrom(App::LinkGroup::getClassTypeId())
-            || sel.getObject()->isDerivedFrom(App::Link::getClassTypeId())) {
+        if (sel.getObject()->isDerivedFrom<App::LinkElement>()
+            || sel.getObject()->isDerivedFrom<App::LinkGroup>()
+            || sel.getObject()->isDerivedFrom<App::Link>()) {
             newXSelection.push_back(sel.getObject());
         }
         else {

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
@@ -92,7 +92,7 @@ TaskLeaderLine::TaskLeaderLine(TechDrawGui::ViewProviderLeader* leadVP) :
     }
     App::DocumentObject* obj = m_lineFeat->LeaderParent.getValue();
     if (obj) {
-        if (obj->isDerivedFrom(TechDraw::DrawView::getClassTypeId()) )  {
+        if (obj->isDerivedFrom<TechDraw::DrawView>() )  {
             m_baseFeat = static_cast<TechDraw::DrawView*>(m_lineFeat->LeaderParent.getValue());
         }
     }
@@ -364,7 +364,7 @@ void TaskLeaderLine::createLeaderFeature(std::vector<Base::Vector3d> sceneDeltas
         throw Base::RuntimeError("TaskLeaderLine - new markup object not found");
     }
 
-    if (obj->isDerivedFrom(TechDraw::DrawLeaderLine::getClassTypeId())) {
+    if (obj->isDerivedFrom<TechDraw::DrawLeaderLine>()) {
         m_lineFeat = static_cast<TechDraw::DrawLeaderLine*>(obj);
         auto forMath{m_attachPoint};
         if (baseRotation != 0) {

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
@@ -82,7 +82,7 @@ TaskRichAnno::TaskRichAnno(TechDrawGui::ViewProviderRichAnno* annoVP) :
     //m_baseFeat can be null
     App::DocumentObject* obj = m_annoFeat->AnnoParent.getValue();
     if (obj) {
-        if ( obj->isDerivedFrom(TechDraw::DrawView::getClassTypeId()) )  {
+        if ( obj->isDerivedFrom<TechDraw::DrawView>() )  {
             m_baseFeat = static_cast<TechDraw::DrawView*>(m_annoFeat->AnnoParent.getValue());
         }
     }
@@ -300,7 +300,7 @@ void TaskRichAnno::createAnnoFeature()
     if (!obj) {
         throw Base::RuntimeError("TaskRichAnno - new RichAnno object not found");
     }
-    if (obj->isDerivedFrom(TechDraw::DrawRichAnno::getClassTypeId())) {
+    if (obj->isDerivedFrom<TechDraw::DrawRichAnno>()) {
         m_annoFeat = static_cast<TechDraw::DrawRichAnno*>(obj);
         commonFeatureUpdate();
         if (m_baseFeat) {
@@ -415,7 +415,7 @@ QPointF TaskRichAnno::calcTextStartPos(double scale)
 
     std::vector<Base::Vector3d> points;
     if (m_baseFeat) {
-        if (m_baseFeat->isDerivedFrom(TechDraw::DrawLeaderLine::getClassTypeId())) {
+        if (m_baseFeat->isDerivedFrom<TechDraw::DrawLeaderLine>()) {
             TechDraw::DrawLeaderLine* dll = static_cast<TechDraw::DrawLeaderLine*>(m_baseFeat);
             points = dll->WayPoints.getValues();
         } else {

--- a/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
@@ -95,7 +95,7 @@ TaskWeldingSymbol::TaskWeldingSymbol(TechDraw::DrawWeldSymbol* weld) :
 
     App::DocumentObject* obj = m_weldFeat->Leader.getValue();
     if (!obj ||
-        !obj->isDerivedFrom(TechDraw::DrawLeaderLine::getClassTypeId()) )  {
+        !obj->isDerivedFrom<TechDraw::DrawLeaderLine>() )  {
         Base::Console().Error("TaskWeldingSymbol - no leader for welding symbol.  Can not proceed.\n");
         return;
     }

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -110,7 +110,7 @@ void ViewProviderDimension::attach(App::DocumentObject *pcFeat)
 
 //    sPixmap = "TechDraw_Dimension";
     setPixmapForType();
-    if (getViewObject()->isDerivedFrom(TechDraw::LandmarkDimension::getClassTypeId())) {
+    if (getViewObject()->isDerivedFrom<TechDraw::LandmarkDimension>()) {
         sPixmap = "TechDraw_LandmarkDimension";
     }
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderPageExtension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPageExtension.cpp
@@ -61,7 +61,7 @@ bool ViewProviderPageExtension::extensionCanDropObjects() const { return true; }
 bool ViewProviderPageExtension::extensionCanDropObject(App::DocumentObject* obj) const
 {
     // Accept links to views as well.
-    if (obj->isDerivedFrom(App::Link::getClassTypeId())) {
+    if (obj->isDerivedFrom<App::Link>()) {
         auto* link = static_cast<App::Link*>(obj);
         obj = link->getLinkedObject();
     }
@@ -107,14 +107,14 @@ bool ViewProviderPageExtension::extensionCanDropObjectEx(App::DocumentObject* ob
 void ViewProviderPageExtension::extensionDropObject(App::DocumentObject* obj)
 {
     bool linkToView = false;
-    if (obj->isDerivedFrom(App::Link::getClassTypeId())) {
+    if (obj->isDerivedFrom<App::Link>()) {
         auto* link = static_cast<App::Link*>(obj);
-        if (link->getLinkedObject()->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+        if (link->getLinkedObject()->isDerivedFrom<TechDraw::DrawView>()) {
             linkToView = true;
         }
     }
 
-    if (obj->isDerivedFrom(TechDraw::DrawView::getClassTypeId()) || linkToView) {
+    if (obj->isDerivedFrom<TechDraw::DrawView>() || linkToView) {
         dropObject(obj);
         return;
     }

--- a/src/Mod/TechDraw/Gui/ViewProviderTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderTemplate.cpp
@@ -81,7 +81,7 @@ void ViewProviderTemplate::attach(App::DocumentObject* pcFeat)
 void ViewProviderTemplate::updateData(const App::Property* prop)
 {
     //This doesn't belong here.  Should be in a ViewProviderSvgTemplate?
-    if (getTemplate()->isDerivedFrom(TechDraw::DrawSVGTemplate::getClassTypeId())) {
+    if (getTemplate()->isDerivedFrom<TechDraw::DrawSVGTemplate>()) {
         auto t = static_cast<TechDraw::DrawSVGTemplate*>(getTemplate());
         if (prop == &(t->Template)) {
             auto page = t->getParentPage();

--- a/src/Mod/TechDraw/Gui/ViewProviderViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewClip.cpp
@@ -111,7 +111,7 @@ TechDraw::DrawViewClip* ViewProviderViewClip::getObject() const
 
 void ViewProviderViewClip::dragObject(App::DocumentObject* docObj)
 {
-    if (!docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+    if (!docObj->isDerivedFrom<TechDraw::DrawView>()) {
         return;
     }
 
@@ -122,14 +122,14 @@ void ViewProviderViewClip::dragObject(App::DocumentObject* docObj)
 
 void ViewProviderViewClip::dropObject(App::DocumentObject* docObj)
 {
-    if (docObj->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())) {
+    if (docObj->isDerivedFrom<TechDraw::DrawProjGroupItem>()) {
         //DPGI can not be dropped onto the Page if it belongs to DPG
         auto* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(docObj);
         if (dpgi->getPGroup()) {
             return;
         }
     }
-    if (!docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+    if (!docObj->isDerivedFrom<TechDraw::DrawView>()) {
         return;
     }
 

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -169,7 +169,7 @@ ViewProviderViewPart::~ViewProviderViewPart()
 
 void ViewProviderViewPart::onChanged(const App::Property* prop)
 {
-    if (auto part = getViewPart(); part && part->isDerivedFrom(TechDraw::DrawViewDetail::getClassTypeId()) &&
+    if (auto part = getViewPart(); part && part->isDerivedFrom<TechDraw::DrawViewDetail>() &&
         prop == &(HighlightAdjust)) {
         auto detail = static_cast<DrawViewDetail*>(getViewPart());
         auto baseDvp = dynamic_cast<DrawViewPart*>(detail->BaseView.getValue());


### PR DESCRIPTION
This simplifies the code which compares types in the codebase. By prefering BaseClass' `isDerivedFrom` and where possible using the template version, we're able to shorten down the code and makes it easier to read and write.

Some places still uses string based lookup of types as this avoids some dependencies between modules.

> [!NOTE]
>  FreeCADs type system seems to be heavily inspired by coin3d's system. There's a lot of coin node types which are compared with `isDerivedFrom` calls, but these are handled by coin's system and only share name.

--- 

The bulk of the change is done in 036de24 and has been done with regex based substitution to avoid errors.
When reviewing, it might be easiest to go through the code per commit. That way it's easier to pay extra attention to the non-regex changes.

I've gone through all changes manually when committing the code but another pair of eyes would be good :)

---

I'd prefer if the commits could be kept when merging.