### PR TITLE
start: fix listview height alwasys being too small

### DIFF
--- a/src/Mod/Start/Gui/FileCardView.cpp
+++ b/src/Mod/Start/Gui/FileCardView.cpp
@@ -26,6 +26,7 @@
 
 #include <App/Application.h>
 #include "../App/DisplayedFilesModel.h"
+#include <algorithm>
 
 namespace StartGui
 {
@@ -61,12 +62,12 @@ int FileCardView::heightForWidth(int width) const
     }
     int numCards = model->rowCount();
     auto cardSize = delegate->sizeHint(QStyleOptionViewItem(), model->index(0, 0));
-    int cardsPerRow = static_cast<int>(width / cardSize.width());
+    int cardsPerRow = std::max(1, static_cast<int>(width / (cardSize.width() + m_cardSpacing)));
     int numRows =
         static_cast<int>(ceil(static_cast<double>(numCards) / static_cast<double>(cardsPerRow)));
     int neededHeight = numRows * cardSize.height();
-
-    return neededHeight + m_cardSpacing * (numRows - 1) + 2 * m_cardSpacing;
+    constexpr int extra = 4;  // avoid tiny scrollbars
+    return neededHeight + m_cardSpacing * (numRows - 1) + 2 * m_cardSpacing + extra;
 }
 
 QSize FileCardView::sizeHint() const


### PR DESCRIPTION
the calculation is currently to tight, add a few pixels of headroom to avoid vertical scrollbars
![output](https://github.com/user-attachments/assets/ff375ab8-5c09-48af-8427-18fb5b5f296a)
