### PR TITLE
AddonManager: open addon's location directory

### DIFF
--- a/src/Mod/AddonManager/Addon.py
+++ b/src/Mod/AddonManager/Addon.py
@@ -150,6 +150,9 @@ class Addon:
     # The location of the Mod directory: overridden by testing code
     mod_directory = fci.DataPaths().mod_dir
 
+    # The location of the Macro directory: overridden by testing code
+    macro_directory = fci.DataPaths().macro_dir
+
     def __init__(
         self,
         name: str,

--- a/src/Mod/AddonManager/Widgets/addonmanager_widget_package_details_view.py
+++ b/src/Mod/AddonManager/Widgets/addonmanager_widget_package_details_view.py
@@ -111,7 +111,7 @@ class PackageDetailsView(QtWidgets.QWidget):
         self.location_label = QtWidgets.QLabel(self)
         self.url_label = QtWidgets.QLabel(self)
         self.url_label.setOpenExternalLinks(True)
-        self.location_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+        self.location_label.setOpenExternalLinks(True)
         self.vertical_layout.addWidget(self.button_bar)
         self.vertical_layout.addWidget(self.message_label)
         self.vertical_layout.addWidget(self.location_label)
@@ -121,10 +121,16 @@ class PackageDetailsView(QtWidgets.QWidget):
 
     def set_location(self, location: Optional[str]):
         if location is not None:
+            location_path = os.path.normpath(location)
             text = (
                 translate("AddonsInstaller", "Installation location")
                 + ": "
-                + os.path.normpath(location)
+                + location_path
+                + ' <a href="file://'
+                + location_path
+                + '">  [ '
+                + translate("AddonsInstaller", "open")
+                + " ]</a>"
             )
             self.location_label.setText(text)
             self.location_label.show()

--- a/src/Mod/AddonManager/addonmanager_package_details_controller.py
+++ b/src/Mod/AddonManager/addonmanager_package_details_controller.py
@@ -114,7 +114,11 @@ class PackageDetailsController(QtCore.QObject):
             elif repo.macro:
                 update_info.version = repo.macro.version
             self.ui.set_update_available(update_info)
-            self.ui.set_location(os.path.join(self.addon.mod_directory, self.addon.name))
+            self.ui.set_location(
+                self.addon.macro_directory
+                if repo.repo_type == Addon.Kind.MACRO
+                else os.path.join(self.addon.mod_directory, self.addon.name)
+            )
             self.ui.set_disabled(self.addon.is_disabled())
         self.ui.allow_running(repo.repo_type == Addon.Kind.MACRO)
         self.ui.allow_disabling(repo.repo_type != Addon.Kind.MACRO)
@@ -125,7 +129,7 @@ class PackageDetailsController(QtCore.QObject):
         if repo.status() == Addon.Status.UNCHECKED:
             self.ui.button_bar.check_for_update.show()
             self.ui.button_bar.check_for_update.setText(
-                translate("AddonsInstaller", "Check for " "update")
+                translate("AddonsInstaller", "Check for update")
             )
             self.ui.button_bar.check_for_update.setEnabled(True)
             if not self.update_check_thread:


### PR DESCRIPTION
Now you can click on the `[ open ]` text and the directory will be open with app set by the OS. Link could be moved over the path.

When the previous behavior of select text flag is on the link doesn't work.

![image](https://github.com/user-attachments/assets/7a33e267-d0fa-47c6-bf28-8bdbfdfbd3fa)
