### PR TITLE
Abort long-running operations with OCCT ProgressIndicator and UserBreak feature

### DIFF
--- a/src/App/Datums.cpp
+++ b/src/App/Datums.cpp
@@ -218,7 +218,7 @@ short LocalCoordinateSystem::mustExecute() const
     return DocumentObject::mustExecute();
 }
 
-App::DocumentObjectExecReturn* LocalCoordinateSystem::execute()
+App::DocumentObjectExecReturn* LocalCoordinateSystem::execute(Base::ProgressRange& progressRange)
 {
     try {  // try to find all base axis and planes in the origin
         for (const char* role : AxisRoles) {
@@ -237,7 +237,7 @@ App::DocumentObjectExecReturn* LocalCoordinateSystem::execute()
         return new App::DocumentObjectExecReturn(ex.what());
     }
 
-    return DocumentObject::execute();
+    return DocumentObject::execute(progressRange);
 }
 
 const std::vector<LocalCoordinateSystem::SetupData>& LocalCoordinateSystem::getSetupData()

--- a/src/App/Datums.h
+++ b/src/App/Datums.h
@@ -218,7 +218,7 @@ public:
 
 protected:
     /// Checks integrity of the LCS
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     /// Creates all corresponding Axes and Planes objects for the LCS if they aren't linked yet
     void setupObject() override;
     /// Removes all planes and axis if they are still linked to the document

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2931,7 +2931,7 @@ void Document::renameObjectIdentifiers(
 }
 
 #ifdef USE_OLD_DAG
-int Document::recompute(const std::vector<App::DocumentObject*>& objs, bool force)
+int Document::recompute(Base::ProgressRange& progressRange, const std::vector<App::DocumentObject*>& objs, bool force)
 {
     if (testStatus(Document::Recomputing)) {
         // this is clearly a bug in the calling instance
@@ -3051,7 +3051,7 @@ int Document::recompute(const std::vector<App::DocumentObject*>& objs, bool forc
 
         if (recomputeList.find(Cur) != recomputeList.end()
             || Cur->ExpressionEngine.depsAreTouched()) {
-            if (_recomputeFeature(Cur)) {
+            if (_recomputeFeature(progressRange, Cur)) {
                 // if something happened break execution of recompute
                 d->vertexMap.clear();
                 return -1;
@@ -3080,7 +3080,8 @@ int Document::recompute(const std::vector<App::DocumentObject*>& objs, bool forc
 
 #else  // ifdef USE_OLD_DAG
 
-int Document::recompute(const std::vector<App::DocumentObject*>& objs,
+int Document::recompute(Base::ProgressRange& progressRange,
+                        const std::vector<App::DocumentObject*>& objs,
                         bool force,
                         bool* hasError,
                         int options)
@@ -3174,7 +3175,7 @@ int Document::recompute(const std::vector<App::DocumentObject*>& objs,
                 if (obj->mustRecompute()) {
                     doRecompute = true;
                     ++objectCount;
-                    int res = _recomputeFeature(obj);
+                    int res = _recomputeFeature(progressRange, obj);
                     if (res) {
                         if (hasError) {
                             *hasError = true;
@@ -3458,7 +3459,7 @@ const char* Document::getErrorDescription(const App::DocumentObject* Obj) const
 }
 
 // call the recompute of the Feature and handle the exceptions and errors.
-int Document::_recomputeFeature(DocumentObject* Feat)
+int Document::_recomputeFeature(Base::ProgressRange& progressRange, DocumentObject* Feat)
 {
     FC_LOG("Recomputing " << Feat->getFullName());
 
@@ -3466,7 +3467,7 @@ int Document::_recomputeFeature(DocumentObject* Feat)
     try {
         returnCode = Feat->ExpressionEngine.execute(PropertyExpressionEngine::ExecuteNonOutput);
         if (returnCode == DocumentObject::StdReturn) {
-            returnCode = Feat->recompute();
+            returnCode = Feat->recompute(progressRange);
             if (returnCode == DocumentObject::StdReturn) {
                 returnCode =
                     Feat->ExpressionEngine.execute(PropertyExpressionEngine::ExecuteOutput);
@@ -3515,7 +3516,7 @@ int Document::_recomputeFeature(DocumentObject* Feat)
     return 0;
 }
 
-bool Document::recomputeFeature(DocumentObject* Feat, bool recursive)
+bool Document::recomputeFeature(Base::ProgressRange& progressRange, DocumentObject* Feat, bool recursive)
 {
     // delete recompute log
     d->clearRecomputeLog(Feat);
@@ -3524,11 +3525,11 @@ bool Document::recomputeFeature(DocumentObject* Feat, bool recursive)
     if (Feat->isAttachedToDocument()) {
         if (recursive) {
             bool hasError = false;
-            recompute({Feat}, true, &hasError);
+            recompute(progressRange, {Feat}, true, &hasError);
             return !hasError;
         }
         else {
-            _recomputeFeature(Feat);
+            _recomputeFeature(progressRange, Feat);
             signalRecomputedObject(*Feat);
             return Feat->isValid();
         }

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -28,6 +28,7 @@
 #include <Base/Persistence.h>
 #include <Base/Type.h>
 #include <Base/Handle.h>
+#include <Base/ProgressRange.h>
 
 #include "PropertyContainer.h"
 #include "PropertyLinks.h"
@@ -380,12 +381,13 @@ public:
      * @param objs: specify a sub set of objects to recompute. If empty, then
      * all object in this document is checked for recompute
      */
-    int recompute(const std::vector<App::DocumentObject*>& objs = {},
+    int recompute(Base::ProgressRange& progressRange,
+                  const std::vector<App::DocumentObject*>& objs = {},
                   bool force = false,
                   bool* hasError = nullptr,
                   int options = 0);
     /// Recompute only one feature
-    bool recomputeFeature(DocumentObject* Feat, bool recursive = false);
+    bool recomputeFeature(Base::ProgressRange& progressRange, DocumentObject* Feat, bool recursive = false);
     /// get the text of the error of a specified object
     const char* getErrorDescription(const App::DocumentObject*) const;
     /// return the status bits
@@ -617,7 +619,7 @@ protected:
     void onChangedProperty(const DocumentObject* Who, const Property* What);
     /// helper which Recompute only this feature
     /// @return 0 if succeeded, 1 if failed, -1 if aborted by user.
-    int _recomputeFeature(DocumentObject* Feat);
+    int _recomputeFeature(Base::ProgressRange& progressRange, DocumentObject* Feat);
     void _clearRedos();
 
     /// refresh the internal dependency graph

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -151,7 +151,7 @@ void DocumentObject::printInvalidLinks() const
     }
 }
 
-App::DocumentObjectExecReturn* DocumentObject::recompute()
+App::DocumentObjectExecReturn* DocumentObject::recompute(Base::ProgressRange& progressRange)
 {
     // check if the links are valid before making the recompute
     if (!GeoFeatureGroupExtension::areLinksValid(this)) {
@@ -164,30 +164,30 @@ App::DocumentObjectExecReturn* DocumentObject::recompute()
     // mark the object to recompute its extensions
     this->setStatus(App::RecomputeExtension, true);
 
-    auto ret = this->execute();
+    auto ret = this->execute(progressRange);
     if (ret == StdReturn) {
         // most feature classes don't call the execute() method of its base class
         // so execute the extensions now
         if (this->testStatus(App::RecomputeExtension)) {
-            ret = executeExtensions();
+            ret = executeExtensions(progressRange);
         }
     }
 
     return ret;
 }
 
-DocumentObjectExecReturn* DocumentObject::execute()
+DocumentObjectExecReturn* DocumentObject::execute(Base::ProgressRange& progressRange)
 {
-    return executeExtensions();
+    return executeExtensions(progressRange);
 }
 
-App::DocumentObjectExecReturn* DocumentObject::executeExtensions()
+App::DocumentObjectExecReturn* DocumentObject::executeExtensions(Base::ProgressRange& progressRange)
 {
     // execute extensions but stop on error
     this->setStatus(App::RecomputeExtension, false);  // reset the flag
     auto vector = getExtensionsDerivedFromType<App::DocumentObjectExtension>();
     for (auto ext : vector) {
-        auto ret = ext->extensionExecute();
+        auto ret = ext->extensionExecute(progressRange);
         if (ret != StdReturn) {
             return ret;
         }
@@ -196,11 +196,11 @@ App::DocumentObjectExecReturn* DocumentObject::executeExtensions()
     return StdReturn;
 }
 
-bool DocumentObject::recomputeFeature(bool recursive)
+bool DocumentObject::recomputeFeature(Base::ProgressRange& progressRange, bool recursive)
 {
     Document* doc = this->getDocument();
     if (doc) {
-        return doc->recomputeFeature(this, recursive);
+        return doc->recomputeFeature(progressRange, this, recursive);
     }
     return isValid();
 }

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -30,6 +30,7 @@
 #include <App/PropertyLinks.h>
 #include <App/PropertyStandard.h>
 #include <Base/SmartPtrPy.h>
+#include <Base/ProgressRange.h>
 
 #include <bitset>
 #include <unordered_map>
@@ -375,9 +376,10 @@ public:
 
     /** Recompute only this feature
      *
+     * @param progressRange: the progress range to report progress to
      * @param recursive: set to true to recompute any dependent objects as well
      */
-    bool recomputeFeature(bool recursive = false);
+    bool recomputeFeature(Base::ProgressRange& progressRange, bool recursive = false);
 
     /// get the status Message
     const char* getStatusString() const;
@@ -692,7 +694,7 @@ public:
 
 protected:
     /// recompute only this object
-    virtual App::DocumentObjectExecReturn* recompute();
+    virtual App::DocumentObjectExecReturn* recompute(Base::ProgressRange& progressRange);
     /** get called by the document to recompute this feature
      * Normally this method get called in the processing of
      * Document::recompute().
@@ -700,12 +702,12 @@ protected:
      * with the data from linked objects and objects own
      * properties.
      */
-    virtual App::DocumentObjectExecReturn* execute();
+    virtual App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange);
 
     /**
      * Executes the extensions of a document object.
      */
-    App::DocumentObjectExecReturn* executeExtensions();
+    App::DocumentObjectExecReturn* executeExtensions(Base::ProgressRange& progressRange);
 
     /** Status bits of the document object
      * The first 8 bits are used for the base system the rest can be used in

--- a/src/App/DocumentObjectExtension.cpp
+++ b/src/App/DocumentObjectExtension.cpp
@@ -45,9 +45,9 @@ short int DocumentObjectExtension::extensionMustExecute()
     return 0;
 }
 
-App::DocumentObjectExecReturn* DocumentObjectExtension::extensionExecute()
+App::DocumentObjectExecReturn* DocumentObjectExtension::extensionExecute(Base::ProgressRange& progressRange)
 {
-
+    (void)progressRange;
     return App::DocumentObject::StdReturn;
 }
 

--- a/src/App/DocumentObjectExtension.h
+++ b/src/App/DocumentObjectExtension.h
@@ -25,6 +25,7 @@
 #define APP_DOCUMENTOBJECTEXTENSION_H
 
 #include "Extension.h"
+#include <Base/ProgressRange.h>
 
 namespace Base
 {
@@ -55,7 +56,7 @@ public:
 
     // override if execution is necessary
     virtual short extensionMustExecute();
-    virtual App::DocumentObjectExecReturn* extensionExecute();
+    virtual App::DocumentObjectExecReturn* extensionExecute(Base::ProgressRange& progressRange);
 
 
     /// get called after setting the document

--- a/src/App/DocumentObjectPyImp.cpp
+++ b/src/App/DocumentObjectPyImp.cpp
@@ -444,7 +444,8 @@ PyObject* DocumentObjectPy::recompute(PyObject* args)
     }
 
     try {
-        bool ok = getDocumentObjectPtr()->recomputeFeature(Base::asBoolean(recursive));
+        Base::NullProgressRange progressRange;
+        bool ok = getDocumentObjectPtr()->recomputeFeature(progressRange, Base::asBoolean(recursive));
         return Py_BuildValue("O", (ok ? Py_True : Py_False));
     }
     catch (const Base::Exception& e) {

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -697,8 +697,9 @@ PyObject* DocumentPy::recompute(PyObject* args)
             options = Document::DepNoCycle;
         }
 
+        Base::NullProgressRange progressrange;
         int objectCount =
-            getDocumentPtr()->recompute(objs, Base::asBoolean(force), nullptr, options);
+            getDocumentPtr()->recompute(progressrange, objs, Base::asBoolean(force), nullptr, options);
 
         // Document::recompute() hides possibly raised Python exceptions by its features
         // So, check if an error is set and return null if yes

--- a/src/App/FeatureCustom.h
+++ b/src/App/FeatureCustom.h
@@ -25,6 +25,7 @@
 #define APP_FEATURECUSTOM_H
 
 #include <App/PropertyContainer.h>
+#include <Base/ProgressRange.h>
 
 namespace App
 {
@@ -57,9 +58,9 @@ public:
         return FeatureT::mustExecute();
     }
     /// recalculate the Feature
-    DocumentObjectExecReturn* execute() override
+    DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
-        return FeatureT::execute();
+        return FeatureT::execute(progressRange);
     }
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override

--- a/src/App/FeaturePython.cpp
+++ b/src/App/FeaturePython.cpp
@@ -72,8 +72,9 @@ void FeaturePythonImp::init(PyObject* pyobj)
  Calls the execute() method of the Python feature class. If the Python feature class doesn't have an
  execute() method or if it returns False this method also return false and true otherwise.
  */
-bool FeaturePythonImp::execute()
+bool FeaturePythonImp::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     FC_PY_CALL_CHECK(execute)
     Base::PyGILStateLocker lock;
     try {

--- a/src/App/FeaturePython.h
+++ b/src/App/FeaturePython.h
@@ -26,7 +26,7 @@
 
 #include <App/GeoFeature.h>
 #include <App/PropertyPythonObject.h>
-
+#include <Base/ProgressRange.h>
 
 namespace App
 {
@@ -47,7 +47,7 @@ public:
     explicit FeaturePythonImp(App::DocumentObject*);
     ~FeaturePythonImp();
 
-    bool execute();
+    bool execute(Base::ProgressRange& progressRange);
     bool mustExecute() const;
     void onBeforeChange(const Property* prop);
     bool onBeforeChangeLabel(std::string& newLabel);
@@ -197,12 +197,12 @@ public:
         return imp->mustExecute() ? 1 : 0;
     }
     /// recalculate the Feature
-    DocumentObjectExecReturn* execute() override
+    DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
         try {
-            bool handled = imp->execute();
+            bool handled = imp->execute(progressRange);
             if (!handled) {
-                return FeatureT::execute();
+                return FeatureT::execute(progressRange);
             }
         }
         catch (const Base::Exception& e) {

--- a/src/App/FeatureTest.cpp
+++ b/src/App/FeatureTest.cpp
@@ -156,8 +156,9 @@ short FeatureTest::mustExecute() const
     return DocumentObject::mustExecute();
 }
 
-DocumentObjectExecReturn* FeatureTest::execute()
+DocumentObjectExecReturn* FeatureTest::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     // Enum handling
     Enumeration enumObj1 = Enum.getEnum();
     enumObj1.setValue(7, false);
@@ -232,8 +233,9 @@ FeatureTestException::FeatureTestException()
     ADD_PROPERTY(ExceptionType, (Base::Exception::getClassTypeId().getKey()));
 }
 
-DocumentObjectExecReturn* FeatureTestException::execute()
+DocumentObjectExecReturn* FeatureTestException::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     // ExceptionType;
     throw Base::RuntimeError("FeatureTestException::execute(): Testexception  ;-)");
 
@@ -252,8 +254,9 @@ FeatureTestColumn::FeatureTestColumn()
     ADD_PROPERTY_TYPE(Value, (0L), "Test", App::Prop_Output, "");
 }
 
-DocumentObjectExecReturn* FeatureTestColumn::execute()
+DocumentObjectExecReturn* FeatureTestColumn::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Value.setValue(decodeColumn(Column.getStrValue(), Silent.getValue()));
     return nullptr;
 }
@@ -270,8 +273,9 @@ FeatureTestRow::FeatureTestRow()
     ADD_PROPERTY_TYPE(Value, (0L), "Test", App::Prop_Output, "");
 }
 
-DocumentObjectExecReturn* FeatureTestRow::execute()
+DocumentObjectExecReturn* FeatureTestRow::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Value.setValue(decodeRow(Row.getStrValue(), Silent.getValue()));
     return nullptr;
 }
@@ -287,8 +291,9 @@ FeatureTestAbsAddress::FeatureTestAbsAddress()
     ADD_PROPERTY_TYPE(Valid, (false), "Test", PropertyType(Prop_Output | Prop_ReadOnly), "");
 }
 
-DocumentObjectExecReturn* FeatureTestAbsAddress::execute()
+DocumentObjectExecReturn* FeatureTestAbsAddress::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     CellAddress address;
     Valid.setValue(address.parseAbsoluteAddress(Address.getValue()));
     return StdReturn;
@@ -307,8 +312,9 @@ FeatureTestPlacement::FeatureTestPlacement()
     ADD_PROPERTY_TYPE(MultRight, (Base::Placement()), "Test", Prop_Output, "");
 }
 
-DocumentObjectExecReturn* FeatureTestPlacement::execute()
+DocumentObjectExecReturn* FeatureTestPlacement::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Base::Placement p1 = Input1.getValue();
     Base::Placement q1 = Input1.getValue();
     Base::Placement p2 = Input2.getValue();
@@ -350,8 +356,9 @@ FeatureTestAttribute::~FeatureTestAttribute()
     }
 }
 
-DocumentObjectExecReturn* FeatureTestAttribute::execute()
+DocumentObjectExecReturn* FeatureTestAttribute::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Base::PyGILStateLocker lock;
     try {
         Object.getValue().getAttr(Attribute.getValue());

--- a/src/App/FeatureTest.h
+++ b/src/App/FeatureTest.h
@@ -107,7 +107,7 @@ public:
     //@{
     short mustExecute() const override;
     /// recalculate the Feature
-    DocumentObjectExecReturn* execute() override;
+    DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     /// returns the type name of the ViewProvider
     // Hint: Probably it makes sense to have a view provider for unittests (e.g.
     // Gui::ViewProviderTest)
@@ -130,7 +130,7 @@ public:
     App::PropertyInteger ExceptionType;
 
     /// recalculate the Feature and throw an exception
-    DocumentObjectExecReturn* execute() override;
+    DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override
     {
@@ -152,7 +152,7 @@ public:
 
     /** @name methods override Feature */
     //@{
-    DocumentObjectExecReturn* execute() override;
+    DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 
@@ -170,7 +170,7 @@ public:
 
     /** @name methods override Feature */
     //@{
-    DocumentObjectExecReturn* execute() override;
+    DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 
@@ -180,7 +180,7 @@ class FeatureTestAbsAddress: public DocumentObject
 
 public:
     FeatureTestAbsAddress();
-    DocumentObjectExecReturn* execute() override;
+    DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     App::PropertyString Address;
     App::PropertyBool Valid;
@@ -201,7 +201,7 @@ public:
 
     /** @name methods override Feature */
     //@{
-    DocumentObjectExecReturn* execute() override;
+    DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 
@@ -212,7 +212,7 @@ class FeatureTestAttribute: public DocumentObject
 public:
     FeatureTestAttribute();
     ~FeatureTestAttribute() override;
-    DocumentObjectExecReturn* execute() override;
+    DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     App::PropertyPythonObject Object;
     App::PropertyString Attribute;

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -450,11 +450,11 @@ bool GroupExtension::extensionGetSubObjects(std::vector<std::string>& ret, int) 
     return true;
 }
 
-App::DocumentObjectExecReturn* GroupExtension::extensionExecute()
+App::DocumentObjectExecReturn* GroupExtension::extensionExecute(Base::ProgressRange& progressRange)
 {
     // This touch property is for propagating changes to upper group
     _GroupTouched.touch();
-    return inherited::extensionExecute();
+    return inherited::extensionExecute(progressRange);
 }
 
 std::vector<App::DocumentObject*> GroupExtension::getAllChildren() const

--- a/src/App/GroupExtension.h
+++ b/src/App/GroupExtension.h
@@ -132,7 +132,7 @@ public:
 
     bool extensionGetSubObjects(std::vector<std::string>& ret, int reason) const override;
 
-    App::DocumentObjectExecReturn* extensionExecute() override;
+    App::DocumentObjectExecReturn* extensionExecute(Base::ProgressRange& progressRange) override;
 
     std::vector<DocumentObject*> getAllChildren() const;
     void getAllChildren(std::vector<DocumentObject*>&, std::set<DocumentObject*>&) const;

--- a/src/App/InventorObject.h
+++ b/src/App/InventorObject.h
@@ -26,7 +26,7 @@
 
 #include "GeoFeature.h"
 #include "PropertyStandard.h"
-
+#include <Base/ProgressRange.h>
 
 namespace App
 {
@@ -45,8 +45,9 @@ public:
     {
         return "Gui::ViewProviderInventorObject";
     }
-    DocumentObjectExecReturn* execute() override
+    DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -36,7 +36,6 @@
 #include "GeoFeatureGroupExtension.h"
 #include "Link.h"
 #include "LinkBaseExtensionPy.h"
-
 // FIXME: ISO C++11 requires at least one argument for the "..." in a variadic macro
 #if defined(__clang__)
 #pragma clang diagnostic push
@@ -339,7 +338,7 @@ void LinkBaseExtension::setProperty(int idx, Property* prop)
 
 static const char _GroupPrefix[] = "Configuration (";
 
-App::DocumentObjectExecReturn* LinkBaseExtension::extensionExecute()
+App::DocumentObjectExecReturn* LinkBaseExtension::extensionExecute(Base::ProgressRange& progressRange)
 {
     // The actual value of LinkTouched is not important, just to notify view
     // provider that the link (in fact, its dependents, i.e. linked ones) have
@@ -454,7 +453,7 @@ App::DocumentObjectExecReturn* LinkBaseExtension::extensionExecute()
             }
         }
     }
-    return inherited::extensionExecute();
+    return inherited::extensionExecute(progressRange);
 }
 
 short LinkBaseExtension::extensionMustExecute()

--- a/src/App/Link.h
+++ b/src/App/Link.h
@@ -375,7 +375,7 @@ public:
                                   bool transform,
                                   int depth) const override;
 
-    App::DocumentObjectExecReturn* extensionExecute() override;
+    App::DocumentObjectExecReturn* extensionExecute(Base::ProgressRange& progressRange) override;
     short extensionMustExecute() override;
     void extensionOnChanged(const Property* p) override;
     void onExtendedUnsetupObject() override;

--- a/src/App/OriginGroupExtension.cpp
+++ b/src/App/OriginGroupExtension.cpp
@@ -143,7 +143,7 @@ short OriginGroupExtension::extensionMustExecute()
     }
 }
 
-App::DocumentObjectExecReturn* OriginGroupExtension::extensionExecute()
+App::DocumentObjectExecReturn* OriginGroupExtension::extensionExecute(Base::ProgressRange& progressRange)
 {
     try {  // try to find all base axis and planes in the origin
         getOrigin();
@@ -153,7 +153,7 @@ App::DocumentObjectExecReturn* OriginGroupExtension::extensionExecute()
         return new App::DocumentObjectExecReturn(ex.what());
     }
 
-    return GeoFeatureGroupExtension::extensionExecute();
+    return GeoFeatureGroupExtension::extensionExecute(progressRange);
 }
 
 App::DocumentObject* OriginGroupExtension::getLocalizedOrigin(App::Document* doc)

--- a/src/App/OriginGroupExtension.h
+++ b/src/App/OriginGroupExtension.h
@@ -81,7 +81,7 @@ public:
 
 protected:
     /// Checks integrity of the Origin
-    App::DocumentObjectExecReturn* extensionExecute() override;
+    App::DocumentObjectExecReturn* extensionExecute(Base::ProgressRange& progressRange) override;
     /// Creates the corresponding Origin object
     void onExtendedSetupObject() override;
     /// Removes all planes and axis if they are still linked to the document

--- a/src/App/VRMLObject.h
+++ b/src/App/VRMLObject.h
@@ -26,7 +26,7 @@
 
 #include "GeoFeature.h"
 #include "PropertyFile.h"
-
+#include <Base/ProgressRange.h>
 
 namespace App
 {
@@ -44,8 +44,9 @@ public:
     {
         return "Gui::ViewProviderVRMLObject";
     }
-    DocumentObjectExecReturn* execute() override
+    DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -265,6 +265,7 @@ SET(FreeCADBase_HPP_SRCS
     Placement.h
     Precision.h
     ProgressIndicatorPy.h
+    ProgressRange.h
     PyExport.h
     PyObjectBase.h
     PyWrapParseTupleAndKeywords.h

--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -1136,7 +1136,8 @@ void RecentMacrosAction::activateFile(int id)
                 Application::Instance->macroManager()->run(Gui::MacroManager::File, fi.filePath().toUtf8());
                 // after macro run recalculate the document
                 if (Application::Instance->activeDocument()) {
-                    Application::Instance->activeDocument()->getDocument()->recompute();
+                    Base::NullProgressRange progressRange;
+                    Application::Instance->activeDocument()->getDocument()->recompute(progressRange);
                 }
             }
             catch (const Base::SystemExitException&) {

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -995,7 +995,8 @@ void Application::checkForRecomputes() {
     bool hasError = false;
     for (auto doc: App::Document::getDependentDocuments(docs, true)) {
         try {
-            doc->recompute({}, false, &hasError);
+            Base::NullProgressRange progressRange;
+            doc->recompute(progressRange, {}, false, &hasError);
         } catch (Base::Exception &e) {
             e.ReportException();
             hasError = true;

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1188,8 +1188,10 @@ void MacroCommand::activated(int iMsg)
     else {
         Application::Instance->macroManager()->run(MacroManager::File, fi.filePath().toUtf8());
         // after macro run recalculate the document
-        if (Application::Instance->activeDocument())
-            Application::Instance->activeDocument()->getDocument()->recompute();
+        if (Application::Instance->activeDocument()) {
+            Base::NullProgressRange progressRange;
+            Application::Instance->activeDocument()->getDocument()->recompute(progressRange);
+        }
     }
 }
 

--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -454,8 +454,10 @@ static void linkConvert(bool unlink) {
             if(obj)
                 recomputes.push_back(obj);
         }
-        if(!recomputes.empty())
-            recomputes.front()->getDocument()->recompute(recomputes);
+        if(!recomputes.empty()) {
+            Base::NullProgressRange progressRange;
+            recomputes.front()->getDocument()->recompute(progressRange, recomputes);
+        }
 
         Command::commitCommand();
 

--- a/src/Gui/DAGView/DAGModel.cpp
+++ b/src/Gui/DAGView/DAGModel.cpp
@@ -1176,7 +1176,8 @@ void Model::editingFinishedSlot()
   Gui::Document* doc = Gui::Application::Instance->getDocument(record.DObject->getDocument());
   doc->commitCommand();
   doc->resetEdit();
-  doc->getDocument()->recompute();
+  Base::NullProgressRange progressRange;
+  doc->getDocument()->recompute(progressRange);
 }
 
 void Model::visiblyIsolate(Gui::DAG::Vertex sourceIn)

--- a/src/Gui/Dialogs/DlgMacroExecuteImp.cpp
+++ b/src/Gui/Dialogs/DlgMacroExecuteImp.cpp
@@ -388,7 +388,8 @@ void DlgMacroExecuteImp::accept()
         Application::Instance->macroManager()->run(Gui::MacroManager::File, fi.filePath().toUtf8());
         // after macro run recalculate the document
         if (Application::Instance->activeDocument()) {
-            Application::Instance->activeDocument()->getDocument()->recompute();
+            Base::NullProgressRange progressRange;
+            Application::Instance->activeDocument()->getDocument()->recompute(progressRange);
         }
         getMainWindow()->unsetCursor();
     }

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1171,7 +1171,8 @@ void Document::slotSkipRecompute(const App::Document& doc, const std::vector<App
         obj = doc.getActiveObject();
     if(!obj || !obj->isAttachedToDocument() || (!objs.empty() && objs.front()!=obj))
         return;
-    obj->recomputeFeature(true);
+    Base::NullProgressRange progressRange;
+    obj->recomputeFeature(progressRange);
 }
 
 void Document::slotTouchedObject(const App::DocumentObject &Obj)

--- a/src/Gui/ManualAlignment.cpp
+++ b/src/Gui/ManualAlignment.cpp
@@ -907,8 +907,10 @@ void ManualAlignment::finish()
     if (myViewer.isNull())
         return;
 
-    if (myDocument)
-        myDocument->getDocument()->recompute();
+    if (myDocument) {
+        Base::NullProgressRange progressRange;
+        myDocument->getDocument()->recompute(progressRange);
+    }
     closeViewer();
     reset();
 

--- a/src/Gui/Placement.cpp
+++ b/src/Gui/Placement.cpp
@@ -405,7 +405,8 @@ std::tuple<Base::Vector3d, std::vector<Base::Vector3d>> PlacementHandler::getSel
 void PlacementHandler::tryRecompute(Gui::Document* document)
 {
     try {
-        document->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        document->getDocument()->recompute(progressRange);
     }
     catch (...) {
     }

--- a/src/Gui/TaskCSysDragger.cpp
+++ b/src/Gui/TaskCSysDragger.cpp
@@ -740,7 +740,8 @@ bool TaskCSysDragger::accept()
         assert(document);
         document->commitCommand();
         document->resetEdit();
-        document->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        document->getDocument()->recompute(progressRange);
     }
 
     return Gui::TaskView::TaskDialog::accept();
@@ -754,7 +755,8 @@ bool TaskCSysDragger::reject()
         assert(document);
         document->abortCommand();
         document->resetEdit();
-        document->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        document->getDocument()->recompute(progressRange);
     }
 
     return Gui::TaskView::TaskDialog::reject();

--- a/src/Gui/TaskElementColors.cpp
+++ b/src/Gui/TaskElementColors.cpp
@@ -218,7 +218,8 @@ public:
         if (touched && ui->recompute->isChecked()) {
             auto obj = vp->getObject();
             obj->touch();
-            obj->getDocument()->recompute(obj->getInListRecursive());
+            Base::NullProgressRange progressRange;
+            obj->getDocument()->recompute(progressRange, obj->getInListRecursive());
             touched = false;
         }
         App::GetApplication().closeActiveTransaction();

--- a/src/Gui/TaskView/TaskImage.cpp
+++ b/src/Gui/TaskView/TaskImage.cpp
@@ -266,7 +266,8 @@ void TaskImage::accept()
     if (!feature.expired()) {
         App::Document* doc = feature->getDocument();
         doc->commitTransaction();
-        doc->recompute();
+        Base::NullProgressRange progressRange;
+        doc->recompute(progressRange);
     }
 }
 

--- a/src/Gui/TaskView/TaskOrientation.cpp
+++ b/src/Gui/TaskView/TaskOrientation.cpp
@@ -76,7 +76,8 @@ void TaskOrientation::accept()
     if (!feature.expired()) {
         App::Document* doc = feature->getDocument();
         doc->commitTransaction();
-        doc->recompute();
+        Base::NullProgressRange progressRange;
+        doc->recompute(progressRange);
     }
 }
 

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1261,7 +1261,8 @@ void TreeWidget::onFinishEditing()
         Gui::Document* doc = Gui::Application::Instance->getDocument(obj->getDocument());
         doc->commitCommand();
         doc->resetEdit();
-        doc->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        doc->getDocument()->recompute(progressRange);
     }
 }
 
@@ -1388,7 +1389,8 @@ void TreeWidget::onRecomputeObject() {
     if (objs.empty())
         return;
     App::AutoTransaction committer("Recompute object");
-    objs.front()->getDocument()->recompute(objs, true);
+    Base::NullProgressRange progressRange;
+    objs.front()->getDocument()->recompute(progressRange, objs, true);
 }
 
 
@@ -2736,7 +2738,8 @@ void TreeWidget::dropEvent(QDropEvent* event)
     }
 
     if (touched && TreeParams::getRecomputeOnDrop()) {
-        targetInfo.targetDoc->recompute();
+        Base::NullProgressRange progressRange;
+        targetInfo.targetDoc->recompute(progressRange);
     }
     if (touched && TreeParams::getSyncView()) {
         auto gdoc = Application::Instance->getDocument(targetInfo.targetDoc);

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -371,7 +371,8 @@ void PropertyEditor::recomputeDocument(App::Document* doc)
             // Between opening and committing a transaction a recompute
             // could already have been done
             if (doc->isTouched()) {
-                doc->recompute();
+                Base::NullProgressRange progressRange;
+                doc->recompute(progressRange);
             }
         }
     }

