### PR TITLE
CAM:  Used inheritance to simplify the refactored postprocessors even more

### DIFF
--- a/src/Mod/CAM/CAMTests/TestRefactoredMassoG3Post.py
+++ b/src/Mod/CAM/CAMTests/TestRefactoredMassoG3Post.py
@@ -35,7 +35,7 @@ import FreeCAD
 
 import Path
 import CAMTests.PathTestUtils as PathTestUtils
-from Path.Post.scripts import refactored_masso_g3_post as postprocessor
+from Path.Post.Processor import PostProcessorFactory
 
 
 Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -54,8 +54,16 @@ class TestRefactoredMassoG3Post(PathTestUtils.PathTestBase):
         is able to call static methods within this same class.
         """
 
-        # Open existing FreeCAD document with test geometry
-        FreeCAD.newDocument("Unnamed")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
+        cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/CAMTests/boxtest.fcstd")
+        cls.job = cls.doc.getObject("Job")
+        cls.post = PostProcessorFactory.get_post_processor(cls.job, "refactored_masso_g3")
+        # locate the operation named "Profile"
+        for op in cls.job.Operations.Group:
+            if op.Label == "Profile":
+                # remember the "Profile" operation
+                cls.profile_op = op
+                return
 
     @classmethod
     def tearDownClass(cls):
@@ -66,8 +74,8 @@ class TestRefactoredMassoG3Post(PathTestUtils.PathTestBase):
         have access to the class `self` reference.  This method
         is able to call static methods within this same class.
         """
-        # Close geometry document without saving
-        FreeCAD.closeDocument(FreeCAD.ActiveDocument.Name)
+        FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     # Setup and tear down methods called before and after each unit test
     def setUp(self):
@@ -75,87 +83,106 @@ class TestRefactoredMassoG3Post(PathTestUtils.PathTestBase):
         This method is called prior to each `test()` method.  Add code and
         objects here that are needed for multiple `test()` methods.
         """
-        self.doc = FreeCAD.ActiveDocument
-        self.con = FreeCAD.Console
-        self.docobj = FreeCAD.ActiveDocument.addObject("Path::Feature", "testpath")
-        reload(
-            postprocessor
-        )  # technical debt.  This shouldn't be necessary but here to bypass a bug
+        # allow a full length "diff" if an error occurs
+        self.maxDiff = None
+        # reinitialize the postprocessor data structures between tests
+        self.post.reinitialize()
 
     def tearDown(self):
         """tearDown()...
         This method is called after each test() method. Add cleanup instructions here.
         Such cleanup instructions will likely undo those in the setUp() method.
         """
-        FreeCAD.ActiveDocument.removeObject("testpath")
+        pass
 
     def test000(self):
         """Test Output Generation.
         Empty path.  Produces only the preamble and postable.
         """
+        nl = "\n"
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
         # Test generating with header
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
-        args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertTrue(len(gcode.splitlines()) == 14)
+        self.job.PostProcessorArgs = "--no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertTrue(len(gcode.splitlines()) == 26)
 
         # Test without header
         expected = """(Begin preamble)
 G17 G54 G40 G49 G80 G90
 G21
-(Begin operation: testpath)
+(Begin operation: Fixture)
 (Machine units: mm/min)
-(Finish operation: testpath)
+G54
+(Finish operation: Fixture)
+(Begin operation: TC: Default Tool)
+(Machine units: mm/min)
+(TC: Default Tool)
+(Begin toolchange)
+M5
+T1 M6
+G43 H1
+(Finish operation: TC: Default Tool)
+(Begin operation: Profile)
+(Machine units: mm/min)
+(Finish operation: Profile)
 (Begin postamble)
 M05
 G17 G54 G90 G80 G40
 M2
 """
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
-        args = "--no-header --no-show-editor"
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "-", args)
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
 
         # test without comments
         expected = """G17 G54 G40 G49 G80 G90
 G21
+G54
+M5
+T1 M6
+G43 H1
 M05
 G17 G54 G90 G80 G40
 M2
 """
 
-        args = "--no-header --no-comments --no-show-editor"
+        self.job.PostProcessorArgs = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "-", args)
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
 
     def test010(self):
         """Test command Generation.
         Test Precision
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
         expected = "G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
-        args = "--no-header --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --precision=2 --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
         expected = "G0 X10.00 Y20.00 Z30.00"
         self.assertEqual(result, expected)
 
@@ -163,27 +190,32 @@ M2
         """
         Test Line Numbers
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
-        expected = "N150 G0 X10.000 Y20.000 Z30.000"
+        self.job.PostProcessorArgs = "--no-header --line-numbers --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
+        expected = "N270 G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
     def test030(self):
         """
         Test Pre-amble
         """
+        nl = "\n"
 
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([])
 
-        args = "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        self.job.PostProcessorArgs = (
+            "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
+        )
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         result = gcode.splitlines()[0]
         self.assertEqual(result, "G18 G55")
 
@@ -191,10 +223,15 @@ M2
         """
         Test Post-amble
         """
-        self.docobj.Path = Path.Path([])
-        postables = [self.docobj]
-        args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        nl = "\n"
+
+        self.profile_op.Path = Path.Path([])
+
+        self.job.PostProcessorArgs = (
+            "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
+        )
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         result = gcode.splitlines()[-2]
         self.assertEqual(result, "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -203,22 +240,25 @@ M2
         """
         Test inches
         """
+        nl = "\n"
 
         c = Path.Command("G0 X10 Y20 Z30")
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
 
-        args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
+        self.profile_op.Path = Path.Path([c])
+
+        self.job.PostProcessorArgs = "--no-header --inches --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[2], "G20")
 
-        result = gcode.splitlines()[5]
+        result = gcode.splitlines()[17]
         expected = "G0 X0.3937 Y0.7874 Z1.1811"
         self.assertEqual(result, expected)
 
-        args = "--no-header --inches --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --inches --precision=2 --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
         expected = "G0 X0.39 Y0.79 Z1.18"
         self.assertEqual(result, expected)
 
@@ -227,15 +267,17 @@ M2
         Test test modal
         Suppress the command name if the same as previous
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
         c1 = Path.Command("G0 X10 Y30 Z30")
 
-        self.docobj.Path = Path.Path([c, c1])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c, c1])
 
-        args = "--no-header --modal --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[6]
+        self.job.PostProcessorArgs = "--no-header --modal --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[18]
         expected = "X10.000 Y30.000 Z30.000"
         self.assertEqual(result, expected)
 
@@ -244,15 +286,17 @@ M2
         Test axis modal
         Suppress the axis coordinate if the same as previous
         """
+        nl = "\n"
+
         c = Path.Command("G0 X10 Y20 Z30")
         c1 = Path.Command("G0 X10 Y30 Z30")
 
-        self.docobj.Path = Path.Path([c, c1])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c, c1])
 
-        args = "--no-header --axis-modal --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[6]
+        self.job.PostProcessorArgs = "--no-header --axis-modal --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[18]
         expected = "G0 Y30.000"
         self.assertEqual(result, expected)
 
@@ -260,35 +304,40 @@ M2
         """
         Test tool change
         """
+        nl = "\n"
+
         c = Path.Command("M6 T2")
         c2 = Path.Command("M3 S3000")
-        self.docobj.Path = Path.Path([c, c2])
-        postables = [self.docobj]
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertEqual(gcode.splitlines()[6], "M5")
-        self.assertEqual(gcode.splitlines()[7], "T2 M6")
-        self.assertEqual(gcode.splitlines()[8], "G43 H2")
-        self.assertEqual(gcode.splitlines()[9], "M3 S3000")
+        self.profile_op.Path = Path.Path([c, c2])
+
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[18], "M5")
+        self.assertEqual(gcode.splitlines()[19], "T2 M6")
+        self.assertEqual(gcode.splitlines()[20], "G43 H2")
+        self.assertEqual(gcode.splitlines()[21], "M3 S3000")
 
         # suppress TLO
