### PR TITLE
Add get and setAxisRadius function to SoFCCSysDragger class

### DIFF
--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -189,6 +189,7 @@ SoSeparator* TDragger::buildCylinderGeometry() const
     cylinderSeparator->addChild(cylinderTranslation);
 
     auto cylinder = new SoCylinder();
+    cylinder->setName("CSysDynamics_TDragger_CylinderShape");
     cylinder->radius.setValue(cylinderRadius);
     cylinder->height.setValue(cylinderHeight);
     cylinderSeparator->addChild(cylinder);
@@ -1821,4 +1822,15 @@ bool SoFCCSysDragger::isHiddenRotationZ()
 {
     SoSwitch* sw = SO_GET_ANY_PART(this, "zRotatorSwitch", SoSwitch);
     return (sw->whichChild.getValue() == SO_SWITCH_NONE);
+}
+
+float Gui::SoFCCSysDragger::getAxisRadius()
+{
+    SoCylinder *cylinder = static_cast<SoCylinder*>(getByName("CSysDynamics_TDragger_CylinderShape"));
+    return cylinder->radius.getValue();
+}
+void Gui::SoFCCSysDragger::setAxisRadius(float radius)
+{
+    SoCylinder *cylinder = static_cast<SoCylinder*>(getByName("CSysDynamics_TDragger_CylinderShape"));
+    cylinder->radius = radius;
 }

--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -88,7 +88,7 @@
 
 using namespace Gui;
 
-constexpr char* TDraggerCylinderShape{"CSysDynamics_TDragger_CylinderShape"};
+constexpr const char* TDraggerCylinderShape{"CSysDynamics_TDragger_CylinderShape"};
 
 SO_KIT_SOURCE(TDragger)
 

--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -88,7 +88,7 @@
 
 using namespace Gui;
 
-constexpr std::array TDraggerCylinderShape{std::to_array("CSysDynamics_TDragger_CylinderShape")};
+constexpr char* TDraggerCylinderShape{"CSysDynamics_TDragger_CylinderShape"};
 
 SO_KIT_SOURCE(TDragger)
 
@@ -191,7 +191,7 @@ SoSeparator* TDragger::buildCylinderGeometry() const
     cylinderSeparator->addChild(cylinderTranslation);
 
     auto cylinder = new SoCylinder();
-    cylinder->setName(TDraggerCylinderShape.data());
+    cylinder->setName(TDraggerCylinderShape);
     cylinder->radius.setValue(cylinderRadius);
     cylinder->height.setValue(cylinderHeight);
     cylinderSeparator->addChild(cylinder);
@@ -1828,11 +1828,11 @@ bool SoFCCSysDragger::isHiddenRotationZ()
 
 float Gui::SoFCCSysDragger::getAxisRadius()
 {
-    SoCylinder *cylinder = static_cast<SoCylinder*>(getByName(TDraggerCylinderShape.data()));
+    SoCylinder *cylinder = static_cast<SoCylinder*>(getByName(TDraggerCylinderShape));
     return cylinder->radius.getValue();
 }
 void Gui::SoFCCSysDragger::setAxisRadius(float radius)
 {
-    SoCylinder *cylinder = static_cast<SoCylinder*>(getByName(TDraggerCylinderShape.data()));
+    SoCylinder *cylinder = static_cast<SoCylinder*>(getByName(TDraggerCylinderShape));
     cylinder->radius = radius;
 }

--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -88,6 +88,8 @@
 
 using namespace Gui;
 
+constexpr std::array TDraggerCylinderShape{std::to_array("CSysDynamics_TDragger_CylinderShape")};
+
 SO_KIT_SOURCE(TDragger)
 
 void TDragger::initClass()
@@ -189,7 +191,7 @@ SoSeparator* TDragger::buildCylinderGeometry() const
     cylinderSeparator->addChild(cylinderTranslation);
 
     auto cylinder = new SoCylinder();
-    cylinder->setName("CSysDynamics_TDragger_CylinderShape");
+    cylinder->setName(TDraggerCylinderShape.data());
     cylinder->radius.setValue(cylinderRadius);
     cylinder->height.setValue(cylinderHeight);
     cylinderSeparator->addChild(cylinder);
@@ -1826,11 +1828,11 @@ bool SoFCCSysDragger::isHiddenRotationZ()
 
 float Gui::SoFCCSysDragger::getAxisRadius()
 {
-    SoCylinder *cylinder = static_cast<SoCylinder*>(getByName("CSysDynamics_TDragger_CylinderShape"));
+    SoCylinder *cylinder = static_cast<SoCylinder*>(getByName(TDraggerCylinderShape.data()));
     return cylinder->radius.getValue();
 }
 void Gui::SoFCCSysDragger::setAxisRadius(float radius)
 {
-    SoCylinder *cylinder = static_cast<SoCylinder*>(getByName("CSysDynamics_TDragger_CylinderShape"));
+    SoCylinder *cylinder = static_cast<SoCylinder*>(getByName(TDraggerCylinderShape.data()));
     cylinder->radius = radius;
 }

--- a/src/Gui/SoFCCSysDragger.h
+++ b/src/Gui/SoFCCSysDragger.h
@@ -303,6 +303,9 @@ public:
 
     void setAxisColors(unsigned long x, unsigned long y, unsigned long z); //!< set the axis colors.
 
+    float getAxisRadius();
+    void setAxisRadius(float radius);
+
     //! @name Visibility Functions
     //@{
     void showTranslationX(); //!< show the x translation dragger.


### PR DESCRIPTION
I am working on a prototype for https://github.com/FreeCAD/FreeCAD/issues/6204 and it was suggested to me that using a thicker arrow will look better. But in the current code the thickness i.e, basically the radius of the cylindrical part  is hardcoded. And changing it causes around 400 files to get recompiled. So, I created this PR to allow changing the thickness easily.
As a side note, I was told that classes like TDragger, RDragger, etc should not be used directly. So, I think that if we move them to a separate header and source and don't include them in SoFCCDragger.h then the recompiling problem will be reduced. If you people agree with this then I can create a separate PR for the same at some point.