### PR TITLE
BIM_Classification dialgue - change tooltips and text to better represent their functions

### DIFF
--- a/src/Mod/BIM/Resources/ui/dialogClassification.ui
+++ b/src/Mod/BIM/Resources/ui/dialogClassification.ui
@@ -183,7 +183,7 @@
          <item>
           <widget class="QPushButton" name="buttonRename">
            <property name="toolTip">
-            <string>Use this class as material name</string>
+            <string>Use this class as object name</string>
            </property>
            <property name="text">
             <string>&lt;&lt; Set as name</string>
@@ -195,7 +195,7 @@
        <item>
         <widget class="QCheckBox" name="checkPrefix">
          <property name="text">
-          <string>Prefix with class name when applying</string>
+          <string>Prefix with classification system name</string>
          </property>
          <property name="checked">
           <bool>true</bool>

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -42,7 +42,7 @@ class BIM_Classification:
             ),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "BIM_Classification",
-                "Manage classification systems and apply classification on objects",
+                "Manage classification systems and apply classification to objects",
             ),
         }
 

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -42,7 +42,7 @@ class BIM_Classification:
             ),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "BIM_Classification",
-                "Manage how the different materials of this documents use classification systems",
+                "Manage classification systems and apply classification on objects",
             ),
         }
 


### PR DESCRIPTION
fixes https://github.com/FreeCAD/FreeCAD/issues/20176

1. Changed text "Prefix with class name when applying"
to
"Prefix with classification system name"

2. Changed button tooltip from "Use this class as material name"
to
"Use this class as object name"

3. Changed to tooltip of the `BIM_Classification` tool from "Manage how the different materials of this documents use classification systems"
to
"Manage classification systems and apply classification on objects"


Before state:
![edit-BIM-classification-nr](https://github.com/user-attachments/assets/fcdb6df9-39ad-45a0-b4e6-4d1165ba619d)