-        args = "--no-header --no-tlo --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        self.assertEqual(gcode.splitlines()[8], "M3 S3000")
+        self.job.PostProcessorArgs = "--no-header --no-tlo --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[19], "M3 S3000")
 
     def test090(self):
         """
         Test comment
         """
+        nl = "\n"
 
         c = Path.Command("(comment)")
 
-        self.docobj.Path = Path.Path([c])
-        postables = [self.docobj]
+        self.profile_op.Path = Path.Path([c])
 
-        args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "-", args)
-        result = gcode.splitlines()[5]
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        result = gcode.splitlines()[17]
         expected = "(comment)"
         self.assertEqual(result, expected)

--- a/src/Mod/CAM/Path/Post/scripts/refactored_centroid_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/refactored_centroid_post.py
@@ -23,13 +23,9 @@
 # *                                                                         *
 # ***************************************************************************
 
-import argparse
-
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict
 
 from Path.Post.Processor import PostProcessor
-import Path.Post.UtilsArguments as PostUtilsArguments
-import Path.Post.UtilsExport as PostUtilsExport
 
 import Path
 import FreeCAD
@@ -46,16 +42,6 @@ else:
 #
 # Define some types that are used throughout this file.
 #
-Defaults = Dict[str, bool]
-FormatHelp = str
-GCodeOrNone = Optional[str]
-GCodeSections = List[Tuple[str, GCodeOrNone]]
-Parser = argparse.ArgumentParser
-ParserArgs = Union[None, str, argparse.Namespace]
-Postables = Union[List, List[Tuple[str, List]]]
-Section = Tuple[str, List]
-Sublist = List
-Units = str
 Values = Dict[str, Any]
 Visible = Dict[str, bool]
 
@@ -63,48 +49,28 @@ Visible = Dict[str, bool]
 class Refactored_Centroid(PostProcessor):
     """The Refactored Centroid post processor class."""
 
-    def __init__(self, job) -> None:
+    def __init__(
+        self,
+        job,
+        tooltip=translate("CAM", "Refactored Centroid post processor"),
+        tooltipargs=[""],
+        units="Metric",
+    ) -> None:
         super().__init__(
             job=job,
-            tooltip=translate("CAM", "Refactored Centroid post processor"),
-            tooltipargs=[""],
-            units="Metric",
+            tooltip=tooltip,
+            tooltipargs=tooltipargs,
+            units=units,
         )
-        self.reinitialize()
         Path.Log.debug("Refactored Centroid post processor initialized.")
-
-    def reinitialize(self) -> None:
-        """Initialize or reinitialize the 'core' data structures for the postprocessor."""
-        #
-        # This is also used to reinitialize the data structures between tests.
-        #
-        self.values: Values = {}
-        self.init_values(self.values)
-        self.argument_defaults: Defaults = {}
-        self.init_argument_defaults(self.argument_defaults)
-        self.arguments_visible: Visible = {}
-        self.init_arguments_visible(self.arguments_visible)
-        self.parser: Parser = self.init_arguments(
-            self.values, self.argument_defaults, self.arguments_visible
-        )
-        #
-        # Create another parser just to get a list of all possible arguments
-        # that may be output using --output_all_arguments.
-        #
-        self.all_arguments_visible: Visible = {}
-        for k in iter(self.arguments_visible):
-            self.all_arguments_visible[k] = True
-        self.all_visible: Parser = self.init_arguments(
-            self.values, self.argument_defaults, self.all_arguments_visible
-        )
 
     def init_values(self, values: Values) -> None:
         """Initialize values that are used throughout the postprocessor."""
         #
-        PostUtilsArguments.init_shared_values(values)
+        super().init_values(values)
         #
         # Set any values here that need to override the default values set
-        # in the init_shared_values routine.
+        # in the parent routine.
         #
         # Use 4 digits for axis precision by default.
         #
@@ -197,7 +163,6 @@ class Refactored_Centroid(PostProcessor):
         ] = """M5
 M25
 G49 H0"""
-        values["UNITS"] = self._units
         #
         # Default to not outputting a G43 following tool changes
         #
@@ -209,128 +174,15 @@ G49 H0"""
         # ZAXISRETURN = """G91 G28 X0 Z0 G90"""
         #
 
-    def init_argument_defaults(self, argument_defaults: Defaults) -> None:
-        """Initialize which arguments (in a pair) are shown as the default argument."""
-        PostUtilsArguments.init_argument_defaults(argument_defaults)
-        #
-        # Modify which argument to show as the default in flag-type arguments here.
-        # If the value is True, the first argument will be shown as the default.
-        # If the value is False, the second argument will be shown as the default.
-        #
-        # For example, if you want to show Metric mode as the default, use:
-        #   argument_defaults["metric_inch"] = True
-        #
-        # If you want to show that "Don't pop up editor for writing output" is
-        # the default, use:
-        #   argument_defaults["show-editor"] = False.
-        #
-        # Note:  You also need to modify the corresponding entries in the "values" hash
-        #        to actually make the default value(s) change to match.
-        #
-
     def init_arguments_visible(self, arguments_visible: Visible) -> None:
         """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
-        PostUtilsArguments.init_arguments_visible(arguments_visible)
+        super().init_arguments_visible(arguments_visible)
         #
         # Modify the visibility of any arguments from the defaults here.
         #
         arguments_visible["axis-modal"] = False
         arguments_visible["precision"] = False
         arguments_visible["tlo"] = False
-
-    def init_arguments(
-        self,
-        values: Values,
-        argument_defaults: Defaults,
-        arguments_visible: Visible,
-    ) -> Parser:
-        """Initialize the shared argument definitions."""
-        _parser: Parser = PostUtilsArguments.init_shared_arguments(
-            values, argument_defaults, arguments_visible
-        )
-        #
-        # Add any argument definitions that are not shared with other postprocessors here.
-        #
-        return _parser
-
-    def process_arguments(self) -> Tuple[bool, ParserArgs]:
-        """Process any arguments to the postprocessor."""
-        #
-        # This function is separated out to make it easier to inherit from this postprocessor.
-        #
-        args: ParserArgs
-        flag: bool
-
-        (flag, args) = PostUtilsArguments.process_shared_arguments(
-            self.values, self.parser, self._job.PostProcessorArgs, self.all_visible, "-"
-        )
-        #
-        # If the flag is True, then all of the arguments should be processed normally.
-        #
-        if flag:
-            #
-            # Process any additional arguments here.
-            #
-            #
-            # Update any variables that might have been modified while processing the arguments.
-            #
-            self._units = self.values["UNITS"]
-        #
-        # If the flag is False, then args is either None (indicating an error while
-        # processing the arguments) or a string containing the argument list formatted
-        # for output.  Either way the calling routine will need to handle the args value.
-        #
-        return (flag, args)
-
-    def process_postables(self) -> GCodeSections:
-        """Postprocess the 'postables' in the job to g code sections."""
-        #
-        # This function is separated out to make it easier to inherit from this postprocessor.
-        #
-        gcode: GCodeOrNone
-        g_code_sections: GCodeSections
-        partname: str
-        postables: Postables
-        section: Section
-        sublist: Sublist
-
-        postables = self._buildPostList()
-
-        Path.Log.debug(f"postables count: {len(postables)}")
-
-        g_code_sections = []
-        for _, section in enumerate(postables):
-            partname, sublist = section
-            gcode = PostUtilsExport.export_common(self.values, sublist, "-")
-            g_code_sections.append((partname, gcode))
-
-        return g_code_sections
-
-    def export(self) -> GCodeSections:
-        """Process the parser arguments, then postprocess the 'postables'."""
-        args: ParserArgs
-        flag: bool
-
-        Path.Log.debug("Exporting the job")
-
-        (flag, args) = self.process_arguments()
-        #
-        # If the flag is True, then continue postprocessing the 'postables'
-        #
-        if flag:
-            return self.process_postables()
-        #
-        # The flag is False meaning something unusual happened.
-        #
-        # If args is None then there was an error during argument processing.
-        #
-        if args is None:
-            return None
-        #
-        # Otherwise args will contain the argument list formatted for output
-        # instead of the "usual" gcode.
-        #
-        return [("allitems", args)]  # type: ignore
 
     @property
     def tooltip(self):
