### PR TITLE
Add units to some spinboxes on preferences pages

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsEditor.ui
+++ b/src/Gui/PreferencePages/DlgSettingsEditor.ui
@@ -163,7 +163,7 @@
          <string>Tabulator raster (how many spaces)</string>
         </property>
         <property name="suffix">
-         <string> spaces</string>
+         <string comment="Do not remove leading space"> spaces</string>
         </property>
         <property name="value">
          <number>4</number>
@@ -189,7 +189,7 @@
          <string>How many spaces will be inserted when pressing &lt;Tab&gt;</string>
         </property>
         <property name="suffix">
-         <string> spaces</string>
+         <string comment="Do not remove leading space"> spaces</string>
         </property>
         <property name="value">
          <number>4</number>

--- a/src/Gui/PreferencePages/DlgSettingsEditor.ui
+++ b/src/Gui/PreferencePages/DlgSettingsEditor.ui
@@ -163,7 +163,7 @@
          <string>Tabulator raster (how many spaces)</string>
         </property>
         <property name="suffix">
-         <string> espacios</string>
+         <string> spaces</string>
         </property>
         <property name="value">
          <number>4</number>
@@ -189,7 +189,7 @@
          <string>How many spaces will be inserted when pressing &lt;Tab&gt;</string>
         </property>
         <property name="suffix">
-         <string> espacios</string>
+         <string> spaces</string>
         </property>
         <property name="value">
          <number>4</number>

--- a/src/Gui/PreferencePages/DlgSettingsEditor.ui
+++ b/src/Gui/PreferencePages/DlgSettingsEditor.ui
@@ -162,6 +162,9 @@
         <property name="toolTip">
          <string>Tabulator raster (how many spaces)</string>
         </property>
+        <property name="suffix">
+         <string> espacios</string>
+        </property>
         <property name="value">
          <number>4</number>
         </property>
@@ -184,6 +187,9 @@
        <widget class="Gui::PrefSpinBox" name="indentSize">
         <property name="toolTip">
          <string>How many spaces will be inserted when pressing &lt;Tab&gt;</string>
+        </property>
+        <property name="suffix">
+         <string> espacios</string>
         </property>
         <property name="value">
          <number>4</number>
@@ -316,6 +322,9 @@
         </property>
         <property name="toolTip">
          <string>Font size to be used for selected code type</string>
+        </property>
+        <property name="suffix">
+         <string notr="true"> pt</string>
         </property>
         <property name="minimum">
          <number>1</number>

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.ui
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.ui
@@ -182,6 +182,9 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
+        <property name="suffix">
+         <string notr="true"> px</string>
+        </property>
         <property name="minimum">
          <number>10</number>
         </property>
@@ -578,7 +581,7 @@ Free Turntable: the part will be rotated around the z-axis.</string>
 The value is the diameter of the sphere to fit on the screen.</string>
         </property>
         <property name="unit" stdset="0">
-         <string>mm</string>
+         <string notr="true">mm</string>
         </property>
         <property name="minimum">
          <double>0.000010000000000</double>
@@ -765,6 +768,25 @@ Mouse tilting is not disabled by this setting.</string>
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkBoxSpinningAnimations">
+        <property name="toolTip">
+         <string>Enable spinning animations that are used in some navigation styles after dragging</string>
+        </property>
+        <property name="text">
+         <string>Enable spinning animations</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>UseSpinningAnimations</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
        <widget class="Gui::PrefSpinBox" name="spinBoxAnimationDuration">
         <property name="maximumSize">
@@ -775,6 +797,9 @@ Mouse tilting is not disabled by this setting.</string>
         </property>
         <property name="toolTip">
          <string>The duration of navigation animations in milliseconds</string>
+        </property>
+        <property name="suffix">
+         <string notr="true"> ms</string>
         </property>
         <property name="minimum">
          <number>100</number>
@@ -808,25 +833,6 @@ Mouse tilting is not disabled by this setting.</string>
          </size>
         </property>
        </spacer>
-      </item>
-      <item row="2" column="0">
-       <widget class="Gui::PrefCheckBox" name="checkBoxSpinningAnimations">
-        <property name="toolTip">
-         <string>Enable spinning animations that are used in some navigation styles after dragging</string>
-        </property>
-        <property name="text">
-         <string>Enable spinning animations</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>UseSpinningAnimations</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>

--- a/src/Gui/PreferencePages/DlgSettingsSelection.ui
+++ b/src/Gui/PreferencePages/DlgSettingsSelection.ui
@@ -118,7 +118,7 @@
      <item>
       <widget class="QLabel" name="spinPickRadiusLabel">
        <property name="text">
