### PR TITLE
XDG: Configure and install thumbnailer

### DIFF
--- a/src/Tools/freecad-thumbnailer.in
+++ b/src/Tools/freecad-thumbnailer.in
@@ -37,6 +37,7 @@ import getopt
 opt, par = getopt.getopt(sys.argv[1:], "-s:")
 input_file = par[0]
 output_file = par[1]
+default_icon = "@CMAKE_INSTALL_DATAROOTDIR@/icons/hicolor/48x48/apps/org.freecad.FreeCAD.png"
 
 try:
     # Read compressed file
@@ -54,7 +55,7 @@ try:
         image = zfile.read(image)
     else:
         # apps should have at least 48x48 icons
-        freecad = open("/usr/share/icons/hicolor/48x48/apps/org.freecad.FreeCAD.png", "rb")
+        freecad = open(default_icon, "rb")
         image = freecad.read()
 
     # Write icon to output_file

--- a/src/XDGData/CMakeLists.txt
+++ b/src/XDGData/CMakeLists.txt
@@ -30,7 +30,20 @@ install(
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/mime/packages
 )
 
+configure_file(
+    FreeCAD.thumbnailer.in
+    ${CMAKE_BINARY_DIR}/FreeCAD.thumbnailer
+)
 install(
-    FILES FreeCAD.thumbnailer
+    FILES ${CMAKE_BINARY_DIR}/FreeCAD.thumbnailer
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/thumbnailers
+)
+
+configure_file(
+    ${CMAKE_SOURCE_DIR}/src/Tools/freecad-thumbnailer.in
+    ${CMAKE_BINARY_DIR}/freecad-thumbnailer
+)
+install(
+    PROGRAMS ${CMAKE_BINARY_DIR}/freecad-thumbnailer
+    TYPE BIN
 )

--- a/src/XDGData/FreeCAD.thumbnailer
+++ b/src/XDGData/FreeCAD.thumbnailer
@@ -1,4 +1,0 @@
-[Thumbnailer Entry]
-TryExec=freecad-thumbnailer
-Exec=freecad-thumbnailer -s %s %i %o
-MimeType=application/x-extension-fcstd;

--- a/src/XDGData/FreeCAD.thumbnailer.in
+++ b/src/XDGData/FreeCAD.thumbnailer.in
@@ -1,0 +1,4 @@
+[Thumbnailer Entry]
+TryExec=@CMAKE_INSTALL_BINDIR@/freecad-thumbnailer
+Exec=@CMAKE_INSTALL_BINDIR@/freecad-thumbnailer -s %s %i %o
+MimeType=application/x-extension-fcstd;


### PR DESCRIPTION
Currently the file `src/XDGData/FreeCAD.thumbnailer` gets installed, but the associated `freecad-thumbnailer` script isn't. Install the script, too.

While here, have the paths to the default icon and `freecad-thumbnailer` script follow `${CMAKE_INSTALL_DATAROOTDIR}` and `${CMAKE_INSTALL_BINDIR}` respectively.