### PR TITLE
* Move pyopen with encoding to utils.

### DIFF
--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -43,6 +43,7 @@ import FreeCAD as App
 from draftutils import params
 from draftutils.messages import _wrn, _err, _log
 from draftutils.translate import translate
+from builtins import open
 
 # TODO: move the functions that require the graphical interface
 # This module should not import any graphical commands; those should be
@@ -1196,5 +1197,11 @@ def use_instead(function, version=""):
         _wrn(translate("draft", "This function will be deprecated in {}. Please use '{}'.") .format(version, function))
     else:
         _wrn(translate("draft", "This function will be deprecated. Please use '{}'.") .format(function))
+
+
+def pyopen(file, mode='r', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None):
+    if encoding is None:
+        encoding = 'utf-8'
+    return open(file, mode, buffering, encoding, errors, newline, closefd, opener)
 
 ## @}

--- a/src/Mod/Draft/importAirfoilDAT.py
+++ b/src/Mod/Draft/importAirfoilDAT.py
@@ -44,8 +44,7 @@ import Draft
 import Part
 from FreeCAD import Vector
 from FreeCAD import Console as FCC
-from builtins import open as pyopen
-
+from draftutils.utils import pyopen
 
 if FreeCAD.GuiUp:
     from draftutils.translate import translate

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -67,7 +67,7 @@ from Draft import LinearDimension
 from draftobjects.dimension import _Dimension
 from draftutils import params
 from draftutils import utils
-from builtins import open as pyopen
+from draftutils.utils import pyopen
 
 gui = FreeCAD.GuiUp
 draftui = None
@@ -1928,13 +1928,24 @@ def addObject(shape, name="Shape", layer=None):
         newob = shape
     if layer:
         lay = locateLayer(layer)
+        # For old style layers, which are just groups
         if hasattr(lay, "Group"):
+            pass
+        # For new Draft Layers
+        elif hasattr(lay, "Proxy") and hasattr(lay.Proxy, "Group"):
+            lay = lay.Proxy
+        else:
+            lay = None
+
+        if lay != None:
             if lay not in layerObjects:
                 l = []
                 layerObjects[lay] = l
             else:
                 l = layerObjects[lay]
             l.append(newob)
+
+
 
     formatObject(newob)
     return newob

--- a/src/Mod/Draft/importOCA.py
+++ b/src/Mod/Draft/importOCA.py
@@ -44,7 +44,7 @@ import FreeCAD, os, Part, DraftVecUtils, DraftGeomUtils
 from FreeCAD import Vector
 from FreeCAD import Console as FCC
 from draftutils import params
-from builtins import open as pyopen
+from draftutils.utils import pyopen
 
 if FreeCAD.GuiUp:
     from draftutils.translate import translate

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -61,13 +61,7 @@ from draftutils import params
 from draftutils import utils
 from draftutils.translate import translate
 from draftutils.messages import _err, _msg, _wrn
-import builtins
-#redefine pyopen as open with encoding='utf-8'
-def utf8_open(file, mode='r', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None):
-    if encoding is None:
-        encoding = 'utf-8'
-    return builtins.open(file, mode, buffering, encoding, errors, newline, closefd, opener)
-pyopen = utf8_open
+from draftutils.utils import pyopen
 
 if FreeCAD.GuiUp:
     from PySide import QtWidgets


### PR DESCRIPTION
Move import.SVG pyopen with encoding to draftutils.utils.
and modify DRAFT importing library that use open function to use open with encoding=utf8.
With this change, DXF OCA AirfoilDAT always read as utf-8.
I'm not sure. it's need this change.because I don't have such a example of OCF or DXF or AirfoilDAT.
I think it's more better checking encoding of files before importing than force encoding=utf8.