### PR TITLE
Refactor Base::Type

### DIFF
--- a/src/App/Extension.cpp
+++ b/src/App/Extension.cpp
@@ -54,7 +54,7 @@ App::PropertyData App::Extension::propertyData;
 
 void App::Extension::init()
 {
-    assert(Extension::classTypeId == Base::Type::badType() && "don't init() twice!");
+    assert(Extension::classTypeId.isBad() && "don't init() twice!");
 
     /* Set up entry in the type system. */
     Extension::classTypeId =
@@ -187,11 +187,11 @@ void Extension::initExtensionSubclass(Base::Type& toInit,
                                       Base::Type::instantiationMethod method)
 {
     // don't init twice!
-    assert(toInit == Base::Type::badType());
+    assert(toInit.isBad());
     // get the parent class
     Base::Type parentType(Base::Type::fromName(ParentName));
     // forgot init parent!
-    assert(parentType != Base::Type::badType());
+    assert(!parentType.isBad());
 
     // create the new type
     toInit = Base::Type::createType(parentType, ClassName, method);

--- a/src/App/Extension.cpp
+++ b/src/App/Extension.cpp
@@ -58,7 +58,7 @@ void App::Extension::init()
 
     /* Set up entry in the type system. */
     Extension::classTypeId =
-        Base::Type::createType(Base::Type::badType(), "App::Extension", Extension::create);
+        Base::Type::createType(Base::Type::BadType, "App::Extension", Extension::create);
 }
 
 using namespace App;

--- a/src/App/Extension.h
+++ b/src/App/Extension.h
@@ -56,7 +56,7 @@ private: \
 #define EXTENSION_TYPESYSTEM_SOURCE_P(_class_) \
 Base::Type _class_::getExtensionClassTypeId(void) { return _class_::classTypeId; } \
 Base::Type _class_::getExtensionTypeId(void) const { return _class_::classTypeId; } \
-Base::Type _class_::classTypeId = Base::Type::badType();  \
+Base::Type _class_::classTypeId = Base::Type::BadType; \
 void * _class_::create(void){\
    return new _class_ ();\
 }
@@ -65,7 +65,7 @@ void * _class_::create(void){\
 #define EXTENSION_TYPESYSTEM_SOURCE_ABSTRACT_P(_class_) \
 Base::Type _class_::getExtensionClassTypeId(void) { return _class_::classTypeId; } \
 Base::Type _class_::getExtensionTypeId(void) const { return _class_::classTypeId; } \
-Base::Type _class_::classTypeId = Base::Type::badType();  \
+Base::Type _class_::classTypeId = Base::Type::BadType; \
 void * _class_::create(void){return 0;}
 
 /// define to implement a subclass of Base::BaseClass
@@ -76,7 +76,7 @@ void _class_::init(void){\
 }
 
 #define EXTENSION_TYPESYSTEM_SOURCE_TEMPLATE(_class_) \
-template<> Base::Type _class_::classTypeId = Base::Type::badType();  \
+template<> Base::Type _class_::classTypeId = Base::Type::BadType; \
 template<> Base::Type _class_::getExtensionClassTypeId(void) { return _class_::classTypeId; } \
 template<> Base::Type _class_::getExtensionTypeId(void) const { return _class_::classTypeId; } \
 template<> void * _class_::create(void){\

--- a/src/App/ProjectFile.cpp
+++ b/src/App/ProjectFile.cpp
@@ -363,7 +363,7 @@ Base::Type ProjectFile::getTypeId(const std::string& name) const
     //   <Object type="Mesh::MeshFeature" name="Mesh" />
     // <Objects/>
     if (!xmlDocument) {
-        return Base::Type::badType();
+        return Base::Type::BadType;
     }
 
     DOMNodeList* nodes = xmlDocument->getElementsByTagName(XStrLiteral("Objects").unicodeForm());
@@ -388,7 +388,7 @@ Base::Type ProjectFile::getTypeId(const std::string& name) const
         }
     }
 
-    return Base::Type::badType();
+    return Base::Type::BadType;
 }
 
 std::list<ProjectFile::PropertyFile> ProjectFile::getPropertyFiles(const std::string& name) const

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -375,7 +375,7 @@ void _class_::init(void){\
 }
 
 #define TYPESYSTEM_SOURCE_TEMPLATE(_class_) \
