### PR TITLE
Draft: make Draft_Edit also detect key up events

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -412,14 +412,14 @@ class Edit(gui_base_original.Modifier):
         """Execute as callback for keyboard event."""
         # TODO: Get the keys from preferences
         event = event_callback.getEvent()
-        if event.getState() == coin.SoKeyboardEvent.DOWN:
+        if event.getState() in (coin.SoKeyboardEvent.DOWN, coin.SoKeyboardEvent.UP):
             key = event.getKey()
             # App.Console.PrintMessage("pressed key : "+str(key)+"\n")
             if key == 65307:  # ESC
                 self.finish()
             if key == 101:  # "e"
                 self.display_tracker_menu(event)
-            if key == 65535 and Gui.Selection.GetSelection() is None: # BUG: delete key activate Std::Delete command at the same time!
+            if key == 65535 and Gui.Selection.getSelection() is None: # BUG: delete key activate Std::Delete command at the same time!
                 print("DELETE PRESSED\n")
                 self.delPoint(event)
 


### PR DESCRIPTION
Fixes #20193.

The key down events can be claimed by shortcuts from other workbenches. Detecting both the down and up events does not seem to cause problems.
