### PR TITLE
[CAM] Fix Job editor UI crashes (potentially)

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -224,6 +224,7 @@ class ViewProvider:
         return hasattr(self, "deleteOnReject") and self.deleteOnReject
 
     def setEdit(self, vobj=None, mode=0):
+        self.taskPanel = None
         Path.Log.track(mode)
         if 0 == mode:
             job = self.vobj.Object
@@ -233,8 +234,8 @@ class ViewProvider:
         return True
 
     def openTaskPanel(self, activate=None):
-        self.taskPanel = TaskPanel(self.vobj, self.deleteObjectsOnReject())
         FreeCADGui.Control.closeDialog()
+        self.taskPanel = TaskPanel(self.vobj, self.deleteObjectsOnReject())
         FreeCADGui.Control.showDialog(self.taskPanel)
         self.taskPanel.setupUi(activate)
         self.showOriginAxis(True)
@@ -696,7 +697,10 @@ class TaskPanel:
         self.vproxy = vobj.Proxy
         self.obj = vobj.Object
         self.deleteOnReject = deleteOnReject
-        self.form = FreeCADGui.PySideUic.loadUi(":/panels/PathEdit.ui")
+        self.wrapper = QtGui.QVBoxLayout()
+        self.wrapper.setContentsMargins(0, 0, 0, 0)
+        self.wrapper.addWidget(FreeCADGui.PySideUic.loadUi(":/panels/PathEdit.ui"))
+        self.form = self.wrapper
         self.template = PathJobDlg.JobTemplateExport(self.obj, self.form.jobBox.widget(1))
         self.name = self.obj.Name
 

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -114,9 +114,9 @@ class ViewProvider(object):
 
     def setupTaskPanel(self, panel):
         """setupTaskPanel(panel) ... internal function to start the editor."""
-        self.panel = panel
         FreeCADGui.Control.closeDialog()
         FreeCADGui.Control.showDialog(panel)
+        self.panel = panel
         panel.setupUi()
         job = self.Object.Proxy.getJob(self.Object)
         if job:


### PR DESCRIPTION
This is a long shot - a mixture of luck and dark magic.

I've been trying to debug and fix random UI crashes when opening CAM Job editor. It would crash randomly in various places with similar PySide errors like "RuntimeError: Internal C++ object (PySide.QtGui.QWidget) already deleted." or random UI objects missing attributes, etc.

This is a combination of changes that theoretically should help with a race condition in UI where garbage collector or class destructors would remove still-referenced objects. Also a potential bug in PySide described here:

https://www.tech-artists.org/t/pyside-in-maya-internal-c-object-already-deleted-for-returned-pyside-objects/4877/6

So far the occurence of this bug is limited to about 20% of what was before. 

Please treat this PR as start of a discussion where the problem may be.