### PR TITLE
Draft: Added snap recenter functionality

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1151,6 +1151,10 @@ class DraftToolBar:
             if hasattr(FreeCADGui,"Snapper"):
                 FreeCADGui.Snapper.addHoldPoint()
             spec = True
+        elif txt == _get_incmd_shortcut("Recenter"):
+            if hasattr(FreeCADGui,"Snapper"):
+                FreeCADGui.Snapper.rencenter_workingplane()
+            spec = True
         elif txt == _get_incmd_shortcut("Snap"):
             self.togglesnap()
             spec = True

--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -94,6 +94,7 @@
         <file>icons/Draft_Snap_Ortho.svg</file>
         <file>icons/Draft_Snap_Parallel.svg</file>
         <file>icons/Draft_Snap_Perpendicular.svg</file>
+        <file>icons/Draft_Snap_Recenter.svg</file>
         <file>icons/Draft_Snap_Special.svg</file>
         <file>icons/Draft_Snap_WorkingPlane.svg</file>
         <file>icons/Draft_Split.svg</file>

--- a/src/Mod/Draft/Resources/icons/Draft_Snap_Recenter.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_Snap_Recenter.svg
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="svg2726"
+   height="64px"
+   width="64px"
+   sodipodi:docname="Draft_Snap_Recenter.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview27"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="8.5278495"
+     inkscape:cx="48.136403"
+     inkscape:cy="33.888966"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2726">
+    <inkscape:grid
+       type="xygrid"
+       id="grid904" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2728">
+    <linearGradient
+       id="linearGradient3773">
+      <stop
+         id="stop3775"
+         offset="0"
+         style="stop-color:#06989a;stop-opacity:1" />
+      <stop
+         id="stop3777"
+         offset="1"
+         style="stop-color:#34e0e2;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3765">
+      <stop
+         id="stop3767"
+         offset="0"
+         style="stop-color:#06989a;stop-opacity:1" />
+      <stop
+         id="stop3769"
+         offset="1"
+         style="stop-color:#34e0e2;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3144">
+      <stop
+         id="stop3146"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3148"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3850"
+       xlink:href="#linearGradient3144" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3850-4"
+       xlink:href="#linearGradient3144-1" />
+    <linearGradient
+       id="linearGradient3144-1">
+      <stop
+         id="stop3146-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3148-8"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="457.10004"
+       x2="133.47093"
+       y1="802.50574"
+       x1="207.48643"
+       id="linearGradient3771"
+       xlink:href="#linearGradient3765"
+       gradientTransform="matrix(0.16670802,0,0,0.16316094,5.836926,-67.568816)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="35.090908"
+       x2="22.545454"
+       y1="49.272728"
+       x1="25.81818"
+       id="linearGradient3779"
+       xlink:href="#linearGradient3773"
+       gradientTransform="matrix(0.91666668,0,0,0.91666668,13.333334,-12.166667)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3765"
+       id="linearGradient970"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16670802,0,0,0.16316094,5.836926,-67.568816)"
+       x1="207.48643"
+       y1="802.50574"
+       x2="133.47093"
+       y2="457.10004" />
+  </defs>
+  <g
+     id="g344-7"
+     transform="matrix(0.78805516,0,0,0.78805516,-0.42818596,14.42218)"
+     style="opacity:0.57483108">
+    <rect
+       ry="4.3329797"
+       y="1.9802104"
+       x="2.3813963"
+       height="58.36945"
+       width="59.638393"
+       id="rect3857-5"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient970);fill-opacity:1;fill-rule:nonzero;stroke:#042a2a;stroke-width:2.58167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="rect3857-3-3"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#34e0e2;stroke-width:2.53356;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 6.8880787,4.5357235 c -1.0783427,0 -1.9481926,0.9160312 -1.9481926,2.0516245 v 49.196853 c 0,1.135593 0.8698499,2.051624 1.9481926,2.051624 H 57.518586 c 1.078342,0 1.945691,-0.916031 1.945691,-2.051624 V 6.587348 c 0,-1.1355933 -0.867349,-2.0516245 -1.945691,-2.0516245 z" />
+  </g>
+  <g
+     id="g344"
+     transform="matrix(0.78805516,0,0,0.78805516,13.140579,2.42389)">
+    <rect
+       ry="4.3329797"
+       y="1.9802104"
+       x="2.3813963"
+       height="58.36945"
+       width="59.638393"
+       id="rect3857"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3771);fill-opacity:1;fill-rule:nonzero;stroke:#042a2a;stroke-width:2.58167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="rect3857-3"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#34e0e2;stroke-width:2.53356;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 6.8880787,4.5357235 c -1.0783427,0 -1.9481926,0.9160312 -1.9481926,2.0516245 v 49.196853 c 0,1.135593 0.8698499,2.051624 1.9481926,2.051624 H 57.518586 c 1.078342,0 1.945691,-0.916031 1.945691,-2.051624 V 6.587348 c 0,-1.1355933 -0.867349,-2.0516245 -1.945691,-2.0516245 z" />
+  </g>
+  <g
+     id="g348"
+     transform="translate(2)">
+    <path
+       d="m 44.999999,26.000001 a 8.9999996,9.0000004 0 0 1 -9,9 A 8.9999996,9.0000004 0 0 1 27,26.000001 8.9999996,9.0000004 0 0 1 35.999999,17 a 8.9999996,9.0000004 0 0 1 9,9.000001 z"
+       id="path4644"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#34e0e2;fill-opacity:1;fill-rule:nonzero;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="M 43,26.000001 A 7,7 0 0 1 36,33 7,7 0 0 1 29,26.000001 7,7 0 0 1 36,19 a 7,7 0 0 1 7,7.000001 z"
+       id="path4644-6"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3779);fill-opacity:1;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  </g>
+  <metadata
+     id="metadata6669">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="https://www.gnu.org/copyleft/lesser.html" />
+        <dc:date>Fri Mar 7 15:58:51 2014 -0300</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[Yorik van Havre]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Snap_WorkingPlane.svg</dc:identifier>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>Square with small circe in lower left corner</dc:description>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>plane</rdf:li>
+            <rdf:li>square</rdf:li>
+            <rdf:li>circle</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>456</width>
-    <height>338</height>
+    <width>506</width>
+    <height>521</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,35 +20,10 @@
       <string>In-command shortcuts</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_1">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_inCommandShortcutRelative">
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutRestrictX">
         <property name="text">
