### PR TITLE
TechDraw: centralize tag functionality

### DIFF
--- a/src/Mod/TechDraw/App/CMakeLists.txt
+++ b/src/Mod/TechDraw/App/CMakeLists.txt
@@ -174,6 +174,8 @@ SET(TechDraw_SRCS
     MattingPropEnum.h
     Preferences.cpp
     Preferences.h
+    Tag.cpp
+    Tag.h
     TechDrawExport.cpp
     TechDrawExport.h
     ProjectionAlgos.cpp

--- a/src/Mod/TechDraw/App/CenterLine.cpp
+++ b/src/Mod/TechDraw/App/CenterLine.cpp
@@ -1093,14 +1093,6 @@ void CenterLine::createNewTag()
     tag = gen();
 }
 
-void CenterLine::assignTag(const TechDraw::CenterLine* ce)
-{
-    if(ce->getTypeId() == this->getTypeId())
-        this->tag = ce->tag;
-    else
-        throw Base::TypeError("CenterLine tag can not be assigned as types do not match.");
-}
-
 CenterLine *CenterLine::clone() const
 {
     CenterLine* cpy = this->copy();

--- a/src/Mod/TechDraw/App/CenterLine.cpp
+++ b/src/Mod/TechDraw/App/CenterLine.cpp
@@ -23,9 +23,6 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-    #include <boost/random.hpp>
-    #include <boost/uuid/uuid_io.hpp>
-    #include <boost/uuid/uuid_generators.hpp>
     #include <BRepBuilderAPI_MakeEdge.hxx>
     #include <BRepBndLib.hxx>
     #include <Bnd_Box.hxx>
@@ -35,8 +32,6 @@
 #include <BRepTools.hxx>
 
 #include <Base/Console.h>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/thread.hpp>
 
 #include "CenterLine.h"
 #include "DrawUtil.h"
@@ -140,8 +135,6 @@ void CenterLine::initialize()
     m_geometry->setHlrVisible( true);
     m_geometry->setCosmetic(true);
     m_geometry->source(SourceType::CENTERLINE);
-
-    createNewTag();
     m_geometry->setCosmeticTag(getTagAsString());
 }
 
@@ -1062,41 +1055,10 @@ CenterLine* CenterLine::copy() const
     return newCL;
 }
 
-boost::uuids::uuid CenterLine::getTag() const
-{
-    return tag;
-}
-
-std::string CenterLine::getTagAsString() const
-{
-    return boost::uuids::to_string(getTag());
-}
-
-void CenterLine::createNewTag()
-{
-    // Initialize a random number generator, to avoid Valgrind false positives.
-    // The random number generator is not threadsafe so we guard it.  See
-    // https://www.boost.org/doc/libs/1_62_0/libs/uuid/uuid.html#Design%20notes
-    static boost::mt19937 ran;
-    static bool seeded = false;
-    static boost::mutex random_number_mutex;
-
-    boost::lock_guard<boost::mutex> guard(random_number_mutex);
-
-    if (!seeded) {
-        ran.seed(static_cast<unsigned int>(std::time(nullptr)));
-        seeded = true;
-    }
-    static boost::uuids::basic_random_generator<boost::mt19937> gen(&ran);
-
-
-    tag = gen();
-}
-
 CenterLine *CenterLine::clone() const
 {
     CenterLine* cpy = this->copy();
-    cpy->tag = this->tag;
+    cpy->setTag(this->getTag());
 
     return cpy;
 }

--- a/src/Mod/TechDraw/App/CenterLine.h
+++ b/src/Mod/TechDraw/App/CenterLine.h
@@ -183,7 +183,6 @@ protected:
     void initialize();
 
     void createNewTag();
-    void assignTag(const TechDraw::CenterLine* cl);
 
     boost::uuids::uuid tag;
 

--- a/src/Mod/TechDraw/App/CenterLine.h
+++ b/src/Mod/TechDraw/App/CenterLine.h
@@ -28,6 +28,7 @@
 #include <Base/Vector3D.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
+#include "Tag.h"
 #include "Cosmetic.h"
 #include "Geometry.h"
 
