### PR TITLE
Start: move showCustomFolder parameter migration to right location

### DIFF
--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -194,15 +194,6 @@ StartView::StartView(QWidget* parent)
     auto cardSpacing = hGrp->GetInt("FileCardSpacing", 15);   // NOLINT
     auto showExamples = hGrp->GetBool("ShowExamples", true);  // NOLINT
 
-    // Migrate legacy property, can be removed in later releases
-    std::string legacyCustomFolder(hGrp->GetASCII("ShowCustomFolder", ""));
-    if (!legacyCustomFolder.empty()) {
-        hGrp->SetASCII("CustomFolder", legacyCustomFolder);
-        hGrp->RemoveASCII("ShowCustomFolder");
-        Base::Console().Message("v1.1: renamed ShowCustomFolder parameter to CustomFolder\n");
-    }
-    // End of migration code
-
     // Verify that the folder specified in preferences is available before showing it
     std::string customFolder(hGrp->GetASCII("CustomFolder", ""));
     bool showCustomFolder = false;

--- a/src/Mod/Start/StartMigrator.py
+++ b/src/Mod/Start/StartMigrator.py
@@ -57,6 +57,7 @@ class StartMigrator2024:
         self._remove_toolbars()
         self._remove_deprecated_parameters()
         self._mark_complete()
+        self._migrate_custom_folder()
         FreeCAD.Console.PrintMessage("done.\n")
 
     # If the old Start workbench was set as the Autoload Module, reconfigure it so the Start command is run at startup,
@@ -99,19 +100,26 @@ class StartMigrator2024:
         if "WebWorkbench" in groups:
             tux_prefs.RemGroup("WebWorkbench")
 
+    # In FreeCAD 1.1, the custom folder parameter was renamed from "ShowCustomFolder"
+    # to "CustomFolder". The new parameter does not yet support multiple locations.
+    def _migrate_custom_folder(self):
+        custom_folder = self.start_prefs.GetString("ShowCustomFolder", "")
+
+        # Note: multiple locations separated by ";;" are not supported at this time
+        # Use the first listed location and discard the rest
+        return custom_folder.split(";;")[0]
+
     # Delete old Start preferences
     def _remove_deprecated_parameters(self):
         show_on_startup = self.start_prefs.GetBool("ShowOnStartup", True)
         show_examples = self.start_prefs.GetBool("ShowExamples", True)
         close_start = self.start_prefs.GetBool("closeStart", False)
-        custom_folder = self.start_prefs.GetString(
-            "ShowCustomFolder", ""
-        )  # Note: allow multiple locations separated by ";;"
+        custom_folder = self._migrate_custom_folder()
         self.start_prefs.Clear()
         self.start_prefs.SetBool("ShowOnStartup", show_on_startup)
         self.start_prefs.SetBool("ShowExamples", show_examples)
         self.start_prefs.SetBool("CloseStart", close_start)
-        self.start_prefs.SetString("ShowCustomFolder", custom_folder)
+        self.start_prefs.SetString("CustomFolder", custom_folder)
 
     # Indicate that this migration has been run
     def _mark_complete(self):


### PR DESCRIPTION
Follow up to https://github.com/FreeCAD/FreeCAD/pull/19473#issuecomment-2671207632

- There is already a location for all migration-related code for the Start page. This PR moves the C++ migration code introduced with https://github.com/FreeCAD/FreeCAD/pull/19473 to this location. Before, the `showCustomFolder` was written and then deleted by the C++ migration, on every FreeCAD start.
- The added benefit as well is that when in the future the full Start page migration is removed, it can be done from a single location 
- Code converted from C++ to Python
- Address lack of support for multiple path specification. The pre-1.0 Start Page with `showCustomFolder` featured the specification of multiple custom folder paths separated by `;;`. This is currently not supported, so if `showCustomFolder` is found to use this feature, use the first location before `;;` and discard the rest.