### PR TITLE
[TD]Headless view creation (fix #20024)

### DIFF
--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -43,6 +43,9 @@
 #include <Base/PyWrapParseTupleAndKeywords.h>
 #include <Base/Vector3D.h>
 #include <Base/VectorPy.h>
+
+#include <Gui/Application.h>
+
 #include <Mod/Import/App/dxf/ImpExpDxf.h>
 #include <Mod/Part/App/OCCError.h>
 #include <Mod/Part/App/TopoShape.h>
@@ -434,6 +437,10 @@ private:
                 obj = static_cast<App::DocumentObjectPy*>(viewObj)->getDocumentObjectPtr();
                 dvp = static_cast<TechDraw::DrawViewPart*>(obj);
                 TechDraw::GeometryObjectPtr gObj = dvp->getGeometryObject();
+                if (!gObj) {
+                    Base::Console().Message("TechDraw: %s has no geometry object!\n", dvp->Label.getValue());
+                    return Py::String();
+                }
                 TopoDS_Shape shape = ShapeUtils::mirrorShape(gObj->getVisHard());
                 ss << dxfOut.exportEdges(shape);
                 shape = ShapeUtils::mirrorShape(gObj->getVisOutline());
@@ -472,6 +479,7 @@ private:
         return dxfReturn;
     }
 
