### PR TITLE
fixed small typo 

### DIFF
--- a/src/Mod/Assembly/CommandCreateJoint.py
+++ b/src/Mod/Assembly/CommandCreateJoint.py
@@ -225,7 +225,7 @@ class CommandCreateJointDistance:
             + "</p><p>"
             + QT_TRANSLATE_NOOP(
                 "Assembly_CreateJointDistance",
-                "Create one of several different joints based on the selection."
+                "Create one of several different joints based on the selection. "
                 "For example, a distance of 0 between a plane and a cylinder creates a tangent joint. A distance of 0 between planes will make them co-planar.",
             )
             + "</p>",


### PR DESCRIPTION
Ok once more. I learned about localisation (new topic to me). As I understood from the wiki/forum the `*.ts` are somehow created by admins and I don't have to do anything?!

Nevertheless, I checked locally with my personal build `Tools/updatets.py Assembly` and it does fix the typo.