### PR TITLE
Sketcher: Add option to hide close button

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
@@ -146,6 +146,13 @@ bool TaskDlgEditSketch::reject()
     return true;
 }
 
+QDialogButtonBox::StandardButtons TaskDlgEditSketch::getStandardButtons() const
+{
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher");
+    bool closeButton = hGrp->GetBool("ShowCloseButton", true);
+    return closeButton ? QDialogButtonBox::Close : QDialogButtonBox::NoButton;
+}
 
 void TaskDlgEditSketch::autoClosedOnClosedView()
 {

--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.h
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.h
@@ -70,10 +70,7 @@ public:
     void autoClosedOnClosedView() override;
 
     /// returns for Close and Help button
-    QDialogButtonBox::StandardButtons getStandardButtons() const override
-    {
-        return QDialogButtonBox::Close;
-    }
+    QDialogButtonBox::StandardButtons getStandardButtons() const override;
 
     /** @brief Function used to register a slot to be triggered when the tool widget is changed. */
     template<typename F>


### PR DESCRIPTION
We can close sketch by 3 ways : Esc, Close tool and Close button on the task panel.

Imo the close button is not ideal as it clutters the task panel and is quite far from the toolbar, region where the mouse is usually located. So I prefer the close tool (although I actually always use Esc anyway).

This PR adds a parameter Preferences/Mod/Sketcher/ShowCloseButton that let user hide the close button of the task panel.

As a lot of people prefer to keep the close button I made this true by default so the default does not change.