### PR TITLE
Addon Manager: Show versions in update all

### DIFF
--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_update_all_gui.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_update_all_gui.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
-# *   Copyright (c) 2022 FreeCAD Project Association                        *
+# *   Copyright (c) 2022-2025 FreeCAD project association AISBL             *
 # *                                                                         *
 # *   This file is part of FreeCAD.                                         *
 # *                                                                         *
@@ -73,6 +73,8 @@ class MockAddon:
         self.display_name = name
         self.name = name
         self.macro = None
+        self.metadata = None
+        self.installed_metadata = None
 
     def status(self):
         return Addon.Status.UPDATE_AVAILABLE
@@ -144,29 +146,29 @@ class TestUpdateAllGui(unittest.TestCase):
     def test_add_addon_to_table(self):
         mock_addon = MockAddon("MockAddon")
         self.test_object.dialog.tableWidget.clear()
-        self.test_object._add_addon_to_table(mock_addon)
+        self.test_object._add_addon_to_table(mock_addon, 1)
         self.assertEqual(self.test_object.dialog.tableWidget.rowCount(), 1)
 
     def test_update_addon_status(self):
         self.test_object._setup_dialog()
         self.test_object._update_addon_status(0, AddonStatus.WAITING)
         self.assertEqual(
-            self.test_object.dialog.tableWidget.item(0, 1).text(),
+            self.test_object.dialog.tableWidget.item(0, 2).text(),
             AddonStatus.WAITING.ui_string(),
         )
         self.test_object._update_addon_status(0, AddonStatus.INSTALLING)
         self.assertEqual(
-            self.test_object.dialog.tableWidget.item(0, 1).text(),
+            self.test_object.dialog.tableWidget.item(0, 2).text(),
             AddonStatus.INSTALLING.ui_string(),
         )
         self.test_object._update_addon_status(0, AddonStatus.SUCCEEDED)
         self.assertEqual(
-            self.test_object.dialog.tableWidget.item(0, 1).text(),
+            self.test_object.dialog.tableWidget.item(0, 2).text(),
             AddonStatus.SUCCEEDED.ui_string(),
         )
         self.test_object._update_addon_status(0, AddonStatus.FAILED)
         self.assertEqual(
-            self.test_object.dialog.tableWidget.item(0, 1).text(),
+            self.test_object.dialog.tableWidget.item(0, 2).text(),
             AddonStatus.FAILED.ui_string(),
         )
 
@@ -175,19 +177,19 @@ class TestUpdateAllGui(unittest.TestCase):
         self.test_object._launch_active_installer = lambda: None
         self.test_object._process_next_update()
         self.assertEqual(
-            self.test_object.dialog.tableWidget.item(0, 1).text(),
+            self.test_object.dialog.tableWidget.item(0, 2).text(),
             AddonStatus.INSTALLING.ui_string(),
         )
 
         self.test_object._process_next_update()
         self.assertEqual(
-            self.test_object.dialog.tableWidget.item(1, 1).text(),
+            self.test_object.dialog.tableWidget.item(1, 2).text(),
             AddonStatus.INSTALLING.ui_string(),
         )
 
         self.test_object._process_next_update()
         self.assertEqual(
-            self.test_object.dialog.tableWidget.item(2, 1).text(),
+            self.test_object.dialog.tableWidget.item(2, 2).text(),
             AddonStatus.INSTALLING.ui_string(),
         )
 
@@ -208,7 +210,7 @@ class TestUpdateAllGui(unittest.TestCase):
         self.test_object._setup_dialog()
         self.test_object._update_succeeded(self.addons[0])
         self.assertEqual(
-            self.test_object.dialog.tableWidget.item(0, 1).text(),
+            self.test_object.dialog.tableWidget.item(0, 2).text(),
             AddonStatus.SUCCEEDED.ui_string(),
         )
 
@@ -216,7 +218,7 @@ class TestUpdateAllGui(unittest.TestCase):
         self.test_object._setup_dialog()
         self.test_object._update_failed(self.addons[0])
         self.assertEqual(
-            self.test_object.dialog.tableWidget.item(0, 1).text(),
+            self.test_object.dialog.tableWidget.item(0, 2).text(),
             AddonStatus.FAILED.ui_string(),
         )
 

--- a/src/Mod/AddonManager/update_all.ui
+++ b/src/Mod/AddonManager/update_all.ui
@@ -27,7 +27,7 @@
    <item>
     <widget class="QTableWidget" name="tableWidget">
      <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
+      <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
      </property>
      <property name="tabKeyNavigation">
       <bool>false</bool>
@@ -39,7 +39,10 @@
       <bool>false</bool>
      </property>
      <property name="selectionMode">
-      <enum>QAbstractItemView::NoSelection</enum>
+      <enum>QAbstractItemView::SelectionMode::NoSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
      </property>
      <property name="showGrid">
       <bool>false</bool>
@@ -58,10 +61,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel</set>
+      <set>QDialogButtonBox::StandardButton::Cancel</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Adds two columns to the "Update All" dialog, showing the version currently installed, and then (if the update succeeds) the version after the update. No functional changes.

Here's what it looks like in-process:

https://github.com/user-attachments/assets/8c5fcad5-5fc3-4af1-9ef4-2fd9829b5b51

