### PR TITLE
Assembly: Make 2 menu texts more consistent

### DIFF
--- a/src/Mod/Assembly/CommandCreateJoint.py
+++ b/src/Mod/Assembly/CommandCreateJoint.py
@@ -73,7 +73,7 @@ class CommandCreateJointFixed:
             "Pixmap": "Assembly_CreateJointFixed",
             "MenuText": QT_TRANSLATE_NOOP(
                 "Assembly_CreateJointFixed",
-                "Create a Fixed Joint",
+                "Create Fixed Joint",
             ),
             "Accel": "F",
             "ToolTip": "<p>"

--- a/src/Mod/Assembly/CommandInsertNewPart.py
+++ b/src/Mod/Assembly/CommandInsertNewPart.py
@@ -51,7 +51,7 @@ class CommandInsertNewPart:
     def GetResources(self):
         return {
             "Pixmap": "Geofeaturegroup",
-            "MenuText": QT_TRANSLATE_NOOP("Assembly_InsertNewPart", "Insert a new part"),
+            "MenuText": QT_TRANSLATE_NOOP("Assembly_InsertNewPart", "Insert New Part"),
             "Accel": "P",
             "ToolTip": "<p>"
             + QT_TRANSLATE_NOOP(


### PR DESCRIPTION
Menu texts in the Assembly WB are in title case without articles.

The following menu texts did not follow that 'standard':
* Insert a new part
* Create a Fixed Joint
