### PR TITLE
GUI: Disable legacy spnav code when legacy is false

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -569,7 +569,11 @@ void View3DInventorViewer::init()
     //filter a few qt events
     viewerEventFilter = new ViewerEventFilter;
     installEventFilter(viewerEventFilter);
-    getEventFilter()->registerInputDevice(new SpaceNavigatorDevice);
+    ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/View");
+    if (hViewGrp->GetBool("LegacySpaceMouseDevices", false)) {
+        getEventFilter()->registerInputDevice(new SpaceNavigatorDevice);
+    }
     getEventFilter()->registerInputDevice(new GesturesDevice(this));
 
     try{


### PR DESCRIPTION
We don't ever want to connect to both libspnav and NavLib. Fixes #19223.