### PR TITLE
CI: Extract `apt` packages installation into a script.

### DIFF
--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -76,66 +76,8 @@ jobs:
         with:
           submodules: true
       - name: Install FreeCAD dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends               \
-                            ccache                                      \
-                            doxygen                                     \
-                            graphviz                                    \
-                            imagemagick                                 \
-                            libboost-date-time-dev                      \
-                            libboost-dev                                \
-                            libboost-filesystem-dev                     \
-                            libboost-graph-dev                          \
-                            libboost-iostreams-dev                      \
-                            libboost-program-options-dev                \
-                            libboost-python-dev                         \
-                            libboost-regex-dev                          \
-                            libboost-serialization-dev                  \
-                            libboost-thread-dev                         \
-                            libcoin-dev                                 \
-                            libeigen3-dev                               \
-                            libkdtree++-dev                             \
-                            libmedc-dev                                 \
-                            libocct-data-exchange-dev                   \
-                            libocct-ocaf-dev                            \
-                            libocct-visualization-dev                   \
-                            libopencv-dev                               \
-                            libproj-dev                                 \
-                            libpyside2-dev                              \
-                            libqt5opengl5-dev                           \
-                            libqt5svg5-dev                              \
-                            libqt5x11extras5-dev                        \
-                            libshiboken2-dev                            \
-                            libspnav-dev                                \
-                            libvtk7-dev                                 \
-                            libx11-dev                                  \
-                            libxerces-c-dev                             \
-                            libyaml-cpp-dev                             \
-                            libzipios++-dev                             \
-                            netgen                                      \
-                            netgen-headers                              \
-                            ninja-build                                 \
-                            occt-draw                                   \
-                            pyqt5-dev-tools                             \
-                            pyside2-tools                               \
-                            python3-dev                                 \
-                            python3-git                                 \
-                            python3-markdown                            \
-                            python3-matplotlib                          \
-                            python3-packaging                           \
-                            python3-pivy                                \
-                            python3-ply                                 \
-                            python3-pyside2.qtcore                      \
-                            python3-pyside2.qtgui                       \
-                            python3-pyside2.qtnetwork                   \
-                            python3-pyside2.qtsvg                       \
-                            python3-pyside2.qtwidgets                   \
-                            qtbase5-dev                                 \
-                            qttools5-dev                                \
-                            shiboken2                                   \
-                            swig                                        \
-                            xvfb
+        run: ./package/ubuntu/install-apt-packages.sh
+
       - name: Make needed directories, files and initializations
         id: Init
         run: |

--- a/package/ubuntu/install-apt-packages.sh
+++ b/package/ubuntu/install-apt-packages.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+# Update package lists quietly
+sudo apt-get update -qq
+
+packages=(
+  ccache
+  doxygen
+  graphviz
+  imagemagick
+  libboost-date-time-dev
+  libboost-dev
+  libboost-filesystem-dev
+  libboost-graph-dev
+  libboost-iostreams-dev
+  libboost-program-options-dev
+  libboost-python-dev
+  libboost-regex-dev
+  libboost-serialization-dev
+  libboost-thread-dev
+  libcoin-dev
+  libeigen3-dev
+  libkdtree++-dev
+  libmedc-dev
+  libocct-data-exchange-dev
+  libocct-ocaf-dev
+  libocct-visualization-dev
+  libopencv-dev
+  libproj-dev
+  libpyside2-dev
+  libqt5opengl5-dev
+  libqt5svg5-dev
+  libqt5x11extras5-dev
+  libshiboken2-dev
+  libspnav-dev
+  libvtk7-dev
+  libx11-dev
+  libxerces-c-dev
+  libyaml-cpp-dev
+  libzipios++-dev
+  netgen
+  netgen-headers
+  ninja-build
+  occt-draw
+  pyqt5-dev-tools
+  pyside2-tools
+  python3-dev
+  python3-git
+  python3-markdown
+  python3-matplotlib
+  python3-packaging
+  python3-pivy
+  python3-ply
+  python3-pyside2.qtcore
+  python3-pyside2.qtgui
+  python3-pyside2.qtnetwork
+  python3-pyside2.qtsvg
+  python3-pyside2.qtwidgets
+  qtbase5-dev
+  qttools5-dev
+  shiboken2
+  swig
+  xvfb
+)
+
+# Install all packages
+sudo apt-get install -y --no-install-recommends "${packages[@]}"


### PR DESCRIPTION
This provides a few benefits, as regular users can just call this script as well and not need to copy this from the CI files to know which packages to install.