### PR TITLE
[Start page] Implement ShowExamples parameter

### DIFF
--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -190,8 +190,8 @@ StartView::StartView(QWidget* parent)
     setObjectName(QLatin1String("StartView"));
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Start");
-    auto cardSpacing = hGrp->GetInt("FileCardSpacing", 15);  // NOLINT
-    auto showExamples = hGrp->GetBool("ShowExamples", true); // NOLINT
+    auto cardSpacing = hGrp->GetInt("FileCardSpacing", 15);   // NOLINT
+    auto showExamples = hGrp->GetBool("ShowExamples", true);  // NOLINT
 
     // First start page
     auto firstStartScrollArea = gsl::owner<QScrollArea*>(new QScrollArea());

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -191,6 +191,7 @@ StartView::StartView(QWidget* parent)
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Start");
     auto cardSpacing = hGrp->GetInt("FileCardSpacing", 15);  // NOLINT
+    auto showExamples = hGrp->GetBool("ShowExamples", true); // NOLINT
 
     // First start page
     auto firstStartScrollArea = gsl::owner<QScrollArea*>(new QScrollArea());
@@ -244,14 +245,18 @@ StartView::StartView(QWidget* parent)
     connect(recentFilesListWidget, &QListView::clicked, this, &StartView::fileCardSelected);
     documentsContentLayout->addWidget(recentFilesListWidget);
 
-    _examplesLabel = gsl::owner<QLabel*>(new QLabel());
-    documentsContentLayout->addWidget(_examplesLabel);
     auto examplesListWidget = gsl::owner<FileCardView*>(new FileCardView(_contents));
+    examplesListWidget->setVisible(showExamples);
+    _examplesLabel = gsl::owner<QLabel*>(new QLabel());
+    _examplesLabel->setVisible(showExamples);
+    documentsContentLayout->addWidget(_examplesLabel);
+
     connect(examplesListWidget, &QListView::clicked, this, &StartView::fileCardSelected);
     documentsContentLayout->addWidget(examplesListWidget);
 
     documentsContentLayout->setSpacing(static_cast<int>(cardSpacing));
     documentsContentLayout->addStretch();
+
 
     // Documents page footer
     auto footerLayout = gsl::owner<QHBoxLayout*>(new QHBoxLayout());
@@ -276,7 +281,6 @@ StartView::StartView(QWidget* parent)
     // Set startup widget according to the first start parameter
     auto firstStart = hGrp->GetBool("FirstStart2024", true);  // NOLINT
     _contents->setCurrentWidget(firstStart ? firstStartScrollArea : documentsWidget);
-
     configureExamplesListWidget(examplesListWidget);
     configureRecentFilesListWidget(recentFilesListWidget, _recentFilesLabel);
 

--- a/src/Mod/Start/Gui/StartView.h
+++ b/src/Mod/Start/Gui/StartView.h
@@ -98,11 +98,9 @@ protected:
 
 private:
     void retranslateUi();
-
     QStackedWidget* _contents = nullptr;
     Start::RecentFilesModel _recentFilesModel;
     Start::ExamplesModel _examplesModel;
-
     QLabel* _newFileLabel;
     QLabel* _examplesLabel;
     QLabel* _recentFilesLabel;


### PR DESCRIPTION
See https://forum.freecad.org/viewtopic.php?t=94485

There exists a ShowExamples parameter in BaseApp/Preferences/Mod/Start but it is currently ignored.  This PR implements this parameter and disables the display of the Example files if ShowExamples is set to false.