### PR TITLE
TechDraw: remove unneeded state, part 1

### DIFF
--- a/src/Mod/TechDraw/Gui/PATPathMaker.cpp
+++ b/src/Mod/TechDraw/Gui/PATPathMaker.cpp
@@ -44,6 +44,7 @@ using namespace TechDraw;
 
 PATPathMaker::PATPathMaker(QGraphicsItem* parent, double lineWidth, double fillScale) :
     m_parent(parent),
+    m_pen(),
     m_fillScale(fillScale),
     m_lineWidth(lineWidth)
 {

--- a/src/Mod/TechDraw/Gui/PATPathMaker.cpp
+++ b/src/Mod/TechDraw/Gui/PATPathMaker.cpp
@@ -213,6 +213,11 @@ QPainterPath PATPathMaker::dashedPPath(const std::vector<double> dashPattern, co
       return result;
 }
 
+void PATPathMaker::setLineWidth(double width)
+{
+    m_lineWidth = width;
+    m_pen.setWidthF(width);
+}
 
 //! convert a dash pattern to an offset dash pattern  (ie offset -> end)
 // dashPattern & offset are already scaled.

--- a/src/Mod/TechDraw/Gui/PATPathMaker.h
+++ b/src/Mod/TechDraw/Gui/PATPathMaker.h
@@ -40,7 +40,7 @@ public:
     explicit PATPathMaker(QGraphicsItem* parent = nullptr, double lineWidth = 0.50, double fillScale = 1.0);
     ~PATPathMaker() = default;
 
-    void setLineWidth(double width) {  m_lineWidth = width; }
+    void setLineWidth(double width);
     void setScale(double scale) { m_fillScale = scale; }
     void setPen(QPen pen) { m_pen = pen; }
     QPen getPen()  { return m_pen; }
@@ -61,7 +61,6 @@ protected:
 
 private:
     QGraphicsItem* m_parent;
-    QPainterPath m_geomhatch;                  //crosshatch fill lines
     QPen m_pen;
 
     std::vector<TechDraw::LineSet> m_lineSets;

--- a/src/Mod/TechDraw/Gui/QGCustomText.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomText.cpp
@@ -43,15 +43,14 @@ using namespace TechDraw;
 using namespace TechDrawGui;
 
 QGCustomText::QGCustomText(QGraphicsItem* parent) :
-    QGraphicsTextItem(parent), isHighlighted(false)
+    QGraphicsTextItem(parent)
 {
     setCacheMode(QGraphicsItem::NoCache);
     setAcceptHoverEvents(false);
     setFlag(QGraphicsItem::ItemIsSelectable, false);
     setFlag(QGraphicsItem::ItemIsMovable, false);
 
-    m_colCurrent = getNormalColor();
-    m_colNormal  = m_colCurrent;
+    m_colNormal  = getNormalColor();
     tightBounding = false;
 }
 
@@ -144,27 +143,23 @@ void QGCustomText::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 }
 
 void QGCustomText::setPrettyNormal() {
-    m_colCurrent = m_colNormal;
-    setDefaultTextColor(m_colCurrent);
+    setDefaultTextColor(m_colNormal);
     update();
 }
 
 void QGCustomText::setPrettyPre() {
-    m_colCurrent = getPreColor();
-    setDefaultTextColor(m_colCurrent);
+    setDefaultTextColor(getPreColor());
     update();
 }
 
 void QGCustomText::setPrettySel() {
-    m_colCurrent = getSelectColor();
-    setDefaultTextColor(m_colCurrent);
+    setDefaultTextColor(getSelectColor());
     update();
 }
 
 void QGCustomText::setColor(QColor c)
 {
     m_colNormal = c;
-    m_colCurrent = c;
     QGraphicsTextItem::setDefaultTextColor(c);
 }
 

--- a/src/Mod/TechDraw/Gui/QGCustomText.h
+++ b/src/Mod/TechDraw/Gui/QGCustomText.h
@@ -87,9 +87,7 @@ protected:
 
     Base::Reference<ParameterGrp> getParmGroup();
 
-    bool isHighlighted;
     bool tightBounding;  // Option to use tighter boundingRect(), works only for plaintext QGCustomText
-    QColor m_colCurrent;
     QColor m_colNormal;
 
 private:

