### PR TITLE
Build: only check Pivy version if Pivy found

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
+++ b/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
@@ -35,7 +35,7 @@ endmacro(SetupCoin3D)
 macro(SetupPivy)
     # -------------------------------- Pivy --------------------------------
 
-    IF (NOT PIVY_VERSION)
+    if (NOT DEFINED PIVY_VERSION)
         message(STATUS "Checking Pivy version by importing it in a Python program...")
         execute_process(
                 COMMAND ${Python3_EXECUTABLE} -c "import pivy as p; print(p.__version__,end='')"
@@ -44,34 +44,42 @@ macro(SetupPivy)
         if (RETURN_CODE EQUAL 0)
             message(STATUS "Found Pivy ${PIVY_VERSION}")
         else ()
-            message(ERROR "Failed to import Pivy using ${Python3_EXECUTABLE}")
+            message(WARNING "Failed to import Pivy using ${Python3_EXECUTABLE}")
+            unset(PIVY_VERSION)
         endif ()
-    ENDIF ()
-
-    message(STATUS "Checking Pivy Coin3D version by importing it in a Python program...")
-    execute_process(
-            COMMAND ${Python3_EXECUTABLE} -c "import pivy as p; print(p.SoDB.getVersion(),end='')"
-            OUTPUT_VARIABLE PIVY_COIN_VERSION
-            RESULT_VARIABLE RETURN_CODE)
-    if (RETURN_CODE EQUAL 0)
-        message(STATUS "Found Pivy Coin3D ${PIVY_COIN_VERSION}")
-    else ()
-        message(ERROR "Failed to get Pivy Coin3D version using ${Python3_EXECUTABLE}")
     endif ()
 
-    if (${PIVY_COIN_VERSION} MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+)")
-        set(PIVY_COIN_MAJOR_VERSION ${CMAKE_MATCH_1})
-        set(PIVY_COIN_MINOR_VERSION ${CMAKE_MATCH_2})
-        set(PIVY_COIN_MICRO_VERSION ${CMAKE_MATCH_3})
-        set(PIVY_COIN_VERSION "${PIVY_COIN_MAJOR_VERSION}.${PIVY_COIN_MINOR_VERSION}.${PIVY_COIN_MICRO_VERSION}")
-    else ()
-        message(FATAL_ERROR "Failed to match Pivy Coin3D version string output")
+    if (NOT DEFINED PIVY_VERSION)
+        message(STATUS "Checking Pivy Coin3D version by importing it in a Python program...")
+        execute_process(
+                COMMAND ${Python3_EXECUTABLE} -c "import pivy as p; print(p.SoDB.getVersion(),end='')"
+                OUTPUT_VARIABLE PIVY_COIN_VERSION
+                RESULT_VARIABLE RETURN_CODE)
+        if (RETURN_CODE EQUAL 0)
+            message(STATUS "Found Pivy Coin3D ${PIVY_COIN_VERSION}")
+        else ()
+            message(WARNING "Failed to get Pivy Coin3D version using ${Python3_EXECUTABLE}")
+            unset(PIVY_VERSION)
+        endif ()
     endif ()
 
-    if (NOT (
-        (${COIN3D_MAJOR_VERSION} EQUAL ${PIVY_COIN_MAJOR_VERSION}) AND
-        (${COIN3D_MINOR_VERSION} EQUAL ${PIVY_COIN_MINOR_VERSION}) AND
-        (${COIN3D_MICRO_VERSION} EQUAL ${PIVY_COIN_MICRO_VERSION})))
-        message(FATAL_ERROR "Coin3D version ${COIN3D_VERSION} mismatches Pivy Coin3D ${PIVY_COIN_VERSION}.")
+    
+    if (DEFINED PIVY_VERSION)
+        message(STATUS "Found Pivy Coin3D ${PIVY_VERSION}")
+        if (${PIVY_COIN_VERSION} MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+            set(PIVY_COIN_MAJOR_VERSION ${CMAKE_MATCH_1})
+            set(PIVY_COIN_MINOR_VERSION ${CMAKE_MATCH_2})
+            set(PIVY_COIN_MICRO_VERSION ${CMAKE_MATCH_3})
+            set(PIVY_COIN_VERSION "${PIVY_COIN_MAJOR_VERSION}.${PIVY_COIN_MINOR_VERSION}.${PIVY_COIN_MICRO_VERSION}")
+        else ()
+            message(FATAL_ERROR "Failed to match Pivy Coin3D version string output")
+        endif ()
+
+        if (NOT (
+            (${COIN3D_MAJOR_VERSION} EQUAL ${PIVY_COIN_MAJOR_VERSION}) AND
+            (${COIN3D_MINOR_VERSION} EQUAL ${PIVY_COIN_MINOR_VERSION}) AND
+            (${COIN3D_MICRO_VERSION} EQUAL ${PIVY_COIN_MICRO_VERSION})))
+            message(FATAL_ERROR "Coin3D version ${COIN3D_VERSION} mismatches Pivy Coin3D ${PIVY_COIN_VERSION}.")
+        endif ()
     endif ()
 endmacro(SetupPivy)


### PR DESCRIPTION
Build halts if Pivy version does not match Coin3D version.

But it should not halt, if Pivy isn't found at all :(