-        <string>Pick radius (px):</string>
+        <string>Pick radius:</string>
        </property>
       </widget>
      </item>
@@ -152,6 +152,9 @@ Larger value eases to pick things, but can make small features impossible to sel
      </property>
      <property name="inputMethodHints">
       <set>Qt::ImhPreferNumbers</set>
+     </property>
+     <property name="suffix">
+      <string notr="true"> px</string>
      </property>
      <property name="decimals">
       <number>1</number>

--- a/src/Gui/PreferencePages/DlgSettingsViewColor.ui
+++ b/src/Gui/PreferencePages/DlgSettingsViewColor.ui
@@ -497,29 +497,32 @@
          </widget>
         </item>
         <item row="1" column="1">
-       <widget class="Gui::PrefSpinBox" name="CbLabelTextSize">
-        <property name="toolTip">
-         <string>Color Bar (used in Mesh and FEM Wbs) Label Text Size</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="minimum">
-         <number>4</number>
-        </property>
-        <property name="maximum">
-         <number>36</number>
-        </property>
-        <property name="value">
-         <number>13</number>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>CbLabelTextSize</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
-        </property>
-       </widget>
+         <widget class="Gui::PrefSpinBox" name="CbLabelTextSize">
+          <property name="toolTip">
+           <string>Color Bar (used in Mesh and FEM Wbs) Label Text Size</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="suffix">
+           <string> pt</string>
+          </property>
+          <property name="minimum">
+           <number>4</number>
+          </property>
+          <property name="maximum">
+           <number>36</number>
+          </property>
+          <property name="value">
+           <number>13</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>CbLabelTextSize</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>View</cstring>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>

--- a/src/Mod/CAM/Gui/DlgSettingsPathColor.ui
+++ b/src/Mod/CAM/Gui/DlgSettingsPathColor.ui
@@ -42,7 +42,7 @@
          <string>The default line thickness for new shapes</string>
         </property>
         <property name="suffix">
-         <string>px</string>
+         <string notr="true"> px</string>
         </property>
         <property name="maximum">
          <number>9</number>

--- a/src/Mod/CAM/Gui/Resources/preferences/PathDressupHoldingTags.ui
+++ b/src/Mod/CAM/Gui/Resources/preferences/PathDressupHoldingTags.ui
@@ -64,6 +64,9 @@ If the specified height is 0 the dressup will use half the height of the part. S
         <property name="toolTip">
          <string>Plunge angle for ascent and descent of holding tag.</string>
         </property>
+        <property name="suffix">
+         <string notr="true"> °</string>
+        </property>
         <property name="minimum">
          <double>5.000000000000000</double>
         </property>
@@ -85,7 +88,7 @@ If the specified height is 0 the dressup will use half the height of the part. S
         </property>
        </widget>
       </item>
-     <item row="3" column="1">
+      <item row="3" column="1">
        <widget class="Gui::InputField" name="ifRadius">
         <property name="toolTip">
          <string>Radius of the fillet on the tag's top edge.
@@ -94,7 +97,7 @@ If the radius is bigger than that which the tag shape itself supports, the resul
         </property>
        </widget>
       </item>
-      </layout>
+     </layout>
     </widget>
    </item>
    <item>

--- a/src/Mod/Draft/Resources/ui/preferences-svg.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-svg.ui
@@ -206,7 +206,7 @@ In this case arcs will be discretized into small line segments.
 This value is the maximum segment length.</string>
           </property>
           <property name="suffix">
-           <string>mm</string>
+           <string notr="true"> mm</string>
           </property>
           <property name="maximum">
            <double>9999.989999999999782</double>

--- a/src/Mod/Fem/Gui/DlgSettingsFemCcx.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemCcx.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>425</width>
-    <height>642</height>
+    <width>595</width>
+    <height>848</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -287,7 +287,50 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_1">
       <item>
-       <layout class="QGridLayout" name="gl_solver" columnstretch="3,2,0,0">
+       <layout class="QGridLayout" name="gl_solver" columnstretch="3,0,0">
+        <item row="7" column="1">
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="l_ccx_initial_time_step">
+          <property name="text">
+           <string>Time Initial Step</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="l_ccx_analysis_time">
+          <property name="text">
+           <string>Time End</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="Gui::PrefCheckBox" name="cb_use_iterations_param">
+          <property name="text">
+           <string>Use non ccx defaults</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>UseNonCcxIterationParam</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Fem/Ccx</cstring>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="l_ccx_numcpu">
           <property name="text">
@@ -295,13 +338,29 @@
           </property>
          </widget>
         </item>
