### PR TITLE
BIM: add support for array elements in BIM Schedule

### DIFF
--- a/src/Mod/BIM/ArchSchedule.py
+++ b/src/Mod/BIM/ArchSchedule.py
@@ -600,16 +600,15 @@ class _ArchSchedule:
 
         import Draft
 
-        try:
-            # TODO: an element can have multiple array parents
-            parent = obj.InList[0]
-        except IndexError:
-            parent = None
+        elementCount = 0
 
-        if parent:
-            if Draft.getType(parent) == "Array":
-                return parent.Count
-        return 0
+        # The given object can belong to multiple arrays
+        # o is a potential parent array of the given object
+        for o in obj.InList:
+            if Draft.getType(o) == "Array":
+                elementCount += o.Count
+
+        return elementCount
 
     def expandArrays(self, objs):
         """Expands array elements in the given list of objects"""

--- a/src/Mod/BIM/ArchSchedule.py
+++ b/src/Mod/BIM/ArchSchedule.py
@@ -254,7 +254,7 @@ class _ArchSchedule:
             ifcfile = None
             elts = None
             if val:
-                import Draft,Arch
+                import Draft
                 if objs:
                     objs = objs.split(";")
                     objs = [FreeCAD.ActiveDocument.getObject(o) for o in objs]
@@ -615,6 +615,7 @@ class _ArchSchedule:
         # An alternative could be to use Arch.pruneIncluded(), but that
         # removes an array's base element
 
+        import Arch
         prunedobjs = []
 
         for obj in objs:
@@ -626,6 +627,10 @@ class _ArchSchedule:
                 for i in range(array):
                     if i > 0: # the first item already went above
                         prunedobjs.append(obj)
+
+        # Remove included objects (e.g. walls that are part of another wall,
+        # base geometry, etc)
+        prunedobjs = Arch.pruneIncluded(prunedobjs, strict=True, silent=True)
 
         return prunedobjs
 


### PR DESCRIPTION
This PR adds functionality to the BIM Schedule command to detect and expand array elements, so that they can be further processed. Before, array elements were ignored.

:information_source: Notes:

1. It covers the array type in the test case file provided in #16719. Element(s) belonging to a single ortho Link array, with `expanded=False`.
1. It has also been successfully tested with:
   - Regular arrays
   - Link arrays with `expanded=True`
1. There might be other cases to cover, but as long as this PR does not break them, they can be addressed in subsequent PRs
1. The approach to expand arrays is nearly the same as what BimIfcQuantities uses. This ensures reusing (yet duplicating) proven code, but there might be a more elegant approach for BIM Schedule. I'm more than open to suggestions.
1. The resulting quantities are correct when using the test case file, but units are not shown in the report. Nor there is unit conversion (e.g. the schedule specifies m³ and the output is in mm³). This is probably a bug outside the scope of this PR.

:warning: Known limitations:

1. The use case of nested arrays (array of an array) is not covered in this PR

Fixes: #16719