### PR TITLE
BIM: move add/removeSpace boundaries implementation to Arch module

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -50,7 +50,6 @@ from ArchWindowPresets import *
 # TODO: migrate this one
 
 from ArchStructure import *
-from ArchSpace import *
 
 # make functions
 
@@ -856,6 +855,27 @@ def makeSpace(objects=None,baseobj=None,name=None):
             space.Proxy.addSubobjects(space, boundaries)
     return space
 
+def addSpaceBoundaries(space,subobjects):
+
+    """addSpaceBoundaries(space,subobjects): adds the given subobjects to the given space"""
+
+    import Draft
+    if Draft.getType(space) == "Space":
+        space.Proxy.addSubobjects(space,subobjects)
+
+def removeSpaceBoundaries(space,subobjects):
+
+    """removeSpaceBoundaries(space,objects): removes the given objects from the given spaces boundaries"""
+
+    import Draft
+    if Draft.getType(space) == "Space":
+        bounds = space.Boundaries
+        for o in objects:
+            for b in bounds:
+                if o.Name == b[0].Name:
+                    bounds.remove(b)
+                    break
+        space.Boundaries = bounds
 
 def makeStairs(baseobj=None,length=None,width=None,height=None,steps=None,name=None):
 

--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -856,17 +856,59 @@ def makeSpace(objects=None,baseobj=None,name=None):
     return space
 
 def addSpaceBoundaries(space,subobjects):
+    """Adds the given subobjects as defining boundaries of the given space.
 
-    """addSpaceBoundaries(space,subobjects): adds the given subobjects to the given space"""
+    Parameters
+    ----------
+    space : ArchSpace._Space
+        Arch space object to add the boundaries to.
+    subobjects : List(<SelectionObject>) or App::PropertyLinkSubList
+        List of boundaries to add to the space.
 
+    Notes
+    -----
+    The subobjects parameter can be passed using either of these different formats:
+    1. List of selection objects, as provided by ``Gui.Selection.getSelectionEx()``. This
+       requires the GUI to be active. The `SubObjects` property of each selection object in the
+       list defines the boundaries to add to the space.
+       ::
+            subobjects = [<SelectionObject>, ...]
+    2. A list of tuples that can be assigned to an ``App::PropertyLinkSubList`` property. Each
+       tuple contains a document object and a nested tuple of subobjects that define the boundaries
+       to add.
+       ::
+            subobjects = [(obj1, ("Face1")), (obj2, ("Face1")), ...]
+            subobjects = [(obj, ("Face1", "Face2", "Face3", "Face4"))]
+    """
     import Draft
     if Draft.getType(space) == "Space":
         space.Proxy.addSubobjects(space,subobjects)
 
 def removeSpaceBoundaries(space,subobjects):
+    """Remove the given subobjects as defining boundaries of the given space.
 
-    """removeSpaceBoundaries(space,objects): removes the given objects from the given spaces boundaries"""
+    Parameters
+    ----------
+    space : ArchSpace._Space
+        Arch space object to remove the boundaries from.
+    subobjects : List(<SelectionObject>) or App::PropertyLinkSubList
+        List of boundaries to remove from the space.
 
+    Notes
+    -----
+    The subobjects parameter can be passed using either of these different formats:
+    1. List of selection objects, as provided by ``Gui.Selection.getSelectionEx()``. This
+       requires the GUI to be active. The `SubObjects` property of each selection object in the
+       list defines the boundaries to remove from the space.
+       ::
+            subobjects = [<SelectionObject>, ...]
+    2. A list of tuples that can be assigned to an ``App::PropertyLinkSubList`` property. Each
+       tuple contains a document object and a nested tuple of subobjects that define the boundaries
+       to remove.
+       ::
+            subobjects = [(obj1, ("Face1")), (obj2, ("Face1")), ...]
+            subobjects = [(obj, ("Face1", "Face2", "Face3", "Face4"))]
+    """
     import Draft
     if Draft.getType(space) == "Space":
         space.Proxy.removeSubobjects(space,subobjects)

--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -869,13 +869,7 @@ def removeSpaceBoundaries(space,subobjects):
 
     import Draft
     if Draft.getType(space) == "Space":
-        bounds = space.Boundaries
-        for o in objects:
-            for b in bounds:
-                if o.Name == b[0].Name:
-                    bounds.remove(b)
-                    break
-        space.Boundaries = bounds
+        space.Proxy.removeSubobjects(space,subobjects)
 
 def makeStairs(baseobj=None,length=None,width=None,height=None,steps=None,name=None):
 

--- a/src/Mod/BIM/ArchSpace.py
+++ b/src/Mod/BIM/ArchSpace.py
@@ -283,6 +283,17 @@ class _Space(ArchComponent.Component):
                             objs.append((o.Object,el))
         obj.Boundaries = objs
 
+    def removeSubobjects(self,obj,subobjects):
+
+        "removes subobjects to this space"
+        bounds = obj.Boundaries
+        for o in subobjects:
+            for b in bounds:
+                if o.Name == b[0].Name:
+                    bounds.remove(b)
+                    break
+        obj.Boundaries = bounds
+
     def addObject(self,obj,child):
 
         "Adds an object to this Space"

--- a/src/Mod/BIM/ArchSpace.py
+++ b/src/Mod/BIM/ArchSpace.py
@@ -180,30 +180,6 @@ else:
 #  building, ie. a room.
 
 
-
-def addSpaceBoundaries(space,subobjects):
-
-    """addSpaceBoundaries(space,subobjects): adds the given subobjects to the given space"""
-
-    import Draft
-    if Draft.getType(space) == "Space":
-        space.Proxy.addSubobjects(space,subobjects)
-
-def removeSpaceBoundaries(space,objects):
-
-    """removeSpaceBoundaries(space,objects): removes the given objects from the given spaces boundaries"""
-
-    import Draft
-    if Draft.getType(space) == "Space":
-        bounds = space.Boundaries
-        for o in objects:
-            for b in bounds:
-                if o.Name == b[0].Name:
-                    bounds.remove(b)
-                    break
-        space.Boundaries = bounds
-
-
 class _Space(ArchComponent.Component):
 
     "A space object"


### PR DESCRIPTION
Follow-up to https://github.com/FreeCAD/FreeCAD/pull/20108.

- Move the `addSpaceBoundaries` and `addSpaceBoundaries` definitions to the `Arch` module.
- Make the top level function definition consistent between the two methods.
- Update and expand docstrings.