### PR TITLE
Gui: fix fx size and location

### DIFF
--- a/src/Gui/ExpressionBinding.cpp
+++ b/src/Gui/ExpressionBinding.cpp
@@ -302,13 +302,11 @@ void ExpressionWidget::makeLabel(QLineEdit* le)
 
     /* Icon for f(x) */
     QFontMetrics fm(le->font());
-    int frameWidth = le->style()->pixelMetric(QStyle::PM_SpinBoxFrameWidth);
-    iconHeight = fm.height() - frameWidth;
+    iconHeight = fm.height();
     iconLabel = new ExpressionLabel(le);
     iconLabel->setCursor(Qt::ArrowCursor);
     QPixmap pixmap = getIcon(":/icons/bound-expression-unset.svg", QSize(iconHeight, iconHeight));
     iconLabel->setPixmap(pixmap);
-    iconLabel->setStyleSheet(QStringLiteral("QLabel { border: none; padding: 0px; padding-top: %2px; width: %1px; height: %1px }").arg(iconHeight).arg(frameWidth/2));
     iconLabel->hide();
     iconLabel->setExpressionText(QString());
 }

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -282,14 +282,6 @@ QuantitySpinBox::QuantitySpinBox(QWidget *parent)
             this, [&]{
         this->handlePendingEmit(true);
     });
-
-    // When a style sheet is set the text margins for top/bottom must be set to avoid to squash the widget
-#ifndef Q_OS_MAC
-    lineEdit()->setTextMargins(0, 2, 0, 2);
-#else
-    // https://forum.freecad.org/viewtopic.php?f=8&t=50615
-    lineEdit()->setTextMargins(0, 2, 0, 0);
-#endif
 }
 
 QuantitySpinBox::~QuantitySpinBox() = default;

--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -60,11 +60,21 @@ ExpressionSpinBox::ExpressionSpinBox(QAbstractSpinBox* sb)
     // horizontal to avoid going under the icon
     lineedit->setAlignment(Qt::AlignVCenter);
     int iconWidth = iconLabel->sizeHint().width();
-    int margin = lineedit->style()->pixelMetric(QStyle::PM_LineEditIconMargin, nullptr, lineedit);
+    int margin = getMargin();
     lineedit->setTextMargins(margin, margin, margin + iconWidth, margin);
 }
 
 ExpressionSpinBox::~ExpressionSpinBox() = default;
+
+int ExpressionSpinBox::getMargin()
+{
+    lineedit = spinbox->findChild<QLineEdit*>();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+    return lineedit->style()->pixelMetric(QStyle::PM_LineEditIconMargin, nullptr, lineedit) / 2;
+#else
+    return lineedit->style()->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, lineedit);
+#endif
+}
 
 void ExpressionSpinBox::bind(const App::ObjectIdentifier &_path)
 {
@@ -169,7 +179,11 @@ void ExpressionSpinBox::onChange()
 
 void ExpressionSpinBox::resizeWidget()
 {
-    int margin = lineedit->style()->pixelMetric(QStyle::PM_LineEditIconMargin, nullptr, lineedit);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+    int margin = lineedit->style()->pixelMetric(QStyle::PM_LineEditIconMargin, nullptr, lineedit) / 2;
+#else
+    int margin = lineedit->style()->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, lineedit);
+#endif
     int iconWidth = iconLabel->width() + margin;
     iconLabel->move(lineedit->width() - iconWidth, (lineedit->height() - iconLabel->height()) / 2);
     updateExpression();

--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -67,9 +67,6 @@ void ExpressionSpinBox::bind(const App::ObjectIdentifier &_path)
 
 void ExpressionSpinBox::showIcon()
 {
-    int frameWidth = spinbox->style()->pixelMetric(QStyle::PM_SpinBoxFrameWidth);
-    lineedit->setStyleSheet(QStringLiteral("QLineEdit { padding-right: %1px } ").arg(iconLabel->sizeHint().width() + frameWidth + 1));
-
     iconLabel->show();
 }
 
@@ -164,10 +161,9 @@ void ExpressionSpinBox::onChange()
 
 void ExpressionSpinBox::resizeWidget()
 {
-    int frameWidth = spinbox->style()->pixelMetric(QStyle::PM_SpinBoxFrameWidth);
-
-    QSize sz = iconLabel->sizeHint();
-    iconLabel->move(lineedit->rect().right() - frameWidth - sz.width(), lineedit->rect().center().y() - sz.height() / 2);
+    int margin = lineedit->style()->pixelMetric(QStyle::PM_LineEditIconMargin, nullptr, lineedit);
+    int iconWidth = iconLabel->width() + margin;
+    iconLabel->move(lineedit->width() - iconWidth, (lineedit->height() - iconLabel->height()) / 2);
     updateExpression();
 }
 

--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -54,6 +54,14 @@ ExpressionSpinBox::ExpressionSpinBox(QAbstractSpinBox* sb)
     QObject::connect(iconLabel, &ExpressionLabel::clicked, [this]() {
         this->openFormulaDialog();
     });
+
+    // Set Margins
+    // vertical to avoid this: https://forum.freecad.org/viewtopic.php?f=8&t=50615
+    // horizontal to avoid going under the icon
+    lineedit->setAlignment(Qt::AlignVCenter);
+    int iconWidth = iconLabel->sizeHint().width();
+    int margin = lineedit->style()->pixelMetric(QStyle::PM_LineEditIconMargin, nullptr, lineedit);
+    lineedit->setTextMargins(margin, margin, margin + iconWidth, margin);
 }
 
 ExpressionSpinBox::~ExpressionSpinBox() = default;

--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -68,7 +68,6 @@ ExpressionSpinBox::~ExpressionSpinBox() = default;
 
 int ExpressionSpinBox::getMargin()
 {
-    lineedit = spinbox->findChild<QLineEdit*>();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
     return lineedit->style()->pixelMetric(QStyle::PM_LineEditIconMargin, nullptr, lineedit) / 2;
 #else
@@ -179,12 +178,7 @@ void ExpressionSpinBox::onChange()
 
 void ExpressionSpinBox::resizeWidget()
 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
-    int margin = lineedit->style()->pixelMetric(QStyle::PM_LineEditIconMargin, nullptr, lineedit) / 2;
-#else
-    int margin = lineedit->style()->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, lineedit);
-#endif
-    int iconWidth = iconLabel->width() + margin;
+    int iconWidth = iconLabel->width() + getMargin();
     iconLabel->move(lineedit->width() - iconWidth, (lineedit->height() - iconLabel->height()) / 2);
     updateExpression();
 }

--- a/src/Gui/SpinBox.h
+++ b/src/Gui/SpinBox.h
@@ -63,6 +63,7 @@ protected:
     virtual void showIcon();
     virtual void validateInput();
     void resizeWidget();
+    int getMargin();
 
     bool handleKeyEvent(const QString&);
     virtual void openFormulaDialog();


### PR DESCRIPTION
The size and location of the fx icon is very inconsistent across themes, with various issues like vertical misalignment, smaller size than the font size and text going under the icon.

this should fix those issues and provide a more reliable experience

classic
![output](https://github.com/user-attachments/assets/cb4199ad-f3de-441a-81c2-9272e826657c)

opendark (notice the vertical misalgnment)
![output](https://github.com/user-attachments/assets/be6cc7b3-6c5f-4027-a485-0f3be03f65fa)

there are more severe examples shown by @benj5378  but i cannot reproduce them in my machine

and the margin tweak:
![output](https://github.com/user-attachments/assets/6bc8e808-19f9-47d3-9691-5a9fee3a3b1f)
