### PR TITLE
QuantitySpinbox: Fix right padding when not bound

### DIFF
--- a/src/Gui/ExpressionBinding.cpp
+++ b/src/Gui/ExpressionBinding.cpp
@@ -311,5 +311,4 @@ void ExpressionWidget::makeLabel(QLineEdit* le)
     iconLabel->setStyleSheet(QStringLiteral("QLabel { border: none; padding: 0px; padding-top: %2px; width: %1px; height: %1px }").arg(iconHeight).arg(frameWidth/2));
     iconLabel->hide();
     iconLabel->setExpressionText(QString());
-    le->setStyleSheet(QStringLiteral("QLineEdit { padding-right: %1px } ").arg(iconHeight+frameWidth));
 }


### PR DESCRIPTION
fix https://github.com/FreeCAD/FreeCAD/issues/20004

This stylesheet modification is done in 
```
void ExpressionSpinBox::showIcon()
{
    int frameWidth = spinbox->style()->pixelMetric(QStyle::PM_SpinBoxFrameWidth);
    lineedit->setStyleSheet(QStringLiteral("QLineEdit { padding-right: %1px } ").arg(iconLabel->sizeHint().width() + frameWidth + 1));
    iconLabel->show();
}
```
already