### PR TITLE
Remove unnecessary check (duplicated)

### DIFF
--- a/src/Mod/Assembly/Gui/PreCompiled.h
+++ b/src/Mod/Assembly/Gui/PreCompiled.h
@@ -41,16 +41,12 @@
 #include <boost/core/ignore_unused.hpp>
 
 // Qt
-#ifndef __QtAll__
 #include <Gui/QtAll.h>
-#endif
 
 #include <QWidgetAction>
 
 // all of Inventor
-#ifndef __InventorAll__
 #include <Gui/InventorAll.h>
-#endif
 
 #endif  //_PreComp_
 

--- a/src/Mod/Cloud/Gui/PreCompiled.h
+++ b/src/Mod/Cloud/Gui/PreCompiled.h
@@ -58,9 +58,7 @@
 #endif
 
 // Qt Toolkit
-#ifndef __QtAll__
 #include <Gui/QtAll.h>
-#endif
 
 #endif  //_PreComp_
 

--- a/src/Mod/Import/Gui/PreCompiled.h
+++ b/src/Mod/Import/Gui/PreCompiled.h
@@ -89,9 +89,7 @@
 #endif
 
 // Qt Toolkit
-#ifndef __QtAll__
 #include <Gui/QtAll.h>
-#endif
 
 
 #endif  //_PreComp_

--- a/src/Mod/Material/Gui/PreCompiled.h
+++ b/src/Mod/Material/Gui/PreCompiled.h
@@ -53,18 +53,13 @@
 #include <string>
 #include <vector>
 
-// OpenCasCade
-// #include <Mod/Part/App/OpenCascadeAll.h>
 
 // Qt Toolkit
-#ifndef __QtAll__
 #include <Gui/QtAll.h>
-#endif
 
 // Inventor includes OpenGL
-#ifndef __InventorAll__
 # include <Gui/InventorAll.h>
-#endif
+
 
 #endif  //_PreComp_
 

--- a/src/Mod/Measure/Gui/PreCompiled.h
+++ b/src/Mod/Measure/Gui/PreCompiled.h
@@ -82,14 +82,10 @@
 #include <Inventor/C/glue/gl.h>
 
 // Qt Toolkit
-#ifndef __QtAll__
 #include <Gui/QtAll.h>
-#endif
 
 // Inventor includes OpenGL
-#ifndef __InventorAll__
 #include <Gui/InventorAll.h>
-#endif
 
 #endif  //_PreComp_
 

--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -23,7 +23,7 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 #ifdef FC_OS_WIN32
-# include <windows.h>
+#include <windows.h>
 #endif
 #include <map>
 

--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -23,7 +23,7 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 #ifdef FC_OS_WIN32
-#include <windows.h>
+# include <windows.h>
 #endif
 #include <map>
 
@@ -35,9 +35,7 @@
 #include <qstringlist.h>
 #endif
 
-#ifndef __InventorAll__
 #include <Gui/InventorAll.h>
-#endif
 
 #include <App/DocumentObject.h>
 #include <App/DocumentObjectGroup.h>

--- a/src/Mod/Mesh/Gui/PreCompiled.h
+++ b/src/Mod/Mesh/Gui/PreCompiled.h
@@ -52,14 +52,10 @@
 #include <vector>
 
 // Qt Toolkit
-#ifndef __QtAll__
 #include <Gui/QtAll.h>
-#endif
 
 // Inventor
-#ifndef __InventorAll__
-#include <Gui/InventorAll.h>
-#endif
+
 
 #elif defined(FC_OS_WIN32)
 #ifndef NOMINMAX

--- a/src/Mod/Part/Gui/PreCompiled.h
+++ b/src/Mod/Part/Gui/PreCompiled.h
@@ -83,14 +83,10 @@
 #include <Inventor/C/glue/gl.h>
 
 // Qt Toolkit
-#ifndef __QtAll__
 # include <Gui/QtAll.h>
-#endif
 
 // Inventor includes OpenGL
-#ifndef __InventorAll__
 # include <Gui/InventorAll.h>
-#endif
 
 #endif  //_PreComp_
 

--- a/src/Mod/PartDesign/Gui/PreCompiled.h
+++ b/src/Mod/PartDesign/Gui/PreCompiled.h
@@ -56,14 +56,10 @@
 #include <TopTools_IndexedMapOfShape.hxx>
 
 // Qt
-#ifndef __QtAll__
 # include <Gui/QtAll.h>
-#endif
 
 // Inventor
-#ifndef __InventorAll__
 # include <Gui/InventorAll.h>
-#endif
 
 #endif // _PreComp_
 #endif // __PRECOMPILED_GUI__

--- a/src/Mod/Sketcher/Gui/PreCompiled.h
+++ b/src/Mod/Sketcher/Gui/PreCompiled.h
@@ -71,16 +71,12 @@
 #include <gp_Pnt.hxx>
 
 // Qt
-#ifndef __QtAll__
 #include <Gui/QtAll.h>
-#endif
 
 #include <QWidgetAction>
 
 // all of Inventor
-#ifndef __InventorAll__
 #include <Gui/InventorAll.h>
-#endif
 
 #endif  //_PreComp_
 

--- a/src/Mod/Spreadsheet/Gui/PreCompiled.h
+++ b/src/Mod/Spreadsheet/Gui/PreCompiled.h
@@ -47,9 +47,7 @@
 #endif
 
 // Qt Toolkit
-#ifndef __QtAll__
 #include <Gui/QtAll.h>
-#endif
 
 #endif  //_PreComp_
 

--- a/src/Tools/_TEMPLATE_/Gui/PreCompiled.h
+++ b/src/Tools/_TEMPLATE_/Gui/PreCompiled.h
@@ -61,9 +61,7 @@
 #endif
 
 // Qt Toolkit
-#ifndef __QtAll__
 #include <Gui/QtAll.h>
-#endif
 
 #endif  //_PreComp_
 


### PR DESCRIPTION
before including the library, it is uselessly checked if the variable __QtAll__ and __InventorAll__ have been defined. The same check is performed again once the library is included