### PR TITLE
[PartDesign] Fix spelling of auxiliary but also handle the properties…

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -635,4 +635,7 @@ void Pipe::handleChangedPropertyName(Base::XMLReader& reader,
     else if (AuxiliaryCurvilinear.getClassTypeId() == type && strAuxilleryCurvelinear == PropName) {
         AuxiliaryCurvilinear.Restore(reader);
     }
+    else {
+        ProfileBased::handleChangedPropertyName(reader, TypeName, PropName);
+    }
 }

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -76,7 +76,7 @@ Pipe::Pipe()
         "Secondary path to orient sweep");
     ADD_PROPERTY_TYPE(AuxiliarySpineTangent, (false), "Sweep", App::Prop_None,
         "Include tangent edges into secondary path");
-    ADD_PROPERTY_TYPE(AuxiliaryCurvelinear, (true), "Sweep", App::Prop_None,
+    ADD_PROPERTY_TYPE(AuxiliaryCurvilinear, (true), "Sweep", App::Prop_None,
         "Calculate normal between equidistant points on both spines");
     ADD_PROPERTY_TYPE(Mode, (long(0)), "Sweep", App::Prop_None, "Profile mode");
     ADD_PROPERTY_TYPE(Binormal, (Base::Vector3d()), "Sweep", App::Prop_None,
@@ -479,8 +479,8 @@ void Pipe::setupAlgorithm(BRepOffsetAPI_MakePipeShell& mkPipeShell, const TopoDS
     }
 
     if (auxiliary) {
-        mkPipeShell.SetMode(TopoDS::Wire(auxshape), AuxiliaryCurvelinear.getValue());
-        // mkPipeShell.SetMode(TopoDS::Wire(auxshape), AuxiliaryCurvelinear.getValue(),
+        mkPipeShell.SetMode(TopoDS::Wire(auxshape), AuxiliaryCurvilinear.getValue());
+        // mkPipeShell.SetMode(TopoDS::Wire(auxshape), AuxiliaryCurvilinear.getValue(),
         // BRepFill_ContactOnBorder);
     }
 }
@@ -622,7 +622,7 @@ void Pipe::handleChangedPropertyName(Base::XMLReader& reader,
     std::string strAuxillerySpine("AuxillerySpine");
     // The AuxiliarySpineTangent property was AuxillerySpineTangent in the past
     std::string strAuxillerySpineTangent("AuxillerySpineTangent");
-    // The AuxiliaryCurvelinear property was AuxilleryCurvelinear in the past
+    // The AuxiliaryCurvilinear property was AuxilleryCurvelinear in the past
     std::string strAuxilleryCurvelinear("AuxilleryCurvelinear");
     Base::Type type = Base::Type::fromName(TypeName);
     if (AuxiliarySpine.getClassTypeId() == type && strAuxillerySpine == PropName) {
@@ -632,7 +632,7 @@ void Pipe::handleChangedPropertyName(Base::XMLReader& reader,
              && strAuxillerySpineTangent == PropName) {
         AuxiliarySpineTangent.Restore(reader);
     }
-    else if (AuxiliaryCurvelinear.getClassTypeId() == type && strAuxilleryCurvelinear == PropName) {
-        AuxiliaryCurvelinear.Restore(reader);
+    else if (AuxiliaryCurvilinear.getClassTypeId() == type && strAuxilleryCurvelinear == PropName) {
+        AuxiliaryCurvilinear.Restore(reader);
     }
 }

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -72,11 +72,11 @@ Pipe::Pipe()
     ADD_PROPERTY_TYPE(Spine, (nullptr), "Sweep", App::Prop_None, "Path to sweep along");
     ADD_PROPERTY_TYPE(SpineTangent, (false), "Sweep", App::Prop_None,
         "Include tangent edges into path");
-    ADD_PROPERTY_TYPE(AuxillerySpine, (nullptr), "Sweep", App::Prop_None,
+    ADD_PROPERTY_TYPE(AuxiliarySpine, (nullptr), "Sweep", App::Prop_None,
         "Secondary path to orient sweep");
-    ADD_PROPERTY_TYPE(AuxillerySpineTangent, (false), "Sweep", App::Prop_None,
+    ADD_PROPERTY_TYPE(AuxiliarySpineTangent, (false), "Sweep", App::Prop_None,
         "Include tangent edges into secondary path");
-    ADD_PROPERTY_TYPE(AuxilleryCurvelinear, (true), "Sweep", App::Prop_None,
+    ADD_PROPERTY_TYPE(AuxiliaryCurvelinear, (true), "Sweep", App::Prop_None,
         "Calculate normal between equidistant points on both spines");
     ADD_PROPERTY_TYPE(Mode, (long(0)), "Sweep", App::Prop_None, "Profile mode");
     ADD_PROPERTY_TYPE(Binormal, (Base::Vector3d()), "Sweep", App::Prop_None,
@@ -191,10 +191,10 @@ App::DocumentObjectExecReturn *Pipe::execute()
         // auxiliary
         TopoDS_Shape auxpath;
         if (Mode.getValue() == 3) {
-            App::DocumentObject* auxspine = AuxillerySpine.getValue();
+            App::DocumentObject* auxspine = AuxiliarySpine.getValue();
             if (!(auxspine && auxspine->isDerivedFrom<Part::Feature>()))
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "No auxiliary spine linked."));
-            std::vector<std::string> auxsubedge = AuxillerySpine.getSubValues();
+            std::vector<std::string> auxsubedge = AuxiliarySpine.getSubValues();
 
             const Part::TopoShape& auxshape =
                 static_cast<Part::Feature*>(auxspine)->Shape.getValue();
@@ -479,8 +479,8 @@ void Pipe::setupAlgorithm(BRepOffsetAPI_MakePipeShell& mkPipeShell, const TopoDS
     }
 
     if (auxiliary) {
-        mkPipeShell.SetMode(TopoDS::Wire(auxshape), AuxilleryCurvelinear.getValue());
-        // mkPipeShell.SetMode(TopoDS::Wire(auxshape), AuxilleryCurvelinear.getValue(),
+        mkPipeShell.SetMode(TopoDS::Wire(auxshape), AuxiliaryCurvelinear.getValue());
+        // mkPipeShell.SetMode(TopoDS::Wire(auxshape), AuxiliaryCurvelinear.getValue(),
         // BRepFill_ContactOnBorder);
     }
 }
@@ -611,5 +611,28 @@ void Pipe::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeNa
     }
     else {
         ProfileBased::handleChangedPropertyType(reader, TypeName, prop);
+    }
+}
+
+void Pipe::handleChangedPropertyName(Base::XMLReader& reader,
+                                     const char* TypeName,
+                                     const char* PropName)
+{
+    // The AuxiliarySpine property was AuxillerySpine in the past
+    std::string strAuxillerySpine("AuxillerySpine");
+    // The AuxiliarySpineTangent property was AuxillerySpineTangent in the past
+    std::string strAuxillerySpineTangent("AuxillerySpineTangent");
+    // The AuxiliaryCurvelinear property was AuxilleryCurvelinear in the past
+    std::string strAuxilleryCurvelinear("AuxilleryCurvelinear");
+    Base::Type type = Base::Type::fromName(TypeName);
+    if (AuxiliarySpine.getClassTypeId() == type && strAuxillerySpine == PropName) {
+        AuxiliarySpine.Restore(reader);
+    }
+    else if (AuxiliarySpineTangent.getClassTypeId() == type
+             && strAuxillerySpineTangent == PropName) {
+        AuxiliarySpineTangent.Restore(reader);
+    }
+    else if (AuxiliaryCurvelinear.getClassTypeId() == type && strAuxilleryCurvelinear == PropName) {
+        AuxiliaryCurvelinear.Restore(reader);
     }
 }

--- a/src/Mod/PartDesign/App/FeaturePipe.h
+++ b/src/Mod/PartDesign/App/FeaturePipe.h
@@ -39,9 +39,9 @@ public:
 
     App::PropertyLinkSub Spine;
     App::PropertyBool SpineTangent;
-    App::PropertyLinkSub AuxillerySpine;
-    App::PropertyBool AuxillerySpineTangent;
-    App::PropertyBool AuxilleryCurvelinear;
+    App::PropertyLinkSub AuxiliarySpine;
+    App::PropertyBool AuxiliarySpineTangent;
+    App::PropertyBool AuxiliaryCurvelinear;
     App::PropertyEnumeration Mode;
     App::PropertyVector Binormal;
     App::PropertyEnumeration Transition;
@@ -74,6 +74,8 @@ protected:
     void setupAlgorithm(BRepOffsetAPI_MakePipeShell& mkPipeShell, const TopoDS_Shape& auxshape);
     /// handle changed property
     void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop) override;
+    void handleChangedPropertyName(Base::XMLReader& reader, const char* TypeName,
+                                   const char* PropName) override;
 
 private:
     static const char* TypeEnums[];

--- a/src/Mod/PartDesign/App/FeaturePipe.h
+++ b/src/Mod/PartDesign/App/FeaturePipe.h
@@ -41,7 +41,7 @@ public:
     App::PropertyBool SpineTangent;
     App::PropertyLinkSub AuxiliarySpine;
     App::PropertyBool AuxiliarySpineTangent;
-    App::PropertyBool AuxiliaryCurvelinear;
+    App::PropertyBool AuxiliaryCurvilinear;
     App::PropertyEnumeration Mode;
     App::PropertyVector Binormal;
     App::PropertyEnumeration Transition;
@@ -59,7 +59,7 @@ public:
                                                    const TopLoc_Location &invObjLoc = TopLoc_Location(),
                                                    int transition = 0,
                                                    const TopoShape &auxpath = TopoShape(),
-                                                   bool auxCurveLinear = true,
+                                                   bool auxCurviLinear = true,
                                                    int mode = 2,
                                                    const Base::Vector3d &binormalVector = Base::Vector3d(),
                                                    int transformation = 0,

--- a/src/Mod/PartDesign/Gui/TaskPipeOrientation.ui
+++ b/src/Mod/PartDesign/Gui/TaskPipeOrientation.ui
@@ -71,9 +71,9 @@
      <widget class="QWidget" name="auxiliary">
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QCheckBox" name="curvelinear">
+        <widget class="QCheckBox" name="curvilinear">
          <property name="text">
-          <string>Curvelinear equivalence</string>
+          <string>Curvilinear equivalence</string>
          </property>
         </widget>
        </item>

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -123,8 +123,8 @@ TaskPipeParameters::TaskPipeParameters(ViewProviderPipe* PipeView, bool /*newObj
             make2DLabel(pipe->Profile.getValue(), pipe->Profile.getSubValues()));
     }
     // the auxiliary spine
-    if (pipe->AuxillerySpine.getValue()) {
-        auto* svp = doc->getViewProvider(pipe->AuxillerySpine.getValue());
+    if (pipe->AuxiliarySpine.getValue()) {
+        auto* svp = doc->getViewProvider(pipe->AuxiliarySpine.getValue());
         auxSpineShow = svp->isShow();
         svp->show();
     }
@@ -432,8 +432,8 @@ void TaskPipeParameters::setVisibilityOfSpineAndProfile()
             profileVP->setVisible(profileShow);
             profileShow = false;
         }
-        if (pipe->AuxillerySpine.getValue()) {
-            auto* svp = doc->getViewProvider(pipe->AuxillerySpine.getValue());
+        if (pipe->AuxiliarySpine.getValue()) {
+            auto* svp = doc->getViewProvider(pipe->AuxiliarySpine.getValue());
             svp->setVisible(auxSpineShow);
             auxSpineShow = false;
         }
@@ -456,7 +456,7 @@ bool TaskPipeParameters::accept()
 
     bool extReference = false;
     App::DocumentObject* spine = pipe->Spine.getValue();
-    App::DocumentObject* auxSpine = pipe->AuxillerySpine.getValue();
+    App::DocumentObject* auxSpine = pipe->AuxiliarySpine.getValue();
 
     // If a spine isn't set but user entered a label then search for the appropriate document object
     QString label = ui->spineBaseEdit->text();
@@ -509,12 +509,12 @@ bool TaskPipeParameters::accept()
             }
             else if (!pcActiveBody->hasObject(auxSpine)
                      && !pcActiveBody->getOrigin()->hasObject(auxSpine)) {
-                pipe->AuxillerySpine.setValue(
+                pipe->AuxiliarySpine.setValue(
                     PartDesignGui::TaskFeaturePick::makeCopy(auxSpine,
                                                              "",
                                                              dlg.radioIndependent->isChecked()),
-                    pipe->AuxillerySpine.getSubValues());
-                copies.push_back(pipe->AuxillerySpine.getValue());
+                    pipe->AuxiliarySpine.getSubValues());
+                copies.push_back(pipe->AuxiliarySpine.getValue());
             }
 
             std::vector<App::PropertyLinkSubList::SubSet> subSets;
@@ -628,12 +628,12 @@ TaskPipeOrientation::TaskPipeOrientation(ViewProviderPipe* PipeView,
     PartDesign::Pipe* pipe = PipeView->getObject<PartDesign::Pipe>();
 
     // add initial values
-    if (pipe->AuxillerySpine.getValue()) {
+    if (pipe->AuxiliarySpine.getValue()) {
         ui->profileBaseEdit->setText(
-            QString::fromUtf8(pipe->AuxillerySpine.getValue()->Label.getValue()));
+            QString::fromUtf8(pipe->AuxiliarySpine.getValue()->Label.getValue()));
     }
 
-    std::vector<std::string> strings = pipe->AuxillerySpine.getSubValues();
+    std::vector<std::string> strings = pipe->AuxiliarySpine.getSubValues();
     for (const auto& string : strings) {
         QString label = QString::fromStdString(string);
         QListWidgetItem* item = new QListWidgetItem();
@@ -643,7 +643,7 @@ TaskPipeOrientation::TaskPipeOrientation(ViewProviderPipe* PipeView,
     }
 
     ui->comboBoxMode->setCurrentIndex(pipe->Mode.getValue());
-    ui->curvelinear->setChecked(pipe->AuxilleryCurvelinear.getValue());
+    ui->curvelinear->setChecked(pipe->AuxiliaryCurvelinear.getValue());
 
     // should be called after panel has become visible
     QMetaObject::invokeMethod(this,
@@ -690,14 +690,14 @@ void TaskPipeOrientation::onClearButton()
     ui->profileBaseEdit->clear();
     if (auto view = getViewObject<ViewProviderPipe>()) {
         view->highlightReferences(ViewProviderPipe::AuxiliarySpine, false);
-        getObject<PartDesign::Pipe>()->AuxillerySpine.setValue(nullptr);
+        getObject<PartDesign::Pipe>()->AuxiliarySpine.setValue(nullptr);
     }
 }
 
 void TaskPipeOrientation::onCurvelinearChanged(bool checked)
 {
     if (auto pipe = getObject<PartDesign::Pipe>()) {
-        pipe->AuxilleryCurvelinear.setValue(checked);
+        pipe->AuxiliaryCurvelinear.setValue(checked);
         recomputeFeature();
     }
 }
@@ -795,7 +795,7 @@ bool TaskPipeOrientation::referenceSelected(const SelectionChanges& msg) const
         if (auto pipe = getObject<PartDesign::Pipe>()) {
             // change the references
             std::string subName(msg.pSubName);
-            std::vector<std::string> refs = pipe->AuxillerySpine.getSubValues();
+            std::vector<std::string> refs = pipe->AuxiliarySpine.getSubValues();
             std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), subName);
 
             if (selectionMode == StateHandlerTaskPipe::SelectionModes::refAuxSpine) {
@@ -817,7 +817,7 @@ bool TaskPipeOrientation::referenceSelected(const SelectionChanges& msg) const
             }
 
             App::Document* doc = pipe->getDocument();
-            pipe->AuxillerySpine.setValue(doc->getObject(msg.pObjectName), refs);
+            pipe->AuxiliarySpine.setValue(doc->getObject(msg.pObjectName), refs);
             return true;
         }
     }
@@ -847,14 +847,14 @@ void TaskPipeOrientation::onDeleteItem()
 
         // search inside the list of spines
         if (auto pipe = getObject<PartDesign::Pipe>()) {
-            std::vector<std::string> refs = pipe->AuxillerySpine.getSubValues();
+            std::vector<std::string> refs = pipe->AuxiliarySpine.getSubValues();
             std::string obj = data.constData();
             std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), obj);
 
             // if something was found, delete it and update the spine list
             if (f != refs.end()) {
                 refs.erase(f);
-                pipe->AuxillerySpine.setValue(pipe->AuxillerySpine.getValue(), refs);
+                pipe->AuxiliarySpine.setValue(pipe->AuxiliarySpine.getValue(), refs);
                 clearButtons();
                 recomputeFeature();
             }

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -597,8 +597,8 @@ TaskPipeOrientation::TaskPipeOrientation(ViewProviderPipe* PipeView,
             this, &TaskPipeOrientation::onClearButton);
     connect(ui->stackedWidget, &QStackedWidget::currentChanged,
             this, &TaskPipeOrientation::updateUI);
-    connect(ui->curvelinear, &QCheckBox::toggled,
-            this, &TaskPipeOrientation::onCurvelinearChanged);
+    connect(ui->curvilinear, &QCheckBox::toggled,
+            this, &TaskPipeOrientation::onCurvilinearChanged);
     connect(ui->doubleSpinBoxX, qOverload<double>(&QDoubleSpinBox::valueChanged),
             this, &TaskPipeOrientation::onBinormalChanged);
     connect(ui->doubleSpinBoxY, qOverload<double>(&QDoubleSpinBox::valueChanged),
@@ -643,7 +643,7 @@ TaskPipeOrientation::TaskPipeOrientation(ViewProviderPipe* PipeView,
     }
 
     ui->comboBoxMode->setCurrentIndex(pipe->Mode.getValue());
-    ui->curvelinear->setChecked(pipe->AuxiliaryCurvelinear.getValue());
+    ui->curvilinear->setChecked(pipe->AuxiliaryCurvilinear.getValue());
 
     // should be called after panel has become visible
     QMetaObject::invokeMethod(this,
@@ -694,10 +694,10 @@ void TaskPipeOrientation::onClearButton()
     }
 }
 
-void TaskPipeOrientation::onCurvelinearChanged(bool checked)
+void TaskPipeOrientation::onCurvilinearChanged(bool checked)
 {
     if (auto pipe = getObject<PartDesign::Pipe>()) {
-        pipe->AuxiliaryCurvelinear.setValue(checked);
+        pipe->AuxiliaryCurvilinear.setValue(checked);
         recomputeFeature();
     }
 }

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -92,10 +92,9 @@ TaskPipeParameters::TaskPipeParameters(ViewProviderPipe* PipeView, bool /*newObj
         remove->setShortcut(QKeySequence(shortcut));
     }
     remove->setShortcutContext(Qt::WidgetShortcut);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+
     // display shortcut behind the context menu entry
-    remove->setShortcutVisibleInContextMenu(true);
-#endif
+    remove->setShortcutVisibleInContextMenu(true); 
     ui->listWidgetReferences->addAction(remove);
     connect(remove, &QAction::triggered, this, &TaskPipeParameters::onDeleteEdge);
     ui->listWidgetReferences->setContextMenuPolicy(Qt::ActionsContextMenu);
@@ -294,13 +293,12 @@ void TaskPipeParameters::onDeleteEdge()
         delete item;
 
         // search inside the list of spines
-        auto pipe = getObject<PartDesign::Pipe>();
+        const auto pipe = getObject<PartDesign::Pipe>();
         std::vector<std::string> refs = pipe->Spine.getSubValues();
-        std::string obj = data.constData();
-        std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), obj);
+        const std::string obj = data.constData();
 
         // if something was found, delete it and update the spine list
-        if (f != refs.end()) {
+        if (const auto f = std::ranges::find(refs, obj); f != refs.end()) {
             refs.erase(f);
             pipe->Spine.setValue(pipe->Spine.getValue(), refs);
             clearButtons();
@@ -339,7 +337,7 @@ bool TaskPipeParameters::referenceSelected(const SelectionChanges& msg) const
                     std::vector<App::DocumentObject*> sections = pipe->Sections.getValues();
 
                     // cannot use the same object for profile and section
-                    if (std::find(sections.begin(), sections.end(), profile) != sections.end()) {
+                    if (std::ranges::find(sections, profile) != sections.end()) {
                         success = false;
                     }
                     else {
@@ -358,10 +356,10 @@ bool TaskPipeParameters::referenceSelected(const SelectionChanges& msg) const
             case StateHandlerTaskPipe::SelectionModes::refSpineEdgeAdd:
             case StateHandlerTaskPipe::SelectionModes::refSpineEdgeRemove: {
                 // change the references
-                std::string subName(msg.pSubName);
-                auto pipe = getObject<PartDesign::Pipe>();
+                const std::string subName(msg.pSubName);
+                const auto pipe = getObject<PartDesign::Pipe>();
                 std::vector<std::string> refs = pipe->Spine.getSubValues();
-                std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), subName);
+                const auto f = std::ranges::find(refs, subName);
 
                 if (selectionMode == StateHandlerTaskPipe::SelectionModes::refSpine) {
                     getViewObject<ViewProviderPipe>()->highlightReferences(ViewProviderPipe::Spine,
@@ -597,8 +595,8 @@ TaskPipeOrientation::TaskPipeOrientation(ViewProviderPipe* PipeView,
             this, &TaskPipeOrientation::onClearButton);
     connect(ui->stackedWidget, &QStackedWidget::currentChanged,
             this, &TaskPipeOrientation::updateUI);
-    connect(ui->curvilinear, &QCheckBox::toggled,
-            this, &TaskPipeOrientation::onCurvilinearChanged);
+    connect(ui->curvelinear, &QCheckBox::toggled,
+            this, &TaskPipeOrientation::onCurvelinearChanged);
     connect(ui->doubleSpinBoxX, qOverload<double>(&QDoubleSpinBox::valueChanged),
             this, &TaskPipeOrientation::onBinormalChanged);
     connect(ui->doubleSpinBoxY, qOverload<double>(&QDoubleSpinBox::valueChanged),
@@ -615,10 +613,9 @@ TaskPipeOrientation::TaskPipeOrientation(ViewProviderPipe* PipeView,
         remove->setShortcut(QKeySequence(shortcut));
     }
     remove->setShortcutContext(Qt::WidgetShortcut);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+
     // display shortcut behind the context menu entry
     remove->setShortcutVisibleInContextMenu(true);
-#endif
     ui->listWidgetReferences->addAction(remove);
     connect(remove, &QAction::triggered, this, &TaskPipeOrientation::onDeleteItem);
     ui->listWidgetReferences->setContextMenuPolicy(Qt::ActionsContextMenu);
@@ -792,11 +789,11 @@ bool TaskPipeOrientation::referenceSelected(const SelectionChanges& msg) const
             return false;
         }
 
-        if (auto pipe = getObject<PartDesign::Pipe>()) {
+        if (const auto pipe = getObject<PartDesign::Pipe>()) {
             // change the references
-            std::string subName(msg.pSubName);
+            const std::string subName(msg.pSubName);
             std::vector<std::string> refs = pipe->AuxiliarySpine.getSubValues();
-            std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), subName);
+            const auto f = std::ranges::find(refs, subName);
 
             if (selectionMode == StateHandlerTaskPipe::SelectionModes::refAuxSpine) {
                 refs.clear();
@@ -846,13 +843,12 @@ void TaskPipeOrientation::onDeleteItem()
         delete item;
 
         // search inside the list of spines
-        if (auto pipe = getObject<PartDesign::Pipe>()) {
+        if (const auto pipe = getObject<PartDesign::Pipe>()) {
             std::vector<std::string> refs = pipe->AuxiliarySpine.getSubValues();
-            std::string obj = data.constData();
-            std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), obj);
+            const std::string obj = data.constData();
 
             // if something was found, delete it and update the spine list
-            if (f != refs.end()) {
+            if (const auto f = std::ranges::find(refs, obj); f != refs.end()) {
                 refs.erase(f);
                 pipe->AuxiliarySpine.setValue(pipe->AuxiliarySpine.getValue(), refs);
                 clearButtons();
@@ -908,10 +904,9 @@ TaskPipeScaling::TaskPipeScaling(ViewProviderPipe* PipeView, bool /*newObj*/, QW
         remove->setShortcut(QKeySequence(shortcut));
     }
     remove->setShortcutContext(Qt::WidgetShortcut);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+
     // display shortcut behind the context menu entry
     remove->setShortcutVisibleInContextMenu(true);
-#endif
     ui->listWidgetReferences->addAction(remove);
     ui->listWidgetReferences->setContextMenuPolicy(Qt::ActionsContextMenu);
     connect(remove, &QAction::triggered, this, &TaskPipeScaling::onDeleteSection);
@@ -1048,11 +1043,10 @@ bool TaskPipeScaling::referenceSelected(const SelectionChanges& msg) const
         }
 
         // change the references
-        if (auto pipe = getObject<PartDesign::Pipe>()) {
+        if (const auto pipe = getObject<PartDesign::Pipe>()) {
             std::vector<App::DocumentObject*> refs = pipe->Sections.getValues();
             App::DocumentObject* obj = pipe->getDocument()->getObject(msg.pObjectName);
-            std::vector<App::DocumentObject*>::iterator f =
-                std::find(refs.begin(), refs.end(), obj);
+            const auto f = std::ranges::find(refs, obj);
 
             if (selectionMode == StateHandlerTaskPipe::SelectionModes::refSectionAdd) {
                 if (f != refs.end()) {
@@ -1100,13 +1094,11 @@ void TaskPipeScaling::onDeleteSection()
                             .first->getNameInDocument());
         delete item;
 
-        if (auto pipe = getObject<PartDesign::Pipe>()) {
+        if (const auto pipe = getObject<PartDesign::Pipe>()) {
             std::vector<App::DocumentObject*> refs = pipe->Sections.getValues();
             App::DocumentObject* obj = pipe->getDocument()->getObject(data.constData());
-            std::vector<App::DocumentObject*>::iterator f =
-                std::find(refs.begin(), refs.end(), obj);
 
-            if (f != refs.end()) {
+            if (const auto f = std::ranges::find(refs.begin(), refs.end(), obj); f != refs.end()) {
                 pipe->Sections.removeValue(obj);
                 clearButtons();
                 recomputeFeature();

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.h
@@ -125,7 +125,7 @@ private Q_SLOTS:
     void onOrientationChanged(int);
     void updateUI(int idx);
     void onClearButton();
-    void onCurvelinearChanged(bool checked);
+    void onCurvilinearChanged(bool checked);
     void onBinormalChanged(double);
     void onDeleteItem();
 

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -504,7 +504,7 @@ bool isFeatureMovable(App::DocumentObject* const feat)
             }
         }
 
-        if (auto prop = dynamic_cast<App::PropertyLinkSub*>(prim->getPropertyByName("AuxillerySpine"))) {
+        if (auto prop = dynamic_cast<App::PropertyLinkSub*>(prim->getPropertyByName("AuxiliarySpine"))) {
             App::DocumentObject* auxSpine = prop->getValue();
             if (auxSpine && !isFeatureMovable(auxSpine)) {
                 return false;
@@ -557,7 +557,7 @@ std::vector<App::DocumentObject*> collectMovableDependencies(std::vector<App::Do
                     unique_objs.insert(axis);
                 }
             }
-            if (auto prop = dynamic_cast<App::PropertyLinkSub*>(prim->getPropertyByName("AuxillerySpine"))) {
+            if (auto prop = dynamic_cast<App::PropertyLinkSub*>(prim->getPropertyByName("AuxiliarySpine"))) {
                 App::DocumentObject* axis = prop->getValue();
                 if (axis && !axis->isDerivedFrom<App::DatumElement>()){
                     unique_objs.insert(axis);

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
@@ -62,7 +62,7 @@ std::vector<App::DocumentObject*> ViewProviderPipe::claimChildren()const
     if (spine && spine->isDerivedFrom<Part::Part2DObject>())
         temp.push_back(spine);
 
-    App::DocumentObject* auxspine = pcPipe->AuxillerySpine.getValue();
+    App::DocumentObject* auxspine = pcPipe->AuxiliarySpine.getValue();
     if (auxspine && auxspine->isDerivedFrom<Part::Part2DObject>())
         temp.push_back(auxspine);
 
@@ -120,8 +120,8 @@ void ViewProviderPipe::highlightReferences(ViewProviderPipe::Reference mode, boo
                             pcPipe->Spine.getSubValuesStartsWith("Edge"), on);
         break;
     case AuxiliarySpine:
-        highlightReferences(dynamic_cast<Part::Feature*>(pcPipe->AuxillerySpine.getValue()),
-                            pcPipe->AuxillerySpine.getSubValuesStartsWith("Edge"), on);
+        highlightReferences(dynamic_cast<Part::Feature*>(pcPipe->AuxiliarySpine.getValue()),
+                            pcPipe->AuxiliarySpine.getSubValuesStartsWith("Edge"), on);
         break;
     case Profile:
         highlightReferences(dynamic_cast<Part::Feature*>(pcPipe->Profile.getValue()),


### PR DESCRIPTION
…name change from old files

Fixes #20006 

Old file opened with the new code:


![OldFile_Opened_With_New_Code](https://github.com/user-attachments/assets/eec700d3-8b21-4321-bed8-f35e8df9f999)

