### PR TITLE
[TD]minor fixes x3

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -231,6 +231,8 @@ DrawViewDimension::DrawViewDimension()
                       "If true, area dimensions return the area of the face minus the areas of any enclosed faces. \
                        If false, the area of the face's outer boundary is returned.");
 
+    ADD_PROPERTY_TYPE(ShowUnits, (Preferences::showUnits()), "Format", App::Prop_None,
+                                          "Show or hide the units.");
     measurement = new Measure::Measurement();
     // TODO: should have better initial datumLabel position than (0, 0) in the DVP?? something
     // closer to the object being measured?
@@ -2076,7 +2078,7 @@ bool DrawViewDimension::hasOverUnderTolerance() const
 
 bool DrawViewDimension::showUnits() const
 {
-    return Preferences::getPreferenceGroup("Dimensions")->GetBool("ShowUnits", false);
+    return ShowUnits.getValue();
 }
 
 bool DrawViewDimension::useDecimals() const

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -94,6 +94,8 @@ public:
     App::PropertyVectorList BoxCorners;
     App::PropertyBool UseActualArea;
 
+    App::PropertyBool ShowUnits;
+
     enum RefType
     {
         invalidRef,

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -682,3 +682,11 @@ bool Preferences::useLegacySvgScaling()
 {
     return getPreferenceGroup("General")->GetBool("LegacySvgScaling", false);
 }
+
+
+bool Preferences::showUnits()
+{
+    return Preferences::getPreferenceGroup("Dimensions")->GetBool("ShowUnits", false);
+}
+
+

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -159,6 +159,8 @@ public:
 
     static bool useLegacySvgScaling();
 
+    static bool showUnits();
+
 };
 
 

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>440</width>
-    <height>508</height>
+    <width>495</width>
+    <height>692</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -35,7 +35,7 @@
       <item>
        <layout class="QGridLayout" name="gridLayout">
         <item row="8" column="2">
-         <widget class="Gui::PrefUnitSpinBox" name="plsb_ArrowSize">
+         <widget class="Gui::PrefUnitSpinBox" name="plsb_ArrowSize" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -45,7 +45,7 @@
           <property name="toolTip">
            <string>Arrowhead size</string>
           </property>
-          <property name="value">
+          <property name="value" stdset="0">
            <double>5.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
@@ -156,6 +156,11 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
           <property name="toolTip">
            <string>Append unit to dimension values</string>
           </property>
@@ -183,7 +188,7 @@
          </widget>
         </item>
         <item row="4" column="2">
-         <widget class="Gui::PrefUnitSpinBox" name="plsb_FontSize">
+         <widget class="Gui::PrefUnitSpinBox" name="plsb_FontSize" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -193,7 +198,7 @@
           <property name="toolTip">
            <string>Dimension text font size</string>
           </property>
-          <property name="value">
+          <property name="value" stdset="0">
            <double>4.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
@@ -544,7 +549,7 @@ Multiplier of 'Font Size'</string>
         </property>
        </widget>
       </item>
-	     <item row="0" column="1">
+      <item row="0" column="1">
        <widget class="QComboBox" name="dimensioningMode">
         <property name="toolTip">
          <string>Select the type of dimensioning tools for your toolbar:
@@ -562,7 +567,7 @@ This setting is only for the toolbar. Whichever you choose, all tools are always
         </property>
        </widget>
       </item>
-	  <item row="1" column="1">
+      <item row="1" column="1">
        <widget class="QComboBox" name="radiusDiameterMode">
         <property name="toolTip">
          <string>While using the Dimension tool you may choose how to handle circles and arcs:
@@ -627,9 +632,7 @@ This setting is only for the toolbar. Whichever you choose, all tools are always
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="Resources/TechDraw.qrc"/>
- </resources>
+ <resources/>
  <connections>
   <connection>
    <sender>cbGlobalDecimals</sender>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScale.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScale.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>440</width>
-    <height>342</height>
+    <width>457</width>
+    <height>481</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -49,6 +49,19 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout">
+        <item row="2" column="1">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="label_13">
           <property name="font">
