### PR TITLE
Fix precompiled build

### DIFF
--- a/src/Base/PreCompiled.h
+++ b/src/Base/PreCompiled.h
@@ -78,6 +78,7 @@
 #include <mutex>
 #include <bitset>
 #include <algorithm>
+#include <iomanip>
 
 // streams
 #include <iostream>


### PR DESCRIPTION
Rebased today and get build errors : 
Base/Color.cpp : setfill not defined in std


Apparantly this header 
`#include <iomanip>`
Is needed and is not in precompiled.h

@chennes 