### PR TITLE
Core: Compute shapes for variants

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -108,6 +108,7 @@
 #include "Link.h"
 #include "LinkBaseExtensionPy.h"
 #include "VarSet.h"
+#include "VariantExtension.h"
 #include "MaterialObject.h"
 #include "MeasureManagerPy.h"
 #include "Origin.h"
@@ -2177,6 +2178,7 @@ void Application::initTypes()
     App::LinkElementPython         ::init();
     App::LinkGroup                 ::init();
     App::LinkGroupPython           ::init();
+    App::VariantExtension          ::init();
     App::VarSet                    ::init();
 
     // Expression classes

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -178,6 +178,7 @@ SET(Document_CPP_SRCS
     Link.cpp
     LinkBaseExtensionPyImp.cpp
     VarSet.cpp
+    VariantExtension.cpp
     License.h
 )
 
@@ -222,6 +223,7 @@ SET(Document_HPP_SRCS
     MergeDocuments.h
     TextDocument.h
     VarSet.h
+    VariantExtension.h
     Link.h
 )
 SET(Document_SRCS

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3194,7 +3194,7 @@ int Document::recompute(const std::vector<App::DocumentObject*>& objs,
                     signalRecomputedObject(*obj);
                     obj->purgeTouched();
                     // set all dependent object touched to force recompute
-                    for (auto inObjIt : obj->getInList()) {
+                    for (auto inObjIt : obj->getInListWithoutExposed()) {
                         inObjIt->enforceRecompute();
                     }
                 }

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include <App/DocumentObjectPy.h>
+#include <App/Expression.h>
 #include <Base/Console.h>
 #include <Base/Matrix.h>
 #include <Base/Tools.h>
@@ -428,12 +429,25 @@ void DocumentObject::getOutList(int options, std::vector<DocumentObject*>& res) 
     std::size_t size = res.size();
     for (auto prop : props) {
         auto link = dynamic_cast<PropertyLinkBase*>(prop);
-        if (link) {
+        if (link && strcmp(link->getName(), "ExpressionEngine") != 0) {
             link->getLinks(res, noHidden);
         }
     }
     if (!(options & OutListNoExpression)) {
-        ExpressionEngine.getLinks(res);
+        //ExpressionEngine.getLinks(res);
+        auto expressions = ExpressionEngine.getExpressions();
+        for (const auto& pair : expressions) {
+            const App::Expression* exp = pair.second;
+            for (const auto& id : exp->getIdentifiers()) {
+                Property* prop = id.first.getProperty();
+                if (prop) {
+                    DocumentObject* obj = dynamic_cast<DocumentObject*>(prop->getContainer());
+                    if (obj && !obj->isExposed(prop)) {
+                        res.push_back(obj);
+                    }
+                }
+            }
+        }
     }
 
     if (options & OutListNoXLinked) {
@@ -921,13 +935,22 @@ void DocumentObject::onChanged(const Property* prop)
     // set object touched if it is an input property
     if (!testStatus(ObjectStatus::NoTouch) && !(prop->getType() & Prop_Output)
         && !prop->testStatus(Property::Output)) {
-        if (!StatusBits.test(ObjectStatus::Touch)) {
-            FC_TRACE("touch '" << getFullName() << "' on change of '" << prop->getName() << "'");
-            StatusBits.set(ObjectStatus::Touch);
+        if (isExposed(prop)) {
+            // The property is exposed: Do not touch this object but the ones
+            // that depend on it.
+            for (auto obj : getInList()) {
+                obj->touch(false);
+            }
         }
-        // must execute on document recompute
-        if (!(prop->getType() & Prop_NoRecompute)) {
-            StatusBits.set(ObjectStatus::Enforce);
+        else {
+            if (!StatusBits.test(ObjectStatus::Touch)) {
+                FC_TRACE("touch '" << getFullName() << "' on change of '" << prop->getName() << "'");
+                StatusBits.set(ObjectStatus::Touch);
+            }
+            // must execute on document recompute
+            if (!(prop->getType() & Prop_NoRecompute)) {
+                StatusBits.set(ObjectStatus::Enforce);
+            }
         }
     }
 

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -182,6 +182,24 @@ DocumentObjectExecReturn* DocumentObject::execute()
     return executeExtensions();
 }
 
+void DocumentObject::pushContext(DocumentObject* objContext)
+{
+    context.push(objContext);
+}
+
+void DocumentObject::popContext()
+{
+    context.pop();
+}
+
+DocumentObject* DocumentObject::getContext()
+{
+    if (!context.empty()) {
+        return context.top();
+    }
+    return nullptr;
+}
+
 App::DocumentObjectExecReturn* DocumentObject::executeExtensions()
 {
     // execute extensions but stop on error

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -734,6 +734,19 @@ bool DocumentObject::testIfLinkDAGCompatible(PropertyLinkSub& linkTo) const
     return this->testIfLinkDAGCompatible(linkTo_in_vector);
 }
 
+bool DocumentObject::isExposed(const Property* prop) const
+{
+    return prop->testStatus(Property::Exposed);
+}
+
+bool DocumentObject::isExposed() const
+{
+    std::vector<Property*> allProps;
+    getPropertyList(allProps);
+    return std::any_of(allProps.begin(), allProps.end(),
+                       [this](Property* prop) { return isExposed(prop); });
+}
+
 void DocumentObject::onLostLinkToObject(DocumentObject*)
 {}
 

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -311,6 +311,7 @@ public:
      * @param recursive [in]: whether to obtain recursive in list
      */
     std::set<App::DocumentObject*> getInListEx(bool recursive) const;
+    std::set<App::DocumentObject*> getInListWithoutExposed() const;
 
     /// get group if object is part of a group, otherwise 0 is returned
     DocumentObjectGroup* getGroup() const;
@@ -761,6 +762,7 @@ protected:
 
 private:
     void printInvalidLinks() const;
+    bool onlyReferencedByExposedIn(const App::DocumentObject* obj) const;
 
     /// python object of this class and all descendent
 protected:  // attributes

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -344,6 +344,12 @@ public:
     bool testIfLinkDAGCompatible(App::PropertyLinkSubList& linksTo) const;
     bool testIfLinkDAGCompatible(App::PropertyLinkSub& linkTo) const;
 
+    /// check if the property is exposed
+    bool isExposed(const Property* prop) const;
+    /// check whether any of the properties in the container are exposed
+    bool isExposed() const;
+
+
     /** Return the element map version of the geometry data stored in the given property
      *
      * @param prop: the geometry property to query for element map version

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -32,6 +32,7 @@
 #include <Base/SmartPtrPy.h>
 
 #include <bitset>
+#include <stack>
 #include <unordered_map>
 
 namespace Base
@@ -259,6 +260,8 @@ public:
     virtual bool hasChildElement() const;
     //@}
 
+    void pushContext(DocumentObject* context);
+    void popContext();
 
     /** DAG handling
         This part of the interface deals with viewing the document as
@@ -379,6 +382,8 @@ public:
      * objects that link it (i.e. its InList) will be recomputed.
      */
     virtual short mustExecute() const;
+
+    DocumentObject* getContext();
 
     /** Recompute only this feature
      *
@@ -791,6 +796,8 @@ private:
     mutable std::unordered_map<const char*, App::DocumentObject*, CStringHasher, CStringHasher>
         _outListMap;
     mutable bool _outListCached = false;
+
+    std::stack<DocumentObject*> context;
 };
 
 }  // namespace App

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -349,9 +349,12 @@ public:
     bool testIfLinkDAGCompatible(App::PropertyLinkSub& linkTo) const;
 
     /// check if the property is exposed
+    bool isExposed(const char* name) const;
+    /// check if the property is exposed
     bool isExposed(const Property* prop) const;
     /// check whether any of the properties in the container are exposed
     bool isExposed() const;
+    void getExposedPropertyList(std::vector<Property*>& props) const;
 
 
     /** Return the element map version of the geometry data stored in the given property
@@ -384,6 +387,7 @@ public:
     virtual short mustExecute() const;
 
     DocumentObject* getContext();
+    App::DocumentObjectExecReturn* executeWithContext(DocumentObject* context);
 
     /** Recompute only this feature
      *

--- a/src/App/Expression.h
+++ b/src/App/Expression.h
@@ -146,8 +146,11 @@ public:
     void getDeps(ExpressionDeps &deps, int option=DepNormal) const;
     ExpressionDeps getDeps(int option=DepNormal) const;
 
-    std::map<App::DocumentObject*,bool> getDepObjects(std::vector<std::string> *labels=nullptr) const;
-    void getDepObjects(std::map<App::DocumentObject*,bool> &, std::vector<std::string> *labels=nullptr) const;
+    std::map<App::DocumentObject*,bool> getDepObjects(std::vector<std::string> *labels=nullptr,
+                                                      bool excludeExposed=false) const;
+    void getDepObjects(std::map<App::DocumentObject*,bool> &,
+                       std::vector<std::string> *labels=nullptr,
+                       bool excludeExposed=false) const;
 
     ExpressionPtr importSubNames(const std::map<std::string,std::string> &nameMap) const;
 

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -1835,6 +1835,10 @@ ObjectIdentifier::access(const ResolveResults& result, Py::Object* value, Depend
                             obj = static_cast<DocumentObject*>(container);
                         }
                     }
+                    DocumentObject* contextObj = obj->getContext();
+                    if (contextObj) {
+                        obj = contextObj;
+                    }
                     pyobj = Py::Object(obj->getPyObject(), true);
                     idx = result.propertyIndex;
                     break;
@@ -1879,6 +1883,10 @@ ObjectIdentifier::access(const ResolveResults& result, Py::Object* value, Depend
     };
 
     App::DocumentObject* lastObj = result.resolvedDocumentObject;
+    DocumentObject* contextObj = lastObj->getContext();
+    if (contextObj) {
+        lastObj = contextObj;
+    }
     if (result.resolvedSubObject) {
         setPropDep(lastObj, nullptr, nullptr);
         lastObj = result.resolvedSubObject;

--- a/src/App/Property.cpp
+++ b/src/App/Property.cpp
@@ -302,12 +302,18 @@ void Property::destroy(Property* p)
 
 void Property::touch()
 {
-    PropertyCleaner guard(this);
-    if (father) {
-        father->onEarlyChange(this);
-        father->onChanged(this);
+    Property* contextProperty = getContextProperty(CreatePropOption::Create);
+    if (contextProperty) {
+        contextProperty->touch();
     }
-    StatusBits.set(Touched);
+    else {
+        PropertyCleaner guard(this);
+        if (father) {
+            father->onEarlyChange(this);
+            father->onChanged(this);
+        }
+        StatusBits.set(Touched);
+    }
 }
 
 void Property::setReadOnly(bool readOnly)

--- a/src/App/Property.cpp
+++ b/src/App/Property.cpp
@@ -21,6 +21,8 @@
  ***************************************************************************/
 
 
+#include "App/DocumentObject.h"
+#include "App/Expression.h"
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
@@ -162,6 +164,52 @@ const char* Property::getDocumentation() const
 void Property::setContainer(PropertyContainer* Father)
 {
     father = Father;
+}
+
+Property* Property::createPropertyContext(const char* name,
+                                          DocumentObject* obj, DocumentObject* objContext) const
+{
+    Property* prop = objContext->addDynamicProperty(getTypeId().getName(), name,
+                                                    getGroup(), getDocumentation());
+    std::unique_ptr<App::Property> pcopy(Copy());
+    prop->Paste(*pcopy);
+
+    auto renameObjIds = [objContext, name](const auto& expressions) {
+        for (const auto& [oldObjId, expression] : expressions) {
+            if (oldObjId.getPropertyName() == name) {
+                ObjectIdentifier newObjId(oldObjId);
+                newObjId.setDocumentObjectName(objContext);
+                std::shared_ptr<Expression> copiedExpr(expression->copy());
+                objContext->setExpression(newObjId, copiedExpr);
+            }
+        }
+    };
+
+    renameObjIds(obj->ExpressionEngine.getExpressions());
+    objContext->ExpressionEngine.execute(PropertyExpressionEngine::ExecuteNonOutput);
+
+    return prop;
+}
+
+Property* Property::getContextProperty(CreatePropOption option) const
+{
+    PropertyContainer* container = getContainer();
+    if (container == nullptr) { return nullptr; }
+
+    auto obj = dynamic_cast<DocumentObject*>(container);
+    if (obj == nullptr) {return nullptr; }
+
+    DocumentObject* objContext = obj->getContext();
+    if (objContext == nullptr) { return nullptr; }
+
+    const char* name = getName();
+    Property* prop = objContext->getPropertyByName(name);
+
+    if (prop == nullptr && option == CreatePropOption::Create) {
+        return createPropertyContext(name, obj, objContext);
+    }
+
+    return prop;
 }
 
 void Property::setPathValue(const ObjectIdentifier& path, const boost::any& value)

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -97,10 +97,11 @@ public:
         PropOutput = 27,       // corresponding to Prop_Output
         PropStaticEnd = 28,
 
-        User1 = 28,  // user-defined status
-        User2 = 29,  // user-defined status
-        User3 = 30,  // user-defined status
-        User4 = 31   // user-defined status
+        User1 = 28,    // user-defined status
+        User2 = 29,    // user-defined status
+        User3 = 30,    // user-defined status
+        Exposed = 31,  // user-defined status
+
     };
 
     Property();

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -350,9 +350,6 @@ private:
     // Sync status with Property_Type
     void syncType(unsigned type);
 
-    Property* createPropertyContext(const char* name,
-                                    DocumentObject* obj, DocumentObject* objContext) const;
-
 private:
     PropertyContainer* father {nullptr};
     const char* myName {nullptr};

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -46,6 +46,8 @@ TYPESYSTEM_SOURCE_ABSTRACT(App::PropertyExpressionContainer, App::PropertyXLinkC
 
 static std::set<PropertyExpressionContainer*> _ExprContainers;
 
+const bool EXCLUDE_EXPOSED = true;
+
 PropertyExpressionContainer::PropertyExpressionContainer()
 {
     static bool inited;
@@ -871,7 +873,7 @@ PropertyExpressionEngine::validateExpression(const ObjectIdentifier& path,
     assert(pathDocObj);
 
     auto inList = pathDocObj->getInListEx(true);
-    for (auto& v : expr->getDepObjects()) {
+    for(auto& v : expr->getDepObjects(nullptr, EXCLUDE_EXPOSED)) {
         auto docObj = v.first;
         if (!v.second && inList.count(docObj)) {
             std::stringstream ss;

--- a/src/App/PropertyGeo.cpp
+++ b/src/App/PropertyGeo.cpp
@@ -68,21 +68,32 @@ PropertyVector::~PropertyVector() = default;
 
 void PropertyVector::setValue(const Base::Vector3d& vec)
 {
-    aboutToSetValue();
-    _cVec = vec;
-    hasSetValue();
+    using FuncType = void (PropertyVector::*)(const Base::Vector3d&);
+    if (!setInContext<PropertyVector, FuncType>(&PropertyVector::setValue, vec)) {
+        aboutToSetValue();
+        _cVec = vec;
+        hasSetValue();
+    }
 }
 
 void PropertyVector::setValue(double x, double y, double z)
 {
-    aboutToSetValue();
-    _cVec.Set(x, y, z);
-    hasSetValue();
+    using FuncType = void (PropertyVector::*)(double, double, double);
+    if (!setInContext<PropertyVector, FuncType>(&PropertyVector::setValue, x, y, z)) {
+        aboutToSetValue();
+        _cVec.Set(x, y, z);
+        hasSetValue();
+    }
 }
 
 const Base::Vector3d& PropertyVector::getValue() const
 {
-    return _cVec;
+    try {
+        return getFromContext<PropertyVector, const Base::Vector3d&>(&PropertyVector::getValue);
+    }
+    catch (const NoContextException& e) {
+        return _cVec;
+    }
 }
 
 PyObject* PropertyVector::getPyObject()
@@ -537,9 +548,11 @@ PropertyPlacement::~PropertyPlacement() = default;
 
 void PropertyPlacement::setValue(const Base::Placement& pos)
 {
-    aboutToSetValue();
-    _cPos = pos;
-    hasSetValue();
+    if (!setInContext<PropertyPlacement>(&PropertyPlacement::setValue, pos)) {
+        aboutToSetValue();
+        _cPos = pos;
+        hasSetValue();
+    }
 }
 
 bool PropertyPlacement::setValueIfChanged(const Base::Placement& pos, double tol, double atol)
@@ -555,7 +568,12 @@ bool PropertyPlacement::setValueIfChanged(const Base::Placement& pos, double tol
 
 const Base::Placement& PropertyPlacement::getValue() const
 {
-    return _cPos;
+    try {
+        return getFromContext<PropertyPlacement, const Base::Placement&>(&PropertyPlacement::getValue);
+    }
+    catch (NoContextException& e) {
+        return _cPos;
+    }
 }
 
 void PropertyPlacement::getPaths(std::vector<ObjectIdentifier>& paths) const

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -1099,7 +1099,13 @@ public:
 
     const std::vector<DocumentObject*>& getValues() const
     {
-        return _lValueList;
+        try {
+            return getFromContext<PropertyLinkSubList, const std::vector<DocumentObject*>&>
+                (&PropertyLinkSubList::getValues);
+        }
+        catch (const NoContextException& e) {
+            return _lValueList;
+        }
     }
 
     const std::string getPyReprString() const;
@@ -1114,7 +1120,15 @@ public:
 
     const std::vector<std::string>& getSubValues() const
     {
-        return _lSubList;
+        try {
+            using FuncType = const std::vector<std::string>& (PropertyLinkSubList::*)() const;
+            return getFromContext<PropertyLinkSubList,
+                                  const std::vector<std::string>&, FuncType>
+                (&PropertyLinkSubList::getSubValues);
+        }
+        catch (const NoContextException& e) {
+            return _lSubList;
+        }
     }
 
     std::vector<std::string> getSubValues(bool newStyle) const;

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -287,16 +287,19 @@ PropertyEnumeration::~PropertyEnumeration() = default;
 
 void PropertyEnumeration::setEnums(const char** plEnums)
 {
-    // For backward compatibility, if the property container is not attached to
-    // any document (i.e. its full name starts with '?'), do not notify, or
-    // else existing code may crash.
-    bool notify = !boost::starts_with(getFullName(), "?");
-    if (notify) {
-        aboutToSetValue();
-    }
-    _enum.setEnums(plEnums);
-    if (notify) {
-        hasSetValue();
+    using FuncType = void (PropertyEnumeration::*)(const char** plEnums);
+    if (!setInContext<PropertyEnumeration, FuncType>(&PropertyEnumeration::setEnums, plEnums)) {
+        // For backward compatibility, if the property container is not attached to
+        // any document (i.e. its full name starts with '?'), do not notify, or
+        // else existing code may crash.
+        bool notify = !boost::starts_with(getFullName(), "?");
+        if (notify) {
+            aboutToSetValue();
+        }
+        _enum.setEnums(plEnums);
+        if (notify) {
+            hasSetValue();
+        }
     }
 }
 
@@ -307,81 +310,133 @@ void PropertyEnumeration::setEnums(const std::vector<std::string>& Enums)
 
 void PropertyEnumeration::setValue(const char* value)
 {
-    aboutToSetValue();
-    _enum.setValue(value);
-    hasSetValue();
+    using FuncType = void (PropertyEnumeration::*)(const char* value);
+    if (!setInContext<PropertyEnumeration, FuncType>(&PropertyEnumeration::setValue, value)) {
+        aboutToSetValue();
+        _enum.setValue(value);
+        hasSetValue();
+    }
 }
 
 void PropertyEnumeration::setValue(long value)
 {
-    aboutToSetValue();
-    _enum.setValue(value);
-    hasSetValue();
+    using FuncType = void (PropertyEnumeration::*)(long value);
+    if (!setInContext<PropertyEnumeration, FuncType>(&PropertyEnumeration::setValue, value)) {
+        aboutToSetValue();
+        _enum.setValue(value);
+        hasSetValue();
+    }
 }
 
 void PropertyEnumeration::setValue(const Enumeration& source)
 {
-    aboutToSetValue();
-    _enum = source;
-    hasSetValue();
+    using FuncType = void (PropertyEnumeration::*)(const Enumeration& source);
+    if (!setInContext<PropertyEnumeration, FuncType>(&PropertyEnumeration::setValue, source)) {
+        aboutToSetValue();
+        _enum = source;
+        hasSetValue();
+    }
 }
 
 long PropertyEnumeration::getValue() const
 {
-    return _enum.getInt();
+    try {
+        return getFromContext<PropertyEnumeration, long>(&PropertyEnumeration::getValue);
+    }
+    catch (const NoContextException& e) {
+        return _enum.getInt();
+    }
 }
 
 bool PropertyEnumeration::isValue(const char* value) const
 {
-    return _enum.isValue(value);
+    try {
+        return getFromContext<PropertyEnumeration, bool>(&PropertyEnumeration::isValue, value);
+    }
+    catch (const NoContextException& e) {
+        return _enum.isValue(value);
+    }
 }
 
 bool PropertyEnumeration::isPartOf(const char* value) const
 {
-    return _enum.contains(value);
+    try {
+        return getFromContext<PropertyEnumeration, bool>(&PropertyEnumeration::isPartOf, value);
+    }
+    catch (const NoContextException& e) {
+        return _enum.contains(value);
+    }
 }
 
 const char* PropertyEnumeration::getValueAsString() const
 {
-    if (!_enum.isValid()) {
-        throw Base::RuntimeError("Cannot get value from invalid enumeration");
+    try {
+        return getFromContext<PropertyEnumeration, const char*>(&PropertyEnumeration::getValueAsString);
     }
-    return _enum.getCStr();
+    catch (const NoContextException& e) {
+        if (!_enum.isValid()) {
+            throw Base::RuntimeError("Cannot get value from invalid enumeration");
+        }
+        return _enum.getCStr();
+    }
 }
 
 const Enumeration& PropertyEnumeration::getEnum() const
 {
-    return _enum;
+    try {
+        return getFromContext<PropertyEnumeration, const Enumeration&>(&PropertyEnumeration::getEnum);
+    }
+    catch (const NoContextException& e) {
+        return _enum;
+    }
 }
 
 std::vector<std::string> PropertyEnumeration::getEnumVector() const
 {
-    return _enum.getEnumVector();
+    try {
+        return getFromContext<PropertyEnumeration, std::vector<std::string>>
+            (&PropertyEnumeration::getEnumVector);
+    }
+    catch (const NoContextException& e) {
+        return _enum.getEnumVector();
+    }
 }
 
 void PropertyEnumeration::setEnumVector(const std::vector<std::string>& values)
 {
-    // For backward compatibility, if the property container is not attached to
-    // any document (i.e. its full name starts with '?'), do not notify, or
-    // else existing code may crash.
-    bool notify = !boost::starts_with(getFullName(), "?");
-    if (notify) {
-        aboutToSetValue();
-    }
-    _enum.setEnums(values);
-    if (notify) {
-        hasSetValue();
+    if (!setInContext<PropertyEnumeration>(&PropertyEnumeration::setEnumVector, values)) {
+        // For backward compatibility, if the property container is not attached to
+        // any document (i.e. its full name starts with '?'), do not notify, or
+        // else existing code may crash.
+        bool notify = !boost::starts_with(getFullName(), "?");
+        if (notify) {
+            aboutToSetValue();
+        }
+        _enum.setEnums(values);
+        if (notify) {
+            hasSetValue();
+        }
     }
 }
 
 bool PropertyEnumeration::hasEnums() const
 {
-    return _enum.hasEnums();
+    try {
+        return getFromContext<PropertyEnumeration, bool>(&PropertyEnumeration::hasEnums);
+    }
+    catch (const NoContextException& e) {
+        return _enum.hasEnums();
+    }
 }
 
 bool PropertyEnumeration::isValid() const
 {
-    return _enum.isValid();
+    try {
+        return getFromContext<PropertyEnumeration, bool>(&PropertyEnumeration::isValid);
+    }
+    catch (const NoContextException& e) {
+        return _enum.isValid();
+    }
 }
 
 void PropertyEnumeration::Save(Base::Writer& writer) const
@@ -1008,14 +1063,21 @@ PropertyFloat::~PropertyFloat() = default;
 
 void PropertyFloat::setValue(double lValue)
 {
-    aboutToSetValue();
-    _dValue = lValue;
-    hasSetValue();
+    if (!setInContext<PropertyFloat>(&PropertyFloat::setValue, lValue)) {
+        aboutToSetValue();
+        _dValue = lValue;
+        hasSetValue();
+    }
 }
 
 double PropertyFloat::getValue() const
 {
-    return _dValue;
+    try {
+        return getFromContext<PropertyFloat, double>(&PropertyFloat::getValue);
+    }
+    catch (const NoContextException& e) {
+        return _dValue;
+    }
 }
 
 PyObject* PropertyFloat::getPyObject()
@@ -2089,14 +2151,21 @@ PropertyBool::~PropertyBool() = default;
 
 void PropertyBool::setValue(bool lValue)
 {
-    aboutToSetValue();
-    _lValue = lValue;
-    hasSetValue();
+    if (!setInContext<PropertyBool>(&PropertyBool::setValue, lValue)) {
+        aboutToSetValue();
+        _lValue = lValue;
+        hasSetValue();
+    }
 }
 
 bool PropertyBool::getValue() const
 {
-    return _lValue;
+    try {
+        return getFromContext<PropertyBool, bool>(&PropertyBool::getValue);
+    }
+    catch (const NoContextException& e) {
+        return _lValue;
+    }
 }
 
 PyObject* PropertyBool::getPyObject()

--- a/src/App/PropertyUnits.cpp
+++ b/src/App/PropertyUnits.cpp
@@ -118,22 +118,29 @@ void PropertyQuantity::setPyObject(PyObject* value)
     }
 }
 
-void PropertyQuantity::setPathValue(const ObjectIdentifier& /*path*/, const boost::any& value)
+void PropertyQuantity::setPathValue(const ObjectIdentifier& path, const boost::any& value)
 {
-    auto q = App::anyToQuantity(value);
-    aboutToSetValue();
-    if (!q.getUnit().isEmpty()) {
-        _Unit = q.getUnit();
+    if (!setInContext<PropertyQuantity>(&PropertyQuantity::setPathValue, path, value)) {
+        auto q = App::anyToQuantity(value);
+        aboutToSetValue();
+        if (!q.getUnit().isEmpty()) {
+            _Unit = q.getUnit();
+        }
+        _dValue = q.getValue();
+        setValue(q.getValue());
     }
-    _dValue = q.getValue();
-    setValue(q.getValue());
 }
 
-const boost::any PropertyQuantity::getPathValue(const ObjectIdentifier& /*path*/) const
+const boost::any PropertyQuantity::getPathValue(const ObjectIdentifier& path) const
 {
-    Quantity quantity(_dValue, _Unit);
-    quantity.setFormat(_Format);
-    return quantity;
+    try {
+        return getFromContext<PropertyQuantity, const boost::any>(&PropertyQuantity::getPathValue, path);
+    }
+    catch (const NoContextException& e) {
+        Quantity quantity(_dValue, _Unit);
+        quantity.setFormat(_Format);
+        return quantity;
+    }
 }
 
 //**************************************************************************

--- a/src/App/VariantExtension.cpp
+++ b/src/App/VariantExtension.cpp
@@ -1,0 +1,308 @@
+/****************************************************************************
+ *   Copyright (c) 2025 Pieter Hijma <info@pieterhijma.net>                 *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#include <Base/Console.h>
+#include "App/Document.h"
+#include "App/Expression.h"
+#include "App/ObjectIdentifier.h"
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#include <boost/algorithm/cxx11/copy_if.hpp>
+#include <boost/range/algorithm/find.hpp>
+#include <boost/range/algorithm/find_if.hpp>
+#include <boost/range/algorithm/for_each.hpp>
+#include <boost/range/algorithm/set_algorithm.hpp>
+#endif
+
+#include "VariantExtension.h"
+
+using boost::algorithm::copy_if;
+using boost::range::find;
+using boost::range::find_if;
+using boost::range::for_each;
+using boost::range::set_difference;
+using std::vector;
+
+using namespace App;
+
+FC_LOG_LEVEL_INIT("App", true, true, true)
+
+EXTENSION_PROPERTY_SOURCE(App::VariantExtension, App::GroupExtension)
+
+VariantExtension::VariantExtension()
+{
+    EXTENSION_ADD_PROPERTY_TYPE(Support, (nullptr, nullptr), "", (App::PropertyType)(App::Prop_None), "Support of the geometry");
+}
+
+
+void VariantExtension::removeDynamicProperties(DocumentObject* obj) const
+{
+    const std::vector<std::string>& namesDynamicProps =
+        obj->getDynamicPropertyNames();
+    for (const auto& name : namesDynamicProps) {
+        obj->removeDynamicProperty(name.c_str());
+    }
+}
+
+
+void VariantExtension::extensionOnChanged(const App::Property* prop)
+{
+    if (prop == &Support) {
+        removeDynamicProperties(getExtendedObject());
+        adoptedExposedProps.clear();
+        getExtendedObject()->touch();
+    }
+
+    auto it = find_if(adoptedExposedProps,
+                      [prop](const App::Property* p) {
+                          return strcmp(prop->getName(), p->getName()) == 0;
+                      });
+    if (it != adoptedExposedProps.end()) {
+        getExtendedObject()->touch();
+    }
+    GroupExtension::extensionOnChanged(prop);
+}
+
+void VariantExtension::adoptProperty(const App::Property* prop)
+{
+    App::Property* newProp =
+        getExtendedObject()->addDynamicProperty(prop->getTypeId().getName(), prop->getName(),
+                                                prop->getGroup(), prop->getDocumentation());
+    std::unique_ptr<App::Property> pcopy(prop->Copy());
+    newProp->Paste(*pcopy);
+}
+
+void VariantExtension::adoptExposedProps(const DocumentObject* support)
+{
+    std::vector<App::Property*> exposedProps;
+    support->getExposedPropertyList(exposedProps);
+
+    std::set<const App::Property*> currentAdoptedExposedProps(adoptedExposedProps);
+    adoptedExposedProps.clear();
+
+    for (const auto prop : exposedProps) {
+        if (currentAdoptedExposedProps.find(prop) == currentAdoptedExposedProps.end()) {
+            adoptProperty(prop);
+        }
+        adoptedExposedProps.insert(prop);
+    }
+
+    std::set<const App::Property*> propsToRemove;
+    set_difference(currentAdoptedExposedProps,
+                   adoptedExposedProps,
+                   std::inserter(propsToRemove, propsToRemove.end()));
+    for_each(propsToRemove, [this](const App::Property* prop) {
+        getExtendedObject()->removeDynamicProperty(prop->getName());
+    });
+}
+
+std::vector<DocumentObject*> VariantExtension::getObjectsRequiringVarSets()
+{
+    std::vector<DocumentObject*> objectsRequiringContexts;
+    DocumentObject* support = Support.getValue();
+    if (support == nullptr) { return objectsRequiringContexts; }
+
+    DocumentObject* extendedObject = getExtendedObject();
+    std::vector<DocumentObject*> outList = support->getOutList();
+    copy_if(outList, std::back_inserter(objectsRequiringContexts),
+            [extendedObject](auto obj) {
+        return obj != extendedObject;
+    });
+    return objectsRequiringContexts;
+}
+
+
+std::set<std::string> VariantExtension::getNamesPropsWithExposedExprs(const DocumentObject* obj,
+                                                                      const DocumentObject* support) const
+{
+    // get the names of properties that have expressions that refer to an
+    // exposed property in support.
+    std::set<std::string> namesPropsExposed;
+
+    auto insertNamePropObjWhenExposed = [&](const auto& deps, const std::string& namePropObj) {
+        for (const auto& [namePropSupport, _] : deps) {
+            if (support->isExposed(namePropSupport.c_str())) {
+                namesPropsExposed.insert(namePropObj);
+            }
+        }
+    };
+
+    for (const auto& [objId, expr] : obj->ExpressionEngine.getExpressions()) {
+        ExpressionDeps deps;
+        expr->getDeps(deps);
+
+        // not a direct deps.find because of difference in const between support and deps
+        auto it = find_if(deps, [&](const auto& pair) {
+            return pair.first == support;
+        });
+        if (it != deps.end()) {
+            insertNamePropObjWhenExposed(it->second, objId.getPropertyName());
+        }
+    }
+
+    return namesPropsExposed;
+}
+
+
+Property* VariantExtension::createPropertyContext(DocumentObject* objContext,
+                                                  const DocumentObject* obj, const char* name)
+{
+    Property* prop = obj->getPropertyByName(name);
+    Property* propContext = objContext->addDynamicProperty(prop->getTypeId().getName(), name,
+                                                           prop->getGroup(), prop->getDocumentation());
+    std::unique_ptr<App::Property> pcopy(prop->Copy());
+    propContext->Paste(*pcopy);
+
+    auto renameObjIds = [objContext, name](const auto& expressions) {
+        for (const auto& [oldObjId, expression] : expressions) {
+            if (oldObjId.getPropertyName() == name) {
+                ObjectIdentifier newObjId(oldObjId);
+                newObjId.setDocumentObjectName(objContext);
+                std::shared_ptr<Expression> copiedExpr(expression->copy());
+                objContext->setExpression(newObjId, copiedExpr);
+            }
+        }
+    };
+
+    renameObjIds(obj->ExpressionEngine.getExpressions());
+    objContext->ExpressionEngine.execute(PropertyExpressionEngine::ExecuteNonOutput);
+
+    return propContext;
+}
+
+void VariantExtension::adoptExpressionEngine(DocumentObject* objContext,
+                                             const DocumentObject* obj,
+                                             const DocumentObject* support) const
+{
+    std::set<std::string> namesPropsWithExposedExprs =
+        getNamesPropsWithExposedExprs(obj, support);
+
+    for (const auto& nameProp : namesPropsWithExposedExprs) {
+        createPropertyContext(objContext, obj, nameProp.c_str());
+    }
+}
+
+DocumentObject* VariantExtension::createNewContext(DocumentObject* obj, Document* doc)
+{
+    std::string name(obj->getNameInDocument());
+    std::string newName = name + "Context";
+    DocumentObject* objContext = doc->addObject("App::VarSet", newName.c_str());
+
+    this->addObject(objContext);
+    objToContext[obj] = objContext;
+    contextToObj[objContext] = obj;
+
+    return objContext;
+}
+
+void VariantExtension::arrangeContext(DocumentObject* obj, Document* doc, DocumentObject* support)
+{
+    DocumentObject* objContext = objToContext[obj];
+
+    if (objContext) {
+        removeDynamicProperties(objContext);
+    }
+    else {
+        objContext = createNewContext(obj, doc);
+    }
+    adoptExpressionEngine(objContext, obj, support);
+}
+
+void VariantExtension::arrangeContexts()
+{
+    std::vector<DocumentObject*> objsRequiringVarSets = getObjectsRequiringVarSets();
+    DocumentObject* extendedObject = getExtendedObject();
+    Document* doc = extendedObject->getDocument();
+    DocumentObject* support = Support.getValue();
+
+    for (auto obj : objsRequiringVarSets) {
+        arrangeContext(obj, doc, support);
+    }
+    objToContext[support] = extendedObject;
+    contextToObj[extendedObject] = support;
+}
+
+std::vector<DocumentObject*> VariantExtension::getSortedDependencies(DocumentObject* support)
+{
+    const vector<DocumentObject*>& outList = support->getOutList();
+    return Document::getDependencyList(outList, Document::DepSort);
+}
+
+void VariantExtension::pushContexts(const std::vector<DocumentObject*>& objs)
+{
+    for (const auto obj : objs) {
+        DocumentObject* context = objToContext[obj];
+        obj->pushContext(context);
+    }
+}
+
+void VariantExtension::popContexts(const std::vector<DocumentObject*>& objs)
+{
+    for (const auto obj : objs) {
+        DocumentObject* context = objToContext[obj];
+        obj->popContext();
+        context->purgeTouched();
+    }
+}
+
+void VariantExtension::executeObjects(const std::vector<DocumentObject*>& objs)
+{
+    for (const auto obj : objs) {
+        FC_MSG("  executing " << obj->getFullName());
+
+        if (DocumentObject* context = objToContext[obj]; context != nullptr) {
+            obj->executeWithContext(context);
+        }
+    }
+}
+
+DocumentObjectExecReturn* VariantExtension::extensionExecute()
+{
+    FC_MSG("VariantExtension::extensionExecute()");
+    DocumentObject* support = Support.getValue();
+
+    auto exit = [this]() {
+        FC_MSG("end VariantExtension::extensionExecute()");
+        return GroupExtension::extensionExecute();
+    };
+
+    if (support == nullptr) {
+        return exit();
+    }
+
+    adoptExposedProps(support);
+    arrangeContexts();
+
+    auto objsWithContexts = getObjectsRequiringVarSets();
+    objsWithContexts.push_back(support);
+
+    auto sortedDeps = getSortedDependencies(support);
+    auto sortedObjs = sortedDeps;
+    sortedObjs.push_back(support);
+
+    pushContexts(objsWithContexts);
+    executeObjects(sortedObjs);
+    popContexts(objsWithContexts);
+
+    return exit();
+}

--- a/src/App/VariantExtension.h
+++ b/src/App/VariantExtension.h
@@ -1,0 +1,72 @@
+/****************************************************************************
+ *   Copyright (c) 2025 Pieter Hijma <info@pieterhijma.net>                 *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#ifndef APP_VARIANT_EXTENSION_H
+#define APP_VARIANT_EXTENSION_H
+
+#include "GroupExtension.h"
+
+namespace App
+{
+
+class AppExport VariantExtension: public GroupExtension
+{
+    EXTENSION_PROPERTY_HEADER_WITH_OVERRIDE(App::VariantExtension);
+
+public:
+    VariantExtension();
+    ~VariantExtension() override = default;
+
+    PropertyXLink Support;
+
+    DocumentObjectExecReturn* extensionExecute() override;
+    void extensionOnChanged(const App::Property* prop) override;
+    static Property* createPropertyContext(DocumentObject* objContext,
+                                           const DocumentObject* obj,
+                                           const char* name);
+
+private:
+    void executeObjects(const std::vector<DocumentObject*>& objs);
+    void pushContexts(const std::vector<DocumentObject*>& objs);
+    void popContexts(const std::vector<DocumentObject*>& objs);
+    std::vector<DocumentObject*> getSortedDependencies(DocumentObject* support);
+    DocumentObject* createNewContext(DocumentObject* obj, Document* doc);
+    void arrangeContext(DocumentObject* obj,
+                        Document* doc, DocumentObject* support);
+    void arrangeContexts();
+    void removeDynamicProperties(DocumentObject* obj) const;
+    void adoptExpressionEngine(DocumentObject* objContext,
+                               const DocumentObject* obj, const DocumentObject* support) const;
+    std::set<std::string> getNamesPropsWithExposedExprs(const DocumentObject* obj,
+                                                        const DocumentObject* support) const;
+    void adoptExposedProps(const DocumentObject* support);
+    void adoptProperty(const App::Property* prop);
+    std::vector<DocumentObject*> getObjectsRequiringVarSets();
+
+private:
+    std::set<const Property*> adoptedExposedProps;
+    std::unordered_map<const DocumentObject*, DocumentObject*> objToContext;
+    std::unordered_map<const DocumentObject*, DocumentObject*> contextToObj;
+};
+
+}  // namespace App
+#endif

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -709,6 +709,7 @@ enum MenuAction
     MA_Touched,
     MA_EvalOnRestore,
     MA_CopyOnChange,
+    MA_Exposed,
 };
 
 void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
@@ -824,6 +825,7 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
         _ACTION_SETUP(Touched);
         _ACTION_SETUP(EvalOnRestore);
         _ACTION_SETUP(CopyOnChange);
+        _ACTION_SETUP(Exposed);
 
         menu.addMenu(subMenu);
     }
@@ -859,6 +861,7 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
             ACTION_CHECK(Hidden);
             ACTION_CHECK(EvalOnRestore);
             ACTION_CHECK(CopyOnChange);
+            ACTION_CHECK(Exposed);
         case MA_Touched:
             for (auto prop : props) {
                 if (action->isChecked()) {

--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -89,6 +89,7 @@
 #include "FeaturePartSpline.h"
 #include "FeatureProjectOnSurface.h"
 #include "FeatureRevolution.h"
+#include "Variant.h"
 #include "Geometry.h"
 #include "Geometry2d.h"
 #include "GeometryBoolExtensionPy.h"
@@ -496,6 +497,7 @@ PyMOD_INIT_FUNC(Part)
     Part::Thickness             ::init();
     Part::Refine                ::init();
     Part::Reverse               ::init();
+    Part::Variant               ::init();
 
     // Geometry types
     Part::GeometryExtension       	::init();

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -223,6 +223,8 @@ SET(Features_SRCS
     PrismExtension.h
     VectorAdapter.cpp
     VectorAdapter.h
+    Variant.cpp
+    Variant.h
 )
 SOURCE_GROUP("Features" FILES ${Features_SRCS})
 

--- a/src/Mod/Part/App/PropertyGeometryList.h
+++ b/src/Mod/Part/App/PropertyGeometryList.h
@@ -68,11 +68,24 @@ public:
 
     /// index operator
     Geometry *operator[] (const int idx) const {
-        return _lValueList[idx];
+        try {
+            using FuncType = Geometry* (PropertyGeometryList::*)(const int) const;
+            FuncType func = &PropertyGeometryList::operator[];
+            return getFromContext<PropertyGeometryList, Geometry*>(func, idx);
+        }
+        catch (const App::NoContextException& e) {
+            return _lValueList[idx];
+        }
     }
 
     const std::vector<Geometry*> &getValues() const {
-        return _lValueList;
+        try {
+            return getFromContext<PropertyGeometryList, const std::vector<Geometry*>&>
+                (&PropertyGeometryList::getValues);
+        }
+        catch (const App::NoContextException& e) {
+            return _lValueList;
+        }
     }
 
     void set1Value(int idx, std::unique_ptr<Geometry> &&);

--- a/src/Mod/Part/App/Variant.cpp
+++ b/src/Mod/Part/App/Variant.cpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *   Copyright (c) 2025 Pieter Hijma <info@pieterhijma.net>                *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <BRepPrimAPI_MakeBox.hxx>
+# include <Precision.hxx>
+#endif
+
+#include <Base/Reader.h>
+
+#include "Variant.h"
+
+using namespace Part;
+
+FC_LOG_LEVEL_INIT("Part", true, true, true)
+
+PROPERTY_SOURCE_WITH_EXTENSIONS(Part::Variant, Part::Feature)
+
+Variant::Variant()
+{
+  App::GroupExtension::initExtension(this);
+}

--- a/src/Mod/Part/App/Variant.h
+++ b/src/Mod/Part/App/Variant.h
@@ -1,0 +1,45 @@
+/***************************************************************************
+ *   Copyright (c) 2025 Pieter Hijma <info@pieterhijma.net>                *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef PART_VARIANT_H
+#define PART_VARIANT_H
+
+#include <App/VariantExtension.h>
+
+#include "PartFeature.h"
+
+
+namespace Part
+{
+
+class PartExport Variant : public Part::Feature, public App::VariantExtension
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(Part::Variant);
+
+public:
+    Variant();
+};
+
+} // namespace Part
+
+
+#endif // PART_VARIANT_H

--- a/src/Mod/Part/Gui/AppPartGui.cpp
+++ b/src/Mod/Part/Gui/AppPartGui.cpp
@@ -75,6 +75,7 @@
 #include "ViewProviderSphereParametric.h"
 #include "ViewProviderSpline.h"
 #include "ViewProviderTorusParametric.h"
+#include "ViewProviderVariant.h"
 #include "Workbench.h"
 #include "WorkbenchManipulator.h"
 
@@ -220,6 +221,7 @@ PyMOD_INIT_FUNC(PartGui)
     PartGui::ViewProviderRuledSurface               ::init();
     PartGui::ViewProviderFace                       ::init();
     PartGui::ViewProviderProjectOnSurface           ::init();
+    PartGui::ViewProviderVariant                    ::init();
 
     PartGui::Workbench                              ::init();
     auto manip = std::make_shared<PartGui::WorkbenchManipulator>();

--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -224,6 +224,8 @@ SET(PartGui_SRCS
     ViewProviderRuledSurface.h
     ViewProviderPrimitive.cpp
     ViewProviderPrimitive.h
+    ViewProviderVariant.cpp
+    ViewProviderVariant.h
     Workbench.cpp
     Workbench.h
     WorkbenchManipulator.cpp

--- a/src/Mod/Part/Gui/ViewProviderVariant.cpp
+++ b/src/Mod/Part/Gui/ViewProviderVariant.cpp
@@ -1,0 +1,52 @@
+/***************************************************************************
+ *   Copyright (c) 2025 Pieter Hijma <info@pieterhijma.net>                *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#include "ViewProviderVariant.h"
+
+
+using namespace PartGui;
+using namespace std;
+
+PROPERTY_SOURCE(PartGui::ViewProviderVariant, PartGui::ViewProviderPart)
+
+ViewProviderVariant::ViewProviderVariant()
+{
+  sPixmap = "Part_Box_Parametric";
+}
+
+ViewProviderVariant::~ViewProviderVariant() = default;
+
+std::vector<std::string> ViewProviderVariant::getDisplayModes() const
+{
+  // get the modes of the father
+  std::vector<std::string> StrList;
+
+  // add your own modes
+  StrList.emplace_back("Flat Lines");
+  StrList.emplace_back("Shaded");
+  StrList.emplace_back("Wireframe");
+  StrList.emplace_back("Points");
+
+  return StrList;
+}

--- a/src/Mod/Part/Gui/ViewProviderVariant.h
+++ b/src/Mod/Part/Gui/ViewProviderVariant.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+ *   Copyright (c) 2025 Pieter Hijma <info@pieterhijma.net>                *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef PARTGUI_VIEWPROVIDERVARIANT_H
+#define PARTGUI_VIEWPROVIDERVARIANT_H
+
+#include <Mod/Part/Gui/ViewProvider.h>
+
+namespace PartGui {
+
+class PartGuiExport ViewProviderVariant : public ViewProviderPart
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(PartGui::ViewProviderVariant);
+
+public:
+    /// constructor
+    ViewProviderVariant();
+    /// destructor
+    ~ViewProviderVariant() override;
+
+    std::vector<std::string> getDisplayModes() const override;
+
+protected:
+
+};
+
+} // namespace PartGui
+
+
+#endif // PARTGUI_VIEWPROVIDERVARIANT_H
+

--- a/src/Mod/Sketcher/App/PropertyConstraintList.h
+++ b/src/Mod/Sketcher/App/PropertyConstraintList.h
@@ -102,18 +102,37 @@ public:
     */
     const Constraint* operator[](const int idx) const
     {
-        return (invalidGeometry || invalidIndices) ? nullptr : _lValueList[idx];
+        try {
+            using OpPtr = const Constraint* (PropertyConstraintList::*)(int) const;
+            OpPtr opPtr = &PropertyConstraintList::operator[];
+            return getFromContext<PropertyConstraintList, const Constraint*>(opPtr, idx);
+        }
+        catch (const App::NoContextException& e) {
+            return (invalidGeometry || invalidIndices) ? nullptr : _lValueList[idx];
+        }
     }
 
     const std::vector<Constraint*>& getValues() const
     {
-        return (invalidGeometry || invalidIndices) ? _emptyValueList : _lValueList;
+        try {
+            return getFromContext<PropertyConstraintList, const std::vector<Constraint*>&>(
+                &PropertyConstraintList::getValues);
+        }
+        catch (const App::NoContextException& e) {
+            return (invalidGeometry || invalidIndices) ? _emptyValueList : _lValueList;
+        }
     }
 
     // to suppress check for invalid geometry, to be used for sketch repairing.
     const std::vector<Constraint*>& getValuesForce() const
     {
-        return _lValueList;
+        try {
+            return getFromContext<PropertyConstraintList, const std::vector<Constraint*>&>(
+                &PropertyConstraintList::getValuesForce);
+        }
+        catch (const App::NoContextException& e) {
+            return _lValueList;
+        }
     }
 
     PyObject* getPyObject() override;


### PR DESCRIPTION
This PR is an outcome of FPA grant proposal [Research Variant Parts](https://github.com/FreeCAD/FPA-grant-proposals/issues/10). 

A `Part::Variant` is introduced together with logic to intercept property access to make sure we can compute shapes from a source object for variant parts.

This PR is not meant to be merged as is but it contains a prototype with a potential option to compute shapes for variants. It builds on (and currently includes) https://github.com/FreeCAD/FreeCAD/pull/18412.