### PR TITLE
Base: Coverity fixes from February 2025 run (round 1)

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1360,7 +1360,7 @@ void Application::addImportType(const char* Type, const char* ModuleName)
         std::string::size_type next = item.filter.find_first_of(" )", pos+1);
         std::string::size_type len = next-pos-2;
         std::string type = item.filter.substr(pos+2,len);
-        item.types.push_back(type);
+        item.types.push_back(std::move(type));
         pos = item.filter.find("*.", next);
     }
 
@@ -1368,12 +1368,12 @@ void Application::addImportType(const char* Type, const char* ModuleName)
     if (strncmp(Type, "FreeCAD", 7) == 0) {
         std::string AppName = Config()["ExeName"];
         AppName += item.filter.substr(7);
-        item.filter = AppName;
+        item.filter = std::move(AppName);
         // put to the front of the array
-        _mImportTypes.insert(_mImportTypes.begin(),item);
+        _mImportTypes.insert(_mImportTypes.begin(),std::move(item));
     }
     else {
-        _mImportTypes.push_back(item);
+        _mImportTypes.push_back(std::move(item));
     }
 }
 
@@ -1483,7 +1483,7 @@ void Application::addExportType(const char* Type, const char* ModuleName)
         std::string::size_type next = item.filter.find_first_of(" )", pos+1);
         std::string::size_type len = next-pos-2;
         std::string type = item.filter.substr(pos+2,len);
-        item.types.push_back(type);
+        item.types.push_back(std::move(type));
         pos = item.filter.find("*.", next);
     }
 
@@ -1491,12 +1491,12 @@ void Application::addExportType(const char* Type, const char* ModuleName)
     if (strncmp(Type, "FreeCAD", 7) == 0) {
         std::string AppName = Config()["ExeName"];
         AppName += item.filter.substr(7);
-        item.filter = AppName;
+        item.filter = std::move(AppName);
         // put to the front of the array
-        _mExportTypes.insert(_mExportTypes.begin(),item);
+        _mExportTypes.insert(_mExportTypes.begin(),std::move(item));
     }
     else {
-        _mExportTypes.push_back(item);
+        _mExportTypes.push_back(std::move(item));
     }
 }
 
@@ -1665,7 +1665,7 @@ void Application::slotBeforeRecompute(const Document& doc)
 
 void Application::slotOpenTransaction(const Document& d, string s)
 {
-    this->signalOpenTransaction(d, s);
+    this->signalOpenTransaction(d, std::move(s));
 }
 
 void Application::slotCommitTransaction(const Document& d)
@@ -1743,7 +1743,7 @@ void Application::destruct()
 
     // now save all other parameter files
     auto& paramMgr = _pcSingleton->mpcPramManager;
