### PR TITLE
Fixes light direction configuration issues between 1.0 and 1.1dev

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
@@ -48,13 +48,6 @@ using namespace Gui::Dialog;
 
 /* TRANSLATOR Gui::Dialog::DlgSettingsLightSources */
 
-static inline SbVec3f getDirectionVector(const SbRotation& rotation)
-{
-    SbVec3f dir {0.0f, 0.0f, -1.0f};
-    rotation.multVec(dir, dir);
-    return dir;
-}
-
 DlgSettingsLightSources::DlgSettingsLightSources(QWidget* parent)
     : PreferencePage(parent)
     , ui(new Ui_DlgSettingsLightSources)

--- a/src/Gui/PreferencePages/DlgSettingsLightSources.h
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.h
@@ -77,7 +77,7 @@ private:
     QPointer <View3DInventorViewer> view;
     SoOrthographicCamera *camera = nullptr;
 
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View/LightSources");
 
     float zoomStep = 3.0f;
 };

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -111,6 +111,29 @@ void View3DSettings::applySettings()
     OnChange(*lightSourcesGrp,"AmbientLightColor");
     OnChange(*lightSourcesGrp,"AmbientLightIntensity");
 
+    // Workaround
+    // Clear old settings that was used for a while in 1.1dev
+    // By clearing these settings, 1.0 will be able to run with same config file again
+    // For more info: https://github.com/FreeCAD/FreeCAD/issues/19880
+    // TODO: Remove when 1.1.0 is about to be released
+    if (hGrp->GetASCII("FillLightDirection").empty()) {
+        hGrp->RemoveBool("EnableHeadlight");
+        hGrp->RemoveUnsigned("HeadlightColor");
+        hGrp->RemoveASCII("HeadlightDirection");
+        hGrp->RemoveInt("HeadlightIntensity");
+        hGrp->RemoveBool("EnableBacklight");
+        hGrp->RemoveUnsigned("BacklightColor");
+        hGrp->RemoveASCII("BacklightDirection");
+        hGrp->RemoveInt("BacklightIntensity");
+        hGrp->RemoveBool("EnableFillLight");
+        hGrp->RemoveUnsigned("FillLightColor");
+        hGrp->RemoveASCII("FillLightDirection");
+        hGrp->RemoveInt("FillLightIntensity");
+        hGrp->RemoveUnsigned("AmbientLightColor");
+        hGrp->RemoveInt("AmbientLightIntensity");
+    }
+    // End of workaround
+
     OnChange(*hGrp,"NavigationStyle");
     OnChange(*hGrp,"OrbitStyle");
     OnChange(*hGrp,"Sensitivity");

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -94,20 +94,23 @@ void View3DSettings::applySettings()
     OnChange(*hGrp,"UseVBO");
     OnChange(*hGrp,"RenderCache");
     OnChange(*hGrp,"Orthographic");
-    OnChange(*hGrp,"EnableHeadlight");
-    OnChange(*hGrp,"HeadlightColor");
-    OnChange(*hGrp,"HeadlightDirection");
-    OnChange(*hGrp,"HeadlightIntensity");
-    OnChange(*hGrp,"EnableBacklight");
-    OnChange(*hGrp,"BacklightColor");
-    OnChange(*hGrp,"BacklightDirection");
-    OnChange(*hGrp,"BacklightIntensity");
-    OnChange(*hGrp,"EnableFillLight");
-    OnChange(*hGrp,"FillLightColor");
-    OnChange(*hGrp,"FillLightDirection");
-    OnChange(*hGrp,"FillLightIntensity");
-    OnChange(*hGrp,"AmbientLightColor");
-    OnChange(*hGrp,"AmbientLightIntensity");
+
+    auto lightSourcesGrp = hGrp->GetGroup("LightSources");
+    OnChange(*lightSourcesGrp,"EnableHeadlight");
+    OnChange(*lightSourcesGrp,"HeadlightColor");
+    OnChange(*lightSourcesGrp,"HeadlightDirection");
+    OnChange(*lightSourcesGrp,"HeadlightIntensity");
+    OnChange(*lightSourcesGrp,"EnableBacklight");
+    OnChange(*lightSourcesGrp,"BacklightColor");
+    OnChange(*lightSourcesGrp,"BacklightDirection");
+    OnChange(*lightSourcesGrp,"BacklightIntensity");
+    OnChange(*lightSourcesGrp,"EnableFillLight");
+    OnChange(*lightSourcesGrp,"FillLightColor");
+    OnChange(*lightSourcesGrp,"FillLightDirection");
+    OnChange(*lightSourcesGrp,"FillLightIntensity");
+    OnChange(*lightSourcesGrp,"AmbientLightColor");
+    OnChange(*lightSourcesGrp,"AmbientLightIntensity");
+
     OnChange(*hGrp,"NavigationStyle");
     OnChange(*hGrp,"OrbitStyle");
     OnChange(*hGrp,"Sensitivity");


### PR DESCRIPTION
* Move configuration for light sources into a new group (no reused settings anymore)
* Clear reused settings if found, making 1.0 get default values when loaded next time

Fixes https://github.com/FreeCAD/FreeCAD/issues/19879