+        <item row="9" column="2">
+         <widget class="Gui::PrefCheckBox" name="cb_BeamShellOutput">
+          <property name="text">
+           <string>3D Output, unchecked for 2D</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>BeamShellOutput</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Fem/Ccx</cstring>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="2">
          <widget class="Gui::PrefSpinBox" name="sb_ccx_numcpu">
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
           <property name="toolTip">
            <string>Number of threads used for analysis</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
           <property name="minimum">
            <number>1</number>
@@ -311,16 +370,6 @@
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/Fem/Ccx</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="l_solver">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>Matrix solver</string>
           </property>
          </widget>
         </item>
@@ -377,6 +426,153 @@
           </property>
          </widget>
         </item>
+        <item row="8" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="dsb_ccx_maximum_time_step">
+          <property name="contextMenuPolicy">
+           <enum>Qt::DefaultContextMenu</enum>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="suffix">
+           <string notr="true"> s</string>
+          </property>
+          <property name="decimals">
+           <number>9</number>
+          </property>
+          <property name="minimum">
+           <double>0.000000001000000</double>
+          </property>
+          <property name="singleStep">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>AnalysisTimeMaximumStep</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Fem/Ccx</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="dsb_ccx_analysis_time">
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="suffix">
+           <string notr="true"> s</string>
+          </property>
+          <property name="decimals">
+           <number>9</number>
+          </property>
+          <property name="minimum">
+           <double>0.000000001000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>AnalysisTime</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Fem/Ccx</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="l_solver">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>Matrix solver</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="l_use_iterations_param">
+          <property name="text">
+           <string>Time incrementation control parameter</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="l_ccx_max_iterations">
+          <property name="text">
+           <string>Maximum number of iterations</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="l_ccx_minimum_time_step">
+          <property name="text">
+           <string>Time Minimum Step</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="7" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="dsb_ccx_minimum_time_step">
+          <property name="contextMenuPolicy">
+           <enum>Qt::DefaultContextMenu</enum>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="suffix">
+           <string notr="true"> s</string>
+          </property>
+          <property name="decimals">
+           <number>9</number>
+          </property>
+          <property name="minimum">
+           <double>0.000000001000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.000010000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>AnalysisTimeMinimumStep</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Fem/Ccx</cstring>
+          </property>
+         </widget>
+        </item>
         <item row="2" column="2">
          <widget class="Gui::PrefCheckBox" name="cb_ccx_non_lin_geom">
           <property name="text">
@@ -393,33 +589,41 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="l_use_iterations_param">
-          <property name="text">
-           <string>Time incrementation control parameter</string>
+        <item row="5" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="dsb_ccx_initial_time_step">
+          <property name="contextMenuPolicy">
+           <enum>Qt::DefaultContextMenu</enum>
           </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="Gui::PrefCheckBox" name="cb_use_iterations_param">
-          <property name="text">
-           <string>Use non ccx defaults</string>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
-          <property name="checked">
-           <bool>false</bool>
+          <property name="suffix">
+           <string notr="true"> s</string>
+          </property>
+          <property name="decimals">
+           <number>9</number>
+          </property>
+          <property name="minimum">
+           <double>0.000000001000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.010000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>UseNonCcxIterationParam</cstring>
+           <cstring>AnalysisTimeInitialStep</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/Fem/Ccx</cstring>
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="l_ccx_max_iterations">
+        <item row="9" column="0">
+         <widget class="QLabel" name="l_BeamShellOutput">
           <property name="text">
-           <string>Maximum number of iterations</string>
+           <string>Beam, shell element 3D output format</string>
           </property>
          </widget>
         </item>
