### PR TITLE
Core: add Ifcopenshell version in about info clipboard

### DIFF
--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -657,12 +657,20 @@ void AboutDialog::copyToClipboard()
     std::stringstream cmd;
     cmd << "import ifcopenshell\n";
     cmd << "version = ifcopenshell.version";
-    PyObject * ifcopenshellVer = Base::Interpreter().getValue(cmd.str().c_str(), "version");
+    PyObject * ifcopenshellVer = nullptr;
+
+    try {
+        ifcopenshellVer = Base::Interpreter().getValue(cmd.str().c_str(), "version");
+    }
+    catch (const Base::Exception& e) {
+        Base::Console().Warning("%s (safe to ignore, unless using the BIM workbench and IFC).\n", e.what());
+    }
+
     if (ifcopenshellVer) {
         const char* ifcopenshellVerAsStr = PyUnicode_AsUTF8(ifcopenshellVer);
 
         if (ifcopenshellVerAsStr) {
-            str << "IfcOpenShell: " << ifcopenshellVerAsStr << ", "; // << '\n';
+            str << "IfcOpenShell: " << ifcopenshellVerAsStr << ", ";
             Py_DECREF(ifcopenshellVerAsStr);
         }
         Py_DECREF(ifcopenshellVer);

--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -670,7 +670,7 @@ void AboutDialog::copyToClipboard()
         const char* ifcopenshellVerAsStr = PyUnicode_AsUTF8(ifcopenshellVer);
 
         if (ifcopenshellVerAsStr) {
-            str << "IfcOpenShell: " << ifcopenshellVerAsStr << ", ";
+            str << "IfcOpenShell " << ifcopenshellVerAsStr << ", ";
             Py_DECREF(ifcopenshellVerAsStr);
         }
         Py_DECREF(ifcopenshellVer);

--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -662,7 +662,7 @@ void AboutDialog::copyToClipboard()
         ifcopenshellVer = Base::Interpreter().getValue(cmd, "version");
     }
     catch (const Base::Exception& e) {
-        Base::Console().Warning("%s (safe to ignore, unless using the BIM workbench and IFC).\n", e.what());
+        Base::Console().Debug("%s (safe to ignore, unless using the BIM workbench and IFC).\n", e.what());
     }
 
     if (ifcopenshellVer) {

--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -648,7 +648,6 @@ void AboutDialog::copyToClipboard()
     if (it != config.end()) {
         str << "Hash: " << QString::fromStdString(it->second) << '\n';
     }
-
     // report also the version numbers of the most important libraries in FreeCAD
     str << "Python " << PY_VERSION << ", ";
     str << "Qt " << QT_VERSION_STR << ", ";

--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -662,7 +662,7 @@ void AboutDialog::copyToClipboard()
         ifcopenshellVer = Base::Interpreter().getValue(cmd, "version");
     }
     catch (const Base::Exception& e) {
-        Base::Console().DeveloperWarning("%s (safe to ignore, unless using the BIM workbench and IFC).\n", e.what());
+        Base::Console().Log("%s (safe to ignore, unless using the BIM workbench and IFC).\n", e.what());
     }
 
     if (ifcopenshellVer) {

--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -662,7 +662,7 @@ void AboutDialog::copyToClipboard()
         ifcopenshellVer = Base::Interpreter().getValue(cmd, "version");
     }
     catch (const Base::Exception& e) {
-        Base::Console().Debug("%s (safe to ignore, unless using the BIM workbench and IFC).\n", e.what());
+        Base::Console().DeveloperWarning("%s (safe to ignore, unless using the BIM workbench and IFC).\n", e.what());
     }
 
     if (ifcopenshellVer) {

--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -45,6 +45,7 @@
 #include <App/Application.h>
 #include <App/Metadata.h>
 #include <Base/Console.h>
+#include <Base/Interpreter.h>
 #include <CXX/WrapPython.h>
 
 #include <boost/filesystem.hpp>
@@ -647,11 +648,27 @@ void AboutDialog::copyToClipboard()
     if (it != config.end()) {
         str << "Hash: " << QString::fromStdString(it->second) << '\n';
     }
+
     // report also the version numbers of the most important libraries in FreeCAD
     str << "Python " << PY_VERSION << ", ";
     str << "Qt " << QT_VERSION_STR << ", ";
     str << "Coin " << COIN_VERSION << ", ";
     str << "Vtk " << fcVtkVersion << ", ";
+
+    std::stringstream cmd;
+    cmd << "import ifcopenshell\n";
+    cmd << "version = ifcopenshell.version";
+    PyObject * ifcopenshellVer = Base::Interpreter().getValue(cmd.str().c_str(), "version");
+    if (ifcopenshellVer) {
+        const char* ifcopenshellVerAsStr = PyUnicode_AsUTF8(ifcopenshellVer);
+
+        if (ifcopenshellVerAsStr) {
+            str << "IfcOpenShell: " << ifcopenshellVerAsStr << ", "; // << '\n';
+            Py_DECREF(ifcopenshellVerAsStr);
+        }
+        Py_DECREF(ifcopenshellVer);
+    }
+
 #if defined(HAVE_OCC_VERSION)
     str << "OCC " << OCC_VERSION_MAJOR << "." << OCC_VERSION_MINOR << "." << OCC_VERSION_MAINTENANCE
 #ifdef OCC_VERSION_DEVELOPMENT

--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -654,13 +654,12 @@ void AboutDialog::copyToClipboard()
     str << "Coin " << COIN_VERSION << ", ";
     str << "Vtk " << fcVtkVersion << ", ";
 
-    std::stringstream cmd;
-    cmd << "import ifcopenshell\n";
-    cmd << "version = ifcopenshell.version";
+    const char* cmd = "import ifcopenshell\n"
+                      "version = ifcopenshell.version";
     PyObject * ifcopenshellVer = nullptr;
 
     try {
-        ifcopenshellVer = Base::Interpreter().getValue(cmd.str().c_str(), "version");
+        ifcopenshellVer = Base::Interpreter().getValue(cmd, "version");
     }
     catch (const Base::Exception& e) {
         Base::Console().Warning("%s (safe to ignore, unless using the BIM workbench and IFC).\n", e.what());


### PR DESCRIPTION
- Add IfcOpenShell version to the information copied into the clipboard when opening the <kbd>Help</kbd> > <kbd>About FreeCAD</kbd> dialog and pressing the <kbd>Copy to clipboard</kbd> button
- If IfcOpenShell is not found in the system, a  log message is issued to the user: ` No module named 'ifcopenshell' (safe to ignore, unless using the BIM workbench and IFC).` to notify them. The copy to clipboard still succeeds, it simply does not contain the IfcOpenShell version text. Log message reporting is disabled by default, so for most users not having if openshell installed and copying the about info will be a silent operation.

Fixes: https://github.com/FreeCAD/FreeCAD/issues/18650