--- a/src/Mod/Fem/App/FemConstraint.cpp
+++ b/src/Mod/Fem/App/FemConstraint.cpp
@@ -123,8 +123,10 @@ Constraint::~Constraint()
     connDocChangedObject.disconnect();
 }
 
-App::DocumentObjectExecReturn* Constraint::execute()
+App::DocumentObjectExecReturn* Constraint::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
+
     try {
         References.touch();
         Scale.touch();

--- a/src/Mod/Fem/App/FemConstraint.h
+++ b/src/Mod/Fem/App/FemConstraint.h
@@ -120,7 +120,7 @@ public:
      *  cleared right after the @ref execute call by the recompute mechanism.
      *  See Document::recompute() and DocumentObject::purgeTouched().
      */
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /**
      * @brief Calculates scale factor based on characteristic length of shape.

--- a/src/Mod/Fem/App/FemConstraintBearing.cpp
+++ b/src/Mod/Fem/App/FemConstraintBearing.cpp
@@ -61,9 +61,9 @@ ConstraintBearing::ConstraintBearing()
                       "Axis of bearing seat");
 }
 
-App::DocumentObjectExecReturn* ConstraintBearing::execute()
+App::DocumentObjectExecReturn* ConstraintBearing::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 void ConstraintBearing::onChanged(const App::Property* prop)

--- a/src/Mod/Fem/App/FemConstraintBearing.h
+++ b/src/Mod/Fem/App/FemConstraintBearing.h
@@ -54,7 +54,7 @@ public:
     App::PropertyVector Axis;
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override

--- a/src/Mod/Fem/App/FemConstraintContact.cpp
+++ b/src/Mod/Fem/App/FemConstraintContact.cpp
@@ -60,9 +60,9 @@ ConstraintContact::ConstraintContact()
                       "Stick slope");
 }
 
-App::DocumentObjectExecReturn* ConstraintContact::execute()
+App::DocumentObjectExecReturn* ConstraintContact::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 const char* ConstraintContact::getViewProviderName() const

--- a/src/Mod/Fem/App/FemConstraintContact.h
+++ b/src/Mod/Fem/App/FemConstraintContact.h
@@ -56,7 +56,7 @@ public:
     /* */
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override;

--- a/src/Mod/Fem/App/FemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/App/FemConstraintDisplacement.cpp
@@ -150,9 +150,9 @@ ConstraintDisplacement::ConstraintDisplacement()
                       "Rotation in local Z direction");
 }
 
-App::DocumentObjectExecReturn* ConstraintDisplacement::execute()
+App::DocumentObjectExecReturn* ConstraintDisplacement::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 const char* ConstraintDisplacement::getViewProviderName() const

--- a/src/Mod/Fem/App/FemConstraintDisplacement.h
+++ b/src/Mod/Fem/App/FemConstraintDisplacement.h
@@ -62,7 +62,7 @@ public:
     App::PropertyBool useFlowSurfaceForce;
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override;

--- a/src/Mod/Fem/App/FemConstraintFixed.cpp
+++ b/src/Mod/Fem/App/FemConstraintFixed.cpp
@@ -33,9 +33,9 @@ PROPERTY_SOURCE(Fem::ConstraintFixed, Fem::Constraint)
 ConstraintFixed::ConstraintFixed()
 {}
 
-App::DocumentObjectExecReturn* ConstraintFixed::execute()
+App::DocumentObjectExecReturn* ConstraintFixed::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 void ConstraintFixed::onChanged(const App::Property* prop)

--- a/src/Mod/Fem/App/FemConstraintFixed.h
+++ b/src/Mod/Fem/App/FemConstraintFixed.h
@@ -39,7 +39,7 @@ public:
     ConstraintFixed();
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override

--- a/src/Mod/Fem/App/FemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/App/FemConstraintFluidBoundary.cpp
@@ -102,9 +102,9 @@ ConstraintFluidBoundary::ConstraintFluidBoundary()
     // clang-format on
 }
 
-App::DocumentObjectExecReturn* ConstraintFluidBoundary::execute()
+App::DocumentObjectExecReturn* ConstraintFluidBoundary::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 void ConstraintFluidBoundary::onChanged(const App::Property* prop)

--- a/src/Mod/Fem/App/FemConstraintFluidBoundary.h
+++ b/src/Mod/Fem/App/FemConstraintFluidBoundary.h
@@ -57,7 +57,7 @@ public:
     App::PropertyVector DirectionVector;
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override

--- a/src/Mod/Fem/App/FemConstraintForce.cpp
+++ b/src/Mod/Fem/App/FemConstraintForce.cpp
@@ -56,9 +56,9 @@ ConstraintForce::ConstraintForce()
     naturalDirectionVector = Base::Vector3d(0, 0, 0);
 }
 
-App::DocumentObjectExecReturn* ConstraintForce::execute()
+App::DocumentObjectExecReturn* ConstraintForce::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 void ConstraintForce::handleChangedPropertyType(Base::XMLReader& reader,

--- a/src/Mod/Fem/App/FemConstraintForce.h
+++ b/src/Mod/Fem/App/FemConstraintForce.h
@@ -44,7 +44,7 @@ public:
     App::PropertyVector DirectionVector;
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override

--- a/src/Mod/Fem/App/FemConstraintGear.cpp
+++ b/src/Mod/Fem/App/FemConstraintGear.cpp
@@ -53,9 +53,9 @@ ConstraintGear::ConstraintGear()
     naturalDirectionVector = Base::Vector3d(1, 1, 1).Normalize();
 }
 
-App::DocumentObjectExecReturn* ConstraintGear::execute()
+App::DocumentObjectExecReturn* ConstraintGear::execute(Base::ProgressRange& progressRange)
 {
-    return ConstraintBearing::execute();
+    return ConstraintBearing::execute(progressRange);
 }
 
 void ConstraintGear::onChanged(const App::Property* prop)

--- a/src/Mod/Fem/App/FemConstraintGear.h
+++ b/src/Mod/Fem/App/FemConstraintGear.h
@@ -47,7 +47,7 @@ public:
     App::PropertyVector DirectionVector;
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override

--- a/src/Mod/Fem/App/FemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/App/FemConstraintHeatflux.cpp
@@ -52,9 +52,9 @@ ConstraintHeatflux::ConstraintHeatflux()
     ConstraintType.setEnums(ConstraintTypes);
 }
 
-App::DocumentObjectExecReturn* ConstraintHeatflux::execute()
+App::DocumentObjectExecReturn* ConstraintHeatflux::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 const char* ConstraintHeatflux::getViewProviderName() const

--- a/src/Mod/Fem/App/FemConstraintHeatflux.h
+++ b/src/Mod/Fem/App/FemConstraintHeatflux.h
@@ -47,7 +47,7 @@ public:
     App::PropertyEnumeration ConstraintType;
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override;

--- a/src/Mod/Fem/App/FemConstraintInitialTemperature.cpp
+++ b/src/Mod/Fem/App/FemConstraintInitialTemperature.cpp
@@ -40,9 +40,10 @@ ConstraintInitialTemperature::ConstraintInitialTemperature()
     References.setStatus(App::Property::Hidden, true);
 }
 
-App::DocumentObjectExecReturn* ConstraintInitialTemperature::execute()
+App::DocumentObjectExecReturn*
+ConstraintInitialTemperature::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 const char* ConstraintInitialTemperature::getViewProviderName() const

--- a/src/Mod/Fem/App/FemConstraintInitialTemperature.h
+++ b/src/Mod/Fem/App/FemConstraintInitialTemperature.h
@@ -45,7 +45,7 @@ public:
 
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override;

--- a/src/Mod/Fem/App/FemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/App/FemConstraintPlaneRotation.cpp
@@ -33,9 +33,9 @@ PROPERTY_SOURCE(Fem::ConstraintPlaneRotation, Fem::Constraint)
 ConstraintPlaneRotation::ConstraintPlaneRotation()
 {}
 
-App::DocumentObjectExecReturn* ConstraintPlaneRotation::execute()
+App::DocumentObjectExecReturn* ConstraintPlaneRotation::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 const char* ConstraintPlaneRotation::getViewProviderName() const

--- a/src/Mod/Fem/App/FemConstraintPlaneRotation.h
+++ b/src/Mod/Fem/App/FemConstraintPlaneRotation.h
@@ -39,7 +39,7 @@ public:
     ConstraintPlaneRotation();
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override;

--- a/src/Mod/Fem/App/FemConstraintPressure.cpp
+++ b/src/Mod/Fem/App/FemConstraintPressure.cpp
@@ -36,9 +36,9 @@ ConstraintPressure::ConstraintPressure()
     ADD_PROPERTY(Reversed, (0));
 }
 
-App::DocumentObjectExecReturn* ConstraintPressure::execute()
+App::DocumentObjectExecReturn* ConstraintPressure::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 const char* ConstraintPressure::getViewProviderName() const

--- a/src/Mod/Fem/App/FemConstraintPressure.h
+++ b/src/Mod/Fem/App/FemConstraintPressure.h
@@ -41,7 +41,7 @@ public:
     App::PropertyBool Reversed;
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override;

--- a/src/Mod/Fem/App/FemConstraintPulley.cpp
+++ b/src/Mod/Fem/App/FemConstraintPulley.cpp
@@ -62,9 +62,9 @@ ConstraintPulley::ConstraintPulley()
     onChanged(&Force);
 }
 
-App::DocumentObjectExecReturn* ConstraintPulley::execute()
+App::DocumentObjectExecReturn* ConstraintPulley::execute(Base::ProgressRange& progressRange)
 {
-    return ConstraintGear::execute();
+    return ConstraintGear::execute(progressRange);
 }
 
 void ConstraintPulley::onChanged(const App::Property* prop)

--- a/src/Mod/Fem/App/FemConstraintPulley.h
+++ b/src/Mod/Fem/App/FemConstraintPulley.h
@@ -52,7 +52,7 @@ public:
     App::PropertyFloat BeltForce2;
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override

--- a/src/Mod/Fem/App/FemConstraintRigidBody.cpp
+++ b/src/Mod/Fem/App/FemConstraintRigidBody.cpp
@@ -117,9 +117,9 @@ ConstraintRigidBody::ConstraintRigidBody()
     RotationalModeZ.setEnums(boundaryModeEnum);
 }
 
-App::DocumentObjectExecReturn* ConstraintRigidBody::execute()
+App::DocumentObjectExecReturn* ConstraintRigidBody::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 void ConstraintRigidBody::onChanged(const App::Property* prop)

--- a/src/Mod/Fem/App/FemConstraintRigidBody.h
+++ b/src/Mod/Fem/App/FemConstraintRigidBody.h
@@ -55,7 +55,7 @@ public:
     App::PropertyEnumeration RotationalModeZ;
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override

--- a/src/Mod/Fem/App/FemConstraintSpring.cpp
+++ b/src/Mod/Fem/App/FemConstraintSpring.cpp
@@ -41,9 +41,9 @@ ConstraintSpring::ConstraintSpring()
     ElmerStiffness.setEnums(Stiffnesses);
 }
 
-App::DocumentObjectExecReturn* ConstraintSpring::execute()
+App::DocumentObjectExecReturn* ConstraintSpring::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 const char* ConstraintSpring::getViewProviderName() const

--- a/src/Mod/Fem/App/FemConstraintSpring.h
+++ b/src/Mod/Fem/App/FemConstraintSpring.h
@@ -42,7 +42,7 @@ public:
     App::PropertyEnumeration ElmerStiffness;
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override;

--- a/src/Mod/Fem/App/FemConstraintTemperature.cpp
+++ b/src/Mod/Fem/App/FemConstraintTemperature.cpp
@@ -46,9 +46,9 @@ ConstraintTemperature::ConstraintTemperature()
     ConstraintType.setEnums(ConstraintTypes);
 }
 
-App::DocumentObjectExecReturn* ConstraintTemperature::execute()
+App::DocumentObjectExecReturn* ConstraintTemperature::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 const char* ConstraintTemperature::getViewProviderName() const

--- a/src/Mod/Fem/App/FemConstraintTemperature.h
+++ b/src/Mod/Fem/App/FemConstraintTemperature.h
@@ -47,7 +47,7 @@ public:
 
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override;

--- a/src/Mod/Fem/App/FemConstraintTransform.cpp
+++ b/src/Mod/Fem/App/FemConstraintTransform.cpp
@@ -72,9 +72,9 @@ ConstraintTransform::ConstraintTransform()
                       "Axis of cylindrical surface");
 }
 
-App::DocumentObjectExecReturn* ConstraintTransform::execute()
+App::DocumentObjectExecReturn* ConstraintTransform::execute(Base::ProgressRange& progressRange)
 {
-    return Constraint::execute();
+    return Constraint::execute(progressRange);
 }
 
 const char* ConstraintTransform::getViewProviderName() const

--- a/src/Mod/Fem/App/FemConstraintTransform.h
+++ b/src/Mod/Fem/App/FemConstraintTransform.h
@@ -47,7 +47,7 @@ public:
     App::PropertyEnumeration TransformType;
 
     /// recalculate the object
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override;

--- a/src/Mod/Fem/App/FemMeshObject.h
+++ b/src/Mod/Fem/App/FemMeshObject.h
@@ -48,8 +48,9 @@ public:
     {
         return "FemGui::ViewProviderFemMesh";
     }
-    App::DocumentObjectExecReturn* execute() override
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return App::DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/Mod/Fem/App/FemMeshShapeNetgenObject.cpp
+++ b/src/Mod/Fem/App/FemMeshShapeNetgenObject.cpp
@@ -80,8 +80,9 @@ FemMeshShapeNetgenObject::FemMeshShapeNetgenObject()
 
 FemMeshShapeNetgenObject::~FemMeshShapeNetgenObject() = default;
 
