### PR TITLE
Draft: fix Draft_Edit isAttachedToDocument issue

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -825,8 +825,7 @@ class Edit(gui_base_original.Modifier):
         """Restore objects style during editing mode.
         """
         for obj in objs:
-            if not obj.isAttachedToDocument():
-                # Object has been deleted.
+            if utils.is_deleted(obj):
                 continue
             obj_gui_tools = self.get_obj_gui_tools(obj)
             if obj_gui_tools:


### PR DESCRIPTION
Fixes #19939

The `isAttachedToDocument` method only works in certain circumstances.
https://forum.freecad.org/viewtopic.php?t=94709
