### PR TITLE
CAM:  Added three command line options to the refactored postprocessors code base, with tests

### DIFF
--- a/src/Mod/CAM/CAMTests/TestRefactoredGrblPost.py
+++ b/src/Mod/CAM/CAMTests/TestRefactoredGrblPost.py
@@ -120,7 +120,7 @@ G54
 (Path: TC: Default Tool)
 (TC: Default Tool)
 (Begin toolchange)
-( M6 T1 )
+(M6 T1)
 (Finish operation: TC: Default Tool)
 (Begin operation: Profile)
 (Path: Profile)
@@ -307,7 +307,7 @@ M2
         self.job.PostProcessorArgs = "--no-header --no-show-editor"
         gcode = self.post.export()[0][1]
         # print(f"--------{nl}{gcode}--------{nl}")
-        self.assertEqual(gcode.splitlines()[16], "( M6 T2 )")
+        self.assertEqual(gcode.splitlines()[16], "(M6 T2)")
         self.assertEqual(gcode.splitlines()[17], "M3 S3000")
 
         # suppress TLO

--- a/src/Mod/CAM/CAMTests/TestRefactoredTestPostGCodes.py
+++ b/src/Mod/CAM/CAMTests/TestRefactoredTestPostGCodes.py
@@ -774,14 +774,14 @@ G54
 (Begin operation)
 (TC: Default Tool)
 (Begin toolchange)
