### PR TITLE
TechDraw: removed gp_* conversion code from TechDraw workbench

### DIFF
--- a/src/Mod/TechDraw/App/CenterLine.cpp
+++ b/src/Mod/TechDraw/App/CenterLine.cpp
@@ -32,6 +32,7 @@
 #include <BRepTools.hxx>
 
 #include <Base/Console.h>
+#include <Base/Converter.h>
 
 #include "CenterLine.h"
 #include "DrawUtil.h"
@@ -320,8 +321,8 @@ TechDraw::BaseGeomPtr CenterLine::scaledAndRotatedGeometry(TechDraw::DrawViewPar
 
     TopoDS_Edge newEdge;
     if (getType() == Type::FACE ) {
-        gp_Pnt gp1(DU::to<gp_Pnt>(p1));
-        gp_Pnt gp2(DU::to<gp_Pnt>(p2));
+        gp_Pnt gp1(Base::convertTo<gp_Pnt>(p1));
+        gp_Pnt gp2(Base::convertTo<gp_Pnt>(p2));
         TopoDS_Edge e = BRepBuilderAPI_MakeEdge(gp1, gp2);
         // Mirror shape in Y and scale
         TopoDS_Shape s = ShapeUtils::mirrorShape(e, gp_Pnt(0.0, 0.0, 0.0), scale);
@@ -330,8 +331,8 @@ TechDraw::BaseGeomPtr CenterLine::scaledAndRotatedGeometry(TechDraw::DrawViewPar
         newEdge = TopoDS::Edge(s);
     } else if (getType() == Type::EDGE  ||
                getType() == Type::VERTEX) {
-        gp_Pnt gp1(DU::to<gp_Pnt>(DU::invertY(p1 * scale)));
-        gp_Pnt gp2(DU::to<gp_Pnt>(DU::invertY(p2 * scale)));
+        gp_Pnt gp1(Base::convertTo<gp_Pnt>(DU::invertY(p1 * scale)));
+        gp_Pnt gp2(Base::convertTo<gp_Pnt>(DU::invertY(p2 * scale)));
         newEdge = BRepBuilderAPI_MakeEdge(gp1, gp2);
     }
 

--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <App/Application.h>
+#include <Base/Converter.h>
 #include <Base/Vector3D.h>
 #include <Mod/TechDraw/App/CosmeticEdgePy.h>
 #include <Mod/TechDraw/App/GeomFormatPy.h>
@@ -160,8 +161,8 @@ TechDraw::BaseGeomPtr CosmeticEdge::makeCanonicalLine(DrawViewPart* dvp, Base::V
 {
     Base::Vector3d cStart = CosmeticVertex::makeCanonicalPoint(dvp, start);
     Base::Vector3d cEnd   = CosmeticVertex::makeCanonicalPoint(dvp, end);
-    gp_Pnt gStart  = DU::to<gp_Pnt>(cStart);
-    gp_Pnt gEnd    = DU::to<gp_Pnt>(cEnd);
+    gp_Pnt gStart  = Base::convertTo<gp_Pnt>(cStart);
+    gp_Pnt gEnd    = Base::convertTo<gp_Pnt>(cEnd);
     TopoDS_Edge edge = BRepBuilderAPI_MakeEdge(gStart, gEnd);
     return TechDraw::BaseGeom::baseFactory(edge);
 }
@@ -169,8 +170,8 @@ TechDraw::BaseGeomPtr CosmeticEdge::makeCanonicalLine(DrawViewPart* dvp, Base::V
 //! makes an unscaled, unrotated line from two canonical points.
 TechDraw::BaseGeomPtr CosmeticEdge::makeLineFromCanonicalPoints(Base::Vector3d start, Base::Vector3d end)
 {
-    gp_Pnt gStart  = DU::to<gp_Pnt>(start);
-    gp_Pnt gEnd    = DU::to<gp_Pnt>(end);
+    gp_Pnt gStart  = Base::convertTo<gp_Pnt>(start);
+    gp_Pnt gEnd    = Base::convertTo<gp_Pnt>(end);
     TopoDS_Edge edge = BRepBuilderAPI_MakeEdge(gStart, gEnd);
     return TechDraw::BaseGeom::baseFactory(edge);
 }

--- a/src/Mod/TechDraw/App/DimensionGeometry.cpp
+++ b/src/Mod/TechDraw/App/DimensionGeometry.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include <Base/Console.h>
+#include <Base/Converter.h>
 #include <Base/Tools.h>
 
 #include "DimensionGeometry.h"
@@ -97,10 +98,10 @@ void pointPair::mapToPage(const DrawViewPart* dvp)
     gp_Ax3 OXYZ;
     xOXYZ.SetTransformation(OXYZ, gp_Ax3(dvp->getRotatedCS()));
 
-    gp_Vec gvFirst = DU::to<gp_Vec>(m_first).Transformed(xOXYZ);
-    m_first = DU::toVector3d(gvFirst);
-    gp_Vec gvSecond = DU::to<gp_Vec>(m_second).Transformed(xOXYZ);
-    m_second = DU::toVector3d(gvSecond);
+    gp_Vec gvFirst = Base::convertTo<gp_Vec>(m_first).Transformed(xOXYZ);
+    m_first = Base::convertTo<Base::Vector3d>(gvFirst);
+    gp_Vec gvSecond = Base::convertTo<gp_Vec>(m_second).Transformed(xOXYZ);
+    m_second = Base::convertTo<Base::Vector3d>(gvSecond);
 }
 
 // this routine is no longer needed since we now use the dvp's projectPoint
@@ -194,8 +195,8 @@ void anglePoints::mapToPage(const DrawViewPart* dvp)
     gp_Trsf xOXYZ;
     gp_Ax3 OXYZ;
     xOXYZ.SetTransformation(OXYZ, gp_Ax3(dvp->getRotatedCS()));
-    gp_Vec gvVertex = DU::to<gp_Vec>(m_vertex).Transformed(xOXYZ);
-    m_vertex = DU::toVector3d(gvVertex);
+    gp_Vec gvVertex = Base::convertTo<gp_Vec>(m_vertex).Transformed(xOXYZ);
+    m_vertex = Base::convertTo<Base::Vector3d>(gvVertex);
 }
 
 // map the points onto the coordinate system used for drawing where -Y direction is "up"
@@ -291,18 +292,18 @@ void arcPoints::mapToPage(const DrawViewPart* dvp)
     gp_Ax3 OXYZ;
     xOXYZ.SetTransformation(OXYZ, gp_Ax3(dvp->getRotatedCS()));
 
-    gp_Vec gvCenter = DU::to<gp_Vec>(center).Transformed(xOXYZ);
-    center = DU::toVector3d(gvCenter);
-    gp_Vec gvOnCurve1 = DU::to<gp_Vec>(onCurve.first()).Transformed(xOXYZ);
-    onCurve.first(DU::toVector3d(gvOnCurve1));
-    gp_Vec gvOnCurve2 = DU::to<gp_Vec>(onCurve.second()).Transformed(xOXYZ);
-    onCurve.second(DU::toVector3d(gvOnCurve2));
-    gp_Vec gvArcEnds1 = DU::to<gp_Vec>(arcEnds.first()).Transformed(xOXYZ);
-    arcEnds.first(DU::toVector3d(gvArcEnds1));
-    gp_Vec gvArcEnds2 = DU::to<gp_Vec>(arcEnds.second()).Transformed(xOXYZ);
-    arcEnds.second(DU::toVector3d(gvArcEnds2));
-    gp_Vec gvMidArc = DU::to<gp_Vec>(midArc).Transformed(xOXYZ);
-    midArc = DU::toVector3d(gvMidArc);
+    gp_Vec gvCenter = Base::convertTo<gp_Vec>(center).Transformed(xOXYZ);
+    center = Base::convertTo<Base::Vector3d>(gvCenter);
+    gp_Vec gvOnCurve1 = Base::convertTo<gp_Vec>(onCurve.first()).Transformed(xOXYZ);
+    onCurve.first(Base::convertTo<Base::Vector3d>(gvOnCurve1));
+    gp_Vec gvOnCurve2 = Base::convertTo<gp_Vec>(onCurve.second()).Transformed(xOXYZ);
+    onCurve.second(Base::convertTo<Base::Vector3d>(gvOnCurve2));
+    gp_Vec gvArcEnds1 = Base::convertTo<gp_Vec>(arcEnds.first()).Transformed(xOXYZ);
+    arcEnds.first(Base::convertTo<Base::Vector3d>(gvArcEnds1));
+    gp_Vec gvArcEnds2 = Base::convertTo<gp_Vec>(arcEnds.second()).Transformed(xOXYZ);
+    arcEnds.second(Base::convertTo<Base::Vector3d>(gvArcEnds2));
+    gp_Vec gvMidArc = Base::convertTo<gp_Vec>(midArc).Transformed(xOXYZ);
+    midArc = Base::convertTo<Base::Vector3d>(gvMidArc);
 }
 
 // obsolete. see above

--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -110,6 +110,7 @@
 #include <App/Material.h>
 #include <Base/BoundBox.h>
 #include <Base/Console.h>
+#include <Base/Converter.h>
 #include <Base/Exception.h>
 #include <Base/FileInfo.h>
 #include <Base/Interpreter.h>
@@ -550,7 +551,7 @@ void DrawComplexSection::makeAlignedPieces(const TopoDS_Shape& rawShape)
     }
 
     //center the compound along SectionCS XDirection