@@ -340,11 +192,3 @@ G49 H0"""
         and output 'real' GCode suitable for a centroid 3 axis mill.
         """
         return tooltip
-
-    @property
-    def tooltipArgs(self) -> FormatHelp:
-        return self.parser.format_help()
-
-    @property
-    def units(self) -> Units:
-        return self._units

--- a/src/Mod/CAM/Path/Post/scripts/refactored_grbl_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/refactored_grbl_post.py
@@ -25,11 +25,9 @@
 
 import argparse
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict
 
 from Path.Post.Processor import PostProcessor
-import Path.Post.UtilsArguments as PostUtilsArguments
-import Path.Post.UtilsExport as PostUtilsExport
 
 import Path
 import FreeCAD
@@ -47,15 +45,6 @@ else:
 # Define some types that are used throughout this file.
 #
 Defaults = Dict[str, bool]
-FormatHelp = str
-GCodeOrNone = Optional[str]
-GCodeSections = List[Tuple[str, GCodeOrNone]]
-Parser = argparse.ArgumentParser
-ParserArgs = Union[None, str, argparse.Namespace]
-Postables = Union[List, List[Tuple[str, List]]]
-Section = Tuple[str, List]
-Sublist = List
-Units = str
 Values = Dict[str, Any]
 Visible = Dict[str, bool]
 
@@ -63,48 +52,28 @@ Visible = Dict[str, bool]
 class Refactored_Grbl(PostProcessor):
     """The Refactored Grbl post processor class."""
 
-    def __init__(self, job) -> None:
+    def __init__(
+        self,
+        job,
+        tooltip=translate("CAM", "Refactored Grbl post processor"),
+        tooltipargs=[""],
+        units="Metric",
+    ) -> None:
         super().__init__(
             job=job,
-            tooltip=translate("CAM", "Refactored Grbl post processor"),
-            tooltipargs=[""],
-            units="Metric",
+            tooltip=tooltip,
+            tooltipargs=tooltipargs,
+            units=units,
         )
-        self.reinitialize()
         Path.Log.debug("Refactored Grbl post processor initialized.")
-
-    def reinitialize(self) -> None:
-        """Initialize or reinitialize the 'core' data structures for the postprocessor."""
-        #
-        # This is also used to reinitialize the data structures between tests.
-        #
-        self.values: Values = {}
-        self.init_values(self.values)
-        self.argument_defaults: Defaults = {}
-        self.init_argument_defaults(self.argument_defaults)
-        self.arguments_visible: Visible = {}
-        self.init_arguments_visible(self.arguments_visible)
-        self.parser: Parser = self.init_arguments(
-            self.values, self.argument_defaults, self.arguments_visible
-        )
-        #
-        # Create another parser just to get a list of all possible arguments
-        # that may be output using --output_all_arguments.
-        #
-        self.all_arguments_visible: Visible = {}
-        for k in iter(self.arguments_visible):
-            self.all_arguments_visible[k] = True
-        self.all_visible: Parser = self.init_arguments(
-            self.values, self.argument_defaults, self.all_arguments_visible
-        )
 
     def init_values(self, values: Values) -> None:
         """Initialize values that are used throughout the postprocessor."""
         #
-        PostUtilsArguments.init_shared_values(values)
+        super().init_values(values)
         #
         # Set any values here that need to override the default values set
-        # in the init_shared_values routine.
+        # in the parent routine.
         #
         #
         # If this is set to True, then commands that are placed in
@@ -168,7 +137,6 @@ M2"""
         # Do not show the current machine units just before the PRE_OPERATION.
         #
         values["SHOW_MACHINE_UNITS"] = False
-        values["UNITS"] = self._units
         #
         # Default to not outputting a G43 following tool changes
         #
@@ -176,7 +144,7 @@ M2"""
 
     def init_argument_defaults(self, argument_defaults: Defaults) -> None:
         """Initialize which arguments (in a pair) are shown as the default argument."""
-        PostUtilsArguments.init_argument_defaults(argument_defaults)
+        super().init_argument_defaults(argument_defaults)
         #
         # Modify which argument to show as the default in flag-type arguments here.
         # If the value is True, the first argument will be shown as the default.
@@ -197,7 +165,7 @@ M2"""
 
     def init_arguments_visible(self, arguments_visible: Visible) -> None:
         """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
-        PostUtilsArguments.init_arguments_visible(arguments_visible)
+        super().init_arguments_visible(arguments_visible)
         #
         # Modify the visibility of any arguments from the defaults here.
         #
@@ -209,100 +177,6 @@ M2"""
         arguments_visible["translate_drill"] = True
         arguments_visible["wait-for-spindle"] = True
 
-    def init_arguments(
-        self,
-        values: Values,
-        argument_defaults: Defaults,
-        arguments_visible: Visible,
-    ) -> Parser:
-        """Initialize the shared argument definitions."""
-        _parser: Parser = PostUtilsArguments.init_shared_arguments(
-            values, argument_defaults, arguments_visible
-        )
-        #
-        # Add any argument definitions that are not shared with other postprocessors here.
-        #
-        return _parser
-
-    def process_arguments(self) -> Tuple[bool, ParserArgs]:
-        """Process any arguments to the postprocessor."""
-        #
-        # This function is separated out to make it easier to inherit from this postprocessor.
-        #
-        args: ParserArgs
-        flag: bool
-
-        (flag, args) = PostUtilsArguments.process_shared_arguments(
-            self.values, self.parser, self._job.PostProcessorArgs, self.all_visible, "-"
-        )
-        #
-        # If the flag is True, then all of the arguments should be processed normally.
-        #
-        if flag:
-            #
-            # Process any additional arguments here.
-            #
-            #
-            # Update any variables that might have been modified while processing the arguments.
-            #
-            self._units = self.values["UNITS"]
-        #
-        # If the flag is False, then args is either None (indicating an error while
-        # processing the arguments) or a string containing the argument list formatted
-        # for output.  Either way the calling routine will need to handle the args value.
-        #
-        return (flag, args)
-
-    def process_postables(self) -> GCodeSections:
-        """Postprocess the 'postables' in the job to g code sections."""
-        #
-        # This function is separated out to make it easier to inherit from this postprocessor.
-        #
-        gcode: GCodeOrNone
-        g_code_sections: GCodeSections
-        partname: str
-        postables: Postables
-        section: Section
-        sublist: Sublist
-
-        postables = self._buildPostList()
-
-        Path.Log.debug(f"postables count: {len(postables)}")
-
-        g_code_sections = []
-        for _, section in enumerate(postables):
-            partname, sublist = section
-            gcode = PostUtilsExport.export_common(self.values, sublist, "-")
-            g_code_sections.append((partname, gcode))
-
-        return g_code_sections
-
-    def export(self) -> Union[None, GCodeSections]:
-        """Process the parser arguments, then postprocess the 'postables'."""
-        args: ParserArgs
-        flag: bool
-
-        Path.Log.debug("Exporting the job")
-
-        (flag, args) = self.process_arguments()
-        #
-        # If the flag is True, then continue postprocessing the 'postables'.
-        #
-        if flag:
-            return self.process_postables()
-        #
-        # The flag is False meaning something unusual happened.
-        #
-        # If args is None then there was an error during argument processing.
-        #
-        if args is None:
-            return None
-        #
-        # Otherwise args will contain the argument list formatted for output
-        # instead of the "usual" gcode.
-        #
-        return [("allitems", args)]  # type: ignore
-
     @property
     def tooltip(self):
         tooltip: str = """
