### PR TITLE
SH3DImporter: Miscellaneous improvements

### DIFF
--- a/src/Mod/BIM/Resources/ui/preferences-sh3d-import.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-sh3d-import.ui
@@ -66,6 +66,23 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout">
             <item>
+              <widget class="Gui::PrefCheckBox" name="checkBox_9">
+                <property name="toolTip">
+                  <string>Merge imported element with existing FC object</string>
+                </property>
+                <property name="text">
+                  <string>Merge into existing document</string>
+                </property>
+                <property name="prefEntry" stdset="0">
+                  <cstring>sh3dMerge</cstring>
+                </property>
+                <property name="prefPath" stdset="0">
+                  <cstring>Mod/Arch</cstring>
+                </property>
+              </widget>
+            </item>
+
+            <item>
               <widget class="Gui::PrefCheckBox" name="checkBox_3">
                 <property name="toolTip">
                   <string>Whether to import the model's doors and windows</string>
@@ -163,21 +180,22 @@
               </widget>
             </item>
             <item>
-              <widget class="Gui::PrefCheckBox" name="checkBox_9">
+              <widget class="Gui::PrefCheckBox" name="checkBox_10">
                 <property name="toolTip">
-                  <string>Merge imported element with existing FC object</string>
+                  <string>Create a default Render project with the newly created Site</string>
                 </property>
                 <property name="text">
-                  <string>Merge into existing document</string>
+                  <string>Create Render Project (requires Render)</string>
                 </property>
                 <property name="prefEntry" stdset="0">
-                  <cstring>sh3dMerge</cstring>
+                  <cstring>sh3dCreateRenderProject</cstring>
                 </property>
                 <property name="prefPath" stdset="0">
                   <cstring>Mod/Arch</cstring>
                 </property>
               </widget>
             </item>
+
             <item>
               <layout class="QGridLayout" columnstretch="2,1,0">
                 <item row="0" column="0">
@@ -259,38 +277,6 @@
               </layout>
             </item>
             <item>
-              <widget class="Gui::PrefCheckBox" name="checkBox_10">
-                <property name="toolTip">
-                  <string>Create a default Render project with the newly created Site</string>
-                </property>
-                <property name="text">
-                  <string>Create Render Project (requires Render)</string>
-                </property>
-                <property name="prefEntry" stdset="0">
-                  <cstring>sh3dCreateRenderProject</cstring>
-                </property>
-                <property name="prefPath" stdset="0">
-                  <cstring>Mod/Arch</cstring>
-                </property>
-              </widget>
-            </item>
-            <item>
-              <widget class="Gui::PrefCheckBox" name="checkBox_11">
-                <property name="toolTip">
-                  <string>Fit view while importing.</string>
-                </property>
-                <property name="text">
-                  <string>Fit view while importing</string>
-                </property>
-                <property name="prefEntry" stdset="0">
-                  <cstring>sh3dFitView</cstring>
-                </property>
-                <property name="prefPath" stdset="0">
-                  <cstring>Mod/Arch</cstring>
-                </property>
-              </widget>
-            </item>
-            <item>
               <widget class="Gui::PrefCheckBox" name="checkBox_12">
                 <property name="toolTip">
                   <string>Create a default IFC project with the newly created Site.</string>
@@ -316,6 +302,102 @@
                 </property>
                 <property name="prefEntry" stdset="0">
                   <cstring>sh3dCreateGroundMesh</cstring>
