### PR TITLE
Build: suppress warnings from 3rd party libraries

### DIFF
--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -56,6 +56,10 @@ include_directories(
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${PYCXX_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -10,6 +10,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${PYCXX_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -58,6 +58,10 @@ include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}/TaskView
     ${CMAKE_CURRENT_BINARY_DIR}/Quarter
     ${CMAKE_CURRENT_BINARY_DIR}/DAGView
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}
@@ -98,7 +102,7 @@ endif(MSVC)
 if (TARGET Coin::Coin)
     list(APPEND FreeCADGui_LIBS Coin::Coin)
 else()
-    include_directories(${COIN3D_INCLUDE_DIRS})
+    include_directories(SYSTEM ${COIN3D_INCLUDE_DIRS})
     link_directories(${COIN3D_LIB_DIRS})
     list(APPEND FreeCADGui_LIBS ${COIN3D_LIBRARIES})
 endif()
@@ -112,6 +116,7 @@ if (WIN32)
 endif()
 
 include_directories(
+    SYSTEM
     ${QtCore_INCLUDE_DIRS}
     ${QtWidgets_INCLUDE_DIRS}
     ${QtOpenGL_INCLUDE_DIRS}
@@ -135,6 +140,7 @@ list(APPEND FreeCADGui_LIBS
 
 if(${Qt5WinExtras_FOUND})
     include_directories(
+        SYSTEM
         ${Qt5WinExtras_INCLUDE_DIRS}
     )
     list(APPEND FreeCADGui_LIBS
@@ -148,7 +154,7 @@ IF(SPNAV_FOUND AND FREECAD_USE_3DCONNEXION_LEGACY)
         add_definitions(-DSPNAV_USE_X11)
         if (FREECAD_QT_MAJOR_VERSION EQUAL 5 AND UNIX AND NOT APPLE)
             find_package(Qt5X11Extras REQUIRED)
-            include_directories(${Qt5X11Extras_INCLUDE_DIRS})
+            include_directories(SYSTEM ${Qt5X11Extras_INCLUDE_DIRS})
             list(APPEND FreeCADGui_LIBS ${Qt5X11Extras_LIBRARIES})
             # Note that Qt6 has removed the QtX11Extras files
         endif()
@@ -186,6 +192,7 @@ IF(SPNAV_FOUND AND FREECAD_USE_3DCONNEXION_LEGACY)
 
     add_definitions(-DSPNAV_FOUND)
     include_directories(
+        SYSTEM
         ${SPNAV_INCLUDE_DIR}
     )
     list(APPEND FreeCADGui_LIBS
@@ -196,6 +203,7 @@ ENDIF(SPNAV_FOUND AND FREECAD_USE_3DCONNEXION_LEGACY)
 IF(OCULUS_FOUND)
     add_definitions(-DOCULUS_FOUND)
     include_directories(
+        SYSTEM
         ${OCULUS_INCLUDE_DIRS}
     )
     list(APPEND FreeCADGui_LIBS
@@ -206,6 +214,7 @@ ENDIF(OCULUS_FOUND)
 if(FREECAD_USE_SHIBOKEN)
     add_definitions(-DHAVE_SHIBOKEN${PYSIDE_MAJOR_VERSION})
     include_directories(
+        SYSTEM
         ${SHIBOKEN_INCLUDE_DIR}
     )
     if (SHIBOKEN_LIBRARY)
@@ -227,6 +236,7 @@ endif(FREECAD_USE_SHIBOKEN)
 
 if(FREECAD_USE_PYSIDE)
     include_directories(
+        SYSTEM
         ${PYSIDE_INCLUDE_DIR}
         ${PYSIDE_INCLUDE_DIR}/QtCore
         ${PYSIDE_INCLUDE_DIR}/QtGui
@@ -247,6 +257,7 @@ if(FREECAD_USE_PYSIDE)
         endif ()
     endif (PYSIDE_LIBRARY)
     include_directories(
+        SYSTEM
         ${PYSIDE_INCLUDE_DIR}/QtWidgets
     )
     add_definitions(-DHAVE_PYSIDE${PYSIDE_MAJOR_VERSION})

--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -5,6 +5,7 @@ file(COPY icon.ico DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 if(BUILD_GUI)
     include_directories(
+        SYSTEM
         ${Boost_INCLUDE_DIRS}
         ${COIN3D_INCLUDE_DIRS}
         ${ZLIB_INCLUDE_DIR}
@@ -16,6 +17,7 @@ if(BUILD_GUI)
     )
 else(BUILD_GUI)
     include_directories(
+        SYSTEM
         ${Boost_INCLUDE_DIRS}
         ${ZLIB_INCLUDE_DIR}
         ${QT_INCLUDE_DIR}

--- a/src/Mod/Assembly/App/CMakeLists.txt
+++ b/src/Mod/Assembly/App/CMakeLists.txt
@@ -4,6 +4,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}

--- a/src/Mod/Assembly/Gui/CMakeLists.txt
+++ b/src/Mod/Assembly/Gui/CMakeLists.txt
@@ -1,6 +1,10 @@
 include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${COIN3D_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/CAM/App/CMakeLists.txt
+++ b/src/Mod/CAM/App/CMakeLists.txt
@@ -7,6 +7,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${EIGEN3_INCLUDE_DIR}

--- a/src/Mod/CAM/Gui/CMakeLists.txt
+++ b/src/Mod/CAM/Gui/CMakeLists.txt
@@ -2,6 +2,10 @@ include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIR}

--- a/src/Mod/CAM/PathSimulator/App/CMakeLists.txt
+++ b/src/Mod/CAM/PathSimulator/App/CMakeLists.txt
@@ -4,6 +4,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/CAM/PathSimulator/AppGL/CMakeLists.txt
+++ b/src/Mod/CAM/PathSimulator/AppGL/CMakeLists.txt
@@ -3,6 +3,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIR}

--- a/src/Mod/CAM/libarea/CMakeLists.txt
+++ b/src/Mod/CAM/libarea/CMakeLists.txt
@@ -9,9 +9,13 @@ if(MSVC)
 endif(MSVC)
 
 include_directories(
+    SYSTEM
     ${PYCXX_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
+)
+
+include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/src/Mod/Import/App/dxf
 )
@@ -39,7 +43,7 @@ if(NOT FREECAD_USE_PYBIND11)
         endif()
 
         if(Boost_FOUND)
-            include_directories(${Boost_INCLUDE_DIRS})
+            include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
             MESSAGE(STATUS "found Boost: " ${Boost_LIB_VERSION})
             MESSAGE(STATUS "boost-incude dirs are: " ${Boost_INCLUDE_DIRS})
             MESSAGE(STATUS "boost-python lib is: " ${Boost_PYTHON_LIBRARY})
@@ -47,10 +51,10 @@ if(NOT FREECAD_USE_PYBIND11)
             MESSAGE(STATUS "Boost_LIBRARIES is: " ${Boost_LIBRARIES})
         endif()
     else()
-        include_directories(${Boost_INCLUDE_DIRS})
+        include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
     endif()
 else()
-    include_directories(${pybind11_INCLUDE_DIR})
+    include_directories(SYSTEM ${pybind11_INCLUDE_DIR})
 endif(NOT FREECAD_USE_PYBIND11)
 
 

--- a/src/Mod/Cloud/App/CMakeLists.txt
+++ b/src/Mod/Cloud/App/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENSSL_CFLAGS}")
 endif()
 
 include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/Cloud/Gui/CMakeLists.txt
+++ b/src/Mod/Cloud/Gui/CMakeLists.txt
@@ -2,6 +2,10 @@
 include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIR}

--- a/src/Mod/Draft/App/CMakeLists.txt
+++ b/src/Mod/Draft/App/CMakeLists.txt
@@ -8,6 +8,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/Drawing/App/CMakeLists.txt
+++ b/src/Mod/Drawing/App/CMakeLists.txt
@@ -1,5 +1,9 @@
 include_directories(
     ${CMAKE_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${ZLIB_INCLUDE_DIR}

--- a/src/Mod/Drawing/Gui/CMakeLists.txt
+++ b/src/Mod/Drawing/Gui/CMakeLists.txt
@@ -2,6 +2,10 @@ include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/Fem/App/CMakeLists.txt
+++ b/src/Mod/Fem/App/CMakeLists.txt
@@ -20,6 +20,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/Fem/Gui/CMakeLists.txt
+++ b/src/Mod/Fem/Gui/CMakeLists.txt
@@ -17,6 +17,10 @@ include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIR}

--- a/src/Mod/Import/App/CMakeLists.txt
+++ b/src/Mod/Import/App/CMakeLists.txt
@@ -2,6 +2,10 @@ include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${ZLIB_INCLUDE_DIR}

--- a/src/Mod/Import/Gui/CMakeLists.txt
+++ b/src/Mod/Import/Gui/CMakeLists.txt
@@ -1,6 +1,10 @@
 include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${COIN3D_INCLUDE_DIRS}

--- a/src/Mod/Inspection/App/CMakeLists.txt
+++ b/src/Mod/Inspection/App/CMakeLists.txt
@@ -2,6 +2,10 @@ include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/Inspection/Gui/CMakeLists.txt
+++ b/src/Mod/Inspection/Gui/CMakeLists.txt
@@ -1,6 +1,10 @@
 include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/JtReader/App/CMakeLists.txt
+++ b/src/Mod/JtReader/App/CMakeLists.txt
@@ -4,6 +4,10 @@ set(JTREADER_TKJT_LIBRARIES CACHE FILEPATH  "File path to TKJT library")
 include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${ZLIB_INCLUDE_DIR}
@@ -33,7 +37,7 @@ SET(JtReader_SRCS
 
 if (EXISTS "${JTREADER_TKJT_INCLUDE_DIRS}/JtData_Object.hxx")
     add_definitions(-DJTREADER_HAVE_TKJT)
-    include_directories(${JTREADER_TKJT_INCLUDE_DIRS})
+    include_directories(SYSTEM ${JTREADER_TKJT_INCLUDE_DIRS})
     list (APPEND JtReader_LIBS
         ${JTREADER_TKJT_LIBRARIES}
     )

--- a/src/Mod/Material/App/CMakeLists.txt
+++ b/src/Mod/Material/App/CMakeLists.txt
@@ -12,6 +12,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${PYCXX_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}
@@ -28,6 +32,7 @@ set(Materials_LIBS
 )
 
 include_directories(
+    SYSTEM
     ${QtConcurrent_INCLUDE_DIRS}
 )
 list(APPEND Materials_LIBS

--- a/src/Mod/Material/Gui/CMakeLists.txt
+++ b/src/Mod/Material/Gui/CMakeLists.txt
@@ -9,6 +9,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
@@ -26,6 +30,7 @@ set(MatGui_LIBS
 )
 
 include_directories(
+    SYSTEM
     ${QtConcurrent_INCLUDE_DIRS}
 )
 list(APPEND MatGui_LIBS

--- a/src/Mod/Measure/App/CMakeLists.txt
+++ b/src/Mod/Measure/App/CMakeLists.txt
@@ -3,6 +3,10 @@ include_directories(
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${ZLIB_INCLUDE_DIR}

--- a/src/Mod/Measure/Gui/CMakeLists.txt
+++ b/src/Mod/Measure/Gui/CMakeLists.txt
@@ -3,6 +3,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}

--- a/src/Mod/Mesh/App/CMakeLists.txt
+++ b/src/Mod/Mesh/App/CMakeLists.txt
@@ -6,6 +6,10 @@ include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/src/3rdParty/libkdtree
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${PYCXX_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}
@@ -22,6 +26,7 @@ set(Mesh_LIBS
 )
 
 include_directories(
+    SYSTEM
     ${QtConcurrent_INCLUDE_DIRS}
 )
 list(APPEND Mesh_LIBS

--- a/src/Mod/Mesh/Gui/CMakeLists.txt
+++ b/src/Mod/Mesh/Gui/CMakeLists.txt
@@ -1,5 +1,9 @@
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}/Inventor/annex

--- a/src/Mod/MeshPart/App/CMakeLists.txt
+++ b/src/Mod/MeshPart/App/CMakeLists.txt
@@ -12,6 +12,10 @@ endif(BUILD_FEM_NETGEN)
 include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}/src
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${ZLIB_INCLUDE_DIR}
@@ -135,7 +139,7 @@ if (BUILD_FLAT_MESH)
             endif()
 
             if(Boost_FOUND)
-                include_directories(${Boost_INCLUDE_DIRS})
+                include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
                 SET(FLATMESH_SRCS
                     MeshFlattening.cpp
                     MeshFlattening.h

--- a/src/Mod/MeshPart/Gui/CMakeLists.txt
+++ b/src/Mod/MeshPart/Gui/CMakeLists.txt
@@ -13,6 +13,10 @@ include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${COIN3D_INCLUDE_DIRS}

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -7,6 +7,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -3,6 +3,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
@@ -27,6 +31,7 @@ if(MSVC)
 endif(MSVC)
 
 include_directories(
+    SYSTEM
     ${QtConcurrent_INCLUDE_DIRS}
 )
 list(APPEND PartGui_LIBS

--- a/src/Mod/PartDesign/App/CMakeLists.txt
+++ b/src/Mod/PartDesign/App/CMakeLists.txt
@@ -3,6 +3,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${QT_INCLUDE_DIR}

--- a/src/Mod/PartDesign/Gui/CMakeLists.txt
+++ b/src/Mod/PartDesign/Gui/CMakeLists.txt
@@ -2,6 +2,10 @@ include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${COIN3D_INCLUDE_DIRS}

--- a/src/Mod/Points/App/CMakeLists.txt
+++ b/src/Mod/Points/App/CMakeLists.txt
@@ -5,6 +5,10 @@ endif(WIN32)
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}
@@ -21,6 +25,7 @@ set(Points_LIBS
 )
 
 include_directories(
+    SYSTEM
     ${QtConcurrent_INCLUDE_DIRS}
 )
 list(APPEND Points_LIBS

--- a/src/Mod/Points/Gui/CMakeLists.txt
+++ b/src/Mod/Points/Gui/CMakeLists.txt
@@ -1,5 +1,9 @@
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIR}

--- a/src/Mod/ReverseEngineering/App/CMakeLists.txt
+++ b/src/Mod/ReverseEngineering/App/CMakeLists.txt
@@ -20,6 +20,10 @@ endif ()
 
 include_directories(
     ${CMAKE_SOURCE_DIR}/src
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/ReverseEngineering/Gui/CMakeLists.txt
+++ b/src/Mod/ReverseEngineering/Gui/CMakeLists.txt
@@ -2,6 +2,10 @@ include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${COIN3D_INCLUDE_DIRS}

--- a/src/Mod/Robot/App/CMakeLists.txt
+++ b/src/Mod/Robot/App/CMakeLists.txt
@@ -3,6 +3,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${EIGEN3_INCLUDE_DIR}

--- a/src/Mod/Robot/Gui/CMakeLists.txt
+++ b/src/Mod/Robot/Gui/CMakeLists.txt
@@ -2,6 +2,10 @@ include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIR}

--- a/src/Mod/Sandbox/App/CMakeLists.txt
+++ b/src/Mod/Sandbox/App/CMakeLists.txt
@@ -5,6 +5,10 @@ endif(WIN32)
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${PYCXX_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}
@@ -14,10 +18,12 @@ include_directories(
 
 if (BUILD_QT5)
     include_directories(
+        SYSTEM
         ${Qt5Core_INCLUDE_DIRS}
     )
 else()
     include_directories(
+        SYSTEM
         ${QT_INCLUDE_DIR}
     )
 endif()

--- a/src/Mod/Sandbox/Gui/CMakeLists.txt
+++ b/src/Mod/Sandbox/Gui/CMakeLists.txt
@@ -1,6 +1,10 @@
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}/src/Gui
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
@@ -13,10 +17,13 @@ include_directories(
 
 if(BUILD_QT5)
     include_directories(
+        SYSTEM
         ${Qt5Core_INCLUDE_DIRS}
     )
 else()
+    SYSTEM
     include_directories(
+        SYSTEM
         ${QT_INCLUDE_DIR}
     )
 endif()

--- a/src/Mod/Sketcher/App/CMakeLists.txt
+++ b/src/Mod/Sketcher/App/CMakeLists.txt
@@ -14,6 +14,10 @@ include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_CURRENT_BINARY_DIR}/..
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${ZIPIOS_INCLUDES}

--- a/src/Mod/Sketcher/Gui/CMakeLists.txt
+++ b/src/Mod/Sketcher/Gui/CMakeLists.txt
@@ -3,6 +3,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${COIN3D_INCLUDE_DIRS}

--- a/src/Mod/Spreadsheet/App/CMakeLists.txt
+++ b/src/Mod/Spreadsheet/App/CMakeLists.txt
@@ -5,6 +5,10 @@ endif(WIN32)
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${PYCXX_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}

--- a/src/Mod/Spreadsheet/Gui/CMakeLists.txt
+++ b/src/Mod/Spreadsheet/Gui/CMakeLists.txt
@@ -1,6 +1,10 @@
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${ZIPIOS_INCLUDES}

--- a/src/Mod/Start/App/CMakeLists.txt
+++ b/src/Mod/Start/App/CMakeLists.txt
@@ -22,6 +22,7 @@
 #  ***************************************************************************/
 
 include_directories(
+        SYSTEM
         ${PYCXX_INCLUDE_DIR}
         ${Python3_INCLUDE_DIRS}
         ${QtCore_INCLUDE_DIRS}

--- a/src/Mod/Start/Gui/CMakeLists.txt
+++ b/src/Mod/Start/Gui/CMakeLists.txt
@@ -23,6 +23,10 @@
 
 include_directories(
         ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+        SYSTEM
         ${Boost_INCLUDE_DIRS}
         ${COIN3D_INCLUDE_DIRS}
         ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/Surface/App/CMakeLists.txt
+++ b/src/Mod/Surface/App/CMakeLists.txt
@@ -4,6 +4,10 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/src
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+include_directories(
+  SYSTEM
   ${Boost_INCLUDE_DIRS}
   ${OCC_INCLUDE_DIR}
   ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/Surface/Gui/CMakeLists.txt
+++ b/src/Mod/Surface/Gui/CMakeLists.txt
@@ -4,6 +4,10 @@ include_directories(
     ${CMAKE_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}

--- a/src/Mod/TechDraw/App/CMakeLists.txt
+++ b/src/Mod/TechDraw/App/CMakeLists.txt
@@ -5,6 +5,10 @@ include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${ZIPIOS_INCLUDES}
@@ -26,6 +30,7 @@ if (BUILD_IMPORT)
 endif ()
 
 include_directories(
+    SYSTEM
     ${QtConcurrent_INCLUDE_DIRS}
     ${QtCore_INCLUDE_DIR}
     ${QtGui_INCLUDE_DIR}

--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -16,6 +16,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${PYCXX_INCLUDE_DIR}

--- a/src/Mod/Test/Gui/CMakeLists.txt
+++ b/src/Mod/Test/Gui/CMakeLists.txt
@@ -1,6 +1,10 @@
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}/src
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${PYCXX_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}

--- a/src/Mod/Web/App/CMakeLists.txt
+++ b/src/Mod/Web/App/CMakeLists.txt
@@ -1,6 +1,10 @@
 
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}
@@ -9,6 +13,7 @@ include_directories(
 )
 
 include_directories(
+    SYSTEM
     ${QtNetwork_INCLUDE_DIRS}
 )
 set(Web_LIBS

--- a/src/Tools/ThumbnailProvider/CMakeLists.txt
+++ b/src/Tools/ThumbnailProvider/CMakeLists.txt
@@ -18,6 +18,10 @@ find_package(ZLIB REQUIRED)
 include_directories(
     .
     ../../../
+)
+
+include_directories(
+    SYSTEM
     ${ZLIB_INCLUDE_DIR}
 )
 

--- a/src/Tools/_TEMPLATE_/App/CMakeLists.txt
+++ b/src/Tools/_TEMPLATE_/App/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/src/Tools/_TEMPLATE_/Gui/CMakeLists.txt
+++ b/src/Tools/_TEMPLATE_/Gui/CMakeLists.txt
@@ -2,6 +2,10 @@
 include_directories(
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     ${COIN3D_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIR}

--- a/src/Tools/embedded/Qt/cxx/CMakeLists.txt
+++ b/src/Tools/embedded/Qt/cxx/CMakeLists.txt
@@ -30,6 +30,11 @@ set(FREECAD_LIBPACK_DIR ${CMAKE_SOURCE_DIR} CACHE PATH  "Directory of the FreeCA
 add_definitions(-DBOOST_ALL_DYN_LINK)
 
 include_directories(
+    ${FREECAD_SRC_DIR}
+)
+
+include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIRS}
     #${COIN3D_INCLUDE_DIRS}
     ${PYCXX_INCLUDE_DIR}
@@ -37,7 +42,6 @@ include_directories(
     ${Qt5Core_INCLUDE_DIRS}
     ${Qt5Gui_INCLUDE_DIRS}
     ${Qt5Widgets_INCLUDE_DIRS}
-    ${FREECAD_SRC_DIR}
     "${FREECAD_LIBPACK_DIR}/include"
 )
 

--- a/src/Tools/plugins/widget/CMakeLists.txt
+++ b/src/Tools/plugins/widget/CMakeLists.txt
@@ -13,6 +13,7 @@ if (NOT IS_SUB_PROJECT)
 endif()
 
 include_directories(
+    SYSTEM
     ${Qt${FREECAD_QT_MAJOR_VERSION}Core_INCLUDE_DIRS}
     ${Qt${FREECAD_QT_MAJOR_VERSION}Widgets_INCLUDE_DIRS}
     ${Qt${FREECAD_QT_MAJOR_VERSION}Designer_INCLUDE_DIRS}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ function(setup_qt_test)
         endif()
 
         target_include_directories(${_testname}_Tests_run PUBLIC
+            SYSTEM
             ${PYCXX_INCLUDE_DIR}
             ${Python3_INCLUDE_DIRS}
             ${XercesC_INCLUDE_DIRS}
@@ -134,7 +135,7 @@ if ( EXISTS "${CMAKE_SOURCE_DIR}/tests/lib/googletest" )
 endif()
 add_subdirectory(src)
 
-target_include_directories(Tests_run PUBLIC
+target_include_directories(Tests_run SYSTEM PUBLIC
     ${PYCXX_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}
     ${XercesC_INCLUDE_DIRS}

--- a/tests/src/Mod/Assembly/CMakeLists.txt
+++ b/tests/src/Mod/Assembly/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-target_include_directories(Assembly_tests_run PUBLIC
+target_include_directories(Assembly_tests_run SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIR}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/tests/src/Mod/Material/App/CMakeLists.txt
+++ b/tests/src/Mod/Material/App/CMakeLists.txt
@@ -8,7 +8,7 @@ target_sources(Material_tests_run PRIVATE
         TestModelProperties.cpp
 )
 
-target_include_directories(Material_tests_run PUBLIC
+target_include_directories(Material_tests_run SYSTEM PUBLIC
         ${QtCore_INCLUDE_DIRS}
 )
 

--- a/tests/src/Mod/Material/CMakeLists.txt
+++ b/tests/src/Mod/Material/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-target_include_directories(Material_tests_run PUBLIC
+target_include_directories(Material_tests_run SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIR}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/tests/src/Mod/Measure/CMakeLists.txt
+++ b/tests/src/Mod/Measure/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-target_include_directories(Measure_tests_run PUBLIC
+target_include_directories(Measure_tests_run SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIR}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/tests/src/Mod/Mesh/CMakeLists.txt
+++ b/tests/src/Mod/Mesh/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-target_include_directories(Mesh_tests_run PUBLIC
+target_include_directories(Mesh_tests_run SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIR}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/tests/src/Mod/MeshPart/CMakeLists.txt
+++ b/tests/src/Mod/MeshPart/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-target_include_directories(MeshPart_tests_run PUBLIC
+target_include_directories(MeshPart_tests_run SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIR}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/tests/src/Mod/Part/CMakeLists.txt
+++ b/tests/src/Mod/Part/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-target_include_directories(Part_tests_run PUBLIC
+target_include_directories(Part_tests_run SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIR}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/tests/src/Mod/PartDesign/CMakeLists.txt
+++ b/tests/src/Mod/PartDesign/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-target_include_directories(PartDesign_tests_run PUBLIC
+target_include_directories(PartDesign_tests_run SYSTEM PUBLIC
         ${EIGEN3_INCLUDE_DIR}
         ${OCC_INCLUDE_DIR}
         ${PYCXX_INCLUDE_DIR}

--- a/tests/src/Mod/Points/CMakeLists.txt
+++ b/tests/src/Mod/Points/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-target_include_directories(Points_tests_run PUBLIC
+target_include_directories(Points_tests_run SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIR}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/tests/src/Mod/Sketcher/CMakeLists.txt
+++ b/tests/src/Mod/Sketcher/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-target_include_directories(Sketcher_tests_run PUBLIC
+target_include_directories(Sketcher_tests_run SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIR}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}

--- a/tests/src/Mod/Spreadsheet/CMakeLists.txt
+++ b/tests/src/Mod/Spreadsheet/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-target_include_directories(Spreadsheet_tests_run PUBLIC
+target_include_directories(Spreadsheet_tests_run SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIR}
     ${OCC_INCLUDE_DIR}
     ${PYCXX_INCLUDE_DIR}


### PR DESCRIPTION
Warnings from 3rd parties are not relevant and are only polluting the warning output. Marking these libraries as `SYSTEM` suppresses warning.

https://gcc.gnu.org/onlinedocs/cpp/Invocation.html#index-I
https://gcc.gnu.org/onlinedocs/cpp/System-Headers.html