### PR TITLE
Sketcher: Disambiguise constraint parallel icon

### DIFF
--- a/src/Mod/Sketcher/Gui/Resources/icons/constraints/Constraint_Parallel.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/constraints/Constraint_Parallel.svg
@@ -6,12 +6,34 @@
    height="64px"
    id="svg2816"
    version="1.1"
+   sodipodi:docname="Constraint_Parallel.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="11.96875"
+     inkscape:cx="32"
+     inkscape:cy="32"
+     inkscape:window-width="1670"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="10"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2816" />
   <defs
      id="defs2818">
     <linearGradient
@@ -217,7 +239,7 @@
   </g>
   <g
      id="g2-5"
-     transform="matrix(0.70710678,0.70710678,-0.64818122,0.64818122,54.81455,4.8942399)"
+     transform="matrix(0.70710678,0.70710678,-0.41087889,0.41087889,43.544635,23.057105)"
      style="stroke-width:1.04447">
     <rect
        style="fill:#280000;fill-opacity:1;stroke:none;stroke-width:3.1334;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:100;stroke-dashoffset:8.71"


### PR DESCRIPTION
In the icon overhaul which happened somewhere along the road to 1.0 , there was a regression in the parallel constraint icon. 

Several years ago I provided the old icon set, (which had parallel constraint indicated by a pair of equal length parallel lines) with a icon having *unequal* parallel  lines, since that is what this icon relates to: parallel, not equal.  This prevented the confusing I constantly had on clicking this icon thinking it was to make lines equal length. 

This was quickly adopted and well received be others having the same confusion I did. For some reason, presumably oversight, this was reverted in the latest makeover.  Here is a similar modification for the new icon set. 

A preview of the toolbar including the new icon is seen here:

https://forum.freecad.org/viewtopic.php?p=813112
https://forum.freecad.org/download/file.php?id=293902