+                </property>
+                <property name="prefPath" stdset="0">
+                  <cstring>Mod/Arch</cstring>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <layout class="QGridLayout" columnstretch="2,1,0">
+                <item row="0" column="0">
+                  <widget class="QLabel" name="label1">
+                    <property name="text">
+                      <string>Default ground Color</string>
+                    </property>
+                    <property name="buddy">
+                      <cstring>sh3dDefaultGroundColor</cstring>
+                    </property>
+                  </widget>
+                </item>
+                <item row="0" column="1">
+                  <widget class="Gui::PrefColorButton" name="ArchSH3DDefaultGroundColor">
+                    <property name="sizePolicy">
+                      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                      </sizepolicy>
+                    </property>
+                    <property name="toolTip">
+                      <string>This color might be used when the environment does not define a color for the ground.</string>
+                    </property>
+                    <property name="color" stdset="0">
+                      <color>
+                        <red>168</red>
+                        <green>168</green>
+                        <blue>168</blue>
+                      </color>
+                    </property>
+                    <property name="prefEntry" stdset="0">
+                      <cstring>sh3dDefaultGroundColor</cstring>
+                    </property>
+                    <property name="prefPath" stdset="0">
+                      <cstring>Mod/Arch</cstring>
+                    </property>
+                  </widget>
+                </item>
+              </layout>
+            </item>
+            <item>
+              <layout class="QGridLayout" columnstretch="2,1,0">
+                <item row="0" column="0">
+                  <widget class="QLabel" name="label1">
+                    <property name="text">
+                      <string>Default sky Color</string>
+                    </property>
+                    <property name="buddy">
+                      <cstring>sh3dDefaultSkyColor</cstring>
+                    </property>
+                  </widget>
+                </item>
+                <item row="0" column="1">
+                  <widget class="Gui::PrefColorButton" name="ArchSH3DDefaultSkyColor">
+                    <property name="sizePolicy">
+                      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                      </sizepolicy>
+                    </property>
+                    <property name="toolTip">
+                      <string>This color might be used when the environment does not define a color for the sky.</string>
+                    </property>
+                    <property name="color" stdset="0">
+                      <color>
+                        <red>204</red>
+                        <green>228</green>
+                        <blue>252</blue>
+                      </color>
+                    </property>
+                    <property name="prefEntry" stdset="0">
+                      <cstring>sh3dDefaultSkyColor</cstring>
+                    </property>
+                    <property name="prefPath" stdset="0">
+                      <cstring>Mod/Arch</cstring>
+                    </property>
+                  </widget>
+                </item>
+              </layout>
+            </item>
+            <item>
+              <widget class="Gui::PrefCheckBox" name="checkBox_11">
+                <property name="toolTip">
+                  <string>Fit view while importing.</string>
+                </property>
+                <property name="text">
+                  <string>Fit view while importing</string>
+                </property>
+                <property name="prefEntry" stdset="0">
+                  <cstring>sh3dFitView</cstring>
                 </property>
                 <property name="prefPath" stdset="0">
                   <cstring>Mod/Arch</cstring>

--- a/src/Mod/BIM/Resources/ui/preferences-sh3d-import.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-sh3d-import.ui
@@ -306,6 +306,22 @@
                 </property>
               </widget>
             </item>
+            <item>
+              <widget class="Gui::PrefCheckBox" name="checkBox_13">
+                <property name="toolTip">
+                  <string>Create a Mesh to represent the default ground level.</string>
+                </property>
+                <property name="text">
+                  <string>Create ground level Mesh</string>
+                </property>
+                <property name="prefEntry" stdset="0">
+                  <cstring>sh3dCreateGroundMesh</cstring>
+                </property>
+                <property name="prefPath" stdset="0">
+                  <cstring>Mod/Arch</cstring>
+                </property>
+              </widget>
+            </item>
           </layout>
         </widget>
       </item>