--- a/src/Mod/TechDraw/Gui/QGIArrow.cpp
+++ b/src/Mod/TechDraw/Gui/QGIArrow.cpp
@@ -46,8 +46,7 @@ QGIArrow::QGIArrow() :
     setFlipped(false);
     setFillStyle(Qt::SolidPattern);
     m_brush.setStyle(m_fill);
-    m_colDefFill = getNormalColor();
-    m_colNormalFill = m_colDefFill;
+    m_colNormalFill = getNormalColor();
 
     setCacheMode(QGraphicsItem::NoCache);
     setAcceptHoverEvents(false);

--- a/src/Mod/TechDraw/Gui/QGIBreakLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGIBreakLine.cpp
@@ -64,9 +64,7 @@ QGIBreakLine::QGIBreakLine()
 
 
     setColor(PreferencesGui::sectionLineQColor());
-
-    // setFill(Qt::NoBrush);
-    setFill(Qt::SolidPattern);
+    m_brush.setStyle(Qt::SolidPattern);
 }
 
 void QGIBreakLine::draw()
@@ -253,9 +251,6 @@ void QGIBreakLine::paint ( QPainter * painter, const QStyleOptionGraphicsItem * 
 
 void QGIBreakLine::setTools()
 {
-    m_pen.setWidthF(m_width);
-    m_pen.setColor(m_colCurrent);
-    m_brush.setStyle(m_brushCurrent);
     m_brush.setColor(PreferencesGui::pageQColor());
 
     m_line0->setPen(m_pen);

--- a/src/Mod/TechDraw/Gui/QGICMark.cpp
+++ b/src/Mod/TechDraw/Gui/QGICMark.cpp
@@ -42,7 +42,7 @@ using namespace TechDrawGui;
 QGICMark::QGICMark(int index) : QGIVertex(index)
 {
     m_size = 3.0;
-    m_width = 0.75;
+    setThick(0.75);
     draw();
 }
 void QGICMark::draw()
@@ -63,7 +63,7 @@ void QGICMark::setSize(float s)
 
 void QGICMark::setThick(float t)
 {
-    m_width = t;
+    m_pen.setWidthF(t);
     draw();
 }
 
@@ -73,7 +73,7 @@ QColor QGICMark::getCMarkColor()
 }
 
 void QGICMark::setPrettyNormal() {
-    m_colCurrent = getCMarkColor();
+    m_pen.setColor(getCMarkColor());
     update();
 }
 

--- a/src/Mod/TechDraw/Gui/QGICMark.h
+++ b/src/Mod/TechDraw/Gui/QGICMark.h
@@ -46,7 +46,7 @@ public:
     void draw(void);
     float getSize() { return m_size; }
     void setSize(float s);
-    float getThick() { return m_width; }
+    float getThick() { return m_pen.widthF(); }
     void setThick(float t);
     void setPrettyNormal() override;
 

--- a/src/Mod/TechDraw/Gui/QGICenterLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGICenterLine.cpp
@@ -104,7 +104,7 @@ void QGICenterLine::setIntersection(bool isIntersecting) {
 
 void QGICenterLine::setTools()
 {
-    if (m_styleCurrent == Qt::DashDotLine) {
+    if (m_pen.style() == Qt::DashDotLine) {
         QVector<qreal> dashes;
         qreal space = 4;  // in unit width
         qreal dash = 16;
@@ -116,7 +116,7 @@ void QGICenterLine::setTools()
         qreal dashlen = dot + 2 * space + dash;
         qreal l_len = sqrt(pow(m_start.x() - m_end.x(), 2) + pow(m_start.y() - m_end.y(), 2)) / 2.0;
         // convert from pixelunits to width units
-        l_len = l_len / m_width;
+        l_len = l_len / m_pen.widthF();
         // note that the additional length using RoundCap or SquareCap does not
         // count here!
         if (m_isintersection) {
@@ -127,12 +127,7 @@ void QGICenterLine::setTools()
 
         m_pen.setDashPattern(dashes);
     }
-    else {
-        m_pen.setStyle(m_styleCurrent);
-    }
     m_pen.setCapStyle(Qt::RoundCap);
-    m_pen.setWidthF(m_width);
-    m_pen.setColor(m_colCurrent);
     m_line->setPen(m_pen);
 }
 

--- a/src/Mod/TechDraw/Gui/QGIDecoration.cpp
+++ b/src/Mod/TechDraw/Gui/QGIDecoration.cpp
@@ -38,9 +38,7 @@ using namespace TechDrawGui;
 using namespace TechDraw;
 
 QGIDecoration::QGIDecoration() :
-    m_colCurrent(Qt::black),
-    m_styleCurrent(Qt::SolidLine),
-    m_brushCurrent(Qt::SolidPattern),
+    m_pen(Qt::SolidLine),
     m_dragState(DragState::NoDrag)
 {
     setCacheMode(QGraphicsItem::NoCache);
@@ -68,22 +66,18 @@ void QGIDecoration::paint ( QPainter * painter, const QStyleOptionGraphicsItem *
 
 void QGIDecoration::setWidth(double w)
 {
-    m_width = w;
-    m_pen.setWidthF(m_width);
+    m_pen.setWidthF(w);
 }
 
 void QGIDecoration::setStyle(Qt::PenStyle s)
 {
-    m_styleCurrent = s;
-    m_pen.setStyle(m_styleCurrent);
+    m_pen.setStyle(s);
 }
 
 void QGIDecoration::setColor(QColor c)
 {
-    m_colNormal = c;
-    m_colCurrent = c;
-    m_pen.setColor(m_colCurrent);
-    m_brush.setColor(m_colCurrent);
+    m_pen.setColor(c);
+    m_brush.setColor(c);
 }
 
 QColor QGIDecoration::prefNormalColor()

--- a/src/Mod/TechDraw/Gui/QGIDecoration.h
+++ b/src/Mod/TechDraw/Gui/QGIDecoration.h
@@ -67,11 +67,10 @@ public:
     virtual void onDragFinished();
 
     void setWidth(double w);
-    double getWidth() { return m_width; }
+    double getWidth() { return m_pen.widthF(); }
     void setStyle(Qt::PenStyle s);
     void setColor(QColor c);
     QColor getColor() { return m_colNormal; }
-    void setFill(Qt::BrushStyle bs) { m_brushCurrent = bs; }
     void makeMark(double x, double y);
     void makeMark(Base::Vector3d v);
 
@@ -84,11 +83,7 @@ protected:
     virtual QColor prefSelectColor();
     QPen m_pen;
     QBrush m_brush;
-    QColor m_colCurrent;
     QColor m_colNormal;
-    double m_width;
-    Qt::PenStyle m_styleCurrent;
-    Qt::BrushStyle m_brushCurrent;
 
     DragState m_dragState;
 

--- a/src/Mod/TechDraw/Gui/QGIDimLines.cpp
+++ b/src/Mod/TechDraw/Gui/QGIDimLines.cpp
@@ -42,7 +42,8 @@ QGIDimLines::QGIDimLines()
     setFlag(QGraphicsItem::ItemIsSelectable, false);
     setFlag(QGraphicsItem::ItemIsMovable, false);
 
-    m_width = 0.5;
+    setFill(QColor(100, 100, 0));
+    setWidth(0.5);
 }
 
 void QGIDimLines::draw()

--- a/src/Mod/TechDraw/Gui/QGIEdge.cpp
+++ b/src/Mod/TechDraw/Gui/QGIEdge.cpp
@@ -51,7 +51,7 @@ QGIEdge::QGIEdge(int index) :
     setFlag(QGraphicsItem::ItemIsFocusable, true);      // to get key press events
     setFlag(QGraphicsItem::ItemIsSelectable, true);
 
-    m_width = 1.0;
+    setWidth(1.0);
     setCosmetic(isCosmetic);
     setFill(Qt::NoBrush);
 }
@@ -70,18 +70,18 @@ void QGIEdge::setCosmetic(bool state)
 void QGIEdge::setHiddenEdge(bool b) {
     isHiddenEdge = b;
     if (b) {
-        m_styleCurrent = getHiddenStyle();
+        m_pen.setStyle(getHiddenStyle());
     } else {
-        m_styleCurrent = Qt::SolidLine;
+        m_pen.setStyle(Qt::SolidLine);
     }
 }
 
 void QGIEdge::setPrettyNormal() {
 //    Base::Console().Message("QGIE::setPrettyNormal()\n");
     if (isHiddenEdge) {
-        m_colCurrent = getHiddenColor();
+        m_pen.setColor(getHiddenColor());
     } else {
-        m_colCurrent = getNormalColor();
+        m_pen.setColor(getNormalColor());
     }
     //should call QGIPP::setPrettyNormal()?
 }
@@ -136,10 +136,4 @@ void QGIEdge::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 void QGIEdge::setLinePen(QPen linePen)
 {
     m_pen = linePen;
-}
-
-void QGIEdge::setCurrentPen()
-{
-    m_pen.setWidthF(m_width);
-    m_pen.setColor(m_colCurrent);
 }

--- a/src/Mod/TechDraw/Gui/QGIEdge.h
+++ b/src/Mod/TechDraw/Gui/QGIEdge.h
@@ -59,8 +59,6 @@ public:
     void setSource(TechDraw::SourceType source) { m_source = source; }
     TechDraw::SourceType getSource() const { return m_source;}
 
-    void setCurrentPen() override;
-
 protected:
 
     void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;

--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -56,7 +56,6 @@ using namespace TechDraw;
 using DU = DrawUtil;
 
 QGIFace::QGIFace(int index) :
-    m_hideSvgTiles(false),
     projIndex(index),
     m_hatchRotation(0.0)
 {
@@ -65,8 +64,6 @@ QGIFace::QGIFace(int index) :
 
     setStyle(Qt::NoPen);    //don't draw face lines, just fill for debugging
     //setStyle(Qt::DashLine);
-    m_geomColor = PreferencesGui::getAccessibleQColor(QColor(Qt::black));
-    setLineWeight(0.0);                   //0 = cosmetic
 
     m_texture = QPixmap();                      //empty texture
 
@@ -85,6 +82,9 @@ QGIFace::QGIFace(int index) :
 
     m_sharedRender = new QSvgRenderer();
     m_patMaker = new PATPathMaker(this, 1.0, 1.0);
+    setHatchColor(PreferencesGui::getAccessibleQColor(QColor(Qt::black)));
+    m_patMaker->setLineWidth(0.5);
+    setLineWeight(0.0);                   //0 = cosmetic
 }
 
 QGIFace::~QGIFace()
@@ -105,7 +105,6 @@ QColor QGIFace::getDefaultFillColor()
 void QGIFace::draw()
 {
 //    Base::Console().Message("QGIF::draw - pen style: %d\n", m_pen.style());
-    setPath(m_outline);                         //Face boundary
 
     m_svgHatchArea->hide();
     m_imageSvgHatchArea->hide();
@@ -226,14 +225,13 @@ void QGIFace::setFillMode(FillMode mode)
 /// update the outline of this face
 void QGIFace::setOutline(const QPainterPath & path)
 {
-    m_outline = path;
+    setPath(path);
 }
 
 /// remove the PAT hatch lines
 void QGIFace::clearLineSets()
 {
-    m_dashSpecs.clear();
-    clearFillItems();
+    return;
 }
 
 /// add PAT hatch line set
@@ -245,7 +243,6 @@ void QGIFace::addLineSet(LineSet& ls)
 /// convert the PAT line set to QGraphicsPathItems
 void QGIFace::lineSetToFillItems(LineSet& ls)
 {
-    m_patMaker->setLineWidth(Rez::guiX(m_geomWeight));
     m_patMaker->setScale(m_fillScale);
     m_patMaker->setPen(setGeomPen());
     m_patMaker->lineSetToFillItems(ls);
@@ -254,8 +251,6 @@ void QGIFace::lineSetToFillItems(LineSet& ls)
 QPen QGIFace::setGeomPen()
 {
     QPen result;
-    result.setWidthF(Rez::guiX(m_geomWeight));
-    result.setColor(m_geomColor);
     result.setStyle(Qt::SolidLine);
     return result;
 }
@@ -278,16 +273,6 @@ double QGIFace::getXForm()
     return 1.0;
 }
 
-/// remove the children that make up a PAT fill
-void QGIFace::clearFillItems()
-{
-    for (auto& fill: m_fillItems) {
-        fill->setParentItem(nullptr);
-        this->scene()->removeItem(fill);
-        delete fill;
-    }
-}
-
 /// debugging tool draws a mark at a position on this face
 void QGIFace::makeMark(double x, double y)  // NOLINT readability-identifier-length
 {
@@ -305,10 +290,10 @@ void QGIFace::buildSvgHatch()
 //    Base::Console().Message("QGIF::buildSvgHatch() - offset: %s\n", DrawUtil::formatVector(getHatchOffset()).c_str());
     double wTile = SVGSIZEW * m_fillScale;
     double hTile = SVGSIZEH * m_fillScale;
-    double faceWidth = m_outline.boundingRect().width();
-    double faceHeight = m_outline.boundingRect().height();
+    double faceWidth = path().boundingRect().width();
+    double faceHeight = path().boundingRect().height();
     double faceOverlaySize = Preferences::svgHatchFactor() * std::max(faceWidth, faceHeight);
-    QPointF faceCenter = m_outline.boundingRect().center();
+    QPointF faceCenter = path().boundingRect().center();
     double tilesWide = ceil(faceOverlaySize / wTile);
     double tilesHigh = ceil(faceOverlaySize / hTile);
 
@@ -348,21 +333,16 @@ void QGIFace::buildSvgHatch()
     m_svgHatchArea->setRotation(m_hatchRotation);
 }
 
-void QGIFace::clearSvg()
-{
-    hideSvg(true);
-}
-
 //! similar to svg hatch, but using pixmaps. we do this because QGraphicsSvgItems are not clipped
 //! when we export the scene to svg, but pixmaps are clipped.
 void QGIFace::buildPixHatch()
 {
     double wTile = SVGSIZEW * m_fillScale;
     double hTile = SVGSIZEH * m_fillScale;
-    double faceWidth = m_outline.boundingRect().width();
-    double faceHeight = m_outline.boundingRect().height();
+    double faceWidth = path().boundingRect().width();
+    double faceHeight = path().boundingRect().height();
     double faceOverlaySize = Preferences::svgHatchFactor() * std::max(faceWidth, faceHeight);
-    QPointF faceCenter = m_outline.boundingRect().center();
+    QPointF faceCenter = path().boundingRect().center();
     double tilesWide = ceil(faceOverlaySize / wTile);
     double tilesHigh = ceil(faceOverlaySize / hTile);
 
@@ -452,23 +432,21 @@ void QGIFace::buildPixHatch()
 void QGIFace::setHatchColor(Base::Color color)
 {
     m_svgCol = color.asHexString();
-    m_geomColor = color.asValue<QColor>();
+
+    QPen p = m_patMaker->getPen();
+    p.setColor(color.asValue<QColor>());
+    m_patMaker->setPen(p);
+}
+
+void QGIFace::setHatchColor(QColor color)
+{
+    setHatchColor(Base::Color::fromValue(color));
 }
 
 void QGIFace::setHatchScale(double scale)
 {
     m_fillScale = scale;
 }
-
-/// turn svg tiles on or off. QtSvg does not handle clipping,
-/// so we must be able to turn the hatching on/off when exporting a face with an
-/// svg hatch.  Otherwise the full tile pattern is shown in the export.
-/// NOTE: there appears to have been a change in Qt that it now clips svg items
-void QGIFace::hideSvg(bool state)
-{
-    m_hideSvgTiles = state;
-}
-
 
 /// create a QPixmap from a bitmap file.  The QPixmap will be used as a QBrush
 /// texture.
@@ -492,13 +470,13 @@ QPixmap QGIFace::textureFromBitmap(std::string fileSpec) const
     return pix;
 }
 
-void QGIFace::setLineWeight(double weight) {
-    m_geomWeight = weight;
+void QGIFace::setLineWeight(double weight)
+{
+    m_patMaker->setLineWidth(Rez::guiX(weight));
 }
 
 void QGIFace::getParameters()
 {
-    m_maxSeg = Preferences::getPreferenceGroup("PAT")->GetInt("MaxSeg", MAXSEGMENT);
     m_maxTile = Preferences::getPreferenceGroup("Decorations")->GetInt("MaxSVGTile", MAXTILES);
 }
 

--- a/src/Mod/TechDraw/Gui/QGIFace.h
+++ b/src/Mod/TechDraw/Gui/QGIFace.h
@@ -82,6 +82,11 @@ public:
     void setDrawEdges(bool state);
     virtual void setOutline(const QPainterPath& path);
 
+    QColor getDefaultFillColor() override;
+    Qt::BrushStyle getDefaultFillStyle() override {
+        return Qt::SolidPattern;
+    }
+
     //shared fill parms
     void isHatched(bool state) {m_isHatched = state; }
     bool isHatched() {return m_isHatched;}
@@ -122,6 +127,10 @@ public:
 
     void setHatchOffset(Base::Vector3d offset) { m_hatchOffset = offset; }
     Base::Vector3d getHatchOffset() { return m_hatchOffset; }
+
+    void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = nullptr ) override {
+        QGIPrimPath::paint(painter, option, widget);
+    }
 
 protected:
     void makeMark(double x, double y);  // NOLINT readability-identifier-length

--- a/src/Mod/TechDraw/Gui/QGIFace.h
+++ b/src/Mod/TechDraw/Gui/QGIFace.h
@@ -48,7 +48,6 @@ class QGCustomImage;
     constexpr uint32_t COLWHITE{0xfffff};       // white
     constexpr int ALPHALOW{0};
     constexpr int ALPHAHIGH{255};
-    constexpr long int MAXSEGMENT{10000L};
     constexpr long int MAXTILES{10000L};
     const std::string SVGCOLDEFAULT = "#000000";  // black
 
@@ -94,25 +93,22 @@ public:
 
     //general hatch parms & methods
     void setHatchColor(Base::Color color);
+    void setHatchColor(QColor color);
     void setHatchScale(double scale);
 
     //svg fill parms & methods
     void setHatchFile(std::string fileSpec);
     void loadSvgHatch(std::string fileSpec);
     void buildSvgHatch();
-    void hideSvg(bool state);
-    void clearSvg();
 
     //tiled pixmap fill from svg
     void buildPixHatch();
 
     //PAT fill parms & methods
-    void setGeomHatchWeight(double weight) { m_geomWeight = weight; }
     void setLineWeight(double weight);
 
-    void clearLineSets();
+    [[deprecated]] void clearLineSets();
     void addLineSet(TechDraw::LineSet& ls);
-    void clearFillItems();
 
     void lineSetToFillItems(TechDraw::LineSet& ls);
     QGraphicsPathItem* geomToLine(TechDraw::BaseGeomPtr base, TechDraw::LineSet& ls);
@@ -153,14 +149,9 @@ protected:
 
 
 private:
-    std::vector<QGraphicsPathItem*> m_fillItems;
     std::vector<TechDraw::LineSet> m_lineSets;
-    std::vector<TechDraw::DashSpec> m_dashSpecs;
-    long int m_segCount{0};
-    long int m_maxSeg{0};
     long int m_maxTile{0};
 
-    bool m_hideSvgTiles{false};
     int projIndex;                              //index of face in Projection. -1 for SectionFace.
 
     QGCustomRect* m_svgHatchArea;
@@ -174,15 +165,6 @@ private:
     bool m_isHatched{false};
     QGIFace::FillMode m_mode;
     QPixmap m_texture;                          //
-
-    QPainterPath m_outline;                     //
-
-    QPainterPath m_geomhatch;                  //crosshatch fill lines
-
-    QColor m_geomColor;                        //color for crosshatch lines
-    double m_geomWeight{0.5};                       //lineweight for crosshatch lines
-
-    QColor m_defFaceColor;
 
     double m_hatchRotation{0.0};
     Base::Vector3d m_hatchOffset;

--- a/src/Mod/TechDraw/Gui/QGIHighlight.cpp
+++ b/src/Mod/TechDraw/Gui/QGIHighlight.cpp
@@ -188,16 +188,10 @@ void QGIHighlight::paint ( QPainter * painter, const QStyleOptionGraphicsItem * 
 
 void QGIHighlight::setTools()
 {
-    m_pen.setWidthF(m_width);
-    m_pen.setColor(m_colCurrent);
-
-    m_brush.setStyle(m_brushCurrent);
-    m_brush.setColor(m_colCurrent);
-
     m_circle->setPen(m_pen);
     m_rect->setPen(m_pen);
 
-    m_reference->setDefaultTextColor(m_colCurrent);
+    m_reference->setDefaultTextColor(m_pen.color());
 }
 
 void QGIHighlight::setLinePen(QPen isoPen)

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.h
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.h
@@ -55,25 +55,22 @@ public:
     virtual void setPrettyPre();
     virtual void setPrettySel();
     virtual void setWidth(double w);
-    virtual double getWidth() { return m_width;}
-    Qt::PenStyle getStyle() { return m_styleCurrent; }
+    virtual double getWidth() { return m_pen.widthF();}
+    Qt::PenStyle getStyle() { return m_pen.style(); }
     void setStyle(Qt::PenStyle s);
     void setStyle(int s);
     virtual void setNormalColor(QColor c);
     virtual void setCapStyle(Qt::PenCapStyle c);
 
     //plain color fill parms
-    void setFillStyle(Qt::BrushStyle f) { m_fillStyleCurrent = f; }
-    Qt::BrushStyle getFillStyle() { return m_fillStyleCurrent; }
+    void setFillStyle(Qt::BrushStyle f) { m_brush.setStyle(f); }
+    Qt::BrushStyle getFillStyle() { return m_brush.style(); }
 
     void setFill(QColor c, Qt::BrushStyle s);
     void setFill(QBrush b);
     void resetFill();
     void setFillColor(QColor c);
-    QColor getFillColor() { return m_colDefFill; }
-    void setFillOverride(bool b) { m_fillOverride = b; }
-
-    virtual void setCurrentPen();
+    QColor getFillColor() { return getDefaultFillColor(); }
 
 protected:
     void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
@@ -88,32 +85,25 @@ protected:
     virtual QColor getNormalColor();
     virtual QColor getPreColor();
     virtual QColor getSelectColor();
+    virtual QColor getDefaultFillColor() {
+        return Qt::white;
+    }
+    virtual Qt::BrushStyle getDefaultFillStyle() {
+        return Qt::NoBrush;
+    }
     Base::Reference<ParameterGrp> getParmGroup();
     virtual Qt::PenCapStyle prefCapStyle();
 
-    bool isHighlighted;
     bool multiselectActivated;
 
     QPen m_pen;
-    QColor m_colCurrent;
     QColor m_colNormal;
-    bool   m_colOverride;
-    Qt::PenStyle m_styleCurrent;
     Qt::PenStyle m_styleNormal;
-    double m_width;
-    Qt::PenCapStyle m_capStyle;
 
     QBrush m_brush;
-    Qt::BrushStyle m_fillStyleCurrent;                 //current fill style
-    QColor m_fillColorCurrent;                         //current fill color
 
-    QColor m_colDefFill;                        //"no color" default normal fill color
     QColor m_colNormalFill;                     //current Normal fill color def or plain fill
-    Qt::BrushStyle m_fillDef;                  //default Normal fill style
     Qt::BrushStyle m_fillNormal;               //current Normal fill style
-    Qt::BrushStyle m_fillSelect;               //Select/preSelect fill style
-
-    bool m_fillOverride;
 
 private:
 

--- a/src/Mod/TechDraw/Gui/QGISectionLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.cpp
@@ -483,22 +483,18 @@ void QGISectionLine::paint ( QPainter * painter, const QStyleOptionGraphicsItem 
 
 void QGISectionLine::setTools()
 {
-    m_pen.setWidthF(m_width);
-    m_pen.setColor(m_colCurrent);
-    m_brush.setStyle(m_brushCurrent);
-    m_brush.setColor(m_colCurrent);
-
     m_line->setPen(m_pen);
+    QColor currentColor = m_pen.color();
 
-    m_arrow1->setNormalColor(m_colCurrent);
-    m_arrow1->setFillColor(m_colCurrent);
+    m_arrow1->setNormalColor(currentColor);
+    m_arrow1->setFillColor(currentColor);
     m_arrow1->setPrettyNormal();
-    m_arrow2->setNormalColor(m_colCurrent);
-    m_arrow2->setFillColor(m_colCurrent);
+    m_arrow2->setNormalColor(currentColor);
+    m_arrow2->setFillColor(currentColor);
     m_arrow2->setPrettyNormal();
 
-    m_symbol1->setDefaultTextColor(m_colCurrent);
-    m_symbol2->setDefaultTextColor(m_colCurrent);
+    m_symbol1->setDefaultTextColor(currentColor);
+    m_symbol2->setDefaultTextColor(currentColor);
 }
 
 

--- a/src/Mod/TechDraw/Gui/QGITile.cpp
+++ b/src/Mod/TechDraw/Gui/QGITile.cpp
@@ -84,7 +84,6 @@ QGITile::QGITile(TechDraw::DrawTileWeld* dtw) :
     setFlag(QGraphicsItem::ItemStacksBehindParent, true);
 
     m_colNormal = prefNormalColor();
-    m_colCurrent = m_colNormal;
 }
 
 
@@ -100,7 +99,6 @@ void QGITile::draw()
 
 void QGITile::makeSymbol()
 {
-//    m_effect->setColor(m_colCurrent);
 //    m_qgSvg->setGraphicsEffect(m_effect);
 
     std::string symbolString = getStringFromFile(m_tileFeat->SymbolFile.getValue());
@@ -123,7 +121,6 @@ void QGITile::makeText()
 
     m_qgTextL->setFont(m_font);
     m_qgTextL->setPlainText(m_textL);
-    m_qgTextL->setColor(m_colCurrent);
     double textWidth = m_qgTextL->boundingRect().width();
     double charWidth = textWidth / m_textL.size();   //not good for non-ASCII chars
     double hMargin = 1;
@@ -148,7 +145,6 @@ void QGITile::makeText()
 
     m_qgTextR->setFont(m_font);
     m_qgTextR->setPlainText(m_textR);
-    m_qgTextR->setColor(m_colCurrent);
     textWidth = m_qgTextR->boundingRect().width();
     charWidth = textWidth / m_textR.size();
     hMargin = 1;
@@ -165,7 +161,6 @@ void QGITile::makeText()
 
     m_qgTextC->setFont(m_font);
     m_qgTextC->setPlainText(m_textC);
-    m_qgTextC->setColor(m_colCurrent);
     double textHeightC = m_qgTextC->boundingRect().height();
     if (m_row < 0) {                      // below line
         vOffset = m_high  * (1 + verticalFudge);
@@ -235,8 +230,6 @@ void QGITile::setSymbolFile(const std::string &fileSpec)
 }
 
 void QGITile::setPrettyNormal() {
-    m_colCurrent = m_colNormal;
-
 //    m_effect->setColor(m_colNormal);
     m_qgTextL->setColor(m_colNormal);
     m_qgTextR->setColor(m_colNormal);
@@ -246,23 +239,23 @@ void QGITile::setPrettyNormal() {
 }
 
 void QGITile::setPrettyPre() {
-    m_colCurrent = prefPreColor();
+    QColor color = prefPreColor();
 
-//    m_effect->setColor(m_colCurrent);
-    m_qgTextL->setColor(m_colCurrent);
-    m_qgTextR->setColor(m_colCurrent);
-    m_qgTextC->setColor(m_colCurrent);
+//    m_effect->setColor(color);
+    m_qgTextL->setColor(color);
+    m_qgTextR->setColor(color);
+    m_qgTextC->setColor(color);
 
     draw();
 }
 
 void QGITile::setPrettySel() {
-    m_colCurrent = prefSelectColor();
+    QColor color = prefSelectColor();
 
-//    m_effect->setColor(m_colCurrent);
-    m_qgTextL->setColor(m_colCurrent);
-    m_qgTextR->setColor(m_colCurrent);
-    m_qgTextC->setColor(m_colCurrent);
+//    m_effect->setColor(color);
+    m_qgTextL->setColor(color);
+    m_qgTextR->setColor(color);
+    m_qgTextC->setColor(color);
 
     draw();
 }

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -267,7 +267,6 @@ QGIViewBalloon::QGIViewBalloon()
     addToGroup(balloonShape);
     balloonShape->setNormalColor(prefNormalColor());
     balloonShape->setFill(Qt::transparent, Qt::SolidPattern);
-    balloonShape->setFillOverride(true);
     balloonShape->setPrettyNormal();
 
     arrow = new QGIArrow();
@@ -863,9 +862,6 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
 void QGIViewBalloon::setPrettyPre(void)
 {
     arrow->setPrettyPre();
-    //TODO: primPath needs override for fill
-    //balloonShape->setFillOverride(true);   //don't fill with pre or select colours.
-    //    balloonShape->setFill(Qt::white, Qt::NoBrush);
     balloonShape->setPrettyPre();
     balloonLines->setPrettyPre();
 }


### PR DESCRIPTION
Previously, all data styling has been saved twice.

First in a local member variable - and then before painting, the QPen will be synchronized with the local variables. This causes great confusion when editing code and can cause bugs. It makes code harder to read and debug as well.

There are no reason to have two copies.  Let's save all styling data directly in QPen.

I have to the best of my abilities tested the changes - though there might be a few bugs introduced. These should be fixed in other ways than reintroducing state. In the long run, these changes will ensure less bugs from being introduced.