### PR TITLE
[Spreadsheet] Remove prepended apostrophe if cell content is copied into clipboard

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -714,6 +714,9 @@ void SheetTableView::_copySelection(const std::vector<App::Range>& ranges, bool 
         for (int j = minCol; j <= maxCol; j++) {
             QModelIndex index = model()->index(i, j);
             QString cell = index.data(Qt::EditRole).toString();
+            if (!cell.isEmpty() && cell.at(0) ==  QLatin1Char('\''))
+                cell.remove(0, 1);
+
             if (j < maxCol) {
                 cell.append(QChar::fromLatin1('\t'));
             }

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -714,8 +714,9 @@ void SheetTableView::_copySelection(const std::vector<App::Range>& ranges, bool 
         for (int j = minCol; j <= maxCol; j++) {
             QModelIndex index = model()->index(i, j);
             QString cell = index.data(Qt::EditRole).toString();
-            if (!cell.isEmpty() && cell.at(0) ==  QLatin1Char('\''))
+            if (!cell.isEmpty() && cell.at(0) == QLatin1Char('\'')) {
                 cell.remove(0, 1);
+            }
 
             if (j < maxCol) {
                 cell.append(QChar::fromLatin1('\t'));


### PR DESCRIPTION
This commit removes an apostrophe if it is the first symbol in the cell content when it is copied to clipboard.


Relevant PR is #9667. Perhaps, @0penBrain might want to comment this PR.


Closes #10058.
