### PR TITLE
App: Fix regression for document creation requests coming from the main document.

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -432,7 +432,7 @@ void Application::renameDocument(const char *OldName, const char *NewName)
     throw Base::RuntimeError("Renaming document internal name is no longer allowed!");
 }
 
-Document* Application::newDocument(const char * proposedName, const char * proposedLabel, DocumentCreateFlags CreateFlags)
+Document* Application::newDocument(const char * proposedName, const char * proposedLabel, DocumentInitFlags CreateFlags)
 {
     bool isUsingDefaultName = Tools::isNullOrEmpty(proposedName);
     // get a valid name anyway!
@@ -669,9 +669,9 @@ public:
     }
 };
 
-Document* Application::openDocument(const char * FileName, DocumentCreateFlags createFlags) {
+Document* Application::openDocument(const char * FileName, DocumentInitFlags initFlags) {
     std::vector<std::string> filenames(1,FileName);
-    auto docs = openDocuments(filenames, nullptr, nullptr, nullptr, createFlags);
+    auto docs = openDocuments(filenames, nullptr, nullptr, nullptr, initFlags);
     if(!docs.empty())
         return docs.front();
     return nullptr;
@@ -716,7 +716,7 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
                                                   const std::vector<std::string> *paths,
                                                   const std::vector<std::string> *labels,
                                                   std::vector<std::string> *errs,
-                                                  DocumentCreateFlags createFlags)
+                                                  DocumentInitFlags initFlags)
 {
     std::vector<Document*> res(filenames.size(), nullptr);
     if (filenames.empty())
@@ -780,7 +780,7 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
                         label = (*labels)[count].c_str();
                 }
 
