### PR TITLE
Coverity fixes 2025.03.02

### DIFF
--- a/src/App/Branding.cpp
+++ b/src/App/Branding.cpp
@@ -93,7 +93,7 @@ Branding::XmlConfig Branding::getUserDefines() const
             std::string name = child.localName().toLatin1().constData();
             std::string value = child.text().toUtf8().constData();
             if (std::ranges::find(filter, name) != filter.end()) {
-                cfg[name] = value;
+                cfg[name] = std::move(value);
             }
             child = child.nextSiblingElement();
         }

--- a/src/App/ComplexGeoData.cpp
+++ b/src/App/ComplexGeoData.cpp
@@ -653,8 +653,11 @@ void ComplexGeoData::RestoreDocFile(Base::Reader& reader)
             return;
         }
     }
-    std::size_t count = atoi(marker.c_str());
-    restoreStream(reader, count);
+    auto count = atoll(marker.c_str());  // Try to prevent UB if the number is unreasonably large
+    if (count < 0 || count > std::numeric_limits<int>::max()) {
+        FC_THROWM(Base::RuntimeError, "Failed to restore element map " << _persistenceName);
+    }
+    restoreStream(reader, static_cast<std::size_t>(count));
 }
 
 unsigned int ComplexGeoData::getMemSize() const

--- a/src/App/ComplexGeoData.cpp
+++ b/src/App/ComplexGeoData.cpp
@@ -586,6 +586,11 @@ void ComplexGeoData::restoreStream(std::istream& stream, std::size_t count)
                 // NOLINTNEXTLINE
                 FC_THROWM(Base::RuntimeError, "Failed to restore element map " << _persistenceName);
             }
