### PR TITLE
BIM: HumanFigure.brep: fix typo in create_qrc.py

### DIFF
--- a/src/Mod/BIM/Resources/Arch.qrc
+++ b/src/Mod/BIM/Resources/Arch.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource>
+        <file>geometry/HumanFigure.brep</file>
         <file>icons/Arch_3Views.svg</file>
         <file>icons/Arch_Add.svg</file>
         <file>icons/Arch_Axis.svg</file>

--- a/src/Mod/BIM/Resources/create_qrc.py
+++ b/src/Mod/BIM/Resources/create_qrc.py
@@ -8,7 +8,7 @@ for subdir in ["geometry", "icons", "icons/IFC", "translations", "ui"]:
     for f in sorted(os.listdir(subpath)):
         if f not in ["Arch.ts", "BIM.ts", "IFC"]:
             ext = os.path.splitext(f)[1]
-            if ext.lower() in [".qm", ".svg", ".ui", ".png", "brep"]:
+            if ext.lower() in [".qm", ".svg", ".ui", ".png", ".brep"]:
                 txt += "        <file>" + subdir + "/" + f + "</file>\n"
 txt += "    </qresource>\n</RCC>\n"
 with open(os.path.join(cdir, "Arch.qrc"), "w") as resfile:


### PR DESCRIPTION
Fixes #20289

My bad. Because of this typo the brep file was not included in Arch_rc.py.