@@ -35,7 +36,7 @@
 namespace TechDraw {
 class DrawViewPart;
 
-class TechDrawExport CenterLine: public Base::Persistence
+class TechDrawExport CenterLine: public Base::Persistence, public TechDraw::Tag
 {
     TYPESYSTEM_HEADER_WITH_OVERRIDE();
 
@@ -175,19 +176,10 @@ public:
 
     TechDraw::BaseGeomPtr m_geometry;
 
-    //Uniqueness
-    boost::uuids::uuid getTag() const;
-    virtual std::string getTagAsString() const;
-
 protected:
     void initialize();
 
-    void createNewTag();
-
-    boost::uuids::uuid tag;
-
     Py::Object PythonObject;
-
 };
 
 }  // namespace TechDraw

--- a/src/Mod/TechDraw/App/CenterLinePyImp.cpp
+++ b/src/Mod/TechDraw/App/CenterLinePyImp.cpp
@@ -21,9 +21,6 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
-#ifndef _PreComp_
-# include <boost/uuid/uuid_io.hpp>
-#endif
 
 #include <Base/Console.h>
 #include <Base/PyWrapParseTupleAndKeywords.h>
@@ -146,7 +143,7 @@ void CenterLinePy::setFormat(Py::Dict arg)
 
 Py::String CenterLinePy::getTag() const
 {
-    std::string tmp = boost::uuids::to_string(getCenterLinePtr()->getTag());
+    std::string tmp = getCenterLinePtr()->getTagAsString();
     return Py::String(tmp);
 }
 

--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -24,12 +24,7 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 # include <BRepBuilderAPI_MakeEdge.hxx>
-# include <boost/random.hpp>
-# include <boost/uuid/uuid_generators.hpp>
-# include <boost/uuid/uuid_io.hpp>
 #endif
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/thread.hpp>
 
 #include <App/Application.h>
 #include <Base/Vector3D.h>
@@ -115,8 +110,6 @@ void CosmeticEdge::initialize()
     m_geometry->setHlrVisible( true);
     m_geometry->setCosmetic(true);
     m_geometry->source(SourceType::COSMETICEDGE);
-
-    createNewTag();
     m_geometry->setCosmeticTag(getTagAsString());
 }
 
@@ -298,43 +291,13 @@ void CosmeticEdge::Restore(Base::XMLReader &reader)
     }
 }
 
-boost::uuids::uuid CosmeticEdge::getTag() const
-{
-    return tag;
-}
-
-std::string CosmeticEdge::getTagAsString() const
-{
-    return boost::uuids::to_string(getTag());
-}
-
-void CosmeticEdge::createNewTag()
-{
-    // Initialize a random number generator, to avoid Valgrind false positives.
-    // The random number generator is not threadsafe so we guard it.  See
-    // https://www.boost.org/doc/libs/1_62_0/libs/uuid/uuid.html#Design%20notes
-    static boost::mt19937 ran;
-    static bool seeded = false;
-    static boost::mutex random_number_mutex;
-
-    boost::lock_guard<boost::mutex> guard(random_number_mutex);
-
-    if (!seeded) {
-        ran.seed(static_cast<unsigned int>(std::time(nullptr)));
-        seeded = true;
-    }
-    static boost::uuids::basic_random_generator<boost::mt19937> gen(&ran);
-
-    tag = gen();
-}
-
 CosmeticEdge* CosmeticEdge::clone() const
 {
     Base::Console().Message("CE::clone()\n");
     CosmeticEdge* cpy = new CosmeticEdge();
     cpy->m_geometry = m_geometry->copy();
     cpy->m_format = m_format;
-    cpy->tag = this->tag;
+    cpy->setTag(this->getTag());
     return cpy;
 }
 
@@ -359,8 +322,6 @@ GeomFormat::GeomFormat() :
     m_format.setColor(LineFormat::getDefEdgeColor());
     m_format.setVisible(true);
     m_format.setLineNumber(LineFormat::InvalidLine);
-
-    createNewTag();
 }
 
 GeomFormat::GeomFormat(const GeomFormat* gf)
@@ -371,8 +332,6 @@ GeomFormat::GeomFormat(const GeomFormat* gf)
     m_format.setColor(gf->m_format.getColor());
     m_format.setVisible(gf->m_format.getVisible());
     m_format.setLineNumber(gf->m_format.getLineNumber());
