### PR TITLE
Draft: introduce new Draft_Layers icon

### DIFF
--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -47,6 +47,7 @@
         <file>icons/Draft_Join.svg</file>
         <file>icons/Draft_Label.svg</file>
         <file>icons/Draft_Layer.svg</file>
+        <file>icons/Draft_Layers.svg</file>
         <file>icons/Draft_LayerManager.svg</file>
         <file>icons/Draft_Line.svg</file>
         <file>icons/Draft_LinkArray.svg</file>

--- a/src/Mod/Draft/Resources/icons/Draft_Layers.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_Layers.svg
@@ -11,7 +11,7 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title853">Draft_Layer</title>
+     id="title853">Draft_Layers</title>
   <defs
      id="defs2987">
     <linearGradient
@@ -61,7 +61,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>Draft_Layer</dc:title>
+        <dc:title>Draft_Layers</dc:title>
         <dc:date>Tue Jun 10 10:21:01 2014 -0300</dc:date>
         <dc:creator>
           <cc:Agent>
@@ -78,7 +78,7 @@
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Layer.svg</dc:identifier>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Layers.svg</dc:identifier>
         <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:contributor>
           <cc:Agent>
@@ -119,6 +119,15 @@
      style="display:inline;stroke-width:0.653981"
      transform="matrix(1.5298962,0,0,1.5282988,-16.690014,-13.850775)">
     <path
+       d="M 26.887294,28.702625 49.196281,37.863018 36.448288,48.332039 14.139301,39.171646 Z"
+       style="display:inline;overflow:visible;fill:url(#linearGradient2);fill-rule:evenodd;stroke:#2e3436;stroke-width:1.2916;stroke-linejoin:round;stroke-dasharray:none;marker:none;enable-background:accumulate"
+       id="path1-2"
+       transform="matrix(1.0254777,0,0,1.000013,-0.3220963,-0.01045756)" />
+    <path
+       id="path3-2"
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.30796;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 16.744141,38.779882 c 6.697265,2.682292 13.394531,5.364583 20.091797,8.046875 3.574869,-2.863281 7.149739,-5.726563 10.724609,-8.589844 -6.697266,-2.682292 -13.394531,-5.364583 -20.091797,-8.046875 -3.57487,2.863281 -7.14974,5.726563 -10.724609,8.589844 z" />
+    <path
        d="M 27.250224,20.840975 50.127593,30.001487 37.05481,40.470644 14.177442,31.310132 Z"
        style="display:inline;overflow:visible;fill:url(#linearGradient1);fill-rule:evenodd;stroke:#2e3436;stroke-width:1.30796;stroke-linejoin:round;stroke-dasharray:none;marker:none;enable-background:accumulate"
        id="path1-2-9" />
@@ -126,5 +135,13 @@
        id="path3-5"
        style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.30796;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
        d="m 16.744141,30.928014 c 6.697265,2.682292 13.394531,5.364583 20.091797,8.046875 3.574869,-2.863281 7.149739,-5.726563 10.724609,-8.589844 -6.697266,-2.682292 -13.394531,-5.364583 -20.091797,-8.046875 -3.57487,2.863281 -7.14974,5.726563 -10.724609,8.589844 z" />
+    <path
+       d="M 27.250224,12.989107 50.127593,22.149619 37.05481,32.618776 14.177442,23.458264 Z"
+       style="display:inline;overflow:visible;fill:url(#linearGradient3);fill-rule:evenodd;stroke:#2e3436;stroke-width:1.30796;stroke-linejoin:round;stroke-dasharray:none;marker:none;enable-background:accumulate"
+       id="path1-2-3" />
+    <path
+       id="path3"
+       style="fill:none;stroke:#ffffff;stroke-width:1.30796;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 16.744141,23.076172 c 6.697265,2.682292 13.394531,5.364583 20.091797,8.046875 3.574869,-2.863281 7.149739,-5.726563 10.724609,-8.589844 -6.697266,-2.682292 -13.394531,-5.364583 -20.091797,-8.046875 -3.57487,2.863281 -7.14974,5.726563 -10.724609,8.589844 z" />
   </g>
 </svg>

--- a/src/Mod/Draft/draftviewproviders/view_layer.py
+++ b/src/Mod/Draft/draftviewproviders/view_layer.py
@@ -527,7 +527,7 @@ class ViewProviderLayerContainer:
 
     def getIcon(self):
         """Return the path to the icon used by the viewprovider."""
-        return ":/icons/Draft_Layer.svg"
+        return ":/icons/Draft_Layers.svg"
 
     def attach(self, vobj):
         """Set up the scene sub-graph of the viewprovider."""
@@ -535,7 +535,7 @@ class ViewProviderLayerContainer:
 
     def setupContextMenu(self, vobj, menu):
         """Set up actions to perform in the context menu."""
-        action_merge = QtGui.QAction(QtGui.QIcon(":/icons/Draft_Layer.svg"),
+        action_merge = QtGui.QAction(QtGui.QIcon(":/icons/Draft_Layers.svg"),
                                      translate("draft", "Merge layer duplicates"),
                                      menu)
         action_merge.triggered.connect(self.merge_by_name)


### PR DESCRIPTION
The current Draft_Layer.svg icon shows multiple layers. It is used for the Draft_Layer command but also for the LayerContainer. This is confusing. There should be separate icons, one with a single layer and one with multiple layers.
