### PR TITLE
Add-On Manager: collapse up-level vendor_path reference for better legibility

### DIFF
--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -421,9 +421,9 @@ def get_pip_target_directory():
 
         vendor_path = site.getusersitepackages()
     else:
-        vendor_path = os.path.join(
+        vendor_path = os.path.normpath(os.path.join(
             fci.DataPaths().mod_dir, "..", "AdditionalPythonPackages", f"py{major}{minor}"
-        )
+        ))
     return vendor_path
 
 

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -421,9 +421,11 @@ def get_pip_target_directory():
 
         vendor_path = site.getusersitepackages()
     else:
-        vendor_path = os.path.normpath(os.path.join(
-            fci.DataPaths().mod_dir, "..", "AdditionalPythonPackages", f"py{major}{minor}"
-        ))
+        vendor_path = os.path.normpath(
+            os.path.join(
+                fci.DataPaths().mod_dir, "..", "AdditionalPythonPackages", f"py{major}{minor}"
+            )
+        )
     return vendor_path
 
 


### PR DESCRIPTION
Follow-up to https://github.com/FreeCAD/FreeCAD/pull/19816, as suggested by @chennes. It should make the user-visible installation path string in the Python dependencies installation dialog easier to read. Via [os.path.normpath](https://docs.python.org/3/library/os.path.html#os.path.normpath).