### PR TITLE
Sketcher: Preference color added for External defining geometry

### DIFF
--- a/src/Gui/PreferencePackTemplates/Sketcher_Colors.cfg
+++ b/src/Gui/PreferencePackTemplates/Sketcher_Colors.cfg
@@ -9,6 +9,7 @@
           <FCUInt Name="EditedEdgeColor" Value="4294967295"/>
           <FCUInt Name="ConstructionColor" Value="56575"/>
           <FCUInt Name="ExternalColor" Value="3425924095"/>
+		  <FCUInt Name="ExternalDefiningColor" Value="3425924095"/>
           <FCUInt Name="InvalidSketchColor" Value="4285333759"/>
           <FCUInt Name="FullyConstrainedColor" Value="16711935"/>
           <FCUInt Name="InternalAlignedGeoColor" Value="2998042623"/>

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -241,6 +241,10 @@ void EditModeCoinManager::ParameterObserver::initParameters()
          [this, drawingParameters = Client.drawingParameters](const std::string& param) {
              updateColor(drawingParameters.CurveExternalColor, param);
          }},
+        {"ExternalDefiningColor",
+         [this, drawingParameters = Client.drawingParameters](const std::string& param) {
+             updateColor(drawingParameters.CurveExternalDefiningColor, param);
+         }},
         {"HighlightColor",
          [this, drawingParameters = Client.drawingParameters](const std::string& param) {
              updateColor(drawingParameters.PreselectColor, param);

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -161,6 +161,10 @@ void EditModeCoinManager::ParameterObserver::initParameters()
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
              updateWidth(drawingParameters.ExternalWidth, param, 2);
          }},
+        {"ExternalDefiningWidth",
+         [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
+             updateWidth(drawingParameters.ExternalDefiningWidth, param, 2);
+         }},
         {"EdgePattern",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
              updatePattern(drawingParameters.CurvePattern, param, 0b1111111111111111);
@@ -176,6 +180,10 @@ void EditModeCoinManager::ParameterObserver::initParameters()
         {"ExternalPattern",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
              updatePattern(drawingParameters.ExternalPattern, param, 0b1111110011111100);
+         }},
+        {"ExternalDefiningPattern",
+         [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
+             updatePattern(drawingParameters.ExternalDefiningPattern, param, 0b1111111111111111);
          }},
         {"CreateLineColor",
          [this, drawingParameters = Client.drawingParameters](const std::string& param) {
@@ -1123,6 +1131,8 @@ void EditModeCoinManager::updateInventorWidths()
         drawingParameters.InternalWidth * drawingParameters.pixelScalingFactor;
     editModeScenegraphNodes.CurvesExternalDrawStyle->lineWidth =
         drawingParameters.ExternalWidth * drawingParameters.pixelScalingFactor;
+    editModeScenegraphNodes.CurvesExternalDefiningDrawStyle->lineWidth =
+        drawingParameters.ExternalDefiningWidth * drawingParameters.pixelScalingFactor;
 }
 
 void EditModeCoinManager::updateInventorPatterns()
@@ -1134,6 +1144,8 @@ void EditModeCoinManager::updateInventorPatterns()
         drawingParameters.InternalPattern;
     editModeScenegraphNodes.CurvesExternalDrawStyle->linePattern =
         drawingParameters.ExternalPattern;
+    editModeScenegraphNodes.CurvesExternalDefiningDrawStyle->linePattern =
+        drawingParameters.ExternalDefiningPattern;
 }
 
 void EditModeCoinManager::updateInventorColors()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
@@ -82,8 +82,9 @@ SbColor DrawingParameters::PreselectColor(0.88f, 0.88f, 0.0f);           // #E1E
 SbColor DrawingParameters::SelectColor(0.11f, 0.68f, 0.11f);             // #1CAD1C -> ( 28,173, 28)
 SbColor DrawingParameters::PreselectSelectedColor(0.36f, 0.48f, 0.11f);  // #5D7B1C -> ( 93,123, 28)
 SbColor DrawingParameters::CurveExternalColor(0.8f, 0.2f, 0.6f);         // #CC3399 -> (204, 51,153)