-App::DocumentObjectExecReturn* FemMeshShapeNetgenObject::execute()
+App::DocumentObjectExecReturn* FemMeshShapeNetgenObject::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
 #ifdef FCWithNetgen
 
     Fem::FemMesh newMesh;

--- a/src/Mod/Fem/App/FemMeshShapeNetgenObject.h
+++ b/src/Mod/Fem/App/FemMeshShapeNetgenObject.h
@@ -52,7 +52,7 @@ public:
     {
         return "FemGui::ViewProviderFemMeshShapeNetgen";
     }
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     // virtual short mustExecute(void) const;
     // virtual PyObject *getPyObject(void);

--- a/src/Mod/Fem/App/FemMeshShapeObject.cpp
+++ b/src/Mod/Fem/App/FemMeshShapeObject.cpp
@@ -61,8 +61,9 @@ FemMeshShapeObject::FemMeshShapeObject() = default;
 
 FemMeshShapeObject::~FemMeshShapeObject() = default;
 
-App::DocumentObjectExecReturn* FemMeshShapeObject::execute()
+App::DocumentObjectExecReturn* FemMeshShapeObject::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Fem::FemMesh newMesh;
 
     Part::Feature* feat = Shape.getValue<Part::Feature*>();

--- a/src/Mod/Fem/App/FemMeshShapeObject.h
+++ b/src/Mod/Fem/App/FemMeshShapeObject.h
@@ -62,7 +62,7 @@ public:
     {
         return "FemGui::ViewProviderFemMeshShape";
     }
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     // virtual short mustExecute(void) const;
     // virtual PyObject *getPyObject(void);

--- a/src/Mod/Fem/App/FemPostFilter.cpp
+++ b/src/Mod/Fem/App/FemPostFilter.cpp
@@ -64,8 +64,9 @@ void FemPostFilter::setActiveFilterPipeline(std::string name)
     }
 }
 
-DocumentObjectExecReturn* FemPostFilter::execute()
+DocumentObjectExecReturn* FemPostFilter::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     if (!m_pipelines.empty() && !m_activePipeline.empty()) {
         FemPostFilter::FilterPipeline& pipe = m_pipelines[m_activePipeline];
         vtkSmartPointer<vtkDataObject> data = getInputData();
@@ -192,10 +193,10 @@ FemPostDataAlongLineFilter::FemPostDataAlongLineFilter()
 
 FemPostDataAlongLineFilter::~FemPostDataAlongLineFilter() = default;
 
-DocumentObjectExecReturn* FemPostDataAlongLineFilter::execute()
+DocumentObjectExecReturn* FemPostDataAlongLineFilter::execute(Base::ProgressRange& progressRange)
 {
     // recalculate the filter
-    return Fem::FemPostFilter::execute();
+    return Fem::FemPostFilter::execute(progressRange);
 }
 
 void FemPostDataAlongLineFilter::handleChangedPropertyType(Base::XMLReader& reader,
@@ -363,10 +364,10 @@ FemPostDataAtPointFilter::FemPostDataAtPointFilter()
 
 FemPostDataAtPointFilter::~FemPostDataAtPointFilter() = default;
 
-DocumentObjectExecReturn* FemPostDataAtPointFilter::execute()
+DocumentObjectExecReturn* FemPostDataAtPointFilter::execute(Base::ProgressRange& progressRange)
 {
     // recalculate the filter
-    return Fem::FemPostFilter::execute();
+    return Fem::FemPostFilter::execute(progressRange);
 }
 
 void FemPostDataAtPointFilter::onChanged(const Property* prop)
@@ -502,13 +503,13 @@ short int FemPostClipFilter::mustExecute() const
     }
 }
 
-DocumentObjectExecReturn* FemPostClipFilter::execute()
+DocumentObjectExecReturn* FemPostClipFilter::execute(Base::ProgressRange& progressRange)
 {
     if (!m_extractor->GetImplicitFunction()) {
         return StdReturn;
     }
 
-    return Fem::FemPostFilter::execute();
+    return Fem::FemPostFilter::execute(progressRange);
 }
 
 // ***************************************************************************
@@ -648,7 +649,7 @@ FemPostContoursFilter::FemPostContoursFilter()
 
 FemPostContoursFilter::~FemPostContoursFilter() = default;
 
-DocumentObjectExecReturn* FemPostContoursFilter::execute()
+DocumentObjectExecReturn* FemPostContoursFilter::execute(Base::ProgressRange& progressRange)
 {
     // update list of available fields and their vectors
     if (!m_blockPropertyChanges) {
@@ -657,7 +658,7 @@ DocumentObjectExecReturn* FemPostContoursFilter::execute()
     }
 
     // recalculate the filter
-    auto returnObject = Fem::FemPostFilter::execute();
+    auto returnObject = Fem::FemPostFilter::execute(progressRange);
 
     // delete contour field
     vtkSmartPointer<vtkDataObject> data = getInputData();
@@ -937,13 +938,13 @@ short int FemPostCutFilter::mustExecute() const
     }
 }
 
-DocumentObjectExecReturn* FemPostCutFilter::execute()
+DocumentObjectExecReturn* FemPostCutFilter::execute(Base::ProgressRange& progressRange)
 {
     if (!m_cutter->GetCutFunction()) {
         return StdReturn;
     }
 
-    return Fem::FemPostFilter::execute();
+    return Fem::FemPostFilter::execute(progressRange);
 }
 
 
@@ -975,7 +976,7 @@ FemPostScalarClipFilter::FemPostScalarClipFilter()
 
 FemPostScalarClipFilter::~FemPostScalarClipFilter() = default;
 
-DocumentObjectExecReturn* FemPostScalarClipFilter::execute()
+DocumentObjectExecReturn* FemPostScalarClipFilter::execute(Base::ProgressRange& progressRange)
 {
     std::string val;
     if (Scalars.getValue() >= 0) {
@@ -1011,7 +1012,7 @@ DocumentObjectExecReturn* FemPostScalarClipFilter::execute()
     }
 
     // recalculate the filter
-    return Fem::FemPostFilter::execute();
+    return Fem::FemPostFilter::execute(progressRange);
 }
 
 void FemPostScalarClipFilter::onChanged(const Property* prop)
@@ -1094,7 +1095,7 @@ FemPostWarpVectorFilter::FemPostWarpVectorFilter()
 
 FemPostWarpVectorFilter::~FemPostWarpVectorFilter() = default;
 
-DocumentObjectExecReturn* FemPostWarpVectorFilter::execute()
+DocumentObjectExecReturn* FemPostWarpVectorFilter::execute(Base::ProgressRange& progressRange)
 {
     std::string val;
     if (Vector.getValue() >= 0) {
@@ -1129,7 +1130,7 @@ DocumentObjectExecReturn* FemPostWarpVectorFilter::execute()
     }
 
     // recalculate the filter
-    return Fem::FemPostFilter::execute();
+    return Fem::FemPostFilter::execute(progressRange);
 }
 
 void FemPostWarpVectorFilter::onChanged(const Property* prop)

--- a/src/Mod/Fem/App/FemPostFilter.h
+++ b/src/Mod/Fem/App/FemPostFilter.h
@@ -56,7 +56,7 @@ public:
 
     App::PropertyLink Input;
 
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
 protected:
     vtkDataObject* getInputData();
@@ -142,7 +142,7 @@ public:
     void GetAxisData();
 
 protected:
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     void onChanged(const App::Property* prop) override;
     void handleChangedPropertyType(Base::XMLReader& reader,
                                    const char* TypeName,
@@ -177,7 +177,7 @@ public:
     short int mustExecute() const override;
 
 protected:
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     void onChanged(const App::Property* prop) override;
     void GetPointData();
 
@@ -207,7 +207,7 @@ public:
         return "FemGui::ViewProviderFemPostClip";
     }
     short int mustExecute() const override;
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
 protected:
     void onChanged(const App::Property* prop) override;
@@ -241,7 +241,7 @@ public:
     short int mustExecute() const override;
 
 protected:
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     void onChanged(const App::Property* prop) override;
 
     void recalculateContours(double min, double max);
@@ -280,7 +280,7 @@ public:
         return "FemGui::ViewProviderFemPostCut";
     }
     short int mustExecute() const override;
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
 protected:
     void onChanged(const App::Property* prop) override;
@@ -312,7 +312,7 @@ public:
     short int mustExecute() const override;
 
 protected:
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     void onChanged(const App::Property* prop) override;
     void setConstraintForField();
 
@@ -344,7 +344,7 @@ public:
     short int mustExecute() const override;
 
 protected:
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     void onChanged(const App::Property* prop) override;
 
 private:

--- a/src/Mod/Fem/App/FemPostFunction.cpp
+++ b/src/Mod/Fem/App/FemPostFunction.cpp
@@ -51,9 +51,9 @@ FemPostFunction::FemPostFunction() = default;
 
 FemPostFunction::~FemPostFunction() = default;
 
-DocumentObjectExecReturn* FemPostFunction::execute()
+DocumentObjectExecReturn* FemPostFunction::execute(Base::ProgressRange& progressRange)
 {
-
+    (void)progressRange;
     return DocumentObject::StdReturn;
 }
 

--- a/src/Mod/Fem/App/FemPostFunction.h
+++ b/src/Mod/Fem/App/FemPostFunction.h
@@ -53,7 +53,7 @@ public:
         return "FemGui::ViewProviderFemPostFunction";
     }
 
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     // bound box handling
     void setBoundingBox(vtkBoundingBox b)

--- a/src/Mod/Fem/App/FemPostPipeline.cpp
+++ b/src/Mod/Fem/App/FemPostPipeline.cpp
@@ -88,9 +88,9 @@ short FemPostPipeline::mustExecute() const
     return FemPostObject::mustExecute();
 }
 
-DocumentObjectExecReturn* FemPostPipeline::execute()
+DocumentObjectExecReturn* FemPostPipeline::execute(Base::ProgressRange& progressRange)
 {
-    return Fem::FemPostObject::execute();
+    return Fem::FemPostObject::execute(progressRange);
 }
 
 

--- a/src/Mod/Fem/App/FemPostPipeline.h
+++ b/src/Mod/Fem/App/FemPostPipeline.h
@@ -47,7 +47,7 @@ public:
     App::PropertyEnumeration Mode;
 
     short mustExecute() const override;
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     PyObject* getPyObject() override;
 
     const char* getViewProviderName() const override

--- a/src/Mod/Fem/App/FemResultObject.h
+++ b/src/Mod/Fem/App/FemResultObject.h
@@ -54,8 +54,9 @@ public:
     {
         return "FemGui::ViewProviderResult";
     }
-    App::DocumentObjectExecReturn* execute() override
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return App::DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/Mod/Fem/App/FemSetElementNodesObject.h
+++ b/src/Mod/Fem/App/FemSetElementNodesObject.h
@@ -47,8 +47,9 @@ public:
     {
         return "FemGui::ViewProviderSetElementNodes";
     }
-    App::DocumentObjectExecReturn* execute() override
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return App::DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/Mod/Fem/App/FemSetElementsObject.h
+++ b/src/Mod/Fem/App/FemSetElementsObject.h
@@ -44,8 +44,9 @@ public:
     {
         return "FemGui::ViewProviderSetElements";
     }
-    App::DocumentObjectExecReturn* execute() override
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return App::DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/Mod/Fem/App/FemSetFacesObject.h
+++ b/src/Mod/Fem/App/FemSetFacesObject.h
@@ -44,8 +44,9 @@ public:
     {
         return "FemGui::ViewProviderSetFaces";
     }
-    App::DocumentObjectExecReturn* execute() override
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return App::DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/Mod/Fem/App/FemSetGeometryObject.h
+++ b/src/Mod/Fem/App/FemSetGeometryObject.h
@@ -44,8 +44,9 @@ public:
     {
         return "FemGui::ViewProviderSetGeometry";
     }
-    App::DocumentObjectExecReturn* execute() override
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return App::DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/Mod/Fem/App/FemSetNodesObject.h
+++ b/src/Mod/Fem/App/FemSetNodesObject.h
@@ -47,8 +47,9 @@ public:
     {
         return "FemGui::ViewProviderSetNodes";
     }
-    App::DocumentObjectExecReturn* execute() override
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return App::DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/Mod/Fem/App/FemSetObject.h
+++ b/src/Mod/Fem/App/FemSetObject.h
@@ -46,8 +46,9 @@ public:
     // virtual const char* getViewProviderName(void) const {
     //     return "FemGui::ViewProviderFemSet";
     // }
-    App::DocumentObjectExecReturn* execute() override
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return App::DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/Mod/Fem/App/FemSolverObject.h
+++ b/src/Mod/Fem/App/FemSolverObject.h
@@ -47,8 +47,9 @@ public:
     {
         return "FemGui::ViewProviderSolver";
     }
-    App::DocumentObjectExecReturn* execute() override
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return App::DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -121,6 +121,8 @@ private:
         int mode = -1;
         static const std::array<const char*, 7>
             kwd_list {"name", "docName", "importHidden", "merge", "useLinkGroup", "mode", nullptr};
+        Base::NullProgressRange progressRange;
+
         if (!Base::Wrapped_ParseTupleAndKeywords(args.ptr(),
                                                  kwds.ptr(),
                                                  "et|sO!O!O!i",
@@ -166,7 +168,7 @@ private:
                     Base::Console().Message("Try to load STEP file without colors...\n");
 
                     Part::ImportStepParts(pcDoc, Utf8Name.c_str());
-                    pcDoc->recompute();
+                    pcDoc->recompute(progressRange);
                 }
             }
             else if (file.hasExtension({"igs", "iges"})) {
@@ -179,7 +181,7 @@ private:
                     Base::Console().Message("Try to load IGES file without colors...\n");
 
                     Part::ImportIgesParts(pcDoc, Utf8Name.c_str());
-                    pcDoc->recompute();
+                    pcDoc->recompute(progressRange);
                 }
             }
             else if (file.hasExtension({"glb", "gltf"})) {
@@ -417,7 +419,8 @@ private:
             dxf_file.setOptionSource(defaultOptions);
             dxf_file.setOptions();
             dxf_file.DoRead(IgnoreErrors);
-            pcDoc->recompute();
+            Base::NullProgressRange progressRange;
+            pcDoc->recompute(progressRange);
         }
         catch (const Standard_Failure& e) {
             throw Py::RuntimeError(e.GetMessageString());

--- a/src/Mod/Import/App/ImportOCAF2.cpp
+++ b/src/Mod/Import/App/ImportOCAF2.cpp
@@ -560,7 +560,8 @@ App::DocumentObject* ImportOCAF2::loadShapes()
         }
     }
     if (ret) {
-        ret->recomputeFeature(true);
+        Base::NullProgressRange progressRange;
+        ret->recomputeFeature(progressRange);
     }
     if (options.merge && ret && !ret->isDerivedFrom<Part::Feature>()) {
         auto shape = Part::Feature::getTopoShape(ret);
@@ -578,7 +579,8 @@ App::DocumentObject* ImportOCAF2::loadShapes()
             v.first->removeObject(v.second.c_str());
         }
         ret = feature;
-        ret->recomputeFeature(true);
+        Base::NullProgressRange progressRange;
+        ret->recomputeFeature(progressRange);
     }
     sequencer = nullptr;
     return ret;

--- a/src/Mod/Inspection/App/InspectionFeature.cpp
+++ b/src/Mod/Inspection/App/InspectionFeature.cpp
@@ -790,8 +790,9 @@ short Feature::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn* Feature::execute()
+App::DocumentObjectExecReturn* Feature::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     bool useMultithreading = true;
 
     App::DocumentObject* pcActual = Actual.getValue();

--- a/src/Mod/Inspection/App/InspectionFeature.h
+++ b/src/Mod/Inspection/App/InspectionFeature.h
@@ -261,7 +261,7 @@ public:
     //@{
     short mustExecute() const override;
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 
     /// returns the type name of the ViewProvider

--- a/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/src/Mod/Measure/App/MeasureAngle.cpp
@@ -211,8 +211,9 @@ gp_Vec MeasureAngle::location2()
     return {temp.x, temp.y, temp.z};
 }
 
-App::DocumentObjectExecReturn* MeasureAngle::execute()
+App::DocumentObjectExecReturn* MeasureAngle::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* ob1 = Element1.getValue();
     std::vector<std::string> subs1 = Element1.getSubValues();
 

--- a/src/Mod/Measure/App/MeasureAngle.h
+++ b/src/Mod/Measure/App/MeasureAngle.h
@@ -54,7 +54,7 @@ public:
     App::PropertyLinkSub Element2;
     App::PropertyAngle Angle;
 
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     const char* getViewProviderName() const override
     {

--- a/src/Mod/Measure/App/MeasureArea.cpp
+++ b/src/Mod/Measure/App/MeasureArea.cpp
@@ -94,8 +94,10 @@ void MeasureArea::parseSelection(const App::MeasureSelection& selection)
 }
 
 
-App::DocumentObjectExecReturn* MeasureArea::execute()
+App::DocumentObjectExecReturn* MeasureArea::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
+
     const std::vector<App::DocumentObject*>& objects = Elements.getValues();
     const std::vector<std::string>& subElements = Elements.getSubValues();
 

--- a/src/Mod/Measure/App/MeasureArea.h
+++ b/src/Mod/Measure/App/MeasureArea.h
@@ -52,7 +52,7 @@ public:
     App::PropertyLinkSubList Elements;
     App::PropertyArea Area;
 
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     const char* getViewProviderName() const override
     {

--- a/src/Mod/Measure/App/MeasureDistance.cpp
+++ b/src/Mod/Measure/App/MeasureDistance.cpp
@@ -223,8 +223,9 @@ void MeasureDistance::setValues(const gp_Pnt& p1, const gp_Pnt& p2)
     DistanceZ.setValue(std::fabs(delta.Z()));
 }
 
-App::DocumentObjectExecReturn* MeasureDistance::execute()
+App::DocumentObjectExecReturn* MeasureDistance::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
 
     App::DocumentObject* ob1 = Element1.getValue();
     std::vector<std::string> subs1 = Element1.getSubValues();
@@ -264,7 +265,8 @@ void MeasureDistance::onChanged(const App::Property* prop)
 
     if (prop == &Element1 || prop == &Element2) {
         if (!isRestoring()) {
-            App::DocumentObjectExecReturn* ret = recompute();
+            Base::NullProgressRange progressRange;
+            App::DocumentObjectExecReturn* ret = recompute(progressRange);
             delete ret;
         }
     }
@@ -378,8 +380,9 @@ void MeasureDistanceDetached::parseSelection(const App::MeasureSelection& select
 }
 
 
-App::DocumentObjectExecReturn* MeasureDistanceDetached::execute()
+App::DocumentObjectExecReturn* MeasureDistanceDetached::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     recalculateDistance();
     return DocumentObject::StdReturn;
 }

--- a/src/Mod/Measure/App/MeasureDistance.h
+++ b/src/Mod/Measure/App/MeasureDistance.h
@@ -76,7 +76,7 @@ public:
     App::PropertyVector Position1;
     App::PropertyVector Position2;
 
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     const char* getViewProviderName() const override
     {
@@ -130,7 +130,7 @@ public:
     App::PropertyVector Position1;
     App::PropertyVector Position2;
 
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     void recalculateDistance();
 
     const char* getViewProviderName() const override

--- a/src/Mod/Measure/App/MeasureLength.cpp
+++ b/src/Mod/Measure/App/MeasureLength.cpp
@@ -96,8 +96,10 @@ void MeasureLength::parseSelection(const App::MeasureSelection& selection)
 }
 
 
-App::DocumentObjectExecReturn* MeasureLength::execute()
+App::DocumentObjectExecReturn* MeasureLength::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
+
     const std::vector<App::DocumentObject*>& objects = Elements.getValues();
     const std::vector<std::string>& subElements = Elements.getSubValues();
 
@@ -128,7 +130,8 @@ void MeasureLength::onChanged(const App::Property* prop)
     }
 
     if (prop == &Elements) {
-        auto ret = recompute();
+        Base::NullProgressRange progressRange;
+        auto ret = recompute(progressRange);
         delete ret;
     }
 

--- a/src/Mod/Measure/App/MeasureLength.h
+++ b/src/Mod/Measure/App/MeasureLength.h
@@ -49,7 +49,7 @@ public:
     App::PropertyLinkSubList Elements;
     App::PropertyDistance Length;
 
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     const char* getViewProviderName() const override
     {

--- a/src/Mod/Measure/App/MeasurePosition.cpp
+++ b/src/Mod/Measure/App/MeasurePosition.cpp
@@ -91,8 +91,10 @@ void MeasurePosition::parseSelection(const App::MeasureSelection& selection)
 }
 
 
-App::DocumentObjectExecReturn* MeasurePosition::execute()
+App::DocumentObjectExecReturn* MeasurePosition::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
+
     const App::DocumentObject* object = Element.getValue();
     const std::vector<std::string>& subElements = Element.getSubValues();
 
@@ -116,7 +118,8 @@ void MeasurePosition::onChanged(const App::Property* prop)
     }
 
     if (prop == &Element) {
-        auto ret = recompute();
+        Base::NullProgressRange progressRange;
+        auto ret = recompute(progressRange);
         delete ret;
     }
     DocumentObject::onChanged(prop);

--- a/src/Mod/Measure/App/MeasurePosition.h
+++ b/src/Mod/Measure/App/MeasurePosition.h
@@ -53,7 +53,7 @@ public:
     App::PropertyLinkSub Element;
     App::PropertyPosition Position;
 
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     const char* getViewProviderName() const override
     {

--- a/src/Mod/Measure/App/MeasureRadius.cpp
+++ b/src/Mod/Measure/App/MeasureRadius.cpp
@@ -117,8 +117,10 @@ void MeasureRadius::parseSelection(const App::MeasureSelection& selection)
 }
 
 
-App::DocumentObjectExecReturn* MeasureRadius::execute()
+App::DocumentObjectExecReturn* MeasureRadius::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
+
     auto info = getMeasureInfoFirst();
     if (!info || !info->valid) {
         return new App::DocumentObjectExecReturn("Cannot calculate radius");
@@ -136,7 +138,8 @@ void MeasureRadius::onChanged(const App::Property* prop)
     }
 
     if (prop == &Element) {
-        auto ret = recompute();
+        Base::NullProgressRange progressRange;
+        auto ret = recompute(progressRange);
         delete ret;
     }
 