-( M6 T1 )
+(M6 T1)
 (Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
 G90
-( G99 )
-( G73 X1.000 Y2.000 Z0.000 R5.000 Q1.500 F7380.000 )
+(G99)
+(G73 X1.000 Y2.000 Z0.000 R5.000 Q1.500 F7380.000)
 G0 X1.000 Y2.000
 G1 Z5.000 F7380.000
 G1 Z3.500 F7380.000
@@ -795,7 +795,7 @@ G0 Z0.750
 G0 Z0.575
 G1 Z0.000 F7380.000
 G0 Z5.000
-( G80 )
+(G80)
 G90
 (Finish operation: Profile)
 (Begin postamble)
@@ -873,14 +873,14 @@ G54
 (Begin operation)
 (TC: Default Tool)
 (Begin toolchange)
-( M6 T1 )
+(M6 T1)
 (Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
 G91
-( G99 )
-( G73 X1.000 Y2.000 Z0.000 R5.000 Q1.500 F7380.000 )
+(G99)
+(G73 X1.000 Y2.000 Z0.000 R5.000 Q1.500 F7380.000)
 G90
 G0 Z13.000
 G0 X2.000 Y4.000
@@ -896,7 +896,7 @@ G0 Z8.575
 G1 Z8.000 F7380.000
 G0 Z13.000
 G91
-( G80 )
+(G80)
 G90
 (Finish operation: Profile)
 (Begin postamble)
@@ -961,19 +961,19 @@ G54
 (Begin operation)
 (TC: Default Tool)
 (Begin toolchange)
-( M6 T1 )
+(M6 T1)
 (Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
 G90
-( G99 )
-( G81 X1.000 Y2.000 Z0.000 R5.000 F7380.000 )
+(G99)
+(G81 X1.000 Y2.000 Z0.000 R5.000 F7380.000)
 G0 X1.000 Y2.000
 G1 Z5.000 F7380.000
 G1 Z0.000 F7380.000
 G0 Z5.000
-( G80 )
+(G80)
 G90
 (Finish operation: Profile)
 (Begin postamble)
@@ -1042,21 +1042,21 @@ G54
 (Begin operation)
 (TC: Default Tool)
 (Begin toolchange)
-( M6 T1 )
+(M6 T1)
 (Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
 G91
-( G99 )
-( G81 X1.000 Y2.000 Z0.000 R5.000 F7380.000 )
+(G99)
+(G81 X1.000 Y2.000 Z0.000 R5.000 F7380.000)
 G90
 G0 Z13.000
 G0 X2.000 Y4.000
 G1 Z8.000 F7380.000
 G0 Z13.000
 G91
-( G80 )
+(G80)
 G90
 (Finish operation: Profile)
 (Begin postamble)
@@ -1122,20 +1122,20 @@ G54
 (Begin operation)
 (TC: Default Tool)
 (Begin toolchange)
-( M6 T1 )
+(M6 T1)
 (Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
 G90
-( G99 )
-( G82 X1.000 Y2.000 Z0.000 R5.000 P1.23456 F7380.000 )
+(G99)
+(G82 X1.000 Y2.000 Z0.000 R5.000 P1.23456 F7380.000)
 G0 X1.000 Y2.000
 G1 Z5.000 F7380.000
 G1 Z0.000 F7380.000
 G4 P1.23456
 G0 Z5.000
-( G80 )
+(G80)
 G90
 (Finish operation: Profile)
 (Begin postamble)
@@ -1205,14 +1205,14 @@ G54
 (Begin operation)
 (TC: Default Tool)
 (Begin toolchange)
-( M6 T1 )
+(M6 T1)
 (Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
 G91
-( G99 )
-( G82 X1.000 Y2.000 Z0.000 R5.000 P1.23456 F7380.000 )
+(G99)
+(G82 X1.000 Y2.000 Z0.000 R5.000 P1.23456 F7380.000)
 G90
 G0 Z13.000
 G0 X2.000 Y4.000
@@ -1220,7 +1220,7 @@ G1 Z8.000 F7380.000
 G4 P1.23456
 G0 Z13.000
 G91
-( G80 )
+(G80)
 G90
 (Finish operation: Profile)
 (Begin postamble)
@@ -1294,14 +1294,14 @@ G54
 (Begin operation)
 (TC: Default Tool)
 (Begin toolchange)
-( M6 T1 )
+(M6 T1)
 (Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
 G90
-( G99 )
-( G83 X1.000 Y2.000 Z0.000 R5.000 Q1.500 F7380.000 )
+(G99)
+(G83 X1.000 Y2.000 Z0.000 R5.000 Q1.500 F7380.000)
 G0 X1.000 Y2.000
 G1 Z5.000 F7380.000
 G1 Z3.500 F7380.000
@@ -1315,7 +1315,7 @@ G0 Z5.000
 G0 Z0.575
 G1 Z0.000 F7380.000
 G0 Z5.000
-( G80 )
+(G80)
 G90
 (Finish operation: Profile)
 (Begin postamble)
@@ -1393,14 +1393,14 @@ G54
 (Begin operation)
 (TC: Default Tool)
 (Begin toolchange)
-( M6 T1 )
+(M6 T1)
 (Finish operation: TC: Default Tool)
 (Begin operation)
 G0 X1.000 Y2.000
 G0 Z8.000
 G91
-( G99 )
-( G83 X1.000 Y2.000 Z0.000 R5.000 Q1.500 F7380.000 )
+(G99)
+(G83 X1.000 Y2.000 Z0.000 R5.000 Q1.500 F7380.000)
 G90
 G0 Z13.000
 G0 X2.000 Y4.000
@@ -1416,7 +1416,7 @@ G0 Z8.575
 G1 Z8.000 F7380.000
 G0 Z13.000
 G91
-( G80 )
+(G80)
 G90
 (Finish operation: Profile)
 (Begin postamble)

--- a/src/Mod/CAM/Path/Post/UtilsArguments.py
+++ b/src/Mod/CAM/Path/Post/UtilsArguments.py
@@ -88,10 +88,13 @@ def init_argument_defaults(argument_defaults: Dict[str, bool]) -> None:
 
 def init_arguments_visible(arguments_visible: Dict[str, bool]) -> None:
     """Initialize the flags for which arguments are visible in the arguments tooltip."""
-    arguments_visible["bcnc"] = False
     arguments_visible["axis-modal"] = True
     arguments_visible["axis-precision"] = True
+    arguments_visible["bcnc"] = False
+    arguments_visible["chipbreaking_amount"] = False
+    arguments_visible["command_space"] = False
     arguments_visible["comments"] = True
+    arguments_visible["comment_symbol"] = False
     arguments_visible["feed-precision"] = True
     arguments_visible["header"] = True
     arguments_visible["line-numbers"] = True
@@ -167,6 +170,29 @@ def init_shared_arguments(
         "Suppress bCNC block header output",
         arguments_visible["bcnc"],
     )
+    if arguments_visible["chipbreaking_amount"]:
+        help_message = (
+            "Amount to move for chipbreaking in a translated G73 command, "
+            f'default is {str(values["CHIPBREAKING_AMOUNT"])}'
+        )
+    else:
+        help_message = argparse.SUPPRESS
+    shared.add_argument(
+        "--chipbreaking_amount",
+        help=help_message,
+    )
+    if arguments_visible["command_space"]:
+        help_message = (
+            "The character to use between parts of a command, "
+            "default is a space, may also use a null string"
+        )
+    else:
+        help_message = argparse.SUPPRESS
+    shared.add_argument(
+        "--command_space",
+        default=" ",
+        help=help_message,
+    )
     add_flag_type_arguments(
         shared,
         argument_defaults["comments"],
@@ -175,6 +201,16 @@ def init_shared_arguments(
         "Output comments",
         "Suppress comment output",
         arguments_visible["comments"],
+    )
+    if arguments_visible["comment_symbol"]:
+        help_message = (
+            f'The character used to start a comment, default is "{values["COMMENT_SYMBOL"]}"'
+        )
+    else:
+        help_message = argparse.SUPPRESS
+    shared.add_argument(
+        "--comment_symbol",
+        help=help_message,
     )
     if arguments_visible["feed-precision"]:
         help_message = (
@@ -680,10 +716,15 @@ def process_shared_arguments(
             values["OUTPUT_BCNC"] = True
         if args.no_bcnc:
             values["OUTPUT_BCNC"] = False
+        if args.chipbreaking_amount:
+            values["CHIPBREAKING_AMOUNT"] = Units.parseQuantity(args.chipbreaking_amount)
+        values["COMMAND_SPACE"] = args.command_space
         if args.comments:
             values["OUTPUT_COMMENTS"] = True
         if args.no_comments:
             values["OUTPUT_COMMENTS"] = False
+        if args.comment_symbol:
+            values["COMMENT_SYMBOL"] = args.comment_symbol
         if args.header:
             values["OUTPUT_HEADER"] = True
         if args.no_header:

--- a/src/Mod/CAM/Path/Post/UtilsParse.py
+++ b/src/Mod/CAM/Path/Post/UtilsParse.py
@@ -82,12 +82,7 @@ def check_for_drill_translate(
 
     if values["TRANSLATE_DRILL_CYCLES"] and command in values["DRILL_CYCLES_TO_TRANSLATE"]:
         if values["OUTPUT_COMMENTS"]:  # Comment the original command
-            comment = create_comment(
-                values,
-                values["COMMAND_SPACE"]
-                + format_command_line(values, command_line)
-                + values["COMMAND_SPACE"],
-            )
+            comment = create_comment(values, format_command_line(values, command_line))
             gcode.append(f"{linenumber(values)}{comment}{nl}")
         # wrap this block to ensure that the value of values["MOTION_MODE"]
         # is restored in case of error
@@ -147,12 +142,7 @@ def check_for_suppressed_commands(
     if command in values["SUPPRESS_COMMANDS"]:
         if values["OUTPUT_COMMENTS"]:
             # convert the command to a comment
-            comment = create_comment(
-                values,
-                values["COMMAND_SPACE"]
-                + format_command_line(values, command_line)
-                + values["COMMAND_SPACE"],
-            )
+            comment = create_comment(values, format_command_line(values, command_line))
             gcode.append(f"{linenumber(values)}{comment}{nl}")
         # remove the command
         return True
@@ -186,12 +176,7 @@ def check_for_tool_change(
                 gcode.append(f"{linenumber(values)}{line}{nl}")
         elif values["OUTPUT_COMMENTS"]:
             # convert the tool change to a comment
-            comment = create_comment(
-                values,
-                values["COMMAND_SPACE"]
-                + format_command_line(values, command_line)
-                + values["COMMAND_SPACE"],
-            )
+            comment = create_comment(values, format_command_line(values, command_line))
             gcode.append(f"{linenumber(values)}{comment}{nl}")
             return True
     return False


### PR DESCRIPTION
The refactored* postprocessor shared code base has many configuration choices that don't have command line options.

This PR adds three command line options along with their corresponding tooltip info and tests.

This PR is the first of several to keep the PR from getting too big.

Please assign this to me.  Thanks!
