### PR TITLE
Draft: improve upgrade and downgrade

### DIFF
--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -558,7 +558,10 @@ def getShapeFromMesh(mesh,fast=True,tolerance=0.001,flat=False,cut=True):
             print("getShapeFromMesh: error creating solid")
             return se
         else:
-            return solid
+            if solid.isClosed():
+                return solid
+            else:
+                return se
 
 def projectToVector(shape,vector):
     '''projectToVector(shape,vector): projects the given shape on the given

--- a/src/Mod/Draft/draftfunctions/downgrade.py
+++ b/src/Mod/Draft/draftfunctions/downgrade.py
@@ -2,6 +2,7 @@
 # *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
 # *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
 # *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2025 The FreeCAD Project Association                    *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -31,11 +32,11 @@ See also the `upgrade` function.
 ## \addtogroup draftfunctions
 # @{
 import FreeCAD as App
-from draftfunctions import cut
 from draftmake import make_copy
 from draftutils import utils
 from draftutils import params
 from draftutils import gui_utils
+from draftutils.groups import is_group
 from draftutils.messages import _msg
 from draftutils.translate import translate
 
@@ -68,23 +69,13 @@ def downgrade(objects, delete=False, force=None):
         A tuple containing two lists, a list of new objects
         and a list of objects to be deleted.
 
-    None
-        If there is a problem it will return `None`.
-
     See Also
     --------
     upgrade
     """
-    _name = "downgrade"
 
-    if not isinstance(objects, list):
-        objects = [objects]
+    # definitions of actions to perform
 
-    delete_list = []
-    add_list = []
-    doc = App.ActiveDocument
-
-    # actions definitions
     def explode(obj):
         """Explode a Draft block or array."""
         obj_pl = obj.Placement
@@ -92,6 +83,7 @@ def downgrade(objects, delete=False, force=None):
         if getattr(obj, "Components", []):
             delete_list.append(obj)
             for comp in obj.Components:
+                # Objects in Components are in the same parent group as the block.
                 comp.Placement = obj_pl.multiply(comp.Placement)
                 comp.Visibility = True
             return True
@@ -100,40 +92,57 @@ def downgrade(objects, delete=False, force=None):
             return False
         if not hasattr(obj, "PlacementList"):
             return False
-        base = obj.Base
+        # Array must be added to delete_list before base. See can_be_deleted.
         delete_list.append(obj)
+        base = obj.Base
+        if not base.Visibility:
+            # Delete base if it is not visible. The can_be_deleted
+            # function will check if it is not used elsewhere.
+            delete_list.append(base)
+        new_list = []
         if getattr(obj, "ExpandArray", False):
+            delete_list.extend(obj.ElementList)
             for lnk in obj.ElementList:
-                new = make_copy.make_copy(base)
-                new.Placement = obj_pl.multiply(lnk.Placement)
-                new.Visibility = True
-                delete_list.append(lnk)
+                newobj = make_copy.make_copy(base)
+                newobj.Placement = obj_pl.multiply(lnk.Placement)
+                newobj.Visibility = True
+                new_list.append(newobj)
         else:
             for arr_pl in obj.PlacementList:
-                new = make_copy.make_copy(base)
-                new.Placement = obj_pl.multiply(arr_pl)
-                new.Visibility = True
+                newobj = make_copy.make_copy(base)
+                newobj.Placement = obj_pl.multiply(arr_pl)
+                newobj.Visibility = True
+                new_list.append(newobj)
+        add_to_parent(obj, new_list)
+        add_list.extend(new_list)
         return True
 
     def cut2(objects):
-        """Cut first object from the last one."""
-        newobj = cut.cut(objects[0], objects[1])
-        if newobj:
-            add_list.append(newobj)
-            return newobj
-        return None
+        """Cut 2nd object from 1st."""
+        newobj = doc.addObject("Part::Cut", "Cut")
+        newobj.Base = objects[0]
+        newobj.Tool = objects[1]
+        format(objects[0], [newobj])
+        add_to_parent(objects[0], [newobj])
+        add_list.append(newobj)
+        return True
 
     def splitCompounds(objects):
         """Split solids contained in compound objects into new objects."""
         result = False
-        for o in objects:
-            if o.Shape.Solids:
-                for s in o.Shape.Solids:
-                    newobj = doc.addObject("Part::Feature", "Solid")
-                    newobj.Shape = s
-                    add_list.append(newobj)
-                result = True
-                delete_list.append(o)
+        for obj in objects:
+            if not obj.Shape.Solids:
+                continue
+            new_list = []
+            for solid in obj.Shape.Solids:
+                newobj = doc.addObject("Part::Feature", "Solid")
+                newobj.Shape = solid
+                new_list.append(newobj)
+            format(obj, new_list)
+            add_to_parent(obj, new_list)
+            add_list.extend(new_list)
+            delete_list.append(obj)
+            result = True
         return result
 
     def splitFaces(objects):
@@ -141,129 +150,231 @@ def downgrade(objects, delete=False, force=None):
         result = False
         preserveFaceColor = params.get_param("preserveFaceColor")
         preserveFaceNames = params.get_param("preserveFaceNames")
-        for o in objects:
-            if App.GuiUp and preserveFaceColor and o.ViewObject:
-                voDColors = o.ViewObject.DiffuseColor
+        for obj in objects:
+            if not obj.Shape.Faces:
+                continue
+            new_list = []
+            if App.GuiUp and preserveFaceColor and obj.ViewObject:
+                colors = obj.ViewObject.DiffuseColor
             else:
-                voDColors = None
-            oLabel = o.Label if hasattr(o, 'Label') else ""
-            if o.Shape.Faces:
-                for ind, f in enumerate(o.Shape.Faces):
-                    newobj = doc.addObject("Part::Feature", "Face")
-                    newobj.Shape = f
-                    if preserveFaceNames:
-                        newobj.Label = "{} {}".format(oLabel, newobj.Label)
-                    if App.GuiUp and preserveFaceColor and voDColors:
-                        # At this point, some single-color objects might have
-                        # just a single value in voDColors for all faces,
-                        # so we handle that
-                        if ind < len(voDColors):
-                            tcolor = voDColors[ind]
-                        else:
-                            tcolor = voDColors[0]
-                        # does is not applied visually on its own
-                        # just in case
-                        newobj.ViewObject.DiffuseColor[0] = tcolor
-                        # this gets applied, works by itself too
-                        newobj.ViewObject.ShapeColor = tcolor
-                    add_list.append(newobj)
-                result = True
-                delete_list.append(o)
+                colors = None
+            label = getattr(obj, "Label", "")
+            for ind, face in enumerate(obj.Shape.Faces):
+                newobj = doc.addObject("Part::Feature", "Face")
+                newobj.Shape = face
+                format(obj, [newobj])
+                if App.GuiUp and preserveFaceColor and colors:
+                    # At this point, some single-color objects might have just
+                    # a single value in colors for all faces, so we handle that:
+                    if ind < len(colors):
+                        color = colors[ind]
+                    else:
+                        color = colors[0]
+                    newobj.ViewObject.ShapeColor = color
+                if preserveFaceNames:
+                    newobj.Label = "{} {}".format(label, newobj.Label)
+                new_list.append(newobj)
+            add_to_parent(obj, new_list)
+            add_list.extend(new_list)
+            delete_list.append(obj)
+            result = True
         return result
 
     def subtr(objects):
-        """Subtract objects from the first one."""
+        """Subtract faces from the first one."""
         faces = []
-        for o in objects:
-            if o.Shape.Faces:
-                faces.extend(o.Shape.Faces)
-                delete_list.append(o)
-        u = faces.pop(0)
-        for f in faces:
-            u = u.cut(f)
-        if not u.isNull():
-            newobj = doc.addObject("Part::Feature", "Subtraction")
-            newobj.Shape = u
-            add_list.append(newobj)
-            return newobj
-        return None
+        done_list = []
+        for obj in objects:
+            if obj.Shape.Faces:
+                faces.extend(obj.Shape.Faces)
+                done_list.append(obj)
+        if not faces:
+            return False
+        main_face = faces.pop(0)
+        for face in faces:
+            main_face = main_face.cut(face)
+        if main_face.isNull():
+            return False
+        newobj = doc.addObject("Part::Feature", "Subtraction")
+        newobj.Shape = main_face
+        format(done_list[0], [newobj])
+        add_to_parent(done_list[0], [newobj])
+        add_list.append(newobj)
+        delete_list.extend(done_list)
+        return True
 
     def getWire(obj):
         """Get the wire from a face object."""
-        result = False
-        for w in obj.Shape.Faces[0].Wires:
+        if not obj.Shape.Faces:
+            return False
+        new_list = []
+        for wire in obj.Shape.Faces[0].Wires:
             newobj = doc.addObject("Part::Feature", "Wire")
-            newobj.Shape = w
-            add_list.append(newobj)
-            result = True
+            newobj.Shape = wire
+            new_list.append(newobj)
+        format(obj, new_list)
+        add_to_parent(obj, new_list)
+        add_list.extend(new_list)
         delete_list.append(obj)
-        return result
+        return True
 
     def splitWires(objects):
         """Split the wires contained in objects into edges."""
         result = False
-        for o in objects:
-            if o.Shape.Edges:
-                for e in o.Shape.Edges:
-                    newobj = doc.addObject("Part::Feature", "Edge")
-                    newobj.Shape = e
-                    add_list.append(newobj)
-                delete_list.append(o)
-                result = True
+        for obj in objects:
+            if not obj.Shape.Edges:
+                continue
+            new_list = []
+            for edge in obj.Shape.Edges:
+                newobj = doc.addObject("Part::Feature", "Edge")
+                newobj.Shape = edge
+                new_list.append(newobj)
+            format(obj, new_list)
+            add_to_parent(obj, new_list)
+            add_list.extend(new_list)
+            delete_list.append(obj)
+            result = True
         return result
 
+    def _shapify(obj):
+        """Wrapper for utils.shapify."""
+        newobj = utils.shapify(obj, delete=False)
+        if newobj:
+            format(obj, [newobj])
+            add_to_parent(obj, [newobj])
+            add_list.append(newobj)
+            delete_list.append(obj)
+            return True
+        return False
+
+
+    # helper functions (same as in upgrade.py)
+
+    def get_parent(obj):
+        # Problem with obj.getParent():
+        # https://github.com/FreeCAD/FreeCAD/issues/19600
+        parent = obj.getParentGroup()
+        if parent is not None:
+            return parent
+        return obj.getParentGeoFeatureGroup()
+
+    def can_be_deleted(obj):
+        if not obj.InList:
+            return True
+        for other in obj.InList:
+            if is_group(other):
+                continue
+            if other.TypeId == "App::Part":
+                continue
+            return False
+        return True
+
     def delete_object(obj):
-        if obj.FullName == "?": # Already deleted.
+        if utils.is_deleted(obj):
             return
-        # special case: obj is a body or belongs to a body:
+        parent = get_parent(obj)
+        if parent is not None and parent.TypeId == "PartDesign::Body":
+            obj = parent
+        if not can_be_deleted(obj):
+            # Make obj invisible instead:
+            obj.Visibility = False
+            return
         if obj.TypeId == "PartDesign::Body":
             obj.removeObjectsFromDocument()
-        if hasattr(obj, "_Body") and obj._Body is not None:
-            obj = obj._Body
-            obj.removeObjectsFromDocument()
-        else:
-            for parent in obj.InList:
-                if parent.TypeId == "PartDesign::Body" \
-                        and obj in parent.Group:
-                    obj = parent
-                    obj.removeObjectsFromDocument()
-                    break
         doc.removeObject(obj.Name)
 
+    def add_to_parent(obj, new_list):
+        parent = get_parent(obj)
+        if parent is None:
+            if doc.getObject("Draft_Construction"):
+                # This cludge is required because the make_* commands may
+                # put new objects in the construction group.
+                constr_group = doc.getObject("Draft_Construction")
+                for newobj in new_list:
+                    constr_group.removeObject(newobj)
+            return
+        if parent.TypeId == "PartDesign::Body":
+            # We don't add to a PD Body. We process its placement and
+            # add to its parent instead.
+            for newobj in new_list:
+                newobj.Placement = parent.Placement.multiply(newobj.Placement)
+            add_to_parent(parent, new_list)
+            return
+        for newobj in new_list:
+            # Using addObject is different from just changing the Group property.
+            # With addObject the object will be added to the parent group, but if
+            # that is a normal group, also to that group's parent GeoFeatureGroup,
+            # if available.
+            parent.addObject(newobj)
+
+    def format(obj, new_list):
+        for newobj in new_list:
+            gui_utils.format_object(newobj, obj, ignore_construction=True)
+
+
+    doc = App.ActiveDocument
+    add_list = []
+    delete_list = []
+    result = False
+
+    if not isinstance(objects, list):
+        objects = [objects]
+    if not objects:
+        return add_list, delete_list
+
     # analyzing objects
+    solids = []
     faces = []
     edges = []
     onlyedges = True
     parts = []
-    solids = []
-    result = None
 
-    for o in objects:
-        if hasattr(o, 'Shape'):
-            for s in o.Shape.Solids:
-                solids.append(s)
-            for f in o.Shape.Faces:
-                faces.append(f)
-            for e in o.Shape.Edges:
-                edges.append(e)
-            if o.Shape.ShapeType != "Edge":
+    for obj in objects:
+        if hasattr(obj, "Shape"):
+            for solid in obj.Shape.Solids:
+                solids.append(False)
+            for face in obj.Shape.Faces:
+                faces.append(face)
+            for edge in obj.Shape.Edges:
+                edges.append(edge)
+            if obj.Shape.ShapeType != "Edge":
                 onlyedges = False
-            parts.append(o)
+            parts.append(obj)
     objects = parts
 
-    if force:
-        if force in ("explode", "shapify", "subtr", "splitFaces",
-                     "cut2", "getWire", "splitWires"):
-            # TODO: Using eval to evaluate a string is not ideal
-            # and potentially a security risk.
-            # How do we execute the function without calling eval?
-            # Best case, a series of if-then statements.
-            shapify = utils.shapify
-            result = eval(force)(objects)
+    if not objects:
+        result = False
+
+    elif force:
+        # functions that work on a single object:
+        single_funcs = {"explode": explode,
+                        "getWire": getWire,
+                        "shapify": _shapify}
+        # functions that work on multiple objects:
+        multi_funcs = {"cut2": cut2,
+                       "splitCompounds": splitCompounds,
+                       "splitFaces": splitFaces,
+                       "splitWires": splitWires,
+                       "subtr": subtr}
+        if force in single_funcs:
+            result = any([single_funcs[force](obj) for obj in objects])
+        elif force in multi_funcs:
+            result = multi_funcs[force](objects)
         else:
-            _msg(translate("draft", "Upgrade: Unknown force method:") + " " + force)
-            result = None
+            _msg(translate("draft", "Downgrade: Unknown force method:") + " " + force)
+            result = False
+
     else:
+        parent = get_parent(objects[0])
+        same_parent = True
+        same_parent_type = getattr(parent, "TypeId", "")  # "" for global space.
+        if len(objects) > 1:
+            for obj in objects[1:]:
+                if get_parent(obj) != parent:
+                    same_parent = False
+                    same_parent_type = None
+                    break
+
         # we have a block, we explode it
         if len(objects) == 1 and utils.get_type(objects[0]) == "Block":
             result = explode(objects[0])
@@ -271,35 +382,29 @@ def downgrade(objects, delete=False, force=None):
                 _msg(translate("draft", "Found 1 block: exploding it"))
 
         # we have an array, we explode it
-        elif len(objects) == 1 \
-                and "Array" in utils.get_type(objects[0]) \
-                and hasattr(objects[0], "PlacementList"):
+        elif len(objects) == 1 and "Array" in utils.get_type(objects[0]):
             result = explode(objects[0])
             if result:
                 _msg(translate("draft", "Found 1 array: exploding it"))
+
+        # special case, we have one parametric object: we "de-parametrize" it
+        elif len(objects) == 1 \
+                and hasattr(objects[0], "Shape") \
+                and (hasattr(objects[0], "Base") or hasattr(objects[0], "Profile")):
+            result = _shapify(objects[0])
+            if result:
+                _msg(translate("draft", "Found 1 parametric object: breaking its dependencies"))
 
         # we have one multi-solids compound object: extract its solids
         elif len(objects) == 1 \
                 and hasattr(objects[0], "Shape") \
                 and len(solids) > 1:
             result = splitCompounds(objects)
-            # print(result)
             if result:
                 _msg(translate("draft", "Found 1 multi-solids compound: exploding it"))
 
-        # special case, we have one parametric object: we "de-parametrize" it
-        elif len(objects) == 1 \
-                and hasattr(objects[0], "Shape") \
-                and hasattr(objects[0], "Base") \
-                and not objects[0].isDerivedFrom("PartDesign::Feature"):
-            result = utils.shapify(objects[0])
-            if result:
-                _msg(translate("draft", "Found 1 parametric object: breaking its dependencies"))
-                add_list.append(result)
-                # delete_list.append(objects[0])
-
         # we have only 2 objects: cut 2nd from 1st
-        elif len(objects) == 2:
+        elif len(objects) == 2 and same_parent and same_parent_type != "PartDesign::Body":
             result = cut2(objects)
             if result:
                 _msg(translate("draft", "Found 2 objects: subtracting them"))
@@ -311,10 +416,10 @@ def downgrade(objects, delete=False, force=None):
                 if result:
                     _msg(translate("draft", "Found several faces: splitting them"))
             # several objects: remove all the faces from the first one
-            else:
+            elif same_parent and same_parent_type != "PartDesign::Body":
                 result = subtr(objects)
                 if result:
-                    _msg(translate("draft", "Found several objects: subtracting them from the first one"))
+                    _msg(translate("draft", "Found several faces: subtracting them from the first one"))
 
         # only one face: we extract its wires
         elif len(faces) > 0:
@@ -328,14 +433,13 @@ def downgrade(objects, delete=False, force=None):
             if result:
                 _msg(translate("draft", "Found only wires: extracting their edges"))
 
-        # no result has been obtained
-        if not result:
-            _msg(translate("draft", "No more downgrade possible"))
+    # no result has been obtained
+    if not result:
+        _msg(translate("draft", "Unable to downgrade these objects"))
 
     if delete:
-        for o in delete_list:
-            delete_object(o)
-        delete_list = []
+        for obj in delete_list:
+            delete_object(obj)
 
     gui_utils.select(add_list)
     return add_list, delete_list

--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -499,7 +499,7 @@ def restore_view_object(obj, vp_module, vp_class, format=True, format_ref=None):
             format_object(obj, format_ref)
 
 
-def format_object(target, origin=None):
+def format_object(target, origin=None, ignore_construction=False):
     """Apply visual properties to an object.
 
     This function only works if the graphical interface is available.
@@ -521,6 +521,10 @@ def format_object(target, origin=None):
         If construction mode is not active, its visual properties are assigned
         to `target`, with the exception of `BoundingBox`, `Proxy`, `RootNode`
         and `Visibility`.
+
+    ignore_construction: bool, optional
+        Defaults to `False`.
+        Set to `True` to ignore construction mode.
     """
     if not target:
         return
@@ -528,30 +532,38 @@ def format_object(target, origin=None):
         return
     if not hasattr(Gui, "draftToolBar"):
         return
-    if not hasattr(target, 'ViewObject'):
+    if not hasattr(target, "ViewObject"):
         return
+    if hasattr(target, "Shape") and target.Shape.Faces:
+        len_faces = len(target.Shape.Faces)
+    else:
+        len_faces = 1
     obrep = target.ViewObject
     obprops = obrep.PropertiesList
-    if origin and hasattr(origin, 'ViewObject'):
+    if origin and hasattr(origin, "ViewObject"):
         matchrep = origin.ViewObject
         for p in matchrep.PropertiesList:
-            if p not in ("DisplayMode", "BoundingBox",
-                         "Proxy", "RootNode", "Visibility"):
-                if p in obprops:
-                    if not obrep.getEditorMode(p):
-                        if hasattr(getattr(matchrep, p), "Value"):
-                            val = getattr(matchrep, p).Value
-                        else:
-                            val = getattr(matchrep, p)
-                        try:
-                            setattr(obrep, p, val)
-                        except Exception:
-                            pass
+            if p in ("DisplayMode", "BoundingBox", "Proxy", "RootNode", "Visibility"):
+                continue
+            if p not in obprops:
+                continue
+            if obrep.getEditorMode(p):
+                continue
+            val = getattr(matchrep, p)
+            if isinstance(val, tuple):
+                if len(val) != len_faces:
+                    val = (val[0], )
+            elif hasattr(val, "Value"):
+                val = val.Value
+            try:
+                setattr(obrep, p, val)
+            except Exception:
+                pass
         if matchrep.DisplayMode in obrep.listDisplayModes():
             obrep.DisplayMode = matchrep.DisplayMode
         if hasattr(obrep, "DiffuseColor"):
             difcol = get_diffuse_color(origin)
-            if difcol:
+            if difcol and len(difcol) == len_faces:
                 obrep.DiffuseColor = difcol
     elif "FontName" not in obprops:
         # Apply 2 Draft style preferences, other style preferences are applied by Core.
@@ -561,6 +573,8 @@ def format_object(target, origin=None):
             dm = utils.DISPLAY_MODES[params.get_param("DefaultDisplayMode")]
             if dm in obrep.listDisplayModes():
                 obrep.DisplayMode = dm
+    if ignore_construction:
+        return
     if Gui.draftToolBar.isConstructionMode():
         doc = App.ActiveDocument
         col = params.get_param("constructioncolor") | 0x000000FF

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -606,7 +606,7 @@ def get_clone_base(obj, strict=False, recursive=True):
 getCloneBase = get_clone_base
 
 
-def shapify(obj):
+def shapify(obj, delete=True):
     """Transform a parametric object into a static, non-parametric shape.
 
     Parameters
@@ -617,6 +617,10 @@ def shapify(obj):
         This object will be removed, and a non-parametric object
         with the same topological shape (`Part::TopoShape`)
         will be created.
+
+    delete: bool, optional
+        It defaults to `False`.
+        If it is `True`, the original object is deleted.
 
     Returns
     -------
@@ -655,7 +659,8 @@ def shapify(obj):
     else:
         name = getRealName(obj.Name)
 
-    App.ActiveDocument.removeObject(obj.Name)
+    if delete:
+        App.ActiveDocument.removeObject(obj.Name)
     newobj = App.ActiveDocument.addObject("Part::Feature", name)
     newobj.Shape = shape
 


### PR DESCRIPTION
Fixes #16333.
Follow-up of #19487.

* The functions have been made nesting-aware. New objects are put in the same container (Group, Part) as the original objects. As a consequence for some operations the original objects must be in the same container as well.
* New objects receive the visual properties of the original objects. This is not always perfect. For example when upgrading to multiple wires there is currently no check to see which edge came from which orginal object. The fact that the `format_object` function is called from the Draft `make*` functions is problematic here. If construction mode is active `make_wire` puts new objects in the construction group and we don't always want that. This has been solved with a workaround (see 'cludge' in the code).
* The 'de-parametrize' downgrade option has also been enabled for features of PartDesign Bodies that have the `Profile` property.
* Before deleting objects there is a check to see if they are in use elsewhere (`InList` check). Base objects of arrays are not deleted if they are visible. If a PartDesign Body, or an object inside a Body is selected, the whole Body is deleted.
* The force options did not work for functions that take a single object.
* The `getShapeFromMesh` function in ArchCommands.py could return a solid that was not closed. A check for that has been added.
