### PR TITLE
Gui: clean up PropertyItem::toString

### DIFF
--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -86,7 +86,7 @@ PropertyItem* PropertyItemFactory::createPropertyItem(const char* sName) const
 
 // ----------------------------------------------------
 
-QVariant PropertyItemAttorney::toString(PropertyItem* item, const QVariant& value)
+QString PropertyItemAttorney::toString(PropertyItem* item, const QVariant& value)
 {
     return item->toString(value);
 }
@@ -447,10 +447,10 @@ QString PropertyItem::toString(const Py::Object& pyobj) const
     return asString(pyobj);
 }
 
-QVariant PropertyItem::toString(const QVariant& prop) const
+QString PropertyItem::toString(const QVariant& prop) const
 {
     if (prop != QVariant() || propertyItems.size() != 1) {
-        return prop;
+        return prop.toString();
     }
 
     std::ostringstream ss;
@@ -982,16 +982,16 @@ QVariant PropertyIntegerItem::editorData(QWidget* editor) const
     return {sb->value()};
 }
 
-QVariant PropertyIntegerItem::toString(const QVariant& v) const
+QString PropertyIntegerItem::toString(const QVariant& v) const
 {
-    QString string(PropertyItem::toString(v).toString());
+    QString string(PropertyItem::toString(v));
 
     if (hasExpression()) {
         string +=
             QStringLiteral("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
     }
 
-    return {string};
+    return string;
 }
 
 
@@ -1064,16 +1064,16 @@ QVariant PropertyIntegerConstraintItem::editorData(QWidget* editor) const
     return {sb->value()};
 }
 
-QVariant PropertyIntegerConstraintItem::toString(const QVariant& v) const
+QString PropertyIntegerConstraintItem::toString(const QVariant& v) const
 {
-    QString string(PropertyItem::toString(v).toString());
+    QString string(PropertyItem::toString(v));
 
     if (hasExpression()) {
         string +=
             QStringLiteral("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
     }
 
-    return {string};
+    return string;
 }
 
 
@@ -1083,7 +1083,7 @@ PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyFloatItem)
 
 PropertyFloatItem::PropertyFloatItem() = default;
 
-QVariant PropertyFloatItem::toString(const QVariant& prop) const
+QString PropertyFloatItem::toString(const QVariant& prop) const
 {
     double value = prop.toDouble();
     QString data = QLocale().toString(value, 'f', decimals());
@@ -1092,7 +1092,7 @@ QVariant PropertyFloatItem::toString(const QVariant& prop) const
         data += QStringLiteral("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
     }
 
-    return {data};
+    return data;
 }
 
 QVariant PropertyFloatItem::value(const App::Property* prop) const
@@ -1149,7 +1149,7 @@ PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyUnitItem)
 
 PropertyUnitItem::PropertyUnitItem() = default;
 
-QVariant PropertyUnitItem::toString(const QVariant& prop) const
+QString PropertyUnitItem::toString(const QVariant& prop) const
 {
     const Base::Quantity& unit = prop.value<Base::Quantity>();
     std::string str = unit.getUserString();
@@ -1157,7 +1157,7 @@ QVariant PropertyUnitItem::toString(const QVariant& prop) const
         str += fmt::format("  ( {} )", getExpressionString());
     }
 
-    return {QString::fromStdString(str)};
+    return QString::fromStdString(str);
 }
 
 QVariant PropertyUnitItem::value(const App::Property* prop) const
@@ -1251,11 +1251,10 @@ PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyFloatConstraintItem)
 
 PropertyFloatConstraintItem::PropertyFloatConstraintItem() = default;
 
-QVariant PropertyFloatConstraintItem::toString(const QVariant& prop) const
+QString PropertyFloatConstraintItem::toString(const QVariant& prop) const
 {
     double value = prop.toDouble();
-    QString data = QLocale().toString(value, 'f', decimals());
-    return {data};
+    return QLocale().toString(value, 'f', decimals());
 }
 
 QVariant PropertyFloatConstraintItem::value(const App::Property* prop) const
