### PR TITLE
Core: Remove link from tooltip

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsDocument.ui
+++ b/src/Gui/PreferencePages/DlgSettingsDocument.ui
@@ -217,19 +217,21 @@ This feature may slightly increase recomputation time.</string>
       <string>Storage</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="Gui::PrefCheckBox" name="prefSaveTransaction">
-        <property name="enabled">
-         <bool>false</bool>
+      <item row="9" column="0">
+       <widget class="QLabel" name="FormatTimeDocsLabel">
+        <property name="font">
+         <font>
+          <italic>true</italic>
+         </font>
         </property>
         <property name="text">
-         <string>Saving transactions (Auto-save)</string>
+         <string>Format time as string documentation</string>
         </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>SaveTransactions</cstring>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Document</cstring>
+        <property name="openExternalLinks">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -248,71 +250,6 @@ This feature may slightly increase recomputation time.</string>
          <cstring>Document</cstring>
         </property>
        </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="Gui::PrefCheckBox" name="prefRecovery">
-        <property name="toolTip">
-         <string>If there is a recovery file available the application will
-automatically run a file recovery when it is started.</string>
-        </property>
-        <property name="text">
-         <string>Run AutoRecovery at startup</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>RecoveryEnabled</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Document</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="prefAutoSaveEnabled">
-          <property name="toolTip">
-           <string>How often a recovery file is written</string>
-          </property>
-          <property name="text">
-           <string>Save AutoRecovery information every</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>AutoSaveEnabled</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Document</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="prefAutoSaveTimeout">
-          <property name="suffix">
-           <string notr="true"> min</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>60</number>
-          </property>
-          <property name="value">
-           <number>15</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>AutoSaveTimeout</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Document</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
       </item>
       <item row="4" column="0">
        <widget class="Line" name="line1_2_3">
@@ -340,11 +277,11 @@ automatically run a file recovery when it is started.</string>
           <property name="toolTip">
            <string>A thumbnail will be stored when document is saved</string>
           </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
           <property name="text">
            <string>Save thumbnail into project file when saving document</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>SaveThumbnail</cstring>
@@ -401,25 +338,6 @@ Common sizes are 128, 256 and 512</string>
          </widget>
         </item>
        </layout>
-      </item>
-      <item row="6" column="0">
-       <widget class="Gui::PrefCheckBox" name="prefAddLogo">
-        <property name="toolTip">
-         <string>The program logo will be added to the thumbnail</string>
-        </property>
-        <property name="text">
-         <string>Add the program logo to the generated thumbnail</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>AddThumbnailLogo</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Document</cstring>
-        </property>
-       </widget>
       </item>
       <item row="7" column="0">
        <layout class="QHBoxLayout">
@@ -488,6 +406,106 @@ Common sizes are 128, 256 and 512</string>
         </item>
        </layout>
       </item>
+      <item row="2" column="0">
+       <widget class="Gui::PrefCheckBox" name="prefRecovery">
+        <property name="toolTip">
+         <string>If there is a recovery file available the application will
+automatically run a file recovery when it is started.</string>
+        </property>
+        <property name="text">
+         <string>Run AutoRecovery at startup</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>RecoveryEnabled</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Document</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="Gui::PrefCheckBox" name="prefSaveTransaction">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Saving transactions (Auto-save)</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SaveTransactions</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Document</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="Gui::PrefCheckBox" name="prefAddLogo">
+        <property name="toolTip">
+         <string>The program logo will be added to the thumbnail</string>
+        </property>
+        <property name="text">
+         <string>Add the program logo to the generated thumbnail</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>AddThumbnailLogo</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Document</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="Gui::PrefCheckBox" name="prefAutoSaveEnabled">
+          <property name="toolTip">
+           <string>How often a recovery file is written</string>
+          </property>
+          <property name="text">
+           <string>Save AutoRecovery information every</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>AutoSaveEnabled</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Document</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefSpinBox" name="prefAutoSaveTimeout">
+          <property name="suffix">
+           <string notr="true"> min</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>60</number>
+          </property>
+          <property name="value">
+           <number>15</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>AutoSaveTimeout</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Document</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
       <item row="8" column="0">
        <layout class="QHBoxLayout">
         <property name="spacing">