@@ -311,11 +185,3 @@ M2"""
         and output 'real' GCode suitable for a Grbl 3 axis mill.
         """
         return tooltip
-
-    @property
-    def tooltipArgs(self) -> FormatHelp:
-        return self.parser.format_help()
-
-    @property
-    def units(self) -> Units:
-        return self._units

--- a/src/Mod/CAM/Path/Post/scripts/refactored_linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/refactored_linuxcnc_post.py
@@ -23,19 +23,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-# ***************************************************************************
-# *  Note: refactored_masso_g3_Post.py is a modified clone of this file     *
-# *        any changes to this file should be applied to the other          *
-# *                                                                         *
-# ***************************************************************************
 
-import argparse
-
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict
 
 from Path.Post.Processor import PostProcessor
-import Path.Post.UtilsArguments as PostUtilsArguments
-import Path.Post.UtilsExport as PostUtilsExport
 
 import Path
 import FreeCAD
@@ -52,65 +43,34 @@ else:
 #
 # Define some types that are used throughout this file.
 #
-Defaults = Dict[str, bool]
-FormatHelp = str
-GCodeOrNone = Optional[str]
-GCodeSections = List[Tuple[str, GCodeOrNone]]
-Parser = argparse.ArgumentParser
-ParserArgs = Union[None, str, argparse.Namespace]
-Postables = Union[List, List[Tuple[str, List]]]
-Section = Tuple[str, List]
-Sublist = List
-Units = str
 Values = Dict[str, Any]
-Visible = Dict[str, bool]
 
 
 class Refactored_Linuxcnc(PostProcessor):
     """The Refactored LinuxCNC post processor class."""
 
-    def __init__(self, job) -> None:
+    def __init__(
+        self,
+        job,
+        tooltip=translate("CAM", "Refactored LinuxCNC post processor"),
+        tooltipargs=[""],
+        units="Metric",
+    ) -> None:
         super().__init__(
             job=job,
-            tooltip=translate("CAM", "Refactored LinuxCNC post processor"),
-            tooltipargs=[""],
-            units="Metric",
+            tooltip=tooltip,
+            tooltipargs=tooltipargs,
+            units=units,
         )
-        self.reinitialize()
         Path.Log.debug("Refactored LinuxCNC post processor initialized.")
-
-    def reinitialize(self) -> None:
-        """Initialize or reinitialize the 'core' data structures for the postprocessor."""
-        #
-        # This is also used to reinitialize the data structures between tests.
-        #
-        self.values: Values = {}
-        self.init_values(self.values)
-        self.argument_defaults: Defaults = {}
-        self.init_argument_defaults(self.argument_defaults)
-        self.arguments_visible: Visible = {}
-        self.init_arguments_visible(self.arguments_visible)
-        self.parser: Parser = self.init_arguments(
-            self.values, self.argument_defaults, self.arguments_visible
-        )
-        #
-        # Create another parser just to get a list of all possible arguments
-        # that may be output using --output_all_arguments.
-        #
-        self.all_arguments_visible: Visible = {}
-        for k in iter(self.arguments_visible):
-            self.all_arguments_visible[k] = True
-        self.all_visible: Parser = self.init_arguments(
-            self.values, self.argument_defaults, self.all_arguments_visible
-        )
 
     def init_values(self, values: Values) -> None:
         """Initialize values that are used throughout the postprocessor."""
         #
-        PostUtilsArguments.init_shared_values(values)
+        super().init_values(values)
         #
         # Set any values here that need to override the default values set
-        # in the init_shared_values routine.
+        # in the parent routine.
         #
         values["ENABLE_COOLANT"] = True
         #
@@ -140,7 +100,7 @@ class Refactored_Linuxcnc(PostProcessor):
         #
         # Used in the argparser code as the "name" of the postprocessor program.
         #
-        values["MACHINE_NAME"] = "Refactored_LinuxCNC"
+        values["MACHINE_NAME"] = "LinuxCNC"
         #
         # Any commands in this value will be output as the last commands
         # in the G-code file.
@@ -156,128 +116,6 @@ M2"""
         # safety block at the beginning of the G-code file.
         #
         values["PREAMBLE"] = """G17 G54 G40 G49 G80 G90"""
-        values["UNITS"] = self._units
-
-    def init_argument_defaults(self, argument_defaults: Defaults) -> None:
-        """Initialize which arguments (in a pair) are shown as the default argument."""
-        PostUtilsArguments.init_argument_defaults(argument_defaults)
-        #
-        # Modify which argument to show as the default in flag-type arguments here.
-        # If the value is True, the first argument will be shown as the default.
-        # If the value is False, the second argument will be shown as the default.
-        #
-        # For example, if you want to show Metric mode as the default, use:
-        #   argument_defaults["metric_inch"] = True
-        #
-        # If you want to show that "Don't pop up editor for writing output" is
-        # the default, use:
-        #   argument_defaults["show-editor"] = False.
-        #
-        # Note:  You also need to modify the corresponding entries in the "values" hash
-        #        to actually make the default value(s) change to match.
-        #
-
-    def init_arguments_visible(self, arguments_visible: Visible) -> None:
-        """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
-        PostUtilsArguments.init_arguments_visible(arguments_visible)
-        #
-        # Modify the visibility of any arguments from the defaults here.
-        #
-
-    def init_arguments(
-        self,
-        values: Values,
-        argument_defaults: Defaults,
-        arguments_visible: Visible,
-    ) -> Parser:
-        """Initialize the shared argument definitions."""
-        _parser: Parser = PostUtilsArguments.init_shared_arguments(
-            values, argument_defaults, arguments_visible
-        )
-        #
-        # Add any argument definitions that are not shared with all other
-        # postprocessors here.
-        #
-        return _parser
-
-    def process_arguments(self) -> Tuple[bool, ParserArgs]:
-        """Process any arguments to the postprocessor."""
-        #
-        # This function is separated out to make it easier to inherit from this postprocessor
-        #
-        args: ParserArgs
-        flag: bool
-
-        (flag, args) = PostUtilsArguments.process_shared_arguments(
-            self.values, self.parser, self._job.PostProcessorArgs, self.all_visible, "-"
-        )
-        #
-        # If the flag is True, then all of the arguments should be processed normally.
-        #
-        if flag:
-            #
-            # Process any additional arguments here.
-            #
-            #
-            # Update any variables that might have been modified while processing the arguments.
-            #
-            self._units = self.values["UNITS"]
-        #
-        # If the flag is False, then args is either None (indicating an error while
-        # processing the arguments) or a string containing the argument list formatted
-        # for output.  Either way the calling routine will need to handle the args value.
-        #
-        return (flag, args)
-
-    def process_postables(self) -> GCodeSections:
-        """Postprocess the 'postables' in the job to g code sections."""
-        #
-        # This function is separated out to make it easier to inherit from this postprocessor.
-        #
-        gcode: GCodeOrNone
-        g_code_sections: GCodeSections
-        partname: str
-        postables: Postables
-        section: Section
-        sublist: Sublist
-
-        postables = self._buildPostList()
-
-        Path.Log.debug(f"postables count: {len(postables)}")
-
-        g_code_sections = []
-        for _, section in enumerate(postables):
-            partname, sublist = section
-            gcode = PostUtilsExport.export_common(self.values, sublist, "-")
-            g_code_sections.append((partname, gcode))
-
-        return g_code_sections
-
-    def export(self) -> GCodeSections:
-        """Process the parser arguments, then postprocess the 'postables'."""
-        args: ParserArgs
-        flag: bool
-
-        Path.Log.debug("Exporting the job")
-
-        (flag, args) = self.process_arguments()
-        #
-        # If the flag is True, then continue postprocessing the 'postables'
-        #
-        if flag:
-            return self.process_postables()
-        #
-        # The flag is False meaning something unusual happened.
-        #
-        # If args is None then there was an error during argument processing.
-        #
-        if args is None:
-            return None
-        #
-        # Otherwise args will contain the argument list formatted for output
-        # instead of the "usual" gcode.
-        #
-        return [("allitems", args)]  # type: ignore
 
     @property
     def tooltip(self):
