### PR TITLE
[CAM] Change VBit tip diameter to 0.1 mm.

### DIFF
--- a/src/Mod/CAM/Tools/Bit/30degree_Vbit.fctb
+++ b/src/Mod/CAM/Tools/Bit/30degree_Vbit.fctb
@@ -1,9 +1,9 @@
 {
   "version": 2,
-  "name": "60 Deg. V-Bit",
+  "name": "30 Deg. V-Bit",
   "shape": "v-bit.fcstd",
   "parameter": {
-    "CuttingEdgeAngle": "60.0000 \u00b0",
+    "CuttingEdgeAngle": "30.0000 \u00b0",
     "Diameter": "10.0000 mm",
     "CuttingEdgeHeight": "1.0000 mm",
     "TipDiameter": "0.1000 mm",

--- a/src/Mod/CAM/Tools/Bit/30degree_Vbit.fctb
+++ b/src/Mod/CAM/Tools/Bit/30degree_Vbit.fctb
@@ -7,7 +7,7 @@
     "Diameter": "10.0000 mm",
     "CuttingEdgeHeight": "1.0000 mm",
     "TipDiameter": "0.1000 mm",
-    "Length": "20.0000 mm",
+    "Length": "30.0000 mm",
     "ShankDiameter": "5.0000 mm"
   },
   "attribute": {}

--- a/src/Mod/CAM/Tools/Bit/45degree_Vbit.fctb
+++ b/src/Mod/CAM/Tools/Bit/45degree_Vbit.fctb
@@ -1,9 +1,9 @@
 {
   "version": 2,
-  "name": "60 Deg. V-Bit",
+  "name": "45 Deg. V-Bit",
   "shape": "v-bit.fcstd",
   "parameter": {
-    "CuttingEdgeAngle": "60.0000 \u00b0",
+    "CuttingEdgeAngle": "45.0000 \u00b0",
     "Diameter": "10.0000 mm",
     "CuttingEdgeHeight": "1.0000 mm",
     "TipDiameter": "0.1000 mm",

--- a/src/Mod/CAM/Tools/Bit/90degree_Vbit.fctb
+++ b/src/Mod/CAM/Tools/Bit/90degree_Vbit.fctb
@@ -1,9 +1,9 @@
 {
   "version": 2,
-  "name": "60 Deg. V-Bit",
+  "name": "90 Deg. V-Bit",
   "shape": "v-bit.fcstd",
   "parameter": {
-    "CuttingEdgeAngle": "60.0000 \u00b0",
+    "CuttingEdgeAngle": "90.0000 \u00b0",
     "Diameter": "10.0000 mm",
     "CuttingEdgeHeight": "1.0000 mm",
     "TipDiameter": "0.1000 mm",

--- a/src/Mod/CAM/Tools/Library/Default.fctl
+++ b/src/Mod/CAM/Tools/Library/Default.fctl
@@ -18,22 +18,34 @@
     },
     {
       "nr": 5,
-      "path": "60degree_Vbit.fctb"
+      "path": "30degree_Vbit.fctb"
     },
     {
       "nr": 6,
-      "path": "45degree_chamfer.fctb"
+      "path": "45degree_Vbit.fctb"
     },
     {
       "nr": 7,
-      "path": "slittingsaw.fctb"
+      "path": "60degree_Vbit.fctb"
     },
     {
       "nr": 8,
-      "path": "probe.fctb"
+      "path": "90degree_Vbit.fctb"
     },
     {
       "nr": 9,
+      "path": "45degree_chamfer.fctb"
+    },
+    {
+      "nr": 10,
+      "path": "slittingsaw.fctb"
+    },
+    {
+      "nr": 11,
+      "path": "probe.fctb"
+    },
+    {
+      "nr": 12,
       "path": "5mm-thread-cutter.fctb"
     }
   ],


### PR DESCRIPTION
Change default V-bit tip diameter to 0.1 mm to avoid confusion and reports about VCarve engraving above the stock.
This diameter also matches most commercial bits anyway.

PR also adds other popular v-bits: 30, 45 and 90 degrees to spare users creating their own tools as the tool bit UI is broken and frustrating.

Fixes: https://github.com/FreeCAD/FreeCAD/issues/16701

cc: @sliptonic 