-    Base::Vector3d centerVector = DU::toVector3d(gMovementVector) * distanceToMove / -2.0;
+    Base::Vector3d centerVector = Base::convertTo<Base::Vector3d>(gMovementVector) * distanceToMove / -2.0;
     TopoDS_Shape centeredCompound = ShapeUtils::moveShape(comp, centerVector);
 
     if (debugSection()) {
@@ -796,7 +797,7 @@ std::pair<Base::Vector3d, Base::Vector3d> DrawComplexSection::sectionArrowDirs()
     }
 
     gp_Vec gProfileVector = makeProfileVector(profileWire);
-    gp_Vec gSectionNormal = gp_Vec(DU::to<gp_Dir>(SectionNormal.getValue()));
+    gp_Vec gSectionNormal = gp_Vec(Base::convertTo<gp_Dir>(SectionNormal.getValue()));
     gp_Vec gExtrudeVector = (gSectionNormal.Crossed(gProfileVector)).Normalized();
     Base::Vector3d vClosestBasis = DrawUtil::closestBasis(gp_Dir(gExtrudeVector), getSectionCS());
     gp_Dir gExtrudeDir = gp_Dir(vClosestBasis.x, vClosestBasis.y, vClosestBasis.z);
@@ -826,8 +827,8 @@ std::pair<Base::Vector3d, Base::Vector3d> DrawComplexSection::sectionArrowDirs()
     }
 
     //TODO: similar code elsewhere. Opportunity for reuse.
