### PR TITLE
[ArchSketchObject / Window]  Links of Window to support Individual Hosts

### DIFF
--- a/src/Mod/BIM/ArchSketchObject.py
+++ b/src/Mod/BIM/ArchSketchObject.py
@@ -24,26 +24,26 @@ import ArchWindow
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 class ArchSketchObject:
-  def __init__(self, obj):
-      pass
+    def __init__(self, obj):
+        pass
 
 class ArchSketch(ArchSketchObject):
-  def __init__(self, obj):
-      pass
+    def __init__(self, obj):
+        pass
 
-  def setPropertiesLinkCommon(self, orgFp, linkFp=None, mode=None):
-      if linkFp:
-          fp = linkFp
-      else:
-          fp = orgFp
-      prop = fp.PropertiesList
-      if not isinstance(fp.getLinkedObject().Proxy, ArchWindow._Window):
-          pass
-      else:
-          if "Hosts" not in prop:
-              fp.addProperty("App::PropertyLinkList","Hosts","Window",
-                             QT_TRANSLATE_NOOP("App::Property",
-                             "The objects that host this window"))
-                             # Arch Window's code
+    def setPropertiesLinkCommon(self, orgFp, linkFp=None, mode=None):
+        if linkFp:
+            fp = linkFp
+        else:
+            fp = orgFp
+        prop = fp.PropertiesList
+        if not isinstance(fp.getLinkedObject().Proxy, ArchWindow._Window):
+            pass
+        else:
+            if "Hosts" not in prop:
+                fp.addProperty("App::PropertyLinkList","Hosts","Window",
+                               QT_TRANSLATE_NOOP("App::Property",
+                               "The objects that host this window"))
+                               # Arch Window's code
 
 #from ArchSketchObjectExt import ArchSketch  # Doesn't work

--- a/src/Mod/BIM/ArchSketchObject.py
+++ b/src/Mod/BIM/ArchSketchObject.py
@@ -1,5 +1,6 @@
 #***************************************************************************
-#*   Copyright (c) 2022 Paul Lee <paullee0@gmail.com>                      *
+#*                                                                         *
+#*   Copyright (c) 2018-25 Paul Lee <paullee0@gmail.com>                   *
 #*                                                                         *
 #*   This program is free software; you can redistribute it and/or modify  *
 #*   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -19,12 +20,30 @@
 #*                                                                         *
 #***************************************************************************
 
+import ArchWindow
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
 class ArchSketchObject:
-    def __init__(self, obj):
-        pass
+  def __init__(self, obj):
+      pass
 
 class ArchSketch(ArchSketchObject):
-    def __init__(self, obj):
-        pass
+  def __init__(self, obj):
+      pass
+
+  def setPropertiesLinkCommon(self, orgFp, linkFp=None, mode=None):
+      if linkFp:
+          fp = linkFp
+      else:
+          fp = orgFp
+      prop = fp.PropertiesList
+      if not isinstance(fp.getLinkedObject().Proxy, ArchWindow._Window):
+          pass
+      else:
+          if "Hosts" not in prop:
+              fp.addProperty("App::PropertyLinkList","Hosts","Window",
+                             QT_TRANSLATE_NOOP("App::Property",
+                             "The objects that host this window"))
+                             # Arch Window's code
 
 #from ArchSketchObjectExt import ArchSketch  # Doesn't work


### PR DESCRIPTION
Currently, Links of Window's Hosts property (and in generall all properties other than e.g. Placement) is shared with its Linked Window object, i.e. all Windows Links instances can only has a common Host(s) which is not flexible for the purpose of Links.

AND, at the same time, Links in linked document suffer from the 'scope' of the original Linked Window, which is in the external Document.

This commit adds feature to support:
  1/ each Links instance of Windows has their own individual setting of Hosts, and
  2/ it see the 'scope' of the Links in its document (rather than the Linked Window in the external document, if inserted from the latter)

FreeCAD Forum:
- https://forum.freecad.org/viewtopic.php?p=808569#p808569

FreeCAD GitHub:
- https://github.com/FreeCAD/FreeCAD/issues/19361