-         <string>Relative</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutRelative">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>R</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutRelative</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
+         <string>Restrict X</string>
         </property>
        </widget>
       </item>
@@ -68,15 +43,15 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="3">
-       <widget class="QLabel" name="label_inCommandShortcutGlobal">
+      <item row="6" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutRestrictZ">
         <property name="text">
-         <string>Global</string>
+         <string>Restrict Z</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="4">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutGlobal">
+      <item row="2" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutCopy">
         <property name="maximumSize">
          <size>
           <width>25</width>
@@ -84,19 +59,311 @@
          </size>
         </property>
         <property name="text">
-         <string>G</string>
+         <string>C</string>
         </property>
         <property name="maxLength">
          <number>1</number>
         </property>
-        <property name="clearButtonEnabled" stdset="0">
+        <property name="clearButtonEnabled">
          <bool>false</bool>
         </property>
         <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutGlobal</cstring>
+         <cstring>inCommandShortcutCopy</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutRelative">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>R</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutRelative</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutClose">
+        <property name="text">
+         <string>Close</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutDecreaseRadius">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string notr="true">M</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutDecreaseRadius</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="4">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutRestrictY">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Y</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutRestrictY</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutSnap">
+        <property name="text">
+         <string>Snap</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutExit">
+        <property name="text">
+         <string>Exit</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutClose">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>O</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutClose</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutSnap">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>S</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutSnap</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutLength">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>L</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutLength</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="4">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutExit">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>A</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutExit</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutSubelementMode">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>B</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutSubelementMode</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="4">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutUndo">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string notr="true">/</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutUndo</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutUndo">
+        <property name="text">
+         <string>Undo</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutContinue">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>N</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutContinue</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutRelative">
+        <property name="text">
+         <string>Relative</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutAddHold">
+        <property name="text">
+         <string>Add hold</string>
         </property>
        </widget>
       </item>
@@ -116,35 +383,24 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="6">
-       <widget class="QLabel" name="label_inCommandShortcutLength">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutFill">
         <property name="text">
-         <string>Length</string>
+         <string>Fill</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="7">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutLength">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutCycleSnap">
         <property name="text">
-         <string>L</string>
+         <string>Cycle snap</string>
         </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutLength</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
+       </widget>
+      </item>
+      <item row="5" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutDecreaseRadius">
+        <property name="text">
+         <string>Decrease radius</string>
         </property>
        </widget>
       </item>
@@ -164,42 +420,17 @@
         </property>
        </spacer>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_inCommandShortcutFill">
+      <item row="1" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutSubelementMode">
         <property name="text">
-         <string>Fill</string>
+         <string>Subelement mode</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutFill">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
+      <item row="0" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutLength">
         <property name="text">
-         <string>F</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutFill</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QLabel" name="label_inCommandShortcutSelectEdge">
-        <property name="text">
-         <string>Select edge</string>
+         <string>Length</string>
         </property>
        </widget>
       </item>
@@ -217,7 +448,7 @@
         <property name="maxLength">
          <number>1</number>
         </property>
-        <property name="clearButtonEnabled" stdset="0">
+        <property name="clearButtonEnabled">
          <bool>false</bool>
         </property>
         <property name="prefEntry" stdset="0">
