### PR TITLE
BIM: make ifcopenshell version upgrade more robust

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_openshell.py
+++ b/src/Mod/BIM/nativeifc/ifc_openshell.py
@@ -143,6 +143,7 @@ class IFC_UpdateIOS:
             if not version[0].isdigit():
                 FreeCAD.Console.PrintLog(f"Invalid IfcOpenShell version detected: {version}\n")
                 version = version[:0] + "0" + version[1:]
+                ifcopenshell.version = version
                 FreeCAD.Console.PrintLog(f"Invalid IfcOpenShell version corrected to: {version}\n")
             # End of workaround
             

--- a/src/Mod/BIM/nativeifc/ifc_openshell.py
+++ b/src/Mod/BIM/nativeifc/ifc_openshell.py
@@ -127,7 +127,7 @@ class IFC_UpdateIOS:
             FreeCAD.Console.PrintError(pe.stderr)
         except:
             text = translate("BIM","Unable to run pip. Please ensure pip is installed on your system.")
-            FreeCAD.Console.PrintError(text + "\n")
+            FreeCAD.Console.PrintError(f"{text} {str(e)}\n")
         return result
 
 

--- a/src/Mod/BIM/nativeifc/ifc_openshell.py
+++ b/src/Mod/BIM/nativeifc/ifc_openshell.py
@@ -125,7 +125,7 @@ class IFC_UpdateIOS:
             result = utils.run_interruptable_subprocess(cmd)
         except CalledProcessError as pe:
             FreeCAD.Console.PrintError(pe.stderr)
-        except:
+        except Exception as e:
             text = translate("BIM","Unable to run pip. Please ensure pip is installed on your system.")
             FreeCAD.Console.PrintError(f"{text} {str(e)}\n")
         return result

--- a/src/Mod/BIM/nativeifc/ifc_openshell.py
+++ b/src/Mod/BIM/nativeifc/ifc_openshell.py
@@ -136,8 +136,8 @@ class IFC_UpdateIOS:
             import ifcopenshell
             version = ifcopenshell.version
             
-            # Workaround for upstream bug
-            # Characters '\' or '-' have been seen instead of the major version
+            # Workaround for https://github.com/FreeCAD/FreeCAD/issues/19829
+            # Characters '\', '.', or '-' have been seen instead of the major version
             # TODO(furgo16): Remove when fixed
             if not version[0].isdigit():
                 FreeCAD.Console.PrintWarning(f"Invalid IfcOpenShell version detected: {version}\n")

--- a/src/Mod/BIM/nativeifc/ifc_openshell.py
+++ b/src/Mod/BIM/nativeifc/ifc_openshell.py
@@ -27,6 +27,7 @@
 import FreeCAD
 import FreeCADGui
 from packaging.version import Version
+from addonmanager_utilities import create_pip_call
 
 translate = FreeCAD.Qt.translate
 QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
@@ -92,6 +93,7 @@ class IFC_UpdateIOS:
             if mode in ["update", "install"]:
                 result = self.install()
                 if result:
+                    FreeCAD.Console.PrintLog(f"{result.stdout}\n")
                     text = translate("BIM", "IfcOpenShell update successfully installed.")
                     buttons = QtGui.QMessageBox.Ok
                     reply = QtGui.QMessageBox.information(None, title, text, buttons)
@@ -115,8 +117,7 @@ class IFC_UpdateIOS:
 
         import addonmanager_utilities as utils
         import freecad.utils
-        cmd = [freecad.utils.get_python_exe(), "-m", "pip"]
-        cmd.extend(args)
+        cmd = create_pip_call(args)
         result = None
         try:
             result = utils.run_interruptable_subprocess(cmd)

--- a/src/Mod/BIM/nativeifc/ifc_openshell.py
+++ b/src/Mod/BIM/nativeifc/ifc_openshell.py
@@ -141,9 +141,9 @@ class IFC_UpdateIOS:
             # Characters '\', '.', or '-' have been seen instead of the major version
             # TODO(furgo16): Remove when fixed
             if not version[0].isdigit():
-                FreeCAD.Console.PrintWarning(f"Invalid IfcOpenShell version detected: {version}\n")
+                FreeCAD.Console.PrintLog(f"Invalid IfcOpenShell version detected: {version}\n")
                 version = version[:0] + "0" + version[1:]
-                FreeCAD.Console.PrintWarning(f"Invalid IfcOpenShell version corrected to: {version}\n")
+                FreeCAD.Console.PrintLog(f"Invalid IfcOpenShell version corrected to: {version}\n")
             # End of workaround
             
             try:

