### PR TITLE
BIM: fix error on double-clicking on non-IFC objects

### DIFF
--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -615,7 +615,7 @@ def show(item, column=None):
                     for storey in storeys:
                         if storey != obj:
                             storey.ViewObject.Visibility = False
-            elif obj.IfcType == "IfcBuilding":
+            elif hasattr(obj, "IfcType") and obj.IfcType == "IfcBuilding":
                 # show all storeys
                 storeys = [o for o in obj.OutList if Draft.getType(o) == "IfcBuildingStorey"]
                 for storey in storeys:


### PR DESCRIPTION
Fixes: https://github.com/FreeCAD/FreeCAD/issues/18559