### PR TITLE
Remove Python-generated bindings comparison against XML-generated versions

### DIFF
--- a/src/Tools/bindings/generate.py
+++ b/src/Tools/bindings/generate.py
@@ -59,8 +59,6 @@ def generate(filename, outputPath):
         Export.export = GenerateModelInst.PythonExport[0]
         Export.is_python = filename.endswith(".pyi")
         Export.Generate()
-        if Export.is_python:
-            Export.Compare()
         print("Done generating: " + GenerateModelInst.PythonExport[0].Name)
 
 


### PR DESCRIPTION
https://github.com/FreeCAD/FreeCAD/pull/19450 has caused build errors across Debian, Fedora and Arch.

There is some weirdness going on which I will have to track down. While that is going on, disable the shadow mode comparison to fix the builds. This is ok since the Python-generated files are still not being used for compilation.

Silver lining here is that at least the comparison mode is working and showing problems, question remains why all CI builds are fine but not the external ones.

Related: 

https://github.com/FreeCAD/FreeCAD/issues/19956

https://github.com/FreeCAD/FreeCAD-snap/issues/178

