### PR TITLE
[AddonManager] Fix construct_git_url return urls with '.git'.

### DIFF
--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -198,7 +198,7 @@ def construct_git_url(repo, filename):
     """Returns a direct download link to a file in an online Git repo"""
 
     parsed_url = urlparse(repo.url)
-    repo_url = repo.url.rstrip(".git")
+    repo_url = repo.url[:-4] if repo.url.endswith(".git") else repo.url
     if parsed_url.netloc == "github.com":
         return f"{repo_url}/raw/{repo.branch}/{filename}"
     if parsed_url.netloc in ["gitlab.com", "framagit.org", "salsa.debian.org"]:

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -198,7 +198,7 @@ def construct_git_url(repo, filename):
     """Returns a direct download link to a file in an online Git repo"""
 
     parsed_url = urlparse(repo.url)
-    repo_url = repo.url.rstrip('.git')
+    repo_url = repo.url.rstrip(".git")
     if parsed_url.netloc == "github.com":
         return f"{repo_url}/raw/{repo.branch}/{filename}"
     if parsed_url.netloc in ["gitlab.com", "framagit.org", "salsa.debian.org"]:

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -198,19 +198,20 @@ def construct_git_url(repo, filename):
     """Returns a direct download link to a file in an online Git repo"""
 
     parsed_url = urlparse(repo.url)
+    repo_url = repo.url.rstrip('.git')
     if parsed_url.netloc == "github.com":
-        return f"{repo.url}/raw/{repo.branch}/{filename}"
+        return f"{repo_url}/raw/{repo.branch}/{filename}"
     if parsed_url.netloc in ["gitlab.com", "framagit.org", "salsa.debian.org"]:
-        return f"{repo.url}/-/raw/{repo.branch}/{filename}"
+        return f"{repo_url}/-/raw/{repo.branch}/{filename}"
     if parsed_url.netloc in ["codeberg.org"]:
-        return f"{repo.url}/raw/branch/{repo.branch}/{filename}"
+        return f"{repo_url}/raw/branch/{repo.branch}/{filename}"
     fci.Console.PrintLog(
         "Debug: addonmanager_utilities.construct_git_url: Unknown git host:"
         + parsed_url.netloc
         + f" for file {filename}\n"
     )
     # Assume it's some kind of local GitLab instance...
-    return f"{repo.url}/-/raw/{repo.branch}/{filename}"
+    return f"{repo_url}/-/raw/{repo.branch}/{filename}"
 
 
 def get_readme_url(repo):


### PR DESCRIPTION
Hi, when I'm using AddonManager Developer Tool, it returns wrong readme url like: `https://github.com/author/project.git/raw/main/README.md`. And it will lead to a 404 error like this:
![image](https://github.com/user-attachments/assets/ceedfc26-c372-4d65-b72b-4fe59e8a13a8)

In order to get the right url, I added `.rstrip('.git')`.
