### PR TITLE
Draft: fix make_sketch hang

### DIFF
--- a/src/Mod/Draft/draftmake/make_sketch.py
+++ b/src/Mod/Draft/draftmake/make_sketch.py
@@ -238,9 +238,9 @@ def make_sketch(objects_list, autoconstraints=False, addTo=None,
     nobj.addConstraint(constraints)
     if autoconstraints:
         nobj.detectMissingPointOnPointConstraints(utils.tolerance())
-        nobj.makeMissingPointOnPointCoincident(True)
+        nobj.makeMissingPointOnPointCoincident(False)
         nobj.detectMissingVerticalHorizontalConstraints(utils.tolerance())
-        nobj.makeMissingVerticalHorizontal(True)
+        nobj.makeMissingVerticalHorizontal(False)
 
     return nobj
 


### PR DESCRIPTION
Fixes #19978

The onebyone argument of makeMissingPointOnPointCoincident and makeMissingVerticalHorizontal should be set to False.