### PR TITLE
Base: Move App::Color to Base 

### DIFF
--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -273,7 +273,6 @@ SET(FreeCADApp_CPP_SRCS
     AutoTransaction.cpp
     Branding.cpp
     CleanupProcess.cpp
-    Color.cpp
     ColorModel.cpp
     ComplexGeoData.cpp
     ComplexGeoDataPyImp.cpp
@@ -303,7 +302,6 @@ SET(FreeCADApp_HPP_SRCS
     AutoTransaction.h
     Branding.h
     CleanupProcess.h
-    Color.h
     ColorModel.h
     ComplexGeoData.h
     ElementMap.h

--- a/src/App/ColorModel.cpp
+++ b/src/App/ColorModel.cpp
@@ -138,8 +138,8 @@ void ColorField::rebuild()
     fConstant = -fAscent * fMin;
 }
 
-// fuellt das Array von Farbe 1, Index 1 bis Farbe 2, Index 2
-void ColorField::interpolate(Color clCol1, std::size_t usInd1, Color clCol2, std::size_t usInd2)
+// fills the array from color 1, index 1 to color 2, index 2
+void ColorField::interpolate(Base::Color clCol1, std::size_t usInd1, Base::Color clCol2, std::size_t usInd2)
 {
     float fStep = 1.0f, fLen = float(usInd2 - usInd1);
 
@@ -154,7 +154,7 @@ void ColorField::interpolate(Color clCol1, std::size_t usInd1, Color clCol2, std
         float ucR = clCol1.r + fR * fStep;
         float ucG = clCol1.g + fG * fStep;
         float ucB = clCol1.b + fB * fStep;
-        colorField[i] = Color(ucR, ucG, ucB);
+        colorField[i] = Base::Color(ucR, ucG, ucB);
         fStep += 1.0f;
     }
 }
@@ -370,20 +370,20 @@ bool ColorLegend::setValue(std::size_t ulPos, float fVal)
     }
 }
 
-Color ColorLegend::getColor(std::size_t ulPos) const
+Base::Color ColorLegend::getColor(std::size_t ulPos) const
 {
     if (ulPos < colorFields.size()) {
         return colorFields[ulPos];
     }
     else {
-        return Color();
+        return Base::Color();
     }
 }
 
 // color as: 0x00rrggbb
 uint32_t ColorLegend::getPackedColor(std::size_t ulPos) const
 {
-    Color clRGB = getColor(ulPos);
+    Base::Color clRGB = getColor(ulPos);
     return clRGB.getPackedValue();
 }
 
@@ -402,7 +402,7 @@ std::size_t ColorLegend::addMin(const std::string& rclName)
     names.push_front(rclName);
     values.push_front(values.front() - 1.0f);
 
-    Color clNewRGB;
+    Base::Color clNewRGB;
     clNewRGB.r = ((float)rand() / (float)RAND_MAX);
     clNewRGB.g = ((float)rand() / (float)RAND_MAX);
     clNewRGB.b = ((float)rand() / (float)RAND_MAX);
@@ -417,7 +417,7 @@ std::size_t ColorLegend::addMax(const std::string& rclName)
     names.push_back(rclName);
     values.push_back(values.back() + 1.0f);
 
-    Color clNewRGB;
+    Base::Color clNewRGB;
     clNewRGB.r = ((float)rand() / (float)RAND_MAX);
     clNewRGB.g = ((float)rand() / (float)RAND_MAX);
     clNewRGB.b = ((float)rand() / (float)RAND_MAX);
@@ -481,7 +481,7 @@ void ColorLegend::resize(std::size_t ulCt)
 bool ColorLegend::setColor(std::size_t ulPos, float ucRed, float ucGreen, float ucBlue)
 {
     if (ulPos < names.size()) {
-        colorFields[ulPos] = Color(ucRed, ucGreen, ucBlue);
+        colorFields[ulPos] = Base::Color(ucRed, ucGreen, ucBlue);
         return true;
     }
 

--- a/src/App/ColorModel.h
+++ b/src/App/ColorModel.h
@@ -32,7 +32,6 @@
 #include <string>
 #include <vector>
 
-
 namespace App
 {
 
@@ -64,7 +63,7 @@ namespace App
 class AppExport ValueFloatToRGB
 {
 public:
-    virtual Color getColor(float fVal) const = 0;
+    virtual Base::Color getColor(float fVal) const = 0;
 
 protected:
     ValueFloatToRGB() = default;
@@ -87,7 +86,7 @@ public:
     {
         return colors.size();
     }
-    std::vector<Color> colors;
+    std::vector<Base::Color> colors;
 };
 
 class AppExport ColorModelBlueGreenRed: public ColorModel
@@ -96,11 +95,11 @@ public:
     ColorModelBlueGreenRed()
         : ColorModel(5)
     {
-        colors[0] = Color(0, 0, 1);
-        colors[1] = Color(0, 1, 1);
-        colors[2] = Color(0, 1, 0);
-        colors[3] = Color(1, 1, 0);
-        colors[4] = Color(1, 0, 0);
+        colors[0] = Base::Color(0, 0, 1);
+        colors[1] = Base::Color(0, 1, 1);
+        colors[2] = Base::Color(0, 1, 0);
+        colors[3] = Base::Color(1, 1, 0);
+        colors[4] = Base::Color(1, 0, 0);
     }
 };
 
@@ -110,9 +109,9 @@ public:
     ColorModelBlueCyanGreen()
         : ColorModel(3)
     {
-        colors[0] = Color(0, 0, 1);
-        colors[1] = Color(0, 1, 1);
-        colors[2] = Color(0, 1, 0);
+        colors[0] = Base::Color(0, 0, 1);
+        colors[1] = Base::Color(0, 1, 1);
+        colors[2] = Base::Color(0, 1, 0);
     }
 };
 
@@ -122,9 +121,9 @@ public:
     ColorModelGreenYellowRed()
         : ColorModel(3)
     {
-        colors[0] = Color(0, 1, 0);
-        colors[1] = Color(1, 1, 0);
-        colors[2] = Color(1, 0, 0);
+        colors[0] = Base::Color(0, 1, 0);
+        colors[1] = Base::Color(1, 1, 0);
+        colors[2] = Base::Color(1, 0, 0);
     }
 };
 
@@ -134,11 +133,11 @@ public:
     ColorModelRedGreenBlue()
         : ColorModel(5)
     {
-        colors[0] = Color(1, 0, 0);
-        colors[1] = Color(1, 1, 0);
-        colors[2] = Color(0, 1, 0);
-        colors[3] = Color(0, 1, 1);
-        colors[4] = Color(0, 0, 1);
+        colors[0] = Base::Color(1, 0, 0);
+        colors[1] = Base::Color(1, 1, 0);
+        colors[2] = Base::Color(0, 1, 0);
+        colors[3] = Base::Color(0, 1, 1);
+        colors[4] = Base::Color(0, 0, 1);
     }
 };
 
@@ -148,9 +147,9 @@ public:
     ColorModelGreenCyanBlue()
         : ColorModel(3)
     {
-        colors[0] = Color(0, 1, 0);
-        colors[1] = Color(0, 1, 1);
-        colors[2] = Color(0, 0, 1);
+        colors[0] = Base::Color(0, 1, 0);
+        colors[1] = Base::Color(0, 1, 1);
+        colors[2] = Base::Color(0, 0, 1);
     }
 };
 
@@ -160,9 +159,9 @@ public:
     ColorModelRedYellowGreen()
         : ColorModel(3)
     {
-        colors[0] = Color(1, 0, 0);
-        colors[1] = Color(1, 1, 0);
-        colors[2] = Color(0, 1, 0);
+        colors[0] = Base::Color(1, 0, 0);
+        colors[1] = Base::Color(1, 1, 0);
+        colors[2] = Base::Color(0, 1, 0);
     }
 };
 
@@ -172,11 +171,11 @@ public:
     ColorModelBlueWhiteRed()
         : ColorModel(5)
     {
-        colors[0] = Color(0, 0, 1);
-        colors[1] = Color(float(85.0 / 255), float(170.0 / 255), 1);
-        colors[2] = Color(1, 1, 1);
-        colors[3] = Color(1, float(85.0 / 255), 0);
-        colors[4] = Color(1, 0, 0);
+        colors[0] = Base::Color(0, 0, 1);
+        colors[1] = Base::Color(float(85.0 / 255), float(170.0 / 255), 1);
+        colors[2] = Base::Color(1, 1, 1);
+        colors[3] = Base::Color(1, float(85.0 / 255), 0);
+        colors[4] = Base::Color(1, 0, 0);
     }
 };
 
@@ -186,9 +185,9 @@ public:
     ColorModelBlueWhite()
         : ColorModel(3)
     {
-        colors[0] = Color(0, 0, 1);
-        colors[1] = Color(float(85.0 / 255), float(170.0 / 255), 1);
-        colors[2] = Color(1, 1, 1);
+        colors[0] = Base::Color(0, 0, 1);
+        colors[1] = Base::Color(float(85.0 / 255), float(170.0 / 255), 1);
+        colors[2] = Base::Color(1, 1, 1);
     }
 };
 
@@ -198,9 +197,9 @@ public:
     ColorModelWhiteRed()
         : ColorModel(3)
     {
-        colors[0] = Color(1, 1, 1);
-        colors[1] = Color(1, float(85.0 / 255), 0);
-        colors[2] = Color(1, 0, 0);
+        colors[0] = Base::Color(1, 1, 1);
+        colors[1] = Base::Color(1, float(85.0 / 255), 0);
+        colors[2] = Base::Color(1, 0, 0);
     }
 };
 
@@ -210,8 +209,8 @@ public:
     ColorModelBlackWhite()
         : ColorModel(2)
     {
-        colors[0] = Color(0, 0, 0);
-        colors[1] = Color(1, 1, 1);
+        colors[0] = Base::Color(0, 0, 0);
+        colors[1] = Base::Color(1, 1, 1);
     }
 };
 
@@ -221,8 +220,8 @@ public:
     ColorModelBlackGray()
         : ColorModel(2)
     {
-        colors[0] = Color(0.0f, 0.0f, 0.0f);
-        colors[1] = Color(0.5f, 0.5f, 0.5f);
+        colors[0] = Base::Color(0.0f, 0.0f, 0.0f);
+        colors[1] = Base::Color(0.5f, 0.5f, 0.5f);
     }
 };
 
@@ -232,8 +231,8 @@ public:
     ColorModelGrayWhite()
         : ColorModel(2)
     {
-        colors[0] = Color(0.5f, 0.5f, 0.5f);
-        colors[1] = Color(1.0f, 1.0f, 1.0f);
+        colors[0] = Base::Color(0.5f, 0.5f, 0.5f);
+        colors[1] = Base::Color(1.0f, 1.0f, 1.0f);
     }
 };
 
@@ -243,8 +242,8 @@ public:
     ColorModelWhiteBlack()
         : ColorModel(2)
     {
-        colors[0] = Color(1, 1, 1);
-        colors[1] = Color(0, 0, 0);
+        colors[0] = Base::Color(1, 1, 1);
+        colors[1] = Base::Color(0, 0, 0);
     }
 };
 
@@ -254,8 +253,8 @@ public:
     ColorModelWhiteGray()
         : ColorModel(2)
     {
-        colors[0] = Color(1.0f, 1.0f, 1.0f);
-        colors[1] = Color(0.5f, 0.5f, 0.5f);
+        colors[0] = Base::Color(1.0f, 1.0f, 1.0f);
+        colors[1] = Base::Color(0.5f, 0.5f, 0.5f);
     }
 };
 
@@ -265,8 +264,8 @@ public:
     ColorModelGrayBlack()
         : ColorModel(2)
     {
-        colors[0] = Color(0.5f, 0.5f, 0.5f);
-        colors[1] = Color(0.0f, 0.0f, 0.0f);
+        colors[0] = Base::Color(0.5f, 0.5f, 0.5f);
+        colors[1] = Base::Color(0.0f, 0.0f, 0.0f);
     }
 };
 
@@ -320,7 +319,7 @@ public:
     {
         return colorModel;
     }
-    void setDirect(std::size_t usInd, Color clCol)
+    void setDirect(std::size_t usInd, Base::Color clCol)
     {
         colorField[usInd] = clCol;
     }
@@ -333,11 +332,11 @@ public:
         return fMax;
     }
 
-    Color getColor(std::size_t usIndex) const
+    Base::Color getColor(std::size_t usIndex) const
     {
         return colorField[usIndex];
     }
-    inline Color getColor(float fVal) const;
+    inline Base::Color getColor(float fVal) const;
     inline std::size_t getColorIndex(float fVal) const;
 
 protected:
@@ -345,13 +344,13 @@ protected:
     float fMin, fMax;
     float fAscent, fConstant;  // Index := _fConstant + _fAscent * WERT
     std::size_t ctColors;
-    std::vector<Color> colorField;
+    std::vector<Base::Color> colorField;
 
     void rebuild();
-    void interpolate(Color clCol1, std::size_t usPos1, Color clCol2, std::size_t usPos2);
+    void interpolate(Base::Color clCol1, std::size_t usPos1, Base::Color clCol2, std::size_t usPos2);
 };
 
-inline Color ColorField::getColor(float fVal) const
+inline Base::Color ColorField::getColor(float fVal) const
 {
     // if the value is outside or at the border of the range
     std::size_t ct = colorModel.getCountColors() - 1;
@@ -362,16 +361,16 @@ inline Color ColorField::getColor(float fVal) const
         return colorModel.colors[ct];
     }
 
-    // get the color field position (with 0 < t < 1)
+    // get the Base::Color field position (with 0 < t < 1)
     float t = (fVal - fMin) / (fMax - fMin);
-    Color col(1.0f, 1.0f, 1.0f);  // white as default
+    Base::Color col(1.0f, 1.0f, 1.0f);  // white as default
     for (std::size_t i = 0; i < ct; i++) {
         float r = (float)(i + 1) / (float)ct;
         if (t < r) {
             // calculate the exact position in the subrange
             float s = t * float(ct) - float(i);
-            Color c1 = colorModel.colors[i];
-            Color c2 = colorModel.colors[i + 1];
+            Base::Color c1 = colorModel.colors[i];
+            Base::Color c2 = colorModel.colors[i + 1];
             col.r = (1.0f - s) * c1.r + s * c2.r;
             col.g = (1.0f - s) * c1.g + s * c2.g;
             col.b = (1.0f - s) * c1.b + s * c2.b;
@@ -484,11 +483,11 @@ public:
         return profile.fMax;
     }
 
-    inline Color getColor(float fVal) const;
+    inline Base::Color getColor(float fVal) const;
     inline std::size_t getColorIndex(float fVal) const;
 
 private:
-    inline Color _getColor(float fVal) const;
+    inline Base::Color _getColor(float fVal) const;
 
 protected:
     void createStandardPacks();
@@ -525,7 +524,7 @@ public:
     void removeFirst();
     void removeLast();
 
-    Color getColor(std::size_t ulPos) const;
+    Base::Color getColor(std::size_t ulPos) const;
     uint32_t getPackedColor(std::size_t ulPos) const;
     bool setColor(std::size_t ulPos, float ucRed, float ucGreen, float ucBlue);
     bool setColor(std::size_t ulPos, unsigned long ulColor);
@@ -548,17 +547,17 @@ public:
     inline float getMinValue() const;
     inline float getMaxValue() const;
 
-    inline Color getColor(float fVal) const;
+    inline Base::Color getColor(float fVal) const;
     inline std::size_t getColorIndex(float fVal) const;
 
 protected:
-    std::deque<Color> colorFields;
+    std::deque<Base::Color> colorFields;
     std::deque<std::string> names;
     std::deque<float> values;
     bool outsideGrayed {false};
 };
 
-inline Color ColorLegend::getColor(float fVal) const
+inline Base::Color ColorLegend::getColor(float fVal) const
 {
     std::deque<float>::const_iterator pI;
     for (pI = values.begin(); pI != values.end(); ++pI) {
@@ -569,7 +568,7 @@ inline Color ColorLegend::getColor(float fVal) const
 
     if (outsideGrayed) {
         if ((pI == values.begin()) || (pI == values.end())) {
-            return Color(0.5f, 0.5f, 0.5f);
+            return Base::Color(0.5f, 0.5f, 0.5f);
         }
         else {
             return colorFields[pI - values.begin() - 1];
@@ -617,23 +616,23 @@ inline float ColorLegend::getMaxValue() const
     return values.back();
 }
 
-inline Color ColorGradient::getColor(float fVal) const
+inline Base::Color ColorGradient::getColor(float fVal) const
 {
-    Color color = _getColor(fVal);
+    Base::Color Color = _getColor(fVal);
     if (isOutsideInvisible()) {
         if (isOutOfRange(fVal)) {
-            color.a = 0.2F;
+            Color.a = 0.2F;
         }
     }
 
-    return color;
+    return Color;
 }
 
-inline Color ColorGradient::_getColor(float fVal) const
+inline Base::Color ColorGradient::_getColor(float fVal) const
 {
     if (isOutsideGrayed()) {
         if (isOutOfRange(fVal)) {
-            return Color(0.5f, 0.5f, 0.5f);
+            return Base::Color(0.5f, 0.5f, 0.5f);
         }
     }
 

--- a/src/App/FeatureTest.cpp
+++ b/src/App/FeatureTest.cpp
@@ -70,7 +70,7 @@ FeatureTest::FeatureTest()
     ADD_PROPERTY(ConstraintFloat, (5.0));
     ConstraintFloat.setConstraints(&floatPercent);
 
-    App::Color c;
+    Base::Color c;
     App::Material mat(App::Material::GOLD);
     ADD_PROPERTY(Colour, (c));
     ADD_PROPERTY(ColourList, (c));

--- a/src/App/Material.cpp
+++ b/src/App/Material.cpp
@@ -339,7 +339,7 @@ App::Material Material::getDefaultAppearance()
     ParameterGrp::handle hGrp =
         App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
 
-    auto getColor = [hGrp](const char* parameter, App::Color& color) {
+    auto getColor = [hGrp](const char* parameter, Base::Color& color) {
         uint32_t packed = color.getPackedRGB();
         packed = hGrp->GetUnsigned(parameter, packed);
         color.setPackedRGB(packed);
@@ -363,10 +363,10 @@ App::Material Material::getDefaultAppearance()
         float red = static_cast<float>(intRandom(0, 255)) / 255.0F;
         float green = static_cast<float>(intRandom(0, 255)) / 255.0F;
         float blue = static_cast<float>(intRandom(0, 255)) / 255.0F;
-        mat.diffuseColor = App::Color(red, green, blue);
+        mat.diffuseColor = Base::Color(red, green, blue);
     }
     else {
-        // Color = (204, 204, 230) = 3435980543UL
+        // Base::Color = (204, 204, 230) = 3435980543UL
         getColor("DefaultShapeColor", mat.diffuseColor);
     }
 

--- a/src/App/Material.h
+++ b/src/App/Material.h
@@ -24,7 +24,7 @@
 #ifndef APP_MATERIAL_H
 #define APP_MATERIAL_H
 
-#include <App/Color.h>
+#include <Base/Color.h>
 
 namespace App
 {
@@ -104,7 +104,7 @@ public:
      *  \li Ruby
      *  \li Emerald
      * Furthermore there two additional modes \a Default which defines a kind of grey metallic and
-     * user defined that does nothing. The Color and the other properties of the material are
+     * user defined that does nothing. The Base::Color and the other properties of the material are
      * defined in the range [0-1]. If \a MatName is an unknown material name then the type
      * USER_DEFINED is set and the material doesn't get changed.
      */
@@ -125,10 +125,10 @@ public:
     /** @name Properties */
     //@{
     // NOLINTBEGIN
-    Color ambientColor;  /**< Defines the ambient color. */
-    Color diffuseColor;  /**< Defines the diffuse color. */
-    Color specularColor; /**< Defines the specular color. */
-    Color emissiveColor; /**< Defines the emissive color. */
+    Base::Color ambientColor;  /**< Defines the ambient color. */
+    Base::Color diffuseColor;  /**< Defines the diffuse color. */
+    Base::Color specularColor; /**< Defines the specular color. */
+    Base::Color emissiveColor; /**< Defines the emissive color. */
     float shininess;
     float transparency;
     std::string image;

--- a/src/App/MaterialPy.xml
+++ b/src/App/MaterialPy.xml
@@ -64,7 +64,7 @@ Satin, Metalized, Neon GNC, Chrome, Aluminium, Obsidian, Neon PHC, Jade, Ruby or
         </Attribute>
         <CustomAttributes />
         <ClassDeclarations>public:
-    static App::Color toColor(PyObject* value);
+    static Base::Color toColor(PyObject* value);
         </ClassDeclarations>
     </PythonExport>
 </GenerateModel>

--- a/src/App/MaterialPyImp.cpp
+++ b/src/App/MaterialPyImp.cpp
@@ -32,9 +32,9 @@
 
 using namespace App;
 
-Color MaterialPy::toColor(PyObject* value)
+Base::Color MaterialPy::toColor(PyObject* value)
 {
-    Color cCol;
+    Base::Color cCol;
     if (PyTuple_Check(value) && (PyTuple_Size(value) == 3 || PyTuple_Size(value) == 4)) {
         PyObject* item {};
         item = PyTuple_GetItem(value, 0);

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -2301,7 +2301,7 @@ PropertyColor::~PropertyColor() = default;
 //**************************************************************************
 // Base class implementer
 
-void PropertyColor::setValue(const Color& col)
+void PropertyColor::setValue(const Base::Color& col)
 {
     aboutToSetValue();
     _cCol = col;
@@ -2322,7 +2322,7 @@ void PropertyColor::setValue(float r, float g, float b, float a)
     hasSetValue();
 }
 
-const Color& PropertyColor::getValue() const
+const Base::Color& PropertyColor::getValue() const
 {
     return _cCol;
 }
@@ -2345,7 +2345,7 @@ PyObject* PropertyColor::getPyObject()
 
 void PropertyColor::setPyObject(PyObject* value)
 {
-    App::Color cCol;
+    Base::Color cCol;
     if (PyTuple_Check(value) && (PyTuple_Size(value) == 3 || PyTuple_Size(value) == 4)) {
         PyObject* item;
         item = PyTuple_GetItem(value, 0);
@@ -2485,7 +2485,7 @@ PyObject* PropertyColorList::getPyObject()
     return list;
 }
 
-Color PropertyColorList::getPyValue(PyObject* item) const
+Base::Color PropertyColorList::getPyValue(PyObject* item) const
 {
     PropertyColor col;
     col.setPyObject(item);
@@ -2529,7 +2529,7 @@ void PropertyColorList::RestoreDocFile(Base::Reader& reader)
     Base::InputStream str(reader);
     uint32_t uCt = 0;
     str >> uCt;
-    std::vector<Color> values(uCt);
+    std::vector<Base::Color> values(uCt);
     uint32_t value;  // must be 32 bit long
     for (auto& it : values) {
         str >> value;
@@ -2552,7 +2552,7 @@ void PropertyColorList::Paste(const Property& from)
 
 unsigned int PropertyColorList::getMemSize() const
 {
-    return static_cast<unsigned int>(_lValueList.size() * sizeof(Color));
+    return static_cast<unsigned int>(_lValueList.size() * sizeof(Base::Color));
 }
 
 //**************************************************************************
@@ -2573,7 +2573,7 @@ void PropertyMaterial::setValue(const Material& mat)
     hasSetValue();
 }
 
-void PropertyMaterial::setValue(const Color& col)
+void PropertyMaterial::setValue(const Base::Color& col)
 {
     setDiffuseColor(col);
 }
@@ -2593,7 +2593,7 @@ const Material& PropertyMaterial::getValue() const
     return _cMat;
 }
 
-void PropertyMaterial::setAmbientColor(const Color& col)
+void PropertyMaterial::setAmbientColor(const Base::Color& col)
 {
     aboutToSetValue();
     _cMat.ambientColor = col;
@@ -2614,7 +2614,7 @@ void PropertyMaterial::setAmbientColor(uint32_t rgba)
     hasSetValue();
 }
 
-void PropertyMaterial::setDiffuseColor(const Color& col)
+void PropertyMaterial::setDiffuseColor(const Base::Color& col)
 {
     aboutToSetValue();
     _cMat.diffuseColor = col;
@@ -2635,7 +2635,7 @@ void PropertyMaterial::setDiffuseColor(uint32_t rgba)
     hasSetValue();
 }
 
-void PropertyMaterial::setSpecularColor(const Color& col)
+void PropertyMaterial::setSpecularColor(const Base::Color& col)
 {
     aboutToSetValue();
     _cMat.specularColor = col;
@@ -2656,7 +2656,7 @@ void PropertyMaterial::setSpecularColor(uint32_t rgba)
     hasSetValue();
 }
 
-void PropertyMaterial::setEmissiveColor(const Color& col)
+void PropertyMaterial::setEmissiveColor(const Base::Color& col)
 {
     aboutToSetValue();
     _cMat.emissiveColor = col;
@@ -2691,22 +2691,22 @@ void PropertyMaterial::setTransparency(float val)
     hasSetValue();
 }
 
-const Color& PropertyMaterial::getAmbientColor() const
+const Base::Color& PropertyMaterial::getAmbientColor() const
 {
     return _cMat.ambientColor;
 }
 
-const Color& PropertyMaterial::getDiffuseColor() const
+const Base::Color& PropertyMaterial::getDiffuseColor() const
 {
     return _cMat.diffuseColor;
 }
 
-const Color& PropertyMaterial::getSpecularColor() const
+const Base::Color& PropertyMaterial::getSpecularColor() const
 {
     return _cMat.specularColor;
 }
 
-const Color& PropertyMaterial::getEmissiveColor() const
+const Base::Color& PropertyMaterial::getEmissiveColor() const
 {
     return _cMat.emissiveColor;
 }
@@ -2894,7 +2894,7 @@ void PropertyMaterialList::setValue(int index, const Material& mat)
     hasSetValue();
 }
 
-void PropertyMaterialList::setAmbientColor(const Color& col)
+void PropertyMaterialList::setAmbientColor(const Base::Color& col)
 {
     aboutToSetValue();
     setMinimumSizeOne();
@@ -2924,7 +2924,7 @@ void PropertyMaterialList::setAmbientColor(uint32_t rgba)
     hasSetValue();
 }
 
-void PropertyMaterialList::setAmbientColor(int index, const Color& col)
+void PropertyMaterialList::setAmbientColor(int index, const Base::Color& col)
 {
     verifyIndex(index);
 
@@ -2954,7 +2954,7 @@ void PropertyMaterialList::setAmbientColor(int index, uint32_t rgba)
     hasSetValue();
 }
 
-void PropertyMaterialList::setDiffuseColor(const Color& col)
+void PropertyMaterialList::setDiffuseColor(const Base::Color& col)
 {
     aboutToSetValue();
     setMinimumSizeOne();
@@ -2984,7 +2984,7 @@ void PropertyMaterialList::setDiffuseColor(uint32_t rgba)
     hasSetValue();
 }
 
-void PropertyMaterialList::setDiffuseColor(int index, const Color& col)
+void PropertyMaterialList::setDiffuseColor(int index, const Base::Color& col)
 {
     verifyIndex(index);
 
@@ -3014,7 +3014,7 @@ void PropertyMaterialList::setDiffuseColor(int index, uint32_t rgba)
     hasSetValue();
 }
 
-void PropertyMaterialList::setDiffuseColors(const std::vector<App::Color>& colors)
+void PropertyMaterialList::setDiffuseColors(const std::vector<Base::Color>& colors)
 {
     aboutToSetValue();
     setSize(colors.size(), _lValueList[0]);
@@ -3025,7 +3025,7 @@ void PropertyMaterialList::setDiffuseColors(const std::vector<App::Color>& color
     hasSetValue();
 }
 
-void PropertyMaterialList::setSpecularColor(const Color& col)
+void PropertyMaterialList::setSpecularColor(const Base::Color& col)
 {
     aboutToSetValue();
     setMinimumSizeOne();
@@ -3055,7 +3055,7 @@ void PropertyMaterialList::setSpecularColor(uint32_t rgba)
     hasSetValue();
 }
 
-void PropertyMaterialList::setSpecularColor(int index, const Color& col)
+void PropertyMaterialList::setSpecularColor(int index, const Base::Color& col)
 {
     verifyIndex(index);
 
@@ -3085,7 +3085,7 @@ void PropertyMaterialList::setSpecularColor(int index, uint32_t rgba)
     hasSetValue();
 }
 
-void PropertyMaterialList::setEmissiveColor(const Color& col)
+void PropertyMaterialList::setEmissiveColor(const Base::Color& col)
 {
     aboutToSetValue();
     setMinimumSizeOne();
@@ -3115,7 +3115,7 @@ void PropertyMaterialList::setEmissiveColor(uint32_t rgba)
     hasSetValue();
 }
 
-void PropertyMaterialList::setEmissiveColor(int index, const Color& col)
+void PropertyMaterialList::setEmissiveColor(int index, const Base::Color& col)
 {
     verifyIndex(index);
 
@@ -3196,29 +3196,29 @@ void PropertyMaterialList::setTransparencies(const std::vector<float>& transpare
     hasSetValue();
 }
 
-const Color& PropertyMaterialList::getAmbientColor() const
+const Base::Color& PropertyMaterialList::getAmbientColor() const
 {
     return _lValueList[0].ambientColor;
 }
 
-const Color& PropertyMaterialList::getAmbientColor(int index) const
+const Base::Color& PropertyMaterialList::getAmbientColor(int index) const
 {
     return _lValueList[index].ambientColor;
 }
 
-const Color& PropertyMaterialList::getDiffuseColor() const
+const Base::Color& PropertyMaterialList::getDiffuseColor() const
 {
     return _lValueList[0].diffuseColor;
 }
 
-const Color& PropertyMaterialList::getDiffuseColor(int index) const
+const Base::Color& PropertyMaterialList::getDiffuseColor(int index) const
 {
     return _lValueList[index].diffuseColor;
 }
 
-std::vector<App::Color> PropertyMaterialList::getDiffuseColors() const
+std::vector<Base::Color> PropertyMaterialList::getDiffuseColors() const
 {
-    std::vector<App::Color> list;
+    std::vector<Base::Color> list;
     for (auto& material : _lValueList) {
         list.push_back(material.diffuseColor);
     }
@@ -3226,22 +3226,22 @@ std::vector<App::Color> PropertyMaterialList::getDiffuseColors() const
     return list;
 }
 
-const Color& PropertyMaterialList::getSpecularColor() const
+const Base::Color& PropertyMaterialList::getSpecularColor() const
 {
     return _lValueList[0].specularColor;
 }
 
-const Color& PropertyMaterialList::getSpecularColor(int index) const
+const Base::Color& PropertyMaterialList::getSpecularColor(int index) const
 {
     return _lValueList[index].specularColor;
 }
 
-const Color& PropertyMaterialList::getEmissiveColor() const
+const Base::Color& PropertyMaterialList::getEmissiveColor() const
 {
     return _lValueList[0].emissiveColor;
 }
 
-const Color& PropertyMaterialList::getEmissiveColor(int index) const
+const Base::Color& PropertyMaterialList::getEmissiveColor(int index) const
 {
     return _lValueList[index].emissiveColor;
 }

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -999,7 +999,7 @@ protected:
 };
 
 
-/** Color properties
+/** Base::Color properties
  * This is the father of all properties handling colors.
  */
 class AppExport PropertyColor: public Property
@@ -1021,13 +1021,13 @@ public:
 
     /** Sets the property
      */
-    void setValue(const Color& col);
+    void setValue(const Base::Color& col);
     void setValue(float r, float g, float b, float a = 1.0F);
     void setValue(uint32_t rgba);
 
     /** This method returns a string representation of the property
      */
-    const Color& getValue() const;
+    const Base::Color& getValue() const;
 
     const char* getEditorName() const override
     {
@@ -1045,7 +1045,7 @@ public:
 
     unsigned int getMemSize() const override
     {
-        return sizeof(Color);
+        return sizeof(Base::Color);
     }
 
     bool isSame(const Property& other) const override
@@ -1058,10 +1058,10 @@ public:
     }
 
 private:
-    Color _cCol;
+    Base::Color _cCol;
 };
 
-class AppExport PropertyColorList: public PropertyListsT<Color>
+class AppExport PropertyColorList: public PropertyListsT<Base::Color>
 {
     TYPESYSTEM_HEADER_WITH_OVERRIDE();
 
@@ -1091,7 +1091,7 @@ public:
     unsigned int getMemSize() const override;
 
 protected:
-    Color getPyValue(PyObject* py) const override;
+    Base::Color getPyValue(PyObject* py) const override;
 };
 
 
@@ -1118,19 +1118,19 @@ public:
     /** Sets the property
      */
     void setValue(const Material& mat);
-    void setValue(const Color& col);
+    void setValue(const Base::Color& col);
     void setValue(float r, float g, float b, float a = 1.0F);
     void setValue(uint32_t rgba);
-    void setAmbientColor(const Color& col);
+    void setAmbientColor(const Base::Color& col);
     void setAmbientColor(float r, float g, float b, float a = 1.0F);
     void setAmbientColor(uint32_t rgba);
-    void setDiffuseColor(const Color& col);
+    void setDiffuseColor(const Base::Color& col);
     void setDiffuseColor(float r, float g, float b, float a = 1.0F);
     void setDiffuseColor(uint32_t rgba);
-    void setSpecularColor(const Color& col);
+    void setSpecularColor(const Base::Color& col);
     void setSpecularColor(float r, float g, float b, float a = 1.0F);
     void setSpecularColor(uint32_t rgba);
-    void setEmissiveColor(const Color& col);
+    void setEmissiveColor(const Base::Color& col);
     void setEmissiveColor(float r, float g, float b, float a = 1.0F);
     void setEmissiveColor(uint32_t rgba);
     void setShininess(float);
@@ -1139,10 +1139,10 @@ public:
     /** This method returns a string representation of the property
      */
     const Material& getValue() const;
-    const Color& getAmbientColor() const;
-    const Color& getDiffuseColor() const;
-    const Color& getSpecularColor() const;
-    const Color& getEmissiveColor() const;
+    const Base::Color& getAmbientColor() const;
+    const Base::Color& getDiffuseColor() const;
+    const Base::Color& getSpecularColor() const;
+    const Base::Color& getEmissiveColor() const;
     double getShininess() const;
     double getTransparency() const;
 
@@ -1204,32 +1204,32 @@ public:
     void setValue(const Material& mat);
     void setValue(int index, const Material& mat);
 
-    void setAmbientColor(const Color& col);
+    void setAmbientColor(const Base::Color& col);
     void setAmbientColor(float r, float g, float b, float a = 1.0F);
     void setAmbientColor(uint32_t rgba);
-    void setAmbientColor(int index, const Color& col);
+    void setAmbientColor(int index, const Base::Color& col);
     void setAmbientColor(int index, float r, float g, float b, float a = 1.0F);
     void setAmbientColor(int index, uint32_t rgba);
 
-    void setDiffuseColor(const Color& col);
+    void setDiffuseColor(const Base::Color& col);
     void setDiffuseColor(float r, float g, float b, float a = 1.0F);
     void setDiffuseColor(uint32_t rgba);
-    void setDiffuseColor(int index, const Color& col);
+    void setDiffuseColor(int index, const Base::Color& col);
     void setDiffuseColor(int index, float r, float g, float b, float a = 1.0F);
     void setDiffuseColor(int index, uint32_t rgba);
-    void setDiffuseColors(const std::vector<App::Color>& colors);
+    void setDiffuseColors(const std::vector<Base::Color>& colors);
 
-    void setSpecularColor(const Color& col);
+    void setSpecularColor(const Base::Color& col);
     void setSpecularColor(float r, float g, float b, float a = 1.0F);
     void setSpecularColor(uint32_t rgba);
-    void setSpecularColor(int index, const Color& col);
+    void setSpecularColor(int index, const Base::Color& col);
     void setSpecularColor(int index, float r, float g, float b, float a = 1.0F);
     void setSpecularColor(int index, uint32_t rgba);
 
-    void setEmissiveColor(const Color& col);
+    void setEmissiveColor(const Base::Color& col);
     void setEmissiveColor(float r, float g, float b, float a = 1.0F);
     void setEmissiveColor(uint32_t rgba);
-    void setEmissiveColor(int index, const Color& col);
+    void setEmissiveColor(int index, const Base::Color& col);
     void setEmissiveColor(int index, float r, float g, float b, float a = 1.0F);
     void setEmissiveColor(int index, uint32_t rgba);
 
@@ -1240,18 +1240,18 @@ public:
     void setTransparency(int index, float);
     void setTransparencies(const std::vector<float>& transparencies);
 
-    const Color& getAmbientColor() const;
-    const Color& getAmbientColor(int index) const;
+    const Base::Color& getAmbientColor() const;
+    const Base::Color& getAmbientColor(int index) const;
 
-    const Color& getDiffuseColor() const;
-    const Color& getDiffuseColor(int index) const;
-    std::vector<App::Color> getDiffuseColors() const;
+    const Base::Color& getDiffuseColor() const;
+    const Base::Color& getDiffuseColor(int index) const;
+    std::vector<Base::Color> getDiffuseColors() const;
 
-    const Color& getSpecularColor() const;
-    const Color& getSpecularColor(int index) const;
+    const Base::Color& getSpecularColor() const;
+    const Base::Color& getSpecularColor(int index) const;
 
-    const Color& getEmissiveColor() const;
-    const Color& getEmissiveColor(int index) const;
+    const Base::Color& getEmissiveColor() const;
+    const Base::Color& getEmissiveColor(int index) const;
 
     float getShininess() const;
     float getShininess(int index) const;

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -173,6 +173,7 @@ SET(FreeCADBase_CPP_SRCS
     Builder3D.cpp
     Console.cpp
     ConsoleObserver.cpp
+    Color.cpp
     CoordinateSystem.cpp
     CoordinateSystemPyImp.cpp
     Debugger.cpp
@@ -244,6 +245,7 @@ SET(FreeCADBase_HPP_SRCS
     Console.h
     ConsoleObserver.h
     Converter.h
+    Color.h
     CoordinateSystem.h
     Debugger.h
     DualNumber.h

--- a/src/Base/Color.cpp
+++ b/src/Base/Color.cpp
@@ -30,7 +30,7 @@
 
 #include "Color.h"
 
-using namespace App;
+using namespace Base;
 
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)

--- a/src/Base/Color.h
+++ b/src/Base/Color.h
@@ -33,7 +33,7 @@
 #include <FCGlobal.h>
 
 // NOLINTBEGIN(readability-magic-numbers)
-namespace App
+namespace Base
 {
 
 template<class color_type>
@@ -86,7 +86,7 @@ private:
 
 /** Color class
  */
-class AppExport Color
+class BaseExport Color
 {
 public:
     /**
@@ -226,7 +226,92 @@ public:
     float r {}, g {}, b {}, a {};
 };
 
-}  // namespace App
+// Specialization for Color
+template<>
+struct color_traits<Base::Color>
+{
+    using color_type = Base::Color;
+    color_traits() = default;
+    explicit color_traits(const color_type& ct)
+        : ct(ct)
+    {}
+    float redF() const
+    {
+        return ct.r;
+    }
+    float greenF() const
+    {
+        return ct.g;
+    }
+    float blueF() const
+    {
+        return ct.b;
+    }
+    float alphaF() const
+    {
+        return ct.a;
+    }
+    void setRedF(float red)
+    {
+        ct.r = red;
+    }
+    void setGreenF(float green)
+    {
+        ct.g = green;
+    }
+    void setBlueF(float blue)
+    {
+        ct.b = blue;
+    }
+    void setAlphaF(float alpha)
+    {
+        ct.a = alpha;
+    }
+    int red() const
+    {
+        return int(std::lround(ct.r * 255.0F));
+    }
+    int green() const
+    {
+        return int(std::lround(ct.g * 255.0F));
+    }
+    int blue() const
+    {
+        return int(std::lround(ct.b * 255.0F));
+    }
+    int alpha() const
+    {
+        return int(std::lround(ct.a * 255.0F));
+    }
+    void setRed(int red)
+    {
+        ct.r = static_cast<float>(red) / 255.0F;
+    }
+    void setGreen(int green)
+    {
+        ct.g = static_cast<float>(green) / 255.0F;
+    }
+    void setBlue(int blue)
+    {
+        ct.b = static_cast<float>(blue) / 255.0F;
+    }
+    void setAlpha(int alpha)
+    {
+        ct.a = static_cast<float>(alpha) / 255.0F;
+    }
+    static color_type makeColor(int red, int green, int blue, int alpha = 255)
+    {
+        return color_type {static_cast<float>(red) / 255.0F,
+                           static_cast<float>(green) / 255.0F,
+                           static_cast<float>(blue) / 255.0F,
+                           static_cast<float>(alpha) / 255.0F};
+    }
+
+private:
+    color_type ct;
+};
+
+}  // namespace Base
 // NOLINTEND(readability-magic-numbers)
 
 #endif  // APP_COLOR_H

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -1252,6 +1252,55 @@ void ParameterGrp::RemoveUnsigned(const char* Name)
     Notify(Name);
 }
 
+Base::Color ParameterGrp::GetColor(const char* Name, Base::Color lPreset) const
+{
+    auto packed = GetUnsigned(Name, lPreset.getPackedValue());
+
+    return Color(static_cast<uint32_t>(packed));
+}
+
+void ParameterGrp::SetColor(const char* Name, Base::Color lValue)
+{
+    SetUnsigned(Name, lValue.getPackedValue());
+}
+
+std::vector<Base::Color> ParameterGrp::GetColors(const char* sFilter) const
+{
+    auto packed = GetUnsigneds(sFilter);
+    std::vector<Base::Color> result;
+
+    std::transform(packed.begin(),
+                   packed.end(),
+                   std::back_inserter(result),
+                   [](const unsigned long lValue) {
+                       return Color(static_cast<uint32_t>(lValue));
+                   });
+
+    return result;
+}
+
+std::vector<std::pair<std::string, Base::Color>>
+ParameterGrp::GetColorMap(const char* sFilter) const
+{
+    auto packed = GetUnsignedMap(sFilter);
+    std::vector<std::pair<std::string, Base::Color>> result;
+
+    std::transform(packed.begin(),
+                   packed.end(),
+                   std::back_inserter(result),
+                   [](const std::pair<std::string, unsigned long>& lValue) {
+                       return std::make_pair(lValue.first,
+                                             Color(static_cast<uint32_t>(lValue.second)));
+                   });
+
+    return result;
+}
+
+void ParameterGrp::RemoveColor(const char* Name)
+{
+    RemoveUnsigned(Name);
+}
+
 void ParameterGrp::RemoveGrp(const char* Name)
 {
     if (!_pGroupNode) {

--- a/src/Base/Parameter.h
+++ b/src/Base/Parameter.h
@@ -31,6 +31,7 @@
 
 #ifndef BASE_PARAMETER_H
 #define BASE_PARAMETER_H
+#include <Base/Color.h>
 
 // Python stuff
 using PyObject = struct _object;

--- a/src/Base/Parameter.h
+++ b/src/Base/Parameter.h
@@ -31,7 +31,6 @@
 
 #ifndef BASE_PARAMETER_H
 #define BASE_PARAMETER_H
-#include <Base/Color.h>
 
 // Python stuff
 using PyObject = struct _object;
@@ -57,6 +56,7 @@ using PyObject = struct _object;
 
 #include "Handle.h"
 #include "Observer.h"
+#include "Color.h"
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4251)
@@ -88,7 +88,6 @@ XERCES_CPP_NAMESPACE_END
 #endif
 
 class ParameterManager;
-
 
 /** The parameter container class
  *  This is the base class of all classes handle parameter.
@@ -306,6 +305,21 @@ public:
     GetUnsignedMap(const char* sFilter = nullptr) const;
     /// remove a uint value from this group
     void RemoveUnsigned(const char* Name);
+    //@}
+
+    /** @name methods for Colors handling, colors are persisted as packed uints */
+    //@{
+    /// read color value or give default
+    Base::Color GetColor(const char* Name, Base::Color lPreset = Base::Color(1.0, 1.0, 1.0)) const;
+    /// set a color value
+    void SetColor(const char* Name, Base::Color lValue);
+    /// get a vector of all color values in this group
+    std::vector<Base::Color> GetColors(const char* sFilter = nullptr) const;
+    /// get a map with all color values and the keys of this group
+    std::vector<std::pair<std::string, Base::Color>>
+    GetColorMap(const char* sFilter = nullptr) const;
+    /// remove a color value from this group
+    void RemoveColor(const char* Name);
     //@}
 
 

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -95,7 +95,7 @@ void StdCmdRandomColor::activated(int iMsg)
         auto fGrn = (float)rand()/fMax;
         auto fBlu = (float)rand()/fMax;
         // NOLINTEND
-        auto objColor = App::Color(fRed, fGrn, fBlu);
+        auto objColor = Base::Color(fRed, fGrn, fBlu);
 
         auto vpLink = dynamic_cast<ViewProviderLink*>(view);
         if (vpLink) {

--- a/src/Gui/Dialogs/DlgMaterialPropertiesImp.h
+++ b/src/Gui/Dialogs/DlgMaterialPropertiesImp.h
@@ -29,9 +29,13 @@
 #include <vector>
 #include <App/Material.h>
 
-namespace App
+namespace Base
 {
 class Color;
+}
+
+namespace App
+{
 class Material;
 }
 

--- a/src/Gui/Inventor/SoAxisCrossKit.cpp
+++ b/src/Gui/Inventor/SoAxisCrossKit.cpp
@@ -52,7 +52,7 @@
 # include <Inventor/nodes/SoTranslation.h>
 #endif
 
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <Gui/ViewParams.h>
 
 #include "SoAxisCrossKit.h"
@@ -225,23 +225,23 @@ SoAxisCrossKit::createAxes()
    set("zAxis.appearance.drawStyle", "lineWidth 1");
 
    unsigned long colorLong;
-   App::Color color;
+   Base::Color color;
    std::stringstream parameterstring;
 
    colorLong = Gui::ViewParams::instance()->getAxisXColor();
-   color = App::Color(static_cast<uint32_t>(colorLong));
+   color = Base::Color(static_cast<uint32_t>(colorLong));
    parameterstring << "diffuseColor " << color.r << " " << color.g << " " << color.b;
    set("xAxis.appearance.material", parameterstring.str().c_str());
    set("xHead.appearance.material", parameterstring.str().c_str());
 
    colorLong = Gui::ViewParams::instance()->getAxisYColor();
-   color = App::Color(static_cast<uint32_t>(colorLong));
+   color = Base::Color(static_cast<uint32_t>(colorLong));
    parameterstring << "diffuseColor " << color.r << " " << color.g << " " << color.b;
    set("yAxis.appearance.material", parameterstring.str().c_str());
    set("yHead.appearance.material", parameterstring.str().c_str());
 
    colorLong = Gui::ViewParams::instance()->getAxisZColor();
-   color = App::Color(static_cast<uint32_t>(colorLong));
+   color = Base::Color(static_cast<uint32_t>(colorLong));
    parameterstring << "diffuseColor " << color.r << " " << color.g << " " << color.b;
    set("zAxis.appearance.material", parameterstring.str().c_str());
    set("zHead.appearance.material", parameterstring.str().c_str());

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -115,7 +115,7 @@
 #include "View3DInventor.h"
 #include "View3DInventorViewer.h"
 #include "Dialogs/DlgObjectSelection.h"
-#include <App/Color.h>
+#include <Base/Color.h>
 
 FC_LOG_LEVEL_INIT("MainWindow",false,true,true)
 
@@ -2348,15 +2348,15 @@ void MainWindow::setWindowTitle(const QString& string)
         auto format = QStringLiteral("#statusBar{color: %1}");
         if (strcmp(sReason, "colorText") == 0) {
             unsigned long col = rclGrp.GetUnsigned(sReason);
-            this->msg = format.arg(App::Color::fromPackedRGB<QColor>(col).name());
+            this->msg = format.arg(Base::Color::fromPackedRGB<QColor>(col).name());
         }
         else if (strcmp(sReason, "colorWarning") == 0) {
             unsigned long col = rclGrp.GetUnsigned(sReason);
-            this->wrn = format.arg(App::Color::fromPackedRGB<QColor>(col).name());
+            this->wrn = format.arg(Base::Color::fromPackedRGB<QColor>(col).name());
         }
         else if (strcmp(sReason, "colorError") == 0) {
             unsigned long col = rclGrp.GetUnsigned(sReason);
-            this->err = format.arg(App::Color::fromPackedRGB<QColor>(col).name());
+            this->err = format.arg(Base::Color::fromPackedRGB<QColor>(col).name());
         }
         else if (strcmp(sReason, "colorCritical") == 0) {
             unsigned long col = rclGrp.GetUnsigned(sReason);

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -45,7 +45,7 @@
 # include <QPainterPath>
 #endif
 
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <Base/Tools.h>
 #include <Eigen/Dense>
 
@@ -180,9 +180,9 @@ public:
     float m_InactiveOpacity = 0.5;
     SbVec2s m_PosOffset = SbVec2s(0,0);
 
-    App::Color m_xColor;
-    App::Color m_yColor;
-    App::Color m_zColor;
+    Base::Color m_xColor;
+    Base::Color m_yColor;
+    Base::Color m_zColor;
 
     bool m_Prepared = false;
     static vector<string> m_commands;
@@ -1181,11 +1181,11 @@ void NaviCube::updateColors()
     unsigned long colorLong;
 
     colorLong = Gui::ViewParams::instance()->getAxisXColor();
-    m_NaviCubeImplementation->m_xColor = App::Color(static_cast<uint32_t>(colorLong));
+    m_NaviCubeImplementation->m_xColor = Base::Color(static_cast<uint32_t>(colorLong));
     colorLong = Gui::ViewParams::instance()->getAxisYColor();
-    m_NaviCubeImplementation->m_yColor = App::Color(static_cast<uint32_t>(colorLong));
+    m_NaviCubeImplementation->m_yColor = Base::Color(static_cast<uint32_t>(colorLong));
     colorLong = Gui::ViewParams::instance()->getAxisZColor();
-    m_NaviCubeImplementation->m_zColor = App::Color(static_cast<uint32_t>(colorLong));
+    m_NaviCubeImplementation->m_zColor = Base::Color(static_cast<uint32_t>(colorLong));
 }
 
 void NaviCube::setNaviCubeCommands(const std::vector<std::string>& cmd)

--- a/src/Gui/PrefWidgets.cpp
+++ b/src/Gui/PrefWidgets.cpp
@@ -30,7 +30,7 @@
 
 #include <Base/Console.h>
 #include <Base/Tools.h>
-#include <App/Color.h>
+#include <Base/Color.h>
 
 #include "PrefWidgets.h"
 
@@ -562,12 +562,12 @@ void PrefColorButton::restorePreferences()
   if (!m_Restored)
     m_Default = color();
 
-  unsigned int icol = App::Color::asPackedRGBA<QColor>(m_Default);
+  unsigned int icol = Base::Color::asPackedRGBA<QColor>(m_Default);
 
   unsigned long lcol = static_cast<unsigned long>(icol);
   lcol = getWindowParameter()->GetUnsigned(entryName(), lcol);
   icol = static_cast<unsigned int>(lcol);
-  QColor value = App::Color::fromPackedRGBA<QColor>(icol);
+  QColor value = Base::Color::fromPackedRGBA<QColor>(icol);
   if (!this->allowTransparency())
     value.setAlpha(0xff);
   setColor(value);
@@ -583,7 +583,7 @@ void PrefColorButton::savePreferences()
 
   QColor col = color();
   // (r,g,b,a) with a = 255 (opaque)
-  unsigned int icol = App::Color::asPackedRGBA<QColor>(col);
+  unsigned int icol = Base::Color::asPackedRGBA<QColor>(col);
   unsigned long lcol = static_cast<unsigned long>(icol);
   getWindowParameter()->SetUnsigned( entryName(), lcol );
 }

--- a/src/Gui/PreferencePages/DlgSettingsEditor.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsEditor.cpp
@@ -26,7 +26,7 @@
 #include <QFontDatabase>
 #endif
 
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <Gui/PythonEditor.h>
 #include <Gui/Tools.h>
 
@@ -85,63 +85,63 @@ DlgSettingsEditor::DlgSettingsEditor(QWidget* parent)
     d = new DlgSettingsEditorP();
     QColor col;
     col = qApp->palette().windowText().color();
-    unsigned int lText = App::Color::asPackedRGB<QColor>(col);
+    unsigned int lText = Base::Color::asPackedRGB<QColor>(col);
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Text")), lText));
 
-    unsigned int lBookmarks = App::Color::asPackedRGB<QColor>(QColor(Qt::cyan));
+    unsigned int lBookmarks = Base::Color::asPackedRGB<QColor>(QColor(Qt::cyan));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Bookmark")), lBookmarks));
 
-    unsigned int lBreakpnts = App::Color::asPackedRGB<QColor>(QColor(Qt::red));
+    unsigned int lBreakpnts = Base::Color::asPackedRGB<QColor>(QColor(Qt::red));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Breakpoint")), lBreakpnts));
 
-    unsigned int lKeywords = App::Color::asPackedRGB<QColor>(QColor(Qt::blue));
+    unsigned int lKeywords = Base::Color::asPackedRGB<QColor>(QColor(Qt::blue));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Keyword")), lKeywords));
 
-    unsigned int lComments = App::Color::asPackedRGB<QColor>(QColor(0, 170, 0));
+    unsigned int lComments = Base::Color::asPackedRGB<QColor>(QColor(0, 170, 0));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Comment")), lComments));
 
-    unsigned int lBlockCom = App::Color::asPackedRGB<QColor>(QColor(160, 160, 164));
+    unsigned int lBlockCom = Base::Color::asPackedRGB<QColor>(QColor(160, 160, 164));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Block comment")), lBlockCom));
 
-    unsigned int lNumbers = App::Color::asPackedRGB<QColor>(QColor(Qt::blue));
+    unsigned int lNumbers = Base::Color::asPackedRGB<QColor>(QColor(Qt::blue));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Number")), lNumbers));
 
-    unsigned int lStrings = App::Color::asPackedRGB<QColor>(QColor(Qt::red));
+    unsigned int lStrings = Base::Color::asPackedRGB<QColor>(QColor(Qt::red));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("String")), lStrings));
 
-    unsigned int lCharacter = App::Color::asPackedRGB<QColor>(QColor(Qt::red));
+    unsigned int lCharacter = Base::Color::asPackedRGB<QColor>(QColor(Qt::red));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Character")), lCharacter));
 
-    unsigned int lClass = App::Color::asPackedRGB<QColor>(QColor(255, 170, 0));
+    unsigned int lClass = Base::Color::asPackedRGB<QColor>(QColor(255, 170, 0));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Class name")), lClass));
 
-    unsigned int lDefine = App::Color::asPackedRGB<QColor>(QColor(255, 170, 0));
+    unsigned int lDefine = Base::Color::asPackedRGB<QColor>(QColor(255, 170, 0));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Define name")), lDefine));
 
-    unsigned int lOperat = App::Color::asPackedRGB<QColor>(QColor(160, 160, 164));
+    unsigned int lOperat = Base::Color::asPackedRGB<QColor>(QColor(160, 160, 164));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Operator")), lOperat));
 
-    unsigned int lPyOutput = App::Color::asPackedRGB<QColor>(QColor(170, 170, 127));
+    unsigned int lPyOutput = Base::Color::asPackedRGB<QColor>(QColor(170, 170, 127));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Python output")), lPyOutput));
 
-    unsigned int lPyError = App::Color::asPackedRGB<QColor>(QColor(Qt::red));
+    unsigned int lPyError = Base::Color::asPackedRGB<QColor>(QColor(Qt::red));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Python error")), lPyError));
 
-    unsigned int lCLine = App::Color::asPackedRGB<QColor>(QColor(224, 224, 224));
+    unsigned int lCLine = Base::Color::asPackedRGB<QColor>(QColor(224, 224, 224));
     d->colormap.push_back(
         QPair<QString, unsigned int>(QString::fromLatin1(QT_TR_NOOP("Current line highlight")),
                                      lCLine));
@@ -195,14 +195,14 @@ void DlgSettingsEditor::onDisplayItemsCurrentItemChanged(QTreeWidgetItem* item)
 {
     int index = ui->displayItems->indexOfTopLevelItem(item);
     unsigned int col = d->colormap[index].second;
-    ui->colorButton->setColor(App::Color::fromPackedRGB<QColor>(col));
+    ui->colorButton->setColor(Base::Color::fromPackedRGB<QColor>(col));
 }
 
 /** Updates the color map if a color was changed */
 void DlgSettingsEditor::onColorButtonChanged()
 {
     QColor col = ui->colorButton->color();
-    unsigned int lcol = App::Color::asPackedRGB<QColor>(col);
+    unsigned int lcol = Base::Color::asPackedRGB<QColor>(col);
 
     int index = ui->displayItems->indexOfTopLevelItem(ui->displayItems->currentItem());
     d->colormap[index].second = lcol;
@@ -272,7 +272,7 @@ void DlgSettingsEditor::loadSettings()
         auto col = static_cast<unsigned long>(textColor);
         col = hGrp->GetUnsigned(textType.toLatin1(), col);
         textColor = static_cast<unsigned int>(col);
-        QColor color = App::Color::fromPackedRGB<QColor>(col);
+        QColor color = Base::Color::fromPackedRGB<QColor>(col);
         pythonSyntax->setColor(textType, color);
     }
 

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -37,7 +37,7 @@
 #endif
 
 #include <Base/Interpreter.h>
-#include <App/Color.h>
+#include <Base/Color.h>
 
 #include "PythonConsole.h"
 #include "PythonConsolePy.h"
@@ -947,7 +947,7 @@ void PythonConsole::changeEvent(QEvent *e)
     else if (e->type() == QEvent::StyleChange) {
         QPalette pal = qApp->palette();
         QColor color = pal.windowText().color();
-        unsigned int text = App::Color::asPackedRGB<QColor>(color);
+        unsigned int text = Base::Color::asPackedRGB<QColor>(color);
         auto value = static_cast<unsigned long>(text);
         // if this parameter is not already set use the style's window text color
         value = getWindowParameter()->GetUnsigned("Text", value);

--- a/src/Gui/Quarter/SoQTQuarterAdaptor.cpp
+++ b/src/Gui/Quarter/SoQTQuarterAdaptor.cpp
@@ -638,7 +638,7 @@ void SIM::Coin3D::Quarter::SoQTQuarterAdaptor::draw2DString(
     const char* str,
     SbVec2s glsize,
     SbVec2f position,
-    App::Color color = App::Color(1.0F, 1.0F, 0.0F))  // retains yellow as default color
+    Base::Color color = Base::Color(1.0F, 1.0F, 0.0F))  // retains yellow as default color
 {
     // Store GL state.
     glPushAttrib(GL_ENABLE_BIT|GL_CURRENT_BIT);

--- a/src/Gui/Quarter/SoQTQuarterAdaptor.h
+++ b/src/Gui/Quarter/SoQTQuarterAdaptor.h
@@ -27,7 +27,7 @@
 #include <Inventor/lists/SoCallbackList.h>
 #include <Inventor/sensors/SoTimerSensor.h>
 
-#include <App/Color.h>
+#include <Base/Color.h>
 
 #include "QuarterWidget.h"
 
@@ -152,7 +152,7 @@ private:
     SoNode * m_storedcamera = nullptr;
 
 protected:
-    static void draw2DString(const char * str, SbVec2s glsize, SbVec2f position, App::Color color);
+    static void draw2DString(const char * str, SbVec2s glsize, SbVec2f position, Base::Color color);
     static void printString(const char * str);
     SbVec2f framesPerSecond;  // NOLINT
 };

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -32,7 +32,7 @@
 #endif
 
 #include <Base/Interpreter.h>
-#include <App/Color.h>
+#include <Base/Color.h>
 
 #include "ReportView.h"
 #include "Application.h"
@@ -566,7 +566,7 @@ void ReportOutput::changeEvent(QEvent *ev)
     if (ev->type() == QEvent::StyleChange) {
         QPalette pal = qApp->palette();
         QColor color = pal.windowText().color();
-        unsigned int text = App::Color::asPackedRGB<QColor>(color);
+        unsigned int text = Base::Color::asPackedRGB<QColor>(color);
         auto value = static_cast<unsigned long>(text);
         // if this parameter is not already set use the style's window text color
         value = getWindowParameter()->GetUnsigned("colorText", value);
@@ -831,7 +831,7 @@ void ReportOutput::OnChange(Base::Subject<const char*> &rCaller, const char * sR
     }
     else if (strcmp(sReason, "colorText") == 0) {
         unsigned long col = rclGrp.GetUnsigned( sReason );
-        reportHl->setTextColor(App::Color::fromPackedRGB<QColor>(col));
+        reportHl->setTextColor(Base::Color::fromPackedRGB<QColor>(col));
     }
     else if (strcmp(sReason, "colorCriticalText") == 0) {
         unsigned long col = rclGrp.GetUnsigned( sReason );
@@ -839,15 +839,15 @@ void ReportOutput::OnChange(Base::Subject<const char*> &rCaller, const char * sR
     }
     else if (strcmp(sReason, "colorLogging") == 0) {
         unsigned long col = rclGrp.GetUnsigned( sReason );
-        reportHl->setLogColor(App::Color::fromPackedRGB<QColor>(col));
+        reportHl->setLogColor(Base::Color::fromPackedRGB<QColor>(col));
     }
     else if (strcmp(sReason, "colorWarning") == 0) {
         unsigned long col = rclGrp.GetUnsigned( sReason );
-        reportHl->setWarningColor(App::Color::fromPackedRGB<QColor>(col));
+        reportHl->setWarningColor(Base::Color::fromPackedRGB<QColor>(col));
     }
     else if (strcmp(sReason, "colorError") == 0) {
         unsigned long col = rclGrp.GetUnsigned( sReason );
-        reportHl->setErrorColor(App::Color::fromPackedRGB<QColor>(col));
+        reportHl->setErrorColor(Base::Color::fromPackedRGB<QColor>(col));
     }
     else if (strcmp(sReason, "checkGoToEnd") == 0) {
         gotoEnd = rclGrp.GetBool(sReason, gotoEnd);

--- a/src/Gui/Selection/SoFCSelectionContext.cpp
+++ b/src/Gui/Selection/SoFCSelectionContext.cpp
@@ -125,8 +125,8 @@ int SoFCSelectionContext::merge(int status, SoFCSelectionContextBasePtr &output,
 /////////////////////////////////////////////////////////////////////////////////////
 
 bool SoFCSelectionContextEx::setColors(
-        const std::map<std::string,App::Color> &colors, const std::string &element) {
-    std::map<int,App::Color> tmp;
+        const std::map<std::string,Base::Color> &colors, const std::string &element) {
+    std::map<int,Base::Color> tmp;
     auto it = colors.find("");
     if(it!=colors.end())
         tmp[-1] = it->second;
@@ -149,7 +149,7 @@ bool SoFCSelectionContextEx::setColors(
     return true;
 }
 
-uint32_t SoFCSelectionContextEx::packColor(const App::Color &c, bool &hasTransparency) {
+uint32_t SoFCSelectionContextEx::packColor(const Base::Color &c, bool &hasTransparency) {
     float trans = std::max(trans0,c.a);
     if(trans>0)
         hasTransparency = true;

--- a/src/Gui/Selection/SoFCSelectionContext.h
+++ b/src/Gui/Selection/SoFCSelectionContext.h
@@ -105,11 +105,11 @@ using SoFCSelectionContextExPtr = std::shared_ptr<SoFCSelectionContextEx>;
 
 struct GuiExport SoFCSelectionContextEx : SoFCSelectionContext
 {
-    std::map<int,App::Color> colors;
+    std::map<int,Base::Color> colors;
     float trans0 = 0.0;
 
-    bool setColors(const std::map<std::string,App::Color> &colors, const std::string &element);
-    uint32_t packColor(const App::Color &c, bool &hasTransparency);
+    bool setColors(const std::map<std::string,Base::Color> &colors, const std::string &element);
+    uint32_t packColor(const Base::Color &c, bool &hasTransparency);
     bool applyColor(int idx, std::vector<uint32_t> &packedColors, bool &hasTransparency);
     bool isSingleColor(uint32_t &color, bool &hasTransparency);
 

--- a/src/Gui/Selection/SoFCUnifiedSelection.h
+++ b/src/Gui/Selection/SoFCUnifiedSelection.h
@@ -297,7 +297,7 @@ public:
         return overrideColor;
     }
 
-    void setColorOverride(App::Color c) {
+    void setColorOverride(Base::Color c) {
         overrideColor = true;
         colorOverride = SbColor(c.r,c.g,c.b);
         transOverride = c.a;
@@ -425,13 +425,13 @@ public:
         _secondary = enable;
     }
 
-    const std::map<std::string,App::Color> &getColors() const {
+    const std::map<std::string,Base::Color> &getColors() const {
         return _colors;
     }
-    void setColors(const std::map<std::string,App::Color> &colors) {
+    void setColors(const std::map<std::string,Base::Color> &colors) {
         _colors = colors;
     }
-    void swapColors(std::map<std::string,App::Color> &colors) {
+    void swapColors(std::map<std::string,Base::Color> &colors) {
         _colors.swap(colors);
     }
 
@@ -447,7 +447,7 @@ private:
     Type _type;
     SbColor _color;
     const SoDetail* _det{nullptr};
-    std::map<std::string,App::Color> _colors;
+    std::map<std::string,Base::Color> _colors;
     bool _secondary;
 };
 

--- a/src/Gui/SoFCColorBar.cpp
+++ b/src/Gui/SoFCColorBar.cpp
@@ -291,7 +291,7 @@ void SoFCColorBar::customize(SoFCColorBarBase* child)
     }
 }
 
-App::Color SoFCColorBar::getColor( float fVal ) const
+Base::Color SoFCColorBar::getColor( float fVal ) const
 {
     return this->getActiveBar()->getColor( fVal );
 }

--- a/src/Gui/SoFCColorBar.h
+++ b/src/Gui/SoFCColorBar.h
@@ -76,7 +76,7 @@ public:
    *
    * This method must be implemented in subclasses.
    */
-  App::Color getColor(float fVal) const override = 0;
+  Base::Color getColor(float fVal) const override = 0;
   /**
    * Returns always true if the color bar is in mode to show colors to arbitrary values of \a fVal,
    * otherwise true is returned if \a fVal is within the specified parameter range, if not false is
@@ -191,7 +191,7 @@ public:
   /**
    * Returns the associated color to the value \a fVal of the currently active color bar.
    */
-  App::Color getColor(float fVal) const override;
+  Base::Color getColor(float fVal) const override;
   /**
    * Sets whether values outside the range should be in gray,
    */

--- a/src/Gui/SoFCColorGradient.cpp
+++ b/src/Gui/SoFCColorGradient.cpp
@@ -105,7 +105,7 @@ const char* SoFCColorGradient::getColorBarName() const
 
 void SoFCColorGradient::applyFormat(const SoLabelTextFormat& fmt)
 {
-    auto textColor = App::Color(fmt.textColor);
+    auto textColor = Base::Color(fmt.textColor);
 
     for (int j = 0; j < labels->getNumChildren(); j++) {
         if (labels->getChild(j)->getTypeId() == SoBaseColor::getClassTypeId()) {
@@ -131,7 +131,7 @@ void SoFCColorGradient::setMarkerLabel(const SoMFString& label)
         auto trans = new SoTransform;
 
         SoLabelTextFormat fmt = getFormat();
-        auto textColor = App::Color(fmt.textColor);
+        auto textColor = Base::Color(fmt.textColor);
         auto textFont = new SoFont;
         auto color = new SoBaseColor;
         textFont->name.setValue("Helvetica,Arial,Times New Roman");
@@ -356,7 +356,7 @@ SoMaterial* SoFCColorGradient::createMaterial() const
     auto mat = new SoMaterial;
     mat->diffuseColor.setNum(2 * numColors);
     for (int k = 0; k < numColors; k++) {
-        App::Color col = model.colors[numColors - k - 1];
+        Base::Color col = model.colors[numColors - k - 1];
         mat->diffuseColor.set1Value(2 * k, col.r, col.g, col.b);
         mat->diffuseColor.set1Value(2 * k + 1, col.r, col.g, col.b);
     }

--- a/src/Gui/SoFCColorGradient.h
+++ b/src/Gui/SoFCColorGradient.h
@@ -58,7 +58,7 @@ public:
   /**
    * Returns the associated color to the value \a fVal.
    */
-  App::Color getColor (float fVal) const override { return _cColGrad.getColor(fVal); }
+  Base::Color getColor (float fVal) const override { return _cColGrad.getColor(fVal); }
   void setOutsideGrayed (bool bVal) override { _cColGrad.setOutsideGrayed(bVal); }
   /**
    * Returns always true if the gradient is in mode to show colors to arbitrary values of \a fVal,

--- a/src/Gui/SoFCColorLegend.cpp
+++ b/src/Gui/SoFCColorLegend.cpp
@@ -339,7 +339,7 @@ void SoFCColorLegend::setColorLegend(const App::ColorLegend& legend)
     auto mat = new SoMaterial;
     mat->diffuseColor.setNum(intFields);
     for (std::size_t k = 0; k < numFields; k++) {
-        App::Color col = legend.getColor(k);
+        Base::Color col = legend.getColor(k);
         mat->diffuseColor.set1Value(k, col.r, col.g, col.b);
     }
 

--- a/src/Gui/SoFCColorLegend.h
+++ b/src/Gui/SoFCColorLegend.h
@@ -58,7 +58,7 @@ public:
   void setColorLegend (const App::ColorLegend& legend);
 
   unsigned short getColorIndex (float fVal) const { return _currentLegend.getColorIndex(fVal);  }
-  App::Color getColor (float fVal) const override { return _currentLegend.getColor(fVal); }
+  Base::Color getColor (float fVal) const override { return _currentLegend.getColor(fVal); }
   void setOutsideGrayed (bool bVal) override { _currentLegend.setOutsideGrayed(bVal); }
   bool isVisible (float) const override { return false; }
   float getMinValue () const override { return _currentLegend.getMinValue(); }

--- a/src/Gui/TaskElementColors.cpp
+++ b/src/Gui/TaskElementColors.cpp
@@ -190,13 +190,13 @@ public:
 
     void apply()
     {
-        std::map<std::string, App::Color> info;
+        std::map<std::string, Base::Color> info;
         int count = ui->elementList->count();
         for (int i = 0; i < count; ++i) {
             auto item = ui->elementList->item(i);
             auto col = item->data(Qt::UserRole).value<QColor>();
             std::string sub = qPrintable(item->data(Qt::UserRole + 1).value<QString>());
-            info.emplace(sub, App::Color::fromValue<QColor>(col));
+            info.emplace(sub, Base::Color::fromValue<QColor>(col));
         }
         if (!App::GetApplication().getActiveTransaction()) {
             App::GetApplication().setActiveTransaction("Set colors");

--- a/src/Gui/TextEdit.cpp
+++ b/src/Gui/TextEdit.cpp
@@ -36,7 +36,7 @@
 #include "TextEdit.h"
 #include "SyntaxHighlighter.h"
 #include "Tools.h"
-#include <App/Color.h>
+#include <Base/Color.h>
 
 
 using namespace Gui;
@@ -375,7 +375,7 @@ void TextEditor::highlightCurrentLine()
     if (!isReadOnly() && isEnabledHighlightCurrentLine()) {
         QTextEdit::ExtraSelection selection;
         QColor lineColor = d->colormap[QLatin1String("Current line highlight")];
-        unsigned int col = App::Color::asPackedRGB<QColor>(lineColor);
+        unsigned int col = Base::Color::asPackedRGB<QColor>(lineColor);
         ParameterGrp::handle hPrefGrp = getWindowParameter();
         auto value = static_cast<unsigned long>(col);
         value = hPrefGrp->GetUnsigned( "Current line highlight", value);
@@ -457,7 +457,7 @@ void TextEditor::OnChange(Base::Subject<const char*> &rCaller,const char* sReaso
         QMap<QString, QColor>::Iterator it = d->colormap.find(QString::fromLatin1(sReason));
         if (it != d->colormap.end()) {
             QColor color = it.value();
-            unsigned int col = App::Color::asPackedRGB<QColor>(color);
+            unsigned int col = Base::Color::asPackedRGB<QColor>(color);
             auto value = static_cast<unsigned long>(col);
             value = hPrefGrp->GetUnsigned(sReason, value);
             col = static_cast<unsigned int>(value);

--- a/src/Gui/Tools/color_traits.h
+++ b/src/Gui/Tools/color_traits.h
@@ -24,12 +24,12 @@
 #ifndef GUI_COLORTRAITS_H
 #define GUI_COLORTRAITS_H
 
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <Inventor/SbColor.h>
 #include <Inventor/SbColor4f.h>
 #include <QColor>
 
-namespace App
+namespace Base
 {
 // Specialization for SbColor
 template<>
@@ -188,91 +188,6 @@ struct color_traits<SbColor4f>
     void setAlpha(int alpha)
     {
         ct[3] = static_cast<float>(alpha) / 255.0F;
-    }
-    static color_type makeColor(int red, int green, int blue, int alpha = 255)
-    {
-        return color_type{static_cast<float>(red) / 255.0F,
-                          static_cast<float>(green) / 255.0F,
-                          static_cast<float>(blue) / 255.0F,
-                          static_cast<float>(alpha) / 255.0F};
-    }
-
-private:
-    color_type ct;
-};
-
-// Specialization for Color
-template<>
-struct color_traits<App::Color>
-{
-    using color_type = App::Color;
-    color_traits() = default;
-    explicit color_traits(const color_type& ct)
-        : ct(ct)
-    {}
-    float redF() const
-    {
-        return ct.r;
-    }
-    float greenF() const
-    {
-        return ct.g;
-    }
-    float blueF() const
-    {
-        return ct.b;
-    }
-    float alphaF() const
-    {
-        return ct.a;
-    }
-    void setRedF(float red)
-    {
-        ct.r = red;
-    }
-    void setGreenF(float green)
-    {
-        ct.g = green;
-    }
-    void setBlueF(float blue)
-    {
-        ct.b = blue;
-    }
-    void setAlphaF(float alpha)
-    {
-        ct.a = alpha;
-    }
-    int red() const
-    {
-        return int(std::lround(ct.r * 255.0F));
-    }
-    int green() const
-    {
-        return int(std::lround(ct.g * 255.0F));
-    }
-    int blue() const
-    {
-        return int(std::lround(ct.b * 255.0F));
-    }
-    int alpha() const
-    {
-        return int(std::lround(ct.a * 255.0F));
-    }
-    void setRed(int red)
-    {
-        ct.r = static_cast<float>(red) / 255.0F;
-    }
-    void setGreen(int green)
-    {
-        ct.g = static_cast<float>(green) / 255.0F;
-    }
-    void setBlue(int blue)
-    {
-        ct.b = static_cast<float>(blue) / 255.0F;
-    }
-    void setAlpha(int alpha)
-    {
-        ct.a = static_cast<float>(alpha) / 255.0F;
     }
     static color_type makeColor(int red, int green, int blue, int alpha = 255)
     {

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -46,7 +46,7 @@
 #include <Base/Tools.h>
 #include <Base/Writer.h>
 
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <App/Document.h>
 #include <App/DocumentObjectGroup.h>
 #include <App/AutoTransaction.h>
@@ -109,7 +109,7 @@ static bool isSelectionCheckBoxesEnabled() {
 void TreeParams::onItemBackgroundChanged()
 {
     if (getItemBackground()) {
-        App::Color color;
+        Base::Color color;
         color.setPackedValue(getItemBackground());
         QColor col;
         col.setRedF(color.r);
@@ -3812,7 +3812,7 @@ void DocumentItem::slotInEdit(const Gui::ViewProviderDocumentObject& v)
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/TreeView");
     unsigned long col = hGrp->GetUnsigned("TreeEditColor", 563609599);
-    QColor color(App::Color::fromPackedRGB<QColor>(col));
+    QColor color(Base::Color::fromPackedRGB<QColor>(col));
 
     if (!getTree()->editingItem) {
         auto doc = Application::Instance->editDocument();
@@ -5255,7 +5255,7 @@ void DocumentObjectItem::setHighlight(bool set, Gui::HighlightMode high) {
             f.setOverline(overlined);
 
             unsigned long col = hGrp->GetUnsigned("TreeActiveColor", 1538528255);
-            color = App::Color::fromPackedRGB<QColor>(col);
+            color = Base::Color::fromPackedRGB<QColor>(col);
         }
         else {
             f.setBold(false);

--- a/src/Gui/Utilities.h
+++ b/src/Gui/Utilities.h
@@ -94,8 +94,8 @@ private:
 
 // Specialization for Color
 template <>
-struct vec_traits<App::Color> {
-    using vec_type = App::Color;
+struct vec_traits<Base::Color> {
+    using vec_type = Base::Color;
     using float_type = float;
     explicit vec_traits(const vec_type& v) : v(v){}
     inline std::tuple<float_type,float_type,float_type> get() const {

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1432,7 +1432,7 @@ void View3DInventorViewer::showRotationCenter(bool show)
                     .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
                     ->GetUnsigned("RotationCenterColor", 4278190131);  // NOLINT
 
-            QColor color = App::Color::fromPackedRGBA<QColor>(rotationCenterColor);
+            QColor color = Base::Color::fromPackedRGBA<QColor>(rotationCenterColor);
 
             rotationCenterGroup = new SoSkipBoundingGroup();
 
@@ -2461,7 +2461,7 @@ void View3DInventorViewer::renderScene()
         draw2DString(stream.str().c_str(),
                      SbVec2s(10, 10),
                      SbVec2f((overlayLeftWidgets.empty() ? 0.1f : 1.1f), 0.1f),
-                     App::Color(static_cast<uint32_t>(axisLetterColor)));  // NOLINT
+                     Base::Color(static_cast<uint32_t>(axisLetterColor)));  // NOLINT
     }
 
     if (naviCubeEnabled) {
@@ -3748,11 +3748,11 @@ void View3DInventorViewer::updateColors()
     unsigned long colorLong;
 
     colorLong = Gui::ViewParams::instance()->getAxisXColor();
-    m_xColor = App::Color(static_cast<uint32_t>(colorLong));
+    m_xColor = Base::Color(static_cast<uint32_t>(colorLong));
     colorLong = Gui::ViewParams::instance()->getAxisYColor();
-    m_yColor = App::Color(static_cast<uint32_t>(colorLong));
+    m_yColor = Base::Color(static_cast<uint32_t>(colorLong));
     colorLong = Gui::ViewParams::instance()->getAxisZColor();
-    m_zColor = App::Color(static_cast<uint32_t>(colorLong));
+    m_zColor = Base::Color(static_cast<uint32_t>(colorLong));
 
     naviCube->updateColors();
 

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -534,9 +534,9 @@ private:
     bool vboEnabled;
     bool naviCubeEnabled;
 
-    App::Color m_xColor;
-    App::Color m_yColor;
-    App::Color m_zColor;
+    Base::Color m_xColor;
+    Base::Color m_yColor;
+    Base::Color m_zColor;
 
     bool editing;
     QCursor editCursor, zoomCursor, panCursor, spinCursor;

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -30,7 +30,7 @@
 #endif
 
 #include <Base/Builder3D.h>
-#include <App/Color.h>
+#include <Base/Color.h>
 
 #include "NaviCube.h"
 #include "Navigation/NavigationStyle.h"
@@ -542,19 +542,19 @@ void NaviCubeSettings::parameterChanged(const char* Name)
     }
     else if (strcmp(Name, "BaseColor") == 0) {
         unsigned long col = hGrp->GetUnsigned("BaseColor", 3806916544);
-        nc->setBaseColor(App::Color::fromPackedRGBA<QColor>(col));
+        nc->setBaseColor(Base::Color::fromPackedRGBA<QColor>(col));
         // update default contrast colors
         parameterChanged("EmphaseColor");
     }
     else if (strcmp(Name, "EmphaseColor") == 0) {
-        App::Color bc((uint32_t)hGrp->GetUnsigned("BaseColor", 3806916544));
+        Base::Color bc((uint32_t)hGrp->GetUnsigned("BaseColor", 3806916544));
         unsigned long d = bc.r + bc.g + bc.b >= 1.5f ? 255 : 4294967295;
         unsigned long col = hGrp->GetUnsigned("EmphaseColor", d);
-        nc->setEmphaseColor(App::Color::fromPackedRGBA<QColor>(col));
+        nc->setEmphaseColor(Base::Color::fromPackedRGBA<QColor>(col));
     }
     else if (strcmp(Name, "HiliteColor") == 0) {
         unsigned long col = hGrp->GetUnsigned("HiliteColor", 2867003391);
-        nc->setHiliteColor(App::Color::fromPackedRGBA<QColor>(col));
+        nc->setHiliteColor(Base::Color::fromPackedRGBA<QColor>(col));
     }
     else if (strcmp(Name, "BorderWidth") == 0) {
         nc->setBorderWidth(hGrp->GetFloat("BorderWidth", 1.1));

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -58,8 +58,6 @@ class QObject;
 
 namespace Base {
   class Matrix4D;
-}
-namespace App {
   class Color;
 }
 
@@ -418,11 +416,11 @@ public:
     /** @name Color management methods
      */
     //@{
-    virtual std::map<std::string, App::Color> getElementColors(const char *element=nullptr) const {
+    virtual std::map<std::string, Base::Color> getElementColors(const char *element=nullptr) const {
         (void)element;
         return {};
     }
-    virtual void setElementColors(const std::map<std::string, App::Color> &colors) {
+    virtual void setElementColors(const std::map<std::string, Base::Color> &colors) {
         (void)colors;
     }
     static const std::string &hiddenMarker();

--- a/src/Gui/ViewProviderAnnotation.cpp
+++ b/src/Gui/ViewProviderAnnotation.cpp
@@ -116,7 +116,7 @@ ViewProviderAnnotation::~ViewProviderAnnotation()
 void ViewProviderAnnotation::onChanged(const App::Property* prop)
 {
     if (prop == &TextColor) {
-        const App::Color& c = TextColor.getValue();
+        const Base::Color& c = TextColor.getValue();
         pColor->rgb.setValue(c.r,c.g,c.b);
     }
     else if (prop == &Justification) {
@@ -315,7 +315,7 @@ ViewProviderAnnotationLabel::~ViewProviderAnnotationLabel()
 void ViewProviderAnnotationLabel::onChanged(const App::Property* prop)
 {
     if (prop == &BackgroundColor) {
-        const App::Color& c = BackgroundColor.getValue();
+        const Base::Color& c = BackgroundColor.getValue();
         pColor->rgb.setValue(c.r,c.g,c.b);
     }
     if (prop == &TextColor || prop == &BackgroundColor ||
@@ -454,10 +454,10 @@ void ViewProviderAnnotationLabel::drawImage(const std::vector<std::string>& s)
     QFontMetrics fm(font);
     int w = 0;
     int h = fm.height() * s.size();
-    const App::Color& b = this->BackgroundColor.getValue();
+    const Base::Color& b = this->BackgroundColor.getValue();
     QColor brush;
     brush.setRgbF(b.r,b.g,b.b);
-    const App::Color& t = this->TextColor.getValue();
+    const Base::Color& t = this->TextColor.getValue();
     QColor front;
     front.setRgbF(t.r,t.g,t.b);
 

--- a/src/Gui/ViewProviderBuilder.cpp
+++ b/src/Gui/ViewProviderBuilder.cpp
@@ -97,7 +97,7 @@ ViewProviderColorBuilder::~ViewProviderColorBuilder() = default;
 void ViewProviderColorBuilder::buildNodes(const App::Property* prop, std::vector<SoNode*>& node) const
 {
     const auto color = static_cast<const App::PropertyColorList*>(prop);
-    const std::vector<App::Color>& val = color->getValues();
+    const std::vector<Base::Color>& val = color->getValues();
     unsigned long i=0;
 
     auto material = new SoMaterial();

--- a/src/Gui/ViewProviderFeature.cpp
+++ b/src/Gui/ViewProviderFeature.cpp
@@ -34,7 +34,7 @@ PROPERTY_SOURCE(Gui::ViewProviderFeature, Gui::ViewProviderDocumentObject)
 
 ViewProviderFeature::ViewProviderFeature()
 {
-    App::Color c;
+    Base::Color c;
     ADD_PROPERTY(ColourList,(c));
 }
 

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -997,7 +997,7 @@ void LinkView::setMaterial(int index, const App::Material *material) {
             pcLinkRoot->removeColorOverride();
             return;
         }
-        App::Color c = material->diffuseColor;
+        Base::Color c = material->diffuseColor;
         c.setTransparency(material->transparency);
         pcLinkRoot->setColorOverride(c);
         for(int i=0;i<getSize();++i)
@@ -1010,7 +1010,7 @@ void LinkView::setMaterial(int index, const App::Material *material) {
             info.pcRoot->removeColorOverride();
             return;
         }
-        App::Color c = material->diffuseColor;
+        Base::Color c = material->diffuseColor;
         c.setTransparency(material->transparency);
         info.pcRoot->setColorOverride(c);
     }
@@ -2933,7 +2933,7 @@ PyObject *ViewProviderLink::getPyLinkView() {
     return linkView->getPyObject();
 }
 
-std::map<std::string, App::Color> ViewProviderLink::getElementColors(const char *subname) const {
+std::map<std::string, Base::Color> ViewProviderLink::getElementColors(const char *subname) const {
     bool isPrefix = true;
     if(!subname)
         subname = "";
@@ -2941,7 +2941,7 @@ std::map<std::string, App::Color> ViewProviderLink::getElementColors(const char 
         auto len = strlen(subname);
         isPrefix = !len || subname[len-1]=='.';
     }
-    std::map<std::string, App::Color> colors;
+    std::map<std::string, Base::Color> colors;
     auto ext = getLinkExtension();
     if(!ext || ! ext->getColoredElementsProperty())
         return colors;
@@ -2951,7 +2951,7 @@ std::map<std::string, App::Color> ViewProviderLink::getElementColors(const char 
     std::string wildcard(subname);
     if(wildcard == "Face" || wildcard == "Face*" || wildcard.empty()) {
         if(wildcard.size()==4 || OverrideMaterial.getValue()) {
-            App::Color c = ShapeMaterial.getValue().diffuseColor;
+            Base::Color c = ShapeMaterial.getValue().diffuseColor;
             c.setTransparency(ShapeMaterial.getValue().transparency);
             colors["Face"] = c;
             if(wildcard.size()==4)
@@ -3072,9 +3072,9 @@ std::map<std::string, App::Color> ViewProviderLink::getElementColors(const char 
     bool found = true;
     if(colors.empty()) {
         found = false;
-        colors.emplace(subname,App::Color());
+        colors.emplace(subname,Base::Color());
     }
-    std::map<std::string, App::Color> ret;
+    std::map<std::string, Base::Color> ret;
     for(const auto &v : colors) {
         const char *pos = nullptr;
         auto sobj = getObject()->resolve(v.first.c_str(),nullptr,nullptr,&pos);
@@ -3098,18 +3098,18 @@ std::map<std::string, App::Color> ViewProviderLink::getElementColors(const char 
     return ret;
 }
 
-void ViewProviderLink::setElementColors(const std::map<std::string, App::Color> &colorMap) {
+void ViewProviderLink::setElementColors(const std::map<std::string, Base::Color> &colorMap) {
     auto ext = getLinkExtension();
     if(!ext || ! ext->getColoredElementsProperty())
         return;
 
     // For checking and collapsing array element color
-    std::map<std::string,std::map<int,App::Color> > subMap;
+    std::map<std::string,std::map<int,Base::Color> > subMap;
     int element_count = ext->getElementCountValue();
 
     std::vector<std::string> subs;
-    std::vector<App::Color> colors;
-    App::Color faceColor;
+    std::vector<Base::Color> colors;
+    Base::Color faceColor;
     bool hasFaceColor = false;
     for(const auto &v : colorMap) {
         if(!hasFaceColor && v.first == "Face") {
@@ -3133,7 +3133,7 @@ void ViewProviderLink::setElementColors(const std::map<std::string, App::Color> 
     }
     for(auto &v : subMap) {
         if(element_count == (int)v.second.size()) {
-            App::Color firstColor = v.second.begin()->second;
+            Base::Color firstColor = v.second.begin()->second;
             subs.push_back(v.first);
             colors.push_back(firstColor);
             for(auto it=v.second.begin();it!=v.second.end();) {
@@ -3179,7 +3179,7 @@ void ViewProviderLink::applyColors() {
     // reset color and visibility first
     action.apply(linkView->getLinkRoot());
 
-    std::map<std::string, std::map<std::string,App::Color> > colorMap;
+    std::map<std::string, std::map<std::string,Base::Color> > colorMap;
     std::set<std::string> hideList;
     auto colors = getElementColors();
     colors.erase("Face");

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -248,8 +248,8 @@ public:
 
     static void updateLinks(ViewProvider *vp);
 
-    std::map<std::string, App::Color> getElementColors(const char *subname=nullptr) const override;
-    void setElementColors(const std::map<std::string, App::Color> &colors) override;
+    std::map<std::string, Base::Color> getElementColors(const char *subname=nullptr) const override;
+    void setElementColors(const std::map<std::string, Base::Color> &colors) override;
 
     void setOverrideMode(const std::string &mode) override;
 

--- a/src/Gui/ViewProviderPyImp.cpp
+++ b/src/Gui/ViewProviderPyImp.cpp
@@ -484,7 +484,7 @@ PyObject* ViewProviderPy::setElementColors(PyObject* args)
     if(!PyDict_Check(pyObj))
         throw Py::TypeError("Expect a dict");
 
-    std::map<std::string,App::Color> colors;
+    std::map<std::string,Base::Color> colors;
     Py::Dict dict(pyObj);
     for(auto it=dict.begin();it!=dict.end();++it) {
         const auto &value = *it;

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -671,7 +671,7 @@ QColor ColorButton::color() const
  */
 void ColorButton::setPackedColor(uint32_t c)
 {
-    App::Color color;
+    Base::Color color;
     color.setPackedValue(c);
     d->col.setRedF(color.r);
     d->col.setGreenF(color.g);
@@ -686,7 +686,7 @@ void ColorButton::setPackedColor(uint32_t c)
  */
 uint32_t ColorButton::packedColor() const
 {
-    App::Color color(d->col.redF(), d->col.greenF(), d->col.blueF(), d->col.alphaF());
+    Base::Color color(d->col.redF(), d->col.greenF(), d->col.blueF(), d->col.alphaF());
     return color.getPackedValue();
 }
 
@@ -1009,7 +1009,7 @@ void StatefulLabel::setState(QString state)
                 if (unsignedEntry.first == entry->second.preferenceString) {
                     // Convert the stored Uint into usable color data:
                     unsigned int col = unsignedEntry.second;
-                    QColor qcolor(App::Color::fromPackedRGB<QColor>(col));
+                    QColor qcolor(Base::Color::fromPackedRGB<QColor>(col));
                     this->setStyleSheet(QStringLiteral("Gui--StatefulLabel{ color : rgba(%1,%2,%3,%4) ;}").arg(qcolor.red()).arg(qcolor.green()).arg(qcolor.blue()).arg(qcolor.alpha()));
                     _styleCache[state] = this->styleSheet();
                     return;

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -3453,7 +3453,7 @@ QVariant PropertyColorItem::value(const App::Property* prop) const
 {
     assert(prop && prop->isDerivedFrom<App::PropertyColor>());
 
-    App::Color value = static_cast<const App::PropertyColor*>(prop)->getValue();
+    Base::Color value = static_cast<const App::PropertyColor*>(prop)->getValue();
     return QVariant(value.asValue<QColor>());
 }
 
@@ -3777,13 +3777,13 @@ void PropertyMaterialItem::setValue(const QVariant& value)
     }
 
     auto mat = value.value<Material>();
-    App::Color dc;
+    Base::Color dc;
     dc.setValue<QColor>(mat.diffuseColor);
-    App::Color ac;
+    Base::Color ac;
     ac.setValue<QColor>(mat.ambientColor);
-    App::Color sc;
+    Base::Color sc;
     sc.setValue<QColor>(mat.specularColor);
-    App::Color ec;
+    Base::Color ec;
     ec.setValue<QColor>(mat.emissiveColor);
     float s = mat.shininess;
     float t = mat.transparency;
@@ -4284,13 +4284,13 @@ void PropertyMaterialListItem::setValue(const QVariant& value)
     str << "(";
 
     auto mat = list[0].value<Material>();
-    App::Color dc;
+    Base::Color dc;
     dc.setValue<QColor>(mat.diffuseColor);
-    App::Color ac;
+    Base::Color ac;
     ac.setValue<QColor>(mat.ambientColor);
-    App::Color sc;
+    Base::Color sc;
     sc.setValue<QColor>(mat.specularColor);
-    App::Color ec;
+    Base::Color ec;
     ec.setValue<QColor>(mat.emissiveColor);
     float s = mat.shininess;
     float t = mat.transparency;

--- a/src/Mod/CAM/Gui/ViewProviderPath.cpp
+++ b/src/Mod/CAM/Gui/ViewProviderPath.cpp
@@ -387,7 +387,7 @@ void ViewProviderPath::onChanged(const App::Property* prop)
     }
     else if (prop == &NormalColor) {
         if (!colorindex.empty() && coordStart >= 0 && coordStart < (int)colorindex.size()) {
-            const App::Color& c = NormalColor.getValue();
+            const Base::Color& c = NormalColor.getValue();
             ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
                 "User parameter:BaseApp/Preferences/Mod/CAM");
             unsigned long rcol =
@@ -429,7 +429,7 @@ void ViewProviderPath::onChanged(const App::Property* prop)
         }
     }
     else if (prop == &MarkerColor) {
-        const App::Color& c = MarkerColor.getValue();
+        const Base::Color& c = MarkerColor.getValue();
         pcMarkerColor->rgb.setValue(c.r, c.g, c.b);
     }
     else if (prop == &ShowNodes) {

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -636,7 +636,7 @@ def getrgb(color):
 
     Parameters
     ----------
-    color : App::Color::Color
+    color : Base::Color::Color
         FreeCAD color.
 
     Returns

--- a/src/Mod/Drawing/App/FeatureViewAnnotation.cpp
+++ b/src/Mod/Drawing/App/FeatureViewAnnotation.cpp
@@ -58,7 +58,7 @@ FeatureViewAnnotation::~FeatureViewAnnotation()
 App::DocumentObjectExecReturn* FeatureViewAnnotation::execute(void)
 {
     stringstream result, hr, hg, hb;
-    const App::Color& c = TextColor.getValue();
+    const Base::Color& c = TextColor.getValue();
     hr << hex << setfill('0') << setw(2) << (int)(255.0 * c.r);
     hg << hex << setfill('0') << setw(2) << (int)(255.0 * c.g);
     hb << hex << setfill('0') << setw(2) << (int)(255.0 * c.b);

--- a/src/Mod/Drawing/App/FeatureViewSpreadsheet.cpp
+++ b/src/Mod/Drawing/App/FeatureViewSpreadsheet.cpp
@@ -153,7 +153,7 @@ App::DocumentObjectExecReturn* FeatureViewSpreadsheet::execute(void)
     // create the containing group
     std::string ViewName = Label.getValue();
     std::stringstream result, hr, hg, hb;
-    const App::Color& c = Color.getValue();
+    const Base::Color& c = Color.getValue();
     hr << std::hex << std::setfill('0') << std::setw(2) << (int)(255.0 * c.r);
     hg << std::hex << std::setfill('0') << std::setw(2) << (int)(255.0 * c.g);
     hb << std::hex << std::setfill('0') << std::setw(2) << (int)(255.0 * c.b);
@@ -207,7 +207,7 @@ App::DocumentObjectExecReturn* FeatureViewSpreadsheet::execute(void)
             std::string textstyle = "";
             Spreadsheet::Cell* cell = sheet->getCell(address);
             if (cell) {
-                App::Color f, b;
+                Base::Color f, b;
                 std::set<std::string> st;
                 int colspan, rowspan;
                 if (cell->getBackground(b)) {

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.cpp
@@ -67,7 +67,7 @@ void ViewProviderFemConstraintOnBoundary::highlightReferences(const bool on)
                 if (originalPointColors[base].empty()) {
                     originalPointColors[base] = vp->PointColorArray.getValues();
                 }
-                std::vector<App::Color> colors = originalPointColors[base];
+                std::vector<Base::Color> colors = originalPointColors[base];
 
                 // go through the subelements with constraint and recolor them
                 // TODO: Replace `ShapeAppearance` with anything more appropriate
@@ -82,7 +82,7 @@ void ViewProviderFemConstraintOnBoundary::highlightReferences(const bool on)
                 if (originalLineColors[base].empty()) {
                     originalLineColors[base] = vp->LineColorArray.getValues();
                 }
-                std::vector<App::Color> colors = originalLineColors[base];
+                std::vector<Base::Color> colors = originalLineColors[base];
 
                 // go through the subelements with constraint and recolor them
                 // TODO: Replace `ShapeAppearance` with anything more appropriate
@@ -97,7 +97,7 @@ void ViewProviderFemConstraintOnBoundary::highlightReferences(const bool on)
                 if (originalFaceColors[base].empty()) {
                     originalFaceColors[base] = vp->ShapeAppearance.getDiffuseColors();
                 }
-                std::vector<App::Color> colors = originalFaceColors[base];
+                std::vector<Base::Color> colors = originalFaceColors[base];
 
                 // go through the subelements with constraint and recolor them
                 // TODO: Replace shape DiffuseColor with anything more appropriate

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.h
@@ -46,9 +46,9 @@ public:
     void highlightReferences(const bool on) override;
 
 private:
-    std::map<Part::Feature*, std::vector<App::Color>> originalPointColors;
-    std::map<Part::Feature*, std::vector<App::Color>> originalLineColors;
-    std::map<Part::Feature*, std::vector<App::Color>> originalFaceColors;
+    std::map<Part::Feature*, std::vector<Base::Color>> originalPointColors;
+    std::map<Part::Feature*, std::vector<Base::Color>> originalLineColors;
+    std::map<Part::Feature*, std::vector<Base::Color>> originalFaceColors;
 };
 
 }  // namespace FemGui

--- a/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
@@ -192,13 +192,13 @@ ViewProviderFemMesh::ViewProviderFemMesh()
 {
     sPixmap = "fem-femmesh-from-shape";
 
-    ADD_PROPERTY(PointColor, (App::Color(0.7f, 0.7f, 0.7f)));
+    ADD_PROPERTY(PointColor, (Base::Color(0.7f, 0.7f, 0.7f)));
     ADD_PROPERTY(PointSize, (5.0f));
     PointSize.setConstraints(&floatRange);
     ADD_PROPERTY(LineWidth, (1.0f));
     LineWidth.setConstraints(&floatRange);
 
-    ShapeAppearance.setDiffuseColor(App::Color(1.0f, 0.7f, 0.0f));
+    ShapeAppearance.setDiffuseColor(Base::Color(1.0f, 0.7f, 0.0f));
     Transparency.setValue(0);
     ADD_PROPERTY(BackfaceCulling, (true));
     ADD_PROPERTY(ShowInner, (false));
@@ -412,7 +412,7 @@ void ViewProviderFemMesh::onChanged(const App::Property* prop)
         pcPointStyle->pointSize = PointSize.getValue();
     }
     else if (prop == &PointColor) {
-        const App::Color& c = PointColor.getValue();
+        const Base::Color& c = PointColor.getValue();
         pcPointMaterial->diffuseColor.setValue(c.r, c.g, c.b);
     }
     else if (prop == &BackfaceCulling) {
@@ -683,11 +683,11 @@ void ViewProviderFemMesh::applyDisplacementToNodes(double factor)
 }
 
 void ViewProviderFemMesh::setColorByNodeId(const std::vector<long>& NodeIds,
-                                           const std::vector<App::Color>& NodeColors)
+                                           const std::vector<Base::Color>& NodeColors)
 {
     long endId = *(std::max_element(NodeIds.begin(), NodeIds.end()));
 
-    std::vector<App::Color> colorVec(endId + 1, App::Color(0, 1, 0));
+    std::vector<Base::Color> colorVec(endId + 1, Base::Color(0, 1, 0));
     long i = 0;
     for (std::vector<long>::const_iterator it = NodeIds.begin(); it != NodeIds.end(); ++it, i++) {
         colorVec[*it] = NodeColors[i];
@@ -696,7 +696,7 @@ void ViewProviderFemMesh::setColorByNodeId(const std::vector<long>& NodeIds,
     setColorByNodeIdHelper(colorVec);
 }
 
-void ViewProviderFemMesh::setColorByNodeIdHelper(const std::vector<App::Color>& colorVec)
+void ViewProviderFemMesh::setColorByNodeIdHelper(const std::vector<Base::Color>& colorVec)
 {
     pcMatBinding->value = SoMaterialBinding::PER_VERTEX_INDEXED;
 
@@ -716,43 +716,43 @@ void ViewProviderFemMesh::setColorByNodeIdHelper(const std::vector<App::Color>& 
 
 void ViewProviderFemMesh::resetColorByNodeId()
 {
-    const App::Color& c = ShapeAppearance.getDiffuseColor();
+    const Base::Color& c = ShapeAppearance.getDiffuseColor();
     NodeColorArray.setValue(c);
 }
 
 void ViewProviderFemMesh::setColorByNodeId(
-    const std::map<std::vector<long>, App::Color>& elemColorMap)
+    const std::map<std::vector<long>, Base::Color>& elemColorMap)
 {
     setColorByIdHelper(elemColorMap, vNodeElementIdx, 0, NodeColorArray);
 }
 
 void ViewProviderFemMesh::setColorByElementId(
-    const std::map<std::vector<long>, App::Color>& elemColorMap)
+    const std::map<std::vector<long>, Base::Color>& elemColorMap)
 {
     setColorByIdHelper(elemColorMap, vFaceElementIdx, 3, ElementColorArray);
 }
 
 void ViewProviderFemMesh::setColorByIdHelper(
-    const std::map<std::vector<long>, App::Color>& elemColorMap,
+    const std::map<std::vector<long>, Base::Color>& elemColorMap,
     const std::vector<unsigned long>& vElementIdx,
     int rShift,
     App::PropertyColorList& prop)
 {
-    std::vector<App::Color> vecColor(vElementIdx.size());
-    std::map<long, const App::Color*> colorMap;
+    std::vector<Base::Color> vecColor(vElementIdx.size());
+    std::map<long, const Base::Color*> colorMap;
     for (const auto& m : elemColorMap) {
         for (long i : m.first) {
             colorMap[i] = &m.second;
         }
     }
 
-    App::Color baseDif = ShapeAppearance.getDiffuseColor();
+    Base::Color baseDif = ShapeAppearance.getDiffuseColor();
     int i = 0;
     for (std::vector<unsigned long>::const_iterator it = vElementIdx.begin();
          it != vElementIdx.end();
          ++it, i++) {
         unsigned long ElemIdx = ((*it) >> rShift);
-        const std::map<long, const App::Color*>::const_iterator pos = colorMap.find(ElemIdx);
+        const std::map<long, const Base::Color*>::const_iterator pos = colorMap.find(ElemIdx);
         vecColor[i] = pos == colorMap.end() ? baseDif : *pos->second;
     }
 
@@ -762,10 +762,10 @@ void ViewProviderFemMesh::setColorByIdHelper(
 void ViewProviderFemMesh::setMaterialOverall() const
 {
     const App::Material& mat = ShapeAppearance[0];
-    App::Color baseDif = mat.diffuseColor;
-    App::Color baseAmb = mat.ambientColor;
-    App::Color baseSpe = mat.specularColor;
-    App::Color baseEmi = mat.emissiveColor;
+    Base::Color baseDif = mat.diffuseColor;
+    Base::Color baseAmb = mat.ambientColor;
+    Base::Color baseSpe = mat.specularColor;
+    Base::Color baseEmi = mat.emissiveColor;
     float baseShi = mat.shininess;
     float baseTra = mat.transparency;
 
@@ -793,15 +793,15 @@ void ViewProviderFemMesh::setMaterialByColorArray(
     const std::vector<unsigned long>& vElementIdx) const
 {
     const App::Material& baseMat = ShapeAppearance[0];
-    App::Color baseDif = baseMat.diffuseColor;
-    App::Color baseAmb = baseMat.ambientColor;
-    App::Color baseSpe = baseMat.specularColor;
-    App::Color baseEmi = baseMat.emissiveColor;
+    Base::Color baseDif = baseMat.diffuseColor;
+    Base::Color baseAmb = baseMat.ambientColor;
+    Base::Color baseSpe = baseMat.specularColor;
+    Base::Color baseEmi = baseMat.emissiveColor;
     float baseShi = baseMat.shininess;
     float baseTra = baseMat.transparency;
 
     // resizing and writing the color vector:
-    std::vector<App::Color> vecColor = prop->getValue();
+    std::vector<Base::Color> vecColor = prop->getValue();
     size_t elemSize = vElementIdx.size();
     if (vecColor.size() == 1) {
         pcMatBinding->value = SoMaterialBinding::OVERALL;
@@ -844,7 +844,7 @@ void ViewProviderFemMesh::setMaterialByColorArray(
     vecColor.resize(elemSize, baseDif);
 
     int i = 0;
-    for (const App::Color& c : vecColor) {
+    for (const Base::Color& c : vecColor) {
         diffuse[i] = SbColor(c.r, c.g, c.b);
         ambient[i] = SbColor(baseAmb.r, baseAmb.g, baseAmb.b);
         specular[i] = SbColor(baseSpe.r, baseSpe.g, baseSpe.b);
@@ -866,7 +866,7 @@ void ViewProviderFemMesh::setMaterialByColorArray(
 
 void ViewProviderFemMesh::resetColorByElementId()
 {
-    const App::Color& c = ShapeAppearance.getDiffuseColor();
+    const Base::Color& c = ShapeAppearance.getDiffuseColor();
     ElementColorArray.setValue(c);
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemMesh.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemMesh.h
@@ -114,9 +114,9 @@ public:
     //@{
 
     /// set the color for each node
-    void setColorByNodeId(const std::map<std::vector<long>, App::Color>& NodeColorMap);
+    void setColorByNodeId(const std::map<std::vector<long>, Base::Color>& NodeColorMap);
     void setColorByNodeId(const std::vector<long>& NodeIds,
-                          const std::vector<App::Color>& NodeColors);
+                          const std::vector<Base::Color>& NodeColors);
 
     /// reset the view of the node colors
     void resetColorByNodeId();
@@ -129,7 +129,7 @@ public:
     /// reaply the node displacement with a certain factor and do a redraw
     void applyDisplacementToNodes(double factor);
     /// set the color for each element
-    void setColorByElementId(const std::map<std::vector<long>, App::Color>& ElementColorMap);
+    void setColorByElementId(const std::map<std::vector<long>, Base::Color>& ElementColorMap);
     /// reset the view of the element colors
     void resetColorByElementId();
     void setMaterialByElement();
@@ -151,9 +151,9 @@ protected:
     /// get called by the container whenever a property has been changed
     void onChanged(const App::Property* prop) override;
 
-    void setColorByNodeIdHelper(const std::vector<App::Color>&);
+    void setColorByNodeIdHelper(const std::vector<Base::Color>&);
     void setDisplacementByNodeIdHelper(const std::vector<Base::Vector3d>& DispVector, long startId);
-    void setColorByIdHelper(const std::map<std::vector<long>, App::Color>& elemColorMap,
+    void setColorByIdHelper(const std::map<std::vector<long>, Base::Color>& elemColorMap,
                             const std::vector<unsigned long>& vElementIdx,
                             int rShift,
                             App::PropertyColorList& prop);

--- a/src/Mod/Fem/Gui/ViewProviderFemMeshPyImp.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemMeshPyImp.cpp
@@ -41,7 +41,7 @@ PyObject* ViewProviderFemMeshPy::applyDisplacement(PyObject* args)
 }
 
 
-App::Color calcColor(double value, double min, double max)
+Base::Color calcColor(double value, double min, double max)
 {
     if (max < 0) {
         max = 0;
@@ -51,27 +51,27 @@ App::Color calcColor(double value, double min, double max)
     }
 
     if (value < min) {
-        return App::Color(0.0, 0.0, 1.0);
+        return Base::Color(0.0, 0.0, 1.0);
     }
     if (value > max) {
-        return App::Color(1.0, 0.0, 0.0);
+        return Base::Color(1.0, 0.0, 0.0);
     }
     if (value == 0.0) {
-        return App::Color(0.0, 1.0, 0.0);
+        return Base::Color(0.0, 1.0, 0.0);
     }
     if (value > max / 2.0) {
-        return App::Color(1.0, 1 - ((value - (max / 2.0)) / (max / 2.0)), 0.0);
+        return Base::Color(1.0, 1 - ((value - (max / 2.0)) / (max / 2.0)), 0.0);
     }
     if (value > 0.0) {
-        return App::Color(value / (max / 2.0), 1.0, 0.0);
+        return Base::Color(value / (max / 2.0), 1.0, 0.0);
     }
     if (value < min / 2.0) {
-        return App::Color(0.0, 1 - ((value - (min / 2.0)) / (min / 2.0)), 1.0);
+        return Base::Color(0.0, 1 - ((value - (min / 2.0)) / (min / 2.0)), 1.0);
     }
     if (value < 0.0) {
-        return App::Color(0.0, 1.0, value / (min / 2.0));
+        return Base::Color(0.0, 1.0, value / (min / 2.0));
     }
-    return App::Color(0, 0, 0);
+    return Base::Color(0, 0, 0);
 }
 
 
@@ -90,7 +90,7 @@ PyObject* ViewProviderFemMeshPy::setNodeColorByScalars(PyObject* args)
             PyErr_SetString(PyExc_ValueError, "PyList_Size < 0. That is not a valid list!");
             Py_Return;
         }
-        std::vector<App::Color> node_colors(num_items);
+        std::vector<Base::Color> node_colors(num_items);
         for (int i = 0; i < num_items; i++) {
             PyObject* id_py = PyList_GetItem(node_ids_py, i);
             long id = PyLong_AsLong(id_py);
@@ -182,9 +182,9 @@ Py::Dict ViewProviderFemMeshPy::getNodeColor() const
 namespace
 {
 
-std::map<std::vector<long>, App::Color> colorMapFromDict(Py::Dict& arg)
+std::map<std::vector<long>, Base::Color> colorMapFromDict(Py::Dict& arg)
 {
-    std::map<std::vector<long>, App::Color> colorMap;
+    std::map<std::vector<long>, Base::Color> colorMap;
         for (Py::Dict::iterator it = arg.begin(); it != arg.end(); ++it) {
         std::vector<long> vecId;
         const Py::Object& id = (*it).first;
@@ -199,7 +199,7 @@ std::map<std::vector<long>, App::Color> colorMapFromDict(Py::Dict& arg)
         }
         const Py::Object& value = (*it).second;
         Py::Tuple color(value);
-        colorMap[vecId] = App::Color(Py::Float(color[0]), Py::Float(color[1]), Py::Float(color[2]));
+        colorMap[vecId] = Base::Color(Py::Float(color[0]), Py::Float(color[1]), Py::Float(color[2]));
     }
 
     return colorMap;

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -701,8 +701,8 @@ void ViewProviderFemPostObject::WriteColorData(bool ResetColorBarRange)
     m_matPlainEdges->transparency.setNum(numPts);
     float* transp = m_material->transparency.startEditing();
     float* edgeTransp = m_matPlainEdges->transparency.startEditing();
-    App::Color c;
-    App::Color cEdge = EdgeColor.getValue();
+    Base::Color c;
+    Base::Color cEdge = EdgeColor.getValue();
     for (int i = 0; i < numPts; i++) {
 
         double value = 0;
@@ -928,7 +928,7 @@ void ViewProviderFemPostObject::onChanged(const App::Property* prop)
         m_drawStyle->pointSize.setValue(PointSize.getValue());
     }
     else if (prop == &EdgeColor && setupPipeline()) {
-        App::Color c = EdgeColor.getValue();
+        Base::Color c = EdgeColor.getValue();
         SbColor* edgeColor = m_matPlainEdges->diffuseColor.startEditing();
         for (int i = 0; i < m_matPlainEdges->diffuseColor.getNum(); ++i) {
             edgeColor[i].setValue(c.r, c.g, c.b);

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -281,7 +281,7 @@ private:
         try {
             Py::Sequence list(object);
             std::vector<App::DocumentObject*> objs;
-            std::map<Part::Feature*, std::vector<App::Color>> partColor;
+            std::map<Part::Feature*, std::vector<Base::Color>> partColor;
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 PyObject* item = (*it).ptr();
                 if (PyObject_TypeCheck(item, &(App::DocumentObjectPy::Type))) {
@@ -310,7 +310,7 @@ private:
             hApp->NewDocument(TCollection_ExtendedString("MDTV-CAF"), hDoc);
 
             auto getShapeColors = [partColor](App::DocumentObject* obj, const char* subname) {
-                std::map<std::string, App::Color> cols;
+                std::map<std::string, Base::Color> cols;
                 auto it = partColor.find(dynamic_cast<Part::Feature*>(obj));
                 if (it != partColor.end() && boost::starts_with(subname, "Face")) {
                     const auto& colors = it->second;

--- a/src/Mod/Import/App/ExportOCAF.cpp
+++ b/src/Mod/Import/App/ExportOCAF.cpp
@@ -133,7 +133,7 @@ void ExportOCAF::exportObjects(std::vector<App::DocumentObject*>& objs)
     std::vector<int> part_id;
     getFreeLabels(hierarchical_label, FreeLabels, part_id);
 
-    std::vector<std::vector<App::Color>> Colors;
+    std::vector<std::vector<Base::Color>> Colors;
     getPartColors(hierarchical_part, FreeLabels, part_id, Colors);
     reallocateFreeShape(hierarchical_part, FreeLabels, part_id, Colors);
 
@@ -179,7 +179,7 @@ int ExportOCAF::exportObject(App::DocumentObject* obj,
 
     if (obj->isDerivedFrom<Part::Feature>()) {
         Part::Feature* part = static_cast<Part::Feature*>(obj);
-        std::vector<App::Color> colors;
+        std::vector<Base::Color> colors;
         findColors(part, colors);
 
         return_label =
@@ -221,7 +221,7 @@ void ExportOCAF::createNode(App::Part* part,
 }
 
 int ExportOCAF::saveShape(Part::Feature* part,
-                          const std::vector<App::Color>& colors,
+                          const std::vector<Base::Color>& colors,
                           std::vector<TDF_Label>& hierarchical_label,
                           std::vector<TopLoc_Location>& hierarchical_loc,
                           std::vector<App::DocumentObject*>& hierarchical_part)
@@ -301,7 +301,7 @@ int ExportOCAF::saveShape(Part::Feature* part,
                 }
 
                 if (!faceLabel.IsNull()) {
-                    const App::Color& color = colors[index - 1];
+                    const Base::Color& color = colors[index - 1];
                     col = Tools::convertColor(color);
                     aColorTool->SetColor(faceLabel, col, XCAFDoc_ColorSurf);
                 }
@@ -310,7 +310,7 @@ int ExportOCAF::saveShape(Part::Feature* part,
         }
     }
     else if (!colors.empty()) {
-        App::Color color = colors.front();
+        Base::Color color = colors.front();
         col = Tools::convertColor(color);
         aColorTool->SetColor(shapeLabel, col, XCAFDoc_ColorGen);
     }
@@ -347,12 +347,12 @@ void ExportOCAF::getFreeLabels(std::vector<TDF_Label>& hierarchical_label,
 void ExportOCAF::getPartColors(std::vector<App::DocumentObject*> hierarchical_part,
                                std::vector<TDF_Label> FreeLabels,
                                std::vector<int> part_id,
-                               std::vector<std::vector<App::Color>>& Colors) const
+                               std::vector<std::vector<Base::Color>>& Colors) const
 {
     // I am seeking for the colors of each parts
     std::size_t n = FreeLabels.size();
     for (std::size_t i = 0; i < n; i++) {
-        std::vector<App::Color> colors;
+        std::vector<Base::Color> colors;
         Part::Feature* part = static_cast<Part::Feature*>(hierarchical_part.at(part_id.at(i)));
         findColors(part, colors);
         Colors.push_back(colors);
@@ -362,7 +362,7 @@ void ExportOCAF::getPartColors(std::vector<App::DocumentObject*> hierarchical_pa
 void ExportOCAF::reallocateFreeShape(std::vector<App::DocumentObject*> hierarchical_part,
                                      std::vector<TDF_Label> FreeLabels,
                                      std::vector<int> part_id,
-                                     std::vector<std::vector<App::Color>>& Colors)
+                                     std::vector<std::vector<Base::Color>>& Colors)
 {
     std::size_t n = FreeLabels.size();
     for (std::size_t i = 0; i < n; i++) {
@@ -372,7 +372,7 @@ void ExportOCAF::reallocateFreeShape(std::vector<App::DocumentObject*> hierarchi
             Part::Feature* part = static_cast<Part::Feature*>(hierarchical_part.at(part_id.at(i)));
             aShapeTool->SetShape(label, part->Shape.getValue());
             // Add color information
-            std::vector<App::Color> colors;
+            std::vector<Base::Color> colors;
             colors = Colors.at(i);
             TopoDS_Shape baseShape = part->Shape.getValue();
 
@@ -409,7 +409,7 @@ void ExportOCAF::reallocateFreeShape(std::vector<App::DocumentObject*> hierarchi
                         }
 
                         if (!faceLabel.IsNull()) {
-                            const App::Color& color = colors[index - 1];
+                            const Base::Color& color = colors[index - 1];
                             col = Tools::convertColor(color);
                             aColorTool->SetColor(faceLabel, col, XCAFDoc_ColorSurf);
                         }
@@ -419,7 +419,7 @@ void ExportOCAF::reallocateFreeShape(std::vector<App::DocumentObject*> hierarchi
                 }
             }
             else if (!colors.empty()) {
-                App::Color color = colors.front();
+                Base::Color color = colors.front();
                 col = Tools::convertColor(color);
                 aColorTool->SetColor(label, col, XCAFDoc_ColorGen);
             }
@@ -463,9 +463,9 @@ ExportOCAFCmd::ExportOCAFCmd(Handle(TDocStd_Document) h, bool explicitPlacement)
     : ExportOCAF(h, explicitPlacement)
 {}
 
-void ExportOCAFCmd::findColors(Part::Feature* part, std::vector<App::Color>& colors) const
+void ExportOCAFCmd::findColors(Part::Feature* part, std::vector<Base::Color>& colors) const
 {
-    std::map<Part::Feature*, std::vector<App::Color>>::const_iterator it = partColors.find(part);
+    std::map<Part::Feature*, std::vector<Base::Color>>::const_iterator it = partColors.find(part);
     if (it != partColors.end()) {
         colors = it->second;
     }

--- a/src/Mod/Import/App/ExportOCAF.h
+++ b/src/Mod/Import/App/ExportOCAF.h
@@ -65,18 +65,18 @@ public:
                      std::vector<TopLoc_Location>& hierarchical_loc,
                      std::vector<App::DocumentObject*>& hierarchical_part);
     int saveShape(Part::Feature* part,
-                  const std::vector<App::Color>&,
+                  const std::vector<Base::Color>&,
                   std::vector<TDF_Label>& hierarchical_label,
                   std::vector<TopLoc_Location>& hierarchical_loc,
                   std::vector<App::DocumentObject*>& hierarchical_part);
     void getPartColors(std::vector<App::DocumentObject*> hierarchical_part,
                        std::vector<TDF_Label> FreeLabels,
                        std::vector<int> part_id,
-                       std::vector<std::vector<App::Color>>& Colors) const;
+                       std::vector<std::vector<Base::Color>>& Colors) const;
     void reallocateFreeShape(std::vector<App::DocumentObject*> hierarchical_part,
                              std::vector<TDF_Label> FreeLabels,
                              std::vector<int> part_id,
-                             std::vector<std::vector<App::Color>>& Colors);
+                             std::vector<std::vector<Base::Color>>& Colors);
     void getFreeLabels(std::vector<TDF_Label>& hierarchical_label,
                        std::vector<TDF_Label>& labels,
                        std::vector<int>& label_part_id);
@@ -91,7 +91,7 @@ public:
                   std::vector<TopLoc_Location>& hierarchical_loc);
 
 private:
-    virtual void findColors(Part::Feature*, std::vector<App::Color>&) const
+    virtual void findColors(Part::Feature*, std::vector<Base::Color>&) const
     {}
     std::vector<App::DocumentObject*> filterPart(App::Part* part) const;
 
@@ -108,16 +108,16 @@ class ImportExport ExportOCAFCmd: public ExportOCAF
 {
 public:
     ExportOCAFCmd(Handle(TDocStd_Document) h, bool explicitPlacement);
-    void setPartColorsMap(const std::map<Part::Feature*, std::vector<App::Color>>& colors)
+    void setPartColorsMap(const std::map<Part::Feature*, std::vector<Base::Color>>& colors)
     {
         partColors = colors;
     }
 
 private:
-    void findColors(Part::Feature*, std::vector<App::Color>&) const override;
+    void findColors(Part::Feature*, std::vector<Base::Color>&) const override;
 
 private:
-    std::map<Part::Feature*, std::vector<App::Color>> partColors;
+    std::map<Part::Feature*, std::vector<Base::Color>> partColors;
 };
 
 

--- a/src/Mod/Import/App/ExportOCAF2.cpp
+++ b/src/Mod/Import/App/ExportOCAF2.cpp
@@ -232,7 +232,7 @@ void ExportOCAF2::setupObject(TDF_Label label,
         return;
     }
 
-    std::map<std::string, std::map<std::string, App::Color>> colors;
+    std::map<std::string, std::map<std::string, Base::Color>> colors;
     static std::string marker(App::DocumentObject::hiddenMarker() + "*");
     static std::array<const char*, 3> keys = {"Face*", "Edge*", marker.c_str()};
     std::string childName;
@@ -280,7 +280,7 @@ void ExportOCAF2::setupObject(TDF_Label label,
                 aColorTool->SetVisibility(nodeLabel, Standard_False);
                 continue;
             }
-            const App::Color& c = vv.second;
+            const Base::Color& c = vv.second;
             Quantity_ColorRGBA color = Tools::convertColor(c);
             auto colorType = vv.first[0] == 'F' ? XCAFDoc_ColorSurf : XCAFDoc_ColorCurv;
             if (vv.first == "Face" || vv.first == "Edge") {

--- a/src/Mod/Import/App/ExportOCAF2.h
+++ b/src/Mod/Import/App/ExportOCAF2.h
@@ -51,7 +51,7 @@ namespace Import
 struct ImportExport ExportOCAFOptions
 {
     ExportOCAFOptions();
-    App::Color defaultColor;
+    Base::Color defaultColor;
     bool exportHidden = true;
     bool keepPlacement = false;
 };
@@ -60,7 +60,7 @@ class ImportExport ExportOCAF2
 {
 public:
     using GetShapeColorsFunc =
-        std::function<std::map<std::string, App::Color>(App::DocumentObject*, const char*)>;
+        std::function<std::map<std::string, Base::Color>(App::DocumentObject*, const char*)>;
     explicit ExportOCAF2(Handle(TDocStd_Document) hDoc,
                          GetShapeColorsFunc func = GetShapeColorsFunc());
 

--- a/src/Mod/Import/App/ImportOCAF.cpp
+++ b/src/Mod/Import/App/ImportOCAF.cpp
@@ -394,12 +394,12 @@ void ImportOCAF::createShape(const TopoDS_Shape& aShape,
 void ImportOCAF::loadColors(Part::Feature* part, const TopoDS_Shape& aShape)
 {
     Quantity_ColorRGBA aColor;
-    App::Color color(0.8f, 0.8f, 0.8f);
+    Base::Color color(0.8f, 0.8f, 0.8f);
     if (aColorTool->GetColor(aShape, XCAFDoc_ColorGen, aColor)
         || aColorTool->GetColor(aShape, XCAFDoc_ColorSurf, aColor)
         || aColorTool->GetColor(aShape, XCAFDoc_ColorCurv, aColor)) {
         color = Tools::convertColor(aColor);
-        std::vector<App::Color> colors;
+        std::vector<Base::Color> colors;
         colors.push_back(color);
         applyColors(part, colors);
     }
@@ -412,7 +412,7 @@ void ImportOCAF::loadColors(Part::Feature* part, const TopoDS_Shape& aShape)
     }
 
     bool found_face_color = false;
-    std::vector<App::Color> faceColors;
+    std::vector<Base::Color> faceColors;
     faceColors.resize(faces.Extent(), color);
     xp.Init(aShape, TopAbs_FACE);
     while (xp.More()) {
@@ -438,7 +438,7 @@ ImportOCAFCmd::ImportOCAFCmd(Handle(TDocStd_Document) h, App::Document* d, const
     : ImportOCAF(h, d, name)
 {}
 
-void ImportOCAFCmd::applyColors(Part::Feature* part, const std::vector<App::Color>& colors)
+void ImportOCAFCmd::applyColors(Part::Feature* part, const std::vector<Base::Color>& colors)
 {
     partColors[part] = colors;
 }
@@ -503,7 +503,7 @@ void ImportXCAF::createShape(const TopoDS_Shape& shape, bool perface, bool setna
     std::map<Standard_Integer, Quantity_ColorRGBA>::const_iterator jt;
     jt = myColorMap.find(Part::ShapeMapHasher {}(shape));
 
-    App::Color partColor(0.8f, 0.8f, 0.8f);
+    Base::Color partColor(0.8f, 0.8f, 0.8f);
 
 
     // set label name if defined
@@ -524,7 +524,7 @@ void ImportXCAF::createShape(const TopoDS_Shape& shape, bool perface, bool setna
             xp.Next();
         }
 
-        std::vector<App::Color> faceColors;
+        std::vector<Base::Color> faceColors;
         faceColors.resize(faces.Extent(), partColor);
         xp.Init(shape, TopAbs_FACE);
         while (xp.More()) {

--- a/src/Mod/Import/App/ImportOCAF.h
+++ b/src/Mod/Import/App/ImportOCAF.h
@@ -81,7 +81,7 @@ private:
                      const std::string&,
                      std::vector<App::DocumentObject*>&);
     void loadColors(Part::Feature* part, const TopoDS_Shape& aShape);
-    virtual void applyColors(Part::Feature*, const std::vector<App::Color>&)
+    virtual void applyColors(Part::Feature*, const std::vector<Base::Color>&)
     {}
     static void tryPlacementFromLoc(App::GeoFeature*, const TopLoc_Location&);
     static void tryPlacementFromMatrix(App::GeoFeature*, const Base::Matrix4D&);
@@ -100,16 +100,16 @@ class ImportExport ImportOCAFCmd: public ImportOCAF
 {
 public:
     ImportOCAFCmd(Handle(TDocStd_Document) h, App::Document* d, const std::string& name);
-    std::map<Part::Feature*, std::vector<App::Color>> getPartColorsMap() const
+    std::map<Part::Feature*, std::vector<Base::Color>> getPartColorsMap() const
     {
         return partColors;
     }
 
 private:
-    void applyColors(Part::Feature* part, const std::vector<App::Color>& colors) override;
+    void applyColors(Part::Feature* part, const std::vector<Base::Color>& colors) override;
 
 private:
-    std::map<Part::Feature*, std::vector<App::Color>> partColors;
+    std::map<Part::Feature*, std::vector<Base::Color>> partColors;
 };
 
 class ImportXCAF
@@ -122,7 +122,7 @@ public:
 private:
     void createShape(const TopoDS_Shape& shape, bool perface = false, bool setname = false) const;
     void loadShapes(const TDF_Label& label);
-    virtual void applyColors(Part::Feature*, const std::vector<App::Color>&)
+    virtual void applyColors(Part::Feature*, const std::vector<Base::Color>&)
     {}
 
 private:

--- a/src/Mod/Import/App/ImportOCAF2.cpp
+++ b/src/Mod/Import/App/ImportOCAF2.cpp
@@ -204,7 +204,7 @@ bool ImportOCAF2::getColor(const TopoDS_Shape& shape, Info& info, bool check, bo
     bool ret = false;
     Quantity_ColorRGBA aColor;
     if (aColorTool->GetColor(shape, XCAFDoc_ColorSurf, aColor)) {
-        App::Color c = Tools::convertColor(aColor);
+        Base::Color c = Tools::convertColor(aColor);
         if (!check || info.faceColor != c) {
             info.faceColor = c;
             info.hasFaceColor = true;
@@ -212,7 +212,7 @@ bool ImportOCAF2::getColor(const TopoDS_Shape& shape, Info& info, bool check, bo
         }
     }
     if (!noDefault && !info.hasFaceColor && aColorTool->GetColor(shape, XCAFDoc_ColorGen, aColor)) {
-        App::Color c = Tools::convertColor(aColor);
+        Base::Color c = Tools::convertColor(aColor);
         if (!check || info.faceColor != c) {
             info.faceColor = c;
             info.hasFaceColor = true;
@@ -220,7 +220,7 @@ bool ImportOCAF2::getColor(const TopoDS_Shape& shape, Info& info, bool check, bo
         }
     }
     if (aColorTool->GetColor(shape, XCAFDoc_ColorCurv, aColor)) {
-        App::Color c = Tools::convertColor(aColor);
+        Base::Color c = Tools::convertColor(aColor);
         // Some STEP include a curve color with the same value of the face
         // color. And this will look weird in FC. So for shape with face
         // we'll ignore the curve color, if it is the same as the face color.
@@ -296,8 +296,8 @@ bool ImportOCAF2::createObject(App::Document* doc,
     bool hasEdgeColors = false;
 
     Part::TopoShape tshape(shape);
-    std::vector<App::Color> faceColors;
-    std::vector<App::Color> edgeColors;
+    std::vector<Base::Color> faceColors;
+    std::vector<Base::Color> edgeColors;
 
     TDF_LabelSequence seq;
     if (!label.IsNull() && aShapeTool->GetSubShapes(label, seq)) {
@@ -328,7 +328,7 @@ bool ImportOCAF2::createObject(App::Document* doc,
                 }
 
                 bool foundFaceColor = false, foundEdgeColor = false;
-                App::Color faceColor, edgeColor;
+                Base::Color faceColor, edgeColor;
                 Quantity_ColorRGBA aColor;
                 if (aColorTool->GetColor(l, XCAFDoc_ColorSurf, aColor)
                     || aColorTool->GetColor(l, XCAFDoc_ColorGen, aColor)) {
@@ -585,7 +585,7 @@ App::DocumentObject* ImportOCAF2::loadShapes()
 }
 
 void ImportOCAF2::getSHUOColors(TDF_Label label,
-                                std::map<std::string, App::Color>& colors,
+                                std::map<std::string, Base::Color>& colors,
                                 bool appendFirst)
 {
     TDF_AttributeSequence seq;
@@ -638,7 +638,7 @@ void ImportOCAF2::getSHUOColors(TDF_Label label,
         }
         if (!aColorTool->IsVisible(slabel)) {
             subname += App::DocumentObject::hiddenMarker();
-            colors.emplace(subname, App::Color());
+            colors.emplace(subname, Base::Color());
         }
         else {
             Quantity_ColorRGBA aColor;
@@ -685,7 +685,7 @@ App::DocumentObject* ImportOCAF2::loadShape(App::Document* doc,
         return it->second.obj;
     }
 
-    std::map<std::string, App::Color> shuoColors;
+    std::map<std::string, Base::Color> shuoColors;
     if (!options.useLinkGroup) {
         getSHUOColors(label, shuoColors, false);
     }
@@ -735,7 +735,7 @@ struct ChildInfo
 {
     std::vector<Base::Placement> plas;
     boost::dynamic_bitset<> vis;
-    std::map<size_t, App::Color> colors;
+    std::map<size_t, Base::Color> colors;
     std::vector<TDF_Label> labels;
     TopoDS_Shape shape;
 };
@@ -751,7 +751,7 @@ bool ImportOCAF2::createAssembly(App::Document* _doc,
     std::vector<App::DocumentObject*> children;
     std::map<App::DocumentObject*, ChildInfo> childrenMap;
     boost::dynamic_bitset<> visibilities;
-    std::map<std::string, App::Color> shuoColors;
+    std::map<std::string, Base::Color> shuoColors;
 
     auto doc = _doc;
     if (newDoc) {
@@ -877,7 +877,7 @@ ImportOCAFExt::ImportOCAFExt(Handle(TDocStd_Document) hStdDoc,
     : ImportOCAF2(hStdDoc, doc, name)
 {}
 
-void ImportOCAFExt::applyFaceColors(Part::Feature* part, const std::vector<App::Color>& colors)
+void ImportOCAFExt::applyFaceColors(Part::Feature* part, const std::vector<Base::Color>& colors)
 {
     partColors[part] = colors;
 }

--- a/src/Mod/Import/App/ImportOCAF2.h
+++ b/src/Mod/Import/App/ImportOCAF2.h
@@ -62,8 +62,8 @@ namespace Import
 struct ImportExport ImportOCAFOptions
 {
     ImportOCAFOptions();
-    App::Color defaultFaceColor;
-    App::Color defaultEdgeColor;
+    Base::Color defaultFaceColor;
+    Base::Color defaultEdgeColor;
     bool merge = false;
     bool useLinkGroup = false;
     bool useBaseName = true;
@@ -130,8 +130,8 @@ private:
         std::string baseName;
         App::DocumentObject* obj = nullptr;
         App::PropertyPlacement* propPlacement = nullptr;
-        App::Color faceColor;
-        App::Color edgeColor;
+        Base::Color faceColor;
+        Base::Color edgeColor;
         bool hasFaceColor = false;
         bool hasEdgeColor = false;
         int free = true;
@@ -162,19 +162,19 @@ private:
     bool
     getColor(const TopoDS_Shape& shape, Info& info, bool check = false, bool noDefault = false);
     void
-    getSHUOColors(TDF_Label label, std::map<std::string, App::Color>& colors, bool appendFirst);
+    getSHUOColors(TDF_Label label, std::map<std::string, Base::Color>& colors, bool appendFirst);
     void setObjectName(Info& info, TDF_Label label);
     std::string getLabelName(TDF_Label label);
     App::DocumentObject*
     expandShape(App::Document* doc, TDF_Label label, const TopoDS_Shape& shape);
 
-    virtual void applyEdgeColors(Part::Feature*, const std::vector<App::Color>&)
+    virtual void applyEdgeColors(Part::Feature*, const std::vector<Base::Color>&)
     {}
-    virtual void applyFaceColors(Part::Feature*, const std::vector<App::Color>&)
+    virtual void applyFaceColors(Part::Feature*, const std::vector<Base::Color>&)
     {}
-    virtual void applyElementColors(App::DocumentObject*, const std::map<std::string, App::Color>&)
+    virtual void applyElementColors(App::DocumentObject*, const std::map<std::string, Base::Color>&)
     {}
-    virtual void applyLinkColor(App::DocumentObject*, int /*index*/, App::Color)
+    virtual void applyLinkColor(App::DocumentObject*, int /*index*/, Base::Color)
     {}
 
 private:
@@ -187,7 +187,7 @@ private:
         {}
 
     private:
-        void applyColors(Part::Feature* part, const std::vector<App::Color>& colors) override
+        void applyColors(Part::Feature* part, const std::vector<Base::Color>& colors) override
         {
             myParent.applyFaceColors(part, colors);
         }
@@ -217,16 +217,16 @@ class ImportExport ImportOCAFExt: public ImportOCAF2
 public:
     ImportOCAFExt(Handle(TDocStd_Document) hStdDoc, App::Document* doc, const std::string& name);
 
-    std::map<Part::Feature*, std::vector<App::Color>> partColors;
+    std::map<Part::Feature*, std::vector<Base::Color>> partColors;
 
 private:
-    void applyFaceColors(Part::Feature* part, const std::vector<App::Color>& colors) override;
+    void applyFaceColors(Part::Feature* part, const std::vector<Base::Color>& colors) override;
 };
 
 struct ImportExport ExportOCAFOptions
 {
     ExportOCAFOptions();
-    App::Color defaultColor;
+    Base::Color defaultColor;
     bool exportHidden = true;
     bool keepPlacement = false;
 };
@@ -235,7 +235,7 @@ class ImportExport ExportOCAF2
 {
 public:
     using GetShapeColorsFunc =
-        std::function<std::map<std::string, App::Color>(App::DocumentObject*, const char*)>;
+        std::function<std::map<std::string, Base::Color>(App::DocumentObject*, const char*)>;
     explicit ExportOCAF2(Handle(TDocStd_Document) h,
                          GetShapeColorsFunc func = GetShapeColorsFunc());
 

--- a/src/Mod/Import/App/ImportOCAFAssembly.cpp
+++ b/src/Mod/Import/App/ImportOCAFAssembly.cpp
@@ -251,14 +251,14 @@ void ImportOCAFAssembly::createShape(const TopoDS_Shape& aShape,
     part->Label.setValue(name);
 
     Quantity_Color aColor;
-    App::Color color(0.8f, 0.8f, 0.8f);
+    Base::Color color(0.8f, 0.8f, 0.8f);
     if (aColorTool->GetColor(aShape, XCAFDoc_ColorGen, aColor)
         || aColorTool->GetColor(aShape, XCAFDoc_ColorSurf, aColor)
         || aColorTool->GetColor(aShape, XCAFDoc_ColorCurv, aColor)) {
         color.r = (float)aColor.Red();
         color.g = (float)aColor.Green();
         color.b = (float)aColor.Blue();
-        std::vector<App::Color> colors;
+        std::vector<Base::Color> colors;
         colors.push_back(color);
         applyColors(part, colors);
     }
@@ -270,7 +270,7 @@ void ImportOCAFAssembly::createShape(const TopoDS_Shape& aShape,
         xp.Next();
     }
     bool found_face_color = false;
-    std::vector<App::Color> faceColors;
+    std::vector<Base::Color> faceColors;
     faceColors.resize(faces.Extent(), color);
     xp.Init(aShape, TopAbs_FACE);
     while (xp.More()) {

--- a/src/Mod/Import/App/ImportOCAFAssembly.h
+++ b/src/Mod/Import/App/ImportOCAFAssembly.h
@@ -76,7 +76,7 @@ private:
                     int dep);
     void createShape(const TDF_Label& label, const TopLoc_Location&, const std::string&);
     void createShape(const TopoDS_Shape& label, const TopLoc_Location&, const std::string&);
-    virtual void applyColors(Part::Feature*, const std::vector<App::Color>&)
+    virtual void applyColors(Part::Feature*, const std::vector<Base::Color>&)
     {}
 
 private:

--- a/src/Mod/Import/App/Tools.cpp
+++ b/src/Mod/Import/App/Tools.cpp
@@ -46,24 +46,24 @@ FC_LOG_LEVEL_INIT("Import", true, true)
 
 using namespace Import;
 
-App::Color Tools::convertColor(const Quantity_ColorRGBA& rgba)
+Base::Color Tools::convertColor(const Quantity_ColorRGBA& rgba)
 {
     Standard_Real red, green, blue;
     rgba.GetRGB().Values(red, green, blue, OCC_COLOR_SPACE);
-    return App::Color(static_cast<float>(red),
-                      static_cast<float>(green),
-                      static_cast<float>(blue),
-                      static_cast<float>(rgba.Alpha()));
+    return Base::Color(static_cast<float>(red),
+                       static_cast<float>(green),
+                       static_cast<float>(blue),
+                       static_cast<float>(rgba.Alpha()));
 }
 
-Quantity_ColorRGBA Tools::convertColor(const App::Color& col)
+Quantity_ColorRGBA Tools::convertColor(const Base::Color& col)
 {
     return Quantity_ColorRGBA(Quantity_Color(col.r, col.g, col.b, OCC_COLOR_SPACE), col.a);
 }
 
 static inline std::ostream& operator<<(std::ostream& os, const Quantity_ColorRGBA& rgba)
 {
-    App::Color color = Tools::convertColor(rgba);
+    Base::Color color = Tools::convertColor(rgba);
     auto toHex = [](float v) {
         return boost::format("%02X") % static_cast<int>(v * 255);
     };

--- a/src/Mod/Import/App/Tools.h
+++ b/src/Mod/Import/App/Tools.h
@@ -27,7 +27,7 @@
 #include <TopoDS_Shape.hxx>
 #include <XCAFDoc_ColorTool.hxx>
 #include <XCAFDoc_ShapeTool.hxx>
-#include <App/Color.h>
+#include <Base/Color.h>
 
 #include <Standard_Version.hxx>
 
@@ -60,8 +60,8 @@ struct LabelHasher
 
 struct Tools
 {
-    static App::Color convertColor(const Quantity_ColorRGBA& rgba);
-    static Quantity_ColorRGBA convertColor(const App::Color& col);
+    static Base::Color convertColor(const Quantity_ColorRGBA& rgba);
+    static Quantity_ColorRGBA convertColor(const Base::Color& col);
     static std::string labelName(TDF_Label label);
     static void printLabel(TDF_Label label,
                            Handle(XCAFDoc_ShapeTool) aShapeTool,

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -644,7 +644,7 @@ ImpExpDxfRead::MakeLayer(const std::string& name, ColorIndex_t color, std::strin
 {
     if (m_preserveLayers) {
         // Hidden layers are implemented in the wrapup code after the entire file has been read.
-        App::Color appColor = ObjectColor(color);
+        Base::Color appColor = ObjectColor(color);
         PyObject* draftModule = nullptr;
         PyObject* layer = nullptr;
         draftModule = getDraftModule();

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -15,7 +15,7 @@
 
 #include "dxf.h"
 #include <App/Application.h>
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <Base/Console.h>
 #include <Base/FileInfo.h>
 #include <Base/Interpreter.h>
@@ -3027,13 +3027,13 @@ inline static double level(int distance, double blackLevel)
     // 8 and beyond yield the black level
     return blackLevel;
 }
-inline static App::Color wheel(int hue, double blackLevel, double multiplier = 1.0)
+inline static Base::Color wheel(int hue, double blackLevel, double multiplier = 1.0)
 {
-    return App::Color((float)(level(hue - 0, blackLevel) * multiplier),
-                      (float)(level(hue - 8, blackLevel) * multiplier),
-                      (float)(level(hue - 16, blackLevel) * multiplier));
+    return Base::Color((float)(level(hue - 0, blackLevel) * multiplier),
+                       (float)(level(hue - 8, blackLevel) * multiplier),
+                       (float)(level(hue - 16, blackLevel) * multiplier));
 }
-App::Color CDxfRead::ObjectColor(ColorIndex_t index)
+Base::Color CDxfRead::ObjectColor(ColorIndex_t index)
 {
     // TODO: If it is ColorByBlock we need to use the color of the INSERT entity.
     // This is tricky because a block can itself contain INSERT entities and we don't currently
@@ -3050,28 +3050,28 @@ App::Color CDxfRead::ObjectColor(ColorIndex_t index)
     // The AA fades as AA 7E 56 45 35 which is almost the exact same percentages.
     // For hue, (index-10)/10 : 0 is ff0000, and each step linearly adds green until 4 is pure
     // yellow ffff00, then red starts to fade... until but not including 24 which is back to ff0000.
-    App::Color result = App::Color();
+    Base::Color result = Base::Color();
     if (index == 0) {
         // Technically, 0 is BYBLOCK and not a real color, but all that means is that an object in a
         // block cannot specifically ask to be black. These colors are all contrasted to the
         // background so there is no objective black colour, through 255 is an objective white.
-        result = App::Color();
+        result = Base::Color();
     }
     else if (index < 7) {
         result = wheel((index - 1) * 4, 0x00);
     }
     else if (index == 7) {
-        result = App::Color(1, 1, 1);
+        result = Base::Color(1, 1, 1);
     }
     else if (index == 8) {
-        result = App::Color(0.5, 0.5, 0.5);
+        result = Base::Color(0.5, 0.5, 0.5);
     }
     else if (index == 9) {
-        result = App::Color(0.75, 0.75, 0.75);
+        result = Base::Color(0.75, 0.75, 0.75);
     }
     else if (index >= 250) {
         auto brightness = (float)((index - 250 + (255 - index) * 0.2) / 5);
-        result = App::Color(brightness, brightness, brightness);
+        result = Base::Color(brightness, brightness, brightness);
     }
     else {
         static const std::array<float, 5> fades = {1.00F, 0.74F, 0.50F, 0.40F, 0.30F};

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -25,7 +25,7 @@
 #include <Base/Matrix.h>
 #include <Base/Vector3D.h>
 #include <Base/Console.h>
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <Mod/Import/ImportGlobal.h>
 
 // For some reason Cpplint complains about some of the categories used by Clang-tidy
@@ -923,7 +923,7 @@ public:
     {
         return m_entityAttributes.m_LineType[0] == 'h' || m_entityAttributes.m_LineType[0] == 'H';
     }
-    static App::Color ObjectColor(ColorIndex_t colorIndex);  // as rgba value
+    static Base::Color ObjectColor(ColorIndex_t colorIndex);  // as rgba value
 
 #ifdef DEBUG
 protected:

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -341,8 +341,8 @@ private:
         return Py::None();
     }
 
-    static std::map<std::string, App::Color> getShapeColors(App::DocumentObject* obj,
-                                                            const char* subname)
+    static std::map<std::string, Base::Color> getShapeColors(App::DocumentObject* obj,
+                                                             const char* subname)
     {
         auto vp = Gui::Application::Instance->getViewProvider(obj);
         if (vp) {

--- a/src/Mod/Import/Gui/ExportOCAFGui.cpp
+++ b/src/Mod/Import/Gui/ExportOCAFGui.cpp
@@ -35,7 +35,7 @@ ExportOCAFGui::ExportOCAFGui(Handle(TDocStd_Document) hDoc, bool explicitPlaceme
     : ExportOCAF(hDoc, explicitPlacement)
 {}
 
-void ExportOCAFGui::findColors(Part::Feature* part, std::vector<App::Color>& colors) const
+void ExportOCAFGui::findColors(Part::Feature* part, std::vector<Base::Color>& colors) const
 {
     Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider(part);
     if (vp && vp->isDerivedFrom<PartGui::ViewProviderPartExt>()) {

--- a/src/Mod/Import/Gui/ExportOCAFGui.h
+++ b/src/Mod/Import/Gui/ExportOCAFGui.h
@@ -33,7 +33,7 @@ class ExportOCAFGui: public Import::ExportOCAF
 {
 public:
     ExportOCAFGui(Handle(TDocStd_Document) hDoc, bool explicitPlacement);
-    void findColors(Part::Feature* part, std::vector<App::Color>& colors) const override;
+    void findColors(Part::Feature* part, std::vector<Base::Color>& colors) const override;
 };
 
 }  // namespace ImportGui

--- a/src/Mod/Import/Gui/ImportOCAFGui.cpp
+++ b/src/Mod/Import/Gui/ImportOCAFGui.cpp
@@ -38,7 +38,7 @@ ImportOCAFGui::ImportOCAFGui(Handle(TDocStd_Document) hDoc,
     : ImportOCAF2(hDoc, pDoc, name)
 {}
 
-void ImportOCAFGui::applyFaceColors(Part::Feature* part, const std::vector<App::Color>& colors)
+void ImportOCAFGui::applyFaceColors(Part::Feature* part, const std::vector<Base::Color>& colors)
 {
     auto vp = dynamic_cast<PartGui::ViewProviderPartExt*>(
         Gui::Application::Instance->getViewProvider(part));
@@ -58,7 +58,7 @@ void ImportOCAFGui::applyFaceColors(Part::Feature* part, const std::vector<App::
     }
 }
 
-void ImportOCAFGui::applyEdgeColors(Part::Feature* part, const std::vector<App::Color>& colors)
+void ImportOCAFGui::applyEdgeColors(Part::Feature* part, const std::vector<Base::Color>& colors)
 {
     auto vp = dynamic_cast<PartGui::ViewProviderPartExt*>(
         Gui::Application::Instance->getViewProvider(part));
@@ -73,7 +73,7 @@ void ImportOCAFGui::applyEdgeColors(Part::Feature* part, const std::vector<App::
     }
 }
 
-void ImportOCAFGui::applyLinkColor(App::DocumentObject* obj, int index, App::Color color)
+void ImportOCAFGui::applyLinkColor(App::DocumentObject* obj, int index, Base::Color color)
 {
     auto vp =
         dynamic_cast<Gui::ViewProviderLink*>(Gui::Application::Instance->getViewProvider(obj));
@@ -98,7 +98,7 @@ void ImportOCAFGui::applyLinkColor(App::DocumentObject* obj, int index, App::Col
 }
 
 void ImportOCAFGui::applyElementColors(App::DocumentObject* obj,
-                                       const std::map<std::string, App::Color>& colors)
+                                       const std::map<std::string, Base::Color>& colors)
 {
     auto vp = Gui::Application::Instance->getViewProvider(obj);
     if (!vp) {

--- a/src/Mod/Import/Gui/ImportOCAFGui.h
+++ b/src/Mod/Import/Gui/ImportOCAFGui.h
@@ -36,11 +36,11 @@ public:
     ImportOCAFGui(Handle(TDocStd_Document) hDoc, App::Document* pDoc, const std::string& name);
 
 private:
-    void applyFaceColors(Part::Feature* part, const std::vector<App::Color>& colors) override;
-    void applyEdgeColors(Part::Feature* part, const std::vector<App::Color>& colors) override;
-    void applyLinkColor(App::DocumentObject* obj, int index, App::Color color) override;
+    void applyFaceColors(Part::Feature* part, const std::vector<Base::Color>& colors) override;
+    void applyEdgeColors(Part::Feature* part, const std::vector<Base::Color>& colors) override;
+    void applyLinkColor(App::DocumentObject* obj, int index, Base::Color color) override;
     void applyElementColors(App::DocumentObject* obj,
-                            const std::map<std::string, App::Color>& colors) override;
+                            const std::map<std::string, Base::Color>& colors) override;
 };
 
 }  // namespace ImportGui

--- a/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
+++ b/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
@@ -69,7 +69,7 @@ ImpExpDxfReadGui::ImpExpDxfReadGui(const std::string& filepath, App::Document* p
 void ImpExpDxfReadGui::ApplyGuiStyles(Part::Feature* object) const
 {
     auto view = static_cast<PartGui::ViewProviderPart*>(GuiDocument->getViewProvider(object));
-    App::Color color = ObjectColor(m_entityAttributes.m_Color);
+    Base::Color color = ObjectColor(m_entityAttributes.m_Color);
     view->LineColor.setValue(color);
     view->PointColor.setValue(color);
     view->ShapeAppearance.setDiffuseColor(color);
@@ -82,7 +82,7 @@ void ImpExpDxfReadGui::ApplyGuiStyles(App::FeaturePython* object) const
     static Base::Type PropertyColorType = App::PropertyColor::getClassTypeId();
 
     auto view = static_cast<Gui::ViewProviderDocumentObject*>(GuiDocument->getViewProvider(object));
-    App::Color color = ObjectColor(m_entityAttributes.m_Color);
+    Base::Color color = ObjectColor(m_entityAttributes.m_Color);
 
     // The properties on this object depend on which Python object is wrapped around it.
     // For now we look for the two colors we expect in text and dimensions, and check that they

--- a/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
+++ b/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
@@ -413,7 +413,7 @@ void ViewProviderInspection::setDistances()
 
     unsigned long j = 0;
     for (std::vector<float>::const_iterator jt = fValues.begin(); jt != fValues.end(); ++jt, j++) {
-        App::Color col = pcColorBar->getColor(*jt);
+        Base::Color col = pcColorBar->getColor(*jt);
         cols[j] = SbColor(col.r, col.g, col.b);
         if (pcColorBar->isVisible(*jt)) {
             tran[j] = 0.0f;

--- a/src/Mod/Material/App/MaterialManager.cpp
+++ b/src/Mod/Material/App/MaterialManager.cpp
@@ -143,7 +143,7 @@ std::shared_ptr<App::Material> MaterialManager::defaultAppearance()
     ParameterGrp::handle hGrp =
         App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
 
-    auto getColor = [hGrp](const char* parameter, App::Color& color) {
+    auto getColor = [hGrp](const char* parameter, Base::Color& color) {
         uint32_t packed = color.getPackedRGB();
         packed = hGrp->GetUnsigned(parameter, packed);
         color.setPackedRGB(packed);
@@ -162,7 +162,7 @@ std::shared_ptr<App::Material> MaterialManager::defaultAppearance()
         float red = static_cast<float>(intRandom(0, 255)) / 255.0F;
         float green = static_cast<float>(intRandom(0, 255)) / 255.0F;
         float blue = static_cast<float>(intRandom(0, 255)) / 255.0F;
-        mat.diffuseColor = App::Color(red, green, blue, 1.0);
+        mat.diffuseColor = Base::Color(red, green, blue, 1.0);
     }
     else {
         getColor("DefaultShapeColor", mat.diffuseColor);

--- a/src/Mod/Material/App/Materials.cpp
+++ b/src/Mod/Material/App/Materials.cpp
@@ -142,7 +142,7 @@ QString MaterialProperty::getYAMLString() const
     return _valuePtr->getYAMLString();
 }
 
-App::Color MaterialProperty::getColor() const
+Base::Color MaterialProperty::getColor() const
 {
     auto colorString = getValue().toString();
     std::stringstream stream(colorString.toStdString());
@@ -163,7 +163,7 @@ App::Color MaterialProperty::getColor() const
         stream >> alpha;
     }
 
-    App::Color color(red, green, blue, alpha);
+    Base::Color color(red, green, blue, alpha);
     return color;
 }
 
@@ -410,7 +410,7 @@ void MaterialProperty::setURL(const QString& value)
     _valuePtr->setValue(QVariant(value));
 }
 
-void MaterialProperty::setColor(const App::Color& value)
+void MaterialProperty::setColor(const Base::Color& value)
 {
     std::stringstream ss;
     ss << "(" << value.r << ", " << value.g << ", " << value.b << ", " << value.a << ")";

--- a/src/Mod/Material/App/Materials.h
+++ b/src/Mod/Material/App/Materials.h
@@ -31,7 +31,7 @@
 #include <QTextStream>
 
 #include <App/Application.h>
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <App/Material.h>
 #include <Base/BaseClass.h>
 
@@ -102,7 +102,7 @@ public:
     {
         return getValue().toString();
     }
-    App::Color getColor() const;
+    Base::Color getColor() const;
 
     MaterialProperty& getColumn(int column);
     const MaterialProperty& getColumn(int column) const;
@@ -129,7 +129,7 @@ public:
     void setQuantity(const QString& value);
     void setList(const QList<QVariant>& value);
     void setURL(const QString& value);
-    void setColor(const App::Color& value);
+    void setColor(const Base::Color& value);
 
     MaterialProperty& operator=(const MaterialProperty& other);
     friend QTextStream& operator<<(QTextStream& output, const MaterialProperty& property);

--- a/src/Mod/Material/Gui/DlgDisplayPropertiesImp.cpp
+++ b/src/Mod/Material/Gui/DlgDisplayPropertiesImp.cpp
@@ -64,7 +64,7 @@ public:
         bool hasElementColor = false;
         for (const auto& view : views) {
             if (auto* prop = dynamic_cast<App::PropertyColor*>(view->getPropertyByName(property))) {
-                App::Color color = prop->getValue();
+                Base::Color color = prop->getValue();
                 QSignalBlocker block(buttonColor);
                 buttonColor->setColor(color.asValue<QColor>());
                 hasElementColor = true;
@@ -83,7 +83,7 @@ public:
         for (const auto& view : views) {
             if (auto* prop =
                     dynamic_cast<App::PropertyMaterial*>(view->getPropertyByName(property))) {
-                App::Color color = prop->getDiffuseColor();
+                Base::Color color = prop->getDiffuseColor();
                 QSignalBlocker block(buttonColor);
                 buttonColor->setColor(color.asValue<QColor>());
                 hasElementColor = true;
@@ -310,7 +310,7 @@ void DlgDisplayPropertiesImp::slotChangedObject(const Gui::ViewProvider& obj,
         }
         std::string prop_name = name;
         if (prop.is<App::PropertyColor>()) {
-            App::Color value = static_cast<const App::PropertyColor&>(prop).getValue();
+            Base::Color value = static_cast<const App::PropertyColor&>(prop).getValue();
             if (prop_name == "LineColor") {
                 bool blocked = d->ui.buttonLineColor->blockSignals(true);
                 d->ui.buttonLineColor->setColor(value.asValue<QColor>());
@@ -479,7 +479,7 @@ void DlgDisplayPropertiesImp::onButtonLineColorChanged()
 {
     std::vector<Gui::ViewProvider*> Provider = getSelection();
     QColor s = d->ui.buttonLineColor->color();
-    App::Color c {};
+    Base::Color c {};
     c.setValue<QColor>(s);
     for (auto it : Provider) {
         if (auto* prop = dynamic_cast<App::PropertyColor*>(it->getPropertyByName("LineColor"))) {
@@ -492,7 +492,7 @@ void DlgDisplayPropertiesImp::onButtonPointColorChanged()
 {
     std::vector<Gui::ViewProvider*> Provider = getSelection();
     QColor s = d->ui.buttonPointColor->color();
-    App::Color c {};
+    Base::Color c {};
     c.setValue<QColor>(s);
     for (auto it : Provider) {
         if (auto* prop = dynamic_cast<App::PropertyColor*>(it->getPropertyByName("PointColor"))) {

--- a/src/Mod/Material/Gui/DlgInspectAppearance.cpp
+++ b/src/Mod/Material/Gui/DlgInspectAppearance.cpp
@@ -39,7 +39,7 @@
 
 using namespace MatGui;
 
-ColorWidget::ColorWidget(const App::Color& color, QWidget* parent)
+ColorWidget::ColorWidget(const Base::Color& color, QWidget* parent)
     : QWidget(parent)
 {
     _color = color.asValue<QColor>();

--- a/src/Mod/Material/Gui/DlgInspectAppearance.h
+++ b/src/Mod/Material/Gui/DlgInspectAppearance.h
@@ -46,7 +46,7 @@ class ColorWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit ColorWidget(const App::Color& color, QWidget* parent = nullptr);
+    explicit ColorWidget(const Base::Color& color, QWidget* parent = nullptr);
     ~ColorWidget() override = default;
 
     QSize sizeHint() const override { return {75,23}; }

--- a/src/Mod/Material/Gui/MaterialTreeWidget.cpp
+++ b/src/Mod/Material/Gui/MaterialTreeWidget.cpp
@@ -31,7 +31,7 @@
 #include <QSpacerItem>
 #include <QVBoxLayout>
 
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <Base/Console.h>
 #include <Base/Tools.h>
 #include <Gui/Command.h>

--- a/src/Mod/Measure/App/Preferences.cpp
+++ b/src/Mod/Measure/App/Preferences.cpp
@@ -46,25 +46,25 @@ Base::Reference<ParameterGrp> Preferences::getPreferenceGroup(const char* Name)
         ->GetGroup(Name);
 }
 
-App::Color Preferences::defaultLineColor()
+Base::Color Preferences::defaultLineColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(
         getPreferenceGroup("Appearance")->GetUnsigned("DefaultLineColor", 0x3CF00000));
     return fcColor;
 }
 
-App::Color Preferences::defaultTextColor()
+Base::Color Preferences::defaultTextColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(
         getPreferenceGroup("Appearance")->GetUnsigned("DefaultTextColor", 0x00000000));
     return fcColor;
 }
 
-App::Color Preferences::defaultTextBackgroundColor()
+Base::Color Preferences::defaultTextBackgroundColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(
         getPreferenceGroup("Appearance")->GetUnsigned("DefaultTextBackgroundColor", 0x3CF00000));
     return fcColor;

--- a/src/Mod/Measure/App/Preferences.h
+++ b/src/Mod/Measure/App/Preferences.h
@@ -44,10 +44,10 @@ class MeasureExport Preferences
 public:
     static Base::Reference<ParameterGrp> getPreferenceGroup(const char* Name);
 
-    static App::Color defaultLineColor();
-    static App::Color defaultTextColor();
+    static Base::Color defaultLineColor();
+    static Base::Color defaultTextColor();
     static int defaultFontSize();
-    static App::Color defaultTextBackgroundColor();
+    static Base::Color defaultTextBackgroundColor();
 };
 
 

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -237,16 +237,16 @@ void ViewProviderMeasureBase::finishRestoring()
 void ViewProviderMeasureBase::onChanged(const App::Property* prop)
 {
     if (prop == &TextColor) {
-        const App::Color& color = TextColor.getValue();
+        const Base::Color& color = TextColor.getValue();
         pLabel->textColor.setValue(color.r, color.g, color.b);
         updateIcon();
     }
     else if (prop == &TextBackgroundColor) {
-        const App::Color& color = TextBackgroundColor.getValue();
+        const Base::Color& color = TextBackgroundColor.getValue();
         pLabel->backgroundColor.setValue(color.r, color.g, color.b);
     }
     else if (prop == &LineColor) {
-        const App::Color& color = LineColor.getValue();
+        const Base::Color& color = LineColor.getValue();
         pColor->rgb.setValue(color.r, color.g, color.b);
     }
     else if (prop == &FontSize) {

--- a/src/Mod/Mesh/App/Core/IO/ReaderOBJ.cpp
+++ b/src/Mod/Mesh/App/Core/IO/ReaderOBJ.cpp
@@ -109,7 +109,7 @@ bool ReaderOBJ::Load(std::istream& str)
             float b = std::min<int>(std::atof(what[12].first), 255) / 255.0F;
             meshPoints.push_back(MeshPoint(Base::Vector3f(fX, fY, fZ)));
 
-            App::Color c(r, g, b);
+            Base::Color c(r, g, b);
             unsigned long prop = static_cast<uint32_t>(c.getPackedValue());
             meshPoints.back().SetProperty(prop);
             rgb_value = MeshIO::PER_VERTEX;
@@ -123,7 +123,7 @@ bool ReaderOBJ::Load(std::istream& str)
             float b = static_cast<float>(std::atof(what[16].first));
             meshPoints.push_back(MeshPoint(Base::Vector3f(fX, fY, fZ)));
 
-            App::Color c(r, g, b);
+            Base::Color c(r, g, b);
             unsigned long prop = static_cast<uint32_t>(c.getPackedValue());
             meshPoints.back().SetProperty(prop);
             rgb_value = MeshIO::PER_VERTEX;
@@ -213,7 +213,7 @@ bool ReaderOBJ::Load(std::istream& str)
 
             for (const auto& it : meshPoints) {
                 unsigned long prop = it._ulProp;
-                App::Color c;
+                Base::Color c;
                 c.setPackedValue(static_cast<uint32_t>(prop));
                 _material->diffuseColor.push_back(c);
             }
@@ -224,7 +224,7 @@ bool ReaderOBJ::Load(std::istream& str)
         // calling instance but the color list is pre-filled with a default value
         if (_material) {
             _material->binding = MeshIO::PER_FACE;
-            _material->diffuseColor.resize(meshFacets.size(), App::Color(0.8F, 0.8F, 0.8F));
+            _material->diffuseColor.resize(meshFacets.size(), Base::Color(0.8F, 0.8F, 0.8F));
         }
     }
 
@@ -259,27 +259,27 @@ bool ReaderOBJ::LoadMaterial(std::istream& str)
         return false;
     }
 
-    std::map<std::string, App::Color> materialAmbientColor;
-    std::map<std::string, App::Color> materialDiffuseColor;
-    std::map<std::string, App::Color> materialSpecularColor;
+    std::map<std::string, Base::Color> materialAmbientColor;
+    std::map<std::string, Base::Color> materialDiffuseColor;
+    std::map<std::string, Base::Color> materialSpecularColor;
     std::map<std::string, float> materialTransparency;
     std::string materialName;
-    std::vector<App::Color> ambientColor;
-    std::vector<App::Color> diffuseColor;
-    std::vector<App::Color> specularColor;
+    std::vector<Base::Color> ambientColor;
+    std::vector<Base::Color> diffuseColor;
+    std::vector<Base::Color> specularColor;
     std::vector<float> transparency;
 
-    auto readColor = [](const std::vector<std::string>& tokens) -> App::Color {
+    auto readColor = [](const std::vector<std::string>& tokens) -> Base::Color {
         if (tokens.size() == 2) {
             // If only R is given then G and B will be equal
             float r = boost::lexical_cast<float>(tokens[1]);
-            return App::Color(r, r, r);
+            return Base::Color(r, r, r);
         }
         if (tokens.size() == 4) {
             float r = boost::lexical_cast<float>(tokens[1]);
             float g = boost::lexical_cast<float>(tokens[2]);
             float b = boost::lexical_cast<float>(tokens[3]);
-            return App::Color(r, g, b);
+            return Base::Color(r, g, b);
         }
 
         throw std::length_error("Unexpected number of tokens");
@@ -322,21 +322,21 @@ bool ReaderOBJ::LoadMaterial(std::istream& str)
         {
             auto jt = materialAmbientColor.find(it.first);
             if (jt != materialAmbientColor.end()) {
-                std::vector<App::Color> mat(it.second, jt->second);
+                std::vector<Base::Color> mat(it.second, jt->second);
                 ambientColor.insert(ambientColor.end(), mat.begin(), mat.end());
             }
         }
         {
             auto jt = materialDiffuseColor.find(it.first);
             if (jt != materialDiffuseColor.end()) {
-                std::vector<App::Color> mat(it.second, jt->second);
+                std::vector<Base::Color> mat(it.second, jt->second);
                 diffuseColor.insert(diffuseColor.end(), mat.begin(), mat.end());
             }
         }
         {
             auto jt = materialSpecularColor.find(it.first);
             if (jt != materialSpecularColor.end()) {
-                std::vector<App::Color> mat(it.second, jt->second);
+                std::vector<Base::Color> mat(it.second, jt->second);
                 specularColor.insert(specularColor.end(), mat.begin(), mat.end());
             }
         }

--- a/src/Mod/Mesh/App/Core/IO/WriterInventor.cpp
+++ b/src/Mod/Mesh/App/Core/IO/WriterInventor.cpp
@@ -122,13 +122,13 @@ public:
             return;
         }
 
-        auto transformColors = [](const std::vector<App::Color>& input) {
+        auto transformColors = [](const std::vector<Base::Color>& input) {
             std::vector<Base::ColorRGB> output;
             output.reserve(input.size());
             std::transform(input.cbegin(),
                            input.cend(),
                            std::back_inserter(output),
-                           [](const App::Color& col) {
+                           [](const Base::Color& col) {
                                return Base::ColorRGB {col.r, col.g, col.b};
                            });
 

--- a/src/Mod/Mesh/App/Core/IO/WriterOBJ.cpp
+++ b/src/Mod/Mesh/App/Core/IO/WriterOBJ.cpp
@@ -34,7 +34,7 @@ using namespace MeshCore;
 
 struct WriterOBJ::Color_Less
 {
-    bool operator()(const App::Color& x, const App::Color& y) const
+    bool operator()(const Base::Color& x, const Base::Color& y) const
     {
         if (x.r != y.r) {
             return x.r < y.r;
@@ -131,7 +131,7 @@ bool WriterOBJ::Save(std::ostream& out)
         }
 
         if (exportColorPerVertex) {
-            App::Color c;
+            Base::Color c;
             if (_material->binding == MeshIO::PER_VERTEX) {
                 c = _material->diffuseColor[index];
             }
@@ -171,14 +171,14 @@ bool WriterOBJ::Save(std::ostream& out)
             // facet indices (no texture and normal indices)
 
             // make sure to use the 'usemtl' statement as less often as possible
-            std::vector<App::Color> colors = _material->diffuseColor;
+            std::vector<Base::Color> colors = _material->diffuseColor;
             std::sort(colors.begin(), colors.end(), Color_Less());
             colors.erase(std::unique(colors.begin(), colors.end()), colors.end());
 
             std::size_t index = 0;
-            App::Color prev;
+            Base::Color prev;
             int faceIdx = 1;
-            const std::vector<App::Color>& Kd = _material->diffuseColor;
+            const std::vector<Base::Color>& Kd = _material->diffuseColor;
             for (auto it = rFacets.begin(); it != rFacets.end(); ++it, index++) {
                 if (index == 0 || prev != Kd[index]) {
                     prev = Kd[index];
@@ -209,13 +209,13 @@ bool WriterOBJ::Save(std::ostream& out)
     else {
         if (exportColorPerFace) {
             // make sure to use the 'usemtl' statement as less often as possible
-            std::vector<App::Color> colors = _material->diffuseColor;
+            std::vector<Base::Color> colors = _material->diffuseColor;
             std::sort(colors.begin(), colors.end(), Color_Less());
             colors.erase(std::unique(colors.begin(), colors.end()), colors.end());
 
             bool first = true;
-            App::Color prev;
-            const std::vector<App::Color>& Kd = _material->diffuseColor;
+            Base::Color prev;
+            const std::vector<Base::Color>& Kd = _material->diffuseColor;
 
             for (const auto& gt : _groups) {
                 out << "g " << Base::Tools::escapedUnicodeFromUtf8(gt.name.c_str()) << '\n';
@@ -263,7 +263,7 @@ bool WriterOBJ::SaveMaterial(std::ostream& out)
     if (_material) {
         if (_material->binding == MeshIO::PER_FACE) {
 
-            std::vector<App::Color> Kd = _material->diffuseColor;
+            std::vector<Base::Color> Kd = _material->diffuseColor;
             std::sort(Kd.begin(), Kd.end(), Color_Less());
             Kd.erase(std::unique(Kd.begin(), Kd.end()), Kd.end());
 

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -481,7 +481,7 @@ bool MeshInput::LoadOFF(std::istream& input)
     boost::cmatch what;
 
     bool colorPerVertex = false;
-    std::vector<App::Color> diffuseColor;
+    std::vector<Base::Color> diffuseColor;
     MeshPointArray meshPoints;
     MeshFacetArray meshFacets;
 
@@ -1808,7 +1808,7 @@ bool MeshOutput::SaveAsymptote(std::ostream& out) const
     bool saveFaceColor = (_material && _material->binding == MeshIO::PER_FACE
                           && _material->diffuseColor.size() == rFacets.size());
     // global mesh color
-    App::Color mc(0.8F, 0.8F, 0.8F);
+    Base::Color mc(0.8F, 0.8F, 0.8F);
     if (_material && _material->binding == MeshIO::OVERALL && _material->diffuseColor.size() == 1) {
         mc = _material->diffuseColor[0];
     }
@@ -1831,7 +1831,7 @@ bool MeshOutput::SaveAsymptote(std::ostream& out) const
             const MeshFacet& face = rFacets[index];
             out << ",\n             new pen[] {";
             for (int i = 0; i < 3; i++) {
-                const App::Color& c = _material->diffuseColor[face._aulPoints[i]];
+                const Base::Color& c = _material->diffuseColor[face._aulPoints[i]];
                 out << "rgb(" << c.r << ", " << c.g << ", " << c.b << ")";
                 if (i < 2) {
                     out << ", ";
@@ -1840,7 +1840,7 @@ bool MeshOutput::SaveAsymptote(std::ostream& out) const
             out << "}));\n";
         }
         else if (saveFaceColor) {
-            const App::Color& c = _material->diffuseColor[index];
+            const Base::Color& c = _material->diffuseColor[index];
             out << "),\n     rgb(" << c.r << ", " << c.g << ", " << c.b << "));\n";
         }
         else {
@@ -1912,7 +1912,7 @@ bool MeshOutput::SaveOFF(std::ostream& out) const
         }
 
         if (exportColor) {
-            App::Color c;
+            Base::Color c;
             if (_material->binding == MeshIO::PER_VERTEX) {
                 c = _material->diffuseColor[index];
             }
@@ -1984,7 +1984,7 @@ bool MeshOutput::SaveBinaryPLY(std::ostream& out) const
             os << p.x << p.y << p.z;
         }
         if (saveVertexColor) {
-            const App::Color& c = _material->diffuseColor[i];
+            const Base::Color& c = _material->diffuseColor[i];
             uint8_t r = uint8_t(255.0F * c.r);
             uint8_t g = uint8_t(255.0F * c.g);
             uint8_t b = uint8_t(255.0F * c.b);
@@ -2046,7 +2046,7 @@ bool MeshOutput::SaveAsciiPLY(std::ostream& out) const
                 out << p.x << " " << p.y << " " << p.z;
             }
 
-            const App::Color& c = _material->diffuseColor[i];
+            const Base::Color& c = _material->diffuseColor[i];
             int r = (int)(255.0F * c.r);
             int g = (int)(255.0F * c.g);
             int b = (int)(255.0F * c.b);
@@ -2359,7 +2359,7 @@ bool MeshOutput::SaveX3DContent(std::ostream& out, bool exportViewpoints) const
         bbox = bbox.Transformed(_transform);
     }
 
-    App::Color mat(0.65F, 0.65F, 0.65F);
+    Base::Color mat(0.65F, 0.65F, 0.65F);
     if (_material && _material->binding == MeshIO::Binding::OVERALL) {
         if (!_material->diffuseColor.empty()) {
             mat = _material->diffuseColor.front();
@@ -2679,7 +2679,7 @@ bool MeshOutput::SaveVRML(std::ostream& output) const
            << "        Material {\n";
     if (_material && _material->binding == MeshIO::OVERALL) {
         if (!_material->diffuseColor.empty()) {
-            App::Color c = _material->diffuseColor.front();
+            Base::Color c = _material->diffuseColor.front();
             output << "          diffuseColor " << c.r << " " << c.g << " " << c.b << "\n";
         }
         else {
@@ -2828,7 +2828,7 @@ void MeshCleanup::RemoveInvalidFacets()
         // adjust the material array if needed
         if (materialArray && materialArray->binding == MeshIO::PER_FACE
             && materialArray->diffuseColor.size() == facetArray.size()) {
-            std::vector<App::Color> colors;
+            std::vector<Base::Color> colors;
             colors.reserve(facetArray.size() - countInvalidFacets);
             for (std::size_t index = 0; index < facetArray.size(); index++) {
                 if (facetArray[index].IsValid()) {
@@ -2887,7 +2887,7 @@ void MeshCleanup::RemoveInvalidPoints()
         // adjust the material array if needed
         if (materialArray && materialArray->binding == MeshIO::PER_VERTEX
             && materialArray->diffuseColor.size() == pointArray.size()) {
-            std::vector<App::Color> colors;
+            std::vector<Base::Color> colors;
             colors.reserve(validPoints);
             for (std::size_t index = 0; index < pointArray.size(); index++) {
                 if (pointArray[index].IsValid()) {

--- a/src/Mod/Mesh/App/Core/MeshIO.h
+++ b/src/Mod/Mesh/App/Core/MeshIO.h
@@ -82,10 +82,10 @@ struct MeshExport Material
     MeshIO::Binding binding {MeshIO::OVERALL};
     mutable std::string library;
 
-    std::vector<App::Color> ambientColor;  /**< Defines the ambient color. */
-    std::vector<App::Color> diffuseColor;  /**< Defines the diffuse color. */
-    std::vector<App::Color> specularColor; /**< Defines the specular color. */
-    std::vector<App::Color> emissiveColor; /**< Defines the emissive color. */
+    std::vector<Base::Color> ambientColor;  /**< Defines the ambient color. */
+    std::vector<Base::Color> diffuseColor;  /**< Defines the diffuse color. */
+    std::vector<Base::Color> specularColor; /**< Defines the specular color. */
+    std::vector<Base::Color> emissiveColor; /**< Defines the emissive color. */
     std::vector<float> shininess;
     std::vector<float> transparency;
 

--- a/src/Mod/Mesh/App/Importer.cpp
+++ b/src/Mod/Mesh/App/Importer.cpp
@@ -65,19 +65,19 @@ void Importer::load(const std::string& fileName)
     }
 }
 
-void Importer::addVertexColors(Feature* feature, const std::vector<App::Color>& colors)
+void Importer::addVertexColors(Feature* feature, const std::vector<Base::Color>& colors)
 {
     addColors(feature, "VertexColors", colors);
 }
 
-void Importer::addFaceColors(Feature* feature, const std::vector<App::Color>& colors)
+void Importer::addFaceColors(Feature* feature, const std::vector<Base::Color>& colors)
 {
     addColors(feature, "FaceColors", colors);
 }
 
 void Importer::addColors(Feature* feature,
                          const std::string& property,
-                         const std::vector<App::Color>& colors)
+                         const std::vector<Base::Color>& colors)
 {
     App::PropertyColorList* prop = static_cast<App::PropertyColorList*>(
         feature->addDynamicProperty("App::PropertyColorList", property.c_str()));
@@ -105,7 +105,7 @@ void Importer::createMeshFromSegments(const std::string& name,
         if (mat.binding == MeshCore::MeshIO::PER_FACE
             && mat.diffuseColor.size() == mesh.countFacets()) {
 
-            std::vector<App::Color> diffuseColor;
+            std::vector<Base::Color> diffuseColor;
             diffuseColor.reserve(group.getIndices().size());
             for (const auto& it : group.getIndices()) {
                 diffuseColor.push_back(mat.diffuseColor[it]);

--- a/src/Mod/Mesh/App/Importer.h
+++ b/src/Mod/Mesh/App/Importer.h
@@ -48,9 +48,9 @@ public:
     void load(const std::string& fileName);
 
 private:
-    void addVertexColors(Feature*, const std::vector<App::Color>&);
-    void addFaceColors(Feature*, const std::vector<App::Color>&);
-    void addColors(Feature*, const std::string& property, const std::vector<App::Color>&);
+    void addVertexColors(Feature*, const std::vector<Base::Color>&);
+    void addFaceColors(Feature*, const std::vector<Base::Color>&);
+    void addColors(Feature*, const std::string& property, const std::vector<Base::Color>&);
     Feature* createMesh(const std::string& name, MeshObject&);
     void createMeshFromSegments(const std::string& name, MeshCore::Material& mat, MeshObject& mesh);
 

--- a/src/Mod/Mesh/App/MeshProperties.cpp
+++ b/src/Mod/Mesh/App/MeshProperties.cpp
@@ -415,22 +415,22 @@ MeshCore::MeshIO::Binding PropertyMaterial::getBinding() const
     return _material.binding;
 }
 
-const std::vector<App::Color>& PropertyMaterial::getAmbientColor() const
+const std::vector<Base::Color>& PropertyMaterial::getAmbientColor() const
 {
     return _material.ambientColor;
 }
 
-const std::vector<App::Color>& PropertyMaterial::getDiffuseColor() const
+const std::vector<Base::Color>& PropertyMaterial::getDiffuseColor() const
 {
     return _material.diffuseColor;
 }
 
-const std::vector<App::Color>& PropertyMaterial::getSpecularColor() const
+const std::vector<Base::Color>& PropertyMaterial::getSpecularColor() const
 {
     return _material.specularColor;
 }
 
-const std::vector<App::Color>& PropertyMaterial::getEmissiveColor() const
+const std::vector<Base::Color>& PropertyMaterial::getEmissiveColor() const
 {
     return _material.emissiveColor;
 }
@@ -452,28 +452,28 @@ void PropertyMaterial::setValue(const MeshCore::Material& value)
     hasSetValue();
 }
 
-void PropertyMaterial::setAmbientColor(const std::vector<App::Color>& value)
+void PropertyMaterial::setAmbientColor(const std::vector<Base::Color>& value)
 {
     aboutToSetValue();
     _material.ambientColor = value;
     hasSetValue();
 }
 
-void PropertyMaterial::setDiffuseColor(const std::vector<App::Color>& value)
+void PropertyMaterial::setDiffuseColor(const std::vector<Base::Color>& value)
 {
     aboutToSetValue();
     _material.diffuseColor = value;
     hasSetValue();
 }
 
-void PropertyMaterial::setSpecularColor(const std::vector<App::Color>& value)
+void PropertyMaterial::setSpecularColor(const std::vector<Base::Color>& value)
 {
     aboutToSetValue();
     _material.specularColor = value;
     hasSetValue();
 }
 
-void PropertyMaterial::setEmissiveColor(const std::vector<App::Color>& value)
+void PropertyMaterial::setEmissiveColor(const std::vector<Base::Color>& value)
 {
     aboutToSetValue();
     _material.emissiveColor = value;
@@ -503,7 +503,7 @@ void PropertyMaterial::setBinding(MeshCore::MeshIO::Binding bind)
 
 PyObject* PropertyMaterial::getPyObject()
 {
-    auto getColorList = [](const std::vector<App::Color>& color) {
+    auto getColorList = [](const std::vector<Base::Color>& color) {
         Py::List list;
         for (const auto& it : color) {
             list.append(Py::TupleN(Py::Float(it.r), Py::Float(it.g), Py::Float(it.b)));
@@ -534,7 +534,7 @@ PyObject* PropertyMaterial::getPyObject()
 void PropertyMaterial::setPyObject(PyObject* obj)
 {
     auto getColorList = [](const Py::Dict& dict, const std::string& key) {
-        std::vector<App::Color> color;
+        std::vector<Base::Color> color;
         if (dict.hasKey(key)) {
             Py::Sequence list(dict.getItem(key));
             color.reserve(list.size());
@@ -610,7 +610,7 @@ void PropertyMaterial::Restore(Base::XMLReader& reader)
 void PropertyMaterial::SaveDocFile(Base::Writer& writer) const
 {
     Base::OutputStream str(writer.Stream());
-    auto saveColor = [&str](const std::vector<App::Color>& color) {
+    auto saveColor = [&str](const std::vector<Base::Color>& color) {
         uint32_t count = static_cast<uint32_t>(color.size());
         str << count;
         for (const auto& it : color) {
@@ -640,7 +640,7 @@ void PropertyMaterial::SaveDocFile(Base::Writer& writer) const
 void PropertyMaterial::RestoreDocFile(Base::Reader& reader)
 {
     Base::InputStream str(reader);
-    auto restoreColor = [&str](std::vector<App::Color>& color) {
+    auto restoreColor = [&str](std::vector<Base::Color>& color) {
         uint32_t count = 0;
         str >> count;
         color.resize(count);
@@ -702,7 +702,7 @@ unsigned int PropertyMaterial::getMemSize() const
 {
     auto size = (_material.ambientColor.size() + _material.diffuseColor.size()
                  + _material.emissiveColor.size() + _material.specularColor.size())
-            * sizeof(App::Color)
+            * sizeof(Base::Color)
         + (_material.shininess.size() + _material.transparency.size()) * sizeof(float)
         + _material.library.size() + sizeof(_material);
     return static_cast<unsigned int>(size);

--- a/src/Mod/Mesh/App/MeshProperties.h
+++ b/src/Mod/Mesh/App/MeshProperties.h
@@ -189,19 +189,19 @@ public:
     /** Sets the property
      */
     void setValue(const MeshCore::Material& value);
-    void setAmbientColor(const std::vector<App::Color>& value);
-    void setDiffuseColor(const std::vector<App::Color>& value);
-    void setSpecularColor(const std::vector<App::Color>& value);
-    void setEmissiveColor(const std::vector<App::Color>& value);
+    void setAmbientColor(const std::vector<Base::Color>& value);
+    void setDiffuseColor(const std::vector<Base::Color>& value);
+    void setSpecularColor(const std::vector<Base::Color>& value);
+    void setEmissiveColor(const std::vector<Base::Color>& value);
     void setShininess(const std::vector<float>&);
     void setTransparency(const std::vector<float>&);
     void setBinding(MeshCore::MeshIO::Binding);
 
     const MeshCore::Material& getValue() const;
-    const std::vector<App::Color>& getAmbientColor() const;
-    const std::vector<App::Color>& getDiffuseColor() const;
-    const std::vector<App::Color>& getSpecularColor() const;
-    const std::vector<App::Color>& getEmissiveColor() const;
+    const std::vector<Base::Color>& getAmbientColor() const;
+    const std::vector<Base::Color>& getDiffuseColor() const;
+    const std::vector<Base::Color>& getSpecularColor() const;
+    const std::vector<Base::Color>& getEmissiveColor() const;
     const std::vector<float>& getShininess() const;
     const std::vector<float>& getTransparency() const;
     MeshCore::MeshIO::Binding getBinding() const;

--- a/src/Mod/Mesh/App/MeshTexture.cpp
+++ b/src/Mod/Mesh/App/MeshTexture.cpp
@@ -47,14 +47,14 @@ MeshTexture::MeshTexture(const Mesh::MeshObject& mesh, const MeshCore::Material&
 }
 
 void MeshTexture::apply(const Mesh::MeshObject& mesh,
-                        const App::Color& defaultColor,
+                        const Base::Color& defaultColor,
                         MeshCore::Material& material)
 {
     apply(mesh, true, defaultColor, -1.0F, material);
 }
 
 void MeshTexture::apply(const Mesh::MeshObject& mesh,
-                        const App::Color& defaultColor,
+                        const Base::Color& defaultColor,
                         float max_dist,
                         MeshCore::Material& material)
 {
@@ -63,31 +63,31 @@ void MeshTexture::apply(const Mesh::MeshObject& mesh,
 
 void MeshTexture::apply(const Mesh::MeshObject& mesh, MeshCore::Material& material)
 {
-    App::Color defaultColor;
+    Base::Color defaultColor;
     apply(mesh, false, defaultColor, -1.0F, material);
 }
 
 void MeshTexture::apply(const Mesh::MeshObject& mesh, float max_dist, MeshCore::Material& material)
 {
-    App::Color defaultColor;
+    Base::Color defaultColor;
     apply(mesh, false, defaultColor, max_dist, material);
 }
 
 void MeshTexture::apply(const Mesh::MeshObject& mesh,
                         bool addDefaultColor,
-                        const App::Color& defaultColor,
+                        const Base::Color& defaultColor,
                         float max_dist,
                         MeshCore::Material& material)
 {
     // copy the color values because the passed material could be the same instance as
     // 'materialRefMesh'
-    std::vector<App::Color> textureColor = materialRefMesh.diffuseColor;
+    std::vector<Base::Color> textureColor = materialRefMesh.diffuseColor;
     material.diffuseColor.clear();
     material.binding = MeshCore::MeshIO::OVERALL;
 
     if (kdTree) {
         // the points of the current mesh
-        std::vector<App::Color> diffuseColor;
+        std::vector<Base::Color> diffuseColor;
         const MeshCore::MeshPointArray& points = mesh.getKernel().GetPoints();
         const MeshCore::MeshFacetArray& facets = mesh.getKernel().GetFacets();
 

--- a/src/Mod/Mesh/App/MeshTexture.h
+++ b/src/Mod/Mesh/App/MeshTexture.h
@@ -53,7 +53,7 @@ public:
      original material is used.
      */
     void apply(const Mesh::MeshObject& mesh,
-               const App::Color& defaultColor,
+               const Base::Color& defaultColor,
                MeshCore::Material& material);
     /*!
      Find common points or facets of this to the original mesh. For points or facets
@@ -61,7 +61,7 @@ public:
      original material is used.
      */
     void apply(const Mesh::MeshObject& mesh,
-               const App::Color& defaultColor,
+               const Base::Color& defaultColor,
                float max_dist,
                MeshCore::Material& material);
     /*!
@@ -80,7 +80,7 @@ public:
 private:
     void apply(const Mesh::MeshObject& mesh,
                bool addDefaultColor,
-               const App::Color& defaultColor,
+               const Base::Color& defaultColor,
                float max_dist,
                MeshCore::Material& material);
     PointIndex findIndex(const Base::Vector3f& p, float max_dist) const

--- a/src/Mod/Mesh/Gui/MeshEditor.cpp
+++ b/src/Mod/Mesh/Gui/MeshEditor.cpp
@@ -117,7 +117,7 @@ void ViewProviderFace::attach(App::DocumentObject* obj)
 
     SoBaseColor* basecol = new SoBaseColor;
     if (mesh) {
-        App::Color col = mesh->ShapeAppearance.getDiffuseColor();
+        Base::Color col = mesh->ShapeAppearance.getDiffuseColor();
         basecol->rgb.setValue(col.r, col.g, col.b);
     }
     else {

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -269,7 +269,7 @@ ViewProviderMesh::ViewProviderMesh()
         Gui::WindowParameter::getDefaultParameter()->GetGroup("Mod/Mesh");
 
     // Mesh color
-    App::Color color = ShapeAppearance.getDiffuseColor();
+    Base::Color color = ShapeAppearance.getDiffuseColor();
     unsigned long current = color.getPackedValue();
     unsigned long setting = hGrp->GetUnsigned("MeshColor", current);
     if (current != setting) {
@@ -353,7 +353,7 @@ void ViewProviderMesh::onChanged(const App::Property* prop)
         }
     }
     else if (prop == &LineColor) {
-        const App::Color& c = LineColor.getValue();
+        const Base::Color& c = LineColor.getValue();
         pLineColor->diffuseColor.setValue(c.r, c.g, c.b);
     }
     else if (prop == &Coloring) {
@@ -373,7 +373,7 @@ void ViewProviderMesh::onChanged(const App::Property* prop)
     ViewProviderGeometryObject::onChanged(prop);
 }
 
-void ViewProviderMesh::setOpenEdgeColorFrom(const App::Color& c)
+void ViewProviderMesh::setOpenEdgeColorFrom(const Base::Color& c)
 {
     float r = 1.0F - c.r;
     r = r < 0.5F ? 0.0F : 1.0F;
@@ -588,7 +588,7 @@ void ViewProviderMesh::tryColorPerVertexOrFace(bool on)
     }
     else {
         pcMatBinding->value = SoMaterialBinding::OVERALL;
-        const App::Color& c = ShapeAppearance.getDiffuseColor();
+        const Base::Color& c = ShapeAppearance.getDiffuseColor();
         pcShapeMaterial->diffuseColor.setValue(c.r, c.g, c.b);
         pcShapeMaterial->transparency.setValue(Transparency.getValue() / 100.0F);
     }
@@ -606,7 +606,7 @@ void ViewProviderMesh::setColorPerFace(const App::PropertyColorList* prop)
     setDiffuseColor(prop->getValues());
 }
 
-void ViewProviderMesh::setColorField(const std::vector<App::Color>& val, SoMFColor& field)
+void ViewProviderMesh::setColorField(const std::vector<Base::Color>& val, SoMFColor& field)
 {
     field.setNum(val.size());
     SbColor* col = field.startEditing();
@@ -619,22 +619,22 @@ void ViewProviderMesh::setColorField(const std::vector<App::Color>& val, SoMFCol
     field.finishEditing();
 }
 
-void ViewProviderMesh::setAmbientColor(const std::vector<App::Color>& val)
+void ViewProviderMesh::setAmbientColor(const std::vector<Base::Color>& val)
 {
     setColorField(val, pcShapeMaterial->ambientColor);
 }
 
-void ViewProviderMesh::setDiffuseColor(const std::vector<App::Color>& val)
+void ViewProviderMesh::setDiffuseColor(const std::vector<Base::Color>& val)
 {
     setColorField(val, pcShapeMaterial->diffuseColor);
 }
 
-void ViewProviderMesh::setSpecularColor(const std::vector<App::Color>& val)
+void ViewProviderMesh::setSpecularColor(const std::vector<Base::Color>& val)
 {
     setColorField(val, pcShapeMaterial->specularColor);
 }
 
-void ViewProviderMesh::setEmissiveColor(const std::vector<App::Color>& val)
+void ViewProviderMesh::setEmissiveColor(const std::vector<Base::Color>& val)
 {
     setColorField(val, pcShapeMaterial->emissiveColor);
 }
@@ -1982,7 +1982,7 @@ void ViewProviderMesh::fillHole(Mesh::FacetIndex uFacet)
 void ViewProviderMesh::setFacetTransparency(const std::vector<float>& facetTransparency)
 {
     if (pcShapeMaterial->diffuseColor.getNum() != int(facetTransparency.size())) {
-        App::Color c = ShapeAppearance.getDiffuseColor();
+        Base::Color c = ShapeAppearance.getDiffuseColor();
         pcShapeMaterial->diffuseColor.setNum(facetTransparency.size());
         SbColor* cols = pcShapeMaterial->diffuseColor.startEditing();
         for (std::size_t index = 0; index < facetTransparency.size(); ++index) {
@@ -2004,7 +2004,7 @@ void ViewProviderMesh::setFacetTransparency(const std::vector<float>& facetTrans
 void ViewProviderMesh::resetFacetTransparency()
 {
     pcMatBinding->value = SoMaterialBinding::OVERALL;
-    App::Color c = ShapeAppearance.getDiffuseColor();
+    Base::Color c = ShapeAppearance.getDiffuseColor();
     pcShapeMaterial->diffuseColor.setValue(c.r, c.g, c.b);
     pcShapeMaterial->transparency.setValue(0);
 }
@@ -2032,8 +2032,8 @@ void ViewProviderMesh::removeFacets(const std::vector<Mesh::FacetIndex>& facets)
             // switch off coloring mode
             Coloring.setValue(false);
 
-            const std::vector<App::Color>& colors = prop->getValues();
-            std::vector<App::Color> valid_colors;
+            const std::vector<Base::Color>& colors = prop->getValues();
+            std::vector<Base::Color> valid_colors;
             valid_colors.reserve(kernel->countPoints() - invalid);
             std::size_t numPoints = pointDegree.size();
             for (std::size_t index = 0; index < numPoints; index++) {
@@ -2054,8 +2054,8 @@ void ViewProviderMesh::removeFacets(const std::vector<Mesh::FacetIndex>& facets)
             validFacets[it] = false;
         }
 
-        const std::vector<App::Color>& colors = prop->getValues();
-        std::vector<App::Color> valid_colors;
+        const std::vector<Base::Color>& colors = prop->getValues();
+        std::vector<Base::Color> valid_colors;
         valid_colors.reserve(colors.size());
         std::size_t numColors = colors.size();
         for (std::size_t index = 0; index < numColors; index++) {
@@ -2112,7 +2112,7 @@ void ViewProviderMesh::deselectFacet(Mesh::FacetIndex facet)
             highlightSelection();
         }
         else {
-            App::Color c = ShapeAppearance.getDiffuseColor();
+            Base::Color c = ShapeAppearance.getDiffuseColor();
             pcShapeMaterial->diffuseColor.set1Value(facet, c.r, c.g, c.b);
         }
     }
@@ -2280,7 +2280,7 @@ void ViewProviderMesh::highlightSelection()
 
     // Colorize the selection
     pcMatBinding->value = SoMaterialBinding::PER_FACE;
-    App::Color c = ShapeAppearance.getDiffuseColor();
+    Base::Color c = ShapeAppearance.getDiffuseColor();
     int uCtFacets = (int)rMesh.countFacets();
     pcShapeMaterial->diffuseColor.setNum(uCtFacets);
 
@@ -2296,7 +2296,7 @@ void ViewProviderMesh::highlightSelection()
 
 void ViewProviderMesh::unhighlightSelection()
 {
-    App::Color c = ShapeAppearance.getDiffuseColor();
+    Base::Color c = ShapeAppearance.getDiffuseColor();
     pcMatBinding->value = SoMaterialBinding::OVERALL;
     pcShapeMaterial->diffuseColor.setNum(1);
     pcShapeMaterial->diffuseColor.setValue(c.r, c.g, c.b);
@@ -2358,13 +2358,13 @@ void ViewProviderMesh::setHighlightedSegments(bool on)
 
 void ViewProviderMesh::highlightSegments()
 {
-    std::vector<App::Color> colors;
+    std::vector<Base::Color> colors;
     const Mesh::MeshObject& rMesh = getMeshObject();
     unsigned long numSegm = rMesh.countSegments();
     colors.resize(numSegm, this->ShapeAppearance.getDiffuseColor());
 
     for (unsigned long i = 0; i < numSegm; i++) {
-        App::Color col;
+        Base::Color col;
         if (col.fromHexString(rMesh.getSegment(i).getColor())) {
             colors[i] = col;
         }
@@ -2373,7 +2373,7 @@ void ViewProviderMesh::highlightSegments()
     highlightSegments(colors);
 }
 
-void ViewProviderMesh::highlightSegments(const std::vector<App::Color>& colors)
+void ViewProviderMesh::highlightSegments(const std::vector<Base::Color>& colors)
 {
     const Mesh::MeshObject& rMesh = getMeshObject();
     unsigned long numSegm = rMesh.countSegments();

--- a/src/Mod/Mesh/Gui/ViewProvider.h
+++ b/src/Mod/Mesh/Gui/ViewProvider.h
@@ -199,7 +199,7 @@ public:
     /*! The size of the array must be equal to the number of facets. */
     void setFacetTransparency(const std::vector<float>&);
     void resetFacetTransparency();
-    void highlightSegments(const std::vector<App::Color>&);
+    void highlightSegments(const std::vector<Base::Color>&);
     //@}
 
     /** @name Restoring view provider from document load */
@@ -215,7 +215,7 @@ protected:
     /// get called by the container whenever a property has been changed
     void onChanged(const App::Property* prop) override;
     virtual void showOpenEdges(bool);
-    void setOpenEdgeColorFrom(const App::Color& col);
+    void setOpenEdgeColorFrom(const Base::Color& col);
     virtual void
     splitMesh(const MeshCore::MeshKernel& toolMesh, const Base::Vector3f& normal, SbBool inner);
     virtual void
@@ -241,11 +241,11 @@ protected:
     const Mesh::PropertyMeshKernel& getMeshProperty() const;
     Mesh::PropertyMeshKernel& getMeshProperty();
 
-    void setColorField(const std::vector<App::Color>&, SoMFColor&);
-    void setAmbientColor(const std::vector<App::Color>&);
-    void setDiffuseColor(const std::vector<App::Color>&);
-    void setSpecularColor(const std::vector<App::Color>&);
-    void setEmissiveColor(const std::vector<App::Color>&);
+    void setColorField(const std::vector<Base::Color>&, SoMFColor&);
+    void setAmbientColor(const std::vector<Base::Color>&);
+    void setDiffuseColor(const std::vector<Base::Color>&);
+    void setSpecularColor(const std::vector<Base::Color>&);
+    void setEmissiveColor(const std::vector<Base::Color>&);
 
     virtual SoShape* getShapeNode() const;
     virtual SoNode* getCoordNode() const;

--- a/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
@@ -360,7 +360,7 @@ void ViewProviderMeshCurvature::setVertexCurvatureMode(int mode)
     float* transp = pcColorMat->transparency.startEditing();
 
     for (auto const& value : fValues | boost::adaptors::indexed(0)) {
-        App::Color c = pcColorBar->getColor(value.value());
+        Base::Color c = pcColorBar->getColor(value.value());
         // NOLINTBEGIN
         diffcol[value.index()].setValue(c.r, c.g, c.b);
         transp[value.index()] = c.transparency();

--- a/src/Mod/MeshPart/App/AppMeshPartPy.cpp
+++ b/src/Mod/MeshPart/App/AppMeshPartPy.cpp
@@ -510,7 +510,7 @@ private:
                     Py::Float r(t[0]);
                     Py::Float g(t[1]);
                     Py::Float b(t[2]);
-                    App::Color c(static_cast<float>(r),
+                    Base::Color c(static_cast<float>(r),
                                  static_cast<float>(g),
                                  static_cast<float>(b));
                     colors.push_back(c.getPackedValue());

--- a/src/Mod/MeshPart/App/Mesher.cpp
+++ b/src/Mod/MeshPart/App/Mesher.cpp
@@ -197,7 +197,7 @@ public:
                 std::stringstream str;
                 str << "patch" << index++;
                 segm.setName(str.str());
-                App::Color col;
+                Base::Color col;
                 col.setPackedValue(it.first);
                 segm.setColor(col.asHexString());
                 meshdata->addSegment(segm);

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -377,7 +377,7 @@ void Tessellation::setFaceColors(int method, App::Document* doc, App::DocumentOb
             auto svp = Base::freecad_dynamic_cast<PartGui::ViewProviderPartExt>(
                 Gui::Application::Instance->getViewProvider(obj));
             if (vpmesh && svp) {
-                std::vector<App::Color> diff_col = svp->ShapeAppearance.getDiffuseColors();
+                std::vector<Base::Color> diff_col = svp->ShapeAppearance.getDiffuseColors();
                 if (ui->groupsFaceColors->isChecked()) {
                     diff_col = getUniqueColors(diff_col);
                 }
@@ -389,15 +389,15 @@ void Tessellation::setFaceColors(int method, App::Document* doc, App::DocumentOb
     }
 }
 
-void Tessellation::addFaceColors(Mesh::Feature* mesh, const std::vector<App::Color>& colorPerSegm)
+void Tessellation::addFaceColors(Mesh::Feature* mesh, const std::vector<Base::Color>& colorPerSegm)
 {
     const Mesh::MeshObject& kernel = mesh->Mesh.getValue();
     unsigned long numSegm = kernel.countSegments();
     if (numSegm > 0 && numSegm == colorPerSegm.size()) {
         unsigned long uCtFacets = kernel.countFacets();
-        std::vector<App::Color> colorPerFace(uCtFacets);
+        std::vector<Base::Color> colorPerFace(uCtFacets);
         for (unsigned long i = 0; i < numSegm; i++) {
-            App::Color segmColor = colorPerSegm[i];
+            Base::Color segmColor = colorPerSegm[i];
             std::vector<Mesh::FacetIndex> segm = kernel.getSegment(i).getIndices();
             for (Mesh::FacetIndex it : segm) {
                 colorPerFace[it] = segmColor;
@@ -412,7 +412,7 @@ void Tessellation::addFaceColors(Mesh::Feature* mesh, const std::vector<App::Col
     }
 }
 
-std::vector<App::Color> Tessellation::getUniqueColors(const std::vector<App::Color>& colors) const
+std::vector<Base::Color> Tessellation::getUniqueColors(const std::vector<Base::Color>& colors) const
 {
     // unique colors
     std::set<uint32_t> col_set;
@@ -420,7 +420,7 @@ std::vector<App::Color> Tessellation::getUniqueColors(const std::vector<App::Col
         col_set.insert(it.getPackedValue());
     }
 
-    std::vector<App::Color> unique;
+    std::vector<Base::Color> unique;
     unique.reserve(col_set.size());
     for (const auto& it : col_set) {
         unique.emplace_back(it);

--- a/src/Mod/MeshPart/Gui/Tessellation.h
+++ b/src/Mod/MeshPart/Gui/Tessellation.h
@@ -97,12 +97,12 @@ protected:
     void process(int method, App::Document* doc, const std::list<App::SubObjectT>&);
     void saveParameters(int method);
     void setFaceColors(int method, App::Document* doc, App::DocumentObject* obj);
-    void addFaceColors(Mesh::Feature* mesh, const std::vector<App::Color>& colorPerSegm);
+    void addFaceColors(Mesh::Feature* mesh, const std::vector<Base::Color>& colorPerSegm);
     QString getMeshingParameters(int method, App::DocumentObject* obj) const;
     QString getStandardParameters(App::DocumentObject* obj) const;
     QString getMefistoParameters() const;
     QString getNetgenParameters() const;
-    std::vector<App::Color> getUniqueColors(const std::vector<App::Color>& colors) const;
+    std::vector<Base::Color> getUniqueColors(const std::vector<Base::Color>& colors) const;
 
 private:
     void setupConnections();

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -1007,7 +1007,7 @@ void TopoShape::exportStl(const char *filename, double deflection) const
 }
 
 void TopoShape::exportFaceSet(double dev, double ca,
-                              const std::vector<App::Color>& colors,
+                              const std::vector<Base::Color>& colors,
                               std::ostream& str) const
 {
     Base::InventorBuilder builder(str);
@@ -1056,7 +1056,7 @@ void TopoShape::exportFaceSet(double dev, double ca,
         Base::ShapeHintsItem shapeHints{static_cast<float>(ca)};
         builder.addNode(shapeHints);
         if (supportFaceColors) {
-            App::Color c = colors[index];
+            Base::Color c = colors[index];
             Base::MaterialItem material;
             material.setDiffuseColor({Base::ColorRGB{c.r, c.g, c.b}});
             material.setTransparency({c.a});

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -49,7 +49,7 @@ class gp_Ax2;
 class gp_Pln;
 class gp_Vec;
 
-namespace App
+namespace Base
 {
 class Color;
 }
@@ -477,7 +477,7 @@ public:
     void exportBrep(std::ostream&) const;
     void exportBinary(std::ostream&) const;
     void exportStl(const char* FileName, double deflection) const;
-    void exportFaceSet(double, double, const std::vector<App::Color>&, std::ostream&) const;
+    void exportFaceSet(double, double, const std::vector<Base::Color>&, std::ostream&) const;
     void exportLineSet(std::ostream&) const;
     //@}
 

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -312,7 +312,7 @@ PyObject* TopoShapePy::writeInventor(PyObject * args, PyObject * keywds)
         return nullptr;
     }
 
-    std::vector<App::Color> faceColors;
+    std::vector<Base::Color> faceColors;
     if (pylist) {
         App::PropertyColorList prop;
         prop.setPyObject(pylist);

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -656,7 +656,7 @@ void PartGui::DlgProjectionOnSurface::show_projected_shapes(
     if (vp) {
         const unsigned int color = 0x8ae23400;
         vp->LineColor.setValue(color);
-        vp->ShapeAppearance.setDiffuseColor(App::Color(color));
+        vp->ShapeAppearance.setDiffuseColor(Base::Color(color));
         vp->PointColor.setValue(color);
         vp->Transparency.setValue(0);
     }
@@ -721,8 +721,8 @@ void PartGui::DlgProjectionOnSurface::higlight_object(Part::Feature* iCurrentObj
     auto vp = dynamic_cast<PartGui::ViewProviderPartExt*>(
         Gui::Application::Instance->getViewProvider(iCurrentObject));
     if (vp) {
-        std::vector<App::Color> colors;
-        App::Color defaultColor;
+        std::vector<Base::Color> colors;
+        Base::Color defaultColor;
         if (currentShapeType == TopAbs_FACE) {
             colors = vp->ShapeAppearance.getDiffuseColors();
             defaultColor = colors.front();
@@ -737,7 +737,7 @@ void PartGui::DlgProjectionOnSurface::higlight_object(Part::Feature* iCurrentObj
         }
 
         if (iHighlight) {
-            App::Color aColor;
+            Base::Color aColor;
             aColor.setPackedValue(iColor);
             colors.at(index - 1) = aColor;
         }

--- a/src/Mod/Part/Gui/ReferenceHighlighter.cpp
+++ b/src/Mod/Part/Gui/ReferenceHighlighter.cpp
@@ -33,7 +33,7 @@
 
 using namespace PartGui;
 
-ReferenceHighlighter::ReferenceHighlighter(const TopoDS_Shape& shape, const App::Color& color)
+ReferenceHighlighter::ReferenceHighlighter(const TopoDS_Shape& shape, const Base::Color& color)
     : defaultColor(color)
     , elementColor(1.0f,0.0f,1.0f) // magenta
     , objectColor(0.6f,0.0f,1.0f) // purple
@@ -44,7 +44,7 @@ ReferenceHighlighter::ReferenceHighlighter(const TopoDS_Shape& shape, const App:
     TopExp::MapShapes(shape, TopAbs_FACE, fMap);
 }
 
-void ReferenceHighlighter::getVertexColor(const std::string& element, std::vector<App::Color>& colors) const
+void ReferenceHighlighter::getVertexColor(const std::string& element, std::vector<Base::Color>& colors) const
 {
     int idx = std::stoi(element.substr(6)) - 1;
     assert ( idx >= 0 );
@@ -53,7 +53,7 @@ void ReferenceHighlighter::getVertexColor(const std::string& element, std::vecto
         colors[pos] = elementColor;
 }
 
-void ReferenceHighlighter::getVertexColorsOfEdge(const std::string& element, std::vector<App::Color>& colors) const
+void ReferenceHighlighter::getVertexColorsOfEdge(const std::string& element, std::vector<Base::Color>& colors) const
 {
     int idx = std::stoi(element.substr(4));
     assert ( idx > 0 );
@@ -71,7 +71,7 @@ void ReferenceHighlighter::getVertexColorsOfEdge(const std::string& element, std
     }
 }
 
-void ReferenceHighlighter::getVertexColorsOfWire(const std::string& element, std::vector<App::Color>& colors) const
+void ReferenceHighlighter::getVertexColorsOfWire(const std::string& element, std::vector<Base::Color>& colors) const
 {
     int idx = std::stoi(element.substr(4));
     assert ( idx > 0 );
@@ -89,7 +89,7 @@ void ReferenceHighlighter::getVertexColorsOfWire(const std::string& element, std
     }
 }
 
-void ReferenceHighlighter::getVertexColorsOfFace(const std::string& element, std::vector<App::Color>& colors) const
+void ReferenceHighlighter::getVertexColorsOfFace(const std::string& element, std::vector<Base::Color>& colors) const
 {
     int idx = std::stoi(element.substr(4));
     assert ( idx > 0 );
@@ -108,7 +108,7 @@ void ReferenceHighlighter::getVertexColorsOfFace(const std::string& element, std
 }
 
 void ReferenceHighlighter::getVertexColors(const std::vector<std::string>& elements,
-                                           std::vector<App::Color>& colors) const
+                                           std::vector<Base::Color>& colors) const
 {
     colors.resize(vMap.Extent(), defaultColor);
 
@@ -133,7 +133,7 @@ void ReferenceHighlighter::getVertexColors(const std::vector<std::string>& eleme
     }
 }
 
-void ReferenceHighlighter::getEdgeColor(const std::string& element, std::vector<App::Color>& colors) const
+void ReferenceHighlighter::getEdgeColor(const std::string& element, std::vector<Base::Color>& colors) const
 {
     int idx = std::stoi(element.substr(4)) - 1;
     assert ( idx >= 0 );
@@ -142,7 +142,7 @@ void ReferenceHighlighter::getEdgeColor(const std::string& element, std::vector<
         colors[pos] = elementColor;
 }
 
-void ReferenceHighlighter::getEdgeColorsOfWire(const std::string& element, std::vector<App::Color>& colors) const
+void ReferenceHighlighter::getEdgeColorsOfWire(const std::string& element, std::vector<Base::Color>& colors) const
 {
     int idx = std::stoi(element.substr(4));
     assert ( idx > 0 );
@@ -160,7 +160,7 @@ void ReferenceHighlighter::getEdgeColorsOfWire(const std::string& element, std::
     }
 }
 
-void ReferenceHighlighter::getEdgeColorsOfFace(const std::string& element, std::vector<App::Color>& colors) const
+void ReferenceHighlighter::getEdgeColorsOfFace(const std::string& element, std::vector<Base::Color>& colors) const
 {
     int idx = std::stoi(element.substr(4));
     assert ( idx > 0 );
@@ -179,7 +179,7 @@ void ReferenceHighlighter::getEdgeColorsOfFace(const std::string& element, std::
 }
 
 void ReferenceHighlighter::getEdgeColors(const std::vector<std::string>& elements,
-                                         std::vector<App::Color>& colors) const
+                                         std::vector<Base::Color>& colors) const
 {
     colors.resize(eMap.Extent(), defaultColor);
 
@@ -201,7 +201,7 @@ void ReferenceHighlighter::getEdgeColors(const std::vector<std::string>& element
     }
 }
 
-void ReferenceHighlighter::getFaceColor(const std::string& element, std::vector<App::Color>& colors) const
+void ReferenceHighlighter::getFaceColor(const std::string& element, std::vector<Base::Color>& colors) const
 {
     int idx = std::stoi(element.substr(4)) - 1;
     assert ( idx >= 0 );
@@ -222,7 +222,7 @@ void ReferenceHighlighter::getFaceColor(const std::string& element,
 }
 
 void ReferenceHighlighter::getFaceColors(const std::vector<std::string>& elements,
-                                         std::vector<App::Color>& colors) const
+                                         std::vector<Base::Color>& colors) const
 {
     colors.resize(fMap.Extent(), defaultColor);
 

--- a/src/Mod/Part/Gui/ReferenceHighlighter.h
+++ b/src/Mod/Part/Gui/ReferenceHighlighter.h
@@ -46,15 +46,15 @@ public:
      * \param shape The input shape.
      * \param color The standard edge color.
      */
-    ReferenceHighlighter(const TopoDS_Shape& shape, const App::Color& color);
+    ReferenceHighlighter(const TopoDS_Shape& shape, const Base::Color& color);
 
-    void setDefaultColor(const App::Color& c) {
+    void setDefaultColor(const Base::Color& c) {
         defaultColor = c;
     }
-    void setElementColor(const App::Color& c) {
+    void setElementColor(const Base::Color& c) {
         elementColor = c;
     }
-    void setObjectColor(const App::Color& c) {
+    void setObjectColor(const Base::Color& c) {
         objectColor = c;
     }
 
@@ -64,21 +64,21 @@ public:
      * \param colors The size of the \a colors array is equal to the number of vertexes of the shape
      */
     void getVertexColors(const std::vector<std::string>& elements,
-                         std::vector<App::Color>& colors) const;
+                         std::vector<Base::Color>& colors) const;
     /*!
      * \brief getEdgeColors
      * \param elements The sub-element names. If this list is empty \a colors will be filled with the default color.
      * \param colors The size of the \a colors array is equal to the number of edges of the shape
      */
     void getEdgeColors(const std::vector<std::string>& elements,
-                       std::vector<App::Color>& colors) const;
+                       std::vector<Base::Color>& colors) const;
     /*!
      * \brief getFaceColors
      * \param elements The sub-element names. If this list is empty \a colors will be filled with the default color.
      * \param colors The size of the \a colors array is equal to the number of faces of the shape
      */
     void getFaceColors(const std::vector<std::string>& elements,
-                       std::vector<App::Color>& colors) const;
+                       std::vector<Base::Color>& colors) const;
     /*!
      * \brief getFaceMaterials
      * \param elements The sub-element names. If this list is empty \a materials will be filled with
@@ -89,20 +89,20 @@ public:
                           std::vector<App::Material>& materials) const;
 
 private:
-    void getVertexColor(const std::string& element, std::vector<App::Color>& colors) const;
-    void getVertexColorsOfEdge(const std::string& element, std::vector<App::Color>& colors) const;
-    void getVertexColorsOfWire(const std::string& element, std::vector<App::Color>& colors) const;
-    void getVertexColorsOfFace(const std::string& element, std::vector<App::Color>& colors) const;
-    void getEdgeColor(const std::string& element, std::vector<App::Color>& colors) const;
-    void getEdgeColorsOfWire(const std::string& element, std::vector<App::Color>& colors) const;
-    void getEdgeColorsOfFace(const std::string& element, std::vector<App::Color>& colors) const;
-    void getFaceColor(const std::string& element, std::vector<App::Color>& colors) const;
+    void getVertexColor(const std::string& element, std::vector<Base::Color>& colors) const;
+    void getVertexColorsOfEdge(const std::string& element, std::vector<Base::Color>& colors) const;
+    void getVertexColorsOfWire(const std::string& element, std::vector<Base::Color>& colors) const;
+    void getVertexColorsOfFace(const std::string& element, std::vector<Base::Color>& colors) const;
+    void getEdgeColor(const std::string& element, std::vector<Base::Color>& colors) const;
+    void getEdgeColorsOfWire(const std::string& element, std::vector<Base::Color>& colors) const;
+    void getEdgeColorsOfFace(const std::string& element, std::vector<Base::Color>& colors) const;
+    void getFaceColor(const std::string& element, std::vector<Base::Color>& colors) const;
     void getFaceColor(const std::string& element, std::vector<App::Material>& materials) const;
 
 private:
-    App::Color defaultColor;
-    App::Color elementColor;
-    App::Color objectColor;
+    Base::Color defaultColor;
+    Base::Color elementColor;
+    Base::Color objectColor;
     TopTools_IndexedMapOfShape vMap;
     TopTools_IndexedMapOfShape eMap;
     TopTools_IndexedMapOfShape wMap;

--- a/src/Mod/Part/Gui/SectionCutting.cpp
+++ b/src/Mod/Part/Gui/SectionCutting.cpp
@@ -145,7 +145,7 @@ void SectionCut::initControls(const Base::BoundBox3d& BoundCompound)
 {
     // lambda function to set color and transparency
     auto setColorTransparency = [&](Part::Box* pcBox) {
-        App::Color cutColor;
+        Base::Color cutColor;
         long cutTransparency{};
         auto vpBox = dynamic_cast<Gui::ViewProviderGeometryObject*>(
             Gui::Application::Instance->getViewProvider(pcBox));
@@ -297,7 +297,7 @@ void SectionCut::initBooleanFragmentControls(Gui::ViewProviderGeometryObject* co
     ui->groupBoxIntersecting->setChecked(true);
 
     if (compoundBF) {
-        App::Color compoundColor = compoundBF->ShapeAppearance.getDiffuseColor();
+        Base::Color compoundColor = compoundBF->ShapeAppearance.getDiffuseColor();
         ui->BFragColor->setColor(compoundColor.asValue<QColor>());
         long compoundTransparency = compoundBF->Transparency.getValue();
         ui->BFragTransparencyHS->setValue(int(compoundTransparency));
@@ -932,9 +932,9 @@ bool SectionCut::isCuttingEnabled() const
 }
 
 namespace {
-App::Color getFirstColor(const std::vector<App::DocumentObject*>& objects)
+Base::Color getFirstColor(const std::vector<App::DocumentObject*>& objects)
 {
-    App::Color cutColor;
+    Base::Color cutColor;
     auto vpFirstObject = dynamic_cast<Gui::ViewProviderGeometryObject*>(
         Gui::Application::Instance->getViewProvider(objects.front()));
     if (vpFirstObject) {
@@ -954,7 +954,7 @@ long getFirstTransparency(const std::vector<App::DocumentObject*>& objects)
     return cutTransparency;
 }
 
-bool isAutoColor(const App::Color& color, const std::vector<App::DocumentObject*>& objects)
+bool isAutoColor(const Base::Color& color, const std::vector<App::DocumentObject*>& objects)
 {
     bool autoColor = true;
     for (auto itCuts : objects) {
@@ -1278,7 +1278,7 @@ void SectionCut::processZBoxAndCut(const Args& args)
 void SectionCut::createAllObjects(const std::vector<App::DocumentObject*>& ObjectsListCut)
 {
     // store color and transparency of first object
-    App::Color cutColor = getFirstColor(ObjectsListCut);
+    Base::Color cutColor = getFirstColor(ObjectsListCut);
     long cutTransparency = getFirstTransparency(ObjectsListCut);
     bool autoColor = true;
     bool autoTransparency = true;
@@ -1325,7 +1325,7 @@ void SectionCut::createAllObjects(const std::vector<App::DocumentObject*>& Objec
     }
 
     // read cutface color for the cut box
-    App::Color boxColor;
+    Base::Color boxColor;
     boxColor.setValue<QColor>(ui->CutColor->color());
     int boxTransparency = ui->CutTransparencyHS->value();
 
@@ -2052,7 +2052,7 @@ void SectionCut::changeCutBoxColors()
         auto boxVP = Gui::Application::Instance->getViewProvider(boxObject);
         auto boxVPGO = dynamic_cast<Gui::ViewProviderGeometryObject*>(boxVP);
         if (boxVPGO) {
-            App::Color boxColor;
+            Base::Color boxColor;
             boxColor.setValue<QColor>(ui->CutColor->color());
             boxVPGO->ShapeAppearance.setDiffuseColor(boxColor);
             int boxTransparency = ui->CutTransparencyHS->value();
@@ -2160,7 +2160,7 @@ void SectionCut::setBooleanFragmentsColor()
         }
         auto CutCompoundBFGeom = dynamic_cast<Gui::ViewProviderGeometryObject*>(CompoundBFVP);
         if (CutCompoundBFGeom) {
-            App::Color BFColor;
+            Base::Color BFColor;
             BFColor.setValue<QColor>(ui->BFragColor->color());
             CutCompoundBFGeom->ShapeAppearance.setDiffuseColor(BFColor);
             int BFTransparency = ui->BFragTransparencyHS->value();

--- a/src/Mod/Part/Gui/TaskFaceAppearances.cpp
+++ b/src/Mod/Part/Gui/TaskFaceAppearances.cpp
@@ -368,9 +368,9 @@ void FaceAppearances::onSelectionChanged(const Gui::SelectionChanges& msg)
         if (docname == msg.pDocName && objname == msg.pObjectName) {
             int index = std::atoi(msg.pSubName + 4) - 1;
             d->index.insert(index);
-            const App::Color& faceColor = d->perface[index].diffuseColor;
+            const Base::Color& faceColor = d->perface[index].diffuseColor;
             QColor color;
-            // alpha of App::Color is contrary to the one of QColor
+            // alpha of Base::Color is contrary to the one of QColor
             color.setRgbF(faceColor.r, faceColor.g, faceColor.b, (1.0 - faceColor.a));
             selection_changed = true;
         }

--- a/src/Mod/Part/Gui/ViewProvider.cpp
+++ b/src/Mod/Part/Gui/ViewProvider.cpp
@@ -58,8 +58,8 @@ bool ViewProviderPart::doubleClicked()
 }
 
 void ViewProviderPart::applyColor(const Part::ShapeHistory& hist,
-                                  const std::vector<App::Color>& colBase,
-                                  std::vector<App::Color>& colBool)
+                                  const std::vector<Base::Color>& colBase,
+                                  std::vector<Base::Color>& colBool)
 {
     // apply color from modified faces
     for (const auto& jt : hist.shapeMap) {
@@ -81,7 +81,7 @@ void ViewProviderPart::applyMaterial(const Part::ShapeHistory& hist,
     }
 }
 
-void ViewProviderPart::applyTransparency(float transparency, std::vector<App::Color>& colors)
+void ViewProviderPart::applyTransparency(float transparency, std::vector<Base::Color>& colors)
 {
     if (transparency != 0.0) {
         // transparency has been set object-wide

--- a/src/Mod/Part/Gui/ViewProvider.h
+++ b/src/Mod/Part/Gui/ViewProvider.h
@@ -55,12 +55,12 @@ public:
 
 protected:
     void applyColor(const Part::ShapeHistory& hist,
-                    const std::vector<App::Color>& colBase,
-                    std::vector<App::Color>& colBool);
+                    const std::vector<Base::Color>& colBase,
+                    std::vector<Base::Color>& colBool);
     void applyMaterial(const Part::ShapeHistory& hist,
                        const std::vector<App::Material>& colBase,
                        std::vector<App::Material>& colBool);
-    void applyTransparency(float transparency, std::vector<App::Color>& colors);
+    void applyTransparency(float transparency, std::vector<Base::Color>& colors);
     void applyTransparency(float transparency, std::vector<App::Material>& colors);
 };
 

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -305,14 +305,14 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
         pcPointStyle->pointSize = PointSize.getValue();
     }
     else if (prop == &LineColor) {
-        const App::Color& c = LineColor.getValue();
+        const Base::Color& c = LineColor.getValue();
         pcLineMaterial->diffuseColor.setValue(c.r,c.g,c.b);
         if (c != LineMaterial.getValue().diffuseColor)
             LineMaterial.setDiffuseColor(c);
         LineColorArray.setValue(LineColor.getValue());
     }
     else if (prop == &PointColor) {
-        const App::Color& c = PointColor.getValue();
+        const Base::Color& c = PointColor.getValue();
         pcPointMaterial->diffuseColor.setValue(c.r,c.g,c.b);
         if (c != PointMaterial.getValue().diffuseColor)
             PointMaterial.setDiffuseColor(c);
@@ -348,7 +348,7 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
     }
     else if (prop == &_diffuseColor) {
         // Used to load the old DiffuseColor values asynchronously
-        std::vector<App::Color> colors = _diffuseColor.getValues();
+        std::vector<Base::Color> colors = _diffuseColor.getValues();
         std::vector<float> transparencies;
         transparencies.resize(static_cast<int>(colors.size()));
         for (int i = 0; i < static_cast<int>(colors.size()); i++) {
@@ -671,8 +671,8 @@ void ViewProviderPartExt::setHighlightedFaces(const App::PropertyMaterialList& a
     setHighlightedFaces(appearance.getValues());
 }
 
-std::map<std::string,App::Color> ViewProviderPartExt::getElementColors(const char *element) const {
-    std::map<std::string,App::Color> ret;
+std::map<std::string,Base::Color> ViewProviderPartExt::getElementColors(const char *element) const {
+    std::map<std::string,Base::Color> ret;
 
     if(!element || !element[0]) {
         auto color = ShapeAppearance.getDiffuseColor();
@@ -766,7 +766,7 @@ void ViewProviderPartExt::unsetHighlightedFaces()
     Transparency.touch();
 }
 
-void ViewProviderPartExt::setHighlightedEdges(const std::vector<App::Color>& colors)
+void ViewProviderPartExt::setHighlightedEdges(const std::vector<Base::Color>& colors)
 {
     if (getObject() && getObject()->testStatus(App::ObjectStatus::TouchOnColorChange))
         getObject()->touch(true);
@@ -803,7 +803,7 @@ void ViewProviderPartExt::unsetHighlightedEdges()
     LineMaterial.touch();
 }
 
-void ViewProviderPartExt::setHighlightedPoints(const std::vector<App::Color>& colors)
+void ViewProviderPartExt::setHighlightedPoints(const std::vector<Base::Color>& colors)
 {
     if (getObject() && getObject()->testStatus(App::ObjectStatus::TouchOnColorChange))
         getObject()->touch(true);

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -76,6 +76,7 @@ public:
     App::PropertyAngle AngularDeflection;
     App::PropertyEnumeration Lighting;
     App::PropertyEnumeration DrawStyle;
+    App::PropertyBool ShowPlacement;
     // Points
     App::PropertyFloatConstraint PointSize;
     App::PropertyColor PointColor;
@@ -127,16 +128,16 @@ public:
     void setHighlightedFaces(const std::vector<App::Material>& materials);
     void setHighlightedFaces(const App::PropertyMaterialList& appearance);
     void unsetHighlightedFaces();
-    void setHighlightedEdges(const std::vector<App::Color>& colors);
+    void setHighlightedEdges(const std::vector<Base::Color>& colors);
     void unsetHighlightedEdges();
-    void setHighlightedPoints(const std::vector<App::Color>& colors);
+    void setHighlightedPoints(const std::vector<Base::Color>& colors);
     void unsetHighlightedPoints();
     //@}
 
     /** @name Color management methods
      */
     //@{
-    std::map<std::string,App::Color> getElementColors(const char *element=nullptr) const override;
+    std::map<std::string,Base::Color> getElementColors(const char *element=nullptr) const override;
     //@}
 
     bool isUpdateForced() const override {

--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -523,13 +523,13 @@ void ViewProviderGridExtension::setGridDivLineWidth(int width)
     drawGrid(false);
 }
 
-void ViewProviderGridExtension::setGridLineColor(const App::Color & color)
+void ViewProviderGridExtension::setGridLineColor(const Base::Color & color)
 {
     pImpl->GridLineColor = color.getPackedValue();
     drawGrid(false);
 }
 
-void ViewProviderGridExtension::setGridDivLineColor(const App::Color & color)
+void ViewProviderGridExtension::setGridDivLineColor(const Base::Color & color)
 {
     pImpl->GridDivLineColor = color.getPackedValue();
     drawGrid(false);

--- a/src/Mod/Part/Gui/ViewProviderGridExtension.h
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.h
@@ -76,8 +76,8 @@ protected:
     void setGridDivLinePattern(int pattern);
     void setGridLineWidth(int width);
     void setGridDivLineWidth(int width);
-    void setGridLineColor(const App::Color & color);
-    void setGridDivLineColor(const App::Color & color);
+    void setGridLineColor(const Base::Color & color);
+    void setGridDivLineColor(const Base::Color & color);
 
     bool extensionHandleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop) override;
 

--- a/src/Mod/Part/Gui/ViewProviderPartExtPyImp.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPartExtPyImp.cpp
@@ -52,7 +52,7 @@ PyObject* ViewProviderPartExtPy::getCustomAttributes(const char* attr) const
         // Get the color properties
         App::PropertyColorList prop;
 
-        std::vector<App::Color> colors = vp->ShapeAppearance.getDiffuseColors();
+        std::vector<Base::Color> colors = vp->ShapeAppearance.getDiffuseColors();
         std::vector<float> transparencies = vp->ShapeAppearance.getTransparencies();
         for (int i = 0; i < static_cast<int>(colors.size()); i++) {
             colors[i].setTransparency(transparencies[i]);
@@ -72,7 +72,7 @@ int ViewProviderPartExtPy::setCustomAttributes(const char* attr, PyObject* obj)
         App::PropertyColorList prop;
         prop.setPyObject(obj);
 
-        std::vector<App::Color> colors = prop.getValues();
+        std::vector<Base::Color> colors = prop.getValues();
         std::vector<float> transparencies;
         transparencies.resize(static_cast<int>(colors.size()));
         for (int i = 0; i < static_cast<int>(colors.size()); i++) {

--- a/src/Mod/Part/Gui/ViewProviderReference.cpp
+++ b/src/Mod/Part/Gui/ViewProviderReference.cpp
@@ -122,13 +122,13 @@ void ViewProviderPartReference::onChanged(const App::Property* /*prop*/)
     //    pcPointStyle->pointSize = PointSize.getValue();
     //}
     //else if (prop == &LineColor) {
-    //    const App::Color& c = LineColor.getValue();
+    //    const Base::Color& c = LineColor.getValue();
     //    pcLineMaterial->diffuseColor.setValue(c.r,c.g,c.b);
     //    if (c != LineMaterial.getValue().diffuseColor)
     //    LineMaterial.setDiffuseColor(c);
     //}
     //else if (prop == &PointColor) {
-    //    const App::Color& c = PointColor.getValue();
+    //    const Base::Color& c = PointColor.getValue();
     //    pcPointMaterial->diffuseColor.setValue(c.r,c.g,c.b);
     //    if (c != PointMaterial.getValue().diffuseColor)
     //    PointMaterial.setDiffuseColor(c);

--- a/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
@@ -83,7 +83,7 @@ ViewProviderDatum::ViewProviderDatum()
             "User parameter:BaseApp/Preferences/Mod/PartDesign");
     unsigned long shcol = hGrp->GetUnsigned ( "DefaultDatumColor", 0xFFD70099 );
 
-    App::Color col ( (uint32_t) shcol );
+    Base::Color col ( (uint32_t) shcol );
     ShapeAppearance.setDiffuseColor(col);
 
     Transparency.setValue (col.a * 100);

--- a/src/Mod/PartDesign/Gui/ViewProviderDressUp.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDressUp.cpp
@@ -108,7 +108,7 @@ void ViewProviderDressUp::highlightReferences(const bool on)
             vp->setHighlightedFaces(materials);
         }
         if (!edges.empty()) {
-            std::vector<App::Color> colors = vp->LineColorArray.getValues();
+            std::vector<Base::Color> colors = vp->LineColorArray.getValues();
 
             PartGui::ReferenceHighlighter highlighter(base->Shape.getValue(), LineColor.getValue());
             highlighter.getEdgeColors(edges, colors);

--- a/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
@@ -153,11 +153,11 @@ void ViewProviderLoft::highlightReferences(Part::Feature* base, const std::vecto
     if (!svp)
         return;
 
-    std::vector<App::Color>& edgeColors = originalLineColors[base->getID()];
+    std::vector<Base::Color>& edgeColors = originalLineColors[base->getID()];
 
     if (on) {
         edgeColors = svp->LineColorArray.getValues();
-        std::vector<App::Color> colors = edgeColors;
+        std::vector<Base::Color> colors = edgeColors;
 
         PartGui::ReferenceHighlighter highlighter(base->Shape.getValue(), svp->LineColor.getValue());
         highlighter.getEdgeColors(elements, colors);

--- a/src/Mod/PartDesign/Gui/ViewProviderLoft.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderLoft.h
@@ -63,7 +63,7 @@ private:
     void highlightReferences(Part::Feature*, const std::vector<std::string>&, bool);
 
 private:
-    std::map<long, std::vector<App::Color>> originalLineColors;
+    std::map<long, std::vector<Base::Color>> originalLineColors;
 };
 
 

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
@@ -151,12 +151,12 @@ void ViewProviderPipe::highlightReferences(Part::Feature* base, const std::vecto
     if (!svp)
         return;
 
-    std::vector<App::Color>& edgeColors = originalLineColors[base->getID()];
+    std::vector<Base::Color>& edgeColors = originalLineColors[base->getID()];
 
     if (on) {
         if (edgeColors.empty()) {
             edgeColors = svp->LineColorArray.getValues();
-            std::vector<App::Color> colors = edgeColors;
+            std::vector<Base::Color> colors = edgeColors;
 
             PartGui::ReferenceHighlighter highlighter(base->Shape.getValue(), svp->LineColor.getValue());
             highlighter.getEdgeColors(edges, colors);

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.h
@@ -64,7 +64,7 @@ private:
     void highlightReferences(Part::Feature*, const std::vector<std::string>&, bool);
 
 private:
-    std::map<long, std::vector<App::Color>> originalLineColors;
+    std::map<long, std::vector<Base::Color>> originalLineColors;
 };
 
 

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -70,7 +70,7 @@ ViewProviderShapeBinder::ViewProviderShapeBinder()
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/PartDesign");
     unsigned long shcol = hGrp->GetUnsigned("DefaultDatumColor", 0xFFD70099);
-    App::Color col((uint32_t)shcol);
+    Base::Color col((uint32_t)shcol);
 
     ShapeAppearance.setDiffuseColor(col);
     LineColor.setValue(col);
@@ -157,7 +157,7 @@ void ViewProviderShapeBinder::highlightReferences(bool on)
             TopTools_IndexedMapOfShape eMap;
             TopExp::MapShapes(static_cast<Part::Feature*>(obj)->Shape.getValue(), TopAbs_EDGE, eMap);
             originalLineColors = svp->LineColorArray.getValues();
-            std::vector<App::Color> lcolors = originalLineColors;
+            std::vector<Base::Color> lcolors = originalLineColors;
             lcolors.resize(eMap.Extent(), svp->LineColor.getValue());
 
             TopExp::MapShapes(static_cast<Part::Feature*>(obj)->Shape.getValue(), TopAbs_FACE, eMap);
@@ -171,13 +171,13 @@ void ViewProviderShapeBinder::highlightReferences(bool on)
                     int idx = std::stoi(e.substr(4)) - 1;
                     assert(idx >= 0);
                     if (idx < static_cast<int>(lcolors.size()))
-                        lcolors[idx] = App::Color(1.0, 0.0, 1.0); // magenta
+                        lcolors[idx] = Base::Color(1.0, 0.0, 1.0); // magenta
                 }
                 else if (e.compare(0, 4, "Face") == 0) {
                     int idx = std::stoi(e.substr(4)) - 1;
                     assert(idx >= 0);
                     if (idx < static_cast<int>(fcolors.size()))
-                        fcolors[idx].diffuseColor = App::Color(1.0, 0.0, 1.0); // magenta
+                        fcolors[idx].diffuseColor = Base::Color(1.0, 0.0, 1.0); // magenta
                 }
             }
             svp->LineColorArray.setValues(lcolors);
@@ -239,7 +239,7 @@ void ViewProviderSubShapeBinder::onChanged(const App::Property* prop) {
     if (prop == &UseBinderStyle
         && (!getObject() || !getObject()->isRestoring()))
     {
-        App::Color shapeColor, lineColor, pointColor;
+        Base::Color shapeColor, lineColor, pointColor;
         int transparency, linewidth;
         if (UseBinderStyle.getValue()) {
             //get the datum coloring scheme

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.h
@@ -47,7 +47,7 @@ protected:
     void attach(App::DocumentObject *obj) override;
 
 private:
-    std::vector<App::Color> originalLineColors;
+    std::vector<Base::Color> originalLineColors;
     std::vector<App::Material> originalFaceAppearance;
 
 };

--- a/src/Mod/Points/App/PointsAlgos.cpp
+++ b/src/Mod/Points/App/PointsAlgos.cpp
@@ -155,7 +155,7 @@ bool Reader::hasIntensities() const
     return (!intensity.empty());
 }
 
-const std::vector<App::Color>& Reader::getColors() const
+const std::vector<Base::Color>& Reader::getColors() const
 {
     return colors;
 }
@@ -1166,7 +1166,7 @@ void PcdReader::read(const std::string& filename)
         if (types[rgba] == "U") {
             for (Eigen::Index i = 0; i < numPoints; i++) {
                 uint32_t packed = static_cast<uint32_t>(data(i, rgba));
-                App::Color col;
+                Base::Color col;
                 col.setPackedARGB(packed);
                 colors.emplace_back(col);
             }
@@ -1178,7 +1178,7 @@ void PcdReader::read(const std::string& filename)
                 float f = static_cast<float>(data(i, rgba));
                 uint32_t packed {};
                 std::memcpy(&packed, &f, sizeof(packed));
-                App::Color col;
+                Base::Color col;
                 col.setPackedARGB(packed);
                 colors.emplace_back(col);
             }
@@ -1413,7 +1413,7 @@ public:
         }
     }
 
-    std::vector<App::Color> getColors() const
+    std::vector<Base::Color> getColors() const
     {
         return colors;
     }
@@ -1705,9 +1705,9 @@ private:
         return pt;
     }
 
-    App::Color getColor(const Proto& proto, size_t index) const
+    Base::Color getColor(const Proto& proto, size_t index) const
     {
-        App::Color c;
+        Base::Color c;
         c.r = static_cast<float>(proto.redData[index]) / 255.0F;
         c.g = static_cast<float>(proto.greenData[index]) / 255.0F;
         c.b = static_cast<float>(proto.blueData[index]) / 255.0F;
@@ -1769,7 +1769,7 @@ private:
     bool checkState;
     double minDistance;
     const size_t buf_size = 1024;
-    std::vector<App::Color> colors;
+    std::vector<Base::Color> colors;
     std::vector<float> intensity;
     PointKernel points;
     std::vector<Base::Vector3f> normals;
@@ -1817,7 +1817,7 @@ void Writer::setIntensities(const std::vector<float>& i)
     intensity = i;
 }
 
-void Writer::setColors(const std::vector<App::Color>& c)
+void Writer::setColors(const std::vector<Base::Color>& c)
 {
     colors = c;
 }
@@ -1972,7 +1972,7 @@ void PlyWriter::write(const std::string& filename)
         Eigen::Index col2 = col + 2;
         Eigen::Index col3 = col + 3;
         for (Eigen::Index i = 0; i < numPoints; i++) {
-            App::Color c = colors[i];
+            Base::Color c = colors[i];
             data(i, col0) = (c.r * 255.0F + 0.5F);
             data(i, col1) = (c.g * 255.0F + 0.5F);
             data(i, col2) = (c.b * 255.0F + 0.5F);

--- a/src/Mod/Points/App/PointsAlgos.h
+++ b/src/Mod/Points/App/PointsAlgos.h
@@ -57,7 +57,7 @@ public:
     bool hasProperties() const;
     const std::vector<float>& getIntensities() const;
     bool hasIntensities() const;
-    const std::vector<App::Color>& getColors() const;
+    const std::vector<Base::Color>& getColors() const;
     bool hasColors() const;
     const std::vector<Base::Vector3f>& getNormals() const;
     bool hasNormals() const;
@@ -74,7 +74,7 @@ protected:
     // NOLINTBEGIN
     PointKernel points;
     std::vector<float> intensity;
-    std::vector<App::Color> colors;
+    std::vector<Base::Color> colors;
     std::vector<Base::Vector3f> normals;
     int width {0};
     int height {1};
@@ -149,7 +149,7 @@ public:
     virtual void write(const std::string& filename) = 0;
 
     void setIntensities(const std::vector<float>&);
-    void setColors(const std::vector<App::Color>&);
+    void setColors(const std::vector<Base::Color>&);
     void setNormals(const std::vector<Base::Vector3f>&);
     void setWidth(int);
     void setHeight(int);
@@ -164,7 +164,7 @@ protected:
     // NOLINTBEGIN
     const PointKernel& points;
     std::vector<float> intensity;
-    std::vector<App::Color> colors;
+    std::vector<Base::Color> colors;
     std::vector<Base::Vector3f> normals;
     int width, height;
     Base::Placement placement;

--- a/src/Mod/Points/Gui/ViewProvider.cpp
+++ b/src/Mod/Points/Gui/ViewProvider.cpp
@@ -113,7 +113,7 @@ void ViewProviderPoints::onChanged(const App::Property* prop)
 
 void ViewProviderPoints::setVertexColorMode(App::PropertyColorList* pcProperty)
 {
-    const std::vector<App::Color>& val = pcProperty->getValues();
+    const std::vector<Base::Color>& val = pcProperty->getValues();
 
     pcColorMat->diffuseColor.setNum(val.size());
     SbColor* col = pcColorMat->diffuseColor.startEditing();
@@ -500,18 +500,18 @@ void ViewProviderScattered::cut(const std::vector<SbVec2f>& picked,
         }
         else if (type == App::PropertyColorList::getClassTypeId()) {
             // static_cast<App::PropertyColorList*>(it->second)->removeIndices(removeIndices);
-            const std::vector<App::Color>& colors =
+            const std::vector<Base::Color>& colors =
                 static_cast<App::PropertyColorList*>(it.second)->getValues();
 
             if (removeIndices.size() > colors.size()) {
                 break;
             }
 
-            std::vector<App::Color> remainValue;
+            std::vector<Base::Color> remainValue;
             remainValue.reserve(colors.size() - removeIndices.size());
 
             std::vector<unsigned long>::iterator pos = removeIndices.begin();
-            for (std::vector<App::Color>::const_iterator jt = colors.begin(); jt != colors.end();
+            for (std::vector<Base::Color>::const_iterator jt = colors.begin(); jt != colors.end();
                  ++jt) {
                 unsigned long index = jt - colors.begin();
                 if (pos == removeIndices.end()) {

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
@@ -24,7 +24,7 @@
 
 #include "Mod/Sketcher/App/ExternalGeometryFacade.h"
 
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <Gui/ViewParams.h>
 
 #include "EditModeCoinManagerParameters.h"
@@ -59,10 +59,10 @@ SbColor DrawingParameters::CreateCurveColor(0.5f, 0.5f, 0.5f);  // ##7f7f7f -> (
 namespace
 {  // Anonymous namespace to avoid making those variables global
 unsigned long HColorLong = Gui::ViewParams::instance()->getAxisXColor();
-App::Color Hcolor = App::Color(static_cast<uint32_t>(HColorLong));
+Base::Color Hcolor = Base::Color(static_cast<uint32_t>(HColorLong));
 
 unsigned long VColorLong = Gui::ViewParams::instance()->getAxisYColor();
-App::Color Vcolor = App::Color(static_cast<uint32_t>(VColorLong));
+Base::Color Vcolor = Base::Color(static_cast<uint32_t>(VColorLong));
 }  // namespace
 SbColor DrawingParameters::CrossColorH(Hcolor.r, Hcolor.g, Hcolor.b);
 SbColor DrawingParameters::CrossColorV(Vcolor.r, Vcolor.g, Vcolor.b);

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -40,7 +40,7 @@
 #include <Inventor/nodes/SoText2.h>
 #include <Inventor/nodes/SoTranslation.h>
 
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <Gui/ViewParams.h>
 #include <Gui/Inventor/SmSwitchboard.h>
 #include <Mod/Sketcher/App/GeoList.h>
@@ -153,14 +153,14 @@ struct DrawingParameters
     DrawingParameters()
     {
         unsigned long colorLong;
-        App::Color color;
+        Base::Color color;
 
         colorLong = Gui::ViewParams::instance()->getAxisXColor();
-        color = App::Color(static_cast<uint32_t>(colorLong));
+        color = Base::Color(static_cast<uint32_t>(colorLong));
         CrossColorH = SbColor(color.r, color.g, color.b);
 
         colorLong = Gui::ViewParams::instance()->getAxisYColor();
-        color = App::Color(static_cast<uint32_t>(colorLong));
+        color = Base::Color(static_cast<uint32_t>(colorLong));
         CrossColorV = SbColor(color.r, color.g, color.b);
     }
 };

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -141,7 +141,7 @@ void ViewProviderSketch::ParameterObserver::updateColorProperty(const std::strin
 
     colorprop->setValue(r, g, b);
 
-    App::Color elementAppColor = colorprop->getValue();
+    Base::Color elementAppColor = colorprop->getValue();
     unsigned long color = (unsigned long)(elementAppColor.getPackedValue());
     color = hGrp->GetUnsigned(string.c_str(), color);
     elementAppColor.setPackedValue((uint32_t)color);
@@ -345,7 +345,7 @@ void ViewProviderSketch::ParameterObserver::initParameters()
          {[this, packedDefaultGridColor](const std::string& string,
                                          [[maybe_unused]] App::Property* property) {
               auto v = getSketcherGeneralParameter(string, packedDefaultGridColor);
-              auto color = App::Color(v);
+              auto color = Base::Color(v);
               Client.setGridLineColor(color);
           },
           nullptr}},
@@ -353,7 +353,7 @@ void ViewProviderSketch::ParameterObserver::initParameters()
          {[this, packedDefaultGridColor](const std::string& string,
                                          [[maybe_unused]] App::Property* property) {
               auto v = getSketcherGeneralParameter(string, packedDefaultGridColor);
-              auto color = App::Color(v);
+              auto color = Base::Color(v);
               Client.setGridDivLineColor(color);
           },
           nullptr}},
@@ -2941,7 +2941,7 @@ void SketcherGui::ViewProviderSketch::finishRestoring()
     // that meaans that we need to run migration strategy and come up with a proper value
     if (!AutoColor.isTouched()) {
         // white is the normally provided default for FreeCAD sketch colors
-        auto white = App::Color(1.f, 1.f, 1.f, 1.f);
+        auto white = Base::Color(1.f, 1.f, 1.f, 1.f);
 
         auto colorWasNeverChanged =
             LineColor.getValue() == white &&

--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -467,13 +467,13 @@ bool Cell::getStyle(std::set<std::string>& _style) const
  *
  */
 
-void Cell::setForeground(const App::Color& color)
+void Cell::setForeground(const Base::Color& color)
 {
     if (color != foregroundColor) {
         PropertySheet::AtomicPropertyChange signaller(*owner);
 
         foregroundColor = color;
-        setUsed(FOREGROUND_COLOR_SET, foregroundColor != App::Color(0, 0, 0, 1));
+        setUsed(FOREGROUND_COLOR_SET, foregroundColor != Base::Color(0, 0, 0, 1));
         setDirty();
 
         signaller.tryInvoke();
@@ -485,7 +485,7 @@ void Cell::setForeground(const App::Color& color)
  *
  */
 
-bool Cell::getForeground(App::Color& color) const
+bool Cell::getForeground(Base::Color& color) const
 {
     color = foregroundColor;
     return isUsed(FOREGROUND_COLOR_SET);
@@ -496,13 +496,13 @@ bool Cell::getForeground(App::Color& color) const
  *
  */
 
-void Cell::setBackground(const App::Color& color)
+void Cell::setBackground(const Base::Color& color)
 {
     if (color != backgroundColor) {
         PropertySheet::AtomicPropertyChange signaller(*owner);
 
         backgroundColor = color;
-        setUsed(BACKGROUND_COLOR_SET, backgroundColor != App::Color(1, 1, 1, 0));
+        setUsed(BACKGROUND_COLOR_SET, backgroundColor != Base::Color(1, 1, 1, 0));
         setDirty();
 
         signaller.tryInvoke();
@@ -516,7 +516,7 @@ void Cell::setBackground(const App::Color& color)
  *
  */
 
-bool Cell::getBackground(App::Color& color) const
+bool Cell::getBackground(Base::Color& color) const
 {
     color = backgroundColor;
     return isUsed(BACKGROUND_COLOR_SET);
@@ -783,12 +783,12 @@ void Cell::restore(Base::XMLReader& reader, bool checkAlias)
         setAlignment(alignmentCode);
     }
     if (foregroundColor) {
-        App::Color color = decodeColor(foregroundColor, App::Color(0, 0, 0, 1));
+        Base::Color color = decodeColor(foregroundColor, Base::Color(0, 0, 0, 1));
 
         setForeground(color);
     }
     if (backgroundColor) {
-        App::Color color = decodeColor(backgroundColor, App::Color(1, 1, 1, 1));
+        Base::Color color = decodeColor(backgroundColor, Base::Color(1, 1, 1, 1));
 
         setBackground(color);
     }
@@ -1016,7 +1016,7 @@ std::string Cell::encodeAlignment(int alignment)
  *
  */
 
-std::string Cell::encodeColor(const App::Color& color)
+std::string Cell::encodeColor(const Base::Color& color)
 {
     std::stringstream tmp;
 
@@ -1064,10 +1064,10 @@ std::string Cell::encodeStyle(const std::set<std::string>& style)
  *
  */
 
-App::Color Cell::decodeColor(const std::string& color, const App::Color& defaultColor)
+Base::Color Cell::decodeColor(const std::string& color, const Base::Color& defaultColor)
 {
     if (color.size() == 7 || color.size() == 9) {
-        App::Color c;
+        Base::Color c;
 
         if (color[0] != '#') {
             return defaultColor;

--- a/src/Mod/Spreadsheet/App/Cell.h
+++ b/src/Mod/Spreadsheet/App/Cell.h
@@ -72,11 +72,11 @@ public:
     void setStyle(const std::set<std::string>& _style);
     bool getStyle(std::set<std::string>& style) const;
 
-    void setForeground(const App::Color& color);
-    bool getForeground(App::Color& color) const;
+    void setForeground(const Base::Color& color);
+    bool getForeground(Base::Color& color) const;
 
-    void setBackground(const App::Color& color);
-    bool getBackground(App::Color& color) const;
+    void setBackground(const Base::Color& color);
+    bool getBackground(Base::Color& color) const;
 
     void setDisplayUnit(const std::string& unit);
     bool getDisplayUnit(DisplayUnit& unit) const;
@@ -161,8 +161,8 @@ public:
 
     static std::string encodeStyle(const std::set<std::string>& style);
 
-    static std::string encodeColor(const App::Color& color);
-    static App::Color decodeColor(const std::string& color, const App::Color& defaultColor);
+    static std::string encodeColor(const Base::Color& color);
+    static Base::Color decodeColor(const std::string& color, const Base::Color& defaultColor);
 
 private:
     void setParseException(const std::string& e);
@@ -199,8 +199,8 @@ private:
     mutable App::ExpressionPtr expression;
     int alignment;
     std::set<std::string> style;
-    App::Color foregroundColor;
-    App::Color backgroundColor;
+    Base::Color foregroundColor;
+    Base::Color backgroundColor;
     DisplayUnit displayUnit;
     std::string alias;
     Base::Unit computedUnit;

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -720,14 +720,14 @@ void PropertySheet::setStyle(CellAddress address, const std::set<std::string>& _
     cell->setStyle(_style);
 }
 
-void PropertySheet::setForeground(CellAddress address, const App::Color& color)
+void PropertySheet::setForeground(CellAddress address, const Base::Color& color)
 {
     Cell* cell = nonNullCellAt(address);
     assert(cell);
     cell->setForeground(color);
 }
 
-void PropertySheet::setBackground(CellAddress address, const App::Color& color)
+void PropertySheet::setBackground(CellAddress address, const Base::Color& color)
 {
     Cell* cell = nonNullCellAt(address);
     assert(cell);

--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -98,9 +98,9 @@ public:
 
     void setStyle(App::CellAddress address, const std::set<std::string>& _style);
 
-    void setForeground(App::CellAddress address, const App::Color& color);
+    void setForeground(App::CellAddress address, const Base::Color& color);
 
-    void setBackground(App::CellAddress address, const App::Color& color);
+    void setBackground(App::CellAddress address, const Base::Color& color);
 
     void setDisplayUnit(App::CellAddress address, const std::string& unit);
 

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -154,9 +154,9 @@ public:
 
     void setStyle(App::CellAddress address, const std::set<std::string>& style);
 
-    void setForeground(App::CellAddress address, const App::Color& color);
+    void setForeground(App::CellAddress address, const Base::Color& color);
 
-    void setBackground(App::CellAddress address, const App::Color& color);
+    void setBackground(App::CellAddress address, const Base::Color& color);
 
     void setDisplayUnit(App::CellAddress address, const std::string& unit);
 

--- a/src/Mod/Spreadsheet/App/SheetPyImp.cpp
+++ b/src/Mod/Spreadsheet/App/SheetPyImp.cpp
@@ -794,7 +794,7 @@ static float decodeFloat(const PyObject* obj)
     throw Base::TypeError("Float or integer expected");
 }
 
-static void decodeColor(PyObject* value, Color& c)
+static void decodeColor(PyObject* value, Base::Color& c)
 {
     if (PyTuple_Check(value)) {
         if (PyTuple_Size(value) < 3 || PyTuple_Size(value) > 4) {
@@ -822,7 +822,7 @@ PyObject* SheetPy::setForeground(PyObject* args)
     try {
         const char* range;
         PyObject* value;
-        Color c;
+        Base::Color c;
 
         if (!PyArg_ParseTuple(args, "sO:setForeground", &range, &value)) {
             return nullptr;
@@ -863,7 +863,7 @@ PyObject* SheetPy::getForeground(PyObject* args)
         return nullptr;
     }
 
-    Color c;
+    Base::Color c;
     const Cell* cell = getSheetPtr()->getCell(address);
     if (cell && cell->getForeground(c)) {
         PyObject* t = PyTuple_New(4);
@@ -886,7 +886,7 @@ PyObject* SheetPy::setBackground(PyObject* args)
     try {
         const char* strAddress;
         PyObject* value;
-        Color c;
+        Base::Color c;
 
         if (!PyArg_ParseTuple(args, "sO:setBackground", &strAddress, &value)) {
             return nullptr;
@@ -927,7 +927,7 @@ PyObject* SheetPy::getBackground(PyObject* args)
         return nullptr;
     }
 
-    Color c;
+    Base::Color c;
     const Cell* cell = getSheetPtr()->getCell(address);
     if (cell && cell->getBackground(c)) {
         PyObject* t = PyTuple_New(4);

--- a/src/Mod/Spreadsheet/Gui/PropertiesDialog.cpp
+++ b/src/Mod/Spreadsheet/Gui/PropertiesDialog.cpp
@@ -153,12 +153,12 @@ PropertiesDialog::PropertiesDialog(Sheet* _sheet,
 
 void PropertiesDialog::foregroundColorChanged(const QColor& color)
 {
-    foregroundColor = App::Color(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+    foregroundColor = Base::Color(color.redF(), color.greenF(), color.blueF(), color.alphaF());
 }
 
 void PropertiesDialog::backgroundColorChanged(const QColor& color)
 {
-    backgroundColor = App::Color(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+    backgroundColor = Base::Color(color.redF(), color.greenF(), color.blueF(), color.alphaF());
 }
 
 void PropertiesDialog::alignmentChanged()

--- a/src/Mod/Spreadsheet/Gui/PropertiesDialog.h
+++ b/src/Mod/Spreadsheet/Gui/PropertiesDialog.h
@@ -59,15 +59,15 @@ private:
     Spreadsheet::Sheet* sheet;
     std::vector<App::Range> ranges;
     Ui::PropertiesDialog* ui;
-    App::Color foregroundColor;
-    App::Color backgroundColor;
+    Base::Color foregroundColor;
+    Base::Color backgroundColor;
     int alignment;
     std::set<std::string> style;
     Spreadsheet::DisplayUnit displayUnit;
     std::string alias;
 
-    App::Color orgForegroundColor;
-    App::Color orgBackgroundColor;
+    Base::Color orgForegroundColor;
+    Base::Color orgBackgroundColor;
     int orgAlignment;
     std::set<std::string> orgStyle;
     Spreadsheet::DisplayUnit orgDisplayUnit;

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -192,7 +192,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
     Property* prop = sheet->getPropertyByName(address.c_str());
 
     if (role == Qt::BackgroundRole) {
-        Color color;
+        Base::Color color;
 
         if (cell->getBackground(color)) {
             return QVariant::fromValue(
@@ -292,7 +292,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
 
         switch (role) {
             case Qt::ForegroundRole: {
-                Color color;
+                Base::Color color;
 
                 if (cell->getForeground(color)) {
                     return QVariant::fromValue(
@@ -327,7 +327,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
 
         switch (role) {
             case Qt::ForegroundRole: {
-                Color color;
+                Base::Color color;
 
                 if (cell->getForeground(color)) {
                     return QVariant::fromValue(
@@ -403,7 +403,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
 
         switch (role) {
             case Qt::ForegroundRole: {
-                Color color;
+                Base::Color color;
 
                 if (cell->getForeground(color)) {
                     return QVariant::fromValue(
@@ -459,7 +459,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
 
         switch (role) {
             case Qt::ForegroundRole: {
-                Color color;
+                Base::Color color;
 
                 if (cell->getForeground(color)) {
                     return QVariant::fromValue(

--- a/src/Mod/Start/Gui/FileCardDelegate.cpp
+++ b/src/Mod/Start/Gui/FileCardDelegate.cpp
@@ -38,7 +38,7 @@
 #include "FileCardDelegate.h"
 #include "../App/DisplayedFilesModel.h"
 #include "App/Application.h"
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <gsl/pointers>
 
 using namespace Start;
@@ -58,27 +58,27 @@ FileCardDelegate::FileCardDelegate(QObject* parent)
 QColor FileCardDelegate::getBorderColor() const
 {
     QColor color(98, 160, 234);  // NOLINT
-    uint32_t packed = App::Color::asPackedRGB<QColor>(color);
+    uint32_t packed = Base::Color::asPackedRGB<QColor>(color);
     packed = _parameterGroup->GetUnsigned("FileThumbnailBorderColor", packed);
-    color = App::Color::fromPackedRGB<QColor>(packed);
+    color = Base::Color::fromPackedRGB<QColor>(packed);
     return color;
 }
 
 QColor FileCardDelegate::getBackgroundColor() const
 {
     QColor color(221, 221, 221);  // NOLINT
-    uint32_t packed = App::Color::asPackedRGB<QColor>(color);
+    uint32_t packed = Base::Color::asPackedRGB<QColor>(color);
     packed = _parameterGroup->GetUnsigned("FileThumbnailBackgroundColor", packed);
-    color = App::Color::fromPackedRGB<QColor>(packed);
+    color = Base::Color::fromPackedRGB<QColor>(packed);
     return color;
 }
 
 QColor FileCardDelegate::getSelectionColor() const
 {
     QColor color(38, 162, 105);  // NOLINT
-    uint32_t packed = App::Color::asPackedRGB<QColor>(color);
+    uint32_t packed = Base::Color::asPackedRGB<QColor>(color);
     packed = _parameterGroup->GetUnsigned("FileThumbnailSelectionColor", packed);
-    color = App::Color::fromPackedRGB<QColor>(packed);
+    color = Base::Color::fromPackedRGB<QColor>(packed);
     return color;
 }
 

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -136,9 +136,9 @@ public:
             "User parameter:BaseApp/Preferences/Mod/Start");
 
         auto getUserColor = [&hGrp](QColor color, const char* parameter) {
-            uint32_t packed = App::Color::asPackedRGB<QColor>(color);
+            uint32_t packed = Base::Color::asPackedRGB<QColor>(color);
             packed = hGrp->GetUnsigned(parameter, packed);
-            color = App::Color::fromPackedRGB<QColor>(packed);
+            color = Base::Color::fromPackedRGB<QColor>(packed);
             return color;
         };
 

--- a/src/Mod/Surface/Gui/TaskFilling.cpp
+++ b/src/Mod/Surface/Gui/TaskFilling.cpp
@@ -115,7 +115,7 @@ void ViewProviderFilling::highlightReferences(ShapeType type, const References& 
                 switch (type) {
                     case ViewProviderFilling::Vertex:
                         if (on) {
-                            std::vector<App::Color> colors;
+                            std::vector<Base::Color> colors;
                             TopTools_IndexedMapOfShape vMap;
                             TopExp::MapShapes(base->Shape.getValue(), TopAbs_VERTEX, vMap);
                             colors.resize(vMap.Extent(), svp->PointColor.getValue());
@@ -126,7 +126,7 @@ void ViewProviderFilling::highlightReferences(ShapeType type, const References& 
                                 std::size_t idx =
                                     static_cast<std::size_t>(std::stoi(jt.substr(6)) - 1);
                                 if (idx < colors.size()) {
-                                    colors[idx] = App::Color(1.0, 0.0, 1.0);  // magenta
+                                    colors[idx] = Base::Color(1.0, 0.0, 1.0);  // magenta
                                 }
                             }
 
@@ -138,7 +138,7 @@ void ViewProviderFilling::highlightReferences(ShapeType type, const References& 
                         break;
                     case ViewProviderFilling::Edge:
                         if (on) {
-                            std::vector<App::Color> colors;
+                            std::vector<Base::Color> colors;
                             TopTools_IndexedMapOfShape eMap;
                             TopExp::MapShapes(base->Shape.getValue(), TopAbs_EDGE, eMap);
                             colors.resize(eMap.Extent(), svp->LineColor.getValue());
@@ -149,7 +149,7 @@ void ViewProviderFilling::highlightReferences(ShapeType type, const References& 
                                 // check again that the index is in range because it's possible that
                                 // the sub-names are invalid
                                 if (idx < colors.size()) {
-                                    colors[idx] = App::Color(1.0, 0.0, 1.0);  // magenta
+                                    colors[idx] = Base::Color(1.0, 0.0, 1.0);  // magenta
                                 }
                             }
 
@@ -173,7 +173,7 @@ void ViewProviderFilling::highlightReferences(ShapeType type, const References& 
                                 // the sub-names are invalid
                                 if (idx < materials.size()) {
                                     materials[idx].diffuseColor =
-                                        App::Color(1.0, 0.0, 1.0);  // magenta
+                                        Base::Color(1.0, 0.0, 1.0);  // magenta
                                 }
                             }
 

--- a/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
+++ b/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
@@ -119,7 +119,7 @@ void ViewProviderGeomFillSurface::highlightReferences(bool on)
                 Gui::Application::Instance->getViewProvider(base));
             if (svp) {
                 if (on) {
-                    std::vector<App::Color> colors;
+                    std::vector<Base::Color> colors;
                     TopTools_IndexedMapOfShape eMap;
                     TopExp::MapShapes(base->Shape.getValue(), TopAbs_EDGE, eMap);
                     colors.resize(eMap.Extent(), svp->LineColor.getValue());
@@ -127,7 +127,7 @@ void ViewProviderGeomFillSurface::highlightReferences(bool on)
                     for (const auto& jt : it.second) {
                         std::size_t idx = static_cast<std::size_t>(std::stoi(jt.substr(4)) - 1);
                         assert(idx < colors.size());
-                        colors[idx] = App::Color(1.0, 0.0, 1.0);  // magenta
+                        colors[idx] = Base::Color(1.0, 0.0, 1.0);  // magenta
                     }
 
                     svp->setHighlightedEdges(colors);

--- a/src/Mod/Surface/Gui/TaskSections.cpp
+++ b/src/Mod/Surface/Gui/TaskSections.cpp
@@ -115,7 +115,7 @@ void ViewProviderSections::highlightReferences(ShapeType type, const References&
                 switch (type) {
                     case ViewProviderSections::Vertex:
                         if (on) {
-                            std::vector<App::Color> colors;
+                            std::vector<Base::Color> colors;
                             TopTools_IndexedMapOfShape vMap;
                             TopExp::MapShapes(base->Shape.getValue(), TopAbs_VERTEX, vMap);
                             colors.resize(vMap.Extent(), svp->PointColor.getValue());
@@ -126,7 +126,7 @@ void ViewProviderSections::highlightReferences(ShapeType type, const References&
                                 std::size_t idx =
                                     static_cast<std::size_t>(std::stoi(jt.substr(6)) - 1);
                                 if (idx < colors.size()) {
-                                    colors[idx] = App::Color(1.0, 0.0, 1.0);  // magenta
+                                    colors[idx] = Base::Color(1.0, 0.0, 1.0);  // magenta
                                 }
                             }
 
@@ -138,7 +138,7 @@ void ViewProviderSections::highlightReferences(ShapeType type, const References&
                         break;
                     case ViewProviderSections::Edge:
                         if (on) {
-                            std::vector<App::Color> colors;
+                            std::vector<Base::Color> colors;
                             TopTools_IndexedMapOfShape eMap;
                             TopExp::MapShapes(base->Shape.getValue(), TopAbs_EDGE, eMap);
                             colors.resize(eMap.Extent(), svp->LineColor.getValue());
@@ -149,7 +149,7 @@ void ViewProviderSections::highlightReferences(ShapeType type, const References&
                                 // check again that the index is in range because it's possible that
                                 // the sub-names are invalid
                                 if (idx < colors.size()) {
-                                    colors[idx] = App::Color(1.0, 0.0, 1.0);  // magenta
+                                    colors[idx] = Base::Color(1.0, 0.0, 1.0);  // magenta
                                 }
                             }
 
@@ -173,7 +173,7 @@ void ViewProviderSections::highlightReferences(ShapeType type, const References&
                                 // the sub-names are invalid
                                 if (idx < materials.size()) {
                                     // magenta
-                                    materials[idx].diffuseColor = App::Color(1.0, 0.0, 1.0);
+                                    materials[idx].diffuseColor = Base::Color(1.0, 0.0, 1.0);
                                 }
                             }
 

--- a/src/Mod/TechDraw/App/CenterLine.cpp
+++ b/src/Mod/TechDraw/App/CenterLine.cpp
@@ -992,7 +992,7 @@ void CenterLine::Restore(Base::XMLReader &reader)
     m_format.setWidth(reader.getAttributeAsFloat("value"));
     reader.readElement("Color");
     std::string tempHex = reader.getAttribute("value");
-    App::Color tempColor;
+    Base::Color tempColor;
     tempColor.fromHexString(tempHex);
     m_format.setColor(tempColor);
     reader.readElement("Visible");

--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -248,7 +248,7 @@ void CosmeticEdge::Restore(Base::XMLReader &reader)
     m_format.setWidth(reader.getAttributeAsFloat("value"));
     reader.readElement("Color");
     std::string tempHex = reader.getAttribute("value");
-    App::Color tempColor;
+    Base::Color tempColor;
     tempColor.fromHexString(tempHex);
     m_format.setColor(tempColor);
     reader.readElement("Visible");
@@ -451,7 +451,7 @@ void GeomFormat::Restore(Base::XMLReader &reader)
     m_format.setWidth(reader.getAttributeAsFloat("value"));
     reader.readElement("Color");
     std::string tempHex = reader.getAttribute("value");
-    App::Color tempColor;
+    Base::Color tempColor;
     tempColor.fromHexString(tempHex);
     m_format.setColor(tempColor);
     reader.readElement("Visible");

--- a/src/Mod/TechDraw/App/Cosmetic.h
+++ b/src/Mod/TechDraw/App/Cosmetic.h
@@ -26,7 +26,7 @@
 #include <QColor>
 
 #include <App/FeaturePython.h>
-#include <App/Color.h>
+#include <Base/Color.h>
 #include <Base/Persistence.h>
 #include <Base/Vector3D.h>
 

--- a/src/Mod/TechDraw/App/CosmeticVertex.h
+++ b/src/Mod/TechDraw/App/CosmeticVertex.h
@@ -73,7 +73,7 @@ public:
     Base::Vector3d permaPoint{Base::Vector3d()};           //permanent, unscaled value
     int            linkGeom{-1};             //connection to corresponding "geom" Vertex (fragile - index based!)
                                          //better to do reverse search for CosmeticTag in vertex geometry
-    App::Color     color{App::Color()};
+    Base::Color     color{Base::Color()};
     double         size{1.0};
     int            style{1};
     bool           visible{true};              //base class vertex also has visible property

--- a/src/Mod/TechDraw/App/CosmeticVertexPyImp.cpp
+++ b/src/Mod/TechDraw/App/CosmeticVertexPyImp.cpp
@@ -169,7 +169,7 @@ void CosmeticVertexPy::setShow(Py::Boolean arg)
 
 Py::Object CosmeticVertexPy::getColor() const
 {
-    App::Color color = getCosmeticVertexPtr()->color;
+    Base::Color color = getCosmeticVertexPtr()->color;
     PyObject* pyColor = DrawUtil::colorToPyTuple(color);
     return Py::asObject(pyColor);
 }
@@ -178,7 +178,7 @@ void CosmeticVertexPy::setColor(Py::Object arg)
 {
     PyObject* pTuple = arg.ptr();
     double red = 0.0, green = 0.0, blue = 0.0, alpha = 0.0;
-    App::Color c(red, green, blue, alpha);
+    Base::Color c(red, green, blue, alpha);
     if (PyTuple_Check(pTuple)) {
         c = DrawUtil::pyTupleToColor(pTuple);
         CosmeticVertex* cv = getCosmeticVertexPtr();

--- a/src/Mod/TechDraw/App/DrawGeomHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.cpp
@@ -612,9 +612,9 @@ std::string DrawGeomHatch::prefGeomHatchName()
     return result;
 }
 
-App::Color DrawGeomHatch::prefGeomHatchColor()
+Base::Color DrawGeomHatch::prefGeomHatchColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Colors")->GetUnsigned("GeomHatch", 0x00FF0000));
     return fcColor;
 }

--- a/src/Mod/TechDraw/App/DrawGeomHatch.h
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.h
@@ -100,7 +100,7 @@ public:
     static TopoDS_Face extractFace(DrawViewPart* source, int iface );
     static std::string prefGeomHatchFile();
     static std::string prefGeomHatchName();
-    static App::Color prefGeomHatchColor();
+    static Base::Color prefGeomHatchColor();
     static std::vector<LineSet> makeLineSets(std::string fileSpec, std::string myPattern);
 
     void translateLabel(std::string context, std::string baseName, std::string uniqueName);

--- a/src/Mod/TechDraw/App/DrawHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawHatch.cpp
@@ -215,9 +215,9 @@ std::string DrawHatch::prefSvgHatch(void)
     return Preferences::svgFile();
 }
 
-App::Color DrawHatch::prefSvgHatchColor(void)
+Base::Color DrawHatch::prefSvgHatchColor(void)
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Colors")->GetUnsigned("Hatch", 0x00FF0000));
     return fcColor;
 }

--- a/src/Mod/TechDraw/App/DrawHatch.h
+++ b/src/Mod/TechDraw/App/DrawHatch.h
@@ -67,7 +67,7 @@ public:
     bool empty();
     static bool faceIsHatched(int i, std::vector<TechDraw::DrawHatch*> hatchObjs);
     static std::string prefSvgHatch();
-    static App::Color prefSvgHatchColor();
+    static Base::Color prefSvgHatchColor();
 
     bool isSvgHatch() const;
     bool isBitmapHatch() const;

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -1097,12 +1097,12 @@ std::vector<std::string> DrawUtil::tokenize(std::string csvLine, std::string del
     return tokens;
 }
 
-App::Color DrawUtil::pyTupleToColor(PyObject* pColor)
+Base::Color DrawUtil::pyTupleToColor(PyObject* pColor)
 {
     //    Base::Console().Message("DU::pyTupleToColor()\n");
     double red = 0.0, green = 0.0, blue = 0.0, alpha = 0.0;
     if (!PyTuple_Check(pColor)) {
-        return App::Color(red, green, blue, alpha);
+        return Base::Color(red, green, blue, alpha);
     }
 
     int tSize = (int)PyTuple_Size(pColor);
@@ -1118,10 +1118,10 @@ App::Color DrawUtil::pyTupleToColor(PyObject* pColor)
         PyObject* pAlpha = PyTuple_GetItem(pColor, 3);
         alpha = PyFloat_AsDouble(pAlpha);
     }
-    return App::Color(red, green, blue, alpha);
+    return Base::Color(red, green, blue, alpha);
 }
 
-PyObject* DrawUtil::colorToPyTuple(App::Color color)
+PyObject* DrawUtil::colorToPyTuple(Base::Color color)
 {
     //    Base::Console().Message("DU::pyTupleToColor()\n");
     PyObject* pTuple = PyTuple_New(4);

--- a/src/Mod/TechDraw/App/DrawUtil.h
+++ b/src/Mod/TechDraw/App/DrawUtil.h
@@ -202,8 +202,8 @@ public:
     static std::vector<std::string> split(std::string csvLine);
     static std::vector<std::string> tokenize(std::string csvLine,
                                              std::string delimiter = ", $$$, ");
-    static App::Color pyTupleToColor(PyObject* pColor);
-    static PyObject* colorToPyTuple(App::Color color);
+    static Base::Color pyTupleToColor(PyObject* pColor);
+    static PyObject* colorToPyTuple(Base::Color color);
     static bool isCrazy(TopoDS_Edge e);
     static Base::Vector3d getFaceCenter(TopoDS_Face f);
     static bool circulation(Base::Vector3d A, Base::Vector3d B, Base::Vector3d C);

--- a/src/Mod/TechDraw/App/DrawViewDraft.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDraft.cpp
@@ -94,7 +94,7 @@ App::DocumentObjectExecReturn *DrawViewDraft::execute()
         // Draft.get_svg(obj, scale=1, linewidth=0.35, fontsize=12, fillstyle="shape color", direction=None, linestyle=None, color=None, linespacing=None, techdraw=False)
 
         std::stringstream paramStr;
-        App::Color col = Color.getValue();
+        Base::Color col = Color.getValue();
         paramStr << ", scale=" << getScale()
                  << ", linewidth=" << LineWidth.getValue()
                  << ", fontsize=" << FontSize.getValue()

--- a/src/Mod/TechDraw/App/DrawViewPartPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPartPyImp.cpp
@@ -351,7 +351,7 @@ PyObject* DrawViewPartPy::makeCosmeticLine(PyObject *args)
     PyObject* pPnt2 = nullptr;
     int style = LineFormat::getDefEdgeStyle();
     double weight = LineFormat::getDefEdgeWidth();
-    App::Color defCol = LineFormat::getDefEdgeColor();
+    Base::Color defCol = LineFormat::getDefEdgeColor();
     PyObject* pColor = nullptr;
 
     if (!PyArg_ParseTuple(args, "O!O!|idO!", &(Base::VectorPy::Type), &pPnt1,
@@ -389,7 +389,7 @@ PyObject* DrawViewPartPy::makeCosmeticLine3D(PyObject *args)
     PyObject* pPnt2 = nullptr;
     int style = LineFormat::getDefEdgeStyle();
     double weight = LineFormat::getDefEdgeWidth();
-    App::Color defCol = LineFormat::getDefEdgeColor();
+    Base::Color defCol = LineFormat::getDefEdgeColor();
     PyObject* pColor = nullptr;
 
     if (!PyArg_ParseTuple(args, "O!O!|idO!", &(Base::VectorPy::Type), &pPnt1,
@@ -434,7 +434,7 @@ PyObject* DrawViewPartPy::makeCosmeticCircle(PyObject *args)
     double radius = 5.0;
     int style = LineFormat::getDefEdgeStyle();
     double weight = LineFormat::getDefEdgeWidth();
-    App::Color defCol = LineFormat::getDefEdgeColor();
+    Base::Color defCol = LineFormat::getDefEdgeColor();
     PyObject* pColor = nullptr;
 
     if (!PyArg_ParseTuple(args, "O!d|idO!", &(Base::VectorPy::Type), &pPnt1,
@@ -474,7 +474,7 @@ PyObject* DrawViewPartPy::makeCosmeticCircleArc(PyObject *args)
     double angle2 = 360.0;
     int style = LineFormat::getDefEdgeStyle();
     double weight = LineFormat::getDefEdgeWidth();
-    App::Color defCol = LineFormat::getDefEdgeColor();
+    Base::Color defCol = LineFormat::getDefEdgeColor();
     PyObject* pColor = nullptr;
 
     if (!PyArg_ParseTuple(args, "O!ddd|idO!", &(Base::VectorPy::Type), &pPnt1,
@@ -516,7 +516,7 @@ PyObject* DrawViewPartPy::makeCosmeticCircle3d(PyObject *args)
     double radius = 5.0;
     int style = LineFormat::getDefEdgeStyle();
     double weight = LineFormat::getDefEdgeWidth();
-    App::Color defCol = LineFormat::getDefEdgeColor();
+    Base::Color defCol = LineFormat::getDefEdgeColor();
     PyObject* pColor = nullptr;
 
     if (!PyArg_ParseTuple(args, "O!d|idO!", &(Base::VectorPy::Type), &pPnt1,
@@ -559,7 +559,7 @@ PyObject* DrawViewPartPy::makeCosmeticCircleArc3d(PyObject *args)
     double angle2 = 360.0;
     int style = LineFormat::getDefEdgeStyle();
     double weight = LineFormat::getDefEdgeWidth();
-    App::Color defCol = LineFormat::getDefEdgeColor();
+    Base::Color defCol = LineFormat::getDefEdgeColor();
     PyObject* pColor = nullptr;
 
     if (!PyArg_ParseTuple(args, "O!ddd|idO!", &(Base::VectorPy::Type), &pPnt1,
@@ -757,7 +757,7 @@ PyObject* DrawViewPartPy::formatGeometricEdge(PyObject *args)
 //    Base::Console().Message("DVPPI::formatGeometricEdge()\n");
     int idx = -1;
     int style = Qt::SolidLine;
-    App::Color color = LineFormat::getDefEdgeColor();
+    Base::Color color = LineFormat::getDefEdgeColor();
     double weight = 0.5;
     int visible = 1;
     PyObject* pColor;

--- a/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
@@ -243,7 +243,7 @@ std::string DrawViewSpreadsheet::getSheetImage()
     result << getSVGHead();
 
     std::string ViewName = Label.getValue();
-    App::Color c = TextColor.getValue();
+    Base::Color c = TextColor.getValue();
     result << "<g id=\"" << ViewName << "\">" << std::endl;
 
     // fill the cells
@@ -296,7 +296,7 @@ std::string DrawViewSpreadsheet::getSheetImage()
             std::string fcolor = c.asHexString();
             std::string textstyle;
             if (cell) {
-                App::Color f, b;
+                Base::Color f, b;
                 std::set<std::string> st;
                 int colspan, rowspan;
                 if (cell->getBackground(b)) {

--- a/src/Mod/TechDraw/App/LineFormat.cpp
+++ b/src/Mod/TechDraw/App/LineFormat.cpp
@@ -72,7 +72,7 @@ void LineFormat::setCurrentLineFormat(LineFormat& newFormat)
 
 LineFormat::LineFormat(const int style,
                        const double weight,
-                       const App::Color& color,
+                       const Base::Color& color,
                        const bool visible) :
     m_style(style),
     m_weight(weight),
@@ -104,7 +104,7 @@ double LineFormat::getDefEdgeWidth()
     return TechDraw::LineGroup::getDefaultWidth("Graphic");
 }
 
-App::Color LineFormat::getDefEdgeColor()
+Base::Color LineFormat::getDefEdgeColor()
 {
     return Preferences::normalColor();
 }

--- a/src/Mod/TechDraw/App/LineFormat.h
+++ b/src/Mod/TechDraw/App/LineFormat.h
@@ -29,7 +29,7 @@
 
 #include <QColor>
 
-#include <App/Color.h>
+#include <Base/Color.h>
 
 
 namespace TechDraw {
@@ -43,13 +43,13 @@ public:
     LineFormat();
     LineFormat(const int style,
                const double weight,
-               const App::Color& color,
+               const Base::Color& color,
                const bool visible,
                const int lineNumber);
    // TODO: phase out the old 4 parameter constructor
    LineFormat(const int style,
                const double weight,
-               const App::Color& color,
+               const Base::Color& color,
                const bool visible);
     ~LineFormat() = default;
 
@@ -60,8 +60,8 @@ public:
     double getWidth() const { return m_weight; }
     void setWidth(double width) {m_weight = width; }
 
-    App::Color getColor() const { return m_color; }
-    void setColor(App::Color color) { m_color = color; }
+    Base::Color getColor() const { return m_color; }
+    void setColor(Base::Color color) { m_color = color; }
     QColor getQColor() const { return m_color.asValue<QColor>(); }
     void setQColor(QColor qColor) { m_color.set(qColor.redF(), qColor.greenF(), qColor.blueF(), 1.0 - qColor.alphaF()); }
 
@@ -72,7 +72,7 @@ public:
     void setLineNumber(int number) { m_lineNumber = number; }
 
     static double getDefEdgeWidth();
-    static App::Color getDefEdgeColor();
+    static Base::Color getDefEdgeColor();
     static int getDefEdgeStyle();
 
     void dump(const char* title);
@@ -85,7 +85,7 @@ public:
 private:
     int m_style;
     double m_weight;
-    App::Color m_color;
+    Base::Color m_color;
     bool m_visible;
     int m_lineNumber {1};
 };

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -77,14 +77,14 @@ double Preferences::dimArrowSize()
     return getPreferenceGroup("Dimensions")->GetFloat("ArrowSize", DefaultArrowSize);
 }
 
-App::Color Preferences::normalColor()
+Base::Color Preferences::normalColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(getPreferenceGroup("Colors")->GetUnsigned("NormalColor", 0x000000FF));//#000000 black
     return fcColor;
 }
 
-App::Color Preferences::selectColor()
+Base::Color Preferences::selectColor()
 {
     Base::Reference<ParameterGrp> hGrp = App::GetApplication()
                                              .GetUserParameter()
@@ -93,12 +93,12 @@ App::Color Preferences::selectColor()
                                              ->GetGroup("View");
     unsigned int defColor = hGrp->GetUnsigned("SelectionColor", 0x00FF00FF);//#00FF00 lime
 
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(getPreferenceGroup("Colors")->GetUnsigned("SelectColor", defColor));
     return fcColor;
 }
 
-App::Color Preferences::preselectColor()
+Base::Color Preferences::preselectColor()
 {
     Base::Reference<ParameterGrp> hGrp = App::GetApplication()
                                              .GetUserParameter()
@@ -107,14 +107,14 @@ App::Color Preferences::preselectColor()
                                              ->GetGroup("View");
     unsigned int defColor = hGrp->GetUnsigned("HighlightColor", 0xFFFF00FF);//#FFFF00 yellow
 
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(getPreferenceGroup("Colors")->GetUnsigned("PreSelectColor", defColor));
     return fcColor;
 }
 
-App::Color Preferences::vertexColor()
+Base::Color Preferences::vertexColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(getPreferenceGroup("Decorations")->GetUnsigned("VertexColor", 0x000000FF));//#000000 black
     return fcColor;
 }
@@ -376,16 +376,16 @@ void Preferences::monochrome(bool state)
     getPreferenceGroup("Colors")->SetBool("Monochrome", state);
 }
 
-App::Color Preferences::lightTextColor()
+Base::Color Preferences::lightTextColor()
 {
-    App::Color result;
+    Base::Color result;
     result.setPackedValue(getPreferenceGroup("Colors")->GetUnsigned("LightTextColor", 0xFFFFFFFF));//#FFFFFFFF white
     return result;
 }
 
 //! attempt to lighten the give color
 // not currently used
-App::Color Preferences::lightenColor(App::Color orig)
+Base::Color Preferences::lightenColor(Base::Color orig)
 {
     // get component colours on [0, 255]
     uchar red = orig.r * 255;
@@ -412,11 +412,11 @@ App::Color Preferences::lightenColor(App::Color orig)
     double greenF = (double)green / 255.0;
     double blueF = (double)blue / 255.0;
 
-    return App::Color(redF, greenF, blueF, orig.a);
+    return Base::Color(redF, greenF, blueF, orig.a);
 }
 
 //! color to use for monochrome display
-App::Color Preferences::getAccessibleColor(App::Color orig)
+Base::Color Preferences::getAccessibleColor(Base::Color orig)
 {
     if (Preferences::lightOnDark() && Preferences::monochrome()) {
         return lightTextColor();

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -34,7 +34,7 @@
 class QColor;
 class QString;
 
-namespace App
+namespace Base
 {
 class Color;
 }
@@ -55,10 +55,10 @@ public:
     static double dimFontSizeMM();
     static double dimArrowSize();
 
-    static App::Color normalColor();
-    static App::Color selectColor();
-    static App::Color preselectColor();
-    static App::Color vertexColor();
+    static Base::Color normalColor();
+    static Base::Color selectColor();
+    static Base::Color preselectColor();
+    static Base::Color vertexColor();
     static double vertexScale();
     static int scaleType();
     static double scale();
@@ -103,9 +103,9 @@ public:
     static void lightOnDark(bool state);
     static bool monochrome();
     static void monochrome(bool state);
-    static App::Color lightTextColor();
-    static App::Color lightenColor(App::Color orig);
-    static App::Color getAccessibleColor(App::Color orig);
+    static Base::Color lightTextColor();
+    static Base::Color lightenColor(Base::Color orig);
+    static Base::Color getAccessibleColor(Base::Color orig);
 
     static bool autoCorrectDimRefs();
     static int scrubCount();

--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -1468,7 +1468,7 @@ std::vector<DrawViewDimension*> TechDrawGui::makeObliqueChainDimension(std::vect
                 edge->m_format.setStyle(1);
                 edge->m_format.setLineNumber(1);
                 edge->m_format.setWidth(TechDraw::LineGroup::getDefaultWidth("Thin"));
-                edge->m_format.setColor(App::Color(0.0f, 0.0f, 0.0f));
+                edge->m_format.setColor(Base::Color(0.0f, 0.0f, 0.0f));
             }
             else
                 carrierVertexes.push_back(oldVertex);
@@ -1851,7 +1851,7 @@ std::vector<DrawViewDimension*> TechDrawGui::makeObliqueCoordDimension(std::vect
                 edge->m_format.setStyle(1);
                 edge->m_format.setLineNumber(1);
                 edge->m_format.setWidth(TechDraw::LineGroup::getDefaultWidth("Thin"));
-                edge->m_format.setColor(App::Color(0.0, 0.0, 0.0));
+                edge->m_format.setColor(Base::Color(0.0, 0.0, 0.0));
             }
             else {
                 carrierVertexes.push_back(oldVertex);

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -85,8 +85,8 @@ void _createThreadLines(const std::vector<std::string>& SubNames, TechDraw::Draw
                         double factor);
 void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge);
 void _setLineAttributes(TechDraw::CenterLine* cosEdge);
-void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge, int style, float weight, App::Color color);
-void _setLineAttributes(TechDraw::CenterLine* cosEdge, int style, float weight, App::Color color);
+void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge, int style, float weight, Base::Color color);
+void _setLineAttributes(TechDraw::CenterLine* cosEdge, int style, float weight, Base::Color color);
 double _getAngle(Base::Vector3d center, Base::Vector3d point);
 std::vector<Base::Vector3d> _getVertexPoints(const std::vector<std::string>& SubNames,
                                              TechDraw::DrawViewPart* objFeat);
@@ -1527,7 +1527,7 @@ void execExtendShortenLine(Gui::Command* cmd, bool extend)
                         std::string uniTag = baseGeo->getCosmeticTag();
                         int oldStyle = 1;
                         float oldWeight = 1.0;
-                        App::Color oldColor;
+                        Base::Color oldColor;
                         std::vector<std::string> toDelete;
                         toDelete.push_back(uniTag);
                         if (baseGeo->source() == SourceType::COSMETICEDGE) {
@@ -1868,7 +1868,7 @@ void CmdTechDrawExtensionAreaAnnotation::activated(int iMsg)
         viewProvider->Fontsize.setValue(2.0);
         viewProvider->LineWidth.setValue(TechDraw::LineGroup::getDefaultWidth("Graphic"));
         viewProvider->LineVisible.setValue(false);
-        viewProvider->Color.setValue(App::Color(1.0, 0.0, 0.0));
+        viewProvider->Color.setValue(Base::Color(1.0, 0.0, 0.0));
     }
     Gui::Command::commitCommand();
     objFeat->touch(true);
@@ -2202,7 +2202,7 @@ void _setLineAttributes(TechDraw::CenterLine* cosEdge)
     cosEdge->m_format.setLineNumber(_getActiveLineAttributes().getLineNumber());
 }
 
-void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge, int style, float weight, App::Color color)
+void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge, int style, float weight, Base::Color color)
 {
     // set line attributes of a cosmetic edge
     cosEdge->m_format.setStyle(style);
@@ -2212,7 +2212,7 @@ void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge, int style, float weight
     cosEdge->m_format.setLineNumber(LineGenerator::fromQtStyle((Qt::PenStyle)style));
 }
 
-void _setLineAttributes(TechDraw::CenterLine* cosEdge, int style, float weight, App::Color color)
+void _setLineAttributes(TechDraw::CenterLine* cosEdge, int style, float weight, Base::Color color)
 {
     // set line attributes of a centerline
     cosEdge->m_format.setStyle(style);

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -66,60 +66,60 @@ int PreferencesGui::dimFontSizePX()
 
 QColor PreferencesGui::normalQColor()
 {
-    App::Color fcColor = Preferences::normalColor();
+    Base::Color fcColor = Preferences::normalColor();
     return fcColor.asValue<QColor>();
 }
 
 QColor PreferencesGui::selectQColor()
 {
-    App::Color fcColor = Preferences::selectColor();
+    Base::Color fcColor = Preferences::selectColor();
     return fcColor.asValue<QColor>();
 }
 
 QColor PreferencesGui::preselectQColor()
 {
-    App::Color fcColor = Preferences::preselectColor();
+    Base::Color fcColor = Preferences::preselectColor();
     return fcColor.asValue<QColor>();
 }
 
-App::Color PreferencesGui::sectionLineColor()
+Base::Color PreferencesGui::sectionLineColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Decorations")->GetUnsigned("SectionColor", 0x000000FF));
     return fcColor;
 }
 
 QColor PreferencesGui::sectionLineQColor()
 {
-//if the App::Color version has already lightened the color, we don't want to do it again
-    App::Color fcColor;
+//if the Base::Color version has already lightened the color, we don't want to do it again
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Decorations")->GetUnsigned("SectionColor", 0x000000FF));
     return fcColor.asValue<QColor>();
 }
 
-App::Color PreferencesGui::breaklineColor()
+Base::Color PreferencesGui::breaklineColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Decorations")->GetUnsigned("BreaklineColor", 0x000000FF));
     return fcColor;
 }
 
 QColor PreferencesGui::breaklineQColor()
 {
-//if the App::Color version has already lightened the color, we don't want to do it again
-    App::Color fcColor;
+//if the Base::Color version has already lightened the color, we don't want to do it again
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Decorations")->GetUnsigned("BreaklineColor", 0x000000FF));
     return fcColor.asValue<QColor>();
 }
 
-App::Color PreferencesGui::centerColor()
+Base::Color PreferencesGui::centerColor()
 {
-    return App::Color((uint32_t) Preferences::getPreferenceGroup("Decorations")->GetUnsigned("CenterColor", 0x000000FF));
+    return Base::Color((uint32_t) Preferences::getPreferenceGroup("Decorations")->GetUnsigned("CenterColor", 0x000000FF));
 }
 
 QColor PreferencesGui::centerQColor()
 {
-    App::Color fcColor = App::Color((uint32_t) Preferences::getPreferenceGroup("Decorations")->GetUnsigned("CenterColor", 0x000000FF));
+    Base::Color fcColor = Base::Color((uint32_t) Preferences::getPreferenceGroup("Decorations")->GetUnsigned("CenterColor", 0x000000FF));
     return fcColor.asValue<QColor>();
 }
 
@@ -128,30 +128,30 @@ QColor PreferencesGui::vertexQColor()
     return Preferences::vertexColor().asValue<QColor>();
 }
 
-App::Color PreferencesGui::dimColor()
+Base::Color PreferencesGui::dimColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Dimensions")->GetUnsigned("Color", 0x000000FF));  //#000000 black
     return fcColor;
 }
 
 QColor PreferencesGui::dimQColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Dimensions")->GetUnsigned("Color", 0x000000FF));  //#000000 black
     return fcColor.asValue<QColor>();
 }
 
-App::Color PreferencesGui::leaderColor()
+Base::Color PreferencesGui::leaderColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("LeaderLine")->GetUnsigned("Color", 0x000000FF));  //#000000 black
     return fcColor;
 }
 
 QColor PreferencesGui::leaderQColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("LeaderLine")->GetUnsigned("Color", 0x000000FF));  //#000000 black
     return fcColor.asValue<QColor>();
 }
@@ -189,16 +189,16 @@ QString PreferencesGui::weldingDirectory()
     return qSymbolDir;
 }
 
-App::Color PreferencesGui::gridColor()
+Base::Color PreferencesGui::gridColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Colors")->GetUnsigned("gridColor", 0x000000FF));  //#000000 black
     return fcColor;
 }
 
 QColor PreferencesGui::gridQColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Colors")->GetUnsigned("gridColor", 0x000000FF));  //#000000 black
     return fcColor.asValue<QColor>();
 }
@@ -219,9 +219,9 @@ bool PreferencesGui::multiSelection()
     return greedy || Preferences::getPreferenceGroup("General")->GetBool("multiSelection", false);
 }
 
-App::Color PreferencesGui::pageColor()
+Base::Color PreferencesGui::pageColor()
 {
-    App::Color result;
+    Base::Color result;
     result.setPackedValue(Preferences::getPreferenceGroup("Colors")->GetUnsigned("PageColor", 0xFFFFFFFF));  //#FFFFFFFF white
     return result;
 }
@@ -292,7 +292,7 @@ double PreferencesGui::templateClickBoxSize()
 
 QColor PreferencesGui::templateClickBoxColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Colors")->GetUnsigned("TemplateUnderlineColor", 0x0000FFFF));  //#0000FF blue
     return fcColor.asValue<QColor>();
 }

--- a/src/Mod/TechDraw/Gui/PreferencesGui.h
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.h
@@ -30,7 +30,7 @@
 class QColor;
 class QString;
 
-namespace App
+namespace Base
 {
 class Color;
 }
@@ -54,18 +54,18 @@ static int         dimFontSizePX();
 static QColor      normalQColor();
 static QColor      selectQColor();
 static QColor      preselectQColor();
-static App::Color  sectionLineColor();
+static Base::Color sectionLineColor();
 static QColor      sectionLineQColor();
-static App::Color  centerColor();
+static Base::Color centerColor();
 static QColor      centerQColor();
 static QColor      vertexQColor();
-static App::Color  leaderColor();
+static Base::Color leaderColor();
 static QColor      leaderQColor();
-static App::Color  dimColor();
+static Base::Color dimColor();
 static QColor      dimQColor();
-static App::Color  pageColor();
+static Base::Color pageColor();
 static QColor      pageQColor();
-static App::Color  breaklineColor();
+static Base::Color breaklineColor();
 static QColor      breaklineQColor();
 
 static int         dimArrowStyle();
@@ -76,7 +76,7 @@ static double      edgeFuzz();
 static QString     weldingDirectory();
 
 static bool showGrid();
-static App::Color gridColor();
+static Base::Color gridColor();
 static QColor gridQColor();
 static double gridSpacing();
 static bool multiSelection();

--- a/src/Mod/TechDraw/Gui/QGIEdge.cpp
+++ b/src/Mod/TechDraw/Gui/QGIEdge.cpp
@@ -88,7 +88,7 @@ void QGIEdge::setPrettyNormal() {
 
 QColor QGIEdge::getHiddenColor()
 {
-    App::Color fcColor = App::Color((uint32_t) Preferences::getPreferenceGroup("Colors")->GetUnsigned("HiddenColor", 0x000000FF));
+    Base::Color fcColor = Base::Color((uint32_t) Preferences::getPreferenceGroup("Colors")->GetUnsigned("HiddenColor", 0x000000FF));
     return PreferencesGui::getAccessibleQColor(fcColor.asValue<QColor>());
 }
 

--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -80,7 +80,7 @@ QGIFace::QGIFace(int index) :
     getParameters();
 
     // set up style & colour defaults
-    m_colDefFill = App::Color(static_cast<uint32_t>(Preferences::getPreferenceGroup("Colors")->GetUnsigned("FaceColor", COLWHITE)))
+    m_colDefFill = Base::Color(static_cast<uint32_t>(Preferences::getPreferenceGroup("Colors")->GetUnsigned("FaceColor", COLWHITE)))
                    .asValue<QColor>();
     m_colDefFill.setAlpha(Preferences::getPreferenceGroup("Colors")->GetBool("ClearFace", false) ? ALPHALOW : ALPHAHIGH);
 
@@ -453,7 +453,7 @@ void QGIFace::buildPixHatch()
 }
 
 
-void QGIFace::setHatchColor(App::Color color)
+void QGIFace::setHatchColor(Base::Color color)
 {
     m_svgCol = color.asHexString();
     m_geomColor = color.asValue<QColor>();

--- a/src/Mod/TechDraw/Gui/QGIFace.h
+++ b/src/Mod/TechDraw/Gui/QGIFace.h
@@ -88,7 +88,7 @@ public:
     void setFillMode(fillMode mode);
 
     //general hatch parms & methods
-    void setHatchColor(App::Color color);
+    void setHatchColor(Base::Color color);
     void setHatchScale(double scale);
 
     //svg fill parms & methods

--- a/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
@@ -315,7 +315,7 @@ QPen QGIRichAnno::rectPen() const
 
     double rectWeight = Rez::guiX(vp->LineWidth.getValue());
     Qt::PenStyle rectStyle = static_cast<Qt::PenStyle>(vp->LineStyle.getValue());
-    App::Color temp = vp->LineColor.getValue();
+    Base::Color temp = vp->LineColor.getValue();
     QColor rectColor = temp.asValue<QColor>();
 
     QPen pen = QPen(rectStyle);

--- a/src/Mod/TechDraw/Gui/QGITile.cpp
+++ b/src/Mod/TechDraw/Gui/QGITile.cpp
@@ -280,7 +280,7 @@ bool QGITile::getAltWeld() const
 //TODO: this is Pen, not Brush. sb Brush to colour background
 QColor QGITile::getTileColor() const
 {
-    App::Color fcColor = App::Color((uint32_t) Preferences::getPreferenceGroup("Colors")->GetUnsigned("TileColor", 0x00000000));
+    Base::Color fcColor = Base::Color((uint32_t) Preferences::getPreferenceGroup("Colors")->GetUnsigned("TileColor", 0x00000000));
     return PreferencesGui::getAccessibleQColor( fcColor.asValue<QColor>());
 }
 

--- a/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
@@ -148,7 +148,7 @@ void QGIViewAnnotation::drawAnnotation()
         ss << "font-weight:normal; font-style:normal; ";
     }
     ss << "line-height:" << viewAnno->LineSpace.getValue() << "%; ";
-    App::Color c = viewAnno->TextColor.getValue();
+    Base::Color c = viewAnno->TextColor.getValue();
     c = TechDraw::Preferences::getAccessibleColor(c);
     ss << "color:" << c.asHexString() << "; ";
     ss << "}\n</style>\n</head>\n<body>\n<p>";

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -948,7 +948,7 @@ QColor QGIViewBalloon::prefNormalColor()
     if (vp) {
         vpBalloon = dynamic_cast<ViewProviderBalloon*>(vp);
         if (vpBalloon) {
-            App::Color fcColor = Preferences::getAccessibleColor(vpBalloon->Color.getValue());
+            Base::Color fcColor = Preferences::getAccessibleColor(vpBalloon->Color.getValue());
             setNormalColor(fcColor.asValue<QColor>());
         }
     }

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -2788,7 +2788,7 @@ QColor QGIViewDimension::prefNormalColor()
     if (vp) {
         vpDim = dynamic_cast<ViewProviderDimension*>(vp);
         if (vpDim) {
-            App::Color fcColor = vpDim->Color.getValue();
+            Base::Color fcColor = vpDim->Color.getValue();
             fcColor = Preferences::getAccessibleColor(fcColor);
             setNormalColor(fcColor.asValue<QColor>());
         }

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -378,7 +378,7 @@ void QGIViewPart::drawAllEdges()
             // geometry edge - apply format if applicable
             TechDraw::GeomFormat* gf = dvp->getGeomFormatBySelection(iEdge);
             if (gf) {
-                App::Color  color = Preferences::getAccessibleColor(gf->m_format.getColor());
+                Base::Color  color = Preferences::getAccessibleColor(gf->m_format.getColor());
                 item->setNormalColor(color.asValue<QColor>());
                 int lineNumber = gf->m_format.getLineNumber();
                 int qtStyle = gf->m_format.getStyle();
@@ -542,7 +542,7 @@ bool QGIViewPart::formatGeomFromCosmetic(std::string cTag, QGIEdge* item)
     auto partFeat(dynamic_cast<TechDraw::DrawViewPart*>(getViewObject()));
     TechDraw::CosmeticEdge* ce = partFeat ? partFeat->getCosmeticEdge(cTag) : nullptr;
     if (ce) {
-        App::Color color = Preferences::getAccessibleColor(ce->m_format.getColor());
+        Base::Color color = Preferences::getAccessibleColor(ce->m_format.getColor());
         item->setNormalColor(color.asValue<QColor>());
         item->setLinePen(m_dashedLineGenerator->getBestPen(ce->m_format.getLineNumber(),
                                                      (Qt::PenStyle)ce->m_format.getStyle(),
@@ -561,7 +561,7 @@ bool QGIViewPart::formatGeomFromCenterLine(std::string cTag, QGIEdge* item)
     auto partFeat(dynamic_cast<TechDraw::DrawViewPart*>(getViewObject()));
     TechDraw::CenterLine* cl = partFeat ? partFeat->getCenterLine(cTag) : nullptr;
     if (cl) {
-        App::Color color = Preferences::getAccessibleColor(cl->m_format.getColor());
+        Base::Color color = Preferences::getAccessibleColor(cl->m_format.getColor());
         item->setNormalColor(color.asValue<QColor>());
         item->setLinePen(m_dashedLineGenerator->getBestPen(cl->m_format.getLineNumber(),
                                                      (Qt::PenStyle)cl->m_format.getStyle(),
@@ -722,7 +722,7 @@ void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b
         QGISectionLine* sectionLine = new QGISectionLine();
         addToGroup(sectionLine);
         sectionLine->setSymbol(const_cast<char*>(viewSection->SectionSymbol.getValue()));
-        App::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
+        Base::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
         sectionLine->setSectionColor(color.asValue<QColor>());
         sectionLine->setPathMode(false);
 
@@ -817,7 +817,7 @@ void QGIViewPart::drawComplexSectionLine(TechDraw::DrawViewSection* viewSection,
     QGISectionLine* sectionLine = new QGISectionLine();
     addToGroup(sectionLine);
     sectionLine->setSymbol(const_cast<char*>(viewSection->SectionSymbol.getValue()));
-    App::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
+    Base::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
     sectionLine->setSectionColor(color.asValue<QColor>());
     sectionLine->setPathMode(true);
     sectionLine->setPath(wirePath);
@@ -956,7 +956,7 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
         scene()->addItem(highlight);
         highlight->setReference(viewDetail->Reference.getValue());
 
-        App::Color color = Preferences::getAccessibleColor(vp->HighlightLineColor.getValue());
+        Base::Color color = Preferences::getAccessibleColor(vp->HighlightLineColor.getValue());
         highlight->setColor(color.asValue<QColor>());
         highlight->setFeatureName(viewDetail->getNameInDocument());
         highlight->setInteractive(true);
@@ -1063,7 +1063,7 @@ void QGIViewPart::drawBreakLines()
         breakLine->setWidth(Rez::guiX(vp->HiddenWidth.getValue()));
         breakLine->setBreakType(breakType);
         breakLine->setZValue(ZVALUE::SECTIONLINE);
-        App::Color color = prefBreaklineColor();
+        Base::Color color = prefBreaklineColor();
         breakLine->setBreakColor(color.asValue<QColor>());
         breakLine->setRotation(-dbv->Rotation.getValue());
         breakLine->draw();
@@ -1197,7 +1197,7 @@ bool QGIViewPart::prefPrintCenters()
     return printCenters;
 }
 
-App::Color QGIViewPart::prefBreaklineColor()
+Base::Color QGIViewPart::prefBreaklineColor()
 {
     return  Preferences::getAccessibleColor(PreferencesGui::breaklineColor());
 }

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -138,7 +138,7 @@ protected:
     void removeDecorations();
     bool prefFaceEdges();
     bool prefPrintCenters();
-    App::Color prefBreaklineColor();
+    Base::Color prefBreaklineColor();
 
     bool formatGeomFromCosmetic(std::string cTag, QGIEdge* item);
     bool formatGeomFromCenterLine(std::string cTag, QGIEdge* item);

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -1256,7 +1256,7 @@ TechDraw::DrawPage* QGSPage::getDrawPage() { return m_vpPage->getDrawPage(); }
 
 QColor QGSPage::getBackgroundColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Colors")->GetUnsigned("Background", 0x70707000));
     return fcColor.asValue<QColor>();
 }

--- a/src/Mod/TechDraw/Gui/QGTracker.cpp
+++ b/src/Mod/TechDraw/Gui/QGTracker.cpp
@@ -477,7 +477,7 @@ void QGTracker::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
 
 QColor QGTracker::getTrackerColor()
 {
-    App::Color trackColor = App::Color((uint32_t) Preferences::getPreferenceGroup("Tracker")->GetUnsigned("TrackerColor", 0xFF000000));
+    Base::Color trackColor = Base::Color((uint32_t) Preferences::getPreferenceGroup("Tracker")->GetUnsigned("TrackerColor", 0xFF000000));
     return PreferencesGui::getAccessibleQColor(trackColor.asValue<QColor>());
 }
 

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -553,7 +553,7 @@ TechDraw::DrawPage* QGVPage::getDrawPage() { return m_vpPage->getDrawPage(); }
 
 QColor QGVPage::getBackgroundColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Colors")->GetUnsigned("Background", 0x70707000));
     return fcColor.asValue<QColor>();
 }

--- a/src/Mod/TechDraw/Gui/TaskBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.cpp
@@ -168,7 +168,7 @@ void TaskBalloon::onTextChanged()
 
 void TaskBalloon::onColorChanged()
 {
-    App::Color ac;
+    Base::Color ac;
     ac.setValue<QColor>(ui->textColor->color());
     m_balloonVP->Color.setValue(ac);
     recomputeFeature();

--- a/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
@@ -317,7 +317,7 @@ void TaskCenterLine::onColorChanged()
         return;
     }
 
-    App::Color ac;
+    Base::Color ac;
     ac.setValue<QColor>(ui->cpLineColor->color());
     m_cl->m_format.getColor().setValue<QColor>(ui->cpLineColor->color());
     m_partFeat->recomputeFeature();
@@ -430,7 +430,7 @@ void TaskCenterLine::createCenterLine()
     cl->setExtend(extendBy);
     cl->setRotate(rotate);
     cl->m_flip2Line = false;
-    App::Color ac;
+    Base::Color ac;
     ac.setValue<QColor>(ui->cpLineColor->color());
     cl->m_format.setColor(ac);
     cl->m_format.setWidth(ui->dsbWeight->value().getValue());

--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -322,7 +322,7 @@ void TaskDimension::onColorChanged()
     if (m_dimensionVP.expired()) {
         return;
     }
-    App::Color ac;
+    Base::Color ac;
     ac.setValue<QColor>(ui->dimensionColor->color());
     m_dimensionVP->Color.setValue(ac);
     recomputeFeature();

--- a/src/Mod/TechDraw/Gui/TaskGeomHatch.h
+++ b/src/Mod/TechDraw/Gui/TaskGeomHatch.h
@@ -76,12 +76,12 @@ private:
     std::string m_name;
     double m_scale;
     double m_weight;
-    App::Color m_color;
+    Base::Color m_color;
     std::string m_origFile;
     std::string m_origName;
     double m_origScale;
     double m_origWeight;
-    App::Color m_origColor;
+    Base::Color m_origColor;
     double m_rotation;
     double m_origRotation;
     Base::Vector3d m_offset;

--- a/src/Mod/TechDraw/Gui/TaskHatch.cpp
+++ b/src/Mod/TechDraw/Gui/TaskHatch.cpp
@@ -218,7 +218,7 @@ void TaskHatch::createHatch()
     Gui::ViewProvider* vp = Gui::Application::Instance->getDocument(doc)->getViewProvider(m_hatch);
     m_vp = dynamic_cast<TechDrawGui::ViewProviderHatch*>(vp);
     if (m_vp) {
-        App::Color ac;
+        Base::Color ac;
         ac.setValue<QColor>(ui->ccColor->color());
         m_vp->HatchColor.setValue(ac);
         m_vp->HatchScale.setValue(ui->sbScale->value().getValue());
@@ -244,7 +244,7 @@ void TaskHatch::updateHatch()
                        FeatName.c_str(),
                        filespec.c_str());
 
-    App::Color ac;
+    Base::Color ac;
     ac.setValue<QColor>(ui->ccColor->color());
     m_vp->HatchColor.setValue(ac);
     m_vp->HatchScale.setValue(ui->sbScale->value().getValue());

--- a/src/Mod/TechDraw/Gui/TaskHatch.h
+++ b/src/Mod/TechDraw/Gui/TaskHatch.h
@@ -84,13 +84,13 @@ private:
     std::vector<std::string> m_subs;
     std::string m_file;
     double m_scale;
-    App::Color m_color;
+    Base::Color m_color;
     double m_rotation;
     Base::Vector3d m_offset;
 
     std::string m_saveFile;
     double m_saveScale;
-    App::Color m_saveColor;
+    Base::Color m_saveColor;
     std::vector<std::string> m_saveSubs;
     double m_saveRotation;
     Base::Vector3d m_saveOffset;

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
@@ -313,7 +313,7 @@ void TaskLeaderLine::onEndSymbolChanged()
 
 void TaskLeaderLine::onColorChanged()
 {
-    App::Color ac;
+    Base::Color ac;
     ac.setValue<QColor>(ui->cpLineColor->color());
     m_lineVP->Color.setValue(ac);
     recomputeFeature();
@@ -395,7 +395,7 @@ void TaskLeaderLine::createLeaderFeature(std::vector<Base::Vector3d> sceneDeltas
         Gui::ViewProvider* vp = QGIView::getViewProvider(m_lineFeat);
         auto leadVP = dynamic_cast<ViewProviderLeader*>(vp);
         if (leadVP) {
-            App::Color ac;
+            Base::Color ac;
             ac.setValue<QColor>(ui->cpLineColor->color());
             leadVP->Color.setValue(ac);
             leadVP->LineWidth.setValue(ui->dsbWeight->rawValue());
@@ -433,7 +433,7 @@ void TaskLeaderLine::updateLeaderFeature()
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Edit Leader"));
     //waypoints & x, y are updated by QGILeaderLine (for edits only!)
     commonFeatureUpdate();
-    App::Color ac;
+    Base::Color ac;
     ac.setValue<QColor>(ui->cpLineColor->color());
     m_lineVP->Color.setValue(ac);
     m_lineVP->LineWidth.setValue(ui->dsbWeight->rawValue());

--- a/src/Mod/TechDraw/Gui/TaskLineDecor.h
+++ b/src/Mod/TechDraw/Gui/TaskLineDecor.h
@@ -84,7 +84,7 @@ private:
     std::vector<std::string> m_createdFormatTags;
 
     int m_style;
-    App::Color m_color;
+    Base::Color m_color;
     double m_weight;
     bool m_visible;
     bool m_apply;

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
@@ -269,7 +269,7 @@ double TaskRichAnno::prefWeight() const
     return TechDraw::LineGroup::getDefaultWidth("Graphic");
 }
 
-App::Color TaskRichAnno::prefLineColor()
+Base::Color TaskRichAnno::prefLineColor()
 {
     return PreferencesGui::leaderColor();
 }
@@ -319,7 +319,7 @@ void TaskRichAnno::createAnnoFeature()
         Gui::ViewProvider* vp = QGIView::getViewProvider(m_annoFeat);
         auto annoVP = dynamic_cast<ViewProviderRichAnno*>(vp);
         if (annoVP) {
-            App::Color ac;
+            Base::Color ac;
             ac.setValue<QColor>(ui->cpFrameColor->color());
             annoVP->LineColor.setValue(ac);
             annoVP->LineWidth.setValue(ui->dsbWidth->rawValue());
@@ -350,7 +350,7 @@ void TaskRichAnno::updateAnnoFeature()
 //    Base::Console().Message("TRA::updateAnnoFeature()\n");
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Edit Anno"));
     commonFeatureUpdate();
-    App::Color ac;
+    Base::Color ac;
     ac.setValue<QColor>(ui->cpFrameColor->color());
     m_annoVP->LineColor.setValue(ac);
     m_annoVP->LineWidth.setValue(ui->dsbWidth->rawValue());

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.h
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.h
@@ -87,7 +87,7 @@ protected:
     void enableTextUi(bool enable);
     void enableVPUi(bool enable);
     double prefWeight() const;
-    App::Color prefLineColor();
+    Base::Color prefLineColor();
 
 protected Q_SLOTS:
     void onSaveAndExit(QString);

--- a/src/Mod/TechDraw/Gui/TaskSelectLineAttributes.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSelectLineAttributes.cpp
@@ -165,7 +165,7 @@ bool TaskSelectLineAttributes::accept()
     }
 
     QColor qTemp = ui->cbColor->color();
-    App::Color temp;
+    Base::Color temp;
     temp.set(qTemp.redF(), qTemp.greenF(), qTemp.blueF(), 1.0 - qTemp.alphaF());
     LineFormat::getCurrentLineFormat().setColor(temp);
 

--- a/src/Mod/TechDraw/Gui/TaskSelectLineAttributes.h
+++ b/src/Mod/TechDraw/Gui/TaskSelectLineAttributes.h
@@ -85,7 +85,7 @@ class Ui_TaskSelectLineAttributes;
 //     float getWidthValue();
 //     void setColor(int);
 //     int getColor() const {return color;}
-//     App::Color getColorValue();
+//     Base::Color getColorValue();
 
 // }; // class lineAttributes
 

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -237,7 +237,7 @@ TechDraw::DrawViewDimension* ViewProviderDimension::getViewObject() const
     return dynamic_cast<TechDraw::DrawViewDimension*>(pcObject);
 }
 
-App::Color ViewProviderDimension::prefColor() const
+Base::Color ViewProviderDimension::prefColor() const
 {
    return PreferencesGui::dimColor();
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.h
@@ -81,7 +81,7 @@ public:
 
     TechDraw::DrawViewDimension* getViewObject() const override;
 
-    App::Color prefColor() const;
+    Base::Color prefColor() const;
     std::string prefFont() const;
     double prefFontSize() const;
     double prefArrowSize() const;

--- a/src/Mod/TechDraw/Gui/ViewProviderLeader.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderLeader.cpp
@@ -157,7 +157,7 @@ double ViewProviderLeader::getDefLineWeight()
     return TechDraw::LineGroup::getDefaultWidth("Thin");
 }
 
-App::Color ViewProviderLeader::getDefLineColor()
+Base::Color ViewProviderLeader::getDefLineColor()
 {
     return PreferencesGui::leaderColor();
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderLeader.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderLeader.h
@@ -71,7 +71,7 @@ public:
 
 protected:
     double getDefLineWeight();
-    App::Color getDefLineColor();
+    Base::Color getDefLineColor();
     void handleChangedPropertyType(Base::XMLReader &reader, const char *TypeName, App::Property * prop) override;
 
 private:

--- a/src/Mod/TechDraw/Gui/ViewProviderRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderRichAnno.cpp
@@ -121,7 +121,7 @@ TechDraw::DrawRichAnno* ViewProviderRichAnno::getFeature() const
     return dynamic_cast<TechDraw::DrawRichAnno*>(pcObject);
 }
 
-App::Color ViewProviderRichAnno::getDefLineColor()
+Base::Color ViewProviderRichAnno::getDefLineColor()
 {
     return PreferencesGui::leaderColor();
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderRichAnno.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderRichAnno.h
@@ -68,7 +68,7 @@ public:
 
 
 protected:
-    App::Color getDefLineColor();
+    Base::Color getDefLineColor();
     std::string getDefFont();
     double getDefFontSize();
     double getDefLineWeight();

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -386,14 +386,14 @@ bool ViewProviderViewPart::canDelete(App::DocumentObject *obj) const
     return true;
 }
 
-App::Color ViewProviderViewPart::prefSectionColor()
+Base::Color ViewProviderViewPart::prefSectionColor()
 {
     return PreferencesGui::sectionLineColor();
 }
 
-App::Color ViewProviderViewPart::prefHighlightColor()
+Base::Color ViewProviderViewPart::prefHighlightColor()
 {
-    App::Color fcColor;
+    Base::Color fcColor;
     fcColor.setPackedValue(Preferences::getPreferenceGroup("Decorations")->GetUnsigned("HighlightColor", 0x00000000));
     return fcColor;
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
@@ -74,8 +74,8 @@ public:
     bool doubleClicked(void) override;
     void onChanged(const App::Property *prop) override;
     void handleChangedPropertyType(Base::XMLReader &reader, const char *TypeName, App::Property * prop) override;
-    App::Color prefSectionColor(void);
-    App::Color prefHighlightColor(void);
+    Base::Color prefSectionColor(void);
+    Base::Color prefHighlightColor(void);
     int prefHighlightStyle(void);
 
     std::vector<App::DocumentObject*> claimChildren(void) const override;

--- a/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
@@ -152,7 +152,7 @@ bool ViewProviderViewSection::doubleClicked()
 
 void ViewProviderViewSection::getParameters()
 {
-    App::Color cutColor = App::Color((uint32_t) Preferences::getPreferenceGroup("Colors")->GetUnsigned("CutSurfaceColor", 0xD3D3D3FF));
+    Base::Color cutColor = Base::Color((uint32_t) Preferences::getPreferenceGroup("Colors")->GetUnsigned("CutSurfaceColor", 0xD3D3D3FF));
     CutSurfaceColor.setValue(cutColor);
 
     double lineWeight = Preferences::getPreferenceGroup("PAT")->GetFloat("GeomWeight", 0.1);

--- a/tests/src/App/Color.cpp
+++ b/tests/src/App/Color.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include <cmath>
-#include "App/Color.h"
+#include "Base/Color.h"
 
 // NOLINTBEGIN
 TEST(TestColor, equal)
@@ -9,10 +9,10 @@ TEST(TestColor, equal)
     int green = 170;
     int blue = 255;
 
-    App::Color color(red / 255.0F, green / 255.0F, blue / 255.0F);
+    Base::Color color(red / 255.0F, green / 255.0F, blue / 255.0F);
     uint32_t packed = color.getPackedValue();
 
-    App::Color color2 {packed};
+    Base::Color color2 {packed};
     EXPECT_EQ(color, color2);
 }
 
@@ -30,9 +30,9 @@ TEST(TestColor, packedValue)
     int green = 170;
     int blue = 255;
 
-    App::Color color(red / 255.0F, green / 255.0F, blue / 255.0F);
+    Base::Color color(red / 255.0F, green / 255.0F, blue / 255.0F);
     uint32_t packed = color.getPackedValue();
-    App::Color color2 {packed};
+    Base::Color color2 {packed};
 
     EXPECT_EQ(std::lround(color2.r * 255.0F), 85);
     EXPECT_EQ(std::lround(color2.g * 255.0F), 170);
@@ -45,9 +45,9 @@ TEST(TestColor, packedRGB)
     int green = 170;
     int blue = 255;
 
-    App::Color color(red / 255.0F, green / 255.0F, blue / 255.0F);
+    Base::Color color(red / 255.0F, green / 255.0F, blue / 255.0F);
     uint32_t packed = color.getPackedRGB();
-    App::Color color2;
+    Base::Color color2;
     color2.setPackedRGB(packed);
 
     EXPECT_EQ(std::lround(color2.r * 255.0F), 85);
@@ -62,9 +62,9 @@ TEST(TestColor, packedARGB)
     int blue = 255;
     int alpha = 127;
 
-    App::Color color(red / 255.0F, green / 255.0F, blue / 255.0F, alpha / 255.0F);
+    Base::Color color(red / 255.0F, green / 255.0F, blue / 255.0F, alpha / 255.0F);
     uint32_t packed = color.getPackedARGB();
-    App::Color color2;
+    Base::Color color2;
     color2.setPackedARGB(packed);
 
     EXPECT_EQ(std::lround(color2.r * 255.0F), 85);
@@ -136,7 +136,7 @@ TEST(TestColor, asPackedRGB)
     int blue = 255;
 
     IntColor intColor {red, green, blue};
-    uint32_t packed = App::Color::asPackedRGB<IntColor>(intColor);
+    uint32_t packed = Base::Color::asPackedRGB<IntColor>(intColor);
 
 
     EXPECT_EQ(packed, 1437269760);
@@ -148,9 +148,9 @@ TEST(TestColor, fromPackedRGB)
     int green = 170;
     int blue = 255;
 
-    App::Color color(red / 255.0F, green / 255.0F, blue / 255.0F);
+    Base::Color color(red / 255.0F, green / 255.0F, blue / 255.0F);
 
-    IntColor intColor = App::Color::fromPackedRGB<IntColor>(color.getPackedRGB());
+    IntColor intColor = Base::Color::fromPackedRGB<IntColor>(color.getPackedRGB());
 
     EXPECT_EQ(intColor.red(), red);
     EXPECT_EQ(intColor.green(), green);
@@ -165,7 +165,7 @@ TEST(TestColor, asPackedRGBA)
     int alpha = 127;
 
     IntColor intColor {red, green, blue, alpha};
-    uint32_t packed = App::Color::asPackedRGBA<IntColor>(intColor);
+    uint32_t packed = Base::Color::asPackedRGBA<IntColor>(intColor);
 
 
     EXPECT_EQ(packed, 1437269887);
@@ -178,9 +178,9 @@ TEST(TestColor, fromPackedRGBA)
     int blue = 255;
     int alpha = 127;
 
-    App::Color color(red / 255.0F, green / 255.0F, blue / 255.0F, alpha / 255.0F);
+    Base::Color color(red / 255.0F, green / 255.0F, blue / 255.0F, alpha / 255.0F);
 
-    IntColor intColor = App::Color::fromPackedRGBA<IntColor>(color.getPackedValue());
+    IntColor intColor = Base::Color::fromPackedRGBA<IntColor>(color.getPackedValue());
 
     EXPECT_EQ(intColor.red(), red);
     EXPECT_EQ(intColor.green(), green);
@@ -195,7 +195,7 @@ TEST(TestColor, setValue)
     int blue = 255;
 
     IntColor intColor {red, green, blue};
-    App::Color color {};
+    Base::Color color {};
     color.setValue<IntColor>(intColor);
 
     EXPECT_FLOAT_EQ(color.r, 85.0F / 255.0F);
@@ -209,7 +209,7 @@ TEST(TestColor, asValue)
     int green = 170;
     int blue = 255;
 
-    App::Color color(red / 255.0F, green / 255.0F, blue / 255.0F);
+    Base::Color color(red / 255.0F, green / 255.0F, blue / 255.0F);
 
     IntColor intColor = color.asValue<IntColor>();
 
@@ -224,14 +224,14 @@ TEST(TestColor, asHexString)
     int green = 170;
     int blue = 255;
 
-    App::Color color(red / 255.0F, green / 255.0F, blue / 255.0F);
+    Base::Color color(red / 255.0F, green / 255.0F, blue / 255.0F);
 
     EXPECT_EQ(color.asHexString(), "#55AAFF");
 }
 
 TEST(TestColor, fromHexString)
 {
-    App::Color color;
+    Base::Color color;
     EXPECT_FALSE(color.fromHexString(std::string("")));
     EXPECT_FALSE(color.fromHexString(std::string("abcdef")));
     EXPECT_TRUE(color.fromHexString(std::string("#abcdef")));

--- a/tests/src/Mod/Points/App/Points.cpp
+++ b/tests/src/Mod/Points/App/Points.cpp
@@ -46,9 +46,9 @@ protected:
         std::vector<Base::Vector3f> vec(8, Base::Vector3f(0, 0, 1));
         return vec;
     }
-    std::vector<App::Color> getColors() const
+    std::vector<Base::Color> getColors() const
     {
-        std::vector<App::Color> col(8);
+        std::vector<Base::Color> col(8);
         col[0].set(0, 0, 0);
         col[1].set(0, 0, 1);
         col[2].set(0, 1, 0);


### PR DESCRIPTION
Every basic data type is stored in Base module, color is standing out as one that does not. Moving it to Base opens possibilities to integrate it better with the rest of FreeCAD like adding `Color` parameter type to User Parameters so it is easier to use from the code.