--- a/src/Mod/BIM/nativeifc/ifc_openshell.py
+++ b/src/Mod/BIM/nativeifc/ifc_openshell.py
@@ -117,10 +117,14 @@ class IFC_UpdateIOS:
 
         import addonmanager_utilities as utils
         import freecad.utils
+        from subprocess import CalledProcessError
+
         cmd = create_pip_call(args)
         result = None
         try:
             result = utils.run_interruptable_subprocess(cmd)
+        except CalledProcessError as pe:
+            FreeCAD.Console.PrintError(pe.stderr)
         except:
             text = translate("BIM","Unable to run pip. Please ensure pip is installed on your system.")
             FreeCAD.Console.PrintError(text + "\n")

--- a/src/Mod/BIM/nativeifc/ifc_openshell.py
+++ b/src/Mod/BIM/nativeifc/ifc_openshell.py
@@ -106,7 +106,7 @@ class IFC_UpdateIOS:
         from PySide import QtCore, QtGui
         QtGui.QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
         vendor_path = utils.get_pip_target_directory()
-        args = ["install", "--disable-pip-version-check", "--target", vendor_path, "ifcopenshell"]
+        args = ["install", "--upgrade", "--disable-pip-version-check", "--target", vendor_path, "ifcopenshell"]
         result = self.run_pip(args)
         QtGui.QApplication.restoreOverrideCursor()
         return result

--- a/src/Mod/BIM/nativeifc/ifc_openshell.py
+++ b/src/Mod/BIM/nativeifc/ifc_openshell.py
@@ -139,18 +139,7 @@ class IFC_UpdateIOS:
 
         try:
             import ifcopenshell
-            version = ifcopenshell.version
-            
-            # Workaround for https://github.com/FreeCAD/FreeCAD/issues/19829
-            # Characters '\', '.', or '-' have been seen instead of the major version
-            # TODO(furgo16): Remove when fixed
-            if not version[0].isdigit():
-                FreeCAD.Console.PrintLog(f"Invalid IfcOpenShell version detected: {version}\n")
-                version = version[:0] + "0" + version[1:]
-                ifcopenshell.version = version
-                FreeCAD.Console.PrintLog(f"Invalid IfcOpenShell version corrected to: {version}\n")
-            # End of workaround
-            
+            version = ifcopenshell.version           
             try:
                 Version(version)
             except InvalidVersion:


### PR DESCRIPTION
- Use Python `packaging`'s methods to compare semver version numbers. It's a dependency installed by default for the CAM workbench. This needs to be checked on different platforms/packages
- Allow upgrading packages by specifying the `--upgrade` option. Before, upgrade did not work if a version of IfcOpenShell was already installed on the system.
- Use `addonmanager_utilities`'s newly changed `create_pip_call` method. This allows the call to run on confined packages (snap) and the AppImage as well.

Other minor changes:
- Remove the now obsolete original method to compare versions
- The check for whether the pip version starts with "v" has also been removed. This no longer seems to be the case with recent releases: https://pypi.org/project/ifcopenshell/#history

## Known issues

- On Windows occasionally the "Unable to run pip. Please ensure pip is installed on your system" error appears. As pointed out at https://github.com/FreeCAD/FreeCAD/issues/19540 and in this PR's comments. This is not addressed in this PR, as it comes from Add-On Manager. It seems if there is a timeout calling `pip` for some reason, the process is killed and a signal is emitted. This PR does not handle any signals. See https://github.com/FreeCAD/FreeCAD/pull/19823#issuecomment-2685769487 and subsequent comments.

## Testing

1. As a shortcut to having to check out the branch and build FreeCAD, the changes are all confined in a single file that can be copied over to your FreeCAD installation => https://github.com/FreeCAD/FreeCAD/blob/031ac554226a9b89bc45097d517fa0610f7eaa83/src/Mod/BIM/nativeifc/ifc_openshell.py
2. Activate <kbd>Edit</kbd> > <kbd>Preferences...</kbd> > <kbd>General</kbd> > <kbd>Report view</kbd> > <kbd>Record log messages</kbd>
   ![Captura de pantalla de 2025-02-25 17-54-43](https://github.com/user-attachments/assets/c9154510-817b-4407-a9e3-2a19fd8c93e6)
4. Watch the Report panel for messages in case something goes wrong, and report any messages
5. Report your About info (<kbd>Help</kbd> > <kbd>About FreeCAD</kbd> > <kbd>Copy to clipboard</kbd>)

Fixes: https://github.com/FreeCAD/FreeCAD/issues/19821