### PR TITLE
Fem: Add check that the solid_name is valid

### DIFF
--- a/src/Mod/Fem/femguiutils/disambiguate_solid_selection.py
+++ b/src/Mod/Fem/femguiutils/disambiguate_solid_selection.py
@@ -155,6 +155,9 @@ def disambiguate_solid_selection(
     highlight_colors_for_solid = build_highlight_map(parent_part, solid_indices)
 
     def set_part_colors(solid_name: Optional[str]) -> None:
+        if solid_name not in highlight_colors_for_solid:
+            solid_name = None
+
         parent_part.ViewObject.DiffuseColor = highlight_colors_for_solid[solid_name]
         parent_part.ViewObject.update()
 


### PR DESCRIPTION
The popup menu uses a disabled menu item to hold the user prompt.  This change adds a check that we are not trying to set a highlighting for this "dummy" menu item.

Addresses #19527 

What is a bit mysterious is that I could only reproduce the behaviour by commenting the line of code which sets the label as [disabled](https://github.com/FreeCAD/FreeCAD/blob/d044d3da84298c4a6cfe831aebe5df322182cc8b/src/Mod/Fem/femguiutils/disambiguate_solid_selection.py#L148).  Unless I did this it did not fire a hover event.  Could this somehow be platform specific?
