### PR TITLE
BIM: add support for links to BIM Schedule

### DIFF
--- a/src/Mod/BIM/ArchSchedule.py
+++ b/src/Mod/BIM/ArchSchedule.py
@@ -299,6 +299,10 @@ class _ArchSchedule:
 
         nobjs = []
         for o in objs:
+            while hasattr(o, "LinkedObject"):
+                # Support for single and nested links: go up the link
+                # chain until the main linked object is found
+                o = o.LinkedObject
             props = [p.upper() for p in o.PropertiesList]
             ok = True
             for f in filters.split(";"):


### PR DESCRIPTION
This PR allows links and nested links to be processed by BIM Schedule. Previously, they were ignored.

Known limitations:
- Links of arrays and links of clones are not (yet) implemented in this PR