@@ -1343,7 +1342,7 @@ void PropertyAngleItem::setEditorData(QWidget* editor, const QVariant& data) con
     PropertyUnitConstraintItem::setEditorData(editor, data);
 }
 
-QVariant PropertyAngleItem::toString(const QVariant& prop) const
+QString PropertyAngleItem::toString(const QVariant& prop) const
 {
     return PropertyUnitConstraintItem::toString(prop);
 }
@@ -1453,7 +1452,7 @@ PropertyVectorItem::PropertyVectorItem()
     this->appendChild(m_z);
 }
 
-QVariant PropertyVectorItem::toString(const QVariant& prop) const
+QString PropertyVectorItem::toString(const QVariant& prop) const
 {
     QLocale loc;
     const Base::Vector3d& value = prop.value<Base::Vector3d>();
@@ -1464,7 +1463,7 @@ QVariant PropertyVectorItem::toString(const QVariant& prop) const
     if (hasExpression()) {
         data += QStringLiteral("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
     }
-    return {data};
+    return data;
 }
 
 QVariant PropertyVectorItem::value(const App::Property* prop) const
@@ -1662,25 +1661,22 @@ PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyVectorListItem)
 
 PropertyVectorListItem::PropertyVectorListItem() = default;
 
-QVariant PropertyVectorListItem::toString(const QVariant& prop) const
+QString PropertyVectorListItem::toString(const QVariant& prop) const
 {
-    QLocale loc;
-    QString data;
     const QList<Base::Vector3d>& value = prop.value<QList<Base::Vector3d>>();
     if (value.isEmpty()) {
-        data = QStringLiteral("[]");
+        return QStringLiteral("[]");
     }
-    else {
-        data = QStringLiteral("[%1 %2 %3], ...")
-                   .arg(loc.toString(value[0].x, 'f', lowPrec),
-                        loc.toString(value[0].y, 'f', lowPrec),
-                        loc.toString(value[0].z, 'f', lowPrec));
-    }
+    QLocale loc;
+    QString data = QStringLiteral("[%1 %2 %3], ...")
+                .arg(loc.toString(value[0].x, 'f', lowPrec),
+                    loc.toString(value[0].y, 'f', lowPrec),
+                    loc.toString(value[0].z, 'f', lowPrec));
 
     if (hasExpression()) {
         data += QStringLiteral("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
     }
-    return {data};
+    return data;
 }
 
 QVariant PropertyVectorListItem::value(const App::Property* prop) const
@@ -1754,7 +1750,7 @@ PropertyVectorDistanceItem::PropertyVectorDistanceItem()
     this->appendChild(m_z);
 }
 
