### PR TITLE
BIM: fix adding/removing boundaries to BIM Spaces

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -50,7 +50,7 @@ from ArchWindowPresets import *
 # TODO: migrate this one
 
 from ArchStructure import *
-
+from ArchSpace import *
 
 # make functions
 


### PR DESCRIPTION
Fixes: https://github.com/FreeCAD/FreeCAD/issues/20106

Note: I see quite a few functions on the Arch module, and a TODO note to migrate the `ArchStructure` import. Does this mean that a curated selection of methods from a given module (e.g. `ArchSpace` or `ArchStructure`) need to be moved to the `Arch` module instead of doing a full import? If so, happy to do it. But it might be worth merging this to unblock users who work with spaces in the meantime. And it might be a simpler backport as well.