### PR TITLE
Add devicePixelRatio to about info

### DIFF
--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -730,7 +730,7 @@ void AboutDialog::copyToClipboard()
         << QString::fromStdString(theme) << "/" << QString::fromStdString(style) << "\n";
 
     // Add DPI information
-    str << "Logical/physical/ratio DPI: "
+    str << "Logical DPI/Physical DPI/Pixel Ratio: "
         << QApplication::primaryScreen()->logicalDotsPerInch()
         << "/"
         << QApplication::primaryScreen()->physicalDotsPerInch()

--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -730,10 +730,12 @@ void AboutDialog::copyToClipboard()
         << QString::fromStdString(theme) << "/" << QString::fromStdString(style) << "\n";
 
     // Add DPI information
-    str << "Logical/physical DPI: "
+    str << "Logical/physical/ratio DPI: "
         << QApplication::primaryScreen()->logicalDotsPerInch()
         << "/"
         << QApplication::primaryScreen()->physicalDotsPerInch()
+        << "/"
+        << QApplication::primaryScreen()->devicePixelRatio()
         << "\n";
 
     // Add installed module information:


### PR DESCRIPTION
This is related to https://github.com/FreeCAD/FreeCAD/issues/19887

For HiDPI scaling, what Qt uses internally, and what FreeCAD uses in some places, is the `devicePixelRatio` variable. How it turns the actual ratio of logical to physical pixels into this value (and what kind of rounding it does) is platform dependent, and also somewhat controllable. 

Anyway, I think this is the important number to capture.

This still only shows it for the primary screen, and so might be misleading for folks with multiple monitors.