### PR TITLE
[Mesh Python] Mesh.show() returns python object, update documentation…

### DIFF
--- a/src/Mod/Mesh/App/AppMeshPy.cpp
+++ b/src/Mod/Mesh/App/AppMeshPy.cpp
@@ -82,7 +82,7 @@ public:
         add_varargs_method("show",
                            &Module::show,
                            "show(shape,[string]) -- Add the mesh to the active document or create "
-                           "one if no document exists.");
+                           "one if no document exists.  Returns document object.");
         add_varargs_method("createBox", &Module::createBox, "Create a solid mesh box");
         add_varargs_method("createPlane", &Module::createPlane, "Create a mesh XY plane normal +Z");
         add_varargs_method("createSphere", &Module::createSphere, "Create a tessellated sphere");
@@ -311,8 +311,7 @@ private:
         }
         // copy the data
         pcFeature->Mesh.setValue(*mo);
-
-        return Py::None();
+        return Py::asObject(pcFeature->getPyObject());
     }
     Py::Object createBox(const Py::Tuple& args)
     {

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -425,7 +425,8 @@ public:
             "read(string) -- Load the file and return the shape."
         );
         add_varargs_method("show",&Module::show,
-            "show(shape,[string]) -- Add the shape to the active document or create one if no document exists."
+            "show(shape,[string]) -- Add the shape to the active document or create one if no document exists.\n"
+            "Returns document object."
         );
         add_varargs_method("getFacets",&Module::getFacets,
             "getFacets(shape): simplified mesh generation"

--- a/src/Mod/Points/App/AppPointsPy.cpp
+++ b/src/Mod/Points/App/AppPointsPy.cpp
@@ -55,7 +55,7 @@ public:
         add_varargs_method("show",
                            &Module::show,
                            "show(points,[string]) -- Add the points to the active document or "
-                           "create one if no document exists.");
+                           "create one if no document exists.  Returns document object.");
         initialize("This module is the Points module.");  // register with Python
     }
 


### PR DESCRIPTION
… for Mesh.show(), Part.show(), and Points.show()

These python functions create new document objects.  With this PR now they all return document objects where previously only Part and Points were returning document objects.  The PR also updates the documentation string returned from help(Part.show), etc. to reflect that the function returns the python document object.

See https://forum.freecad.org/viewtopic.php?t=94194#p806395