### PR TITLE
Aborting long-running operations (Work in Progress)

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2286,6 +2286,7 @@ void parseProgramOptions(int ac, char ** av, const string& exe, variables_map& v
     ("input-file", boost::program_options::value< vector<string> >(), "input file")
     ("output",     boost::program_options::value<string>(),"output file")
     ("hidden",                                             "don't show the main window")
+    ("boolean-worker", "Run the boolean worker")
     // this are to ignore for the window system (QApplication)
     ("style",      boost::program_options::value< string >(), "set the application GUI style")
     ("stylesheet", boost::program_options::value< string >(), "set the application stylesheet")
@@ -2525,6 +2526,10 @@ void processProgramOptions(const variables_map& vm, std::map<std::string,std::st
         mConfig["ExitTests"] = vm.count("run-open") == 0  ? "yes" : "no";
     }
 
+    if (vm.count("boolean-worker")) {
+        mConfig["RunMode"] = "BooleanWorker";
+    }
+
     if (vm.count("single-instance")) {
         mConfig["SingleInstance"] = "1";
     }
@@ -2696,7 +2701,7 @@ void Application::initConfig(int argc, char ** argv)
         _pConsoleObserverFile = nullptr;
 
     // Banner ===========================================================
-    if (!(mConfig["RunMode"] == "Cmd")) {
+    if (!(mConfig["RunMode"] == "Cmd" || mConfig["RunMode"] == "BooleanWorker")) {
         // Remove banner if FreeCAD is invoked via the -c command as regular
         // Python interpreter
         if (!(mConfig["Verbose"] == "Strict"))
@@ -3005,6 +3010,12 @@ void Application::runApplication()
         // run internal script
         Base::Console().Log("Running internal script:\n");
         Base::Interpreter().runString(Base::ScriptFactory().ProduceScript(mConfig["ScriptFileName"].c_str()));
+    }
+    else if (mConfig["RunMode"] == "BooleanWorker") {
+        // run boolean worker
+        Base::Interpreter().loadModule("Part");
+        Base::Interpreter().runString("import Part\nPart.RunBooleanWorker()");
+        _exit(0);
     }
     else if (mConfig["RunMode"] == "Exit") {
         // getting out

--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -206,6 +206,8 @@ PyObject* Part::PartExceptionOCCRangeError;
 PyObject* Part::PartExceptionOCCConstructionError;
 PyObject* Part::PartExceptionOCCDimensionError;
 
+extern PyMethodDef BooleanWorkerMethods[];
+
 // clang-format off
 PyMOD_INIT_FUNC(Part)
 {
@@ -580,6 +582,9 @@ PyMOD_INIT_FUNC(Part)
 
     Base::registerServiceImplementation<App::SubObjectPlacementProvider>(new AttacherSubObjectPlacement);
     Base::registerServiceImplementation<App::CenterOfMassProvider>(new PartCenterOfMass);
+
+    // Add the BooleanWorker method to the module
+    PyModule_AddFunctions(partModule, BooleanWorkerMethods);
 
     PyMOD_Return(partModule);
 }

--- a/src/Mod/Part/App/AsyncProcessHandle.cpp
+++ b/src/Mod/Part/App/AsyncProcessHandle.cpp
@@ -1,0 +1,100 @@
+#include "PreCompiled.h"
+#include "TopoShape.h"
+#include "AsyncProcessHandle.h"
+#include "BooleanOperation.h"
+
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <sstream>
+#include <vector>
+
+#include <Base/Exception.h>
+#include <Base/Console.h>
+
+#include <Mod/Part/PartGlobal.h>
+
+using namespace Part;
+
+AsyncProcessHandle::AsyncProcessHandle(pid_t childPid, int resultFd)
+    : pid(childPid)
+    , fd(resultFd)
+    , joined(false)
+{
+}
+
+AsyncProcessHandle::~AsyncProcessHandle()
+{
+    if (!joined) {
+        // Attempt to abort if we haven't joined
+        try {
+            abort();
+        } catch (...) {
+            // Ignore exceptions in destructor
+        }
+    }
+    
+    if (fd >= 0) {
+        close(fd);
+    }
+}
+
+void AsyncProcessHandle::abort()
+{
+    if (pid > 0) {
+        kill(pid, SIGTERM);
+        // Give it a moment to terminate gracefully
+        usleep(100000);  // 100ms
+        
+        // Force kill if still running
+        if (kill(pid, 0) == 0) {
+            kill(pid, SIGKILL);
+        }
+    }
+}
+
+ssize_t AsyncProcessHandle::readExact(void* buffer, size_t length) {
+    ssize_t totalRead = 0;
+    while (totalRead < length) {
+        ssize_t bytes = read(fd, static_cast<char*>(buffer) + totalRead, length - totalRead);
+        if (bytes <= 0) {
+            waitpid(pid, nullptr, 0); // Ensure child process is cleaned up
+            throw Base::RuntimeError("Failed to read exact number of bytes");
+        }
+        totalRead += bytes;
+    }
+    return totalRead;
+}
+
+TopoShape AsyncProcessHandle::join()
+{
+    bool expected = false;
+    if (!joined.compare_exchange_strong(expected, true)) {
+        throw Base::RuntimeError("Process has already been joined");
+    }
+
+    // Wait for child process first to ensure clean exit
+    int status;
+    if (waitpid(pid, &status, 0) == -1) {
+        throw Base::RuntimeError("Error waiting for child process");
+    }
+
+    // Check exit status before processing any data
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        throw Base::RuntimeError("Child process failed");
+    }
+
+    // Read result using BooleanOperation's protocol
+    bool isError;
+    std::string result = BooleanOperation::readResult(fd, isError);
+    
+    if (isError) {
+        throw Base::RuntimeError(result);
+    }
+
+    // Process shape data
+    std::istringstream str(result);
+    Part::TopoShape shape;
+    shape.importBinary(str);
+    return shape;
+}

--- a/src/Mod/Part/App/AsyncProcessHandle.cpp
+++ b/src/Mod/Part/App/AsyncProcessHandle.cpp
@@ -81,7 +81,7 @@ TopoShape AsyncProcessHandle::join()
 
     // Check exit status before processing any data
     if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-        throw Base::RuntimeError("Child process failed");
+        throw Base::RuntimeError("Child process failed, exit status: " + std::to_string(WEXITSTATUS(status)));
     }
 
     // Read result using BooleanOperation's protocol

--- a/src/Mod/Part/App/AsyncProcessHandle.cpp
+++ b/src/Mod/Part/App/AsyncProcessHandle.cpp
@@ -16,38 +16,11 @@
 
 using namespace Part;
 
-AsyncProcessHandle::AsyncProcessHandle(pid_t childPid, int resultFd)
-    : pid(childPid)
-    , fd(resultFd)
+void AsyncProcessHandle::setup(pid_t childPid, int resultFd)
 {
+    pid = childPid;
+    fd = resultFd;
     valid.store(true);
-}
-
-AsyncProcessHandle::AsyncProcessHandle(AsyncProcessHandle&& other) noexcept
-    : pid(other.pid)
-    , fd(other.fd)
-    , valid(other.valid.load())
-{
-    // Invalidate the other object
-    other.pid = -1;
-    other.fd = -1;
-    other.valid.store(false);
-}
-
-AsyncProcessHandle& AsyncProcessHandle::operator=(AsyncProcessHandle&& other) noexcept
-{
-    if (this != &other) {
-        // Transfer ownership
-        pid = other.pid;
-        fd = other.fd;
-        valid = other.valid.load();
-
-        // Invalidate the other object
-        other.pid = -1;
-        other.fd = -1;
-        other.valid.store(false);
-    }
-    return *this;
 }
 
 AsyncProcessHandle::~AsyncProcessHandle()
@@ -75,14 +48,14 @@ bool AsyncProcessHandle::isValid()
 void AsyncProcessHandle::abort()
 {
     if (!isValid()) {
-        Base::Console().Error("Aborting process: not valid\n");
+        //Base::Console().Error("Aborting process: not valid\n");
         return;
     }
 
-    Base::Console().Error("Aborting process: valid\n");
+    //Base::Console().Error("Aborting process: valid\n");
 
     if (pid > 0) {
-        Base::Console().Error("Aborting process: pid > 0 (%d)\n", pid);
+        //Base::Console().Error("Aborting process: pid > 0 (%d)\n", pid);
         kill(pid, SIGTERM);
         // Give it a moment to terminate gracefully
         usleep(100000);  // 100ms

--- a/src/Mod/Part/App/AsyncProcessHandle.h
+++ b/src/Mod/Part/App/AsyncProcessHandle.h
@@ -14,6 +14,11 @@ class TopoShape;
 class PartExport AsyncProcessHandle {
 public:
     AsyncProcessHandle(pid_t childPid, int resultFd);
+    AsyncProcessHandle() = default;
+    AsyncProcessHandle(AsyncProcessHandle&& other) noexcept;
+    AsyncProcessHandle& operator=(AsyncProcessHandle&& other) noexcept;
+    AsyncProcessHandle(const AsyncProcessHandle&) = delete;
+    AsyncProcessHandle& operator=(const AsyncProcessHandle&) = delete;
     ~AsyncProcessHandle();
 
     // Abort the child process
@@ -23,11 +28,12 @@ public:
     // Returns either a TopoShape or throws an exception with the error message
     TopoShape join();
 
+    bool isValid();
+
 private:
     pid_t pid;
     int fd;
-    std::atomic<bool> joined;  // Atomic flag for thread-safe access
-    ssize_t readExact(void* buffer, size_t length);
+    std::atomic<bool> valid;
 };
 
 } // namespace Part

--- a/src/Mod/Part/App/AsyncProcessHandle.h
+++ b/src/Mod/Part/App/AsyncProcessHandle.h
@@ -13,13 +13,10 @@ class TopoShape;
 
 class PartExport AsyncProcessHandle {
 public:
-    AsyncProcessHandle(pid_t childPid, int resultFd);
     AsyncProcessHandle() = default;
-    AsyncProcessHandle(AsyncProcessHandle&& other) noexcept;
-    AsyncProcessHandle& operator=(AsyncProcessHandle&& other) noexcept;
-    AsyncProcessHandle(const AsyncProcessHandle&) = delete;
-    AsyncProcessHandle& operator=(const AsyncProcessHandle&) = delete;
     ~AsyncProcessHandle();
+
+    void setup(pid_t childPid, int resultFd);
 
     // Abort the child process
     void abort();

--- a/src/Mod/Part/App/AsyncProcessHandle.h
+++ b/src/Mod/Part/App/AsyncProcessHandle.h
@@ -1,0 +1,35 @@
+#ifndef PART_ASYNCPROCESSHANDLE_H
+#define PART_ASYNCPROCESSHANDLE_H
+
+#include <sys/types.h>
+#include <Base/Exception.h>
+#include <Mod/Part/PartGlobal.h>
+#include <atomic>
+
+namespace Part {
+
+// Forward declaration
+class TopoShape;
+
+class PartExport AsyncProcessHandle {
+public:
+    AsyncProcessHandle(pid_t childPid, int resultFd);
+    ~AsyncProcessHandle();
+
+    // Abort the child process
+    void abort();
+
+    // Wait for child process to complete and return results
+    // Returns either a TopoShape or throws an exception with the error message
+    TopoShape join();
+
+private:
+    pid_t pid;
+    int fd;
+    std::atomic<bool> joined;  // Atomic flag for thread-safe access
+    ssize_t readExact(void* buffer, size_t length);
+};
+
+} // namespace Part
+
+#endif // PART_ASYNCPROCESSHANDLE_H

--- a/src/Mod/Part/App/BooleanOperation.cpp
+++ b/src/Mod/Part/App/BooleanOperation.cpp
@@ -1,0 +1,178 @@
+#include <Base/Console.h>
+#include <Mod/Part/App/TopoShape.h>
+#include <Mod/Part/App/TopoShapeOpCode.h>
+#include <Mod/Part/PartGlobal.h>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <sstream>
+#include "BooleanOperation.h"
+#include <unistd.h>
+
+// Helper functions for I/O with file descriptors
+bool readExact(int fd, void* buffer, size_t size) {
+    size_t total_read = 0;
+    while (total_read < size) {
+        ssize_t bytes_read = read(fd, static_cast<char*>(buffer) + total_read, size - total_read);
+        if (bytes_read <= 0) {
+            return false;
+        }
+        total_read += bytes_read;
+    }
+    return true;
+}
+
+bool writeExact(int fd, const void* buffer, size_t size) {
+    size_t total_written = 0;
+    while (total_written < size) {
+        ssize_t bytes_written = write(fd, static_cast<const char*>(buffer) + total_written, size - total_written);
+        if (bytes_written <= 0) {
+            return false;
+        }
+        total_written += bytes_written;
+    }
+    return true;
+}
+
+BooleanOperation BooleanOperation::readInput(int fd) {
+    BooleanOperation op_data;
+    
+    // Read operation type (single char)
+    char op_type;
+    if (!readExact(fd, &op_type, 1)) {
+        throw std::runtime_error("Failed to read operation type");
+    }
+    op_data.maker = op_type;
+
+    // Read tolerance
+    if (!readExact(fd, &op_data.tolerance, sizeof(double))) {
+        throw std::runtime_error("Failed to read tolerance");
+    }
+
+    // Read operation string
+    ssize_t op_size;
+    if (!readExact(fd, &op_size, sizeof(ssize_t))) {
+        throw std::runtime_error("Failed to read operation size");
+    }
+    
+    std::vector<char> op_buffer(op_size);
+    if (!readExact(fd, op_buffer.data(), op_size)) {
+        throw std::runtime_error("Failed to read operation");
+    }
+    op_data.op = std::string(op_buffer.begin(), op_buffer.end());
+
+    // Read number of shapes
+    uint8_t numShapes;
+    if (!readExact(fd, &numShapes, 1)) {
+        throw std::runtime_error("Failed to read shape count");
+    }
+
+    if (numShapes < 2) {
+        throw std::runtime_error("Need at least 2 shapes");
+    }
+
+    // Read shapes
+    for (uint8_t i = 0; i < numShapes; i++) {
+        uint32_t size;
+        if (!readExact(fd, &size, 4)) {
+            throw std::runtime_error("Failed to read shape size");
+        }
+
+        std::string brep_data(size, '\0');
+        if (!readExact(fd, brep_data.data(), size)) {
+            throw std::runtime_error("Failed to read shape data");
+        }
+
+        Part::TopoShape shape;
+        std::istringstream shape_is(brep_data);
+        shape.importBinary(shape_is);
+        op_data.shapes.push_back(shape);
+    }
+
+    return op_data;
+}
+
+std::string BooleanOperation::performOperation() const {
+    Part::TopoShape result;
+    result.makeElementBoolean(
+        maker == 'C' ? Part::OpCodes::Cut : Part::OpCodes::Fuse,
+        shapes,
+        op.c_str(),
+        tolerance
+    );
+
+    std::ostringstream os;
+    result.exportBinary(os);
+    return os.str();
+}
+
+void BooleanOperation::writeInput(int fd) const {
+    // Write operation type
+    if (!writeExact(fd, &maker, 1)) {
+        throw std::runtime_error("Failed to write operation type");
+    }
+
+    // Write tolerance
+    if (!writeExact(fd, &tolerance, sizeof(double))) {
+        throw std::runtime_error("Failed to write tolerance");
+    }
+
+    // Write operation
+    ssize_t op_size = op.size();
+    if (!writeExact(fd, &op_size, sizeof(ssize_t))) {
+        throw std::runtime_error("Failed to write operation size");
+    }
+    if (!writeExact(fd, op.c_str(), op_size)) {
+        throw std::runtime_error("Failed to write operation");
+    }
+
+    // Write number of shapes
+    uint8_t numShapes = static_cast<uint8_t>(shapes.size());
+    if (!writeExact(fd, &numShapes, 1)) {
+        throw std::runtime_error("Failed to write shape count");
+    }
+
+    // Write shapes
+    for (const auto& shape : shapes) {
+        std::ostringstream shape_os;
+        shape.exportBinary(shape_os);
+        std::string brep_data = shape_os.str();
+        
+        uint32_t size = brep_data.size();
+        if (!writeExact(fd, &size, 4) ||
+            !writeExact(fd, brep_data.data(), size)) {
+            throw std::runtime_error("Failed to write shape data");
+        }
+    }
+}
+
+void BooleanOperation::writeResult(int fd, const std::string& data, bool isError) const {
+    uint32_t size = data.size();
+    
+    if (!writeExact(fd, &size, 4) ||
+        !writeExact(fd, &isError, 1) ||
+        !writeExact(fd, data.data(), size)) {
+        throw std::runtime_error("Failed to write output");
+    }
+}
+
+std::string BooleanOperation::readResult(int fd, bool& isError) {
+    // Read size
+    uint32_t size;
+    if (!readExact(fd, &size, 4)) {
+        throw std::runtime_error("Failed to read result size");
+    }
+
+    // Read error flag
+    if (!readExact(fd, &isError, 1)) {
+        throw std::runtime_error("Failed to read error flag");
+    }
+
+    // Read data
+    std::string data(size, '\0');
+    if (!readExact(fd, data.data(), size)) {
+        throw std::runtime_error("Failed to read result data");
+    }
+
+    return data;
+}

--- a/src/Mod/Part/App/BooleanOperation.cpp
+++ b/src/Mod/Part/App/BooleanOperation.cpp
@@ -159,20 +159,25 @@ void BooleanOperation::writeResult(int fd, const std::string& data, bool isError
 std::string BooleanOperation::readResult(int fd, bool& isError) {
     // Read size
     uint32_t size;
+    Base::Console().Error("Reading result size\n");
     if (!readExact(fd, &size, 4)) {
         throw std::runtime_error("Failed to read result size");
     }
+    Base::Console().Error("Result size read: %d\n", size);
 
     // Read error flag
+    Base::Console().Error("Reading error flag\n");
     if (!readExact(fd, &isError, 1)) {
         throw std::runtime_error("Failed to read error flag");
     }
+    Base::Console().Error("Error flag read: %d\n", isError);
 
     // Read data
     std::string data(size, '\0');
+    Base::Console().Error("Reading result data\n");
     if (!readExact(fd, data.data(), size)) {
         throw std::runtime_error("Failed to read result data");
     }
-
+    Base::Console().Error("Result data read\n");
     return data;
 }

--- a/src/Mod/Part/App/BooleanOperation.h
+++ b/src/Mod/Part/App/BooleanOperation.h
@@ -1,0 +1,29 @@
+#ifndef BOOLEAN_WORKER_H
+#define BOOLEAN_WORKER_H
+
+#include <Mod/Part/App/TopoShape.h>
+#include <string>
+#include <vector>
+
+// Helper functions for I/O (kept as free functions)
+bool readExact(int fd, void* buffer, size_t size);
+bool writeExact(int fd, const void* buffer, size_t size);
+
+class BooleanOperation {
+public:
+    char maker;
+    std::vector<Part::TopoShape> shapes;
+    std::string op;
+    double tolerance;
+
+    // Static factory method
+    static BooleanOperation readInput(int fd);
+    
+    // Member functions
+    void writeInput(int fd) const;
+    void writeResult(int fd, const std::string& data, bool isError) const;
+    static std::string readResult(int fd, bool& isError);
+    std::string performOperation() const;
+};
+
+#endif // BOOLEAN_WORKER_H 

--- a/src/Mod/Part/App/BooleanWorker.cpp
+++ b/src/Mod/Part/App/BooleanWorker.cpp
@@ -1,0 +1,23 @@
+#include "BooleanOperation.h"
+#include <iostream>
+
+int main() {
+    BooleanOperation op_data;
+    try {
+        op_data = BooleanOperation::readInput(STDIN_FILENO);
+        std::string result = op_data.performOperation();
+        op_data.writeResult(STDOUT_FILENO, result, false);
+        return 0;
+    }
+    catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        try {
+            op_data.writeResult(STDOUT_FILENO, e.what(), true);
+        }
+        catch (...) {
+            std::cerr << "Failed to write error message to stdout" << std::endl;
+            return 1;
+        }
+        return 0;
+    }
+} 

--- a/src/Mod/Part/App/BooleanWorkerPyImp.cpp
+++ b/src/Mod/Part/App/BooleanWorkerPyImp.cpp
@@ -1,13 +1,12 @@
 #include "BooleanOperation.h"
 #include <iostream>
 
-int main() {
+PyObject* RunBooleanWorker(PyObject* /*self*/, PyObject* /*args*/) {
     BooleanOperation op_data;
     try {
         op_data = BooleanOperation::readInput(STDIN_FILENO);
         std::string result = op_data.performOperation();
         op_data.writeResult(STDOUT_FILENO, result, false);
-        return 0;
     }
     catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << std::endl;
@@ -16,8 +15,13 @@ int main() {
         }
         catch (...) {
             std::cerr << "Failed to write error message to stdout" << std::endl;
-            return 1;
+            _exit(1);
         }
-        return 0;
     }
+    _exit(0);
 } 
+
+PyMethodDef BooleanWorkerMethods[] = {
+    {"RunBooleanWorker", RunBooleanWorker, METH_VARARGS, "Run the boolean worker"},
+    {NULL, NULL, 0, NULL}
+};

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -566,6 +566,7 @@ SET(Part_SRCS
     TopoShapeOpCode.h
     BooleanOperation.cpp
     BooleanOperation.h
+    BooleanWorkerPyImp.cpp
     AsyncProcessHandle.cpp
     AsyncProcessHandle.h
     edgecluster.cpp
@@ -611,15 +612,7 @@ if (FREECAD_WARN_ERROR)
     target_compile_warn_error(Part)
 endif()
 
-# Add BooleanWorker executable
-add_executable(BooleanWorker BooleanWorker.cpp ${Part_SRCS} ${FCBRepAlgoAPI_SRCS})
-target_link_libraries(BooleanWorker ${Part_LIBS})
-if (FREECAD_WARN_ERROR)
-    target_compile_warn_error(BooleanWorker)
-endif()
-
 SET_BIN_DIR(Part Part /Mod/Part)
-SET_BIN_DIR(BooleanWorker BooleanWorker /Mod/Part)
 SET_PYTHON_PREFIX_SUFFIX(Part)
 
-INSTALL(TARGETS Part BooleanWorker DESTINATION ${CMAKE_INSTALL_LIBDIR})
+INSTALL(TARGETS Part DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -564,6 +564,10 @@ SET(Part_SRCS
     TopoShapeMapper.h
     TopoShapeMapper.cpp
     TopoShapeOpCode.h
+    BooleanOperation.cpp
+    BooleanOperation.h
+    AsyncProcessHandle.cpp
+    AsyncProcessHandle.h
     edgecluster.cpp
     edgecluster.h
     MeasureClient.cpp
@@ -607,7 +611,15 @@ if (FREECAD_WARN_ERROR)
     target_compile_warn_error(Part)
 endif()
 
+# Add BooleanWorker executable
+add_executable(BooleanWorker BooleanWorker.cpp ${Part_SRCS} ${FCBRepAlgoAPI_SRCS})
+target_link_libraries(BooleanWorker ${Part_LIBS})
+if (FREECAD_WARN_ERROR)
+    target_compile_warn_error(BooleanWorker)
+endif()
+
 SET_BIN_DIR(Part Part /Mod/Part)
+SET_BIN_DIR(BooleanWorker BooleanWorker /Mod/Part)
 SET_PYTHON_PREFIX_SUFFIX(Part)
 
-INSTALL(TARGETS Part DESTINATION ${CMAKE_INSTALL_LIBDIR})
+INSTALL(TARGETS Part BooleanWorker DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -1422,11 +1422,17 @@ public:
         return TopoShape(0, Hasher).makeElementCut({*this, source}, op, tol);
     }
 
-    AsyncProcessHandle
-    makeElementFuseAsync(const std::vector<TopoShape>& shapes, const char* op = nullptr, double tol = -1.0);
+    void
+    makeElementFuseAsync(AsyncProcessHandle* handle,
+                         const std::vector<TopoShape>& shapes,
+                         const char* op = nullptr,
+                         double tol = -1.0);
 
-    AsyncProcessHandle
-    makeElementCutAsync(const std::vector<TopoShape>& shapes, const char* op = nullptr, double tol = -1.0);
+    void
+    makeElementCutAsync(AsyncProcessHandle* handle,
+                        const std::vector<TopoShape>& shapes,
+                        const char* op = nullptr,
+                        double tol = -1.0);
 
     /** Try to simplify geometry of any linear/planar subshape to line/plane
      *
@@ -1869,8 +1875,9 @@ public:
         return TopoShape(Tag, Hasher).makeElementCopy(*this, op, copyGeom, copyMesh);
     }
 
-    AsyncProcessHandle
-    makeElementBooleanAsync(const char* maker,
+    void
+    makeElementBooleanAsync(AsyncProcessHandle* handle,
+                            const char* maker,
                             const std::vector<TopoShape>& shapes,
                             const char* op,
                             double tolerance);

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -44,6 +44,8 @@
 #include <BRepTools_ReShape.hxx>
 #include <ShapeFix_Root.hxx>
 
+#include "AsyncProcessHandle.h"
+
 class gp_Ax1;
 class gp_Ax2;
 class gp_Pln;
@@ -1420,6 +1422,12 @@ public:
         return TopoShape(0, Hasher).makeElementCut({*this, source}, op, tol);
     }
 
+    AsyncProcessHandle
+    makeElementFuseAsync(const std::vector<TopoShape>& shapes, const char* op = nullptr, double tol = -1.0);
+
+    AsyncProcessHandle
+    makeElementCutAsync(const std::vector<TopoShape>& shapes, const char* op = nullptr, double tol = -1.0);
+
     /** Try to simplify geometry of any linear/planar subshape to line/plane
      *
      * @return Return true if the shape is modified
@@ -1861,6 +1869,11 @@ public:
         return TopoShape(Tag, Hasher).makeElementCopy(*this, op, copyGeom, copyMesh);
     }
 
+    AsyncProcessHandle
+    makeElementBooleanAsync(const char* maker,
+                            const std::vector<TopoShape>& shapes,
+                            const char* op,
+                            double tolerance);
 
     /** Generalized shape making with mapped element name from shape history
      *

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -106,6 +106,14 @@
 
 #include "Tools.h"
 
+#include "AsyncProcessHandle.h"
+#include "BooleanOperation.h"
+
+// Add these includes at the top with the other includes
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
 FC_LOG_LEVEL_INIT("TopoShape", true, true)  // NOLINT
 
 #if OCC_VERSION_HEX >= 0x070600
@@ -4123,6 +4131,17 @@ TopoShape::makeElementCut(const std::vector<TopoShape>& shapes, const char* op, 
     return makeElementBoolean(Part::OpCodes::Cut, shapes, op, tol);
 }
 
+AsyncProcessHandle
+TopoShape::makeElementFuseAsync(const std::vector<TopoShape>& shapes, const char* op, double tol)
+{
+    return makeElementBooleanAsync(Part::OpCodes::Fuse, shapes, op, tol);
+}
+
+AsyncProcessHandle
+TopoShape::makeElementCutAsync(const std::vector<TopoShape>& shapes, const char* op, double tol)
+{
+    return makeElementBooleanAsync(Part::OpCodes::Cut, shapes, op, tol);
+}
 
 TopoShape& TopoShape::makeElementShape(BRepBuilderAPI_MakeShape& mkShape,
                                        const TopoShape& source,
@@ -5560,6 +5579,105 @@ bool TopoShape::fixSolidOrientation()
     }
 
     return false;
+}
+
+AsyncProcessHandle TopoShape::makeElementBooleanAsync(const char* maker,
+                                         const std::vector<TopoShape>& shapes,
+                                         const char* op,
+                                         double tolerance)
+{
+    if (!maker) {
+        FC_THROWM(Base::CADKernelError, "No maker specified");
+    }
+    if (shapes.empty()) {
+        FC_THROWM(Base::CADKernelError, "No shapes provided");
+    }
+
+    // Validate operation type upfront
+    char maker_type;
+    if (strcmp(maker, Part::OpCodes::Fuse) == 0) {
+        maker_type = 'F';
+    } else if (strcmp(maker, Part::OpCodes::Cut) == 0) {
+        maker_type = 'C'; 
+    } else {
+        FC_THROWM(Base::CADKernelError, "Unsupported boolean operation");
+    }
+
+    // Create pipes for stdin and stdout
+    int stdin_pipe[2];  // Parent writes to child's stdin
+    int stdout_pipe[2]; // Parent reads from child's stdout
+    
+    if (pipe(stdin_pipe) == -1 || pipe(stdout_pipe) == -1) {
+        // Clean up if second pipe failed
+        if (stdin_pipe[0] >= 0) {
+            close(stdin_pipe[0]);
+            close(stdin_pipe[1]);
+        }
+        FC_THROWM(Base::CADKernelError, "Failed to create pipes");
+    }
+
+    pid_t pid = fork();
+    if (pid == -1) {
+        // Clean up pipes
+        close(stdin_pipe[0]);
+        close(stdin_pipe[1]); 
+        close(stdout_pipe[0]);
+        close(stdout_pipe[1]);
+        FC_THROWM(Base::CADKernelError, "Failed to fork process");
+    }
+
+    if (pid == 0) {  // Child process
+        // Close unused pipe ends
+        close(stdin_pipe[1]);  // Close write end of stdin pipe
+        close(stdout_pipe[0]); // Close read end of stdout pipe
+
+        // Redirect stdin and stdout
+        if (dup2(stdin_pipe[0], STDIN_FILENO) == -1 || 
+            dup2(stdout_pipe[1], STDOUT_FILENO) == -1) {
+            std::cerr << "Failed to redirect stdin/stdout" << std::endl;
+            exit(1);
+        }
+
+        // Close original file descriptors
+        close(stdin_pipe[0]);
+        close(stdout_pipe[1]);
+
+        // Execute the boolean worker with full path
+        execl("./src/Mod/Part/BooleanWorker", "BooleanWorker", nullptr);
+        
+        // If we get here, exec failed
+        std::cerr << "Failed to execute BooleanWorker" << std::endl;
+        exit(1);
+    }
+
+    // Parent process
+    // Close unused pipe ends
+    close(stdin_pipe[0]);  // Close read end of stdin pipe
+    close(stdout_pipe[1]); // Close write end of stdout pipe
+    
+    // Create BooleanOperation object and write input
+    try {
+        BooleanOperation op_data;
+        op_data.maker = maker_type;
+        op_data.shapes = shapes;
+        op_data.op = op;
+        op_data.tolerance = tolerance;
+        
+        // Write operation data to child's stdin
+        op_data.writeInput(stdin_pipe[1]);
+    } catch (const std::exception& e) {
+        close(stdin_pipe[1]);
+        close(stdout_pipe[0]);
+        kill(pid, SIGTERM);
+        waitpid(pid, nullptr, 0);
+        FC_THROWM(Base::CADKernelError, e.what());
+    }
+    
+    // Close write end of stdin pipe since we're done writing
+    close(stdin_pipe[1]);
+    
+    // Return handle with read end of stdout pipe
+    return AsyncProcessHandle(pid, stdout_pipe[0]);
 }
 
 TopoShape& TopoShape::makeElementBoolean(const char* maker,

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -5643,11 +5643,11 @@ AsyncProcessHandle TopoShape::makeElementBooleanAsync(const char* maker,
         close(stdout_pipe[1]);
 
         // Execute the boolean worker with full path
-        execl("./src/Mod/Part/BooleanWorker", "BooleanWorker", nullptr);
+        execl("./Mod/Part/BooleanWorker", "BooleanWorker", nullptr);
         
         // If we get here, exec failed
         std::cerr << "Failed to execute BooleanWorker" << std::endl;
-        exit(1);
+        exit(2);
     }
 
     // Parent process

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -5660,7 +5660,7 @@ AsyncProcessHandle TopoShape::makeElementBooleanAsync(const char* maker,
         BooleanOperation op_data;
         op_data.maker = maker_type;
         op_data.shapes = shapes;
-        op_data.op = op;
+        op_data.op = op ? op : ""; // TODO: we really need to be able to pass a null ptr into the child process in order to keep the old behaviour unchanged
         op_data.tolerance = tolerance;
         
         // Write operation data to child's stdin

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -5652,11 +5652,11 @@ void TopoShape::makeElementBooleanAsync(AsyncProcessHandle* handle,
         close(stdout_pipe[1]);
 
         // Construct path to worker executable
-        std::string workerExe = App::GetApplication().getHomePath() + "/Mod/Part/BooleanWorker";
-        execl(workerExe.c_str(), "BooleanWorker", nullptr);
+        std::string workerExe = App::GetApplication().getHomePath() + "/bin/" + App::GetApplication().getExecutableName();
+        execl(workerExe.c_str(), App::GetApplication().getExecutableName().c_str(), "--boolean-worker", nullptr);
 
         // If we get here, exec failed
-        std::cerr << "Failed to execute BooleanWorker at " << workerExe << std::endl;
+        std::cerr << "Failed to execute FreeCAD BooleanWorker at " << workerExe << std::endl;
         _exit(3);
     }
 

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -106,6 +106,8 @@
 
 #include "Tools.h"
 
+#include <App/Application.h>
+
 #include "AsyncProcessHandle.h"
 #include "BooleanOperation.h"
 
@@ -5642,19 +5644,20 @@ void TopoShape::makeElementBooleanAsync(AsyncProcessHandle* handle,
         if (dup2(stdin_pipe[0], STDIN_FILENO) == -1 || 
             dup2(stdout_pipe[1], STDOUT_FILENO) == -1) {
             std::cerr << "Failed to redirect stdin/stdout" << std::endl;
-            exit(1);
+            _exit(2);
         }
 
         // Close original file descriptors
         close(stdin_pipe[0]);
         close(stdout_pipe[1]);
 
-        // Execute the boolean worker with full path
-        execl("./Mod/Part/BooleanWorker", "BooleanWorker", nullptr);
-        
+        // Construct path to worker executable
+        std::string workerExe = App::GetApplication().getHomePath() + "/Mod/Part/BooleanWorker";
+        execl(workerExe.c_str(), "BooleanWorker", nullptr);
+
         // If we get here, exec failed
-        std::cerr << "Failed to execute BooleanWorker" << std::endl;
-        exit(2);
+        std::cerr << "Failed to execute BooleanWorker at " << workerExe << std::endl;
+        _exit(3);
     }
 
     // Parent process

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -198,11 +198,12 @@ short Transformed::mustExecute() const
 
 void Transformed::abort()
 {
-    Base::Console().Error("Aborting transformation: maybe\n");
+    //Base::Console().Error("Aborting transformation: maybe\n");
     if (processHandle.isValid()) {
-        Base::Console().Error("Aborting transformation: yes\n");
+        //Base::Console().Error("Aborting transformation: yes\n");
         processHandle.abort();
     }
+    wantAbort.store(true);
 }
 
 App::DocumentObjectExecReturn* Transformed::execute()
@@ -294,6 +295,8 @@ App::DocumentObjectExecReturn* Transformed::execute()
         return shapes;
     };
 
+    wantAbort.store(false);
+
     switch (mode) {
         case Mode::TransformToolShapes:
             // NOTE: It would be possible to build a compound from all original addShapes/subShapes
@@ -306,6 +309,12 @@ App::DocumentObjectExecReturn* Transformed::execute()
                 // Extract the original shape and determine whether to cut or to fuse
                 Part::TopoShape fuseShape;
                 Part::TopoShape cutShape;
+
+                if (wantAbort.load()) {
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                        "Exception",
+                        "Transformation aborted"));
+                }
 
                 auto feature = Base::freecad_dynamic_cast<PartDesign::FeatureAddSub>(original);
                 if (!feature) {
@@ -328,17 +337,17 @@ App::DocumentObjectExecReturn* Transformed::execute()
                     cutShape = cutShape.makeElementTransform(trsf);
                 }
                 if (!fuseShape.isNull()) {
-                    processHandle = supportShape.makeElementFuseAsync(getTransformedCompShape(supportShape, fuseShape));
+                    supportShape.makeElementFuseAsync(&processHandle, getTransformedCompShape(supportShape, fuseShape));
                     supportShape = processHandle.join();
                 }
                 if (!cutShape.isNull()) {
-                    processHandle = supportShape.makeElementCutAsync(getTransformedCompShape(supportShape, cutShape));
+                    supportShape.makeElementCutAsync(&processHandle, getTransformedCompShape(supportShape, cutShape));
                     supportShape = processHandle.join();
                 }
             }
             break;
         case Mode::TransformBody: {
-            processHandle = supportShape.makeElementFuseAsync(getTransformedCompShape(supportShape, supportShape));
+            supportShape.makeElementFuseAsync(&processHandle, getTransformedCompShape(supportShape, supportShape));
             supportShape = processHandle.join();
             break;
         }

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -35,11 +35,9 @@
 
 #include <array>
 
-#include <App/DynamicProperty.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Reader.h>
-#include <Base/Writer.h>
 #include <Mod/Part/App/modelRefine.h>
 
 #include "FeatureTransformed.h"
@@ -52,10 +50,6 @@
 #include "FeatureSketchBased.h"
 #include "Mod/Part/App/TopoShapeOpCode.h"
 
-#include <sys/wait.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sstream>
 
 using namespace PartDesign;
 
@@ -69,7 +63,7 @@ std::array<char const*, 3> transformModeEnums = {"Transform tool shapes",
                                                  "Transform body",
                                                  nullptr};
 
-Transformed::Transformed() : child_pid(0)
+Transformed::Transformed()
 {
     ADD_PROPERTY(Originals, (nullptr));
     Originals.setSize(0);
@@ -204,9 +198,7 @@ short Transformed::mustExecute() const
 
 void Transformed::abort()
 {
-    if (child_pid.load() > 0) {
-        kill(child_pid.load(), SIGTERM);
-    }
+    Base::Console().Log("Aborting transformation\n");
 }
 
 App::DocumentObjectExecReturn* Transformed::execute()
@@ -265,7 +257,7 @@ App::DocumentObjectExecReturn* Transformed::execute()
     // Get the support
     Part::Feature* supportFeature = nullptr;
 
-    try {    
+    try {
         supportFeature = getBaseObject();
     }
     catch (Base::Exception& e) {
@@ -285,136 +277,78 @@ App::DocumentObjectExecReturn* Transformed::execute()
 
     supportShape.setTransform(Base::Matrix4D());
 
-    // Setup pipe for IPC
-    int pipefd[2];
-    if (pipe(pipefd) == -1) {
-        return new App::DocumentObjectExecReturn("Failed to create pipe");
-    }
+    auto getTransformedCompShape = [&](const auto& supportShape, const auto& origShape) {
+        std::vector<TopoShape> shapes = {supportShape};
+        TopoShape shape (origShape);
+        int idx=1;
+        auto transformIter = transformations.cbegin();
+        transformIter++;
+        for ( ; transformIter != transformations.end(); transformIter++) {
+            auto opName = Data::indexSuffix(idx++);
+            shapes.emplace_back(shape.makeElementTransform(*transformIter, opName.c_str()));
+        }
+        return shapes;
+    };
 
-    pid_t pid = fork();
-    if (pid == -1) {
-        close(pipefd[0]);
-        close(pipefd[1]);
-        return new App::DocumentObjectExecReturn("Failed to fork process");
-    }
+    switch (mode) {
+        case Mode::TransformToolShapes:
+            // NOTE: It would be possible to build a compound from all original addShapes/subShapes
+            // and then transform the compounds as a whole. But we choose to apply the
+            // transformations to each Original separately. This way it is easier to discover what
+            // feature causes a fuse/cut to fail. The downside is that performance suffers when
+            // there are many originals. But it seems safe to assume that in most cases there are
+            // few originals and many transformations
+            for (auto original : originals) {
+                // Extract the original shape and determine whether to cut or to fuse
+                Part::TopoShape fuseShape;
+                Part::TopoShape cutShape;
 
-    if (pid == 0) {  // Child process
-        close(pipefd[0]); // Close read end
-
-        // Move all the heavy computation into try-catch block
-        try {
-            auto getTransformedCompShape = [&](const auto& supportShape, const auto& origShape) {
-                std::vector<TopoShape> shapes = {supportShape};
-                TopoShape shape (origShape);
-                int idx=1;
-                auto transformIter = transformations.cbegin();
-                transformIter++;
-                for ( ; transformIter != transformations.end(); transformIter++) {
-                    auto opName = Data::indexSuffix(idx++);
-                    shapes.emplace_back(shape.makeElementTransform(*transformIter, opName.c_str()));
+                auto feature = Base::freecad_dynamic_cast<PartDesign::FeatureAddSub>(original);
+                if (!feature) {
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                        "Exception",
+                        "Only additive and subtractive features can be transformed"));
                 }
-                return shapes;
-            };
 
-            switch (mode) {
-                case Mode::TransformToolShapes:
-                    // NOTE: It would be possible to build a compound from all original addShapes/subShapes
-                    // and then transform the compounds as a whole. But we choose to apply the
-                    // transformations to each Original separately. This way it is easier to discover what
-                    // feature causes a fuse/cut to fail. The downside is that performance suffers when
-                    // there are many originals. But it seems safe to assume that in most cases there are
-                    // few originals and many transformations
-                    for (auto original : originals) {
-                        // Extract the original shape and determine whether to cut or to fuse
-                        Part::TopoShape fuseShape;
-                        Part::TopoShape cutShape;
-
-                        auto feature = Base::freecad_dynamic_cast<PartDesign::FeatureAddSub>(original);
-                        if (!feature) {
-                            close(pipefd[1]);
-                            _exit(1);
-                        }
-
-                        feature->getAddSubShape(fuseShape, cutShape);
-                        if (fuseShape.isNull() && cutShape.isNull()) {
-                            close(pipefd[1]);
-                            _exit(1);
-                        }
-                        gp_Trsf trsf = feature->getLocation().Transformation().Multiplied(trsfInv);
-                        if (!fuseShape.isNull()) {
-                            fuseShape = fuseShape.makeElementTransform(trsf);
-                        }
-                        if (!cutShape.isNull()) {
-                            cutShape = cutShape.makeElementTransform(trsf);
-                        }
-                        if (!fuseShape.isNull()) {
-                            supportShape.makeElementFuse(getTransformedCompShape(supportShape, fuseShape));
-                        }
-                        if (!cutShape.isNull()) {
-                            supportShape.makeElementCut(getTransformedCompShape(supportShape, cutShape));
-                        }
-                    }
-                    break;
-                case Mode::TransformBody: {
-                    supportShape.makeElementFuse(getTransformedCompShape(supportShape, supportShape));
-                    break;
+                feature->getAddSubShape(fuseShape, cutShape);
+                if (fuseShape.isNull() && cutShape.isNull()) {
+                    return new App::DocumentObjectExecReturn(
+                        QT_TRANSLATE_NOOP("Exception",
+                                          "Shape of additive/subtractive feature is empty"));
+                }
+                gp_Trsf trsf = feature->getLocation().Transformation().Multiplied(trsfInv);
+                if (!fuseShape.isNull()) {
+                    fuseShape = fuseShape.makeElementTransform(trsf);
+                }
+                if (!cutShape.isNull()) {
+                    cutShape = cutShape.makeElementTransform(trsf);
+                }
+                if (!fuseShape.isNull()) {
+                    auto handle = supportShape.makeElementFuseAsync(getTransformedCompShape(supportShape, fuseShape));
+                    supportShape = handle.join();
+                }
+                if (!cutShape.isNull()) {
+                    auto handle = supportShape.makeElementCutAsync(getTransformedCompShape(supportShape, cutShape));
+                    supportShape = handle.join();
                 }
             }
-
-            supportShape = refineShapeIfActive(supportShape);
-            
-            // Write shape to binary format
-            std::ostringstream str;
-            supportShape.exportBinary(str);
-            std::string dump = str.str();
-            
-            write(pipefd[1], dump.c_str(), dump.size());
-            close(pipefd[1]);
-            _exit(0);  // Exit child process
-        }
-        catch (...) {
-            close(pipefd[1]);
-            _exit(1);  // Exit with error
+            break;
+        case Mode::TransformBody: {
+            auto handle = supportShape.makeElementFuseAsync(getTransformedCompShape(supportShape, supportShape));
+            supportShape = handle.join();
+            break;
         }
     }
 
-    // Parent process
-    close(pipefd[1]); // Close write end
-    child_pid.store(pid);
-    
-    // Read result from pipe
-    std::string result;
-    char buffer[4096];
-    ssize_t count;
-    while ((count = read(pipefd[0], buffer, sizeof(buffer))) > 0) {
-        result.append(buffer, count);
+    supportShape = refineShapeIfActive((supportShape));
+    if (!isSingleSolidRuleSatisfied(supportShape.getShape())) {
+        Base::Console().Warning("Transformed: Result has multiple solids. Only keeping the first.\n");
     }
-    close(pipefd[0]);
 
-    // Wait for child process
-    int status;
-    waitpid(pid, &status, 0);
+    this->Shape.setValue(getSolid(supportShape));  // picking the first solid
+    rejected = getRemainingSolids(supportShape.getShape());
 
-    child_pid.store(-1);
-
-    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
-        // Process result
-        std::istringstream str(result);
-        Part::TopoShape supportShape;
-        supportShape.importBinary(str);
-
-        if (!isSingleSolidRuleSatisfied(supportShape.getShape())) {
-            Base::Console().Warning("Transformed: Result has multiple solids. Only keeping the first.\n");
-        }
-
-        this->Shape.setValue(getSolid(supportShape));  // picking the first solid
-        rejected = getRemainingSolids(supportShape.getShape());
-        
-        return App::DocumentObject::StdReturn;
-    }
-    else {
-        return new App::DocumentObjectExecReturn("Child process failed");
-    }
+    return App::DocumentObject::StdReturn;
 }
 
 TopoDS_Shape Transformed::getRemainingSolids(const TopoDS_Shape& shape)

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -198,7 +198,11 @@ short Transformed::mustExecute() const
 
 void Transformed::abort()
 {
-    Base::Console().Log("Aborting transformation\n");
+    Base::Console().Error("Aborting transformation: maybe\n");
+    if (processHandle.isValid()) {
+        Base::Console().Error("Aborting transformation: yes\n");
+        processHandle.abort();
+    }
 }
 
 App::DocumentObjectExecReturn* Transformed::execute()
@@ -324,18 +328,18 @@ App::DocumentObjectExecReturn* Transformed::execute()
                     cutShape = cutShape.makeElementTransform(trsf);
                 }
                 if (!fuseShape.isNull()) {
-                    auto handle = supportShape.makeElementFuseAsync(getTransformedCompShape(supportShape, fuseShape));
-                    supportShape = handle.join();
+                    processHandle = supportShape.makeElementFuseAsync(getTransformedCompShape(supportShape, fuseShape));
+                    supportShape = processHandle.join();
                 }
                 if (!cutShape.isNull()) {
-                    auto handle = supportShape.makeElementCutAsync(getTransformedCompShape(supportShape, cutShape));
-                    supportShape = handle.join();
+                    processHandle = supportShape.makeElementCutAsync(getTransformedCompShape(supportShape, cutShape));
+                    supportShape = processHandle.join();
                 }
             }
             break;
         case Mode::TransformBody: {
-            auto handle = supportShape.makeElementFuseAsync(getTransformedCompShape(supportShape, supportShape));
-            supportShape = handle.join();
+            processHandle = supportShape.makeElementFuseAsync(getTransformedCompShape(supportShape, supportShape));
+            supportShape = processHandle.join();
             break;
         }
     }

--- a/src/Mod/PartDesign/App/FeatureTransformed.h
+++ b/src/Mod/PartDesign/App/FeatureTransformed.h
@@ -117,6 +117,7 @@ protected:
 
 private:
     Part::AsyncProcessHandle processHandle;
+    std::atomic<bool> wantAbort;
 };
 
 }  // namespace PartDesign

--- a/src/Mod/PartDesign/App/FeatureTransformed.h
+++ b/src/Mod/PartDesign/App/FeatureTransformed.h
@@ -29,8 +29,8 @@
 #include <App/PropertyStandard.h>
 #include "FeatureRefine.h"
 
-#include <atomic>
-
+// Add include for AsyncProcessHandle
+#include <Mod/Part/App/AsyncProcessHandle.h>
 
 namespace PartDesign
 {
@@ -116,7 +116,7 @@ protected:
     static TopoDS_Shape getRemainingSolids(const TopoDS_Shape&);
 
 private:
-    std::atomic<pid_t> child_pid;
+    Part::AsyncProcessHandle processHandle;
 };
 
 }  // namespace PartDesign

--- a/src/Mod/PartDesign/App/FeatureTransformed.h
+++ b/src/Mod/PartDesign/App/FeatureTransformed.h
@@ -29,6 +29,8 @@
 #include <App/PropertyStandard.h>
 #include "FeatureRefine.h"
 
+#include <atomic>
+
 
 namespace PartDesign
 {
@@ -81,6 +83,10 @@ public:
         return std::list<gp_Trsf>();  // Default method
     }
 
+    /** This is used to abort an ongoing transformation
+     */
+    void abort();
+
     /** @name methods override feature */
     //@{
     /** Recalculate the feature
@@ -99,6 +105,7 @@ public:
      */
     TopoDS_Shape rejected;
 
+
 protected:
     void Restore(Base::XMLReader& reader) override;
     void handleChangedPropertyType(Base::XMLReader& reader,
@@ -109,6 +116,7 @@ protected:
     static TopoDS_Shape getRemainingSolids(const TopoDS_Shape&);
 
 private:
+    std::atomic<pid_t> child_pid;
 };
 
 }  // namespace PartDesign

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -54,6 +54,7 @@
 # include <Gui/MainWindow.h>
 # include <mutex>
 # include <condition_variable>
+# include <QProgressBar>
 #endif
 
 #include <App/Document.h>
@@ -179,6 +180,12 @@ public:
         auto label = new QLabel(tr("This operation may take a while.\nPlease wait or press 'Abort' to cancel."), this);
         label->setAlignment(Qt::AlignCenter);
         layout->addWidget(label);
+        
+        // Add progress bar in indeterminate mode
+        auto progressBar = new QProgressBar(this);
+        progressBar->setMinimum(0);
+        progressBar->setMaximum(0); // This makes it indeterminate
+        layout->addWidget(progressBar);
         
         auto abortButton = new QPushButton(tr("Abort"), this);
         layout->addWidget(abortButton);

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -44,6 +44,16 @@
 # include <Inventor/nodes/SoTransparencyType.h>
 # include <QAction>
 # include <QMenu>
+# include <QDialog>
+# include <QPushButton>
+# include <QVBoxLayout>
+# include <QCloseEvent>
+# include <thread>
+# include <atomic>
+# include <QApplication>
+# include <Gui/MainWindow.h>
+# include <mutex>
+# include <condition_variable>
 #endif
 
 #include <App/Document.h>
@@ -158,11 +168,63 @@ bool ViewProviderTransformed::onDelete(const std::vector<std::string> &s)
     return ViewProvider::onDelete(s);
 }
 
+class ComputationDialog : public QDialog {
+public:
+    ComputationDialog(QWidget* parent = nullptr) : QDialog(parent) {
+        setWindowTitle(tr("Computing transformation"));
+        setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint);
+        auto layout = new QVBoxLayout(this);
+        
+        // Add informative label
+        auto label = new QLabel(tr("This operation may take a while.\nPlease wait or press 'Abort' to cancel."), this);
+        label->setAlignment(Qt::AlignCenter);
+        layout->addWidget(label);
+        
+        auto abortButton = new QPushButton(tr("Abort"), this);
+        layout->addWidget(abortButton);
+        connect(abortButton, &QPushButton::clicked, this, &QDialog::reject);
+    }
+
+protected:
+    void closeEvent(QCloseEvent* event) override {
+        event->ignore();
+    }
+};
+
 void ViewProviderTransformed::recomputeFeature(bool recompute)
 {
     PartDesign::Transformed* pcTransformed = getObject<PartDesign::Transformed>();
-    if(recompute || (pcTransformed->isError() || pcTransformed->mustExecute()))
-        pcTransformed->recomputeFeature(true);
+    if(recompute || (pcTransformed->isError() || pcTransformed->mustExecute())) {
+        std::atomic<bool> computationDone(false);
+        std::mutex mutex;  // Still needed for the condition variable
+        std::condition_variable cv;
+
+        // Start computation thread
+        std::thread computeThread([&]() {
+            pcTransformed->recomputeFeature(true);
+            computationDone.store(true);  // Atomic store
+            QMetaObject::invokeMethod(QApplication::activeModalWidget(), "accept", Qt::QueuedConnection);
+            cv.notify_one();
+        });
+
+        // Wait for a brief moment to see if computation completes quickly
+        {
+            std::unique_lock<std::mutex> lock(mutex);  // Fixed: std::lock -> std::mutex
+            if (!cv.wait_for(lock, std::chrono::milliseconds(3000), 
+                [&]{ return computationDone.load(); }))  // Atomic load
+            {
+                // Computation didn't finish quickly, show dialog
+                ComputationDialog dialog(Gui::MainWindow::getInstance());
+                
+                if (dialog.exec() == QDialog::Rejected) {
+                    pcTransformed->abort();
+                    Base::Console().Warning("Aborting transformation computation\n");
+                }
+            }
+        }
+
+        computeThread.join();
+    }
 
     unsigned rejected = 0;
     TopoDS_Shape cShape = pcTransformed->rejected;

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -207,8 +207,8 @@ void ViewProviderTransformed::recomputeFeature(bool recompute)
             cv.notify_one();
         });
 
-        // Wait for a brief moment to see if computation completes quickly
-        {
+        while (!computationDone.load()) {
+            // Wait for a brief moment to see if computation completes quickly
             std::unique_lock<std::mutex> lock(mutex);  // Fixed: std::lock -> std::mutex
             if (!cv.wait_for(lock, std::chrono::milliseconds(3000), 
                 [&]{ return computationDone.load(); }))  // Atomic load
@@ -218,7 +218,6 @@ void ViewProviderTransformed::recomputeFeature(bool recompute)
                 
                 if (dialog.exec() == QDialog::Rejected) {
                     pcTransformed->abort();
-                    Base::Console().Warning("Aborting transformation computation\n");
                 }
             }
         }


### PR DESCRIPTION
Hi, I've been using FreeCAD for hobby projects for the last 8 years, but I've never managed to do any programming on it before so this is my first Pull Request.

One issue I have with FreeCAD is that long-running operations block up the entire application until they're done. I have a project where computing a MultiTransform takes over 10 minutes. If I realise I made a typo, or change my mind, while the calculation is being done, I still have to wait for it to finish.

So this Pull Request offloads Transform processing into a child process so that the operation can be interrupted (by killing the child process) without messing up OpenCascade state in the main FreeCAD process.

I have a demo video here: https://www.youtube.com/watch?v=c9CPuT3z1OM

This is obviously not going to be accepted into FreeCAD as-is. Known issues are:

 * won't work on Windows (probably the easiest start is to check `#ifdef WIN32` and make the `...Async()` function directly call the non-async function, and make all the `abort()`/`join()` stuff into a no-op)
 * only works on PartDesign Transforms (but I'm not totally clear on where it will and will not apply)
 * comments are bad
 * coding style is bad
 * commits not squashed
 * naming conventions are bad
 * I don't know enough about the FreeCAD architecture or build system to make good judgments on where things should live
 * AppImage/Snap/etc. build systems probably won't put the `BooleanWorker` binary in a place where it will be found
 * if it happens that the `...Async()` function can't execute `BooleanWorker` then we should probably fallback to the synchronous version instead of totally failing
 * `BooleanWorker` is 400 megabytes, maybe should load the Part workbench from a .so file instead of building it in

And probably there are unknown issues with it as well.

I'd love to get some feedback on this, and hopefully work towards getting something like this merged for real.