### PR TITLE
Gui: "Open File Location/Reveal in Finder" in Tree view

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -2899,9 +2899,9 @@ void TreeWidget::onOpenFileLocation()
     const QString filePath = fileInfo.canonicalPath();
     bool success = false;
 
-#ifdef Q_OS_MAC
+#if defined(Q_OS_MAC)
     success = QProcess::startDetached(QStringLiteral("open"), {filePath});
-#elif Q_OS_WIN
+#elif defined(Q_OS_WIN)
     QStringList param;
     if (!fileInfo.isDir()) {
         param += QStringLiteral("/select,");

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -190,6 +190,7 @@ protected Q_SLOTS:
     void onShowHidden();
     void onToggleVisibilityInTree();
     void onSearchObjects();
+    void onOpenFileLocation();
 
 private Q_SLOTS:
     void onItemSelectionChanged();
@@ -240,6 +241,7 @@ private:
     QAction* reloadDocAction;
     QAction* closeDocAction;
     QAction* searchObjectsAction;
+    QAction* openFileLocationAction;
     QTreeWidgetItem *contextItem;
     App::DocumentObject *searchObject;
     Gui::Document *searchDoc;


### PR DESCRIPTION
Fixes #12801 

~TODO:~

- [x] Handle windows and macOS 
- [x] Include screenshot of working version here

1. Right click on model and select option:

![open-file-location-button-and-tip](https://github.com/user-attachments/assets/6a9b0998-1414-4d56-8acb-0336f9d30929)

2. File opens up in explorer:

![opened-file-location](https://github.com/user-attachments/assets/ccbe4f30-0af0-40a0-9e2c-e0fc579b4beb)