-    for (auto it : paramMgr) {
+    for (const auto &it : paramMgr) {
         if ((it.second != _pcSysParamMngr) && (it.second != _pcUserParamMngr)) {
             if (it.second->HasSerializer() && !it.second->IgnoreSave()) {
                 Base::Console().Log("Saving %s...\n", it.first.c_str());
@@ -2449,7 +2449,7 @@ void processProgramOptions(const variables_map& vm, std::map<std::string,std::st
         for (const auto & It : Macros)
             temp += It + ";";
         temp.erase(temp.end()-1);
-        mConfig["AdditionalMacroPaths"] = temp;
+        mConfig["AdditionalMacroPaths"] = std::move(temp);
     }
 
     if (vm.count("python-path")) {
@@ -2484,8 +2484,7 @@ void processProgramOptions(const variables_map& vm, std::map<std::string,std::st
     }
 
     if (vm.count("output")) {
-        string file = vm["output"].as<string>();
-        mConfig["SaveFile"] = file;
+        mConfig["SaveFile"] = vm["output"].as<string>();
     }
 
     if (vm.count("hidden")) {
@@ -2519,7 +2518,7 @@ void processProgramOptions(const variables_map& vm, std::map<std::string,std::st
         else if (testCase.empty()) {
             testCase = "TestApp.PrintAll";
         }
-        mConfig["TestCase"] = testCase;
+        mConfig["TestCase"] = std::move(testCase);
         mConfig["RunMode"] = "Internal";
         mConfig["ScriptFileName"] = "FreeCADTest";
         mConfig["ExitTests"] = vm.count("run-open") == 0  ? "yes" : "no";
@@ -2556,7 +2555,7 @@ void processProgramOptions(const variables_map& vm, std::map<std::string,std::st
             if (pos != std::string::npos) {
                 std::string key = it.substr(0, pos);
                 std::string val = it.substr(pos + 1);
-                mConfig[key] = val;
+                mConfig[key] = std::move(val);
             }
         }
     }
@@ -2871,9 +2870,7 @@ std::list<std::string> Application::getCmdLineFiles()
         // getting file name
         std::ostringstream temp;
         temp << "OpenFile" << i;
-
-        std::string file(mConfig[temp.str()]);
-        files.push_back(file);
+        files.emplace_back(mConfig[temp.str()]);
     }
 
     return files;
@@ -3400,7 +3397,7 @@ void Application::ExtractUserPath()
 
     // Set the default macro directory
     //
-    std::vector<std::string> macrodirs = subdirs;
+    std::vector<std::string> macrodirs = std::move(subdirs);  // Last use in this method, just move
     macrodirs.emplace_back("Macro");
     std::filesystem::path macro = findPath(dataHome, customData, macrodirs, true);
     mConfig["UserMacroPath"] = Base::FileInfo::pathToString(macro) + PATHSEP;

--- a/src/Base/Console.h
+++ b/src/Base/Console.h
@@ -1169,7 +1169,17 @@ template<Base::LogStyle category,
 inline void
 Base::ConsoleSingleton::Send(const std::string& notifiername, const char* pMsg, Args&&... args)
 {
-    std::string format = fmt::sprintf(pMsg, args...);
+    std::string format;
+    try {
+        format = fmt::sprintf(pMsg, args...);
+    }
+    catch (fmt::format_error& e) {
+        // We can't allow an exception to propagate out of this method, which gets used in some
+        // destructors. Instead, make the string's contents the error message that fmt::sprintf gave
+        // us.
+        format = std::string("ERROR: Invalid format string or arguments provided.\n");
+        format += e.what();
+    }
 
     if (connectionMode == Direct) {
         Notify<category, recipient, contenttype>(notifiername, format);

--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -543,7 +543,7 @@ void Cell::setDisplayUnit(const std::string& unit)
     if (newDisplayUnit != displayUnit) {
         PropertySheet::AtomicPropertyChange signaller(*owner);
 
-        displayUnit = newDisplayUnit;
+        displayUnit = std::move(newDisplayUnit);
         setUsed(DISPLAY_UNIT_SET, !displayUnit.isEmpty());
         setDirty();
 

--- a/src/Mod/Spreadsheet/App/DisplayUnit.h
+++ b/src/Mod/Spreadsheet/App/DisplayUnit.h
@@ -39,7 +39,7 @@ public:
     explicit DisplayUnit(const std::string _stringRep = "",
                          const Base::Unit _unit = Base::Unit(),
                          double _scaler = 0.0)
-        : stringRep(_stringRep)
+        : stringRep(std::move(_stringRep))
         , unit(_unit)
         , scaler(_scaler)
     {}

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -787,7 +787,7 @@ void PropertySheet::setAlias(CellAddress address, const std::string& alias)
         App::ObjectIdentifier key(owner, oldAlias);
         App::ObjectIdentifier value(owner, alias.empty() ? address.toString() : alias);
 
-        m[key] = value;
+        m[key] = std::move(value);
 
         owner->getDocument()->renameObjectIdentifiers(m);
     }
@@ -1397,7 +1397,7 @@ void PropertySheet::addDependencies(CellAddress key)
 
                         // Insert into maps
                         propertyNameToCellMap[propName].insert(key);
-                        cellToPropertyNameMap[key].insert(propName);
+                        cellToPropertyNameMap[key].insert(std::move(propName));
                     }
                 }
             }

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -104,7 +104,15 @@ Sheet::Sheet()
 
 Sheet::~Sheet()
 {
-    clearAll();
+    try {
+        clearAll();
+    }
+    catch (boost::wrapexcept<boost::regex_error>&) {
+        // Don't let an exception propagate out of a destructor (calls terminate())
+        Base::Console().Error(
+            "clearAll() resulted in an exception when deleting the spreadsheet : %s\n",
+            *pcNameInDocument);
+    }
 }
 
 /**

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -24,6 +24,7 @@
 
 #ifndef _PreComp_
 #include <boost/tokenizer.hpp>
+#include <boost/regex.hpp>
 #include <deque>
 #include <memory>
 #include <sstream>
@@ -107,7 +108,7 @@ Sheet::~Sheet()
     try {
         clearAll();
     }
-    catch (boost::wrapexcept<boost::regex_error>&) {
+    catch (boost::regex_error&) {
         // Don't let an exception propagate out of a destructor (calls terminate())
         Base::Console().Error(
             "clearAll() resulted in an exception when deleting the spreadsheet : %s\n",

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -108,7 +108,7 @@ Sheet::~Sheet()
     try {
         clearAll();
     }
-    catch (boost::regex_error&) {
+    catch (...) {
         // Don't let an exception propagate out of a destructor (calls terminate())
         Base::Console().Error(
             "clearAll() resulted in an exception when deleting the spreadsheet : %s\n",

--- a/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
@@ -191,7 +191,7 @@ void DlgBindSheet::accept()
                 addr = std::string("<<") + copy + ">>";
             }
             else {
-                addr = copy;
+                addr = std::move(copy);
             }
         };
 

--- a/src/Mod/Spreadsheet/Gui/ZoomableView.h
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.h
@@ -68,9 +68,9 @@ private:
 
     QPointer<SpreadsheetGui::SheetTableView> stv;
     QGraphicsScene m_scene;
-    QGraphicsProxyWidget* qpw;
+    QGraphicsProxyWidget* qpw {nullptr};
 
-    int m_zoomLevel;
+    int m_zoomLevel {100};
 
 protected:
     void focusOutEvent(QFocusEvent* event) override;


### PR DESCRIPTION
Our most recent Coverity scan pointed out a couple of things that I've started addressing:
* With the use of `fmt::sprintf` in things like `Console().Warning()`, it's now possible for those console calls to raise an exception, which means they really shouldn't get used in a destructor (destructors are `noexcept` by definition). To avoid this warning from Coverity, instead of raising an exception, make the actual console output the error message from `fmt`.
* In many place in our code, we create a resource (like a `std::string`), and then as a final step *copy* it into some storage location. Of course, these copies can all be `std::move` instead. This PR cleans up `App/Application.cpp` and `Mod/Spreadsheet` in this regard.

There were many others, but rather than cram everything into one PR, I'm going to part them out.