### PR TITLE
Sketcher: Clean up compiler warnings

### DIFF
--- a/src/Mod/Sketcher/App/ExternalGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/ExternalGeometryExtension.cpp
@@ -33,9 +33,6 @@ using namespace Sketcher;
 
 //---------- Geometry Extension
 
-constexpr std::array<const char*, ExternalGeometryExtension::NumFlags>
-    ExternalGeometryExtension::flag2str;
-
 TYPESYSTEM_SOURCE(Sketcher::ExternalGeometryExtension, Part::GeometryMigrationPersistenceExtension)
 
 void ExternalGeometryExtension::copyAttributes(Part::GeometryExtension* cpy) const

--- a/src/Mod/Sketcher/App/SketchGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/SketchGeometryExtension.cpp
@@ -32,10 +32,6 @@
 using namespace Sketcher;
 
 //---------- Geometry Extension
-constexpr std::array<const char*, InternalType::NumInternalGeometryType>
-    SketchGeometryExtension::internaltype2str;
-constexpr std::array<const char*, GeometryMode::NumGeometryMode>
-    SketchGeometryExtension::geometrymode2str;
 
 TYPESYSTEM_SOURCE(Sketcher::SketchGeometryExtension, Part::GeometryMigrationPersistenceExtension)
 

--- a/src/Mod/Sketcher/App/planegcs/Constraints.h
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.h
@@ -228,7 +228,7 @@ public:
 
 private:
     std::vector<double> weights;
-    double numpoints;
+    std::size_t numpoints;
 };
 
 // Weighted Linear Combination


### PR DESCRIPTION
* numpoints from double to int
* Remove redundant out-of-line definition for constexpr static data member