### PR TITLE
refactor taskpanel look on FreeCAD classic

### DIFF
--- a/src/Gui/QSint/actionpanel/actionpanel.cpp
+++ b/src/Gui/QSint/actionpanel/actionpanel.cpp
@@ -26,7 +26,7 @@ ActionPanel::ActionPanel(QWidget *parent) :
     setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
 
     QVBoxLayout *vbl = new QVBoxLayout();
-    vbl->setContentsMargins(8, 8, 8, 8);
+    vbl->setContentsMargins(4, 8, 4, 8);
     vbl->setSpacing(8);
     setLayout(vbl);
 }

--- a/src/Gui/QSint/actionpanel/freecadscheme.cpp
+++ b/src/Gui/QSint/actionpanel/freecadscheme.cpp
@@ -202,13 +202,11 @@ SystemPanelScheme::SystemPanelScheme()
     headerAnimation = true;
 
     QPalette p = QApplication::palette();
-    QPalette p2 = p;
-    p2.setColor(QPalette::Highlight,p2.color(QPalette::Highlight).lighter());
 
-    headerButtonFold = drawFoldIcon(p, true);
-    headerButtonFoldOver = drawFoldIcon(p2, true);
-    headerButtonUnfold = drawFoldIcon(p, false);
-    headerButtonUnfoldOver = drawFoldIcon(p2, false);
+    headerButtonFold = drawFoldIcon(p, true, false);
+    headerButtonFoldOver = drawFoldIcon(p, true, true);
+    headerButtonUnfold = drawFoldIcon(p, false, false);
+    headerButtonUnfoldOver = drawFoldIcon(p, false, true);
     headerButtonSize = QSize(17,17);
 
     groupFoldSteps = 20;
@@ -219,134 +217,121 @@ SystemPanelScheme::SystemPanelScheme()
     actionStyle = systemStyle(QApplication::palette());
 }
 
