### PR TITLE
BIM: allow boundaries to be defined from a single object (e.g. wall)

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -768,12 +768,43 @@ def makeSite(objectslist=None,baseobj=None,name=None):
 
 
 def makeSpace(objects=None,baseobj=None,name=None):
+    """Creates a space object from the given objects.
 
-    """makeSpace([objects],[baseobj],[name]): Creates a space object from the given objects.
-    Objects can be one document object, in which case it becomes the base shape of the space
-    object, or a list of selection objects as got from getSelectionEx(), or a list of tuples
-    [ (object, [subobjectname, ...]), ... ]"""
+    Parameters
+    ----------
+    objects : object or List(<SelectionObject>) or App::PropertyLinkSubList, optional
+        The object or selection set that defines the space. If a single object is given,
+        it becomes the base shape for the object. If the object or selection set contains
+        subelements, these will be used as the boundaries to create the space. By default None.
+    baseobj : object or List(<SelectionObject>) or App::PropertyLinkSubList, optional
+        Currently unimplemented, it replaces and behaves in the same way as the objects parameter
+        if defined. By default None.
+    name : str, optional
+        The user-facing name to assign to the space object's label. By default None, in
+        which case the label is set to "Space".
 
+    Notes
+    -----
+    The objects parameter can be passed using either of these different formats:
+    1. Single object (e.g. a Part::Feature document object). Will be used as the space's base
+       shape.
+       ::
+            objects = <Part::Feature>
+    2. List of selection objects, as provided by ``Gui.Selection.getSelectionEx()``. This
+       requires the GUI to be active. The `SubObjects` property of each selection object in the
+       list defines the space's boundaries. If the list contains a single selection object without
+       subobjects, or with only one subobject, the object in its ``Object`` property is used as
+       the base shape.
+       ::
+            objects = [<SelectionObject>, ...]
+    3. A list of tuples that can be assigned to an ``App::PropertyLinkSubList`` property. Each
+       tuple contains a document object and a nested tuple of subobjects that define boundaries. If
+       the list contains a single tuple without a nested subobjects tuple, or a subobjects tuple
+       with only one subobject, the object in the tuple is used as the base shape.
+       ::
+            objects = [(obj1, ("Face1")), (obj2, ("Face1")), ...]
+            objects = [(obj, ("Face1", "Face2", "Face3", "Face4"))]
+    """
     import ArchSpace
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")

--- a/src/Mod/BIM/bimcommands/BimSpace.py
+++ b/src/Mod/BIM/bimcommands/BimSpace.py
@@ -56,10 +56,7 @@ class Arch_Space:
         sel = FreeCADGui.Selection.getSelection()
         if sel:
             FreeCADGui.Control.closeDialog()
-            if len(sel) == 1:
-                FreeCADGui.doCommand("obj = Arch.makeSpace(FreeCADGui.Selection.getSelection())")
-            else:
-                FreeCADGui.doCommand("obj = Arch.makeSpace(FreeCADGui.Selection.getSelectionEx())")
+            FreeCADGui.doCommand("obj = Arch.makeSpace(FreeCADGui.Selection.getSelectionEx())")
             FreeCADGui.addModule("Draft")
             FreeCADGui.doCommand("Draft.autogroup(obj)")
             FreeCAD.ActiveDocument.commitTransaction()


### PR DESCRIPTION
Fixes: https://github.com/FreeCAD/FreeCAD/issues/20137

- When clicking on an object, it is assumed to be a single object that does not define boundaries if:
  - it has no subelements (e.g. clicked from the Tree View) OR
  - if it has only one subelement (e.g. clicked a face from the 3D window to select the object).
- In the cases above, the whole object will be converted to an Arch.Space and no boundaries will be used.
- All other cases where the number of subelements is > 1 will be considered to define boundaries. In these cases, Arch Space will be created from the boundaries defined as subelements. 
- Adds a unit test for this feature. The unit test can run both with CLI (tests parameter passing) and GUI (tests and replicates user selection in the UI).

To test the feature:
1. Start FreeCAD and load the BIM Workbench.
1. Create a Draft rectangle. Make sure "Make face" is false.
1. Select it and click on the Wall command. This creates a single wall object (with four "walls", each on one edge of the base rectangle).
1. Select all of the four interior faces of the new wall (press and hold Ctrl while clicking on each face).
1. Then click on the Arch Space button on the toolbar.
1. Expected: an [Arch Space](https://wiki.freecad.org/Arch_Space) that fills the interior cube of empty space within the walls is created.

|State|Screenshot|Notes|
|---|---|---|
|Before|![Image](https://github.com/user-attachments/assets/df64c929-e889-4b3f-ba7f-fc66aa77d572)|Unexpected: wall converted to space|
|After|![image](https://github.com/user-attachments/assets/debceb62-193d-4d2f-8d30-5f806299115a)|Expected: space created within the wall|

To run the unit test:

```shell
# Run the test without GUI.
$ ./build/bin/FreeCADCmd --run-test TestArch.ArchTest.test_SpaceFromSingleWall

# Run the test with GUI.
$ ./build/bin/FreeCAD --run-open TestArch.ArchTest.test_SpaceFromSingleWall

# Alternative: run the test with GUI, terminal only. Needs installation of xvfb, might work on Linux only.
$ xvfb-run ./build/bin/FreeCAD --run-test TestArch.ArchTest.test_SpaceFromSingleWall
```