--- a/src/Mod/Measure/App/MeasureRadius.h
+++ b/src/Mod/Measure/App/MeasureRadius.h
@@ -52,7 +52,7 @@ public:
     App::PropertyLinkSub Element;
     App::PropertyDistance Radius;
 
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     const char* getViewProviderName() const override
     {
         return "MeasureGui::ViewProviderMeasureRadius";

--- a/src/Mod/Mesh/App/FeatureMeshCurvature.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshCurvature.cpp
@@ -50,8 +50,9 @@ short Curvature::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn* Curvature::execute()
+App::DocumentObjectExecReturn* Curvature::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Mesh::Feature* pcFeat = dynamic_cast<Mesh::Feature*>(Source.getValue());
     if (!pcFeat || pcFeat->isError()) {
         return new App::DocumentObjectExecReturn("No mesh object attached.");

--- a/src/Mod/Mesh/App/FeatureMeshCurvature.h
+++ b/src/Mod/Mesh/App/FeatureMeshCurvature.h
@@ -25,6 +25,7 @@
 
 #include <App/DocumentObject.h>
 #include <App/PropertyLinks.h>
+#include <Base/ProgressRange.h>
 
 #include "MeshProperties.h"
 
@@ -49,7 +50,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override

--- a/src/Mod/Mesh/App/FeatureMeshDefects.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshDefects.cpp
@@ -52,8 +52,9 @@ short FixDefects::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn* FixDefects::execute()
+App::DocumentObjectExecReturn* FixDefects::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     return App::DocumentObject::StdReturn;
 }
 
@@ -63,8 +64,9 @@ PROPERTY_SOURCE(Mesh::HarmonizeNormals, Mesh::FixDefects)
 
 HarmonizeNormals::HarmonizeNormals() = default;
 
-App::DocumentObjectExecReturn* HarmonizeNormals::execute()
+App::DocumentObjectExecReturn* HarmonizeNormals::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* link = Source.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No mesh linked");
@@ -87,8 +89,9 @@ PROPERTY_SOURCE(Mesh::FlipNormals, Mesh::FixDefects)
 
 FlipNormals::FlipNormals() = default;
 
-App::DocumentObjectExecReturn* FlipNormals::execute()
+App::DocumentObjectExecReturn* FlipNormals::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* link = Source.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No mesh linked");
@@ -111,8 +114,9 @@ PROPERTY_SOURCE(Mesh::FixNonManifolds, Mesh::FixDefects)
 
 FixNonManifolds::FixNonManifolds() = default;
 
-App::DocumentObjectExecReturn* FixNonManifolds::execute()
+App::DocumentObjectExecReturn* FixNonManifolds::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* link = Source.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No mesh linked");
@@ -135,8 +139,9 @@ PROPERTY_SOURCE(Mesh::FixDuplicatedFaces, Mesh::FixDefects)
 
 FixDuplicatedFaces::FixDuplicatedFaces() = default;
 
-App::DocumentObjectExecReturn* FixDuplicatedFaces::execute()
+App::DocumentObjectExecReturn* FixDuplicatedFaces::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* link = Source.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No mesh linked");
@@ -159,8 +164,9 @@ PROPERTY_SOURCE(Mesh::FixDuplicatedPoints, Mesh::FixDefects)
 
 FixDuplicatedPoints::FixDuplicatedPoints() = default;
 
-App::DocumentObjectExecReturn* FixDuplicatedPoints::execute()
+App::DocumentObjectExecReturn* FixDuplicatedPoints::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* link = Source.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No mesh linked");
@@ -183,8 +189,9 @@ PROPERTY_SOURCE(Mesh::FixDegenerations, Mesh::FixDefects)
 
 FixDegenerations::FixDegenerations() = default;
 
-App::DocumentObjectExecReturn* FixDegenerations::execute()
+App::DocumentObjectExecReturn* FixDegenerations::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* link = Source.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No mesh linked");
@@ -210,8 +217,9 @@ FixDeformations::FixDeformations()
     ADD_PROPERTY(MaxAngle, (5.0F));
 }
 
-App::DocumentObjectExecReturn* FixDeformations::execute()
+App::DocumentObjectExecReturn* FixDeformations::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* link = Source.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No mesh linked");
@@ -235,8 +243,9 @@ PROPERTY_SOURCE(Mesh::FixIndices, Mesh::FixDefects)
 
 FixIndices::FixIndices() = default;
 
-App::DocumentObjectExecReturn* FixIndices::execute()
+App::DocumentObjectExecReturn* FixIndices::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* link = Source.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No mesh linked");
@@ -263,8 +272,9 @@ FillHoles::FillHoles()
     ADD_PROPERTY(MaxArea, (0.1F));
 }
 
-App::DocumentObjectExecReturn* FillHoles::execute()
+App::DocumentObjectExecReturn* FillHoles::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* link = Source.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No mesh linked");
@@ -292,8 +302,9 @@ RemoveComponents::RemoveComponents()
     ADD_PROPERTY(RemoveCompOfSize, (0));
 }
 
-App::DocumentObjectExecReturn* RemoveComponents::execute()
+App::DocumentObjectExecReturn* RemoveComponents::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* link = Source.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No mesh linked");

--- a/src/Mod/Mesh/App/FeatureMeshDefects.h
+++ b/src/Mod/Mesh/App/FeatureMeshDefects.h
@@ -24,6 +24,7 @@
 #define MESH_FEATURE_MESH_DEFECTS_H
 
 #include <App/PropertyLinks.h>
+#include <Base/ProgressRange.h>
 
 #include "MeshFeature.h"
 
@@ -52,7 +53,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
 
@@ -75,7 +76,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 
@@ -94,7 +95,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 
@@ -113,7 +114,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 
@@ -132,7 +133,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 
@@ -151,7 +152,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 
@@ -170,7 +171,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 
@@ -193,7 +194,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 
@@ -212,7 +213,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 
@@ -233,7 +234,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 
@@ -254,7 +255,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     //@}
 };
 

--- a/src/Mod/Mesh/App/FeatureMeshExport.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshExport.cpp
@@ -54,8 +54,9 @@ short Export::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn* Export::execute()
+App::DocumentObjectExecReturn* Export::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Mesh::Feature* pcFeat = dynamic_cast<Mesh::Feature*>(Source.getValue());
     if (!pcFeat || pcFeat->isError()) {
         return new App::DocumentObjectExecReturn("Cannot export invalid mesh feature");

--- a/src/Mod/Mesh/App/FeatureMeshExport.h
+++ b/src/Mod/Mesh/App/FeatureMeshExport.h
@@ -25,6 +25,7 @@
 
 #include <App/DocumentObject.h>
 #include <App/PropertyLinks.h>
+#include <Base/ProgressRange.h>
 
 #ifndef MESH_GLOBAL_H
 #include <Mod/Mesh/MeshGlobal.h>
@@ -55,7 +56,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
 };

--- a/src/Mod/Mesh/App/FeatureMeshImport.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshImport.cpp
@@ -44,8 +44,9 @@ short Mesh::Import::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn* Mesh::Import::execute()
+App::DocumentObjectExecReturn* Mesh::Import::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     std::unique_ptr<MeshObject> apcKernel(new MeshObject());
     apcKernel->load(FileName.getValue());
     Mesh.setValuePtr(apcKernel.release());

--- a/src/Mod/Mesh/App/FeatureMeshImport.h
+++ b/src/Mod/Mesh/App/FeatureMeshImport.h
@@ -26,7 +26,7 @@
 #include "MeshFeature.h"
 
 #include <App/PropertyFile.h>
-
+#include <Base/ProgressRange.h>
 
 namespace Mesh
 {
@@ -48,7 +48,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
 };

--- a/src/Mod/Mesh/App/FeatureMeshSegmentByMesh.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshSegmentByMesh.cpp
@@ -58,8 +58,9 @@ short SegmentByMesh::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn* SegmentByMesh::execute()
+App::DocumentObjectExecReturn* SegmentByMesh::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Mesh::PropertyMeshKernel* kernel = nullptr;
     App::DocumentObject* mesh = Source.getValue();
     if (mesh) {

--- a/src/Mod/Mesh/App/FeatureMeshSegmentByMesh.h
+++ b/src/Mod/Mesh/App/FeatureMeshSegmentByMesh.h
@@ -24,6 +24,7 @@
 #define FEATURE_MESH_SEGMENTBYMESH_H
 
 #include <App/PropertyLinks.h>
+#include <Base/ProgressRange.h>
 
 #include "MeshFeature.h"
 
@@ -52,7 +53,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
 };

--- a/src/Mod/Mesh/App/FeatureMeshSetOperations.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshSetOperations.cpp
@@ -58,8 +58,9 @@ short SetOperations::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn* SetOperations::execute()
+App::DocumentObjectExecReturn* SetOperations::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Mesh::Feature* mesh1 = dynamic_cast<Mesh::Feature*>(Source1.getValue());
     Mesh::Feature* mesh2 = dynamic_cast<Mesh::Feature*>(Source2.getValue());
 

--- a/src/Mod/Mesh/App/FeatureMeshSetOperations.h
+++ b/src/Mod/Mesh/App/FeatureMeshSetOperations.h
@@ -24,6 +24,7 @@
 #define FEATURE_MESH_SETOPERATIONS_H
 
 #include <App/PropertyLinks.h>
+#include <Base/ProgressRange.h>
 
 #include "MeshFeature.h"
 
@@ -50,7 +51,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
 };

--- a/src/Mod/Mesh/App/FeatureMeshSolid.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshSolid.cpp
@@ -54,8 +54,9 @@ short Sphere::mustExecute() const
     return Feature::mustExecute();
 }
 
-App::DocumentObjectExecReturn* Sphere::execute()
+App::DocumentObjectExecReturn* Sphere::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     std::unique_ptr<MeshObject> mesh(
         MeshObject::createSphere((float)Radius.getValue(), Sampling.getValue()));
     if (mesh) {
@@ -103,8 +104,9 @@ short Ellipsoid::mustExecute() const
     return Feature::mustExecute();
 }
 
-App::DocumentObjectExecReturn* Ellipsoid::execute()
+App::DocumentObjectExecReturn* Ellipsoid::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     std::unique_ptr<MeshObject> mesh(MeshObject::createEllipsoid((float)Radius1.getValue(),
                                                                  (float)Radius2.getValue(),
                                                                  Sampling.getValue()));
@@ -158,8 +160,9 @@ short Cylinder::mustExecute() const
     return Feature::mustExecute();
 }
 
