### PR TITLE
Gui: put SolidWorks navigation style in A-Z order

### DIFF
--- a/src/Mod/Tux/NavigationIndicatorGui.py
+++ b/src/Mod/Tux/NavigationIndicatorGui.py
@@ -74,9 +74,9 @@ def RePopulateIcons():
     a6.setIcon(QtGui.QIcon(":/icons/NavigationOpenInventor_" + StyleSheetType + ".svg"))
     a7.setIcon(QtGui.QIcon(":/icons/NavigationOpenSCAD_" + StyleSheetType + ".svg"))
     a8.setIcon(QtGui.QIcon(":/icons/NavigationRevit_" + StyleSheetType + ".svg"))
-    a9.setIcon(QtGui.QIcon(":/icons/NavigationTinkerCAD_" + StyleSheetType + ".svg"))
-    a10.setIcon(QtGui.QIcon(":/icons/NavigationTouchpad_" + StyleSheetType + ".svg"))
-    a11.setIcon(QtGui.QIcon(":/icons/NavigationSolidWorks_" + StyleSheetType + ".svg"))
+    a9.setIcon(QtGui.QIcon(":/icons/NavigationSolidWorks_" + StyleSheetType + ".svg"))
+    a10.setIcon(QtGui.QIcon(":/icons/NavigationTinkerCAD_" + StyleSheetType + ".svg"))
+    a11.setIcon(QtGui.QIcon(":/icons/NavigationTouchpad_" + StyleSheetType + ".svg"))
 
 
 def retranslateUi():
@@ -474,6 +474,44 @@ def retranslateUi():
 
     global t9
     t9 = (
+        "<p align='center'><b>SolidWorks</b> "
+        + text06
+        + """</p>
+    <table>
+     <tr>
+      <th><small>"""
+        + text01
+        + """</small></th>
+      <th><small>"""
+        + text02
+        + """</small></th>
+      <th><small>"""
+        + text02
+        + """</small></th>
+      <th><small>"""
+        + text03
+        + """</small></th>
+      <th><small>"""
+        + text04
+        + """</small></th>
+     </tr>
+     <tr>
+      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
+      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
+      <td align='center'><img src=':/icons/Navigation_Mouse_ShiftMiddle.svg'></td>
+      <td align='center'><img src=':/icons/Navigation_Mouse_Middle.svg'></td>
+      <td align='center'><img src=':/icons/Navigation_Mouse_CtrlMiddle.svg'></td>
+     </tr>
+    </table>
+    <b>"""
+        + text08
+        + ":</b> "
+        + text10
+        + "</small></p>"
+    )
+
+    global t10
+    t10 = (
         "<p align='center'><b>TinkerCAD</b> "
         + text06
         + """</p>
@@ -501,8 +539,8 @@ def retranslateUi():
     </table>"""
     )
 
-    global t10
-    t10 = (
+    global t11
+    t11 = (
         "<p align='center'><b>Touchpad</b> "
         + text06
         + """</p>
@@ -565,44 +603,6 @@ def retranslateUi():
         + ":</b> "
         + text07
         + "</p>"
-    )
-
-    global t11
-    t11 = (
-        "<p align='center'><b>SolidWorks</b> "
-        + text06
-        + """</p>
-    <table>
-     <tr>
-      <th><small>"""
-        + text01
-        + """</small></th>
-      <th><small>"""
-        + text02
-        + """</small></th>
-      <th><small>"""
-        + text02
-        + """</small></th>
-      <th><small>"""
-        + text03
-        + """</small></th>
-      <th><small>"""
-        + text04
-        + """</small></th>
-     </tr>
-     <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_ShiftMiddle.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Middle.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_CtrlMiddle.svg'></td>
-     </tr>
-    </table>
-    <b>"""
-        + text08
-        + ":</b> "
-        + text10
-        + "</small></p>"
     )
 
     menuSettings.setTitle(translate("NavigationIndicator", "Settings"))
@@ -700,19 +700,19 @@ a8.setData("Gui::RevitNavigationStyle")
 a8.setObjectName("Indicator_NavigationRevit")
 
 a9 = QtGui.QAction(gStyle)
-a9.setText("TinkerCAD  ")
-a9.setData("Gui::TinkerCADNavigationStyle")
-a9.setObjectName("Indicator_NavigationTinkerCAD")
+a9.setText("SolidWorks  ")
+a9.setData("Gui::SolidWorksNavigationStyle")
+a9.setObjectName("Indicator_NavigationSolidWorks")
 
 a10 = QtGui.QAction(gStyle)
-a10.setText("Touchpad  ")
-a10.setData("Gui::TouchpadNavigationStyle")
-a10.setObjectName("Indicator_NavigationTouchpad")
+a10.setText("TinkerCAD  ")
+a10.setData("Gui::TinkerCADNavigationStyle")
+a10.setObjectName("Indicator_NavigationTinkerCAD")
 
 a11 = QtGui.QAction(gStyle)
-a11.setText("SolidWorks  ")
-a11.setData("Gui::SolidWorksNavigationStyle")
-a11.setObjectName("Indicator_NavigationSolidWorks")
+a11.setText("Touchpad  ")
+a11.setData("Gui::TouchpadNavigationStyle")
+a11.setObjectName("Indicator_NavigationTouchpad")
 
 RePopulateIcons()
 


### PR DESCRIPTION
#19568 adds the SolidWorks navigation style. In the Gui the new style appeared at the bottom of the list below 'Touchpad'. This PR restores the A-Z order of the list.
