### PR TITLE
Draft: fix Draft_Trimex boundary subelement selection

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -323,10 +323,16 @@ class Trimex(gui_base_original.Modifier):
 
         # snapping
         if snapped:
-            snapped = self.doc.getObject(snapped['Object'])
-            if hasattr(snapped, "Shape"):
+            parent = snapped.get("ParentObject", None)
+            if parent:
+                subname = snapped["SubName"]
+            else:
+                parent = self.doc.getObject(snapped["Object"])
+                subname = snapped["Component"]
+            shape = Part.getShape(parent, subname, needSubElement=True, noElementMap=True)
+            if shape.Edges:
                 pts = []
-                for e in snapped.Shape.Edges:
+                for e in shape.Edges:
                     int = DraftGeomUtils.findIntersection(edge, e, True, True)
                     if int:
                         pts.extend(int)


### PR DESCRIPTION
Fixes #19614

Instead of using the whole object, the hovered subelement should be used for the boundary.

With this PR the handling of the boundary is also  'nesting-aware'. This is however still not the case for the object being extended/trimmed. That object has to be in the global space.