-
-    createNewTag();
 }
 
 GeomFormat::GeomFormat(const int idx,
@@ -384,8 +343,6 @@ GeomFormat::GeomFormat(const int idx,
     m_format.setColor(fmt.getColor());
     m_format.setVisible(fmt.getVisible());
     m_format.setLineNumber(fmt.getLineNumber());
-
-    createNewTag();
 }
 
 GeomFormat::~GeomFormat()
@@ -466,40 +423,10 @@ void GeomFormat::Restore(Base::XMLReader &reader)
     }
 }
 
-boost::uuids::uuid GeomFormat::getTag() const
-{
-    return tag;
-}
-
-std::string GeomFormat::getTagAsString() const
-{
-    return boost::uuids::to_string(getTag());
-}
-
-void GeomFormat::createNewTag()
-{
-    // Initialize a random number generator, to avoid Valgrind false positives.
-    // The random number generator is not threadsafe so we guard it.  See
-    // https://www.boost.org/doc/libs/1_62_0/libs/uuid/uuid.html#Design%20notes
-    static boost::mt19937 ran;
-    static bool seeded = false;
-    static boost::mutex random_number_mutex;
-
-    boost::lock_guard<boost::mutex> guard(random_number_mutex);
-
-    if (!seeded) {
-        ran.seed(static_cast<unsigned int>(std::time(nullptr)));
-        seeded = true;
-    }
-    static boost::uuids::basic_random_generator<boost::mt19937> gen(&ran);
-
-    tag = gen();
-}
-
 GeomFormat *GeomFormat::clone() const
 {
     GeomFormat* cpy = this->copy();
-    cpy->tag = this->tag;
+    cpy->setTag(this->getTag());
     return cpy;
 }
 

--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -328,14 +328,6 @@ void CosmeticEdge::createNewTag()
     tag = gen();
 }
 
-void CosmeticEdge::assignTag(const TechDraw::CosmeticEdge* ce)
-{
-    if(ce->getTypeId() == this->getTypeId())
-        this->tag = ce->tag;
-    else
-        throw Base::TypeError("CosmeticEdge tag can not be assigned as types do not match.");
-}
-
 CosmeticEdge* CosmeticEdge::clone() const
 {
     Base::Console().Message("CE::clone()\n");
@@ -502,14 +494,6 @@ void GeomFormat::createNewTag()
     static boost::uuids::basic_random_generator<boost::mt19937> gen(&ran);
 
     tag = gen();
-}
-
-void GeomFormat::assignTag(const TechDraw::GeomFormat* ce)
-{
-    if(ce->getTypeId() == this->getTypeId())
-        this->tag = ce->tag;
-    else
-        throw Base::TypeError("GeomFormat tag can not be assigned as types do not match.");
 }
 
 GeomFormat *GeomFormat::clone() const

--- a/src/Mod/TechDraw/App/Cosmetic.h
+++ b/src/Mod/TechDraw/App/Cosmetic.h
@@ -81,22 +81,14 @@ public:
     TechDraw::BaseGeomPtr m_geometry;
     LineFormat m_format;
 
-    boost::uuids::uuid getTag() const;
-    std::string getTagAsString() const override;
-
 protected:
-    //Uniqueness
-    void createNewTag();
-    boost::uuids::uuid tag;
-
     Py::Object PythonObject;
-
 };
 
 //********** GeomFormat ********************************************************
 
 // format specifier for geometric edges (Edge5)
-class TechDrawExport GeomFormat: public Base::Persistence
+class TechDrawExport GeomFormat: public Base::Persistence, public TechDraw::Tag
 {
     TYPESYSTEM_HEADER_WITH_OVERRIDE();
 
@@ -123,14 +115,7 @@ public:
     int m_geomIndex;            //connection to edgeGeom
     LineFormat m_format;
 
-    //Uniqueness
-    boost::uuids::uuid getTag() const;
-    virtual std::string getTagAsString() const;
-
 protected:
-    void createNewTag();
-
-    boost::uuids::uuid tag;
     Py::Object PythonObject;
 };
 

--- a/src/Mod/TechDraw/App/Cosmetic.h
+++ b/src/Mod/TechDraw/App/Cosmetic.h
@@ -87,7 +87,6 @@ public:
 protected:
     //Uniqueness
     void createNewTag();
