### PR TITLE
Start: fix filecards black background under some themes

### DIFF
--- a/src/Mod/Start/Gui/FileCardDelegate.cpp
+++ b/src/Mod/Start/Gui/FileCardDelegate.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
+#include <qstringliteral.h>
 
 #ifndef _PreComp_
 #include <QFile>
@@ -40,7 +41,6 @@
 #include "../App/DisplayedFilesModel.h"
 #include "App/Application.h"
 #include <Base/Color.h>
-#include <gsl/pointers>
 
 using namespace Start;
 
@@ -49,11 +49,7 @@ FileCardDelegate::FileCardDelegate(QObject* parent)
 {
     _parameterGroup = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Start");
-    _widget = std::make_unique<QPushButton>();
-    _widget->setObjectName(QLatin1String("thumbnailWidget"));
-    auto layout = gsl::owner<QVBoxLayout*>(new QVBoxLayout());
-    layout->setSpacing(0);
-    _widget->setLayout(layout);
+    setObjectName(QStringLiteral("thumbnailWidget"));
 }
 
 void FileCardDelegate::paint(QPainter* painter,
@@ -61,10 +57,9 @@ void FileCardDelegate::paint(QPainter* painter,
                              const QModelIndex& index) const
 {
     painter->save();
-
     // Step 1: Styling
     QStyleOptionButton buttonOption;
-    buttonOption.initFrom(_widget.get());
+    buttonOption.initFrom(option.widget);
     buttonOption.rect = option.rect;
     buttonOption.state = QStyle::State_Enabled;
 
@@ -77,8 +72,7 @@ void FileCardDelegate::paint(QPainter* painter,
     if ((option.state & QStyle::State_Sunken) != 0) {
         buttonOption.state |= QStyle::State_Sunken;
     }
-
-    QApplication::style()->drawControl(QStyle::CE_PushButton, &buttonOption, painter);
+    qApp->style()->drawControl(QStyle::CE_PushButton, &buttonOption, painter, &styleButton);
 
     // Step 2: Fetch required data
     auto thumbnailSize =

--- a/src/Mod/Start/Gui/FileCardDelegate.cpp
+++ b/src/Mod/Start/Gui/FileCardDelegate.cpp
@@ -22,7 +22,6 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
-#include <qstringliteral.h>
 
 #ifndef _PreComp_
 #include <QFile>
@@ -35,6 +34,7 @@
 #include <QVBoxLayout>
 #include <QApplication>
 #include <QPushButton>
+#include <QString>
 #endif
 
 #include "FileCardDelegate.h"

--- a/src/Mod/Start/Gui/FileCardDelegate.h
+++ b/src/Mod/Start/Gui/FileCardDelegate.h
@@ -26,7 +26,7 @@
 
 #include <Base/Parameter.h>
 #include <QImage>
-
+#include <QPushButton>
 #include <QStyledItemDelegate>
 
 class FileCardDelegate: public QStyledItemDelegate
@@ -46,9 +46,9 @@ protected:
 
 private:
     Base::Reference<ParameterGrp> _parameterGroup;
-    std::unique_ptr<QWidget> _widget;
     const int margin = 11;
     const int textspacing = 2;
+    QPushButton styleButton;
 };
 
 


### PR DESCRIPTION
some themes are rendering the filecards with black background, this should fix it
![output](https://github.com/user-attachments/assets/62eec545-d9c8-42ad-9a9e-ab07e994b1d7)

@benj5378
@Syres916 