### PR TITLE
Core: Update copyright date range to include 2025

### DIFF
--- a/src/Main/MainCmd.cpp
+++ b/src/Main/MainCmd.cpp
@@ -51,7 +51,7 @@ using App::Application;
 using Base::Console;
 
 const char sBanner[] =
-    "(C) 2001-2024 FreeCAD contributors\n"
+    "(C) 2001-2025 FreeCAD contributors\n"
     "FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.\n\n";
 
 int main(int argc, char** argv)

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -61,7 +61,7 @@
 void PrintInitHelp();
 
 const char sBanner[] =
-    "(C) 2001-2024 FreeCAD contributors\n"
+    "(C) 2001-2025 FreeCAD contributors\n"
     "FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.\n\n";
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
Maybe someday we should unify these string definitions instead of maintaining two of them. Squash on merge.