### PR TITLE
refactor: add disambiguation to clearance hole names and use names from the standard

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -69,8 +69,11 @@ namespace PartDesign {
 const char* Hole::DepthTypeEnums[]                   = { "Dimension", "ThroughAll", /*, "UpToFirst", */ nullptr };
 const char* Hole::ThreadDepthTypeEnums[]             = { "Hole Depth", "Dimension", "Tapped (DIN76)",  nullptr };
 const char* Hole::ThreadTypeEnums[]                  = { "None", "ISOMetricProfile", "ISOMetricFineProfile", "UNC", "UNF", "UNEF", "NPT", "BSP", "BSW", "BSF", nullptr};
-const char* Hole::ClearanceMetricEnums[]             = { "Standard", "Close", "Wide", nullptr};
+
+const char* Hole::ClearanceNoneEnums[]               = { "-", "-", "-", nullptr};
+const char* Hole::ClearanceMetricEnums[]             = { "Medium", "Fine", "Coarse", nullptr};
 const char* Hole::ClearanceUTSEnums[]                = { "Normal", "Close", "Loose", nullptr };
+const char* Hole::ClearanceOtherEnums[]              = { "Normal", "Close", "Wide", nullptr };
 const char* Hole::DrillPointEnums[]                  = { "Flat", "Angled", nullptr};
 
 /* "None" profile */
@@ -526,7 +529,7 @@ const std::vector<Hole::ThreadDescription> Hole::threadDescription[] =
 const double Hole::metricHoleDiameters[51][4] =
 {
     /* ISO metric clearance hole diameters according to ISO 273 */
-    // {screw diameter, close, standard, coarse}
+    // {screw diameter, fine, medium, coarse}
         { 1.0,    1.1,    1.2,    1.3},
         { 1.2,    1.3,    1.4,    1.5},
         { 1.4,    1.5,    1.6,    1.8},
@@ -1415,6 +1418,7 @@ void Hole::onChanged(const App::Property* prop)
             Threaded.setValue(false);
             ModelThread.setValue(false);
             UseCustomThreadClearance.setValue(false);
+            ThreadFit.setEnums(ClearanceNoneEnums);
         }
         else if (type == "ISOMetricProfile") {
             ThreadClass.setEnums(ThreadClass_ISOmetric_Enums);
@@ -1444,18 +1448,22 @@ void Hole::onChanged(const App::Property* prop)
         else if (type == "BSP") {
             ThreadClass.setEnums(ThreadClass_None_Enums);
             HoleCutType.setEnums(HoleCutType_BSP_Enums);
+            ThreadFit.setEnums(ClearanceMetricEnums);
         }
         else if (type == "NPT") {
             ThreadClass.setEnums(ThreadClass_None_Enums);
             HoleCutType.setEnums(HoleCutType_NPT_Enums);
+            ThreadFit.setEnums(ClearanceUTSEnums);
         }
         else if (type == "BSW") {
             ThreadClass.setEnums(ThreadClass_BSW_Enums);
             HoleCutType.setEnums(HoleCutType_BSW_Enums);
+            ThreadFit.setEnums(ClearanceOtherEnums);
         }
         else if (type == "BSF") {
             ThreadClass.setEnums(ThreadClass_BSF_Enums);
             HoleCutType.setEnums(HoleCutType_BSF_Enums);
+            ThreadFit.setEnums(ClearanceOtherEnums);
         }
 
         bool isNone = type == "None";

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -119,8 +119,10 @@ private:
     static const char* DepthTypeEnums[];
     static const char* ThreadDepthTypeEnums[];
     static const char* ThreadTypeEnums[];
+    static const char* ClearanceNoneEnums[];
     static const char* ClearanceMetricEnums[];
     static const char* ClearanceUTSEnums[];
+    static const char* ClearanceOtherEnums[];
     static const char* DrillPointEnums[];
     static const char* ThreadDirectionEnums[];
 

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -662,22 +662,19 @@ void TaskHoleParameters::threadTypeChanged(int index)
         ui->ThreadFit->setItemText(2, noneText);
     }
     else if (TypeClass == QByteArray("ISO")) {
-        const char* disambiguation = "Distance between thread crest and hole wall, use ISO-273 nomenclature or equivalent if possible";
-        ui->ThreadFit->setItemText(0, tr("Medium", disambiguation));
-        ui->ThreadFit->setItemText(1, tr("Fine", disambiguation));
-        ui->ThreadFit->setItemText(2, tr("Coarse", disambiguation));
+        ui->ThreadFit->setItemText(0, tr("Medium", "Distance between thread crest and hole wall, use ISO-273 nomenclature or equivalent if possible"));
+        ui->ThreadFit->setItemText(1, tr("Fine", "Distance between thread crest and hole wall, use ISO-273 nomenclature or equivalent if possible"));
+        ui->ThreadFit->setItemText(2, tr("Coarse", "Distance between thread crest and hole wall, use ISO-273 nomenclature or equivalent if possible"));
     }
     else if (TypeClass == QByteArray("UTS")) {
-        const char* disambiguation = "Distance between thread crest and hole wall, use ASME B18.2.8 nomenclature or equivalent if possible";
-        ui->ThreadFit->setItemText(0, tr("Normal", disambiguation));
-        ui->ThreadFit->setItemText(1, tr("Close", disambiguation));
-        ui->ThreadFit->setItemText(2, tr("Loose", disambiguation));
+        ui->ThreadFit->setItemText(0, tr("Normal", "Distance between thread crest and hole wall, use ASME B18.2.8 nomenclature or equivalent if possible"));
+        ui->ThreadFit->setItemText(1, tr("Close", "Distance between thread crest and hole wall, use ASME B18.2.8 nomenclature or equivalent if possible"));
+        ui->ThreadFit->setItemText(2, tr("Loose", "Distance between thread crest and hole wall, use ASME B18.2.8 nomenclature or equivalent if possible"));
     }
     else {
-        const char* disambiguation = "Distance between thread crest and hole wall";
-        ui->ThreadFit->setItemText(0, tr("Normal", disambiguation));
-        ui->ThreadFit->setItemText(1, tr("Close", disambiguation));
-        ui->ThreadFit->setItemText(2, tr("Wide", disambiguation));
+        ui->ThreadFit->setItemText(0, tr("Normal", "Distance between thread crest and hole wall"));
+        ui->ThreadFit->setItemText(1, tr("Close", "Distance between thread crest and hole wall"));
+        ui->ThreadFit->setItemText(2, tr("Wide", "Distance between thread crest and hole wall"));
     }
 
     // Class and cut type

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -66,10 +66,10 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
     ui->ThreadType->addItem(tr("UTS coarse"), QByteArray("UTS"));
     ui->ThreadType->addItem(tr("UTS fine"), QByteArray("UTS"));
     ui->ThreadType->addItem(tr("UTS extra fine"), QByteArray("UTS"));
-    ui->ThreadType->addItem(tr("ANSI pipes"), QByteArray("None"));
-    ui->ThreadType->addItem(tr("ISO/BSP pipes"), QByteArray("None"));
-    ui->ThreadType->addItem(tr("BSW whitworth"), QByteArray("None"));
-    ui->ThreadType->addItem(tr("BSF whitworth fine"), QByteArray("None"));
+    ui->ThreadType->addItem(tr("ANSI pipes"), QByteArray("UTS"));
+    ui->ThreadType->addItem(tr("ISO/BSP pipes"), QByteArray("ISO"));
+    ui->ThreadType->addItem(tr("BSW whitworth"), QByteArray("Other"));
+    ui->ThreadType->addItem(tr("BSF whitworth fine"), QByteArray("Other"));
 
     // read values from the hole properties
     auto pcHole = getObject<PartDesign::Hole>();
@@ -655,29 +655,29 @@ void TaskHoleParameters::threadTypeChanged(int index)
     ui->labelSize->setHidden(isNone);
     ui->ClearanceWidget->setHidden(isNone || isThreaded);
 
-    if (TypeClass == QByteArray("ISO")) {
-        // the names of the clearance types are different in ISO and UTS
-        ui->ThreadFit->setItemText(
-            0,
-            QCoreApplication::translate("TaskHoleParameters", "Standard", nullptr));
-        ui->ThreadFit->setItemText(
-            1,
-            QCoreApplication::translate("TaskHoleParameters", "Close", nullptr));
-        ui->ThreadFit->setItemText(
-            2,
-            QCoreApplication::translate("TaskHoleParameters", "Wide", nullptr));
+    if (TypeClass == QByteArray("None")) {
+        QString noneText = QStringLiteral("-");
+        ui->ThreadFit->setItemText(0, noneText);
+        ui->ThreadFit->setItemText(1, noneText);
+        ui->ThreadFit->setItemText(2, noneText);
+    }
+    else if (TypeClass == QByteArray("ISO")) {
+        const char* disambiguation = "Distance between thread crest and hole wall, use ISO-273 nomenclature or equivalent if possible";
+        ui->ThreadFit->setItemText(0, tr("Medium", disambiguation));
+        ui->ThreadFit->setItemText(1, tr("Fine", disambiguation));
+        ui->ThreadFit->setItemText(2, tr("Coarse", disambiguation));
     }
     else if (TypeClass == QByteArray("UTS")) {
-        // the names of the clearance types are different in ISO and UTS
-        ui->ThreadFit->setItemText(
-            0,
-            QCoreApplication::translate("TaskHoleParameters", "Normal", nullptr));
-        ui->ThreadFit->setItemText(
-            1,
-            QCoreApplication::translate("TaskHoleParameters", "Close", nullptr));
-        ui->ThreadFit->setItemText(
-            2,
-            QCoreApplication::translate("TaskHoleParameters", "Loose", nullptr));
+        const char* disambiguation = "Distance between thread crest and hole wall, use ASME B18.2.8 nomenclature or equivalent if possible";
+        ui->ThreadFit->setItemText(0, tr("Normal", disambiguation));
+        ui->ThreadFit->setItemText(1, tr("Close", disambiguation));
+        ui->ThreadFit->setItemText(2, tr("Loose", disambiguation));
+    }
+    else {
+        const char* disambiguation = "Distance between thread crest and hole wall";
+        ui->ThreadFit->setItemText(0, tr("Normal", disambiguation));
+        ui->ThreadFit->setItemText(1, tr("Close", disambiguation));
+        ui->ThreadFit->setItemText(2, tr("Wide", disambiguation));
     }
 
     // Class and cut type


### PR DESCRIPTION
![Captura de pantalla_20250226_075252](https://github.com/user-attachments/assets/18ff7b22-6d99-4d97-9af6-c959f3ad6ec7)

motivation: in spanish `Close` has been translated to `Cerrar` which is correct in some places, but not in this particular one and there it seems no way to untangle this translation