-App::DocumentObjectExecReturn* Cylinder::execute()
+App::DocumentObjectExecReturn* Cylinder::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     std::unique_ptr<MeshObject> mesh(MeshObject::createCylinder((float)Radius.getValue(),
                                                                 (float)Length.getValue(),
                                                                 Closed.getValue(),
@@ -217,8 +220,9 @@ short Cone::mustExecute() const
     return Feature::mustExecute();
 }
 
-App::DocumentObjectExecReturn* Cone::execute()
+App::DocumentObjectExecReturn* Cone::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     std::unique_ptr<MeshObject> mesh(MeshObject::createCone((float)Radius1.getValue(),
                                                             (float)Radius2.getValue(),
                                                             (float)Length.getValue(),
@@ -271,8 +275,9 @@ short Torus::mustExecute() const
     return Feature::mustExecute();
 }
 
-App::DocumentObjectExecReturn* Torus::execute()
+App::DocumentObjectExecReturn* Torus::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     std::unique_ptr<MeshObject> mesh(MeshObject::createTorus((float)Radius1.getValue(),
                                                              (float)Radius2.getValue(),
                                                              Sampling.getValue()));
@@ -322,8 +327,9 @@ short Cube::mustExecute() const
     return Feature::mustExecute();
 }
 
-App::DocumentObjectExecReturn* Cube::execute()
+App::DocumentObjectExecReturn* Cube::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     std::unique_ptr<MeshObject> mesh(MeshObject::createCube((float)Length.getValue(),
                                                             (float)Width.getValue(),
                                                             (float)Height.getValue()));

--- a/src/Mod/Mesh/App/FeatureMeshSolid.h
+++ b/src/Mod/Mesh/App/FeatureMeshSolid.h
@@ -26,6 +26,7 @@
 #include "MeshFeature.h"
 
 #include <App/PropertyUnits.h>
+#include <Base/ProgressRange.h>
 
 
 namespace Mesh
@@ -47,7 +48,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     void handleChangedPropertyType(Base::XMLReader& reader,
                                    const char* TypeName,
@@ -71,7 +72,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     void handleChangedPropertyType(Base::XMLReader& reader,
                                    const char* TypeName,
@@ -97,7 +98,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     void handleChangedPropertyType(Base::XMLReader& reader,
                                    const char* TypeName,
@@ -124,7 +125,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     void handleChangedPropertyType(Base::XMLReader& reader,
                                    const char* TypeName,
@@ -148,7 +149,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     void handleChangedPropertyType(Base::XMLReader& reader,
                                    const char* TypeName,
@@ -172,7 +173,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     void handleChangedPropertyType(Base::XMLReader& reader,
                                    const char* TypeName,

--- a/src/Mod/Mesh/App/FeatureMeshTransform.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshTransform.cpp
@@ -39,8 +39,9 @@ Transform::Transform()
     ADD_PROPERTY(Position, (Matrix4D()));
 }
 
-App::DocumentObjectExecReturn* Transform::execute()
+App::DocumentObjectExecReturn* Transform::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     /*
         Feature* pcFirst = dynamic_cast<Feature*>(Source.getValue());
         if (!pcFirst || pcFirst->isError())

--- a/src/Mod/Mesh/App/FeatureMeshTransform.h
+++ b/src/Mod/Mesh/App/FeatureMeshTransform.h
@@ -24,6 +24,7 @@
 #define FEATURE_MESH_TRANSFORM_H
 
 #include <App/PropertyLinks.h>
+#include <Base/ProgressRange.h>
 
 #include "MeshFeature.h"
 
@@ -50,7 +51,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override
     {

--- a/src/Mod/Mesh/App/FeatureMeshTransformDemolding.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshTransformDemolding.cpp
@@ -38,8 +38,10 @@ TransformDemolding::TransformDemolding()
     ADD_PROPERTY(Axis, (0.0, 0.0, 1.0));
 }
 
-App::DocumentObjectExecReturn* TransformDemolding::execute()
-{ /*
+App::DocumentObjectExecReturn* TransformDemolding::execute(Base::ProgressRange& progressRange)
+{
+    (void)progressRange;
+    /*
   Feature *pcFirst  = dynamic_cast<Feature*>(Source.getValue());
   if (!pcFirst || pcFirst->isError())
       return new App::DocumentObjectExecReturn("Unknown Error");

--- a/src/Mod/Mesh/App/FeatureMeshTransformDemolding.h
+++ b/src/Mod/Mesh/App/FeatureMeshTransformDemolding.h
@@ -24,6 +24,7 @@
 #define FEATURE_MESH_TRANSFORM_DEMOLDING_H
 
 #include <App/PropertyLinks.h>
+#include <Base/ProgressRange.h>
 
 #include "FeatureMeshTransform.h"
 
@@ -48,7 +49,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override
     {

--- a/src/Mod/Mesh/App/MeshFeature.cpp
+++ b/src/Mod/Mesh/App/MeshFeature.cpp
@@ -42,8 +42,9 @@ Feature::Feature()
     ADD_PROPERTY_TYPE(Mesh, (MeshObject()), 0, App::Prop_Output, "The mesh kernel");
 }
 
-App::DocumentObjectExecReturn* Feature::execute()
+App::DocumentObjectExecReturn* Feature::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     this->Mesh.touch();
     return App::DocumentObject::StdReturn;
 }

--- a/src/Mod/Mesh/App/MeshFeature.h
+++ b/src/Mod/Mesh/App/MeshFeature.h
@@ -26,6 +26,7 @@
 #include <App/FeatureCustom.h>
 #include <App/FeaturePython.h>
 #include <App/GeoFeature.h>  // must be before FeatureCustom.h
+#include <Base/ProgressRange.h>
 
 #include "Core/MeshKernel.h"
 
@@ -70,7 +71,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     void onChanged(const App::Property* prop) override;
     //@}
 

--- a/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
+++ b/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
@@ -557,7 +557,8 @@ void DlgEvaluateMeshImp::onRepairOrientationButtonClicked()
         }
 
         doc->commitCommand();
-        doc->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        doc->getDocument()->recompute(progressRange);
 
         d->ui.repairOrientationButton->setEnabled(false);
         d->ui.checkOrientationButton->setChecked(false);
@@ -679,7 +680,8 @@ void DlgEvaluateMeshImp::onRepairNonmanifoldsButtonClicked()
         }
 
         doc->commitCommand();
-        doc->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        doc->getDocument()->recompute(progressRange);
 
         d->ui.repairNonmanifoldsButton->setEnabled(false);
         d->ui.checkNonmanifoldsButton->setChecked(false);
@@ -772,7 +774,8 @@ void DlgEvaluateMeshImp::onRepairIndicesButtonClicked()
         }
 
         doc->commitCommand();
-        doc->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        doc->getDocument()->recompute(progressRange);
 
         d->ui.repairIndicesButton->setEnabled(false);
         d->ui.checkIndicesButton->setChecked(false);
@@ -842,7 +845,8 @@ void DlgEvaluateMeshImp::onRepairDegeneratedButtonClicked()
         }
 
         doc->commitCommand();
-        doc->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        doc->getDocument()->recompute(progressRange);
 
         d->ui.repairDegeneratedButton->setEnabled(false);
         d->ui.checkDegenerationButton->setChecked(false);
@@ -913,7 +917,8 @@ void DlgEvaluateMeshImp::onRepairDuplicatedFacesButtonClicked()
         }
 
         doc->commitCommand();
-        doc->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        doc->getDocument()->recompute(progressRange);
 
         d->ui.repairDuplicatedFacesButton->setEnabled(false);
         d->ui.checkDuplicatedFacesButton->setChecked(false);
@@ -982,7 +987,8 @@ void DlgEvaluateMeshImp::onRepairDuplicatedPointsButtonClicked()
         }
 
         doc->commitCommand();
-        doc->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        doc->getDocument()->recompute(progressRange);
 
         d->ui.repairDuplicatedPointsButton->setEnabled(false);
         d->ui.checkDuplicatedPointsButton->setChecked(false);
@@ -1060,7 +1066,8 @@ void DlgEvaluateMeshImp::onRepairSelfIntersectionButtonClicked()
         mesh->removeSelfIntersections(d->self_intersections);
         d->meshFeature->Mesh.finishEditing();
         doc->commitCommand();
-        doc->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        doc->getDocument()->recompute(progressRange);
 
         d->ui.repairSelfIntersectionButton->setEnabled(false);
         d->ui.checkSelfIntersectionButton->setChecked(false);
@@ -1145,7 +1152,8 @@ void DlgEvaluateMeshImp::onRepairFoldsButtonClicked()
         }
 
         doc->commitCommand();
-        doc->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        doc->getDocument()->recompute(progressRange);
 
         qApp->restoreOverrideCursor();
         d->ui.repairFoldsButton->setEnabled(false);
@@ -1282,7 +1290,8 @@ void DlgEvaluateMeshImp::onRepairAllTogetherClicked()
         }
 
         doc->commitCommand();
-        doc->getDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        doc->getDocument()->recompute(progressRange);
     }
     // clang-format on
 }

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -732,12 +732,15 @@ private:
             App::Document *pcDoc = App::GetApplication().newDocument();
             ImportStepParts(pcDoc,EncodedName.c_str());
 
-            pcDoc->recompute();
+            Base::NullProgressRange progressRange;
+            pcDoc->recompute(progressRange);
         }
         else if (file.hasExtension({"igs", "iges"})) {
             App::Document *pcDoc = App::GetApplication().newDocument();
             ImportIgesParts(pcDoc,EncodedName.c_str());
-            pcDoc->recompute();
+
+            Base::NullProgressRange progressRange;
+            pcDoc->recompute(progressRange);
         }
         else {
             TopoShape shape;
@@ -748,7 +751,9 @@ private:
             Part::Feature *object = static_cast<Part::Feature *>(pcDoc->addObject
                 ("Part::Feature",file.fileNamePure().c_str()));
             object->Shape.setValue(shape);
-            pcDoc->recompute();
+
+            Base::NullProgressRange progressRange;
+            pcDoc->recompute(progressRange);
         }
 
         return Py::None();
@@ -778,11 +783,14 @@ private:
         if (file.hasExtension({"stp", "step"})) {
             ImportStepParts(pcDoc,EncodedName.c_str());
 
-            pcDoc->recompute();
+            Base::NullProgressRange progressRange;
+            pcDoc->recompute(progressRange);
         }
         else if (file.hasExtension({"igs", "iges"})) {
             ImportIgesParts(pcDoc,EncodedName.c_str());
-            pcDoc->recompute();
+
+            Base::NullProgressRange progressRange;
+            pcDoc->recompute(progressRange);
         }
         else {
             TopoShape shape;
@@ -791,7 +799,8 @@ private:
             Part::Feature *object = static_cast<Part::Feature *>(pcDoc->addObject
                 ("Part::Feature",file.fileNamePure().c_str()));
             object->Shape.setValue(shape);
-            pcDoc->recompute();
+            Base::NullProgressRange progressRange;
+            pcDoc->recompute(progressRange);
         }
 
         return Py::None();

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -379,7 +379,7 @@ short int AttachExtension::extensionMustExecute()
 }
 
 
-App::DocumentObjectExecReturn* AttachExtension::extensionExecute()
+App::DocumentObjectExecReturn* AttachExtension::extensionExecute(Base::ProgressRange& progressRange)
 {
     if (this->isTouched_Mapping()) {
         try {
@@ -395,7 +395,7 @@ App::DocumentObjectExecReturn* AttachExtension::extensionExecute()
             //            return new App::DocumentObjectExecReturn(e.GetMessageString());
         }
     }
-    return App::DocumentObjectExtension::extensionExecute();
+    return App::DocumentObjectExtension::extensionExecute(progressRange);
 }
 
 void AttachExtension::extensionOnChanged(const App::Property* prop)

--- a/src/Mod/Part/App/AttachExtension.h
+++ b/src/Mod/Part/App/AttachExtension.h
@@ -114,7 +114,7 @@ public:
     }
 
     short int extensionMustExecute() override;
-    App::DocumentObjectExecReturn* extensionExecute() override;
+    App::DocumentObjectExecReturn* extensionExecute(Base::ProgressRange& progressRange) override;
     PyObject* getExtensionPyObject() override;
     void onExtendedDocumentRestored() override;
 

--- a/src/Mod/Part/App/CustomFeature.cpp
+++ b/src/Mod/Part/App/CustomFeature.cpp
@@ -40,8 +40,9 @@ short CustomFeature::mustExecute() const
     return Part::Feature::mustExecute();
 }
 
-App::DocumentObjectExecReturn *CustomFeature::execute()
+App::DocumentObjectExecReturn *CustomFeature::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     return App::DocumentObject::StdReturn;
 }
 

--- a/src/Mod/Part/App/CustomFeature.h
+++ b/src/Mod/Part/App/CustomFeature.h
@@ -44,7 +44,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
 

--- a/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.cpp
+++ b/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.cpp
@@ -147,17 +147,26 @@ void FCBRepAlgoAPI_BooleanOperation::Build(Message_ProgressRange& progressRange)
         if (!myTools.IsEmpty()) {
             myOperation = BOPAlgo_FUSE; // fuse tools together
             Build(progressRange);
+            if (progressRange.UserBreak()) {
+                Standard_ConstructionError::Raise("User aborted");
+            }
             myOperation = BOPAlgo_CUT; // restore
             myArguments = myOriginalArguments;
             if (IsDone()) {
                 myTools.Append(myShape);
                 Build(progressRange); // cut with fused tools
+                if (progressRange.UserBreak()) {
+                    Standard_ConstructionError::Raise("User aborted");
+                }
             }
             myTools = myOriginalTools; //restore
         } else { // there was less than 2 shapes in the compound
             myArguments = myOriginalArguments;
             myTools = myOriginalTools; //restore
             Build(progressRange);
+            if (progressRange.UserBreak()) {
+                Standard_ConstructionError::Raise("User aborted");
+            }
         }
     } else if (myOperation==BOPAlgo_CUT && myArguments.Size()==1 && myArguments.First().ShapeType() == TopAbs_COMPOUND) {
         TopTools_ListOfShape myOriginalArguments = myArguments;

--- a/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.cpp
+++ b/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.cpp
@@ -98,37 +98,8 @@ void FCBRepAlgoAPI_BooleanOperation::RecursiveAddArguments(const TopoDS_Shape& t
 }
 
 void FCBRepAlgoAPI_BooleanOperation::Build() {
-
-    if (myOperation == BOPAlgo_CUT && myArguments.Size() == 1 && myTools.Size() == 1 && myTools.First().ShapeType() == TopAbs_COMPOUND) {
-        TopTools_ListOfShape myOriginalArguments = myArguments;
-        TopTools_ListOfShape myOriginalTools = myTools;
-        TopTools_ListOfShape currentTools;
-        TopTools_ListOfShape currentArguments;
-        myArguments = currentArguments;
-        myTools = currentTools;
-        RecursiveAddArguments(myOriginalTools.First());
-        if (!myTools.IsEmpty()) {
-            myOperation = BOPAlgo_FUSE; // fuse tools together
-            Build();
-            myOperation = BOPAlgo_CUT; // restore
-            myArguments = myOriginalArguments;
-            if (IsDone()) {
-                myTools.Append(myShape);
-                Build(); // cut with fused tools
-            }
-            myTools = myOriginalTools; //restore
-        } else { // there was less than 2 shapes in the compound
-            myArguments = myOriginalArguments;
-            myTools = myOriginalTools; //restore
-            Build();
-        }
-    } else if (myOperation==BOPAlgo_CUT && myArguments.Size()==1 && myArguments.First().ShapeType() == TopAbs_COMPOUND) {
-        TopTools_ListOfShape myOriginalArguments = myArguments;
-        myShape = RecursiveCutCompound(myOriginalArguments.First());
-        myArguments = myOriginalArguments;
-    } else {
-        BRepAlgoAPI_BooleanOperation::Build();
-    }
+    Message_ProgressRange progressRange;
+    FCBRepAlgoAPI_BooleanOperation::Build(progressRange);
 }
 
 void FCBRepAlgoAPI_BooleanOperation::Build(Message_ProgressRange& progressRange) {

--- a/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.h
+++ b/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.h
@@ -51,6 +51,7 @@ public:
 
     // not an override - real Build() has optionals, sadly type of those optionals that are differs between OCCT versions
     Standard_EXPORT virtual void Build(); // NOLINT(clang-diagnostic-overloaded-virtual, -Woverloaded-virtual)
+    Standard_EXPORT virtual void Build(Message_ProgressRange& progressRange);
 
 protected: //! @name Constructors
 

--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -41,7 +41,7 @@ PROPERTY_SOURCE(Part::Chamfer, Part::FilletBase)
 
 Chamfer::Chamfer() = default;
 
-App::DocumentObjectExecReturn *Chamfer::execute()
+App::DocumentObjectExecReturn *Chamfer::execute(Base::ProgressRange& progressRange)
 {
     App::DocumentObject* link = Base.getValue();
     if (!link)
@@ -86,7 +86,7 @@ App::DocumentObjectExecReturn *Chamfer::execute()
 
         TopoShape res(0);
         this->Shape.setValue(res.makeElementShape(mkChamfer,baseTopoShape,Part::OpCodes::Chamfer));
-        return Part::FilletBase::execute();
+        return Part::FilletBase::execute(progressRange);
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());

--- a/src/Mod/Part/App/FeatureChamfer.h
+++ b/src/Mod/Part/App/FeatureChamfer.h
@@ -39,7 +39,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderChamfer";

--- a/src/Mod/Part/App/FeatureCompound.cpp
+++ b/src/Mod/Part/App/FeatureCompound.cpp
@@ -51,7 +51,7 @@ short Compound::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn *Compound::execute()
+App::DocumentObjectExecReturn *Compound::execute(Base::ProgressRange& progressRange)
 {
     try {
         // avoid duplicates without changing the order
@@ -73,7 +73,7 @@ App::DocumentObjectExecReturn *Compound::execute()
             App::DocumentObject* link = Links.getValues()[0];
             copyMaterial(link);
         }
-        return Part::Feature::execute();
+        return Part::Feature::execute(progressRange);
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());
@@ -90,7 +90,8 @@ Compound2::Compound2() {
 
 void Compound2::onDocumentRestored() {
     Base::Placement pla = Placement.getValue();
-    auto res = execute();
+    Base::NullProgressRange progressRange;
+    auto res = execute(progressRange);
     delete res;
     Placement.setValue(pla);
 }

--- a/src/Mod/Part/App/FeatureCompound.h
+++ b/src/Mod/Part/App/FeatureCompound.h
@@ -44,7 +44,7 @@ public:
     //@{
     short mustExecute() const override;
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderCompound";

--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -353,8 +353,9 @@ void Extrusion::extrudeShape(TopoShape &result, const TopoShape &source, const E
     }
 }
 
-App::DocumentObjectExecReturn* Extrusion::execute()
+App::DocumentObjectExecReturn* Extrusion::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* link = Base.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No object linked");

--- a/src/Mod/Part/App/FeatureExtrusion.h
+++ b/src/Mod/Part/App/FeatureExtrusion.h
@@ -57,7 +57,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/Part/App/FeatureFace.cpp
+++ b/src/Mod/Part/App/FeatureFace.cpp
@@ -57,8 +57,9 @@ void Face::setupObject()
     Feature::setupObject();
 }
 
-App::DocumentObjectExecReturn *Face::execute()
+App::DocumentObjectExecReturn *Face::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     std::vector<App::DocumentObject*> links = Sources.getValues();
     if (links.empty())
         return new App::DocumentObjectExecReturn("No shapes linked");

--- a/src/Mod/Part/App/FeatureFace.h
+++ b/src/Mod/Part/App/FeatureFace.h
@@ -42,7 +42,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {

--- a/src/Mod/Part/App/FeatureFillet.cpp
+++ b/src/Mod/Part/App/FeatureFillet.cpp
@@ -43,7 +43,7 @@ PROPERTY_SOURCE(Part::Fillet, Part::FilletBase)
 
 Fillet::Fillet() = default;
 
-App::DocumentObjectExecReturn *Fillet::execute()
+App::DocumentObjectExecReturn *Fillet::execute(Base::ProgressRange& progressRange)
 {
     App::DocumentObject* link = Base.getValue();
     if (!link)
@@ -90,7 +90,7 @@ App::DocumentObjectExecReturn *Fillet::execute()
 
         TopoShape res(0);
         this->Shape.setValue(res.makeElementShape(mkFillet,baseTopoShape,Part::OpCodes::Fillet));
-        return Part::FilletBase::execute();
+        return Part::FilletBase::execute(progressRange);
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());

--- a/src/Mod/Part/App/FeatureFillet.h
+++ b/src/Mod/Part/App/FeatureFillet.h
@@ -39,7 +39,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderFillet";

--- a/src/Mod/Part/App/FeatureGeometrySet.cpp
+++ b/src/Mod/Part/App/FeatureGeometrySet.cpp
@@ -37,8 +37,9 @@ FeatureGeometrySet::FeatureGeometrySet()
 }
 
 
-App::DocumentObjectExecReturn *FeatureGeometrySet::execute()
+App::DocumentObjectExecReturn *FeatureGeometrySet::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     TopoShape result;
 
     const std::vector<Geometry*> &Geoms = GeometrySet.getValues();

--- a/src/Mod/Part/App/FeatureGeometrySet.h
+++ b/src/Mod/Part/App/FeatureGeometrySet.h
@@ -42,7 +42,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
      /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderGeometrySet";

--- a/src/Mod/Part/App/FeatureMirroring.cpp
+++ b/src/Mod/Part/App/FeatureMirroring.cpp
@@ -101,7 +101,8 @@ void Mirroring::onChanged(const App::Property* prop)
         }
         if (needsRecompute){
             try {
-                App::DocumentObjectExecReturn *ret = recompute();
+                Base::NullProgressRange progressRange;
+                App::DocumentObjectExecReturn *ret = recompute(progressRange);
                 delete ret;
             }
             catch (...) {
@@ -132,7 +133,7 @@ void Mirroring::handleChangedPropertyType(Base::XMLReader &reader, const char *T
     }
 }
 
-App::DocumentObjectExecReturn *Mirroring::execute()
+App::DocumentObjectExecReturn *Mirroring::execute(Base::ProgressRange& progressRange)
 {
     App::DocumentObject* link = Source.getValue();
     if (!link)
@@ -259,7 +260,7 @@ App::DocumentObjectExecReturn *Mirroring::execute()
         this->Shape.setValue(TopoShape(0).makeElementMirror(shape,ax2));
         copyMaterial(link);
 
-        return Part::Feature::execute();
+        return Part::Feature::execute(progressRange);
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());

--- a/src/Mod/Part/App/FeatureMirroring.h
+++ b/src/Mod/Part/App/FeatureMirroring.h
@@ -46,7 +46,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {

--- a/src/Mod/Part/App/FeatureOffset.cpp
+++ b/src/Mod/Part/App/FeatureOffset.cpp
@@ -74,8 +74,9 @@ short Offset::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn *Offset::execute()
+App::DocumentObjectExecReturn *Offset::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* source = Source.getValue();
     if (!source)
         return new App::DocumentObjectExecReturn("No source shape linked.");
@@ -125,8 +126,9 @@ short Offset2D::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn *Offset2D::execute()
+App::DocumentObjectExecReturn *Offset2D::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* source = Source.getValue();
 
     if (!source) {

--- a/src/Mod/Part/App/FeatureOffset.h
+++ b/src/Mod/Part/App/FeatureOffset.h
@@ -50,7 +50,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderOffset";
@@ -72,7 +72,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderOffset2D";

--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -101,7 +101,7 @@ const char *Boolean::opCode() const
     return Part::OpCodes::Boolean;
 }
 
-App::DocumentObjectExecReturn* Boolean::execute()
+App::DocumentObjectExecReturn* Boolean::execute(Base::ProgressRange& progressRange)
 {
     try {
 #if defined(__GNUC__) && defined(FC_OS_LINUX)
@@ -153,7 +153,7 @@ App::DocumentObjectExecReturn* Boolean::execute()
         }
         this->Shape.setValue(res);
         copyMaterial(base);
-        return Part::Feature::execute();
+        return Part::Feature::execute(progressRange);
     }
     catch (const Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());

--- a/src/Mod/Part/App/FeaturePartBoolean.h
+++ b/src/Mod/Part/App/FeaturePartBoolean.h
@@ -47,7 +47,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
 

--- a/src/Mod/Part/App/FeaturePartBox.cpp
+++ b/src/Mod/Part/App/FeaturePartBox.cpp
@@ -52,7 +52,7 @@ short Box::mustExecute() const
     return Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Box::execute()
+App::DocumentObjectExecReturn *Box::execute(Base::ProgressRange& progressRange)
 {
     double L = Length.getValue();
     double W = Width.getValue();
@@ -72,7 +72,7 @@ App::DocumentObjectExecReturn *Box::execute()
         BRepPrimAPI_MakeBox mkBox(L, W, H);
         TopoDS_Shape ResultShape = mkBox.Shape();
         this->Shape.setValue(ResultShape, false);
-        return Primitive::execute();
+        return Primitive::execute(progressRange);
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());
@@ -224,7 +224,8 @@ void Box::onChanged(const App::Property* prop)
 {
     if (prop == &Length || prop == &Width || prop == &Height) {
         if (!isRestoring()) {
-            App::DocumentObjectExecReturn *ret = recompute();
+            Base::NullProgressRange progressRange;
+            App::DocumentObjectExecReturn *ret = recompute(progressRange);
             delete ret;
         }
     }
@@ -232,7 +233,8 @@ void Box::onChanged(const App::Property* prop)
         // see Box::Restore
         if (this->Shape.testStatus(App::Property::User1)) {
             this->Shape.setStatus(App::Property::User1, false);
-            App::DocumentObjectExecReturn *ret = recompute();
+            Base::NullProgressRange progressRange;
+            App::DocumentObjectExecReturn *ret = recompute(progressRange);
             delete ret;
             return;
         }

--- a/src/Mod/Part/App/FeaturePartBox.h
+++ b/src/Mod/Part/App/FeaturePartBox.h
@@ -44,7 +44,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {

--- a/src/Mod/Part/App/FeaturePartCircle.cpp
+++ b/src/Mod/Part/App/FeaturePartCircle.cpp
@@ -59,7 +59,7 @@ short Circle::mustExecute() const
     return Part::Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Circle::execute()
+App::DocumentObjectExecReturn *Circle::execute(Base::ProgressRange& progressRange)
 {
     gp_Circ circle;
     circle.SetRadius(this->Radius.getValue());
@@ -68,7 +68,7 @@ App::DocumentObjectExecReturn *Circle::execute()
                                                Base::toRadians<double>(this->Angle2.getValue()));
     const TopoDS_Edge& edge = clMakeEdge.Edge();
     this->Shape.setValue(edge);
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 void Circle::onChanged(const App::Property* prop)
@@ -76,7 +76,8 @@ void Circle::onChanged(const App::Property* prop)
     if (!isRestoring()) {
         if (prop == &Radius || prop == &Angle1 || prop == &Angle2){
             try {
-                App::DocumentObjectExecReturn *ret = recompute();
+                Base::NullProgressRange progressRange;
+                App::DocumentObjectExecReturn *ret = recompute(progressRange);
                 delete ret;
             }
             catch (...) {

--- a/src/Mod/Part/App/FeaturePartCircle.h
+++ b/src/Mod/Part/App/FeaturePartCircle.h
@@ -45,7 +45,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     void onChanged(const App::Property*) override;
     /// returns the type name of the ViewProvider

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -84,7 +84,7 @@ short MultiCommon::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn *MultiCommon::execute()
+App::DocumentObjectExecReturn *MultiCommon::execute(Base::ProgressRange& progressRange)
 {
     std::vector<TopoShape> shapes;
     for (auto obj : Shapes.getValues()) {
@@ -112,5 +112,5 @@ App::DocumentObjectExecReturn *MultiCommon::execute()
         copyMaterial(link);
     }
 
-    return Part::Feature::execute();
+    return Part::Feature::execute(progressRange);
 }

--- a/src/Mod/Part/App/FeaturePartCommon.h
+++ b/src/Mod/Part/App/FeaturePartCommon.h
@@ -59,7 +59,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
     /// returns the type name of the ViewProvider

--- a/src/Mod/Part/App/FeaturePartCurveNet.cpp
+++ b/src/Mod/Part/App/FeaturePartCurveNet.cpp
@@ -43,8 +43,9 @@ short CurveNet::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn *CurveNet::execute()
+App::DocumentObjectExecReturn *CurveNet::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Base::FileInfo fi(FileName.getValue());
     if (!fi.isReadable()) {
         Base::Console().Log("CurveNet::execute() not able to open %s!\n",FileName.getValue());

--- a/src/Mod/Part/App/FeaturePartCurveNet.h
+++ b/src/Mod/Part/App/FeaturePartCurveNet.h
@@ -41,7 +41,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -86,7 +86,7 @@ short MultiFuse::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn *MultiFuse::execute()
+App::DocumentObjectExecReturn *MultiFuse::execute(Base::ProgressRange& progressRange)
 {
     std::vector<TopoShape> shapes;
     std::vector<App::DocumentObject*> obj = Shapes.getValues();
@@ -204,7 +204,7 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
 
             App::DocumentObject* link = Shapes.getValues()[0];
             copyMaterial(link);
-            return Part::Feature::execute();
+            return Part::Feature::execute(progressRange);
         }
         catch (Standard_Failure& e) {
             return new App::DocumentObjectExecReturn(e.GetMessageString());

--- a/src/Mod/Part/App/FeaturePartFuse.h
+++ b/src/Mod/Part/App/FeaturePartFuse.h
@@ -59,7 +59,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
     /// returns the type name of the ViewProvider

--- a/src/Mod/Part/App/FeaturePartImportBrep.cpp
+++ b/src/Mod/Part/App/FeaturePartImportBrep.cpp
@@ -48,8 +48,9 @@ short ImportBrep::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn *ImportBrep::execute()
+App::DocumentObjectExecReturn *ImportBrep::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Base::FileInfo fi(FileName.getValue());
     if (!fi.isReadable()) {
         Base::Console().Log("ImportBrep::execute() not able to open %s!\n",FileName.getValue());

--- a/src/Mod/Part/App/FeaturePartImportBrep.h
+++ b/src/Mod/Part/App/FeaturePartImportBrep.h
@@ -41,7 +41,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {

--- a/src/Mod/Part/App/FeaturePartImportIges.cpp
+++ b/src/Mod/Part/App/FeaturePartImportIges.cpp
@@ -48,8 +48,9 @@ short ImportIges::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn *ImportIges::execute()
+App::DocumentObjectExecReturn *ImportIges::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Base::FileInfo fi(FileName.getValue());
     if (!fi.isReadable()) {
         Base::Console().Log("ImportIges::execute() not able to open %s!\n",FileName.getValue());

--- a/src/Mod/Part/App/FeaturePartImportIges.h
+++ b/src/Mod/Part/App/FeaturePartImportIges.h
@@ -41,7 +41,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {

--- a/src/Mod/Part/App/FeaturePartImportStep.cpp
+++ b/src/Mod/Part/App/FeaturePartImportStep.cpp
@@ -48,8 +48,9 @@ short ImportStep::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn *ImportStep::execute()
+App::DocumentObjectExecReturn *ImportStep::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Base::FileInfo fi(FileName.getValue());
     if (!fi.isReadable()) {
         Base::Console().Log("ImportStep::execute() not able to open %s!\n",FileName.getValue());

--- a/src/Mod/Part/App/FeaturePartImportStep.h
+++ b/src/Mod/Part/App/FeaturePartImportStep.h
@@ -43,7 +43,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {

--- a/src/Mod/Part/App/FeaturePartPolygon.cpp
+++ b/src/Mod/Part/App/FeaturePartPolygon.cpp
@@ -48,8 +48,9 @@ short Part::Polygon::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn *Part::Polygon::execute()
+App::DocumentObjectExecReturn *Part::Polygon::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     BRepBuilderAPI_MakePolygon poly;
     const std::vector<Base::Vector3d> nodes = Nodes.getValues();
 

--- a/src/Mod/Part/App/FeaturePartPolygon.h
+++ b/src/Mod/Part/App/FeaturePartPolygon.h
@@ -45,7 +45,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
 };

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -65,8 +65,9 @@ ProjectOnSurface::ProjectOnSurface()
     ADD_PROPERTY_TYPE(Projection,(nullptr), "Projection", App::Prop_None, "Shapes to project onto support face");
 }
 
-App::DocumentObjectExecReturn* ProjectOnSurface::execute()
+App::DocumentObjectExecReturn* ProjectOnSurface::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     try {
         tryExecute();
         return App::DocumentObject::StdReturn;

--- a/src/Mod/Part/App/FeatureProjectOnSurface.h
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.h
@@ -54,7 +54,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     const char* getViewProviderName() const override;
     //@}
 

--- a/src/Mod/Part/App/FeatureRevolution.cpp
+++ b/src/Mod/Part/App/FeatureRevolution.cpp
@@ -121,7 +121,7 @@ bool Revolution::fetchAxisLink(const App::PropertyLinkSub &axisLink,
     return true;
 }
 
-App::DocumentObjectExecReturn *Revolution::execute()
+App::DocumentObjectExecReturn *Revolution::execute(Base::ProgressRange& progressRange)
 {
     App::DocumentObject* link = Source.getValue();
     if (!link)
@@ -165,7 +165,7 @@ App::DocumentObjectExecReturn *Revolution::execute()
             return new App::DocumentObjectExecReturn("Resulting shape is null");
         }
         this->Shape.setValue(revolve);
-        return Part::Feature::execute();
+        return Part::Feature::execute(progressRange);
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());

--- a/src/Mod/Part/App/FeatureRevolution.h
+++ b/src/Mod/Part/App/FeatureRevolution.h
@@ -51,7 +51,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
 
     void onChanged(const App::Property* prop) override;

--- a/src/Mod/Part/App/FeatureScale.cpp
+++ b/src/Mod/Part/App/FeatureScale.cpp
@@ -142,8 +142,9 @@ TopoShape Scale::nonuniformScale(const TopoShape& source, const Scale::ScalePara
     return transTopo;
 }
 
-App::DocumentObjectExecReturn* Scale::execute()
+App::DocumentObjectExecReturn* Scale::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
 //    Base::Console().Message("FS::execute()\n");
     App::DocumentObject* link = Base.getValue();
     if (!link)

--- a/src/Mod/Part/App/FeatureScale.h
+++ b/src/Mod/Part/App/FeatureScale.h
@@ -62,7 +62,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/Part/App/Part2DObject.cpp
+++ b/src/Mod/Part/App/Part2DObject.cpp
@@ -64,9 +64,9 @@ Part2DObject::Part2DObject()
 }
 
 
-App::DocumentObjectExecReturn *Part2DObject::execute()
+App::DocumentObjectExecReturn *Part2DObject::execute(Base::ProgressRange& progressRange)
 {
-    return Feature::execute();
+    return Feature::execute(progressRange);
 }
 
 void Part2DObject::transformPlacement(const Base::Placement &transform)

--- a/src/Mod/Part/App/Part2DObject.h
+++ b/src/Mod/Part/App/Part2DObject.h
@@ -85,7 +85,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -101,10 +101,10 @@ short Feature::mustExecute() const
     return GeoFeature::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Feature::recompute()
+App::DocumentObjectExecReturn *Feature::recompute(Base::ProgressRange& progressRange)
 {
     try {
-        return App::GeoFeature::recompute();
+        return App::GeoFeature::recompute(progressRange);
     }
     catch (Standard_Failure& e) {
 
@@ -114,10 +114,10 @@ App::DocumentObjectExecReturn *Feature::recompute()
     }
 }
 
-App::DocumentObjectExecReturn *Feature::execute()
+App::DocumentObjectExecReturn *Feature::execute(Base::ProgressRange& progressRange)
 {
     this->Shape.touch();
-    return GeoFeature::execute();
+    return GeoFeature::execute(progressRange);
 }
 
 PyObject *Feature::getPyObject()
@@ -1765,14 +1765,14 @@ short FilletBase::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn* FilletBase::execute()
+App::DocumentObjectExecReturn* FilletBase::execute(Base::ProgressRange& progressRange)
 {
     App::DocumentObject* link = this->Base.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No object linked");
     }
     copyMaterial(link);
-    return Part::Feature::execute();
+    return Part::Feature::execute(progressRange);
 }
 
 void FilletBase::onChanged(const App::Property *prop) {

--- a/src/Mod/Part/App/PartFeature.h
+++ b/src/Mod/Part/App/PartFeature.h
@@ -163,9 +163,9 @@ public:
                                                        double atol = 1e-10) const override;
 protected:
     /// recompute only this object
-    App::DocumentObjectExecReturn *recompute() override;
+    App::DocumentObjectExecReturn *recompute(Base::ProgressRange& progressRange) override;
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     void onBeforeChange(const App::Property* prop) override;
     void onChanged(const App::Property* prop) override;
     void onDocumentRestored() override;
@@ -214,7 +214,7 @@ public:
     App::PropertyLinkSub   EdgeLinks;
 
     short mustExecute() const override;
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     void onUpdateElementReference(const App::Property* prop) override;
 
 protected:

--- a/src/Mod/Part/App/PartFeatureReference.cpp
+++ b/src/Mod/Part/App/PartFeatureReference.cpp
@@ -49,8 +49,9 @@ short FeatureReference::mustExecute() const
     return GeoFeature::mustExecute();
 }
 
-App::DocumentObjectExecReturn *FeatureReference::execute()
+App::DocumentObjectExecReturn *FeatureReference::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     return App::DocumentObject::StdReturn;
 }
 

--- a/src/Mod/Part/App/PartFeatureReference.h
+++ b/src/Mod/Part/App/PartFeatureReference.h
@@ -49,7 +49,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
 

--- a/src/Mod/Part/App/PartFeatures.cpp
+++ b/src/Mod/Part/App/PartFeatures.cpp
@@ -120,7 +120,7 @@ App::DocumentObjectExecReturn* RuledSurface::getShape(const App::PropertyLinkSub
     return nullptr;
 }
 
-App::DocumentObjectExecReturn* RuledSurface::execute()
+App::DocumentObjectExecReturn* RuledSurface::execute(Base::ProgressRange& progressRange)
 {
     try {
         std::vector<TopoShape> shapes;
@@ -149,7 +149,7 @@ App::DocumentObjectExecReturn* RuledSurface::execute()
         TopoShape res(0);
         res.makeElementRuledSurface(shapes, Orientation.getValue());
         this->Shape.setValue(res);
-        return Part::Feature::execute();
+        return Part::Feature::execute(progressRange);
 
     }
     catch (Standard_Failure& e) {
@@ -207,7 +207,7 @@ void Loft::onChanged(const App::Property* prop)
     Part::Feature::onChanged(prop);
 }
 
-App::DocumentObjectExecReturn* Loft::execute()
+App::DocumentObjectExecReturn* Loft::execute(Base::ProgressRange& progressRange)
 {
     if (Sections.getSize() == 0) {
         return new App::DocumentObjectExecReturn("No sections linked.");
@@ -231,7 +231,7 @@ App::DocumentObjectExecReturn* Loft::execute()
             result.linearize( LinearizeFace::linearizeFaces, LinearizeEdge::noEdges);
         }
         this->Shape.setValue(result);
-        return Part::Feature::execute();
+        return Part::Feature::execute(progressRange);
     }
     catch (Standard_Failure& e) {
 
@@ -292,8 +292,9 @@ void Sweep::onChanged(const App::Property* prop)
     Part::Feature::onChanged(prop);
 }
 
-App::DocumentObjectExecReturn* Sweep::execute()
+App::DocumentObjectExecReturn* Sweep::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     if (Sections.getSize() == 0) {
         return new App::DocumentObjectExecReturn("No sections linked.");
     }
@@ -412,7 +413,7 @@ void Thickness::handleChangedPropertyType(Base::XMLReader& reader,
     }
 }
 
-App::DocumentObjectExecReturn* Thickness::execute()
+App::DocumentObjectExecReturn* Thickness::execute(Base::ProgressRange& progressRange)
 {
     std::vector<TopoShape> shapes;
     auto base = getTopoShape(Faces.getValue());
@@ -444,7 +445,7 @@ App::DocumentObjectExecReturn* Thickness::execute()
                                                     self,
                                                     mode,
                                                     static_cast<JoinType>(join)));
-    return Part::Feature::execute();
+    return Part::Feature::execute(progressRange);
 }
 
 // ----------------------------------------------------------------------------
@@ -456,8 +457,9 @@ Refine::Refine()
     ADD_PROPERTY_TYPE(Source, (nullptr), "Refine", App::Prop_None, "Source shape");
 }
 
-App::DocumentObjectExecReturn* Refine::execute()
+App::DocumentObjectExecReturn* Refine::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Part::Feature* source = Source.getValue<Part::Feature*>();
     if (!source) {
         return new App::DocumentObjectExecReturn("No part object linked.");
@@ -482,8 +484,9 @@ Reverse::Reverse()
     ADD_PROPERTY_TYPE(Source, (nullptr), "Reverse", App::Prop_None, "Source shape");
 }
 
-App::DocumentObjectExecReturn* Reverse::execute()
+App::DocumentObjectExecReturn* Reverse::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     App::DocumentObject* source = Source.getValue<App::DocumentObject*>();
     Part::TopoShape topoShape = Part::Feature::getTopoShape(source);
     if (topoShape.isNull()) {

--- a/src/Mod/Part/App/PartFeatures.h
+++ b/src/Mod/Part/App/PartFeatures.h
@@ -46,7 +46,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderRuledSurface";
@@ -81,7 +81,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderLoft";
@@ -113,7 +113,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderSweep";
@@ -145,7 +145,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderThickness";
@@ -172,7 +172,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderRefine";
     }
@@ -191,7 +191,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderReverse";
     }

--- a/src/Mod/Part/App/PrimitiveFeature.cpp
+++ b/src/Mod/Part/App/PrimitiveFeature.cpp
@@ -78,8 +78,8 @@ short Primitive::mustExecute() const
     return Feature::mustExecute();
 }
 
-App::DocumentObjectExecReturn* Primitive::execute() {
-    return Part::Feature::execute();
+App::DocumentObjectExecReturn* Primitive::execute(Base::ProgressRange& progressRange) {
+    return Part::Feature::execute(progressRange);
 }
 
 // suppress warning about tp_print for Py3.8
@@ -140,7 +140,8 @@ void Primitive::onChanged(const App::Property* prop)
         std::string grp = (prop->getGroup() ? prop->getGroup() : "");
         if (grp == "Plane" || grp == "Cylinder" || grp == "Cone") {
             try {
-                App::DocumentObjectExecReturn *ret = recompute();
+                Base::NullProgressRange progressRange;
+                App::DocumentObjectExecReturn *ret = recompute(progressRange);
                 delete ret;
             }
             catch (...) {
@@ -170,7 +171,7 @@ short Vertex::mustExecute() const
     return Part::Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Vertex::execute()
+App::DocumentObjectExecReturn *Vertex::execute(Base::ProgressRange& progressRange)
 {
     gp_Pnt point;
     point.SetX(this->X.getValue());
@@ -181,7 +182,7 @@ App::DocumentObjectExecReturn *Vertex::execute()
     const TopoDS_Vertex& vertex = MakeVertex.Vertex();
     this->Shape.setValue(vertex);
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 
@@ -190,7 +191,8 @@ void Vertex::onChanged(const App::Property* prop)
     if (!isRestoring()) {
         if (prop == &X || prop == &Y || prop == &Z){
             try {
-                App::DocumentObjectExecReturn *ret = recompute();
+                Base::NullProgressRange progressRange;
+                App::DocumentObjectExecReturn *ret = recompute(progressRange);
                 delete ret;
             }
             catch (...) {
@@ -226,7 +228,7 @@ short Line::mustExecute() const
     return Part::Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Line::execute()
+App::DocumentObjectExecReturn *Line::execute(Base::ProgressRange& progressRange)
 {
     gp_Pnt point1;
     point1.SetX(this->X1.getValue());
@@ -244,7 +246,7 @@ App::DocumentObjectExecReturn *Line::execute()
     const TopoDS_Edge& edge = mkEdge.Edge();
     this->Shape.setValue(edge);
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 void Line::onChanged(const App::Property* prop)
@@ -252,7 +254,8 @@ void Line::onChanged(const App::Property* prop)
     if (!isRestoring()) {
         if (prop == &X1 || prop == &Y1 || prop == &Z1 || prop == &X2 || prop == &Y2 || prop == &Z2){
             try {
-                App::DocumentObjectExecReturn *ret = recompute();
+                Base::NullProgressRange progressRange;
+                App::DocumentObjectExecReturn *ret = recompute(progressRange);
                 delete ret;
             }
             catch (...) {
@@ -278,7 +281,7 @@ short Plane::mustExecute() const
     return Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Plane::execute()
+App::DocumentObjectExecReturn *Plane::execute(Base::ProgressRange& progressRange)
 {
     double L = this->Length.getValue();
     double W = this->Width.getValue();
@@ -321,7 +324,7 @@ App::DocumentObjectExecReturn *Plane::execute()
     TopoDS_Shape ResultShape = mkFace.Shape();
     this->Shape.setValue(ResultShape);
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 PROPERTY_SOURCE(Part::Sphere, Part::Primitive)
@@ -351,7 +354,7 @@ short Sphere::mustExecute() const
     return Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Sphere::execute()
+App::DocumentObjectExecReturn *Sphere::execute(Base::ProgressRange& progressRange)
 {
     // Build a sphere
     if (Radius.getValue() < Precision::Confusion())
@@ -369,7 +372,7 @@ App::DocumentObjectExecReturn *Sphere::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 PROPERTY_SOURCE(Part::Ellipsoid, Part::Primitive)
@@ -407,7 +410,7 @@ short Ellipsoid::mustExecute() const
     return Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Ellipsoid::execute()
+App::DocumentObjectExecReturn *Ellipsoid::execute(Base::ProgressRange& progressRange)
 {
     // Build a sphere
     if (Radius1.getValue() < Precision::Confusion())
@@ -451,7 +454,7 @@ App::DocumentObjectExecReturn *Ellipsoid::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 PROPERTY_SOURCE(Part::Cylinder, Part::Primitive)
@@ -477,7 +480,7 @@ short Cylinder::mustExecute() const
     return Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Cylinder::execute()
+App::DocumentObjectExecReturn *Cylinder::execute(Base::ProgressRange& progressRange)
 {
     // Build a cylinder
     if (Radius.getValue() < Precision::Confusion())
@@ -500,7 +503,7 @@ App::DocumentObjectExecReturn *Cylinder::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 App::PropertyIntegerConstraint::Constraints Prism::polygonRange = {3,INT_MAX,1};
@@ -528,7 +531,7 @@ short Prism::mustExecute() const
     return Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Prism::execute()
+App::DocumentObjectExecReturn *Prism::execute(Base::ProgressRange& progressRange)
 {
     // Build a prism
     if (Polygon.getValue() < 3)
@@ -559,7 +562,7 @@ App::DocumentObjectExecReturn *Prism::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 App::PropertyIntegerConstraint::Constraints RegularPolygon::polygon = {3,INT_MAX,1};
@@ -582,7 +585,7 @@ short RegularPolygon::mustExecute() const
     return Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *RegularPolygon::execute()
+App::DocumentObjectExecReturn *RegularPolygon::execute(Base::ProgressRange& progressRange)
 {
     // Build a regular polygon
     if (Polygon.getValue() < 3)
@@ -611,7 +614,7 @@ App::DocumentObjectExecReturn *RegularPolygon::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 
@@ -639,7 +642,7 @@ short Cone::mustExecute() const
     return Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Cone::execute()
+App::DocumentObjectExecReturn *Cone::execute(Base::ProgressRange& progressRange)
 {
     if (Radius1.getValue() < 0)
         return new App::DocumentObjectExecReturn("Radius of cone too small");
@@ -670,7 +673,7 @@ App::DocumentObjectExecReturn *Cone::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 PROPERTY_SOURCE(Part::Torus, Part::Primitive)
@@ -704,7 +707,7 @@ short Torus::mustExecute() const
     return Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Torus::execute()
+App::DocumentObjectExecReturn *Torus::execute(Base::ProgressRange& progressRange)
 {
     if (Radius1.getValue() < Precision::Confusion())
         return new App::DocumentObjectExecReturn("Radius of torus too small");
@@ -722,7 +725,7 @@ App::DocumentObjectExecReturn *Torus::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 PROPERTY_SOURCE(Part::Helix, Part::Primitive)
@@ -757,7 +760,8 @@ void Helix::onChanged(const App::Property* prop)
             prop == &Angle || prop == &LocalCoord || prop == &Style ||
             prop == &SegmentLength) {
             try {
-                App::DocumentObjectExecReturn *ret = recompute();
+                Base::NullProgressRange progressRange;
+                App::DocumentObjectExecReturn *ret = recompute(progressRange);
                 delete ret;
             }
             catch (...) {
@@ -784,7 +788,7 @@ short Helix::mustExecute() const
     return Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Helix::execute()
+App::DocumentObjectExecReturn *Helix::execute(Base::ProgressRange& progressRange)
 {
     try {
         Standard_Real myPitch  = Pitch.getValue();
@@ -813,7 +817,7 @@ App::DocumentObjectExecReturn *Helix::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 PROPERTY_SOURCE(Part::Spiral, Part::Primitive)
@@ -838,7 +842,8 @@ void Spiral::onChanged(const App::Property* prop)
         if (prop == &Growth || prop == &Rotations || prop == &Radius ||
             prop == &SegmentLength) {
             try {
-                App::DocumentObjectExecReturn *ret = recompute();
+                Base::NullProgressRange progressRange;
+                App::DocumentObjectExecReturn *ret = recompute(progressRange);
                 delete ret;
             }
             catch (...) {
@@ -859,7 +864,7 @@ short Spiral::mustExecute() const
     return Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Spiral::execute()
+App::DocumentObjectExecReturn *Spiral::execute(Base::ProgressRange& progressRange)
 {
     try {
         Standard_Real myNumRot = Rotations.getValue();
@@ -875,7 +880,7 @@ App::DocumentObjectExecReturn *Spiral::execute()
         GProp_GProps props;
         BRepGProp::LinearProperties(Shape.getShape().getShape(), props);
         Length.setValue(props.Mass());
-        return Primitive::execute();
+        return Primitive::execute(progressRange);
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());
@@ -914,7 +919,7 @@ short Wedge::mustExecute() const
     return Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Wedge::execute()
+App::DocumentObjectExecReturn *Wedge::execute(Base::ProgressRange& progressRange)
 {
     double xmin = Xmin.getValue();
     double ymin = Ymin.getValue();
@@ -963,7 +968,7 @@ App::DocumentObjectExecReturn *Wedge::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 void Wedge::onChanged(const App::Property* prop)
@@ -973,7 +978,8 @@ void Wedge::onChanged(const App::Property* prop)
         prop == &Xmax || prop == &Ymax || prop == &Zmax ||
         prop == &X2max || prop == &Z2max) {
         if (!isRestoring()) {
-            App::DocumentObjectExecReturn *ret = recompute();
+            Base::NullProgressRange progressRange;
+            App::DocumentObjectExecReturn *ret = recompute(progressRange);
             delete ret;
         }
     }
@@ -1007,7 +1013,7 @@ short Ellipse::mustExecute() const
     return Part::Primitive::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Ellipse::execute()
+App::DocumentObjectExecReturn *Ellipse::execute(Base::ProgressRange& progressRange)
 {
     if (this->MinorRadius.getValue() > this->MajorRadius.getValue())
         return new App::DocumentObjectExecReturn("Minor radius greater than major radius");
@@ -1023,7 +1029,7 @@ App::DocumentObjectExecReturn *Ellipse::execute()
     const TopoDS_Edge& edge = clMakeEdge.Edge();
     this->Shape.setValue(edge);
 
-    return Primitive::execute();
+    return Primitive::execute(progressRange);
 }
 
 void Ellipse::onChanged(const App::Property* prop)
@@ -1031,7 +1037,8 @@ void Ellipse::onChanged(const App::Property* prop)
     if (!isRestoring()) {
         if (prop == &MajorRadius || prop == &MinorRadius || prop == &Angle1 || prop == &Angle2){
             try {
-                App::DocumentObjectExecReturn *ret = recompute();
+                Base::NullProgressRange progressRange;
+                App::DocumentObjectExecReturn *ret = recompute(progressRange);
                 delete ret;
             }
             catch (...) {

--- a/src/Mod/Part/App/PrimitiveFeature.h
+++ b/src/Mod/Part/App/PrimitiveFeature.h
@@ -41,7 +41,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     PyObject* getPyObject() override;
     //@}
@@ -67,7 +67,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     void onChanged(const App::Property*) override;
     /// returns the type name of the ViewProvider
@@ -95,7 +95,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     void onChanged(const App::Property*) override;
     /// returns the type name of the ViewProvider
@@ -118,7 +118,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {
@@ -142,7 +142,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {
@@ -168,7 +168,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
     const char* getViewProviderName() const override {
@@ -191,7 +191,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {
@@ -215,7 +215,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {
@@ -239,7 +239,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {
@@ -265,7 +265,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {
@@ -290,7 +290,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {
@@ -318,7 +318,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {
@@ -350,7 +350,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {
@@ -383,7 +383,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {
@@ -411,7 +411,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     void onChanged(const App::Property*) override;
     /// returns the type name of the ViewProvider

--- a/src/Mod/Part/App/PrismExtension.cpp
+++ b/src/Mod/Part/App/PrismExtension.cpp
@@ -57,9 +57,9 @@ short int PrismExtension::extensionMustExecute()
     return DocumentObjectExtension::extensionMustExecute();
 }
 
-App::DocumentObjectExecReturn *PrismExtension::extensionExecute()
+App::DocumentObjectExecReturn *PrismExtension::extensionExecute(Base::ProgressRange& progressRange)
 {
-    return App::DocumentObjectExtension::extensionExecute();
+    return App::DocumentObjectExtension::extensionExecute(progressRange);
 }
 
 void PrismExtension::extensionOnChanged(const App::Property* prop)

--- a/src/Mod/Part/App/PrismExtension.h
+++ b/src/Mod/Part/App/PrismExtension.h
@@ -47,7 +47,7 @@ public:
     TopoDS_Shape makePrism(double height, const TopoDS_Face& face) const;
 
     short int extensionMustExecute() override;
-    App::DocumentObjectExecReturn *extensionExecute() override;
+    App::DocumentObjectExecReturn *extensionExecute(Base::ProgressRange& progressRange) override;
 
 protected:
     void extensionOnChanged(const App::Property* /*prop*/) override;

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -1376,6 +1376,7 @@ public:
     TopoShape& makeElementFuse(const std::vector<TopoShape>& sources,
                                const char* op = nullptr,
                                double tol = -1.0);
+    TopoShape& makeElementFuseProgress(Message_ProgressRange& progressRange, const std::vector<TopoShape>& shapes, const char* op = nullptr, double tol = -1.0);
     /** Make a fusion of this shape and an input shape
      *
      * @param source: the source shape
@@ -1405,6 +1406,7 @@ public:
      */
     TopoShape&
     makeElementCut(const std::vector<TopoShape>& sources, const char* op = nullptr, double tol = -1.0);
+    TopoShape& makeElementCutProgress(Message_ProgressRange& progressRange, const std::vector<TopoShape>& shapes, const char* op = nullptr, double tol = -1.0);
     /** Make a boolean cut of this shape with an input shape
      *
      * @param source: the source shape
@@ -1880,6 +1882,10 @@ public:
                                   const std::vector<TopoShape>& sources,
                                   const char* op = nullptr,
                                   double tol = -1.0);
+    TopoShape& makeElementBooleanProgress(Message_ProgressRange& progressRange, const char* maker,
+                                         const std::vector<TopoShape>& shapes,
+                                         const char* op = nullptr,
+                                         double tolerance = -1.0);
     /** Generalized shape making with mapped element name from shape history
      *
      * @param maker: op code from TopoShapeOpCodes

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4111,8 +4111,16 @@ TopoShape& TopoShape::makeElementGeneralFuse(const std::vector<TopoShape>& _shap
     return *this;
 }
 
-TopoShape&
-TopoShape::makeElementFuse(const std::vector<TopoShape>& shapes, const char* op, double tol)
+TopoShape& TopoShape::makeElementFuseProgress(Message_ProgressRange& progressRange, const std::vector<TopoShape>& shapes, const char* op, double tol)
+{
+    return makeElementBooleanProgress(progressRange, Part::OpCodes::Fuse, shapes, op, tol);
+}
+
+TopoShape& TopoShape::makeElementCutProgress(Message_ProgressRange& progressRange, const std::vector<TopoShape>& shapes, const char* op, double tol)
+{
+    return makeElementBooleanProgress(progressRange, Part::OpCodes::Cut, shapes, op, tol);
+}
+TopoShape& TopoShape::makeElementFuse(const std::vector<TopoShape>& shapes, const char* op, double tol)
 {
     return makeElementBoolean(Part::OpCodes::Fuse, shapes, op, tol);
 }
@@ -5575,8 +5583,18 @@ TopoShape& TopoShape::makeElementBoolean(const char* maker,
 TopoShape& TopoShape::makeElementBoolean(const char* maker,
                                          const std::vector<TopoShape>& shapes,
                                          const char* op,
-                                         double tolerance)
-{
+                                         double tolerance) {
+    Message_ProgressRange progressRange;
+    return makeElementBooleanProgress(progressRange, maker, shapes, op, tolerance);
+}
+
+TopoShape& TopoShape::makeElementBooleanProgress(Message_ProgressRange& progressRange, const char* maker,
+                                         const std::vector<TopoShape>& shapes,
+                                         const char* op,
+                                         double tolerance) {
+    if (progressRange.UserBreak()) {
+        FC_THROWM(Base::CADKernelError, "User aborted");
+    }
     if (!maker) {
         FC_THROWM(Base::CADKernelError, "no maker");
     }
@@ -5761,7 +5779,7 @@ TopoShape& TopoShape::makeElementBoolean(const char* maker,
     } else if (tolerance < 0.0) {
         FCBRepAlgoAPIHelper::setAutoFuzzy(mk.get());
     }
-    mk->Build();
+    mk->Build(progressRange);
     makeElementShape(*mk, inputs, op);
 
     if (buildShell) {

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -5780,6 +5780,9 @@ TopoShape& TopoShape::makeElementBooleanProgress(Message_ProgressRange& progress
         FCBRepAlgoAPIHelper::setAutoFuzzy(mk.get());
     }
     mk->Build(progressRange);
+    if (progressRange.UserBreak()) {
+        FC_THROWM(Base::CADKernelError, "User aborted");
+    }
     makeElementShape(*mk, inputs, op);
 
     if (buildShell) {

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -374,9 +374,9 @@ std::vector<App::DocumentObject*> Body::removeObject(App::DocumentObject* featur
 }
 
 
-App::DocumentObjectExecReturn *Body::execute()
+App::DocumentObjectExecReturn *Body::execute(Base::ProgressRange& progressRange)
 {
-    Part::BodyBase::execute();
+    Part::BodyBase::execute(progressRange);
     /*
     Base::Console().Error("Body '%s':\n", getNameInDocument());
     App::DocumentObject* tip = Tip.getValue();

--- a/src/Mod/PartDesign/App/Body.h
+++ b/src/Mod/PartDesign/App/Body.h
@@ -51,7 +51,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
 
     /// returns the type name of the view provider

--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -72,19 +72,19 @@ Feature::Feature()
     App::SuppressibleExtension::initExtension(this);
 }
 
-App::DocumentObjectExecReturn* Feature::recompute()
+App::DocumentObjectExecReturn* Feature::recompute(Base::ProgressRange& progressRange)
 {
     setMaterialToBodyMaterial();
 
     SuppressedShape.setValue(TopoShape());
 
     if (!Suppressed.getValue()) {
-        return Part::Feature::recompute();
+        return Part::Feature::recompute(progressRange);
     }
 
     bool failed = false;
     try {
-        std::unique_ptr<App::DocumentObjectExecReturn> ret(Part::Feature::recompute());
+        std::unique_ptr<App::DocumentObjectExecReturn> ret(Part::Feature::recompute(progressRange));
         if (ret) {
             throw Base::RuntimeError(ret->Why);
         }

--- a/src/Mod/PartDesign/App/Feature.h
+++ b/src/Mod/PartDesign/App/Feature.h
@@ -60,7 +60,7 @@ public:
 
     /// Keep a copy of suppressed shapes so that we can restore them (and maybe display them)
     Part::PropertyPartShape SuppressedShape;
-    App::DocumentObjectExecReturn* recompute() override;
+    App::DocumentObjectExecReturn* recompute(Base::ProgressRange& progressRange) override;
 
     short mustExecute() const override;
 

--- a/src/Mod/PartDesign/App/FeatureBase.cpp
+++ b/src/Mod/PartDesign/App/FeatureBase.cpp
@@ -56,8 +56,9 @@ short int FeatureBase::mustExecute() const {
 }
 
 
-App::DocumentObjectExecReturn* FeatureBase::execute()
+App::DocumentObjectExecReturn* FeatureBase::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
 
     if (!BaseFeature.getValue()) {
         return new App::DocumentObjectExecReturn(

--- a/src/Mod/PartDesign/App/FeatureBase.h
+++ b/src/Mod/PartDesign/App/FeatureBase.h
@@ -46,7 +46,7 @@ public:
     }
 
     void onChanged(const App::Property* prop) override;
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     void onDocumentRestored() override;
 
 private:

--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -66,8 +66,9 @@ short Boolean::mustExecute() const
     return PartDesign::Feature::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Boolean::execute()
+App::DocumentObjectExecReturn *Boolean::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     // Get the operation type
     std::string type = Type.getValueAsString();
 

--- a/src/Mod/PartDesign/App/FeatureBoolean.h
+++ b/src/Mod/PartDesign/App/FeatureBoolean.h
@@ -51,7 +51,7 @@ public:
    /** @name methods override feature */
     //@{
     /// Recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -102,8 +102,9 @@ short Chamfer::mustExecute() const
     return DressUp::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Chamfer::execute()
+App::DocumentObjectExecReturn *Chamfer::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     if (onlyHaveRefined()) { return App::DocumentObject::StdReturn; }
 
     // NOTE: Normally the Base property and the BaseFeature property should point to the same object.

--- a/src/Mod/PartDesign/App/FeatureChamfer.h
+++ b/src/Mod/PartDesign/App/FeatureChamfer.h
@@ -48,7 +48,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -95,8 +95,9 @@ short Draft::mustExecute() const
     return DressUp::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Draft::execute()
+App::DocumentObjectExecReturn *Draft::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     // Get parameters
     // Base shape
     Part::TopoShape TopShape;

--- a/src/Mod/PartDesign/App/FeatureDraft.h
+++ b/src/Mod/PartDesign/App/FeatureDraft.h
@@ -48,7 +48,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -63,8 +63,9 @@ short Fillet::mustExecute() const
     return DressUp::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Fillet::execute()
+App::DocumentObjectExecReturn *Fillet::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     if (onlyHaveRefined()) { return App::DocumentObject::StdReturn; }
 
 

--- a/src/Mod/PartDesign/App/FeatureFillet.h
+++ b/src/Mod/PartDesign/App/FeatureFillet.h
@@ -44,7 +44,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -79,8 +79,9 @@ short Groove::mustExecute() const
     return ProfileBased::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Groove::execute()
+App::DocumentObjectExecReturn *Groove::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     if (onlyHaveRefined()) { return App::DocumentObject::StdReturn; }
 
     // Validate parameters

--- a/src/Mod/PartDesign/App/FeatureGroove.h
+++ b/src/Mod/PartDesign/App/FeatureGroove.h
@@ -57,7 +57,7 @@ public:
       * If Reversed is true then the direction of revolution will be reversed.
       * The created material will be cut out of the sketch support
       */
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -124,8 +124,9 @@ short Helix::mustExecute() const
     return ProfileBased::mustExecute();
 }
 
-App::DocumentObjectExecReturn* Helix::execute()
+App::DocumentObjectExecReturn* Helix::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     if (onlyHaveRefined()) { return App::DocumentObject::StdReturn; }
 
     // Validate and normalize parameters

--- a/src/Mod/PartDesign/App/FeatureHelix.h
+++ b/src/Mod/PartDesign/App/FeatureHelix.h
@@ -65,7 +65,7 @@ public:
 
     /** @name methods override feature */
     //@{
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1783,9 +1783,10 @@ static gp_Pnt toPnt(gp_Vec dir)
     return {dir.X(), dir.Y(), dir.Z()};
 }
 
-App::DocumentObjectExecReturn* Hole::execute()
+App::DocumentObjectExecReturn* Hole::execute(Base::ProgressRange& progressRange)
 {
-     TopoShape profileshape;
+    (void)progressRange;
+    TopoShape profileshape;
     try {
         profileshape = getTopoShapeVerifiedFace();
     }

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -78,7 +78,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -110,8 +110,9 @@ Loft::getSectionShape(const char *name,
     return vertices;
 }
 
-App::DocumentObjectExecReturn *Loft::execute()
+App::DocumentObjectExecReturn *Loft::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     if (onlyHaveRefined()) { return App::DocumentObject::StdReturn; }
 
     std::vector<TopoShape> wires;

--- a/src/Mod/PartDesign/App/FeatureLoft.h
+++ b/src/Mod/PartDesign/App/FeatureLoft.h
@@ -42,7 +42,7 @@ public:
 
     /** @name methods override feature */
     //@{
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -69,7 +69,8 @@ Pad::Pad()
 }
 
 
-App::DocumentObjectExecReturn* Pad::execute()
+App::DocumentObjectExecReturn* Pad::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     return buildExtrusion(ExtrudeOption::MakeFace | ExtrudeOption::MakeFuse);
 }

--- a/src/Mod/PartDesign/App/FeaturePad.h
+++ b/src/Mod/PartDesign/App/FeaturePad.h
@@ -51,7 +51,7 @@ public:
       * If Reversed is true then the direction of revolution will be reversed.
       * The created material will be fused with the sketch support (if there is one)
       */
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {
         return "PartDesignGui::ViewProviderPad";

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -102,8 +102,9 @@ short Pipe::mustExecute() const
     return ProfileBased::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Pipe::execute()
+App::DocumentObjectExecReturn *Pipe::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     if (onlyHaveRefined()) { return App::DocumentObject::StdReturn; }
 
     auto getSectionShape = [](App::DocumentObject* feature,

--- a/src/Mod/PartDesign/App/FeaturePipe.h
+++ b/src/Mod/PartDesign/App/FeaturePipe.h
@@ -48,7 +48,7 @@ public:
     App::PropertyEnumeration Transformation;
     App::PropertyLinkSubList Sections;
 
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -69,8 +69,9 @@ Pocket::Pocket()
     Length2.setConstraints(nullptr);
 }
 
-App::DocumentObjectExecReturn *Pocket::execute()
+App::DocumentObjectExecReturn *Pocket::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     // MakeFace|MakeFuse: because we want a solid.
     // InverseDirection: to inverse the auto detected extrusion direction for
     // backward compatibility to upstream

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -66,13 +66,14 @@ FeaturePrimitive::FeaturePrimitive()
     Part::AttachExtension::initExtension(this);
 }
 
-App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& primitive)
+App::DocumentObjectExecReturn* FeaturePrimitive::execute(Base::ProgressRange& progressRange, const TopoDS_Shape& primitive)
 {
+    (void)progressRange;
     if (onlyHaveRefined()) { return App::DocumentObject::StdReturn; }
 
     try {
         //transform the primitive in the correct coordinance
-        FeatureAddSub::execute();
+        FeatureAddSub::execute(progressRange);
 
         //if we have no base we just add the standard primitive shape
         TopoShape primitiveShape;
@@ -192,7 +193,7 @@ Box::Box()
     primitiveType = FeaturePrimitive::Box;
 }
 
-App::DocumentObjectExecReturn* Box::execute()
+App::DocumentObjectExecReturn* Box::execute(Base::ProgressRange& progressRange)
 {
     double L = Length.getValue();
     double W = Width.getValue();
@@ -208,7 +209,7 @@ App::DocumentObjectExecReturn* Box::execute()
     try {
         // Build a box using the dimension attributes
         BRepPrimAPI_MakeBox mkBox(L, W, H);
-        return FeaturePrimitive::execute(mkBox.Shape());
+        return FeaturePrimitive::execute(progressRange, mkBox.Shape());
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());
@@ -245,7 +246,7 @@ Cylinder::Cylinder()
     primitiveType = FeaturePrimitive::Cylinder;
 }
 
-App::DocumentObjectExecReturn* Cylinder::execute()
+App::DocumentObjectExecReturn* Cylinder::execute(Base::ProgressRange& progressRange)
 {
     // Build a cylinder
     if (Radius.getValue() < Precision::Confusion())
@@ -263,7 +264,7 @@ App::DocumentObjectExecReturn* Cylinder::execute()
         BRepPrim_Cylinder prim = mkCylr.Cylinder();
         TopoDS_Shape result = makePrism(Height.getValue(), prim.BottomFace());
 
-        return FeaturePrimitive::execute(result);
+        return FeaturePrimitive::execute(progressRange, result);
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());
@@ -302,7 +303,7 @@ Sphere::Sphere()
     primitiveType = FeaturePrimitive::Sphere;
 }
 
-App::DocumentObjectExecReturn* Sphere::execute()
+App::DocumentObjectExecReturn* Sphere::execute(Base::ProgressRange& progressRange)
 {
    // Build a sphere
     if (Radius.getValue() < Precision::Confusion())
@@ -312,7 +313,7 @@ App::DocumentObjectExecReturn* Sphere::execute()
                                         Base::toRadians<double>(Angle1.getValue()),
                                         Base::toRadians<double>(Angle2.getValue()),
                                         Base::toRadians<double>(Angle3.getValue()));
-        return FeaturePrimitive::execute(mkSphere.Shape());
+        return FeaturePrimitive::execute(progressRange, mkSphere.Shape());
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());
@@ -352,7 +353,7 @@ Cone::Cone()
     primitiveType = FeaturePrimitive::Cone;
 }
 