-                auto doc = openDocumentPrivate(path, name.c_str(), label, isMainDoc, createFlags, std::move(objNames));
+                auto doc = openDocumentPrivate(path, name.c_str(), label, isMainDoc, initFlags, std::move(objNames));
                 FC_DURATION_PLUS(timing.d1,t1);
                 if (doc) {
                     timings[doc].d1 += timing.d1;
@@ -919,7 +919,7 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
 
 Document* Application::openDocumentPrivate(const char * FileName,
         const char *propFileName, const char *label,
-        bool isMainDoc, DocumentCreateFlags createFlags,
+        bool isMainDoc, DocumentInitFlags initFlags,
         std::vector<std::string> &&objNames)
 {
     FileInfo File(FileName);
@@ -994,7 +994,7 @@ Document* Application::openDocumentPrivate(const char * FileName,
     if(!label)
         label = name.c_str();
 
-    Document* newDoc = newDocument(name.c_str(), label, createFlags);
+    Document* newDoc = newDocument(name.c_str(), label, initFlags);
     newDoc->FileName.setValue(propFileName==FileName?File.filePath():propFileName);
 
     try {

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -994,6 +994,7 @@ Document* Application::openDocumentPrivate(const char * FileName,
     if(!label)
         label = name.c_str();
 
+    initFlags.createView &= isMainDoc;
     Document* newDoc = newDocument(name.c_str(), label, initFlags);
     newDoc->FileName.setValue(propFileName==FileName?File.filePath():propFileName);
 

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -73,7 +73,7 @@ enum class MessageOption {
     Throw, /**< Throw an exception. */
 };
 
-struct DocumentCreateFlags {
+struct DocumentInitFlags {
     bool createView {true};
     bool temporary {false};
 };
@@ -102,13 +102,13 @@ public:
      * the user and stored in the App::Document::Label property.
      */
     App::Document* newDocument(const char * proposedName=nullptr, const char * proposedLabel=nullptr,
-            DocumentCreateFlags CreateFlags=DocumentCreateFlags());
+            DocumentInitFlags CreateFlags=DocumentInitFlags());
     /// Closes the document \a name and removes it from the application.
     bool closeDocument(const char* name);
     /// find a unique document name
     std::string getUniqueDocumentName(const char *Name, bool tempDoc=false) const;
     /// Open an existing document from a file
-    App::Document* openDocument(const char * FileName=nullptr, DocumentCreateFlags createFlags = DocumentCreateFlags{});
+    App::Document* openDocument(const char * FileName=nullptr, DocumentInitFlags initFlags = DocumentInitFlags{});
     /** Open multiple documents
      *
      * @param filenames: input file names
@@ -130,7 +130,7 @@ public:
             const std::vector<std::string> *paths=nullptr,
             const std::vector<std::string> *labels=nullptr,
             std::vector<std::string> *errs=nullptr,
-            DocumentCreateFlags createFlags = DocumentCreateFlags{});
+            DocumentInitFlags initFlags = DocumentInitFlags{});
     /// Retrieve the active document
     App::Document* getActiveDocument() const;
     /// Retrieve a named document
@@ -495,7 +495,7 @@ protected:
 
     /// open single document only
     App::Document* openDocumentPrivate(const char * FileName, const char *propFileName,
-            const char *label, bool isMainDoc, DocumentCreateFlags createFlags, std::vector<std::string> &&objNames);
+            const char *label, bool isMainDoc, DocumentInitFlags initFlags, std::vector<std::string> &&objNames);
 
     /// Helper class for App::Document to signal on close/abort transaction
     class AppExport TransactionSignaller {

--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -357,9 +357,10 @@ PyObject* Application::sOpenDocument(PyObject* /*self*/, PyObject* args, PyObjec
     std::string EncodedName = std::string(Name);
     PyMem_Free(Name);
     try {
-        DocumentCreateFlags createFlags;
-        createFlags.createView = !Base::asBoolean(hidden);
-        createFlags.temporary = Base::asBoolean(temporary);
+        DocumentCreateFlags createFlags {
+            .createView = !Base::asBoolean(hidden),
+            .temporary = Base::asBoolean(temporary)
+        };
 
         // return new document
         return (GetApplication()
@@ -401,10 +402,10 @@ PyObject* Application::sNewDocument(PyObject* /*self*/, PyObject* args, PyObject
 
     PY_TRY
     {
-        DocumentCreateFlags createFlags;
-        createFlags.createView = !Base::asBoolean(hidden);
-        createFlags.temporary = Base::asBoolean(temp);
-
+        DocumentCreateFlags createFlags {
+            .createView = !Base::asBoolean(hidden),
+            .temporary = Base::asBoolean(temp)
+        };
         App::Document* doc = GetApplication().newDocument(docName,
                                                           usrName,
                                                           createFlags);

--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -409,6 +409,7 @@ PyObject* Application::sNewDocument(PyObject* /*self*/, PyObject* args, PyObject
         App::Document* doc = GetApplication().newDocument(docName,
                                                           usrName,
                                                           createFlags);
+        PyMem_Free(docName);
         PyMem_Free(usrName);
         return doc->getPyObject();
     }

--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -357,14 +357,14 @@ PyObject* Application::sOpenDocument(PyObject* /*self*/, PyObject* args, PyObjec
     std::string EncodedName = std::string(Name);
     PyMem_Free(Name);
     try {
-        DocumentCreateFlags createFlags {
+        DocumentInitFlags initFlags {
             .createView = !Base::asBoolean(hidden),
             .temporary = Base::asBoolean(temporary)
         };
 
         // return new document
         return (GetApplication()
-                    .openDocument(EncodedName.c_str(), createFlags)
+                    .openDocument(EncodedName.c_str(), initFlags)
                     ->getPyObject());
     }
     catch (const Base::Exception& e) {
@@ -402,13 +402,13 @@ PyObject* Application::sNewDocument(PyObject* /*self*/, PyObject* args, PyObject
 
     PY_TRY
     {
-        DocumentCreateFlags createFlags {
+        DocumentInitFlags initFlags {
             .createView = !Base::asBoolean(hidden),
             .temporary = Base::asBoolean(temp)
         };
         App::Document* doc = GetApplication().newDocument(docName,
                                                           usrName,
-                                                          createFlags);
+                                                          initFlags);
         PyMem_Free(docName);
         PyMem_Free(usrName);
         return doc->getPyObject();

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2592,8 +2592,9 @@ App::Document* Application::reopen(App::Document* doc)
         }
 
         for (auto& file : docs) {
-            App::DocumentCreateFlags createFlags;
-            createFlags.createView = false;
+            App::DocumentCreateFlags createFlags {
+                .createView = false
+            };
             App::GetApplication().openDocument(file.c_str(), createFlags);
         }
     }

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2592,10 +2592,10 @@ App::Document* Application::reopen(App::Document* doc)
         }
 
         for (auto& file : docs) {
-            App::DocumentCreateFlags createFlags {
+            App::DocumentInitFlags initFlags {
                 .createView = false
             };
-            App::GetApplication().openDocument(file.c_str(), createFlags);
+            App::GetApplication().openDocument(file.c_str(), initFlags);
         }
     }
 

--- a/src/Mod/Import/App/ImportOCAF2.cpp
+++ b/src/Mod/Import/App/ImportOCAF2.cpp
@@ -409,10 +409,8 @@ App::Document* ImportOCAF2::getDocument(App::Document* doc, TDF_Label label)
         return doc;
     }
 
-    App::DocumentCreateFlags createFlags {
-        .createView = false
-    };
-    auto newDoc = App::GetApplication().newDocument(name.c_str(), name.c_str(), createFlags);
+    App::DocumentInitFlags initFlags {.createView = false};
+    auto newDoc = App::GetApplication().newDocument(name.c_str(), name.c_str(), initFlags);
 
     std::ostringstream ss;
     Base::FileInfo fi(doc->FileName.getValue());

--- a/src/Mod/Import/App/ImportOCAF2.cpp
+++ b/src/Mod/Import/App/ImportOCAF2.cpp
@@ -409,8 +409,9 @@ App::Document* ImportOCAF2::getDocument(App::Document* doc, TDF_Label label)
         return doc;
     }
 
-    App::DocumentCreateFlags createFlags;
-    createFlags.createView = false;
+    App::DocumentCreateFlags createFlags {
+        .createView = false
+    };
     auto newDoc = App::GetApplication().newDocument(name.c_str(), name.c_str(), createFlags);
 
     std::ostringstream ss;

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -595,11 +595,11 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
                 recomputeCopy = true;
                 clearCopiedObjects();
 
-                App::DocumentCreateFlags createFlags {
+                App::DocumentInitFlags initFlags {
                     .createView = false,
                     .temporary = true
                 };
-                auto tmpDoc = App::GetApplication().newDocument("_tmp_binder", nullptr, createFlags);
+                auto tmpDoc = App::GetApplication().newDocument("_tmp_binder", nullptr, initFlags);
                 tmpDoc->setUndoMode(0);
                 auto objs = tmpDoc->copyObject({ obj }, true, true);
                 if (!objs.empty()) {

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -595,10 +595,10 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
                 recomputeCopy = true;
                 clearCopiedObjects();
 
-                App::DocumentCreateFlags createFlags;
-                createFlags.createView = false;
-                createFlags.temporary = true;
-
+                App::DocumentCreateFlags createFlags {
+                    .createView = false,
+                    .temporary = true
+                };
                 auto tmpDoc = App::GetApplication().newDocument("_tmp_binder", nullptr, createFlags);
                 tmpDoc->setUndoMode(0);
                 auto objs = tmpDoc->copyObject({ obj }, true, true);


### PR DESCRIPTION
So a couple things going down on this one:

The main changes are these two, which are fairly simple to review in isolation:

[App: Fix memory leak regression in ApplicationPy::newDocument.](https://github.com/FreeCAD/FreeCAD/commit/d6510061b3a5be68b1dbad7d91d26b7d69df1d37)

[App: Fix regression when creating new document coming from the main document.](https://github.com/FreeCAD/FreeCAD/commit/9685a1a6efaf4d8bd4b62ac940c609b1f18c3a8c) 

Then it does some code quality changes, using C++20 designed initializers for simpler initialization, and renames `DocumentCreateFlags` to `DocumentInitFlags` as it's used both for creation and opening, so I think that name fits better.

Closes https://github.com/FreeCAD/FreeCAD/issues/19482
Fixes regression from  https://github.com/FreeCAD/FreeCAD/pull/19136.