### PR TITLE
Sketcher: DSH: add OVP constraints before AutoConstraints.

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -491,9 +491,9 @@ protected:
                 executeCommands();
 
                 if (sugConstraints.size() > 0) {
-                    generateAutoConstraints();
-
                     beforeCreateAutoConstraints();
+
+                    generateAutoConstraints();
 
                     createAutoConstraints();
                 }
@@ -988,13 +988,20 @@ protected:
             // redundants anymore
         }
 
-        // This is an awful situation. It should not be possible if the DSH works properly. It is
-        // just a safeguard.
+        // This can happen if OVP generated constraints and autoconstraints are conflicting
+        // For instance : https://github.com/FreeCAD/FreeCAD/issues/17722
         if (sketchobject->getLastHasConflicts()) {
-            THROWM(Base::RuntimeError,
-                   QT_TRANSLATE_NOOP(
-                       "Notifications",
-                       "Autoconstraints cause conflicting constraints - Please report!") "\n");
+            auto lastsketchconstraintindex = sketchobject->Constraints.getSize() - 1;
+
+            auto conflicting = sketchobject->getLastConflicting();
+
+            for (int index = conflicting.size() - 1; index >= 0; index--) {
+                int conflictingIndex = conflicting[index] - 1;
+                if (conflictingIndex > lastsketchconstraintindex) {
+                    int removeindex = conflictingIndex - lastsketchconstraintindex - 1;
+                    AutoConstraints.erase(std::next(AutoConstraints.begin(), removeindex));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/17722

Currently when a DrawSketchHandler (circle tool for instance) was finishing, the following was done : 
```
    bool finish()
    {
        ...
                if (sugConstraints.size() > 0) {
                    generateAutoConstraints();

                    beforeCreateAutoConstraints(); //OVP's constraints added here

                    createAutoConstraints();
                }
            }
```

Which basically was giving priority to autoconstraint over OVP (onViewParameters)'s constraints. Since first the autoconstraints were generated, then OVP constraints were added only if they did not conflicts.

IMO this is not correct. If the user has typed in a dimension, the dimension should have the priority.

So this PR suggest first adding the OVP's constraints. Then try to add the auto-constraints if they are not redundant/conflicting.
