### PR TITLE
Gui: HiDPI fixes for Sketcher

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -366,44 +366,21 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(
 
     int sketcherfontSize = hGrp->GetInt("EditSketcherFontSize", defaultFontSizePixels);
 
-    int dpi = Client.getApplicationLogicalDPIX();
+    qreal devicePixelRatio = Client.getDevicePixelRatio();
 
     // simple scaling factor for hardcoded pixel values in the Sketcher
-    Client.drawingParameters.pixelScalingFactor = viewScalingFactor * dpi
-        / 96;  // 96 ppi is the standard pixel density for which pixel quantities were calculated
+    Client.drawingParameters.pixelScalingFactor = devicePixelRatio;
 
     // About sizes:
     // SoDatumLabel takes the size in points, not in pixels. This is because it uses QFont
     // internally. Coin, at least our coin at this time, takes pixels, not points.
-    //
-    // DPI considerations:
-    // With hdpi monitors, the coin font labels do not respect the size passed in pixels:
-    // https://forum.freecad.org/viewtopic.php?f=3&t=54347&p=467610#p467610
-    // https://forum.freecad.org/viewtopic.php?f=10&t=49972&start=40#p467471
-    //
-    // Because I (abdullah) have  96 dpi logical, 82 dpi physical, and I see a 35px font setting for
-    // a "1" in a datum label as 34px, and I see kilsore and Elyas screenshots showing 41px and 61px
-    // in higher resolution monitors for the same configuration, I think that coin pixel size has to
-    // be corrected by the logical dpi of the monitor. The rationale is that: a) it obviously needs
-    // dpi correction, b) with physical dpi, the ratio of representation between kilsore and me is
-    // too far away.
-    //
-    // This means that the following correction does not have a documented basis, but appears
-    // necessary so that the Sketcher is usable in HDPI monitors.
 
     Client.drawingParameters.coinFontSize =
-        std::lround(sketcherfontSize * 96.0f / dpi);  // this is in pixels
+        std::lround(sketcherfontSize * devicePixelRatio);  // this is in pixels
     Client.drawingParameters.labelFontSize = std::lround(
-        sketcherfontSize * 72.0f / dpi);  // this is in points, as SoDatumLabel uses points
-    Client.drawingParameters.constraintIconSize = std::lround(0.8 * sketcherfontSize);
-
-    // For marker size the global default is used.
-    //
-    // Rationale:
-    // -> Other WBs use the default value as is
-    // -> If a user has a HDPI, he will eventually change the value for the other WBs
-    // -> If we correct the value here in addition, we would get two times a resize
-    Client.drawingParameters.markerSize = markersize;
+        sketcherfontSize * devicePixelRatio * 96 / 72);  // this is in points, as SoDatumLabel uses points
+    Client.drawingParameters.constraintIconSize = std::lround(0.8 * sketcherfontSize * devicePixelRatio);
+    Client.drawingParameters.markerSize = std::lround(markersize * devicePixelRatio);
 
     Client.updateInventorNodeSizes();
 }
@@ -1070,6 +1047,11 @@ void EditModeCoinManager::updateVirtualSpace()
 int EditModeCoinManager::defaultApplicationFontSizePixels() const
 {
     return ViewProviderSketchCoinAttorney::defaultApplicationFontSizePixels(viewProvider);
+}
+
+qreal EditModeCoinManager::getDevicePixelRatio() const
+{
+    return ViewProviderSketchCoinAttorney::getDevicePixelRatio(viewProvider);
 }
 
 int EditModeCoinManager::getApplicationLogicalDPIX() const

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -377,9 +377,11 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(
 
     Client.drawingParameters.coinFontSize =
         std::lround(sketcherfontSize * devicePixelRatio);  // this is in pixels
-    Client.drawingParameters.labelFontSize = std::lround(
-        sketcherfontSize * devicePixelRatio * 96 / 72);  // this is in points, as SoDatumLabel uses points
-    Client.drawingParameters.constraintIconSize = std::lround(0.8 * sketcherfontSize * devicePixelRatio);
+    Client.drawingParameters.labelFontSize =
+        std::lround(sketcherfontSize * devicePixelRatio * 96
+                    / 72);  // this is in points, as SoDatumLabel uses points
+    Client.drawingParameters.constraintIconSize =
+        std::lround(0.8 * sketcherfontSize * devicePixelRatio);
     Client.drawingParameters.markerSize = std::lround(markersize * devicePixelRatio);
 
     Client.updateInventorNodeSizes();

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -366,7 +366,7 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(
 
     int sketcherfontSize = hGrp->GetInt("EditSketcherFontSize", defaultFontSizePixels);
 
-    qreal devicePixelRatio = Client.getDevicePixelRatio();
+    double devicePixelRatio = Client.getDevicePixelRatio();
 
     // simple scaling factor for hardcoded pixel values in the Sketcher
     Client.drawingParameters.pixelScalingFactor = devicePixelRatio;
@@ -1051,7 +1051,7 @@ int EditModeCoinManager::defaultApplicationFontSizePixels() const
     return ViewProviderSketchCoinAttorney::defaultApplicationFontSizePixels(viewProvider);
 }
 
-qreal EditModeCoinManager::getDevicePixelRatio() const
+double EditModeCoinManager::getDevicePixelRatio() const
 {
     return ViewProviderSketchCoinAttorney::getDevicePixelRatio(viewProvider);
 }

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -280,7 +280,7 @@ private:
 
     int defaultApplicationFontSizePixels() const;
 
-    qreal getDevicePixelRatio() const;
+    double getDevicePixelRatio() const;
 
     int getApplicationLogicalDPIX() const;
 

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -280,6 +280,8 @@ private:
 
     int defaultApplicationFontSizePixels() const;
 
+    qreal getDevicePixelRatio() const;
+
     int getApplicationLogicalDPIX() const;
 
     void updateInventorNodeSizes();

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3968,6 +3968,17 @@ int ViewProviderSketch::defaultFontSizePixels() const
     return static_cast<int>(metrics.height());
 }
 
