### PR TITLE
Start: add initial preferences page

### DIFF
--- a/src/Mod/Start/Gui/AppStartGui.cpp
+++ b/src/Mod/Start/Gui/AppStartGui.cpp
@@ -33,6 +33,8 @@
 #include <Gui/Language/Translator.h>
 #include <Gui/Command.h>
 #include <Gui/MainWindow.h>
+#include <Gui/WidgetFactory.h>
+#include "DlgStartPreferencesImp.h"
 
 
 #include <gsl/pointers>
@@ -123,6 +125,10 @@ PyMOD_INIT_FUNC(StartGui)
     Gui::WorkbenchManipulator::installManipulator(manipulator);
     loadStartResource();
     Base::Console().Log("done\n");
+
+    // register preferences pages
+    new Gui::PrefPageProducer<StartGui::DlgStartPreferencesImp>(
+        QT_TRANSLATE_NOOP("QObject", "Start"));
 
     PyMOD_Return(mod);
 }

--- a/src/Mod/Start/Gui/CMakeLists.txt
+++ b/src/Mod/Start/Gui/CMakeLists.txt
@@ -44,6 +44,10 @@ set(StartGui_LIBS
         FreeCADGui
         )
 
+set(StartGui_UIC_SRCS
+        DlgStartPreferences.ui
+    )
+
 set(Start_TR_QRC ${CMAKE_CURRENT_BINARY_DIR}/Resources/Start_translation.qrc)
 qt_find_and_add_translation(QM_SRCS "Resources/translations/*_*.ts"
         ${CMAKE_CURRENT_BINARY_DIR}/Resources/translations)
