### PR TITLE
[WIP] Add interactive control for partdesign pad operation

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -60,6 +60,8 @@ TaskPadParameters::TaskPadParameters(ViewProviderPad *PadView, QWidget *parent, 
     if (newObj) {
         readValuesFromHistory();
     }
+
+    connect(ui->lengthEdit, qOverload<double>(&Gui::PrefQuantitySpinBox::valueChanged), [PadView](double value) { PadView->setDraggerPosFromUI(value); });
 }
 
 TaskPadParameters::~TaskPadParameters() = default;
@@ -74,6 +76,14 @@ void TaskPadParameters::translateModeList(int index)
     ui->changeMode->addItem(tr("Two dimensions"));
     ui->changeMode->addItem(tr("Up to shape"));
     ui->changeMode->setCurrentIndex(index);
+}
+
+double TaskPadParameters::getPadLength() {
+    return ui->lengthEdit->value().getValue();
+}
+
+void TaskPadParameters::setPadLength(double val) {
+    ui->lengthEdit->setValue(val);
 }
 
 void TaskPadParameters::updateUI(int index)
@@ -140,6 +150,14 @@ TaskDlgPadParameters::TaskDlgPadParameters(ViewProviderPad *PadView, bool /*newO
     : TaskDlgExtrudeParameters(PadView), parameters(new TaskPadParameters(PadView))
 {
     Content.push_back(parameters);
+}
+
+double TaskDlgPadParameters::getPadLength() {
+    return parameters->getPadLength();
+}
+
+void TaskDlgPadParameters::setPadLength(double val) {
+    parameters->setPadLength(val);
 }
 
 //==== calls from the TaskView ===============================================================

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.h
@@ -46,6 +46,9 @@ public:
     explicit TaskPadParameters(ViewProviderPad *PadView, QWidget *parent = nullptr, bool newObj=false);
     ~TaskPadParameters() override;
 
+    double getPadLength();
+    void setPadLength(double val);
+
     void apply() override;
 
 private:
@@ -62,7 +65,10 @@ class TaskDlgPadParameters : public TaskDlgExtrudeParameters
 public:
     explicit TaskDlgPadParameters(ViewProviderPad *PadView, bool newObj=false);
 
-protected:
+    double getPadLength();
+    void setPadLength(double val);
+
+// protected:
     TaskExtrudeParameters* getTaskParameters() override
     {
         return parameters;

--- a/src/Mod/PartDesign/Gui/ViewProviderPad.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderPad.h
@@ -25,8 +25,11 @@
 #define PARTGUI_ViewProviderPad_H
 
 #include "ViewProviderExtrude.h"
+#include <Gui/ViewProviderPart.h>
 
 namespace PartDesignGui {
+
+class TaskDlgPadParameters;
 
 class PartDesignGuiExport ViewProviderPad : public ViewProviderExtrude
 {
@@ -43,6 +46,27 @@ public:
 protected:
     /// Returns a newly created TaskDlgPadParameters
     TaskDlgFeatureParameters *getEditDialog() override;
+
+public:
+    bool setEdit(int ModNum) override;
+    void unsetEdit(int ModNum) override;
+    void setEditViewer(Gui::View3DInventorViewer*, int ModNum) override;
+
+    void updatePosition();
+    Base::Placement getDraggerPlacement();
+    double getPadLengthFromDragger();
+    void hideUnWantedAxes();
+
+    void setDraggerPosFromUI(double value);
+
+private:
+    Gui::CoinPtr<Gui::SoFCCSysDragger> dragger = nullptr;
+    TaskDlgPadParameters *dialog = nullptr;
+    double padLength = 0;
+
+    static void dragStartCallback(void *data, SoDragger *d);
+    static void dragFinishCallback(void *data, SoDragger *d);
+    static void dragMotionCallback(void *data, SoDragger *d);
 
 };
 


### PR DESCRIPTION
This PR is created so that people can more easily see and review my prototype for the interactive controls as discussed in the discord server. The PR just implements a dragger that can be used to dynamically change the pad length. It is not a full representation of the final solution. We plan to make that in a more portable way (currently everything is done and hardwired in ViewProviderPad class). Also, due to limitations in the SoFCCSysDragger, the dragger looks and feels very rudimentary.
The long term goal is to solve https://github.com/FreeCAD/FreeCAD/issues/6204 as part of the GSoC 2025 program.
Here is a video showcasing the dragger in action:

https://github.com/user-attachments/assets/2037da14-95b7-43d9-92f5-72d9b786576a

Known issues:
* The label interferes with the head of the dragger
* The dragger becomes problematic once the pad length becomes equal or less than 0. Currently, I used a hack to lock the minimum size at 0.001. But that is no solution and it is still somewhat buggy. I am looking for potential solutions.