### PR TITLE
CMake: Silence Coin3D deprecation warning

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
+++ b/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
@@ -6,8 +6,11 @@ macro(SetupCoin3D)
         find_library(COIN3D_LIBRARIES Coin)
     endif ()
 
-    # Try CONFIG mode
+    # Try CONFIG mode -- Coin supports very old CMake files, which emits noisy warnings. Silence them.
+    set(CMAKE_WARN_DEPRECATED_OLD_STATE ${CMAKE_WARN_DEPRECATED})
+    set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
     find_package(Coin CONFIG)
+    set(CMAKE_WARN_DEPRECATED ${CMAKE_WARN_DEPRECATED_OLD_STATE} CACHE BOOL "" FORCE)
     if (Coin_FOUND)
         set(COIN3D_INCLUDE_DIRS ${Coin_INCLUDE_DIR})
         set(COIN3D_LIBRARIES ${Coin_LIBRARIES})


### PR DESCRIPTION
In recent versions of CMake, Coin3D's support for using older versions of CMake causes a fairly noisy deprecation warning. Coin's support for old CMake doesn't seem to cause any problems (at least in the CMake 3.x line) so I think it is reasonably safe to silence this warning.