### PR TITLE
[Spreadsheet] Fix popup close issue

### DIFF
--- a/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
@@ -187,6 +187,11 @@ void ZoomableView::updateView(void)
     centerOn(new_geometry.center());
 }
 
+void ZoomableView::focusOutEvent(QFocusEvent *event)
+{
+    Q_UNUSED(event);
+}
+
 void ZoomableView::keyPressEvent(QKeyEvent* event)
 {
     if (event->modifiers() & Qt::ControlModifier) {

--- a/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
@@ -187,7 +187,7 @@ void ZoomableView::updateView(void)
     centerOn(new_geometry.center());
 }
 
-void ZoomableView::focusOutEvent(QFocusEvent *event)
+void ZoomableView::focusOutEvent(QFocusEvent* event)
 {
     Q_UNUSED(event);
 }

--- a/src/Mod/Spreadsheet/Gui/ZoomableView.h
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.h
@@ -73,6 +73,7 @@ private:
     int m_zoomLevel;
 
 protected:
+    void focusOutEvent(QFocusEvent *event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;

--- a/src/Mod/Spreadsheet/Gui/ZoomableView.h
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.h
@@ -73,7 +73,7 @@ private:
     int m_zoomLevel;
 
 protected:
-    void focusOutEvent(QFocusEvent *event) override;
+    void focusOutEvent(QFocusEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;


### PR DESCRIPTION
The issue #16987 and #19357 are caused by _FocusOut_ event. When I implemented _ZoomableView_, I missed the fact that _FocusOut_ event of _QGraphicsView_ is different from that of _QWidget_.

_ExpressionCompleter_ creates a popup, making _QGraphicsView_ lose focus. If _QGraphicsView_ loses focus, the scene loses focus too,[^1] which in turn, causes _FocusOut_ event of the _ExpressionCompleter_, leading to _editingFinished_ signal, thus closing the editor.

This commit implements a dummy _FocusOut_ event, preventing the propagation of _FocusOut_ event, thus closing #16987.


CC @benj5378








[^1]: https://github.com/qt/qtbase/blob/84e09e060bedd37d8de7cded7e430371e335c029/src/widgets/graphicsview/qgraphicsview.cpp#L3108-L3114
