### PR TITLE
Git: Ignore extra suffixed build directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ install_manifest.txt
 /Mod/
 /ZERO_CHECK.dir/
 /build/
+/build-*/
 /cmake-build*/
 /src/Tools/offlinedoc/localwiki/
 /src/Tools/offlinedoc/*.txt


### PR DESCRIPTION
Its pretty helpful when developing to have multiple build directories for different branches.

This adds such pattern to .gitignore to be able to have a sane Git experience.