### PR TITLE
BIM: Connect "only visible" checkbox signal to corresponding slot

### DIFF
--- a/src/Mod/BIM/Resources/ui/dialogClassification.ui
+++ b/src/Mod/BIM/Resources/ui/dialogClassification.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>Dialog</class>
- <widget class="QDialog" name="Dialog">
+ <widget class="QDialog" name="bimDialogClassification">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -64,6 +64,10 @@ class BIM_Classification:
         # load the form and set the tree model up
         self.form = FreeCADGui.PySideUic.loadUi(":/ui/dialogClassification.ui")
         self.form.setWindowIcon(QtGui.QIcon(":/icons/BIM_Classification.svg"))
+        self.form.groupMode.setItemIcon(0, QtGui.QIcon(":/icons/Arch_SectionPlane_Tree.svg")) # Alphabetical
+        self.form.groupMode.setItemIcon(1, QtGui.QIcon(":/icons/IFC.svg")) # Type
+        self.form.groupMode.setItemIcon(2, QtGui.QIcon(":/icons/Arch_Material.svg")) # Material
+        self.form.groupMode.setItemIcon(3, QtGui.QIcon(":/icons/Document.svg")) # Model structure
 
         # restore saved values
         self.form.onlyVisible.setChecked(PARAMS.GetInt("BimClassificationVisibleState", 0))

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -29,6 +29,7 @@ import os
 
 QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate
+PARAMS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM")
 
 
 class BIM_Classification:
@@ -65,9 +66,9 @@ class BIM_Classification:
         self.form.setWindowIcon(QtGui.QIcon(":/icons/BIM_Classification.svg"))
 
         # restore saved values
-        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM")
-        w = p.GetInt("BimClassificationDialogWidth", 629)
-        h = p.GetInt("BimClassificationDialogHeight", 516)
+        self.form.onlyVisible.setChecked(PARAMS.GetInt("BimClassificationVisibleState", 0))
+        w = PARAMS.GetInt("BimClassificationDialogWidth", 629)
+        h = PARAMS.GetInt("BimClassificationDialogHeight", 516)
         self.form.resize(w, h)
 
         # add modified search box from bimmaterial
@@ -151,6 +152,7 @@ class BIM_Classification:
         self.form.treeClass.itemDoubleClicked.connect(self.apply)
         self.form.search.up.connect(self.onUpArrow)
         self.form.search.down.connect(self.onDownArrow)
+        self.form.onlyVisible.stateChanged.connect(self.onVisible)
 
         # center the dialog over FreeCAD window
         mw = FreeCADGui.getMainWindow()
@@ -649,6 +651,10 @@ class BIM_Classification:
             i = self.form.treeClass.currentItem()
             if self.form.treeClass.itemBelow(i):
                 self.form.treeClass.setCurrentItem(self.form.treeClass.itemBelow(i))
+
+    def onVisible(self, index):
+        PARAMS.SetInt("BimClassificationVisibleState", index)
+        self.updateObjects()
 
     def getIcon(self,obj):
         """returns a QIcon for an object"""


### PR DESCRIPTION
- Connect "only visible" checkbox signal to slot
- Create corresponding "onVisible" slot
- Remember the status of checkbox between dialog launches (store status as a parameter)

Since they were small, this PR also introduces some minor changes, mostly visual:
- Change default ui dialog `Dialog` name to `bimDialogClassification` to make debugging easier
- Add icons to classification dropdown box. Before, some items were indented to accomodate an (inexistent) icon, some others were not

| Before | After |
| --- | --- |
| ![Captura de pantalla de 2025-01-23 13-33-47](https://github.com/user-attachments/assets/83b3a140-0de5-44cd-874a-e32cc29ddc5a) | ![Captura de pantalla de 2025-01-23 13-31-55](https://github.com/user-attachments/assets/e60ad872-9ceb-4a36-b6c5-985b2cc9dcc9) |

Notes:
- :bulb: Other BIM/IFC dialogs, which have icons in the same dropboxes partially implemented also require the fix above. Given that there are a handful of BIM/IFC manager dialogs all using the same or similar widgets, it might be worth thinking of defining that code in one single place. Currently the code is duplicated for each manager dialog. This PR does not modify this situation.

Fixes: #16721