@@ -225,365 +456,6 @@
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="6">
-       <widget class="QLabel" name="label_inCommandShortcutSubelementMode">
-        <property name="text">
-         <string>Subelement mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="7">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutSubelementMode">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>B</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutSubelementMode</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_inCommandShortcutCopy">
-        <property name="text">
-         <string>Copy</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutCopy">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>C</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutCopy</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="3">
-       <widget class="QLabel" name="label_inCommandShortcutUndo">
-        <property name="text">
-         <string>Undo</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="4">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutUndo">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string notr="true">/</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutUndo</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="6">
-       <widget class="QLabel" name="label_inCommandShortcutWipe">
-        <property name="text">
-         <string>Wipe</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="7">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutWipe">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>W</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutWipe</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_inCommandShortcutClose">
-        <property name="text">
-         <string>Close</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutClose">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>O</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutClose</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="3">
-       <widget class="QLabel" name="label_inCommandShortcutExit">
-        <property name="text">
-         <string>Exit</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="4">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutExit">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>A</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutExit</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="6">
-       <widget class="QLabel" name="label_inCommandShortcutContinue">
-        <property name="text">
-         <string>Continue</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="7">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutContinue">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>N</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutContinue</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_inCommandShortcutCycleSnap">
-        <property name="text">
-         <string>Cycle snap</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutCycleSnap">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string notr="true">`</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutCycleSnap</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="3">
-       <widget class="QLabel" name="label_inCommandShortcutAddHold">
-        <property name="text">
-         <string>Add hold</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="4">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutAddHold">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Q</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutAddHold</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="6">
-       <widget class="QLabel" name="label_inCommandShortcutSetWP">
-        <property name="text">
-         <string>Set working plane</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="7">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutSetWP">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>U</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutSetWP</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_inCommandShortcutSnap">
-        <property name="text">
-         <string>Snap</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutSnap">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>S</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutSnap</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="3">
-       <widget class="QLabel" name="label_inCommandShortcutIncreaseRadius">
-        <property name="text">
-         <string>Increase radius</string>
         </property>
        </widget>
       </item>
@@ -601,7 +473,7 @@
         <property name="maxLength">
          <number>1</number>
         </property>
-        <property name="clearButtonEnabled" stdset="0">
+        <property name="clearButtonEnabled">
          <bool>false</bool>
         </property>
         <property name="prefEntry" stdset="0">
@@ -612,106 +484,24 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="6">
-       <widget class="QLabel" name="label_inCommandShortcutDecreaseRadius">
+      <item row="5" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutIncreaseRadius">
         <property name="text">
-         <string>Decrease radius</string>
+         <string>Increase radius</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="7">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutDecreaseRadius">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutCopy">
         <property name="text">
-         <string notr="true">M</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutDecreaseRadius</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
+         <string>Copy</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_inCommandShortcutRestrictX">
+      <item row="4" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutSetWP">
         <property name="text">
-         <string>Restrict X</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutRestrictX">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>X</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutRestrictX</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="3">
-       <widget class="QLabel" name="label_inCommandShortcutRestrictY">
-        <property name="text">
-         <string>Restrict Y</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="4">
-       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutRestrictY">
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Y</string>
-        </property>
-        <property name="maxLength">
-         <number>1</number>
-        </property>
-        <property name="clearButtonEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>inCommandShortcutRestrictY</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="6">
-       <widget class="QLabel" name="label_inCommandShortcutRestrictZ">
-        <property name="text">
-         <string>Restrict Z</string>
+         <string>Set working plane</string>
         </property>
        </widget>
       </item>
@@ -729,11 +519,250 @@
         <property name="maxLength">
          <number>1</number>
         </property>
-        <property name="clearButtonEnabled" stdset="0">
+        <property name="clearButtonEnabled">
          <bool>false</bool>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>inCommandShortcutRestrictZ</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutWipe">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>W</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutWipe</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutRestrictY">
+        <property name="text">
+         <string>Restrict Y</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutGlobal">
+        <property name="text">
+         <string>Global</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutCycleSnap">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string notr="true">`</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutCycleSnap</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutFill">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>F</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutFill</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutContinue">
+        <property name="text">
+         <string>Continue</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutGlobal">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>G</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutGlobal</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutRestrictX">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>X</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutRestrictX</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutSetWP">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>U</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutSetWP</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutSelectEdge">
+        <property name="text">
+         <string>Select edge</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutWipe">
+        <property name="text">
+         <string>Wipe</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="4">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutAddHold">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Q</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutAddHold</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutRecenter">
+        <property name="text">
+         <string>Recenter</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutRecenter">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>1</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutRecenter</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Draft</cstring>
@@ -813,6 +842,12 @@
     <spacer name="verticalSpacer_1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -1663,4 +1663,11 @@ class Snapper:
                 self.holdTracker.on()
             self.holdPoints.append(self.spoint)
 
+    def recenter_workingplane(self):
+        """Recenters the working plane on the current snap position"""
+        if self.spoint:
+            self._get_wp().pos = self.to_WP(self.spoint)
+            if self.grid:
+                self.grid.set()
+
 ## @}


### PR DESCRIPTION
Still WIP...

* [x] Allow to align the working plane on selected edge + face of a same object, which aligns the plane with the face, but positions it on the edge (the WP is positioned on the edge's first vertex, the WP's X axis is aligned with the edge, and the face's center point provides the third point to define the plane)
* [x] Added a "Recenter" in-command shortcut. This moves the WP to be centered on the current snap position (the WorkingPlane snap button is taken into account, so one can only move the WP in the same plane or not).
* [ ] Test everything