@@ -61,49 +74,15 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="pdsbPageScale">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>174</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Default scale for new pages</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="decimals">
-           <number>2</number>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>DefaultScale</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_14">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_15">
           <property name="font">
            <font>
             <italic>true</italic>
            </font>
           </property>
           <property name="text">
-           <string>View Scale Type</string>
+           <string>View Custom Scale</string>
           </property>
          </widget>
         </item>
@@ -150,30 +129,39 @@
           </item>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_15">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
+        <item row="0" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="pdsbPageScale">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="text">
-           <string>View Custom Scale</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
+          <property name="minimumSize">
            <size>
-            <width>40</width>
-            <height>20</height>
+            <width>174</width>
+            <height>0</height>
            </size>
           </property>
-         </spacer>
+          <property name="toolTip">
+           <string>Default scale for new pages</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="decimals">
+           <number>2</number>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>DefaultScale</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
         </item>
         <item row="2" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="pdsbViewScale">
@@ -209,6 +197,39 @@
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>DefaultViewScale</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_14">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>View Scale Type</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbLegacyScale">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, Svg symbols, spreadsheet views and Draft views will use the original (incorrect) scaling method as used in v1.0 and earlier.  If unchecked, a more accurate method will be used.  &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Legacy Symbol Scaling</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>LegacySvgScaling</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/General</cstring>
@@ -306,7 +327,7 @@
           </property>
          </spacer>
         </item>
-       <item row="1" column="2">
+        <item row="1" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="pdsbCenterScale">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -351,7 +372,7 @@
          </widget>
         </item>
         <item row="2" column="2">
-         <widget class="Gui::PrefUnitSpinBox" name="pdsbTemplateMark">
+         <widget class="Gui::PrefUnitSpinBox" name="pdsbTemplateMark" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -367,10 +388,7 @@
           <property name="toolTip">
            <string>Size of template field click handles</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
+          <property name="value" stdset="0">
            <double>3.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
@@ -410,7 +428,7 @@
           </property>
          </widget>
         </item>
-        </layout>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -424,7 +442,7 @@
       </font>
      </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; Items in &lt;span style=" font-style:italic;"&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -451,6 +469,11 @@
    <class>Gui::QuantitySpinBox</class>
    <extends>QWidget</extends>
    <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefCheckBox</class>
+   <extends>QCheckBox</extends>
+   <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
    <class>Gui::PrefComboBox</class>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScaleImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScaleImp.cpp
@@ -67,6 +67,7 @@ void DlgPrefsTechDrawScaleImp::saveSettings()
     ui->pdsbCenterScale->onSave();
     ui->pdsbTemplateMark->onSave();
     ui->pdsbSymbolScale->onSave();
+    ui->cbLegacyScale->onSave();
 }
 
 void DlgPrefsTechDrawScaleImp::loadSettings()
@@ -80,6 +81,7 @@ void DlgPrefsTechDrawScaleImp::loadSettings()
     ui->pdsbTemplateMark->setValue(markDefault);
     ui->pdsbTemplateMark->onRestore();
     ui->pdsbSymbolScale->onRestore();
