### PR TITLE
Add Start label for Start page PRs

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -80,6 +80,10 @@
 - changed-files:
   - any-glob-to-any-file:  ['src/Mod/Spreadsheet/**/*']
 
+"Mod: Start":
+- changed-files:
+  - any-glob-to-any-file:  ['src/Mod/Start/**/*']
+
 "Mod: Surface":
 - changed-files:
   - any-glob-to-any-file:  ['src/Mod/Surface/**/*/']


### PR DESCRIPTION
Currently PRs against the Start page sources are not automatically labeled as other parts of the code. This PR adds the `Mod: Start` label.