### PR TITLE
Fixing copr build by adding git submodule update --init to spec file for now

### DIFF
--- a/package/fedora/freecad.spec
+++ b/package/fedora/freecad.spec
@@ -179,6 +179,9 @@ rm -rf src/zipios++
 %build
 rm -rf build && mkdir build && cd build
 
+# update submodules so they are available
+git submodule update --init
+
 # Deal with cmake projects that tend to link excessively.
 CXXFLAGS='-Wno-error=cast-function-type'; export CXXFLAGS
 LDFLAGS='-Wl,--as-needed -Wl,--no-undefined'; export LDFLAGS


### PR DESCRIPTION
Adding a missing git submodule update --init to build step in spec file for the copr build.