### PR TITLE
Start: fix fileview use scrollbars as needed

### DIFF
--- a/src/Mod/Start/Gui/FileCardView.cpp
+++ b/src/Mod/Start/Gui/FileCardView.cpp
@@ -39,7 +39,7 @@ FileCardView::FileCardView(QWidget* parent)
     sizePolicy.setHeightForWidth(true);
     setSizePolicy(sizePolicy);
     setHorizontalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAlwaysOff);
-    setVerticalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAlwaysOff);
+    setVerticalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAsNeeded);
     setViewMode(QListView::ViewMode::IconMode);
     setFlow(QListView::Flow::LeftToRight);
     setResizeMode(QListView::ResizeMode::Adjust);


### PR DESCRIPTION
if for whatever reason the viewport failed to resize let qt add the scrollbars

fixes #15113

if #19901 gets merged this will be very unlikely to happen, to my understanding it's an issue caused by lag between render and viewport realization, with the utilization of painter and styled delegate i couldn't reproduce the issue anymore, still this should be added as safeguard in case it happens to someone