### PR TITLE
TechDraw: Fix flickering cursor issue

### DIFF
--- a/src/Mod/TechDraw/Gui/QGVNavStyleTouchpad.cpp
+++ b/src/Mod/TechDraw/Gui/QGVNavStyleTouchpad.cpp
@@ -113,8 +113,12 @@ void QGVNavStyleTouchpad::handleMouseMoveEvent(QMouseEvent *event)
 
     // if the mouse moves, but we are not zooming or panning, then we should make
     // sure that zoom and pan are turned off.
-    stopPan();
-    stopZoom();
+    if (panningActive) {
+        stopPan();
+    }
+    if (zoomingActive) {
+        stopZoom();
+    }
 }
 
 void QGVNavStyleTouchpad::setAnchor()


### PR DESCRIPTION
The cursor flickers (changes between the picker cursor and the normal one) in techdraw workbench while picking a cosmetic vertex using the picker. This problem is can be reproduced only using the touchpad control scheme. This PR aims to solve that by preventing the continuous calls to stopPan and stopZoom (both of these functions set the cursor to normal).
Here is the video showing how to reproduce the issue:

https://github.com/user-attachments/assets/9aab8325-a006-4b97-9a91-585a6002057a

Ideally, calls to stopPan and stopZoom shouldn't be needed at all there since the handleKeyReleaseEvent should be handling that gracefully. But for some reason releasing the shift key isn't registered from time to time.
Actually, that can be reproduced as a separate problem in techdraw. Start panning, leave the mouse and release the shift key. You will notice that the cursor is still a panning cursor instead of a normal one.