-    void assignTag(const TechDraw::CosmeticEdge* ce);
     boost::uuids::uuid tag;
 
     Py::Object PythonObject;
@@ -130,7 +129,6 @@ public:
 
 protected:
     void createNewTag();
-    void assignTag(const TechDraw::GeomFormat* gf);
 
     boost::uuids::uuid tag;
     Py::Object PythonObject;

--- a/src/Mod/TechDraw/App/CosmeticEdgePyImp.cpp
+++ b/src/Mod/TechDraw/App/CosmeticEdgePyImp.cpp
@@ -24,7 +24,6 @@
 
 #ifndef _PreComp_
 # include <BRepBuilderAPI_MakeEdge.hxx>
-# include <boost/uuid/uuid_io.hpp>
 #endif
 
 #include <Base/PyWrapParseTupleAndKeywords.h>
@@ -152,7 +151,7 @@ Py::Dict CosmeticEdgePy::getFormat() const
 
 Py::String CosmeticEdgePy::getTag() const
 {
-    std::string tmp = boost::uuids::to_string(getCosmeticEdgePtr()->getTag());
+    std::string tmp = getCosmeticEdgePtr()->getTagAsString();
     return Py::String(tmp);
 }
 

--- a/src/Mod/TechDraw/App/CosmeticVertex.cpp
+++ b/src/Mod/TechDraw/App/CosmeticVertex.cpp
@@ -24,17 +24,10 @@
 //! CosmeticVertex point is stored in unscaled, unrotated form
 
 #include "PreCompiled.h"
-#ifndef _PreComp_
-    #include <boost/random.hpp>
-    #include <boost/uuid/uuid_generators.hpp>
-    #include <boost/uuid/uuid_io.hpp>
-#endif // _PreComp_
 
 #include <App/Application.h>
 #include <Base/Persistence.h>
 #include <Base/Vector3D.h>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/thread.hpp>
 
 #include "CosmeticVertex.h"
 #include "CosmeticVertexPy.h"
@@ -56,8 +49,6 @@ CosmeticVertex::CosmeticVertex() : TechDraw::Vertex()
             LineGroup::getDefaultWidth("Thin");
     hlrVisible = true;
     cosmetic = true;
-
-    createNewTag();
 }
 
 CosmeticVertex::CosmeticVertex(const TechDraw::CosmeticVertex* cv) : TechDraw::Vertex(cv)
@@ -70,8 +61,6 @@ CosmeticVertex::CosmeticVertex(const TechDraw::CosmeticVertex* cv) : TechDraw::V
     visible = cv->visible;
     hlrVisible = true;
     cosmetic = true;
-
-    createNewTag();
 }
 
 CosmeticVertex::CosmeticVertex(const Base::Vector3d& loc) : TechDraw::Vertex(loc)
@@ -85,9 +74,6 @@ CosmeticVertex::CosmeticVertex(const Base::Vector3d& loc) : TechDraw::Vertex(loc
     visible = true;
     hlrVisible = true;
     cosmetic = true;
-
-    createNewTag();
-
 }
 
 void CosmeticVertex::move(const Base::Vector3d& newPos)
@@ -140,7 +126,7 @@ void CosmeticVertex::Save(Base::Writer &writer) const
     writer.Stream() << writer.ind() << "<Style value=\"" <<  style << "\"/>" << endl;
     const char v = visible?'1':'0';
     writer.Stream() << writer.ind() << "<Visible value=\"" <<  v << "\"/>" << endl;
-    writer.Stream() << writer.ind() << "<Tag value=\"" <<  getTagAsString() << "\"/>" << endl;
+    Tag::Save(writer);
 }
 
 void CosmeticVertex::Restore(Base::XMLReader &reader)
@@ -164,11 +150,7 @@ void CosmeticVertex::Restore(Base::XMLReader &reader)
     style = reader.getAttributeAsInteger("value");
     reader.readElement("Visible");
     visible = (int)reader.getAttributeAsInteger("value")==0?false:true;
-    reader.readElement("Tag");
-    temp = reader.getAttribute("value");
-    boost::uuids::string_generator gen;
-    boost::uuids::uuid u1 = gen(temp);
-    tag = u1;
+    Tag::Restore(reader);
 }
 
 Base::Vector3d CosmeticVertex::scaled(const double factor)
