### PR TITLE
Gui: Properly reset light directions

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
@@ -327,6 +327,10 @@ void DlgSettingsLightSources::resetSettingsToDefaults()
 {
     PreferencePage::resetSettingsToDefaults();
 
+    hGrp->RemoveASCII("HeadlightDirection");
+    hGrp->RemoveASCII("BacklightDirection");
+    hGrp->RemoveASCII("FillLightDirection");
+
     loadSettings();
     configureViewer();
 }


### PR DESCRIPTION
This fixes lights not getting reset after user demands so.