### PR TITLE
Mesh: Fix mistaken deletion of #include <Gui/InventorAll.h>

### DIFF
--- a/src/Mod/Mesh/Gui/PreCompiled.h
+++ b/src/Mod/Mesh/Gui/PreCompiled.h
@@ -55,7 +55,7 @@
 #include <Gui/QtAll.h>
 
 // Inventor
-
+#include <Gui/InventorAll.h>
 
 #elif defined(FC_OS_WIN32)
 #ifndef NOMINMAX


### PR DESCRIPTION
This was inadvertently deleted in a recent cleanup PR.