### PR TITLE
Gui: Add bounding box data to scene inspector.

### DIFF
--- a/src/Gui/SceneInspector.ui
+++ b/src/Gui/SceneInspector.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>805</width>
-    <height>583</height>
+    <width>1200</width>
+    <height>700</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
As title says, adds bounding box data to scene inspector. This helps with some debugging scenarios.

I've also organized the UI a little bit by adding columns for caching data as well as for bounding box, as previously everything was going to the `Data` column, and it was getting cluttered and hard to visually parse the info.

![image](https://github.com/user-attachments/assets/674168b8-385b-45af-9ffc-9834911cbc41)