-    Base::Vector3d vDir0 = DU::toVector3d(gDir0);
-    Base::Vector3d vDir1 = DU::toVector3d(gDir1);
+    Base::Vector3d vDir0 = Base::convertTo<Base::Vector3d>(gDir0);
+    Base::Vector3d vDir1 = Base::convertTo<Base::Vector3d>(gDir1);
     vDir0.Normalize();
     vDir1.Normalize();
     DrawViewPart* baseDvp = dynamic_cast<DrawViewPart*>(BaseView.getValue());
@@ -981,8 +982,8 @@ std::pair<Base::Vector3d, Base::Vector3d> DrawComplexSection::getSegmentEnds(Top
     gp_Pnt gpFirst = BRep_Tool::Pnt(tvFirst);
     gp_Pnt gpLast = BRep_Tool::Pnt(tvLast);
     std::pair<Base::Vector3d, Base::Vector3d> result;
-    result.first = DU::toVector3d(gpFirst);
-    result.second = DU::toVector3d(gpLast);
+    result.first = Base::convertTo<Base::Vector3d>(gpFirst);
+    result.second = Base::convertTo<Base::Vector3d>(gpLast);
     return result;
 }
 

--- a/src/Mod/TechDraw/App/DrawGeomHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.cpp
@@ -49,6 +49,7 @@
 #include <App/Application.h>
 #include <App/Document.h>
 #include <Base/Console.h>
+#include <Base/Converter.h>
 #include <Base/FileInfo.h>
 #include <Base/Parameter.h>
 
@@ -336,7 +337,7 @@ std::vector<LineSet> DrawGeomHatch::getTrimmedLines(DrawViewPart* source,
 
         TopoDS_Shape grid = gridComp;
         gp_Trsf xGridTranslate;
-        xGridTranslate.SetTranslation(DrawUtil::to<gp_Vec>(hatchOffset));
+        xGridTranslate.SetTranslation(Base::convertTo<gp_Vec>(hatchOffset));
         BRepBuilderAPI_Transform mkTransTranslate(grid, xGridTranslate, true);
         grid = mkTransTranslate.Shape();
 

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -58,6 +58,7 @@
 #endif
 
 #include <Base/Console.h>
+#include <Base/Converter.h>
 #include <Base/FileInfo.h>
 #include <Base/Parameter.h>
 #include <Base/Stream.h>
@@ -414,7 +415,7 @@ bool DrawUtil::apparentIntersection(const Handle(Geom_Curve) curve1,
     //for our purposes, only one intersection point is required.
     gp_Pnt p1, p2;
     intersector.Points(1, p1, p2);
-    result = toVector3d(p1);
+    result = Base::convertTo<Base::Vector3d>(p1);
     return true;
 }
 
@@ -519,6 +520,15 @@ std::string DrawUtil::formatVector(const Base::Vector3d& v)
     return builder.str();
 }
 //template std::string DrawUtil::formatVector<Base::Vector3d>(const Base::Vector3d &v);
+
+// template specialization
+std::string DrawUtil::formatVector(const QPointF& v)
+{
+    std::stringstream builder;
+    builder << std::fixed << std::setprecision(Base::UnitsApi::getDecimals());
+    builder << " (" << v.x() << ", " << v.y() << ") ";
+    return builder.str();
+}
 
 //! compare 2 vectors for sorting - true if v1 < v2
 //! precision::Confusion() is too strict for vertex - vertex comparisons
@@ -648,7 +658,7 @@ Base::Vector3d DrawUtil::vecRotate(Base::Vector3d vec, double angle, Base::Vecto
 
 gp_Vec DrawUtil::closestBasis(gp_Vec inVec)
 {
-    return gp_Vec(to<gp_Dir>(closestBasis(toVector3d(inVec))));
+    return gp_Vec(Base::convertTo<gp_Dir>(closestBasis(Base::convertTo<Base::Vector3d>(inVec))));
 }
 
 //! returns stdX, stdY or stdZ.
@@ -836,7 +846,7 @@ double DrawUtil::getWidthInDirection(gp_Dir direction, TopoDS_Shape& shape)
     Base::Vector3d stdXr(-1.0, 0.0, 0.0);
     Base::Vector3d stdYr(0.0, -1.0, 0.0);
     Base::Vector3d stdZr(0.0, 0.0, -1.0);
-    Base::Vector3d vClosestBasis = closestBasis(toVector3d(direction));
+    Base::Vector3d vClosestBasis = closestBasis(Base::convertTo<Base::Vector3d>(direction));
 
     Bnd_Box shapeBox;
     shapeBox.SetGap(0.0);
@@ -888,7 +898,7 @@ gp_Vec DrawUtil::maskDirection(gp_Vec inVec, gp_Dir directionToMask)
 
 Base::Vector3d DrawUtil::maskDirection(Base::Vector3d inVec, Base::Vector3d directionToMask)
 {
-    return toVector3d(maskDirection(to<gp_Vec>(inVec), to<gp_Vec>(directionToMask)));
+    return Base::convertTo<Base::Vector3d>(maskDirection(Base::convertTo<gp_Vec>(inVec), Base::convertTo<gp_Vec>(directionToMask)));
 }
 
 //! get the coordinate of inPoint for the cardinal unit direction.

--- a/src/Mod/TechDraw/App/DrawUtil.h
+++ b/src/Mod/TechDraw/App/DrawUtil.h
@@ -44,7 +44,9 @@
 #include <gp_Vec.hxx>
 
 #include <Base/Vector3D.h>
+#include <Base/Converter.h>
 #include <Mod/Part/App/PartFeature.h>
+#include <Mod/Part/App/Tools.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
 
@@ -121,9 +123,10 @@ public:
     template <typename T>
     static std::string formatVector(const T& v)
     {
-        return formatVector(toVector3d(v));
+        return formatVector(Base::convertTo<Base::Vector3d>(v));
     }
     static std::string formatVector(const Base::Vector3d& v);
+    static std::string formatVector(const QPointF& v);
 
     static bool vectorLess(const Base::Vector3d& v1, const Base::Vector3d& v2);
     //!std::map require comparator to be a type not a function
@@ -171,23 +174,9 @@ public:
                                       Base::Vector2d d2);
 
 