+
     Py::Object viewPartAsSvg(const Py::Tuple& args)
     {
         PyObject *viewObj(nullptr);
@@ -482,6 +490,7 @@ private:
         std::string grpHead1 = "<g fill=\"none\" stroke=\"#000000\" stroke-opacity=\"1\" stroke-width=\"";
         std::string grpHead2 = "\" stroke-linecap=\"butt\" stroke-linejoin=\"miter\" stroke-miterlimit=\"4\">\n";
         std::string grpTail  = "</g>\n";
+        Base::Console().Message("TechDraw:: gui is up? %d\n", (int)DrawUtil::isGuiUp());
         try {
             App::DocumentObject* obj = nullptr;
             TechDraw::DrawViewPart* dvp = nullptr;
@@ -492,9 +501,13 @@ private:
                 obj = static_cast<App::DocumentObjectPy*>(viewObj)->getDocumentObjectPtr();
                 dvp = static_cast<TechDraw::DrawViewPart*>(obj);
                 TechDraw::GeometryObjectPtr gObj = dvp->getGeometryObject();
+                if (!gObj) {
+                    Base::Console().Message("TechDraw: %s has no geometry object!\n", dvp->Label.getValue());
+                    return Py::String();
+                }
+
                 //visible group begin "<g ... >"
                 ss << grpHead1;
-//                double thick = dvp->LineWidth.getValue();
                 double thick = DrawUtil::getDefaultLineWeight("Thick");
                 ss << thick;
                 ss << grpHead2;
@@ -518,7 +531,6 @@ private:
                      dvp->SeamHidden.getValue() ) {
                     //hidden group begin
                     ss << grpHead1;
-//                    thick = dvp->HiddenWidth.getValue();
                     thick = DrawUtil::getDefaultLineWeight("Thin");
                     ss << thick;
                     ss << grpHead2;
@@ -553,9 +565,16 @@ private:
 
     void write1ViewDxf( ImpExpDxfWrite& writer, TechDraw::DrawViewPart* dvp, bool alignPage)
     {
-        if(!dvp->hasGeometry())
+        if(!dvp->hasGeometry()) {
             return;
+        }
+
         TechDraw::GeometryObjectPtr gObj = dvp->getGeometryObject();
+        if (!gObj) {
+            // this test might be redundent here since we already checked hasGeometry.
+            Base::Console().Message("TechDraw: %s has no geometry object!\n", dvp->Label.getValue());
+            return;
+        }
         TopoDS_Shape shape = ShapeUtils::mirrorShape(gObj->getVisHard());
         double offX = 0.0;
         double offY = 0.0;

--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -44,8 +44,6 @@
 #include <Base/Vector3D.h>
 #include <Base/VectorPy.h>
 
-#include <Gui/Application.h>
-
 #include <Mod/Import/App/dxf/ImpExpDxf.h>
 #include <Mod/Part/App/OCCError.h>
 #include <Mod/Part/App/TopoShape.h>
@@ -74,7 +72,6 @@
 #include "GeometryObject.h"
 #include "ProjectionAlgos.h"
 #include "TechDrawExport.h"
-#include "CosmeticVertexPy.h"
 #include "DrawLeaderLinePy.h"
 
 namespace TechDraw {

--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -490,7 +490,6 @@ private:
         std::string grpHead1 = "<g fill=\"none\" stroke=\"#000000\" stroke-opacity=\"1\" stroke-width=\"";
         std::string grpHead2 = "\" stroke-linecap=\"butt\" stroke-linejoin=\"miter\" stroke-miterlimit=\"4\">\n";
         std::string grpTail  = "</g>\n";
-        Base::Console().Message("TechDraw:: gui is up? %d\n", (int)DrawUtil::isGuiUp());
         try {
             App::DocumentObject* obj = nullptr;
             TechDraw::DrawViewPart* dvp = nullptr;

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -1890,9 +1890,8 @@ std::string DrawUtil::cleanFilespecBackslash(const std::string& filespec)
 //! returns true if the Gui module and its event loop are active.
 bool DrawUtil::isGuiUp()
 {
-    std::string pyCommand{"import FreeCAD\nguiState = FreeCAD.GuiUp"};
-    std::string result{Base::Interpreter().runStringWithKey(pyCommand.c_str(), "guiState", "None")};
-    return  (result == "1");
+    auto* app = QCoreApplication::instance();
+    return (app != nullptr) && app->inherits("QApplication");
 }
 
 

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -1887,6 +1887,14 @@ std::string DrawUtil::cleanFilespecBackslash(const std::string& filespec)
     return noBackslash;
 }
 
+//! returns true if the Gui module and its event loop are active.
+bool DrawUtil::isGuiUp()
+{
+    std::string pyCommand{"import FreeCAD\nguiState = FreeCAD.GuiUp"};
+    std::string result{Base::Interpreter().runStringWithKey(pyCommand.c_str(), "guiState", "None")};
+    return  (result == "1");
+}
+
 
 //============================
 // various debugging routines.

--- a/src/Mod/TechDraw/App/DrawUtil.h
+++ b/src/Mod/TechDraw/App/DrawUtil.h
@@ -271,6 +271,7 @@ public:
 
     static std::string cleanFilespecBackslash(const std::string& filespec);
 
+    static bool isGuiUp();
 
     //debugging routines
     static void dumpVertexes(const char* text, const TopoDS_Shape& s);

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -189,6 +189,12 @@ void DrawViewDetail::detailExec(TopoDS_Shape& shape, DrawViewPart* dvp, DrawView
         return;
     }
 
+    if (!DU::isGuiUp()) {
+        makeDetailShape(shape, dvp, dvs);
+        onMakeDetailFinished();
+        waitingForDetail(false);
+    }
+
     //note that &m_detailWatcher in the third parameter is not strictly required, but using the
     //4 parameter signature instead of the 3 parameter signature prevents clazy warning:
     //https://github.com/KDE/clazy/blob/1.11/docs/checks/README-connect-3arg-lambda.md
@@ -404,8 +410,10 @@ void DrawViewDetail::onMakeDetailFinished(void)
     waitingForDetail(false);
     QObject::disconnect(connectDetailWatcher);
 
-    //ancestor's buildGeometryObject will run HLR and face finding in a separate thread
     m_tempGeometryObject = buildGeometryObject(m_scaledShape, m_viewAxis);
+    if (!DU::isGuiUp()) {
+        onHlrFinished();
+    }
 }
 
 bool DrawViewDetail::waitingForResult() const

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -284,7 +284,6 @@ void DrawViewPart::onChanged(const App::Property* prop)
 
 void DrawViewPart::partExec(TopoDS_Shape& shape)
 {
-    //    Base::Console().Message("DVP::partExec() - %s\n", getNameInDocument());
     if (waitingForHlr()) {
         //finish what we are already doing before starting a new cycle
         return;
@@ -292,8 +291,9 @@ void DrawViewPart::partExec(TopoDS_Shape& shape)
 
     //we need to keep using the old geometryObject until the new one is fully populated
     m_tempGeometryObject = makeGeometryForShape(shape);
-    if (CoarseView.getValue()) {
-        onHlrFinished();//poly algo does not run in separate thread, so we need to invoke
+    if (CoarseView.getValue() ||
+        !DU::isGuiUp()) {
+        onHlrFinished();//poly algo and console mode do not run in separate thread, so we need to invoke
                         //the post hlr processing manually
     }
 }
@@ -301,8 +301,6 @@ void DrawViewPart::partExec(TopoDS_Shape& shape)
 //! prepare the shape for HLR processing by centering, scaling and rotating it
 GeometryObjectPtr DrawViewPart::makeGeometryForShape(TopoDS_Shape& shape)
 {
-//    Base::Console().Message("DVP::makeGeometryForShape() - %s\n", getNameInDocument());
-
     // if we use the passed reference directly, the centering doesn't work.  Maybe the underlying OCC TShape
     // isn't modified?  using a copy works and the referenced shape (from getSourceShape in execute())
     // isn't used for anything anyway.
@@ -322,7 +320,6 @@ GeometryObjectPtr DrawViewPart::makeGeometryForShape(TopoDS_Shape& shape)
 TopoDS_Shape DrawViewPart::centerScaleRotate(const DrawViewPart *dvp, TopoDS_Shape& inOutShape,
                                              Base::Vector3d centroid)
 {
-//    Base::Console().Message("DVP::centerScaleRotate() - %s\n", dvp->getNameInDocument());
     gp_Ax2 viewAxis = dvp->getProjectionCS();
 
     //center shape on origin
@@ -341,9 +338,6 @@ TopoDS_Shape DrawViewPart::centerScaleRotate(const DrawViewPart *dvp, TopoDS_Sha
 TechDraw::GeometryObjectPtr DrawViewPart::buildGeometryObject(TopoDS_Shape& shape,
                                                               const gp_Ax2& viewAxis)
 {
-//    Base::Console().Message("DVP::buildGeometryObject() - %s\n", getNameInDocument());
-    showProgressMessage(getNameInDocument(), "is finding hidden lines");
-
     TechDraw::GeometryObjectPtr go(
         std::make_shared<TechDraw::GeometryObject>(getNameInDocument(), this));
     go->setIsoCount(IsoCount.getValue());
@@ -356,31 +350,37 @@ TechDraw::GeometryObjectPtr DrawViewPart::buildGeometryObject(TopoDS_Shape& shap
         //the polygon approximation HLR process runs quickly, so doesn't need to be in a
         //separate thread
         go->projectShapeWithPolygonAlgo(shape, viewAxis);
+        return go;
     }
-    else {
-        //projectShape (the HLR process) runs in a separate thread since it can take a long time
-        //note that &m_hlrWatcher in the third parameter is not strictly required, but using the
-        //4 parameter signature instead of the 3 parameter signature prevents clazy warning:
-        //https://github.com/KDE/clazy/blob/1.11/docs/checks/README-connect-3arg-lambda.md
-        connectHlrWatcher = QObject::connect(&m_hlrWatcher, &QFutureWatcherBase::finished,
-                                             &m_hlrWatcher, [this] { this->onHlrFinished(); });
 
-        // We create a lambda closure to hold a copy of go, shape and viewAxis.
-        // This is important because those variables might be local to the calling
-        // function and might get destructed before the parallel processing finishes.
-        auto lambda = [go, shape, viewAxis]{go->projectShape(shape, viewAxis);};
-        m_hlrFuture = QtConcurrent::run(std::move(lambda));
-        m_hlrWatcher.setFuture(m_hlrFuture);
-        waitingForHlr(true);
+    if (!DU::isGuiUp()) {
+        // if the Gui is not running (actual the event loop), we cannot use the separate thread,
+        // since we will never be notified of thread completion.
+        go->projectShape(shape, viewAxis);
+        return go;
     }
+
+    //projectShape (the HLR process) runs in a separate thread since it can take a long time
+    //note that &m_hlrWatcher in the third parameter is not strictly required, but using the
+    //4 parameter signature instead of the 3 parameter signature prevents clazy warning:
+    //https://github.com/KDE/clazy/blob/1.11/docs/checks/README-connect-3arg-lambda.md
+    connectHlrWatcher = QObject::connect(&m_hlrWatcher, &QFutureWatcherBase::finished,
+                                         &m_hlrWatcher, [this] { this->onHlrFinished(); });
+
+    // We create a lambda closure to hold a copy of go, shape and viewAxis.
+    // This is important because those variables might be local to the calling
+    // function and might get destructed before the parallel processing finishes.
+    auto lambda = [go, shape, viewAxis]{go->projectShape(shape, viewAxis);};
+    m_hlrFuture = QtConcurrent::run(std::move(lambda));
+    m_hlrWatcher.setFuture(m_hlrFuture);
+    waitingForHlr(true);
+
     return go;
 }
 
 //! continue processing after hlr thread completes
 void DrawViewPart::onHlrFinished()
 {
-    //    Base::Console().Message("DVP::onHlrFinished() - %s\n", getNameInDocument());
-
     //now that the new GeometryObject is fully populated, we can replace the old one
     if (m_tempGeometryObject) {
         geometryObject = m_tempGeometryObject;//replace with new
@@ -406,6 +406,13 @@ void DrawViewPart::onHlrFinished()
 
     //start face finding in a separate thread.  We don't find faces when using the polygon
     //HLR method.
+
+    if (handleFaces() && !DU::isGuiUp()) {
+        extractFaces();
+        onFacesFinished();
+        return;
+    }
+
     if (handleFaces() && !CoarseView.getValue()) {
         try {
             //note that &m_faceWatcher in the third parameter is not strictly required, but using the
@@ -432,7 +439,6 @@ void DrawViewPart::onHlrFinished()
 //! run any tasks that need to been done after geometry is available
 void DrawViewPart::postHlrTasks()
 {
-    // Base::Console().Message("DVP::postHlrTasks() - %s\n", getNameInDocument());
     //add geometry that doesn't come from HLR
     addCosmeticVertexesToGeom();
     addCosmeticEdgesToGeom();
@@ -469,7 +475,6 @@ void DrawViewPart::postHlrTasks()
 // Run any tasks that need to be done after faces are available
 void DrawViewPart::postFaceExtractionTasks()
 {
-    // Base::Console().Message("DVP::postFaceExtractionTasks() - %s\n", getNameInDocument());
     // Some centerlines depend on faces so we could not add CL geometry before now
     addCenterLinesToGeom();
 
@@ -487,8 +492,6 @@ void DrawViewPart::postFaceExtractionTasks()
 //! make faces from the edge geometry
 void DrawViewPart::extractFaces()
 {
-    //    Base::Console().Message("DVP::extractFaces() - %s waitingForHlr: %d waitingForFaces: %d\n",
-    //                            getNameInDocument(), waitingForHlr(), waitingForFaces());
     if (!geometryObject) {
         //geometry is in flux, can not make faces right now
         return;


### PR DESCRIPTION
This PR implements a fix for issue #20024.  

In headless mode, the program will not receive a notification that the separate threads for long running OCCT methods, and processing will not continue after the completion of the thread.

This PR implements a check for the availability of the Gui (and its event loop) and does not start separate threads if the Gui is not available, but runs those methods in the main thread.