@@ -287,11 +125,3 @@ M2"""
         and output 'real' GCode suitable for a linuxcnc 3 axis mill.
         """
         return tooltip
-
-    @property
-    def tooltipArgs(self) -> FormatHelp:
-        return self.parser.format_help()
-
-    @property
-    def units(self) -> Units:
-        return self._units

--- a/src/Mod/CAM/Path/Post/scripts/refactored_mach3_mach4_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/refactored_mach3_mach4_post.py
@@ -23,13 +23,9 @@
 # *                                                                         *
 # ***************************************************************************
 
-import argparse
-
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict
 
 from Path.Post.Processor import PostProcessor
-import Path.Post.UtilsArguments as PostUtilsArguments
-import Path.Post.UtilsExport as PostUtilsExport
 
 import Path
 import FreeCAD
@@ -46,16 +42,6 @@ else:
 #
 # Define some types that are used throughout this file.
 #
-Defaults = Dict[str, bool]
-FormatHelp = str
-GCodeOrNone = Optional[str]
-GCodeSections = List[Tuple[str, GCodeOrNone]]
-Parser = argparse.ArgumentParser
-ParserArgs = Union[None, str, argparse.Namespace]
-Postables = Union[List, List[Tuple[str, List]]]
-Section = Tuple[str, List]
-Sublist = List
-Units = str
 Values = Dict[str, Any]
 Visible = Dict[str, bool]
 
@@ -63,48 +49,28 @@ Visible = Dict[str, bool]
 class Refactored_Mach3_Mach4(PostProcessor):
     """The Refactored Mach3_Mach4 post processor class."""
 
-    def __init__(self, job) -> None:
+    def __init__(
+        self,
+        job,
+        tooltip=translate("CAM", "Refactored Mach3_Mach4 post processor"),
+        tooltipargs=[""],
+        units="Metric",
+    ) -> None:
         super().__init__(
             job=job,
-            tooltip=translate("CAM", "Refactored Mach3_Mach4 post processor"),
-            tooltipargs=[""],
-            units="Metric",
+            tooltip=tooltip,
+            tooltipargs=tooltipargs,
+            units=units,
         )
-        self.reinitialize()
         Path.Log.debug("Refactored Mach3_Mach4 post processor initialized.")
-
-    def reinitialize(self) -> None:
-        """Initialize or reinitialize the 'core' data structures for the postprocessor."""
-        #
-        # This is also used to reinitialize the data structures between tests.
-        #
-        self.values: Values = {}
-        self.init_values(self.values)
-        self.argument_defaults: Defaults = {}
-        self.init_argument_defaults(self.argument_defaults)
-        self.arguments_visible: Visible = {}
-        self.init_arguments_visible(self.arguments_visible)
-        self.parser: Parser = self.init_arguments(
-            self.values, self.argument_defaults, self.arguments_visible
-        )
-        #
-        # Create another parser just to get a list of all possible arguments
-        # that may be output using --output_all_arguments.
-        #
-        self.all_arguments_visible: Visible = {}
-        for k in iter(self.arguments_visible):
-            self.all_arguments_visible[k] = True
-        self.all_visible: Parser = self.init_arguments(
-            self.values, self.argument_defaults, self.all_arguments_visible
-        )
 
     def init_values(self, values: Values) -> None:
         """Initialize values that are used throughout the postprocessor."""
         #
-        PostUtilsArguments.init_shared_values(values)
+        super().init_values(values)
         #
         # Set any values here that need to override the default values set
-        # in the init_shared_values routine.
+        # in the parent routine.
         #
         values["ENABLE_COOLANT"] = True
         #
@@ -163,128 +129,14 @@ M2"""
         # Output the machine name for mach3_mach4 instead of the machine units alone.
         #
         values["SHOW_MACHINE_UNITS"] = False
-        values["UNITS"] = self._units
-
-    def init_argument_defaults(self, argument_defaults: Defaults) -> None:
-        """Initialize which arguments (in a pair) are shown as the default argument."""
-        PostUtilsArguments.init_argument_defaults(argument_defaults)
-        #
-        # Modify which argument to show as the default in flag-type arguments here.
-        # If the value is True, the first argument will be shown as the default.
-        # If the value is False, the second argument will be shown as the default.
-        #
-        # For example, if you want to show Metric mode as the default, use:
-        #   argument_defaults["metric_inch"] = True
-        #
-        # If you want to show that "Don't pop up editor for writing output" is
-        # the default, use:
-        #   argument_defaults["show-editor"] = False.
-        #
-        # Note:  You also need to modify the corresponding entries in the "values" hash
-        #        to actually make the default value(s) change to match.
-        #
 
     def init_arguments_visible(self, arguments_visible: Visible) -> None:
         """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
-        PostUtilsArguments.init_arguments_visible(arguments_visible)
+        super().init_arguments_visible(arguments_visible)
         #
         # Modify the visibility of any arguments from the defaults here.
         #
         arguments_visible["axis-modal"] = True
-
-    def init_arguments(
-        self,
-        values: Values,
-        argument_defaults: Defaults,
-        arguments_visible: Visible,
-    ) -> Parser:
-        """Initialize the shared argument definitions."""
-        _parser: Parser = PostUtilsArguments.init_shared_arguments(
-            values, argument_defaults, arguments_visible
-        )
-        #
-        # Add any argument definitions that are not shared with other postprocessors here.
-        #
-        return _parser
-
-    def process_arguments(self) -> Tuple[bool, ParserArgs]:
-        """Process any arguments to the postprocessor."""
-        #
-        # This function is separated out to make it easier to inherit from this postprocessor.
-        #
-        args: ParserArgs
-        flag: bool
-
-        (flag, args) = PostUtilsArguments.process_shared_arguments(
-            self.values, self.parser, self._job.PostProcessorArgs, self.all_visible, "-"
-        )
-        #
-        # If the flag is True, then all of the arguments should be processed normally.
-        #
-        if flag:
-            #
-            # Process any additional arguments here.
-            #
-            #
-            # Update any variables that might have been modified while processing the arguments.
-            #
-            self._units = self.values["UNITS"]
-        #
-        # If the flag is False, then args is either None (indicating an error while
-        # processing the arguments) or a string containing the argument list formatted
-        # for output.  Either way the calling routine will need to handle the args value.
-        #
-        return (flag, args)
-
-    def process_postables(self) -> GCodeSections:
-        """Postprocess the 'postables' in the job to g code sections."""
-        #
-        # This function is separated out to make it easier to inherit from this postprocessor.
-        #
-        gcode: GCodeOrNone
-        g_code_sections: GCodeSections
-        partname: str
-        postables: Postables
-        section: Section
-        sublist: Sublist
-
-        postables = self._buildPostList()
-
-        Path.Log.debug(f"postables count: {len(postables)}")
-
-        g_code_sections = []
-        for _, section in enumerate(postables):
-            partname, sublist = section
-            gcode = PostUtilsExport.export_common(self.values, sublist, "-")
-            g_code_sections.append((partname, gcode))
-
-        return g_code_sections
-
-    def export(self) -> GCodeSections:
-        """Process the parser arguments, then postprocess the 'postables'."""
-        args: ParserArgs
-        flag: bool
-
-        Path.Log.debug("Exporting the job")
-
-        (flag, args) = self.process_arguments()
-        #
-        # If the flag is True, then continue postprocessing the 'postables'.
-        #
-        if flag:
-            return self.process_postables()
-        #
-        # The flag is False meaning something unusual happened.
-        #
-        # If args is None then there was an error during argument processing.
-        #
-        if args is None:
-            return None
-        #
-        # Otherwise args will contain the argument list formatted for output
-        # instead of the "usual" gcode.
-        #
-        return [("allitems", args)]  # type: ignore
 
     @property
     def tooltip(self):
