### PR TITLE
CI: Make black line length match pre-commit

### DIFF
--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -442,7 +442,7 @@ jobs:
           blackFails=0
           pip install --break-system-packages black
           set +e
-          black --check ${{ inputs.changedPythonFiles }} &> ${{ env.logdir }}black.log
+          black --line-length 100 --check ${{ inputs.changedPythonFiles }} &> ${{ env.logdir }}black.log
           exitCode=$?
           set -e
           # If black has run successfully, write the Log to the console with the Problem Matchers


### PR DESCRIPTION
Our coding standard specifies a max line length for Python of 100 chars, enforced by `pre-commit` via `black` for modules that are run through pre-commit. However, the CI is running `black` without any line length specified, so effectively using `black`'s default of 80. This results in nearly every Python file generating a spurious CI linter warning that `black` would reformat the file. This PR syncs the CI with the pre-commit.