@@ -448,230 +652,10 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="l_ccx_initial_time_step">
-          <property name="text">
-           <string>Time Initial Step</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="5" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="dsb_ccx_initial_time_step">
-          <property name="contextMenuPolicy">
-           <enum>Qt::DefaultContextMenu</enum>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="decimals">
-           <number>9</number>
-          </property>
-          <property name="minimum">
-           <double>0.000000001000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>AnalysisTimeInitialStep</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Fem/Ccx</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="3">
-         <widget class="QLabel" name="l_hz_1">
-          <property name="text">
-           <string>s</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="l_ccx_analysis_time">
-          <property name="text">
-           <string>Time End</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="dsb_ccx_analysis_time">
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="decimals">
-           <number>9</number>
-          </property>
-          <property name="minimum">
-           <double>0.000000001000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>AnalysisTime</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Fem/Ccx</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="3">
-         <widget class="QLabel" name="l_hz_2">
-          <property name="text">
-           <string>s</string>
-          </property>
-         </widget>
-        </item>
-       <item row="7" column="0">
-         <widget class="QLabel" name="l_ccx_minimum_time_step">
-          <property name="text">
-           <string>Time Minimum Step</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="7" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="dsb_ccx_minimum_time_step">
-          <property name="contextMenuPolicy">
-           <enum>Qt::DefaultContextMenu</enum>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="decimals">
-           <number>9</number>
-          </property>
-          <property name="minimum">
-           <double>0.000000001000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.000010000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>AnalysisTimeMinimumStep</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Fem/Ccx</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="3">
-         <widget class="QLabel" name="l_hz_3">
-          <property name="text">
-           <string>s</string>
-          </property>
-         </widget>
-        </item>
-       <item row="8" column="0">
+        <item row="8" column="0">
          <widget class="QLabel" name="l_ccx_maximum_time_step">
           <property name="text">
            <string>Time Maximum Step</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1">
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="8" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="dsb_ccx_maximum_time_step">
-          <property name="contextMenuPolicy">
-           <enum>Qt::DefaultContextMenu</enum>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="decimals">
-           <number>9</number>
-          </property>
-          <property name="minimum">
-           <double>0.000000001000000</double>
-          </property>
-          <property name="singleStep">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>AnalysisTimeMaximumStep</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Fem/Ccx</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="3">
-         <widget class="QLabel" name="l_hz_4">
-          <property name="text">
-           <string>s</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0">
-         <widget class="QLabel" name="l_BeamShellOutput">
-          <property name="text">
-           <string>Beam, shell element 3D output format</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="2">
-         <widget class="Gui::PrefCheckBox" name="cb_BeamShellOutput">
-          <property name="text">
-           <string>3D Output, unchecked for 2D</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>BeamShellOutput</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Fem/Ccx</cstring>
           </property>
          </widget>
         </item>
@@ -723,27 +707,7 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <layout class="QGridLayout" name="gl_frequ" columnstretch="6,3,1,0">
-        <item row="1" column="0">
-         <widget class="QLabel" name="l_eigenmode_number">
-          <property name="text">
-           <string>Eigenmode number</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
+       <layout class="QGridLayout" name="gl_frequ" columnstretch="6,0,0">
         <item row="1" column="2">
          <widget class="Gui::PrefSpinBox" name="sb_eigenmode_number">
           <property name="minimumSize">
@@ -776,6 +740,13 @@
           </property>
          </widget>
         </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="l_eigenmode_number">
+          <property name="text">
+           <string>Eigenmode number</string>
+          </property>
+         </widget>
+        </item>
         <item row="2" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="dsb_eigenmode_high_limit">
           <property name="minimumSize">
@@ -786,6 +757,9 @@
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="suffix">
+           <string notr="true"> Hz</string>
           </property>
           <property name="decimals">
            <number>1</number>
@@ -807,12 +781,18 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="3">
-         <widget class="QLabel" name="l_hz_5">
-          <property name="text">
-           <string>Hz</string>
+        <item row="1" column="1">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-         </widget>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
         <item row="3" column="0">
          <widget class="QLabel" name="l_eigenmode_low_limit">
@@ -831,6 +811,9 @@
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="suffix">
+           <string> Hz</string>
           </property>
           <property name="decimals">
            <number>1</number>
@@ -852,13 +835,6 @@
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/Fem/Ccx</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="3">
-         <widget class="QLabel" name="l_hz">
-          <property name="text">
-           <string>Hz</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
@@ -106,7 +106,7 @@
            <item>
             <widget class="Gui::QuantitySpinBox" name="qsb_film_coef">
              <property name="unit" stdset="0">
-              <string>W/m^2/K</string>
+              <string notr="true">W/m^2/K</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignLeft|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -133,7 +133,7 @@
            <item>
             <widget class="Gui::QuantitySpinBox" name="qsb_ambienttemp_conv">
              <property name="unit" stdset="0">
-              <string>K</string>
+              <string notr="true">K</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignLeft|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -195,7 +195,7 @@
            <item>
             <widget class="Gui::QuantitySpinBox" name="qsb_ambienttemp_rad">
              <property name="unit" stdset="0">
-              <string>K</string>
+              <string notr="true">K</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignLeft|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -231,7 +231,7 @@
          <item>
           <widget class="Gui::QuantitySpinBox" name="qsb_heat_flux">
            <property name="unit" stdset="0">
-            <string>W/m^2</string>
+            <string notr="true">W/m^2</string>
            </property>
              <property name="alignment">
               <set>Qt::AlignLeft|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
+++ b/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
@@ -189,7 +189,7 @@
            <string>The default transparency for new shapes</string>
           </property>
           <property name="suffix">