+qreal ViewProviderSketch::getDevicePixelRatio() const
+{
+    auto activeView = this->getActiveView();
+    if (activeView) {
+        auto glWidget = qobject_cast<Gui::View3DInventor*>(activeView)->getViewer()->getGLWidget();
+        return glWidget->devicePixelRatio();
+    }
+
+    return QApplication::primaryScreen()->devicePixelRatio();
+}
+
 int ViewProviderSketch::getApplicationLogicalDPIX() const
 {
     return int(QApplication::primaryScreen()->logicalDotsPerInchX());

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3970,9 +3970,8 @@ int ViewProviderSketch::defaultFontSizePixels() const
 
 qreal ViewProviderSketch::getDevicePixelRatio() const
 {
-    auto activeView = this->getActiveView();
-    if (activeView) {
-        auto glWidget = qobject_cast<Gui::View3DInventor*>(activeView)->getViewer()->getGLWidget();
+    if (auto activeView = qobject_cast<Gui::View3DInventor*>(this->getActiveView())) {
+        auto glWidget = activeView->getViewer()->getGLWidget();
         return glWidget->devicePixelRatio();
     }
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -857,6 +857,8 @@ private:
 
     int defaultFontSizePixels() const;
 
+    qreal getDevicePixelRatio() const;
+
     int getApplicationLogicalDPIX() const;
 
     double getRotation(SbVec3f pos0, SbVec3f pos1) const;

--- a/src/Mod/Sketcher/Gui/ViewProviderSketchCoinAttorney.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketchCoinAttorney.h
@@ -97,6 +97,7 @@ private:
     static inline QFont getApplicationFont(const ViewProviderSketch& vp);
     static inline double getRotation(const ViewProviderSketch& vp, SbVec3f pos0, SbVec3f pos1);
     static inline int defaultApplicationFontSizePixels(const ViewProviderSketch& vp);
+    static inline qreal getDevicePixelRatio(const ViewProviderSketch& vp);
     static inline int getApplicationLogicalDPIX(const ViewProviderSketch& vp);
     static inline int getViewOrientationFactor(const ViewProviderSketch& vp);
 
@@ -193,6 +194,11 @@ inline int
 ViewProviderSketchCoinAttorney::defaultApplicationFontSizePixels(const ViewProviderSketch& vp)
 {
     return vp.defaultFontSizePixels();
+}
+
+inline qreal ViewProviderSketchCoinAttorney::getDevicePixelRatio(const ViewProviderSketch& vp)
+{
+    return vp.getDevicePixelRatio();
 }
 
 inline int ViewProviderSketchCoinAttorney::getApplicationLogicalDPIX(const ViewProviderSketch& vp)

--- a/src/Mod/Sketcher/Gui/ViewProviderSketchCoinAttorney.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketchCoinAttorney.h
@@ -97,7 +97,7 @@ private:
     static inline QFont getApplicationFont(const ViewProviderSketch& vp);
     static inline double getRotation(const ViewProviderSketch& vp, SbVec3f pos0, SbVec3f pos1);
     static inline int defaultApplicationFontSizePixels(const ViewProviderSketch& vp);
-    static inline qreal getDevicePixelRatio(const ViewProviderSketch& vp);
+    static inline double getDevicePixelRatio(const ViewProviderSketch& vp);
     static inline int getApplicationLogicalDPIX(const ViewProviderSketch& vp);
     static inline int getViewOrientationFactor(const ViewProviderSketch& vp);
 
@@ -196,7 +196,7 @@ ViewProviderSketchCoinAttorney::defaultApplicationFontSizePixels(const ViewProvi
     return vp.defaultFontSizePixels();
 }
 
-inline qreal ViewProviderSketchCoinAttorney::getDevicePixelRatio(const ViewProviderSketch& vp)
+inline double ViewProviderSketchCoinAttorney::getDevicePixelRatio(const ViewProviderSketch& vp)
 {
     return vp.getDevicePixelRatio();
 }


### PR DESCRIPTION
This is the Sketcher part of of fixing issue https://github.com/FreeCAD/FreeCAD/issues/19887 and is a follow up PR to #19929 for NaviCube.

It follows basically the same approach as the NaviCube PR, which is to use devicePixelRatio. Unlike that one, Sketcher was already doing some math related to pixel ratio, but it didn't seem to be working. It was also hard coded to look at the primary screen. I believe I fixed that, but I still need to actually plug in an external monitor and verify it.

I deleted the comments explaining the old approach since my change means it's no longer following it.

I think the same "adjusting the projection matrix" matrix objection applies here too. (See https://github.com/FreeCAD/FreeCAD/pull/19929#issuecomment-2692626506 and https://github.com/FreeCAD/FreeCAD/issues/19887#issuecomment-2692211114 ).

So I won't submit any more of these until we figure that out. (I'm not convinced it will work, but there's also a lot I don't know.)

I kept / reworked the pixel to point math, but I haven't taken the time to verify if it does the right thing or not (both before and after my change).