@@ -294,11 +146,3 @@ M2"""
         and output 'real' GCode suitable for a Mach3_4 3 axis mill.
         """
         return tooltip
-
-    @property
-    def tooltipArgs(self) -> FormatHelp:
-        return self.parser.format_help()
-
-    @property
-    def units(self) -> Units:
-        return self._units

--- a/src/Mod/CAM/Path/Post/scripts/refactored_masso_g3_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/refactored_masso_g3_post.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2014 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
+# *   Copyright (c) 2022 - 2025 Larry Woestman <LarryWoestman2@gmail.com>   *
+# *   Copyright (c) 2024 Ondsel <development@ondsel.com>                    *
 # *   Copyright (c) 2024 Carl Slater <CandLWorkshopLLC@gmail.com>           *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -23,205 +24,70 @@
 # *                                                                         *
 # ***************************************************************************
 
-# ***************************************************************************
-# *  Note: this is copy & mod of refactored_linuxcnc_post.py                *
-# *                                                                         *
-# *                                                                         *
-# ***************************************************************************
+from typing import Any, Dict
 
-import argparse
+from Path.Post.scripts.refactored_linuxcnc_post import Refactored_Linuxcnc
 
-from typing import Any, Dict, Union
+import Path
+import FreeCAD
 
-import Path.Post.UtilsArguments as PostUtilsArguments
-import Path.Post.UtilsExport as PostUtilsExport
+translate = FreeCAD.Qt.translate
 
-# Define some types that are used throughout this file
-Parser = argparse.ArgumentParser
+DEBUG = False
+if DEBUG:
+    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+    Path.Log.trackModule(Path.Log.thisModule())
+else:
+    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
+#
+# Define some types that are used throughout this file.
+#
 Values = Dict[str, Any]
 
-#
-# The following variables need to be global variables
-# to keep the PathPostProcessor.load method happy:
-#
-#    TOOLTIP
-#    TOOLTIP_ARGS
-#    UNITS
-#
-#    The "argument_defaults", "arguments_visible", and the "values" hashes
-#    need to be defined before the "init_shared_arguments" routine can be
-#    called to create TOOLTIP_ARGS, so they also end up having to be globals.
-#
-TOOLTIP: str = """This is a postprocessor file for the Path workbench. It is used to
-take a pseudo-gcode fragment outputted by a Path object, and output
-real GCode suitable for a Masso G3 3 axis mill. This postprocessor, once placed
-in the appropriate PathScripts folder, can be used directly from inside
-FreeCAD, via the GUI importer or via python scripts with:
 
-import refactored_masso_g3_post
-refactored_masso_g3_post.export(object,"/path/to/file.ncc","")
-"""
-#
-# Default to metric mode
-#
-UNITS: str = "G21"
+class Refactored_Masso_G3(Refactored_Linuxcnc):
+    """The Refactored Masso G3 post processor class."""
 
+    def __init__(
+        self,
+        job,
+        tooltip=translate("CAM", "Refactored Masso G3 post processor"),
+        tooltipargs=[""],
+        units="Metric",
+    ) -> None:
+        super().__init__(
+            job=job,
+            tooltip=tooltip,
+            tooltipargs=tooltipargs,
+            units=units,
+        )
+        Path.Log.debug("Refactored Masso G3 post processor initialized.")
 
-def init_values(values: Values) -> None:
-    """Initialize values that are used throughout the postprocessor."""
-    #
-    PostUtilsArguments.init_shared_values(values)
-    #
-    # Set any values here that need to override the default values set
-    # in the init_shared_values routine.
-    #
-    values["ENABLE_COOLANT"] = True
-    # the order of parameters
-    # Masso G3 doesn't want K properties on XY plane; Arcs need work.
-    values["PARAMETER_ORDER"] = [
-        "X",
-        "Y",
-        "Z",
-        "A",
-        "B",
-        "C",
-        "I",
-        "J",
-        "F",
-        "S",
-        "T",
-        "Q",
-        "R",
-        "L",
-        "H",
-        "D",
-        "P",
-    ]
-    #
-    # Used in the argparser code as the "name" of the postprocessor program.
-    # This would normally show up in the usage message in the TOOLTIP_ARGS,
-    # but we are suppressing the usage message, so it doesn't show up after all.
-    #
-    values["MACHINE_NAME"] = "Masso G3"
-    #
-    # Any commands in this value will be output as the last commands
-    # in the G-code file.
-    #
-    values[
-        "POSTAMBLE"
-    ] = """M05
-G17 G54 G90 G80 G40
-M2"""
-    values["POSTPROCESSOR_FILE_NAME"] = __name__
-    #
-    # Any commands in this value will be output after the header and
-    # safety block at the beginning of the G-code file.
-    #
-    values["PREAMBLE"] = """G17 G54 G40 G49 G80 G90"""
+    def init_values(self, values: Values) -> None:
+        """Initialize values that are used throughout the postprocessor."""
+        #
+        super().init_values(values)
+        #
+        # Set any values here that need to override the default values set
+        # in the parent routine.
+        #
+        #
+        # Used in the argparser code as the "name" of the postprocessor program.
+        #
+        values["MACHINE_NAME"] = "Masso G3"
+        values["POSTPROCESSOR_FILE_NAME"] = __name__
+        #
+        # setting TOOL_BEFORE_CHANGE to True will output T# M6 before each tool change
+        # rather than M6 T#.
+        #
+        values["TOOL_BEFORE_CHANGE"] = True
 
