### PR TITLE
Draft: gui_utils.py fix error in select function

### DIFF
--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -705,7 +705,7 @@ def select(objs=None, gui=App.GuiUp):
                     if parent and parent.getSubObject(obj[2]):
                         Gui.Selection.addSelection(*obj)
                     continue
-                if not obj.isAttachedToDocument():
+                if utils.is_deleted(obj):
                     continue
                 Gui.Selection.addSelection(obj)
 

--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -696,12 +696,16 @@ def select(objs=None, gui=App.GuiUp):
                 if not obj:
                     continue
                 if isinstance(obj, tuple):
-                    Gui.Selection.addSelection(*obj)
+                    # Example of tuple (Rectangle in Part):
+                    #   ("", "Part", "Rectangle.")
+                    # See:
+                    #   utils._modifiers_process_selection()
+                    #   utils._modifiers_process_subselection()
+                    parent = App.ActiveDocument.getObject(obj[1])
+                    if parent and parent.getSubObject(obj[2]):
+                        Gui.Selection.addSelection(*obj)
                     continue
-                try:
-                    if not obj.isAttachedToDocument():
-                        continue
-                except:
+                if not obj.isAttachedToDocument():
                     continue
                 Gui.Selection.addSelection(obj)
 

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -389,6 +389,14 @@ def tolerance():
     return 10 ** -precision()
 
 
+def is_deleted(obj):
+    """Return `True` if obj is deleted."""
+    try:
+        return not obj.isAttachedToDocument()
+    except:
+        return True
+
+
 def get_real_name(name):
     """Strip the trailing numbers from a string to get only the letters.
 


### PR DESCRIPTION
PR #18795 changed the select function to also handle tuples. This PR adds a check to ensure the referenced objects in the tuple still exist before calling `Gui.Selection.addSelection()`.
