### PR TITLE
Mesh: change context for strings on task panel

### DIFF
--- a/src/Mod/Mesh/Gui/Workbench.cpp
+++ b/src/Mod/Mesh/Gui/Workbench.cpp
@@ -23,6 +23,7 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 #include <QGroupBox>
+#include <QObject>
 #include <QLabel>
 #endif
 
@@ -65,27 +66,27 @@ public:
     {
         // NOLINTBEGIN
         labelPoints = new QLabel();
-        labelPoints->setText(tr("Number of points:"));
+        labelPoints->setText(QObject::tr("Number of points:"));
 
         labelFacets = new QLabel();
-        labelFacets->setText(tr("Number of facets:"));
+        labelFacets->setText(QObject::tr("Number of facets:"));
 
         numPoints = new QLabel();
         numFacets = new QLabel();
 
         labelMin = new QLabel();
-        labelMin->setText(tr("Minimum bound:"));
+        labelMin->setText(QObject::tr("Minimum bound:"));
 
         labelMax = new QLabel();
-        labelMax->setText(tr("Maximum bound:"));
+        labelMax->setText(QObject::tr("Maximum bound:"));
 
         numMin = new QLabel();
         numMax = new QLabel();
         // NOLINTEND
 
         QGroupBox* box = new QGroupBox();
-        box->setTitle(tr("Mesh info box"));
-        box->setWindowTitle(tr("Mesh info"));
+        box->setTitle(QObject::tr("Mesh info box"));
+        box->setWindowTitle(QObject::tr("Mesh info"));
         // box->setAutoFillBackground(true);
         QGridLayout* grid = new QGridLayout(box);
         grid->addWidget(labelPoints, 0, 0);


### PR DESCRIPTION
_I'm not a Qt expert so I don't know if this is the proper solution or a dirty hack._

I tested by adding the translations on `src/Mod/Mesh/Gui/Resources/translations/Mesh_es-ES.ts` file on `QObject` context, recompiled and it works.

![image](https://github.com/user-attachments/assets/00fdcb25-ccbb-47cf-ae6c-2da53289daea)

Fix https://github.com/FreeCAD/FreeCAD-translations/issues/233