### PR TITLE
[Gui] Trigger the same checks for Drag & Dropping files as File > Open

### DIFF
--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -79,6 +79,10 @@ public:
     App::Document *reopen(App::Document *doc);
     /// Prompt about recomputing if needed
     static void checkForRecomputes();
+    /// Prompt about PartialRestore
+    void checkPartialRestore(App::Document* doc);
+    /// Prompt for Errors on open
+    void checkRestoreError(App::Document* doc);
     //@}
 
 

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -96,26 +96,6 @@ StdCmdOpen::StdCmdOpen()
 
 void StdCmdOpen::activated(int iMsg)
 {
-    // clang-format off
-    auto checkPartialRestore = [](App::Document* doc) {
-        if (doc && doc->testStatus(App::Document::PartialRestore)) {
-            QMessageBox::critical(getMainWindow(), QObject::tr("Error"),
-            QObject::tr("There were errors while loading the file. Some data might have been "
-                        "modified or not recovered at all. Look in the report view for more "
-                        "specific information about the objects involved."));
-        }
-    };
-
-    auto checkRestoreError = [](App::Document* doc) {
-        if (doc && doc->testStatus(App::Document::RestoreError)) {
-            QMessageBox::critical(getMainWindow(), QObject::tr("Error"),
-            QObject::tr("There were serious errors while loading the file. Some data might have "
-                        "been modified or not recovered at all. Saving the project will most "
-                        "likely result in loss of data."));
-        }
-    };
-    // clang-format on
-
     Q_UNUSED(iMsg);
 
     // fill the list of registered endings
@@ -183,8 +163,8 @@ void StdCmdOpen::activated(int iMsg)
 
             App::Document *doc = App::GetApplication().getActiveDocument();
 
-            checkPartialRestore(doc);
-            checkRestoreError(doc);
+            getGuiApplication()->checkPartialRestore(doc);
+            getGuiApplication()->checkRestoreError(doc);
         }
     }
 }


### PR DESCRIPTION
Replaces https://github.com/FreeCAD/FreeCAD/pull/18951

@tritao regarding previous feedback, I can confirm testing a 0.21.x file there is a single `checkForRecomputes` triggered for both Drag & Drop and File > Open
Also tested a version 1.0 file to ensure that there wasn't a Recompute triggered, as well as a Step and a DXF file, all worked as I would expect.

I've left the checks in Application primarily because I tried and failed to compile it any other way. With Werner creating them as separate checks I'm not inclined to combine them at this stage.

@wwmayer would you mind reviewing please.

Fixes #18889 