-    template <typename T>
-    static Base::Vector3d toVector3d(const T& v)
-    {
-        return Base::Vector3d(v.X(), v.Y(), v.Z());
-    }
-
     static Base::Vector3d toVector3d(const QPointF& v)
     {
         return Base::Vector3d(v.x(), v.y(), 0);
-    }
-
-    //! To gp_*
-    // TODO: Would this be relevant to move to Base::Vector3d? Probably
-    template <typename T>
-    static T to(const Base::Vector3d &v)
-    {
-        return T(v.x, v.y, v.z);
     }
 
     static QPointF toQPointF(const Base::Vector3d &v)
@@ -289,9 +278,6 @@ public:
 
 // GCC BUG 85282, wanting this to be outside class body. This is only the declaration, the definition .cpp
 //template<> std::string DrawUtil::formatVector<Base::Vector3d>(const Base::Vector3d &v);
-
-// GCC BUG 85282, wanting this to be outside class body. This is only the declaration, the definition .cpp
-//template<> Base::Vector3d DrawUtil::toVector3d<QPointF>(const QPointF& v);
 
 }//end namespace TechDraw
 #endif

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -58,6 +58,7 @@
 #include <App/Application.h>
 #include <App/Document.h>
 #include <Base/Console.h>
+#include <Base/Converter.h>
 #include <Base/Parameter.h>
 #include <Base/Quantity.h>
 #include <Base/Tools.h>
@@ -842,7 +843,7 @@ pointPair DrawViewDimension::getPointsOneEdge(ReferenceVector references)
     gp_Pnt gEnd0 = BRep_Tool::Pnt(TopExp::FirstVertex(edge));
     gp_Pnt gEnd1 = BRep_Tool::Pnt(TopExp::LastVertex(edge));
 
-    pointPair pts(DrawUtil::toVector3d(gEnd0), DrawUtil::toVector3d(gEnd1));
+    pointPair pts(Base::convertTo<Base::Vector3d>(gEnd0), Base::convertTo<Base::Vector3d>(gEnd1));
     pts.move(getViewPart()->getCurrentCentroid());
     pts.project(getViewPart());
     return pts;
@@ -911,7 +912,7 @@ pointPair DrawViewDimension::getPointsTwoVerts(ReferenceVector references)
     gp_Pnt gPoint0 = BRep_Tool::Pnt(vertex0);
     gp_Pnt gPoint1 = BRep_Tool::Pnt(vertex1);
 
-    pointPair pts(DrawUtil::toVector3d(gPoint0), DrawUtil::toVector3d(gPoint1));
+    pointPair pts(Base::convertTo<Base::Vector3d>(gPoint0), Base::convertTo<Base::Vector3d>(gPoint1));
     pts.move(getViewPart()->getCurrentCentroid());
     pts.project(getViewPart());
     return pts;
@@ -1117,23 +1118,23 @@ arcPoints DrawViewDimension::arcPointsFromEdge(TopoDS_Edge occEdge)
     double pLast = adapt.LastParameter();
     double pMid = (pFirst + pLast) / 2;
     BRepLProp_CLProps props(adapt, pFirst, 0, Precision::Confusion());
-    pts.arcEnds.first(DrawUtil::toVector3d(props.Value()));
+    pts.arcEnds.first(Base::convertTo<Base::Vector3d>(props.Value()));
     props.SetParameter(pLast);
-    pts.arcEnds.second(DrawUtil::toVector3d(props.Value()));
+    pts.arcEnds.second(Base::convertTo<Base::Vector3d>(props.Value()));
     props.SetParameter(pMid);
