### PR TITLE
#18458 Fix SVG import error at non-utf8 native environment.

### DIFF
--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -61,7 +61,13 @@ from draftutils import params
 from draftutils import utils
 from draftutils.translate import translate
 from draftutils.messages import _err, _msg, _wrn
-from builtins import open as pyopen
+import builtins
+#redefine pyopen as open with encoding='utf-8'
+def utf8_open(file, mode='r', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None):
+    if encoding is None:
+        encoding = 'utf-8'
+    return builtins.open(file, mode, buffering, encoding, errors, newline, closefd, opener)
+pyopen = utf8_open
 
 if FreeCAD.GuiUp:
     from PySide import QtWidgets


### PR DESCRIPTION
#18458
Force encoding=utf8 when opening file if encoding is not specified.