### PR TITLE
Added support for adding self forming threads to the hole tool

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -2158,7 +2158,7 @@ App::DocumentObjectExecReturn* Hole::execute()
             double numberOfThreaders = 3; // number of self threaders to create
             double boreHoleMargin = 0.15;  // how much wider we'll bore out the hole
             double selfThreaderHeight = 0.4;  // how deep into the hole bore do the self threaders protrude
-            double edgeCutToolMargin = 5.0; // how much wider the edge cut tool is than the base cyclinder when creating our shape
+            double edgeCutToolMargin = 5.0; // how much wider the edge cut tool is than the base cylinder when creating our shape
             double taperLength = 3.0; // how long the threaders are tapered
             double boreHoleRadius = (Diameter.getValue() + boreHoleMargin) / 2.0; // the radius of our hole
             double edgeCutToolRadius = boreHoleRadius + edgeCutToolMargin; // the radius of our edge cut tool
@@ -2170,11 +2170,11 @@ App::DocumentObjectExecReturn* Hole::execute()
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Could not get active document for debugging."));
             }            
 
-            // we will create a base cyclinder, then an edge cut tool
+            // we will create a base cylinder, then an edge cut tool
             // we will move the edge cut tool around the perimeter the hole and cut 
-            // it from the initial cyclinder resulting in our final tool
+            // it from the initial cylinder resulting in our final tool
 
-            // our points when drawing the wire for our initial cyclinder
+            // our points when drawing the wire for our initial cylinder
             gp_Pnt firstPoint(0, 0, 0);
             gp_Pnt lastPoint(0, 0, 0);
 
@@ -2219,20 +2219,20 @@ App::DocumentObjectExecReturn* Hole::execute()
             if (!RevolMaker.IsDone())
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Hole error: Could not revolve sketch"));
 
-            // our initial cyclinder
-            TopoDS_Shape initialCyclinder = RevolMaker.Shape();
+            // our initial cylinder
+            TopoDS_Shape initialCylinder = RevolMaker.Shape();
             if (protoHole.IsNull())
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Hole error: Resulting shape is empty"));
 
             // for debugging only.  To be removed.
             if (selfThreadingDebug) {
                 Part::Feature* feature = static_cast<Part::Feature*>(document->addObject("Part::Feature", "InitialCylinder"));
-                feature->Shape.setValue(initialCyclinder);
+                feature->Shape.setValue(initialCylinder);
                 feature->Visibility.setValue(false);
             }
 
             // now create our edge cut tool to make our tapered edge cuts from 
-            // the initial cyclinder
+            // the initial cylinder
             BRepBuilderAPI_MakeWire mkWireEdgeCutTool;                    
             
             // reset our first point to the origin
@@ -2345,24 +2345,24 @@ App::DocumentObjectExecReturn* Hole::execute()
                 }
 
                 // cut the edge cut tool from our initial cylinder
-                BRepAlgoAPI_Cut cutMaker(initialCyclinder, translatedTool);
+                BRepAlgoAPI_Cut cutMaker(initialCylinder, translatedTool);
                 if (!cutMaker.IsDone()) {
                     throw std::runtime_error("Cut operation failed");
                 }
 
                 // set our initial cylinder to the newly cut shape
-                initialCyclinder = cutMaker.Shape();
+                initialCylinder = cutMaker.Shape();
             }
 
             // for debugging only.  To be removed.
             if (selfThreadingDebug) { 
                 Part::Feature* feature = static_cast<Part::Feature*>(document->addObject("Part::Feature", "FinalTool"));
-                feature->Shape.setValue(initialCyclinder);
+                feature->Shape.setValue(initialCylinder);
                 feature->Visibility.setValue(false);
             }
 
             // our finalized cutting tool is now the hole prototype
-            protoHole = initialCyclinder;
+            protoHole = initialCylinder;
         }
         
         std::vector<TopoShape> holes;

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -70,6 +70,7 @@ public:
     App::PropertyAngle          DrillPointAngle;
     App::PropertyBool           DrillForDepth;
     App::PropertyBool           Tapered;
