### PR TITLE
Change BIM Ifc Properties window default size

### DIFF
--- a/src/Mod/BIM/Resources/ui/dialogIfcProperties.ui
+++ b/src/Mod/BIM/Resources/ui/dialogIfcProperties.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>567</width>
+    <width>1024</width>
     <height>608</height>
    </rect>
   </property>
@@ -59,8 +59,7 @@
         </property>
         <property name="icon">
          <iconset theme="format-text-direction-ltr">
-          <normaloff/>
-         </iconset>
+          <normaloff>.</normaloff>.</iconset>
         </property>
        </item>
        <item>
@@ -69,8 +68,7 @@
         </property>
         <property name="icon">
          <iconset theme="application-drawing">
-          <normaloff/>
-         </iconset>
+          <normaloff>.</normaloff>.</iconset>
         </property>
        </item>
        <item>
@@ -176,8 +174,7 @@
        </property>
        <property name="icon">
         <iconset theme="gtk-delete">
-         <normaloff/>
-        </iconset>
+         <normaloff>.</normaloff>.</iconset>
        </property>
       </widget>
      </item>

--- a/src/Mod/BIM/bimcommands/BimIfcProperties.py
+++ b/src/Mod/BIM/bimcommands/BimIfcProperties.py
@@ -75,7 +75,7 @@ class BIM_IfcProperties:
         # restore saved values
         self.form.onlySelected.setChecked(PARAMS.GetInt("IfcPropertiesSelectedState", 0))
         self.form.onlyVisible.setChecked(PARAMS.GetInt("IfcPropertiesVisibleState", 0))
-        w = PARAMS.GetInt("BimIfcPropertiesDialogWidth", 567)
+        w = PARAMS.GetInt("BimIfcPropertiesDialogWidth", 1024)
         h = PARAMS.GetInt("BimIfcPropertiesDialogHeight", 608)
         self.form.resize(w, h)
 


### PR DESCRIPTION
changed default window width in BimIfcProperties.py to 1024px
changed default window width in dialogIfcProperties.ui to 1024px

I did not test by building FreeCAD myself.
The width 1024 is minimum that was suitable for Linux - GNOME. For Windows it was less.