### PR TITLE
CMake: Add GCC/Clang `-fdiagnostics=color` compiler option.

### DIFF
--- a/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
+++ b/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
@@ -48,6 +48,8 @@ macro(CompilerChecksAndSetups)
         configure_file(${CMAKE_SOURCE_DIR}/src/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
         add_definitions(-DHAVE_CONFIG_H)
 
+        set(CMAKE_CXX_FLAGS "-fdiagnostics-color ${CMAKE_CXX_FLAGS}")
+
         # For now only set pedantic option for clang
         if(CMAKE_COMPILER_IS_CLANGXX)
             set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic -Wno-write-strings ${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
Adds some colors with makes it much easier to parse/navigate compiler output.
![image](https://github.com/user-attachments/assets/7f1751af-8479-4964-959e-4a6d3e0ca87f)
