### PR TITLE
Tools: Re-enable XML comparison mode in Python API bindings generator.

### DIFF
--- a/src/Tools/bindings/generate.py
+++ b/src/Tools/bindings/generate.py
@@ -59,6 +59,8 @@ def generate(filename, outputPath):
         Export.export = GenerateModelInst.PythonExport[0]
         Export.is_python = filename.endswith(".pyi")
         Export.Generate()
+        if Export.is_python:
+            Export.Compare()
         print("Done generating: " + GenerateModelInst.PythonExport[0].Name)
 
 

--- a/src/Tools/bindings/model/generateModel_Python.py
+++ b/src/Tools/bindings/model/generateModel_Python.py
@@ -331,7 +331,7 @@ def _get_module_from_path(path: str) -> str:
 
     # 2. Attempt to find "src" in the path components.
     try:
-        idx_src = parts.index("src")
+        idx_src = len(parts) - 1 - list(reversed(parts)).index("src")
     except ValueError:
         # If "src" is not found, we cannot determine the module name.
         return None


### PR DESCRIPTION
When this was introduced it caused a few failures (see https://github.com/FreeCAD/FreeCAD-snap/issues/178).

The problem was a faulty comparison, that was looking for the first index of `src`, when it should be the last index.

Fix it and re-enable the comparison. If there are no more build failures, we can think of removing the XML files for Base in a follow up PR.