### PR TITLE
Sketcher: Changed how tool active state is checked to only enable on…

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -63,10 +63,10 @@ void ActivateBSplineHandler(Gui::Document* doc, DrawSketchHandler* handler)
     }
 }
 
-/// For a knot given by (GeoId, PosId) finds the B-Spline and the knot's
-/// index within it (by OCC numbering).
-/// Returns true if the entities are found, false otherwise.
-/// If returns false, `splineGeoId` and `knotIndexOCC` have garbage values.
+// For a knot given by (GeoId, PosId) finds the B-Spline and the knot's
+// index within it (by OCC numbering).
+// Returns true if the entities are found, false otherwise.
+// If returns false, `splineGeoId` and `knotIndexOCC` have garbage values.
 bool findBSplineAndKnotIndex(Sketcher::SketchObject* Obj,
                              int knotGeoId,
                              Sketcher::PointPos knotPosId,
@@ -177,7 +177,7 @@ void CmdSketcherConvertToNURBS::activated(int iMsg)
 
 bool CmdSketcherConvertToNURBS::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandActive(getActiveGuiDocument(), NEEDS_GEOMETRY | NEEDS_NOT_ONLY_BSPLINE);
 }
 
 // Increase degree of the spline
@@ -253,7 +253,7 @@ void CmdSketcherIncreaseDegree::activated(int iMsg)
 
 bool CmdSketcherIncreaseDegree::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandActive(getActiveGuiDocument(), NEEDS_BSPLINE);
 }
 
 
@@ -336,7 +336,7 @@ void CmdSketcherDecreaseDegree::activated(int iMsg)
 
 bool CmdSketcherDecreaseDegree::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandActive(getActiveGuiDocument(), NEEDS_BSPLINE);
 }
 
 
@@ -485,7 +485,7 @@ void CmdSketcherIncreaseKnotMultiplicity::activated(int iMsg)
 
 bool CmdSketcherIncreaseKnotMultiplicity::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandActive(getActiveGuiDocument(), NEEDS_BSPLINE);
 }
 
 DEF_STD_CMD_A(CmdSketcherDecreaseKnotMultiplicity)
@@ -621,7 +621,7 @@ void CmdSketcherDecreaseKnotMultiplicity::activated(int iMsg)
 
 bool CmdSketcherDecreaseKnotMultiplicity::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandActive(getActiveGuiDocument(), NEEDS_BSPLINE);
 }
 
 
@@ -723,7 +723,7 @@ void CmdSketcherCompModifyKnotMultiplicity::updateAction(int /*mode*/)
 
 bool CmdSketcherCompModifyKnotMultiplicity::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument(), NEEDS_BSPLINE);
 }
 
 class DrawSketchHandlerBSplineInsertKnot: public DrawSketchHandler
@@ -945,7 +945,7 @@ void CmdSketcherInsertKnot::activated(int iMsg)
 
 bool CmdSketcherInsertKnot::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandActive(getActiveGuiDocument(), NEEDS_BSPLINE);
 }
 
 DEF_STD_CMD_A(CmdSketcherJoinCurves)
@@ -1101,7 +1101,7 @@ void CmdSketcherJoinCurves::activated(int iMsg)
 
 bool CmdSketcherJoinCurves::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandActive(getActiveGuiDocument(), NEEDS_BSPLINE);
 }
 
 void CreateSketcherCommandsBSpline()

--- a/src/Mod/Sketcher/Gui/CommandSketcherOverlay.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherOverlay.cpp
@@ -83,7 +83,7 @@ void CmdSketcherBSplineDegree::activated(int iMsg)
 
 bool CmdSketcherBSplineDegree::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument(), DOES_NOT_ACT_ON_SELECTION);
 }
 
 // Show/Hide B-spline polygon
@@ -113,7 +113,7 @@ void CmdSketcherBSplinePolygon::activated(int iMsg)
 
 bool CmdSketcherBSplinePolygon::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument(), DOES_NOT_ACT_ON_SELECTION);
 }
 
 // Show/Hide B-spline comb
@@ -143,7 +143,7 @@ void CmdSketcherBSplineComb::activated(int iMsg)
 
 bool CmdSketcherBSplineComb::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument(), DOES_NOT_ACT_ON_SELECTION);
 }
 
 //
@@ -173,7 +173,7 @@ void CmdSketcherBSplineKnotMultiplicity::activated(int iMsg)
 
 bool CmdSketcherBSplineKnotMultiplicity::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument(), DOES_NOT_ACT_ON_SELECTION);
 }
 
 //
@@ -203,7 +203,7 @@ void CmdSketcherBSplinePoleWeight::activated(int iMsg)
 
 bool CmdSketcherBSplinePoleWeight::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument(), DOES_NOT_ACT_ON_SELECTION);
 }
 
 // Composite drop down menu for show/hide BSpline information layer