-    pts.onCurve.first(DrawUtil::toVector3d(props.Value()));
-    pts.onCurve.second(DrawUtil::toVector3d(props.Value()));
-    pts.midArc = DrawUtil::toVector3d(props.Value());
+    pts.onCurve.first(Base::convertTo<Base::Vector3d>(props.Value()));
+    pts.onCurve.second(Base::convertTo<Base::Vector3d>(props.Value()));
+    pts.midArc = Base::convertTo<Base::Vector3d>(props.Value());
 
     if (adapt.GetType() == GeomAbs_Circle) {
         gp_Circ circle = adapt.Circle();
-        pts.center = DrawUtil::toVector3d(circle.Location());
+        pts.center = Base::convertTo<Base::Vector3d>(circle.Location());
         pts.radius = circle.Radius();
         if (pts.isArc) {
             // part of circle
             gp_Ax1 axis = circle.Axis();
-            gp_Vec startVec = DrawUtil::to<gp_Vec>(pts.arcEnds.first() - pts.center);
-            gp_Vec endVec = DrawUtil::to<gp_Vec>(pts.arcEnds.second() - pts.center);
+            gp_Vec startVec = Base::convertTo<gp_Vec>(pts.arcEnds.first() - pts.center);
+            gp_Vec endVec = Base::convertTo<gp_Vec>(pts.arcEnds.second() - pts.center);
             double angle = startVec.AngleWithRef(endVec, axis.Direction().XYZ());
             pts.arcCW = (angle < 0.0);
         }
@@ -1147,13 +1148,13 @@ arcPoints DrawViewDimension::arcPointsFromEdge(TopoDS_Edge occEdge)
     }
     else if (adapt.GetType() == GeomAbs_Ellipse) {
         gp_Elips ellipse = adapt.Ellipse();
-        pts.center = DrawUtil::toVector3d(ellipse.Location());
+        pts.center = Base::convertTo<Base::Vector3d>(ellipse.Location());
         pts.radius = (ellipse.MajorRadius() + ellipse.MinorRadius()) / 2.0;
         if (pts.isArc) {
             // part of ellipse
             gp_Ax1 axis = ellipse.Axis();
-            gp_Vec startVec = DrawUtil::to<gp_Vec>(pts.arcEnds.first() - pts.center);
-            gp_Vec endVec = DrawUtil::to<gp_Vec>(pts.arcEnds.second() - pts.center);
+            gp_Vec startVec = Base::convertTo<gp_Vec>(pts.arcEnds.first() - pts.center);
+            gp_Vec endVec = Base::convertTo<gp_Vec>(pts.arcEnds.second() - pts.center);
             double angle = startVec.AngleWithRef(endVec, axis.Direction().XYZ());
             pts.arcCW = (angle < 0.0);
         }
@@ -1176,13 +1177,13 @@ arcPoints DrawViewDimension::arcPointsFromEdge(TopoDS_Edge occEdge)
             }
             gp_Circ circle = adapt.Circle();
             // TODO: same code as above. reuse opportunity.
-            pts.center = DrawUtil::toVector3d(circle.Location());
+            pts.center = Base::convertTo<Base::Vector3d>(circle.Location());
             pts.radius = circle.Radius();
             if (pts.isArc) {
                 // part of circle
                 gp_Ax1 axis = circle.Axis();
-                gp_Vec startVec = DrawUtil::to<gp_Vec>(pts.arcEnds.first() - pts.center);
-                gp_Vec endVec = DrawUtil::to<gp_Vec>(pts.arcEnds.second() - pts.center);
+                gp_Vec startVec = Base::convertTo<gp_Vec>(pts.arcEnds.first() - pts.center);
+                gp_Vec endVec = Base::convertTo<gp_Vec>(pts.arcEnds.second() - pts.center);
                 double angle = startVec.AngleWithRef(endVec, axis.Direction().XYZ());
                 pts.arcCW = (angle < 0.0);
             }
