### PR TITLE
App: Break infinite cycle in `GroupExtension::removeObjectsFromDocument`.

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3472,19 +3472,27 @@ void Document::removeObject(const char* sName)
         return;
     }
 
-    if (pos->second->testStatus(ObjectStatus::Remove)) {
-        FC_LOG("Avoid recursive deletion of " << pos->second->getFullName());
+    auto object = pos->second;
+    if (object->testStatus(ObjectStatus::Remove)) {
+        FC_LOG("Avoid recursive deletion of " << object->getFullName());
         return;
     }
 
-    if (pos->second->testStatus(ObjectStatus::PendingRecompute)) {
+    if (object->testStatus(ObjectStatus::PendingRecompute)) {
         // TODO: shall we allow removal if there is active undo transaction?
+        if (object->testStatus(ObjectStatus::PendingRemoval)) {
+            FC_LOG("Object " << object->getFullName() << " is already pending removal");
+            return;
+        }
         FC_MSG("pending remove of " << sName << " after recomputing document " << getName());
-        d->pendingRemove.emplace_back(pos->second);
+        object->setStatus(ObjectStatus::PendingRemoval, true);
+        d->pendingRemove.emplace_back(object);
         return;
     }
 
-    _removeObject(pos->second, RemoveObjectOption::MayRemoveWhileRecomputing | RemoveObjectOption::MayDestroyOutOfTransaction);
+    _removeObject(object,
+                  RemoveObjectOption::MayRemoveWhileRecomputing
+                      | RemoveObjectOption::MayDestroyOutOfTransaction);
 }
 void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions options)
 {
@@ -3531,6 +3539,7 @@ void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions optio
     }
 
     // Mark the object as about to be removed
+    pcObject->setStatus(ObjectStatus::PendingRemoval, false);
     pcObject->setStatus(ObjectStatus::Remove, true);
     if (!d->undoing && !d->rollback) {
         pcObject->unsetupObject();

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -70,6 +70,7 @@ enum ObjectStatus
     Recompute2 = 9, ///< Whether the object is going to be recomputed in the second pass.
     PartialObject = 10, ///< Whether this is a partially loaded object.
     PendingRecompute = 11, ///< Whether the object is in the recomputation queue, set by Document.
+    PendingRemoval = 12, ///< Whether the object is pending removal, set by Document.
     ObjImporting = 13, ///< Whether the object is being imported.
     NoTouch = 14, ///< Whether the object should be touched on a property change.
     GeoExcluded = 15, ///< Whether the object is a member but not claimed by a GeoFeatureGroup.

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -30,6 +30,8 @@
 #include "GeoFeatureGroupExtension.h"
 #include "GroupExtensionPy.h"
 
+#include <string>
+
 
 using namespace App;
 namespace sp = std::placeholders;
@@ -164,12 +166,30 @@ std::vector<DocumentObject*> GroupExtension::removeObjects(std::vector<DocumentO
 
 void GroupExtension::removeObjectsFromDocument()
 {
-    while (Group.getSize() > 0) {
+    auto nextObjectToRemove = [this]() -> DocumentObject* {
+        for (auto docObject : Group.getValues()) {
+            if (!docObject || !docObject->isAttachedToDocument()
+                || docObject->testStatus(ObjectStatus::PendingRemoval)) {
+                continue;
+            }
+            return docObject;
+        }
+        return nullptr;
+    };
+
+    while (auto objectToRemove = nextObjectToRemove()) {
         // Remove the objects step by step because it can happen
         // that an object is part of several groups and thus a
         // double destruction could be possible
-        const std::vector<DocumentObject*>& grp = Group.getValues();
-        removeObjectFromDocument(grp.front());
+        auto document = objectToRemove->getDocument();
+        const std::string objectName = objectToRemove->getNameInDocument();
+        removeObjectFromDocument(objectToRemove);
+
+        auto objectAfterRemoval = document->getObject(objectName.c_str());
+        if (objectAfterRemoval && !objectAfterRemoval->testStatus(ObjectStatus::PendingRemoval)
+            && hasObject(objectAfterRemoval, false)) {
+            break;
+        }
     }
 }
 

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -1403,6 +1403,37 @@ class DocumentGroupCases(unittest.TestCase):
         self.Doc.removeObject("Label_2")
         self.Doc.removeObject("Label_3")
 
+    def testRemoveObjectsFromDocumentDuringRecompute(self):
+        class GroupRemover:
+            def execute(self, obj):
+                obj.Document.Group.removeObjectsFromDocument()
+
+        class NoOp:
+            def execute(self, obj):
+                pass
+
+        remover = self.Doc.addObject("App::FeaturePython", "Remover")
+        remover.Proxy = GroupRemover()
+        group = self.Doc.addObject("App::DocumentObjectGroup", "Group")
+
+        def add_child(name):
+            child = self.Doc.addObject("App::FeaturePython", name)
+            child.Proxy = NoOp()
+            child.addProperty("App::PropertyLink", "Dependency")
+            child.Dependency = remover
+            group.addObject(child)
+            child.touch()
+            return child.Name
+
+        child_names = [add_child("Child1"), add_child("Child2")]
+
+        remover.touch()
+        self.Doc.recompute()
+
+        for child_name in child_names:
+            self.assertIsNone(self.Doc.getObject(child_name))
+        self.assertEqual(group.Group, [])
+
     def testGroupAndGeoFeatureGroup(self):
 
         # an object can only be in one group at once, that must be enforced


### PR DESCRIPTION
The existing code could enter an infinite loop when removing group objects from a document using `GroupExtension::removeObjectsFromDocument()` during recompute.

`Document::removeObject(const char* sName)` defers removal when the target object is still pending recompute:

```cpp
if (object->testStatus(ObjectStatus::PendingRecompute)) {
    d->pendingRemove.emplace_back(object);
    return;
}
```

In that case the object remains in the group until recompute teardown processes the pending removals. The old group-removal loop kept retrying while the group was non-empty, so it could repeatedly attempt to remove the same deferred child forever.

This PR fixes that by:

- adding an `ObjectStatus::PendingRemoval` bit for deferred removals
- avoiding duplicate pending-remove queue entries for objects already marked `PendingRemoval`
- making `GroupExtension::removeObjectsFromDocument()` skip children already pending removal and continue with other attached children
- clearing `PendingRemoval` when the object is actually removed
- adding a regression test that removes a group with multiple children pending recompute

The regression test reproduces the previous hang without the C++ fix and passes with the fix.