### PR TITLE
[Gui] Expression dialog OK button capitalised and Alt+O shortcut applied

### DIFF
--- a/src/Gui/Dialogs/DlgExpressionInput.ui
+++ b/src/Gui/Dialogs/DlgExpressionInput.ui
@@ -273,7 +273,7 @@
        <item>
         <widget class="QPushButton" name="okBtn">
          <property name="text">
-          <string>Ok</string>
+          <string>&amp;OK</string>
          </property>
          <property name="autoDefault">
           <bool>true</bool>


### PR DESCRIPTION
Fixes #19776 

With this fix:


![Expression_OK_Button_Fix](https://github.com/user-attachments/assets/cf9b2d4e-2cbc-4af8-b7b0-81139c2d307d)