-    #
-    # setting TOOL_BEFORE_CHANGE to True will output T# M6 before each tool change
-    # rather than M6  T#.
-    #
-    values["TOOL_BEFORE_CHANGE"] = type(True)
-    values["UNITS"] = UNITS
-
-
-def init_argument_defaults(argument_defaults: Dict[str, bool]) -> None:
-    """Initialize which arguments (in a pair) are shown as the default argument."""
-    PostUtilsArguments.init_argument_defaults(argument_defaults)
-    #
-    # Modify which argument to show as the default in flag-type arguments here.
-    # If the value is True, the first argument will be shown as the default.
-    # If the value is False, the second argument will be shown as the default.
-    #
-    # For example, if you want to show Metric mode as the default, use:
-    #   argument_defaults["metric_inch"] = True
-    #
-    # If you want to show that "Don't pop up editor for writing output" is
-    # the default, use:
-    #   argument_defaults["show-editor"] = False.
-    #
-    # Note:  You also need to modify the corresponding entries in the "values" hash
-    #        to actually make the default value(s) change to match.
-    #
-
-
-def init_arguments_visible(arguments_visible: Dict[str, bool]) -> None:
-    """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
-    PostUtilsArguments.init_arguments_visible(arguments_visible)
-    #
-    # Modify the visibility of any arguments from the defaults here.
-    #
-
-
-def init_arguments(
-    values: Values,
-    argument_defaults: Dict[str, bool],
-    arguments_visible: Dict[str, bool],
-) -> Parser:
-    """Initialize the shared argument definitions."""
-    parser: Parser = PostUtilsArguments.init_shared_arguments(
-        values, argument_defaults, arguments_visible
-    )
-    #
-    # Add any argument definitions that are not shared with all other
-    # postprocessors here.
-    #
-    return parser
-
-
-#
-# Creating global variables and using functions to modify them
-# is useful for being able to test things later.
-#
-global_values: Values = {}
-init_values(global_values)
-global_argument_defaults: Dict[str, bool] = {}
-init_argument_defaults(global_argument_defaults)
-global_arguments_visible: Dict[str, bool] = {}
-init_arguments_visible(global_arguments_visible)
-global_parser: Parser = init_arguments(
-    global_values, global_argument_defaults, global_arguments_visible
-)
-#
-# The TOOLTIP_ARGS value is created from the help information about the arguments.
-#
-TOOLTIP_ARGS: str = global_parser.format_help()
-#
-# Create another parser just to get a list of all possible arguments
-# that may be output using --output_all_arguments.
-#
-global_all_arguments_visible: Dict[str, bool] = {}
-for k in iter(global_arguments_visible):
-    global_all_arguments_visible[k] = True
-global_all_visible: Parser = init_arguments(
-    global_values, global_argument_defaults, global_all_arguments_visible
-)
-
-
-def export(objectslist, filename: str, argstring: str) -> str:
-    """Postprocess the objects in objectslist to filename."""
-    args: Union[str, argparse.Namespace]
-    flag: bool
-
-    global UNITS  # pylint: disable=global-statement
-
-    # print(parser.format_help())
-
-    (flag, args) = PostUtilsArguments.process_shared_arguments(
-        global_values, global_parser, argstring, global_all_visible, filename
-    )
-    if not flag:
-        return args  # type: ignore
-    #
-    # Process any additional arguments here
-    #
-
-    #
-    # Update the global variables that might have been modified
-    # while processing the arguments.
-    #
-    UNITS = global_values["UNITS"]
-
-    return PostUtilsExport.export_common(global_values, objectslist, filename)
+    @property
+    def tooltip(self):
+        tooltip: str = """
+        This is a postprocessor file for the CAM workbench.
+        It is used to take a pseudo-gcode fragment from a CAM object
+        and output 'real' GCode suitable for a Masso G3 3 axis mill.
+        """
+        return tooltip

--- a/src/Mod/CAM/Path/Post/scripts/refactored_test_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/refactored_test_post.py
@@ -23,13 +23,9 @@
 # *                                                                         *
 # ***************************************************************************
 
-import argparse
-
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict
 
 from Path.Post.Processor import PostProcessor
-import Path.Post.UtilsArguments as PostUtilsArguments
-import Path.Post.UtilsExport as PostUtilsExport
 
 import Path
 import FreeCAD
@@ -46,16 +42,6 @@ else:
 #
 # Define some types that are used throughout this file.
 #
-Defaults = Dict[str, bool]
-FormatHelp = str
-GCodeOrNone = Optional[str]
-GCodeSections = List[Tuple[str, GCodeOrNone]]
-Parser = argparse.ArgumentParser
-ParserArgs = Union[None, str, argparse.Namespace]
-Postables = Union[List, List[Tuple[str, List]]]
-Section = Tuple[str, List]
-Sublist = List
-Units = str
 Values = Dict[str, Any]
 Visible = Dict[str, bool]
 
@@ -63,48 +49,28 @@ Visible = Dict[str, bool]
 class Refactored_Test(PostProcessor):
     """The Refactored Test post processor class."""
 
-    def __init__(self, job) -> None:
+    def __init__(
+        self,
+        job,
+        tooltip=translate("CAM", "Refactored Test post processor"),
+        tooltipargs=[""],
+        units="Metric",
+    ) -> None:
         super().__init__(
             job=job,
-            tooltip=translate("CAM", "Refactored Test post processor"),
-            tooltipargs=[""],
-            units="Metric",
+            tooltip=tooltip,
+            tooltipargs=tooltipargs,
+            units=units,
         )
-        self.reinitialize()
         Path.Log.debug("Refactored Test post processor initialized")
-
-    def reinitialize(self) -> None:
-        """Initialize or reinitialize the 'core' data structures for the postprocessor."""
-        #
-        # This is also used to reinitialize the data structures between tests.
-        #
-        self.values: Values = {}
-        self.init_values(self.values)
-        self.argument_defaults: Defaults = {}
-        self.init_argument_defaults(self.argument_defaults)
-        self.arguments_visible: Visible = {}
-        self.init_arguments_visible(self.arguments_visible)
-        self.parser: Parser = self.init_arguments(
-            self.values, self.argument_defaults, self.arguments_visible
-        )
-        #
-        # Create another parser just to get a list of all possible arguments
-        # that may be output using --output_all_arguments.
-        #
-        self.all_arguments_visible: Visible = {}
-        for k in iter(self.arguments_visible):
-            self.all_arguments_visible[k] = True
-        self.all_visible: Parser = self.init_arguments(
-            self.values, self.argument_defaults, self.all_arguments_visible
-        )
 
     def init_values(self, values: Values) -> None:
         """Initialize values that are used throughout the postprocessor."""
         #
-        PostUtilsArguments.init_shared_values(values)
+        super().init_values(values)
         #
         # Set any values here that need to override the default values set
-        # in the init_shared_values routine.
+        # in the parent routine.
         #
         # Used in the argparser code as the "name" of the postprocessor program.
         #
@@ -143,30 +109,10 @@ class Refactored_Test(PostProcessor):
         # Don't output a G43 tool length command following tool changes by default.
         #
         values["USE_TLO"] = False
-        values["UNITS"] = self._units
-
-    def init_argument_defaults(self, argument_defaults: Defaults) -> None:
-        """Initialize which arguments (in a pair) are shown as the default argument."""
-        PostUtilsArguments.init_argument_defaults(argument_defaults)
-        #
-        # Modify which argument to show as the default in flag-type arguments here.
-        # If the value is True, the first argument will be shown as the default.
-        # If the value is False, the second argument will be shown as the default.
-        #
-        # For example, if you want to show Metric mode as the default, use:
-        #   argument_defaults["metric_inch"] = True
-        #
-        # If you want to show that "Don't pop up editor for writing output" is
-        # the default, use:
-        #   argument_defaults["show-editor"] = False.
-        #
-        # Note:  You also need to modify the corresponding entries in the "values" hash
-        #        to actually make the default value(s) change to match.
-        #
 
     def init_arguments_visible(self, arguments_visible: Visible) -> None:
         """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
-        PostUtilsArguments.init_arguments_visible(arguments_visible)
+        super().init_arguments_visible(arguments_visible)
         #
         # Modify the visibility of any arguments from the defaults here.
         #
@@ -175,100 +121,6 @@ class Refactored_Test(PostProcessor):
         for key in iter(arguments_visible):
             arguments_visible[key] = False
 
