### PR TITLE
fix dialogs button size in case of long text (fix for #18019)

### DIFF
--- a/src/Gui/Stylesheets/FreeCAD Dark.qss
+++ b/src/Gui/Stylesheets/FreeCAD Dark.qss
@@ -1289,13 +1289,9 @@ QPushButton::menu-indicator {
 
 QDialogButtonBox QPushButton {
   /* Issue # 194 # 248 - Special case of QPushButton inside dialogs, for better UI */
-  min-width: 80px;
+  min-width: -1;
 }
 
-QMessageBox[objectName="macroGuideWalkthrough"] QDialogButtonBox QPushButton,
-QMessageBox[objectName="confirmSave"] QDialogButtonBox QPushButton {
-  min-width: 20px;
-}
 /* QToolButton ------------------------------------------------------------
 
 https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtoolbutton

--- a/src/Gui/Stylesheets/FreeCAD Light.qss
+++ b/src/Gui/Stylesheets/FreeCAD Light.qss
@@ -1286,12 +1286,7 @@ QPushButton::menu-indicator {
 
 QDialogButtonBox QPushButton {
   /* Issue # 194 # 248 - Special case of QPushButton inside dialogs, for better UI */
-  min-width: 80px;
-}
-
-QMessageBox[objectName="macroGuideWalkthrough"] QDialogButtonBox QPushButton,
-QMessageBox[objectName="confirmSave"] QDialogButtonBox QPushButton {
-  min-width: 20px;
+  min-width: -1;
 }
 
 /* QToolButton ------------------------------------------------------------


### PR DESCRIPTION
Let the layout engine computes the size of all QPushButton by unset the minimalSize value set by "min-width" QSS property in themes.

Fix #18019.

**Before**

![image](https://github.com/user-attachments/assets/d22b1f63-73c1-4a08-a79a-d798202a83f3)

**After**

![image](https://github.com/user-attachments/assets/53e5b068-58ee-4383-a774-efe77a340044)
