### PR TITLE
App: Cleanup parameter names in Application.*

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1581,46 +1581,46 @@ void Application::slotChangedDocument(const App::Document& doc, const Property& 
     this->signalChangedDocument(doc, prop);
 }
 
-void Application::slotNewObject(const App::DocumentObject&O)
+void Application::slotNewObject(const App::DocumentObject& obj)
 {
-    this->signalNewObject(O);
+    this->signalNewObject(obj);
     _objCount = -1;
 }
 
-void Application::slotDeletedObject(const App::DocumentObject&O)
+void Application::slotDeletedObject(const App::DocumentObject& obj)
 {
-    this->signalDeletedObject(O);
+    this->signalDeletedObject(obj);
     _objCount = -1;
 }
 
-void Application::slotBeforeChangeObject(const DocumentObject& O, const Property& Prop)
+void Application::slotBeforeChangeObject(const App::DocumentObject& obj, const App::Property& prop)
 {
-    this->signalBeforeChangeObject(O, Prop);
+    this->signalBeforeChangeObject(obj, prop);
 }
 
-void Application::slotChangedObject(const App::DocumentObject&O, const App::Property& P)
+void Application::slotChangedObject(const App::DocumentObject& obj, const App::Property& prop)
 {
-    this->signalChangedObject(O,P);
+    this->signalChangedObject(obj, prop);
 }
 
-void Application::slotRelabelObject(const App::DocumentObject&O)
+void Application::slotRelabelObject(const App::DocumentObject& obj)
 {
-    this->signalRelabelObject(O);
+    this->signalRelabelObject(obj);
 }
 
-void Application::slotActivatedObject(const App::DocumentObject&O)
+void Application::slotActivatedObject(const App::DocumentObject& obj)
 {
-    this->signalActivatedObject(O);
+    this->signalActivatedObject(obj);
 }
 
-void Application::slotUndoDocument(const App::Document& d)
+void Application::slotUndoDocument(const App::Document& doc)
 {
-    this->signalUndoDocument(d);
+    this->signalUndoDocument(doc);
 }
 
-void Application::slotRedoDocument(const App::Document& d)
+void Application::slotRedoDocument(const App::Document& doc)
 {
-    this->signalRedoDocument(d);
+    this->signalRedoDocument(doc);
 }
 
 void Application::slotRecomputedObject(const DocumentObject& obj)
@@ -1638,19 +1638,19 @@ void Application::slotBeforeRecompute(const Document& doc)
     this->signalBeforeRecomputeDocument(doc);
 }
 
-void Application::slotOpenTransaction(const Document& d, string s)
+void Application::slotOpenTransaction(const Document &doc, string name)
 {
-    this->signalOpenTransaction(d, std::move(s));
+    this->signalOpenTransaction(doc, std::move(name));
 }
 
-void Application::slotCommitTransaction(const Document& d)
+void Application::slotCommitTransaction(const Document& doc)
 {
-    this->signalCommitTransaction(d);
+    this->signalCommitTransaction(doc);
 }
 
-void Application::slotAbortTransaction(const Document& d)
+void Application::slotAbortTransaction(const Document& doc)
 {
-    this->signalAbortTransaction(d);
+    this->signalAbortTransaction(doc);
 }
 
 void Application::slotStartSaveDocument(const App::Document& doc, const std::string& filename)
@@ -1664,9 +1664,9 @@ void Application::slotFinishSaveDocument(const App::Document& doc, const std::st
     this->signalFinishSaveDocument(doc, filename);
 }
 
-void Application::slotChangePropertyEditor(const App::Document &doc, const App::Property &prop)
+void Application::slotChangePropertyEditor(const App::Document& doc, const App::Property& prop)
 {
-    this->signalChangePropertyEditor(doc,prop);
+    this->signalChangePropertyEditor(doc, prop);
 }
 
 //**************************************************************************
@@ -3474,7 +3474,7 @@ std::string Application::FindHomePath(const char* sCall)
 #include <cstdlib>
 #include <sys/param.h>
 
-std::string Application::FindHomePath(const char* call)
+std::string Application::FindHomePath(const char* sCall)
 {
     // If Python is initialized at this point, then we're being run from
     // MainPy.cpp, which hopefully rewrote argv[0] to point at the
@@ -3503,7 +3503,7 @@ std::string Application::FindHomePath(const char* call)
         }
     }
 
-    return call;
+    return sCall;
 }
 
 #elif defined (FC_OS_WIN32)

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -472,25 +472,25 @@ protected:
      * This slot gets connected to all App::Documents created
      */
     //@{
-    void slotBeforeChangeDocument(const App::Document&, const App::Property&);
-    void slotChangedDocument(const App::Document&, const App::Property&);
-    void slotNewObject(const App::DocumentObject&);
-    void slotDeletedObject(const App::DocumentObject&);
-    void slotBeforeChangeObject(const App::DocumentObject&, const App::Property& Prop);
-    void slotChangedObject(const App::DocumentObject&, const App::Property& Prop);
-    void slotRelabelObject(const App::DocumentObject&);
-    void slotActivatedObject(const App::DocumentObject&);
-    void slotUndoDocument(const App::Document&);
-    void slotRedoDocument(const App::Document&);
-    void slotRecomputedObject(const App::DocumentObject&);
-    void slotRecomputed(const App::Document&);
-    void slotBeforeRecompute(const App::Document&);
-    void slotOpenTransaction(const App::Document&, std::string);
-    void slotCommitTransaction(const App::Document&);
-    void slotAbortTransaction(const App::Document&);
-    void slotStartSaveDocument(const App::Document&, const std::string&);
-    void slotFinishSaveDocument(const App::Document&, const std::string&);
-    void slotChangePropertyEditor(const App::Document&, const App::Property &);
+    void slotBeforeChangeDocument(const App::Document& doc, const App::Property& prop);
+    void slotChangedDocument(const App::Document& doc, const App::Property& prop);
+    void slotNewObject(const App::DocumentObject& obj);
+    void slotDeletedObject(const App::DocumentObject& obj);
+    void slotBeforeChangeObject(const App::DocumentObject& obj, const App::Property& prop);
+    void slotChangedObject(const App::DocumentObject& obj, const App::Property& prop);
+    void slotRelabelObject(const App::DocumentObject& obj);
+    void slotActivatedObject(const App::DocumentObject& obj);
+    void slotUndoDocument(const App::Document& doc);
+    void slotRedoDocument(const App::Document& doc);
+    void slotRecomputedObject(const App::DocumentObject& obj);
+    void slotRecomputed(const App::Document& doc);
+    void slotBeforeRecompute(const App::Document& doc);
+    void slotOpenTransaction(const App::Document& doc, std::string name);
+    void slotCommitTransaction(const App::Document& doc);
+    void slotAbortTransaction(const App::Document& doc);
+    void slotStartSaveDocument(const App::Document& doc, const std::string& filename);
+    void slotFinishSaveDocument(const App::Document& doc, const std::string& filename);
+    void slotChangePropertyEditor(const App::Document& doc, const App::Property& prop);
     //@}
 
     /// open single document only


### PR DESCRIPTION
This unifies the names of the parameters between the *.h and *.cpp files, making clang-tidy happier, and names them all the same thing when used in the same way across different calls, making *me* happier. Note that this file is not currently covered by our clang-format policy, so any formatting changes here are incidental.