-App::DocumentObjectExecReturn* Cone::execute()
+App::DocumentObjectExecReturn* Cone::execute(Base::ProgressRange& progressRange)
 {
     if (Radius1.getValue() < 0.0)
         return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Radius of cone cannot be negative"));
@@ -366,14 +367,14 @@ App::DocumentObjectExecReturn* Cone::execute()
             BRepPrimAPI_MakeCylinder mkCylr(Radius1.getValue(),
                                             Height.getValue(),
                                             Base::toRadians<double>(Angle.getValue()));
-            return FeaturePrimitive::execute(mkCylr.Shape());
+            return FeaturePrimitive::execute(progressRange, mkCylr.Shape());
         }
         // Build a cone
         BRepPrimAPI_MakeCone mkCone(Radius1.getValue(),
                                     Radius2.getValue(),
                                     Height.getValue(),
                                     Base::toRadians<double>(Angle.getValue()));
-        return FeaturePrimitive::execute(mkCone.Shape());
+        return FeaturePrimitive::execute(progressRange, mkCone.Shape());
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());
@@ -418,7 +419,7 @@ Ellipsoid::Ellipsoid()
     primitiveType = FeaturePrimitive::Ellipsoid;
 }
 
-App::DocumentObjectExecReturn* Ellipsoid::execute()
+App::DocumentObjectExecReturn* Ellipsoid::execute(Base::ProgressRange& progressRange)
 {
     // Build a sphere
     if (Radius1.getValue() < Precision::Confusion())
@@ -454,7 +455,7 @@ App::DocumentObjectExecReturn* Ellipsoid::execute()
         mat.SetValue(2,3,0.0);
         mat.SetValue(3,3,scaleZ);
         BRepBuilderAPI_GTransform mkTrsf(mkSphere.Shape(), mat);
-        return FeaturePrimitive::execute(mkTrsf.Shape());
+        return FeaturePrimitive::execute(progressRange, mkTrsf.Shape());
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());
@@ -503,7 +504,7 @@ Torus::Torus()
     primitiveType = FeaturePrimitive::Torus;
 }
 
