### PR TITLE
Sketcher: Refactor C++20 code

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -6767,8 +6767,9 @@ int SketchObject::deleteUnusedInternalGeometryWhenBSpline(int GeoId, bool delgeo
         }
 
         // look for a point at geoid index
-        numConstr = std::count_if(vals.begin(), vals.end(), [&kGeoId](const auto& constr) {
-            return constr->involvesGeoId(kGeoId);
+        auto tempGeoID = kGeoId;  // C++17 and earlier do not support captured structured bindings
+        numConstr = std::count_if(vals.begin(), vals.end(), [&tempGeoID](const auto& constr) {
+            return constr->involvesGeoId(tempGeoID);
         });
 
         if (numConstr < 2) { // IA


### PR DESCRIPTION
A small bit of C++20 code was mistakenly included in an earlier PR: this refactors to remove it until we switch to C++20 as our required standard (not supported on Ubuntu 20.04 LTS).