### PR TITLE
[Part TopoShapeExpansion] move shape transform from make element copy…

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -2203,8 +2203,8 @@ TopoShape& TopoShape::makeElementRuledSurface(const std::vector<TopoShape>& shap
     // if both shapes are sub-elements of one common shape then the fill
     // algorithm leads to problems if the shape has set a placement. The
     // workaround is to copy the sub-shape
-    S1 = S1.makeElementCopy();
-    S2 = S2.makeElementCopy();
+    S1.setTransform(S1.getTransform());
+    S2.setTransform(S2.getTransform());
 
     if (orientation == 0) {
         // Automatic
@@ -3427,7 +3427,7 @@ TopoShape::makeElementCopy(const TopoShape& shape, const char* op, bool copyGeom
 
     TopoShape tmp(shape);
     tmp.setShape(BRepBuilderAPI_Copy(shape.getShape(), copyGeom, copyMesh).Shape(), false);
-    tmp.setTransform(shape.getTransform());
+
     if (op || (shape.Tag && shape.Tag != Tag)) {
         setShape(tmp._Shape);
         initCache();


### PR DESCRIPTION
… into ruled surface function since it does not work well when copying vertex objects.

See https://forum.freecad.org/viewtopic.php?t=94158

https://github.com/FreeCAD/FreeCAD/pull/17436

For background, the above PR was to fix an issue with ruled surfaces.  We decided to move it out of the ruled surface function and into the general copy function.  This moves it back into the ruled surface function because it is causing an issue sometimes copying Part.Vertex objects.