### PR TITLE
Refactoring code with by adding Document::addObject<T>()

### DIFF
--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -593,6 +593,9 @@ protected:
     void writeObjects(const std::vector<App::DocumentObject*>&, Base::Writer& writer) const;
     bool saveToFile(const char* filename) const;
     int countObjectsOfType(const Base::Type& typeId) const;
+    DocumentObject* addObject(const Base::Type& type, const char* pObjectName = nullptr,
+                              bool isNew = true, const char* viewType = nullptr,
+                              bool isPartial = false);
 
     void onBeforeChange(const Property* prop) override;
     void onChanged(const Property* prop) override;

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -268,6 +268,21 @@ public:
                               bool isNew = true,
                               const char* viewType = nullptr,
                               bool isPartial = false);
+    //@{
+    /** Add a feature of T type with sName (ASCII) to this document and set it active.
+     * Unicode names are set through the Label property.
+     * @param pObjectName if nonNULL use that name otherwise generate a new unique name based on the
+     * \a sType
+     * @param isNew       if false don't call the \c DocumentObject::setupObject() callback (default
+     * is true)
+     * @param viewType    override object's view provider name
+     * @param isPartial   indicate if this object is meant to be partially loaded
+     */
+    template<typename T>
+    T* addObject(const char* pObjectName = nullptr,
+                 bool isNew = true,
+                 const char* viewType = nullptr,
+                 bool isPartial = false);
     /** Add an array of features of the given types and names.
      * Unicode names are set through the Label property.
      * @param sType       The type of created object
@@ -663,6 +678,13 @@ inline int Document::countObjectsOfType() const
     static_assert(std::is_base_of<App::DocumentObject, T>::value,
                   "T must be derived from App::DocumentObject");
     return this->countObjectsOfType(T::getClassTypeId());
+}
+
+template<typename T>
+T* Document::addObject(const char* pObjectName, bool isNew, const char* viewType, bool isPartial)
+{
+    static_assert(std::is_base_of<DocumentObject, T>::value, "T must be derived from DocumentObject");
+    return static_cast<T*>(addObject(T::getClassTypeId(), pObjectName, isNew, viewType, isPartial));
 }
 
 

--- a/src/App/OriginGroupExtension.cpp
+++ b/src/App/OriginGroupExtension.cpp
@@ -158,7 +158,7 @@ App::DocumentObjectExecReturn* OriginGroupExtension::extensionExecute()
 
 App::DocumentObject* OriginGroupExtension::getLocalizedOrigin(App::Document* doc)
 {
-    App::DocumentObject* originObject = doc->addObject("App::Origin", "Origin");
+    auto* originObject = doc->addObject<App::Origin>("Origin");
     QByteArray byteArray = tr("Origin").toUtf8();
     originObject->Label.setValue(byteArray.constData());
     return originObject;

--- a/src/Base/Type.cpp
+++ b/src/Base/Type.cpp
@@ -59,7 +59,7 @@ map<string, unsigned int> Type::typemap;
 vector<TypeData*> Type::typedata;
 set<string> Type::loadModuleSet;
 
-void* Type::createInstance()
+void* Type::createInstance() const
 {
     instantiationMethod method = typedata[index]->instMethod;
     return method ? (*method)() : nullptr;
@@ -226,9 +226,7 @@ Type Type::getTypeIfDerivedFrom(const char* name, const Type& parent, bool bLoad
         importModule(name);
     }
 
-    Type type = fromName(name);
-
-    if (type.isDerivedFrom(parent)) {
+    if (Type type = fromName(name); type.isDerivedFrom(parent)) {
         return type;
     }
 

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -88,7 +88,7 @@ public:
     ~Type() = default;
 
     /// creates a instance of this type
-    void* createInstance();
+    void* createInstance() const;
     /// Checks whether this type can instantiate
     bool canInstantiate() const;
     /// creates a instance of the named type

--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -413,7 +413,7 @@ static void linkConvert(bool unlink) {
                     continue;
             }else{
                 auto name = doc->getUniqueObjectName("Link");
-                auto link = static_cast<App::Link*>(doc->addObject("App::Link",name.c_str()));
+                auto link = doc->addObject<App::Link>(name.c_str());
                 if(!link)
                     FC_THROWM(Base::RuntimeError,"Failed to create link");
                 link->setLink(-1,obj);

--- a/src/Mod/CAM/App/AppPathPy.cpp
+++ b/src/Mod/CAM/App/AppPathPy.cpp
@@ -228,8 +228,7 @@ private:
             std::string gcode = buffer.str();
             Path::Toolpath path;
             path.setFromGCode(gcode);
-            Path::Feature* object = static_cast<Path::Feature*>(
-                pcDoc->addObject("Path::Feature", file.fileNamePure().c_str()));
+            Path::Feature* object = pcDoc->addObject<Path::Feature>(file.fileNamePure().c_str());
             object->Path.setValue(path);
             pcDoc->recompute();
         }
@@ -256,7 +255,7 @@ private:
             }
             Path::PathPy* pPath = static_cast<Path::PathPy*>(pcObj);
             Path::Feature* pcFeature =
-                static_cast<Path::Feature*>(pcDoc->addObject("Path::Feature", name));
+                pcDoc->addObject<Path::Feature>(name);
             Path::Toolpath* pa = pPath->getToolpathPtr();
             if (!pa) {
                 throw Py::Exception(PyExc_ReferenceError, "object doesn't reference a valid path");

--- a/src/Mod/CAM/App/Area.cpp
+++ b/src/Mod/CAM/App/Area.cpp
@@ -1452,8 +1452,7 @@ void Area::showShape(const TopoDS_Shape& shape, const char* name, const char* fm
             va_end(args);
             name = buf;
         }
-        Part::Feature* pcFeature =
-            static_cast<Part::Feature*>(pcDoc->addObject("Part::Feature", name));
+        Part::Feature* pcFeature = pcDoc->addObject<Part::Feature>(name);
         pcFeature->Shape.setValue(shape);
     }
 }

--- a/src/Mod/Drawing/Gui/TaskOrthoViews.cpp
+++ b/src/Mod/Drawing/Gui/TaskOrthoViews.cpp
@@ -150,8 +150,7 @@ orthoview::orthoview(App::Document* parent,
     cy = partbox->GetCenter().y;
     cz = partbox->GetCenter().z;
 
-    this_view = static_cast<Drawing::FeatureViewPart*>(
-        parent_doc->addObject("Drawing::FeatureViewPart", myname.c_str()));
+    this_view = parent_doc->addObject<Drawing::FeatureViewPart>(myname.c_str());
     static_cast<App::DocumentObjectGroup*>(page)->addObject(this_view);
     this_view->Source.setValue(part);
 

--- a/src/Mod/Fem/App/AppFemPy.cpp
+++ b/src/Mod/Fem/App/AppFemPy.cpp
@@ -123,8 +123,7 @@ private:
         Base::FileInfo file(EncodedName.c_str());
         // create new document and add Import feature
         App::Document* pcDoc = App::GetApplication().newDocument();
-        FemMeshObject* pcFeature = static_cast<FemMeshObject*>(
-            pcDoc->addObject("Fem::FemMeshObject", file.fileNamePure().c_str()));
+        FemMeshObject* pcFeature = pcDoc->addObject<FemMeshObject>(file.fileNamePure().c_str());
         pcFeature->Label.setValue(file.fileNamePure().c_str());
         pcFeature->FemMesh.setValuePtr(mesh.release());
         pcFeature->purgeTouched();
@@ -160,8 +159,7 @@ private:
             std::unique_ptr<FemMesh> mesh(new FemMesh);
             mesh->read(EncodedName.c_str());
 
-            FemMeshObject* pcFeature = static_cast<FemMeshObject*>(
-                pcDoc->addObject("Fem::FemMeshObject", file.fileNamePure().c_str()));
+            FemMeshObject* pcFeature = pcDoc->addObject<FemMeshObject>(file.fileNamePure().c_str());
             pcFeature->Label.setValue(file.fileNamePure().c_str());
             pcFeature->FemMesh.setValuePtr(mesh.release());
             pcFeature->purgeTouched();
@@ -170,8 +168,7 @@ private:
 #ifdef FC_USE_VTK
             if (FemPostPipeline::canRead(file)) {
 
-                FemPostPipeline* pcFeature = static_cast<FemPostPipeline*>(
-                    pcDoc->addObject("Fem::FemPostPipeline", file.fileNamePure().c_str()));
+                FemPostPipeline* pcFeature = pcDoc->addObject<FemPostPipeline>(file.fileNamePure().c_str());
 
                 pcFeature->Label.setValue(file.fileNamePure().c_str());
                 pcFeature->read(file);
@@ -322,8 +319,7 @@ private:
         }
 
         FemMeshPy* pShape = static_cast<FemMeshPy*>(pcObj);
-        Fem::FemMeshObject* pcFeature =
-            static_cast<Fem::FemMeshObject*>(pcDoc->addObject("Fem::FemMeshObject", name));
+        Fem::FemMeshObject* pcFeature = pcDoc->addObject<Fem::FemMeshObject>(name);
         // copy the data
         pcFeature->FemMesh.setValue(*(pShape->getFemMeshPtr()));
         pcDoc->recompute();

--- a/src/Mod/Fem/App/FemVTKTools.cpp
+++ b/src/Mod/Fem/App/FemVTKTools.cpp
@@ -619,7 +619,7 @@ App::DocumentObject* FemVTKTools::readResult(const char* filename, App::Document
         }
     }
 
-    App::DocumentObject* mesh = pcDoc->addObject("Fem::FemMeshObject", "ResultMesh");
+    auto* mesh = pcDoc->addObject<Fem::FemMeshObject>("ResultMesh");
     std::unique_ptr<FemMesh> fmesh(new FemMesh());
     importVTKMesh(dataset, fmesh.get());
     static_cast<PropertyFemMesh*>(mesh->getPropertyByName("FemMesh"))->setValuePtr(fmesh.release());

--- a/src/Mod/Import/App/ImportOCAF.cpp
+++ b/src/Mod/Import/App/ImportOCAF.cpp
@@ -266,7 +266,7 @@ void ImportOCAF::loadShapes(const TDF_Label& label,
             if (!localValue.empty()) {
                 if (aShapeTool->IsAssembly(label)) {
                     App::Part* pcPart = nullptr;
-                    pcPart = static_cast<App::Part*>(doc->addObject("App::Part", asm_name.c_str()));
+                    pcPart = doc->addObject<App::Part>(asm_name.c_str());
                     pcPart->Label.setValue(asm_name);
                     pcPart->addObjects(localValue);
 
@@ -342,7 +342,7 @@ void ImportOCAF::createShape(const TDF_Label& label,
             // Ok we got a Compound which is computed
             // Just need to add it to a Part::Feature and push it to lValue
             if (!comp.IsNull() && (ctSolids || ctShells || ctEdges || ctVertices)) {
-                Part::Feature* part = static_cast<Part::Feature*>(doc->addObject("Part::Feature"));
+                Part::Feature* part = doc->addObject<Part::Feature>();
                 // Let's allocate the relative placement of the Compound from the STEP file
                 tryPlacementFromLoc(part, loc);
                 if (!loc.IsIdentity()) {
@@ -368,7 +368,7 @@ void ImportOCAF::createShape(const TDF_Label& label,
         }
 
         if (!localValue.empty() && !mergeShape) {
-            pcPart = static_cast<App::Part*>(doc->addObject("App::Part", name.c_str()));
+            pcPart = doc->addObject<App::Part>(name.c_str());
             pcPart->Label.setValue(name);
 
             // localValue contain the objects that  must added to the local Part
@@ -392,7 +392,7 @@ void ImportOCAF::createShape(const TopoDS_Shape& aShape,
                              const std::string& name,
                              std::vector<App::DocumentObject*>& lvalue)
 {
-    Part::Feature* part = static_cast<Part::Feature*>(doc->addObject("Part::Feature"));
+    Part::Feature* part = doc->addObject<Part::Feature>();
 
     if (!loc.IsIdentity()) {
         part->Shape.setValue(aShape.Moved(loc));
@@ -513,7 +513,7 @@ void ImportXCAF::loadShapes()
 void ImportXCAF::createShape(const TopoDS_Shape& shape, bool perface, bool setname) const
 {
     Part::Feature* part;
-    part = static_cast<Part::Feature*>(doc->addObject("Part::Feature", default_name.c_str()));
+    part = doc->addObject<Part::Feature>(default_name.c_str());
     part->Label.setValue(default_name);
     part->Shape.setValue(shape);
     std::map<Standard_Integer, Quantity_ColorRGBA>::const_iterator jt;

--- a/src/Mod/Import/App/ImportOCAF2.cpp
+++ b/src/Mod/Import/App/ImportOCAF2.cpp
@@ -269,8 +269,7 @@ ImportOCAF2::expandShape(App::Document* doc, TDF_Label label, const TopoDS_Shape
         if (objs.empty()) {
             return nullptr;
         }
-        auto compound =
-            static_cast<Part::Compound2*>(doc->addObject("Part::Compound2", "Compound"));
+        auto compound = doc->addObject<Part::Compound2>("Compound");
         compound->Links.setValues(objs);
         setPlacement(&compound->Placement, shape);
         return compound;
@@ -382,8 +381,7 @@ bool ImportOCAF2::createObject(App::Document* doc,
         assert(feature);
     }
     else {
-        feature = static_cast<Part::Feature*>(
-            doc->addObject("Part::Feature", tshape.shapeName().c_str()));
+        feature = doc->addObject<Part::Feature>(tshape.shapeName().c_str());
         feature->Shape.setValue(shape);
     }
     applyFaceColors(feature, {info.faceColor});
@@ -476,10 +474,10 @@ bool ImportOCAF2::createGroup(App::Document* doc,
         myCollapsedObjects.emplace(info.obj, info.propPlacement);
         return true;
     }
-    auto group = static_cast<App::LinkGroup*>(doc->addObject("App::LinkGroup", "LinkGroup"));
+    auto group = doc->addObject<App::LinkGroup>("LinkGroup");
     for (auto& child : children) {
         if (child->getDocument() != doc) {
-            auto link = static_cast<App::Link*>(doc->addObject("App::Link", "Link"));
+            auto link = doc->addObject<App::Link>("Link");
             link->Label.setValue(child->Label.getValue());
             link->setLink(-1, child);
             auto pla = Base::freecad_dynamic_cast<App::PropertyPlacement>(
@@ -563,8 +561,7 @@ App::DocumentObject* ImportOCAF2::loadShapes()
     }
     if (options.merge && ret && !ret->isDerivedFrom(Part::Feature::getClassTypeId())) {
         auto shape = Part::Feature::getTopoShape(ret);
-        auto feature =
-            static_cast<Part::Feature*>(pDocument->addObject("Part::Feature", "Feature"));
+        auto feature = pDocument->addObject<Part::Feature>("Feature");
         auto name = Tools::labelName(pDoc->Main());
         feature->Label.setValue(name.empty() ? default_name.c_str() : name.c_str());
         feature->Shape.setValue(shape);
@@ -698,8 +695,7 @@ App::DocumentObject* ImportOCAF2::loadShape(App::Document* doc,
         auto name = getLabelName(label);
         if (info.faceColor != it->second.faceColor || info.edgeColor != it->second.edgeColor
             || (!name.empty() && !info.baseName.empty() && name != info.baseName)) {
-            auto compound =
-                static_cast<Part::Compound2*>(doc->addObject("Part::Compound2", "Compound"));
+            auto compound = doc->addObject<Part::Compound2>("Compound");
             compound->Links.setValue(info.obj);
             info.propPlacement = &compound->Placement;
             if (info.faceColor != it->second.faceColor) {
@@ -716,7 +712,7 @@ App::DocumentObject* ImportOCAF2::loadShape(App::Document* doc,
         return info.obj;
     }
 
-    auto link = static_cast<App::Link*>(doc->addObject("App::Link", "Link"));
+    auto link = doc->addObject<App::Link>("Link");
     link->setLink(-1, info.obj);
     setPlacement(&link->Placement, shape);
     info.obj = link;
@@ -823,7 +819,7 @@ bool ImportOCAF2::createAssembly(App::Document* _doc,
             visibilities[i] = true;
 
             // Okay, we are creating a link array
-            auto link = static_cast<App::Link*>(doc->addObject("App::Link", "Link"));
+            auto link = doc->addObject<App::Link>("Link");
             link->setLink(-1, child);
             link->ShowElement.setValue(false);
             link->ElementCount.setValue(childInfo.plas.size());

--- a/src/Mod/Import/App/ImportOCAFAssembly.cpp
+++ b/src/Mod/Import/App/ImportOCAFAssembly.cpp
@@ -241,7 +241,7 @@ void ImportOCAFAssembly::createShape(const TopoDS_Shape& aShape,
                                      const TopLoc_Location& loc,
                                      const std::string& name)
 {
-    Part::Feature* part = static_cast<Part::Feature*>(doc->addObject("Part::Feature"));
+    Part::Feature* part = doc->addObject<Part::Feature>();
     if (!loc.IsIdentity()) {
         part->Shape.setValue(aShape.Moved(loc));
     }

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -736,8 +736,7 @@ std::string ImpExpDxfRead::Deformat(const char* text)
 void ImpExpDxfRead::DrawingEntityCollector::AddObject(const TopoDS_Shape& shape,
                                                       const char* nameBase)
 {
-    auto pcFeature =
-        dynamic_cast<Part::Feature*>(Reader.document->addObject("Part::Feature", nameBase));
+    auto pcFeature = Reader.document->addObject<Part::Feature>(nameBase);
     pcFeature->Shape.setValue(shape);
     Reader.MoveToLayer(pcFeature);
     Reader.ApplyGuiStyles(pcFeature);

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -370,11 +370,10 @@ void TaskMeasure::ensureGroup(Measure::MeasureBase* measurement)
 
 
     if (!obj || !obj->isValid()
-        || !obj->isDerivedFrom(App::DocumentObjectGroup::getClassTypeId())) {
-        obj = doc->addObject("App::DocumentObjectGroup",
-                             measurementGroupName,
-                             true,
-                             "MeasureGui::ViewProviderMeasureGroup");
+        || !obj->isDerivedFrom<App::DocumentObjectGroup>()) {
+        obj = doc->addObject<App::DocumentObjectGroup>(measurementGroupName,
+                                                       true,
+                                                       "MeasureGui::ViewProviderMeasureGroup");
     }
 
     auto group = static_cast<App::DocumentObjectGroup*>(obj);

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -219,13 +219,12 @@ Measure::MeasureBase* TaskMeasure::createObject(const App::MeasureType* measureT
         auto pyMeasureClass = measureType->pythonClass;
 
         // Create a MeasurePython instance
-        auto featurePython = doc->addObject("Measure::MeasurePython", measureType->label.c_str());
-        _mMeasureObject = dynamic_cast<Measure::MeasureBase*>(featurePython);
+        _mMeasureObject = doc->addObject<Measure::MeasurePython>(measureType->label.c_str());
 
         // Create an instance of the pyMeasureClass, the classe's initializer sets the object as
         // proxy
         Py::Tuple args(1);
-        args.setItem(0, Py::asObject(featurePython->getPyObject()));
+        args.setItem(0, Py::asObject(_mMeasureObject->getPyObject()));
         PyObject* result = PyObject_CallObject(pyMeasureClass, args.ptr());
         Py_XDECREF(result);
     }
@@ -249,8 +248,7 @@ void TaskMeasure::update()
         App::DocumentObject* sub = ob->getSubObject(sel.SubName);
 
         // Resolve App::Link
-        if (sub->isDerivedFrom<App::Link>()) {
-            auto link = static_cast<App::Link*>(sub);
+        if (auto link = Base::freecad_dynamic_cast<App::Link>(sub)) {
             sub = link->getLinkedObject(true);
         }
 
@@ -341,7 +339,7 @@ void TaskMeasure::initViewObject()
     dynamic_cast<MeasureGui::ViewProviderMeasureBase*>(viewObject)->positionAnno(_mMeasureObject);
 
     // Set the ShowDelta Property if it exists on the measurements view object
-    auto* prop = dynamic_cast<App::PropertyBool*>(viewObject->getPropertyByName("ShowDelta"));
+    auto* prop = viewObject->getPropertyByName<App::PropertyBool>("ShowDelta");
     setDeltaPossible(prop != nullptr);
     if (prop) {
         prop->setValue(showDelta->isChecked());

--- a/src/Mod/Mesh/App/AppMeshPy.cpp
+++ b/src/Mod/Mesh/App/AppMeshPy.cpp
@@ -303,8 +303,7 @@ private:
             pcDoc = App::GetApplication().newDocument();
         }
         MeshPy* pMesh = static_cast<MeshPy*>(pcObj);
-        Mesh::Feature* pcFeature =
-            static_cast<Mesh::Feature*>(pcDoc->addObject("Mesh::Feature", name));
+        Mesh::Feature* pcFeature = pcDoc->addObject<Mesh::Feature>(name);
         Mesh::MeshObject* mo = pMesh->getMeshObjectPtr();
         if (!mo) {
             throw Py::Exception(PyExc_ReferenceError, "object doesn't reference a valid mesh");

--- a/src/Mod/Mesh/App/Importer.cpp
+++ b/src/Mod/Mesh/App/Importer.cpp
@@ -119,8 +119,7 @@ void Importer::createMeshFromSegments(const std::string& name,
 
 Feature* Importer::createMesh(const std::string& name, MeshObject& mesh)
 {
-    Mesh::Feature* pcFeature =
-        static_cast<Mesh::Feature*>(document->addObject("Mesh::Feature", name.c_str()));
+    Mesh::Feature* pcFeature = document->addObject<Mesh::Feature>(name.c_str());
     pcFeature->Label.setValue(name);
     pcFeature->Mesh.swapMesh(mesh);
     return pcFeature;

--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -503,8 +503,7 @@ void CmdMeshFromGeometry::activated(int)
             }
 
             // create a mesh feature and assign the mesh
-            Mesh::Feature* mf =
-                static_cast<Mesh::Feature*>(doc->addObject("Mesh::Feature", "Mesh"));
+            Mesh::Feature* mf = doc->addObject<Mesh::Feature>("Mesh");
             mf->Mesh.setValue(mesh.getKernel());
         }
     }
@@ -1703,8 +1702,7 @@ void CmdMeshMerge::activated(int)
     }
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Mesh merge"));
-    Mesh::Feature* pcFeature =
-        static_cast<Mesh::Feature*>(pcDoc->addObject("Mesh::Feature", "Mesh"));
+    Mesh::Feature* pcFeature = pcDoc->addObject<Mesh::Feature>("Mesh");
     Mesh::MeshObject* newMesh = pcFeature->Mesh.startEditing();
     std::vector<App::DocumentObject*> objs =
         Gui::Selection().getObjectsOfType(Mesh::Feature::getClassTypeId());
@@ -1759,8 +1757,7 @@ void CmdMeshSplitComponents::activated(int)
             std::unique_ptr<MeshObject> kernel(mesh.meshFromSegment(comp));
             kernel->setTransform(mesh.getTransform());
 
-            Mesh::Feature* feature =
-                static_cast<Mesh::Feature*>(pcDoc->addObject("Mesh::Feature", "Component"));
+            Mesh::Feature* feature = pcDoc->addObject<Mesh::Feature>("Component");
             feature->Mesh.setValuePtr(kernel.release());
         }
     }

--- a/src/Mod/Mesh/Gui/Segmentation.cpp
+++ b/src/Mod/Mesh/Gui/Segmentation.cpp
@@ -120,8 +120,7 @@ void Segmentation::accept()
 
     std::string internalname = "Segments_";
     internalname += myMesh->getNameInDocument();
-    App::DocumentObjectGroup* group = static_cast<App::DocumentObjectGroup*>(
-        document->addObject("App::DocumentObjectGroup", internalname.c_str()));
+    App::DocumentObjectGroup* group = document->addObject<App::DocumentObjectGroup>(internalname.c_str());
     std::string labelname = "Segments ";
     labelname += myMesh->Label.getValue();
     group->Label.setValue(labelname);

--- a/src/Mod/Mesh/Gui/SegmentationBestFit.cpp
+++ b/src/Mod/Mesh/Gui/SegmentationBestFit.cpp
@@ -505,8 +505,7 @@ void SegmentationBestFit::accept()
 
     std::string internalname = "Segments_";
     internalname += myMesh->getNameInDocument();
-    App::DocumentObjectGroup* group = static_cast<App::DocumentObjectGroup*>(
-        document->addObject("App::DocumentObjectGroup", internalname.c_str()));
+    App::DocumentObjectGroup* group = document->addObject<App::DocumentObjectGroup>(internalname.c_str());
     std::string labelname = "Segments ";
     labelname += myMesh->Label.getValue();
     group->Label.setValue(labelname);

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -975,7 +975,7 @@ public:
         Gui::Document* gui = mesh->getDocument();
         App::Document* doc = gui->getDocument();
 
-        auto cpy = static_cast<Mesh::Feature*>(doc->addObject("Mesh::Feature"));
+        auto cpy = doc->addObject<Mesh::Feature>();
         auto org = mesh->getObject<Mesh::Feature>();
         cpy->Label.setValue(org->Label.getValue());
         cpy->Mesh.setValue(org->Mesh.getValue());

--- a/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
@@ -480,8 +480,7 @@ public:
             }
         }
         if (!group) {
-            group = dynamic_cast<App::DocumentObjectGroup*>(
-                doc->addObject("App::DocumentObjectGroup", internalname.c_str()));
+            group = doc->addObject<App::DocumentObjectGroup>(internalname.c_str());
         }
 
         auto anno = dynamic_cast<App::AnnotationLabel*>(

--- a/src/Mod/MeshPart/Gui/Command.cpp
+++ b/src/Mod/MeshPart/Gui/Command.cpp
@@ -159,7 +159,7 @@ void CmdMeshPartTrimByPlane::activated(int)
 
             copy.trimByPlane(plnBase, -plnNormal);
             App::Document* doc = it->getDocument();
-            Mesh::Feature* fea = static_cast<Mesh::Feature*>(doc->addObject("Mesh::Feature"));
+            Mesh::Feature* fea = doc->addObject<Mesh::Feature>();
             fea->Label.setValue(it->Label.getValue());
             Mesh::MeshObject* feamesh = fea->Mesh.startEditing();
             feamesh->swap(copy);

--- a/src/Mod/MeshPart/Gui/CrossSections.cpp
+++ b/src/Mod/MeshPart/Gui/CrossSections.cpp
@@ -327,8 +327,7 @@ void CrossSections::apply()
         App::Document* doc = it->getDocument();
         std::string s = it->getNameInDocument();
         s += "_cs";
-        Part::Feature* section =
-            static_cast<Part::Feature*>(doc->addObject("Part::Feature", s.c_str()));
+        Part::Feature* section = doc->addObject<Part::Feature>(s.c_str());
         section->Shape.setValue(comp);
         section->purgeTouched();
     }

--- a/src/Mod/MeshPart/Gui/CurveOnMesh.cpp
+++ b/src/Mod/MeshPart/Gui/CurveOnMesh.cpp
@@ -533,7 +533,7 @@ void CurveOnMeshHandler::displaySpline(const Handle(Geom_BSplineCurve) & spline)
         Gui::View3DInventorViewer* view3d = d_ptr->viewer->getViewer();
         App::Document* doc = view3d->getDocument()->getDocument();
         doc->openTransaction("Add spline");
-        Part::Feature* part = static_cast<Part::Feature*>(doc->addObject("Part::Spline", "Spline"));
+        Part::Feature* part = doc->addObject<Part::Feature>("Spline");
         part->Shape.setValue(edge);
         doc->commitTransaction();
     }
@@ -562,8 +562,7 @@ void CurveOnMeshHandler::displayPolyline(const TopoDS_Wire& wire)
         Gui::View3DInventorViewer* view3d = d_ptr->viewer->getViewer();
         App::Document* doc = view3d->getDocument()->getDocument();
         doc->openTransaction("Add polyline");
-        Part::Feature* part =
-            static_cast<Part::Feature*>(doc->addObject("Part::Feature", "Polyline"));
+        Part::Feature* part = doc->addObject<Part::Feature>("Polyline");
         part->Shape.setValue(wire);
         doc->commitTransaction();
     }

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -655,7 +655,7 @@ bool Mesh2ShapeGmsh::loadOutput()
     stlIn.close();
     kernel.harmonizeNormals();
 
-    auto fea = static_cast<Mesh::Feature*>(doc->addObject("Mesh::Feature", "Mesh"));
+    auto fea = doc->addObject<Mesh::Feature>("Mesh");
     fea->Label.setValue(d->label);
     fea->Mesh.setValue(kernel.getKernel());
     stl.deleteFile();

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -865,7 +865,7 @@ private:
         } else {
             throw Py::TypeError("Expects argument of type DocumentObject, Shape, or Geometry");
         }
-        Part::Feature *pcFeature = static_cast<Part::Feature*>(pcDoc->addObject("Part::Feature", name));
+        Part::Feature *pcFeature = pcDoc->addObject<Part::Feature>(name);
         // copy the data
         pcFeature->Shape.setValue(shape);
         pcFeature->purgeTouched();

--- a/src/Mod/Part/App/ImportIges.cpp
+++ b/src/Mod/Part/App/ImportIges.cpp
@@ -103,8 +103,8 @@ int Part::ImportIgesParts(App::Document *pcDoc, const char* FileName)
                 if (aShape.ShapeType() == TopAbs_SOLID ||
                     aShape.ShapeType() == TopAbs_COMPOUND ||
                     aShape.ShapeType() == TopAbs_SHELL) {
-                        App::DocumentObject* obj = pcDoc->addObject("Part::Feature", aName.c_str());
-                        static_cast<Part::Feature*>(obj)->Shape.setValue(aShape);
+                        auto* obj = pcDoc->addObject<Part::Feature>(aName.c_str());
+                        obj->Shape.setValue(aShape);
                 }
                 else {
                     builder.Add(comp, aShape);
@@ -114,8 +114,7 @@ int Part::ImportIgesParts(App::Document *pcDoc, const char* FileName)
         }
         if (!emptyComp) {
             std::string name = fi.fileNamePure();
-            Part::Feature *pcFeature = static_cast<Part::Feature*>(pcDoc->addObject
-                ("Part::Feature", name.c_str()));
+            auto* pcFeature = pcDoc->addObject<Part::Feature>(name.c_str());
             pcFeature->Shape.setValue(comp);
         }
     }

--- a/src/Mod/Part/App/ImportStep.cpp
+++ b/src/Mod/Part/App/ImportStep.cpp
@@ -132,7 +132,7 @@ int Part::ImportStepParts(App::Document *pcDoc, const char* Name)
                 //}
 
                 Part::Feature *pcFeature;
-                pcFeature = static_cast<Part::Feature*>(pcDoc->addObject("Part::Feature", name.c_str()));
+                pcFeature = pcDoc->addObject<Part::Feature>(name.c_str());
                 pcFeature->Shape.setValue(aSolid);
 
                 // This is a trick to access the GUI via Python and set the color property
@@ -167,7 +167,7 @@ int Part::ImportStepParts(App::Document *pcDoc, const char* Name)
                 //    name += ws->Model()->StringLabel(ent)->ToCString();
                 //}
 
-                Part::Feature *pcFeature = static_cast<Part::Feature*>(pcDoc->addObject("Part::Feature", name.c_str()));
+                Part::Feature *pcFeature = pcDoc->addObject<Part::Feature>(name.c_str());
                 pcFeature->Shape.setValue(aShell);
             }
 

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -1575,7 +1575,7 @@ Feature* Feature::create(const TopoShape& shape, const char* name, App::Document
             document = App::GetApplication().newDocument();
         }
     }
-    auto res = static_cast<Part::Feature*>(document->addObject("Part::Feature", name));
+    auto res = document->addObject<Part::Feature>(name);
     res->Shape.setValue(shape);
     res->purgeTouched();
     return res;

--- a/src/Mod/Part/Gui/CrossSections.cpp
+++ b/src/Mod/Part/Gui/CrossSections.cpp
@@ -260,8 +260,7 @@ void CrossSections::apply()
         App::Document* doc = (*it)->getDocument();
         std::string s = (*it)->getNameInDocument();
         s += "_cs";
-        Part::Feature* section = static_cast<Part::Feature*>
-            (doc->addObject("Part::Feature",s.c_str()));
+        auto* section = doc->addObject<Part::Feature>(s.c_str());
         section->Shape.setValue(comp);
         section->purgeTouched();
     }

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -165,8 +165,7 @@ DlgProjectionOnSurface::DlgProjectionOnSurface(QWidget* parent)
     }
     this->attachDocument(m_partDocument);
     m_partDocument->openTransaction("Project on surface");
-    m_projectionObject = dynamic_cast<Part::Feature*>(
-        m_partDocument->addObject("Part::Feature", "Projection Object"));
+    m_projectionObject = m_partDocument->addObject<Part::Feature>("Projection Object");
     if (!m_projectionObject) {
         throw Base::ValueError(QString(tr("Can not create a projection object!!!")).toUtf8());
     }

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -1556,8 +1556,7 @@ TaskProjectOnSurface::TaskProjectOnSurface(App::Document* doc)
 {
     setDocumentName(doc->getName());
     doc->openTransaction(QT_TRANSLATE_NOOP("Command", "Project on surface"));
-    auto obj = doc->addObject("Part::ProjectOnSurface", "Projection");
-    auto feature = dynamic_cast<Part::ProjectOnSurface*>(obj);
+    auto feature = doc->addObject<Part::ProjectOnSurface>("Projection");
     widget = new DlgProjectOnSurface(feature);
     taskbox = new Gui::TaskView::TaskBox(Gui::BitmapFactory().pixmap("Part_ProjectionOnSurface"),
                                          widget->windowTitle(), true, nullptr);

--- a/src/Mod/Part/Gui/SectionCutting.cpp
+++ b/src/Mod/Part/Gui/SectionCutting.cpp
@@ -1026,13 +1026,10 @@ std::vector<App::DocumentObject*> createLinks(App::Document* doc, const std::vec
 
         // if the object is part of an App::Part container,
         // the link needs to get the container placement
-        auto parents = itCuts->getInList();
-        if (!parents.empty()) {
+        if (auto parents = itCuts->getInList(); !parents.empty()) {
             for (auto parent : parents) {
                 if (auto pcPartParent = dynamic_cast<App::Part*>(parent)) {
-                    auto placement = Base::freecad_dynamic_cast<App::PropertyPlacement>(
-                                      pcPartParent->getPropertyByName("Placement"));
-                    if (placement) {
+                    if (auto placement = pcPartParent->getPropertyByName<App::PropertyPlacement>("Placement")) {
                         pcLink->Placement.setValue(placement->getValue());
                     }
                 }

--- a/src/Mod/Part/Gui/SectionCutting.cpp
+++ b/src/Mod/Part/Gui/SectionCutting.cpp
@@ -604,7 +604,7 @@ void SectionCut::restoreVisibility()
 Part::Box* SectionCut::createBox(const char* name, const Base::Vector3f& size)  // NOLINT
 {
     // create a box
-    auto pcBox = dynamic_cast<Part::Box*>(doc->addObject("Part::Box", name));
+    auto pcBox = doc->addObject<Part::Box>(name);
     if (!pcBox) {
         throw Base::RuntimeError(std::string("SectionCut error: ")
             + std::string(name) + std::string(" could not be added\n"));
@@ -783,7 +783,7 @@ Part::Box* SectionCut::createZBox(const Base::Vector3f& pos, const Base::Vector3
 
 Part::Cut* SectionCut::createCut(const char* name)
 {
-    auto pcCut = dynamic_cast<Part::Cut*>(doc->addObject("Part::Cut", name));
+    auto pcCut = doc->addObject<Part::Cut>(name);
     if (!pcCut) {
         throw Base::RuntimeError(std::string("SectionCut error: ")
             + std::string(name) + std::string(" could not be added\n"));
@@ -1011,7 +1011,7 @@ std::vector<App::DocumentObject*> createLinks(App::Document* doc, const std::vec
         }
         newName += "_CutLink";
 
-        auto pcLink = dynamic_cast<App::Link*>(doc->addObject("App::Link", newName.c_str()));
+        auto pcLink = doc->addObject<App::Link>(newName.c_str());
         if (!pcLink) {
             throw Base::RuntimeError("'App::Link' could not be added");
         }

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -442,7 +442,7 @@ void Body::onChanged(const App::Property* prop) {
             if (BaseFeature.getValue()) {
                 //setup the FeatureBase if needed
                 if (!first || !first->isDerivedFrom(FeatureBase::getClassTypeId())) {
-                    bf = static_cast<FeatureBase*>(getDocument()->addObject("PartDesign::FeatureBase", "BaseFeature"));
+                    bf = getDocument()->addObject<FeatureBase>("BaseFeature");
                     insertObject(bf, first, false);
 
                     if (!Tip.getValue())

--- a/src/Mod/Points/App/AppPointsPy.cpp
+++ b/src/Mod/Points/App/AppPointsPy.cpp
@@ -295,8 +295,7 @@ private:
                 pcFeature->purgeTouched();
             }
             else {
-                Points::Feature* pcFeature = static_cast<Points::Feature*>(
-                    pcDoc->addObject("Points::Feature", file.fileNamePure().c_str()));
+                Points::Feature* pcFeature = pcDoc->addObject<Points::Feature>(file.fileNamePure().c_str());
                 pcFeature->Points.setValue(reader->getPoints());
                 pcDoc->recomputeFeature(pcFeature);
                 pcFeature->purgeTouched();
@@ -415,8 +414,7 @@ private:
                 pcDoc = App::GetApplication().newDocument();
             }
             PointsPy* pPoints = static_cast<PointsPy*>(pcObj);
-            Points::Feature* pcFeature =
-                static_cast<Points::Feature*>(pcDoc->addObject("Points::Feature", name));
+            Points::Feature* pcFeature = pcDoc->addObject<Points::Feature>(name);
             // copy the data
             pcFeature->Points.setValue(*(pPoints->getPointKernelPtr()));
             return Py::asObject(pcFeature->getPyObject());

--- a/src/Mod/Points/Gui/Command.cpp
+++ b/src/Mod/Points/Gui/Command.cpp
@@ -386,8 +386,7 @@ void CmdPointsMerge::activated(int iMsg)
 
     App::Document* doc = App::GetApplication().getActiveDocument();
     doc->openTransaction("Merge point clouds");
-    Points::Feature* pts =
-        static_cast<Points::Feature*>(doc->addObject("Points::Feature", "Merged Points"));
+    Points::Feature* pts = doc->addObject<Points::Feature>("Merged Points");
     Points::PointKernel* kernel = pts->Points.startEditing();
 
     std::vector<App::DocumentObject*> docObj =
@@ -455,8 +454,7 @@ void CmdPointsStructure::activated(int iMsg)
     for (auto it : docObj) {
         std::string name = it->Label.getValue();
         name += " (Structured)";
-        Points::Structured* output =
-            static_cast<Points::Structured*>(doc->addObject("Points::Structured", name.c_str()));
+        Points::Structured* output = doc->addObject<Points::Structured>(name.c_str());
         output->Label.setValue(name);
 
         // Already sorted, so just make a copy

--- a/src/Mod/ReverseEngineering/Gui/Command.cpp
+++ b/src/Mod/ReverseEngineering/Gui/Command.cpp
@@ -497,8 +497,7 @@ void CmdSegmentationFromComponents::activated(int)
     for (auto it : sel) {
         std::string internalname = "Segments_";
         internalname += it->getNameInDocument();
-        App::DocumentObjectGroup* group = static_cast<App::DocumentObjectGroup*>(
-            doc->addObject("App::DocumentObjectGroup", internalname.c_str()));
+        App::DocumentObjectGroup* group = doc->addObject<App::DocumentObjectGroup>(internalname.c_str());
         std::string labelname = "Segments ";
         labelname += it->Label.getValue();
         group->Label.setValue(labelname);
@@ -507,8 +506,7 @@ void CmdSegmentationFromComponents::activated(int)
         std::vector<std::vector<MeshCore::FacetIndex>> comps = mesh.getComponents();
         for (const auto& jt : comps) {
             std::unique_ptr<Mesh::MeshObject> segment(mesh.meshFromSegment(jt));
-            Mesh::Feature* feaSegm =
-                static_cast<Mesh::Feature*>(group->addObject("Mesh::Feature", "Segment"));
+            Mesh::Feature* feaSegm = group->addObject<Mesh::Feature>("Segment");
             Mesh::MeshObject* feaMesh = feaSegm->Mesh.startEditing();
             feaMesh->swap(*segment);
             feaSegm->Mesh.finishEditing();
@@ -576,13 +574,11 @@ void CmdMeshBoundary::activated(int)
         }
 
         if (!shape.IsNull()) {
-            Part::Feature* shapeFea =
-                static_cast<Part::Feature*>(document->addObject("Part::Feature", "Face from mesh"));
+            Part::Feature* shapeFea = document->addObject<Part::Feature>("Face from mesh");
             shapeFea->Shape.setValue(shape);
         }
         else {
-            Part::Feature* shapeFea =
-                static_cast<Part::Feature*>(document->addObject("Part::Feature", "Wire from mesh"));
+            Part::Feature* shapeFea = document->addObject<Part::Feature>("Wire from mesh");
             shapeFea->Shape.setValue(compound);
         }
     }

--- a/src/Mod/ReverseEngineering/Gui/Segmentation.cpp
+++ b/src/Mod/ReverseEngineering/Gui/Segmentation.cpp
@@ -138,8 +138,7 @@ void Segmentation::accept()
     std::string internalname = "Segments_";
     internalname += myMesh->getNameInDocument();
 
-    App::DocumentObjectGroup* group = static_cast<App::DocumentObjectGroup*>(
-        document->addObject("App::DocumentObjectGroup", internalname.c_str()));
+    App::DocumentObjectGroup* group = document->addObject<App::DocumentObjectGroup>(internalname.c_str());
     std::string labelname = "Segments ";
     labelname += myMesh->Label.getValue();
     group->Label.setValue(labelname);

--- a/src/Mod/ReverseEngineering/Gui/SegmentationManual.cpp
+++ b/src/Mod/ReverseEngineering/Gui/SegmentationManual.cpp
@@ -295,8 +295,7 @@ void SegmentationManual::createSegment()
             algo.GetFacetsFlag(facets, MeshCore::MeshFacet::SELECTED);
 
             std::unique_ptr<Mesh::MeshObject> segment(mesh.meshFromSegment(facets));
-            Mesh::Feature* feaSegm =
-                static_cast<Mesh::Feature*>(adoc->addObject("Mesh::Feature", "Segment"));
+            Mesh::Feature* feaSegm = adoc->addObject<Mesh::Feature>("Segment"));
             Mesh::MeshObject* feaMesh = feaSegm->Mesh.startEditing();
             feaMesh->swap(*segment);
             feaMesh->clearFacetSelection();

--- a/src/Mod/Sandbox/App/DocumentThread.cpp
+++ b/src/Mod/Sandbox/App/DocumentThread.cpp
@@ -218,7 +218,7 @@ void DocumentTestThread::run()
     Base::Console().Message("DocumentTestThread::run()\n");
     App::Document* doc = App::GetApplication().getActiveDocument();
     DocumentProtector dp(doc);
-    SandboxObject* obj = static_cast<SandboxObject*>(dp.addObject("Sandbox::SandboxObject"));
+    SandboxObject* obj = dp.addObject<SandboxObject>();
 
     DocumentObjectProtector op(obj);
     App::PropertyString Name;Name.setValue("MyLabel");

--- a/src/Mod/Sandbox/Gui/Command.cpp
+++ b/src/Mod/Sandbox/Gui/Command.cpp
@@ -593,7 +593,7 @@ void CmdSandboxMeshLoader::activated(int)
 
     Base::Reference<Mesh::MeshObject> data = thread.getMesh();
     App::Document* doc = App::GetApplication().getActiveDocument();
-    Mesh::Feature* mesh = static_cast<Mesh::Feature*>(doc->addObject("Mesh::Feature","Mesh"));
+    Mesh::Feature* mesh = doc->addObject<Mesh::Feature>("Mesh");
     mesh->Mesh.setValuePtr((Mesh::MeshObject*)data);
     mesh->purgeTouched();
 }
@@ -650,7 +650,7 @@ void CmdSandboxMeshLoaderBoost::activated(int)
     fi.wait(); // wait for it to be finished
 
     App::Document* doc = App::GetApplication().getActiveDocument();
-    Mesh::Feature* mesh = static_cast<Mesh::Feature*>(doc->addObject("Mesh::Feature","Mesh"));
+    Mesh::Feature* mesh = doc->addObject<Mesh::Feature>("Mesh");
     mesh->Mesh.setValuePtr((Mesh::MeshObject*)fi.get());
     mesh->purgeTouched();
 }
@@ -704,7 +704,7 @@ void CmdSandboxMeshLoaderFuture::activated(int)
 
     App::Document* doc = App::GetApplication().getActiveDocument();
     for (QFuture< Base::Reference<Mesh::MeshObject> >::const_iterator it = future.begin(); it != future.end(); ++it) {
-        Mesh::Feature* mesh = static_cast<Mesh::Feature*>(doc->addObject("Mesh::Feature","Mesh"));
+        Mesh::Feature* mesh = doc->addObject<Mesh::Feature>("Mesh");
         mesh->Mesh.setValuePtr((Mesh::MeshObject*)(*it));
         mesh->purgeTouched();
     }
@@ -1368,7 +1368,7 @@ void CmdMengerSponge::activated(int)
     kernel.RebuildNeighbours();
 
     App::Document* doc = App::GetApplication().newDocument();
-    Mesh::Feature* feature = static_cast<Mesh::Feature*>(doc->addObject("Mesh::Feature","MengerSponge"));
+    Mesh::Feature* feature = doc->addObject<Mesh::Feature>("MengerSponge");
     feature->Mesh.setValue(*mesh);
     feature->purgeTouched();
 }

--- a/src/Mod/Sketcher/App/AppSketcherPy.cpp
+++ b/src/Mod/Sketcher/App/AppSketcherPy.cpp
@@ -95,8 +95,7 @@ private:
             }
 
             if (file.hasExtension("skf")) {
-                Sketcher::SketchObjectSF* pcFeature = static_cast<Sketcher::SketchObjectSF*>(
-                    pcDoc->addObject("Sketcher::SketchObjectSF", file.fileNamePure().c_str()));
+                Sketcher::SketchObjectSF* pcFeature = pcDoc->addObject<Sketcher::SketchObjectSF>(file.fileNamePure().c_str());
                 pcFeature->SketchFlatFile.setValue(EncodedName.c_str());
 
                 pcDoc->recompute();

--- a/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp
+++ b/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp
@@ -69,8 +69,7 @@ private:
     {
         try {
             Base::FileInfo file(Name);
-            Spreadsheet::Sheet* pcSheet = static_cast<Spreadsheet::Sheet*>(
-                pcDoc->addObject("Spreadsheet::Sheet", file.fileNamePure().c_str()));
+            Spreadsheet::Sheet* pcSheet = pcDoc->addObject<Spreadsheet::Sheet>(file.fileNamePure().c_str());
 
             pcSheet->importFromFile(Name, '\t', '"', '\\');
             pcSheet->execute();

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -124,15 +124,13 @@ void CmdTechDrawPageDefault::activated(int iMsg)
         Gui::WaitCursor wc;
         openCommand(QT_TRANSLATE_NOOP("Command", "Drawing create page"));
 
-        auto page = dynamic_cast<TechDraw::DrawPage *>
-                        (getDocument()->addObject("TechDraw::DrawPage", "Page"));
+        auto page = getDocument()->addObject<TechDraw::DrawPage>("Page");
         if (!page) {
             throw Base::TypeError("CmdTechDrawPageDefault - page not created");
         }
         page->translateLabel("DrawPage", "Page", page->getNameInDocument());
 
-        auto svgTemplate = dynamic_cast<TechDraw::DrawSVGTemplate *>
-                               (getDocument()->addObject("TechDraw::DrawSVGTemplate", "Template"));
+        auto svgTemplate = getDocument()->addObject<TechDraw::DrawSVGTemplate>("Template");
         if (!svgTemplate) {
             throw Base::TypeError("CmdTechDrawPageDefault - template not created");
         }
@@ -195,15 +193,13 @@ void CmdTechDrawPageTemplate::activated(int iMsg)
         Gui::WaitCursor wc;
         openCommand(QT_TRANSLATE_NOOP("Command", "Drawing create page"));
 
-        auto page = dynamic_cast<TechDraw::DrawPage *>
-                        (getDocument()->addObject("TechDraw::DrawPage", "Page"));
+        auto page = getDocument()->addObject<TechDraw::DrawPage>("Page");
         if (!page) {
             throw Base::TypeError("CmdTechDrawPageTemplate - page not created");
         }
         page->translateLabel("DrawPage", "Page", page->getNameInDocument());
 
-        auto svgTemplate = dynamic_cast<TechDraw::DrawSVGTemplate *>
-                               (getDocument()->addObject("TechDraw::DrawSVGTemplate", "Template"));
+        auto svgTemplate = getDocument()->addObject<TechDraw::DrawSVGTemplate>("Template");
         if (!svgTemplate) {
             throw Base::TypeError("CmdTechDrawPageTemplate - template not created");
         }

--- a/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
@@ -457,7 +457,7 @@ TechDraw::DrawWeldSymbol* TaskWeldingSymbol::createWeldingSymbol()
 {
 //    Base::Console().Message("TWS::createWeldingSymbol()\n");
     App::Document *doc = Application::Instance->activeDocument()->getDocument();
-    auto weldSymbol = dynamic_cast<TechDraw::DrawWeldSymbol*>(doc->addObject("TechDraw::DrawWeldSymbol", "WeldSymbol"));
+    auto weldSymbol = doc->addObject<TechDraw::DrawWeldSymbol>("WeldSymbol");
     if (!weldSymbol) {
         throw Base::RuntimeError("TaskWeldingSymbol - new symbol object not found");
     }

--- a/tests/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/tests/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -24,8 +24,7 @@ protected:
     {
         _docName = App::GetApplication().getUniqueDocumentName("test");
         auto _doc = App::GetApplication().newDocument(_docName.c_str(), "testUser");
-        _assemblyObj =
-            static_cast<Assembly::AssemblyObject*>(_doc->addObject("Assembly::AssemblyObject"));
+        _assemblyObj = _doc->addObject<Assembly::AssemblyObject>();
         _jointGroupObj = static_cast<Assembly::JointGroup*>(
             _assemblyObj->addObject("Assembly::JointGroup", "jointGroupTest"));
     }

--- a/tests/src/Mod/Measure/App/MeasureDistance.cpp
+++ b/tests/src/Mod/Measure/App/MeasureDistance.cpp
@@ -48,13 +48,12 @@ private:
 TEST_F(MeasureDistance, testCircleCircle)
 {
     App::Document* doc = getDocument();
-    auto p1 = dynamic_cast<Part::Feature*>(doc->addObject("Part::Feature", "Shape1"));
+    auto p1 = doc->addObject<Part::Feature>("Shape1");
     p1->Shape.setValue(makeCircle(gp_Pnt(0.0, 0.0, 0.0)));
-    auto p2 = dynamic_cast<Part::Feature*>(doc->addObject("Part::Feature", "Shape2"));
+    auto p2 = doc->addObject<Part::Feature>("Shape2");
     p2->Shape.setValue(makeCircle(gp_Pnt(3.0, 4.0, 0.0)));
 
-    auto md = dynamic_cast<Measure::MeasureDistance*>(
-        doc->addObject("Measure::MeasureDistance", "Distance"));
+    auto md = doc->addObject<Measure::MeasureDistance>("Distance");
     md->Element1.setValue(p1, {"Edge1"});
     md->Element2.setValue(p2, {"Edge1"});
 

--- a/tests/src/Mod/Mesh/App/Exporter.cpp
+++ b/tests/src/Mod/Mesh/App/Exporter.cpp
@@ -22,11 +22,11 @@ protected:
         fileInfo.setFile(Base::FileInfo::getTempFileName() + ".stl");
 
         const double value = 10.0;
-        cube1 = dynamic_cast<Mesh::Cube*>(document->addObject("Mesh::Cube", "Cube1"));
+        cube1 = document->addObject<Mesh::Cube>("Cube1");
         cube1->Length.setValue(value);
         cube1->Width.setValue(value);
         cube1->Height.setValue(value);
-        cube2 = dynamic_cast<Mesh::Cube*>(document->addObject("Mesh::Cube", "Cube2"));
+        cube2 = document->addObject<Mesh::Cube>("Cube2");
         cube2->Length.setValue(value);
         cube2->Width.setValue(value);
         cube2->Height.setValue(value);
@@ -130,7 +130,7 @@ TEST_F(ExporterTest, TestMeshesInPart)
 
     // add extra scope because the file will be written when destroying the exporter
     {
-        auto part = dynamic_cast<App::Part*>(getDocument()->addObject("App::Part", "Part"));
+        auto part = getDocument()->addObject<App::Part>("Part");
         part->placement().setValue(plm);
         part->addObjects(getObjects());
         Mesh::MergeExporter exporter(getFileName(), MeshCore::MeshIO::Format::STL);

--- a/tests/src/Mod/Part/App/AttachExtension.cpp
+++ b/tests/src/Mod/Part/App/AttachExtension.cpp
@@ -38,8 +38,8 @@ private:
 
 TEST_F(AttachExtensionTest, testPlanePlane)
 {
-    auto plane1 = dynamic_cast<Part::Plane*>(getDocument()->addObject("Part::Plane", "Plane1"));
-    auto plane2 = dynamic_cast<Part::Plane*>(getDocument()->addObject("Part::Plane", "Plane2"));
+    auto plane1 = getDocument()->addObject<Part::Plane>("Plane1");
+    auto plane2 = getDocument()->addObject<Part::Plane>("Plane2");
 
     ASSERT_TRUE(plane1);
     ASSERT_TRUE(plane2);
@@ -57,7 +57,7 @@ TEST_F(AttachExtensionTest, testPlanePlane)
 
 TEST_F(AttachExtensionTest, testAttacherEngineType)
 {
-    auto plane = dynamic_cast<Part::Plane*>(getDocument()->addObject("Part::Plane", "Plane"));
+    auto plane = getDocument()->addObject<Part::Plane>("Plane");
     EXPECT_STREQ(plane->AttacherType.getValue(), "Attacher::AttachEngine3D");
     EXPECT_STREQ(plane->AttacherEngine.getValueAsString(), "Engine 3D");
 
@@ -76,7 +76,7 @@ TEST_F(AttachExtensionTest, testAttacherEngineType)
 
 TEST_F(AttachExtensionTest, testAttacherTypeEngine)
 {
-    auto plane = dynamic_cast<Part::Plane*>(getDocument()->addObject("Part::Plane", "Plane"));
+    auto plane = getDocument()->addObject<Part::Plane>("Plane");
     EXPECT_STREQ(plane->AttacherType.getValue(), "Attacher::AttachEngine3D");
     EXPECT_STREQ(plane->AttacherEngine.getValueAsString(), "Engine 3D");
 

--- a/tests/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/tests/src/Mod/Part/App/FeatureChamfer.cpp
@@ -28,11 +28,11 @@ protected:
         _boxes[1]->Length.setValue(1);
         _boxes[1]->Width.setValue(2);
         _boxes[1]->Height.setValue(3);
-        _fused = dynamic_cast<Part::Fuse*>(_doc->addObject("Part::Fuse"));
+        _fused = _doc->addObject<Part::Fuse>();
         _fused->Base.setValue(_boxes[0]);
         _fused->Tool.setValue(_boxes[1]);
         _fused->execute();
-        _chamfer = dynamic_cast<Part::Chamfer*>(_doc->addObject("Part::Chamfer"));
+        _chamfer = _doc->addObject<Part::Chamfer>();
     }
 
     void TearDown() override

--- a/tests/src/Mod/Part/App/FeatureCompound.cpp
+++ b/tests/src/Mod/Part/App/FeatureCompound.cpp
@@ -19,7 +19,7 @@ protected:
     void SetUp() override
     {
         createTestDoc();
-        _compound = dynamic_cast<Part::Compound*>(_doc->addObject("Part::Compound"));
+        _compound = _doc->addObject<Part::Compound>();
     }
 
     void TearDown() override

--- a/tests/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/tests/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -21,7 +21,7 @@ protected:
     void SetUp() override
     {
         createTestDoc();
-        _extrusion = dynamic_cast<Part::Extrusion*>(_doc->addObject("Part::Extrusion"));
+        _extrusion = _doc->addObject<Part::Extrusion>();
         PartTestHelpers::rectangle(len, wid, "Rect1");
         _extrusion->Base.setValue(_doc->getObjects().back());
         _extrusion->LengthFwd.setValue(ext1);
@@ -252,7 +252,7 @@ TEST_F(FeatureExtrusionTest, testExecuteEdge)
     const double ang = 30;
     const double tangent = tan(ang / 180.0 * M_PI);
     BRepBuilderAPI_MakeEdge e1(gp_Pnt(0, 0, 0), gp_Pnt(ext1, ext1, ext1));
-    auto edge = dynamic_cast<Part::Feature*>(_doc->addObject("Part::Feature", "Edge"));
+    auto edge = _doc->addObject<Part::Feature>("Edge");
     edge->Shape.setValue(e1);
     _extrusion->DirLink.setValue(edge);
     _extrusion->DirMode.setValue(1);
@@ -310,7 +310,7 @@ TEST_F(FeatureExtrusionTest, testFaceWithHoles)
     // newFace cleans that up and is the outside minus the internal hole.
     auto face2 = newFace.getShape();
 
-    auto partFeature = dynamic_cast<Part::Feature*>(_doc->addObject("Part::Feature"));
+    auto partFeature = _doc->addObject<Part::Feature>();
     partFeature->Shape.setValue(face2);
     _extrusion->Base.setValue(_doc->getObjects().back());
     _extrusion->FaceMakerClass.setValue("Part::FaceMakerCheese");

--- a/tests/src/Mod/Part/App/FeatureFillet.cpp
+++ b/tests/src/Mod/Part/App/FeatureFillet.cpp
@@ -28,11 +28,11 @@ protected:
         _boxes[1]->Length.setValue(1);
         _boxes[1]->Width.setValue(2);
         _boxes[1]->Height.setValue(3);
-        _fused = dynamic_cast<Part::Fuse*>(_doc->addObject("Part::Fuse"));
+        _fused = _doc->addObject<Part::Fuse>();
         _fused->Base.setValue(_boxes[0]);
         _fused->Tool.setValue(_boxes[1]);
         _fused->execute();
-        _fillet = dynamic_cast<Part::Fillet*>(_doc->addObject("Part::Fillet"));
+        _fillet = _doc->addObject<Part::Fillet>();
     }
 
     void TearDown() override

--- a/tests/src/Mod/Part/App/FeatureMirroring.cpp
+++ b/tests/src/Mod/Part/App/FeatureMirroring.cpp
@@ -21,7 +21,7 @@ protected:
     void SetUp() override
     {
         createTestDoc();
-        _mirror = dynamic_cast<Part::Mirroring*>(_doc->addObject("Part::Mirroring"));
+        _mirror = _doc->addObject<Part::Mirroring>();
         _mirror->Source.setValue(_boxes[0]);
         _mirror->Base.setValue(1, 0, 0);
         _mirror->execute();
@@ -61,7 +61,7 @@ TEST_F(FeatureMirroringTest, testYMirrorWithExistingElementMap)
 {
     // Arrange
     Part::Fuse* _fuse = nullptr;  // NOLINT Can't be private in a test framework
-    _fuse = dynamic_cast<Part::Fuse*>(_doc->addObject("Part::Fuse"));
+    _fuse = _doc->addObject<Part::Fuse>();
     _fuse->Base.setValue(_boxes[0]);
     _fuse->Tool.setValue(_boxes[1]);
     // Act

--- a/tests/src/Mod/Part/App/FeatureOffset.cpp
+++ b/tests/src/Mod/Part/App/FeatureOffset.cpp
@@ -21,7 +21,7 @@ protected:
     void SetUp() override
     {
         createTestDoc();
-        _offset = dynamic_cast<Part::Offset*>(_doc->addObject("Part::Offset"));
+        _offset = _doc->addObject<Part::Offset>();
         _offset->Source.setValue(_boxes[0]);
         _offset->Value.setValue(1);
         _offset->Join.setValue((int)JoinType::intersection);
@@ -52,7 +52,7 @@ TEST_F(FeatureOffsetTest, testOffset3DWithExistingElementMap)
 {
     // Arrange
     Part::Fuse* _fuse = nullptr;  // NOLINT Can't be private in a test framework
-    _fuse = dynamic_cast<Part::Fuse*>(_doc->addObject("Part::Fuse"));
+    _fuse = _doc->addObject<Part::Fuse>();
     _fuse->Base.setValue(_boxes[0]);
     _fuse->Tool.setValue(_boxes[1]);
     _fuse->Refine.setValue(true);
@@ -76,8 +76,8 @@ TEST_F(FeatureOffsetTest, testOffset3DWithExistingElementMap)
 TEST_F(FeatureOffsetTest, testOffset2D)
 {
     // Arrange
-    Part::Offset2D* _offset2 = dynamic_cast<Part::Offset2D*>(_doc->addObject("Part::Offset2D"));
-    Part::Plane* _pln = dynamic_cast<Part::Plane*>(_doc->addObject("Part::Plane"));
+    Part::Offset2D* _offset2 = _doc->addObject<Part::Offset2D>();
+    Part::Plane* _pln = _doc->addObject<Part::Plane>();
     _pln->Length.setValue(2);
     _pln->Width.setValue(3);
     _offset2->Source.setValue(_pln);

--- a/tests/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/tests/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -19,7 +19,7 @@ protected:
     void SetUp() override
     {
         // createTestDoc();
-        // _boolean = dynamic_cast<Part::Boolean*>(_doc->addObject("Part::Boolean"));
+        // _boolean = _doc->addObject<Part::Boolean>();
     }
 
     void TearDown() override

--- a/tests/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/tests/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -19,7 +19,7 @@ protected:
     void SetUp() override
     {
         createTestDoc();
-        _common = dynamic_cast<Part::Common*>(_doc->addObject("Part::Common"));
+        _common = _doc->addObject<Part::Common>();
     }
 
     void TearDown() override

--- a/tests/src/Mod/Part/App/FeaturePartCut.cpp
+++ b/tests/src/Mod/Part/App/FeaturePartCut.cpp
@@ -18,7 +18,7 @@ protected:
     void SetUp() override
     {
         createTestDoc();
-        _cut = dynamic_cast<Part::Cut*>(_doc->addObject("Part::Cut"));
+        _cut = _doc->addObject<Part::Cut>();
     }
 
     void TearDown() override

--- a/tests/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/tests/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -20,8 +20,8 @@ protected:
     void SetUp() override
     {
         createTestDoc();
-        _fuse = dynamic_cast<Part::Fuse*>(_doc->addObject("Part::Fuse"));
-        _multiFuse = dynamic_cast<Part::MultiFuse*>(_doc->addObject("Part::MultiFuse"));
+        _fuse = _doc->addObject<Part::Fuse>();
+        _multiFuse = _doc->addObject<Part::MultiFuse>();
     }
 
     void TearDown() override
@@ -58,7 +58,7 @@ TEST_F(FeaturePartFuseTest, testCompound)
 {
     // Arrange
     Part::Compound* _compound = nullptr;
-    _compound = dynamic_cast<Part::Compound*>(_doc->addObject("Part::Compound"));
+    _compound = _doc->addObject<Part::Compound>();
     _compound->Links.setValues({_boxes[0], _boxes[1]});
     _multiFuse->Shapes.setValues({_compound});
 
@@ -85,7 +85,7 @@ TEST_F(FeaturePartFuseTest, testRecursiveCompound)
     Part::Compound* _compound[3] = {nullptr};
     int t;
     for (t = 0; t < 3; t++) {
-        _compound[t] = dynamic_cast<Part::Compound*>(_doc->addObject("Part::Compound"));
+        _compound[t] = _doc->addObject<Part::Compound>();
     }
     _compound[0]->Links.setValues({_boxes[0], _boxes[1]});
     _compound[1]->Links.setValues({_compound[0]});

--- a/tests/src/Mod/Part/App/FeatureRevolution.cpp
+++ b/tests/src/Mod/Part/App/FeatureRevolution.cpp
@@ -25,7 +25,7 @@ protected:
     void SetUp() override
     {
         createTestDoc();
-        _revolution = dynamic_cast<Part::Revolution*>(_doc->addObject("Part::Revolution"));
+        _revolution = _doc->addObject<Part::Revolution>();
         PartTestHelpers::rectangle(len, wid, "Rect1");
         _revolution->Source.setValue(_doc->getObjects().back());
         _revolution->Axis.setValue(0, 1, 0);
@@ -95,7 +95,7 @@ TEST_F(FeatureRevolutionTest, testAxisLink)
 {
     // Arrange
     BRepBuilderAPI_MakeEdge e1(gp_Pnt(0, 0, 0), gp_Pnt(0, 0, ext1));
-    auto edge = dynamic_cast<Part::Feature*>(_doc->addObject("Part::Feature", "Edge"));
+    auto edge = _doc->addObject<Part::Feature>("Edge");
     edge->Shape.setValue(e1);
     _revolution->AxisLink.setValue(edge);
     // double puckVolume = wid * wid * M_PI * len;  // Area is PIr2; apply height

--- a/tests/src/Mod/Part/App/FuzzyBoolean.cpp
+++ b/tests/src/Mod/Part/App/FuzzyBoolean.cpp
@@ -22,10 +22,10 @@ protected:
     {
         createTestDoc();
         std::string testPath = App::Application::getHomePath() + "/tests/brepfiles/";
-        _fuse = dynamic_cast<Part::Fuse*>(_doc->addObject("Part::Fuse"));
-        _cylinder1 = dynamic_cast<Part::ImportBrep*>(_doc->addObject("Part::ImportBrep"));
+        _fuse = _doc->addObject<Part::Fuse>();
+        _cylinder1 = _doc->addObject<Part::ImportBrep>();
         _cylinder1->FileName.setValue(testPath + "cylinder1.brep");
-        _helix1 = dynamic_cast<Part::ImportBrep*>(_doc->addObject("Part::ImportBrep"));
+        _helix1 = _doc->addObject<Part::ImportBrep>();
         _helix1->FileName.setValue(testPath + "helix1.brep");
 
         // Load

--- a/tests/src/Mod/Part/App/PartFeature.cpp
+++ b/tests/src/Mod/Part/App/PartFeature.cpp
@@ -24,7 +24,7 @@ protected:
     void SetUp() override
     {
         createTestDoc();
-        _common = dynamic_cast<Common*>(_doc->addObject("Part::Common"));
+        _common = _doc->addObject<Common>();
     }
 
     void TearDown() override

--- a/tests/src/Mod/Part/App/PartFeatures.cpp
+++ b/tests/src/Mod/Part/App/PartFeatures.cpp
@@ -30,8 +30,8 @@ protected:
 TEST_F(PartFeaturesTest, testRuledSurface)
 {
     // Arrange
-    auto _edge1 = dynamic_cast<Line*>(_doc->addObject("Part::Line"));
-    auto _edge2 = dynamic_cast<Line*>(_doc->addObject("Part::Line"));
+    auto _edge1 = _doc->addObject<Line>();
+    auto _edge2 = _doc->addObject<Line>();
     _edge1->X1.setValue(0);
     _edge1->Y1.setValue(0);
     _edge1->Z1.setValue(0);
@@ -44,7 +44,7 @@ TEST_F(PartFeaturesTest, testRuledSurface)
     _edge2->X2.setValue(2);
     _edge2->Y2.setValue(2);
     _edge2->Z2.setValue(0);
-    auto _ruled = dynamic_cast<RuledSurface*>(_doc->addObject("Part::RuledSurface"));
+    auto _ruled = _doc->addObject<RuledSurface>();
     _ruled->Curve1.setValue(_edge1);
     _ruled->Curve2.setValue(_edge2);
     // Act
@@ -65,14 +65,14 @@ TEST_F(PartFeaturesTest, testRuledSurface)
 TEST_F(PartFeaturesTest, testLoft)
 {
     // Arrange
-    auto _plane1 = dynamic_cast<Plane*>(_doc->addObject("Part::Plane"));
+    auto _plane1 = _doc->addObject<Plane>();
     _plane1->Length.setValue(4);
     _plane1->Width.setValue(4);
-    auto _plane2 = dynamic_cast<Plane*>(_doc->addObject("Part::Plane"));
+    auto _plane2 = _doc->addObject<Plane>();
     _plane2->Length.setValue(4);
     _plane2->Width.setValue(4);
     _plane2->Placement.setValue(Base::Placement(Base::Vector3d(0, 0, 2), Base::Rotation()));
-    auto _loft = dynamic_cast<Loft*>(_doc->addObject("Part::Loft"));
+    auto _loft = _doc->addObject<Loft>();
     _loft->Sections.setValues({_plane1, _plane2});
     _loft->Solid.setValue((true));
     // Act
@@ -93,17 +93,17 @@ TEST_F(PartFeaturesTest, testLoft)
 TEST_F(PartFeaturesTest, testSweep)
 {
     // Arrange
-    auto _edge1 = dynamic_cast<Line*>(_doc->addObject("Part::Line"));
+    auto _edge1 = _doc->addObject<Line>();
     _edge1->X1.setValue(0);
     _edge1->Y1.setValue(0);
     _edge1->Z1.setValue(0);
     _edge1->X2.setValue(0);
     _edge1->Y2.setValue(0);
     _edge1->Z2.setValue(3);
-    auto _plane1 = dynamic_cast<Plane*>(_doc->addObject("Part::Plane"));
+    auto _plane1 = _doc->addObject<Plane>();
     _plane1->Length.setValue(4);
     _plane1->Width.setValue(4);
-    auto _sweep = dynamic_cast<Sweep*>(_doc->addObject("Part::Sweep"));
+    auto _sweep = _doc->addObject<Sweep>();
     _sweep->Sections.setValues({_plane1});
     _sweep->Spine.setValue(_edge1);
     // Act
@@ -124,7 +124,7 @@ TEST_F(PartFeaturesTest, testSweep)
 TEST_F(PartFeaturesTest, testThickness)
 {
     // Arrange
-    auto _thickness = dynamic_cast<Thickness*>(_doc->addObject("Part::Thickness"));
+    auto _thickness = _doc->addObject<Thickness>();
     _thickness->Faces.setValue(_boxes[0], {"Face1"});
     _thickness->Value.setValue(0.25);
     _thickness->Join.setValue("Intersection");
@@ -146,12 +146,12 @@ TEST_F(PartFeaturesTest, testThickness)
 TEST_F(PartFeaturesTest, testRefine)
 {
     // Arrange
-    auto _fuse = dynamic_cast<Part::Fuse*>(_doc->addObject("Part::Fuse"));
+    auto _fuse = _doc->addObject<Part::Fuse>();
     _fuse->Base.setValue(_boxes[0]);
     _fuse->Tool.setValue(_boxes[3]);
     _fuse->execute();
     Part::TopoShape fusedts = _fuse->Shape.getShape();
-    auto _refine = dynamic_cast<Refine*>(_doc->addObject("Part::Refine"));
+    auto _refine = _doc->addObject<Refine>();
     _refine->Source.setValue(_fuse);
     // Act
     _refine->execute();
@@ -175,7 +175,7 @@ TEST_F(PartFeaturesTest, testRefine)
 TEST_F(PartFeaturesTest, testReverse)
 {
     // Arrange
-    auto _reverse = dynamic_cast<Reverse*>(_doc->addObject("Part::Reverse"));
+    auto _reverse = _doc->addObject<Reverse>();
     _reverse->Source.setValue(_boxes[0]);
     // Act
     _reverse->execute();

--- a/tests/src/Mod/Part/App/PartTestHelpers.cpp
+++ b/tests/src/Mod/Part/App/PartTestHelpers.cpp
@@ -44,7 +44,7 @@ void PartTestHelperClass::createTestDoc()
         Base::Vector3d(0, 2 - minimalDistance, 0)};
 
     for (unsigned i = 0; i < _boxes.size(); i++) {
-        auto box = _boxes[i] = dynamic_cast<Part::Box*>(_doc->addObject("Part::Box"));  // NOLINT
+        auto box = _boxes[i] = _doc->addObject<Part::Box>();  // NOLINT
         box->Length.setValue(1);
         box->Width.setValue(2);
         box->Height.setValue(3);

--- a/tests/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/tests/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -23,7 +23,7 @@ protected:
     void SetUp() override
     {
         createTestDoc();
-        _common = dynamic_cast<Common*>(_doc->addObject("Part::Common"));
+        _common = _doc->addObject<Common>();
         _common->Base.setValue(_boxes[0]);
         _common->Tool.setValue(_boxes[1]);
         _common->execute();  // We should now have an elementMap with 26 entries.

--- a/tests/src/Mod/Part/App/TopoShapeMakeElementRefine.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeMakeElementRefine.cpp
@@ -29,7 +29,7 @@ TEST_F(FeaturePartMakeElementRefineTest, makeElementRefineBoxes)
 {
     // Arrange
     auto _doc = App::GetApplication().getActiveDocument();
-    auto _fuse = dynamic_cast<Part::Fuse*>(_doc->addObject("Part::Fuse"));
+    auto _fuse = _doc->addObject<Part::Fuse>();
     _fuse->Base.setValue(_boxes[0]);
     _fuse->Tool.setValue(_boxes[3]);
     // Act

--- a/tests/src/Mod/PartDesign/App/DatumPlane.cpp
+++ b/tests/src/Mod/PartDesign/App/DatumPlane.cpp
@@ -22,7 +22,7 @@ protected:
     {
         _docName = App::GetApplication().getUniqueDocumentName("test");
         _doc = App::GetApplication().newDocument(_docName.c_str(), "testUser");
-        _body = dynamic_cast<PartDesign::Body*>(_doc->addObject("PartDesign::Body"));
+        _body = _doc->addObject<PartDesign::Body>();
     }
 
     void TearDown() override
@@ -48,7 +48,7 @@ private:
 
 TEST_F(DatumPlaneTest, attachDatumPlane)
 {
-    auto datumPlane = getDocument()->addObject("PartDesign::Plane", "Plane");
+    auto datumPlane = getDocument()->addObject<PartDesign::Plane>("Plane");
     ASSERT_TRUE(datumPlane);
     getBody()->addObject(datumPlane);
     auto origin = getBody()->getOrigin();

--- a/tests/src/Mod/PartDesign/App/Pad.cpp
+++ b/tests/src/Mod/PartDesign/App/Pad.cpp
@@ -23,9 +23,8 @@ protected:
     void SetUp() override
     {
         _doc = App::GetApplication().newDocument("Pad_test", "testUser");
-        _body = dynamic_cast<PartDesign::Body*>(_doc->addObject("PartDesign::Body"));
-        _sketch = dynamic_cast<Sketcher::SketchObject*>(
-            _doc->addObject("Sketcher::SketchObject", "Sketch"));
+        _body = _doc->addObject<PartDesign::Body>();
+        _sketch = _doc->addObject<Sketcher::SketchObject>("Sketch");
         _body->addObject(_sketch);
 
         _sketch->AttachmentSupport.setValue(_doc->getObject("XY_Plane"), "");
@@ -69,7 +68,7 @@ TEST_F(PadTest, TestMidPlaneTwoLength)
 
     doc->recompute();
 
-    auto pad = dynamic_cast<PartDesign::Pad*>(doc->addObject("PartDesign::Pad", "Pad"));
+    auto pad = doc->addObject<PartDesign::Pad>("Pad");
     body->addObject(pad);
     pad->Profile.setValue(sketch, {""});
     pad->Direction.setValue(0.0, 0.0, 1.0);

--- a/tests/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/tests/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -23,8 +23,8 @@ protected:
     {
         _docName = App::GetApplication().getUniqueDocumentName("test");
         _doc = App::GetApplication().newDocument(_docName.c_str(), "testUser");
-        _body = dynamic_cast<PartDesign::Body*>(_doc->addObject("PartDesign::Body"));  // NOLINT
-        _box = dynamic_cast<Part::Box*>(_doc->addObject("Part::Box"));                 // NOLINT
+        _body = _doc->addObject<PartDesign::Body>();
+        _box = _doc->addObject<Part::Box>();
         _box->Length.setValue(1);
         _box->Width.setValue(2);
         _box->Height.setValue(3);
@@ -32,10 +32,8 @@ protected:
             Base::Placement(Base::Vector3d(), Base::Rotation(), Base::Vector3d()));  // NOLINT
         //        _body->addObject(_box); // Invalid, Part::Features can't go in a PartDesign::Body,
         //        but we can bind them.
-        _binder = dynamic_cast<PartDesign::ShapeBinder*>(
-            _doc->addObject("PartDesign::ShapeBinder", "ShapeBinderFoo"));  // NOLINT
-        _subbinder = dynamic_cast<PartDesign::SubShapeBinder*>(
-            _doc->addObject("PartDesign::SubShapeBinder", "SubShapeBinderBar"));  // NOLINT
+        _binder = _doc->addObject<PartDesign::ShapeBinder>("ShapeBinderFoo");
+        _subbinder = _doc->addObject<PartDesign::SubShapeBinder>("SubShapeBinderBar");
         _binder->Shape.setValue(_box->Shape.getShape());
         _subbinder->setLinks({{_box, {"Face1", "Face2"}}}, false);
         _body->addObject(_binder);

--- a/tests/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObject.cpp
@@ -146,8 +146,7 @@ protected:
         _docName = App::GetApplication().getUniqueDocumentName("test");
         auto _doc = App::GetApplication().newDocument(_docName.c_str(), "testUser");
         // TODO: Do we add a body newName, or is just adding sketch sufficient for this test?
-        _sketchobj =
-            static_cast<Sketcher::SketchObject*>(_doc->addObject("Sketcher::SketchObject"));
+        _sketchobj = _doc->addObject<Sketcher::SketchObject>();
     }
 
     void TearDown() override


### PR DESCRIPTION
There's a lot of repeated code when using Document::addObject(), by adding a template function we can avoid that and avoid some runtime issues by catching some type issues at compile time.