-App::DocumentObjectExecReturn* Torus::execute()
+App::DocumentObjectExecReturn* Torus::execute(Base::ProgressRange& progressRange)
 {
     if (Radius1.getValue() < Precision::Confusion())
         return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Radius of torus too small"));
@@ -517,7 +518,7 @@ App::DocumentObjectExecReturn* Torus::execute()
                                       Base::toRadians<double>(Angle1.getValue()),
                                       Base::toRadians<double>(Angle2.getValue()),
                                       Base::toRadians<double>(Angle3.getValue()));
-        return FeaturePrimitive::execute(mkTorus.Solid());
+        return FeaturePrimitive::execute(progressRange, mkTorus.Solid());
 #else
         Part::TopoShape shape;
         return FeaturePrimitive::execute(shape.makeTorus(Radius1.getValue(),
@@ -567,7 +568,7 @@ Prism::Prism()
     primitiveType = FeaturePrimitive::Prism;
 }
 
-App::DocumentObjectExecReturn* Prism::execute()
+App::DocumentObjectExecReturn* Prism::execute(Base::ProgressRange& progressRange)
 {
     // Build a prism
     if (Polygon.getValue() < 3)
@@ -593,7 +594,7 @@ App::DocumentObjectExecReturn* Prism::execute()
         BRepBuilderAPI_MakeFace mkFace(mkPoly.Wire());
         // the direction vector for the prism is the height for z and the given angle
         TopoDS_Shape prism = makePrism(Height.getValue(), mkFace.Face());
-        return FeaturePrimitive::execute(prism);
+        return FeaturePrimitive::execute(progressRange, prism);
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());
@@ -636,7 +637,7 @@ Wedge::Wedge()
     primitiveType = FeaturePrimitive::Wedge;
 }
 
-App::DocumentObjectExecReturn* Wedge::execute()
+App::DocumentObjectExecReturn* Wedge::execute(Base::ProgressRange& progressRange)
 {
     double xmin = Xmin.getValue();
     double ymin = Ymin.getValue();
@@ -678,7 +679,7 @@ App::DocumentObjectExecReturn* Wedge::execute()
             xmax, ymax, zmax, z2max, x2max);
         BRepBuilderAPI_MakeSolid mkSolid;
         mkSolid.Add(mkWedge.Shell());
-        return FeaturePrimitive::execute(mkSolid.Solid());
+        return FeaturePrimitive::execute(progressRange, mkSolid.Solid());
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());

--- a/src/Mod/PartDesign/App/FeaturePrimitive.h
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.h
@@ -57,12 +57,12 @@ public:
     PyObject* getPyObject() override;
 
     /// Do nothing, just to suppress warning, must be redefined in derived classes
-    App::DocumentObjectExecReturn* execute() override {
-        return PartDesign::FeatureAddSub::execute();
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override {
+        return PartDesign::FeatureAddSub::execute(progressRange);
     }
 protected:
     //make the boolean ops with the primitives provided by the derived features
-    App::DocumentObjectExecReturn* execute(const TopoDS_Shape& primitiveShape);
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange, const TopoDS_Shape& primitiveShape);
     Type primitiveType = Box;
 };
 
@@ -79,7 +79,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
 
 protected:
@@ -118,7 +118,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
 };
 
@@ -155,7 +155,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
 
 protected:
@@ -194,7 +194,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
 
 protected:
@@ -236,7 +236,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
 
 protected:
@@ -277,7 +277,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
 
 protected:
@@ -315,7 +315,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
 };
 
@@ -358,7 +358,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
 
 protected:

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -78,8 +78,9 @@ short Revolution::mustExecute() const
     return ProfileBased::mustExecute();
 }
 
-App::DocumentObjectExecReturn* Revolution::execute()
+App::DocumentObjectExecReturn* Revolution::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     if (onlyHaveRefined()) { return App::DocumentObject::StdReturn; }
 
 

--- a/src/Mod/PartDesign/App/FeatureRevolution.h
+++ b/src/Mod/PartDesign/App/FeatureRevolution.h
@@ -57,7 +57,7 @@ public:
       * If Reversed is true then the direction of revolution will be reversed.
       * The created material will be fused with the sketch support (if there is one)
       */
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/PartDesign/App/FeatureThickness.cpp
+++ b/src/Mod/PartDesign/App/FeatureThickness.cpp
@@ -64,7 +64,8 @@ int16_t Thickness::mustExecute() const {
     return DressUp::mustExecute();
 }
 
-App::DocumentObjectExecReturn *Thickness::execute() {
+App::DocumentObjectExecReturn *Thickness::execute(Base::ProgressRange& progressRange) {
+    (void)progressRange;
     if (onlyHaveRefined()) { return App::DocumentObject::StdReturn; }
 
     // Base shape

--- a/src/Mod/PartDesign/App/FeatureThickness.h
+++ b/src/Mod/PartDesign/App/FeatureThickness.h
@@ -47,7 +47,7 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute() override;
+    App::DocumentObjectExecReturn *execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// returns the type name of the view provider
     const char* getViewProviderName() const override {

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -196,7 +196,7 @@ short Transformed::mustExecute() const
     return PartDesign::Feature::mustExecute();
 }
 
-App::DocumentObjectExecReturn* Transformed::execute()
+App::DocumentObjectExecReturn* Transformed::execute(Base::ProgressRange& progressRange)
 {
     if (isMultiTransformChild()) {
         return App::DocumentObject::StdReturn;

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -298,6 +298,10 @@ App::DocumentObjectExecReturn* Transformed::execute()
                 Part::TopoShape fuseShape;
                 Part::TopoShape cutShape;
 
+                if (progressRange.UserBreak()) {
+                    return new App::DocumentObjectExecReturn("User aborted");
+                }
+
                 auto feature = Base::freecad_dynamic_cast<PartDesign::FeatureAddSub>(original);
                 if (!feature) {
                     return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
@@ -319,15 +323,15 @@ App::DocumentObjectExecReturn* Transformed::execute()
                     cutShape = cutShape.makeElementTransform(trsf);
                 }
                 if (!fuseShape.isNull()) {
-                    supportShape.makeElementFuse(getTransformedCompShape(supportShape, fuseShape));
+                    supportShape.makeElementFuseProgress(progressRange, getTransformedCompShape(supportShape, fuseShape));
                 }
                 if (!cutShape.isNull()) {
-                    supportShape.makeElementCut(getTransformedCompShape(supportShape, cutShape));
+                    supportShape.makeElementCutProgress(progressRange, getTransformedCompShape(supportShape, cutShape));
                 }
             }
             break;
         case Mode::TransformBody: {
-            supportShape.makeElementFuse(getTransformedCompShape(supportShape, supportShape));
+            supportShape.makeElementFuseProgress(progressRange, getTransformedCompShape(supportShape, supportShape));
             break;
         }
     }

--- a/src/Mod/PartDesign/App/FeatureTransformed.h
+++ b/src/Mod/PartDesign/App/FeatureTransformed.h
@@ -98,6 +98,10 @@ public:
      * because they did not overlap with the support
      */
     TopoDS_Shape rejected;
+    void setProgressRange(const Message_ProgressRange& progressRange) {
+        this->progressRange = progressRange;
+    }
+
 
 protected:
     void Restore(Base::XMLReader& reader) override;
@@ -109,6 +113,7 @@ protected:
     static TopoDS_Shape getRemainingSolids(const TopoDS_Shape&);
 
 private:
+    Message_ProgressRange progressRange;
 };
 
 }  // namespace PartDesign

--- a/src/Mod/PartDesign/App/FeatureTransformed.h
+++ b/src/Mod/PartDesign/App/FeatureTransformed.h
@@ -90,7 +90,7 @@ public:
      * If Originals is empty, execute() returns immediately without doing anything as
      * the actual processing will happen in the MultiTransform feature
      */
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     //@}
 
@@ -98,10 +98,6 @@ public:
      * because they did not overlap with the support
      */
     TopoDS_Shape rejected;
-    void setProgressRange(const Message_ProgressRange& progressRange) {
-        this->progressRange = progressRange;
-    }
-
 
 protected:
     void Restore(Base::XMLReader& reader) override;
@@ -111,9 +107,6 @@ protected:
 
     virtual void positionBySupport();
     static TopoDS_Shape getRemainingSolids(const TopoDS_Shape&);
-
-private:
-    Message_ProgressRange progressRange;
 };
 
 }  // namespace PartDesign

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -124,7 +124,7 @@ bool ShapeBinder::hasPlacementChanged() const
     return this->Placement.getValue() != placement;
 }
 
-App::DocumentObjectExecReturn* ShapeBinder::execute()
+App::DocumentObjectExecReturn* ShapeBinder::execute(Base::ProgressRange& progressRange)
 {
     if (!this->isRestoring()) {
         Part::TopoShape shape(updatedShape());
@@ -134,7 +134,7 @@ App::DocumentObjectExecReturn* ShapeBinder::execute()
         }
     }
 
-    return Part::Feature::execute();
+    return Part::Feature::execute(progressRange);
 }
 
 void ShapeBinder::getFilteredReferences(const App::PropertyLinkSubList* prop,
@@ -499,6 +499,7 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
     std::vector<Part::TopoShape> shapes;
     std::vector<std::pair<int,int> > shapeOwners;
     std::vector<const Base::Matrix4D*> shapeMats;
+    Base::NullProgressRange progressRange;
 
     bool forced = (Shape.getValue().IsNull() || (options & UpdateForced)) ? true : false;
     bool init = (!forced && (options & UpdateForced)) ? true : false;
@@ -609,7 +610,7 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
                     // IMPORTANT! must make a recomputation first before any
                     // further change so that we can generate the correct
                     // geometry element map.
-                    if (!copied->recomputeFeature(true))
+                    if (!copied->recomputeFeature(progressRange, true))
                         copyerror = 1;
                 }
             }
@@ -642,7 +643,7 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
                     };
 
                     copyPropertyValues(true);
-                    if (recomputeCopy && !copied->recomputeFeature(true))
+                    if (recomputeCopy && !copied->recomputeFeature(progressRange, true))
                         copyerror = 2;
                     if (!copyerror)
                         copyPropertyValues(false);
@@ -870,14 +871,14 @@ void SubShapeBinder::slotRecomputedObject(const App::DocumentObject& Obj) {
     }
 }
 
