### PR TITLE
PartDesign: Fix App::Line as ref for polar pattern

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
@@ -129,6 +129,8 @@ const std::list<gp_Trsf> PolarPattern::getTransformations(const std::vector<App:
         axdir = gp_Dir(dir.x, dir.y, dir.z);
     } else if (refObject->isDerivedFrom<App::Line>()) {
         App::Line* line = static_cast<App::Line*>(refObject);
+        Base::Vector3d base = line->getBasePoint();
+        axbase = gp_Pnt(base.x, base.y, base.z);
         Base::Vector3d d = line->getDirection();
         axdir = gp_Dir(d.x, d.y, d.z);
     } else if (refObject->isDerivedFrom<Part::Feature>()) {


### PR DESCRIPTION
Fix App::Line as ref for polar pattern position ignored.
Fix https://github.com/FreeCAD/FreeCAD/issues/19401