### PR TITLE
CMake: Force OpenGL to use legacy

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupOpenGL.cmake
+++ b/cMake/FreeCAD_Helpers/SetupOpenGL.cmake
@@ -1,6 +1,11 @@
 macro(SetupOpenGL)
 # -------------------------------- OpenGL --------------------------------
 
+    # If on a system with both a legacy GL library and GLVND, prefer the legacy library.
+    # This is probably needed until we no longer have any gl.*ARB calls in the codebase
+    # See, e.g. SoBrepFaceSet.cpp
+    set(OpenGL_GL_PREFERENCE LEGACY)
+
     find_package(OpenGL)
     include(FindPackageMessage)
     if(OPENGL_GLU_FOUND)


### PR DESCRIPTION
Functionally this reverts 16ac5f0a5025ed97cf1ffee0a23accd43a390dd7, though I'm putting this OpenGL-specific code in the SetupOpenGL file instead of the make CMakeLists file. Eventually it would be good to narrow the list of systems this actually applies to so we know where we need to test if we eventually want to remove it.