+    ui->cbLegacyScale->onRestore();
 }
 
 /**

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -548,19 +548,6 @@ void QGIDatumLabel::setToleranceString()
     updateFrameRect();
 }
 
-void QGIDatumLabel::setUnitString(QString text)
-{
-    prepareGeometryChange();
-    if (text.isEmpty()) {
-        m_unitText->hide();
-    }
-    else {
-        m_unitText->setPlainText(text);
-        m_unitText->show();
-    }
-    updateFrameRect();
-}
-
 
 int QGIDatumLabel::getPrecision()
 {

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.h
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.h
@@ -83,7 +83,6 @@ public:
     QFont getFont() const { return m_dimText->font(); }
     void setDimString(QString text);
     void setDimString(QString text, qreal maxWidth);
-    void setUnitString(QString text);
     void setToleranceString();
     void setPrettySel();
     void setPrettyPre();

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
@@ -42,6 +42,7 @@
 #include "QGCustomSvg.h"
 #include "QGDisplayArea.h"
 #include "Rez.h"
+#include "ViewProviderSymbol.h"
 
 
 using namespace TechDrawGui;
@@ -110,8 +111,14 @@ void QGIViewSymbol::drawSvg()
         return;
     }
 
+    auto vp = getViewProvider(viewSymbol);
+    auto vps = dynamic_cast<ViewProviderSymbol*>(vp);
+    if (!vp || !vps) {
+        return;
+    }
+
     double scaling{1};
-    if (Preferences::useLegacySvgScaling()) {
+    if (vps->LegacyScaling.getValue()) {
         scaling = legacyScaler(viewSymbol);
     } else {
         scaling = symbolScaler(viewSymbol);
@@ -206,18 +213,15 @@ double QGIViewSymbol::symbolScaler(TechDraw::DrawViewSymbol* feature) const
         matchUnits = matchHeight.captured(1);
     }
 
-    if (matchUnits.isEmpty() ||
-        matchUnits == pxToken) {
-        scaling *= rezfactor;
-    }
+    // if there are no units specified, or the units are px, we just draw the symbol
 
     if (matchUnits == mmToken) {
         auto svgSize = m_svgItem->renderer()->defaultSize();
-        auto vpSize = m_svgItem->renderer()->viewBox();
+        auto vportSize = m_svgItem->renderer()->viewBox();
         // wf: this calculation works, but I don't know why. :(
         // hints here: https://stackoverflow.com/questions/49866474/get-svg-size-from-qsvgrenderer
         // and here: https://stackoverflow.com/questions/7544921/qt-qgraphicssvgitem-renders-too-big-0-5-unit-on-each-side
-        scaling *= rezfactor * vpSize.width() / svgSize.width();
+        scaling *= rezfactor * vportSize.width() / svgSize.width();
     }
 
     return scaling;

--- a/src/Mod/TechDraw/Gui/TaskCosmeticCircle.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCosmeticCircle.cpp
@@ -72,6 +72,8 @@ TaskCosmeticCircle::TaskCosmeticCircle(TechDraw::DrawViewPart* partFeat,
 
     connect(ui->qsbRadius, qOverload<double>(&QuantitySpinBox::valueChanged),
             this, &TaskCosmeticCircle::radiusChanged);
+    connect(ui->rbArc, &QRadioButton::clicked, this, &TaskCosmeticCircle::arcButtonClicked);
+
 
 }
 
@@ -91,6 +93,11 @@ TaskCosmeticCircle::TaskCosmeticCircle(TechDraw::DrawViewPart* partFeat,
     ui->setupUi(this);
 
     setUiPrimary();
+
+    connect(ui->qsbRadius, qOverload<double>(&QuantitySpinBox::valueChanged),
+            this, &TaskCosmeticCircle::radiusChanged);
+    connect(ui->rbArc, &QRadioButton::clicked, this, &TaskCosmeticCircle::arcButtonClicked);
+
 }
 
 TaskCosmeticCircle::~TaskCosmeticCircle()
@@ -154,8 +161,13 @@ void TaskCosmeticCircle::setUiPrimary()
     double radius = (mathPoints[1] - mathPoints[0]).Length() / m_partFeat->getScale();
     ui->qsbRadius->setValue(radius);
 
-    ui->qsbStartAngle->setValue(Base::toDegrees(DU::angleWithX(mathPoints[1] - mathPoints[0])));
-    ui->qsbEndAngle->setValue(Base::toDegrees(DU::angleWithX(mathPoints[2] - mathPoints[0])));
+    ui->qsbStartAngle->setValue(0);
+    ui->qsbEndAngle->setValue(360);
+
+    enableArcWidgets(false);
+    ui->qsbStartAngle->setEnabled(false);
+    ui->qsbEndAngle->setEnabled(false);
+    ui->cbClockwise->setEnabled(false);
 }
 
 void TaskCosmeticCircle::setUiEdit()
@@ -174,6 +186,15 @@ void TaskCosmeticCircle::setUiEdit()
 
     ui->qsbStartAngle->setValue(Base::toDegrees(m_ce->m_geometry->getStartAngle()));
     ui->qsbEndAngle->setValue(Base::toDegrees(m_ce->m_geometry->getEndAngle()));
+
+    if (m_ce->m_geometry->getGeomType() == GeomType::ARCOFCIRCLE) {
+        ui->rbArc->setChecked(true);
+        enableArcWidgets(true);
+    } else {
+        ui->rbArc->setChecked(false);
+        enableArcWidgets(false);
+    }
+
 }
 
 void TaskCosmeticCircle::radiusChanged()
@@ -182,6 +203,23 @@ void TaskCosmeticCircle::radiusChanged()
         QString msg = tr("Radius must be non-zero positive number");
         QMessageBox::critical(Gui::getMainWindow(), QObject::tr("Parameter Error"), msg);
     }
+}
+
+void TaskCosmeticCircle::arcButtonClicked()
+{
+    if (ui->rbArc->isChecked()) {
+        enableArcWidgets(true);
+    } else {
+        enableArcWidgets(false);
+    }
+}
+
+void TaskCosmeticCircle::enableArcWidgets(bool newState)
+{
+    ui->qsbStartAngle->setEnabled(newState);
+    ui->qsbEndAngle->setEnabled(newState);
+    ui->cbClockwise->setEnabled(newState);
+
 }
 
 
@@ -205,8 +243,7 @@ void TaskCosmeticCircle::createCosmeticCircle(void)
     }
 
     TechDraw::BaseGeomPtr bg;
-    if (ui->qsbStartAngle->value().getValue() == 0.0 &&
-        ui->qsbEndAngle->value().getValue() == 0.0)  {
+    if (!ui->rbArc->isChecked()) {
         bg = std::make_shared<TechDraw::Circle> (center, ui->qsbRadius->value().getValue());
     } else {
         bg = std::make_shared<TechDraw::AOC>(center, ui->qsbRadius->value().getValue(),
@@ -234,8 +271,7 @@ void TaskCosmeticCircle::updateCosmeticCircle(void)
     m_ce->permaRadius = ui->qsbRadius->value().getValue();
 
     TechDraw::BaseGeomPtr bg;
-    if (ui->qsbStartAngle->value().getValue() == 0.0 &&
-        ui->qsbEndAngle->value().getValue() == 0.0)  {
+    if (!ui->rbArc->isChecked()) {
         bg = std::make_shared<TechDraw::Circle> (p0, m_ce->permaRadius);
     } else {
         bg = std::make_shared<TechDraw::AOC>(p0, ui->qsbRadius->value().getValue(),

--- a/src/Mod/TechDraw/Gui/TaskCosmeticCircle.h
+++ b/src/Mod/TechDraw/Gui/TaskCosmeticCircle.h
@@ -66,6 +66,7 @@ public:
 
 protected Q_SLOTS:
     void radiusChanged();
+    void arcButtonClicked();
 
 protected:
     void changeEvent(QEvent *e) override;
@@ -75,6 +76,8 @@ protected:
 
     void createCosmeticCircle();
     void updateCosmeticCircle();
+
+    void enableArcWidgets(bool newState);
 
 private:
     std::unique_ptr<Ui_TaskCosmeticCircle> ui;

--- a/src/Mod/TechDraw/Gui/TaskCosmeticCircle.ui
+++ b/src/Mod/TechDraw/Gui/TaskCosmeticCircle.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>350</width>
-    <height>390</height>
+    <height>409</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -103,7 +103,7 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbCenterX">
+      <widget class="Gui::QuantitySpinBox" name="qsbCenterX" native="true">
        <property name="unit" stdset="0">
         <string notr="true"/>
        </property>
@@ -117,7 +117,7 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbCenterY">
+      <widget class="Gui::QuantitySpinBox" name="qsbCenterY" native="true">
        <property name="unit" stdset="0">
         <string notr="true"/>
        </property>
@@ -131,7 +131,7 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbCenterZ">
+      <widget class="Gui::QuantitySpinBox" name="qsbCenterZ" native="true">
        <property name="unit" stdset="0">
         <string notr="true"/>
        </property>
@@ -149,14 +149,14 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbRadius">
+      <widget class="Gui::QuantitySpinBox" name="qsbRadius" native="true">
        <property name="unit" stdset="0">
         <string notr="true"/>
        </property>
-       <property name="minimum">
+       <property name="minimum" stdset="0">
         <double>0.000000000000000</double>
        </property>
-       <property name="value">
+       <property name="value" stdset="0">
         <double>10.000000000000000</double>
        </property>
       </widget>
@@ -166,19 +166,12 @@
    <item>
     <layout class="QGridLayout" name="gridLayout_5" columnstretch="1,0">
      <item row="1" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbStartAngle">
+      <widget class="Gui::QuantitySpinBox" name="qsbStartAngle" native="true">
        <property name="toolTip">
         <string>Start angle (conventional) of arc in degrees.</string>
        </property>
        <property name="unit" stdset="0">
         <string notr="true"/>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_7">
-       <property name="text">
-        <string>Arc of Circle</string>
        </property>
       </widget>
      </item>
@@ -189,8 +182,18 @@
        </property>
       </widget>
      </item>
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="cbClockwise">
+       <property name="toolTip">
+        <string>Check this box to make an arc from start angle to end angle in a clockwise direction.</string>
+       </property>
+       <property name="text">
+        <string>Clockwise Angle</string>
+       </property>
+      </widget>
+     </item>
      <item row="2" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbEndAngle">
+      <widget class="Gui::QuantitySpinBox" name="qsbEndAngle" native="true">
        <property name="toolTip">
         <string>End angle (conventional) of arc in degrees.</string>
        </property>
@@ -206,13 +209,13 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="cbClockwise">
+     <item row="0" column="0">
+      <widget class="QRadioButton" name="rbArc">
        <property name="toolTip">
-        <string>Check this box to make an arc from start angle to end angle in a clockwise direction.</string>
+        <string>Select to enter angles and create a circular arc.</string>
        </property>
        <property name="text">
-        <string>Clockwise Angle</string>
+        <string>Arc of Circle</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/TechDraw/Gui/ViewProviderSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderSymbol.cpp
@@ -24,9 +24,15 @@
 #include "PreCompiled.h"
 
 #include <App/DocumentObject.h>
+
+#include <Mod/TechDraw/App/Preferences.h>
+
+#include "QGIViewSymbol.h"
 #include "ViewProviderSymbol.h"
 
 using namespace TechDrawGui;
+using namespace TechDraw;
+
 
 PROPERTY_SOURCE(TechDrawGui::ViewProviderSymbol, TechDrawGui::ViewProviderDrawingView)
 
@@ -36,6 +42,11 @@ PROPERTY_SOURCE(TechDrawGui::ViewProviderSymbol, TechDrawGui::ViewProviderDrawin
 ViewProviderSymbol::ViewProviderSymbol()
 {
     sPixmap = "TechDraw_TreeSymbol";
+
+    ADD_PROPERTY_TYPE(LegacyScaling, (Preferences::useLegacySvgScaling()), "Svg Scaling", App::Prop_None,
+      "If true, Svg will be scaled using the original (v1.0 and earlier) scaling method.\
+ If false, a more accurate method will be used.");
+
 }
 
 ViewProviderSymbol::~ViewProviderSymbol()
@@ -53,6 +64,18 @@ void ViewProviderSymbol::updateData(const App::Property* prop)
     }
 
     ViewProviderDrawingView::updateData(prop);
+}
+
+void ViewProviderSymbol::onChanged(const App::Property* prop)
+{
+    if (prop == &(LegacyScaling)) {
+        QGIView* qgiv = getQView();
+        if (qgiv) {
+            qgiv->updateView(true);
+        }
+    }
+
+    ViewProviderDrawingView::onChanged(prop);
 }
 
 TechDraw::DrawViewSymbol* ViewProviderSymbol::getViewObject() const

--- a/src/Mod/TechDraw/Gui/ViewProviderSymbol.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderSymbol.h
@@ -43,8 +43,11 @@ public:
     /// destructor
     ~ViewProviderSymbol() override;
 
+    App::PropertyBool LegacyScaling;
+
     bool useNewSelectionModel() const override {return false;}
     void updateData(const App::Property*) override;
+    void onChanged(const App::Property* prop) override;
 
     TechDraw::DrawViewSymbol* getViewObject() const override;
 };


### PR DESCRIPTION
This PR implements 3 minor fixes.
- allow showing/hiding units on individual dimensions.  Previously this was set at the system preference level.
- a similar fix allows control of legacy scaling in symbols, spreadsheets and draft views at teh view level
- fix the handling of arcs in TaskCosmeticCircle.