@@ -511,11 +529,11 @@ Common sizes are 128, 256 and 512</string>
            <string>Backup files will get extension '.FCbak' and file names
 get date suffix according to the specified format</string>
           </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
           <property name="text">
            <string>Use date and FCBak extension</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>UseFCBakExtension</cstring>
@@ -732,13 +750,13 @@ You can also use the form: John Doe &lt;john@doe.com&gt;</string>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>Gui::PrefCheckBox</class>
-   <extends>QCheckBox</extends>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefSpinBox</class>
-   <extends>QSpinBox</extends>
+   <class>Gui::PrefCheckBox</class>
+   <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>

--- a/src/Gui/PreferencePages/DlgSettingsDocument.ui
+++ b/src/Gui/PreferencePages/DlgSettingsDocument.ui
@@ -225,7 +225,7 @@ This feature may slightly increase recomputation time.</string>
          </font>
         </property>
         <property name="text">
-         <string>Format time as string documentation</string>
+         <string>Show format documentation</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Gui/PreferencePages/DlgSettingsDocumentImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsDocumentImp.cpp
@@ -56,7 +56,7 @@ DlgSettingsDocumentImp::DlgSettingsDocumentImp(QWidget* parent)
         QString::fromLatin1("<html><head/><body>"
                             "<a href=\"http://www.cplusplus.com/reference/ctime/strftime/\">%1</a>"
                             "</body></html>")
-            .arg(tr("Format time as string documentation"));
+            .arg(tr("Show format documentation"));
     ui->prefSaveBackupDateFormat->setToolTip(tip);
     ui->FormatTimeDocsLabel->setText(link);
 

--- a/src/Gui/PreferencePages/DlgSettingsDocumentImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsDocumentImp.cpp
@@ -38,8 +38,8 @@ using namespace Gui::Dialog;
  *  Constructs a DlgSettingsDocumentImp which is a child of 'parent', with the
  *  name 'name' and widget flags set to 'f'
  */
-DlgSettingsDocumentImp::DlgSettingsDocumentImp( QWidget* parent )
-    : PreferencePage( parent )
+DlgSettingsDocumentImp::DlgSettingsDocumentImp(QWidget* parent)
+    : PreferencePage(parent)
     , ui(new Ui_DlgSettingsDocument)
 {
     ui->setupUi(this);
@@ -50,9 +50,15 @@ DlgSettingsDocumentImp::DlgSettingsDocumentImp( QWidget* parent )
 
     QString tip = QString::fromLatin1("<html><head/><body><p>%1</p>"
                                       "<p>%2: %Y%m%d-%H%M%S</p>"
-                                      "<p>%3: <a href=\"http://www.cplusplus.com/reference/ctime/strftime/\">C++ strftime</a>"
-                                      "</p></body></html>").arg(tr("The format of the date to use."), tr("Default"), tr("Format"));
+                                      "</p></body></html>")
+                      .arg(tr("The format of the date to use."), tr("Default"));
+    QString link =
+        QString::fromLatin1("<html><head/><body>"
+                            "<a href=\"http://www.cplusplus.com/reference/ctime/strftime/\">%1</a>"
+                            "</body></html>")
+            .arg(tr("Format time as string documentation"));
     ui->prefSaveBackupDateFormat->setToolTip(tip);
+    ui->FormatTimeDocsLabel->setText(link);
 
     ui->prefCountBackupFiles->setMaximum(INT_MAX);
     ui->prefCompression->setMinimum(Z_NO_COMPRESSION);


### PR DESCRIPTION
It's impossible to click on the link because the tooltip fades away, from ~30 attempts none worked. `Preferences > General > Document`


I used a `Gui::UrlLabel` from the FreeCAD's custom Qt elements, **is preferred a simple Label with hyperlink?** Qt Designer 5 used, it moved lots of lines but only one element was added.

![image](https://github.com/user-attachments/assets/23b6574d-3eac-4873-9359-67950adccf26)