-SbColor DrawingParameters::CurveExternalDefiningColor(1.0f, 0.5f, 0.69f); // #FF7FAF -> (255,127,175)
-SbColor DrawingParameters::CurveDraftColor(0.0f, 0.0f, 0.86f);           // #0000DC -> (  0,  0,220)
+SbColor
+    DrawingParameters::CurveExternalDefiningColor(1.0f, 0.5f, 0.69f);  // #FF7FAF -> (255,127,175)
+SbColor DrawingParameters::CurveDraftColor(0.0f, 0.0f, 0.86f);         // #0000DC -> (  0,  0,220)
 SbColor
     DrawingParameters::FullyConstraintConstructionElementColor(0.56f,
                                                                0.66f,

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
@@ -40,10 +40,8 @@ int GeometryLayerParameters::getSubLayerIndex(const int geoId,
     bool isExternal = geoId <= Sketcher::GeoEnum::RefExt;
     if (isExternal) {
         auto egf = Sketcher::ExternalGeometryFacade::getFacade(geom->clone());
-        if (egf->testFlag(Sketcher::ExternalGeometryExtension::Defining)) {
-            // Defining external are added to the Normal sublayers because they
-            // share the same line style.
-            return static_cast<int>(SubLayer::Normal);
+        if (egf->testFlag(Sketcher::ExternalGeometryExtension::Defining)) {            
+            return static_cast<int>(SubLayer::ExternalDefining);
         }
     }
 
@@ -83,7 +81,7 @@ SbColor DrawingParameters::SelectColor(0.11f, 0.68f, 0.11f);             // #1CA
 SbColor DrawingParameters::PreselectSelectedColor(0.36f, 0.48f, 0.11f);  // #5D7B1C -> ( 93,123, 28)
 SbColor DrawingParameters::CurveExternalColor(0.8f, 0.2f, 0.6f);         // #CC3399 -> (204, 51,153)
 SbColor
-    DrawingParameters::CurveExternalDefiningColor(1.0f, 0.5f, 0.69f);  // #FF7FAF -> (255,127,175)
+    DrawingParameters::CurveExternalDefiningColor(0.8f, 0.2f, 0.6f);   // #CC3399 -> (204, 51,153)
 SbColor DrawingParameters::CurveDraftColor(0.0f, 0.0f, 0.86f);         // #0000DC -> (  0,  0,220)
 SbColor
     DrawingParameters::FullyConstraintConstructionElementColor(0.56f,

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
@@ -40,7 +40,7 @@ int GeometryLayerParameters::getSubLayerIndex(const int geoId,
     bool isExternal = geoId <= Sketcher::GeoEnum::RefExt;
     if (isExternal) {
         auto egf = Sketcher::ExternalGeometryFacade::getFacade(geom->clone());
-        if (egf->testFlag(Sketcher::ExternalGeometryExtension::Defining)) {            
+        if (egf->testFlag(Sketcher::ExternalGeometryExtension::Defining)) {
             return static_cast<int>(SubLayer::ExternalDefining);
         }
     }
@@ -81,8 +81,8 @@ SbColor DrawingParameters::SelectColor(0.11f, 0.68f, 0.11f);             // #1CA
 SbColor DrawingParameters::PreselectSelectedColor(0.36f, 0.48f, 0.11f);  // #5D7B1C -> ( 93,123, 28)
 SbColor DrawingParameters::CurveExternalColor(0.8f, 0.2f, 0.6f);         // #CC3399 -> (204, 51,153)
 SbColor
-    DrawingParameters::CurveExternalDefiningColor(0.8f, 0.2f, 0.6f);   // #CC3399 -> (204, 51,153)
-SbColor DrawingParameters::CurveDraftColor(0.0f, 0.0f, 0.86f);         // #0000DC -> (  0,  0,220)
+    DrawingParameters::CurveExternalDefiningColor(0.8f, 0.2f, 0.6f);  // #CC3399 -> (204, 51,153)
+SbColor DrawingParameters::CurveDraftColor(0.0f, 0.0f, 0.86f);        // #0000DC -> (  0,  0,220)
 SbColor
     DrawingParameters::FullyConstraintConstructionElementColor(0.56f,
                                                                0.66f,

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
@@ -82,6 +82,7 @@ SbColor DrawingParameters::PreselectColor(0.88f, 0.88f, 0.0f);           // #E1E
 SbColor DrawingParameters::SelectColor(0.11f, 0.68f, 0.11f);             // #1CAD1C -> ( 28,173, 28)
 SbColor DrawingParameters::PreselectSelectedColor(0.36f, 0.48f, 0.11f);  // #5D7B1C -> ( 93,123, 28)
 SbColor DrawingParameters::CurveExternalColor(0.8f, 0.2f, 0.6f);         // #CC3399 -> (204, 51,153)
+SbColor DrawingParameters::CurveExternalDefiningColor(1.0f, 0.5f, 0.69f); // #FF7FAF -> (255,127,175)
 SbColor DrawingParameters::CurveDraftColor(0.0f, 0.0f, 0.86f);           // #0000DC -> (  0,  0,220)
 SbColor
     DrawingParameters::FullyConstraintConstructionElementColor(0.56f,

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -116,9 +116,9 @@ struct DrawingParameters
     static SbColor
         PreselectSelectedColor;  // Color used for pre-selection when geometry is already selected
     static SbColor SelectColor;  // Color used for selected geometry
-    static SbColor CurveExternalColor;                       // Color used for external geometry
-    static SbColor CurveExternalDefiningColor;               // Color used for external defining geometry
-    static SbColor CurveDraftColor;                          // Color used for construction geometry
+    static SbColor CurveExternalColor;          // Color used for external geometry
+    static SbColor CurveExternalDefiningColor;  // Color used for external defining geometry
+    static SbColor CurveDraftColor;             // Color used for construction geometry
     static SbColor FullyConstraintConstructionElementColor;  // Color used for a fully constrained
                                                              // construction element
     static SbColor ConstrDimColor;  // Color used for a dimensional constraints

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -117,6 +117,7 @@ struct DrawingParameters
         PreselectSelectedColor;  // Color used for pre-selection when geometry is already selected
     static SbColor SelectColor;  // Color used for selected geometry
     static SbColor CurveExternalColor;                       // Color used for external geometry
+    static SbColor CurveExternalDefiningColor;               // Color used for external defining geometry
     static SbColor CurveDraftColor;                          // Color used for construction geometry
     static SbColor FullyConstraintConstructionElementColor;  // Color used for a fully constrained
                                                              // construction element

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -140,17 +140,18 @@ struct DrawingParameters
     int constraintIconSize = 15;  // Size of constraint icons
     int markerSize = 7;           // Size used for markers
 
-    int CurveWidth = 2;         // width of normal edges
-    int ConstructionWidth = 1;  // width of construction edges
-    int InternalWidth = 1;      // width of internal edges
-    int ExternalWidth = 1;      // width of external edges
+    int CurveWidth = 2;             // width of normal edges
+    int ConstructionWidth = 1;      // width of construction edges
+    int InternalWidth = 1;          // width of internal edges
+    int ExternalWidth = 1;          // width of external edges
     int ExternalDefiningWidth = 1;  // width of external defining edges
 
     unsigned int CurvePattern = 0b1111111111111111;         // pattern of normal edges
     unsigned int ConstructionPattern = 0b1111110011111100;  // pattern of construction edges
     unsigned int InternalPattern = 0b1111110011111100;      // pattern of internal edges
     unsigned int ExternalPattern = 0b1111110011111100;      // pattern of external edges
-    unsigned int ExternalDefiningPattern = 0b1111111111111111; // pattern of external defining edges
+    unsigned int ExternalDefiningPattern =
+        0b1111111111111111;  // pattern of external defining edges
     //@}
 
     DrawingParameters()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -144,11 +144,13 @@ struct DrawingParameters
     int ConstructionWidth = 1;  // width of construction edges
     int InternalWidth = 1;      // width of internal edges
     int ExternalWidth = 1;      // width of external edges
+    int ExternalDefiningWidth = 1;  // width of external defining edges
 
     unsigned int CurvePattern = 0b1111111111111111;         // pattern of normal edges
     unsigned int ConstructionPattern = 0b1111110011111100;  // pattern of construction edges
     unsigned int InternalPattern = 0b1111110011111100;      // pattern of internal edges
     unsigned int ExternalPattern = 0b1111110011111100;      // pattern of external edges
+    unsigned int ExternalDefiningPattern = 0b1111111111111111; // pattern of external defining edges
     //@}
 
     DrawingParameters()
@@ -290,6 +292,7 @@ public:
         Construction = 1,
         Internal = 2,
         External = 3,
+        ExternalDefining = 4
     };
 
     void reset()
@@ -343,9 +346,15 @@ public:
         return t == static_cast<int>(SubLayer::External);
     }
 
+    bool isExternalDefiningSubLayer(int t) const
+    {
+        return t == static_cast<int>(SubLayer::ExternalDefining);
+    }
+
+
 private:
     int CoinLayers = 1;  // defaults to a single Coin Geometry Layer.
-    int SubLayers = 4;   // Normal, Construction, Internal, External.
+    int SubLayers = 5;   // Normal, Construction, Internal, External.
 };
 
 /** @brief     Struct to hold the results of analysis performed on geometry
@@ -411,6 +420,7 @@ struct EditModeScenegraphNodes
     SoDrawStyle* CurvesConstructionDrawStyle;
     SoDrawStyle* CurvesInternalDrawStyle;
     SoDrawStyle* CurvesExternalDrawStyle;
+    SoDrawStyle* CurvesExternalDefiningDrawStyle;
     SoDrawStyle* HiddenCurvesDrawStyle;
     //@}
 

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -136,7 +136,7 @@ void EditModeGeometryCoinManager::updateGeometryColor(const GeoListFacade& geoli
     };
 
     auto isExternalDefiningGeomPoint = [&geolistfacade](int GeoId) {
-        auto geom = geolistfacade.getGeometryFacadeFromGeoId(GeoId);    
+        auto geom = geolistfacade.getGeometryFacadeFromGeoId(GeoId);
         if (geom) {
             auto egf = ExternalGeometryFacade::getFacade(geom->clone());
             auto ref = egf->getRef();

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -135,6 +135,16 @@ void EditModeGeometryCoinManager::updateGeometryColor(const GeoListFacade& geoli
         return false;
     };
 
+    auto isExternalDefiningGeomPoint = [&geolistfacade](int GeoId) {
+        auto geom = geolistfacade.getGeometryFacadeFromGeoId(GeoId);    
+        if (geom) {
+            auto egf = ExternalGeometryFacade::getFacade(geom->clone());
+            auto ref = egf->getRef();
+            return egf->testFlag(ExternalGeometryExtension::Defining);
+        }
+        return false;
+    };
+
     auto isCoincident = [&](int GeoId, Sketcher::PointPos PosId) {
         const std::vector<Sketcher::Constraint*>& constraints =
             ViewProviderSketchCoinAttorney::getConstraints(viewProvider);
@@ -202,7 +212,9 @@ void EditModeGeometryCoinManager::updateGeometryColor(const GeoListFacade& geoli
                     pcolor[i] = drawingParameters.ConstrIcoColor;
                 }
                 else {
-                    pcolor[i] = drawingParameters.CurveExternalColor;
+                    pcolor[i] = isExternalDefiningGeomPoint(GeoId)
+                        ? drawingParameters.CurveExternalDefiningColor
+                        : drawingParameters.CurveExternalColor;
                 }
             }
             else if (issketchinvalid) {
@@ -423,7 +435,9 @@ void EditModeGeometryCoinManager::updateGeometryColor(const GeoListFacade& geoli
                         color[i] = drawingParameters.InvalidSketchColor;
                     }
                     else {
-                        color[i] = drawingParameters.CurveExternalColor;
+                        color[i] = egf->testFlag(ExternalGeometryExtension::Defining)
+                            ? drawingParameters.CurveExternalDefiningColor
+                            : drawingParameters.CurveExternalColor;
                     }
                     for (int k = j; j < k + indexes; j++) {
                         verts[j].getValue(x, y, z);

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -656,6 +656,14 @@ void EditModeGeometryCoinManager::createEditModeCurveInventorNodes()
         drawingParameters.ExternalPattern;
     editModeScenegraphNodes.CurvesExternalDrawStyle->linePatternScaleFactor = 2;
 
+    editModeScenegraphNodes.CurvesExternalDefiningDrawStyle = new SoDrawStyle;
+    editModeScenegraphNodes.CurvesExternalDefiningDrawStyle->setName("CurvesExternalDefiningDrawStyle");
+    editModeScenegraphNodes.CurvesExternalDefiningDrawStyle->lineWidth =
+        drawingParameters.ExternalDefiningWidth * drawingParameters.pixelScalingFactor;
+    editModeScenegraphNodes.CurvesExternalDefiningDrawStyle->linePattern =
+        drawingParameters.ExternalDefiningPattern;
+    editModeScenegraphNodes.CurvesExternalDefiningDrawStyle->linePatternScaleFactor = 2;
+
     for (int i = 0; i < geometryLayerParameters.getCoinLayerCount(); i++) {
         editModeScenegraphNodes.CurvesMaterials.emplace_back();
         editModeScenegraphNodes.CurvesCoordinate.emplace_back();
@@ -687,6 +695,9 @@ void EditModeGeometryCoinManager::createEditModeCurveInventorNodes()
             }
             else if (geometryLayerParameters.isExternalSubLayer(t)) {
                 sep->addChild(editModeScenegraphNodes.CurvesExternalDrawStyle);
+            }
+            else if (geometryLayerParameters.isExternalDefiningSubLayer(t)) {
+                sep->addChild(editModeScenegraphNodes.CurvesExternalDefiningDrawStyle);
             }
             else {
                 sep->addChild(editModeScenegraphNodes.CurvesDrawStyle);

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -657,7 +657,8 @@ void EditModeGeometryCoinManager::createEditModeCurveInventorNodes()
     editModeScenegraphNodes.CurvesExternalDrawStyle->linePatternScaleFactor = 2;
 
     editModeScenegraphNodes.CurvesExternalDefiningDrawStyle = new SoDrawStyle;
-    editModeScenegraphNodes.CurvesExternalDefiningDrawStyle->setName("CurvesExternalDefiningDrawStyle");
+    editModeScenegraphNodes.CurvesExternalDefiningDrawStyle->setName(
+        "CurvesExternalDefiningDrawStyle");
     editModeScenegraphNodes.CurvesExternalDefiningDrawStyle->lineWidth =
         drawingParameters.ExternalDefiningWidth * drawingParameters.pixelScalingFactor;
     editModeScenegraphNodes.CurvesExternalDefiningDrawStyle->linePattern =

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -550,6 +550,7 @@ void SketcherSettingsAppearance::saveSettings()
     ui->EditedEdgeColor->onSave();
     ui->ConstructionColor->onSave();
     ui->ExternalColor->onSave();
+    ui->ExternalDefiningColor->onSave();
     ui->InvalidSketchColor->onSave();
     ui->FullyConstrainedColor->onSave();
     ui->InternalAlignedGeoColor->onSave();
@@ -599,6 +600,7 @@ void SketcherSettingsAppearance::loadSettings()
     ui->EditedEdgeColor->onRestore();
     ui->ConstructionColor->onRestore();
     ui->ExternalColor->onRestore();
+    ui->ExternalDefiningColor->onRestore();
     ui->InvalidSketchColor->onRestore();
     ui->FullyConstrainedColor->onRestore();
     ui->InternalAlignedGeoColor->onRestore();

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -512,6 +512,7 @@ SketcherSettingsAppearance::SketcherSettingsAppearance(QWidget* parent)
     ui->ConstructionPattern->setIconSize(QSize(70, 12));
     ui->InternalPattern->setIconSize(QSize(70, 12));
     ui->ExternalPattern->setIconSize(QSize(70, 12));
+    ui->ExternalDefiningPattern->setIconSize(QSize(70, 12));
     for (auto& style : styles) {
         QPixmap px(ui->EdgePattern->iconSize());
         px.fill(Qt::transparent);
@@ -531,6 +532,7 @@ SketcherSettingsAppearance::SketcherSettingsAppearance(QWidget* parent)
         ui->ConstructionPattern->addItem(QIcon(px), QString(), QVariant(style));
         ui->InternalPattern->addItem(QIcon(px), QString(), QVariant(style));
         ui->ExternalPattern->addItem(QIcon(px), QString(), QVariant(style));
+        ui->ExternalDefiningPattern->addItem(QIcon(px), QString(), QVariant(style));
     }
 }
 
@@ -572,6 +574,7 @@ void SketcherSettingsAppearance::saveSettings()
     ui->ConstructionWidth->onSave();
     ui->InternalWidth->onSave();
     ui->ExternalWidth->onSave();
+    ui->ExternalDefiningWidth->onSave();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Sketcher/View");
@@ -590,6 +593,10 @@ void SketcherSettingsAppearance::saveSettings()
     data = ui->ExternalPattern->itemData(ui->ExternalPattern->currentIndex());
     pattern = data.toInt();
     hGrp->SetInt("ExternalPattern", pattern);
+
+    data = ui->ExternalDefiningPattern->itemData(ui->ExternalDefiningPattern->currentIndex());
+    pattern = data.toInt();
+    hGrp->SetInt("ExternalDefiningPattern", pattern);
 }
 
 void SketcherSettingsAppearance::loadSettings()
@@ -622,6 +629,7 @@ void SketcherSettingsAppearance::loadSettings()
     ui->ConstructionWidth->onRestore();
     ui->InternalWidth->onRestore();
     ui->ExternalWidth->onRestore();
+    ui->ExternalDefiningWidth->onRestore();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Sketcher/View");
@@ -652,6 +660,13 @@ void SketcherSettingsAppearance::loadSettings()
         index = 0;
     }
     ui->ExternalPattern->setCurrentIndex(index);
+
+    pattern = hGrp->GetInt("ExternalDefiningPattern", 0b1111111111111111);
+    index = ui->ExternalDefiningPattern->findData(QVariant(pattern));
+    if (index < 0) {
+        index = 0;
+    }
+    ui->ExternalDefiningPattern->setCurrentIndex(index);
 }
 
 /**

--- a/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
@@ -487,7 +487,7 @@
       <item row="9" column="0">
        <widget class="QLabel" name="label_20">
         <property name="text">
-         <string>External geometry</string>
+         <string>External reference geometry</string>
         </property>
        </widget>
       </item>
@@ -575,9 +575,9 @@
         </property>
         <property name="color" stdset="0">
          <color>
-          <red>255</red>
-          <green>114</green>
-          <blue>243</blue>
+          <red>204</red>
+          <green>51</green>
+          <blue>153</blue>
          </color>
         </property>
         <property name="prefEntry" stdset="0">
@@ -585,6 +585,44 @@
         </property>
         <property name="prefPath" stdset="0">
          <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+	  <item row="10" column="3">
+       <widget class="QComboBox" name="ExternalDefiningPattern">
+        <property name="toolTip">
+         <string>Line pattern of external defining edges.</string>
+        </property>
+        <property name="currentIndex">
+         <number>-1</number>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="4">
+       <widget class="Gui::PrefSpinBox" name="ExternalDefiningWidth">
+        <property name="toolTip">
+         <string>Width of external defining edges.</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">px</string>
+        </property>
+        <property name="suffix">
+         <string notr="true"> px</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>99</number>
+        </property>
+        <property name="value">
+         <number>2</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ExternalDefiningWidth</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Sketcher/View</cstring>
         </property>
        </widget>
       </item>

--- a/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
@@ -555,7 +555,40 @@
         </property>
        </widget>
       </item>
-      <item row="10" column="0">
+	  <item row="10" column="0">
+       <widget class="QLabel" name="label_21">
+        <property name="text">
+         <string>External defining geometry</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="Gui::PrefColorButton" name="ExternalDefiningColor">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Color of external defining geometry in edit mode</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>114</green>
+          <blue>243</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ExternalDefiningColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="0">
        <widget class="QLabel" name="label_45">
         <property name="minimumSize">
          <size>
@@ -568,7 +601,7 @@
         </property>
        </widget>
       </item>
-      <item row="10" column="1">
+      <item row="11" column="1">
        <widget class="Gui::PrefColorButton" name="FullyConstrainedColor">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -594,14 +627,14 @@
         </property>
        </widget>
       </item>
-      <item row="11" column="0">
+      <item row="12" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Invalid sketch</string>
         </property>
        </widget>
       </item>
-      <item row="11" column="1">
+      <item row="12" column="1">
        <widget class="Gui::PrefColorButton" name="InvalidSketchColor">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">


### PR DESCRIPTION
Since I working a lot with projecting and using external geometry in my project I struggle a lot with differentiation between defining and reference geometry. Pattern helps a bit, but there are 2 problems with it:
1) pattern applies only to curves - there is no way to see right away where is reference point and where defining
2) pattern look awful when used on external geometry, since under projected geometry is always a line of source geometry, so to see it clearly I have to hide underlining sketch or rotate current one, so lines not overlaps.

My suggestion is addition of defining geometry color that will work for curves and vertices. If someone do not need aid of color, it could be set the same as for not defining geometry.

Here is an example how it looks with this PR:

![image](https://github.com/user-attachments/assets/5b111de8-417d-4d58-842d-efa501765551)

![image](https://github.com/user-attachments/assets/3f84a945-d97e-41b2-a25a-09749eeeff60)

Defining geometry still reuse all other properties from normal geometry - only color changed.