### PR TITLE
PartDesign: Update counterbore min size in reaction to diameter changes

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -838,6 +838,7 @@ void TaskHoleParameters::changedObject(const App::Document&, const App::Property
     else if (&Prop == &hole->Diameter) {
         ui->Diameter->setEnabled(true);
         updateSpinBox(ui->Diameter, hole->Diameter.getValue());
+        ui->HoleCutDiameter->setMinimum(hole->Diameter.getValue() + 0.1);
     }
     else if (&Prop == &hole->ThreadDirection) {
         ui->directionRightHand->setEnabled(true);

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -1132,9 +1132,9 @@ void TaskHoleParameters::apply()
 
 void TaskHoleParameters::updateHoleCutLimits(PartDesign::Hole* hole)
 {
-    constexpr double MIN_HOLE_CUT_DIFFERENCE = 0.1;
+    constexpr double minHoleCutDifference = 0.1;
     // HoleCutDiameter must not be smaller or equal than the Diameter
-    ui->HoleCutDiameter->setMinimum(hole->Diameter.getValue() + MIN_HOLE_CUT_DIFFERENCE);
+    ui->HoleCutDiameter->setMinimum(hole->Diameter.getValue() + minHoleCutDifference);
 }
 
 

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -128,7 +128,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
         || pcHole->HoleCutCustomValues.isReadOnly()
     );
     // HoleCutDiameter must not be smaller or equal than the Diameter
-    ui->HoleCutDiameter->setMinimum(pcHole->Diameter.getValue() + 0.1);
+    updateHoleCutLimits(pcHole);
     ui->HoleCutDiameter->setValue(pcHole->HoleCutDiameter.getValue());
     ui->HoleCutDiameter->setDisabled(pcHole->HoleCutDiameter.isReadOnly());
     ui->HoleCutDepth->setValue(pcHole->HoleCutDepth.getValue());
@@ -731,8 +731,7 @@ void TaskHoleParameters::threadDiameterChanged(double value)
     if (auto hole = getObject<PartDesign::Hole>()) {
         hole->Diameter.setValue(value);
 
-        // HoleCutDiameter must not be smaller or equal than the Diameter
-        ui->HoleCutDiameter->setMinimum(value + 0.1);
+        updateHoleCutLimits(hole);
 
         recomputeFeature();
     }
@@ -838,7 +837,7 @@ void TaskHoleParameters::changedObject(const App::Document&, const App::Property
     else if (&Prop == &hole->Diameter) {
         ui->Diameter->setEnabled(true);
         updateSpinBox(ui->Diameter, hole->Diameter.getValue());
-        ui->HoleCutDiameter->setMinimum(hole->Diameter.getValue() + 0.1);
+        updateHoleCutLimits(hole);
     }
     else if (&Prop == &hole->ThreadDirection) {
         ui->directionRightHand->setEnabled(true);
@@ -1130,6 +1129,14 @@ void TaskHoleParameters::apply()
 
     isApplying = false;
 }
+
+void TaskHoleParameters::updateHoleCutLimits(PartDesign::Hole* hole)
+{
+    constexpr double MIN_HOLE_CUT_DIFFERENCE = 0.1;
+    // HoleCutDiameter must not be smaller or equal than the Diameter
+    ui->HoleCutDiameter->setMinimum(hole->Diameter.getValue() + MIN_HOLE_CUT_DIFFERENCE);
+}
+
 
 //**************************************************************************
 //**************************************************************************

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -126,6 +126,7 @@ protected:
 
 private:
     void onSelectionChanged(const Gui::SelectionChanges &msg) override;
+    void updateHoleCutLimits(PartDesign::Hole* hole);
 
 private:
 


### PR DESCRIPTION
Can't rely purely on `TaskHoleParameters::threadDiameterChanged` to update it since the signal is intentionally blocked while syncing state to GUI.

Closes #19744