-QVariant PropertyVectorDistanceItem::toString(const QVariant& prop) const
+QString PropertyVectorDistanceItem::toString(const QVariant& prop) const
 {
     const Base::Vector3d& value = prop.value<Base::Vector3d>();
     std::string str = fmt::format("[{} {} {}]",
@@ -1764,7 +1760,7 @@ QVariant PropertyVectorDistanceItem::toString(const QVariant& prop) const
     if (hasExpression()) {
         str += fmt::format("  ( {} )", getExpressionString());
     }
-    return {QString::fromStdString(str)};
+    return QString::fromStdString(str);
 }
 
 
@@ -1799,7 +1795,7 @@ void PropertyVectorDistanceItem::setEditorData(QWidget* editor, const QVariant& 
 {
     auto le = qobject_cast<QLineEdit*>(editor);
     le->setProperty("coords", data);
-    le->setText(toString(data).toString());
+    le->setText(toString(data));
 }
 
 QWidget* PropertyVectorDistanceItem::createEditor(QWidget* parent,
@@ -1955,7 +1951,7 @@ PropertyMatrixItem::PropertyMatrixItem()
     this->appendChild(m_a44);
 }
 
-QVariant PropertyMatrixItem::toString(const QVariant& prop) const
+QString PropertyMatrixItem::toString(const QVariant& prop) const
 {
     QLocale loc;
     const Base::Matrix4D& value = prop.value<Base::Matrix4D>();
@@ -1978,7 +1974,7 @@ QVariant PropertyMatrixItem::toString(const QVariant& prop) const
                             loc.toString(value[3][2], 'f', lowPrec),
                             loc.toString(value[3][3], 'f', lowPrec));
     // NOLINTEND
-    return {text};
+    return text;
 }
 
 QVariant PropertyMatrixItem::value(const App::Property* prop) const
@@ -2038,29 +2034,8 @@ QWidget* PropertyMatrixItem::createEditor(QWidget* parent,
 
 void PropertyMatrixItem::setEditorData(QWidget* editor, const QVariant& data) const
 {
-    QLocale loc;
     auto le = qobject_cast<QLineEdit*>(editor);
-    const Base::Matrix4D& value = data.value<Base::Matrix4D>();
-    // NOLINTBEGIN
-    QString text = QStringLiteral("[%1 %2 %3 %4 %5 %6 %7 %8 %9 %10 %11 %12 %13 %14 %15 %16]")
-                       .arg(loc.toString(value[0][0], 'f', lowPrec),  //(unsigned short usNdx)
-                            loc.toString(value[0][1], 'f', lowPrec),
-                            loc.toString(value[0][2], 'f', lowPrec),
-                            loc.toString(value[0][3], 'f', lowPrec),
-                            loc.toString(value[1][0], 'f', lowPrec),
-                            loc.toString(value[1][1], 'f', lowPrec),
-                            loc.toString(value[1][2], 'f', lowPrec),
-                            loc.toString(value[1][3], 'f', lowPrec),
-                            loc.toString(value[2][0], 'f', lowPrec))
-                       .arg(loc.toString(value[2][1], 'f', lowPrec),
-                            loc.toString(value[2][2], 'f', lowPrec),
-                            loc.toString(value[2][3], 'f', lowPrec),
-                            loc.toString(value[3][0], 'f', lowPrec),
-                            loc.toString(value[3][1], 'f', lowPrec),
-                            loc.toString(value[3][2], 'f', lowPrec),
-                            loc.toString(value[3][3], 'f', lowPrec));
-    // NOLINTEND
-    le->setText(text);
+    le->setText(toString(data));
 }
 
 QVariant PropertyMatrixItem::editorData(QWidget* editor) const
@@ -2513,7 +2488,7 @@ QVariant PropertyRotationItem::toolTip(const App::Property* prop) const
     return {data};
 }
 
-QVariant PropertyRotationItem::toString(const QVariant& prop) const
+QString PropertyRotationItem::toString(const QVariant& prop) const
 {
     const Base::Rotation& p = prop.value<Base::Rotation>();
     double angle {};
@@ -2528,7 +2503,7 @@ QVariant PropertyRotationItem::toString(const QVariant& prop) const
                  loc.toString(dir.y, 'f', lowPrec),
                  loc.toString(dir.z, 'f', lowPrec),
                  QString::fromStdString(Base::Quantity(angle, Base::Unit::Angle).getUserString()));
-    return {data};
+    return data;
 }
 
 void PropertyRotationItem::setValue(const QVariant& value)
@@ -2821,7 +2796,7 @@ QVariant PropertyPlacementItem::toolTip(const App::Property* prop) const
     return {data};
 }
 
-QVariant PropertyPlacementItem::toString(const QVariant& prop) const
+QString PropertyPlacementItem::toString(const QVariant& prop) const
 {
     const Base::Placement& p = prop.value<Base::Placement>();
     double angle {};
@@ -2841,7 +2816,7 @@ QVariant PropertyPlacementItem::toString(const QVariant& prop) const
                  QString::fromStdString(Base::Quantity(pos.x, Base::Unit::Length).getUserString()),
                  QString::fromStdString(Base::Quantity(pos.y, Base::Unit::Length).getUserString()),
                  QString::fromStdString(Base::Quantity(pos.z, Base::Unit::Length).getUserString()));
