### PR TITLE
Do not decrease reference counting for string

### DIFF
--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -670,7 +670,6 @@ void AboutDialog::copyToClipboard()
 
         if (ifcopenshellVerAsStr) {
             str << "IfcOpenShell " << ifcopenshellVerAsStr << ", ";
-            Py_DECREF(ifcopenshellVerAsStr);
         }
         Py_DECREF(ifcopenshellVer);
     }


### PR DESCRIPTION
If I understand it correctly, as `ifcopenshellVerAsStr` is not a PyObject, there is no need to decrease reference counting. See also the [PyUnicode_AsUTF8 API documentation](https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF8).

Fixes #19829 