@@ -349,7 +349,7 @@ void CmdSketcherCompBSplineShowHideGeometryInformation::updateAction(int /*mode*
 
 bool CmdSketcherCompBSplineShowHideGeometryInformation::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument(), DOES_NOT_ACT_ON_SELECTION);
 }
 
 //

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -928,7 +928,7 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
 
 bool CmdSketcherSelectElementsAssociatedWithConstraints::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), NEEDS_CONSTRAINT); 
+    return isCommandActive(getActiveGuiDocument(), NEEDS_CONSTRAINT);
 }
 
 // ================================================================================

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -563,7 +563,7 @@ bool SketcherGui::isCommandActive(Gui::Document* doc, int actsOn)
                             selectionHasOnlyElipses = false;
                         }
                         else if (isArcOfEllipse(*Obj->getGeometry(geoId))
-                                    || isEllipse(*Obj->getGeometry(geoId))) {
+                                 || isEllipse(*Obj->getGeometry(geoId))) {
                             selectionHasOnlyBsplines = false;
                         }
                         else {
@@ -591,7 +591,7 @@ bool SketcherGui::isCommandActive(Gui::Document* doc, int actsOn)
                     }
                 }
             }
-            
+
             // example actsOn
             return !(actsOn & NEEDS_GEOMETRY && !selectionHasGeo)
                 && !(actsOn & NEEDS_BSPLINE && !selectionHasBSpline)
@@ -599,8 +599,8 @@ bool SketcherGui::isCommandActive(Gui::Document* doc, int actsOn)
                 && !(actsOn & NEEDS_NOT_ONLY_ELLIPSE && selectionHasOnlyElipses)
                 && !(actsOn & NEEDS_NOT_ONLY_POINT && selectionHasOnlyPoints)
                 && !(actsOn & NEEDS_CONSTRAINT && !selectionHasConstraint);
-            }
         }
+    }
 
     return false;
 }

--- a/src/Mod/Sketcher/Gui/Utils.h
+++ b/src/Mod/Sketcher/Gui/Utils.h
@@ -177,14 +177,24 @@ void GetCirclesMinimalDistance(const Part::Geometry* geom1,
 
 void ActivateHandler(Gui::Document* doc, std::unique_ptr<DrawSketchHandler> handler);
 
-/// Returns if a sketch is in edit mode
+// Returns if a sketch is in edit mode
 bool isSketchInEdit(Gui::Document* doc);
+enum ACTS_ON_SELECTION_TYPE
+{
+    DOES_NOT_ACT_ON_SELECTION = 0x00,
+    ACTS_ON_SELECTION = 0x01,
+    NEEDS_GEOMETRY = 0x04,
+    NEEDS_BSPLINE = 0x08,
+    NEEDS_NOT_ONLY_BSPLINE = 0x10,
+    NEEDS_NOT_ONLY_ELLIPSE = 0x20,
+    NEEDS_NOT_ONLY_POINT = 0x40,
+    NEEDS_CONSTRAINT = 0x80
+};
 
-/// Returns whether an edit mode command should be activated or not. It is only activated if the
-/// sketcher is no special state or a sketchHandler is active.
-bool isCommandActive(Gui::Document* doc, bool actsOnSelection = false);
+// Returns whether an edit mode command should be activated or not. It is only activated if the
+// sketcher is no special state or a sketchHandler is active.
+bool isCommandActive(Gui::Document* doc, int actsOn = DOES_NOT_ACT_ON_SELECTION);
 
-bool isSketcherBSplineActive(Gui::Document* doc, bool actsOnSelection);
 
 SketcherGui::ViewProviderSketch* getInactiveHandlerEditModeSketchViewProvider(Gui::Document* doc);
 


### PR DESCRIPTION
Fixes #19059 
This adds a more through check of what is being selected before setting a tool to active :
- If  the selection is a line :
![image](https://github.com/user-attachments/assets/e2aef457-8267-429d-85d8-62a3e57e3e47)
- If the selection is a constraint :
![image](https://github.com/user-attachments/assets/080182e7-8e79-4148-8a57-3efbe4354fb1)
- If the selection is only a B-Spline :
![image](https://github.com/user-attachments/assets/a227acc1-1999-428d-88eb-a81c49e9d827)
(the offset tool is not enabled if the geometry is only a point, a B-Spline or an ellipse as they are not supported by the tool)

I am not sure when this tool should be enabled : 
(it was enabled on selection before)
```c++
bool CmdSketcherRestoreInternalAlignmentGeometry::isActive()
{
    return isCommandActive(getActiveGuiDocument(), true, true);
}
```

I also am not sure how to properly implement caching to not go through every selection element for every `::isActive()` of every button :
I did it with a timer with an arbitrary delay of `0.1s`. With large selections, this takes the time from `9ms` down to `0.2ms`, this is why I felt the need to cache the selection types. 