-template<> Base::Type _class_::classTypeId = Base::Type::badType();  \
+template<> Base::Type _class_::classTypeId = Base::Type::BadType; \
 template<> Base::Type _class_::getClassTypeId(void) { return _class_::classTypeId; } \
 template<> Base::Type _class_::getTypeId(void) const { return _class_::classTypeId; } \
 template<> void * _class_::create(void){\

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -3527,17 +3527,10 @@ unsigned int PropertyPersistentObject::getMemSize() const
 
 void PropertyPersistentObject::setValue(const char* type)
 {
-    if (!type) {
-        type = "";
-    }
-    if (type[0]) {
-        Base::Type::importModule(type);
-        Base::Type t = Base::Type::fromName(type);
+    if (!Base::Tools::isNullOrEmpty(type)) {
+        Base::Type t = Base::Type::getTypeIfDerivedFrom(type, Persistence::getClassTypeId());
         if (t.isBad()) {
-            throw Base::TypeError("Invalid type");
-        }
-        if (!t.isDerivedFrom(Persistence::getClassTypeId())) {
-            throw Base::TypeError("Type must be derived from Base::Persistence");
+            throw Base::TypeError("Invalid type or type must be derived from Base::Persistence");
         }
         if (_pObject && _pObject->getTypeId() == t) {
             return;

--- a/src/Base/BaseClass.cpp
+++ b/src/Base/BaseClass.cpp
@@ -56,11 +56,11 @@ BaseClass::~BaseClass() = default;
 
 void BaseClass::init()
 {
-    assert(BaseClass::classTypeId == Type::badType() && "don't init() twice!");
+    assert(BaseClass::classTypeId.isBad() && "don't init() twice!");
     /* Make sure superclass gets initialized before subclass. */
     /*assert(strcmp(#_parentclass_), "inherited"));*/
     /*Type parentType(Type::fromName(#_parentclass_));*/
-    /*assert(parentType != Type::badType() && "you forgot init() on parentclass!");*/
+    /*assert(!parentType.isBad() && "you forgot init() on parentclass!");*/
 
     /* Set up entry in the type system. */
     BaseClass::classTypeId =
@@ -84,11 +84,11 @@ void BaseClass::initSubclass(Base::Type& toInit,
                              Type::instantiationMethod method)
 {
     // don't init twice!
-    assert(toInit == Base::Type::badType());
+    assert(toInit.isBad());
     // get the parent class
     Base::Type parentType(Base::Type::fromName(ParentName));
     // forgot init parent!
-    assert(parentType != Base::Type::badType());
+    assert(!parentType.isBad());
 
     // create the new type
     toInit = Base::Type::createType(parentType, ClassName, method);

--- a/src/Base/BaseClass.cpp
+++ b/src/Base/BaseClass.cpp
@@ -32,7 +32,7 @@
 
 using namespace Base;
 
-Type BaseClass::classTypeId = Base::Type::badType();  // NOLINT
+Type BaseClass::classTypeId = Base::Type::BadType;
 
 
 //**************************************************************************
@@ -63,8 +63,7 @@ void BaseClass::init()
     /*assert(!parentType.isBad() && "you forgot init() on parentclass!");*/
 
     /* Set up entry in the type system. */
-    BaseClass::classTypeId =
-        Type::createType(Type::badType(), "Base::BaseClass", BaseClass::create);
+    BaseClass::classTypeId = Type::createType(Type::BadType, "Base::BaseClass", BaseClass::create);
 }
 
 Type BaseClass::getClassTypeId()

--- a/src/Base/BaseClass.h
+++ b/src/Base/BaseClass.h
@@ -65,7 +65,7 @@ private:                                                                        
     {                                                                                              \
         return _class_::classTypeId;                                                               \
     }                                                                                              \
-    Base::Type _class_::classTypeId = Base::Type::badType();                                       \
+    Base::Type _class_::classTypeId = Base::Type::BadType;                                         \
     void* _class_::create(void)                                                                    \
     {                                                                                              \
         return new _class_();                                                                      \
@@ -99,7 +99,7 @@ private:                                                                        
     {                                                                                              \
         return _class_::classTypeId;                                                               \
     }                                                                                              \
-    Base::Type _class_::classTypeId = Base::Type::badType();                                       \
+    Base::Type _class_::classTypeId = Base::Type::BadType;                                         \
     void* _class_::create(void)                                                                    \
     {                                                                                              \
         return 0;                                                                                  \

--- a/src/Base/BaseClassPyImp.cpp
+++ b/src/Base/BaseClassPyImp.cpp
@@ -44,7 +44,7 @@ PyObject* BaseClassPy::isDerivedFrom(PyObject* args)
     }
 
     Base::Type type = Base::Type::fromName(name);
-    bool valid = (type != Base::Type::badType() && getBaseClassPtr()->isDerivedFrom(type));
+    bool valid = (!type.isBad() && getBaseClassPtr()->isDerivedFrom(type));
     return PyBool_FromLong(valid ? 1 : 0);
 }
 

--- a/src/Base/Type.cpp
+++ b/src/Base/Type.cpp
@@ -72,15 +72,25 @@ std::set<std::string> Type::loadModuleSet;
 
 const Type Type::BadType;
 
+Type::instantiationMethod Type::getInstantiationMethod() const
+{
+    assert(typedata.size() >= 1 && "Type::init() must be called before creating instances");
+    assert(typedata.size() > index && "Type index out of bounds");
+    if (isBad() || typedata.size() <= index) {
+        return nullptr;
+    }
+    return typedata[index]->instMethod;
+}
+
 void* Type::createInstance() const
 {
-    instantiationMethod method = typedata[index]->instMethod;
+    const auto method = getInstantiationMethod();
     return method ? (*method)() : nullptr;
 }
 
 bool Type::canInstantiate() const
 {
-    instantiationMethod method = typedata[index]->instMethod;
+    const auto method = getInstantiationMethod();
     return method != nullptr;
 }
 
@@ -183,11 +193,15 @@ const Type Type::fromKey(TypeId key)
 
 const char* Type::getName() const
 {
+    assert(typedata.size() >= 1
+           && "Type::init() must be called before fetching names, even for bad types");
     return typedata[index]->name.c_str();
 }
 
 const Type Type::getParent() const
 {
+    assert(typedata.size() >= 1
+           && "Type::init() must be called before fetching parents, even for bad types");
     return typedata[index]->parent;
 }
 

--- a/src/Base/Type.cpp
+++ b/src/Base/Type.cpp
@@ -37,8 +37,8 @@ using namespace Base;
 struct Base::TypeData
 {
     TypeData(const char* theName,
-             const Type type = Type::badType(),
-             const Type theParent = Type::badType(),
+             const Type type = Type::BadType,
+             const Type theParent = Type::BadType,
              Type::instantiationMethod method = nullptr)
         : name(theName)
         , parent(theParent)
@@ -55,6 +55,8 @@ struct Base::TypeData
 std::map<std::string, unsigned int> Type::typemap;
 std::vector<TypeData*> Type::typedata;
 std::set<std::string> Type::loadModuleSet;
+
+const Type Type::BadType;
 
 void* Type::createInstance() const
 {
@@ -77,7 +79,7 @@ void* Type::createInstanceByName(const char* TypeName, bool bLoadModule)
 
     // now the type should be in the type map
     Type type = fromName(TypeName);
-    if (type == badType()) {
+    if (type == BadType) {
         return nullptr;
     }
 
@@ -115,13 +117,6 @@ std::string Type::getModuleName(const char* ClassName)
 
     return pos != std::string_view::npos ? std::string(classNameView.substr(0, pos))
                                          : std::string();
-}
-
-Type Type::badType()
-{
-    Type bad;
-    bad.index = 0;
-    return bad;
 }
 
 
@@ -167,7 +162,7 @@ Type Type::fromName(const char* name)
         return typedata[pos->second]->type;
     }
 
-    return Type::badType();
+    return Type::BadType;
 }
 
 Type Type::fromKey(unsigned int key)
@@ -176,7 +171,7 @@ Type Type::fromKey(unsigned int key)
         return typedata[key]->type;
     }
 
-    return Type::badType();
+    return BadType;
 }
 
 const char* Type::getName() const
@@ -198,7 +193,7 @@ bool Type::isDerivedFrom(const Type& type) const
             return true;
         }
         temp = temp.getParent();
-    } while (temp != badType());
+    } while (!temp.isBad());
 
     return false;
 }