-    def init_arguments(
-        self,
-        values: Values,
-        argument_defaults: Defaults,
-        arguments_visible: Visible,
-    ) -> Parser:
-        """Initialize the shared argument definitions."""
-        _parser: Parser = PostUtilsArguments.init_shared_arguments(
-            values, argument_defaults, arguments_visible
-        )
-        #
-        # Add any argument definitions that are not shared with other postprocessors here.
-        #
-        return _parser
-
-    def process_arguments(self) -> Tuple[bool, ParserArgs]:
-        """Process any arguments to the postprocessor."""
-        #
-        # This function is separated out to make it easier to inherit from this postprocessor.
-        #
-        args: ParserArgs
-        flag: bool
-
-        (flag, args) = PostUtilsArguments.process_shared_arguments(
-            self.values, self.parser, self._job.PostProcessorArgs, self.all_visible, "-"
-        )
-        #
-        # If the flag is True, then all of the arguments should be processed normally.
-        #
-        if flag:
-            #
-            # Process any additional arguments here.
-            #
-            #
-            # Update any variables that might have been modified while processing the arguments.
-            #
-            self._units = self.values["UNITS"]
-        #
-        # If the flag is False, then args is either None (indicating an error while
-        # processing the arguments) or a string containing the argument list formatted
-        # for output.  Either way the calling routine will need to handle the args value.
-        #
-        return (flag, args)
-
-    def process_postables(self) -> GCodeSections:
-        """Postprocess the 'postables' in the job to g code sections."""
-        #
-        # This function is separated out to make it easier to inherit from this postprocessor.
-        #
-        gcode: GCodeOrNone
-        g_code_sections: GCodeSections
-        partname: str
-        postables: Postables
-        section: Section
-        sublist: Sublist
-
-        postables = self._buildPostList()
-
-        Path.Log.debug(f"postables count: {len(postables)}")
-
-        g_code_sections = []
-        for _, section in enumerate(postables):
-            partname, sublist = section
-            gcode = PostUtilsExport.export_common(self.values, sublist, "-")
-            g_code_sections.append((partname, gcode))
-
-        return g_code_sections
-
-    def export(self) -> Union[None, GCodeSections]:
-        """Process the parser arguments, then postprocess the 'postables'."""
-        args: ParserArgs
-        flag: bool
-
-        Path.Log.debug("Exporting the job")
-
-        (flag, args) = self.process_arguments()
-        #
-        # If the flag is True, then continue postprocessing the 'postables'.
-        #
-        if flag:
-            return self.process_postables()
-        #
-        # The flag is False meaning something unusual happened.
-        #
-        # If args is None then there was an error during argument processing.
-        #
-        if args is None:
-            return None
-        #
-        # Otherwise args will contain the argument list formatted for output
-        # instead of the "usual" gcode.
-        #
-        return [("allitems", args)]  # type: ignore
-
     @property
     def tooltip(self):
         tooltip: str = """
@@ -276,11 +128,3 @@ class Refactored_Test(PostProcessor):
         to test the postprocessor code.  It probably isn't useful for "real" gcode.
         """
         return tooltip
-
-    @property
-    def tooltipArgs(self) -> FormatHelp:
-        return self.parser.format_help()
-
-    @property
-    def units(self) -> Units:
-        return self._units

--- a/src/Mod/CAM/Path/Post/scripts/snapmaker_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/snapmaker_post.py
@@ -116,22 +116,24 @@ class Snapmaker(Path.Post.Processor.PostProcessor):
         self.arguments_visible: dict[str, bool] = dict()
         self.parser = argparse.ArgumentParser()
 
-        self.init_values()
-        self.init_argument_defaults()
-        self.init_arguments_visible()
-        self.parser = self.init_parser(self.values, self.argument_defaults, self.arguments_visible)
+        self.snapmaker_init_values()
+        self.snapmaker_init_argument_defaults()
+        self.snapmaker_init_arguments_visible()
+        self.parser = self.snapmaker_init_parser(
+            self.values, self.argument_defaults, self.arguments_visible
+        )
 
         # create another parser with all visible arguments
         all_arguments_visible = dict()
         for key in iter(self.arguments_visible):
             all_arguments_visible[key] = True
-        self.visible_parser = self.init_parser(
+        self.visible_parser = self.snapmaker_init_parser(
             self.values, self.argument_defaults, all_arguments_visible
         )
 
         FreeCAD.Console.PrintLog(f'{self.values["POSTPROCESSOR_FILE_NAME"]}: initialized.\n')
 
-    def init_values(self):
+    def snapmaker_init_values(self):
         """Initialize values that are used throughout the postprocessor."""
         Path.Post.UtilsArguments.init_shared_values(self.values)
 
@@ -197,7 +199,7 @@ class Snapmaker(Path.Post.Processor.PostProcessor):
             "percent"
         ]
 
-    def init_argument_defaults(self) -> None:
+    def snapmaker_init_argument_defaults(self) -> None:
         """Initialize which arguments (in a pair) are shown as the default argument."""
         Path.Post.UtilsArguments.init_argument_defaults(self.argument_defaults)
 
@@ -210,7 +212,7 @@ class Snapmaker(Path.Post.Processor.PostProcessor):
         self.argument_defaults["boundaries-check"] = True
         self.argument_defaults["spindle-percent"] = True
 
-    def init_arguments_visible(self) -> None:
+    def snapmaker_init_arguments_visible(self) -> None:
         """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
         Path.Post.UtilsArguments.init_arguments_visible(self.arguments_visible)
 
@@ -232,7 +234,9 @@ class Snapmaker(Path.Post.Processor.PostProcessor):
         self.arguments_visible["line-increment"] = True
         self.arguments_visible["spindle-speeds"] = True
 
-    def init_parser(self, values, argument_defaults, arguments_visible) -> argparse.ArgumentParser:
+    def snapmaker_init_parser(
+        self, values, argument_defaults, arguments_visible
+    ) -> argparse.ArgumentParser:
         """Initialize the postprocessor arguments parser"""
         parser = Path.Post.UtilsArguments.init_shared_arguments(
             values, argument_defaults, arguments_visible
@@ -335,7 +339,7 @@ class Snapmaker(Path.Post.Processor.PostProcessor):
 
         return parser
 
-    def process_arguments(self, filename: str = "-") -> (bool, str | argparse.Namespace):
+    def snapmaker_process_arguments(self, filename: str = "-") -> (bool, str | argparse.Namespace):
         """Process any arguments to the postprocessor."""
         (flag, args) = Path.Post.UtilsArguments.process_shared_arguments(
             self.values, self.parser, self._job.PostProcessorArgs, self.visible_parser, filename
@@ -389,7 +393,7 @@ class Snapmaker(Path.Post.Processor.PostProcessor):
 
         return flag, args
 
-    def process_postables(self, filename: str = "-") -> [(str, str)]:
+    def snapmaker_process_postables(self, filename: str = "-") -> [(str, str)]:
         """process job sections to gcode"""
         sections: [(str, str)] = list()
 
@@ -622,11 +626,12 @@ class Snapmaker(Path.Post.Processor.PostProcessor):
 
     def export(self, filename: str | pathlib.Path = "-"):
         """process gcode and export"""
-        (flag, args) = self.process_arguments()
+        (flag, args) = self.snapmaker_process_arguments()
         if flag:
-            return self.process_postables(filename)
-        else:
-            return [("allitems", args)]
+            return self.snapmaker_process_postables(filename)
+        if args is None:
+            return None
+        return [("allitems", args)]
 
     @property
     def tooltip(self) -> str:


### PR DESCRIPTION
This PR fixes #19909.

Now that the refactored* postprocessors are much more "object-oriented", this PR takes advantage of inheritance to simplify the refactored* postprocessors even more.

It adds a new "UtilsPostBase.py" file which contains a "base" class for all of the refactored* postprocessors.

The refactored* postprocessors have been refactored to become even simpler than they were before.  

The refactored Masso G3 postprocessor now inherits from the refactored LinuxCNC postprocessor, which simplifies it down to not much more than the one variable setting that it needs.   It also makes it obvious that it depends on the refactored LinuxCNC postprocessor while making it easy to see just what the differences are.

This will simplify the maintenance of all of the refactored* postprocessors and opens up the possibility that future "custom" postprocessors will be able to inherit from existing refactored postprocessors instead of having to copy the code from one of them.  There is still work to be done to have enough "customization" ability to take full advantage of inheritance rather than copying code.

Updated the refactored Masso G3 tests now that the refactored Masso G3 postprocessor is using the new API.

Please assign this to me.  Thanks!