-App::DocumentObjectExecReturn* SubShapeBinder::execute() {
+App::DocumentObjectExecReturn* SubShapeBinder::execute(Base::ProgressRange& progressRange) {
 
     setupCopyOnChange();
 
     if (BindMode.getValue() == 0)
         update(UpdateForced);
 
-    return inherited::execute();
+    return inherited::execute(progressRange);
 }
 
 void SubShapeBinder::onDocumentRestored() {

--- a/src/Mod/PartDesign/App/ShapeBinder.h
+++ b/src/Mod/PartDesign/App/ShapeBinder.h
@@ -65,7 +65,7 @@ protected:
     bool hasPlacementChanged() const;
     void handleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop) override;
     short int mustExecute() const override;
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     void onChanged(const App::Property* prop) override;
 
 private:
@@ -124,7 +124,7 @@ public:
             Base::Matrix4D *mat=nullptr, bool transform=true, int depth=0) const override;
 
 protected:
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     void onChanged(const App::Property *prop) override;
 
     void handleChangedPropertyType(

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -258,7 +258,7 @@ void ViewProviderTransformed::recomputeFeature(bool recompute)
         QMessageBox forceAbortBox(
             QMessageBox::Warning,
             QObject::tr("Operation not responding"),
-            QObject::tr("The abort operation is taking longer than expected.\nDo you want to forcibly cancel the thread? This will probably crash FreeCAD.");
+            QObject::tr("The abort operation is taking longer than expected.\nDo you want to forcibly cancel the thread? This will probably crash FreeCAD."),
             QMessageBox::Yes | QMessageBox::No,
             Gui::MainWindow::getInstance());
         forceAbortBox.setDefaultButton(QMessageBox::No);

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -278,7 +278,7 @@ void ViewProviderTransformed::recomputeFeature(bool recompute)
             #endif
             
             try {
-                pcTransformed->recomputeFeature(true);
+                pcTransformed->recomputeFeature(progressRange, true);
             } catch (const std::exception& e) {
                 Base::Console().Error("Computation thread caught exception: %s\n", e.what());
             } catch (...) {

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -178,6 +178,7 @@ public:
     {
         setWindowTitle(tr("Computing"));
         setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowStaysOnTopHint);
+        setWindowModality(Qt::ApplicationModal); // Make sure dialog is modal but doesn't block event processing
         
         auto layout = new QVBoxLayout(this);
         
@@ -222,6 +223,9 @@ public:
                                 Q_ARG(int, pct));
         QMetaObject::invokeMethod(progressBar, "setMaximum", Qt::QueuedConnection,
                                 Q_ARG(int, 100));
+                                
+        // Process events to keep UI responsive
+        QApplication::processEvents();
     }
 
     void abort() {

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -176,7 +176,8 @@ public:
         , aborted(false) 
     {
         setWindowTitle(tr("Computing"));
-        setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint);
+        setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowStaysOnTopHint);
+        
         auto layout = new QVBoxLayout(this);
         
         // Add informative label
@@ -197,6 +198,10 @@ public:
         auto abortButton = new QPushButton(tr("Abort"), this);
         layout->addWidget(abortButton);
         connect(abortButton, &QPushButton::clicked, this, &ComputationDialog::onAbort);
+
+        setMinimumSize(300, 150);  // Set reasonable minimum dimensions
+        adjustSize();  // Adjust to content
+        setFixedSize(size());  // Lock the size
     }
 
     // Message_ProgressIndicator interface implementation

--- a/src/Mod/Points/App/AppPointsPy.cpp
+++ b/src/Mod/Points/App/AppPointsPy.cpp
@@ -165,8 +165,9 @@ private:
                 }
 
                 // delayed adding of the points feature
+                Base::NullProgressRange progressRange;
                 pcDoc->addObject(pcFeature, file.fileNamePure().c_str());
-                pcDoc->recomputeFeature(pcFeature);
+                pcDoc->recomputeFeature(progressRange, pcFeature);
                 pcFeature->purgeTouched();
             }
             else {
@@ -182,8 +183,9 @@ private:
 
                 // delayed adding of the points feature
                 pcFeature->Points.setValue(reader->getPoints());
+                Base::NullProgressRange progressRange;
                 pcDoc->addObject(pcFeature, file.fileNamePure().c_str());
-                pcDoc->recomputeFeature(pcFeature);
+                pcDoc->recomputeFeature(progressRange, pcFeature);
                 pcFeature->purgeTouched();
             }
         }
@@ -291,13 +293,15 @@ private:
 
                 // delayed adding of the points feature
                 pcDoc->addObject(pcFeature, file.fileNamePure().c_str());
-                pcDoc->recomputeFeature(pcFeature);
+                Base::NullProgressRange progressRange;
+                pcDoc->recomputeFeature(progressRange, pcFeature);
                 pcFeature->purgeTouched();
             }
             else {
                 auto* pcFeature = pcDoc->addObject<Points::Feature>(file.fileNamePure().c_str());
                 pcFeature->Points.setValue(reader->getPoints());
-                pcDoc->recomputeFeature(pcFeature);
+                Base::NullProgressRange progressRange;
+                pcDoc->recomputeFeature(progressRange, pcFeature);
                 pcFeature->purgeTouched();
             }
         }

--- a/src/Mod/Points/App/PointsFeature.cpp
+++ b/src/Mod/Points/App/PointsFeature.cpp
@@ -27,7 +27,7 @@
 #endif
 
 #include "PointsFeature.h"
-
+#include <Base/ProgressRange.h>
 
 using namespace Points;
 
@@ -47,8 +47,9 @@ short Feature::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn* Feature::execute()
+App::DocumentObjectExecReturn* Feature::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     this->Points.touch();
     return App::DocumentObject::StdReturn;
 }

--- a/src/Mod/Points/App/PointsFeature.h
+++ b/src/Mod/Points/App/PointsFeature.h
@@ -27,6 +27,7 @@
 #include <App/FeaturePython.h>
 #include <App/GeoFeature.h>
 #include <App/PropertyGeo.h>
+#include <Base/ProgressRange.h>
 
 #include "Points.h"
 #include "PropertyPointKernel.h"
@@ -64,7 +65,7 @@ public:
     void RestoreDocFile(Base::Reader& reader) override;
     short mustExecute() const override;
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override
     {

--- a/src/Mod/Points/App/Structured.cpp
+++ b/src/Mod/Points/App/Structured.cpp
@@ -70,8 +70,9 @@ Structured::Structured()
     // Height.setStatus(App::Property::ReadOnly, true);
 }
 
-App::DocumentObjectExecReturn* Structured::execute()
+App::DocumentObjectExecReturn* Structured::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     std::size_t size = Height.getValue() * Width.getValue();
     if (size != Points.getValue().size()) {
         throw Base::ValueError("(Width * Height) doesn't match with number of points");

--- a/src/Mod/Points/App/Structured.h
+++ b/src/Mod/Points/App/Structured.h
@@ -25,7 +25,7 @@
 #define POINTS_VIEW_FEATURE_H
 
 #include "PointsFeature.h"
-
+#include <Base/ProgressRange.h>
 
 namespace Points
 {
@@ -48,7 +48,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override
     {

--- a/src/Mod/Robot/App/Edge2TracObject.cpp
+++ b/src/Mod/Robot/App/Edge2TracObject.cpp
@@ -61,8 +61,10 @@ Edge2TracObject::Edge2TracObject()
     NbrOfCluster = 0;
 }
 
-App::DocumentObjectExecReturn* Edge2TracObject::execute()
+App::DocumentObjectExecReturn* Edge2TracObject::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
+
     App::DocumentObject* link = Source.getValue();
     if (!link) {
         return new App::DocumentObjectExecReturn("No object linked");

--- a/src/Mod/Robot/App/Edge2TracObject.h
+++ b/src/Mod/Robot/App/Edge2TracObject.h
@@ -53,7 +53,7 @@ public:
     {
         return "RobotGui::ViewProviderEdge2TracObject";
     }
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
 protected:
     /// get called by the container when a property has changed

--- a/src/Mod/Robot/App/RobotObject.h
+++ b/src/Mod/Robot/App/RobotObject.h
@@ -45,8 +45,9 @@ public:
     {
         return "RobotGui::ViewProviderRobotObject";
     }
-    App::DocumentObjectExecReturn* execute() override
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return App::DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/Mod/Robot/App/TrajectoryCompound.cpp
+++ b/src/Mod/Robot/App/TrajectoryCompound.cpp
@@ -38,8 +38,10 @@ TrajectoryCompound::TrajectoryCompound()
     ADD_PROPERTY_TYPE(Source, (nullptr), "Compound", Prop_None, "list of trajectories to combine");
 }
 
-App::DocumentObjectExecReturn* TrajectoryCompound::execute()
+App::DocumentObjectExecReturn* TrajectoryCompound::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
+
     const std::vector<DocumentObject*>& Tracs = Source.getValues();
     Robot::Trajectory result;
 

--- a/src/Mod/Robot/App/TrajectoryCompound.h
+++ b/src/Mod/Robot/App/TrajectoryCompound.h
@@ -46,7 +46,7 @@ public:
     {
         return "RobotGui::ViewProviderTrajectoryCompound";
     }
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
 protected:
     /// get called by the container when a property has changed

--- a/src/Mod/Robot/App/TrajectoryDressUpObject.cpp
+++ b/src/Mod/Robot/App/TrajectoryDressUpObject.cpp
@@ -73,8 +73,9 @@ TrajectoryDressUpObject::TrajectoryDressUpObject()
     AddType.setEnums(AddTypeEnums);
 }
 
-App::DocumentObjectExecReturn* TrajectoryDressUpObject::execute()
+App::DocumentObjectExecReturn* TrajectoryDressUpObject::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Robot::Trajectory result;
 
     App::DocumentObject* link = Source.getValue();

--- a/src/Mod/Robot/App/TrajectoryDressUpObject.h
+++ b/src/Mod/Robot/App/TrajectoryDressUpObject.h
@@ -55,7 +55,7 @@ public:
     {
         return "RobotGui::ViewProviderTrajectoryDressUp";
     }
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     static const char* ContTypeEnums[];
     static const char* AddTypeEnums[];

--- a/src/Mod/Robot/App/TrajectoryObject.h
+++ b/src/Mod/Robot/App/TrajectoryObject.h
@@ -46,8 +46,9 @@ public:
     {
         return "RobotGui::ViewProviderTrajectory";
     }
-    App::DocumentObjectExecReturn* execute() override
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override
     {
+        (void)progressRange;
         return App::DocumentObject::StdReturn;
     }
     short mustExecute() const override;

--- a/src/Mod/Sketcher/App/AppSketcherPy.cpp
+++ b/src/Mod/Sketcher/App/AppSketcherPy.cpp
@@ -99,7 +99,8 @@ private:
                 auto* pcFeature = pcDoc->addObject<Sketcher::SketchObjectSF>(filename);
                 pcFeature->SketchFlatFile.setValue(EncodedName.c_str());
 
-                pcDoc->recompute();
+                Base::NullProgressRange progressRange;
+                pcDoc->recompute(progressRange);
             }
             else {
                 throw Py::RuntimeError("Unknown file extension");

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -255,10 +255,11 @@ short SketchObject::mustExecute() const
     return Part2DObject::mustExecute();
 }
 
-App::DocumentObjectExecReturn* SketchObject::execute()
+App::DocumentObjectExecReturn* SketchObject::execute(Base::ProgressRange& progressRange)
 {
+
     try {
-        App::DocumentObjectExecReturn* rtn = Part2DObject::execute();// to positionBySupport
+        App::DocumentObjectExecReturn* rtn = Part2DObject::execute(progressRange);// to positionBySupport
         if (rtn != App::DocumentObject::StdReturn)
             // error
             return rtn;

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -95,7 +95,7 @@ public:
     short mustExecute() const override;
     /// recalculate the Feature (if no recompute is needed see also solve() and solverNeedsUpdate
     /// boolean)
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override

--- a/src/Mod/Sketcher/App/SketchObjectSF.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectSF.cpp
@@ -48,8 +48,9 @@ short SketchObjectSF::mustExecute() const
     return 0;
 }
 
-App::DocumentObjectExecReturn* SketchObjectSF::execute()
+App::DocumentObjectExecReturn* SketchObjectSF::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     Base::Console().Warning(
         "%s: This feature is deprecated and won't be longer supported in future FreeCAD versions\n",
         this->getNameInDocument());

--- a/src/Mod/Sketcher/App/SketchObjectSF.h
+++ b/src/Mod/Sketcher/App/SketchObjectSF.h
@@ -44,7 +44,7 @@ public:
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     /// Uses the standard ViewProvider
     // const char* getViewProviderName(void) const {

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -1026,8 +1026,9 @@ void Sheet::updateBindings()
  *
  */
 
-DocumentObjectExecReturn* Sheet::execute()
+DocumentObjectExecReturn* Sheet::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     updateBindings();
 
     // Get dirty cells that we have to recompute
@@ -1630,7 +1631,8 @@ std::set<CellAddress> Sheet::providesTo(CellAddress address) const
 
 void Sheet::onDocumentRestored()
 {
-    auto ret = execute();
+    Base::NullProgressRange progressRange;
+    auto ret = execute(progressRange);
     if (ret != DocumentObject::StdReturn) {
         FC_ERR("Failed to restore " << getFullName() << ": " << ret->Why);
         delete ret;

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -35,6 +35,7 @@
 #include <App/FeaturePython.h>
 #include <App/PropertyUnits.h>
 #include <App/Range.h>
+#include <Base/ProgressRange.h>
 #include <Base/Unit.h>
 
 #include "PropertyColumnWidths.h"
@@ -191,7 +192,7 @@ public:
 
     short mustExecute() const override;
 
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
 
     bool getCellAddress(const App::Property* prop, App::CellAddress& address);
 

--- a/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp
+++ b/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp
@@ -73,7 +73,8 @@ private:
             auto* pcSheet = pcDoc->addObject<Spreadsheet::Sheet>(filename);
 
             pcSheet->importFromFile(Name, '\t', '"', '\\');
-            pcSheet->execute();
+            Base::NullProgressRange progressRange;
+            pcSheet->execute(progressRange);
         }
         catch (const Base::Exception& e) {
             throw Py::RuntimeError(e.what());

--- a/src/Mod/Spreadsheet/Gui/Command.cpp
+++ b/src/Mod/Spreadsheet/Gui/Command.cpp
@@ -209,7 +209,8 @@ void CmdSpreadsheetImport::activated(int iMsg)
 
             if (isValid) {
                 sheet->importFromFile(fileName.toStdString(), delim, quote, escape);
-                sheet->execute();
+                Base::NullProgressRange progressRange;
+                sheet->execute(progressRange);
             }
             else {
                 Base::Console().Error(errMsg.c_str());

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -798,7 +798,8 @@ void SheetTableView::pasteClipboard()
             sheet->getCells()->pasteCells(reader, range);
         }
 
-        GetApplication().getActiveDocument()->recompute();
+        Base::NullProgressRange progressRange;
+        GetApplication().getActiveDocument()->recompute(progressRange);
     }
     catch (Base::Exception& e) {
         e.ReportException();

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -163,7 +163,8 @@ bool SheetView::onMsg(const char* pMsg, const char**)
         getGuiDocument()->undo(1);
         App::Document* doc = getAppDocument();
         if (doc) {
-            doc->recompute();
+            Base::NullProgressRange progressRange;
+            doc->recompute(progressRange);
         }
         return true;
     }
@@ -171,7 +172,8 @@ bool SheetView::onMsg(const char* pMsg, const char**)
         getGuiDocument()->redo(1);
         App::Document* doc = getAppDocument();
         if (doc) {
-            doc->recompute();
+            Base::NullProgressRange progressRange;
+            doc->recompute(progressRange);
         }
         return true;
     }

--- a/src/Mod/Surface/App/Blending/FeatureBlendCurve.cpp
+++ b/src/Mod/Surface/App/Blending/FeatureBlendCurve.cpp
@@ -175,8 +175,9 @@ BlendPoint FeatureBlendCurve::GetBlendPoint(App::PropertyLinkSub& link,
     return bp;
 }
 
-App::DocumentObjectExecReturn* FeatureBlendCurve::execute()
+App::DocumentObjectExecReturn* FeatureBlendCurve::execute(Base::ProgressRange& progressRange)
 {
+    (void)progressRange;
     BlendPoint bp1 = GetBlendPoint(StartEdge, StartParameter, StartContinuity);
     BlendPoint bp2 = GetBlendPoint(EndEdge, EndParameter, EndContinuity);
 
@@ -220,7 +221,8 @@ void FeatureBlendCurve::onChanged(const App::Property* prop)
     if (prop == &StartContinuity || prop == &StartParameter || prop == &StartSize
         || prop == &EndContinuity || prop == &EndParameter || prop == &EndSize) {
         if (!isRestoring()) {
-            App::DocumentObjectExecReturn* ret = recompute();
+            Base::NullProgressRange progressRange;
+            App::DocumentObjectExecReturn* ret = recompute(progressRange);
             delete ret;
         }
     }

--- a/src/Mod/Surface/App/Blending/FeatureBlendCurve.h
+++ b/src/Mod/Surface/App/Blending/FeatureBlendCurve.h
@@ -52,7 +52,7 @@ public:
 
     Standard_Integer maxDegree;
 
-    App::DocumentObjectExecReturn* execute() override;
+    App::DocumentObjectExecReturn* execute(Base::ProgressRange& progressRange) override;
     short mustExecute() const override;
     const char* getViewProviderName() const override
     {

--- a/tests/src/Mod/Mesh/App/Exporter.cpp
+++ b/tests/src/Mod/Mesh/App/Exporter.cpp
@@ -31,7 +31,8 @@ protected:
         cube2->Width.setValue(value);
         cube2->Height.setValue(value);
 
-        document->recompute();
+        Base::NullProgressRange progressRange;
+        document->recompute(progressRange);
     }
 
     void TearDown() override

--- a/tests/src/Mod/Part/App/AttachExtension.cpp
+++ b/tests/src/Mod/Part/App/AttachExtension.cpp
@@ -44,14 +44,15 @@ TEST_F(AttachExtensionTest, testPlanePlane)
     ASSERT_TRUE(plane1);
     ASSERT_TRUE(plane2);
 
-    getDocument()->recompute();
+    Base::NullProgressRange progressRange;
+    getDocument()->recompute(progressRange);
 
     plane2->MapReversed.setValue(false);
     plane2->AttachmentSupport.setValue(plane1);
     plane2->MapPathParameter.setValue(0.0);
     plane2->MapMode.setValue("FlatFace");
 
-    getDocument()->recompute();
+    getDocument()->recompute(progressRange);
     EXPECT_TRUE(true);
 }
 

--- a/tests/src/Mod/Part/App/Attacher.cpp
+++ b/tests/src/Mod/Part/App/Attacher.cpp
@@ -34,7 +34,8 @@ protected:
         _boxes[1]->AttachmentSupport.setValue(_boxes[0]);
         _boxes[1]->MapPathParameter.setValue(0.0);
         _boxes[1]->MapMode.setValue("ObjectXY");  // There are lots of attachment modes!
-        _boxes[1]->recomputeFeature();
+        Base::NullProgressRange progressRange;
+        _boxes[1]->recomputeFeature(progressRange);
     }
 
     void TearDown() override
@@ -177,7 +178,8 @@ TEST_F(AttacherTest, TestAllStringModesValid)
     int index = 0;
     for (auto mode : modes) {
         _boxes[1]->MapMode.setValue(mode);  // There are lots of attachment modes!
-        _boxes[1]->recomputeFeature();
+        Base::NullProgressRange progressRange;
+        _boxes[1]->recomputeFeature(progressRange);
         EXPECT_STREQ(_boxes[1]->MapMode.getValueAsString(), mode);
         EXPECT_EQ(_boxes[1]->MapMode.getValue(), index);
         index++;
@@ -187,172 +189,173 @@ TEST_F(AttacherTest, TestAllStringModesValid)
 TEST_F(AttacherTest, TestAllModesBoundaries)
 {
     _boxes[1]->MapMode.setValue(mmTranslate);
-    _boxes[1]->recomputeFeature();
+    Base::NullProgressRange progressRange;
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 1, 2, 3)));
     _boxes[1]->MapMode.setValue(mmObjectXY);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 1, 2, 3)));
     _boxes[1]->MapMode.setValue(mmObjectXZ);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, -3, 0, 1, 0, 2)));
     _boxes[1]->MapMode.setValue(mmObjectYZ);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
 
     _boxes[1]->MapMode.setValue(mmParallelPlane);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mmFlatFace);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mmTangentPlane);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1Normal);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
 
     _boxes[1]->MapMode.setValue(mmFrenetNB);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mmFrenetTN);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mmFrenetTB);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mmConcentric);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mmRevolutionSection);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mmThreePointsNormal);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mmThreePointsPlane);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mmFolding);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
 
     _boxes[1]->MapMode.setValue(mm1AxisX);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1AxisY);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1AxisZ);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1AxisCurv);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1Directrix1);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1Directrix2);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1Asymptote1);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1Asymptote2);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1Tangent);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1TangentU);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1TangentV);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1TwoPoints);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1Intersection);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1Proximity);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
 
     _boxes[1]->MapMode.setValue(mm0Origin);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm0Focus1);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm0Focus2);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm0OnEdge);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm0CenterOfCurvature);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm0CenterOfMass);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1Intersection);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm0Vertex);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm0ProximityPoint1);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm0ProximityPoint2);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
 
     _boxes[1]->MapMode.setValue(mm1AxisInertia1);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1AxisInertia2);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mm1AxisInertia3);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
 
     _boxes[1]->MapMode.setValue(mmInertialCS);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(
         boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0.5, 1, 1.5, 3.5, 2, 3.5)));
 
     _boxes[1]->MapMode.setValue(mm1FaceNormal);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(
         boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0.5, 1, 1.5, 3.5, 2, 3.5)));
 
     _boxes[1]->MapMode.setValue(mmOZX);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(
         boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0.5, 1, 1.5, 3.5, 2, 3.5)));
     _boxes[1]->MapMode.setValue(mmOZY);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(
         boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0.5, 1, 1.5, 3.5, 2, 3.5)));
     _boxes[1]->MapMode.setValue(mmOXY);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(
         boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0.5, 1, 1.5, 3.5, 2, 3.5)));
     _boxes[1]->MapMode.setValue(mmOXZ);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(
         boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0.5, 1, 1.5, 3.5, 2, 3.5)));
     _boxes[1]->MapMode.setValue(mmOYZ);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(
         boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0.5, 1, 1.5, 3.5, 2, 3.5)));
     _boxes[1]->MapMode.setValue(mmOYX);
-    _boxes[1]->recomputeFeature();
+    _boxes[1]->recomputeFeature(progressRange);
     EXPECT_TRUE(
         boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0.5, 1, 1.5, 3.5, 2, 3.5)));
 }


### PR DESCRIPTION
Following on from #19710 - this time using OCCT's native functionality for aborting operations, and also for reporting progress percentage.

Current issues:

 * we should factor the "ComputationDialog" etc. out of `ViewProviderTransformed.cpp` and make it more generally available for everything to use
 * where possible everything that interfaces with OCCT should take & pass on a `Message_ProgressRange` (or `Message_ProgressScope`? still not 100% sure on the distinction)
 * sometimes OCCT can be in a code path that doesn't check `UserBreak()` frequently enough, and then the abort doesn't work, and we ask the user if they want to force quit by cancelling the thread - this nearly always segfaults FreeCAD, we could try to work out if we can make it not do that; further, if we find particularly bad examples we should upstream fixes to make it call `UserBreak()` in places that are helpful for us
 * we should save the backup document before doing the forced `pthread_cancel()` :)
 * make sure all the places that can trigger a recompute can abort it