### PR TITLE
 Measure: add translation source file for uploading to Crowdin

### DIFF
--- a/src/Mod/Measure/Gui/Resources/translations/Measure_es-ES.ts
+++ b/src/Mod/Measure/Gui/Resources/translations/Measure_es-ES.ts
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es_ES" sourcelanguage="en_US">
+<context>
+    <name>Gui::TaskMeasure</name>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="69"/>
+        <source>Measurement</source>
+        <translation>Medición</translation>
+    </message>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="87"/>
+        <source>Show Delta:</source>
+        <translation>Mostrar delta:</translation>
+    </message>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="90"/>
+        <source>Auto Save</source>
+        <translation>Guardar automáticamente</translation>
+    </message>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="93"/>
+        <source>Auto saving of the last measurement when starting a new measurement. Use SHIFT to temporarily invert the behaviour.</source>
+        <translation>Guardar automáticamente la última medición al comenzar una nueva medición. Utilice MAYÚS para invertir el comportamiento temporalmente.</translation>
+    </message>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="97"/>
+        <source>Additive Selection</source>
+        <translation>Selección aditiva</translation>
+    </message>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="102"/>
+        <source>If checked, new selection will be added to the measurement. If unchecked, CTRL must be pressed to add a selection to the current measurement otherwise a new measurement will be started</source>
+        <translation>Si está marcado, las nuevas selecciones serán agregadas a la medición. De lo contrario, CTRL debe de ser presionado para agregar una selección a la medición actual, de otro modo, una nueva medición será iniciada.</translation>
+    </message>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="111"/>
+        <source>Settings</source>
+        <translation>Ajustes</translation>
+    </message>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="152"/>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="154"/>
+        <source>Result:</source>
+        <translation>Resultado:</translation>
+    </message>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="183"/>
+        <source>Save</source>
+        <translation>Guardar</translation>
+    </message>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="184"/>
+        <source>Save the measurement in the active document.</source>
+        <translation>Guardar la medición en el documento activo.</translation>
+    </message>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="190"/>
+        <source>Close</source>
+        <translation>Cerrar</translation>
+    </message>
+    <message>
+        <location filename="../../TaskMeasure.cpp" line="191"/>
+        <source>Close the measurement task.</source>
+        <translation>Cerrar la tarea de medición.</translation>
+    </message>
+</context>
+<context>
+    <name>MeasureGui::DlgPrefsMeasureAppearanceImp</name>
+    <message>
+        <location filename="../../DlgPrefsMeasureAppearanceImp.ui" line="20"/>
+        <source>Appearance</source>
+        <translation>Apariencia</translation>
+    </message>
+    <message>
+        <location filename="../../DlgPrefsMeasureAppearanceImp.ui" line="142"/>
+        <source>Text color</source>
+        <translation>Color de texto</translation>
+    </message>
+    <message>
+        <location filename="../../DlgPrefsMeasureAppearanceImp.ui" line="59"/>
+        <source>Text size</source>
+        <translation>Tamaño de texto</translation>
+    </message>
+    <message>
+        <location filename="../../DlgPrefsMeasureAppearanceImp.ui" line="51"/>
+        <source>Default property values</source>
+        <translation>Valores de propiedad por defecto</translation>
+    </message>
+    <message>
+        <location filename="../../DlgPrefsMeasureAppearanceImp.ui" line="66"/>
+        <source>Line color</source>
+        <translation>Color de línea</translation>
+    </message>
+    <message>
+        <location filename="../../DlgPrefsMeasureAppearanceImp.ui" line="76"/>
+        <source> px</source>
+        <translation> px</translation>
+    </message>
+    <message>
+        <location filename="../../DlgPrefsMeasureAppearanceImp.ui" line="112"/>
+        <source>Background color</source>
+        <translation>Color de fondo</translation>
+    </message>
+</context>
+<context>
+    <name>MeasureGui::QuickMeasure</name>
+    <message>
+        <location filename="../../QuickMeasure.cpp" line="204"/>
+        <source>Total area: %1</source>
+        <translation>Área total: %1</translation>
+    </message>
+    <message>
+        <location filename="../../QuickMeasure.cpp" line="215"/>
+        <location filename="../../QuickMeasure.cpp" line="229"/>
+        <source>Nominal distance: %1</source>
+        <translation>Distancia nominal: %1</translation>
+    </message>
+    <message>
+        <location filename="../../QuickMeasure.cpp" line="218"/>
+        <source>Area: %1</source>
+        <translation>Área: %1</translation>
+    </message>
+    <message>
+        <location filename="../../QuickMeasure.cpp" line="222"/>
+        <source>Area: %1, Radius: %2</source>
+        <translation>Área: %1, Radio: %2</translation>
+    </message>
+    <message>
+        <location filename="../../QuickMeasure.cpp" line="226"/>
+        <source>Total length: %1</source>
+        <translation>Longitud total: %1</translation>
+    </message>
+    <message>
+        <location filename="../../QuickMeasure.cpp" line="232"/>
+        <source>Angle: %1, Total length: %2</source>
+        <translation>Ángulo: %1, Longitud total: %2</translation>
+    </message>
+    <message>
+        <location filename="../../QuickMeasure.cpp" line="236"/>
+        <source>Length: %1</source>
+        <translation>Longitud: %1</translation>
+    </message>
+    <message>
+        <location filename="../../QuickMeasure.cpp" line="239"/>
+        <source>Radius: %1</source>
+        <translation>Radio: %1</translation>
+    </message>
+    <message>
+        <location filename="../../QuickMeasure.cpp" line="242"/>
+        <source>Distance: %1</source>
+        <translation>Distancia: %1</translation>
+    </message>
+    <message>
+        <location filename="../../QuickMeasure.cpp" line="245"/>
+        <source>Minimum distance: %1</source>
+        <translation>Distancia mínima: %1</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../AppMeasureGui.cpp" line="113"/>
+        <source>Measure</source>
+        <translation>Medición</translation>
+    </message>
+</context>
+<context>
+    <name>StdCmdMeasure</name>
+    <message>
+        <location filename="../../Command.cpp" line="48"/>
+        <source>&amp;Measure</source>
+        <translation>&amp;Medición</translation>
+    </message>
+    <message>
+        <location filename="../../Command.cpp" line="49"/>
+        <location filename="../../Command.cpp" line="51"/>
+        <source>Measure a feature</source>
+        <translation>Medir una característica</translation>
+    </message>
+</context>
+</TS>

