### PR TITLE
FEM: Constraint transform - selection error message update

### DIFF
--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
@@ -385,9 +385,9 @@ void TaskFemConstraintTransform::addToSelection()
                     QMessageBox::warning(
                         this,
                         tr("Selection error"),
-                        tr("Only transformable faces can be selected! Apply displacement boundary "
-                           "condition to surface first then apply local coordinate system to "
-                           "surface"));
+                        tr("Only transformable faces can be selected! Apply a displacement boundary "
+                           "condition or a force load to a face first then apply local coordinate system to "
+                           "the face."));
                     Gui::Selection().clearSelection();
                     return;
                 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
@@ -382,12 +382,13 @@ void TaskFemConstraintTransform::addToSelection()
                     }
                 }
                 if (Objects.empty()) {
-                    QMessageBox::warning(
-                        this,
-                        tr("Selection error"),
-                        tr("Only transformable faces can be selected! Apply a displacement boundary "
-                           "condition or a force load to a face first then apply local coordinate system to "
-                           "the face."));
+                    QMessageBox::warning(this,
+                                         tr("Selection error"),
+                                         tr("Only transformable faces can be selected! Apply a "
+                                            "displacement boundary "
+                                            "condition or a force load to a face first then apply "
+                                            "local coordinate system to "
+                                            "the face."));
                     Gui::Selection().clearSelection();
                     return;
                 }


### PR DESCRIPTION
Update of the error message shown when selecting a face without displacement boundary condition or force load - the latter wasn't included in the message since support for it was added later.