### PR TITLE
PartDesign: Auto switch label to edit after adding new part

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsDocument.ui
+++ b/src/Gui/PreferencePages/DlgSettingsDocument.ui
@@ -610,6 +610,22 @@ icon in the tree view to fully reload it.</string>
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="Gui::PrefCheckBox" name="prefTreeAutoRelabel">
+        <property name="toolTip">
+         <string>After a new top-level object is created, its tree label is automatically put into edit mode to quickly perform a rename (F2)</string>
+        </property>
+        <property name="text">
+         <string>Edit object label after creation</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>AutoRelabelNew</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>TreeView</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Gui/PreferencePages/DlgSettingsDocumentImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsDocumentImp.cpp
@@ -106,6 +106,7 @@ void DlgSettingsDocumentImp::saveSettings()
     ui->prefAutoSaveEnabled->onSave();
     ui->prefAutoSaveTimeout->onSave();
     ui->prefCanAbortRecompute->onSave();
+    ui->prefTreeAutoRelabel->onSave();
 
     int timeout = ui->prefAutoSaveTimeout->value();
     if (!ui->prefAutoSaveEnabled->isChecked()) {
@@ -141,6 +142,7 @@ void DlgSettingsDocumentImp::loadSettings()
     ui->prefAutoSaveEnabled->onRestore();
     ui->prefAutoSaveTimeout->onRestore();
     ui->prefCanAbortRecompute->onRestore();
+    ui->prefTreeAutoRelabel->onRestore();
 }
 
 /**

--- a/src/Gui/PreferencePages/DlgSettingsSelection.ui
+++ b/src/Gui/PreferencePages/DlgSettingsSelection.ui
@@ -259,6 +259,22 @@ A larger value makes it easier to select elements, but may prevent selection of 
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBoxTreeAutoRelabel">
+        <property name="text">
+         <string>Auto relabel objects after they are created</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>AutoRelabelNew</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>TreeView</cstring>
+        </property>
+        <property name="toolTip">
+         <string>After a object is created, its tree label is automatically put into edit mode to quickly perform a rename (F2)</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -3430,7 +3430,10 @@ void TreeWidget::onUpdateStatus()
         if (!docItem) {
             continue;
         }
-        for (auto id : v.second) {
+
+        std::vector<App::DocumentObject*> sels;
+        for (auto j = 0; j < v.second.size(); j++) {
+            auto id = v.second[j];
             auto obj = doc->getObjectByID(id);
             if (!obj) {
                 continue;
@@ -3442,12 +3445,23 @@ void TreeWidget::onUpdateStatus()
                 continue;
             }
             auto vpd = freecad_cast<ViewProviderDocumentObject*>(gdoc->getViewProvider(obj));
-            if (vpd) {
-                docItem->createNewItem(*vpd);
+
+            if (!vpd) {
+                continue;
             }
-            else {
-                RelabelQueue.insert(obj);
+
+            docItem->createNewItem(*vpd);
+                        
+            if (j != v.second.size() - 1) {
+                continue;
             }
+
+            // Select the newest item
+            sels.push_back(obj);
+            Selection().clearSelection();
+            Selection().setSelection(gdoc->getDocument()->getName(), sels);
+
+            tryOfferRelabel(obj, docItem);
         }
     }
 

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -108,7 +108,8 @@ static bool isSelectionCheckBoxesEnabled()
     return TreeParams::getCheckBoxesSelection();
 }
 
-static bool isAutoRelabelNewEnabled() {
+static bool isAutoRelabelNewEnabled()
+{
     return TreeParams::getAutoRelabelNew();
 }
 
@@ -3451,7 +3452,7 @@ void TreeWidget::onUpdateStatus()
             }
 
             docItem->createNewItem(*vpd);
-                        
+
             if (j != v.second.size() - 1) {
                 continue;
             }
@@ -3625,21 +3626,17 @@ void TreeWidget::tryOfferRelabel(App::DocumentObject* obj, DocumentItem* docItem
     }
 
     auto data = it->second;
-    QTreeWidgetItem* item = data->rootItem 
-        ? data->rootItem 
-        : (!data->items.empty() ? *data->items.begin() : nullptr);
+    QTreeWidgetItem* item = data->rootItem ? data->rootItem
+                                           : (!data->items.empty() ? *data->items.begin() : nullptr);
 
     if (!item) {
-        return;        
+        return;
     }
 
     // Make sure any labels already in edit are closed
     closeEditor(viewport()->findChild<QLineEdit*>(), QAbstractItemDelegate::RevertModelCache);
-    
-    QTimer::singleShot(200, this, [this, item]() {
-        editItem(item);
-    });
 
+    QTimer::singleShot(200, this, [this, item]() { editItem(item); });
 }
 
 void TreeWidget::onItemEntered(QTreeWidgetItem* item)

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -247,7 +247,7 @@ private:
 
     bool CheckForDependents();
     void addDependentToSelection(App::Document* doc, App::DocumentObject* docObject);
-    void tryOfferRelabel(App::DocumentObject*& object);
+    void tryOfferRelabel(App::DocumentObject* obj, DocumentItem* docItem);
     static TreeWidget* getTreeForSelection();
 
 private:

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -247,6 +247,7 @@ private:
 
     bool CheckForDependents();
     void addDependentToSelection(App::Document* doc, App::DocumentObject* docObject);
+    void tryOfferRelabel(App::DocumentObject*& object);
     static TreeWidget* getTreeForSelection();
 
 private:

--- a/src/Gui/TreeParams.cpp
+++ b/src/Gui/TreeParams.cpp
@@ -50,6 +50,7 @@ public:
     bool PreSelection;
     bool SyncPlacement;
     bool RecordSelection;
+    bool AutoRelabelNew;
     long DocumentMode;
     long StatusTimeout;
     long SelectionTimeout;
@@ -104,6 +105,8 @@ public:
         funcs["SyncPlacement"] = &TreeParamsP::updateSyncPlacement;
         RecordSelection = handle->GetBool("RecordSelection", true);
         funcs["RecordSelection"] = &TreeParamsP::updateRecordSelection;
+        AutoRelabelNew = handle->GetBool("AutoRelabelNew", false);
+        funcs["AutoRelabelNew"] = &TreeParamsP::updateAutoRelabelNew;
         DocumentMode = handle->GetInt("DocumentMode", 2);
         funcs["DocumentMode"] = &TreeParamsP::updateDocumentMode;
         StatusTimeout = handle->GetInt("StatusTimeout", 100);
@@ -229,8 +232,16 @@ public:
         self->RecordSelection = self->handle->GetBool("RecordSelection", true);
     }
     // Auto generated code (Tools/params_utils.py:296)
-    static void updateDocumentMode(TreeParamsP* self)
+    static void updateAutoRelabelNew(TreeParamsP *self) 
     {
+        auto v = self->handle->GetBool("AutoRelabelNew", false);
+        if (self->AutoRelabelNew != v) {
+            self->AutoRelabelNew = v;
+            TreeParams::onAutoRelabelNewChanged();
+        }
+    }
+    // Auto generated code (Tools/params_utils.py:296)
+    static void updateDocumentMode(TreeParamsP *self) {
         auto v = self->handle->GetInt("DocumentMode", 2);
         if (self->DocumentMode != v) {
             self->DocumentMode = v;
@@ -675,7 +686,39 @@ void TreeParams::removeRecordSelection()
 }
 
 // Auto generated code (Tools/params_utils.py:350)
-const char* TreeParams::docDocumentMode()
+const char *TreeParams::docAutoRelabelNew() 
+{
+    return "";
+}
+
+// Auto generated code (Tools/params_utils.py:358)
+const bool & TreeParams::getAutoRelabelNew() 
+{
+    return instance()->AutoRelabelNew;
+}
+
+// Auto generated code (Tools/params_utils.py:366)
+const bool & TreeParams::defaultAutoRelabelNew() 
+{
+    const static bool def = false;
+    return def;
+}
+
+// Auto generated code (Tools/params_utils.py:375)
+void TreeParams::setAutoRelabelNew(const bool &v) 
+{
+    instance()->handle->SetBool("AutoRelabelNew",v);
+    instance()->AutoRelabelNew = v;
+}
+
+// Auto generated code (Tools/params_utils.py:384)
+void TreeParams::removeAutoRelabelNew() 
+{
+    instance()->handle->RemoveBool("AutoRelabelNew");
+}
+
+// Auto generated code (Tools/params_utils.py:350)
+const char *TreeParams::docDocumentMode() 
 {
     return "";
 }
@@ -1748,7 +1791,12 @@ void TreeParams::onCheckBoxesSelectionChanged()
     TreeWidget::synchronizeSelectionCheckBoxes();
 }
 
-void TreeParams::onDocumentModeChanged()
+void TreeParams::onAutoRelabelNewChanged()
+{
+    TreeWidget::synchronizeSelectionCheckBoxes();
+}
+
+void TreeParams::onDocumentModeChanged() 
 {
     App::GetApplication().setActiveDocument(App::GetApplication().getActiveDocument());
 }

--- a/src/Gui/TreeParams.cpp
+++ b/src/Gui/TreeParams.cpp
@@ -232,7 +232,7 @@ public:
         self->RecordSelection = self->handle->GetBool("RecordSelection", true);
     }
     // Auto generated code (Tools/params_utils.py:296)
-    static void updateAutoRelabelNew(TreeParamsP *self) 
+    static void updateAutoRelabelNew(TreeParamsP* self)
     {
         auto v = self->handle->GetBool("AutoRelabelNew", false);
         if (self->AutoRelabelNew != v) {
@@ -241,7 +241,8 @@ public:
         }
     }
     // Auto generated code (Tools/params_utils.py:296)
-    static void updateDocumentMode(TreeParamsP *self) {
+    static void updateDocumentMode(TreeParamsP* self)
+    {
         auto v = self->handle->GetInt("DocumentMode", 2);
         if (self->DocumentMode != v) {
             self->DocumentMode = v;
@@ -686,39 +687,39 @@ void TreeParams::removeRecordSelection()
 }
 
 // Auto generated code (Tools/params_utils.py:350)
-const char *TreeParams::docAutoRelabelNew() 
+const char* TreeParams::docAutoRelabelNew()
 {
     return "";
 }
 
 // Auto generated code (Tools/params_utils.py:358)
-const bool & TreeParams::getAutoRelabelNew() 
+const bool& TreeParams::getAutoRelabelNew()
 {
     return instance()->AutoRelabelNew;
 }
 
 // Auto generated code (Tools/params_utils.py:366)
-const bool & TreeParams::defaultAutoRelabelNew() 
+const bool& TreeParams::defaultAutoRelabelNew()
 {
     const static bool def = false;
     return def;
 }
 
 // Auto generated code (Tools/params_utils.py:375)
-void TreeParams::setAutoRelabelNew(const bool &v) 
+void TreeParams::setAutoRelabelNew(const bool& v)
 {
-    instance()->handle->SetBool("AutoRelabelNew",v);
+    instance()->handle->SetBool("AutoRelabelNew", v);
     instance()->AutoRelabelNew = v;
 }
 
 // Auto generated code (Tools/params_utils.py:384)
-void TreeParams::removeAutoRelabelNew() 
+void TreeParams::removeAutoRelabelNew()
 {
     instance()->handle->RemoveBool("AutoRelabelNew");
 }
 
 // Auto generated code (Tools/params_utils.py:350)
-const char *TreeParams::docDocumentMode() 
+const char* TreeParams::docDocumentMode()
 {
     return "";
 }
@@ -1796,7 +1797,7 @@ void TreeParams::onAutoRelabelNewChanged()
     TreeWidget::synchronizeSelectionCheckBoxes();
 }
 
-void TreeParams::onDocumentModeChanged() 
+void TreeParams::onDocumentModeChanged()
 {
     App::GetApplication().setActiveDocument(App::GetApplication().getActiveDocument());
 }

--- a/src/Gui/TreeParams.h
+++ b/src/Gui/TreeParams.h
@@ -135,11 +135,11 @@ public:
     // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter AutoRelabelNew
-    static const bool & getAutoRelabelNew();
-    static const bool & defaultAutoRelabelNew();
+    static const bool& getAutoRelabelNew();
+    static const bool& defaultAutoRelabelNew();
     static void removeAutoRelabelNew();
-    static void setAutoRelabelNew(const bool &v);
-    static const char *docAutoRelabelNew();
+    static void setAutoRelabelNew(const bool& v);
+    static const char* docAutoRelabelNew();
     static void onAutoRelabelNewChanged();
     //@}
 

--- a/src/Gui/TreeParams.h
+++ b/src/Gui/TreeParams.h
@@ -134,6 +134,17 @@ public:
 
     // Auto generated code (Tools/params_utils.py:138)
     //@{
+    /// Accessor for parameter AutoRelabelNew
+    static const bool & getAutoRelabelNew();
+    static const bool & defaultAutoRelabelNew();
+    static void removeAutoRelabelNew();
+    static void setAutoRelabelNew(const bool &v);
+    static const char *docAutoRelabelNew();
+    static void onAutoRelabelNewChanged();
+    //@}
+
+    // Auto generated code (Tools/params_utils.py:138)
+    //@{
     /// Accessor for parameter DocumentMode
     static const long& getDocumentMode();
     static const long& defaultDocumentMode();

--- a/src/Gui/TreeParams.py
+++ b/src/Gui/TreeParams.py
@@ -50,6 +50,7 @@ Params = [
     ParamBool("PreSelection", True),
     ParamBool("SyncPlacement", False),
     ParamBool("RecordSelection", True),
+    ParamBool("AutoRelabelNew", False, on_change=True),
     ParamInt("DocumentMode", 2, on_change=True),
     ParamInt("StatusTimeout", 100),
     ParamInt("SelectionTimeout", 100),


### PR DESCRIPTION
After adding a new body, the tree will auto switch the body label to edit mode so a user can type a name.

There are several approaches that could work here but tracking state on the DocumentObject and having the tree react was cleanest.

NEW BEHAVIOR
![relabelNewBehavior](https://github.com/user-attachments/assets/edf934af-0f40-4cde-8992-d8b9a912b27a)

OLD BEHAVIOR
![relabelOldBehavior](https://github.com/user-attachments/assets/f4852c7b-11ad-4bf5-b423-9f5edc9c19f6)

