### PR TITLE
CI: fix assembly unit tests executable name

### DIFF
--- a/.github/workflows/actions/runCPPTests/runAllTests/action.yml
+++ b/.github/workflows/actions/runCPPTests/runAllTests/action.yml
@@ -44,7 +44,7 @@ runs:
         id: assembly
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
         with:
-          testCommand: ${{ inputs.builddir }}/tests/Tests_run --gtest_output=json:${{ inputs.reportdir }}assembly_gtest_results.json
+          testCommand: ${{ inputs.builddir }}/tests/Assembly_tests_run --gtest_output=json:${{ inputs.reportdir }}assembly_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}assembly_gtest_test_log.txt
           testName: Assembly
       - name: C++ core tests


### PR DESCRIPTION
seems like there was a copy paste error at #18686?