-           <string notr="true">%</string>
+           <string notr="true"> %</string>
           </property>
           <property name="maximum">
            <number>100</number>
@@ -224,7 +224,7 @@
            <string>The default shininess for new shapes</string>
           </property>
           <property name="suffix">
-           <string notr="true">%</string>
+           <string notr="true"> %</string>
           </property>
           <property name="maximum">
            <number>100</number>
@@ -295,7 +295,7 @@
            <string>The default line thickness for new shapes</string>
           </property>
           <property name="suffix">
-           <string>px</string>
+           <string notr="true"> px</string>
           </property>
           <property name="maximum">
            <number>9</number>
@@ -363,7 +363,7 @@
            <string>The default size for new vertices</string>
           </property>
           <property name="suffix">
-           <string>px</string>
+           <string notr="true"> px</string>
           </property>
           <property name="maximum">
            <number>9</number>
@@ -431,7 +431,7 @@
            <string>The font size of bounding boxes in the 3D view</string>
           </property>
           <property name="suffix">
-           <string notr="true">pt</string>
+           <string notr="true"> pt</string>
           </property>
           <property name="decimals">
            <number>1</number>

--- a/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
@@ -268,10 +268,10 @@
          <string>Width of normal edges.</string>
         </property>
         <property name="unit" stdset="0">
-         <string notr="true">mm</string>
+         <string notr="true">px</string>
         </property>
         <property name="suffix">
-         <string notr="true"> mm</string>
+         <string notr="true"> px</string>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -365,10 +365,10 @@
          <string>Width of construction edges.</string>
         </property>
         <property name="unit" stdset="0">
-         <string notr="true">mm</string>
+         <string notr="true">px</string>
         </property>
         <property name="suffix">
-         <string notr="true"> mm</string>
+         <string notr="true"> px</string>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -462,10 +462,10 @@
          <string>Width of internal aligned edges.</string>
         </property>
         <property name="unit" stdset="0">
-         <string notr="true">mm</string>
+         <string notr="true">px</string>
         </property>
         <property name="suffix">
-         <string notr="true"> mm</string>
+         <string notr="true"> px</string>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -533,10 +533,10 @@
          <string>Width of external edges.</string>
         </property>
         <property name="unit" stdset="0">
-         <string notr="true">mm</string>
+         <string notr="true">px</string>
         </property>
         <property name="suffix">
-         <string notr="true"> mm</string>
+         <string notr="true"> px</string>
         </property>
         <property name="minimum">
          <number>1</number>

--- a/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
@@ -270,6 +270,9 @@
         <property name="unit" stdset="0">
          <string notr="true">mm</string>
         </property>
+        <property name="suffix">
+         <string notr="true"> mm</string>
+        </property>
         <property name="minimum">
          <number>1</number>
         </property>
@@ -363,6 +366,9 @@
         </property>
         <property name="unit" stdset="0">
          <string notr="true">mm</string>
+        </property>
+        <property name="suffix">
+         <string notr="true"> mm</string>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -458,6 +464,9 @@
         <property name="unit" stdset="0">
          <string notr="true">mm</string>
         </property>
+        <property name="suffix">
+         <string notr="true"> mm</string>
+        </property>
         <property name="minimum">
          <number>1</number>
         </property>
@@ -525,6 +534,9 @@
         </property>
         <property name="unit" stdset="0">
          <string notr="true">mm</string>
+        </property>
+        <property name="suffix">
+         <string notr="true"> mm</string>
         </property>
         <property name="minimum">
          <number>1</number>

--- a/src/Mod/Sketcher/Gui/SketcherSettingsGrid.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsGrid.ui
@@ -125,6 +125,9 @@ If 'Grid Auto Spacing' is enabled, will be used as base value.</string>
          <string>While using 'Grid Auto Spacing' this sets a threshold in pixel to the grid spacing.
 The grid spacing change if it becomes smaller than this number of pixel.</string>
         </property>
+        <property name="suffix">
+         <string notr="true"> px</string>
+        </property>
         <property name="minimum">
          <number>3</number>
         </property>


### PR DESCRIPTION
Ensure units have a space, ex: " px"

FEM: Don't mark units for translation
### Part/PartDesign
![image](https://github.com/user-attachments/assets/299f7947-f058-4af6-b623-6b053f91075e)

### Sketcher
Fixed mm -> px
![image](https://github.com/user-attachments/assets/c68399a0-3850-4862-8ec7-2f93d99a01b1)

### FEM
![image](https://github.com/user-attachments/assets/90592f2f-fce5-4995-848a-66266533b22b)