-    return {data};
+    return data;
 }
 
 void PropertyPlacementItem::setValue(const QVariant& value)
@@ -3211,18 +3186,16 @@ QVariant PropertyStringListItem::editorData(QWidget* editor) const
     return {list};
 }
 
-QVariant PropertyStringListItem::toString(const QVariant& prop) const
+QString PropertyStringListItem::toString(const QVariant& prop) const
 {
     QStringList list = prop.toStringList();
     const int size = 10;
     if (list.size() > size) {
         list = list.mid(0, size);
-        list.append(QLatin1String("..."));
+        list.append(QStringLiteral("..."));
     }
 
-    QString text = QStringLiteral("[%1]").arg(list.join(QLatin1String(",")));
-
-    return {text};
+    return QStringLiteral("[%1]").arg(list.join(QLatin1Char(',')));
 }
 
 QVariant PropertyStringListItem::value(const App::Property* prop) const
@@ -3288,16 +3261,15 @@ QVariant PropertyFloatListItem::editorData(QWidget* editor) const
     return {list};
 }
 
-QVariant PropertyFloatListItem::toString(const QVariant& prop) const
+QString PropertyFloatListItem::toString(const QVariant& prop) const
 {
     QStringList list = prop.toStringList();
     const int size = 10;
     if (list.size() > size) {
         list = list.mid(0, size);
-        list.append(QLatin1String("..."));
+        list.append(QStringLiteral("..."));
     }
-    QString text = QStringLiteral("[%1]").arg(list.join(QLatin1String(",")));
-    return {text};
+    return QStringLiteral("[%1]").arg(list.join(QLatin1Char(',')));
 }
 
 QVariant PropertyFloatListItem::value(const App::Property* prop) const
@@ -3366,15 +3338,15 @@ QVariant PropertyIntegerListItem::editorData(QWidget* editor) const
     return {list};
 }
 
-QVariant PropertyIntegerListItem::toString(const QVariant& prop) const
+QString PropertyIntegerListItem::toString(const QVariant& prop) const
 {
     QStringList list = prop.toStringList();
     const int size = 10;
     if (list.size() > size) {
         list = list.mid(0, size);
-        list.append(QLatin1String("..."));
+        list.append(QStringLiteral("..."));
     }
-    QString text = QStringLiteral("[%1]").arg(list.join(QLatin1String(",")));
+    QString text = QStringLiteral("[%1]").arg(list.join(QLatin1Char(',')));
 
     return {text};
 }
@@ -3430,12 +3402,11 @@ QVariant PropertyColorItem::decoration(const QVariant& value) const
     return QVariant(p);
 }
 
-QVariant PropertyColorItem::toString(const QVariant& prop) const
+QString PropertyColorItem::toString(const QVariant& prop) const
 {
     auto value = prop.value<QColor>();
-    QString color =
+    return
         QStringLiteral("[%1, %2, %3]").arg(value.red()).arg(value.green()).arg(value.blue());
-    return {color};
 }
 
 QVariant PropertyColorItem::value(const App::Property* prop) const
@@ -3698,14 +3669,13 @@ QVariant PropertyMaterialItem::decoration(const QVariant& value) const
     return QVariant(p);
 }
 
-QVariant PropertyMaterialItem::toString(const QVariant& prop) const
+QString PropertyMaterialItem::toString(const QVariant& prop) const
 {
     // use the diffuse color
     auto val = prop.value<Material>();
     QColor value = val.diffuseColor;
-    QString color =
+    return
         QStringLiteral("[%1, %2, %3]").arg(value.red()).arg(value.green()).arg(value.blue());
-    return {color};
 }
 
 QVariant PropertyMaterialItem::toolTip(const App::Property* prop) const