@@ -233,5 +228,5 @@ Type Type::getTypeIfDerivedFrom(const char* name, const Type& parent, bool bLoad
         return type;
     }
 
-    return Type::badType();
+    return BadType;
 }

--- a/src/Base/Type.cpp
+++ b/src/Base/Type.cpp
@@ -129,7 +129,7 @@ std::string Type::getModuleName(const char* ClassName)
 }
 
 
-Type Type::createType(const Type& parent, const char* name, instantiationMethod method)
+Type Type::createType(const Type parent, const char* name, instantiationMethod method)
 {
     Type newType;
     newType.index = static_cast<unsigned int>(Type::typedata.size());
@@ -193,9 +193,8 @@ Type Type::getParent() const
     return typedata[index]->parent;
 }
 
-bool Type::isDerivedFrom(const Type& type) const
+bool Type::isDerivedFrom(const Type type) const
 {
-
     Type temp(*this);
     do {
         if (temp == type) {
@@ -207,7 +206,7 @@ bool Type::isDerivedFrom(const Type& type) const
     return false;
 }
 
-int Type::getAllDerivedFrom(const Type& type, std::vector<Type>& List)
+int Type::getAllDerivedFrom(const Type type, std::vector<Type>& List)
 {
     int cnt = 0;
 
@@ -225,15 +224,13 @@ int Type::getNumTypes()
     return static_cast<int>(typedata.size());
 }
 
-Type Type::getTypeIfDerivedFrom(const char* name, const Type& parent, bool bLoadModule)
+Type Type::getTypeIfDerivedFrom(const char* name, const Type parent, bool loadModule)
 {
-    if (bLoadModule) {
+    if (loadModule) {
         importModule(name);
     }
 
-    Type type = fromName(name);
-
-    if (type.isDerivedFrom(parent)) {
+    if (Type type(fromName(name)); type.isDerivedFrom(parent)) {
         return type;
     }
 

--- a/src/Base/Type.cpp
+++ b/src/Base/Type.cpp
@@ -33,6 +33,15 @@
 
 using namespace Base;
 
+static_assert(sizeof(Base::Type) == sizeof(unsigned int),
+              "Base::Type has been designed to be small to be passed around by value efficiently. "
+              "The size of Base::Type has changed. Be careful when adding more data members.");
+
+static_assert(
+    sizeof(Base::Type) <= 2 * sizeof(void*),
+    "Base::Type has been designed to be small to be passed around by value efficiently. "
+    "When the size grows larger than ~2 words, consider passing by const reference instead. "
+    "Exact limit depends on the architecture and ABI.");
 
 struct Base::TypeData
 {

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -101,17 +101,17 @@ public:
     static Type fromKey(unsigned int key);
     const char* getName() const;
     Type getParent() const;
-    bool isDerivedFrom(const Type& type) const;
+    bool isDerivedFrom(const Type type) const;
 
-    static int getAllDerivedFrom(const Type& type, std::vector<Type>& List);
+    static int getAllDerivedFrom(const Type type, std::vector<Type>& List);
     /// Returns the given named type if is derived from parent type, otherwise return bad type
     static Type
-    getTypeIfDerivedFrom(const char* name, const Type& parent, bool bLoadModule = false);
+    getTypeIfDerivedFrom(const char* name, const Type parent, bool loadModule = false);
 
     static int getNumTypes();
 
     static Type
-    createType(const Type& parent, const char* name, instantiationMethod method = nullptr);
+    createType(const Type parent, const char* name, instantiationMethod method = nullptr);
 
     unsigned int getKey() const;
     bool isBad() const;

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -88,33 +88,39 @@ public:
     /// Destruction
     ~Type() = default;
 
-    /// creates a instance of this type
+    /// Creates an instance of this type
     [[nodiscard]] void* createInstance() const;
     /// Checks whether this type can instantiate
     [[nodiscard]] bool canInstantiate() const;
-    /// creates a instance of the named type
+    /// Creates an instance of the named type
     [[nodiscard]] static void* createInstanceByName(const char* typeName, bool loadModule = false);
     static void importModule(const char* TypeName);
 
     using instantiationMethod = void* (*)();
 
+    /// Returns a type object by name
     [[nodiscard]] static const Type fromName(const char* name);
+    /// Returns a type object by key
     [[nodiscard]] static const Type fromKey(TypeId key);
+    /// Returns the name of the type
     [[nodiscard]] const char* getName() const;
+    /// Returns the parent type
     [[nodiscard]] const Type getParent() const;
+    /// Checks whether this type is derived from "type"
     [[nodiscard]] bool isDerivedFrom(const Type type) const;
-
+    /// Returns all descendants from the given type
     static int getAllDerivedFrom(const Type type, std::vector<Type>& list);
     /// Returns the given named type if is derived from parent type, otherwise return bad type
     [[nodiscard]] static const Type
     getTypeIfDerivedFrom(const char* name, const Type parent, bool loadModule = false);
-
+    /// Returns the number of types created so far
     [[nodiscard]] static int getNumTypes();
-
+    /// Creates a new type with the given name, parent and instantiation method
     [[nodiscard]] static const Type
     createType(const Type parent, const char* name, instantiationMethod method = nullptr);
-
+    /// Returns the inner index of the type
     [[nodiscard]] TypeId getKey() const;
+    /// Checks if the type is invalid
     [[nodiscard]] bool isBad() const;
 
     Type& operator=(const Type& type) = default;
@@ -131,6 +137,7 @@ public:
     static void init();
     static void destruct();
 
+    /// Returns the name of the module the class is defined in
     static const std::string getModuleName(const char* className);
 
 private:

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -126,7 +126,7 @@ public:
     bool operator>=(const Type& type) const;
     bool operator>(const Type& type) const;
 
-    static Type badType();
+    static const Type BadType;
     static void init();
     static void destruct();
 

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -134,6 +134,8 @@ public:
     static const std::string getModuleName(const char* className);
 
 private:
+    [[nodiscard]] instantiationMethod getInstantiationMethod() const;
+
     TypeId index {BadTypeIndex};
 
     static std::map<std::string, TypeId> typemap;

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -77,9 +77,10 @@ struct TypeData;
   information: super classes must be registered before any of their
   derived classes are.
 */
-class BaseExport Type
+class BaseExport Type final
 {
 public:
+    using TypeId = unsigned int;
     /// Construction
     Type(const Type& type) = default;
     Type(Type&& type) = default;
@@ -88,33 +89,33 @@ public:
     ~Type() = default;
 
     /// creates a instance of this type
-    void* createInstance() const;
+    [[nodiscard]] void* createInstance() const;
     /// Checks whether this type can instantiate
-    bool canInstantiate() const;
+    [[nodiscard]] bool canInstantiate() const;
     /// creates a instance of the named type
-    static void* createInstanceByName(const char* TypeName, bool bLoadModule = false);
+    [[nodiscard]] static void* createInstanceByName(const char* typeName, bool loadModule = false);
     static void importModule(const char* TypeName);
 
     using instantiationMethod = void* (*)();
 
-    static Type fromName(const char* name);
-    static Type fromKey(unsigned int key);
-    const char* getName() const;
-    Type getParent() const;
-    bool isDerivedFrom(const Type type) const;
+    [[nodiscard]] static const Type fromName(const char* name);
+    [[nodiscard]] static const Type fromKey(TypeId key);
+    [[nodiscard]] const char* getName() const;
+    [[nodiscard]] const Type getParent() const;
+    [[nodiscard]] bool isDerivedFrom(const Type type) const;
 
-    static int getAllDerivedFrom(const Type type, std::vector<Type>& List);
+    static int getAllDerivedFrom(const Type type, std::vector<Type>& list);
     /// Returns the given named type if is derived from parent type, otherwise return bad type
-    static Type
+    [[nodiscard]] static const Type
     getTypeIfDerivedFrom(const char* name, const Type parent, bool loadModule = false);
 
-    static int getNumTypes();
+    [[nodiscard]] static int getNumTypes();
 
-    static Type
+    [[nodiscard]] static const Type
     createType(const Type parent, const char* name, instantiationMethod method = nullptr);
 
-    unsigned int getKey() const;
-    bool isBad() const;
+    [[nodiscard]] TypeId getKey() const;
+    [[nodiscard]] bool isBad() const;
 
     Type& operator=(const Type& type) = default;
     Type& operator=(Type&& type) = default;
@@ -130,19 +131,20 @@ public:
     static void init();
     static void destruct();
 
-    static std::string getModuleName(const char* ClassName);
-
+    static const std::string getModuleName(const char* className);
 
 private:
-    unsigned int index {0};
+    TypeId index {BadTypeIndex};
 
-    static std::map<std::string, unsigned int> typemap;
-    static std::vector<TypeData*> typedata;
+    static std::map<std::string, TypeId> typemap;
+    static std::vector<TypeData*> typedata;  // use pointer to hide implementation details
     static std::set<std::string> loadModuleSet;
+
+    static constexpr TypeId BadTypeIndex = 0;
 };
 
 
-inline unsigned int Type::getKey() const
+inline Type::TypeId Type::getKey() const
 {
     return this->index;
 }
@@ -179,7 +181,7 @@ inline bool Type::operator>(const Type& type) const
 
 inline bool Type::isBad() const
 {
-    return (this->index == 0);
+    return this->index == BadTypeIndex;
 }
 
 }  // namespace Base

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -94,7 +94,6 @@ public:
     [[nodiscard]] bool canInstantiate() const;
     /// Creates an instance of the named type
     [[nodiscard]] static void* createInstanceByName(const char* typeName, bool loadModule = false);
-    static void importModule(const char* TypeName);
 
     using instantiationMethod = void* (*)();
 
@@ -142,6 +141,7 @@ public:
 
 private:
     [[nodiscard]] instantiationMethod getInstantiationMethod() const;
+    static void importModule(const char* TypeName);
 
     TypeId index {BadTypeIndex};
 

--- a/src/Base/TypePyImp.cpp
+++ b/src/Base/TypePyImp.cpp
@@ -122,7 +122,7 @@ PyObject* TypePy::isDerivedFrom(PyObject* args)
         return nullptr;
     } while (false);
 
-    bool val = (type != Base::Type::badType() && getBaseTypePtr()->isDerivedFrom(type));
+    bool val = (!type.isBad() && getBaseTypePtr()->isDerivedFrom(type));
     return PyBool_FromLong(val ? 1 : 0);
 }
 

--- a/src/Base/TypePyImp.cpp
+++ b/src/Base/TypePyImp.cpp
@@ -76,8 +76,7 @@ PyObject* TypePy::getBadType(PyObject* args)
         return nullptr;
     }
 
-    Base::Type type = Base::Type::badType();
-    return new TypePy(new Base::Type(type));
+    return new TypePy(new Base::Type(Base::Type::BadType));
 }
 
 PyObject* TypePy::getParent(PyObject* args)

--- a/src/Gui/DAGView/DAGFilter.cpp
+++ b/src/Gui/DAGView/DAGFilter.cpp
@@ -44,7 +44,7 @@ FilterOrigin::FilterOrigin() : FilterBase()
 bool FilterOrigin::goFilter(const Vertex &vertexIn, const Graph &graphIn, const GraphLinkContainer &linkIn) const
 {
   Base::Type originType = Base::Type::fromName("App::Origin");
-  assert (originType != Base::Type::badType());
+  assert (!originType.isBad());
   //if child of origin hide.
   InEdgeIterator it, itEnd;
   for (boost::tie(it, itEnd) = boost::in_edges(vertexIn, graphIn); it != itEnd; ++it)
@@ -72,7 +72,7 @@ bool FilterTyped::goFilter(const Gui::DAG::Vertex& vertexIn, const Graph& graphI
   if (type.empty())
     return false;
   Base::Type theType = Base::Type::fromName(type.c_str());
-  if (theType == Base::Type::badType())
+  if (theType.isBad())
     return false;
 
   const GraphLinkRecord &sourceRecord = findRecord(vertexIn, linkIn);

--- a/src/Gui/DAGView/DAGModel.cpp
+++ b/src/Gui/DAGView/DAGModel.cpp
@@ -1186,11 +1186,11 @@ void Model::visiblyIsolate(Gui::DAG::Vertex sourceIn)
     std::vector<Base::Type> out;
     Base::Type type;
     type = Base::Type::fromName("App::DocumentObjectGroup");
-    if (type != Base::Type::badType()) out.push_back(type);
+    if (!type.isBad()) out.push_back(type);
     type = Base::Type::fromName("App::Part");
-    if (type != Base::Type::badType()) out.push_back(type);
+    if (!type.isBad()) out.push_back(type);
     type = Base::Type::fromName("PartDesign::Body");
-    if (type != Base::Type::badType()) out.push_back(type);
+    if (!type.isBad()) out.push_back(type);
 
     return out;
   };

--- a/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
@@ -441,7 +441,7 @@ void DlgAddPropertyVarSet::checkGroup() {
 void DlgAddPropertyVarSet::checkType() {
     std::string type = ui->comboBoxType->currentText().toStdString();
 
-    if (Base::Type::fromName(type.c_str()) == Base::Type::badType()) {
+    if (Base::Type::fromName(type.c_str()).isBad()) {
         throw CreatePropertyException("Invalid name");
     }
 }

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -190,7 +190,7 @@ Base::Type DlgExpressionInput::determineTypeVarSet()
 bool DlgExpressionInput::typeOkForVarSet()
 {
     std::string unitType = impliedUnit.getTypeString();
-    return determineTypeVarSet() != Base::Type::badType();
+    return !determineTypeVarSet().isBad();
 }
 
 void DlgExpressionInput::initializeVarSets()

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -179,7 +179,7 @@ Base::Type DlgExpressionInput::determineTypeVarSet()
     std::string unitTypeString = impliedUnit.getTypeString();
     if (unitTypeString.empty()) {
         // no type was provided
-        return Base::Type::badType();
+        return Base::Type::BadType;
     }
 
     std::string typeString = "App::Property" + unitTypeString;

--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -330,7 +330,7 @@ std::vector<SelectionObject> SelectionSingleton::getObjectList(const char* pDocN
     std::map<App::DocumentObject*,size_t> SortMap;
 
     // check the type
-    if (typeId == Base::Type::badType())
+    if (typeId.isBad())
         return temp;
 
     App::Document *pcDoc = nullptr;
@@ -519,7 +519,7 @@ vector<App::DocumentObject*> SelectionSingleton::getObjectsOfType(const Base::Ty
 std::vector<App::DocumentObject*> SelectionSingleton::getObjectsOfType(const char* typeName, const char* pDocName, ResolveMode resolve) const
 {
     Base::Type typeId = Base::Type::fromName(typeName);
-    if (typeId == Base::Type::badType())
+    if (typeId.isBad())
         return {};
     return getObjectsOfType(typeId, pDocName, resolve);
 }
@@ -541,7 +541,7 @@ unsigned int SelectionSingleton::countObjectsOfType(const Base::Type& typeId, co
 unsigned int SelectionSingleton::countObjectsOfType(const char* typeName, const char* pDocName, ResolveMode resolve) const
 {
     Base::Type typeId = Base::Type::fromName(typeName);
-    if (typeId == Base::Type::badType())
+    if (typeId.isBad())
         return 0;
     return countObjectsOfType(typeId, pDocName, resolve);
 }

--- a/src/Mod/Measure/App/MeasureDistance.cpp
+++ b/src/Mod/Measure/App/MeasureDistance.cpp
@@ -415,12 +415,12 @@ std::vector<App::DocumentObject*> MeasureDistanceDetached::getSubject() const
 
 Base::Type MeasureDistanceType::getClassTypeId()
 {
-    return Base::Type::badType();
+    return Base::Type::BadType;
 }
 
 Base::Type MeasureDistanceType::getTypeId() const
 {
-    return Base::Type::badType();
+    return Base::Type::BadType;
 }
 
 void MeasureDistanceType::init()
@@ -436,7 +436,7 @@ void* MeasureDistanceType::create()
     return new MeasureDistanceDetached();
 }
 
-Base::Type MeasureDistanceType::classTypeId = Base::Type::badType();
+Base::Type MeasureDistanceType::classTypeId = Base::Type::BadType;
 
 
 // Migrate old MeasureDistance Type

--- a/src/Mod/Part/App/GeometryDefaultExtension.h
+++ b/src/Mod/Part/App/GeometryDefaultExtension.h
@@ -87,7 +87,7 @@ namespace Part {
     // 6. Register your type and corresponding python type in AppPart.cpp
 
     template <typename T>
-    Base::Type GeometryDefaultExtension<T>::classTypeId{Base::Type::badType()};
+    Base::Type GeometryDefaultExtension<T>::classTypeId{Base::Type::BadType};
 
     // Must be explicitly declared here
     template<> void * GeometryDefaultExtension<long>::create();

--- a/src/Mod/Part/App/GeometryPyImp.cpp
+++ b/src/Mod/Part/App/GeometryPyImp.cpp
@@ -242,7 +242,7 @@ PyObject* GeometryPy::getExtensionOfType(PyObject *args)
 
         Base::Type type = Base::Type::fromName(o);
 
-        if(type != Base::Type::badType()) {
+        if(!type.isBad()) {
             try {
                 std::shared_ptr<const GeometryExtension> ext(this->getGeometryPtr()->getExtension(type));
 
@@ -313,7 +313,7 @@ PyObject* GeometryPy::hasExtensionOfType(PyObject *args)
 
         Base::Type type = Base::Type::fromName(o);
 
-        if(type != Base::Type::badType()) {
+        if(!type.isBad()) {
             try {
                 return Py::new_reference_to(Py::Boolean(this->getGeometryPtr()->hasExtension(type)));
             }
@@ -360,7 +360,7 @@ PyObject* GeometryPy::deleteExtensionOfType(PyObject *args)
 
         Base::Type type = Base::Type::fromName(o);
 
-        if(type != Base::Type::badType()) {
+        if(!type.isBad()) {
             try {
                 this->getGeometryPtr()->deleteExtension(type);
                 Py_Return;

--- a/src/Mod/Sketcher/App/ExternalGeometryFacadePyImp.cpp
+++ b/src/Mod/Sketcher/App/ExternalGeometryFacadePyImp.cpp
@@ -302,7 +302,7 @@ PyObject* ExternalGeometryFacadePy::getExtensionOfType(PyObject* args)
 
         Base::Type type = Base::Type::fromName(o);
 
-        if (type != Base::Type::badType()) {
+        if (!type.isBad()) {
             try {
                 std::shared_ptr<const Part::GeometryExtension> ext(
                     this->getExternalGeometryFacadePtr()->getExtension(type));
@@ -379,7 +379,7 @@ PyObject* ExternalGeometryFacadePy::hasExtensionOfType(PyObject* args)
 
         Base::Type type = Base::Type::fromName(o);
 
-        if (type != Base::Type::badType()) {
+        if (!type.isBad()) {
             try {
                 return Py::new_reference_to(
                     Py::Boolean(this->getExternalGeometryFacadePtr()->hasExtension(type)));
@@ -427,7 +427,7 @@ PyObject* ExternalGeometryFacadePy::deleteExtensionOfType(PyObject* args)
 
         Base::Type type = Base::Type::fromName(o);
 
-        if (type != Base::Type::badType()) {
+        if (!type.isBad()) {
             try {
                 this->getExternalGeometryFacadePtr()->deleteExtension(type);
                 Py_Return;

--- a/src/Mod/Sketcher/App/GeometryFacadePyImp.cpp
+++ b/src/Mod/Sketcher/App/GeometryFacadePyImp.cpp
@@ -278,7 +278,7 @@ PyObject* GeometryFacadePy::getExtensionOfType(PyObject* args)
 
         Base::Type type = Base::Type::fromName(o);
 
-        if (type != Base::Type::badType()) {
+        if (!type.isBad()) {
             try {
                 std::shared_ptr<const Part::GeometryExtension> ext(
                     this->getGeometryFacadePtr()->getExtension(type));
@@ -355,7 +355,7 @@ PyObject* GeometryFacadePy::hasExtensionOfType(PyObject* args)
 
         Base::Type type = Base::Type::fromName(o);
 
-        if (type != Base::Type::badType()) {
+        if (!type.isBad()) {
             try {
                 return Py::new_reference_to(
                     Py::Boolean(this->getGeometryFacadePtr()->hasExtension(type)));
@@ -403,7 +403,7 @@ PyObject* GeometryFacadePy::deleteExtensionOfType(PyObject* args)
 
         Base::Type type = Base::Type::fromName(o);
 
-        if (type != Base::Type::badType()) {
+        if (!type.isBad()) {
             try {
                 this->getGeometryFacadePtr()->deleteExtension(type);
                 Py_Return;

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1526,7 +1526,7 @@ public:
         selIdPair.GeoId = GeoEnum::GeoUndef;
         selIdPair.PosId = Sketcher::PointPos::none;
         std::stringstream ss;
-        Base::Type newselGeoType = Base::Type::badType();
+        Base::Type newselGeoType = Base::Type::BadType;
 
         int VtId = getPreselectPoint();
         int CrvId = getPreselectCurve();
@@ -1662,7 +1662,7 @@ protected:
             SelIdPair selIdPair;
             getIdsFromName(selElement, Obj, selIdPair.GeoId, selIdPair.PosId);
 
-            Base::Type newselGeoType = Base::Type::badType();
+            Base::Type newselGeoType = Base::Type::BadType;
             if (isEdge(selIdPair.GeoId, selIdPair.PosId)) {
                 const Part::Geometry* geo = Obj->getGeometry(selIdPair.GeoId);
                 newselGeoType = geo->getTypeId();

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -463,7 +463,7 @@ private:
 
         icons.emplace(
             std::piecewise_construct,
-            std::forward_as_tuple(Base::Type::badType()),
+            std::forward_as_tuple(Base::Type::BadType),
             std::forward_as_tuple(
                 std::initializer_list<
                     std::pair<const Sketcher::PointPos, std::tuple<QIcon, QIcon, QIcon, QIcon>>> {
@@ -479,14 +479,14 @@ private:
         auto typekey = icons.find(type);
 
         if (typekey == icons.end()) {// Not supported Geometry Type - Defaults to invalid icon
-            typekey = icons.find(Base::Type::badType());
+            typekey = icons.find(Base::Type::BadType);
             pos = Sketcher::PointPos::none;
         }
 
         auto poskey = typekey->second.find(pos);
 
         if (poskey == typekey->second.end()) {// invalid PointPos for type - Provide Invalid icon
-            typekey = icons.find(Base::Type::badType());
+            typekey = icons.find(Base::Type::BadType);
             pos = Sketcher::PointPos::none;
             poskey = typekey->second.find(pos);
         }


### PR DESCRIPTION
This PR includes:
* add documentation for public functions
* change functions to use pass-by-value instead of -by-reference for parameters, as intended for this class
* add `static_cast`s to ensure size doesn't grow to the point where passing Type by value is slower than by reference.
* use `BadType` constant instead of `badType()`.
* use `isBad()` instead of `==operator` (should be more lightweight and align better with the intent)