@@ -1310,15 +1311,15 @@ anglePoints DrawViewDimension::getAnglePointsTwoEdges(ReferenceVector references
     gp_Pnt gEnd1 = BRep_Tool::Pnt(TopExp::LastVertex(edge1));
     gp_Vec gDir1(gEnd1.XYZ() - gStart1.XYZ());
     Base::Vector3d vApex;
-    bool haveIntersection = DrawUtil::intersect2Lines3d(DrawUtil::toVector3d(gStart0),
-                                                        DrawUtil::toVector3d(gDir0),
-                                                        DrawUtil::toVector3d(gStart1),
-                                                        DrawUtil::toVector3d(gDir1),
+    bool haveIntersection = DrawUtil::intersect2Lines3d(Base::convertTo<Base::Vector3d>(gStart0),
+                                                        Base::convertTo<Base::Vector3d>(gDir0),
+                                                        Base::convertTo<Base::Vector3d>(gStart1),
+                                                        Base::convertTo<Base::Vector3d>(gDir1),
                                                         vApex);
     if (!haveIntersection) {
         throw Base::RuntimeError("Geometry for 3d angle dimension does not intersect");
     }
-    gp_Pnt gApex = DrawUtil::to<gp_Pnt>(vApex);
+    gp_Pnt gApex = Base::convertTo<gp_Pnt>(vApex);
 
     gp_Pnt gFar0 = gEnd0;
     if (gStart0.Distance(gApex) > gEnd0.Distance(gApex)) {
@@ -1329,9 +1330,9 @@ anglePoints DrawViewDimension::getAnglePointsTwoEdges(ReferenceVector references
     if (gStart1.Distance(gApex) > gEnd1.Distance(gApex)) {
         gFar1 = gStart1;
     }
-    anglePoints pts(DrawUtil::toVector3d(gApex),
-                    DrawUtil::toVector3d(gFar0),
-                    DrawUtil::toVector3d(gFar1));
+    anglePoints pts(Base::convertTo<Base::Vector3d>(gApex),
+                    Base::convertTo<Base::Vector3d>(gFar0),
+                    Base::convertTo<Base::Vector3d>(gFar1));
     pts.move(getViewPart()->getCurrentCentroid());
     pts.project(getViewPart());
     return pts;
@@ -1376,9 +1377,9 @@ anglePoints DrawViewDimension::getAnglePointsThreeVerts(ReferenceVector referenc
     gp_Pnt point1 = BRep_Tool::Pnt(vertex1);
     TopoDS_Vertex vertex2 = TopoDS::Vertex(geometry2);
     gp_Pnt point2 = BRep_Tool::Pnt(vertex2);
-    anglePoints pts(DrawUtil::toVector3d(point1),
-                    DrawUtil::toVector3d(point0),
-                    DrawUtil::toVector3d(point2));
+    anglePoints pts(Base::convertTo<Base::Vector3d>(point1),
+                    Base::convertTo<Base::Vector3d>(point0),
+                    Base::convertTo<Base::Vector3d>(point2));
     pts.move(getViewPart()->getCurrentCentroid());
     pts.project(getViewPart());
     return pts;
@@ -1435,7 +1436,7 @@ Base::Vector3d DrawViewDimension::getFaceCenter(const TopoDS_Face& face)
 {
     GProp_GProps props;
     BRepGProp::SurfaceProperties(face, props);
-    auto center = DrawUtil::toVector3d(props.CentreOfMass());
+    auto center = Base::convertTo<Base::Vector3d>(props.CentreOfMass());
     return center;
 }
 
@@ -1718,9 +1719,9 @@ double DrawViewDimension::getArcAngle(Base::Vector3d center, Base::Vector3d star
     auto leg0 = startPoint - center;
     auto leg1 = endPoint - startPoint;
     auto referenceDirection = leg0.Cross(leg1);
-    gp_Ax1 axis{DU::to<gp_Pnt>(center), DU::to<gp_Vec>(referenceDirection)};
-    gp_Vec startVec = DrawUtil::to<gp_Vec>(leg0);
-    gp_Vec endVec = DrawUtil::to<gp_Vec>(leg1);
+    gp_Ax1 axis{Base::convertTo<gp_Pnt>(center), Base::convertTo<gp_Vec>(referenceDirection)};
+    gp_Vec startVec = Base::convertTo<gp_Vec>(leg0);
+    gp_Vec endVec = Base::convertTo<gp_Vec>(leg1);
     double angle = startVec.AngleWithRef(endVec, axis.Direction().XYZ());
     return angle;
 }

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -68,6 +68,7 @@
 #include <App/Document.h>
 #include <Base/BoundBox.h>
 #include <Base/Console.h>
+#include <Base/Converter.h>
 #include <Base/Exception.h>
 #include <Base/Parameter.h>
 
@@ -312,7 +313,7 @@ GeometryObjectPtr DrawViewPart::makeGeometryForShape(TopoDS_Shape& shape)
     TopoDS_Shape localShape = copier.Shape();
 
     gp_Pnt gCentroid = ShapeUtils::findCentroid(localShape, getProjectionCS());
-    m_saveCentroid = DU::toVector3d(gCentroid);
+    m_saveCentroid = Base::convertTo<Base::Vector3d>(gCentroid);
     m_saveShape = centerScaleRotate(this, localShape, m_saveCentroid);
 
     return buildGeometryObject(localShape, getProjectionCS());
@@ -1074,7 +1075,7 @@ Base::Vector3d DrawViewPart::localVectorToDirection(const Base::Vector3d localUn
 {
     //    Base::Console().Message("DVP::localVectorToDirection() - localUnit: %s\n", DrawUtil::formatVector(localUnit).c_str());
     gp_Ax2 cs = localVectorToCS(localUnit);
-    return DrawUtil::toVector3d(cs.Direction());
+    return Base::convertTo<Base::Vector3d>(cs.Direction());
 }
 
 gp_Ax2 DrawViewPart::getProjectionCS(const Base::Vector3d pt) const
@@ -1099,7 +1100,7 @@ gp_Ax2 DrawViewPart::getRotatedCS(const Base::Vector3d basePoint) const
 {
     //    Base::Console().Message("DVP::getRotatedCS() - %s - %s\n", getNameInDocument(), Label.getValue());
     gp_Ax2 unrotated = getProjectionCS(basePoint);
-    gp_Ax1 rotationAxis(DU::to<gp_Pnt>(basePoint), unrotated.Direction());
+    gp_Ax1 rotationAxis(Base::convertTo<gp_Pnt>(basePoint), unrotated.Direction());
     double angleRad = Rotation.getValue() * M_PI / 180.0;
     gp_Ax2 rotated = unrotated.Rotated(rotationAxis, -angleRad);
     return rotated;
@@ -1126,7 +1127,7 @@ Base::Vector3d DrawViewPart::getCurrentCentroid() const
     }
     gp_Ax2 cs = getProjectionCS();
     gp_Pnt gCenter = ShapeUtils::findCentroid(shape, cs);
-    return DU::toVector3d(gCenter);
+    return Base::convertTo<Base::Vector3d>(gCenter);
 }
 
 std::vector<DrawViewSection*> DrawViewPart::getSectionRefs() const

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -78,6 +78,7 @@
 #include <App/Document.h>
 #include <Base/BoundBox.h>
 #include <Base/Console.h>
+#include <Base/Converter.h>
 #include <Base/FileInfo.h>
 #include <Base/Parameter.h>
 #include <Base/Tools.h>
@@ -968,8 +969,8 @@ ChangePointVector DrawViewSection::getChangePointsFromSectionLine()
     if (baseDvp) {
         std::pair<Base::Vector3d, Base::Vector3d> lineEnds = sectionLineEnds();
         // make start and end marks
-        gp_Pnt location0 = DU::to<gp_Pnt>(lineEnds.first);
-        gp_Pnt location1 = DU::to<gp_Pnt>(lineEnds.second);
+        gp_Pnt location0 = Base::convertTo<gp_Pnt>(lineEnds.first);
+        gp_Pnt location1 = Base::convertTo<gp_Pnt>(lineEnds.second);
         gp_Dir postDir = gp_Dir(location1.XYZ() - location0.XYZ());
         gp_Dir preDir = postDir.Reversed();
         ChangePoint startPoint(location0, preDir, postDir);
@@ -1067,13 +1068,13 @@ void DrawViewSection::setCSFromLocalUnit(const Base::Vector3d localUnit)
     //    Base::Console().Message("DVS::setCSFromLocalUnit(%s)\n",
     //    DrawUtil::formatVector(localUnit).c_str());
     gp_Dir verticalDir = getSectionCS().YDirection();
-    gp_Ax1 verticalAxis(DrawUtil::to<gp_Pnt>(SectionOrigin.getValue()), verticalDir);
+    gp_Ax1 verticalAxis(Base::convertTo<gp_Pnt>(SectionOrigin.getValue()), verticalDir);
     gp_Dir oldNormal = getSectionCS().Direction();
-    gp_Dir newNormal = DrawUtil::to<gp_Dir>(projectPoint(localUnit));
+    gp_Dir newNormal = Base::convertTo<gp_Dir>(projectPoint(localUnit));
     double angle = oldNormal.AngleWithRef(newNormal, verticalDir);
     gp_Ax2 newCS = getSectionCS().Rotated(verticalAxis, angle);
-    SectionNormal.setValue(DrawUtil::toVector3d(newCS.Direction()));
-    XDirection.setValue(DrawUtil::toVector3d(newCS.XDirection()));
+    SectionNormal.setValue(Base::convertTo<Base::Vector3d>(newCS.Direction()));
+    XDirection.setValue(Base::convertTo<Base::Vector3d>(newCS.XDirection()));
 }
 
 gp_Ax2 DrawViewSection::getCSFromBase(const std::string sectionName) const

--- a/src/Mod/TechDraw/App/GeometryMatcher.cpp
+++ b/src/Mod/TechDraw/App/GeometryMatcher.cpp
@@ -90,9 +90,9 @@ bool GeometryMatcher::comparePoints(const TopoDS_Shape& shape1, const TopoDS_Sha
         return false;
     }
     auto vert1 = TopoDS::Vertex(shape1);
-    Base::Vector3d point1 = DU::toVector3d(BRep_Tool::Pnt(vert1));
+    Base::Vector3d point1 = Base::convertTo<Base::Vector3d>(BRep_Tool::Pnt(vert1));
     auto vert2 = TopoDS::Vertex(shape2);
-    Base::Vector3d point2 = DU::toVector3d(BRep_Tool::Pnt(vert2));
+    Base::Vector3d point2 = Base::convertTo<Base::Vector3d>(BRep_Tool::Pnt(vert2));
     return point1.IsEqual(point2, EWTOLERANCE);
 }
 
@@ -179,8 +179,8 @@ bool GeometryMatcher::compareCircles(const TopoDS_Edge& edge1, const TopoDS_Edge
     gp_Circ circle2 = adapt2.Circle();
     double radius1 = circle1.Radius();
     double radius2 = circle2.Radius();
-    auto center1 = DU::toVector3d(circle1.Location());
-    auto center2 = DU::toVector3d(circle2.Location());
+    auto center1 = Base::convertTo<Base::Vector3d>(circle1.Location());
+    auto center2 = Base::convertTo<Base::Vector3d>(circle2.Location());
     return DU::fpCompare(radius1, radius2, EWTOLERANCE) && center1.IsEqual(center2, EWTOLERANCE);
 }
 
@@ -199,8 +199,8 @@ bool GeometryMatcher::compareEllipses(const TopoDS_Edge& edge1, const TopoDS_Edg
     double minor1 = ellipse1.MinorRadius();
     double major2 = ellipse2.MajorRadius();
     double minor2 = ellipse2.MinorRadius();
-    auto center1 = DU::toVector3d(ellipse1.Location());
-    auto center2 = DU::toVector3d(ellipse2.Location());
+    auto center1 = Base::convertTo<Base::Vector3d>(ellipse1.Location());
+    auto center2 = Base::convertTo<Base::Vector3d>(ellipse2.Location());
     return  (DU::fpCompare(major1, major2, EWTOLERANCE) &&
              DU::fpCompare(minor1, minor2, EWTOLERANCE) &&
              center1.IsEqual(center2, EWTOLERANCE));

--- a/src/Mod/TechDraw/App/ShapeUtils.cpp
+++ b/src/Mod/TechDraw/App/ShapeUtils.cpp
@@ -399,8 +399,8 @@ std::pair<Base::Vector3d, Base::Vector3d> ShapeUtils::getEdgeEnds(TopoDS_Edge ed
     gp_Pnt gpFirst = BRep_Tool::Pnt(tvFirst);
     gp_Pnt gpLast = BRep_Tool::Pnt(tvLast);
 
-    result.first = DU::toVector3d(gpFirst);
-    result.second = DU::toVector3d(gpLast);
+    result.first = Base::convertTo<Base::Vector3d>(gpFirst);
+    result.second = Base::convertTo<Base::Vector3d>(gpLast);
     return result;
 }
 

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -1811,7 +1811,7 @@ void CmdTechDrawExtensionAreaAnnotation::activated(int iMsg)
 
         double faceArea = faceProps.Mass();
         totalArea += faceArea;
-        center += faceArea*DrawUtil::toVector3d(faceProps.CentreOfMass());
+        center += faceArea*Base::convertTo<Base::Vector3d>(faceProps.CentreOfMass());
     }
     if (totalArea > 0.0) {
         center /= totalArea;
@@ -1976,7 +1976,7 @@ void CmdTechDrawExtensionArcLengthAnnotation::activated(int iMsg)
     }
 
     double scale = objFeat->getScale();
-    Base::Vector3d anchor = DrawUtil::invertY(DrawUtil::toVector3d(midPoint)/scale);
+    Base::Vector3d anchor = DrawUtil::invertY(Base::convertTo<Base::Vector3d>(midPoint)/scale);
     totalLength /= scale;
 
     // Use virtual dimension view helper to format resulting value

--- a/src/Mod/TechDraw/Gui/DimensionValidators.cpp
+++ b/src/Mod/TechDraw/Gui/DimensionValidators.cpp
@@ -426,9 +426,9 @@ DimensionGeometry TechDraw::isValidSingleEdge3d(DrawViewPart* dvp, ReferenceEntr
     TopoDS_Edge occEdge = TopoDS::Edge(refShape);
     BRepAdaptor_Curve adapt(occEdge);
     if (adapt.GetType() == GeomAbs_Line) {
-        Base::Vector3d point0 = DU::toVector3d(BRep_Tool::Pnt(TopExp::FirstVertex(occEdge)));
+        Base::Vector3d point0 = Base::convertTo<Base::Vector3d>(BRep_Tool::Pnt(TopExp::FirstVertex(occEdge)));
         point0 = dvp->projectPoint(point0);
-        Base::Vector3d point1 = DU::toVector3d(BRep_Tool::Pnt(TopExp::LastVertex(occEdge)));
+        Base::Vector3d point1 = Base::convertTo<Base::Vector3d>(BRep_Tool::Pnt(TopExp::LastVertex(occEdge)));
         point1 = dvp->projectPoint(point1);
         Base::Vector3d line = point1 - point0;
         if (fabs(line.y) < FLT_EPSILON) {
@@ -594,11 +594,11 @@ DimensionGeometry TechDraw::isValidMultiEdge3d(DrawViewPart* dvp, ReferenceVecto
     }
 
     if (edgesAll.size() == 2) {
-        Base::Vector3d first0 = DU::toVector3d(BRep_Tool::Pnt(TopExp::FirstVertex(edgesAll.at(0))));
-        Base::Vector3d last0 = DU::toVector3d(BRep_Tool::Pnt(TopExp::LastVertex(edgesAll.at(1))));
+        Base::Vector3d first0 = Base::convertTo<Base::Vector3d>(BRep_Tool::Pnt(TopExp::FirstVertex(edgesAll.at(0))));
+        Base::Vector3d last0 = Base::convertTo<Base::Vector3d>(BRep_Tool::Pnt(TopExp::LastVertex(edgesAll.at(1))));
         Base::Vector3d line0 = last0 - first0;
-        Base::Vector3d first1 = DU::toVector3d(BRep_Tool::Pnt(TopExp::FirstVertex(edgesAll.at(0))));
-        Base::Vector3d last1 = DU::toVector3d(BRep_Tool::Pnt(TopExp::LastVertex(edgesAll.at(1))));
+        Base::Vector3d first1 = Base::convertTo<Base::Vector3d>(BRep_Tool::Pnt(TopExp::FirstVertex(edgesAll.at(0))));
+        Base::Vector3d last1 = Base::convertTo<Base::Vector3d>(BRep_Tool::Pnt(TopExp::LastVertex(edgesAll.at(1))));
         Base::Vector3d line1 = last1 - first1;
         line0.Normalize();
         line1.Normalize();
@@ -666,9 +666,9 @@ DimensionGeometry TechDraw::isValidVertexes3d(DrawViewPart* dvp, ReferenceVector
             || geometry1.ShapeType() != TopAbs_VERTEX) {
             return DimensionGeometry::isInvalid;
         }
-        Base::Vector3d point0 = DU::toVector3d(BRep_Tool::Pnt(TopoDS::Vertex(geometry0)));
+        Base::Vector3d point0 = Base::convertTo<Base::Vector3d>(BRep_Tool::Pnt(TopoDS::Vertex(geometry0)));
         point0 = dvp->projectPoint(point0);
-        Base::Vector3d point1 = DU::toVector3d(BRep_Tool::Pnt(TopoDS::Vertex(geometry1)));
+        Base::Vector3d point1 = Base::convertTo<Base::Vector3d>(BRep_Tool::Pnt(TopoDS::Vertex(geometry1)));
         point1 = dvp->projectPoint(point1);
         Base::Vector3d line = point1 - point0;
         if (fabs(line.y) < FLT_EPSILON) {

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
@@ -29,6 +29,7 @@
 #include <App/Document.h>
 #include <App/Link.h>
 #include <Base/Console.h>
+#include <Base/Converter.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
 #include <Gui/Control.h>
@@ -501,8 +502,8 @@ bool TaskComplexSection::apply(bool forceUpdate)
     }
     else {
         gp_Pnt stdOrigin(0.0, 0.0, 0.0);
-        gp_Ax2 sectionCS(stdOrigin, DrawUtil::to<gp_Dir>(m_saveNormal),
-                         DrawUtil::to<gp_Dir>(m_saveXDir));
+        gp_Ax2 sectionCS(stdOrigin, Base::convertTo<gp_Dir>(m_saveNormal),
+                         Base::convertTo<gp_Dir>(m_saveXDir));
         if (!DrawComplexSection::canBuild(sectionCS, m_profileObject)) {
             Base::Console().Error(
                 "Can not build Complex Section with this profile and direction (2)\n");


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/18886

I have duplicated the specialization of vec_traits for gp_Pnt and co in DrawUtil.h because I wasn't sure if I should include the Tool.h header from Part workbench that also defines these. If you want I can create another public header that defines these and include it wherever needed to avoid the code duplication. Let me know which approach should I take.