@@ -224,37 +206,6 @@ Base::Vector3d CosmeticVertex::makeCanonicalPointInverted(DrawViewPart* dvp, Bas
     return DU::invertY(result);
 }
 
-
-boost::uuids::uuid CosmeticVertex::getTag() const
-{
-    return tag;
-}
-
-std::string CosmeticVertex::getTagAsString() const
-{
-    return boost::uuids::to_string(getTag());
-}
-
-void CosmeticVertex::createNewTag()
-{
-    // Initialize a random number generator, to avoid Valgrind false positives.
-    // The random number generator is not threadsafe so we guard it.  See
-    // https://www.boost.org/doc/libs/1_62_0/libs/uuid/uuid.html#Design%20notes
-    static boost::mt19937 ran;
-    static bool seeded = false;
-    static boost::mutex random_number_mutex;
-
-    boost::lock_guard<boost::mutex> guard(random_number_mutex);
-
-    if (!seeded) {
-        ran.seed(static_cast<unsigned int>(std::time(nullptr)));
-        seeded = true;
-    }
-    static boost::uuids::basic_random_generator<boost::mt19937> gen(&ran);
-
-    tag = gen();
-}
-
 CosmeticVertex* CosmeticVertex::copy() const
 {
 //    Base::Console().Message("CV::copy()\n");
@@ -265,7 +216,7 @@ CosmeticVertex* CosmeticVertex::clone() const
 {
 //    Base::Console().Message("CV::clone()\n");
     CosmeticVertex* cpy = this->copy();
-    cpy->tag = this->tag;
+    cpy->setTag(this->getTag());
     return cpy;
 }
 

--- a/src/Mod/TechDraw/App/CosmeticVertex.cpp
+++ b/src/Mod/TechDraw/App/CosmeticVertex.cpp
@@ -255,14 +255,6 @@ void CosmeticVertex::createNewTag()
     tag = gen();
 }
 
-void CosmeticVertex::assignTag(const TechDraw::CosmeticVertex* cv)
-{
-    if(cv->getTypeId() == this->getTypeId())
-        this->tag = cv->tag;
-    else
-        throw Base::TypeError("CosmeticVertex tag can not be assigned as types do not match.");
-}
-
 CosmeticVertex* CosmeticVertex::copy() const
 {
 //    Base::Console().Message("CV::copy()\n");

--- a/src/Mod/TechDraw/App/CosmeticVertex.h
+++ b/src/Mod/TechDraw/App/CosmeticVertex.h
@@ -78,18 +78,8 @@ public:
     int            style{1};
     bool           visible{true};              //base class vertex also has visible property
 
-    boost::uuids::uuid getTag() const;
-    std::string getTagAsString() const override;
-
 protected:
-    //Uniqueness
-    void createNewTag();
-
-    boost::uuids::uuid tag;
-
     Py::Object PythonObject;
-
-
 };
 
 } //end namespace TechDraw

--- a/src/Mod/TechDraw/App/CosmeticVertex.h
+++ b/src/Mod/TechDraw/App/CosmeticVertex.h
@@ -84,7 +84,6 @@ public:
 protected:
     //Uniqueness
     void createNewTag();
-    void assignTag(const TechDraw::CosmeticVertex* cv);
 
     boost::uuids::uuid tag;
 

--- a/src/Mod/TechDraw/App/CosmeticVertexPyImp.cpp
+++ b/src/Mod/TechDraw/App/CosmeticVertexPyImp.cpp
@@ -22,10 +22,6 @@
 
 #include "PreCompiled.h"
 
-#ifndef _PreComp_
-# include <boost/uuid/uuid_io.hpp>
-#endif
-
 #include <Base/Console.h>
 #include <Base/GeometryPyCXX.h>
 #include <Base/Vector3D.h>
@@ -118,7 +114,7 @@ PyObject* CosmeticVertexPy::copy(PyObject *args)
 
 Py::String CosmeticVertexPy::getTag() const
 {
-    std::string tmp = boost::uuids::to_string(getCosmeticVertexPtr()->getTag());
+    std::string tmp = getCosmeticVertexPtr()->getTagAsString();
     return Py::String(tmp);
 }
 

