### PR TITLE
Fix bug preventing filtering named constraints

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1649,6 +1649,8 @@ bool TaskSketcherConstraints::isConstraintFiltered(QListWidgetItem* item)
                 break;
         }
 
+        visible |= constraint->Name != "" && checkFilterBitset(multiFilterStatus, FilterValue::Named);
+
         // Then we re-filter based on selected/associated if such mode selected.
         if (visible && specialFilterMode == SpecialFilterType::Selected) {
             visible = (std::find(selectionFilter.begin(), selectionFilter.end(), it->ConstraintNbr)


### PR DESCRIPTION
There was a bug (see issue #11843) that displayed a filter for named constraints in the Sketcher Workbench whose toggling did not affect the UI in any way. This enables this feature by checking if a given constraint has a custom name or not and then appropriately toggling its visibility.