### PR TITLE
Sketcher: Move getStandardButtons to cpp file

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
@@ -146,6 +146,10 @@ bool TaskDlgEditSketch::reject()
     return true;
 }
 
+QDialogButtonBox::StandardButtons TaskDlgEditSketch::getStandardButtons() const
+{
+    return QDialogButtonBox::Close;
+}
 
 void TaskDlgEditSketch::autoClosedOnClosedView()
 {

--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.h
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.h
@@ -69,7 +69,6 @@ public:
     }
     void autoClosedOnClosedView() override;
 
-    /// returns for Close and Help button
     QDialogButtonBox::StandardButtons getStandardButtons() const override;
 
     /** @brief Function used to register a slot to be triggered when the tool widget is changed. */

--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.h
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.h
@@ -70,10 +70,7 @@ public:
     void autoClosedOnClosedView() override;
 
     /// returns for Close and Help button
-    QDialogButtonBox::StandardButtons getStandardButtons() const override
-    {
-        return QDialogButtonBox::Close;
-    }
+    QDialogButtonBox::StandardButtons getStandardButtons() const override;
 
     /** @brief Function used to register a slot to be triggered when the tool widget is changed. */
     template<typename F>


### PR DESCRIPTION
This PR is based on @PaddleStroke's https://github.com/FreeCAD/FreeCAD/pull/19849 but only contains the part of moving the function from the h file to the cpp file.

I've credited paddle as the author in this commit due to the code was created in his PR, though the commit splitting was done by me.

While this will create a collision for astocad currently, I believe it will make it easier for paddle to rebase his fork in the future.