--- a/src/Mod/TechDraw/App/GeomFormatPyImp.cpp
+++ b/src/Mod/TechDraw/App/GeomFormatPyImp.cpp
@@ -21,9 +21,6 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
-#ifndef _PreComp_
-# include <boost/uuid/uuid_io.hpp>
-#endif
 
 #include "GeomFormatPy.h"
 #include "GeomFormatPy.cpp"
@@ -107,7 +104,7 @@ PyObject* GeomFormatPy::copy(PyObject *args)
 
 Py::String GeomFormatPy::getTag(void) const
 {
-    std::string tmp = boost::uuids::to_string(getGeomFormatPtr()->getTag());
+    std::string tmp = getGeomFormatPtr()->getTagAsString();
     return Py::String(tmp);
 }
 

--- a/src/Mod/TechDraw/App/Geometry.h
+++ b/src/Mod/TechDraw/App/Geometry.h
@@ -37,6 +37,8 @@
 #include <TopoDS_Vertex.hxx>
 #include <TopoDS_Wire.hxx>
 
+#include "Tag.h"
+
 namespace Part {
 class TopoShape;
 }
@@ -106,7 +108,7 @@ using BSplinePtr = std::shared_ptr<BSpline>;
 class Generic;
 using GenericPtr = std::shared_ptr<Generic>;
 
-class TechDrawExport BaseGeom : public std::enable_shared_from_this<BaseGeom>
+class TechDrawExport BaseGeom : public std::enable_shared_from_this<BaseGeom>, public TechDraw::Tag
 {
     public:
         BaseGeom();
@@ -132,10 +134,6 @@ class TechDrawExport BaseGeom : public std::enable_shared_from_this<BaseGeom>
         std::string dump();
         virtual std::string toString() const;
         std::vector<Base::Vector3d> intersection(TechDraw::BaseGeomPtr geom2);
-
-        //Uniqueness
-        boost::uuids::uuid getTag() const;
-        virtual std::string getTagAsString() const;
 
         std::string geomTypeName();
         BaseGeomPtr inverted();
@@ -169,8 +167,6 @@ class TechDrawExport BaseGeom : public std::enable_shared_from_this<BaseGeom>
         virtual void clockwiseAngle(bool direction) { (void) direction; }
 
 protected:
-        void createNewTag();
-
         GeomType geomType;
         ExtractionType extractType;     //obs
         EdgeClass classOfEdge;
@@ -183,7 +179,6 @@ protected:
         SourceType m_source;
         int m_sourceIndex;
         std::string cosmeticTag;
-        boost::uuids::uuid tag;
 
 };
 using BaseGeomPtrVector = std::vector<BaseGeomPtr>;    //new style
@@ -370,7 +365,7 @@ class TechDrawExport Face
 };
 using FacePtr = std::shared_ptr<Face>;
 
-class TechDrawExport Vertex
+class TechDrawExport Vertex : public TechDraw::Tag
 {
     public:
         Vertex();
@@ -389,9 +384,6 @@ class TechDrawExport Vertex
 
         double x() {return pnt.x;}
         double y() {return pnt.y;}
-
-        boost::uuids::uuid getTag() const;
-        virtual std::string getTagAsString() const;
 
         // attribute setters and getters
         bool getHlrVisible() { return hlrVisible; }
@@ -412,9 +404,6 @@ class TechDrawExport Vertex
         Part::TopoShape asTopoShape(double scale = 1.0);
 
     protected:
-        //Uniqueness
-        void createNewTag();
-
         Base::Vector3d pnt;
         ExtractionType extractType;       //obs?
         bool hlrVisible;                 //visible according to HLR
@@ -425,8 +414,6 @@ class TechDrawExport Vertex
         int cosmeticLink;                 //deprec. use cosmeticTag
         std::string cosmeticTag;
         bool m_reference;                   //reference vertex (ex robust dimension)
-
-        boost::uuids::uuid tag;
 };
 using VertexPtr = std::shared_ptr<Vertex>;
 

--- a/src/Mod/TechDraw/App/Geometry.h
+++ b/src/Mod/TechDraw/App/Geometry.h
@@ -414,7 +414,6 @@ class TechDrawExport Vertex
     protected:
         //Uniqueness
         void createNewTag();
-        void assignTag(const TechDraw::Vertex* v);
 
         Base::Vector3d pnt;
         ExtractionType extractType;       //obs?

