### PR TITLE
Start: fix newbuttons vertical sizing

### DIFF
--- a/src/Mod/Start/Gui/CMakeLists.txt
+++ b/src/Mod/Start/Gui/CMakeLists.txt
@@ -59,6 +59,8 @@ SET(StartGui_SRCS
         GeneralSettingsWidget.h
         Manipulator.cpp
         Manipulator.h
+        NewFileButton.cpp
+        NewFileButton.h
         PreCompiled.cpp
         PreCompiled.h
         StartView.cpp

--- a/src/Mod/Start/Gui/NewFileButton.cpp
+++ b/src/Mod/Start/Gui/NewFileButton.cpp
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Alfredo Monclus <alfredomonclus@gmail.com>          *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#include <QLabel>
+#include <QFont>
+#include <QIcon>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QString>
+#endif
+
+#include "NewFileButton.h"
+#include <algorithm>
+
+namespace StartGui
+{
+
+NewFileButton::NewFileButton(const NewButton& newButton)
+    : mainLayout(new QHBoxLayout(this))
+    , textLayout(new QVBoxLayout())
+    , headingLabel(new QLabel())
+    , descriptionLabel(new QLabel())
+{
+    setObjectName(QStringLiteral("newFileButton"));
+    auto hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Start");
+
+    constexpr int defaultWidth = 180;  // #newFileButton width in QSS
+    labelWidth = int(hGrp->GetInt("FileCardLabelWith", defaultWidth));
+
+    constexpr int defaultSize = 48;
+    iconSize = int(hGrp->GetInt("NewFileIconSize", defaultSize));
+
+    auto iconLabel = new QLabel(this);
+    QIcon baseIcon(newButton.iconPath);
+    iconLabel->setPixmap(baseIcon.pixmap(iconSize, iconSize));
+
+    textLayout->addWidget(headingLabel);
+    textLayout->addWidget(descriptionLabel);
+    textLayout->setSpacing(0);
+    textLayout->setContentsMargins(0, 0, 0, 0);
+
+    headingLabel->setText(newButton.heading);
+    QFont font = headingLabel->font();
+    font.setWeight(QFont::Bold);
+    headingLabel->setFont(font);
+
+    descriptionLabel->setText(newButton.description);
+    descriptionLabel->setWordWrap(true);
+    descriptionLabel->setFixedWidth(labelWidth);
+    descriptionLabel->setAlignment(Qt::AlignTop);
+
+    mainLayout->setAlignment(Qt::AlignVCenter);
+    mainLayout->addWidget(iconLabel);
+    mainLayout->addLayout(textLayout);
+    mainLayout->addStretch();
+    QFontMetrics qfm(font);
+    int margin = qfm.height() / 2;
+    mainLayout->setSpacing(margin);
+    mainLayout->setContentsMargins(margin, margin, 2 * margin, margin);
+    setLayout(mainLayout);
+    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+}
+
+QSize NewFileButton::minimumSizeHint() const
+{
+    int minWidth = labelWidth + iconSize + mainLayout->contentsMargins().left()
+        + mainLayout->contentsMargins().right() + mainLayout->spacing();
+
+    int textHeight = headingLabel->sizeHint().height() + descriptionLabel->sizeHint().height();
+
+    int minHeight = std::max(iconSize, textHeight) + mainLayout->contentsMargins().top()
+        + mainLayout->contentsMargins().bottom();
+
+    return {minWidth, minHeight};
+}
+
+}  // namespace StartGui

--- a/src/Mod/Start/Gui/NewFileButton.h
+++ b/src/Mod/Start/Gui/NewFileButton.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Alfredo Monclus <alfredomonclus@gmail.com>          *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#ifndef FREECAD_NEWFILEBUTTON_H
+#define FREECAD_NEWFILEBUTTON_H
+
+#include <QLabel>
+#include <QString>
+#include <QPushButton>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+
+#include <App/Application.h>
+
+namespace StartGui
+{
+
+struct NewButton
+{
+    QString heading;
+    QString description;
+    QString iconPath;
+};
+
+class NewFileButton: public QPushButton
+{
+public:
+    explicit NewFileButton(const NewButton& newButton);
+
+private:
+    int iconSize;
+    int labelWidth;
+    QHBoxLayout* mainLayout;
+    QVBoxLayout* textLayout;
+    QLabel* headingLabel;
+    QLabel* descriptionLabel;
+
+protected:
+    QSize minimumSizeHint() const override;
+};
+
+}  // namespace StartGui
+
+#endif  // FREECAD_NEWFILEBUTTON_H

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -42,6 +42,7 @@
 #include "FileCardView.h"
 #include "FirstStartWidget.h"
 #include "FlowLayout.h"
+#include "NewFileButton.h"
 #include <App/DocumentObject.h>
 #include <App/Application.h>
 #include <Base/Interpreter.h>
@@ -58,69 +59,6 @@
 using namespace StartGui;
 
 TYPESYSTEM_SOURCE_ABSTRACT(StartGui::StartView, Gui::MDIView)  // NOLINT
-
-namespace
-{
-
-struct NewButton
-{
-    QString heading;
-    QString description;
-    QString iconPath;
-};
-
-class NewFileButton: public QPushButton
-{
-
-public:
-    explicit NewFileButton(const NewButton& newButton)
-    {
-        auto hGrp = App::GetApplication().GetParameterGroupByPath(
-            "User parameter:BaseApp/Preferences/Mod/Start");
-        const auto cardSpacing = static_cast<int>(hGrp->GetInt("FileCardSpacing", 25));  // NOLINT
-        const auto newFileIconSize =
-            static_cast<int>(hGrp->GetInt("NewFileIconSize", 48));  // NOLINT
-        const auto cardLabelWith =
-            static_cast<int>(hGrp->GetInt("FileCardLabelWith", 180));  // NOLINT
-
-        auto mainLayout = gsl::owner<QHBoxLayout*>(new QHBoxLayout(this));
-        mainLayout->setAlignment(Qt::AlignVCenter);
-        auto iconLabel = gsl::owner<QLabel*>(new QLabel(this));
-        mainLayout->addWidget(iconLabel);
-        QIcon baseIcon(newButton.iconPath);
-        iconLabel->setPixmap(baseIcon.pixmap(newFileIconSize, newFileIconSize));
-        iconLabel->setPixmap(baseIcon.pixmap(newFileIconSize, newFileIconSize));
-
-        auto textLayout = gsl::owner<QVBoxLayout*>(new QVBoxLayout);
-        auto textLabelLine1 = gsl::owner<QLabel*>(new QLabel(this));
-        textLabelLine1->setText(newButton.heading);
-        QFont font = textLabelLine1->font();
-        font.setWeight(QFont::Bold);
-        textLabelLine1->setFont(font);
-        auto textLabelLine2 = gsl::owner<QLabel*>(new QLabel(this));
-        textLabelLine2->setText(newButton.description);
-        textLabelLine2->setWordWrap(true);
-        textLayout->addWidget(textLabelLine1);
-        textLayout->addWidget(textLabelLine2);
-        textLayout->setSpacing(0);
-        mainLayout->addItem(textLayout);
-
-        mainLayout->addStretch();
-
-        textLabelLine1->adjustSize();
-        textLabelLine2->adjustSize();
-        int textHeight =
-            textLabelLine1->height() + textLabelLine2->height() + textLayout->spacing();
-
-        int minWidth = newFileIconSize + cardLabelWith + cardSpacing;
-        int minHeight = std::max(newFileIconSize, textHeight) + cardSpacing;
-
-        this->setMinimumHeight(minHeight);
-        this->setMinimumWidth(minWidth);
-    }
-};
-
-}  // namespace
 
 
 StartView::StartView(QWidget* parent)


### PR DESCRIPTION
in classic if one of the buttons wraps 3 lines, since my patch it doesn't cut the label, but it will be a different size:
![Captura de pantalla_20250315_141656](https://github.com/user-attachments/assets/dcfdeeca-ed9a-4b14-80ce-c488e7523af0)

and more broken are some themes are breaking the newfile buttons like this
![Captura de pantalla_20250314_143139](https://github.com/user-attachments/assets/794c9aa4-80ae-4a16-b147-bfefaf24b74b)

so i've split the buttons into new widgets to use minimumSizeHint override and modified the flowlayout to set the sizing