### PR TITLE
TechDraw: hard type enums, part 1

### DIFF
--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -732,9 +732,9 @@ private:
                         std::string sDimText;
                         //this is the same code as in QGIViewDimension::updateDim
                         if (dvd->isMultiValueSchema()) {
-                            sDimText = dvd->getFormattedDimensionValue(0); //don't format multis
+                            sDimText = dvd->getFormattedDimensionValue(DimensionFormatter::Format::UNALTERED); //don't format multis
                         } else {
-                            sDimText = dvd->getFormattedDimensionValue(1);
+                            sDimText = dvd->getFormattedDimensionValue(DimensionFormatter::Format::FORMATTED);
                         }
                         char* dimText = &sDimText[0u];                  //hack for const-ness
                         float gap = 5.0;                                //hack. don't know font size here.

--- a/src/Mod/TechDraw/App/CenterLine.cpp
+++ b/src/Mod/TechDraw/App/CenterLine.cpp
@@ -54,12 +54,12 @@ CenterLine::CenterLine()
 {
     m_start = Base::Vector3d(0.0, 0.0, 0.0);
     m_end = Base::Vector3d(0.0, 0.0, 0.0);
-    m_mode = CLMODE::VERTICAL;
+    m_mode = Mode::VERTICAL;
     m_hShift = 0.0;
     m_vShift = 0.0;
     m_rotate = 0.0;
     m_extendBy = 0.0;
-    m_type = CLTYPE::FACE;
+    m_type = Type::FACE;
     m_flip2Line = false;
 
     m_geometry = std::make_shared<TechDraw::BaseGeom> ();
@@ -85,7 +85,7 @@ CenterLine::CenterLine(const TechDraw::CenterLine* cl)
 }
 
 CenterLine::CenterLine(const TechDraw::BaseGeomPtr& bg,
-                       const int m,
+                       const Mode m,
                        const double h,
                        const double v,
                        const double r,
@@ -98,7 +98,7 @@ CenterLine::CenterLine(const TechDraw::BaseGeomPtr& bg,
     m_vShift = v;
     m_rotate = r;
     m_extendBy = x;
-    m_type = CLTYPE::FACE;
+    m_type = Type::FACE;
     m_flip2Line = false;
 
     m_geometry = bg;
@@ -108,7 +108,7 @@ CenterLine::CenterLine(const TechDraw::BaseGeomPtr& bg,
 
 CenterLine::CenterLine(const Base::Vector3d& pt1,
                        const Base::Vector3d& pt2,
-                       const int m,
+                       const Mode m,
                        const double h,
                        const double v,
                        const double r,
@@ -121,7 +121,7 @@ CenterLine::CenterLine(const Base::Vector3d& pt1,
     m_vShift = v;
     m_rotate = r;
     m_extendBy = x;
-    m_type = CLTYPE::FACE;
+    m_type = Type::FACE;
     m_flip2Line = false;
 
     m_geometry = BaseGeomPtrFromVectors(pt1, pt2);
@@ -159,7 +159,7 @@ TechDraw::BaseGeomPtr CenterLine::BaseGeomPtrFromVectors(Base::Vector3d pt1, Bas
 
 CenterLine* CenterLine::CenterLineBuilder(const DrawViewPart* partFeat,
                                           const std::vector<std::string>& subNames,
-                                          const int mode,
+                                          const Mode mode,
                                           const bool flip)
 {
 //    Base::Console().Message("CL::CLBuilder()\n - subNames: %d\n", subNames.size());
@@ -169,9 +169,9 @@ CenterLine* CenterLine::CenterLineBuilder(const DrawViewPart* partFeat,
     std::vector<std::string> verts;
 
     std::string geomType = TechDraw::DrawUtil::getGeomTypeFromName(subNames.front());
-    int type = CLTYPE::FACE;
+    Type type = Type::FACE;
     if (geomType == "Face") {
-        type = CLTYPE::FACE;
+        type = Type::FACE;
         ends = TechDraw::CenterLine::calcEndPoints(partFeat,
                              subNames,
                              mode,
@@ -179,7 +179,7 @@ CenterLine* CenterLine::CenterLineBuilder(const DrawViewPart* partFeat,
                              0.0, 0.0, 0.0);
         faces = subNames;
     } else if (geomType == "Edge") {
-        type = CLTYPE::EDGE;
+        type = Type::EDGE;
         ends = TechDraw::CenterLine::calcEndPoints2Lines(partFeat,
                          subNames,
                          mode,
@@ -187,7 +187,7 @@ CenterLine* CenterLine::CenterLineBuilder(const DrawViewPart* partFeat,
                          0.0, 0.0, 0.0, flip);
         edges = subNames;
     } else if (geomType == "Vertex") {
-        type = CLTYPE::VERTEX;
+        type = Type::VERTEX;
         ends = TechDraw::CenterLine::calcEndPoints2Points(partFeat,
                          subNames,
                          mode,
@@ -229,18 +229,18 @@ TechDraw::BaseGeomPtr CenterLine::scaledGeometry(const TechDraw::DrawViewPart* p
             //CenterLine was created by points without a geometry reference,
             ends = calcEndPointsNoRef(m_start, m_end, scale, m_extendBy,
                                       m_hShift, m_vShift, m_rotate, viewAngleDeg);
-        } else if (m_type == CLTYPE::FACE) {
+        } else if (m_type == Type::FACE) {
             ends = calcEndPoints(partFeat,
                                  m_faces,
                                  m_mode, m_extendBy,
                                  m_hShift, m_vShift, m_rotate);
-        } else if (m_type == CLTYPE::EDGE) {
+        } else if (m_type == Type::EDGE) {
             ends = calcEndPoints2Lines(partFeat,
                                        m_edges,
                                        m_mode,
                                        m_extendBy,
                                        m_hShift, m_vShift, m_rotate, m_flip2Line);
-        } else if (m_type == CLTYPE::VERTEX) {
+        } else if (m_type == Type::VERTEX) {
             ends = calcEndPoints2Points(partFeat,
                                         m_verts,
                                         m_mode,
@@ -291,18 +291,18 @@ TechDraw::BaseGeomPtr CenterLine::scaledAndRotatedGeometry(TechDraw::DrawViewPar
             //CenterLine was created by points without a geometry reference,
             ends = calcEndPointsNoRef(m_start, m_end, scale, m_extendBy,
                                       m_hShift, m_vShift, m_rotate, viewAngleDeg);
-        } else if (m_type == CLTYPE::FACE) {
+        } else if (m_type == Type::FACE) {
             ends = calcEndPoints(partFeat,
                                  m_faces,
                                  m_mode, m_extendBy,
                                  m_hShift, m_vShift, m_rotate);
-        } else if (m_type == CLTYPE::EDGE) {
+        } else if (m_type == Type::EDGE) {
             ends = calcEndPoints2Lines(partFeat,
                                        m_edges,
                                        m_mode,
                                        m_extendBy,
                                        m_hShift, m_vShift, m_rotate, m_flip2Line);
-        } else if (m_type == CLTYPE::VERTEX) {
+        } else if (m_type == Type::VERTEX) {
             ends = calcEndPoints2Points(partFeat,
                                         m_verts,
                                         m_mode,
@@ -326,7 +326,7 @@ TechDraw::BaseGeomPtr CenterLine::scaledAndRotatedGeometry(TechDraw::DrawViewPar
     }
 
     TopoDS_Edge newEdge;
-    if (getType() == CLTYPE::FACE ) {
+    if (getType() == Type::FACE ) {
         gp_Pnt gp1(DU::to<gp_Pnt>(p1));
         gp_Pnt gp2(DU::to<gp_Pnt>(p2));
         TopoDS_Edge e = BRepBuilderAPI_MakeEdge(gp1, gp2);
@@ -335,8 +335,8 @@ TechDraw::BaseGeomPtr CenterLine::scaledAndRotatedGeometry(TechDraw::DrawViewPar
         // rotate using OXYZ as the coordinate system
         s = ShapeUtils::rotateShape(s, gp_Ax2(), - partFeat->Rotation.getValue());
         newEdge = TopoDS::Edge(s);
-    } else if (getType() == CLTYPE::EDGE  ||
-               getType() == CLTYPE::VERTEX) {
+    } else if (getType() == Type::EDGE  ||
+               getType() == Type::VERTEX) {
         gp_Pnt gp1(DU::to<gp_Pnt>(DU::invertY(p1 * scale)));
         gp_Pnt gp2(DU::to<gp_Pnt>(DU::invertY(p2 * scale)));
         newEdge = BRepBuilderAPI_MakeEdge(gp1, gp2);
@@ -464,7 +464,7 @@ std::pair<Base::Vector3d, Base::Vector3d> CenterLine::calcEndPointsNoRef(const B
 //end points for face centerline
 std::pair<Base::Vector3d, Base::Vector3d> CenterLine::calcEndPoints(const DrawViewPart* partFeat,
                                                       const std::vector<std::string>& faceNames,
-                                                      const int mode,
+                                                      const CenterLine::Mode mode,
                                                       const double ext,
                                                       const double hShift,
                                                       const double vShift,
@@ -534,13 +534,13 @@ std::pair<Base::Vector3d, Base::Vector3d> CenterLine::calcEndPoints(const DrawVi
     Ymin = Ymid - Yspan;
 
     Base::Vector3d p1, p2;
-    if (mode == CenterLine::VERTICAL) {                    //vertical
+    if (mode == Mode::VERTICAL) {                    //vertical
         p1 = Base::Vector3d(Xmid, Ymax, 0.0);
         p2 = Base::Vector3d(Xmid, Ymin, 0.0);
-    } else if (mode == CenterLine::HORIZONTAL) {            //horizontal
+    } else if (mode == Mode::HORIZONTAL) {            //horizontal
         p1 = Base::Vector3d(Xmin, Ymid, 0.0);
         p2 = Base::Vector3d(Xmax, Ymid, 0.0);
-    } else {      //vert == CenterLine::ALIGNED //aligned, but aligned doesn't make sense for face(s) bbox
+    } else {      //vert == Mode::ALIGNED //aligned, but aligned doesn't make sense for face(s) bbox
         Base::Console().Message("CL::calcEndPoints - aligned is not applicable to Face center lines\n");
         p1 = Base::Vector3d(Xmid, Ymax, 0.0);
         p2 = Base::Vector3d(Xmid, Ymin, 0.0);
@@ -586,7 +586,7 @@ std::pair<Base::Vector3d, Base::Vector3d> CenterLine::calcEndPoints(const DrawVi
 
 std::pair<Base::Vector3d, Base::Vector3d> CenterLine::calcEndPoints2Lines(const DrawViewPart* partFeat,
                                                       const std::vector<std::string>& edgeNames,
-                                                      const int mode,
+                                                      const Mode mode,
                                                       const double ext,
                                                       const double hShift,
                                                       const double vShift,
@@ -663,13 +663,13 @@ std::pair<Base::Vector3d, Base::Vector3d> CenterLine::calcEndPoints2Lines(const 
     //orientation
     if (partFeat->Rotation.getValue() == 0.0) {
         // if the view is rotated, then horizontal and vertical lose their meaning
-        if (mode == 0 && !inhibitVertical) {           //Vertical
+        if (mode == CenterLine::Mode::VERTICAL && !inhibitVertical) {
             p1.x = mid.x;
             p2.x = mid.x;
-        } else if (mode == 1 && !inhibitHorizontal) {    //Horizontal
+        } else if (mode == CenterLine::Mode::HORIZONTAL && !inhibitHorizontal) {
             p1.y = mid.y;
             p2.y = mid.y;
-        } else if (mode == 2) {    //Aligned
+        } else if (mode == CenterLine::Mode::ALIGNED) {
             // no op
         }
     }
@@ -706,7 +706,7 @@ std::pair<Base::Vector3d, Base::Vector3d> CenterLine::calcEndPoints2Lines(const 
 
 std::pair<Base::Vector3d, Base::Vector3d> CenterLine::calcEndPoints2Points(const DrawViewPart* partFeat,
                                                       const std::vector<std::string>& vertNames,
-                                                      const int mode,
+                                                      const Mode mode,
                                                       const double ext,
                                                       const double hShift,
                                                       const double vShift,
@@ -760,15 +760,15 @@ std::pair<Base::Vector3d, Base::Vector3d> CenterLine::calcEndPoints2Points(const
     //orientation
     if (partFeat->Rotation.getValue() == 0.0) {
         // if the view is rotated, then horizontal and vertical lose their meaning
-        if (mode == CenterLine::VERTICAL  && !inhibitVertical) {
+        if (mode == Mode::VERTICAL  && !inhibitVertical) {
             //Vertical
             v1.x = mid.x;
             v2.x = mid.x;
-        } else if (mode == CenterLine::HORIZONTAL && !inhibitHorizontal) {
+        } else if (mode == Mode::HORIZONTAL && !inhibitHorizontal) {
             //Horizontal
             v1.y = mid.y;
             v2.y = mid.y;
-        } else if (mode == CenterLine::ALIGNED) {    //Aligned
+        } else if (mode == Mode::ALIGNED) {    //Aligned
             // no op
         }
     }
@@ -936,7 +936,7 @@ void CenterLine::Restore(Base::XMLReader &reader)
     m_end.z = reader.getAttributeAsFloat("Z");
 
     reader.readElement("Mode");
-    m_mode = reader.getAttributeAsInteger("value");
+    m_mode = static_cast<Mode>(reader.getAttributeAsInteger("value"));
 
     reader.readElement("HShift");
     m_hShift = reader.getAttributeAsFloat("value");
@@ -947,7 +947,7 @@ void CenterLine::Restore(Base::XMLReader &reader)
     reader.readElement("Extend");
     m_extendBy = reader.getAttributeAsFloat("value");
     reader.readElement("Type");
-    m_type = reader.getAttributeAsInteger("value");
+    m_type = static_cast<Type>(reader.getAttributeAsInteger("value"));
     reader.readElement("Flip");
     m_flip2Line = (bool)reader.getAttributeAsInteger("value")==0?false:true;
 

--- a/src/Mod/TechDraw/App/CenterLine.cpp
+++ b/src/Mod/TechDraw/App/CenterLine.cpp
@@ -136,10 +136,10 @@ CenterLine::~CenterLine()
 
 void CenterLine::initialize()
 {
-    m_geometry->setClassOfEdge(ecHARD);
+    m_geometry->setClassOfEdge(EdgeClass::HARD);
     m_geometry->setHlrVisible( true);
     m_geometry->setCosmetic(true);
-    m_geometry->source(CENTERLINE);
+    m_geometry->source(SourceType::CENTERLINE);
 
     createNewTag();
     m_geometry->setCosmeticTag(getTagAsString());
@@ -268,10 +268,10 @@ TechDraw::BaseGeomPtr CenterLine::scaledGeometry(const TechDraw::DrawViewPart* p
     TopoDS_Shape s = ShapeUtils::scaleShape(e, scale);
     TopoDS_Edge newEdge = TopoDS::Edge(s);
     TechDraw::BaseGeomPtr newGeom = TechDraw::BaseGeom::baseFactory(newEdge);
-    newGeom->setClassOfEdge(ecHARD);
+    newGeom->setClassOfEdge(EdgeClass::HARD);
     newGeom->setHlrVisible( true);
     newGeom->setCosmetic(true);
-    newGeom->source(CENTERLINE);
+    newGeom->source(SourceType::CENTERLINE);
     newGeom->setCosmeticTag(getTagAsString());
 
     return newGeom;
@@ -346,10 +346,10 @@ TechDraw::BaseGeomPtr CenterLine::scaledAndRotatedGeometry(TechDraw::DrawViewPar
     if (!newGeom) {
         throw Base::RuntimeError("Failed to create center line");
     }
-    newGeom->setClassOfEdge(ecHARD);
+    newGeom->setClassOfEdge(EdgeClass::HARD);
     newGeom->setHlrVisible( true);
     newGeom->setCosmetic(true);
-    newGeom->source(CENTERLINE);
+    newGeom->source(SourceType::CENTERLINE);
     newGeom->setCosmeticTag(getTagAsString());
 
     return newGeom;
@@ -900,13 +900,13 @@ void CenterLine::Save(Base::Writer &writer) const
     }
 
     writer.Stream() << writer.ind() << "<GeometryType value=\"" << m_geometry->getGeomType() <<"\"/>" << std::endl;
-    if (m_geometry->getGeomType() == TechDraw::GeomType::GENERIC) {
+    if (m_geometry->getGeomType() == GeomType::GENERIC) {
         GenericPtr gen = std::static_pointer_cast<Generic>(m_geometry);
         gen->Save(writer);
-    } else if (m_geometry->getGeomType() == TechDraw::GeomType::CIRCLE) {
+    } else if (m_geometry->getGeomType() == GeomType::CIRCLE) {
         TechDraw::CirclePtr circ = std::static_pointer_cast<TechDraw::Circle>(m_geometry);
         circ->Save(writer);
-    } else if (m_geometry->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE) {
+    } else if (m_geometry->getGeomType() == GeomType::ARCOFCIRCLE) {
         TechDraw::AOCPtr aoc = std::static_pointer_cast<TechDraw::AOC>(m_geometry);
         aoc->Save(writer);
     } else {
@@ -1000,18 +1000,18 @@ void CenterLine::Restore(Base::XMLReader &reader)
 
 //stored geometry
     reader.readElement("GeometryType");
-    TechDraw::GeomType gType = static_cast<TechDraw::GeomType>(reader.getAttributeAsInteger("value"));
-    if (gType == TechDraw::GeomType::GENERIC) {
+    GeomType gType = static_cast<GeomType>(reader.getAttributeAsInteger("value"));
+    if (gType == GeomType::GENERIC) {
         TechDraw::GenericPtr gen = std::make_shared<TechDraw::Generic> ();
         gen->Restore(reader);
         gen->setOCCEdge(GeometryUtils::edgeFromGeneric(gen));
         m_geometry = gen;
-    } else if (gType == TechDraw::GeomType::CIRCLE) {
+    } else if (gType == GeomType::CIRCLE) {
         TechDraw::CirclePtr circ = std::make_shared<TechDraw::Circle> ();
         circ->Restore(reader);
         circ->setOCCEdge(GeometryUtils::edgeFromCircle(circ));
         m_geometry = circ;
-    } else if (gType == TechDraw::GeomType::ARCOFCIRCLE) {
+    } else if (gType == GeomType::ARCOFCIRCLE) {
         TechDraw::AOCPtr aoc = std::make_shared<TechDraw::AOC> ();
         aoc->Restore(reader);
         aoc->setOCCEdge(GeometryUtils::edgeFromCircleArc(aoc));

--- a/src/Mod/TechDraw/App/CenterLine.h
+++ b/src/Mod/TechDraw/App/CenterLine.h
@@ -40,30 +40,44 @@ class TechDrawExport CenterLine: public Base::Persistence
     TYPESYSTEM_HEADER_WITH_OVERRIDE();
 
 public:
-    enum CLMODE
+    enum class Mode
     {
         VERTICAL,
         HORIZONTAL,
         ALIGNED
     };
-    enum CLTYPE
+    // TODO: when C++ 20
+    // using Mode;
+    enum class Type
     {
         FACE,
         EDGE,
         VERTEX
-    };
+    };  // TODO: Make this global
+    // TODO: when C++ 20
+    // using Mode;
+
+    template <typename U, std::enable_if_t<
+        std::is_same_v<CenterLine::Type, U> ||
+        std::is_same_v<CenterLine::Mode, U>,
+        bool
+    > =true>
+    friend std::ostream& operator<<(std::ostream& out, const U& type) {
+        out << static_cast<int>(type);
+        return out;
+    }
 
     CenterLine();
     CenterLine(const CenterLine* cl);
     //set m_faces after using next 3 ctors
     CenterLine(const TechDraw::BaseGeomPtr& bg,
-               const int m = CLMODE::VERTICAL,
+               const Mode m = Mode::VERTICAL,
                const double h = 0.0,
                const double v = 0.0,
                const double r = 0.0,
                const double x = 0.0);
     CenterLine(const Base::Vector3d& p1, const Base::Vector3d& p2,
-               const int m = CLMODE::VERTICAL,
+               const Mode m = Mode::VERTICAL,
                const double h = 0.0,
                const double v = 0.0,
                const double r = 0.0,
@@ -85,7 +99,7 @@ public:
 
     static CenterLine* CenterLineBuilder(const TechDraw::DrawViewPart* partFeat,
                                          const std::vector<std::string>& subs,
-                                         const int mode = 0,
+                                         const Mode mode = Mode::VERTICAL,
                                          const bool flip = false);
     TechDraw::BaseGeomPtr scaledGeometry(const TechDraw::DrawViewPart* partFeat);
     TechDraw::BaseGeomPtr scaledAndRotatedGeometry(TechDraw::DrawViewPart* partFeat);
@@ -107,7 +121,7 @@ public:
     static std::pair<Base::Vector3d, Base::Vector3d> calcEndPoints(
                                           const TechDraw::DrawViewPart* partFeat,
                                           const std::vector<std::string>& faceNames,
-                                          const int mode,
+                                          const Mode mode,
                                           const double ext,
                                           const double m_hShift,
                                           const double m_vShift,
@@ -115,7 +129,7 @@ public:
     static std::pair<Base::Vector3d, Base::Vector3d> calcEndPoints2Lines(
                                           const TechDraw::DrawViewPart* partFeat,
                                           const std::vector<std::string>& faceNames,
-                                          const int vert,
+                                          const Mode mode,
                                           const double ext,
                                           const double m_hShift,
                                           const double m_vShift,
@@ -124,7 +138,7 @@ public:
     static std::pair<Base::Vector3d, Base::Vector3d> calcEndPoints2Points(
                                           const TechDraw::DrawViewPart* partFeat,
                                           const std::vector<std::string>& faceNames,
-                                          const int vert,
+                                          const Mode mode,
                                           const double ext,
                                           const double m_hShift,
                                           const double m_vShift,
@@ -140,8 +154,8 @@ public:
     double getExtend() const;
     void setFlip(const bool f);
     bool getFlip() const;
-    void setType(const int type) { m_type = type; };
-    int getType() const { return m_type; }
+    void setType(const Type type) { m_type = type; };
+    Type getType() const { return m_type; }
 
     Base::Vector3d m_start;
     Base::Vector3d m_end;
@@ -150,8 +164,8 @@ public:
     std::vector<std::string> m_faces;
     std::vector<std::string> m_edges;
     std::vector<std::string> m_verts;
-    int m_type;  // CLTYPE enum
-    int m_mode;  // CLMODE enum
+    Type m_type;
+    Mode m_mode;
     double m_hShift;
     double m_vShift;
     double m_rotate;

--- a/src/Mod/TechDraw/App/CenterLinePyImp.cpp
+++ b/src/Mod/TechDraw/App/CenterLinePyImp.cpp
@@ -153,20 +153,20 @@ Py::String CenterLinePy::getTag() const
 
 Py::Long CenterLinePy::getType() const
 {
-    int tmp = getCenterLinePtr()->m_type;
-    return Py::Long(tmp);
+    CenterLine::Type tmp = getCenterLinePtr()->m_type;
+    return Py::Long(static_cast<int>(tmp));
 }
 
 Py::Long CenterLinePy::getMode() const
 {
-    int tmp = getCenterLinePtr()->m_mode;
-    return Py::Long(tmp);
+    CenterLine::Mode tmp = getCenterLinePtr()->m_mode;
+    return Py::Long(static_cast<int>(tmp));
 }
 
 void CenterLinePy::setMode(Py::Long arg)
 {
     int temp = static_cast<int>(arg);
-    getCenterLinePtr()->m_mode = temp;
+    getCenterLinePtr()->m_mode = static_cast<CenterLine::Mode>(temp);
 }
 
 Py::Float CenterLinePy::getHorizShift() const

--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -46,10 +46,6 @@ using namespace TechDraw;
 using namespace std;
 using DU = DrawUtil;
 
-#define GEOMETRYEDGE 0
-#define COSMETICEDGE 1
-#define CENTERLINE   2
-
 TYPESYSTEM_SOURCE(TechDraw::CosmeticEdge, Base::Persistence)
 
 //note this ctor has no occEdge or first/last point for geometry!
@@ -89,13 +85,13 @@ CosmeticEdge::CosmeticEdge(const TechDraw::BaseGeomPtr g)
     //we assume input edge is already in Yinverted coordinates
     permaStart = m_geometry->getStartPoint();
     permaEnd   = m_geometry->getEndPoint();
-    if ((g->getGeomType() == TechDraw::GeomType::CIRCLE) ||
-       (g->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE)) {
+    if ((g->getGeomType() == GeomType::CIRCLE) ||
+       (g->getGeomType() == GeomType::ARCOFCIRCLE)) {
        TechDraw::CirclePtr circ = std::static_pointer_cast<TechDraw::Circle>(g);
        permaStart  = circ->center;
        permaEnd    = circ->center;
        permaRadius = circ->radius;
-       if (g->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE) {
+       if (g->getGeomType() == GeomType::ARCOFCIRCLE) {
            TechDraw::AOCPtr aoc = std::static_pointer_cast<TechDraw::AOC>(circ);
            aoc->clockwiseAngle(g->clockwiseAngle());
            aoc->startPnt = g->getStartPoint();
@@ -115,10 +111,10 @@ CosmeticEdge::~CosmeticEdge()
 
 void CosmeticEdge::initialize()
 {
-    m_geometry->setClassOfEdge(ecHARD);
+    m_geometry->setClassOfEdge(EdgeClass::HARD);
     m_geometry->setHlrVisible( true);
     m_geometry->setCosmetic(true);
-    m_geometry->source(COSMETICEDGE);
+    m_geometry->source(SourceType::COSMETICEDGE);
 
     createNewTag();
     m_geometry->setCosmeticTag(getTagAsString());
@@ -137,10 +133,10 @@ TechDraw::BaseGeomPtr CosmeticEdge::scaledGeometry(const double scale)
     TopoDS_Shape s = ShapeUtils::scaleShape(e, scale);
     TopoDS_Edge newEdge = TopoDS::Edge(s);
     TechDraw::BaseGeomPtr newGeom = TechDraw::BaseGeom::baseFactory(newEdge);
-    newGeom->setClassOfEdge(ecHARD);
+    newGeom->setClassOfEdge(EdgeClass::HARD);
     newGeom->setHlrVisible( true);
     newGeom->setCosmetic(true);
-    newGeom->source(COSMETICEDGE);
+    newGeom->source(SourceType::COSMETICEDGE);
     newGeom->setCosmeticTag(getTagAsString());
     return newGeom;
 }
@@ -156,10 +152,10 @@ TechDraw::BaseGeomPtr CosmeticEdge::scaledAndRotatedGeometry(const double scale,
     s = ShapeUtils::mirrorShape(s);
     TopoDS_Edge newEdge = TopoDS::Edge(s);
     TechDraw::BaseGeomPtr newGeom = TechDraw::BaseGeom::baseFactory(newEdge);
-    newGeom->setClassOfEdge(ecHARD);
+    newGeom->setClassOfEdge(EdgeClass::HARD);
     newGeom->setHlrVisible( true);
     newGeom->setCosmetic(true);
-    newGeom->source(COSMETICEDGE);
+    newGeom->source(SourceType::COSMETICEDGE);
     newGeom->setCosmeticTag(getTagAsString());
     newGeom->clockwiseAngle(saveCW);
     return newGeom;
@@ -223,13 +219,13 @@ void CosmeticEdge::Save(Base::Writer &writer) const
     writer.Stream() << writer.ind() << "<Visible value=\"" <<  v << "\"/>" << endl;
 
     writer.Stream() << writer.ind() << "<GeometryType value=\"" << m_geometry->getGeomType() <<"\"/>" << endl;
-    if (m_geometry->getGeomType() == TechDraw::GeomType::GENERIC) {
+    if (m_geometry->getGeomType() == GeomType::GENERIC) {
         GenericPtr gen = std::static_pointer_cast<Generic>(m_geometry);
         gen->Save(writer);
-    } else if (m_geometry->getGeomType() == TechDraw::GeomType::CIRCLE) {
+    } else if (m_geometry->getGeomType() == GeomType::CIRCLE) {
         TechDraw::CirclePtr circ = std::static_pointer_cast<TechDraw::Circle>(m_geometry);
         circ->Save(writer);
-    } else if (m_geometry->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE) {
+    } else if (m_geometry->getGeomType() == GeomType::ARCOFCIRCLE) {
         TechDraw::AOCPtr aoc = std::static_pointer_cast<TechDraw::AOC>(m_geometry);
         aoc->inverted()->Save(writer);
     } else {
@@ -259,16 +255,16 @@ void CosmeticEdge::Restore(Base::XMLReader &reader)
     m_format.setVisible(reader.getAttributeAsInteger("value") != 0);
 
     reader.readElement("GeometryType");
-    TechDraw::GeomType gType = static_cast<TechDraw::GeomType>(reader.getAttributeAsInteger("value"));
+    GeomType gType = static_cast<GeomType>(reader.getAttributeAsInteger("value"));
 
-    if (gType == TechDraw::GeomType::GENERIC) {
+    if (gType == GeomType::GENERIC) {
         TechDraw::GenericPtr gen = std::make_shared<TechDraw::Generic> ();
         gen->Restore(reader);
         gen->setOCCEdge(GeometryUtils::edgeFromGeneric(gen));
         m_geometry = gen;
         permaStart = gen->getStartPoint();
         permaEnd   = gen->getEndPoint();
-    } else if (gType == TechDraw::GeomType::CIRCLE) {
+    } else if (gType == GeomType::CIRCLE) {
         TechDraw::CirclePtr circ = std::make_shared<TechDraw::Circle> ();
         circ->Restore(reader);
         circ->setOCCEdge(GeometryUtils::edgeFromCircle(circ));
@@ -276,7 +272,7 @@ void CosmeticEdge::Restore(Base::XMLReader &reader)
         permaRadius = circ->radius;
         permaStart  = circ->center;
         permaEnd    = circ->center;
-    } else if (gType == TechDraw::GeomType::ARCOFCIRCLE) {
+    } else if (gType == GeomType::ARCOFCIRCLE) {
         TechDraw::AOCPtr aoc = std::make_shared<TechDraw::AOC> ();
         aoc->Restore(reader);
         aoc->setOCCEdge(GeometryUtils::edgeFromCircleArc(aoc));

--- a/src/Mod/TechDraw/App/CosmeticEdgePyImp.cpp
+++ b/src/Mod/TechDraw/App/CosmeticEdgePyImp.cpp
@@ -231,9 +231,9 @@ void CosmeticEdgePy::setEnd(Py::Vector arg)
 
 Py::Float CosmeticEdgePy::getRadius() const
 {
-    TechDraw::GeomType gt = getCosmeticEdgePtr()->m_geometry->getGeomType();
-    if ( (gt != TechDraw::GeomType::CIRCLE) &&
-         (gt != TechDraw::GeomType::ARCOFCIRCLE) ) {
+    GeomType gt = getCosmeticEdgePtr()->m_geometry->getGeomType();
+    if ( (gt != GeomType::CIRCLE) &&
+         (gt != GeomType::ARCOFCIRCLE) ) {
         throw Py::TypeError("Not a circle. Can not get radius");
     }
     double r = getCosmeticEdgePtr()->permaRadius;
@@ -242,9 +242,9 @@ Py::Float CosmeticEdgePy::getRadius() const
 
 void CosmeticEdgePy::setRadius(Py::Float arg)
 {
-    TechDraw::GeomType gt = getCosmeticEdgePtr()->m_geometry->getGeomType();
-    if ( (gt != TechDraw::GeomType::CIRCLE) &&
-         (gt != TechDraw::GeomType::ARCOFCIRCLE) ) {
+    GeomType gt = getCosmeticEdgePtr()->m_geometry->getGeomType();
+    if ( (gt != GeomType::CIRCLE) &&
+         (gt != GeomType::ARCOFCIRCLE) ) {
         throw Py::TypeError("Not a circle. Can not set radius");
     }
 
@@ -258,9 +258,9 @@ void CosmeticEdgePy::setRadius(Py::Float arg)
 
 Py::Vector CosmeticEdgePy::getCenter() const
 {
-    TechDraw::GeomType gt = getCosmeticEdgePtr()->m_geometry->getGeomType();
-    if ( (gt != TechDraw::GeomType::CIRCLE) &&
-         (gt != TechDraw::GeomType::ARCOFCIRCLE) ) {
+    GeomType gt = getCosmeticEdgePtr()->m_geometry->getGeomType();
+    if ( (gt != GeomType::CIRCLE) &&
+         (gt != GeomType::ARCOFCIRCLE) ) {
         throw Py::TypeError("Not a circle. Can not get center");
     }
     Base::Vector3d point = getCosmeticEdgePtr()->permaStart;
@@ -270,10 +270,10 @@ Py::Vector CosmeticEdgePy::getCenter() const
 
 void CosmeticEdgePy::setCenter(Py::Vector arg)
 {
-    TechDraw::GeomType gt = getCosmeticEdgePtr()->m_geometry->getGeomType();
+    GeomType gt = getCosmeticEdgePtr()->m_geometry->getGeomType();
 //    PyObject* p = arg.ptr();
-    if ( (gt != TechDraw::GeomType::CIRCLE) &&
-         (gt != TechDraw::GeomType::ARCOFCIRCLE) ) {
+    if ( (gt != GeomType::CIRCLE) &&
+         (gt != GeomType::ARCOFCIRCLE) ) {
         throw Py::TypeError("Not a circle. Can not set center");
     }
 

--- a/src/Mod/TechDraw/App/CosmeticExtension.cpp
+++ b/src/Mod/TechDraw/App/CosmeticExtension.cpp
@@ -328,7 +328,7 @@ void CosmeticExtension::refreshCEGeoms()
     std::vector<TechDraw::BaseGeomPtr> gEdges = getOwner()->getEdgeGeometry();
     std::vector<TechDraw::BaseGeomPtr> oldGEdges;
     for (auto& ge : gEdges) {
-        if (ge->source() != SourceType::COSEDGE) {
+        if (ge->source() != SourceType::COSMETICEDGE) {
             oldGEdges.push_back(ge);
         }
     }

--- a/src/Mod/TechDraw/App/DimensionFormatter.cpp
+++ b/src/Mod/TechDraw/App/DimensionFormatter.cpp
@@ -29,9 +29,11 @@
 #include <Base/Console.h>
 #include <Base/UnitsApi.h>
 
+#include "DrawViewDimension.h"
 #include "DimensionFormatter.h"
 #include "Preferences.h"
 
+// TODO: Cyclic dependency issue with DrawViewDimension
 
 using namespace TechDraw;
 
@@ -50,14 +52,9 @@ bool DimensionFormatter::isMultiValueSchema() const
     return false;
 }
 
-// Todo: make this enum
-//partial = 0 return the unaltered user string from the Units subsystem
-//partial = 1 return value formatted according to the format spec and preferences for
-//            useAltDecimals and showUnits
-//partial = 2 return only the unit of measure
 std::string DimensionFormatter::formatValue(const qreal value,
                                             const QString& qFormatSpec,
-                                            const int partial,
+                                            const Format partial,
                                             const bool isDim) const
 {
 //    Base::Console().Message("DF::formatValue() - %s isRestoring: %d\n",
@@ -92,7 +89,7 @@ std::string DimensionFormatter::formatValue(const qreal value,
     QString qBasicUnit = QString::fromStdString(Base::UnitsApi::getBasicLengthUnit());
 
     QString formattedValue;
-    if (isMultiValueSchema() && partial == 0) {
+    if (isMultiValueSchema() && partial == Format::UNALTERED) {
         //handle multi value schemes (yd/ft/in, dms, etc). don't even try to use Alt Decimals or hide units
         qMultiValueStr = formatPrefix + qUserString + formatSuffix;
         return qMultiValueStr.toStdString();
@@ -156,12 +153,12 @@ std::string DimensionFormatter::formatValue(const qreal value,
 
     //formattedValue is now in formatSpec format with local decimal separator
     std::string formattedValueString = formattedValue.toStdString();
-    if (partial == 0) {   //prefix + unit subsystem string + suffix
+    if (partial == Format::UNALTERED) {  // prefix + unit subsystem string + suffix
         return formatPrefix.toStdString() +
                  qUserString.toStdString() +
                  formatSuffix.toStdString();
     }
-    else if (partial == 1)  {            // prefix number[unit] suffix
+    else if (partial == Format::FORMATTED)  {
         if (angularMeasure) {
             //always insert unit after value
             return formatPrefix.toStdString() + formattedValueString + "°" +
@@ -189,7 +186,7 @@ std::string DimensionFormatter::formatValue(const qreal value,
                      formatSuffix.toStdString();
         }
     }
-    else if (partial == 2) {             // just the unit
+    else if (partial == Format::UNIT) {
         if (angularMeasure) {
             return qBasicUnit.toStdString();
         }
@@ -207,7 +204,7 @@ std::string DimensionFormatter::formatValue(const qreal value,
 
 //! get the formatted OverTolerance value
 // wf: is this a leftover from when we only had 1 tolerance instead of over/under?
-std::string DimensionFormatter::getFormattedToleranceValue(const int partial) const
+std::string DimensionFormatter::getFormattedToleranceValue(const Format partial) const
 {
     QString FormatSpec = QString::fromUtf8(m_dimension->FormatSpecOverTolerance.getStrValue().data());
     QString ToleranceString;
@@ -224,7 +221,7 @@ std::string DimensionFormatter::getFormattedToleranceValue(const int partial) co
 }
 
 //! get formatted over and under tolerances
-std::pair<std::string, std::string> DimensionFormatter::getFormattedToleranceValues(const int partial) const
+std::pair<std::string, std::string> DimensionFormatter::getFormattedToleranceValues(const Format partial) const
 {
     QString underFormatSpec = QString::fromUtf8(m_dimension->FormatSpecUnderTolerance.getStrValue().data());
     QString overFormatSpec = QString::fromUtf8(m_dimension->FormatSpecOverTolerance.getStrValue().data());
@@ -252,7 +249,7 @@ std::pair<std::string, std::string> DimensionFormatter::getFormattedToleranceVal
 }
 
 //partial = 2 unit only
-std::string DimensionFormatter::getFormattedDimensionValue(const int partial) const
+std::string DimensionFormatter::getFormattedDimensionValue(const Format partial) const
 {
     QString qFormatSpec = QString::fromUtf8(m_dimension->FormatSpec.getStrValue().data());
 
@@ -271,19 +268,21 @@ std::string DimensionFormatter::getFormattedDimensionValue(const int partial) co
     // (OverTolerance != 0.0 (so a tolerance has been specified) or
     // ArbitraryTolerances are specified)
     // concatenate the tolerance to dimension
+
+    // TODO: why all this QString if returned as std::string???
     if (m_dimension->EqualTolerance.getValue() &&
         !m_dimension->TheoreticalExact.getValue() &&
         (!DrawUtil::fpCompare(m_dimension->OverTolerance.getValue(), 0.0) ||
           m_dimension->ArbitraryTolerances.getValue())) {
         QString labelText = QString::fromUtf8(formatValue(m_dimension->getDimValue(),
                                                           qFormatSpec,
-                                                          1,
+                                                          Format::FORMATTED,
                                                           true).c_str()); //just the number pref/spec[unit]/suf
         QString unitText = QString::fromUtf8(formatValue(m_dimension->getDimValue(),
                                                          qFormatSpec,
-                                                         2,
+                                                         Format::UNIT,
                                                          false).c_str()); //just the unit
-        QString tolerance = QString::fromStdString(getFormattedToleranceValue(1).c_str());
+        QString tolerance = QString::fromStdString(getFormattedToleranceValue(Format::FORMATTED).c_str());
 
         // tolerance might start with a plus sign that we don't want, so cut it off
         // note plus sign is not at pos = 0!
@@ -294,7 +293,8 @@ std::string DimensionFormatter::getFormattedDimensionValue(const int partial) co
                  QStringLiteral(" \xC2\xB1 ") +          // +/- symbol
                  tolerance).toStdString();
 
-        if (partial == 2) {
+        // Unreachable code??
+        if (partial == Format::UNIT) {
             return unitText.toStdString();
         }
 

--- a/src/Mod/TechDraw/App/DimensionFormatter.h
+++ b/src/Mod/TechDraw/App/DimensionFormatter.h
@@ -25,26 +25,35 @@
 
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
-#include <DrawViewDimension.h>
+//#include <DrawViewDimension.h> Cyclic dependency issue!
 
 
 namespace TechDraw {
+class DrawViewDimension;
 
+//TODO: Why is this a class if it has no state???
 class TechDrawExport DimensionFormatter {
 public:
+    enum class Format : int {
+        UNALTERED, // return the unaltered user string from the Units subsystem
+        FORMATTED, // return value formatted according to the format spec and
+                   // preferences for useAltDecimals and showUnits
+        UNIT       // return only the unit of measure
+    };
+
     DimensionFormatter() {}
     DimensionFormatter(DrawViewDimension* dim) { m_dimension = dim; }
     ~DimensionFormatter() = default;
 
-    void setDimension(DrawViewDimension* dim) { m_dimension = dim; }
+    //void setDimension(DrawViewDimension* dim) { m_dimension = dim; }
     bool isMultiValueSchema() const;
     std::string formatValue(const qreal value,
                             const QString& qFormatSpec,
-                            const int partial,
+                            const Format partial,
                             const bool isDim) const;
-    std::string getFormattedToleranceValue(const int partial) const;
-    std::pair<std::string, std::string> getFormattedToleranceValues(const int partial) const;
-    std::string getFormattedDimensionValue(const int partial) const;
+    std::string getFormattedToleranceValue(const Format partial) const;
+    std::pair<std::string, std::string> getFormattedToleranceValues(const Format partial) const;
+    std::string getFormattedDimensionValue(const Format partial) const;
     QStringList getPrefixSuffixSpec(const QString& fSpec) const;
     std::string getDefaultFormatSpec(bool isToleranceFormat) const;
     bool isTooSmall(const double value, const QString& formatSpec) const;

--- a/src/Mod/TechDraw/App/DrawBrokenView.h
+++ b/src/Mod/TechDraw/App/DrawBrokenView.h
@@ -60,8 +60,7 @@ class TechDrawExport DrawBrokenView: public TechDraw::DrawViewPart
     PROPERTY_HEADER_WITH_OVERRIDE(TechDraw::DrawBrokenView);
 
 public:
-    enum BreakType
-    {
+    enum class BreakType : int {
         NONE,
         ZIGZAG,
         SIMPLE

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -1859,7 +1859,7 @@ bool DrawUtil::isCosmeticEdge(App::DocumentObject* owner, std::string element)
 {
     auto ownerView = static_cast<TechDraw::DrawViewPart*>(owner);
     auto edge = ownerView->getEdge(element);
-    if (edge && edge->source() == 1 && edge->getCosmetic()) {
+    if (edge && edge->source() == SourceType::COSMETICEDGE && edge->getCosmetic()) {
         return true;
     }
     return false;
@@ -1870,7 +1870,7 @@ bool DrawUtil::isCenterLine(App::DocumentObject* owner, std::string element)
 {
     auto ownerView = static_cast<TechDraw::DrawViewPart*>(owner);
     auto edge = ownerView->getEdge(element);
-    if (edge && edge->source() == 2 && edge->getCosmetic()) {
+    if (edge && edge->source() == SourceType::CENTERLINE && edge->getCosmetic()) {
         return true;
     }
     return false;

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -821,7 +821,7 @@ pointPair DrawViewDimension::getPointsOneEdge(ReferenceVector references)
             ssMessage << getNameInDocument() << " can not find geometry for 2d reference (1)";
             throw Base::RuntimeError(ssMessage.str());
         }
-        if (geom->getGeomType() != TechDraw::GeomType::GENERIC) {
+        if (geom->getGeomType() != GeomType::GENERIC) {
             std::stringstream ssMessage;
             ssMessage << getNameInDocument() << " 2d reference is a " << geom->geomTypeName();
             throw Base::RuntimeError(ssMessage.str());
@@ -1007,12 +1007,12 @@ arcPoints DrawViewDimension::arcPointsFromBaseGeom(TechDraw::BaseGeomPtr base)
     arcPoints pts;
     pts.center = Base::Vector3d(0.0, 0.0, 0.0);
     pts.radius = 0.0;
-    if ((base && base->getGeomType() == TechDraw::GeomType::CIRCLE)
-        || (base && base->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE)) {
+    if ((base && base->getGeomType() == GeomType::CIRCLE)
+        || (base && base->getGeomType() == GeomType::ARCOFCIRCLE)) {
         circle = std::static_pointer_cast<TechDraw::Circle>(base);
         pts.center = Base::Vector3d(circle->center.x, circle->center.y, 0.0);
         pts.radius = circle->radius;
-        if (base->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE) {
+        if (base->getGeomType() == GeomType::ARCOFCIRCLE) {
             TechDraw::AOCPtr aoc = std::static_pointer_cast<TechDraw::AOC>(circle);
             pts.isArc = true;
             pts.onCurve.first(Base::Vector3d(aoc->midPnt.x, aoc->midPnt.y, 0.0));
@@ -1029,8 +1029,8 @@ arcPoints DrawViewDimension::arcPointsFromBaseGeom(TechDraw::BaseGeomPtr base)
                 pts.center + Base::Vector3d(-1, 0, 0) * circle->radius);  // arbitrary point on edge
         }
     }
-    else if ((base && base->getGeomType() == TechDraw::GeomType::ELLIPSE)
-             || (base && base->getGeomType() == TechDraw::GeomType::ARCOFELLIPSE)) {
+    else if ((base && base->getGeomType() == GeomType::ELLIPSE)
+             || (base && base->getGeomType() == GeomType::ARCOFELLIPSE)) {
         TechDraw::EllipsePtr ellipse = std::static_pointer_cast<TechDraw::Ellipse>(base);
         if (ellipse->closed()) {
             double r1 = ellipse->minor;
@@ -1063,7 +1063,7 @@ arcPoints DrawViewDimension::arcPointsFromBaseGeom(TechDraw::BaseGeomPtr base)
                                + Base::Vector3d(-1, 0, 0) * rAvg);  // arbitrary point on edge
         }
     }
-    else if (base && base->getGeomType() == TechDraw::GeomType::BSPLINE) {
+    else if (base && base->getGeomType() == GeomType::BSPLINE) {
         TechDraw::BSplinePtr spline = std::static_pointer_cast<TechDraw::BSpline>(base);
         if (spline->isCircle()) {
             bool arc{false};
@@ -1219,13 +1219,13 @@ anglePoints DrawViewDimension::getAnglePointsTwoEdges(ReferenceVector references
             ssMessage << getNameInDocument() << " can not find geometry for 2d reference (5)";
             throw Base::RuntimeError(ssMessage.str());
         }
-        if (geom0->getGeomType() != TechDraw::GeomType::GENERIC) {
+        if (geom0->getGeomType() != GeomType::GENERIC) {
             std::stringstream ssMessage;
             ssMessage << getNameInDocument() << " first 2d reference is a "
                       << geom0->geomTypeName();
             throw Base::RuntimeError(ssMessage.str());
         }
-        if (geom1->getGeomType() != TechDraw::GeomType::GENERIC) {
+        if (geom1->getGeomType() != GeomType::GENERIC) {
             std::stringstream ssMessage;
             ssMessage << getNameInDocument() << " second 2d reference is a "
                       << geom0->geomTypeName();
@@ -1977,13 +1977,13 @@ bool DrawViewDimension::leaderIntersectsArc(Base::Vector3d s, Base::Vector3d poi
     const std::vector<std::string>& subElements = References2D.getSubValues();
     int idx = DrawUtil::getIndexFromName(subElements[0]);
     TechDraw::BaseGeomPtr base = getViewPart()->getGeomByIndex(idx);
-    if (base && base->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE) {
+    if (base && base->getGeomType() == GeomType::ARCOFCIRCLE) {
         TechDraw::AOCPtr aoc = std::static_pointer_cast<TechDraw::AOC>(base);
         if (aoc->intersectsArc(s, pointOnCircle)) {
             result = true;
         }
     }
-    else if (base && base->getGeomType() == TechDraw::GeomType::BSPLINE) {
+    else if (base && base->getGeomType() == GeomType::BSPLINE) {
         TechDraw::BSplinePtr spline = std::static_pointer_cast<TechDraw::BSpline>(base);
         if (spline->isCircle()) {
             if (spline->intersectsArc(s, pointOnCircle)) {

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -605,7 +605,7 @@ bool DrawViewDimension::isMultiValueSchema() const
 }
 
 std::string
-DrawViewDimension::formatValue(qreal value, QString qFormatSpec, int partial, bool isDim)
+DrawViewDimension::formatValue(qreal value, QString qFormatSpec, DimensionFormatter::Format partial, bool isDim)
 {
     return m_formatter->formatValue(value, qFormatSpec, partial, isDim);
 }
@@ -622,19 +622,19 @@ bool DrawViewDimension::haveTolerance()
     return false;
 }
 
-std::string DrawViewDimension::getFormattedToleranceValue(int partial)
+std::string DrawViewDimension::getFormattedToleranceValue(DimensionFormatter::Format partial)
 {
     return m_formatter->getFormattedToleranceValue(partial);
 }
 
 ////get over and under tolerances
-std::pair<std::string, std::string> DrawViewDimension::getFormattedToleranceValues(int partial)
+std::pair<std::string, std::string> DrawViewDimension::getFormattedToleranceValues(DimensionFormatter::Format partial)
 {
     return m_formatter->getFormattedToleranceValues(partial);
 }
 
 ////partial = 2 unit only
-std::string DrawViewDimension::getFormattedDimensionValue(int partial)
+std::string DrawViewDimension::getFormattedDimensionValue(DimensionFormatter::Format partial)
 {
     return m_formatter->getFormattedDimensionValue(partial);
 }

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -29,6 +29,7 @@
 
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
+#include "DimensionFormatter.h"
 #include "DimensionGeometry.h"
 #include "DimensionReferences.h"
 #include "DrawUtil.h"
@@ -44,9 +45,11 @@ class Measurement;
 namespace TechDraw
 {
 class DrawViewPart;
-class DimensionFormatter;
 class GeometryMatcher;
 class DimensionAutoCorrect;
+using DF = DimensionFormatter;
+
+//TODO: Cyclic dependency issue with DimensionFormatter
 
 class TechDrawExport DrawViewDimension: public TechDraw::DrawView
 {
@@ -123,11 +126,11 @@ public:
     // return PyObject as DrawViewDimensionPy
     PyObject* getPyObject() override;
 
-    virtual std::string getFormattedToleranceValue(int partial);
-    virtual std::pair<std::string, std::string> getFormattedToleranceValues(int partial = 0);
-    virtual std::string getFormattedDimensionValue(int partial = 0);
+    virtual std::string getFormattedToleranceValue(DF::Format partial);
+    virtual std::pair<std::string, std::string> getFormattedToleranceValues(DF::Format partial = DF::Format::UNALTERED);
+    virtual std::string getFormattedDimensionValue(DF::Format partial = DF::Format::UNALTERED);
     virtual std::string
-    formatValue(qreal value, QString qFormatSpec, int partial = 0, bool isDim = true);
+    formatValue(qreal value, QString qFormatSpec, DF::Format partial = DF::Format::UNALTERED, bool isDim = true);
 
     virtual bool haveTolerance();
 

--- a/src/Mod/TechDraw/App/DrawViewPartPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPartPyImp.cpp
@@ -658,7 +658,7 @@ PyObject* DrawViewPartPy::makeCenterLine(PyObject *args)
 {
 //    Base::Console().Message("DVPPI::makeCenterLine()\n");
     PyObject* pSubs;
-    int mode = 0;
+    CenterLine::Mode mode = CenterLine::Mode::VERTICAL;
     std::vector<std::string> subs;
 
     if (!PyArg_ParseTuple(args, "O!i", &PyList_Type, &pSubs, &mode)) {

--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -101,10 +101,6 @@ using DU = DrawUtil;
 using BRepAdaptor_HCurve = BRepAdaptor_Curve;
 #endif
 
-#define GEOMETRYEDGE 0
-#define COSMETICEDGE 1
-#define CENTERLINE   2
-
 // Collection of Geometric Features
 Wire::Wire()
 {
@@ -195,14 +191,14 @@ Face::~Face()
 }
 
 BaseGeom::BaseGeom() :
-    geomType(NOTDEF),
-    extractType(Plain),             //obs
-    classOfEdge(ecNONE),
+    geomType(GeomType::NOTDEF),
+    extractType(ExtractionType::Plain),             //obs
+    classOfEdge(EdgeClass::NONE),
     hlrVisible(true),
     reversed(false),
     ref3D(-1),                      //obs?
     cosmetic(false),
-    m_source(0),
+    m_source(SourceType::GEOMETRY),
     m_sourceIndex(-1)
 {
     occEdge = TopoDS_Edge();
@@ -270,7 +266,7 @@ void BaseGeom::Save(Base::Writer &writer) const
     writer.Stream() << writer.ind() << "<Ref3D value=\"" << ref3D << "\"/>" << endl;
     const char c = cosmetic?'1':'0';
     writer.Stream() << writer.ind() << "<Cosmetic value=\"" << c << "\"/>" << endl;
-    writer.Stream() << writer.ind() << "<Source value=\"" << m_source << "\"/>" << endl;
+    writer.Stream() << writer.ind() << "<Source value=\"" << m_source << "\"/>" << endl; // Should this save as text and not number?
     writer.Stream() << writer.ind() << "<SourceIndex value=\"" << m_sourceIndex << "\"/>" << endl;
     writer.Stream() << writer.ind() << "<CosmeticTag value=\"" <<  cosmeticTag << "\"/>" << endl;
 //    writer.Stream() << writer.ind() << "<Tag value=\"" <<  getTagAsString() << "\"/>" << endl;
@@ -279,11 +275,11 @@ void BaseGeom::Save(Base::Writer &writer) const
 void BaseGeom::Restore(Base::XMLReader &reader)
 {
     reader.readElement("GeomType");
-    geomType = static_cast<TechDraw::GeomType>(reader.getAttributeAsInteger("value"));
+    geomType = static_cast<GeomType>(reader.getAttributeAsInteger("value"));
     reader.readElement("ExtractType");
-    extractType = static_cast<TechDraw::ExtractionType>(reader.getAttributeAsInteger("value"));
+    extractType = static_cast<ExtractionType>(reader.getAttributeAsInteger("value"));
     reader.readElement("EdgeClass");
-    classOfEdge = static_cast<TechDraw::edgeClass>(reader.getAttributeAsInteger("value"));
+    classOfEdge = static_cast<EdgeClass>(reader.getAttributeAsInteger("value"));
     reader.readElement("HLRVisible");
     hlrVisible = reader.getAttributeAsInteger("value") != 0;
     reader.readElement("Reversed");
@@ -293,7 +289,7 @@ void BaseGeom::Restore(Base::XMLReader &reader)
     reader.readElement("Cosmetic");
     cosmetic = reader.getAttributeAsInteger("value") != 0;
     reader.readElement("Source");
-    m_source = reader.getAttributeAsInteger("value");
+    m_source = static_cast<SourceType>(reader.getAttributeAsInteger("value"));
     reader.readElement("SourceIndex");
     m_sourceIndex = reader.getAttributeAsInteger("value");
     reader.readElement("CosmeticTag");
@@ -470,11 +466,8 @@ std::string BaseGeom::geomTypeName()
         "Bezier",
         "BSpline",
         "Line",         //why was this ever called "Generic"?
-        "Unknown" } ;
-    if (geomType >= typeNames.size()) {
-        return "Unknown";
-    }
-    return typeNames.at(geomType);
+    };
+    return typeNames.at(static_cast<int>(geomType));
 }
 
 //! Convert 1 OCC edge into 1 BaseGeom (static factory method)
@@ -651,7 +644,7 @@ TopoShape BaseGeom::asTopoShape(double scale)
 
 Ellipse::Ellipse(const TopoDS_Edge &e)
 {
-    geomType = ELLIPSE;
+    geomType = GeomType::ELLIPSE;
     BRepAdaptor_Curve c(e);
     occEdge = e;
     gp_Elips ellp = c.Ellipse();
@@ -668,7 +661,7 @@ Ellipse::Ellipse(const TopoDS_Edge &e)
 
 Ellipse::Ellipse(Base::Vector3d c, double mnr, double mjr)
 {
-    geomType = ELLIPSE;
+    geomType = GeomType::ELLIPSE;
     center = c;
     major = mjr;
     minor = mnr;
@@ -688,7 +681,7 @@ Ellipse::Ellipse(Base::Vector3d c, double mnr, double mjr)
 
 AOE::AOE(const TopoDS_Edge &e) : Ellipse(e)
 {
-    geomType = ARCOFELLIPSE;
+    geomType = GeomType::ARCOFELLIPSE;
 
     BRepAdaptor_Curve c(e);
     double f = c.FirstParameter();
@@ -725,14 +718,14 @@ AOE::AOE(const TopoDS_Edge &e) : Ellipse(e)
 
 Circle::Circle()
 {
-    geomType = CIRCLE;
+    geomType = GeomType::CIRCLE;
     radius = 0.0;
     center = Base::Vector3d(0.0, 0.0, 0.0);
 }
 
 Circle::Circle(Base::Vector3d c, double r)
 {
-    geomType = CIRCLE;
+    geomType = GeomType::CIRCLE;
     radius = r;
     center = c;
     gp_Pnt loc(c.x, c.y, c.z);
@@ -753,7 +746,7 @@ Circle::Circle(Base::Vector3d c, double r)
 
 Circle::Circle(const TopoDS_Edge &e)
 {
-    geomType = CIRCLE;             //center, radius
+    geomType = GeomType::CIRCLE;             //center, radius
     BRepAdaptor_Curve c(e);
     occEdge = e;
 
@@ -802,7 +795,7 @@ void Circle::Restore(Base::XMLReader &reader)
 
 AOC::AOC(const TopoDS_Edge &e) : Circle(e)
 {
-    geomType = ARCOFCIRCLE;
+    geomType = GeomType::ARCOFCIRCLE;
     BRepAdaptor_Curve c(e);
 
     double f = c.FirstParameter();
@@ -834,7 +827,7 @@ AOC::AOC(const TopoDS_Edge &e) : Circle(e)
 
 AOC::AOC(Base::Vector3d c, double r, double sAng, double eAng) : Circle()
 {
-    geomType = ARCOFCIRCLE;
+    geomType = GeomType::ARCOFCIRCLE;
 
     radius = r;
     center = c;
@@ -883,7 +876,7 @@ AOC::AOC(Base::Vector3d c, double r, double sAng, double eAng) : Circle()
 
 AOC::AOC() : Circle()
 {
-    geomType = ARCOFCIRCLE;
+    geomType = GeomType::ARCOFCIRCLE;
 
     startPnt = Base::Vector3d(0.0, 0.0, 0.0);
     endPnt = Base::Vector3d(0.0, 0.0, 0.0);
@@ -1028,7 +1021,7 @@ void AOC::Restore(Base::XMLReader &reader)
 //! Generic is a multiline
 Generic::Generic(const TopoDS_Edge &e)
 {
-    geomType = GENERIC;
+    geomType = GeomType::GENERIC;
     occEdge = e;
     BRepLib::BuildCurve3d(occEdge);
 
@@ -1055,7 +1048,7 @@ Generic::Generic(const TopoDS_Edge &e)
 
 Generic::Generic()
 {
-    geomType = GENERIC;
+    geomType = GeomType::GENERIC;
 }
 
 std::string Generic::toString() const
@@ -1145,7 +1138,7 @@ Base::Vector3d Generic::apparentInter(GenericPtr g)
 
 BSpline::BSpline(const TopoDS_Edge &e)
 {
-    geomType = BSPLINE;
+    geomType = GeomType::BSPLINE;
     BRepAdaptor_Curve c(e);
     isArc = !c.IsClosed();
     Handle(Geom_BSplineCurve) cSpline = c.BSpline();
@@ -1260,7 +1253,7 @@ bool BSpline::intersectsArc(Base::Vector3d p1, Base::Vector3d p2)
 
 BezierSegment::BezierSegment(const TopoDS_Edge &e)
 {
-    geomType = BEZIER;
+    geomType = GeomType::BEZIER;
     occEdge = e;
     BRepAdaptor_Curve c(e);
     Handle(Geom_BezierCurve) bez = c.Bezier();

--- a/src/Mod/TechDraw/App/Geometry.h
+++ b/src/Mod/TechDraw/App/Geometry.h
@@ -45,22 +45,22 @@ namespace TechDraw {
 
 class DrawViewPart;
 
-enum ExtractionType {               //obs
+enum class ExtractionType : int {               //obs
     Plain,
     WithHidden,
     WithSmooth
 };
 
-enum edgeClass {
-    ecNONE,  // Not used, OCC index starts at 1
-    ecUVISO,
-    ecOUTLINE,
-    ecSMOOTH,
-    ecSEAM,
-    ecHARD
+enum class EdgeClass : int {
+    NONE,  // Not used, OCC index starts at 1
+    UVISO,
+    OUTLINE,
+    SMOOTH,
+    SEAM,
+    HARD
 };
 
-enum GeomType {
+enum class GeomType : int {
     NOTDEF,
     CIRCLE,
     ARCOFCIRCLE,
@@ -71,11 +71,23 @@ enum GeomType {
     GENERIC
 };
 
-enum SourceType {
-    GEOM,
-    COSEDGE,
+enum class SourceType : int {
+    GEOMETRY,
+    COSMETICEDGE,
     CENTERLINE
 };
+
+template <typename T, std::enable_if_t<
+    std::is_same_v<EdgeClass, T> ||
+    std::is_same_v<ExtractionType, T> ||
+    std::is_same_v<GeomType, T> ||
+    std::is_same_v<SourceType, T>,
+    bool
+> =true>
+std::ostream& operator<<(std::ostream& out, const T& type) {
+    out << static_cast<int>(type);
+    return out;
+}
 
 class BaseGeom;
 using BaseGeomPtr = std::shared_ptr<BaseGeom>;
@@ -131,8 +143,8 @@ class TechDrawExport BaseGeom : public std::enable_shared_from_this<BaseGeom>
         // attribute setters and getters
         GeomType getGeomType() { return geomType; }
         void setGeomType(GeomType type) { geomType = type; }
-        edgeClass getClassOfEdge() { return classOfEdge; }
-        void setClassOfEdge(edgeClass newClass) { classOfEdge = newClass; }
+        EdgeClass getClassOfEdge() { return classOfEdge; }
+        void setClassOfEdge(EdgeClass newClass) { classOfEdge = newClass; }
         bool getHlrVisible() { return hlrVisible; }
         void setHlrVisible(bool state) { hlrVisible = state; }
         bool getReversed()  { return reversed; }
@@ -143,8 +155,8 @@ class TechDrawExport BaseGeom : public std::enable_shared_from_this<BaseGeom>
         void setOCCEdge(TopoDS_Edge newEdge)  { occEdge = newEdge; }
         bool getCosmetic()  { return cosmetic; }
         void setCosmetic (bool state)  { cosmetic = state; }
-        int source() { return m_source; }
-        void source(int s) { m_source = s; }
+        SourceType source() { return m_source; }
+        void source(SourceType s) { m_source = s; }
         int sourceIndex() { return m_sourceIndex; }
         void sourceIndex(int si) { m_sourceIndex = si; }
         std::string getCosmeticTag() { return cosmeticTag; }
@@ -161,14 +173,14 @@ protected:
 
         GeomType geomType;
         ExtractionType extractType;     //obs
-        edgeClass classOfEdge;
+        EdgeClass classOfEdge;
         bool hlrVisible;
         bool reversed;
         int ref3D;                      //obs?
         TopoDS_Edge occEdge;            //projected Edge
         bool cosmetic;
         //TODO: all these attributes should be private
-        int m_source;         //0 - geom, 1 - cosmetic edge, 2 - centerline
+        SourceType m_source;
         int m_sourceIndex;
         std::string cosmeticTag;
         boost::uuids::uuid tag;

--- a/src/Mod/TechDraw/App/GeometryObject.h
+++ b/src/Mod/TechDraw/App/GeometryObject.h
@@ -86,7 +86,7 @@ public:
     static TopoDS_Shape simpleProjection(const TopoDS_Shape& shape, const gp_Ax2& projCS);
     static TopoDS_Shape projectFace(const TopoDS_Shape& face, const gp_Ax2& CS);
     void makeTDGeometry();
-    void extractGeometry(edgeClass category, bool visible);
+    void extractGeometry(EdgeClass category, bool visible);
     void addFaceGeom(FacePtr f);
     void clearFaceGeom();
     void setIsoCount(int i) { m_isoCount = i; }
@@ -141,7 +141,7 @@ protected:
     TopoDS_Shape hidSeam;
     TopoDS_Shape hidIso;
 
-    void addGeomFromCompound(TopoDS_Shape edgeCompound, edgeClass category, bool visible);
+    void addGeomFromCompound(TopoDS_Shape edgeCompound, EdgeClass category, bool visible);
     TechDraw::DrawViewDetail* isParentDetail();
 
     //similar function in Geometry?

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -34,6 +34,7 @@
 #include <Base/Parameter.h>
 
 #include "Preferences.h"
+#include "DrawBrokenView.h"
 #include "LineGenerator.h"
 
 //getters for parameters used in multiple places.
@@ -593,9 +594,10 @@ bool Preferences::useExactMatchOnDims()
     return getPreferenceGroup("Dimensions")->GetBool("UseMatcher", true);
 }
 
-int Preferences::BreakType()
+DrawBrokenView::BreakType Preferences::BreakType()
 {
-    return getPreferenceGroup("Decorations")->GetInt("BreakType", 2);
+    int temp = getPreferenceGroup("Decorations")->GetInt("BreakType", 2);
+    return static_cast<DrawBrokenView::BreakType>(temp);
 }
 
 

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -29,6 +29,7 @@
 #include <Base/Parameter.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
+#include "DrawBrokenView.h"
 
 class QColor;
 class QString;
@@ -136,7 +137,7 @@ public:
     static bool showSectionLine();
     static bool includeCutLine();
 
-    static int BreakType();
+    static DrawBrokenView::BreakType BreakType();
 
     static bool useExactMatchOnDims();
 

--- a/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
@@ -1074,7 +1074,7 @@ void execLine2Points(Gui::Command* cmd)
     //check if editing existing edge
     if (!edgeNames.empty() && (edgeNames.size() == 1)) {
         TechDraw::CosmeticEdge* ce = baseFeat->getCosmeticEdgeBySelection(edgeNames.front());
-        if (!ce || ce->m_geometry->getGeomType() != TechDraw::GeomType::GENERIC) {
+        if (!ce || ce->m_geometry->getGeomType() != GeomType::GENERIC) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong Selection"),
                              QObject::tr("Selection is not a Cosmetic Line."));
             return;
@@ -1218,8 +1218,8 @@ void execCosmeticCircle(Gui::Command* cmd)
     if (!edgeNames.empty() && (edgeNames.size() == 1)) {
         TechDraw::CosmeticEdge* ce = baseFeat->getCosmeticEdgeBySelection(edgeNames.front());
         if (!ce
-            || !(ce->m_geometry->getGeomType() == TechDraw::GeomType::CIRCLE
-                || ce->m_geometry->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE)) {
+            || !(ce->m_geometry->getGeomType() == GeomType::CIRCLE
+                || ce->m_geometry->getGeomType() == GeomType::ARCOFCIRCLE)) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong Selection"),
                              QObject::tr("Selection is not a Cosmetic Circle or a Cosmetic Arc of Circle."));
             return;
@@ -1274,10 +1274,6 @@ void execCosmeticCircle(Gui::Command* cmd)
 //===========================================================================
 // TechDraw_CosmeticEraser
 //===========================================================================
-
-#define GEOMETRYEDGE 0
-#define COSMETICEDGE 1
-#define CENTERLINE 2
 
 DEF_STD_CMD_A(CmdTechDrawCosmeticEraser)
 
@@ -1345,15 +1341,15 @@ void CmdTechDrawCosmeticEraser::activated(int iMsg)
             if (geomType == "Edge") {
                 TechDraw::BaseGeomPtr bg = objFeat->getGeomByIndex(idx);
                 if (bg && bg->getCosmetic()) {
-                    int source = bg->source();
+                    SourceType source = bg->source();
                     std::string tag = bg->getCosmeticTag();
-                    if (source == COSMETICEDGE) {
+                    if (source == SourceType::COSMETICEDGE) {
                         ce2Delete.push_back(tag);
-                    } else if (source == CENTERLINE) {
+                    } else if (source == SourceType::CENTERLINE) {
                         cl2Delete.push_back(tag);
                     } else {
                         Base::Console().Message(
-                            "CMD::CosmeticEraser - edge: %d is confused - source: %d\n", idx, source);
+                            "CMD::CosmeticEraser - edge: %d is confused - source: %d\n", idx, static_cast<int>(source));
                     }
                 }
             } else if (geomType == "Vertex") {

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -673,7 +673,7 @@ protected:
                 return emptyVector;
             }
 
-            if (geom->getGeomType() == TechDraw::GENERIC) {
+            if (geom->getGeomType() == GeomType::GENERIC) {
                 TechDraw::GenericPtr gen1 = std::static_pointer_cast<TechDraw::Generic>(geom);
                 if (gen1->points.size() < 2) {
                     return emptyVector;
@@ -681,13 +681,13 @@ protected:
                 return selLine;
                 //Base::Vector3d line = gen1->points.at(1) - gen1->points.at(0);
             }
-            else if (geom->getGeomType() == TechDraw::CIRCLE || geom->getGeomType() == TechDraw::ARCOFCIRCLE) {
+            else if (geom->getGeomType() == GeomType::CIRCLE || geom->getGeomType() == GeomType::ARCOFCIRCLE) {
                 return selCircleArc;
             }
-            else if (geom->getGeomType() == TechDraw::ELLIPSE || geom->getGeomType() == TechDraw::ARCOFELLIPSE) {
+            else if (geom->getGeomType() == GeomType::ELLIPSE || geom->getGeomType() == GeomType::ARCOFELLIPSE) {
                 return selEllipseArc;
             }
-            else if (geom->getGeomType() == TechDraw::BSPLINE) {
+            else if (geom->getGeomType() == GeomType::BSPLINE) {
                 //TechDraw::BSplinePtr spline = std::static_pointer_cast<TechDraw::BSpline>(geom);
                 //if (spline->isCircle()) {
                 //    return isBSplineCircle;
@@ -981,7 +981,7 @@ protected:
         }
         if (availableDimension == AvailableDimension::SECOND) {
             createRadiusDiameterDimension(selCircleArc[0], false);
-            if (selCircleArc[0].geomEdgeType() != TechDraw::ARCOFCIRCLE) {
+            if (selCircleArc[0].geomEdgeType() != GeomType::ARCOFCIRCLE) {
                 availableDimension = AvailableDimension::RESET;
             }
         }
@@ -1015,7 +1015,7 @@ protected:
         }
         if (availableDimension == AvailableDimension::SECOND) {
             createRadiusDiameterDimension(selEllipseArc[0], false);
-            if (selEllipseArc[0].geomEdgeType() != TechDraw::ARCOFELLIPSE) {
+            if (selEllipseArc[0].geomEdgeType() != GeomType::ARCOFELLIPSE) {
                 availableDimension = AvailableDimension::RESET;
             }
         }
@@ -1074,7 +1074,7 @@ protected:
     void createRadiusDiameterDimension(ReferenceEntry ref, bool firstCstr) {
         int GeoId(TechDraw::DrawUtil::getIndexFromName(ref.getSubName()));
         TechDraw::BaseGeomPtr geom = partFeat->getGeomByIndex(GeoId);
-        bool isCircleGeom = (geom->getGeomType() == TechDraw::CIRCLE) || (geom->getGeomType() == TechDraw::ELLIPSE);
+        bool isCircleGeom = (geom->getGeomType() == GeomType::CIRCLE) || (geom->getGeomType() == GeomType::ELLIPSE);
 
         // Use same preference as in sketcher?
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/TechDraw/dimensioning");

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -1981,9 +1981,10 @@ void CmdTechDrawExtensionArcLengthAnnotation::activated(int iMsg)
 
     // Use virtual dimension view helper to format resulting value
     TechDraw::DrawViewDimension helperDim;
+    using Format = DimensionFormatter::Format;
     std::string valueStr = helperDim.formatValue(totalLength,
                                                  QString::fromUtf8(helperDim.FormatSpec.getStrValue().data()),
-                                                 helperDim.isMultiValueSchema() ? 0 : 1);
+                                                 helperDim.isMultiValueSchema() ? Format::UNALTERED : Format::FORMATTED);
     balloon->Text.setValue("◠ " + valueStr);
 
     // Set balloon format to be referencing dimension-like

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -113,7 +113,7 @@ void execHoleCircle(Gui::Command* cmd)
         std::string GeoType = TechDraw::DrawUtil::getGeomTypeFromName(Name);
         TechDraw::BaseGeomPtr geom = objFeat->getGeomByIndex(GeoId);
         if (GeoType == "Edge") {
-            if (geom->getGeomType() == TechDraw::CIRCLE || geom->getGeomType() == TechDraw::ARCOFCIRCLE) {
+            if (geom->getGeomType() == GeomType::CIRCLE || geom->getGeomType() == GeomType::ARCOFCIRCLE) {
                 TechDraw::CirclePtr cgen = std::static_pointer_cast<TechDraw::Circle>(geom);
                 Circles.push_back(cgen);
             }
@@ -212,7 +212,7 @@ void execCircleCenterLines(Gui::Command* cmd)
         TechDraw::BaseGeomPtr geom = objFeat->getGeomByIndex(GeoId);
         std::string GeoType = TechDraw::DrawUtil::getGeomTypeFromName(Name);
         if (GeoType == "Edge") {
-            if (geom->getGeomType() == TechDraw::CIRCLE || geom->getGeomType() == TechDraw::ARCOFCIRCLE) {
+            if (geom->getGeomType() == GeomType::CIRCLE || geom->getGeomType() == GeomType::ARCOFCIRCLE) {
                 TechDraw::CirclePtr cgen = std::static_pointer_cast<TechDraw::Circle>(geom);
                 // cgen->center is a scaled, rotated and inverted point
                 Base::Vector3d center = CosmeticVertex::makeCanonicalPointInverted(objFeat, cgen->center);
@@ -803,11 +803,11 @@ void CmdTechDrawExtensionChangeLineAttributes::activated(int iMsg)
         BaseGeomPtr baseGeo = objFeat->getGeomByIndex(num);
         if (baseGeo) {
             if (baseGeo->getCosmetic()) {
-                if (baseGeo->source() == 1) {
+                if (baseGeo->source() == SourceType::COSMETICEDGE) {
                     TechDraw::CosmeticEdge* cosEdgeTag = objFeat->getCosmeticEdgeBySelection(name);
                     _setLineAttributes(cosEdgeTag);
                 }
-                else if (baseGeo->source() == 2) {
+                else if (baseGeo->source() == SourceType::CENTERLINE) {
                     TechDraw::CenterLine* centerLineTag = objFeat->getCenterLineBySelection(name);
                     _setLineAttributes(centerLineTag);
                 }
@@ -1516,7 +1516,7 @@ void execExtendShortenLine(Gui::Command* cmd, bool extend)
         if (geoType == "Edge") {
             TechDraw::BaseGeomPtr baseGeo = objFeat->getGeomByIndex(num);
             if (baseGeo) {
-                if (baseGeo->getGeomType() == TechDraw::GENERIC) {
+                if (baseGeo->getGeomType() == GeomType::GENERIC) {
                     // start and end points are geometry points and are scaled, rotated and inverted
                     // convert start and end to unscaled, unrotated.
                     Base::Vector3d P0 = CosmeticVertex::makeCanonicalPointInverted(objFeat, baseGeo->getStartPoint());
@@ -1530,7 +1530,7 @@ void execExtendShortenLine(Gui::Command* cmd, bool extend)
                         App::Color oldColor;
                         std::vector<std::string> toDelete;
                         toDelete.push_back(uniTag);
-                        if (baseGeo->source() == 1) {
+                        if (baseGeo->source() == SourceType::COSMETICEDGE) {
                             // cosmetic edge
                             auto cosEdge = objFeat->getCosmeticEdge(uniTag);
                             oldStyle = cosEdge->m_format.getLineNumber();
@@ -1538,7 +1538,7 @@ void execExtendShortenLine(Gui::Command* cmd, bool extend)
                             oldColor = cosEdge->m_format.getColor();
                             objFeat->removeCosmeticEdge(toDelete);
                         }
-                        else if (baseGeo->source() == 2) {
+                        else if (baseGeo->source() == SourceType::CENTERLINE) {
                             // centerline
                             isCenterLine = true;
                             centerEdge = objFeat->getCenterLine(uniTag);
@@ -2121,7 +2121,7 @@ void _createThreadCircle(const std::string Name, TechDraw::DrawViewPart* objFeat
     TechDraw::BaseGeomPtr geom = objFeat->getGeomByIndex(GeoId);
     std::string GeoType = TechDraw::DrawUtil::getGeomTypeFromName(Name);
 
-    if (GeoType == "Edge" && geom->getGeomType() == TechDraw::CIRCLE) {
+    if (GeoType == "Edge" && geom->getGeomType() == GeomType::CIRCLE) {
         TechDraw::CirclePtr cgen = std::static_pointer_cast<TechDraw::Circle>(geom);
         // center is rotated and scaled
         Base::Vector3d center = CosmeticVertex::makeCanonicalPointInverted(objFeat, cgen->center);
@@ -2146,7 +2146,7 @@ void _createThreadLines(const std::vector<std::string>& SubNames, TechDraw::Draw
         int GeoId1 = TechDraw::DrawUtil::getIndexFromName(SubNames[1]);
         TechDraw::BaseGeomPtr geom0 = objFeat->getGeomByIndex(GeoId0);
         TechDraw::BaseGeomPtr geom1 = objFeat->getGeomByIndex(GeoId1);
-        if (geom0->getGeomType() != TechDraw::GENERIC || geom1->getGeomType() != TechDraw::GENERIC) {
+        if (geom0->getGeomType() != GeomType::GENERIC || geom1->getGeomType() != GeomType::GENERIC) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("TechDraw Thread Hole Side"),
                                  QObject::tr("Please select two straight lines"));
             return;

--- a/src/Mod/TechDraw/Gui/DimensionValidators.cpp
+++ b/src/Mod/TechDraw/Gui/DimensionValidators.cpp
@@ -379,7 +379,7 @@ DimensionGeometryType TechDraw::isValidSingleEdge(ReferenceEntry ref)
         return isInvalid;
     }
 
-    if (geom->getGeomType() == TechDraw::GENERIC) {
+    if (geom->getGeomType() == GeomType::GENERIC) {
         TechDraw::GenericPtr gen1 = std::static_pointer_cast<TechDraw::Generic>(geom);
         if (gen1->points.size() < 2) {
             return isInvalid;
@@ -392,11 +392,11 @@ DimensionGeometryType TechDraw::isValidSingleEdge(ReferenceEntry ref)
         } else {
             return TechDraw::isDiagonal;
         }
-    } else if (geom->getGeomType() == TechDraw::CIRCLE || geom->getGeomType() == TechDraw::ARCOFCIRCLE) {
+    } else if (geom->getGeomType() == GeomType::CIRCLE || geom->getGeomType() == GeomType::ARCOFCIRCLE) {
         return isCircle;
-    } else if (geom->getGeomType() == TechDraw::ELLIPSE || geom->getGeomType() == TechDraw::ARCOFELLIPSE) {
+    } else if (geom->getGeomType() == GeomType::ELLIPSE || geom->getGeomType() == GeomType::ARCOFELLIPSE) {
         return isEllipse;
-    } else if (geom->getGeomType() == TechDraw::BSPLINE) {
+    } else if (geom->getGeomType() == GeomType::BSPLINE) {
         TechDraw::BSplinePtr spline = std::static_pointer_cast<TechDraw::BSpline>(geom);
         if (spline->isCircle()) {
             return isBSplineCircle;
@@ -529,7 +529,7 @@ DimensionGeometryType TechDraw::isValidMultiEdge(ReferenceVector refs)
     TechDraw::BaseGeomPtr geom0 = objFeat0->getGeomByIndex(GeoId0);
     TechDraw::BaseGeomPtr geom1 = objFeat0->getGeomByIndex(GeoId1);
 
-    if (geom0->getGeomType() == TechDraw::GENERIC && geom1->getGeomType() == TechDraw::GENERIC) {
+    if (geom0->getGeomType() == GeomType::GENERIC && geom1->getGeomType() == GeomType::GENERIC) {
         TechDraw::GenericPtr gen0 = std::static_pointer_cast<TechDraw::Generic>(geom0);
         TechDraw::GenericPtr gen1 = std::static_pointer_cast<TechDraw::Generic>(geom1);
         if (gen0->points.size() > 2 || gen1->points.size() > 2) {//the edge is a polyline

--- a/src/Mod/TechDraw/Gui/PathBuilder.cpp
+++ b/src/Mod/TechDraw/Gui/PathBuilder.cpp
@@ -43,7 +43,7 @@ QPainterPath PathBuilder::geomToPainterPath(BaseGeomPtr baseGeom, double rot) co
         return path;
 
     switch (baseGeom->getGeomType()) {
-        case CIRCLE: {
+        case GeomType::CIRCLE: {
             TechDraw::CirclePtr geom = std::static_pointer_cast<TechDraw::Circle>(baseGeom);
 
             double x = geom->center.x - geom->radius;
@@ -52,7 +52,7 @@ QPainterPath PathBuilder::geomToPainterPath(BaseGeomPtr baseGeom, double rot) co
             path.addEllipse(Rez::guiX(x), Rez::guiX(y), Rez::guiX(geom->radius * 2),
                             Rez::guiX(geom->radius * 2));//topleft@(x, y) radx, rady
         } break;
-        case ARCOFCIRCLE: {
+        case GeomType::ARCOFCIRCLE: {
             TechDraw::AOCPtr geom = std::static_pointer_cast<TechDraw::AOC>(baseGeom);
             if (baseGeom->getReversed()) {      // OCC reversed flag
                 path.moveTo(Rez::guiX(geom->endPnt.x), Rez::guiX(geom->endPnt.y));
@@ -69,7 +69,7 @@ QPainterPath PathBuilder::geomToPainterPath(BaseGeomPtr baseGeom, double rot) co
                         Rez::guiX(geom->startPnt.x), Rez::guiX(geom->startPnt.y));
             }
         } break;
-        case TechDraw::ELLIPSE: {
+        case GeomType::ELLIPSE: {
             TechDraw::AOEPtr geom = std::static_pointer_cast<TechDraw::AOE>(baseGeom);
 
             // Calculate start and end points as ellipse with theta = 0 and pi
@@ -84,7 +84,7 @@ QPainterPath PathBuilder::geomToPainterPath(BaseGeomPtr baseGeom, double rot) co
             pathArc(path, Rez::guiX(geom->major), Rez::guiX(geom->minor), geom->angle, false, false,
                     Rez::guiX(startX), Rez::guiX(startY), Rez::guiX(endX), Rez::guiX(endY));
         } break;
-        case TechDraw::ARCOFELLIPSE: {
+        case GeomType::ARCOFELLIPSE: {
             TechDraw::AOEPtr geom = std::static_pointer_cast<TechDraw::AOE>(baseGeom);
             if (baseGeom->getReversed()) {
                 path.moveTo(Rez::guiX(geom->endPnt.x), Rez::guiX(geom->endPnt.y));
@@ -101,7 +101,7 @@ QPainterPath PathBuilder::geomToPainterPath(BaseGeomPtr baseGeom, double rot) co
                         Rez::guiX(geom->startPnt.y));
             }
         } break;
-        case TechDraw::BEZIER: {
+        case GeomType::BEZIER: {
             TechDraw::BezierSegmentPtr geom =
                 std::static_pointer_cast<TechDraw::BezierSegment>(baseGeom);
             if (baseGeom->getReversed()) {
@@ -158,7 +158,7 @@ QPainterPath PathBuilder::geomToPainterPath(BaseGeomPtr baseGeom, double rot) co
                 }
             }
         } break;
-        case TechDraw::BSPLINE: {
+        case GeomType::BSPLINE: {
             TechDraw::BSplinePtr geom = std::static_pointer_cast<TechDraw::BSpline>(baseGeom);
             if (baseGeom->getReversed()) {
                 // Move painter to the end of our last segment
@@ -221,7 +221,7 @@ QPainterPath PathBuilder::geomToPainterPath(BaseGeomPtr baseGeom, double rot) co
                 }
             }
         } break;
-        case TechDraw::GENERIC: {
+        case GeomType::GENERIC: {
             TechDraw::GenericPtr geom = std::static_pointer_cast<TechDraw::Generic>(baseGeom);
             if (baseGeom->getReversed()) {
                 if (!geom->points.empty()) {

--- a/src/Mod/TechDraw/Gui/QGIBreakLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGIBreakLine.cpp
@@ -71,21 +71,21 @@ QGIBreakLine::QGIBreakLine()
 
 void QGIBreakLine::draw()
 {
-    if (breakType() == 0) {
+    if (breakType() == DrawBrokenView::BreakType::NONE) {
         // none
         m_background->hide();
         m_line0->hide();
         m_line1->hide();
     }
 
-    if (breakType() == 1) {
+    if (breakType() == DrawBrokenView::BreakType::ZIGZAG) {
         drawLargeZigZag();
         m_background->show();
         m_line0->show();
         m_line1->show();
     }
 
-    if (breakType() == 2) {
+    if (breakType() == DrawBrokenView::BreakType::SIMPLE) {
         // simple line from pref
         drawSimpleLines();
         m_background->hide();

--- a/src/Mod/TechDraw/Gui/QGIBreakLine.h
+++ b/src/Mod/TechDraw/Gui/QGIBreakLine.h
@@ -36,6 +36,7 @@
 #include "QGCustomText.h"
 #include "QGIDecoration.h"
 
+using BreakType = TechDraw::DrawBrokenView::BreakType;
 
 namespace TechDrawGui
 {
@@ -59,8 +60,8 @@ public:
     void setLinePen(QPen isoPen);
     void setBreakColor(QColor c);
 
-    void setBreakType(int style) { m_breakType = style; }
-    int  breakType() const { return m_breakType; }
+    void setBreakType(BreakType style) { m_breakType = style; }
+    BreakType breakType() const { return m_breakType; }
 
 protected:
 
@@ -84,7 +85,7 @@ private:
     double             m_left;
     double             m_right;
 
-    int                m_breakType{0};
+    BreakType m_breakType = BreakType::NONE;
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIDrawingTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGIDrawingTemplate.cpp
@@ -86,9 +86,7 @@ void QGIDrawingTemplate::draw()
     // Draw Edges
     // iterate through all the geometries
     for(; it != geoms.end(); ++it) {
-        switch((*it)->getGeomType()) {
-          case TechDraw::GENERIC: {
-
+        if((*it)->getGeomType() == TechDraw::GeomType::GENERIC) {
             TechDraw::GenericPtr geom = std::static_pointer_cast<TechDraw::Generic>(*it);
 
             path.moveTo(geom->points[0].x, geom->points[0].y);
@@ -97,10 +95,6 @@ void QGIDrawingTemplate::draw()
             for(++it; it != geom->points.end(); ++it) {
                 path.lineTo((*it).x, (*it).y);
             }
-            break;
-          }
-          default:
-            break;
         }
     }
 

--- a/src/Mod/TechDraw/Gui/QGIEdge.h
+++ b/src/Mod/TechDraw/Gui/QGIEdge.h
@@ -23,6 +23,7 @@
 #ifndef DRAWINGGUI_QGRAPHICSITEMEDGE_H
 #define DRAWINGGUI_QGRAPHICSITEMEDGE_H
 
+#include <Mod/TechDraw/App/Geometry.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
 #include "QGIPrimPath.h"
@@ -55,8 +56,8 @@ public:
 
     void setLinePen(QPen isoPen);
 
-    void setSource(int source) { m_source = source; }
-    int getSource() const { return m_source;}
+    void setSource(TechDraw::SourceType source) { m_source = source; }
+    TechDraw::SourceType getSource() const { return m_source;}
 
     void setCurrentPen() override;
 
@@ -75,7 +76,7 @@ protected:
     Qt::PenStyle getHiddenStyle();
 
 private:
-    int m_source{0};
+    TechDraw::SourceType m_source{TechDraw::SourceType::GEOMETRY};
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -69,6 +69,7 @@
 
 using namespace TechDraw;
 using namespace TechDrawGui;
+using Format = DimensionFormatter::Format;
 
 enum SnapMode
 {
@@ -522,19 +523,19 @@ void QGIDatumLabel::setToleranceString()
     std::pair<std::string, std::string> labelTexts, unitTexts;
 
     if (dim->ArbitraryTolerances.getValue()) {
-        labelTexts = dim->getFormattedToleranceValues(1);//copy tolerance spec
+        labelTexts = dim->getFormattedToleranceValues(Format::FORMATTED);//copy tolerance spec
         unitTexts.first = "";
         unitTexts.second = "";
     }
     else {
         if (dim->isMultiValueSchema()) {
-            labelTexts = dim->getFormattedToleranceValues(0);//don't format multis
+            labelTexts = dim->getFormattedToleranceValues(Format::UNALTERED);//don't format multis
             unitTexts.first = "";
             unitTexts.second = "";
         }
         else {
-            labelTexts = dim->getFormattedToleranceValues(1);// prefix value [unit] postfix
-            unitTexts = dim->getFormattedToleranceValues(2); //just the unit
+            labelTexts = dim->getFormattedToleranceValues(Format::FORMATTED);// prefix value [unit] postfix
+            unitTexts = dim->getFormattedToleranceValues(Format::UNIT); //just the unit
         }
     }
 
@@ -831,10 +832,11 @@ void QGIViewDimension::updateDim()
     }
 
     QString labelText =
-        QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str());// pre value [unit] post
+        // what about fromStdString?
+        QString::fromUtf8(dim->getFormattedDimensionValue(Format::FORMATTED).c_str());// pre value [unit] post
     if (dim->isMultiValueSchema()) {
         labelText =
-            QString::fromUtf8(dim->getFormattedDimensionValue(0).c_str());//don't format multis
+            QString::fromUtf8(dim->getFormattedDimensionValue(Format::UNALTERED).c_str());//don't format multis
     }
 
     QFont font = datumLabel->getFont();

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -71,10 +71,6 @@ using namespace TechDrawGui;
 using namespace std;
 using DU = DrawUtil;
 
-#define GEOMETRYEDGE 0
-#define COSMETICEDGE 1
-#define CENTERLINE 2
-
 const float lineScaleFactor = Rez::guiX(1.);// temp fiddle for devel
 
 QGIViewPart::QGIViewPart()
@@ -365,18 +361,18 @@ void QGIViewPart::drawAllEdges()
         item->setNormalColor(PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor()));
         if ((*itGeom)->getCosmetic()) {
             // cosmetic edge - format appropriately
-            int source = (*itGeom)->source();
-            if (source == COSMETICEDGE) {
+            TechDraw::SourceType source = (*itGeom)->source();
+            if (source == TechDraw::SourceType::COSMETICEDGE) {
                 std::string cTag = (*itGeom)->getCosmeticTag();
                 showItem = formatGeomFromCosmetic(cTag, item);
             }
-            else if (source == CENTERLINE) {
+            else if (source == TechDraw::SourceType::CENTERLINE) {
                 std::string cTag = (*itGeom)->getCosmeticTag();
                 showItem = formatGeomFromCenterLine(cTag, item);
             }
             else {
                 Base::Console().Message("QGIVP::drawVP - cosmetic edge: %d is confused - source: %d\n",
-                                        iEdge, source);
+                                        iEdge, static_cast<int>(source));
             }
         } else {
             // geometry edge - apply format if applicable
@@ -407,7 +403,7 @@ void QGIViewPart::drawAllEdges()
             }
         }
 
-        if ((*itGeom)->getClassOfEdge()  == ecUVISO) {
+        if ((*itGeom)->getClassOfEdge() == EdgeClass::UVISO) {
             // we don't have a style option for iso-parametric lines so draw continuous
             item->setLinePen(m_dashedLineGenerator->getLinePen(1, vp->IsoWidth.getValue()));
             item->setWidth(Rez::guiX(vp->IsoWidth.getValue()));   //graphic
@@ -475,18 +471,18 @@ bool QGIViewPart::showThisEdge(BaseGeomPtr geom)
     auto dvp(static_cast<TechDraw::DrawViewPart*>(getViewObject()));
 
     if (geom->getHlrVisible()) {
-        if ((geom->getClassOfEdge()  == ecHARD) || (geom->getClassOfEdge()  == ecOUTLINE)
-            || ((geom->getClassOfEdge()  == ecSMOOTH) && dvp->SmoothVisible.getValue())
-            || ((geom->getClassOfEdge()  == ecSEAM) && dvp->SeamVisible.getValue())
-            || ((geom->getClassOfEdge()  == ecUVISO) && dvp->IsoVisible.getValue())) {
+        if ((geom->getClassOfEdge() == EdgeClass::HARD) || (geom->getClassOfEdge() == EdgeClass::OUTLINE)
+            || ((geom->getClassOfEdge() == EdgeClass::SMOOTH) && dvp->SmoothVisible.getValue())
+            || ((geom->getClassOfEdge() == EdgeClass::SEAM) && dvp->SeamVisible.getValue())
+            || ((geom->getClassOfEdge() == EdgeClass::UVISO) && dvp->IsoVisible.getValue())) {
             return true;
         }
     } else {
-        if (((geom->getClassOfEdge()  == ecHARD) && (dvp->HardHidden.getValue()))
-            || ((geom->getClassOfEdge()  == ecOUTLINE) && (dvp->HardHidden.getValue()))
-            || ((geom->getClassOfEdge()  == ecSMOOTH) && (dvp->SmoothHidden.getValue()))
-            || ((geom->getClassOfEdge()  == ecSEAM) && (dvp->SeamHidden.getValue()))
-            || ((geom->getClassOfEdge()  == ecUVISO) && (dvp->IsoHidden.getValue()))) {
+        if (((geom->getClassOfEdge() == EdgeClass::HARD) && (dvp->HardHidden.getValue()))
+            || ((geom->getClassOfEdge() == EdgeClass::OUTLINE) && (dvp->HardHidden.getValue()))
+            || ((geom->getClassOfEdge() == EdgeClass::SMOOTH) && (dvp->SmoothHidden.getValue()))
+            || ((geom->getClassOfEdge() == EdgeClass::SEAM) && (dvp->SeamHidden.getValue()))
+            || ((geom->getClassOfEdge() == EdgeClass::UVISO) && (dvp->IsoHidden.getValue()))) {
             return true;
         }
     }

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -1043,7 +1043,7 @@ void QGIViewPart::drawBreakLines()
         return;
     }
 
-    auto breakType = vp->BreakLineType.getValue();
+    DrawBrokenView::BreakType breakType = static_cast<DrawBrokenView::BreakType>(vp->BreakLineType.getValue());
     auto breaks = dbv->Breaks.getValues();
     for (auto& breakObj : breaks) {
         QGIBreakLine* breakLine = new QGIBreakLine();

--- a/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
@@ -48,6 +48,8 @@ using namespace Gui;
 using namespace TechDraw;
 using namespace TechDrawGui;
 using DU = DrawUtil;
+using Mode = CenterLine::Mode;
+using Type = CenterLine::Type;
 
 //ctor for edit
 TaskCenterLine::TaskCenterLine(TechDraw::DrawViewPart* partFeat,
@@ -61,8 +63,8 @@ TaskCenterLine::TaskCenterLine(TechDraw::DrawViewPart* partFeat,
     m_btnOK(nullptr),
     m_btnCancel(nullptr),
     m_edgeName(edgeName),
-    m_type(CenterLine::FACE),
-    m_mode(CenterLine::VERTICAL),
+    m_type(Type::FACE),
+    m_mode(Mode::VERTICAL),
     m_editMode(editMode)
 {
     ui->setupUi(this);
@@ -97,8 +99,8 @@ TaskCenterLine::TaskCenterLine(TechDraw::DrawViewPart* partFeat,
     m_subNames(subNames),
     m_geomIndex(0),
     m_cl(nullptr),
-    m_type(CenterLine::FACE),
-    m_mode(CenterLine::VERTICAL),
+    m_type(Type::FACE),
+    m_mode(Mode::VERTICAL),
     m_editMode(editMode)
 {
     //existence of page and feature are checked by isActive method of calling command
@@ -107,11 +109,11 @@ TaskCenterLine::TaskCenterLine(TechDraw::DrawViewPart* partFeat,
     std::string check = subNames.front();
     std::string geomType = TechDraw::DrawUtil::getGeomTypeFromName(check);
     if (geomType == "Face") {
-        m_type = CenterLine::FACE;
+        m_type = Type::FACE;
     } else if (geomType == "Edge") {
-        m_type = CenterLine::EDGE;
+        m_type = Type::EDGE;
     } else if (geomType == "Vertex") {
-        m_type = CenterLine::VERTEX;
+        m_type = Type::VERTEX;
     } else {
         Base::Console().Error("TaskCenterLine - unknown geometry type: %s.  Can not proceed.\n", geomType.c_str());
         return;
@@ -143,7 +145,7 @@ void TaskCenterLine::changeEvent(QEvent *event)
 void TaskCenterLine::setUiConnect()
 {
     // first enabling/disabling
-    if (m_type == CenterLine::FACE) // if face, then aligned is not possible
+    if (m_type == Type::FACE) // if face, then aligned is not possible
         ui->rbAligned->setEnabled(false);
     else
         ui->rbAligned->setEnabled(true);
@@ -196,12 +198,12 @@ void TaskCenterLine::setUiPrimary()
     int precision = Base::UnitsApi::getDecimals();
     ui->qsbRotate->setDecimals(precision);
 
-    if (m_type == CenterLine::EDGE) {
-       int orientation = checkPathologicalEdges(m_mode);
+    if (m_type == Type::EDGE) {
+       Mode orientation = checkPathologicalEdges(m_mode);
        setUiOrientation(orientation);
     }
-    if (m_type == CenterLine::VERTEX) {
-       int orientation = checkPathologicalVertices(m_mode);
+    if (m_type == Type::VERTEX) {
+       Mode orientation = checkPathologicalVertices(m_mode);
        setUiOrientation(orientation);
     }
 }
@@ -226,11 +228,11 @@ void TaskCenterLine::setUiEdit()
     ui->rbVertical->setChecked(false);
     ui->rbHorizontal->setChecked(false);
     ui->rbAligned->setChecked(false);
-    if (m_cl->m_mode == CenterLine::VERTICAL)
+    if (m_cl->m_mode == Mode::VERTICAL)
         ui->rbVertical->setChecked(true);
-    else if (m_cl->m_mode == CenterLine::HORIZONTAL)
+    else if (m_cl->m_mode == Mode::HORIZONTAL)
         ui->rbHorizontal->setChecked(true);
-    else if (m_cl->m_mode == CenterLine::ALIGNED)
+    else if (m_cl->m_mode == Mode::ALIGNED)
         ui->rbAligned->setChecked(true);
 
     Base::Quantity qVal;
@@ -256,14 +258,14 @@ void TaskCenterLine::onOrientationChanged()
         return;
     }
     if (ui->rbVertical->isChecked())
-        m_cl->m_mode = CenterLine::CLMODE::VERTICAL;
+        m_cl->m_mode = Mode::VERTICAL;
     else if (ui->rbHorizontal->isChecked())
-        m_cl->m_mode = CenterLine::CLMODE::HORIZONTAL;
+        m_cl->m_mode = Mode::HORIZONTAL;
     else if (ui->rbAligned->isChecked())
-        m_cl->m_mode = CenterLine::CLMODE::ALIGNED;
+        m_cl->m_mode = Mode::ALIGNED;
     // for centerlines between 2 lines we cannot just recompute
     // because the new orientation might lead to an invalid centerline
-    if (m_type == CenterLine::EDGE)
+    if (m_type == Type::EDGE)
         updateOrientation();
     else
         m_partFeat->recomputeFeature();
@@ -343,9 +345,9 @@ void TaskCenterLine::onStyleChanged()
 
 // check that we are not trying to create an impossible centerline (ex a vertical centerline
 // between 2 horizontal edges)
-int TaskCenterLine::checkPathologicalEdges(int inMode)
+Mode TaskCenterLine::checkPathologicalEdges(Mode inMode)
 {
-    if (m_type != CenterLine::EDGE) {
+    if (m_type != Type::EDGE) {
         // not an edge based centerline, this doesn't apply
         return inMode;
     }
@@ -361,10 +363,10 @@ int TaskCenterLine::checkPathologicalEdges(int inMode)
     bool edge2Horizontal = DU::fpCompare(ends2.front().y, ends2.back().y, EWTOLERANCE);
 
     if (edge1Vertical && edge2Vertical) {
-        return CenterLine::CLMODE::VERTICAL;
+        return Mode::VERTICAL;
     }
     if (edge1Horizontal && edge2Horizontal) {
-        return CenterLine::CLMODE::HORIZONTAL;
+        return Mode::HORIZONTAL;
     }
 
     // not pathological case, just return the input mode
@@ -373,9 +375,9 @@ int TaskCenterLine::checkPathologicalEdges(int inMode)
 
 // check that we are not trying to create an impossible centerline (ex a vertical centerline
 // between 2 vertices aligned vertically)
-int TaskCenterLine::checkPathologicalVertices(int inMode)
+Mode TaskCenterLine::checkPathologicalVertices(Mode inMode)
 {
-    if (m_type != CenterLine::VERTEX) {
+    if (m_type != Type::VERTEX) {
         // not a vertex based centerline, this doesn't apply
         return inMode;
     }
@@ -387,12 +389,12 @@ int TaskCenterLine::checkPathologicalVertices(int inMode)
 
     if (DU::fpCompare(point1.x, point2.x, EWTOLERANCE)) {
         // points are aligned vertically, CL must be horizontal
-        return CenterLine::CLMODE::HORIZONTAL;
+        return Mode::HORIZONTAL;
     }
 
     if (DU::fpCompare(point1.y, point2.y, EWTOLERANCE)) {
         // points are aligned horizontally, CL must be vertical
-        return CenterLine::CLMODE::VERTICAL;
+        return Mode::VERTICAL;
     }
 
     // not pathological case, just return the input mode
@@ -405,10 +407,10 @@ void TaskCenterLine::createCenterLine()
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Centerline"));
 
     // check for illogical parameters
-    if (m_type == CenterLine::EDGE) {
+    if (m_type == Type::EDGE) {
         // between lines
         m_mode = checkPathologicalEdges(m_mode);
-    } else if (m_type == CenterLine::VERTEX) {
+    } else if (m_type == Type::VERTEX) {
         // between points
         m_mode = checkPathologicalVertices(m_mode);
     }
@@ -455,15 +457,15 @@ void TaskCenterLine::updateOrientation()
     // this can lead to a crash, see e.g.
     // https://forum.freecad.org/viewtopic.php?f=35&t=44255&start=20#p503220
     // The centerline creation can fail if m_type is edge and both selected edges are vertical or horizontal.
-    int orientation = m_cl->m_mode;
-    if (m_type == CenterLine::EDGE) {
+    Mode orientation = m_cl->m_mode;
+    if (m_type == Type::EDGE) {
         // between lines
         if (!m_edgeName.empty() && !m_cl->m_edges.empty()) {
              // we have an existing centerline, not a freshly created one, and it is a centerline between edges
             m_subNames = m_cl->m_edges;
             orientation = checkPathologicalEdges(orientation);
         }
-    } else if (m_type == CenterLine::VERTEX) {
+    } else if (m_type == Type::VERTEX) {
         // between points
         if (!m_edgeName.empty() && !m_cl->m_verts.empty()) {
              // we have an existing centerline, not a freshly created one, and it is a centerline between points
@@ -477,15 +479,15 @@ void TaskCenterLine::updateOrientation()
     m_partFeat->recomputeFeature();
 }
 
-void TaskCenterLine::setUiOrientation(int orientation)
+void TaskCenterLine::setUiOrientation(Mode orientation)
 {
     ui->rbVertical->blockSignals(true);
     ui->rbVertical->blockSignals(true);
 
-    if (orientation == CenterLine::CLMODE::VERTICAL) {
+    if (orientation == Mode::VERTICAL) {
         ui->rbVertical->setChecked(true);
         ui->rbHorizontal->setChecked(false);
-    } else if (orientation == CenterLine::CLMODE::HORIZONTAL) {
+    } else if (orientation == Mode::HORIZONTAL) {
         ui->rbVertical->setChecked(false);
         ui->rbHorizontal->setChecked(true);
     }

--- a/src/Mod/TechDraw/Gui/TaskCenterLine.h
+++ b/src/Mod/TechDraw/Gui/TaskCenterLine.h
@@ -87,9 +87,9 @@ protected:
     QColor getCenterColor();
     double getExtendBy();
 
-    int checkPathologicalEdges(int inMode);
-    int checkPathologicalVertices(int inMode);
-    void setUiOrientation(int orientation);
+    TechDraw::CenterLine::Mode checkPathologicalEdges(TechDraw::CenterLine::Mode inMode);
+    TechDraw::CenterLine::Mode checkPathologicalVertices(TechDraw::CenterLine::Mode inMode);
+    void setUiOrientation(TechDraw::CenterLine::Mode orientation);
 
 private:
     std::unique_ptr<Ui_TaskCenterLine> ui;
@@ -106,8 +106,8 @@ private:
     int m_geomIndex;
     TechDraw::CenterLine* m_cl;
     TechDraw::CenterLine orig_cl;
-    int m_type;
-    int m_mode;
+    TechDraw::CenterLine::Type m_type;
+    TechDraw::CenterLine::Mode m_mode;
     bool m_editMode;
 
 private Q_SLOTS:

--- a/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
@@ -108,7 +108,7 @@ TechDraw::LineFormat *TaskLineDecor::getFormatAccessPtr(const std::string &edgeN
     BaseGeomPtr bg = m_partFeat->getEdge(edgeName);
     if (bg) {
         if (bg->getCosmetic()) {
-            if (bg->source() == SourceType::COSEDGE) {
+            if (bg->source() == SourceType::COSMETICEDGE) {
                 TechDraw::CosmeticEdge *ce = m_partFeat->getCosmeticEdgeBySelection(edgeName);
                 if (ce) {
                     return &ce->m_format;

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -132,7 +132,7 @@ ViewProviderViewPart::ViewProviderViewPart()
 
     // properties that affect BrokenViews
     BreakLineType.setEnums(DrawBrokenView::BreakTypeEnums);
-    ADD_PROPERTY_TYPE(BreakLineType, (Preferences::BreakType()), bvgroup, App::Prop_None,
+    ADD_PROPERTY_TYPE(BreakLineType, (static_cast<int>(Preferences::BreakType())), bvgroup, App::Prop_None,
                         "Adjusts the type of break line depiction on broken views");
     ADD_PROPERTY_TYPE(BreakLineStyle, (Preferences::BreakLineStyle()), bvgroup, App::Prop_None,
                         "Set break line style if applicable");


### PR DESCRIPTION
- Remove currently present magic numbers
- Hard type enums, so magic numbers can no longer be introduced. We don't want people to introduce magic numbers.

Not having magic numbers improves readability greatly, and might reduce introduction of bugs. Further, the type safety might reduce introduction of bugs.