### PR TITLE
PartDesign: Allow Draft negative angles

### DIFF
--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -58,7 +58,7 @@ using namespace PartDesign;
 
 PROPERTY_SOURCE(PartDesign::Draft, PartDesign::DressUp)
 
-const App::PropertyAngle::Constraints Draft::floatAngle = { 0.0, 90.0 - Base::toDegrees<double>(Precision::Angular()), 0.1 };
+const App::PropertyAngle::Constraints Draft::floatAngle = { -90.0, 90.0 - Base::toDegrees<double>(Precision::Angular()), 0.1 };
 
 Draft::Draft()
 {


### PR DESCRIPTION
Fix #19532
Changes staged in:
src/Mod/PartDesign/App/FeatureDraft.cpp

Modified the `Constrains`'s `LowerBound` to accept the negative angles