### PR TITLE
Add-On Manager: list correct vendor path for snaps

### DIFF
--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -414,8 +414,15 @@ def is_float(element: Any) -> bool:
 def get_pip_target_directory():
     """Get the default location to install new pip packages"""
     major, minor, _ = platform.python_version_tuple()
+    snap_package = os.getenv("SNAP_REVISION")
+    
+    if snap_package:
+        target_dir = os.path.join(
+            ".local", "lib", f"python{major}.{minor}", "site-packages")
+    else:
+        target_dir = os.path.join("AdditionalPythonPackages", f"py{major}{minor}")
     vendor_path = os.path.join(
-        fci.DataPaths().mod_dir, "..", "AdditionalPythonPackages", f"py{major}{minor}"
+        fci.DataPaths().mod_dir, "..", target_dir
     )
     return vendor_path
 


### PR DESCRIPTION
Fixes: https://github.com/FreeCAD/FreeCAD/issues/19815

Not addressed: it would be great to remove the two dots on the path when displaying it on the dialog. For now, I did not look into it to keep the PR simple.