### PR TITLE
Start: set specific zoom level for new BIM projects

### DIFF
--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -553,7 +553,7 @@ Py::Object View3DInventorPy::viewDefaultOrientation(const Py::Tuple& args)
 {
     char* view = nullptr;
     double scale = -1.0;
-    if (!PyArg_ParseTuple(args.ptr(), "|sd", &view, &scale))
+    if (!PyArg_ParseTuple(args.ptr(), "|zd", &view, &scale))
         throw Py::Exception();
 
     try {

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -330,6 +330,11 @@ void StartView::newArchFile() const
     catch (...) {
         Gui::Application::Instance->activateWorkbench("ArchWorkbench");
     }
+
+    // Set the camera zoom level to 10 m, which is more appropriate for architectural projects
+    Gui::Command::doCommand(
+        Gui::Command::Gui,
+        "Gui.activeDocument().activeView().viewDefaultOrientation(None, 10000.0)");
     postStart(PostStartBehavior::doNotSwitchWorkbench);
 }
 


### PR DESCRIPTION
## Summary

The default zoom level of 100 mm does not work well with architectural projects, where the model scale is a few magnitudes bigger than Part Design models, for instance. To enable BIM users to work more efficiently by avoiding the manual operation of zooming out when creating a new BIM document, this PR sets the **zoom level to 10 m**. This only applies to new BIM projects created from the Start page's "Architectural/BIM" button.

Fixes: https://github.com/FreeCAD/FreeCAD/issues/20234

## Known limitations

- While this improves initial arch object creation by reducing the zoom out step, the grid size is left unchanged from the default 100 mm x 100 mm size. With the new zoom level, the grid appears as extremely small. While the grid default size is not appropriate for architectural models, it has been left unchanged as it's a set of parameters shared with the Draft workbench. The set of parameters in question is under `BaseApp/Preferences/Mod/Draft`:
  - `gridEvery`
  - `gridSize`
  - `gridSpacing`

## Alternative implementations

Analog to the `NewDocumentCameraScale` global setting, a new `NewBimDocumentCameraScale` parameter could be created with the appropriate default value, and an entry in the BIM Preferences page.

## Additional changes

This PR does an additional modification to the `viewDefaultOrientation()` function, so that it accepts the `None` value. This is done so that the function works as per the description in the original docstring:

<details>

https://github.com/FreeCAD/FreeCAD/blob/723a25c57d526b65055bf7dd29d3ab58ef8b28c2/src/Gui/View3DPy.cpp#L101-L103

Without this change, it was not possible to pass an empty string from Python to the described `ori_string` argument. Thus the `else` path here could not be taken when the function was invoked from Python:

https://github.com/FreeCAD/FreeCAD/blob/723a25c57d526b65055bf7dd29d3ab58ef8b28c2/src/Gui/View3DPy.cpp#L562-L568

The motivation for passing an empty arg for `ori_string` is simply to not modify the default view and have it loaded from parameters. This PR's intention is to change the camera zoom only.

</details>