@@ -54,6 +58,8 @@ qt_add_resources(Start_QRC_SRCS Resources/Start.qrc ${Start_TR_QRC})
 SET(StartGui_SRCS
         ${Start_QRC_SRCS}
         ${StartGui_UIC_SRCS}
+        DlgStartPreferencesImp.cpp
+        DlgStartPreferencesImp.h
         AppStartGui.cpp
         FileCardDelegate.cpp
         FileCardDelegate.h

--- a/src/Mod/Start/Gui/DlgStartPreferences.ui
+++ b/src/Mod/Start/Gui/DlgStartPreferences.ui
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DlgStartPreferences</class>
+ <widget class="QWidget" name="DlgStartPreferences">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>537</width>
+    <height>766</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>General</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBoxContents">
+     <property name="title">
+      <string>Contents</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelCustomFolder">
+        <property name="text">
+         <string>Show additional folder contents</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefCheckBox" name="checkBoxShowExamples">
+        <property name="toolTip">
+         <string>If you want the examples to show on the first page</string>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowExamples</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefFileChooser" name="fileChooserCustomFolder" native="true">
+        <property name="toolTip">
+         <string>An optional custom folder to be displayed at the bottom of the first page.
+By using &quot;;;&quot; to separate paths, you can add several folders here</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>CustomFolder</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Show examples folder contents</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBoxOptions">
+     <property name="title">
+      <string>Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="1">
+       <widget class="Gui::PrefCheckBox" name="checkBoxCloseAfterLoading">
+        <property name="toolTip">
+         <string>If checked, will automatically close the Start page when FreeCAD launches</string>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>closeStart</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_11">
+        <property name="text">
+         <string>Close start page after loading</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::FileChooser</class>
+   <extends>QWidget</extends>
+   <header>Gui/FileDialog.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefFileChooser</class>
+   <extends>Gui::FileChooser</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefCheckBox</class>
+   <extends>QCheckBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/Start/Gui/DlgStartPreferences.ui
+++ b/src/Mod/Start/Gui/DlgStartPreferences.ui
@@ -52,8 +52,10 @@
       <item row="1" column="1">
        <widget class="Gui::PrefFileChooser" name="fileChooserCustomFolder" native="true">
         <property name="toolTip">
-         <string>An optional custom folder to be displayed at the bottom of the first page.
-By using &quot;;;&quot; to separate paths, you can add several folders here</string>
+         <string>An optional custom folder to be displayed on the Start page.</string>
+        </property>
+        <property name="mode">
+         <enum>Gui::FileChooser::Directory</enum>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>CustomFolder</cstring>

--- a/src/Mod/Start/Gui/DlgStartPreferencesImp.cpp
+++ b/src/Mod/Start/Gui/DlgStartPreferencesImp.cpp
@@ -1,0 +1,84 @@
+/***************************************************************************
+ *   Copyright (c) 2018 Yorik van Havre <yorik@uncreated.net>              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#include <Gui/Application.h>
+
+#include "DlgStartPreferencesImp.h"
+#include "ui_DlgStartPreferences.h"
+
+
+using namespace StartGui;
+
+/**
+ *  Constructs a DlgStartPreferencesImp which is a child of 'parent'
+ */
+DlgStartPreferencesImp::DlgStartPreferencesImp(QWidget* parent)
+    : PreferencePage(parent)
+    , ui(new Ui_DlgStartPreferences)
+{
+    ui->setupUi(this);
+}
+
+/**
+ *  Destroys the object and frees any allocated resources
+ */
+DlgStartPreferencesImp::~DlgStartPreferencesImp()
+{
+    // no need to delete child widgets, Qt does it all for us
+}
+
+void DlgStartPreferencesImp::saveSettings()
+{
+    ui->fileChooserCustomFolder->onSave();
+    ui->checkBoxShowExamples->onSave();
+    ui->checkBoxCloseAfterLoading->onSave();
+}
+
+void DlgStartPreferencesImp::loadSettings()
+{
+    // std::string start = App::Application::Config()["StartWorkbench"];
+    // start = App::GetApplication().GetParameterGroupByPath("User
+    // parameter:BaseApp/Preferences/Mod/Start")->
+    //                               GetASCII("AutoloadModule", start.c_str());
+    // QString startWbName = QLatin1String(start.c_str());
+
+    ui->fileChooserCustomFolder->onRestore();
+    ui->checkBoxShowExamples->onRestore();
+    ui->checkBoxCloseAfterLoading->onRestore();
+}
+
+/**
+ * Sets the strings of the subwidgets using the current language.
+ */
+void DlgStartPreferencesImp::changeEvent(QEvent* e)
+{
+    if (e->type() == QEvent::LanguageChange) {
+        ui->retranslateUi(this);
+    }
+    else {
+        QWidget::changeEvent(e);
+    }
+}
+
+#include "moc_DlgStartPreferencesImp.cpp"

--- a/src/Mod/Start/Gui/DlgStartPreferencesImp.cpp
+++ b/src/Mod/Start/Gui/DlgStartPreferencesImp.cpp
@@ -57,12 +57,6 @@ void DlgStartPreferencesImp::saveSettings()
 
 void DlgStartPreferencesImp::loadSettings()
 {
-    // std::string start = App::Application::Config()["StartWorkbench"];
-    // start = App::GetApplication().GetParameterGroupByPath("User
-    // parameter:BaseApp/Preferences/Mod/Start")->
-    //                               GetASCII("AutoloadModule", start.c_str());
-    // QString startWbName = QLatin1String(start.c_str());
-
     ui->fileChooserCustomFolder->onRestore();
     ui->checkBoxShowExamples->onRestore();
     ui->checkBoxCloseAfterLoading->onRestore();

--- a/src/Mod/Start/Gui/DlgStartPreferencesImp.h
+++ b/src/Mod/Start/Gui/DlgStartPreferencesImp.h
@@ -1,0 +1,52 @@
+/***************************************************************************
+ *   Copyright (c) 2018 Yorik van Havre <yorik@uncreated.net>              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef STARTGUI_DLGSTARTPREFERENCESIMP_H
+#define STARTGUI_DLGSTARTPREFERENCESIMP_H
+
+#include <memory>
+#include <Gui/PropertyPage.h>
+
+
+class Ui_DlgStartPreferences;
+namespace StartGui
+{
+class DlgStartPreferencesImp: public Gui::Dialog::PreferencePage
+{
+    Q_OBJECT
+
+public:
+    explicit DlgStartPreferencesImp(QWidget* parent = nullptr);
+    ~DlgStartPreferencesImp() override;
+
+protected:
+    void saveSettings() override;
+    void loadSettings() override;
+    void changeEvent(QEvent* e) override;
+
+private:
+    std::unique_ptr<Ui_DlgStartPreferences> ui;
+};
+
+}  // namespace StartGui
+
+#endif  // STARTGUI_DLGSTARTPREFERENCESIMP_H

--- a/src/Mod/Start/Gui/Resources/Start.qrc
+++ b/src/Mod/Start/Gui/Resources/Start.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/">
         <file>icons/StartCommandIcon.svg</file>
+        <file>icons/preferences-start.svg</file>
         <file>icons/PartDesignWorkbench.svg</file>
         <file>thumbnails/Theme_thumbnail_classic.png</file>
         <file>thumbnails/Theme_thumbnail_light.png</file>

--- a/src/Mod/Start/Gui/Resources/icons/preferences-start.svg
+++ b/src/Mod/Start/Gui/Resources/icons/preferences-start.svg
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg3037"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="StartWorkbench.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs3039">
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         id="stop3796"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop3798"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3841">
+      <stop
+         style="stop-color:#0619c0;stop-opacity:1;"
+         offset="0"
+         id="stop3843" />
+      <stop
+         style="stop-color:#379cfb;stop-opacity:1;"
+         offset="1"
+         id="stop3845" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3841"
+       id="linearGradient3847"
+       x1="3709.3296"
+       y1="1286.7291"
+       x2="3935.5251"
+       y2="1076.6174"
+       gradientUnits="userSpaceOnUse" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective3045" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3794"
+       id="linearGradient2991"
+       gradientUnits="userSpaceOnUse"
+       x1="3718.145"
+       y1="1190.5608"
+       x2="3940.3335"
+       y2="1143.1339"
+       gradientTransform="matrix(0,0.1731146,-0.1731146,0,232.90021,-635.22046)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3841-6"
+       id="linearGradient2991-3"
+       gradientUnits="userSpaceOnUse"
+       x1="3709.3296"
+       y1="1286.7291"
+       x2="3935.5251"
+       y2="1076.6174"
+       gradientTransform="matrix(0,0.1731146,-0.1731146,0,232.90021,-635.22046)" />
+    <linearGradient
+       id="linearGradient3841-6">
+      <stop
+         style="stop-color:#0619c0;stop-opacity:1;"
+         offset="0"
+         id="stop3843-7" />
+      <stop
+         style="stop-color:#379cfb;stop-opacity:1;"
+         offset="1"
+         id="stop3845-5" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.598799"
+     inkscape:cx="-13.439241"
+     inkscape:cy="44.491229"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="800"
+     inkscape:window-height="836"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2990"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3042">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[triplus]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>StartWorkbench</dc:title>
+        <dc:date>2016-02-26</dc:date>
+        <dc:relation>http://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Start/Gui/Resources/icons/StartWorkbench.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>right</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Arrow pointing towards the right</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient2991);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 61,31 31,5 l 0,14 -24,0 0,24 24,0 0,14 z"
+       id="rect3066"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 58,31 33.012263,9.3801382 33,21 9,21 l 0,20 24,0 0,11.600864 z"
+       id="rect3066-3"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>


### PR DESCRIPTION
Follow up to https://github.com/FreeCAD/FreeCAD/pull/19473 and https://github.com/FreeCAD/FreeCAD/pull/19473#issuecomment-2644363171 to add GUI support for modifying the location of the custom folder, and other associated Start page preferences. Before, the existing parameters had to be specified through the Parameter Editor. The motivation for this PR is to make it easier and more intuitive for the user to modify those as settings in the standard Preferences dialog.

## Details

- [x] Create preferences page scaffolding
- [x] Add icon for Start preference page (`src/Mod/Start/Gui/Resources/icons/preferences-start.svg`)
- [x] Add "Show Custom Folder" preference
- [x] Add "Show Examples Folder" preference
- [x] Add "Close Start page after loading" preference
- [ ] Optional: remove <kbd>Don't show this Start page again</kbd> checkbox from Start page, as the same setting is now under Preferences => should it be removed?

![image](https://github.com/user-attachments/assets/6a97d8cd-b035-4aa2-a5a2-dd8d70047891)

## Known issues

1. When changing the preferences, they are not reflected on the Start page until after a restart. This is the same behavior as the original Start workbench with FreeCAD 0.21. Is there a best practice recommendation as to how/when show the "Restart required" dialog?

## Out of scope

1. In FreeCAD 0.21, it was possible to specify more than one custom folder by separating multiple folder paths with `;;`. While it would be great to bring back that functionality, it is not addressed on this PR.

## Additional info

1. Related PR, as it affects migration of the `CustomFolder` parameter: https://github.com/FreeCAD/FreeCAD/pull/19922. They're not dependent on each other, though.
2. Related PR: https://github.com/FreeCAD/FreeCAD/pull/19376
3. Related issue: https://github.com/FreeCAD/FreeCAD/issues/14817