### PR TITLE
Base: make getAttribute template

### DIFF
--- a/src/App/ComplexGeoData.cpp
+++ b/src/App/ComplexGeoData.cpp
@@ -480,7 +480,7 @@ void ComplexGeoData::Restore(Base::XMLReader& reader)
 
     reader.readElement("ElementMap");
     bool newTag = false;
-    if (reader.hasAttribute("new") && reader.getAttribute<long>("new") > 0) {
+    if (reader.hasAttribute("new") && reader.getAttribute<bool>("new")) {
         reader.readEndElement("ElementMap");
         reader.readElement("ElementMap2");
         newTag = true;

--- a/src/App/ComplexGeoData.cpp
+++ b/src/App/ComplexGeoData.cpp
@@ -480,7 +480,7 @@ void ComplexGeoData::Restore(Base::XMLReader& reader)
 
     reader.readElement("ElementMap");
     bool newTag = false;
-    if (reader.hasAttribute("new") && reader.getAttributeAsInteger("new") > 0) {
+    if (reader.hasAttribute("new") && reader.getAttribute<long>("new") > 0) {
         reader.readEndElement("ElementMap");
         reader.readElement("ElementMap2");
         newTag = true;
@@ -488,7 +488,7 @@ void ComplexGeoData::Restore(Base::XMLReader& reader)
 
     const char* file = "";
     if (reader.hasAttribute("file")) {
-        file = reader.getAttribute("file");
+        file = reader.getAttribute<const char*>("file");
     }
     if (*file != 0) {
         reader.addFile(file, this);
@@ -497,7 +497,7 @@ void ComplexGeoData::Restore(Base::XMLReader& reader)
 
     std::size_t count = 0;
     if (reader.hasAttribute("count")) {
-        count = reader.getAttributeAsUnsigned("count");
+        count = reader.getAttribute<unsigned long>("count");
     }
     if (count == 0) {
         return;
@@ -539,7 +539,7 @@ void ComplexGeoData::readElements(Base::XMLReader& reader, size_t count)
                 }
             }
             else {
-                const char* attr = reader.getAttribute("sid");
+                const char* attr = reader.getAttribute<const char*>("sid");
                 bio::stream<bio::array_source> iss(attr, std::strlen(attr));
                 long id {};
                 while ((iss >> id)) {
@@ -558,8 +558,8 @@ void ComplexGeoData::readElements(Base::XMLReader& reader, size_t count)
                 }
             }
         }
-        ensureElementMap()->setElementName(IndexedName(reader.getAttribute("value"), types),
-                                           MappedName(reader.getAttribute("key")),
+        ensureElementMap()->setElementName(IndexedName(reader.getAttribute<const char*>("value"), types),
+                                           MappedName(reader.getAttribute<const char*>("key")),
                                            Tag,
                                            &sids);
     }

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1524,7 +1524,7 @@ std::vector<App::DocumentObject*> Document::readObjects(Base::XMLReader& reader)
                 }
                 if (reader.hasAttribute("Invalid")) {
                     obj->setStatus(ObjectStatus::Error,
-                                   reader.getAttribute<long>("Invalid") != 0);
+                                   reader.getAttribute<bool>("Invalid"));
                     if (obj->isError() && reader.hasAttribute("Error")) {
                         d->addRecomputeLog(reader.getAttribute<const char*>("Error"), obj);
                     }

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1042,16 +1042,16 @@ void Document::Restore(Base::XMLReader& reader)
     setStatus(Document::PartialDoc, false);
 
     reader.readElement("Document");
-    long scheme = reader.getAttributeAsInteger("SchemaVersion");
+    long scheme = reader.getAttribute<long>("SchemaVersion");
     reader.DocumentSchema = scheme;
     if (reader.hasAttribute("ProgramVersion")) {
-        reader.ProgramVersion = reader.getAttribute("ProgramVersion");
+        reader.ProgramVersion = reader.getAttribute<const char*>("ProgramVersion");
     }
     else {
         reader.ProgramVersion = "pre-0.14";
     }
     if (reader.hasAttribute("FileVersion")) {
-        reader.FileVersion = reader.getAttributeAsUnsigned("FileVersion");
+        reader.FileVersion = reader.getAttribute<unsigned long>("FileVersion");
     }
     else {
         reader.FileVersion = 0;
@@ -1087,11 +1087,11 @@ void Document::Restore(Base::XMLReader& reader)
     if (scheme == 2) {
         // read the feature types
         reader.readElement("Features");
-        Cnt = reader.getAttributeAsInteger("Count");
+        Cnt = reader.getAttribute<long>("Count");
         for (i = 0; i < Cnt; i++) {
             reader.readElement("Feature");
-            string type = reader.getAttribute("type");
-            string name = reader.getAttribute("name");
+            string type = reader.getAttribute<const char*>("type");
+            string name = reader.getAttribute<const char*>("name");
             try {
                 addObject(type.c_str(), name.c_str(), /*isNew=*/false);
             }
@@ -1103,10 +1103,10 @@ void Document::Restore(Base::XMLReader& reader)
 
         // read the features itself
         reader.readElement("FeatureData");
-        Cnt = reader.getAttributeAsInteger("Count");
+        Cnt = reader.getAttribute<long>("Count");
         for (i = 0; i < Cnt; i++) {
             reader.readElement("Feature");
-            string name = reader.getAttribute("name");
+            string name = reader.getAttribute<const char*>("name");
             DocumentObject* pObj = getObject(name.c_str());
             if (pObj) {  // check if this feature has been registered
                 pObj->setStatus(ObjectStatus::Restore, true);
@@ -1409,7 +1409,7 @@ std::vector<App::DocumentObject*> Document::readObjects(Base::XMLReader& reader)
 
     // read the object types
     reader.readElement("Objects");
-    int Cnt = reader.getAttributeAsInteger("Count");
+    int Cnt = reader.getAttribute<long>("Count");
 
     if (!reader.hasAttribute(FC_ATTR_DEPENDENCIES)) {
         d->partialLoadObjects.clear();
@@ -1418,17 +1418,17 @@ std::vector<App::DocumentObject*> Document::readObjects(Base::XMLReader& reader)
         std::unordered_map<std::string, DepInfo> deps;
         for (int i = 0; i < Cnt; i++) {
             reader.readElement(FC_ELEMENT_OBJECT_DEPS);
-            int dcount = reader.getAttributeAsInteger(FC_ATTR_DEP_COUNT);
+            int dcount = reader.getAttribute<long>(FC_ATTR_DEP_COUNT);
             if (!dcount) {
                 continue;
             }
-            auto& info = deps[reader.getAttribute(FC_ATTR_DEP_OBJ_NAME)];
+            auto& info = deps[reader.getAttribute<const char*>(FC_ATTR_DEP_OBJ_NAME)];
             if (reader.hasAttribute(FC_ATTR_DEP_ALLOW_PARTIAL)) {
-                info.canLoadPartial = reader.getAttributeAsInteger(FC_ATTR_DEP_ALLOW_PARTIAL);
+                info.canLoadPartial = reader.getAttribute<long>(FC_ATTR_DEP_ALLOW_PARTIAL);
             }
             for (int j = 0; j < dcount; ++j) {
                 reader.readElement(FC_ELEMENT_OBJECT_DEP);
-                const char* name = reader.getAttribute(FC_ATTR_DEP_OBJ_NAME);
+                const char* name = reader.getAttribute<const char*>(FC_ATTR_DEP_OBJ_NAME);
                 if (!Base::Tools::isNullOrEmpty(name)) {
                     info.deps.insert(name);
                 }
@@ -1462,10 +1462,10 @@ std::vector<App::DocumentObject*> Document::readObjects(Base::XMLReader& reader)
     long lastId = 0;
     for (int i = 0; i < Cnt; i++) {
         reader.readElement("Object");
-        std::string type = reader.getAttribute("type");
-        std::string name = reader.getAttribute("name");
+        std::string type = reader.getAttribute<const char*>("type");
+        std::string name = reader.getAttribute<const char*>("name");
         std::string viewType =
-            reader.hasAttribute("ViewType") ? reader.getAttribute("ViewType") : "";
+            reader.hasAttribute("ViewType") ? reader.getAttribute<const char*>("ViewType") : "";
 
         bool partial = false;
         if (!d->partialLoadObjects.empty()) {
@@ -1479,7 +1479,7 @@ std::vector<App::DocumentObject*> Document::readObjects(Base::XMLReader& reader)
         if (!testStatus(Status::Importing) && reader.hasAttribute("id")) {
             // if not importing, then temporary reset lastObjectId and make the
             // following addObject() generate the correct id for this object.
-            d->lastObjectId = reader.getAttributeAsInteger("id") - 1;
+            d->lastObjectId = reader.getAttribute<long>("id") - 1;
         }
 
         // To prevent duplicate name when export/import of objects from
@@ -1518,15 +1518,15 @@ std::vector<App::DocumentObject*> Document::readObjects(Base::XMLReader& reader)
 
                 // restore touch/error status flags
                 if (reader.hasAttribute("Touched")) {
-                    if (reader.getAttributeAsInteger("Touched") != 0) {
+                    if (reader.getAttribute<long>("Touched") != 0) {
                         d->touchedObjs.insert(obj);
                     }
                 }
                 if (reader.hasAttribute("Invalid")) {
                     obj->setStatus(ObjectStatus::Error,
-                                   reader.getAttributeAsInteger("Invalid") != 0);
+                                   reader.getAttribute<long>("Invalid") != 0);
                     if (obj->isError() && reader.hasAttribute("Error")) {
-                        d->addRecomputeLog(reader.getAttribute("Error"), obj);
+                        d->addRecomputeLog(reader.getAttribute<const char*>("Error"), obj);
                     }
                 }
             }
@@ -1545,10 +1545,10 @@ std::vector<App::DocumentObject*> Document::readObjects(Base::XMLReader& reader)
     // read the features itself
     reader.clearPartialRestoreDocumentObject();
     reader.readElement("ObjectData");
-    Cnt = reader.getAttributeAsInteger("Count");
+    Cnt = reader.getAttribute<long>("Count");
     for (int i = 0; i < Cnt; i++) {
         reader.readElement("Object");
-        std::string name = reader.getName(reader.getAttribute("name"));
+        std::string name = reader.getName(reader.getAttribute<const char*>("name"));
         DocumentObject* pObj = getObject(name.c_str());
         if (pObj
             && !pObj->testStatus(
@@ -1609,16 +1609,16 @@ std::vector<App::DocumentObject*> Document::importObjects(Base::XMLReader& reade
     Base::ObjectStatusLocker<Status, Document> restoreBit2(Status::Importing, this);
     ExpressionParser::ExpressionImporter expImporter(reader);
     reader.readElement("Document");
-    long scheme = reader.getAttributeAsInteger("SchemaVersion");
+    long scheme = reader.getAttribute<long>("SchemaVersion");
     reader.DocumentSchema = scheme;
     if (reader.hasAttribute("ProgramVersion")) {
-        reader.ProgramVersion = reader.getAttribute("ProgramVersion");
+        reader.ProgramVersion = reader.getAttribute<const char*>("ProgramVersion");
     }
     else {
         reader.ProgramVersion = "pre-0.14";
     }
     if (reader.hasAttribute("FileVersion")) {
-        reader.FileVersion = reader.getAttributeAsUnsigned("FileVersion");
+        reader.FileVersion = reader.getAttribute<unsigned long>("FileVersion");
     }
     else {
         reader.FileVersion = 0;

--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -352,25 +352,25 @@ Property* DynamicProperty::restore(PropertyContainer& pc,
     short attribute = 0;
     bool readonly = false, hidden = false;
     const char *group = nullptr, *doc = nullptr, *attr = nullptr, *ro = nullptr, *hide = nullptr;
-    group = reader.getAttribute("group");
+    group = reader.getAttribute<const char*>("group");
     if (reader.hasAttribute("doc")) {
-        doc = reader.getAttribute("doc");
+        doc = reader.getAttribute<const char*>("doc");
     }
     if (reader.hasAttribute("attr")) {
-        attr = reader.getAttribute("attr");
+        attr = reader.getAttribute<const char*>("attr");
         if (attr) {
             std::istringstream str(attr);
             str >> attribute;
         }
     }
     if (reader.hasAttribute("ro")) {
-        ro = reader.getAttribute("ro");
+        ro = reader.getAttribute<const char*>("ro");
         if (ro) {
             readonly = (ro[0] - 48) != 0;
         }
     }
     if (reader.hasAttribute("hide")) {
-        hide = reader.getAttribute("hide");
+        hide = reader.getAttribute<const char*>("hide");
         if (hide) {
             hidden = (hide[0] - 48) != 0;
         }

--- a/src/App/ExtensionContainer.cpp
+++ b/src/App/ExtensionContainer.cpp
@@ -431,12 +431,12 @@ void ExtensionContainer::restoreExtensions(Base::XMLReader& reader)
     }
 
     reader.readElement("Extensions");
-    int Cnt = reader.getAttributeAsInteger("Count");
+    int Cnt = reader.getAttribute<long>("Count");
 
     for (int i = 0; i < Cnt; i++) {
         reader.readElement("Extension");
-        const char* Type = reader.getAttribute("type");
-        const char* Name = reader.getAttribute("name");
+        const char* Type = reader.getAttribute<const char*>("type");
+        const char* Name = reader.getAttribute<const char*>("name");
         try {
             App::Extension* ext = getExtension(Name);
             if (!ext) {

--- a/src/App/ProjectFile.cpp
+++ b/src/App/ProjectFile.cpp
@@ -338,10 +338,10 @@ bool ProjectFile::restoreObject(const std::string& name, App::PropertyContainer*
     reader.readEndElement("Objects");
 
     reader.readElement("ObjectData");
-    long Cnt = reader.getAttributeAsInteger("Count");
+    long Cnt = reader.getAttribute<long>("Count");
     for (long i = 0; i < Cnt; i++) {
         reader.readElement("Object");
-        std::string nameAttr = reader.getAttribute("name");
+        std::string nameAttr = reader.getAttribute<const char*>("name");
 
         if (nameAttr == name) {
             // obj->StatusBits.set(4);

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -344,25 +344,25 @@ void PropertyContainer::Restore(Base::XMLReader &reader)
 {
     reader.clearPartialRestoreProperty();
     reader.readElement("Properties");
-    int Cnt = reader.getAttributeAsInteger("Count");
+    int Cnt = reader.getAttribute<long>("Count");
 
     int transientCount = 0;
     if(reader.hasAttribute("TransientCount"))
-        transientCount = reader.getAttributeAsUnsigned("TransientCount");
+        transientCount = reader.getAttribute<unsigned long>("TransientCount");
 
     for (int i=0;i<transientCount; ++i) {
         reader.readElement("_Property");
-        Property* prop = getPropertyByName(reader.getAttribute("name"));
+        Property* prop = getPropertyByName(reader.getAttribute<const char*>("name"));
         if(prop)
             FC_TRACE("restore transient '" << prop->getName() << "'");
         if(prop && reader.hasAttribute("status"))
-            prop->setStatusValue(reader.getAttributeAsUnsigned("status"));
+            prop->setStatusValue(reader.getAttribute<unsigned long>("status"));
     }
 
     for (int i=0 ;i<Cnt ;i++) {
         reader.readElement("Property");
-        std::string PropName = reader.getAttribute("name");
-        std::string TypeName = reader.getAttribute("type");
+        std::string PropName = reader.getAttribute<const char*>("name");
+        std::string TypeName = reader.getAttribute<const char*>("type");
         // NOTE: We must also check the type of the current property because a
         // subclass of PropertyContainer might change the type of a property but
         // not its name. In this case we would force to read-in a wrong property
@@ -375,7 +375,7 @@ void PropertyContainer::Restore(Base::XMLReader &reader)
 
             decltype(Property::StatusBits) status;
             if(reader.hasAttribute("status")) {
-                status = decltype(status)(reader.getAttributeAsUnsigned("status"));
+                status = decltype(status)(reader.getAttribute<unsigned long>("status"));
                 if(prop)
                     prop->setStatusValue(status.to_ulong());
             }

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -327,9 +327,9 @@ void PropertyExpressionEngine::Save(Base::Writer& writer) const
 void PropertyExpressionEngine::Restore(Base::XMLReader& reader)
 {
     reader.readElement("ExpressionEngine");
-    int count = reader.getAttributeAsFloat("count");
+    int count = reader.getAttribute<double>("count");
 
-    if (reader.hasAttribute("xlink") && reader.getAttributeAsInteger("xlink")) {
+    if (reader.hasAttribute("xlink") && reader.getAttribute<long>("xlink")) {
         PropertyExpressionContainer::Restore(reader);
     }
 
@@ -340,10 +340,10 @@ void PropertyExpressionEngine::Restore(Base::XMLReader& reader)
         reader.readElement("Expression");
         restoredExpressions->emplace_back();
         auto& info = restoredExpressions->back();
-        info.path = reader.getAttribute("path");
-        info.expr = reader.getAttribute("expression");
+        info.path = reader.getAttribute<const char*>("path");
+        info.expr = reader.getAttribute<const char*>("expression");
         if (reader.hasAttribute("comment")) {
-            info.comment = reader.getAttribute("comment");
+            info.comment = reader.getAttribute<const char*>("comment");
         }
     }
 

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -329,7 +329,7 @@ void PropertyExpressionEngine::Restore(Base::XMLReader& reader)
     reader.readElement("ExpressionEngine");
     int count = reader.getAttribute<double>("count");
 
-    if (reader.hasAttribute("xlink") && reader.getAttribute<long>("xlink")) {
+    if (reader.hasAttribute("xlink") && reader.getAttribute<bool>("xlink")) {
         PropertyExpressionContainer::Restore(reader);
     }
 

--- a/src/App/PropertyFile.cpp
+++ b/src/App/PropertyFile.cpp
@@ -398,7 +398,7 @@ void PropertyFileIncluded::Restore(Base::XMLReader& reader)
 {
     reader.readElement("FileIncluded");
     if (reader.hasAttribute("file")) {
-        string file(reader.getAttribute("file"));
+        string file(reader.getAttribute<const char*>("file"));
         if (!file.empty()) {
             // initiate a file read
             reader.addFile(file.c_str(), this);
@@ -411,7 +411,7 @@ void PropertyFileIncluded::Restore(Base::XMLReader& reader)
     }
     // section is XML stream
     else if (reader.hasAttribute("data")) {
-        string file(reader.getAttribute("data"));
+        string file(reader.getAttribute<const char*>("data"));
         if (!file.empty()) {
             // is in the document transient path
             aboutToSetValue();

--- a/src/App/PropertyGeo.cpp
+++ b/src/App/PropertyGeo.cpp
@@ -160,9 +160,9 @@ void PropertyVector::Restore(Base::XMLReader& reader)
     reader.readElement("PropertyVector");
     // get the value of my Attribute
     aboutToSetValue();
-    _cVec.x = reader.getAttributeAsFloat("valueX");
-    _cVec.y = reader.getAttributeAsFloat("valueY");
-    _cVec.z = reader.getAttributeAsFloat("valueZ");
+    _cVec.x = reader.getAttribute<double>("valueX");
+    _cVec.y = reader.getAttribute<double>("valueY");
+    _cVec.z = reader.getAttribute<double>("valueZ");
     hasSetValue();
 }
 
@@ -320,7 +320,7 @@ void PropertyVectorList::Save(Base::Writer& writer) const
 void PropertyVectorList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("VectorList");
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read
@@ -478,25 +478,25 @@ void PropertyMatrix::Restore(Base::XMLReader& reader)
     reader.readElement("PropertyMatrix");
     // get the value of my Attribute
     aboutToSetValue();
-    _cMat[0][0] = reader.getAttributeAsFloat("a11");
-    _cMat[0][1] = reader.getAttributeAsFloat("a12");
-    _cMat[0][2] = reader.getAttributeAsFloat("a13");
-    _cMat[0][3] = reader.getAttributeAsFloat("a14");
+    _cMat[0][0] = reader.getAttribute<double>("a11");
+    _cMat[0][1] = reader.getAttribute<double>("a12");
+    _cMat[0][2] = reader.getAttribute<double>("a13");
+    _cMat[0][3] = reader.getAttribute<double>("a14");
 
-    _cMat[1][0] = reader.getAttributeAsFloat("a21");
-    _cMat[1][1] = reader.getAttributeAsFloat("a22");
-    _cMat[1][2] = reader.getAttributeAsFloat("a23");
-    _cMat[1][3] = reader.getAttributeAsFloat("a24");
+    _cMat[1][0] = reader.getAttribute<double>("a21");
+    _cMat[1][1] = reader.getAttribute<double>("a22");
+    _cMat[1][2] = reader.getAttribute<double>("a23");
+    _cMat[1][3] = reader.getAttribute<double>("a24");
 
-    _cMat[2][0] = reader.getAttributeAsFloat("a31");
-    _cMat[2][1] = reader.getAttributeAsFloat("a32");
-    _cMat[2][2] = reader.getAttributeAsFloat("a33");
-    _cMat[2][3] = reader.getAttributeAsFloat("a34");
+    _cMat[2][0] = reader.getAttribute<double>("a31");
+    _cMat[2][1] = reader.getAttribute<double>("a32");
+    _cMat[2][2] = reader.getAttribute<double>("a33");
+    _cMat[2][3] = reader.getAttribute<double>("a34");
 
-    _cMat[3][0] = reader.getAttributeAsFloat("a41");
-    _cMat[3][1] = reader.getAttributeAsFloat("a42");
-    _cMat[3][2] = reader.getAttributeAsFloat("a43");
-    _cMat[3][3] = reader.getAttributeAsFloat("a44");
+    _cMat[3][0] = reader.getAttribute<double>("a41");
+    _cMat[3][1] = reader.getAttribute<double>("a42");
+    _cMat[3][2] = reader.getAttribute<double>("a43");
+    _cMat[3][3] = reader.getAttribute<double>("a44");
     hasSetValue();
 }
 
@@ -865,22 +865,22 @@ void PropertyPlacement::Restore(Base::XMLReader& reader)
     aboutToSetValue();
 
     if (reader.hasAttribute("A")) {
-        _cPos = Base::Placement(Vector3d(reader.getAttributeAsFloat("Px"),
-                                         reader.getAttributeAsFloat("Py"),
-                                         reader.getAttributeAsFloat("Pz")),
-                                Rotation(Vector3d(reader.getAttributeAsFloat("Ox"),
-                                                  reader.getAttributeAsFloat("Oy"),
-                                                  reader.getAttributeAsFloat("Oz")),
-                                         reader.getAttributeAsFloat("A")));
+        _cPos = Base::Placement(Vector3d(reader.getAttribute<double>("Px"),
+                                         reader.getAttribute<double>("Py"),
+                                         reader.getAttribute<double>("Pz")),
+                                Rotation(Vector3d(reader.getAttribute<double>("Ox"),
+                                                  reader.getAttribute<double>("Oy"),
+                                                  reader.getAttribute<double>("Oz")),
+                                         reader.getAttribute<double>("A")));
     }
     else {
-        _cPos = Base::Placement(Vector3d(reader.getAttributeAsFloat("Px"),
-                                         reader.getAttributeAsFloat("Py"),
-                                         reader.getAttributeAsFloat("Pz")),
-                                Rotation(reader.getAttributeAsFloat("Q0"),
-                                         reader.getAttributeAsFloat("Q1"),
-                                         reader.getAttributeAsFloat("Q2"),
-                                         reader.getAttributeAsFloat("Q3")));
+        _cPos = Base::Placement(Vector3d(reader.getAttribute<double>("Px"),
+                                         reader.getAttribute<double>("Py"),
+                                         reader.getAttribute<double>("Pz")),
+                                Rotation(reader.getAttribute<double>("Q0"),
+                                         reader.getAttribute<double>("Q1"),
+                                         reader.getAttribute<double>("Q2"),
+                                         reader.getAttribute<double>("Q3")));
     }
 
     hasSetValue();
@@ -947,7 +947,7 @@ void PropertyPlacementList::Save(Base::Writer& writer) const
 void PropertyPlacementList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("PlacementList");
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read
@@ -1258,10 +1258,10 @@ void PropertyRotation::Restore(Base::XMLReader& reader)
     reader.readElement("PropertyRotation");
     aboutToSetValue();
 
-    _rot = Rotation(Vector3d(reader.getAttributeAsFloat("Ox"),
-                             reader.getAttributeAsFloat("Oy"),
-                             reader.getAttributeAsFloat("Oz")),
-                    reader.getAttributeAsFloat("A"));
+    _rot = Rotation(Vector3d(reader.getAttribute<double>("Ox"),
+                             reader.getAttribute<double>("Oy"),
+                             reader.getAttribute<double>("Oz")),
+                    reader.getAttribute<double>("A"));
     hasSetValue();
 }
 

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -776,7 +776,7 @@ void PropertyLink::Restore(Base::XMLReader& reader)
     // read my element
     reader.readElement("Link");
     // get the value of my attribute
-    std::string name = reader.getName(reader.getAttribute("value"));
+    std::string name = reader.getName(reader.getAttribute<const char*>("value"));
 
     // Property not in a DocumentObject!
     assert(getContainer()->isDerivedFrom<App::DocumentObject>());
@@ -1060,7 +1060,7 @@ void PropertyLinkList::Restore(Base::XMLReader& reader)
     // read my element
     reader.readElement("LinkList");
     // get the value of my attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
     App::PropertyContainer* container = getContainer();
     if (!container) {
         throw Base::RuntimeError("Property is not part of a container");
@@ -1075,7 +1075,7 @@ void PropertyLinkList::Restore(Base::XMLReader& reader)
     values.reserve(count);
     for (int i = 0; i < count; i++) {
         reader.readElement("Link");
-        std::string name = reader.getName(reader.getAttribute("value"));
+        std::string name = reader.getName(reader.getAttribute<const char*>("value"));
         // In order to do copy/paste it must be allowed to have defined some
         // referenced objects in XML which do not exist anymore in the new
         // document. Thus, we should silently ignore this.
@@ -1888,8 +1888,8 @@ void PropertyLinkSub::Restore(Base::XMLReader& reader)
     // read my element
     reader.readElement("LinkSub");
     // get the values of my attributes
-    std::string name = reader.getName(reader.getAttribute("value"));
-    int count = reader.getAttributeAsInteger("count");
+    std::string name = reader.getName(reader.getAttribute<const char*>("value"));
+    int count = reader.getAttribute<long>("count");
 
     // Property not in a DocumentObject!
     assert(getContainer()->isDerivedFrom<App::DocumentObject>());
@@ -1913,16 +1913,16 @@ void PropertyLinkSub::Restore(Base::XMLReader& reader)
     // Sub may store '.' separated object names, so be aware of the possible mapping when import
     for (int i = 0; i < count; i++) {
         reader.readElement("Sub");
-        shadows[i].oldName = importSubName(reader, reader.getAttribute("value"), restoreLabel);
+        shadows[i].oldName = importSubName(reader, reader.getAttribute<const char*>("value"), restoreLabel);
         if (reader.hasAttribute(ATTR_SHADOWED) && !IGNORE_SHADOW) {
             values[i] = shadows[i].newName =
-                importSubName(reader, reader.getAttribute(ATTR_SHADOWED), restoreLabel);
+                importSubName(reader, reader.getAttribute<const char*>(ATTR_SHADOWED), restoreLabel);
         }
         else {
             values[i] = shadows[i].oldName;
             if (reader.hasAttribute(ATTR_SHADOW) && !IGNORE_SHADOW) {
                 shadows[i].newName =
-                    importSubName(reader, reader.getAttribute(ATTR_SHADOW), restoreLabel);
+                    importSubName(reader, reader.getAttribute<const char*>(ATTR_SHADOW), restoreLabel);
             }
         }
         if (reader.hasAttribute(ATTR_MAPPED)) {
@@ -2836,7 +2836,7 @@ void PropertyLinkSubList::Restore(Base::XMLReader& reader)
     // read my element
     reader.readElement("LinkSubList");
     // get the value of my attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
 
     std::vector<DocumentObject*> values;
     values.reserve(count);
@@ -2850,7 +2850,7 @@ void PropertyLinkSubList::Restore(Base::XMLReader& reader)
     bool restoreLabel = false;
     for (int i = 0; i < count; i++) {
         reader.readElement("Link");
-        std::string name = reader.getName(reader.getAttribute("obj"));
+        std::string name = reader.getName(reader.getAttribute<const char*>("obj"));
         // In order to do copy/paste it must be allowed to have defined some
         // referenced objects in XML which do not exist anymore in the new
         // document. Thus, we should silently ignore this.
@@ -2860,17 +2860,17 @@ void PropertyLinkSubList::Restore(Base::XMLReader& reader)
             values.push_back(child);
             shadows.emplace_back();
             auto& shadow = shadows.back();
-            shadow.oldName = importSubName(reader, reader.getAttribute("sub"), restoreLabel);
+            shadow.oldName = importSubName(reader, reader.getAttribute<const char*>("sub"), restoreLabel);
             if (reader.hasAttribute(ATTR_SHADOWED) && !IGNORE_SHADOW) {
                 shadow.newName =
-                    importSubName(reader, reader.getAttribute(ATTR_SHADOWED), restoreLabel);
+                    importSubName(reader, reader.getAttribute<const char*>(ATTR_SHADOWED), restoreLabel);
                 SubNames.push_back(shadow.newName);
             }
             else {
                 SubNames.push_back(shadow.oldName);
                 if (reader.hasAttribute(ATTR_SHADOW) && !IGNORE_SHADOW) {
                     shadow.newName =
-                        importSubName(reader, reader.getAttribute(ATTR_SHADOW), restoreLabel);
+                        importSubName(reader, reader.getAttribute<const char*>(ATTR_SHADOW), restoreLabel);
                 }
             }
             if (reader.hasAttribute(ATTR_MAPPED)) {
@@ -4232,20 +4232,20 @@ void PropertyXLink::Restore(Base::XMLReader& reader)
     reader.readElement("XLink");
     std::string stampAttr, file;
     if (reader.hasAttribute("stamp")) {
-        stampAttr = reader.getAttribute("stamp");
+        stampAttr = reader.getAttribute<const char*>("stamp");
     }
     if (reader.hasAttribute("file")) {
-        file = reader.getAttribute("file");
+        file = reader.getAttribute<const char*>("file");
     }
 
     setFlag(LinkAllowPartial,
-            reader.hasAttribute("partial") && reader.getAttributeAsInteger("partial"));
+            reader.hasAttribute("partial") && reader.getAttribute<long>("partial"));
     std::string name;
     if (file.empty()) {
-        name = reader.getName(reader.getAttribute("name"));
+        name = reader.getName(reader.getAttribute<const char*>("name"));
     }
     else {
-        name = reader.getAttribute("name");
+        name = reader.getAttribute<const char*>("name");
     }
 
     assert(getContainer()->isDerivedFrom<App::DocumentObject>());
@@ -4275,35 +4275,35 @@ void PropertyXLink::Restore(Base::XMLReader& reader)
         auto& subname = subs.back();
         shadows.emplace_back();
         auto& shadow = shadows.back();
-        shadow.oldName = importSubName(reader, reader.getAttribute("sub"), restoreLabel);
+        shadow.oldName = importSubName(reader, reader.getAttribute<const char*>("sub"), restoreLabel);
         if (reader.hasAttribute(ATTR_SHADOWED) && !IGNORE_SHADOW) {
             subname = shadow.newName =
-                importSubName(reader, reader.getAttribute(ATTR_SHADOWED), restoreLabel);
+                importSubName(reader, reader.getAttribute<const char*>(ATTR_SHADOWED), restoreLabel);
         }
         else {
             subname = shadow.oldName;
             if (reader.hasAttribute(ATTR_SHADOW) && !IGNORE_SHADOW) {
                 shadow.newName =
-                    importSubName(reader, reader.getAttribute(ATTR_SHADOW), restoreLabel);
+                    importSubName(reader, reader.getAttribute<const char*>(ATTR_SHADOW), restoreLabel);
             }
         }
     }
     else if (reader.hasAttribute("count")) {
-        int count = reader.getAttributeAsInteger("count");
+        int count = reader.getAttribute<long>("count");
         subs.resize(count);
         shadows.resize(count);
         for (int i = 0; i < count; i++) {
             reader.readElement("Sub");
-            shadows[i].oldName = importSubName(reader, reader.getAttribute("value"), restoreLabel);
+            shadows[i].oldName = importSubName(reader, reader.getAttribute<const char*>("value"), restoreLabel);
             if (reader.hasAttribute(ATTR_SHADOWED) && !IGNORE_SHADOW) {
                 subs[i] = shadows[i].newName =
-                    importSubName(reader, reader.getAttribute(ATTR_SHADOWED), restoreLabel);
+                    importSubName(reader, reader.getAttribute<const char*>(ATTR_SHADOWED), restoreLabel);
             }
             else {
                 subs[i] = shadows[i].oldName;
                 if (reader.hasAttribute(ATTR_SHADOW) && !IGNORE_SHADOW) {
                     shadows[i].newName =
-                        importSubName(reader, reader.getAttribute(ATTR_SHADOW), restoreLabel);
+                        importSubName(reader, reader.getAttribute<const char*>(ATTR_SHADOW), restoreLabel);
                 }
             }
             if (reader.hasAttribute(ATTR_MAPPED)) {
@@ -5128,8 +5128,8 @@ void PropertyXLinkSubList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("XLinkSubList");
     setFlag(LinkAllowPartial,
-            reader.hasAttribute("partial") && reader.getAttributeAsInteger("partial"));
-    int count = reader.getAttributeAsInteger("count");
+            reader.hasAttribute("partial") && reader.getAttribute<long>("partial"));
+    int count = reader.getAttribute<long>("count");
     atomic_change guard(*this, false);
     _Links.clear();
     for (int i = 0; i < count; ++i) {
@@ -5789,11 +5789,11 @@ void PropertyXLinkContainer::Save(Base::Writer& writer) const
 void PropertyXLinkContainer::Restore(Base::XMLReader& reader)
 {
     reader.readElement("XLinks");
-    auto count = reader.getAttributeAsUnsigned("count");
+    auto count = reader.getAttribute<unsigned long>("count");
     _XLinkRestores = std::make_unique<std::vector<RestoreInfo>>(count);
 
     if (reader.hasAttribute("hidden")) {
-        std::istringstream iss(reader.getAttribute("hidden"));
+        std::istringstream iss(reader.getAttribute<const char*>("hidden"));
         int index;
         while (iss >> index) {
             if (index >= 0 && index < static_cast<int>(count)) {
@@ -5803,18 +5803,18 @@ void PropertyXLinkContainer::Restore(Base::XMLReader& reader)
     }
 
     if (reader.hasAttribute("docs")) {
-        auto docCount = reader.getAttributeAsUnsigned("docs");
+        auto docCount = reader.getAttribute<unsigned long>("docs");
         _DocMap.clear();
         for (unsigned i = 0; i < docCount; ++i) {
             reader.readElement("DocMap");
-            auto index = reader.getAttributeAsUnsigned("index");
+            auto index = reader.getAttribute<unsigned long>("index");
             if (index >= count) {
                 FC_ERR(propertyName(this) << " invalid document map entry");
                 continue;
             }
             auto& info = _XLinkRestores->at(index);
-            info.docName = reader.getAttribute("name");
-            info.docLabel = reader.getAttribute("label");
+            info.docName = reader.getAttribute<const char*>("name");
+            info.docLabel = reader.getAttribute<const char*>("label");
         }
     }
 

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -4239,7 +4239,7 @@ void PropertyXLink::Restore(Base::XMLReader& reader)
     }
 
     setFlag(LinkAllowPartial,
-            reader.hasAttribute("partial") && reader.getAttribute<long>("partial"));
+            reader.hasAttribute("partial") && reader.getAttribute<bool>("partial"));
     std::string name;
     if (file.empty()) {
         name = reader.getName(reader.getAttribute<const char*>("name"));
@@ -5128,7 +5128,7 @@ void PropertyXLinkSubList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("XLinkSubList");
     setFlag(LinkAllowPartial,
-            reader.hasAttribute("partial") && reader.getAttribute<long>("partial"));
+            reader.hasAttribute("partial") && reader.getAttribute<bool>("partial"));
     int count = reader.getAttribute<long>("count");
     atomic_change guard(*this, false);
     _Links.clear();

--- a/src/App/PropertyPythonObject.cpp
+++ b/src/App/PropertyPythonObject.cpp
@@ -277,13 +277,13 @@ void PropertyPythonObject::restoreObject(Base::XMLReader& reader)
     try {
         PropertyContainer* parent = this->getContainer();
         if (reader.hasAttribute("object")) {
-            if (strcmp(reader.getAttribute("object"), "yes") == 0) {
+            if (strcmp(reader.getAttribute<const char*>("object"), "yes") == 0) {
                 Py::Object obj = Py::asObject(parent->getPyObject());
                 this->object.setAttr("__object__", obj);
             }
         }
         if (reader.hasAttribute("vobject")) {
-            if (strcmp(reader.getAttribute("vobject"), "yes") == 0) {
+            if (strcmp(reader.getAttribute<const char*>("vobject"), "yes") == 0) {
                 Py::Object obj = Py::asObject(parent->getPyObject());
                 this->object.setAttr("__vobject__", obj);
             }
@@ -335,15 +335,15 @@ void PropertyPythonObject::Restore(Base::XMLReader& reader)
 {
     reader.readElement("Python");
     if (reader.hasAttribute("file")) {
-        std::string file(reader.getAttribute("file"));
+        std::string file(reader.getAttribute<const char*>("file"));
         reader.addFile(file.c_str(), this);
     }
     else {
         bool load_json = false;
         bool load_pickle = false;
         bool load_failed = false;
-        std::string buffer = reader.getAttribute("value");
-        if (reader.hasAttribute("encoded") && strcmp(reader.getAttribute("encoded"), "yes") == 0) {
+        std::string buffer = reader.getAttribute<const char*>("value");
+        if (reader.hasAttribute("encoded") && strcmp(reader.getAttribute<const char*>("encoded"), "yes") == 0) {
             buffer = Base::base64_decode(buffer);
         }
         else {
@@ -358,15 +358,15 @@ void PropertyPythonObject::Restore(Base::XMLReader& reader)
             start = buffer.begin();
             end = buffer.end();
             if (reader.hasAttribute("module") && reader.hasAttribute("class")) {
-                Py::Module mod(PyImport_ImportModule(reader.getAttribute("module")), true);
+                Py::Module mod(PyImport_ImportModule(reader.getAttribute<const char*>("module")), true);
                 if (mod.isNull()) {
                     throw Py::Exception();
                 }
-                PyObject* cls = mod.getAttr(reader.getAttribute("class")).ptr();
+                PyObject* cls = mod.getAttr(reader.getAttribute<const char*>("class")).ptr();
                 if (!cls) {
                     std::stringstream s;
-                    s << "Module " << reader.getAttribute("module") << " has no class "
-                      << reader.getAttribute("class");
+                    s << "Module " << reader.getAttribute<const char*>("module") << " has no class "
+                      << reader.getAttribute<const char*>("class");
                     throw Py::AttributeError(s.str());
                 }
                 if (PyType_Check(cls)) {

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -123,7 +123,7 @@ void PropertyInteger::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Integer");
     // get the value of my Attribute
-    setValue(reader.getAttributeAsInteger("value"));
+    setValue(reader.getAttribute<long>("value"));
 }
 
 Property* PropertyInteger::Copy() const
@@ -250,7 +250,7 @@ void PropertyPath::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Path");
     // get the value of my Attribute
-    setValue(reader.getAttribute("value"));
+    setValue(reader.getAttribute<const char*>("value"));
 }
 
 Property* PropertyPath::Copy() const
@@ -420,18 +420,18 @@ void PropertyEnumeration::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Integer");
     // get the value of my Attribute
-    long val = reader.getAttributeAsInteger("value");
+    long val = reader.getAttribute<long>("value");
 
     aboutToSetValue();
 
     if (reader.hasAttribute("CustomEnum")) {
         reader.readElement("CustomEnumList");
-        int count = reader.getAttributeAsInteger("count");
+        int count = reader.getAttribute<long>("count");
         std::vector<std::string> values(count);
 
         for (int i = 0; i < count; i++) {
             reader.readElement("Enum");
-            values[i] = reader.getAttribute("value");
+            values[i] = reader.getAttribute<const char*>("value");
         }
 
         reader.readEndElement("CustomEnumList");
@@ -844,12 +844,12 @@ void PropertyIntegerList::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("IntegerList");
     // get the value of my Attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
 
     std::vector<long> values(count);
     for (int i = 0; i < count; i++) {
         reader.readElement("I");
-        values[i] = reader.getAttributeAsInteger("v");
+        values[i] = reader.getAttribute<long>("v");
     }
 
     reader.readEndElement("IntegerList");
@@ -965,12 +965,12 @@ void PropertyIntegerSet::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("IntegerSet");
     // get the value of my Attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
 
     std::set<long> values;
     for (int i = 0; i < count; i++) {
         reader.readElement("I");
-        values.insert(reader.getAttributeAsInteger("v"));
+        values.insert(reader.getAttribute<long>("v"));
     }
 
     reader.readEndElement("IntegerSet");
@@ -1066,7 +1066,7 @@ void PropertyFloat::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Float");
     // get the value of my Attribute
-    setValue(reader.getAttributeAsFloat("value"));
+    setValue(reader.getAttribute<double>("value"));
 }
 
 Property* PropertyFloat::Copy() const
@@ -1355,7 +1355,7 @@ void PropertyFloatList::Save(Base::Writer& writer) const
 void PropertyFloatList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("FloatList");
-    string file(reader.getAttribute("file"));
+    string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read
@@ -1537,22 +1537,22 @@ void PropertyString::Restore(Base::XMLReader& reader)
     auto obj = dynamic_cast<DocumentObject*>(getContainer());
     if (obj && &obj->Label == this) {
         if (reader.hasAttribute("restore")) {
-            int restore = reader.getAttributeAsInteger("restore");
+            int restore = reader.getAttribute<long>("restore");
             if (restore == 1) {
                 aboutToSetValue();
-                _cValue = reader.getAttribute("value");
+                _cValue = reader.getAttribute<const char*>("value");
                 hasSetValue();
             }
             else {
-                setValue(reader.getName(reader.getAttribute("value")));
+                setValue(reader.getName(reader.getAttribute<const char*>("value")));
             }
         }
         else {
-            setValue(reader.getAttribute("value"));
+            setValue(reader.getAttribute<const char*>("value"));
         }
     }
     else {
-        setValue(reader.getAttribute("value"));
+        setValue(reader.getAttribute<const char*>("value"));
     }
 }
 
@@ -1692,7 +1692,7 @@ void PropertyUUID::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Uuid");
     // get the value of my Attribute
-    setValue(reader.getAttribute("value"));
+    setValue(reader.getAttribute<const char*>("value"));
 }
 
 Property* PropertyUUID::Copy() const
@@ -1808,12 +1808,12 @@ void PropertyStringList::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("StringList");
     // get the value of my Attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
 
     std::vector<std::string> values(count);
     for (int i = 0; i < count; i++) {
         reader.readElement("String");
-        values[i] = reader.getAttribute("value");
+        values[i] = reader.getAttribute<const char*>("value");
     }
 
     reader.readEndElement("StringList");
@@ -1969,12 +1969,12 @@ void PropertyMap::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Map");
     // get the value of my Attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
 
     std::map<std::string, std::string> values;
     for (int i = 0; i < count; i++) {
         reader.readElement("Item");
-        values[reader.getAttribute("key")] = reader.getAttribute("value");
+        values[reader.getAttribute<const char*>("key")] = reader.getAttribute<const char*>("value");
     }
 
     reader.readEndElement("Map");
@@ -2064,7 +2064,7 @@ void PropertyBool::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Bool");
     // get the value of my Attribute
-    string b = reader.getAttribute("value");
+    string b = reader.getAttribute<const char*>("value");
     (b == "true") ? setValue(true) : setValue(false);
 }
 
@@ -2193,7 +2193,7 @@ void PropertyBoolList::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("BoolList");
     // get the value of my Attribute
-    string str = reader.getAttribute("value");
+    string str = reader.getAttribute<const char*>("value");
     boost::dynamic_bitset<> bitset(str);
     setValues(bitset);
 }
@@ -2360,7 +2360,7 @@ void PropertyColor::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("PropertyColor");
     // get the value of my Attribute
-    unsigned long rgba = reader.getAttributeAsUnsigned("value");
+    unsigned long rgba = reader.getAttribute<unsigned long>("value");
     setValue(rgba);
 }
 
@@ -2436,7 +2436,7 @@ void PropertyColorList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("ColorList");
     if (reader.hasAttribute("file")) {
-        std::string file(reader.getAttribute("file"));
+        std::string file(reader.getAttribute<const char*>("file"));
 
         if (!file.empty()) {
             // initiate a file read
@@ -2690,20 +2690,20 @@ void PropertyMaterial::Restore(Base::XMLReader& reader)
     reader.readElement("PropertyMaterial");
     // get the value of my Attribute
     aboutToSetValue();
-    _cMat.ambientColor.setPackedValue(reader.getAttributeAsUnsigned("ambientColor"));
-    _cMat.diffuseColor.setPackedValue(reader.getAttributeAsUnsigned("diffuseColor"));
-    _cMat.specularColor.setPackedValue(reader.getAttributeAsUnsigned("specularColor"));
-    _cMat.emissiveColor.setPackedValue(reader.getAttributeAsUnsigned("emissiveColor"));
-    _cMat.shininess = (float)reader.getAttributeAsFloat("shininess");
-    _cMat.transparency = (float)reader.getAttributeAsFloat("transparency");
+    _cMat.ambientColor.setPackedValue(reader.getAttribute<unsigned long>("ambientColor"));
+    _cMat.diffuseColor.setPackedValue(reader.getAttribute<unsigned long>("diffuseColor"));
+    _cMat.specularColor.setPackedValue(reader.getAttribute<unsigned long>("specularColor"));
+    _cMat.emissiveColor.setPackedValue(reader.getAttribute<unsigned long>("emissiveColor"));
+    _cMat.shininess = (float)reader.getAttribute<double>("shininess");
+    _cMat.transparency = (float)reader.getAttribute<double>("transparency");
     if (reader.hasAttribute("image")) {
-        _cMat.image = reader.getAttribute("image");
+        _cMat.image = reader.getAttribute<const char*>("image");
     }
     if (reader.hasAttribute("imagePath")) {
-        _cMat.imagePath = reader.getAttribute("imagePath");
+        _cMat.imagePath = reader.getAttribute<const char*>("imagePath");
     }
     if (reader.hasAttribute("uuid")) {
-        _cMat.uuid = reader.getAttribute("uuid");
+        _cMat.uuid = reader.getAttribute<const char*>("uuid");
     }
     hasSetValue();
 }
@@ -3232,9 +3232,9 @@ void PropertyMaterialList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("MaterialList");
     if (reader.hasAttribute("file")) {
-        std::string file(reader.getAttribute("file"));
+        std::string file(reader.getAttribute<const char*>("file"));
         if (reader.hasAttribute("version")) {
-            formatVersion = static_cast<Format>(reader.getAttributeAsInteger("version"));
+            formatVersion = static_cast<Format>(reader.getAttribute<long>("version"));
         }
 
         if (!file.empty()) {

--- a/src/App/StringHasher.cpp
+++ b/src/App/StringHasher.cpp
@@ -791,10 +791,10 @@ void StringHasher::Restore(Base::XMLReader& reader)
     clear();
     reader.readElement("StringHasher");
     _hashes->SaveAll = reader.getAttribute<long>("saveall") != 0L;
-    _hashes->Threshold = static_cast<int>(reader.getAttribute<long>("threshold"));
+    _hashes->Threshold = reader.getAttribute<int>("threshold");
 
     bool newTag = false;
-    if (reader.hasAttribute("new") && reader.getAttribute<long>("new") > 0) {
+    if (reader.hasAttribute("new") && reader.getAttribute<bool>("new")) {
         reader.readElement("StringHasher2");
         newTag = true;
     }

--- a/src/App/StringHasher.cpp
+++ b/src/App/StringHasher.cpp
@@ -790,24 +790,24 @@ void StringHasher::Restore(Base::XMLReader& reader)
 {
     clear();
     reader.readElement("StringHasher");
-    _hashes->SaveAll = reader.getAttributeAsInteger("saveall") != 0L;
-    _hashes->Threshold = static_cast<int>(reader.getAttributeAsInteger("threshold"));
+    _hashes->SaveAll = reader.getAttribute<long>("saveall") != 0L;
+    _hashes->Threshold = static_cast<int>(reader.getAttribute<long>("threshold"));
 
     bool newTag = false;
-    if (reader.hasAttribute("new") && reader.getAttributeAsInteger("new") > 0) {
+    if (reader.hasAttribute("new") && reader.getAttribute<long>("new") > 0) {
         reader.readElement("StringHasher2");
         newTag = true;
     }
 
     if (reader.hasAttribute("file")) {
-        const char* file = reader.getAttribute("file");
+        const char* file = reader.getAttribute<const char*>("file");
         if (*file != '\0') {
             reader.addFile(file, this);
         }
         return;
     }
 
-    std::size_t count = reader.getAttributeAsUnsigned("count");
+    std::size_t count = reader.getAttribute<unsigned long>("count");
     if (newTag) {
         try {
             restoreStreamNew(reader.beginCharStream(), count);
@@ -826,15 +826,15 @@ void StringHasher::Restore(Base::XMLReader& reader)
         for (std::size_t i = 0; i < count; ++i) {
             reader.readElement("Item");
             StringIDRef sid;
-            long id = reader.getAttributeAsInteger("id");
+            long id = reader.getAttribute<long>("id");
             bool hashed = reader.hasAttribute("hash");
             if (hashed || reader.hasAttribute("data")) {
                 const char* value =
-                    hashed ? reader.getAttribute("hash") : reader.getAttribute("data");
+                    hashed ? reader.getAttribute<const char*>("hash") : reader.getAttribute<const char*>("data");
                 sid = new StringID(id, QByteArray::fromBase64(value), StringID::Flag::Hashed);
             }
             else {
-                sid = new StringID(id, QByteArray(reader.getAttribute("text")));
+                sid = new StringID(id, QByteArray(reader.getAttribute<const char*>("text")));
             }
             insert(sid);
         }

--- a/src/Base/Persistence.h
+++ b/src/Base/Persistence.h
@@ -70,9 +70,9 @@ public:
      *   // read my Element
      *   reader.readElement("PropertyVector");
      *   // get the value of my Attribute
-     *   _cVec.x = reader.getAttributeAsFloat("valueX");
-     *   _cVec.y = reader.getAttributeAsFloat("valueY");
-     *   _cVec.z = reader.getAttributeAsFloat("valueZ");
+     *   _cVec.x = reader.getAttribute<double>("valueX");
+     *   _cVec.y = reader.getAttribute<double>("valueY");
+     *   _cVec.z = reader.getAttribute<double>("valueZ");
      * }
      * \endcode
      */
@@ -119,7 +119,7 @@ public:
      * void PropertyMeshKernel::Restore(Base::XMLReader &reader)
      * {
      *   reader.readElement("Mesh");
-     *   std::string file (reader.getAttribute("file") );
+     *   std::string file (reader.getAttribute<const char*>("file") );
      *
      *   if(file == "")
      *   {

--- a/src/Doc/templates/doxy-boot.js
+++ b/src/Doc/templates/doxy-boot.js
@@ -92,7 +92,7 @@ $( document ).ready(function() {
 
 	function getOriginalWidthOfImg(img_element) {
 		var t = new Image();
-		t.src = (img_element.getAttribute ? img_element.getAttribute("src") : false) || img_element.src;
+		t.src = (img_element.getAttribute ? img_element.getAttribute<const char*>("src") : false) || img_element.src;
 		return t.width;
 	}
 

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1652,7 +1652,7 @@ void Document::RestoreDocFile(Base::Reader &reader)
     localreader->FileVersion = reader.getFileVersion();
 
     localreader->readElement("Document");
-    long scheme = localreader->getAttributeAsInteger("SchemaVersion");
+    long scheme = localreader->getAttribute<long>("SchemaVersion");
     localreader->DocumentSchema = scheme;
 
     bool hasExpansion = localreader->hasAttribute("HasExpansion");
@@ -1672,14 +1672,14 @@ void Document::RestoreDocFile(Base::Reader &reader)
     if (scheme == 1) {
         // read the viewproviders itself
         localreader->readElement("ViewProviderData");
-        int Cnt = localreader->getAttributeAsInteger("Count");
+        int Cnt = localreader->getAttribute<long>("Count");
         for (int i=0; i<Cnt; i++) {
             localreader->readElement("ViewProvider");
-            std::string name = localreader->getAttribute("name");
+            std::string name = localreader->getAttribute<const char*>("name");
 
             bool expanded = false;
             if (!hasExpansion && localreader->hasAttribute("expanded")) {
-                const char* attr = localreader->getAttribute("expanded");
+                const char* attr = localreader->getAttribute<const char*>("expanded");
                 if (strcmp(attr,"1") == 0) {
                     expanded = true;
                 }
@@ -1687,7 +1687,7 @@ void Document::RestoreDocFile(Base::Reader &reader)
 
             int treeRank = -1;
             if (localreader->hasAttribute("treeRank")) {
-                treeRank = int(localreader->getAttributeAsInteger("treeRank"));
+                treeRank = int(localreader->getAttribute<long>("treeRank"));
             }
 
             auto pObj = dynamic_cast<ViewProviderDocumentObject*>(getViewProviderByName(name.c_str()));
@@ -1709,7 +1709,7 @@ void Document::RestoreDocFile(Base::Reader &reader)
 
         // read camera settings
         localreader->readElement("Camera");
-        const char* ppReturn = localreader->getAttribute("settings");
+        const char* ppReturn = localreader->getAttribute<const char*>("settings");
         cameraSettings.clear();
         if(!Base::Tools::isNullOrEmpty(ppReturn)) {
             saveCameraSettings(ppReturn);
@@ -1902,7 +1902,7 @@ void Document::importObjects(const std::vector<App::DocumentObject*>& obj, Base:
     // We must create an XML parser to read from the input stream
     std::shared_ptr<Base::XMLReader> localreader = std::make_shared<Base::XMLReader>("GuiDocument.xml", reader);
     localreader->readElement("Document");
-    long scheme = localreader->getAttributeAsInteger("SchemaVersion");
+    long scheme = localreader->getAttribute<long>("SchemaVersion");
 
     // At this stage all the document objects and their associated view providers exist.
     // Now we must restore the properties of the view providers only.
@@ -1911,20 +1911,20 @@ void Document::importObjects(const std::vector<App::DocumentObject*>& obj, Base:
     if (scheme == 1) {
         // read the viewproviders itself
         localreader->readElement("ViewProviderData");
-        int Cnt = localreader->getAttributeAsInteger("Count");
+        int Cnt = localreader->getAttribute<long>("Count");
         auto it = obj.begin();
         for (int i=0;i<Cnt&&it!=obj.end();++i,++it) {
             // The stored name usually doesn't match with the current name anymore
             // thus we try to match by type. This should work because the order of
             // objects should not have changed
             localreader->readElement("ViewProvider");
-            std::string name = localreader->getAttribute("name");
+            std::string name = localreader->getAttribute<const char*>("name");
             auto jt = nameMapping.find(name);
             if (jt != nameMapping.end())
                 name = jt->second;
             bool expanded = false;
             if (localreader->hasAttribute("expanded")) {
-                const char* attr = localreader->getAttribute("expanded");
+                const char* attr = localreader->getAttribute<const char*>("expanded");
                 if (strcmp(attr,"1") == 0) {
                     expanded = true;
                 }

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1687,7 +1687,7 @@ void Document::RestoreDocFile(Base::Reader &reader)
 
             int treeRank = -1;
             if (localreader->hasAttribute("treeRank")) {
-                treeRank = int(localreader->getAttribute<long>("treeRank"));
+                treeRank = localreader->getAttribute<int>("treeRank");
             }
 
             auto pObj = dynamic_cast<ViewProviderDocumentObject*>(getViewProviderByName(name.c_str()));

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -387,10 +387,10 @@ class DocumentItem::ExpandInfo :
 public:
     void restore(Base::XMLReader& reader) {
         int level = reader.level();
-        int count = reader.getAttributeAsInteger("count");
+        int count = reader.getAttribute<long>("count");
         for (int i = 0; i < count; ++i) {
             reader.readElement("Expand");
-            auto& entry = (*this)[reader.getAttribute("name")];
+            auto& entry = (*this)[reader.getAttribute<const char*>("name")];
             if (!reader.hasAttribute("count"))
                 continue;
             entry.reset(new ExpandInfo);

--- a/src/Mod/CAM/App/Command.cpp
+++ b/src/Mod/CAM/App/Command.cpp
@@ -351,6 +351,6 @@ void Command::Save(Writer& writer) const
 void Command::Restore(XMLReader& reader)
 {
     reader.readElement("Command");
-    std::string gcode = reader.getAttribute("gcode");
+    std::string gcode = reader.getAttribute<const char*>("gcode");
     setFromGCode(gcode);
 }

--- a/src/Mod/CAM/App/Path.cpp
+++ b/src/Mod/CAM/App/Path.cpp
@@ -507,7 +507,7 @@ void Toolpath::SaveDocFile(Base::Writer& writer) const
 void Toolpath::Restore(XMLReader& reader)
 {
     reader.readElement("Path");
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read

--- a/src/Mod/CAM/App/PropertyPath.cpp
+++ b/src/Mod/CAM/App/PropertyPath.cpp
@@ -104,19 +104,19 @@ void PropertyPath::Restore(Base::XMLReader& reader)
 {
     reader.readElement("Path");
 
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
     if (!file.empty()) {
         // initiate a file read
         reader.addFile(file.c_str(), this);
     }
 
     if (reader.hasAttribute("version")) {
-        int version = reader.getAttributeAsInteger("version");
+        int version = reader.getAttribute<long>("version");
         if (version >= Toolpath::SchemaVersion) {
             reader.readElement("Center");
-            double x = reader.getAttributeAsFloat("x");
-            double y = reader.getAttributeAsFloat("y");
-            double z = reader.getAttributeAsFloat("z");
+            double x = reader.getAttribute<double>("x");
+            double y = reader.getAttribute<double>("y");
+            double z = reader.getAttribute<double>("z");
             Base::Vector3d center(x, y, z);
             _Path.setCenter(center);
         }

--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -2341,32 +2341,32 @@ void FemMesh::Save(Base::Writer& writer) const
 void FemMesh::Restore(Base::XMLReader& reader)
 {
     reader.readElement("FemMesh");
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read
         reader.addFile(file.c_str(), this);
     }
     if (reader.hasAttribute("a11")) {
-        _Mtrx[0][0] = reader.getAttributeAsFloat("a11");
-        _Mtrx[0][1] = reader.getAttributeAsFloat("a12");
-        _Mtrx[0][2] = reader.getAttributeAsFloat("a13");
-        _Mtrx[0][3] = reader.getAttributeAsFloat("a14");
+        _Mtrx[0][0] = reader.getAttribute<double>("a11");
+        _Mtrx[0][1] = reader.getAttribute<double>("a12");
+        _Mtrx[0][2] = reader.getAttribute<double>("a13");
+        _Mtrx[0][3] = reader.getAttribute<double>("a14");
 
-        _Mtrx[1][0] = reader.getAttributeAsFloat("a21");
-        _Mtrx[1][1] = reader.getAttributeAsFloat("a22");
-        _Mtrx[1][2] = reader.getAttributeAsFloat("a23");
-        _Mtrx[1][3] = reader.getAttributeAsFloat("a24");
+        _Mtrx[1][0] = reader.getAttribute<double>("a21");
+        _Mtrx[1][1] = reader.getAttribute<double>("a22");
+        _Mtrx[1][2] = reader.getAttribute<double>("a23");
+        _Mtrx[1][3] = reader.getAttribute<double>("a24");
 
-        _Mtrx[2][0] = reader.getAttributeAsFloat("a31");
-        _Mtrx[2][1] = reader.getAttributeAsFloat("a32");
-        _Mtrx[2][2] = reader.getAttributeAsFloat("a33");
-        _Mtrx[2][3] = reader.getAttributeAsFloat("a34");
+        _Mtrx[2][0] = reader.getAttribute<double>("a31");
+        _Mtrx[2][1] = reader.getAttribute<double>("a32");
+        _Mtrx[2][2] = reader.getAttribute<double>("a33");
+        _Mtrx[2][3] = reader.getAttribute<double>("a34");
 
-        _Mtrx[3][0] = reader.getAttributeAsFloat("a41");
-        _Mtrx[3][1] = reader.getAttributeAsFloat("a42");
-        _Mtrx[3][2] = reader.getAttributeAsFloat("a43");
-        _Mtrx[3][3] = reader.getAttributeAsFloat("a44");
+        _Mtrx[3][0] = reader.getAttribute<double>("a41");
+        _Mtrx[3][1] = reader.getAttribute<double>("a42");
+        _Mtrx[3][2] = reader.getAttribute<double>("a43");
+        _Mtrx[3][3] = reader.getAttribute<double>("a44");
     }
 }
 

--- a/src/Mod/Fem/App/PropertyPostDataObject.cpp
+++ b/src/Mod/Fem/App/PropertyPostDataObject.cpp
@@ -298,7 +298,7 @@ void PropertyPostDataObject::Restore(Base::XMLReader& reader)
         return;
     }
 
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
     if (!file.empty()) {
         // initiate a file read
         reader.addFile(file.c_str(), this);

--- a/src/Mod/Inspection/App/InspectionFeature.cpp
+++ b/src/Mod/Inspection/App/InspectionFeature.cpp
@@ -646,7 +646,7 @@ void PropertyDistanceList::Save(Base::Writer& writer) const
 void PropertyDistanceList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("FloatList");
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read

--- a/src/Mod/Material/App/PropertyMaterial.cpp
+++ b/src/Mod/Material/App/PropertyMaterial.cpp
@@ -91,7 +91,7 @@ void PropertyMaterial::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("PropertyMaterial");
     // get the value of my Attribute
-    auto uuid = reader.getAttribute("uuid");
+    auto uuid = reader.getAttribute<const char*>("uuid");
 
     setValue(*MaterialManager::getManager().getMaterial(QString::fromLatin1(uuid)));
 }

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -867,29 +867,29 @@ void MeshInput::LoadXML(Base::XMLReader& reader)
     //  reader.readElement("Mesh");
 
     reader.readElement("Points");
-    int Cnt = reader.getAttributeAsInteger("Count");
+    int Cnt = reader.getAttribute<long>("Count");
 
     cPoints.resize(Cnt);
     for (int i = 0; i < Cnt; i++) {
         reader.readElement("P");
-        cPoints[i].x = (float)reader.getAttributeAsFloat("x");
-        cPoints[i].y = (float)reader.getAttributeAsFloat("y");
-        cPoints[i].z = (float)reader.getAttributeAsFloat("z");
+        cPoints[i].x = (float)reader.getAttribute<double>("x");
+        cPoints[i].y = (float)reader.getAttribute<double>("y");
+        cPoints[i].z = (float)reader.getAttribute<double>("z");
     }
     reader.readEndElement("Points");
 
     reader.readElement("Faces");
-    Cnt = reader.getAttributeAsInteger("Count");
+    Cnt = reader.getAttribute<long>("Count");
 
     cFacets.resize(Cnt);
     for (int i = 0; i < Cnt; i++) {
         reader.readElement("F");
-        cFacets[i]._aulPoints[0] = reader.getAttributeAsInteger("p0");
-        cFacets[i]._aulPoints[1] = reader.getAttributeAsInteger("p1");
-        cFacets[i]._aulPoints[2] = reader.getAttributeAsInteger("p2");
-        cFacets[i]._aulNeighbours[0] = reader.getAttributeAsInteger("n0");
-        cFacets[i]._aulNeighbours[1] = reader.getAttributeAsInteger("n1");
-        cFacets[i]._aulNeighbours[2] = reader.getAttributeAsInteger("n2");
+        cFacets[i]._aulPoints[0] = reader.getAttribute<long>("p0");
+        cFacets[i]._aulPoints[1] = reader.getAttribute<long>("p1");
+        cFacets[i]._aulPoints[2] = reader.getAttribute<long>("p2");
+        cFacets[i]._aulNeighbours[0] = reader.getAttribute<long>("n0");
+        cFacets[i]._aulNeighbours[1] = reader.getAttribute<long>("n1");
+        cFacets[i]._aulNeighbours[2] = reader.getAttribute<long>("n2");
     }
 
     reader.readEndElement("Faces");

--- a/src/Mod/Mesh/App/MeshProperties.cpp
+++ b/src/Mod/Mesh/App/MeshProperties.cpp
@@ -135,7 +135,7 @@ void PropertyNormalList::Save(Base::Writer& writer) const
 void PropertyNormalList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("VectorList");
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read
@@ -326,7 +326,7 @@ void PropertyCurvatureList::Save(Base::Writer& writer) const
 void PropertyCurvatureList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("CurvatureList");
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read
@@ -598,7 +598,7 @@ void PropertyMaterial::Restore(Base::XMLReader& reader)
 {
     reader.readElement("Material");
     if (reader.hasAttribute("file")) {
-        std::string file(reader.getAttribute("file"));
+        std::string file(reader.getAttribute<const char*>("file"));
 
         if (!file.empty()) {
             // initiate a file read
@@ -896,7 +896,7 @@ void PropertyMeshKernel::Save(Base::Writer& writer) const
 void PropertyMeshKernel::Restore(Base::XMLReader& reader)
 {
     reader.readElement("Mesh");
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
 
     if (file.empty()) {
         // read XML

--- a/src/Mod/Part/App/FeaturePartBox.cpp
+++ b/src/Mod/Part/App/FeaturePartBox.cpp
@@ -87,16 +87,16 @@ App::DocumentObjectExecReturn *Box::execute()
 void Box::Restore(Base::XMLReader &reader)
 {
     reader.readElement("Properties");
-    int Cnt = reader.getAttributeAsInteger("Count");
+    int Cnt = reader.getAttribute<long>("Count");
     int transientCount = 0;
     if(reader.hasAttribute("TransientCount"))
-        transientCount = reader.getAttributeAsUnsigned("TransientCount");
+        transientCount = reader.getAttribute<unsigned long>("TransientCount");
 
     for (int i=0;i<transientCount; ++i) {
         reader.readElement("_Property");
-        App::Property* prop = getPropertyByName(reader.getAttribute("name"));
+        App::Property* prop = getPropertyByName(reader.getAttribute<const char*>("name"));
         if(prop && reader.hasAttribute("status"))
-            prop->setStatusValue(reader.getAttributeAsUnsigned("status"));
+            prop->setStatusValue(reader.getAttribute<unsigned long>("status"));
     }
 
     bool location_xyz = false;
@@ -109,15 +109,15 @@ void Box::Restore(Base::XMLReader &reader)
     Axis.setValue(0.0f,0.0f,1.0f);
     for (int i=0 ;i<Cnt;i++) {
         reader.readElement("Property");
-        const char* PropName = reader.getAttribute("name");
-        const char* TypeName = reader.getAttribute("type");
+        const char* PropName = reader.getAttribute<const char*>("name");
+        const char* TypeName = reader.getAttribute<const char*>("type");
         auto prop = dynamicProps.restore(*this,PropName,TypeName,reader);
         if(!prop)
             prop = getPropertyByName(PropName);
 
         std::bitset<32> status;
         if(reader.hasAttribute("status")) {
-            status = reader.getAttributeAsUnsigned("status");
+            status = reader.getAttribute<unsigned long>("status");
             if(prop)
                 prop->setStatusValue(status.to_ulong());
         }

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -313,11 +313,11 @@ void Geometry::Restore(Base::XMLReader &reader)
 
     if(strcmp(reader.localName(),"GeoExtensions") == 0) { // new format
 
-        long count = reader.getAttributeAsInteger("count");
+        long count = reader.getAttribute<long>("count");
 
         for (long index = 0; index < count; index++) {
             reader.readElement("GeoExtension");
-            const char* TypeName = reader.getAttribute("type");
+            const char* TypeName = reader.getAttribute<const char*>("type");
             Base::Type type = Base::Type::fromName(TypeName);
             auto *newExtension = static_cast<GeometryPersistenceExtension *>(type.createInstance());
             if (newExtension) {
@@ -334,7 +334,7 @@ void Geometry::Restore(Base::XMLReader &reader)
     }
     else if(strcmp(reader.localName(),"Construction") == 0) { // legacy
 
-        bool construction = (int)reader.getAttributeAsInteger("value") != 0;
+        bool construction = (int)reader.getAttribute<long>("value") != 0;
 
         // prepare migration
         if(!this->hasExtension(GeometryMigrationExtension::getClassTypeId()))
@@ -636,9 +636,9 @@ void GeomPoint::Restore(Base::XMLReader &reader)
     // read my Element
     reader.readElement("GeomPoint");
     // get the value of my Attribute
-    X = reader.getAttributeAsFloat("X");
-    Y = reader.getAttributeAsFloat("Y");
-    Z = reader.getAttributeAsFloat("Z");
+    X = reader.getAttribute<double>("X");
+    Y = reader.getAttribute<double>("Y");
+    Z = reader.getAttribute<double>("Z");
 
     // set the read geometry
     setPoint(Base::Vector3d(X,Y,Z) );
@@ -1252,17 +1252,17 @@ void GeomBezierCurve::Restore(Base::XMLReader& reader)
 
     reader.readElement("BezierCurve");
     // get the value of my attribute
-    int polescount = reader.getAttributeAsInteger("PolesCount");
+    int polescount = reader.getAttribute<long>("PolesCount");
 
     TColgp_Array1OfPnt poleArray(1,polescount);
     TColStd_Array1OfReal weightArray(1,polescount);
 
     for (int index = 1; index <= polescount; index++) {
         reader.readElement("Pole");
-        double X = reader.getAttributeAsFloat("X");
-        double Y = reader.getAttributeAsFloat("Y");
-        double Z = reader.getAttributeAsFloat("Z");
-        double W = reader.getAttributeAsFloat("Weight");
+        double X = reader.getAttribute<double>("X");
+        double Y = reader.getAttribute<double>("Y");
+        double Z = reader.getAttribute<double>("Z");
+        double W = reader.getAttribute<double>("Weight");
         poleArray.SetValue(index, gp_Pnt(X,Y,Z));
         weightArray.SetValue(index, W);
     }
@@ -2006,10 +2006,10 @@ void GeomBSplineCurve::Restore(Base::XMLReader& reader)
 
     reader.readElement("BSplineCurve");
     // get the value of my attribute
-    int polescount = reader.getAttributeAsInteger("PolesCount");
-    int knotscount = reader.getAttributeAsInteger("KnotsCount");
-    int degree = reader.getAttributeAsInteger("Degree");
-    bool isperiodic = (bool) reader.getAttributeAsInteger("IsPeriodic");
+    int polescount = reader.getAttribute<long>("PolesCount");
+    int knotscount = reader.getAttribute<long>("KnotsCount");
+    int degree = reader.getAttribute<long>("Degree");
+    bool isperiodic = (bool) reader.getAttribute<long>("IsPeriodic");
 
     // Handle(Geom_BSplineCurve) spline = new
     // Geom_BSplineCurve(occpoles,occweights,occknots,occmults,degree,
@@ -2023,18 +2023,18 @@ void GeomBSplineCurve::Restore(Base::XMLReader& reader)
 
     for (int i = 1; i <= polescount; i++) {
         reader.readElement("Pole");
-        double X = reader.getAttributeAsFloat("X");
-        double Y = reader.getAttributeAsFloat("Y");
-        double Z = reader.getAttributeAsFloat("Z");
-        double W = reader.getAttributeAsFloat("Weight");
+        double X = reader.getAttribute<double>("X");
+        double Y = reader.getAttribute<double>("Y");
+        double Z = reader.getAttribute<double>("Z");
+        double W = reader.getAttribute<double>("Weight");
         p.SetValue(i, gp_Pnt(X,Y,Z));
         w.SetValue(i, W);
     }
 
     for (int i = 1; i <= knotscount; i++) {
         reader.readElement("Knot");
-        double val = reader.getAttributeAsFloat("Value");
-        Standard_Integer mult = reader.getAttributeAsInteger("Mult");
+        double val = reader.getAttribute<double>("Value");
+        Standard_Integer mult = reader.getAttribute<long>("Mult");
         k.SetValue(i, val);
         m.SetValue(i, mult);
     }
@@ -2746,15 +2746,15 @@ void GeomCircle::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Circle");
     // get the value of my Attribute
-    CenterX = reader.getAttributeAsFloat("CenterX");
-    CenterY = reader.getAttributeAsFloat("CenterY");
-    CenterZ = reader.getAttributeAsFloat("CenterZ");
-    NormalX = reader.getAttributeAsFloat("NormalX");
-    NormalY = reader.getAttributeAsFloat("NormalY");
-    NormalZ = reader.getAttributeAsFloat("NormalZ");
+    CenterX = reader.getAttribute<double>("CenterX");
+    CenterY = reader.getAttribute<double>("CenterY");
+    CenterZ = reader.getAttribute<double>("CenterZ");
+    NormalX = reader.getAttribute<double>("NormalX");
+    NormalY = reader.getAttribute<double>("NormalY");
+    NormalZ = reader.getAttribute<double>("NormalZ");
     if (reader.hasAttribute("AngleXU"))
-        AngleXU = reader.getAttributeAsFloat("AngleXU");
-    Radius = reader.getAttributeAsFloat("Radius");
+        AngleXU = reader.getAttribute<double>("AngleXU");
+    Radius = reader.getAttribute<double>("Radius");
 
     // set the read geometry
     gp_Pnt p1(CenterX,CenterY,CenterZ);
@@ -2996,17 +2996,17 @@ void GeomArcOfCircle::Restore(Base::XMLReader &reader)
     // read my Element
     reader.readElement("ArcOfCircle");
     // get the value of my Attribute
-    CenterX = reader.getAttributeAsFloat("CenterX");
-    CenterY = reader.getAttributeAsFloat("CenterY");
-    CenterZ = reader.getAttributeAsFloat("CenterZ");
-    NormalX = reader.getAttributeAsFloat("NormalX");
-    NormalY = reader.getAttributeAsFloat("NormalY");
-    NormalZ = reader.getAttributeAsFloat("NormalZ");
+    CenterX = reader.getAttribute<double>("CenterX");
+    CenterY = reader.getAttribute<double>("CenterY");
+    CenterZ = reader.getAttribute<double>("CenterZ");
+    NormalX = reader.getAttribute<double>("NormalX");
+    NormalY = reader.getAttribute<double>("NormalY");
+    NormalZ = reader.getAttribute<double>("NormalZ");
     if (reader.hasAttribute("AngleXU"))
-        AngleXU = reader.getAttributeAsFloat("AngleXU");
-    Radius = reader.getAttributeAsFloat("Radius");
-    StartAngle = reader.getAttributeAsFloat("StartAngle");
-    EndAngle = reader.getAttributeAsFloat("EndAngle");
+        AngleXU = reader.getAttribute<double>("AngleXU");
+    Radius = reader.getAttribute<double>("Radius");
+    StartAngle = reader.getAttribute<double>("StartAngle");
+    EndAngle = reader.getAttribute<double>("EndAngle");
 
     // set the read geometry
     gp_Pnt p1(CenterX,CenterY,CenterZ);
@@ -3257,18 +3257,18 @@ void GeomEllipse::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Ellipse");
     // get the value of my Attribute
-    CenterX = reader.getAttributeAsFloat("CenterX");
-    CenterY = reader.getAttributeAsFloat("CenterY");
-    CenterZ = reader.getAttributeAsFloat("CenterZ");
-    NormalX = reader.getAttributeAsFloat("NormalX");
-    NormalY = reader.getAttributeAsFloat("NormalY");
-    NormalZ = reader.getAttributeAsFloat("NormalZ");
-    MajorRadius = reader.getAttributeAsFloat("MajorRadius");
-    MinorRadius = reader.getAttributeAsFloat("MinorRadius");
+    CenterX = reader.getAttribute<double>("CenterX");
+    CenterY = reader.getAttribute<double>("CenterY");
+    CenterZ = reader.getAttribute<double>("CenterZ");
+    NormalX = reader.getAttribute<double>("NormalX");
+    NormalY = reader.getAttribute<double>("NormalY");
+    NormalZ = reader.getAttribute<double>("NormalZ");
+    MajorRadius = reader.getAttribute<double>("MajorRadius");
+    MinorRadius = reader.getAttribute<double>("MinorRadius");
 
     // This is for backwards compatibility
     if(reader.hasAttribute("AngleXU"))
-        AngleXU = reader.getAttributeAsFloat("AngleXU");
+        AngleXU = reader.getAttribute<double>("AngleXU");
     else
         AngleXU = 0;
 
@@ -3545,17 +3545,17 @@ void GeomArcOfEllipse::Restore(Base::XMLReader &reader)
     // read my Element
     reader.readElement("ArcOfEllipse");
     // get the value of my Attribute
-    CenterX = reader.getAttributeAsFloat("CenterX");
-    CenterY = reader.getAttributeAsFloat("CenterY");
-    CenterZ = reader.getAttributeAsFloat("CenterZ");
-    NormalX = reader.getAttributeAsFloat("NormalX");
-    NormalY = reader.getAttributeAsFloat("NormalY");
-    NormalZ = reader.getAttributeAsFloat("NormalZ");
-    MajorRadius = reader.getAttributeAsFloat("MajorRadius");
-    MinorRadius = reader.getAttributeAsFloat("MinorRadius");
-    AngleXU = reader.getAttributeAsFloat("AngleXU");
-    StartAngle = reader.getAttributeAsFloat("StartAngle");
-    EndAngle = reader.getAttributeAsFloat("EndAngle");
+    CenterX = reader.getAttribute<double>("CenterX");
+    CenterY = reader.getAttribute<double>("CenterY");
+    CenterZ = reader.getAttribute<double>("CenterZ");
+    NormalX = reader.getAttribute<double>("NormalX");
+    NormalY = reader.getAttribute<double>("NormalY");
+    NormalZ = reader.getAttribute<double>("NormalZ");
+    MajorRadius = reader.getAttribute<double>("MajorRadius");
+    MinorRadius = reader.getAttribute<double>("MinorRadius");
+    AngleXU = reader.getAttribute<double>("AngleXU");
+    StartAngle = reader.getAttribute<double>("StartAngle");
+    EndAngle = reader.getAttribute<double>("EndAngle");
 
 
     // set the read geometry
@@ -3724,15 +3724,15 @@ void GeomHyperbola::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Hyperbola");
     // get the value of my Attribute
-    CenterX = reader.getAttributeAsFloat("CenterX");
-    CenterY = reader.getAttributeAsFloat("CenterY");
-    CenterZ = reader.getAttributeAsFloat("CenterZ");
-    NormalX = reader.getAttributeAsFloat("NormalX");
-    NormalY = reader.getAttributeAsFloat("NormalY");
-    NormalZ = reader.getAttributeAsFloat("NormalZ");
-    MajorRadius = reader.getAttributeAsFloat("MajorRadius");
-    MinorRadius = reader.getAttributeAsFloat("MinorRadius");
-    AngleXU = reader.getAttributeAsFloat("AngleXU");
+    CenterX = reader.getAttribute<double>("CenterX");
+    CenterY = reader.getAttribute<double>("CenterY");
+    CenterZ = reader.getAttribute<double>("CenterZ");
+    NormalX = reader.getAttribute<double>("NormalX");
+    NormalY = reader.getAttribute<double>("NormalY");
+    NormalZ = reader.getAttribute<double>("NormalZ");
+    MajorRadius = reader.getAttribute<double>("MajorRadius");
+    MinorRadius = reader.getAttribute<double>("MinorRadius");
+    AngleXU = reader.getAttribute<double>("AngleXU");
 
     // set the read geometry
     gp_Pnt p1(CenterX,CenterY,CenterZ);
@@ -4000,17 +4000,17 @@ void GeomArcOfHyperbola::Restore(Base::XMLReader &reader)
     // read my Element
     reader.readElement("ArcOfHyperbola");
     // get the value of my Attribute
-    CenterX = reader.getAttributeAsFloat("CenterX");
-    CenterY = reader.getAttributeAsFloat("CenterY");
-    CenterZ = reader.getAttributeAsFloat("CenterZ");
-    NormalX = reader.getAttributeAsFloat("NormalX");
-    NormalY = reader.getAttributeAsFloat("NormalY");
-    NormalZ = reader.getAttributeAsFloat("NormalZ");
-    MajorRadius = reader.getAttributeAsFloat("MajorRadius");
-    MinorRadius = reader.getAttributeAsFloat("MinorRadius");
-    AngleXU = reader.getAttributeAsFloat("AngleXU");
-    StartAngle = reader.getAttributeAsFloat("StartAngle");
-    EndAngle = reader.getAttributeAsFloat("EndAngle");
+    CenterX = reader.getAttribute<double>("CenterX");
+    CenterY = reader.getAttribute<double>("CenterY");
+    CenterZ = reader.getAttribute<double>("CenterZ");
+    NormalX = reader.getAttribute<double>("NormalX");
+    NormalY = reader.getAttribute<double>("NormalY");
+    NormalZ = reader.getAttribute<double>("NormalZ");
+    MajorRadius = reader.getAttribute<double>("MajorRadius");
+    MinorRadius = reader.getAttribute<double>("MinorRadius");
+    AngleXU = reader.getAttribute<double>("AngleXU");
+    StartAngle = reader.getAttribute<double>("StartAngle");
+    EndAngle = reader.getAttribute<double>("EndAngle");
 
 
     // set the read geometry
@@ -4159,14 +4159,14 @@ void GeomParabola::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Parabola");
     // get the value of my Attribute
-    CenterX = reader.getAttributeAsFloat("CenterX");
-    CenterY = reader.getAttributeAsFloat("CenterY");
-    CenterZ = reader.getAttributeAsFloat("CenterZ");
-    NormalX = reader.getAttributeAsFloat("NormalX");
-    NormalY = reader.getAttributeAsFloat("NormalY");
-    NormalZ = reader.getAttributeAsFloat("NormalZ");
-    Focal = reader.getAttributeAsFloat("Focal");
-    AngleXU = reader.getAttributeAsFloat("AngleXU");
+    CenterX = reader.getAttribute<double>("CenterX");
+    CenterY = reader.getAttribute<double>("CenterY");
+    CenterZ = reader.getAttribute<double>("CenterZ");
+    NormalX = reader.getAttribute<double>("NormalX");
+    NormalY = reader.getAttribute<double>("NormalY");
+    NormalZ = reader.getAttribute<double>("NormalZ");
+    Focal = reader.getAttribute<double>("Focal");
+    AngleXU = reader.getAttribute<double>("AngleXU");
 
     // set the read geometry
     gp_Pnt p1(CenterX,CenterY,CenterZ);
@@ -4366,16 +4366,16 @@ void GeomArcOfParabola::Restore(Base::XMLReader &reader)
     // read my Element
     reader.readElement("ArcOfParabola");
     // get the value of my Attribute
-    CenterX = reader.getAttributeAsFloat("CenterX");
-    CenterY = reader.getAttributeAsFloat("CenterY");
-    CenterZ = reader.getAttributeAsFloat("CenterZ");
-    NormalX = reader.getAttributeAsFloat("NormalX");
-    NormalY = reader.getAttributeAsFloat("NormalY");
-    NormalZ = reader.getAttributeAsFloat("NormalZ");
-    Focal = reader.getAttributeAsFloat("Focal");
-    AngleXU = reader.getAttributeAsFloat("AngleXU");
-    StartAngle = reader.getAttributeAsFloat("StartAngle");
-    EndAngle = reader.getAttributeAsFloat("EndAngle");
+    CenterX = reader.getAttribute<double>("CenterX");
+    CenterY = reader.getAttribute<double>("CenterY");
+    CenterZ = reader.getAttribute<double>("CenterZ");
+    NormalX = reader.getAttribute<double>("NormalX");
+    NormalY = reader.getAttribute<double>("NormalY");
+    NormalZ = reader.getAttribute<double>("NormalZ");
+    Focal = reader.getAttribute<double>("Focal");
+    AngleXU = reader.getAttribute<double>("AngleXU");
+    StartAngle = reader.getAttribute<double>("StartAngle");
+    EndAngle = reader.getAttribute<double>("EndAngle");
 
 
     // set the read geometry
@@ -4508,12 +4508,12 @@ void GeomLine::Restore(Base::XMLReader &reader)
     // read my Element
     reader.readElement("GeomLine");
     // get the value of my Attribute
-    PosX = reader.getAttributeAsFloat("PosX");
-    PosY = reader.getAttributeAsFloat("PosY");
-    PosZ = reader.getAttributeAsFloat("PosZ");
-    DirX = reader.getAttributeAsFloat("DirX");
-    DirY = reader.getAttributeAsFloat("DirY");
-    DirZ = reader.getAttributeAsFloat("DirZ");
+    PosX = reader.getAttribute<double>("PosX");
+    PosY = reader.getAttribute<double>("PosY");
+    PosZ = reader.getAttribute<double>("PosZ");
+    DirX = reader.getAttribute<double>("DirX");
+    DirY = reader.getAttribute<double>("DirY");
+    DirZ = reader.getAttribute<double>("DirZ");
 
     // set the read geometry
     setLine(Base::Vector3d(PosX,PosY,PosZ),Base::Vector3d(DirX,DirY,DirZ) );
@@ -4665,12 +4665,12 @@ void GeomLineSegment::Restore    (Base::XMLReader &reader)
     // read my Element
     reader.readElement("LineSegment");
     // get the value of my Attribute
-    StartX = reader.getAttributeAsFloat("StartX");
-    StartY = reader.getAttributeAsFloat("StartY");
-    StartZ = reader.getAttributeAsFloat("StartZ");
-    EndX   = reader.getAttributeAsFloat("EndX");
-    EndY   = reader.getAttributeAsFloat("EndY");
-    EndZ   = reader.getAttributeAsFloat("EndZ");
+    StartX = reader.getAttribute<double>("StartX");
+    StartY = reader.getAttribute<double>("StartY");
+    StartZ = reader.getAttribute<double>("StartZ");
+    EndX   = reader.getAttribute<double>("EndX");
+    EndY   = reader.getAttribute<double>("EndY");
+    EndZ   = reader.getAttribute<double>("EndZ");
 
     Base::Vector3d start(StartX,StartY,StartZ);
     Base::Vector3d end(EndX,EndY,EndZ);

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -2009,7 +2009,7 @@ void GeomBSplineCurve::Restore(Base::XMLReader& reader)
     int polescount = reader.getAttribute<long>("PolesCount");
     int knotscount = reader.getAttribute<long>("KnotsCount");
     int degree = reader.getAttribute<long>("Degree");
-    bool isperiodic = (bool) reader.getAttribute<long>("IsPeriodic");
+    bool isperiodic = reader.getAttribute<bool>("IsPeriodic");
 
     // Handle(Geom_BSplineCurve) spline = new
     // Geom_BSplineCurve(occpoles,occweights,occknots,occmults,degree,

--- a/src/Mod/Part/App/Geometry2d.cpp
+++ b/src/Mod/Part/App/Geometry2d.cpp
@@ -187,8 +187,8 @@ void Geom2dPoint::Restore(Base::XMLReader &reader)
     // read my Element
     reader.readElement("Geom2dPoint");
     // get the value of my Attribute
-    X = reader.getAttributeAsFloat("X");
-    Y = reader.getAttributeAsFloat("Y");
+    X = reader.getAttribute<double>("X");
+    Y = reader.getAttribute<double>("Y");
 
     // set the read geometry
     setPoint(Base::Vector2d(X,Y));
@@ -635,12 +635,12 @@ void Geom2dConic::SaveAxis(Base::Writer& writer, const gp_Ax22d& axis) const
 void Geom2dConic::RestoreAxis(Base::XMLReader& reader, gp_Ax22d& axis)
 {
     double CenterX,CenterY,XdirX,XdirY,YdirX,YdirY;
-    CenterX = reader.getAttributeAsFloat("CenterX");
-    CenterY = reader.getAttributeAsFloat("CenterY");
-    XdirX = reader.getAttributeAsFloat("XAxisX");
-    XdirY = reader.getAttributeAsFloat("XAxisY");
-    YdirX = reader.getAttributeAsFloat("YAxisX");
-    YdirY = reader.getAttributeAsFloat("YAxisY");
+    CenterX = reader.getAttribute<double>("CenterX");
+    CenterY = reader.getAttribute<double>("CenterY");
+    XdirX = reader.getAttribute<double>("XAxisX");
+    XdirY = reader.getAttribute<double>("XAxisY");
+    YdirX = reader.getAttribute<double>("YAxisX");
+    YdirY = reader.getAttribute<double>("YAxisY");
 
     // set the read geometry
     gp_Pnt2d p1(CenterX,CenterY);
@@ -763,14 +763,14 @@ void Geom2dArcOfConic::SaveAxis(Base::Writer& writer, const gp_Ax22d& axis, doub
 void Geom2dArcOfConic::RestoreAxis(Base::XMLReader& reader, gp_Ax22d& axis, double& u, double &v)
 {
     double CenterX,CenterY,XdirX,XdirY,YdirX,YdirY;
-    CenterX = reader.getAttributeAsFloat("CenterX");
-    CenterY = reader.getAttributeAsFloat("CenterY");
-    XdirX = reader.getAttributeAsFloat("XAxisX");
-    XdirY = reader.getAttributeAsFloat("XAxisY");
-    YdirX = reader.getAttributeAsFloat("YAxisX");
-    YdirY = reader.getAttributeAsFloat("YAxisY");
-    u = reader.getAttributeAsFloat("FirstParameter");
-    v = reader.getAttributeAsFloat("LastParameter");
+    CenterX = reader.getAttribute<double>("CenterX");
+    CenterY = reader.getAttribute<double>("CenterY");
+    XdirX = reader.getAttribute<double>("XAxisX");
+    XdirY = reader.getAttribute<double>("XAxisY");
+    YdirX = reader.getAttribute<double>("YAxisX");
+    YdirY = reader.getAttribute<double>("YAxisY");
+    u = reader.getAttribute<double>("FirstParameter");
+    v = reader.getAttribute<double>("LastParameter");
 
     // set the read geometry
     gp_Pnt2d p1(CenterX,CenterY);
@@ -863,7 +863,7 @@ void Geom2dCircle::Restore(Base::XMLReader& reader)
     reader.readElement("Geom2dCircle");
     // get the value of my Attribute
     RestoreAxis(reader, axis);
-    Radius = reader.getAttributeAsFloat("Radius");
+    Radius = reader.getAttribute<double>("Radius");
 
     try {
         GCE2d_MakeCircle mc(axis, Radius);
@@ -1022,7 +1022,7 @@ void Geom2dArcOfCircle::Restore(Base::XMLReader &reader)
     reader.readElement("Geom2dArcOfCircle");
     // get the value of my Attribute
     RestoreAxis(reader, axis, u, v);
-    Radius = reader.getAttributeAsFloat("Radius");
+    Radius = reader.getAttribute<double>("Radius");
 
     try {
         GCE2d_MakeCircle mc(axis, Radius);
@@ -1182,8 +1182,8 @@ void Geom2dEllipse::Restore(Base::XMLReader& reader)
     reader.readElement("Geom2dEllipse");
     // get the value of my Attribute
     RestoreAxis(reader, axis);
-    MajorRadius = reader.getAttributeAsFloat("MajorRadius");
-    MinorRadius = reader.getAttributeAsFloat("MinorRadius");
+    MajorRadius = reader.getAttribute<double>("MajorRadius");
+    MinorRadius = reader.getAttribute<double>("MinorRadius");
 
     try {
         GCE2d_MakeEllipse mc(axis, MajorRadius, MinorRadius);
@@ -1357,8 +1357,8 @@ void Geom2dArcOfEllipse::Restore(Base::XMLReader &reader)
     reader.readElement("Geom2dArcOfEllipse");
     // get the value of my Attribute
     RestoreAxis(reader, axis, u, v);
-    MajorRadius = reader.getAttributeAsFloat("MajorRadius");
-    MinorRadius = reader.getAttributeAsFloat("MinorRadius");
+    MajorRadius = reader.getAttribute<double>("MajorRadius");
+    MinorRadius = reader.getAttribute<double>("MinorRadius");
 
     try {
         GCE2d_MakeEllipse mc(axis, MajorRadius, MinorRadius);
@@ -1484,8 +1484,8 @@ void Geom2dHyperbola::Restore(Base::XMLReader& reader)
     reader.readElement("Geom2dHyperbola");
     // get the value of my Attribute
     RestoreAxis(reader, axis);
-    MajorRadius = reader.getAttributeAsFloat("MajorRadius");
-    MinorRadius = reader.getAttributeAsFloat("MinorRadius");
+    MajorRadius = reader.getAttribute<double>("MajorRadius");
+    MinorRadius = reader.getAttribute<double>("MinorRadius");
 
     try {
         GCE2d_MakeHyperbola mc(axis, MajorRadius, MinorRadius);
@@ -1615,8 +1615,8 @@ void Geom2dArcOfHyperbola::Restore(Base::XMLReader &reader)
     reader.readElement("Geom2dHyperbola");
     // get the value of my Attribute
     RestoreAxis(reader, axis, u, v);
-    MajorRadius = reader.getAttributeAsFloat("MajorRadius");
-    MinorRadius = reader.getAttributeAsFloat("MinorRadius");
+    MajorRadius = reader.getAttribute<double>("MajorRadius");
+    MinorRadius = reader.getAttribute<double>("MinorRadius");
 
     try {
         GCE2d_MakeHyperbola mc(axis, MajorRadius, MinorRadius);
@@ -1724,7 +1724,7 @@ void Geom2dParabola::Restore(Base::XMLReader& reader)
     gp_Ax22d axis;
     // get the value of my Attribute
     RestoreAxis(reader, axis);
-    Focal = reader.getAttributeAsFloat("Focal");
+    Focal = reader.getAttribute<double>("Focal");
 
     try {
         GCE2d_MakeParabola mc(axis, Focal);
@@ -1835,7 +1835,7 @@ void Geom2dArcOfParabola::Restore(Base::XMLReader &reader)
     reader.readElement("Geom2dParabola");
     // get the value of my Attribute
     RestoreAxis(reader, axis, u, v);
-    Focal = reader.getAttributeAsFloat("Focal");
+    Focal = reader.getAttribute<double>("Focal");
 
     try {
         GCE2d_MakeParabola mc(axis, Focal);
@@ -1946,10 +1946,10 @@ void Geom2dLine::Restore(Base::XMLReader &reader)
     // read my Element
     reader.readElement("Geom2dLine");
     // get the value of my Attribute
-    PosX = reader.getAttributeAsFloat("PosX");
-    PosY = reader.getAttributeAsFloat("PosY");
-    DirX = reader.getAttributeAsFloat("DirX");
-    DirY = reader.getAttributeAsFloat("DirY");
+    PosX = reader.getAttribute<double>("PosX");
+    PosY = reader.getAttribute<double>("PosY");
+    DirX = reader.getAttribute<double>("DirX");
+    DirY = reader.getAttribute<double>("DirY");
     gp_Pnt2d pnt(PosX, PosY);
     gp_Dir2d dir(DirX, DirY);
 
@@ -2078,10 +2078,10 @@ void Geom2dLineSegment::Restore(Base::XMLReader &reader)
     // read my Element
     reader.readElement("Geom2dLineSegment");
     // get the value of my Attribute
-    StartX = reader.getAttributeAsFloat("StartX");
-    StartY = reader.getAttributeAsFloat("StartY");
-    EndX   = reader.getAttributeAsFloat("EndX");
-    EndY   = reader.getAttributeAsFloat("EndY");
+    StartX = reader.getAttribute<double>("StartX");
+    StartY = reader.getAttribute<double>("StartY");
+    EndX   = reader.getAttribute<double>("EndX");
+    EndY   = reader.getAttribute<double>("EndY");
 
     gp_Pnt2d p1(StartX, StartY);
     gp_Pnt2d p2(EndX, EndY);

--- a/src/Mod/Part/App/GeometryDefaultExtension.cpp
+++ b/src/Mod/Part/App/GeometryDefaultExtension.cpp
@@ -126,7 +126,7 @@ void GeometryDefaultExtension<bool>::restoreAttributes(Base::XMLReader &reader)
 {
     Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
-    value = (bool)reader.getAttribute<long>("value");
+    value = reader.getAttribute<bool>("value");
 }
 
 // ---------- GeometryDoubleExtension ----------

--- a/src/Mod/Part/App/GeometryDefaultExtension.cpp
+++ b/src/Mod/Part/App/GeometryDefaultExtension.cpp
@@ -54,7 +54,7 @@ void GeometryDefaultExtension<T>::restoreAttributes(Base::XMLReader &reader)
 {
     Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
-    value = reader.getAttribute("value");
+    value = reader.getAttribute<const char*>("value");
 }
 
 template <typename T>
@@ -100,7 +100,7 @@ void GeometryDefaultExtension<long>::restoreAttributes(Base::XMLReader &reader)
 {
     Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
-    value = reader.getAttributeAsInteger("value");
+    value = reader.getAttribute<long>("value");
 }
 
 // ---------- GeometryStringExtension ----------
@@ -126,7 +126,7 @@ void GeometryDefaultExtension<bool>::restoreAttributes(Base::XMLReader &reader)
 {
     Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
-    value = (bool)reader.getAttributeAsInteger("value");
+    value = (bool)reader.getAttribute<long>("value");
 }
 
 // ---------- GeometryDoubleExtension ----------
@@ -143,7 +143,7 @@ void GeometryDefaultExtension<double>::restoreAttributes(Base::XMLReader &reader
 {
     Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
-    value = reader.getAttributeAsFloat("value");
+    value = reader.getAttribute<double>("value");
 }
 
 

--- a/src/Mod/Part/App/GeometryExtension.cpp
+++ b/src/Mod/Part/App/GeometryExtension.cpp
@@ -52,7 +52,7 @@ TYPESYSTEM_SOURCE_ABSTRACT(Part::GeometryPersistenceExtension,Part::GeometryExte
 void GeometryPersistenceExtension::restoreAttributes(Base::XMLReader &reader)
 {
     if(reader.hasAttribute("name")) {
-        std::string name = reader.getAttribute("name");
+        std::string name = reader.getAttribute<const char*>("name");
         setName(name);
     }
 }

--- a/src/Mod/Part/App/PropertyGeometryList.cpp
+++ b/src/Mod/Part/App/PropertyGeometryList.cpp
@@ -205,13 +205,13 @@ void PropertyGeometryList::tryRestoreGeometry(Geometry * geom, Base::XMLReader &
 {
     // Not all geometry classes implement Restore() and throw an exception instead
     try {
-        if (!reader.getAttributeAsInteger("migrated", "0") && reader.hasAttribute("id")) {
+        if (!reader.getAttribute<long>("migrated", 0) && reader.hasAttribute("id")) {
             auto ext = std::make_unique<GeometryMigrationExtension>();
-            ext->setId(reader.getAttributeAsInteger("id"));
+            ext->setId(reader.getAttribute<long>("id"));
             if(reader.hasAttribute("ref")) {
-                const char *ref = reader.getAttribute("ref");
-                int index = reader.getAttributeAsInteger("refIndex", "1");
-                unsigned long flags = (unsigned long)reader.getAttributeAsUnsigned("flags");
+                const char *ref = reader.getAttribute<const char*>("ref");
+                int index = reader.getAttribute<long>("refIndex", 1);
+                unsigned long flags = (unsigned long)reader.getAttribute<unsigned long>("flags");
                 ext->setReference(ref, index, flags);
             }
             geom->setExtension(std::move(ext));
@@ -253,12 +253,12 @@ void PropertyGeometryList::Restore(Base::XMLReader &reader)
     reader.clearPartialRestoreObject();
     reader.readElement("GeometryList");
     // get the value of my attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
     std::vector<Geometry*> values;
     values.reserve(count);
     for (int i = 0; i < count; i++) {
         reader.readElement("Geometry");
-        const char* TypeName = reader.getAttribute("type");
+        const char* TypeName = reader.getAttribute<const char*>("type");
         Geometry *newG = static_cast<Geometry *>(Base::Type::fromName(TypeName).createInstance());
         tryRestoreGeometry(newG, reader);
 

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -327,26 +327,26 @@ void PropertyPartShape::Restore(Base::XMLReader &reader)
     _Ver = "?";
     bool has_ver = reader.hasAttribute("ElementMap");
     if (has_ver)
-        _Ver = reader.getAttribute("ElementMap");
+        _Ver = reader.getAttribute<const char*>("ElementMap");
 
-    int hasher_idx = static_cast<int>(reader.getAttributeAsInteger("HasherIndex", "-1"));
-    int save_hasher = static_cast<int>(reader.getAttributeAsInteger("SaveHasher", "0"));
+    int hasher_idx = reader.getAttribute<int>("HasherIndex", -1);
+    int save_hasher = reader.getAttribute<int>("SaveHasher", 0);
 
     TopoShape shape;
 
     if (reader.hasAttribute("file")) {
-        std::string file = reader.getAttribute("file");
+        std::string file = reader.getAttribute<const char*>("file");
         if (!file.empty()) {
             // initiate a file read
             reader.addFile(file.c_str(), this);
         }
     }
-    else if (reader.hasAttribute(("binary")) && reader.getAttributeAsInteger("binary")) {
+    else if (reader.hasAttribute(("binary")) && reader.getAttribute<long>("binary")) {
         TopoShape shape;
         shape.importBinary(reader.beginCharStream());
         shape = shape.getShape();
     }
-    else if (reader.hasAttribute("brep") && reader.getAttributeAsInteger("brep")) {
+    else if (reader.hasAttribute("brep") && reader.getAttribute<long>("brep")) {
         shape.importBrep(reader.beginCharStream(Base::CharStreamFormat::Raw));
     }
 
@@ -843,7 +843,7 @@ void PropertyFilletEdges::Save (Base::Writer &writer) const
 void PropertyFilletEdges::Restore(Base::XMLReader &reader)
 {
     reader.readElement("FilletEdges");
-    std::string file (reader.getAttribute("file") );
+    std::string file (reader.getAttribute<const char*>("file") );
 
     if (!file.empty()) {
         // initiate a file read

--- a/src/Mod/Part/App/PropertyTopoShapeList.cpp
+++ b/src/Mod/Part/App/PropertyTopoShapeList.cpp
@@ -212,20 +212,20 @@ void PropertyTopoShapeList::SaveDocFile(Base::Writer& writer) const
 void PropertyTopoShapeList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("ShapeList");
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
     m_restorePointers.clear();  // just in case
     m_restorePointers.reserve(count);
     for (int i = 0; i < count; i++) {
         auto newShape = std::make_shared<TopoShape>();
         reader.readElement("TopoShape");
-        std::string file(reader.getAttribute("file"));
+        std::string file(reader.getAttribute<const char*>("file"));
         if (!file.empty()) {
             reader.addFile(file.c_str(), this);
         }
-        else if (reader.hasAttribute("binary") && reader.getAttributeAsInteger("binary")) {
+        else if (reader.hasAttribute("binary") && reader.getAttribute<long>("binary")) {
             newShape->importBinary(reader.beginCharStream());
         }
-        else if (reader.hasAttribute("brep") && reader.getAttributeAsInteger("brep")) {
+        else if (reader.hasAttribute("brep") && reader.getAttribute<long>("brep")) {
             newShape->importBrep(reader.beginCharStream());
         }
         m_restorePointers.push_back(newShape);

--- a/src/Mod/Part/App/PropertyTopoShapeList.cpp
+++ b/src/Mod/Part/App/PropertyTopoShapeList.cpp
@@ -222,10 +222,10 @@ void PropertyTopoShapeList::Restore(Base::XMLReader& reader)
         if (!file.empty()) {
             reader.addFile(file.c_str(), this);
         }
-        else if (reader.hasAttribute("binary") && reader.getAttribute<long>("binary")) {
+        else if (reader.hasAttribute("binary") && reader.getAttribute<bool>("binary")) {
             newShape->importBinary(reader.beginCharStream());
         }
-        else if (reader.hasAttribute("brep") && reader.getAttribute<long>("brep")) {
+        else if (reader.hasAttribute("brep") && reader.getAttribute<bool>("brep")) {
             newShape->importBrep(reader.beginCharStream());
         }
         m_restorePointers.push_back(newShape);

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -1495,7 +1495,7 @@ void ProfileBased::handleChangedPropertyName(Base::XMLReader & reader, const cha
         // read my element
         reader.readElement("Link");
         // get the value of my attribute
-        std::string name = reader.getAttribute("value");
+        std::string name = reader.getAttribute<const char*>("value");
 
         if (!name.empty()) {
             App::Document* document = getDocument();

--- a/src/Mod/Points/App/Points.cpp
+++ b/src/Mod/Points/App/Points.cpp
@@ -203,14 +203,14 @@ void PointKernel::Restore(Base::XMLReader& reader)
     clear();
 
     reader.readElement("Points");
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read
         reader.addFile(file.c_str(), this);
     }
     if (reader.DocumentSchema > 3) {
-        std::string Matrix(reader.getAttribute("mtrx"));
+        std::string Matrix(reader.getAttribute<const char*>("mtrx"));
         _Mtrx.fromString(Matrix);
     }
 }

--- a/src/Mod/Points/App/Properties.cpp
+++ b/src/Mod/Points/App/Properties.cpp
@@ -137,7 +137,7 @@ void PropertyGreyValueList::Save(Base::Writer& writer) const
 void PropertyGreyValueList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("FloatList");
-    string file(reader.getAttribute("file"));
+    string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read
@@ -309,7 +309,7 @@ void PropertyNormalList::Save(Base::Writer& writer) const
 void PropertyNormalList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("VectorList");
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read
@@ -584,7 +584,7 @@ void PropertyCurvatureList::Save(Base::Writer& writer) const
 void PropertyCurvatureList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("CurvatureList");
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read

--- a/src/Mod/Points/App/PropertyPointKernel.cpp
+++ b/src/Mod/Points/App/PropertyPointKernel.cpp
@@ -103,14 +103,14 @@ void PropertyPointKernel::Save(Base::Writer& writer) const
 void PropertyPointKernel::Restore(Base::XMLReader& reader)
 {
     reader.readElement("Points");
-    std::string file(reader.getAttribute("file"));
+    std::string file(reader.getAttribute<const char*>("file"));
 
     if (!file.empty()) {
         // initiate a file read
         reader.addFile(file.c_str(), this);
     }
     if (reader.DocumentSchema > 3) {
-        std::string Matrix(reader.getAttribute("mtrx"));
+        std::string Matrix(reader.getAttribute<const char*>("mtrx"));
         Base::Matrix4D mtrx;
         mtrx.fromString(Matrix);
 

--- a/src/Mod/Robot/App/Robot6Axis.cpp
+++ b/src/Mod/Robot/App/Robot6Axis.cpp
@@ -188,32 +188,32 @@ void Robot6Axis::Restore(XMLReader& reader)
         // read my Element
         reader.readElement("Axis");
         // get the value of the placement
-        Tip = Base::Placement(Base::Vector3d(reader.getAttributeAsFloat("Px"),
-                                             reader.getAttributeAsFloat("Py"),
-                                             reader.getAttributeAsFloat("Pz")),
-                              Base::Rotation(reader.getAttributeAsFloat("Q0"),
-                                             reader.getAttributeAsFloat("Q1"),
-                                             reader.getAttributeAsFloat("Q2"),
-                                             reader.getAttributeAsFloat("Q3")));
+        Tip = Base::Placement(Base::Vector3d(reader.getAttribute<double>("Px"),
+                                             reader.getAttribute<double>("Py"),
+                                             reader.getAttribute<double>("Pz")),
+                              Base::Rotation(reader.getAttribute<double>("Q0"),
+                                             reader.getAttribute<double>("Q1"),
+                                             reader.getAttribute<double>("Q2"),
+                                             reader.getAttribute<double>("Q3")));
         Temp.addSegment(Segment(Joint(Joint::RotZ), toFrame(Tip)));
 
 
         if (reader.hasAttribute("rotDir")) {
-            Velocity[i] = reader.getAttributeAsFloat("rotDir");
+            Velocity[i] = reader.getAttribute<double>("rotDir");
         }
         else {
             Velocity[i] = 1.0;
         }
         // read the axis constraints
-        Min(i) = Base::toRadians<double>(reader.getAttributeAsFloat("maxAngle"));
-        Max(i) = Base::toRadians<double>(reader.getAttributeAsFloat("minAngle"));
+        Min(i) = Base::toRadians<double>(reader.getAttribute<double>("maxAngle"));
+        Max(i) = Base::toRadians<double>(reader.getAttribute<double>("minAngle"));
         if (reader.hasAttribute("AxisVelocity")) {
-            Velocity[i] = reader.getAttributeAsFloat("AxisVelocity");
+            Velocity[i] = reader.getAttribute<double>("AxisVelocity");
         }
         else {
             Velocity[i] = 156.0;
         }
-        Actual(i) = reader.getAttributeAsFloat("Pos");
+        Actual(i) = reader.getAttribute<double>("Pos");
     }
     Kinematic = Temp;
 

--- a/src/Mod/Robot/App/Trajectory.cpp
+++ b/src/Mod/Robot/App/Trajectory.cpp
@@ -335,7 +335,7 @@ void Trajectory::Restore(XMLReader& reader)
     // read my element
     reader.readElement("Trajectory");
     // get the value of my Attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
     vpcWaypoints.resize(count);
 
     for (int i = 0; i < count; i++) {

--- a/src/Mod/Robot/App/Waypoint.cpp
+++ b/src/Mod/Robot/App/Waypoint.cpp
@@ -111,23 +111,23 @@ void Waypoint::Restore(XMLReader& reader)
 {
     // read my Element
     reader.readElement("Waypoint");
-    Name = reader.getAttribute("name");
+    Name = reader.getAttribute<const char*>("name");
     // get the value of the placement
-    EndPos = Base::Placement(Base::Vector3d(reader.getAttributeAsFloat("Px"),
-                                            reader.getAttributeAsFloat("Py"),
-                                            reader.getAttributeAsFloat("Pz")),
-                             Base::Rotation(reader.getAttributeAsFloat("Q0"),
-                                            reader.getAttributeAsFloat("Q1"),
-                                            reader.getAttributeAsFloat("Q2"),
-                                            reader.getAttributeAsFloat("Q3")));
+    EndPos = Base::Placement(Base::Vector3d(reader.getAttribute<double>("Px"),
+                                            reader.getAttribute<double>("Py"),
+                                            reader.getAttribute<double>("Pz")),
+                             Base::Rotation(reader.getAttribute<double>("Q0"),
+                                            reader.getAttribute<double>("Q1"),
+                                            reader.getAttribute<double>("Q2"),
+                                            reader.getAttribute<double>("Q3")));
 
-    Velocity = (float)reader.getAttributeAsFloat("vel");
-    Acceleration = (float)reader.getAttributeAsFloat("acc");
-    Cont = (reader.getAttributeAsInteger("cont") != 0) ? true : false;
-    Tool = reader.getAttributeAsInteger("tool");
-    Base = reader.getAttributeAsInteger("base");
+    Velocity = (float)reader.getAttribute<double>("vel");
+    Acceleration = (float)reader.getAttribute<double>("acc");
+    Cont = (reader.getAttribute<long>("cont") != 0) ? true : false;
+    Tool = reader.getAttribute<long>("tool");
+    Base = reader.getAttribute<long>("base");
 
-    std::string type = reader.getAttribute("type");
+    std::string type = reader.getAttribute<const char*>("type");
     if (type == "PTP") {
         Type = Waypoint::PTP;
     }

--- a/src/Mod/Robot/App/Waypoint.cpp
+++ b/src/Mod/Robot/App/Waypoint.cpp
@@ -123,7 +123,7 @@ void Waypoint::Restore(XMLReader& reader)
 
     Velocity = (float)reader.getAttribute<double>("vel");
     Acceleration = (float)reader.getAttribute<double>("acc");
-    Cont = (reader.getAttribute<long>("cont") != 0) ? true : false;
+    Cont = reader.getAttribute<bool>("cont");
     Tool = reader.getAttribute<long>("tool");
     Base = reader.getAttribute<long>("base");
 

--- a/src/Mod/Sketcher/App/Constraint.cpp
+++ b/src/Mod/Sketcher/App/Constraint.cpp
@@ -179,16 +179,15 @@ void Constraint::Restore(XMLReader& reader)
 {
     reader.readElement("Constrain");
     Name = reader.getAttribute<const char*>("Name");
-    Type = static_cast<ConstraintType>(reader.getAttribute<long>("Type"));
+    Type = reader.getAttribute<ConstraintType>("Type");
     Value = reader.getAttribute<double>("Value");
     First = reader.getAttribute<long>("First");
-    FirstPos = static_cast<PointPos>(reader.getAttribute<long>("FirstPos"));
+    FirstPos = reader.getAttribute<PointPos>("FirstPos");
     Second = reader.getAttribute<long>("Second");
     SecondPos = reader.getAttribute<PointPos>("SecondPos");
 
     if (this->Type == InternalAlignment) {
-        AlignmentType = static_cast<InternalAlignmentType>(
-            reader.getAttribute<long>("InternalAlignmentType"));
+        AlignmentType = reader.getAttribute<InternalAlignmentType>("InternalAlignmentType");
 
         if (reader.hasAttribute("InternalAlignmentIndex")) {
             InternalAlignmentIndex = reader.getAttribute<long>("InternalAlignmentIndex");
@@ -201,7 +200,7 @@ void Constraint::Restore(XMLReader& reader)
     // read the third geo group if present
     if (reader.hasAttribute("Third")) {
         Third = reader.getAttribute<long>("Third");
-        ThirdPos = static_cast<PointPos>(reader.getAttribute<long>("ThirdPos"));
+        ThirdPos = reader.getAttribute<PointPos>("ThirdPos");
     }
 
     // Read the distance a constraint label has been moved
@@ -214,15 +213,15 @@ void Constraint::Restore(XMLReader& reader)
     }
 
     if (reader.hasAttribute("IsDriving")) {
-        isDriving = reader.getAttribute<long>("IsDriving") ? true : false;
+        isDriving = reader.getAttribute<bool>("IsDriving");
     }
 
     if (reader.hasAttribute("IsInVirtualSpace")) {
-        isInVirtualSpace = reader.getAttribute<long>("IsInVirtualSpace") ? true : false;
+        isInVirtualSpace = reader.getAttribute<bool>("IsInVirtualSpace");
     }
 
     if (reader.hasAttribute("IsActive")) {
-        isActive = reader.getAttribute<long>("IsActive") ? true : false;
+        isActive = reader.getAttribute<bool>("IsActive");
     }
 }
 

--- a/src/Mod/Sketcher/App/Constraint.cpp
+++ b/src/Mod/Sketcher/App/Constraint.cpp
@@ -178,20 +178,20 @@ void Constraint::Save(Writer& writer) const
 void Constraint::Restore(XMLReader& reader)
 {
     reader.readElement("Constrain");
-    Name = reader.getAttribute("Name");
-    Type = static_cast<ConstraintType>(reader.getAttributeAsInteger("Type"));
-    Value = reader.getAttributeAsFloat("Value");
-    First = reader.getAttributeAsInteger("First");
-    FirstPos = static_cast<PointPos>(reader.getAttributeAsInteger("FirstPos"));
-    Second = reader.getAttributeAsInteger("Second");
-    SecondPos = static_cast<PointPos>(reader.getAttributeAsInteger("SecondPos"));
+    Name = reader.getAttribute<const char*>("Name");
+    Type = static_cast<ConstraintType>(reader.getAttribute<long>("Type"));
+    Value = reader.getAttribute<double>("Value");
+    First = reader.getAttribute<long>("First");
+    FirstPos = static_cast<PointPos>(reader.getAttribute<long>("FirstPos"));
+    Second = reader.getAttribute<long>("Second");
+    SecondPos = reader.getAttribute<PointPos>("SecondPos");
 
     if (this->Type == InternalAlignment) {
         AlignmentType = static_cast<InternalAlignmentType>(
-            reader.getAttributeAsInteger("InternalAlignmentType"));
+            reader.getAttribute<long>("InternalAlignmentType"));
 
         if (reader.hasAttribute("InternalAlignmentIndex")) {
-            InternalAlignmentIndex = reader.getAttributeAsInteger("InternalAlignmentIndex");
+            InternalAlignmentIndex = reader.getAttribute<long>("InternalAlignmentIndex");
         }
     }
     else {
@@ -200,29 +200,29 @@ void Constraint::Restore(XMLReader& reader)
 
     // read the third geo group if present
     if (reader.hasAttribute("Third")) {
-        Third = reader.getAttributeAsInteger("Third");
-        ThirdPos = static_cast<PointPos>(reader.getAttributeAsInteger("ThirdPos"));
+        Third = reader.getAttribute<long>("Third");
+        ThirdPos = static_cast<PointPos>(reader.getAttribute<long>("ThirdPos"));
     }
 
     // Read the distance a constraint label has been moved
     if (reader.hasAttribute("LabelDistance")) {
-        LabelDistance = (float)reader.getAttributeAsFloat("LabelDistance");
+        LabelDistance = (float)reader.getAttribute<double>("LabelDistance");
     }
 
     if (reader.hasAttribute("LabelPosition")) {
-        LabelPosition = (float)reader.getAttributeAsFloat("LabelPosition");
+        LabelPosition = (float)reader.getAttribute<double>("LabelPosition");
     }
 
     if (reader.hasAttribute("IsDriving")) {
-        isDriving = reader.getAttributeAsInteger("IsDriving") ? true : false;
+        isDriving = reader.getAttribute<long>("IsDriving") ? true : false;
     }
 
     if (reader.hasAttribute("IsInVirtualSpace")) {
-        isInVirtualSpace = reader.getAttributeAsInteger("IsInVirtualSpace") ? true : false;
+        isInVirtualSpace = reader.getAttribute<long>("IsInVirtualSpace") ? true : false;
     }
 
     if (reader.hasAttribute("IsActive")) {
-        isActive = reader.getAttributeAsInteger("IsActive") ? true : false;
+        isActive = reader.getAttribute<long>("IsActive") ? true : false;
     }
 }
 

--- a/src/Mod/Sketcher/App/ExternalGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/ExternalGeometryExtension.cpp
@@ -48,9 +48,9 @@ void ExternalGeometryExtension::restoreAttributes(Base::XMLReader& reader)
 {
     Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
-    Ref = reader.getAttribute("Ref", "");
-    RefIndex = reader.getAttributeAsInteger("RefIndex", "-1");
-    Flags = FlagType(reader.getAttributeAsUnsigned("Flags", "0"));
+    Ref = reader.getAttribute<const char*>("Ref", "");
+    RefIndex = reader.getAttribute<long>("RefIndex", -1);
+    Flags = FlagType(reader.getAttribute<unsigned long>("Flags", 0));
 }
 
 void ExternalGeometryExtension::saveAttributes(Base::Writer& writer) const

--- a/src/Mod/Sketcher/App/PropertyConstraintList.cpp
+++ b/src/Mod/Sketcher/App/PropertyConstraintList.cpp
@@ -341,7 +341,7 @@ void PropertyConstraintList::Restore(Base::XMLReader& reader)
     // read my element
     reader.readElement("ConstraintList");
     // get the value of my attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
 
     std::vector<Constraint*> values;
     values.reserve(count);

--- a/src/Mod/Sketcher/App/SketchGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/SketchGeometryExtension.cpp
@@ -65,16 +65,16 @@ void SketchGeometryExtension::restoreAttributes(Base::XMLReader& reader)
     Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
     if (reader.hasAttribute("id")) {
-        Id = reader.getAttributeAsInteger("id");
+        Id = reader.getAttribute<long>("id");
     }
 
     InternalGeometryType = static_cast<InternalType::InternalType>(
-        reader.getAttributeAsInteger("internalGeometryType"));
+        reader.getAttribute<long>("internalGeometryType"));
 
-    GeometryModeFlags = GeometryModeFlagType(reader.getAttribute("geometryModeFlags"));
+    GeometryModeFlags = GeometryModeFlagType(reader.getAttribute<const char*>("geometryModeFlags"));
 
     if (reader.hasAttribute("geometryLayer")) {
-        GeometryLayer = reader.getAttributeAsInteger("geometryLayer");
+        GeometryLayer = reader.getAttribute<long>("geometryLayer");
     }
 }
 

--- a/src/Mod/Sketcher/App/SketchGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/SketchGeometryExtension.cpp
@@ -68,8 +68,7 @@ void SketchGeometryExtension::restoreAttributes(Base::XMLReader& reader)
         Id = reader.getAttribute<long>("id");
     }
 
-    InternalGeometryType = static_cast<InternalType::InternalType>(
-        reader.getAttribute<long>("internalGeometryType"));
+    InternalGeometryType = reader.getAttribute<InternalType::InternalType>("internalGeometryType");
 
     GeometryModeFlags = GeometryModeFlagType(reader.getAttribute<const char*>("geometryModeFlags"));
 

--- a/src/Mod/Sketcher/Gui/PropertyVisualLayerList.cpp
+++ b/src/Mod/Sketcher/Gui/PropertyVisualLayerList.cpp
@@ -75,7 +75,7 @@ void PropertyVisualLayerList::Restore(Base::XMLReader& reader)
 {
     reader.readElement("VisualLayerList");
     // get the value of my attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
 
     std::vector<VisualLayer> layers;
     layers.reserve(count);

--- a/src/Mod/Sketcher/Gui/ViewProviderSketchGeometryExtension.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketchGeometryExtension.cpp
@@ -65,7 +65,7 @@ void ViewProviderSketchGeometryExtension::restoreAttributes(Base::XMLReader& rea
     Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
     if (reader.hasAttribute("visualLayerId")) {
-        VisualLayerId = reader.getAttributeAsInteger("visualLayerId");
+        VisualLayerId = reader.getAttribute<long>("visualLayerId");
     }
 }
 

--- a/src/Mod/Sketcher/Gui/VisualLayer.cpp
+++ b/src/Mod/Sketcher/Gui/VisualLayer.cpp
@@ -80,9 +80,9 @@ void VisualLayer::Restore(Base::XMLReader& reader)
 {
     reader.readElement("VisualLayer");
 
-    std::string str = reader.getAttribute("visible");
+    std::string str = reader.getAttribute<const char*>("visible");
     visible = (str == "true");
 
-    linePattern = reader.getAttributeAsUnsigned("linePattern");
-    lineWidth = reader.getAttributeAsFloat("lineWidth");
+    linePattern = reader.getAttribute<unsigned long>("linePattern");
+    lineWidth = reader.getAttribute<double>("lineWidth");
 }

--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -728,19 +728,27 @@ void Cell::moveAbsolute(CellAddress newAddress)
 
 void Cell::restore(Base::XMLReader& reader, bool checkAlias)
 {
-    const char* style = reader.hasAttribute("style") ? reader.getAttribute("style") : nullptr;
+    const char* style =
+        reader.hasAttribute("style") ? reader.getAttribute<const char*>("style") : nullptr;
     const char* alignment =
-        reader.hasAttribute("alignment") ? reader.getAttribute("alignment") : nullptr;
-    const char* content = reader.hasAttribute("content") ? reader.getAttribute("content") : "";
-    const char* foregroundColor =
-        reader.hasAttribute("foregroundColor") ? reader.getAttribute("foregroundColor") : nullptr;
-    const char* backgroundColor =
-        reader.hasAttribute("backgroundColor") ? reader.getAttribute("backgroundColor") : nullptr;
-    const char* displayUnit =
-        reader.hasAttribute("displayUnit") ? reader.getAttribute("displayUnit") : nullptr;
-    const char* alias = reader.hasAttribute("alias") ? reader.getAttribute("alias") : nullptr;
-    const char* rowSpan = reader.hasAttribute("rowSpan") ? reader.getAttribute("rowSpan") : nullptr;
-    const char* colSpan = reader.hasAttribute("colSpan") ? reader.getAttribute("colSpan") : nullptr;
+        reader.hasAttribute("alignment") ? reader.getAttribute<const char*>("alignment") : nullptr;
+    const char* content =
+        reader.hasAttribute("content") ? reader.getAttribute<const char*>("content") : "";
+    const char* foregroundColor = reader.hasAttribute("foregroundColor")
+        ? reader.getAttribute<const char*>("foregroundColor")
+        : nullptr;
+    const char* backgroundColor = reader.hasAttribute("backgroundColor")
+        ? reader.getAttribute<const char*>("backgroundColor")
+        : nullptr;
+    const char* displayUnit = reader.hasAttribute("displayUnit")
+        ? reader.getAttribute<const char*>("displayUnit")
+        : nullptr;
+    const char* alias =
+        reader.hasAttribute("alias") ? reader.getAttribute<const char*>("alias") : nullptr;
+    const char* rowSpan =
+        reader.hasAttribute("rowSpan") ? reader.getAttribute<const char*>("rowSpan") : nullptr;
+    const char* colSpan =
+        reader.hasAttribute("colSpan") ? reader.getAttribute<const char*>("colSpan") : nullptr;
 
     // Don't trigger multiple updates below; wait until everything is loaded by calling unfreeze()
     // below.

--- a/src/Mod/Spreadsheet/App/PropertyColumnWidths.cpp
+++ b/src/Mod/Spreadsheet/App/PropertyColumnWidths.cpp
@@ -129,11 +129,13 @@ void PropertyColumnWidths::Restore(Base::XMLReader& reader)
 
     // Column info
     reader.readElement("ColumnInfo");
-    Cnt = reader.hasAttribute("Count") ? reader.getAttributeAsInteger("Count") : 0;
+    Cnt = reader.hasAttribute("Count") ? reader.getAttribute<long>("Count") : 0;
     for (int i = 0; i < Cnt; i++) {
         reader.readElement("Column");
-        const char* name = reader.hasAttribute("name") ? reader.getAttribute("name") : nullptr;
-        const char* width = reader.hasAttribute("width") ? reader.getAttribute("width") : nullptr;
+        const char* name =
+            reader.hasAttribute("name") ? reader.getAttribute<const char*>("name") : nullptr;
+        const char* width =
+            reader.hasAttribute("width") ? reader.getAttribute<const char*>("width") : nullptr;
 
         try {
             if (name && width) {

--- a/src/Mod/Spreadsheet/App/PropertyRowHeights.cpp
+++ b/src/Mod/Spreadsheet/App/PropertyRowHeights.cpp
@@ -122,12 +122,13 @@ void PropertyRowHeights::Restore(Base::XMLReader& reader)
 
     // Row info
     reader.readElement("RowInfo");
-    Cnt = reader.hasAttribute("Count") ? reader.getAttributeAsInteger("Count") : 0;
+    Cnt = reader.hasAttribute("Count") ? reader.getAttribute<long>("Count") : 0;
     for (int i = 0; i < Cnt; i++) {
         reader.readElement("Row");
-        const char* name = reader.hasAttribute("name") ? reader.getAttribute("name") : nullptr;
+        const char* name =
+            reader.hasAttribute("name") ? reader.getAttribute<const char*>("name") : nullptr;
         const char* height =
-            reader.hasAttribute("height") ? reader.getAttribute("height") : nullptr;
+            reader.hasAttribute("height") ? reader.getAttribute<const char*>("height") : nullptr;
 
         try {
             if (name && height) {

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -425,7 +425,7 @@ void PropertySheet::Restore(Base::XMLReader& reader)
     reader.readElement("Cells");
     Cnt = reader.getAttribute<long>("Count");
 
-    if (reader.hasAttribute("xlink") && reader.getAttribute<long>("xlink")) {
+    if (reader.hasAttribute("xlink") && reader.getAttribute<bool>("xlink")) {
         PropertyExpressionContainer::Restore(reader);
     }
 

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -423,9 +423,9 @@ void PropertySheet::Restore(Base::XMLReader& reader)
     AtomicPropertyChange signaller(*this);
 
     reader.readElement("Cells");
-    Cnt = reader.getAttributeAsInteger("Count");
+    Cnt = reader.getAttribute<long>("Count");
 
-    if (reader.hasAttribute("xlink") && reader.getAttributeAsInteger("xlink")) {
+    if (reader.hasAttribute("xlink") && reader.getAttribute<long>("xlink")) {
         PropertyExpressionContainer::Restore(reader);
     }
 
@@ -433,7 +433,7 @@ void PropertySheet::Restore(Base::XMLReader& reader)
         reader.readElement("Cell");
 
         const char* strAddress =
-            reader.hasAttribute("address") ? reader.getAttribute("address") : "";
+            reader.hasAttribute("address") ? reader.getAttribute<const char*>("address") : "";
 
         try {
             CellAddress address(strAddress);
@@ -490,7 +490,7 @@ void PropertySheet::copyCells(Base::Writer& writer, const std::vector<Range>& ra
 void PropertySheet::pasteCells(XMLReader& reader, Range dstRange)
 {
     reader.readElement("Cells");
-    int rangeCount = reader.getAttributeAsInteger("count");
+    int rangeCount = reader.getAttribute<long>("count");
     if (rangeCount <= 0) {
         return;
     }
@@ -504,9 +504,9 @@ void PropertySheet::pasteCells(XMLReader& reader, Range dstRange)
     AtomicPropertyChange signaller(*this);
     for (int ri = 0; ri < rangeCount; ++ri) {
         reader.readElement("Range");
-        CellAddress from(reader.getAttribute("from"));
-        CellAddress to(reader.getAttribute("to"));
-        int cellCount = reader.getAttributeAsInteger("count");
+        CellAddress from(reader.getAttribute<const char*>("from"));
+        CellAddress to(reader.getAttribute<const char*>("to"));
+        int cellCount = reader.getAttribute<long>("count");
 
         Range range(from, to);
 
@@ -533,7 +533,7 @@ void PropertySheet::pasteCells(XMLReader& reader, Range dstRange)
         }
         for (int ci = 0; ci < cellCount; ++ci) {
             reader.readElement("Cell");
-            CellAddress src(reader.getAttribute("address"));
+            CellAddress src(reader.getAttribute<const char*>("address"));
 
             if (ci) {
                 range.next();

--- a/src/Mod/TechDraw/App/CenterLine.cpp
+++ b/src/Mod/TechDraw/App/CenterLine.cpp
@@ -921,60 +921,60 @@ void CenterLine::Restore(Base::XMLReader &reader)
     // read my Element
     reader.readElement("Start");
     // get the value of my Attribute
-    m_start.x = reader.getAttributeAsFloat("X");
-    m_start.y = reader.getAttributeAsFloat("Y");
-    m_start.z = reader.getAttributeAsFloat("Z");
+    m_start.x = reader.getAttribute<double>("X");
+    m_start.y = reader.getAttribute<double>("Y");
+    m_start.z = reader.getAttribute<double>("Z");
 
     reader.readElement("End");
-    m_end.x = reader.getAttributeAsFloat("X");
-    m_end.y = reader.getAttributeAsFloat("Y");
-    m_end.z = reader.getAttributeAsFloat("Z");
+    m_end.x = reader.getAttribute<double>("X");
+    m_end.y = reader.getAttribute<double>("Y");
+    m_end.z = reader.getAttribute<double>("Z");
 
     reader.readElement("Mode");
-    m_mode = static_cast<Mode>(reader.getAttributeAsInteger("value"));
+    m_mode = static_cast<Mode>(reader.getAttribute<long>("value"));
 
     reader.readElement("HShift");
-    m_hShift = reader.getAttributeAsFloat("value");
+    m_hShift = reader.getAttribute<double>("value");
     reader.readElement("VShift");
-    m_vShift = reader.getAttributeAsFloat("value");
+    m_vShift = reader.getAttribute<double>("value");
     reader.readElement("Rotate");
-    m_rotate = reader.getAttributeAsFloat("value");
+    m_rotate = reader.getAttribute<double>("value");
     reader.readElement("Extend");
-    m_extendBy = reader.getAttributeAsFloat("value");
+    m_extendBy = reader.getAttribute<double>("value");
     reader.readElement("Type");
-    m_type = static_cast<Type>(reader.getAttributeAsInteger("value"));
+    m_type = static_cast<Type>(reader.getAttribute<long>("value"));
     reader.readElement("Flip");
-    m_flip2Line = (bool)reader.getAttributeAsInteger("value")==0?false:true;
+    m_flip2Line = (bool)reader.getAttribute<long>("value")==0?false:true;
 
     reader.readElement("Faces");
-    int count = reader.getAttributeAsInteger("FaceCount");
+    int count = reader.getAttribute<long>("FaceCount");
 
     int i = 0;
     for ( ; i < count; i++) {
         reader.readElement("Face");
-        std::string f = reader.getAttribute("value");
+        std::string f = reader.getAttribute<const char*>("value");
         m_faces.push_back(f);
     }
     reader.readEndElement("Faces");
 
     reader.readElement("Edges");
-    count = reader.getAttributeAsInteger("EdgeCount");
+    count = reader.getAttribute<long>("EdgeCount");
 
     i = 0;
     for ( ; i < count; i++) {
         reader.readElement("Edge");
-        std::string e = reader.getAttribute("value");
+        std::string e = reader.getAttribute<const char*>("value");
         m_edges.push_back(e);
     }
     reader.readEndElement("Edges");
 
     reader.readElement("CLPoints");
-    count = reader.getAttributeAsInteger("CLPointCount");
+    count = reader.getAttribute<long>("CLPointCount");
 
     i = 0;
     for ( ; i < count; i++) {
         reader.readElement("CLPoint");
-        std::string p = reader.getAttribute("value");
+        std::string p = reader.getAttribute<const char*>("value");
         m_verts.push_back(p);
     }
     reader.readEndElement("CLPoints");
@@ -982,20 +982,20 @@ void CenterLine::Restore(Base::XMLReader &reader)
     // style is deprecated in favour of line number, but we still save and restore it
     // to avoid problems with old documents.
     reader.readElement("Style");
-    m_format.setStyle(reader.getAttributeAsInteger("value"));
+    m_format.setStyle(reader.getAttribute<long>("value"));
     reader.readElement("Weight");
-    m_format.setWidth(reader.getAttributeAsFloat("value"));
+    m_format.setWidth(reader.getAttribute<double>("value"));
     reader.readElement("Color");
-    std::string tempHex = reader.getAttribute("value");
+    std::string tempHex = reader.getAttribute<const char*>("value");
     Base::Color tempColor;
     tempColor.fromHexString(tempHex);
     m_format.setColor(tempColor);
     reader.readElement("Visible");
-    m_format.setVisible( (int)reader.getAttributeAsInteger("value")==0 ? false : true);
+    m_format.setVisible( (int)reader.getAttribute<long>("value")==0 ? false : true);
 
 //stored geometry
     reader.readElement("GeometryType");
-    GeomType gType = static_cast<GeomType>(reader.getAttributeAsInteger("value"));
+    GeomType gType = static_cast<GeomType>(reader.getAttribute<long>("value"));
     if (gType == GeomType::GENERIC) {
         TechDraw::GenericPtr gen = std::make_shared<TechDraw::Generic> ();
         gen->Restore(reader);
@@ -1024,7 +1024,7 @@ void CenterLine::Restore(Base::XMLReader &reader)
         if(strcmp(reader.localName(),"LineNumber") == 0 ||
            strcmp(reader.localName(),"ISOLineNumber") == 0 ) {
             // this centerline has an LineNumber attribute
-            m_format.setLineNumber(reader.getAttributeAsInteger("value"));
+            m_format.setLineNumber(reader.getAttribute<long>("value"));
         } else {
             // LineNumber not found.
             m_format.setLineNumber(LineFormat::InvalidLine);

--- a/src/Mod/TechDraw/App/CenterLine.cpp
+++ b/src/Mod/TechDraw/App/CenterLine.cpp
@@ -931,7 +931,7 @@ void CenterLine::Restore(Base::XMLReader &reader)
     m_end.z = reader.getAttribute<double>("Z");
 
     reader.readElement("Mode");
-    m_mode = static_cast<Mode>(reader.getAttribute<long>("value"));
+    m_mode = reader.getAttribute<Mode>("value");
 
     reader.readElement("HShift");
     m_hShift = reader.getAttribute<double>("value");
@@ -942,9 +942,9 @@ void CenterLine::Restore(Base::XMLReader &reader)
     reader.readElement("Extend");
     m_extendBy = reader.getAttribute<double>("value");
     reader.readElement("Type");
-    m_type = static_cast<Type>(reader.getAttribute<long>("value"));
+    m_type = reader.getAttribute<Type>("value");
     reader.readElement("Flip");
-    m_flip2Line = (bool)reader.getAttribute<long>("value")==0?false:true;
+    m_flip2Line = reader.getAttribute<bool>("value") == 0;
 
     reader.readElement("Faces");
     int count = reader.getAttribute<long>("FaceCount");
@@ -991,11 +991,11 @@ void CenterLine::Restore(Base::XMLReader &reader)
     tempColor.fromHexString(tempHex);
     m_format.setColor(tempColor);
     reader.readElement("Visible");
-    m_format.setVisible( (int)reader.getAttribute<long>("value")==0 ? false : true);
+    m_format.setVisible(reader.getAttribute<bool>("value"));
 
 //stored geometry
     reader.readElement("GeometryType");
-    GeomType gType = static_cast<GeomType>(reader.getAttribute<long>("value"));
+    GeomType gType = reader.getAttribute<GeomType>("value");
     if (gType == GeomType::GENERIC) {
         TechDraw::GenericPtr gen = std::make_shared<TechDraw::Generic> ();
         gen->Restore(reader);

--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -249,7 +249,7 @@ void CosmeticEdge::Restore(Base::XMLReader &reader)
     m_format.setVisible(reader.getAttribute<long>("value") != 0);
 
     reader.readElement("GeometryType");
-    GeomType gType = static_cast<GeomType>(reader.getAttribute<long>("value"));
+    GeomType gType = reader.getAttribute<GeomType>("value");
 
     if (gType == GeomType::GENERIC) {
         TechDraw::GenericPtr gen = std::make_shared<TechDraw::Generic> ();
@@ -405,7 +405,7 @@ void GeomFormat::Restore(Base::XMLReader &reader)
     tempColor.fromHexString(tempHex);
     m_format.setColor(tempColor);
     reader.readElement("Visible");
-    m_format.setVisible((int)reader.getAttribute<long>("value") == 0 ? false : true);
+    m_format.setVisible(reader.getAttribute<bool>("value"));
     // older documents may not have the LineNumber element, so we need to check the
     // next entry.  if it is a start element, then we check if it is a start element
     // for LineNumber.

--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -237,19 +237,19 @@ void CosmeticEdge::Restore(Base::XMLReader &reader)
     }
 //    Base::Console().Message("CE::Restore - reading elements\n");
     reader.readElement("Style");
-    m_format.setStyle(reader.getAttributeAsInteger("value"));
+    m_format.setStyle(reader.getAttribute<long>("value"));
     reader.readElement("Weight");
-    m_format.setWidth(reader.getAttributeAsFloat("value"));
+    m_format.setWidth(reader.getAttribute<double>("value"));
     reader.readElement("Color");
-    std::string tempHex = reader.getAttribute("value");
+    std::string tempHex = reader.getAttribute<const char*>("value");
     Base::Color tempColor;
     tempColor.fromHexString(tempHex);
     m_format.setColor(tempColor);
     reader.readElement("Visible");
-    m_format.setVisible(reader.getAttributeAsInteger("value") != 0);
+    m_format.setVisible(reader.getAttribute<long>("value") != 0);
 
     reader.readElement("GeometryType");
-    GeomType gType = static_cast<GeomType>(reader.getAttributeAsInteger("value"));
+    GeomType gType = static_cast<GeomType>(reader.getAttribute<long>("value"));
 
     if (gType == GeomType::GENERIC) {
         TechDraw::GenericPtr gen = std::make_shared<TechDraw::Generic> ();
@@ -283,7 +283,7 @@ void CosmeticEdge::Restore(Base::XMLReader &reader)
     if (reader.readNextElement()) {
         if(strcmp(reader.localName(),"LineNumber") == 0 ) {
             // this CosmeticEdge has an LineNumber attribute
-            m_format.setLineNumber(reader.getAttributeAsInteger("value"));
+            m_format.setLineNumber(reader.getAttribute<long>("value"));
         } else {
             // LineNumber not found.
             // TODO: line number should be set to DashedLineGenerator.fromQtStyle(m_format.m_style)
@@ -391,21 +391,21 @@ void GeomFormat::Restore(Base::XMLReader &reader)
     // read my Element
     reader.readElement("GeomIndex");
     // get the value of my Attribute
-    m_geomIndex = reader.getAttributeAsInteger("value");
+    m_geomIndex = reader.getAttribute<long>("value");
 
     // style is deprecated in favour of line number, but we still save and restore it
     // to avoid problems with old documents.
     reader.readElement("Style");
-    m_format.setStyle(reader.getAttributeAsInteger("value"));
+    m_format.setStyle(reader.getAttribute<long>("value"));
     reader.readElement("Weight");
-    m_format.setWidth(reader.getAttributeAsFloat("value"));
+    m_format.setWidth(reader.getAttribute<double>("value"));
     reader.readElement("Color");
-    std::string tempHex = reader.getAttribute("value");
+    std::string tempHex = reader.getAttribute<const char*>("value");
     Base::Color tempColor;
     tempColor.fromHexString(tempHex);
     m_format.setColor(tempColor);
     reader.readElement("Visible");
-    m_format.setVisible((int)reader.getAttributeAsInteger("value") == 0 ? false : true);
+    m_format.setVisible((int)reader.getAttribute<long>("value") == 0 ? false : true);
     // older documents may not have the LineNumber element, so we need to check the
     // next entry.  if it is a start element, then we check if it is a start element
     // for LineNumber.
@@ -414,7 +414,7 @@ void GeomFormat::Restore(Base::XMLReader &reader)
     if (reader.readNextElement()) {
         if(strcmp(reader.localName(),"LineNumber") == 0 ||
            strcmp(reader.localName(),"ISOLineNumber") == 0 ) {            // this GeomFormat has an LineNumber attribute
-            m_format.setLineNumber(reader.getAttributeAsInteger("value"));
+            m_format.setLineNumber(reader.getAttribute<long>("value"));
         } else {
             // LineNumber not found.
             // TODO: line number should be set to DashedLineGenerator.fromQtStyle(m_format.m_style),

--- a/src/Mod/TechDraw/App/CosmeticVertex.cpp
+++ b/src/Mod/TechDraw/App/CosmeticVertex.cpp
@@ -149,7 +149,7 @@ void CosmeticVertex::Restore(Base::XMLReader &reader)
     reader.readElement("Style");
     style = reader.getAttribute<long>("value");
     reader.readElement("Visible");
-    visible = (int)reader.getAttribute<long>("value")==0?false:true;
+    visible = reader.getAttribute<bool>("value");
     Tag::Restore(reader);
 }
 

--- a/src/Mod/TechDraw/App/CosmeticVertex.cpp
+++ b/src/Mod/TechDraw/App/CosmeticVertex.cpp
@@ -136,20 +136,20 @@ void CosmeticVertex::Restore(Base::XMLReader &reader)
     }
     TechDraw::Vertex::Restore(reader);
     reader.readElement("PermaPoint");
-    permaPoint.x = reader.getAttributeAsFloat("X");
-    permaPoint.y = reader.getAttributeAsFloat("Y");
-    permaPoint.z = reader.getAttributeAsFloat("Z");
+    permaPoint.x = reader.getAttribute<double>("X");
+    permaPoint.y = reader.getAttribute<double>("Y");
+    permaPoint.z = reader.getAttribute<double>("Z");
     reader.readElement("LinkGeom");
-    linkGeom = reader.getAttributeAsInteger("value");
+    linkGeom = reader.getAttribute<long>("value");
     reader.readElement("Color");
-    std::string temp = reader.getAttribute("value");
+    std::string temp = reader.getAttribute<const char*>("value");
     color.fromHexString(temp);
     reader.readElement("Size");
-    size = reader.getAttributeAsFloat("value");
+    size = reader.getAttribute<double>("value");
     reader.readElement("Style");
-    style = reader.getAttributeAsInteger("value");
+    style = reader.getAttribute<long>("value");
     reader.readElement("Visible");
-    visible = (int)reader.getAttributeAsInteger("value")==0?false:true;
+    visible = (int)reader.getAttribute<long>("value")==0?false:true;
     Tag::Restore(reader);
 }
 

--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -260,21 +260,21 @@ void BaseGeom::Save(Base::Writer &writer) const
 void BaseGeom::Restore(Base::XMLReader &reader)
 {
     reader.readElement("GeomType");
-    geomType = static_cast<GeomType>(reader.getAttribute<long>("value"));
+    geomType = reader.getAttribute<GeomType>("value");
     reader.readElement("ExtractType");
-    extractType = static_cast<ExtractionType>(reader.getAttribute<long>("value"));
+    extractType = reader.getAttribute<ExtractionType>("value");
     reader.readElement("EdgeClass");
-    classOfEdge = static_cast<EdgeClass>(reader.getAttribute<long>("value"));
+    classOfEdge = reader.getAttribute<EdgeClass>("value");
     reader.readElement("HLRVisible");
-    hlrVisible = reader.getAttribute<long>("value") != 0;
+    hlrVisible = reader.getAttribute<bool>("value");
     reader.readElement("Reversed");
-    reversed = reader.getAttribute<long>("value") != 0;
+    reversed = reader.getAttribute<bool>("value");
     reader.readElement("Ref3D");
     ref3D = reader.getAttribute<long>("value");
     reader.readElement("Cosmetic");
-    cosmetic = reader.getAttribute<long>("value") != 0;
+    cosmetic = reader.getAttribute<bool>("value");
     reader.readElement("Source");
-    m_source = static_cast<SourceType>(reader.getAttribute<long>("value"));
+    m_source = reader.getAttribute<SourceType>("value");
     reader.readElement("SourceIndex");
     m_sourceIndex = reader.getAttribute<long>("value");
     reader.readElement("CosmeticTag");
@@ -996,9 +996,9 @@ void AOC::Restore(Base::XMLReader &reader)
     reader.readElement("EndAngle");
     endAngle = reader.getAttribute<double>("value");
     reader.readElement("Clockwise");
-    cw = (int)reader.getAttribute<long>("value")==0?false:true;
+    cw = reader.getAttribute<bool>("value");
     reader.readElement("Large");
-    largeArc = (int)reader.getAttribute<long>("value")==0?false:true;
+    largeArc = reader.getAttribute<bool>("value");
 }
 
 //! Generic is a multiline
@@ -1346,15 +1346,15 @@ void Vertex::Restore(Base::XMLReader &reader)
     pnt.z = reader.getAttribute<double>("Z");
 
     reader.readElement("Extract");
-    extractType = static_cast<ExtractionType>(reader.getAttribute<long>("value"));
+    extractType = reader.getAttribute<ExtractionType>("value");
 //    reader.readElement("Visible");
-//    hlrVisible = (bool)reader.getAttribute<long>("value")==0?false:true;
+//    hlrVisible = reader.getAttribute<bool>("value");
     reader.readElement("Ref3D");
     ref3D = reader.getAttribute<long>("value");
     reader.readElement("IsCenter");
-    hlrVisible = reader.getAttribute<long>("value") != 0;
+    hlrVisible = reader.getAttribute<bool>("value");
     reader.readElement("Cosmetic");
-    cosmetic = reader.getAttribute<long>("value") != 0;
+    cosmetic = reader.getAttribute<bool>("value");
     reader.readElement("CosmeticLink");
     cosmeticLink = reader.getAttribute<long>("value");
     reader.readElement("CosmeticTag");
@@ -1362,7 +1362,7 @@ void Vertex::Restore(Base::XMLReader &reader)
 
     //will restore read to eof looking for "Reference" in old docs??  YES!!
 //    reader.readElement("Reference");
-//    m_reference = (bool)reader.getAttribute<long>("value")==0?false:true;
+//    m_reference = reader.getAttribute<bool>("value");
 
     Tag::Restore(reader, "VertexTag");
 

--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -260,25 +260,25 @@ void BaseGeom::Save(Base::Writer &writer) const
 void BaseGeom::Restore(Base::XMLReader &reader)
 {
     reader.readElement("GeomType");
-    geomType = static_cast<GeomType>(reader.getAttributeAsInteger("value"));
+    geomType = static_cast<GeomType>(reader.getAttribute<long>("value"));
     reader.readElement("ExtractType");
-    extractType = static_cast<ExtractionType>(reader.getAttributeAsInteger("value"));
+    extractType = static_cast<ExtractionType>(reader.getAttribute<long>("value"));
     reader.readElement("EdgeClass");
-    classOfEdge = static_cast<EdgeClass>(reader.getAttributeAsInteger("value"));
+    classOfEdge = static_cast<EdgeClass>(reader.getAttribute<long>("value"));
     reader.readElement("HLRVisible");
-    hlrVisible = reader.getAttributeAsInteger("value") != 0;
+    hlrVisible = reader.getAttribute<long>("value") != 0;
     reader.readElement("Reversed");
-    reversed = reader.getAttributeAsInteger("value") != 0;
+    reversed = reader.getAttribute<long>("value") != 0;
     reader.readElement("Ref3D");
-    ref3D = reader.getAttributeAsInteger("value");
+    ref3D = reader.getAttribute<long>("value");
     reader.readElement("Cosmetic");
-    cosmetic = reader.getAttributeAsInteger("value") != 0;
+    cosmetic = reader.getAttribute<long>("value") != 0;
     reader.readElement("Source");
-    m_source = static_cast<SourceType>(reader.getAttributeAsInteger("value"));
+    m_source = static_cast<SourceType>(reader.getAttribute<long>("value"));
     reader.readElement("SourceIndex");
-    m_sourceIndex = reader.getAttributeAsInteger("value");
+    m_sourceIndex = reader.getAttribute<long>("value");
     reader.readElement("CosmeticTag");
-    cosmeticTag = reader.getAttribute("value");
+    cosmeticTag = reader.getAttribute<const char*>("value");
 }
 
 std::vector<Base::Vector3d> BaseGeom::findEndPoints()
@@ -768,12 +768,12 @@ void Circle::Restore(Base::XMLReader &reader)
     // read my Element
     reader.readElement("Center");
     // get the value of my Attribute
-    center.x = reader.getAttributeAsFloat("X");
-    center.y = reader.getAttributeAsFloat("Y");
-    center.z = reader.getAttributeAsFloat("Z");
+    center.x = reader.getAttribute<double>("X");
+    center.y = reader.getAttribute<double>("Y");
+    center.z = reader.getAttribute<double>("Z");
 
     reader.readElement("Radius");
-    radius = reader.getAttributeAsFloat("value");
+    radius = reader.getAttribute<double>("value");
 }
 
 AOC::AOC(const TopoDS_Edge &e) : Circle(e)
@@ -979,26 +979,26 @@ void AOC::Restore(Base::XMLReader &reader)
 {
     Circle::Restore(reader);
     reader.readElement("Start");
-    startPnt.x = reader.getAttributeAsFloat("X");
-    startPnt.y = reader.getAttributeAsFloat("Y");
-    startPnt.z = reader.getAttributeAsFloat("Z");
+    startPnt.x = reader.getAttribute<double>("X");
+    startPnt.y = reader.getAttribute<double>("Y");
+    startPnt.z = reader.getAttribute<double>("Z");
     reader.readElement("End");
-    endPnt.x = reader.getAttributeAsFloat("X");
-    endPnt.y = reader.getAttributeAsFloat("Y");
-    endPnt.z = reader.getAttributeAsFloat("Z");
+    endPnt.x = reader.getAttribute<double>("X");
+    endPnt.y = reader.getAttribute<double>("Y");
+    endPnt.z = reader.getAttribute<double>("Z");
     reader.readElement("Middle");
-    midPnt.x = reader.getAttributeAsFloat("X");
-    midPnt.y = reader.getAttributeAsFloat("Y");
-    midPnt.z = reader.getAttributeAsFloat("Z");
+    midPnt.x = reader.getAttribute<double>("X");
+    midPnt.y = reader.getAttribute<double>("Y");
+    midPnt.z = reader.getAttribute<double>("Z");
 
     reader.readElement("StartAngle");
-    startAngle = reader.getAttributeAsFloat("value");
+    startAngle = reader.getAttribute<double>("value");
     reader.readElement("EndAngle");
-    endAngle = reader.getAttributeAsFloat("value");
+    endAngle = reader.getAttribute<double>("value");
     reader.readElement("Clockwise");
-    cw = (int)reader.getAttributeAsInteger("value")==0?false:true;
+    cw = (int)reader.getAttribute<long>("value")==0?false:true;
     reader.readElement("Large");
-    largeArc = (int)reader.getAttributeAsInteger("value")==0?false:true;
+    largeArc = (int)reader.getAttribute<long>("value")==0?false:true;
 }
 
 //! Generic is a multiline
@@ -1072,14 +1072,14 @@ void Generic::Restore(Base::XMLReader &reader)
 {
     BaseGeom::Restore(reader);
     reader.readElement("Points");
-    int stop = reader.getAttributeAsInteger("PointsCount");
+    int stop = reader.getAttribute<long>("PointsCount");
     int i = 0;
     for ( ; i < stop; i++) {
         reader.readElement("Point");
         Base::Vector3d p;
-        p.x = reader.getAttributeAsFloat("X");
-        p.y = reader.getAttributeAsFloat("Y");
-        p.z = reader.getAttributeAsFloat("Z");
+        p.x = reader.getAttribute<double>("X");
+        p.y = reader.getAttribute<double>("Y");
+        p.z = reader.getAttribute<double>("Z");
         points.push_back(p);
     }
     reader.readEndElement("Points");
@@ -1341,28 +1341,28 @@ void Vertex::Save(Base::Writer &writer) const
 void Vertex::Restore(Base::XMLReader &reader)
 {
     reader.readElement("Point");
-    pnt.x = reader.getAttributeAsFloat("X");
-    pnt.y = reader.getAttributeAsFloat("Y");
-    pnt.z = reader.getAttributeAsFloat("Z");
+    pnt.x = reader.getAttribute<double>("X");
+    pnt.y = reader.getAttribute<double>("Y");
+    pnt.z = reader.getAttribute<double>("Z");
 
     reader.readElement("Extract");
-    extractType = static_cast<ExtractionType>(reader.getAttributeAsInteger("value"));
+    extractType = static_cast<ExtractionType>(reader.getAttribute<long>("value"));
 //    reader.readElement("Visible");
-//    hlrVisible = (bool)reader.getAttributeAsInteger("value")==0?false:true;
+//    hlrVisible = (bool)reader.getAttribute<long>("value")==0?false:true;
     reader.readElement("Ref3D");
-    ref3D = reader.getAttributeAsInteger("value");
+    ref3D = reader.getAttribute<long>("value");
     reader.readElement("IsCenter");
-    hlrVisible = reader.getAttributeAsInteger("value") != 0;
+    hlrVisible = reader.getAttribute<long>("value") != 0;
     reader.readElement("Cosmetic");
-    cosmetic = reader.getAttributeAsInteger("value") != 0;
+    cosmetic = reader.getAttribute<long>("value") != 0;
     reader.readElement("CosmeticLink");
-    cosmeticLink = reader.getAttributeAsInteger("value");
+    cosmeticLink = reader.getAttribute<long>("value");
     reader.readElement("CosmeticTag");
-    cosmeticTag = reader.getAttribute("value");
+    cosmeticTag = reader.getAttribute<const char*>("value");
 
     //will restore read to eof looking for "Reference" in old docs??  YES!!
 //    reader.readElement("Reference");
-//    m_reference = (bool)reader.getAttributeAsInteger("value")==0?false:true;
+//    m_reference = (bool)reader.getAttribute<long>("value")==0?false:true;
 
     Tag::Restore(reader, "VertexTag");
 

--- a/src/Mod/TechDraw/App/PropertyCenterLineList.cpp
+++ b/src/Mod/TechDraw/App/PropertyCenterLineList.cpp
@@ -147,12 +147,12 @@ void PropertyCenterLineList::Restore(Base::XMLReader &reader)
     reader.clearPartialRestoreObject();
     reader.readElement("CenterLineList");
     // get the value of my attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
     std::vector<CenterLine*> values;
     values.reserve(count);
     for (int i = 0; i < count; i++) {
         reader.readElement("CenterLine");
-        const char* TypeName = reader.getAttribute("type");
+        const char* TypeName = reader.getAttribute<const char*>("type");
         CenterLine *newG = static_cast<CenterLine *>(Base::Type::fromName(TypeName).createInstance());
         newG->Restore(reader);
 

--- a/src/Mod/TechDraw/App/PropertyCosmeticEdgeList.cpp
+++ b/src/Mod/TechDraw/App/PropertyCosmeticEdgeList.cpp
@@ -151,12 +151,12 @@ void PropertyCosmeticEdgeList::Restore(Base::XMLReader &reader)
     reader.clearPartialRestoreObject();
     reader.readElement("CosmeticEdgeList");
     // get the value of my attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
     std::vector<CosmeticEdge*> values;
     values.reserve(count);
     for (int i = 0; i < count; i++) {
         reader.readElement("CosmeticEdge");
-        const char* TypeName = reader.getAttribute("type");
+        const char* TypeName = reader.getAttribute<const char*>("type");
         CosmeticEdge *newG = static_cast<CosmeticEdge *>(Base::Type::fromName(TypeName).createInstance());
         newG->Restore(reader);
 

--- a/src/Mod/TechDraw/App/PropertyCosmeticVertexList.cpp
+++ b/src/Mod/TechDraw/App/PropertyCosmeticVertexList.cpp
@@ -149,12 +149,12 @@ void PropertyCosmeticVertexList::Restore(Base::XMLReader &reader)
     reader.clearPartialRestoreObject();
     reader.readElement("CosmeticVertexList");
     // get the value of my attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
     std::vector<CosmeticVertex*> values;
     values.reserve(count);
     for (int i = 0; i < count; i++) {
         reader.readElement("CosmeticVertex");
-        const char* TypeName = reader.getAttribute("type");
+        const char* TypeName = reader.getAttribute<const char*>("type");
         CosmeticVertex *newG = static_cast<CosmeticVertex *>(Base::Type::fromName(TypeName).createInstance());
         newG->Restore(reader);
 

--- a/src/Mod/TechDraw/App/PropertyGeomFormatList.cpp
+++ b/src/Mod/TechDraw/App/PropertyGeomFormatList.cpp
@@ -161,12 +161,12 @@ void PropertyGeomFormatList::Restore(Base::XMLReader &reader)
     reader.clearPartialRestoreObject();
     reader.readElement("GeomFormatList");
     // get the value of my attribute
-    int count = reader.getAttributeAsInteger("count");
+    int count = reader.getAttribute<long>("count");
     std::vector<GeomFormat*> values;
     values.reserve(count);
     for (int i = 0; i < count; i++) {
         reader.readElement("GeomFormat");
-        const char* TypeName = reader.getAttribute("type");
+        const char* TypeName = reader.getAttribute<const char*>("type");
         GeomFormat *newG = static_cast<GeomFormat *>(Base::Type::fromName(TypeName).createInstance());
         newG->Restore(reader);
 

--- a/src/Mod/TechDraw/App/Tag.cpp
+++ b/src/Mod/TechDraw/App/Tag.cpp
@@ -86,7 +86,7 @@ void Tag::Restore(Base::XMLReader& reader, std::string_view elementName)
 {
     // Setting elementName is only for backwards compatibility!
     reader.readElement(elementName.data());
-    std::string temp = reader.getAttribute("value");
+    std::string temp = reader.getAttribute<const char*>("value");
     boost::uuids::string_generator gen;
     boost::uuids::uuid u1 = gen(temp);
     tag = u1;


### PR DESCRIPTION
- Prevents unneeded conversion
- Prevents verbose casting

Before:
```cpp
MyEnumClass a = static_cast<MyEnumClass>(getAttributeAsUnsigned("attr2"));
bool b = getAttributeAsUnsigned("attr2") == 0 ? true : false;
```

After:
```cpp
MyEnumClass a = getAttribute<MyEnumClass>("attr2"));
bool b = getAttribute<bool>("attr2");
```