### PR TITLE
[no merge] Fix compile: missing pyside6

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -217,21 +217,17 @@ if(FREECAD_USE_SHIBOKEN)
         SYSTEM
         ${SHIBOKEN_INCLUDE_DIR}
     )
-    if (SHIBOKEN_LIBRARY)
-        list(APPEND FreeCADGui_LIBS
-            ${SHIBOKEN_LIBRARY}
+       
+    if (TARGET Shiboken2::libshiboken)
+    	list(APPEND FreeCADGui_LIBS
+    		Shiboken2::libshiboken
         )
-    else (SHIBOKEN_LIBRARY)
-        if (TARGET Shiboken2::libshiboken)
-            list(APPEND FreeCADGui_LIBS
-                Shiboken2::libshiboken
-            )
-        elseif (TARGET Shiboken6::libshiboken)
-            list(APPEND FreeCADGui_LIBS
-                Shiboken6::libshiboken
-            )
-        endif (TARGET Shiboken2::libshiboken)
-    endif (SHIBOKEN_LIBRARY)
+    elseif (TARGET Shiboken6::libshiboken)
+        list(APPEND FreeCADGui_LIBS
+    		Shiboken6::libshiboken
+        )
+    endif()
+        
 endif(FREECAD_USE_SHIBOKEN)
 
 if(FREECAD_USE_PYSIDE)
@@ -240,26 +236,19 @@ if(FREECAD_USE_PYSIDE)
         ${PYSIDE_INCLUDE_DIR}
         ${PYSIDE_INCLUDE_DIR}/QtCore
         ${PYSIDE_INCLUDE_DIR}/QtGui
-    )
-    if (PYSIDE_LIBRARY)
-        list(APPEND FreeCADGui_LIBS
-            ${PYSIDE_LIBRARY}
-        )
-    else (PYSIDE_LIBRARY)
-        if (TARGET PySide2::pyside2)
-            list(APPEND FreeCADGui_LIBS
-                PySide2::pyside2
-            )
-        elseif (TARGET PySide6::pyside6)
-            list(APPEND FreeCADGui_LIBS
-                PySide6::pyside6
-            )
-        endif ()
-    endif (PYSIDE_LIBRARY)
-    include_directories(
-        SYSTEM
         ${PYSIDE_INCLUDE_DIR}/QtWidgets
     )
+
+    if (TARGET PySide2::pyside2)
+    	list(APPEND FreeCADGui_LIBS
+    		PySide2::pyside2
+    	)
+    elseif (TARGET PySide6::pyside6)
+        list(APPEND FreeCADGui_LIBS
+     	   PySide6::pyside6
+        )
+    endif()
+ 
     add_definitions(-DHAVE_PYSIDE${PYSIDE_MAJOR_VERSION})
 endif(FREECAD_USE_PYSIDE)
 


### PR DESCRIPTION
fix #18104
Compile under debian/: Missing pyside6

the removed code overwrites the pyside and shiboken environment variables, and creating compilation problems.

Problems could also occur when using qt 6 and qt5 was present.

fix:

CMake Error in src/Gui/CMakeLists.txt:
  Imported target "PySide6::pyside6" includes non-existent path

    "/usr/lib/include/PySide6"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.

