### PR TITLE
Remove hack around geometry visibility in active sketch

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -107,7 +107,6 @@ void SketcherSettings::saveSettings()
     ui->checkBoxAdvancedSolverTaskBox->onSave();
     ui->checkBoxRecalculateInitialSolutionWhileDragging->onSave();
     ui->checkBoxEnableEscape->onSave();
-    ui->checkBoxDisableShading->onSave();
     ui->checkBoxNotifyConstraintSubstitutions->onSave();
     ui->checkBoxAutoRemoveRedundants->onSave();
     ui->checkBoxUnifiedCoincident->onSave();
@@ -180,7 +179,6 @@ void SketcherSettings::loadSettings()
     ui->checkBoxAdvancedSolverTaskBox->onRestore();
     ui->checkBoxRecalculateInitialSolutionWhileDragging->onRestore();
     ui->checkBoxEnableEscape->onRestore();
-    ui->checkBoxDisableShading->onRestore();
     ui->checkBoxNotifyConstraintSubstitutions->onRestore();
     ui->checkBoxAutoRemoveRedundants->onRestore();
     ui->checkBoxUnifiedCoincident->onRestore();

--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -141,25 +141,6 @@ Requires to re-enter edit mode to take effect.</string>
        </widget>
       </item>
       <item>
-       <widget class="Gui::PrefCheckBox" name="checkBoxDisableShading">
-        <property name="toolTip">
-         <string>Disables the shaded view when entering the sketch edit mode.</string>
-        </property>
-        <property name="text">
-         <string>Disable shading in edit mode</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="1">
-         <cstring>DisableShadedView</cstring>
-        </property>
-        <property name="prefPath" stdset="1">
-         <cstring>Mod/Sketcher/General</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="Gui::PrefCheckBox" name="checkBoxNotifyConstraintSubstitutions">
         <property name="toolTip">
          <string>Notifies about automatic constraint substitutions</string>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3294,31 +3294,6 @@ void ViewProviderSketch::unsetEdit(int ModNum)
         if (sketchHandler)
             deactivateHandler();
 
-        Gui::MDIView* mdi = getInventorView();
-
-        // handle the override draw style mode only if there's a 3D view, otherwise SIGSEGV may
-        // occur as described in https://github.com/FreeCAD/FreeCAD/issues/15918
-        if (mdi) {
-
-            // Resets the override draw style mode when leaving the sketch edit mode.
-            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-                "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-            auto disableShadedView = hGrp->GetBool("DisableShadedView", false);
-            if (disableShadedView) {
-                Gui::View3DInventorViewer* viewer =
-                    static_cast<Gui::View3DInventor*>(mdi)->getViewer();
-
-                ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-                    "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-                auto OverrideMode = hGrp->GetASCII("OverrideMode", "As Is");
-
-                if (viewer) {
-                    viewer->updateOverrideMode(OverrideMode);
-                    viewer->setOverrideMode(OverrideMode);
-                }
-            }
-        }
-
         editCoinManager = nullptr;
         snapManager = nullptr;
         preselection.reset();
@@ -3396,24 +3371,6 @@ void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int Mo
                 e.what());
         }
     }
-
-    // Sets the view mode to no shading to prevent visibility issues against parallel surfaces with shininess when entering the sketch mode.
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-    auto disableShadedView = hGrp->GetBool("DisableShadedView", false);
-
-    hGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-    hGrp->SetASCII("OverrideMode", viewer->getOverrideMode());
-
-    if (disableShadedView) {
-
-
-            viewer->updateOverrideMode("No Shading");
-            viewer->setOverrideMode("No Shading");
-
-    }
-
 
     auto editDoc = Gui::Application::Instance->editDocument();
     editDocName.clear();


### PR DESCRIPTION
This removes my workaround to see sketcher geometry in front of planar geometry normal to the camera as the three point lightning has fixed this with https://github.com/FreeCAD/FreeCAD/pull/19397
This PR reverts #14386 which solves the issues which came from this workaround.

Fixes #15352
Fixes #16570
Fixes #16885 
Fixes #19338