--- a/src/Mod/BIM/importers/importSH3DHelper.py
+++ b/src/Mod/BIM/importers/importSH3DHelper.py
@@ -445,6 +445,8 @@ class SH3DImporter:
         """
         closest_space = None
         for (space_floor, space, space_face) in self.space_upper_faces:
+            if not space_face: #?!?
+                continue
             space_face_z = space_face.CenterOfMass.z
             projection = App.Vector(p.x, p.y, space_face_z)
             # Checks that:
@@ -890,7 +892,10 @@ class RoomHandler(BaseHandler):
         self.importer.fc_objects[space.id] = space
 
         upper_face = self._get_upper_face(slab.Shape.Faces)
-        self.importer.space_upper_faces.append((floor, space, upper_face))
+        if not upper_face:
+            _wrn(f"Couldn't find the upper face of slab {slab.Label} on level {floor.Label}!")
+        else:
+            self.importer.space_upper_faces.append((floor, space, upper_face))
 
         slab.Visibility = True
 
@@ -1439,7 +1444,7 @@ class WallHandler(BaseHandler):
         lowest_z = float('inf')
         bottom_edge = None
         for edge in face.Edges:
-            if edge.CenterOfMass.z < lowest_z:
+            if edge and edge.CenterOfMass and edge.CenterOfMass.z < lowest_z:
                 lowest_z = edge.CenterOfMass.z
                 bottom_edge = edge
 

--- a/src/Mod/BIM/importers/importSH3DHelper.py
+++ b/src/Mod/BIM/importers/importSH3DHelper.py
@@ -1634,7 +1634,13 @@ class FurnitureHandler(BaseFurnitureHandler):
             group = floor.newObject("App::DocumentObjectGroup", "Furnitures")
             self.setp(floor, "App::PropertyString", "FurnitureGroupName", "The DocumentObjectGroup name for all furnitures on this floor", group.Name)
 
-        space = self.get_space(feature.Mesh.BoundBox.Center)
+        if self.importer.preferences["CREATE_ARCH_EQUIPMENT"]:
+            p = feature.Shape.BoundBox.Center
+        else:
+            p = feature.Mesh.BoundBox.Center
+
+        space = self.get_space(p)
+
         if space:
             space.Group = space.Group + [feature]
         else:
@@ -1680,10 +1686,10 @@ class FurnitureHandler(BaseFurnitureHandler):
 
         if self.importer.preferences["CREATE_ARCH_EQUIPMENT"]:
             shape = Part.Shape()
-            shape.makeShapeFromMesh(mesh.Topology, 0.100000)
+            shape.makeShapeFromMesh(mesh.Topology, 1)
             equipment = Arch.makeEquipment(name=name)
             equipment.Shape = shape
-            equipment.purgeTouched()
+            # equipment.purgeTouched()
         else:
             equipment = App.ActiveDocument.addObject("Mesh::Feature", name)
             equipment.Mesh = mesh

--- a/src/Mod/BIM/importers/importSH3DHelper.py
+++ b/src/Mod/BIM/importers/importSH3DHelper.py
@@ -1792,7 +1792,7 @@ class FurnitureHandler(BaseFurnitureHandler):
         # In FC the reference is the "upper left" corner
         transform.move(-bb.Center)
         if model_rotation:
-            rij = [ float(x=v) for v in model_rotation.split() ]
+            rij = [ float(v) for v in model_rotation.split() ]
             rotation = App.Rotation(
                 App.Vector(rij[0], rij[1], rij[2]),
                 App.Vector(rij[3], rij[4], rij[5]),

--- a/src/Mod/BIM/importers/importSH3DHelper.py
+++ b/src/Mod/BIM/importers/importSH3DHelper.py
@@ -1781,6 +1781,7 @@ class FurnitureHandler(BaseFurnitureHandler):
         roll = float(elm.get('roll', 0.0))    # Y SH3D Axis
         angle = float(elm.get('angle', 0.0))  # Z SH3D Axis
         name = elm.get('name')
+        model_rotation = elm.get('modelRotation', None)
         mirrored = bool(elm.get('modelMirrored', "false") == "true")
 
         # The meshes are normalized, centered, facing up.
@@ -1790,12 +1791,20 @@ class FurnitureHandler(BaseFurnitureHandler):
         transform = App.Matrix()
         # In FC the reference is the "upper left" corner
         transform.move(-bb.Center)
+        if model_rotation:
+            rij = [ float(x=v) for v in model_rotation.split() ]
+            rotation = App.Rotation(
+                App.Vector(rij[0], rij[1], rij[2]),
+                App.Vector(rij[3], rij[4], rij[5]),
+                App.Vector(rij[6], rij[7], rij[8])
+                )
+            _msg(f"model_rotation is not yet implemented ...")
         transform.scale(width/bb.XLength, height/bb.YLength, depth/bb.ZLength)
         # NOTE: the model is facing up, thus y and z are inverted
         transform.rotateX(math.pi/2)
         transform.rotateX(-pitch)
         transform.rotateY(roll)
-        transform.rotateZ(-angle)
+        transform.rotateZ(ang_sh2fc(angle))
 
         mesh.transform(transform)
 

--- a/src/Mod/BIM/importers/importSH3DHelper.py
+++ b/src/Mod/BIM/importers/importSH3DHelper.py
@@ -251,7 +251,6 @@ class SH3DImporter:
             if self.preferences["DEBUG"]: _log("No level defined. Using default level ...")
             self.default_floor = self.fc_objects.get('Level') if 'Level' in self.fc_objects else self._create_default_floor()
 
-
         # Importing <room> elements ...
         self._import_elements(home, 'room')
 
@@ -272,6 +271,17 @@ class SH3DImporter:
             self._import_elements(home, 'doorOrWindow')
             for furniture_group in home.findall('furnitureGroup'):
                 self._import_elements(furniture_group, 'doorOrWindow', False)
+            self._refresh()
+            group = App.ActiveDocument.Facebinders
+            for element in group.Group:
+                faces = []
+                new_sel_subshapes = []
+                for (sel_object, sel_subshapes) in element.Faces:
+                    for sel_subshape in sel_subshapes:
+                        sel_subshape = sel_subshape[1:] if sel_subshape.startswith('?') else sel_subshape
+                        new_sel_subshapes.append(sel_subshape)
+                    faces.append((sel_object, new_sel_subshapes))
+                element.Faces = faces
             self._refresh()
 
         # Importing <pieceOfFurniture> && <furnitureGroup> elements ...

--- a/src/Mod/Part/App/BRepOffsetAPI_MakePipeShellPy.xml
+++ b/src/Mod/Part/App/BRepOffsetAPI_MakePipeShellPy.xml
@@ -14,7 +14,10 @@
         Delete="true">
         <Documentation>
             <Author Licence="LGPL" Name="Werner Mayer" EMail="wmayer[at]users.sourceforge.net"/>
-            <UserDocu>Describes a portion of a circle</UserDocu>
+            <UserDocu>Low level API to create a PipeShell using OCC API
+
+            Ref: https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___make_pipe_shell.html
+            </UserDocu>
         </Documentation>
         <Methode Name="setFrenetMode">
             <Documentation>

--- a/src/Mod/Part/App/BRepOffsetAPI_MakePipeShellPyImp.cpp
+++ b/src/Mod/Part/App/BRepOffsetAPI_MakePipeShellPyImp.cpp
@@ -182,13 +182,13 @@ PyObject* BRepOffsetAPI_MakePipeShellPy::setAuxiliarySpine(PyObject *args)
 
 PyObject* BRepOffsetAPI_MakePipeShellPy::add(PyObject *args, PyObject *kwds)
 {
-    PyObject *prof, *curv=Py_False, *keep=Py_False;
+    PyObject *profile, *withContact=Py_False, *withCorrection=Py_False;
     static const std::array<const char *, 4> keywords_pro{"Profile", "WithContact", "WithCorrection", nullptr};
-    if (Base::Wrapped_ParseTupleAndKeywords(args, kwds, "O!|O!O!", keywords_pro, &Part::TopoShapePy::Type, &prof,
-                                            &PyBool_Type, &curv, &PyBool_Type, &keep)) {
+    if (Base::Wrapped_ParseTupleAndKeywords(args, kwds, "O!|O!O!", keywords_pro, &Part::TopoShapePy::Type, &profile,
+                                            &PyBool_Type, &withContact, &PyBool_Type, &withCorrection)) {
         try {
-            const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(prof)->getTopoShapePtr()->getShape();
-            this->getBRepOffsetAPI_MakePipeShellPtr()->Add(s, Base::asBoolean(curv), Base::asBoolean(keep));
+            const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(profile)->getTopoShapePtr()->getShape();
+            this->getBRepOffsetAPI_MakePipeShellPtr()->Add(s, Base::asBoolean(withContact), Base::asBoolean(withCorrection));
             Py_Return;
         }
         catch (Standard_Failure& e) {
@@ -198,16 +198,16 @@ PyObject* BRepOffsetAPI_MakePipeShellPy::add(PyObject *args, PyObject *kwds)
     }
 
     PyErr_Clear();
-    PyObject *loc;
+    PyObject *location;
     static const std::array<const char *, 5> keywords_loc{"Profile", "Location", "WithContact", "WithCorrection",
                                                           nullptr};
-    if (Base::Wrapped_ParseTupleAndKeywords(args, kwds, "O!O!|O!O!", keywords_loc, &Part::TopoShapePy::Type, &prof,
-                                            &Part::TopoShapeVertexPy::Type, &loc, &PyBool_Type, &curv, &PyBool_Type,
-                                            &keep)) {
+    if (Base::Wrapped_ParseTupleAndKeywords(args, kwds, "O!O!|O!O!", keywords_loc, &Part::TopoShapePy::Type, &profile,
+                                            &Part::TopoShapeVertexPy::Type, &location, &PyBool_Type, &withContact, &PyBool_Type,
+                                            &withCorrection)) {
         try {
-            const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(prof)->getTopoShapePtr()->getShape();
-            const TopoDS_Vertex& v = TopoDS::Vertex(static_cast<Part::TopoShapePy*>(loc)->getTopoShapePtr()->getShape());
-            this->getBRepOffsetAPI_MakePipeShellPtr()->Add(s, v, Base::asBoolean(curv), Base::asBoolean(keep));
+            const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(profile)->getTopoShapePtr()->getShape();
+            const TopoDS_Vertex& v = TopoDS::Vertex(static_cast<Part::TopoShapePy*>(location)->getTopoShapePtr()->getShape());
+            this->getBRepOffsetAPI_MakePipeShellPtr()->Add(s, v, Base::asBoolean(withContact), Base::asBoolean(withCorrection));
             Py_Return;
         }
         catch (Standard_Failure& e) {


### PR DESCRIPTION
As suggested in [#19010](https://github.com/FreeCAD/FreeCAD/pull/19010#issuecomment-2604708078) opening this PR from a branch instead of main. 

## Improvements:

-Adding Arch::Space for each room, and group furniture in these spaces
- Fixed baseboard import: the baseboard import was broken and did not create the baseboards along the bottom edge of the wall.
- Allow creation of reference ground mesh @z=0. This is controlled by a setting in the preference page.
- Avoid gap between floors: The floors' slab were extrudes to -z which left a gap between the walls of each level.
- As mentioned in https://github.com/FreeCAD/FreeCAD/pull/17165#issuecomment-2506655439 the "Join Wall" hits some strange bug in the Part::Sweep (https://github.com/FreeCAD/FreeCAD/issues/18658).

It solves the problem for straight wall by using a ruled surface instead of the `Part::Sweep` as proposed by @mwganson in https://github.com/FreeCAD/FreeCAD/issues/18658#issuecomment-2585548148

## There are some details left though:

- The workaround only works for the straight walls. Curved walls are still failing.
- When importing curved wall some message from `Measure.radius` are displayed:

```
Measurement::radius - Invalid References3D Provided
```

It seems that since the `Spine` is constructed from an Arc, not all the attributes are set to allow all the measurement on the newly created wall. It might be due to the fact that https://github.com/FreeCAD/FreeCAD/blob/main/src/Mod/Measure/App/Measurement.cpp#L524 does not handle a `measureType == MeasureType::Circle` and a `curve.GetType() == GeomAbs_BSplineCurve`. Not sure why the Arc is transformed into a BSpline...