+    App::PropertyBool           SelfFormingThreads;
     App::PropertyAngle          TaperedAngle;
     App::PropertyBool           UseCustomThreadClearance;
     App::PropertyLength         CustomThreadClearance;

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -166,6 +166,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
     ui->TaperedAngle->setMinimum(pcHole->TaperedAngle.getMinimum());
     ui->TaperedAngle->setMaximum(pcHole->TaperedAngle.getMaximum());
     ui->TaperedAngle->setValue(pcHole->TaperedAngle.getValue());
+    ui->SelfFormingThreads->setChecked(pcHole->SelfFormingThreads.getValue());
     ui->Reversed->setChecked(pcHole->Reversed.getValue());
 
     bool isThreaded = ui->Threaded->isChecked();
@@ -235,6 +236,8 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
             this, &TaskHoleParameters::reversedChanged);
     connect(ui->TaperedAngle, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
             this, &TaskHoleParameters::taperedAngleChanged);
+    connect(ui->SelfFormingThreads, &QCheckBox::clicked,
+            this, &TaskHoleParameters::selfFormingThreadsChanged);
     connect(ui->ModelThread, &QCheckBox::clicked,
             this, &TaskHoleParameters::modelThreadChanged);
     connect(ui->UpdateView, &QCheckBox::toggled,
@@ -574,6 +577,14 @@ void TaskHoleParameters::taperedChanged()
     ui->TaperedAngle->setEnabled(ui->Tapered->isChecked());
     if (auto hole = getObject<PartDesign::Hole>()) {
         hole->Tapered.setValue(ui->Tapered->isChecked());
+        recomputeFeature();
+    }
+}
+
+void TaskHoleParameters::selfFormingThreadsChanged() 
+{
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->SelfFormingThreads.setValue(ui->SelfFormingThreads->isChecked());
         recomputeFeature();
     }
 }
@@ -1161,6 +1172,11 @@ Base::Quantity TaskHoleParameters::getTaperedAngle() const
     return ui->TaperedAngle->value();
 }
 
+bool TaskHoleParameters::getSelfFormingThreads() const
+{
+    return ui->SelfFormingThreads->isChecked();
+}
+
 bool TaskHoleParameters::getUseCustomThreadClearance() const
 {
     return ui->UseCustomThreadClearance->isChecked();
@@ -1251,6 +1267,9 @@ void TaskHoleParameters::apply()
     }
     if (!hole->Tapered.isReadOnly()) {
         FCMD_OBJ_CMD(hole, "Tapered = " << getTapered());
+    }
+    if (!hole->SelfFormingThreads.isReadOnly()) {
+        FCMD_OBJ_CMD(hole, "SelfFormingThreads = " << getSelfFormingThreads());
     }
 
     isApplying = false;

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -74,6 +74,7 @@ public:
     bool   getDrillForDepth() const;
     bool   getTapered() const;
     Base::Quantity getTaperedAngle() const;
+    bool getSelfFormingThreads() const;
     bool getUseCustomThreadClearance() const;
     double getCustomThreadClearance() const;
     bool getModelThread() const;
@@ -101,6 +102,7 @@ private Q_SLOTS:
     void drillForDepthChanged();
     void taperedChanged();
     void taperedAngleChanged(double value);
+    void selfFormingThreadsChanged();
     void reversedChanged();
     void modelThreadChanged();
     void useCustomThreadClearanceChanged();

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -86,6 +86,22 @@ over 90: larger hole radius at the bottom</string>
        </property>
       </widget>
      </item>
+     <item row="6" column="0">
+      <widget class="QCheckBox" name="SelfFormingThreads">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Adds self-forming fastener threads for holes in plastic</string>
+       </property>
+       <property name="text">
+        <string>Self-Forming Threads</string>
+       </property>
+      </widget>
+     </item>     
      <item row="4" column="0">
       <layout class="QHBoxLayout" name="horizontalLayout_7">
        <item>


### PR DESCRIPTION
After seeing this YouTuber's video on 3d printed thread solutions, I tried this thread type and found it worked well.  

[A better way to add threads to your 3D prints - Made with Layers (Thomas Sanladerer)](https://www.youtube.com/watch?v=HgEEtk85rAY&t=309s)


so I implemented it as part of the FreeCAD hole tool.  Here's a little demo video showing it in action.
[Demo video showing it in action](https://github.com/user-attachments/assets/da268c20-10b5-4888-a81e-be8996a96ba1)


I don't know if the hole tool is the right spot for this feature.  I'm opening this draft PR hoping for feedback or guidance.

