### PR TITLE
CMake: Fix PySide6 pip search

### DIFF
--- a/cMake/FindPySide6.cmake
+++ b/cMake/FindPySide6.cmake
@@ -5,12 +5,12 @@
 
 find_package(PySide6 CONFIG QUIET)
 
-if(NOT PySide6_INCLUDE_DIRS AND TARGET PySide6::pyside6)
-    get_property(PySide6_INCLUDE_DIRS TARGET PySide6::pyside6 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+if(NOT PySide6_FOUND)
+    find_pip_package(PySide6)
 endif()
 
-if(NOT PySide6_INCLUDE_DIRS)
-    find_pip_package(PySide6)
+if(NOT PySide6_INCLUDE_DIRS AND TARGET PySide6::pyside6)
+    get_property(PySide6_INCLUDE_DIRS TARGET PySide6::pyside6 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 endif()
 
 # Also provide the old-style variables so we don't have to update everything yet


### PR DESCRIPTION
Since ac77cd779ed1 ("CMake: PySide cleanup") compatibility variables depends on PySide6_FOUND, but setting that was later removed, leaving pip installed PySide6 undetected.

Fixes: 9119d392c990 ("CMake: Fix PySide6 search")

@marioalexis84, @chennes