### PR TITLE
Fix the Measure Tool which will crash the app with a stack overflow if you measure the same amount twice

### DIFF
--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1425,23 +1425,27 @@ PropertyString::PropertyString() = default;
 
 PropertyString::~PropertyString() = default;
 
-void PropertyString::setValue(const char* newLabel)
+void PropertyString::setValue(const char* newValue)
 {
-    if (!newLabel) {
+    if (!newValue) {
         return;
     }
 
-    if (_cValue == newLabel) {
+    if (_cValue == newValue) {
         return;
     }
 
     std::vector<std::pair<Property*, std::unique_ptr<Property>>> propChanges;
-    std::string label = newLabel;
+    std::string newValueStr = newValue;
     auto obj = dynamic_cast<DocumentObject*>(getContainer());
     bool commit = false;
 
     if (obj && this == &obj->Label) {
-        propChanges = obj->onProposedLabelChange(label);
+        propChanges = obj->onProposedLabelChange(newValueStr);
+        if (_cValue == newValueStr) {
+            // OnProposedLabelChange has changed the new value to what the current value is
+            return;
+        }
         if (!propChanges.empty() && !GetApplication().getActiveTransaction()) {
             commit = true;
             std::ostringstream str;
@@ -1451,7 +1455,7 @@ void PropertyString::setValue(const char* newLabel)
     }
 
     aboutToSetValue();
-    _cValue = label;
+    _cValue = newValueStr;
     hasSetValue();
 
     for (auto& change : propChanges) {


### PR DESCRIPTION
Fixes #19980

PR #18676 changed the management of Label uniqueness. A bug in that change meant that if a DrawingObject were created, then deleted, in the same transaction, the record of its Label would remain, and subsequent attempts to use the same Label might find the intended Label changed to make it unique.

The Measure tool is quite insistent that the Label of its object be of the form "some text: actual measurement". If it attempts to set this but uniqueness forces the text to be "some text: actual measurement001", it will, in the Change notification for the Label property again try to set "some text: actual measurement", which again instead sets "some text: actual measurement001", generating an infinite recursion of these notifications and futile Label changes.

It is also possible to produce this stack overflow with release 1.0.0, as detailed in #19980.

This is a twofold fix:

1. If the uniquified Label value is equal to the current Label, the value is not set and no Change notification takes place; the Measure tool is unaware that the Label that was set was not the same as what was requested. Note the the Label-setting code already did a quick return if the *proposed* label was equal to the current one; now the code also does a quick return if the *modified* label matches the current one.
2. Code in `Document::removeObject` has been corrected to properly remove the Label of the removed object from the Label registry. As a result the label proposed by the Measure tool is generally used unchanged. The exception is when the procedure to produce the effect in 1.0.0 is used, in which case part (1) of this fix still cures the problem.

In the long run, the Measure object should probably override `allowDuplicateLabels()` to allow their labels to be the same as those of any other object in the drawing. Also, `allowDuplicateLabels()` should work symmetrically by not registering the labels of such objects.
