### PR TITLE
TechDraw: rename user-facing strings Arch to BIM

### DIFF
--- a/src/Mod/BIM/bimcommands/BimTDView.py
+++ b/src/Mod/BIM/bimcommands/BimTDView.py
@@ -77,7 +77,7 @@ class BIM_TDView:
         FreeCAD.ActiveDocument.openTransaction("Create view")
         for section in sections:
             view = FreeCAD.ActiveDocument.addObject(
-                "TechDraw::DrawViewArch", "ArchView"
+                "TechDraw::DrawViewArch", "BIM view"
             )
             view.Label = section.Label
             view.Source = section

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -65,7 +65,7 @@ using DU = DrawUtil;
     QT_TRANSLATE_NOOP("DrawViewAnnotation", "Annotation");
     QT_TRANSLATE_NOOP("DrawViewImage", "Image");
     QT_TRANSLATE_NOOP("DrawViewSymbol", "Symbol");
-    QT_TRANSLATE_NOOP("DrawViewArch", "Arch");
+    QT_TRANSLATE_NOOP("DrawViewArch", "BIM");
     QT_TRANSLATE_NOOP("DrawViewDraft", "Draft");
     QT_TRANSLATE_NOOP("DrawLeaderLine", "LeaderLine");
     QT_TRANSLATE_NOOP("DrawViewBalloon", "Balloon");

--- a/src/Mod/TechDraw/App/DrawViewArch.cpp
+++ b/src/Mod/TechDraw/App/DrawViewArch.cpp
@@ -49,14 +49,14 @@ const char* DrawViewArch::RenderModeEnums[]= {"Wireframe",
 
 DrawViewArch::DrawViewArch()
 {
-    static const char *group = "Arch view";
+    static const char *group = "BIM view";
 
     ADD_PROPERTY_TYPE(Source ,(nullptr), group, App::Prop_None, "SectionPlane or BuildingPart object for this view");
     Source.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(AllOn ,(false), group, App::Prop_None, "If hidden objects must be shown or not");
     RenderMode.setEnums(RenderModeEnums);
     ADD_PROPERTY_TYPE(RenderMode, ((long)0), group, App::Prop_None, "The render mode to use");
-    ADD_PROPERTY_TYPE(FillSpaces ,(false), group, App::Prop_None, "If True, Arch Spaces are shown as a colored area");
+    ADD_PROPERTY_TYPE(FillSpaces ,(false), group, App::Prop_None, "If True, BIM Spaces are shown as a colored area");
     ADD_PROPERTY_TYPE(ShowHidden ,(false), group, App::Prop_None, "If the hidden geometry behind the section plane is shown or not");
     ADD_PROPERTY_TYPE(ShowFill ,(false), group, App::Prop_None, "If cut areas must be filled with a hatch pattern or not");
     ADD_PROPERTY_TYPE(LineWidth, (0.25), group, App::Prop_None, "Line width of this view");

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -303,7 +303,7 @@ CmdTechDrawView::CmdTechDrawView() : Command("TechDraw_View")
     sGroup = QT_TR_NOOP("TechDraw");
     sMenuText = QT_TR_NOOP("Insert View");
     sToolTipText = QT_TR_NOOP("Insert a View in current page.\n"
-        "Selected objects, spreadsheets or Arch WB section planes will be added.\n"
+        "Selected objects, spreadsheets or BIM section planes will be added.\n"
         "Without a selection, a file browser lets you select a SVG or image file.");
     sWhatsThis = "TechDraw_View";
     sStatusTip = sToolTipText;
@@ -360,12 +360,12 @@ void CmdTechDrawView::activated(int iMsg)
             continue;
         }
         else if (DrawGuiUtil::isArchSection(obj)) {
-            std::string FeatName = getUniqueObjectName("ArchView");
+            std::string FeatName = getUniqueObjectName("BIM view");
             std::string SourceName = obj->getNameInDocument();
-            openCommand(QT_TRANSLATE_NOOP("Command", "Create BIM View"));
+            openCommand(QT_TRANSLATE_NOOP("Command", "Create BIM view"));
             doCommand(Doc, "App.activeDocument().addObject('TechDraw::DrawViewArch', '%s')",
                 FeatName.c_str());
-            doCommand(Doc, "App.activeDocument().%s.translateLabel('DrawViewArch', 'ArchView', '%s')",
+            doCommand(Doc, "App.activeDocument().%s.translateLabel('DrawViewArch', 'BIM view', '%s')",
                 FeatName.c_str(), FeatName.c_str());
             doCommand(Doc, "App.activeDocument().%s.Source = App.activeDocument().%s", FeatName.c_str(),
                 SourceName.c_str());
@@ -1661,7 +1661,7 @@ CmdTechDrawArchView::CmdTechDrawArchView() : Command("TechDraw_ArchView")
     // setting the Gui eye-candy
     sGroup = QT_TR_NOOP("TechDraw");
     sMenuText = QT_TR_NOOP("Insert BIM Workbench Object");
-    sToolTipText = QT_TR_NOOP("Insert a View of a Section Plane from BIM Workbench");
+    sToolTipText = QT_TR_NOOP("Insert a View of a BIM Workbench section plane");
     sWhatsThis = "TechDraw_NewArch";
     sStatusTip = sToolTipText;
     sPixmap = "actions/TechDraw_ArchView";
@@ -1688,13 +1688,13 @@ void CmdTechDrawArchView::activated(int iMsg)
     }
     if (archCount > 1) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Please select only 1 BIM Section."));
+                             QObject::tr("Please select only 1 BIM section plane."));
         return;
     }
 
     if (!archObject) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("No BIM Sections in selection."));
+                             QObject::tr("No BIM section plane in selection."));
         return;
     }
 
@@ -1704,12 +1704,12 @@ void CmdTechDrawArchView::activated(int iMsg)
     }
     std::string PageName = page->getNameInDocument();
 
-    std::string FeatName = getUniqueObjectName("ArchView");
+    std::string FeatName = getUniqueObjectName("BIM view");
     std::string SourceName = archObject->getNameInDocument();
-    openCommand(QT_TRANSLATE_NOOP("Command", "Create ArchView"));
+    openCommand(QT_TRANSLATE_NOOP("Command", "Create BIM view"));
     doCommand(Doc, "App.activeDocument().addObject('TechDraw::DrawViewArch', '%s')",
               FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.translateLabel('DrawViewArch', 'ArchView', '%s')",
+    doCommand(Doc, "App.activeDocument().%s.translateLabel('DrawViewArch', 'BIM view', '%s')",
               FeatName.c_str(), FeatName.c_str());
     doCommand(Doc, "App.activeDocument().%s.Source = App.activeDocument().%s", FeatName.c_str(),
               SourceName.c_str());
@@ -2058,5 +2058,3 @@ std::pair<App::DocumentObject*, std::string> faceFromSelection()
 
     return { nullptr, "" };
 }
-
-


### PR DESCRIPTION
Only the texts in the Property Panel, the Menus, Tooltips and default label for new created BIM views are changed.
The internal names (ArchView), messages in the Report/Console too, files (Cpp and SVG icons) are kept.
They can be changed if wanted too, let me know.
Also, the Join Arch property is kept for now.