### PR TITLE
Workaround for transparency problems on wayland.

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -2456,6 +2456,26 @@ void View3DInventorViewer::renderScene()
     if (naviCubeEnabled) {
         naviCube->drawNaviCube();
     }
+
+    // Workaround for inconsistent QT behavior related to handling custom OpenGL widgets that
+    // leave non opaque alpha values in final output.
+    // On wayland that can cause window to become transparent or blurry trail effect in the
+    // parts that contain partially transparent objects.
+    //
+    // At the end of rendering clear alpha value, so that it doesn't matter how rest of the
+    // compositing stack at QT and desktop level would interpret transparent pixels.
+    //
+    // Related issues:
+    // https://bugreports.qt.io/browse/QTBUG-110014
+    // https://bugreports.qt.io/browse/QTBUG-132197
+    // https://bugreports.qt.io/browse/QTBUG-119214
+    // https://github.com/FreeCAD/FreeCAD/issues/8341
+    // https://github.com/FreeCAD/FreeCAD/issues/6177
+    glPushAttrib(GL_COLOR_BUFFER_BIT);
+    glColorMask(false, false, false, true);
+    glClearColor(0, 0, 0, 1);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glPopAttrib();
 }
 
 void View3DInventorViewer::setSeekMode(bool on)


### PR DESCRIPTION
Should fix the symptoms of #8341 and #6177 .

Workaround for inconsistent QT behavior related to handling custom OpenGL widgets that leave non opaque alpha values in final output.
On wayland that can cause window to become transparent or blurry trail effect in the parts that contain partially transparent objects.
At the end of rendering clear alpha value, so that it doesn't matter how rest of the compositing stack at QT and desktop level would interpret transparent pixels. There might be a cleaner solution by changing some Qt options but I wasn't able get that working.

## Related issues:
* https://bugreports.qt.io/browse/QTBUG-110014
* https://bugreports.qt.io/browse/QTBUG-132197 (here you can also find links to Cura and OpenScad having similar issue)
* https://bugreports.qt.io/browse/QTBUG-119214

Amount of links in code comment for workaround is a bit excessive, but links tend to die. And it's annoying when you are trying to find out more details about X-years old code but all the links are dead. This way if the links themselves don't survive there is bigger chance to at least find someone mentioning one of them somewhere else.

## Other things I tried

More or less setting opposite values for all the options that Qt docs suggests changing if you intentionally want to achieve transparent OpenGL widget. It more or less had no effect.
* `setAutoFillBackground(true);` -> no effect
* `setAttribute(Qt::WA_OpaquePaintEvent, false)`; 
* ` setAttribute(Qt::WA_PaintOnScreen, false);`
* `setAlphaBufferSize(0) `

Also tried `setAttribute(Qt::WidgetAttribute::WA_AlwaysStackOnTop, true);`,  it prevented window from becoming completely transparent. But as you would expected from documentation, it causes it to be drawn on top of rest of the UI including various overlays like the transparent task panel which is not something we want.  And the look of those transparent pixels blended with qt background color isn't the intended effect either.


## Other workarounds mentioned in various discussions

* Change the start of frame clear to `glClearColor(0, 0, 0, 1);`. Not applicable in general case. Only reason it works for the sample qt opengl project is because only source of transparency within it is the empty background.
* Changing alpha blending settings. It is possible to setup things so that final rendered output contains no transparent pixels, especially if you have opaque background like FreeCad has. Problem is that it depends on how each object is rendered, that way there is high chance of problem reappearing as various changes get made to the stuff rendered in 3d view.  And in FreeCad there is not just the transparent model geometry but various 2d and 3d overlays and labels. 
* QT_WAYLAND_DISABLE_WINDOWDECORATION=1, supposedly one of the reasons why qt window gets forced to render into buffer with transparency thus not dropping any leftover transparency from 3dview is client side decoration. If the rendering of titlebar is responsibility of window instead of window manager and you want rounded window corners, the window needs to use buffer with alpha channel.


## What's the real bug/solution:

On one hand without going into details of what the API various libraries promise. It wouldn't seem unreasonable that if you don't want transparency -> don't output transparent pixels. If the final output contains transparent pixels, that is what you get. That would be much simpler compared to current half a dozen Qt  flags across multiple places which don't work properly anyway.

On the other hand Quarter is based on QOpenGLWidget, it is not some kind of FreeCad  homebrew context created using low level OS specific window/glContext handles which fully bypass Qt. The issues in QT issue tracker were able to reproduce it using Qt sample projects with no or very little modifications. So even if it were intended behavior, Qt developers themselves didn't expect it. There have also been no answer from Qt devs saying "you are using it wrong, you need to use this option". Qt docs also mention that you would potentially need to change quite a few options if you intentionally wanted to achieve such effect.  I checked how it all gets rendered and combined using `apitrace` tool. At least in the configs I tested, the OpenGL widget content get's rendered to separate buffer (which has alpha channel both when using wayland and x11 backends) and afterwards combined with rest of Qt GUI. If there was single buffer created by desktop environment and everything had to render directly into it in single pass, it would be a lot messier, but that's not what's happening here. 


## Other suspicious observations made during the investigation process

Writing them down in case someone want's  to dig deeper into this, remove the workaround or repeat the problem for other reasons.

* Repeating the problem requires using Qt wayland backend. When using QT_QPA_PLATFORM=xcb the buffer in which 3d View gets combined with rest of UI doesn't have alpha channel. So the alpha values get dropped that way. The buffer in which 3d rendering happens has alpha channel regardless of qt backend.
* Whether you got blurry trail or transparent window is affected by opening a popup, or pressing "super" for opening overview. Opening certain popups in Qt using exec methods, blocks the top level event loop from running directly and starts a nested event loop processing. 
* Blurry trail/transparent window was also affected by initial size of FreeCad window. Make the FreeCad window 1/4 of screen, restart FreeCad (which should restore window size before closing) and then increase size of window. When transparent objects are placed above top left corner area roughly the size of initial window you can see the trails, placing transparent objects over bottom and right sides of window resulted in transparent window.
* The transparency issue could be also observed around edges. Seems like "Line smooth" anti-aliasing mode also resulted in writing alpha values. After the workaround some edges look more pixelated, but I have a feeling that it wasn't functioning properly correctly even before workaround. With xcb backed it was pixelated either way, and on wayland it occasionally introduced light pixels when drawing dark line on dark background.   I see that there are a couple of other open issues related to line smooth mode.
* Making window smaller than initial size also creates <10px edge outside the window which isn't properly redrawn and produces solitire effect as you move the window around. This might be related to observation 3. It happens with and and without the workaround.

