### PR TITLE
Fem: Add Z-refinement support for Netgen

### DIFF
--- a/src/Mod/Fem/femobjects/mesh_netgen.py
+++ b/src/Mod/Fem/femobjects/mesh_netgen.py
@@ -469,11 +469,32 @@ class MeshNetgen(base_fempythonobject.BaseFemPythonObject):
         )
         prop.append(
             _PropHelper(
-                type="App::PropertyBool",
-                name="AutoZRefine",
+                type="App::PropertyEnumeration",
+                name="ZRefine",
                 group="Mesh Parameters",
-                doc="Automatic Z refine",
-                value=False,
+                doc="Z-refinement for extruded shapes",
+                value=["No", "Regular", "Custom"],
+            )
+        )
+        prop.append(
+            _PropHelper(
+                type="App::PropertyVector",
+                name="ZRefineDirection",
+                group="Mesh Parameters",
+                doc="Z-refinement direction",
+                value=Base.Vector(0, 0, 1),
+            )
+        )
+        prop.append(
+            _PropHelper(
+                type="App::PropertyFloatList",
+                name="ZRefineSize",
+                group="Mesh Parameters",
+                doc="Z-refinement size given as a fraction of the shape size.\n"
+                + "For a regular partition only one value is needed",
+                value=[
+                    0.1,
+                ],
             )
         )
         prop.append(

--- a/src/Mod/Fem/femtaskpanels/base_femmeshtaskpanel.py
+++ b/src/Mod/Fem/femtaskpanels/base_femmeshtaskpanel.py
@@ -107,8 +107,10 @@ class _BaseMeshTaskPanel(base_femtaskpanel._BaseTaskPanel, ABC):
         if status == QtCore.QProcess.ExitStatus.NormalExit:
             if code != 0:
                 self.write_log(
-                    "Meshing finished with errors\n", QtGui.QColor(getOutputWinColor("Error"))
+                    "Process finished with errors. Mesh not updated\n",
+                    QtGui.QColor(getOutputWinColor("Error")),
                 )
+                return
             self.tool.update_properties()
             self.write_log("Process finished\n", QtGui.QColor(getOutputWinColor("Text")))
         else:


### PR DESCRIPTION
With Netgen's zrefine function it is possible to create first-order meshes hexa dominated (using `QuadDominated` property) or with pentahedron elements from solid shapes based on extrusions.
There are two modes in `ZRefine` property for z-refinement: `Regular` (all elements have the same height) and `Custom` (the height of each element must be specified). This height is given as a fraction of the total height in the `ZRefineSize` property.
It is also possible to refine in custom directions (`ZRefineDirection` property) if the shape is extruded in a direction other than the Z axis.

Note that in general meshing will be successful only for first-order elements (unless the generated elements are all hexahedrons).

@FEA-eng 