@@ -4167,7 +4137,7 @@ QVariant PropertyMaterialListItem::decoration(const QVariant& value) const
     return QVariant(p);
 }
 
-QVariant PropertyMaterialListItem::toString(const QVariant& prop) const
+QString PropertyMaterialListItem::toString(const QVariant& prop) const
 {
     if (!prop.canConvert<QVariantList>()) {
         return {};
@@ -4185,9 +4155,8 @@ QVariant PropertyMaterialListItem::toString(const QVariant& prop) const
     // use the diffuse color
     auto mat = list[0].value<Material>();
     QColor value = mat.diffuseColor;
-    QString color =
+    return
         QStringLiteral("[%1, %2, %3]").arg(value.red()).arg(value.green()).arg(value.blue());
-    return {color};
 }
 
 QVariant PropertyMaterialListItem::toolTip(const App::Property* prop) const
@@ -4672,15 +4641,14 @@ PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyLinkItem)
 
 PropertyLinkItem::PropertyLinkItem() = default;
 
-QVariant PropertyLinkItem::toString(const QVariant& prop) const
+QString PropertyLinkItem::toString(const QVariant& prop) const
 {
-    QString res;
-    if (!propertyItems.empty()) {
-        App::DocumentObjectT owner(propertyItems[0]);
-        res = DlgPropertyLink::formatLinks(owner.getDocument(),
-                                           qvariant_cast<QList<App::SubObjectT>>(prop));
+    if (propertyItems.empty()) {
+        return {};
     }
-    return res;
+    App::DocumentObjectT owner(propertyItems[0]);
+    return DlgPropertyLink::formatLinks(owner.getDocument(),
+                                           qvariant_cast<QList<App::SubObjectT>>(prop));
 }
 
 QVariant PropertyLinkItem::data(int column, int role) const

--- a/src/Gui/propertyeditor/PropertyItem.h
+++ b/src/Gui/propertyeditor/PropertyItem.h
@@ -121,7 +121,7 @@ public:
 class PropertyItemAttorney
 {
 public:
-    static QVariant toString(PropertyItem* item, const QVariant& v);
+    static QString toString(PropertyItem* item, const QVariant& v);
 };
 
 class GuiExport PropertyItem: public QObject, public ExpressionBinding
@@ -207,7 +207,7 @@ protected:
     virtual QVariant displayName() const;
     virtual QVariant decoration(const QVariant&) const;
     virtual QVariant toolTip(const App::Property*) const;
-    virtual QVariant toString(const QVariant&) const;
+    virtual QString toString(const QVariant&) const;
     virtual QVariant value(const App::Property*) const;
     virtual void setValue(const QVariant&);
     virtual void initialize();
@@ -319,7 +319,7 @@ class GuiExport PropertyIntegerItem: public PropertyItem
     QVariant editorData(QWidget* editor) const override;
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -352,7 +352,7 @@ class GuiExport PropertyIntegerConstraintItem: public PropertyItem
     }
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -379,7 +379,7 @@ class GuiExport PropertyFloatItem: public PropertyItem
     QVariant editorData(QWidget* editor) const override;
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -401,7 +401,7 @@ class GuiExport PropertyUnitItem: public PropertyItem
     QVariant editorData(QWidget* editor) const override;
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -464,7 +464,7 @@ class GuiExport PropertyFloatConstraintItem: public PropertyItem
     }
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -499,7 +499,7 @@ class GuiExport PropertyAngleItem: public PropertyUnitConstraintItem
 
 protected:
     void setEditorData(QWidget* editor, const QVariant& data) const override;
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
 
 protected:
     PropertyAngleItem();
