### PR TITLE
PrefPacks: reset tree view font size in FreeCAD Classic theme

### DIFF
--- a/src/Gui/PreferencePacks/FreeCAD Classic/FreeCAD Classic.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Classic/FreeCAD Classic.cfg
@@ -131,6 +131,7 @@
         <FCParamGroup Name="TreeView">
           <FCUInt Name="TreeActiveColor" Value="1016200447"/>
           <FCUInt Name="TreeEditColor" Value="1588208639"/>
+          <FCInt Name="FontSize" Value="0"/>
         </FCParamGroup>
         <FCParamGroup Name="View">
           <FCBool Name="Gradient" Value="1"/>


### PR DESCRIPTION
Some themes define a tree view font size different than the default `0`. When selecting those themes and then switching back to Classic, that custom font size remains, which might make the tree view look out of place.

This PR adds the tree view's `FontSize` parameter default to the FreeCAD Classic configuration, so that it is reset to defaults when choosing the FreeCAD Classic theme.