-/*!
-  \code
-    QPalette p = QApplication::palette();
-    QPalette p2 = p;
-    p2.setColor(QPalette::Highlight,p2.color(QPalette::Highlight).lighter());
-    headerButtonFold = drawFoldIcon(p, true);
-    headerButtonFoldOver = drawFoldIcon(p2, true);
-    headerButtonUnfold = drawFoldIcon(p, false);
-    headerButtonUnfoldOver = drawFoldIcon(p2, false);
-  \endcode
- */
-QPixmap SystemPanelScheme::drawFoldIcon(const QPalette& p, bool fold) const
+QPixmap SystemPanelScheme::drawFoldIcon(const QPalette& palette, bool fold, bool hover) const
 {
-    QImage img(17,17,QImage::Format_ARGB32_Premultiplied);
-    img.fill(0x00000000);
-    QPainter painter;
-    painter.begin(&img);
-    painter.setBrush(p.window());
-    painter.drawEllipse(2,2,13,13);
-    painter.setPen(p.color(QPalette::Base));
-    painter.drawEllipse(2,2,13,13);
-    painter.setPen(p.color(QPalette::Highlight));
-    painter.drawLine(QLine(5,7,8,4));
-    painter.drawLine(QLine(6,7,8,5));
-    painter.drawLine(QLine(8,4,11,7));
-    painter.drawLine(QLine(8,5,10,7));
-    painter.drawLine(QLine(5,11,8,8));
-    painter.drawLine(QLine(6,11,8,9));
-    painter.drawLine(QLine(8,8,11,11));
-    painter.drawLine(QLine(9,8,10,11));
-    painter.end();
+    QSize bSize = headerButtonSize;
+    QImage img(bSize.width(), bSize.height(), QImage::Format_ARGB32_Premultiplied);
+    img.fill(Qt::transparent);
 
-    if (!fold) {
-        QTransform mat;
-        mat.rotate(180.0);
-        img = img.transformed(mat);
+    QPainter painter(&img);
+
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    qreal penWidth = bSize.width() / 14.0;
+    qreal lef_X = 0.25 * bSize.width();
+    qreal mid_X = 0.50 * bSize.width();
+    qreal rig_X = 0.75 * bSize.width();
+    qreal bot_Y = 0.40 * bSize.height();
+    qreal top_Y = 0.64 * bSize.height();
+
+    if (hover) {
+        penWidth *= 1.8;
     }
+
+    painter.setBrush(Qt::NoBrush);
+    painter.setPen(QPen(palette.color(QPalette::HighlightedText), penWidth));
+
+    QPolygon chevron;
+    if (fold) {
+        // Upward
+        chevron << QPoint(lef_X, top_Y)
+                << QPoint(mid_X, bot_Y)
+                << QPoint(rig_X, top_Y);
+    } else {
+        // Downward
+        chevron << QPoint(lef_X, bot_Y)
+                << QPoint(mid_X, top_Y)
+                << QPoint(rig_X, bot_Y);
+    }
+
+    painter.drawPolyline(chevron);
+    painter.end();
     return QPixmap::fromImage(img);
 }
 
+
 QString SystemPanelScheme::systemStyle(const QPalette& p) const
 {
-  QColor panelBackground1 = p.color(QPalette::Dark);
-  QColor panelBackground2 = p.color(QPalette::Midlight);
+    QColor headerBackground = p.color(QPalette::Highlight);
+    QColor headerLabelText = p.color(QPalette::HighlightedText);
+    QColor headerLabelTextOver = p.color(QPalette::BrightText);
+    QColor groupBorder = p.color(QPalette::Mid);
+    QColor disabledActionText = p.color(QPalette::Disabled, QPalette::Text);
+    QColor actionSelectedBg = p.color(QPalette::Active, QPalette::Light);
+    QColor actionSelectedText = p.color(QPalette::Active, QPalette::ButtonText);
+    QColor actionSelectedBorder = p.color(QPalette::Active, QPalette::Highlight);
 
-  QColor headerBackground1 = p.color(QPalette::Highlight);
-  QColor headerBackground2 = p.color(QPalette::Highlight).lighter();
+    QString style = QString::fromLatin1(
+        "QSint--ActionGroup QFrame[class='header'] {"
+            "border: 1px solid transparent;"
+            "background-color: %1;"
+        "}"
 
-  QColor headerLabelText = p.color(QPalette::HighlightedText);
-  QColor headerLabelTextOver = p.color(QPalette::BrightText);
+        "QSint--ActionGroup QToolButton[class='header'] {"
+            "text-align: left;"
+            "color: %2;"
+            "background-color: transparent;"
+            "border: 1px solid transparent;"
+            "font-weight: bold;"
+        "}"
 
-  QColor groupBackground = p.window().color();
-  QColor groupBorder = p.color(QPalette::Window);
+        "QSint--ActionGroup QToolButton[class='header']:hover {"
+            "color: %3;"
+        "}"
 
-  QColor taskLabelText = p.color(QPalette::Text);
-  QColor taskLabelTextOver = p.color(QPalette::Highlight);
+        "QSint--ActionGroup QFrame[class='content'] {"
+            "border: 1px solid %4;"
+        "}"
 
-  QString style = QString::fromLatin1(
-    "QFrame[class='panel'] {"
-        "background-color:qlineargradient(x1:1, y1:0.3, x2:1, y2:0, stop:0 %1, stop:1 %2);"
-    "}"
+        "QSint--ActionGroup QFrame[class='content'][header='true'] {"
+            "border-top: none;"
+        "}"
 
-    "QSint--ActionGroup QFrame[class='header'] {"
-        "border: 1px solid #ffffff;"                                // todo
-        "border-top-left-radius: 4px;"
-        "border-top-right-radius: 4px;"
-        "background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 %3, stop: 1 %4);"
-    "}"
+        "QSint--ActionGroup QToolButton[class='action'] {"
+            "background-color: transparent;"
+            "border: 1px solid transparent;"
+            "text-align: left;"
+        "}"
 
-    "QSint--ActionGroup QToolButton[class='header'] {"
-        "text-align: left;"
-        "color: %5;"
-        "background-color: transparent;"
-        "border: 1px solid transparent;"
-        "font-weight: bold;"
-    "}"
+        "QSint--ActionGroup QToolButton[class='action']:!enabled {"
+            "color: %5;"
+        "}"
 
-    "QSint--ActionGroup QToolButton[class='header']:hover {"
-        "color: %6;"
-    "}"
+        "QSint--ActionGroup QToolButton[class='action']:hover {"
+            "text-decoration: underline;"
+        "}"
 
-    "QSint--ActionGroup QFrame[class='content'] {"
-        "background-color: %7;"
-        "border: 1px solid %8;"
-    "}"
+        "QSint--ActionGroup QToolButton[class='action']:focus {"
+            "color: %7;"
+            "border: 1px dotted %8;"
+        "}"
 
-    "QSint--ActionGroup QFrame[class='content'][header='true'] {"
-        "border-top: none;"
-    "}"
+        "QSint--ActionGroup QToolButton[class='action']:on {"
+            "background-color: %6;"
+            "color: %7;"
+        "}"
+    ).arg(
+        headerBackground.name(),
+        headerLabelText.name(),
+        headerLabelTextOver.name(),
+        groupBorder.name(),
+        disabledActionText.name(),
+        actionSelectedBg.name(),
+        actionSelectedText.name(),
+        actionSelectedBorder.name()
+    );
 
-    "QSint--ActionGroup QToolButton[class='action'] {"
-        "background-color: transparent;"
-        "border: 1px solid transparent;"
-        "color: %9;"
-        "text-align: left;"
-    "}"
-
-    "QSint--ActionGroup QToolButton[class='action']:!enabled {"
-        "color: #999999;"                                           // todo
-    "}"
-
-    "QSint--ActionGroup QToolButton[class='action']:hover {"
-        "color: %10;"
-        "text-decoration: underline;"
-    "}"
-
-    "QSint--ActionGroup QToolButton[class='action']:focus {"
-        "border: 1px dotted black;"
-    "}"
-
-    "QSint--ActionGroup QToolButton[class='action']:on {"
-        "background-color: #ddeeff;"                                // todo
-        "color: #006600;"                                           // todo
-    "}"
-  )
-          .arg(panelBackground1.name(),
-               panelBackground2.name(),
-               headerBackground1.name(),
-               headerBackground2.name(),
-               headerLabelText.name(),
-               headerLabelTextOver.name(),
-               groupBackground.name(),
-               groupBorder.name(),
-               taskLabelText.name())
-           .arg(taskLabelTextOver.name())
-  ;
-
-  return style;
+    return style;
 }
 
 }