--- a/src/Tools/updatets.py
+++ b/src/Tools/updatets.py
@@ -98,6 +98,11 @@ directories = [
         "tsdir": "Resources/translations",
     },
     {
+        "tsname": "Measure",
+        "workingdir": "./src/Mod/Measure/",
+        "tsdir": "Gui/Resources/translations",
+    },
+    {
         "tsname": "Mesh",
         "workingdir": "./src/Mod/Mesh/",
         "tsdir": "Gui/Resources/translations",


### PR DESCRIPTION
Before this change when compiling this message appeared:
- _RCC: Warning: No resources in '/opt/FreeCAD/src/Mod/Measure/Gui/Resources/Measure_translation.qrc'._

After I manually created file for Spanish translation:
```txt
[88/348] Generating Resources/translations/Measure_es-ES.qm
Updating '/opt/FreeCAD/src/Mod/Measure/Gui/Resources/translations/Measure_es-ES.qm'...
    Generated 33 translation(s) (33 finished and 0 unfinished)
```

> [!NOTE]
> Changes must be pushed to Crowdin with `./updatecrowdin.py gather && ./updatecrowdin.py update`

And translations work

![2025-03-13-103836_hyprshot](https://github.com/user-attachments/assets/c710b890-5fd2-40c9-a75b-feb9bcd5dfde)
![2025-03-13-103546_hyprshot](https://github.com/user-attachments/assets/53a12806-4ed8-4dff-9664-1c9bd02215d4)

Except on strings for measure task where context is `Gui::TaskMeasure` but class is named 

https://github.com/FreeCAD/FreeCAD/blob/33631507f61c30ba0007728983496e16015e19e5/src/Mod/Measure/Gui/TaskMeasure.cpp#L63

![image](https://github.com/user-attachments/assets/a6b78a97-fad7-4ce2-8c7b-d752c9d7652d)

Add Spanish translation file for testing, can be removed later

Fix https://github.com/FreeCAD/FreeCAD-translations/issues/333