--- a/src/Mod/TechDraw/App/PreCompiled.h
+++ b/src/Mod/TechDraw/App/PreCompiled.h
@@ -49,9 +49,6 @@
 #include <boost/graph/is_kuratowski_subgraph.hpp>
 #include <boost/random.hpp>
 #include <boost_regex.hpp>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
 
 // Qt
 #include <QApplication>

--- a/src/Mod/TechDraw/App/Tag.cpp
+++ b/src/Mod/TechDraw/App/Tag.cpp
@@ -1,0 +1,93 @@
+/***************************************************************************
+ *   Copyright (c) 2025 WandererFan <wandererfan@gmail.com>                *
+ *   Copyright (c) 2025 Benjamin Bræstrup Sayoc <benj5378@outlook.com>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+    #include <boost/random.hpp>
+    #include <boost/uuid/uuid_io.hpp>
+    #include <boost/uuid/uuid_generators.hpp>
+    #include <boost/thread/mutex.hpp>
+    #include <boost/thread/lock_guard.hpp>
+#endif
+
+#include <Base/Reader.h>
+#include <Base/Writer.h>
+
+#include "Tag.h"
+
+using namespace TechDraw;
+
+Tag::Tag()
+{
+    createNewTag();
+}
+
+boost::uuids::uuid Tag::getTag() const
+{
+    return tag;
+}
+
+std::string Tag::getTagAsString() const
+{
+    return boost::uuids::to_string(getTag());
+}
+
+void Tag::setTag(const boost::uuids::uuid& newTag)
+{
+    tag = newTag;
+}
+
+void Tag::createNewTag()
+{
+    // Initialize a random number generator, to avoid Valgrind false positives.
+    // The random number generator is not threadsafe so we guard it.  See
+    // https://www.boost.org/doc/libs/1_62_0/libs/uuid/uuid.html#Design%20notes
+    static boost::mt19937 ran;
+    static bool seeded = false;
+    static boost::mutex random_number_mutex;
+
+    boost::lock_guard<boost::mutex> guard(random_number_mutex);
+
+    if (!seeded) {
+        ran.seed(static_cast<unsigned int>(std::time(nullptr)));
+        seeded = true;
+    }
+    static boost::uuids::basic_random_generator<boost::mt19937> gen(&ran);
+
+    tag = gen();
+}
+
+void Tag::Save(Base::Writer& writer) const
+{
+    writer.Stream() << writer.ind() << "<Tag value=\"" <<  getTagAsString() << "\"/>" << std::endl;
+}
+
+void Tag::Restore(Base::XMLReader& reader, std::string_view elementName)
+{
+    // Setting elementName is only for backwards compatibility!
+    reader.readElement(elementName.data());
+    std::string temp = reader.getAttribute("value");
+    boost::uuids::string_generator gen;
+    boost::uuids::uuid u1 = gen(temp);
+    tag = u1;
+}

--- a/src/Mod/TechDraw/App/Tag.h
+++ b/src/Mod/TechDraw/App/Tag.h
@@ -1,0 +1,56 @@
+/***************************************************************************
+ *   Copyright (c) 2025 WandererFan <wandererfan@gmail.com>                *
+ *   Copyright (c) 2025 Benjamin Bræstrup Sayoc <benj5378@outlook.com>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef TECHDRAW_TAG_H
+#define TECHDRAW_TAG_H
+
+#include <boost/uuid/uuid.hpp>
+
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+namespace Base {
+class XMLReader;
+class Writer;
+}
+
+namespace TechDraw {
+class TechDrawExport Tag {
+public:
+    //Uniqueness
+    boost::uuids::uuid getTag() const;
+    virtual std::string getTagAsString() const;
+
+protected:
+    Tag();
+    void setTag(const boost::uuids::uuid& newTag);
+    void Save(Base::Writer& writer) const;
+    // Setting elementName is only for backwards compatibility!
+    void Restore(Base::XMLReader& reader, std::string_view elementName="Tag");
+
+private:
+    void createNewTag();
+    boost::uuids::uuid tag;
+};
+}
+
+#endif


### PR DESCRIPTION
- Reuses code
- Avoids heavy boost uuid headers in files

- Makes `Tag` a base class
- Classes needing tag inherits `Tag` class