### PR TITLE
Clean AppPartPy.cpp

### DIFF
--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -720,7 +720,6 @@ private:
         std::string EncodedName = std::string(Name);
         PyMem_Free(Name);
 
-        //Base::Console().Log("Open in Part with %s",Name);
         Base::FileInfo file(EncodedName.c_str());
 
         // extract ending
@@ -2015,9 +2014,7 @@ private:
             }
 
             pysize = PyUnicode_GetLength(p);
-#if PY_VERSION_HEX < 0x03090000
-            unichars = PyUnicode_AS_UNICODE(p);
-#else
+
 #ifdef FC_OS_WIN32
             //PyUNICODE is only 16 bits on Windows (wchar_t), so passing 32 bit UCS4
             //will result in unknown glyph in even positions, and wrong characters in
@@ -2026,14 +2023,11 @@ private:
 #else
             unichars = (Py_UNICODE *)PyUnicode_AsUCS4Copy(p);
 #endif
-#endif
         }
         else if (PyUnicode_Check(intext)) {
             pysize = PyUnicode_GetLength(intext);
 
-#if PY_VERSION_HEX < 0x03090000
-            unichars = PyUnicode_AS_UNICODE(intext);
-#else
+
 #ifdef FC_OS_WIN32
             //PyUNICODE is only 16 bits on Windows (wchar_t), so passing 32 bit UCS4
             //will result in unknown glyph in even positions, and wrong characters in
@@ -2041,7 +2035,6 @@ private:
             unichars = (Py_UNICODE*)PyUnicode_AsWideCharString(intext, &pysize);
 #else
             unichars = (Py_UNICODE *)PyUnicode_AsUCS4Copy(intext);
-#endif
 #endif
         }
         else {
@@ -2055,11 +2048,9 @@ private:
             else {
                 CharList = FT2FC(unichars,pysize,dir,fontfile,height,track);
             }
-#if PY_VERSION_HEX >= 0x03090000
             if (unichars) {
                 PyMem_Free(unichars);
             }
-#endif
         }
         catch (Standard_DomainError&) {                                      // Standard_DomainError is OCC error.
             throw Py::Exception(PartExceptionOCCDomainError, "makeWireString failed - Standard_DomainError");


### PR DESCRIPTION
Python version is always greater than 3.9