### PR TITLE
Switch to oldest supported ubuntu

### DIFF
--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -22,9 +22,9 @@
 # ***************************************************************************
 
 # This is a build and test workflow for CI of FreeCAD.
-# This workflow aims at building and testing FreeCAD on Ubuntu 22.04 using GCC.
+# This workflow aims at building and testing FreeCAD on Ubuntu 24.04 using GCC.
 
-name: Build Ubuntu 22.04
+name: Build Ubuntu 24.04
 
 on:
   workflow_call:
@@ -47,7 +47,7 @@ on:
 jobs:
 
   Build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ inputs.allowedToFail }}
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache

--- a/package/ubuntu/install-apt-packages.sh
+++ b/package/ubuntu/install-apt-packages.sh
@@ -34,7 +34,7 @@ packages=(
   libqt5x11extras5-dev
   libshiboken2-dev
   libspnav-dev
-  libvtk7-dev
+  libvtk9-dev
   libx11-dev
   libxerces-c-dev
   libyaml-cpp-dev

--- a/tools/build/Docker/Dockerfile.Conda
+++ b/tools/build/Docker/Dockerfile.Conda
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Ubuntu 22.04 ended "Hardware & Maintenance" support 5 months ago. The oldest supported version of ubuntu lts is 24.04