### PR TITLE
Gui: Disable spacemouse init if not legacy

### DIFF
--- a/src/Gui/GuiApplicationNativeEventAware.cpp
+++ b/src/Gui/GuiApplicationNativeEventAware.cpp
@@ -59,7 +59,11 @@ Gui::GUIApplicationNativeEventAware::~GUIApplicationNativeEventAware() = default
 void Gui::GUIApplicationNativeEventAware::initSpaceball(QMainWindow *window)
 {
 #if defined(_USE_3DCONNEXION_SDK) || defined(SPNAV_FOUND)
-    nativeEvent->initSpaceball(window);
+    ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath(
+         "User parameter:BaseApp/Preferences/View");
+    if (nativeEvent && hViewGrp->GetBool("LegacySpaceMouseDevices", false)) {
+        nativeEvent->initSpaceball(window);
+    }
 #else
     Q_UNUSED(window);
 #endif


### PR DESCRIPTION
If we aren't using the legacy space mouse code, we shouldn't call the init method. This is a second round of fixes for space mouse on the Mac. Follow-up to #19226 