@@ -553,7 +553,7 @@ class GuiExport PropertyVectorItem: public PropertyItem
     void setZ(double z);
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -625,7 +625,7 @@ class GuiExport PropertyVectorListItem: public PropertyItem
     QVariant editorData(QWidget* editor) const override;
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -662,7 +662,7 @@ class GuiExport PropertyVectorDistanceItem: public PropertyItem
     void setZ(Base::Quantity z);
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -747,7 +747,7 @@ class GuiExport PropertyMatrixItem: public PropertyItem
     void setA44(double A44);
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -825,7 +825,7 @@ protected:
     PropertyRotationItem();
     ~PropertyRotationItem() override;
     QVariant toolTip(const App::Property*) const override;
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -887,7 +887,7 @@ protected:
     PropertyPlacementItem();
     ~PropertyPlacementItem() override;
     QVariant toolTip(const App::Property*) const override;
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -960,7 +960,7 @@ class GuiExport PropertyStringListItem: public PropertyItem
     QVariant editorData(QWidget* editor) const override;
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -982,7 +982,7 @@ class GuiExport PropertyFloatListItem: public PropertyItem
     QVariant editorData(QWidget* editor) const override;
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -1004,7 +1004,7 @@ class GuiExport PropertyIntegerListItem: public PropertyItem
     QVariant editorData(QWidget* editor) const override;
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -1027,7 +1027,7 @@ class GuiExport PropertyColorItem: public PropertyItem
 
 protected:
     QVariant decoration(const QVariant&) const override;
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -1077,7 +1077,7 @@ protected:
 
     QVariant decoration(const QVariant&) const override;
     QVariant toolTip(const App::Property*) const override;
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -1128,7 +1128,7 @@ protected:
 
     QVariant decoration(const QVariant&) const override;
     QVariant toolTip(const App::Property*) const override;
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
 
@@ -1267,7 +1267,7 @@ class GuiExport PropertyLinkItem: public PropertyItem
     QVariant editorData(QWidget* editor) const override;
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
     QVariant data(int column, int role) const override;

--- a/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
+++ b/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
@@ -47,7 +47,7 @@ PropertyConstraintListItem::PropertyConstraintListItem()
 PropertyConstraintListItem::~PropertyConstraintListItem()
 {}
 
-QVariant PropertyConstraintListItem::toString(const QVariant& prop) const
+QString PropertyConstraintListItem::toString(const QVariant& prop) const
 {
     const QList<Base::Quantity>& value = prop.value<QList<Base::Quantity>>();
     std::stringstream out;
@@ -59,7 +59,7 @@ QVariant PropertyConstraintListItem::toString(const QVariant& prop) const
         out << it->getUserString();
     }
     out << "]";
-    return QVariant(QString::fromStdString(out.str()));
+    return QString::fromStdString(out.str());
 }
 
 void PropertyConstraintListItem::initialize()
@@ -380,7 +380,7 @@ QWidget* PropertyConstraintListItem::createEditor(QWidget* parent,
 void PropertyConstraintListItem::setEditorData(QWidget* editor, const QVariant& data) const
 {
     QLineEdit* le = qobject_cast<QLineEdit*>(editor);
-    le->setText(toString(data).toString());
+    le->setText(toString(data));
 }
 
 QVariant PropertyConstraintListItem::editorData(QWidget* editor) const

--- a/src/Mod/Sketcher/Gui/PropertyConstraintListItem.h
+++ b/src/Mod/Sketcher/Gui/PropertyConstraintListItem.h
@@ -43,7 +43,7 @@ class PropertyConstraintListItem: public Gui::PropertyEditor::PropertyItem
     QVariant editorData(QWidget* editor) const override;
 
 protected:
-    QVariant toString(const QVariant&) const override;
+    QString toString(const QVariant&) const override;
     QVariant value(const App::Property*) const override;
     void setValue(const QVariant&) override;
     bool event(QEvent* ev) override;


### PR DESCRIPTION
I have no idea why the return type of `toString` was ever `QVariant`

I'm not even sure why there are so many `toString` functions implemented - I don't think they are ever used?