### PR TITLE
TechDraw: Add a format spec. to round a value 

### DIFF
--- a/src/Mod/TechDraw/App/DimensionFormatter.h
+++ b/src/Mod/TechDraw/App/DimensionFormatter.h
@@ -48,7 +48,7 @@ public:
     QStringList getPrefixSuffixSpec(const QString& fSpec) const;
     std::string getDefaultFormatSpec(bool isToleranceFormat) const;
     bool isTooSmall(const double value, const QString& formatSpec) const;
-    QString formatValueToSpec(const double value, const QString& formatSpecifier) const;
+    QString formatValueToSpec(const double value, QString formatSpecifier) const;
     bool isNumericFormat(const QString& formatSpecifier) const;
 
 private:


### PR DESCRIPTION
Add a `"r"` type field to the format specifier. The decimal value specifies the step to round to.
Example:

with `"%0.5r"`
- 13.235 mm will become 13.0 mm
- 56.322 mm will become 56.5 mm
- 22.680 mm will become 22.5 mm
- 0.78 mm will become 1.0 mm

with `"%0.25r"`

- 13.235 mm will become 13.25 mm
- 56.322 mm will become 56.50 mm
- 22.680 mm will become 22.75 mm
- 0.78 mm will become 1.00 mm

![Capture d’écran_2025-02-03_20-06-07](https://github.com/user-attachments/assets/1c51f3ba-1fcf-4570-8376-42a5532e2654)


https://forum.freecad.org/viewtopic.php?p=808983


EDIT: a step > 1 is allowed too
![image](https://github.com/user-attachments/assets/8e3bf910-ddb9-4033-b86f-eb567714352a)
