### PR TITLE
Start: enable multiple custom folder paths

### DIFF
--- a/src/Mod/Start/App/CustomFolderModel.h
+++ b/src/Mod/Start/App/CustomFolderModel.h
@@ -25,7 +25,7 @@
 #define FREECAD_START_CUSTOMFOLDERMODEL_H
 
 #include <QAbstractListModel>
-#include <QDir>
+#include <QString>
 #include <Base/Parameter.h>
 
 #include "DisplayedFilesModel.h"
@@ -45,7 +45,7 @@ public:
     void loadCustomFolder();
 
 private:
-    QDir _customFolderDirectory;
+    QString _customFolderPathSpec;
     bool _showOnlyFCStd;  // Show only FreeCAD files
 };
 

--- a/src/Mod/Start/Gui/DlgStartPreferences.ui
+++ b/src/Mod/Start/Gui/DlgStartPreferences.ui
@@ -44,11 +44,12 @@
       <item row="1" column="1">
        <widget class="Gui::PrefFileChooser" name="fileChooserCustomFolder" native="true">
         <property name="toolTip">
-         <string>An optional custom folder to be displayed on the Start page.</string>
+         <string>An optional custom folder to be displayed on the Start page.
+By using &quot;;;&quot; to separate paths, you can add several folders here.</string>
         </property>
         <property name="mode">
          <enum>Gui::FileChooser::Directory</enum>
-	</property>
+        </property>
         <property name="prefEntry" stdset="0">
          <cstring>CustomFolder</cstring>
         </property>

--- a/src/Mod/Start/Gui/PreCompiled.h
+++ b/src/Mod/Start/Gui/PreCompiled.h
@@ -66,6 +66,7 @@
 #include <QSpacerItem>
 #include <QStackedWidget>
 #include <QString>
+#include <QStringList>
 #include <QStyleHints>
 #include <QStyleOptionViewItem>
 #include <QTimer>

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -53,6 +53,7 @@
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
 #include <gsl/pointers>
+#include <string>
 
 using namespace StartGui;
 
@@ -198,15 +199,7 @@ StartView::StartView(QWidget* parent)
     std::string customFolder(hGrp->GetASCII("CustomFolder", ""));
     bool showCustomFolder = false;
     if (!customFolder.empty()) {
-        auto customFolderDirectory = QDir(QString::fromStdString(customFolder));
-        if (customFolderDirectory.exists()) {
-            showCustomFolder = true;
-        }
-        else {
-            Base::Console().Warning(
-                "BaseApp/Preferences/Mod/Start/CustomFolder: '%s' does not exist\n",
-                customFolderDirectory.absolutePath().toStdString().c_str());
-        }
+        showCustomFolder = true;
     }
 
     // First start page

--- a/src/Mod/Start/StartMigrator.py
+++ b/src/Mod/Start/StartMigrator.py
@@ -57,7 +57,6 @@ class StartMigrator2024:
         self._remove_toolbars()
         self._remove_deprecated_parameters()
         self._mark_complete()
-        self._migrate_custom_folder()
         FreeCAD.Console.PrintMessage("done.\n")
 
     # If the old Start workbench was set as the Autoload Module, reconfigure it so the Start command is run at startup,
@@ -100,25 +99,17 @@ class StartMigrator2024:
         if "WebWorkbench" in groups:
             tux_prefs.RemGroup("WebWorkbench")
 
-    # In FreeCAD 1.1, the custom folder parameter was renamed from "ShowCustomFolder"
-    # to "CustomFolder". The new parameter does not yet support multiple locations.
-    def _migrate_custom_folder(self):
-        custom_folder = self.start_prefs.GetString("ShowCustomFolder", "")
-
-        # Note: multiple locations separated by ";;" are not supported at this time
-        # Use the first listed location and discard the rest
-        return custom_folder.split(";;")[0]
-
     # Delete old Start preferences
     def _remove_deprecated_parameters(self):
         show_on_startup = self.start_prefs.GetBool("ShowOnStartup", True)
         show_examples = self.start_prefs.GetBool("ShowExamples", True)
         close_start = self.start_prefs.GetBool("closeStart", False)
-        custom_folder = self._migrate_custom_folder()
+        custom_folder = self.start_prefs.GetString("ShowCustomFolder", "")
         self.start_prefs.Clear()
         self.start_prefs.SetBool("ShowOnStartup", show_on_startup)
         self.start_prefs.SetBool("ShowExamples", show_examples)
         self.start_prefs.SetBool("CloseStart", close_start)
+        # ShowCustomFolder renamed to CustomFolder in 1.1
         self.start_prefs.SetString("CustomFolder", custom_folder)
 
     # Indicate that this migration has been run


### PR DESCRIPTION
Brings back the same functionality from 0.21: the ability to specify multiple custom folders whose contents will be shown as a combined set of files in the "Custom Folder" file card on the Start page.

Multiple folder paths are specified using the `;;` separator (e.g. `/home/me/folder1;;/home/me/folder2`), in the file chooser entry on the Start page's preference dialog.

- [x] Add logic to split paths and load multiple folder contents
- [x] Update tooltip in the Start page's preferences dialog

![image](https://github.com/user-attachments/assets/dd8e9edd-8643-4457-ae54-9384d00c2e1d)

## Notes

1. The code to split paths has been adapted from https://stackoverflow.com/a/14266139/25233079 using standard C++. Using Qt classes could have been another alternative.
2. If any of the paths specified is not readable or does not exist, a warning is shown to the user. Entries from that location are not subsequently shown in the Custom Folder file card.
3. If none of the paths specified are correct as validated by the previous step, the Custom Folder file card is shown as empty. An alternative might be not to show it at all, but to keep the changes to a minimum, and given that this is consistent with Recent Files (shown even if empty) and Examples (shown even if empty), it is kept like this (Custom Files shown even if empty, if `CustomFolder` is defined).