--- a/src/Gui/QSint/actionpanel/freecadscheme.h
+++ b/src/Gui/QSint/actionpanel/freecadscheme.h
@@ -66,7 +66,7 @@ public:
     }
 
 private:
-    QPixmap drawFoldIcon(const QPalette& p, bool fold) const;
+    QPixmap drawFoldIcon(const QPalette& p, bool fold, bool hover) const;
     QString systemStyle(const QPalette& p) const;
 };
 


### PR DESCRIPTION
All the changes except the margin will only be visible for linux users since i edited the base styles of that part specifically

Main changes:
* remove the background gradient
* remove top border radius because it looks wrong collapsed
* redraw the chevrons to a simple chevron more visible and modern
* use the qpalette for system colors (fixes the varous TODOs left in the code)
* reduce the margin from 8px to 4px (the only thing that will affect all Operating systems)
* redo the keyboard focus effect using accent color instead of just black
* do not use accent color on hover as it makes it difficult to read


1.0 | PR
-|-
![Captura de pantalla_20250126_130852](https://github.com/user-attachments/assets/b87a4600-dd92-4649-a560-2b5b443672fc) | ![Captura de pantalla_20250126_132325](https://github.com/user-attachments/assets/be401209-bd2f-4961-855a-aaa9c160ed98)
![Captura de pantalla_20250126_131008](https://github.com/user-attachments/assets/2623e259-47d9-44a8-a473-46db32424285) | ![Captura de pantalla_20250126_132338](https://github.com/user-attachments/assets/b524c869-90ee-402e-bca7-b2e70cf51d57)
![Captura de pantalla_20250126_131045](https://github.com/user-attachments/assets/89194e5b-81f8-4376-869d-e444f592fece) | ![Captura de pantalla_20250126_132348](https://github.com/user-attachments/assets/1f1e97d0-1f89-46c5-8303-f07789914f09)
![Captura de pantalla_20250126_132012](https://github.com/user-attachments/assets/af3182f6-b056-49a9-ae27-5f107a7f5599) | ![Captura de pantalla_20250126_132216](https://github.com/user-attachments/assets/2acce6b2-b668-4820-83b7-311dbdee5c00)
![Captura de pantalla_20250126_132030](https://github.com/user-attachments/assets/989efb65-7f0b-4397-9d26-1ab3e39d7d98) | ![Captura de pantalla_20250126_132236](https://github.com/user-attachments/assets/0a4d1592-0b46-4b39-8ea4-12d00b6f8d89)
![Captura de pantalla_20250126_132038](https://github.com/user-attachments/assets/372bbc9a-eb84-4f17-95fe-ecb0cbc57f95) | ![Captura de pantalla_20250126_132246](https://github.com/user-attachments/assets/96da6bdd-18c3-4330-958e-197e74ea82d4)

I was going to a more OpenDark style, but backtracked into simpler modifications