### PR TITLE
BIM: add unit test for addSpaceBoundaries

### DIFF
--- a/src/Mod/BIM/TestArch.py
+++ b/src/Mod/BIM/TestArch.py
@@ -27,7 +27,6 @@ import os
 import unittest
 
 import FreeCAD as App
-import FreeCADGui as Gui
 from FreeCAD import Units
 
 import Arch
@@ -852,9 +851,7 @@ class ArchTest(unittest.TestCase):
         wall.Normal = wp.axis
 
         # Add the boundary
-        Gui.Selection.clearSelection()
-        Gui.Selection.addSelection(wall, "Face1")
-        wallBoundary = Gui.Selection.getSelectionEx()
+        wallBoundary = [(wall, ["Face1"])]
         Arch.addSpaceBoundaries(App.ActiveDocument.Space, wallBoundary)
         App.ActiveDocument.recompute()  # To recalculate area
 

--- a/src/Mod/BIM/TestArch.py
+++ b/src/Mod/BIM/TestArch.py
@@ -27,12 +27,15 @@ import os
 import unittest
 
 import FreeCAD as App
+import FreeCADGui as Gui
+from FreeCAD import Units
 
 import Arch
 import Draft
 import Part
 import Sketcher
 import TechDraw
+import WorkingPlane
 
 from draftutils.messages import _msg
 
@@ -817,6 +820,53 @@ class ArchTest(unittest.TestCase):
         view.Y = "15cm"
         App.ActiveDocument.recompute()
         assert True
+
+    def test_addSpaceBoundaries(self):
+        """Test the Arch.addSpaceBoundaries method.
+        Create a space and a wall that intersects it. Add the wall as a boundary to the space,
+        and check if the resulting space area is as expected.
+        """
+        operation = " Add a wall face as a boundary to a space"
+        _msg("  Test '{}'".format(operation))
+
+        # Create the space
+        pl = App.Placement()
+        pl.Rotation.Q = (0.0, 0.0, 0.0, 1.0)
+        pl.Base = App.Vector(-2000.0, -2000.0, 0.0)
+        rectangleBase = Draft.make_rectangle(
+            length=4000.0, height=4000.0, placement=pl, face=True, support=None)
+        App.ActiveDocument.recompute()
+        extr = rectangleBase.Shape.extrude(App.Vector(0,0,2000))
+        Part.show(extr, 'Extrusion')
+        space = Arch.makeSpace(App.activeDocument().getObject('Extrusion'))
+        App.ActiveDocument.recompute()  # To calculate area
+
+        # Create the wall
+        trace = Part.LineSegment(App.Vector (3000.0, 1000.0, 0.0), 
+                                 App.Vector (-3000.0, 1000.0, 0.0))
+        wp = WorkingPlane.get_working_plane()
+        base = App.ActiveDocument.addObject("Sketcher::SketchObject","WallTrace")
+        base.Placement = wp.get_placement()
+        base.addGeometry(trace)
+        wall = Arch.makeWall(base,width=200.0,height=3000.0,align="Left")
+        wall.Normal = wp.axis
+
+        # Add the boundary
+        Gui.Selection.clearSelection()
+        Gui.Selection.addSelection(wall, "Face1")
+        wallBoundary = Gui.Selection.getSelectionEx()
+        Arch.addSpaceBoundaries(App.ActiveDocument.Space, wallBoundary)
+        App.ActiveDocument.recompute()  # To recalculate area
+
+        # Assert if area is as expected
+        expectedArea = Units.parseQuantity('12 m^2')
+        actualArea = Units.parseQuantity(str(space.Area))
+
+        self.assertAlmostEqual(
+            expectedArea.Value,
+            actualArea.Value,
+            msg = (f"Invalid area value. " + 
+                   f"Expected: {expectedArea.UserString}, actual: {actualArea.UserString}"))
 
     def tearDown(self):
         App.closeDocument("ArchTest")


### PR DESCRIPTION
Adds a unit test to check that boundaries can be added to an [Arch Space](https://wiki.freecad.org/Arch_Space) object via the [Arch Add](https://wiki.freecad.org/Arch_Add) command. It was originally intended as a regression test for https://github.com/FreeCAD/FreeCAD/issues/20106, but it was not ready at the time.

To test on Linux:

```shell
# Assumes an out of source build in a directory called 'build'
# Assumes xvfb is installed
./build/bin/FreeCAD --console --run-test TestArch.ArchTest.test_addSpaceBoundaries
```

~The original intention was to make the test CLI only, but the `addSpaceBoundaries()` method takes a list of selection objects as the second argument. The only way (I know of) to pass such a list is by using `getSelectionEx()`, which is only defined in `FreeCADGui`. Thus this test requires the FreeCAD GUI to run.~ => This has been addressed.