### PR TITLE
[Sketcher] Allow user to revert to legacy axes size via Preferences...

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -808,6 +808,13 @@ void EditModeCoinManager::processGeometryConstraintsInformationOverlay(
 
     processGeometryInformationOverlay(geolistfacade);
 
+    ParameterGrp::handle hGrpskg = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher");
+
+    if (hGrpskg->GetBool("UseLegacyAxes", false)) {
+        updateLegacyAxesLength();
+    }
+
     pEditModeConstraintCoinManager->processConstraints(geolistfacade);
 }
 
@@ -862,6 +869,24 @@ void EditModeCoinManager::updateAxesLength(const Base::BoundBox2d& bb)
                                                                  SbVec3f(0.0f, bb.MinY, zCrossH));
     editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(3,
                                                                  SbVec3f(0.0f, bb.MaxY, zCrossH));
+}
+
+void EditModeCoinManager::updateLegacyAxesLength()
+{
+    auto zCrossH = ViewProviderSketchCoinAttorney::getViewOrientationFactor(viewProvider)
+        * drawingParameters.zCross;
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
+        0,
+        SbVec3f(-analysisResults.boundingBoxMagnitudeOrder, 0.0f, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
+        1,
+        SbVec3f(analysisResults.boundingBoxMagnitudeOrder, 0.0f, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
+        2,
+        SbVec3f(0.0f, -analysisResults.boundingBoxMagnitudeOrder, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
+        3,
+        SbVec3f(0.0f, analysisResults.boundingBoxMagnitudeOrder, zCrossH));
 }
 
 void EditModeCoinManager::updateColor()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -261,6 +261,9 @@ public:
     // Updates the Axes extension to span the specified area.
     void updateAxesLength(const Base::BoundBox2d& bb);
 
+    // updates the Axes length to extend beyond the calculated bounding box magnitude
+    void updateLegacyAxesLength();
+
 private:
     // This function populates the coin nodes with the information of the current geometry
     void processGeometry(const GeoListFacade& geolistfacade);

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -423,6 +423,7 @@ void SketcherSettingsDisplay::saveSettings()
     ui->checkBoxUseSystemDecimals->onSave();
     ui->checkBoxShowDimensionalName->onSave();
     ui->prefDimensionalStringFormat->onSave();
+    ui->checkBoxUseLegacyAxes->onSave();
     ui->checkBoxTVHideDependent->onSave();
     ui->checkBoxTVShowLinks->onSave();
     ui->checkBoxTVShowSupport->onSave();
@@ -444,6 +445,7 @@ void SketcherSettingsDisplay::loadSettings()
     ui->checkBoxUseSystemDecimals->onRestore();
     ui->checkBoxShowDimensionalName->onRestore();
     ui->prefDimensionalStringFormat->onRestore();
+    ui->checkBoxUseLegacyAxes->onRestore();
     ui->checkBoxTVHideDependent->onRestore();
     ui->checkBoxTVShowLinks->onRestore();
     ui->checkBoxTVShowSupport->onRestore();

--- a/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
@@ -125,6 +125,22 @@ Defaults to: %N = %V
         </property>
        </widget>
       </item>
+      <item row="10" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkBoxUseLegacyAxes">
+        <property name="toolTip">
+         <string>If checked, reverts to the legacy method for setting the size of the axes.</string>
+        </property>
+        <property name="text">
+         <string>Use Legacy Axes (non-infinite length)</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>UseLegacyAxes</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Sketcher</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3546,13 +3546,18 @@ void ViewProviderSketch::onCameraChanged(SoCamera* cam)
         Base::Interpreter().runStringObject(cmdStr.toLatin1());
     }
 
-    // Stretch the axes to cover the whole viewport.
-    Gui::View3DInventor* view = qobject_cast<Gui::View3DInventor*>(this->getActiveView());
-    if (view) {
-        Base::Placement plc = getEditingPlacement();
-        const Base::BoundBox2d vpBBox = view->getViewer()
-                ->getViewportOnXYPlaneOfPlacement(plc);
-        editCoinManager->updateAxesLength(vpBBox);
+    ParameterGrp::handle hGrpskg = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher");
+
+    if (!hGrpskg->GetBool("UseLegacyAxes", false)) {
+        // Stretch the axes to cover the whole viewport.
+        Gui::View3DInventor* view = qobject_cast<Gui::View3DInventor*>(this->getActiveView());
+        if (view) {
+            Base::Placement plc = getEditingPlacement();
+            const Base::BoundBox2d vpBBox = view->getViewer()
+                    ->getViewportOnXYPlaneOfPlacement(plc);
+            editCoinManager->updateAxesLength(vpBBox);
+        }
     }
 
     drawGrid(true);


### PR DESCRIPTION
...new checkbox, default is unchecked i.e. axes are set to infinite as it is currently:

![Preferences_Sketcher_Display_New_checkbox](https://github.com/user-attachments/assets/93f8b9d9-120c-4941-afa5-1d60fb23a986)


Fixes #19191 