+            constexpr std::size_t oneGbOfInts {(1 << 30) / sizeof(int)};
+            if (sCount > oneGbOfInts) {
+                // NOLINTNEXTLINE
+                FC_THROWM(Base::RuntimeError, "Failed to restore element map (>1GB) " << _persistenceName);
+            }
             sids.reserve(static_cast<int>(sCount));
             for (std::size_t j = 0; j < sCount; ++j) {
                 long id = 0;

--- a/src/App/ComplexGeoData.h
+++ b/src/App/ComplexGeoData.h
@@ -369,7 +369,7 @@ public:
      */
     void traceElement(const MappedName& name, TraceCallback cb) const
     {
-        _elementMap->traceElement(name, Tag, cb);
+        _elementMap->traceElement(name, Tag, std::move(cb));
     }
 
     /** Flush an internal buffering for element mapping */

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -1162,7 +1162,7 @@ void DocumentObject::Save(Base::Writer& writer) const
 
 void DocumentObject::setExpression(const ObjectIdentifier& path, std::shared_ptr<Expression> expr)
 {
-    ExpressionEngine.setValue(path, expr);
+    ExpressionEngine.setValue(path, std::move(expr));
 }
 
 /**

--- a/src/App/DocumentObjectPyImp.cpp
+++ b/src/App/DocumentObjectPyImp.cpp
@@ -383,7 +383,7 @@ PyObject* DocumentObjectPy::setExpression(PyObject* args)
             shared_expr->comment = comment;
         }
 
-        getDocumentObjectPtr()->setExpression(p, shared_expr);
+        getDocumentObjectPtr()->setExpression(p, std::move(shared_expr));
         Py_Return;
     }
 

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1728,7 +1728,7 @@ FunctionExpression::FunctionExpression(const DocumentObject *_owner, Function _f
     : UnitExpression(_owner)
     , f(_f)
     , fname(std::move(name))
-    , args(_args)
+    , args(std::move(_args))
 {
     switch (f) {
     case ABS:
@@ -2643,7 +2643,7 @@ Expression *FunctionExpression::simplify() const
         return eval();
     }
     else
-        return new FunctionExpression(owner, f, std::string(fname), a);
+        return new FunctionExpression(owner, f, std::string(fname), std::move(a));
 }
 
 /**
@@ -2811,7 +2811,7 @@ Expression *FunctionExpression::_copy() const
         a.push_back((*i)->copy());
         ++i;
     }
-    return new FunctionExpression(owner, f, std::string(fname), a);
+    return new FunctionExpression(owner, f, std::string(fname), std::move(a));
 }
 
 void FunctionExpression::_visit(ExpressionVisitor &v)

--- a/src/App/ExpressionTokenizer.cpp
+++ b/src/App/ExpressionTokenizer.cpp
@@ -75,14 +75,17 @@ QString ExpressionTokenizer::perform(const QString& prefix, int pos)
     // Pop those trailing tokens depending on the given position, which may be
     // in the middle of a token, and we shall include that token.
     for (auto it = tokens.begin(); it != tokens.end(); ++it) {
-        if (std::get<1>(*it) >= pos) {
+        int tokenType = std::get<0>(*it);
+        int location = std::get<1>(*it);
+        int tokenLength = static_cast<int> (std::get<2>(*it).size());
+        if (location >= pos) {
             // Include the immediately followed '.' or '#', because we'll be
             // inserting these separators too, in ExpressionCompleteModel::pathFromIndex()
-            if (it != tokens.begin() && std::get<0>(*it) != '.' && std::get<0>(*it) != '#') {
+            if (it != tokens.begin() && tokenType != '.' && tokenType != '#') {
                 it = it - 1;
             }
-            tokens.resize(it - tokens.begin() + 1);
-            prefixEnd = start + std::get<1>(*it) + (int)std::get<2>(*it).size();
+            tokens.resize(it - tokens.begin() + 1); // Invalidates it, but we already calculated tokenLength
+            prefixEnd = start + location + tokenLength;
             break;
         }
     }

--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -223,14 +223,6 @@ bool GeoFeature::getCameraAlignmentDirection(Base::Vector3d& direction, const ch
 bool GeoFeature::hasMissingElement(const char* subname)
 {
     return Data::hasMissingElement(subname);
-    if (!subname) {
-        return false;
-    }
-    auto dot = strrchr(subname, '.');
-    if (!dot) {
-        return subname[0] == '?';
-    }
-    return dot[1] == '?';
 }
 
 void GeoFeature::updateElementReference()

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -421,10 +421,8 @@ bool GeoFeatureGroupExtension::extensionGetSubObject(DocumentObject*& ret,
             }
         }
         if (ret) {
-            if (dot) {
-                ++dot;
-            }
-            if (dot && *dot && !ret->hasExtension(App::LinkBaseExtension::getExtensionClassTypeId())
+            ++dot;
+            if (*dot && !ret->hasExtension(App::LinkBaseExtension::getExtensionClassTypeId())
                 && !ret->hasExtension(App::GeoFeatureGroupExtension::getExtensionClassTypeId())) {
                 // Consider this
                 // Body
@@ -451,7 +449,7 @@ bool GeoFeatureGroupExtension::extensionGetSubObject(DocumentObject*& ret,
                 *mat *=
                     const_cast<GeoFeatureGroupExtension*>(this)->placement().getValue().toMatrix();
             }
-            ret = ret->getSubObject(dot ? dot : "", pyObj, mat, true, depth + 1);
+            ret = ret->getSubObject(dot, pyObj, mat, true, depth + 1);
         }
     }
     return true;

--- a/src/Gui/DAGView/DAGRectItem.cpp
+++ b/src/Gui/DAGView/DAGRectItem.cpp
@@ -64,7 +64,7 @@ void RectItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, 
         styleOption.state |= QStyle::State_Selected;
         QPalette palette = styleOption.palette;
         QColor tempColor = palette.color(QPalette::Active, QPalette::Highlight);
-        tempColor.setAlphaF(0.15);
+        tempColor.setAlphaF(0.15F);
         palette.setColor(QPalette::Inactive, QPalette::Highlight, tempColor);
         styleOption.palette = palette;
       }


### PR DESCRIPTION
Most of the fixes are trivial (use of `std::move`), but a couple of them are more subtle and need careful review. No functional changes are intended. The most serious of these is the fixed iterator invalidation on the expression parsing: everything else is basically just performance.