### PR TITLE
Draft: Implement Dim Auto Flip Text

### DIFF
--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -388,6 +388,7 @@ def _get_param_dictionary():
         "DefaultDisplayMode":          ("int",       0),
         "DefaultDrawStyle":            ("int",       0),
         "DefaultPrintColor":           ("unsigned",  255),
+        "DimAutoFlipText":             ("bool",      True),
         "Draft_array_fuse":            ("bool",      False),
         "Draft_array_Link":            ("bool",      True),
         "FilletRadius":                ("float",     100.0),

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -376,7 +376,7 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
         vobj = obj.ViewObject
 
         if prop == "Diameter":
-            if hasattr(vobj, "Override") and vobj.Override:
+            if getattr(vobj, "Override", False):
                 if obj.Diameter:
                     vobj.Override = vobj.Override.replace("R $dim", "Ø $dim")
                 else:
@@ -503,7 +503,7 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
         else:
             self.trot = (0, 0, 0, 1)
 
-        if hasattr(vobj, "FlipArrows") and vobj.FlipArrows:
+        if getattr(vobj, "FlipArrows", False):
             u = u.negative()
 
         v2 = norm.cross(u)
@@ -535,7 +535,7 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
         else:
             offset = DraftVecUtils.scaleTo(v1, 0.05)
 
-        if hasattr(vobj, "FlipText") and vobj.FlipText:
+        if getattr(vobj, "FlipText", False):
             _rott = App.Rotation(self.trot[0], self.trot[1], self.trot[2], self.trot[3])
             self.trot = _rott.multiply(App.Rotation(App.Vector(0, 0, 1), 180)).Q
             offset = offset.negative()
@@ -602,7 +602,7 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
                                                  None,
                                                  'Length', show_unit, unit)
 
-        if hasattr(vobj, "Override") and vobj.Override:
+        if getattr(vobj, "Override", False):
             self.string = vobj.Override.replace("$dim", self.string)
 
         self.text_wld.string = utils.string_encode_coin(self.string)
@@ -935,7 +935,7 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
                                       obj.LastAngle.Value)
         self.p2 = self.circle.Vertexes[0].Point
         self.p3 = self.circle.Vertexes[-1].Point
-        midp = DraftGeomUtils.findMidpoint(self.circle.Edges[0])
+        midp = DraftGeomUtils.findMidpoint(self.circle)
         ray = midp - obj.Center
 
         # Set text value
@@ -1085,11 +1085,15 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
         r = App.Placement(_plane_rot_3).Rotation
         offset = r.multVec(App.Vector(0, 1, 0))
 
-        if hasattr(vobj, "TextSpacing"):
-            offset = DraftVecUtils.scaleTo(offset,
-                                           vobj.TextSpacing.Value)
+        if hasattr(vobj, "TextSpacing") and hasattr(vobj, "ScaleMultiplier"):
+            ts = vobj.TextSpacing.Value * vobj.ScaleMultiplier
+            offset = DraftVecUtils.scaleTo(offset, ts)
         else:
             offset = DraftVecUtils.scaleTo(offset, 0.05)
+
+        if getattr(vobj, "FlipText", False):
+            r = r.multiply(App.Rotation(App.Vector(0, 0, 1), 180))
+            offset = offset.negative()
 
         if m == "Screen":
             offset = offset.negative()


### PR DESCRIPTION
Fixes #19993.

* To determine the `FlipText` value the normal (either the working plane Z axis or its reverse) and the working plane X axis are used.
* A new fine-tuning parameter `DimAutoFlipText` can be used to disable the functionality. Its default value is `True`.
* The `FlipText` property did not work for angular dimensions and the `TextSpacing` property of angular dimensions was not multiplied by `ScaleMultiplier`. This has been corrected.
