### PR TITLE
BIM: cleanup imports take 2

### DIFF
--- a/src/Mod/BIM/bimcommands/BimArchUtils.py
+++ b/src/Mod/BIM/bimcommands/BimArchUtils.py
@@ -23,7 +23,6 @@
 """Misc Arch util commands"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimAxis.py
+++ b/src/Mod/BIM/bimcommands/BimAxis.py
@@ -23,7 +23,6 @@
 """The BIM Axis-related commands"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimBox.py
+++ b/src/Mod/BIM/bimcommands/BimBox.py
@@ -23,7 +23,6 @@
 
 """The BIM Box command"""
 
-import os
 import FreeCAD
 import FreeCADGui
 
@@ -141,7 +140,7 @@ class BIM_Box:
     def taskbox(self):
         "sets up a taskbox widget"
 
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         wid = QtGui.QWidget()
         ui = FreeCADGui.UiLoader()

--- a/src/Mod/BIM/bimcommands/BimBuilder.py
+++ b/src/Mod/BIM/bimcommands/BimBuilder.py
@@ -43,7 +43,6 @@ class BIM_Builder:
         }
 
     def Activated(self):
-        import PartGui
         FreeCADGui.runCommand("Part_Builder")
 
 

--- a/src/Mod/BIM/bimcommands/BimBuildingPart.py
+++ b/src/Mod/BIM/bimcommands/BimBuildingPart.py
@@ -25,7 +25,6 @@
 # TODO: Refactor the Site code so it becomes a BuildingPart too
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -22,10 +22,10 @@
 
 """The BIM Classification command"""
 
+import os
 
 import FreeCAD
 import FreeCADGui
-import os
 
 QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate
@@ -306,7 +306,7 @@ class BIM_Classification:
         # self.spanTopLevels()
 
     def updateByTree(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         # order by hierarchy
         def istop(obj):
@@ -368,8 +368,8 @@ class BIM_Classification:
         self.form.treeObjects.expandAll()
 
     def updateDefault(self):
+        from PySide import QtGui
         import Draft
-        from PySide import QtCore, QtGui
 
         d = self.objectslist.copy()
         d.update(self.matlist)
@@ -389,7 +389,7 @@ class BIM_Classification:
                         self.form.treeObjects.setCurrentItem(it)
 
     def updateClasses(self, search=""):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         self.form.treeClass.clear()
 
@@ -436,7 +436,7 @@ class BIM_Classification:
                 first = False
 
     def addChildren(self, children, parent, search=""):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         if children:
             for c in children:
@@ -663,7 +663,7 @@ class BIM_Classification:
     def getIcon(self,obj):
         """returns a QIcon for an object"""
 
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
         import Arch_rc
 
         if hasattr(obj.ViewObject, "Icon"):

--- a/src/Mod/BIM/bimcommands/BimCommon.py
+++ b/src/Mod/BIM/bimcommands/BimCommon.py
@@ -47,7 +47,6 @@ class BIM_Common:
         return v
 
     def Activated(self):
-        import PartGui
         FreeCADGui.runCommand("Part_Common")
 
 

--- a/src/Mod/BIM/bimcommands/BimCompound.py
+++ b/src/Mod/BIM/bimcommands/BimCompound.py
@@ -47,7 +47,6 @@ class BIM_Compound:
         return v
 
     def Activated(self):
-        import PartGui
         FreeCADGui.runCommand("Part_Compound")
 
 

--- a/src/Mod/BIM/bimcommands/BimCurtainwall.py
+++ b/src/Mod/BIM/bimcommands/BimCurtainwall.py
@@ -23,7 +23,6 @@
 """Misc Arch util commands"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimCut.py
+++ b/src/Mod/BIM/bimcommands/BimCut.py
@@ -46,7 +46,6 @@ class BIM_Cut:
         return v
 
     def Activated(self):
-        import PartGui
         FreeCADGui.runCommand("Part_Cut")
 
 

--- a/src/Mod/BIM/bimcommands/BimCutPlane.py
+++ b/src/Mod/BIM/bimcommands/BimCutPlane.py
@@ -24,7 +24,6 @@
 """The Arch CutPlane command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimDiff.py
+++ b/src/Mod/BIM/bimcommands/BimDiff.py
@@ -22,7 +22,6 @@
 
 """The BIM Diff command"""
 
-import os
 import FreeCAD
 import FreeCADGui
 
@@ -49,7 +48,7 @@ class BIM_Diff:
         # make the main doc the active one before running this script!
 
         # what will be compared: IDs, geometry, materials. Everything else is discarded.
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
         import Draft
 
         MOVE_TOLERANCE = 0.2  # the max allowed move in mm

--- a/src/Mod/BIM/bimcommands/BimDrawingView.py
+++ b/src/Mod/BIM/bimcommands/BimDrawingView.py
@@ -23,10 +23,8 @@
 """The BIM DrawingView command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
-from bimcommands import BimBuildingPart
 
 QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate

--- a/src/Mod/BIM/bimcommands/BimEquipment.py
+++ b/src/Mod/BIM/bimcommands/BimEquipment.py
@@ -23,7 +23,6 @@
 """BIM equipment commands"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimExamples.py
+++ b/src/Mod/BIM/bimcommands/BimExamples.py
@@ -44,7 +44,7 @@ class BIM_Examples:
         }
 
     def Activated(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
         QtGui.QDesktopServices.openUrl("https://github.com/yorikvanhavre/FreeCAD-BIM-examples")
 
 

--- a/src/Mod/BIM/bimcommands/BimExtrude.py
+++ b/src/Mod/BIM/bimcommands/BimExtrude.py
@@ -45,7 +45,6 @@ class BIM_Extrude:
         return v
 
     def Activated(self):
-        import PartGui
         FreeCADGui.runCommand("Part_Extrude")
 
 

--- a/src/Mod/BIM/bimcommands/BimFence.py
+++ b/src/Mod/BIM/bimcommands/BimFence.py
@@ -23,7 +23,6 @@
 """BIM fence command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimFrame.py
+++ b/src/Mod/BIM/bimcommands/BimFrame.py
@@ -23,7 +23,6 @@
 """BIM Frame command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 
@@ -62,4 +61,3 @@ class Arch_Frame:
 
 
 FreeCADGui.addCommand('Arch_Frame',Arch_Frame())
-

--- a/src/Mod/BIM/bimcommands/BimFuse.py
+++ b/src/Mod/BIM/bimcommands/BimFuse.py
@@ -44,7 +44,6 @@ class BIM_Fuse:
         return v
 
     def Activated(self):
-        import PartGui
         FreeCADGui.runCommand("Part_Fuse")
 
 

--- a/src/Mod/BIM/bimcommands/BimHelp.py
+++ b/src/Mod/BIM/bimcommands/BimHelp.py
@@ -44,7 +44,7 @@ class BIM_Help:
         }
 
     def Activated(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
         QtGui.QDesktopServices.openUrl("https://www.freecadweb.org/wiki/BIM_Workbench")
 
 

--- a/src/Mod/BIM/bimcommands/BimIfcElements.py
+++ b/src/Mod/BIM/bimcommands/BimIfcElements.py
@@ -24,7 +24,6 @@
 
 """This module contains FreeCAD commands for the BIM workbench"""
 
-import os
 import FreeCAD
 import FreeCADGui
 
@@ -50,7 +49,7 @@ class BIM_IfcElements:
 
     def Activated(self):
         import Draft
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         # build objects list
         self.objectslist = {}
@@ -634,7 +633,7 @@ if FreeCAD.GuiUp:
 def getIcon(obj):
     """returns a QIcon for an object"""
 
-    from PySide import QtCore, QtGui
+    from PySide import QtGui
     import Arch_rc
 
     if hasattr(obj.ViewObject, "Icon"):

--- a/src/Mod/BIM/bimcommands/BimIfcExplorer.py
+++ b/src/Mod/BIM/bimcommands/BimIfcExplorer.py
@@ -44,7 +44,7 @@ class BIM_IfcExplorer:
 
     def Activated(self):
 
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         try:
             import ifcopenshell
@@ -174,7 +174,7 @@ class BIM_IfcExplorer:
         "opens a file"
 
         import ifcopenshell
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         self.filename = ""
         lastfolder = FreeCAD.ParamGet(
@@ -253,7 +253,7 @@ class BIM_IfcExplorer:
         "inserts selected objects in the active document"
 
         from importers import importIFC
-        from PySide import QtCore, QtGui
+        from PySide import QtCore
 
         doc = FreeCAD.ActiveDocument
         if doc and self.filename:
@@ -472,7 +472,7 @@ class BIM_IfcExplorer:
         "adds the attributes of the given IFC entity under the given QTreeWidgetITem"
 
         import ifcopenshell
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         entity = self.ifc[eid]
 
@@ -555,7 +555,7 @@ class BIM_IfcExplorer:
     def addProperties(self, eid, parent):
         "adds properties of a given entity to the given QTReeWidgetItem"
 
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         entity = self.ifc[eid]
         if hasattr(entity, "IsDefinedBy"):
@@ -585,7 +585,7 @@ class BIM_IfcExplorer:
     def onSelectTree(self, item, previous):
         "displays attributes and properties of a tree item"
 
-        from PySide import QtCore, QtGui
+        from PySide import QtCore
 
         self.backnav.append(previous)
         eid = item.data(0, QtCore.Qt.UserRole)
@@ -628,7 +628,7 @@ class BIM_IfcExplorer:
     def onDoubleClickTree(self, item, column):
         "when a property or attribute is double-clicked"
 
-        from PySide import QtCore, QtGui
+        from PySide import QtCore
 
         if self.tree:
             txt = item.text(column)

--- a/src/Mod/BIM/bimcommands/BimIfcProperties.py
+++ b/src/Mod/BIM/bimcommands/BimIfcProperties.py
@@ -53,7 +53,7 @@ class BIM_IfcProperties:
         return v
 
     def Activated(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         try:
             import ArchIFC
@@ -244,7 +244,7 @@ class BIM_IfcProperties:
         return result
 
     def updateByType(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         groups = {}
         for name, role in self.objectslist.items():
@@ -278,7 +278,7 @@ class BIM_IfcProperties:
         self.spanTopLevels()
 
     def updateByTree(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         # order by hierarchy
         def istop(obj):
@@ -336,7 +336,7 @@ class BIM_IfcProperties:
         self.form.tree.expandAll()
 
     def updateDefault(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         for name, role in self.objectslist.items():
             role = role[0]
@@ -432,7 +432,7 @@ class BIM_IfcProperties:
         return props
 
     def getSearchResults(self, obj):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         text = self.form.searchField.currentText()
         if not text:
@@ -465,7 +465,7 @@ class BIM_IfcProperties:
                 return QtGui.QStandardItem()
 
     def updateProperties(self, sel1=None, sel2=None):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         self.propmodel.clear()
         self.propmodel.setHorizontalHeaderLabels(
@@ -628,7 +628,7 @@ class BIM_IfcProperties:
                                 del self.objectslist[name][1][prop]
 
     def addProperty(self, idx=0, pset=None, prop=None, ptype=None):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         if not self.form.tree.selectedIndexes():
             return
@@ -685,7 +685,7 @@ class BIM_IfcProperties:
             self.form.comboProperty.setCurrentIndex(0)
 
     def addPset(self, idx):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         if not self.form.tree.selectedIndexes():
             return
@@ -732,7 +732,7 @@ class BIM_IfcProperties:
             self.form.comboPset.setCurrentIndex(0)
 
     def removeProperty(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         sel = self.form.treeProperties.selectedIndexes()
         remove = []
@@ -764,7 +764,7 @@ class BIM_IfcProperties:
 
 
 if FreeCAD.GuiUp:
-    from PySide import QtCore, QtGui
+    from PySide import QtGui
 
     class propertiesDelegate(QtGui.QStyledItemDelegate):
         def __init__(self, parent=None, container=None, ptypes=[], plabels=[], *args):

--- a/src/Mod/BIM/bimcommands/BimIfcQuantities.py
+++ b/src/Mod/BIM/bimcommands/BimIfcQuantities.py
@@ -81,7 +81,7 @@ class BIM_IfcQuantities:
         return v
 
     def Activated(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         # build objects list
         self.objectslist = {}
@@ -329,7 +329,7 @@ class BIM_IfcQuantities:
         """Updates a single line of the table, without updating
         the actual object"""
 
-        from PySide import QtCore, QtGui
+        from PySide import QtCore
 
         i = self.get_row(name)
         if i == -1:

--- a/src/Mod/BIM/bimcommands/BimLayers.py
+++ b/src/Mod/BIM/bimcommands/BimLayers.py
@@ -22,7 +22,6 @@
 
 """Layers manager for FreeCAD"""
 
-import os
 import FreeCAD
 import FreeCADGui
 
@@ -35,7 +34,7 @@ def getColorIcon(color):
 
     "returns a QtGui.QIcon from a color 3-float tuple"
 
-    from PySide import QtCore, QtGui
+    from PySide import QtGui
 
     c = QtGui.QColor(int(color[0] * 255), int(color[1] * 255), int(color[2] * 255))
     im = QtGui.QImage(48, 48, QtGui.QImage.Format_ARGB32)
@@ -64,7 +63,7 @@ class BIM_Layers:
 
     def Activated(self):
 
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         # store changes to be committed
         self.deleteList = []
@@ -441,7 +440,7 @@ class BIM_Layers:
     def onToggle(self):
         "toggle selected layers on/off"
 
-        from PySide import QtCore, QtGui
+        from PySide import QtCore
 
         state = None
         for index in self.dialog.tree.selectedIndexes():
@@ -460,7 +459,7 @@ class BIM_Layers:
     def onIsolate(self):
         "isolates the selected layers (turns all the others off"
 
-        from PySide import QtCore, QtGui
+        from PySide import QtCore
 
         onrows = []
         for index in self.dialog.tree.selectedIndexes():
@@ -473,7 +472,7 @@ class BIM_Layers:
     def onIFC(self):
         "attributes this layer to an IFC project"
 
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         for index in self.dialog.tree.selectedIndexes():
             if index.column() == 1:

--- a/src/Mod/BIM/bimcommands/BimLibrary.py
+++ b/src/Mod/BIM/bimcommands/BimLibrary.py
@@ -108,7 +108,7 @@ class BIM_Library_TaskPanel:
 
     def __init__(self, offlinemode=False):
 
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         self.mainDocName = FreeCAD.Gui.ActiveDocument.Document.Name
         self.previewDocName = "Viewer"
@@ -380,7 +380,6 @@ class BIM_Library_TaskPanel:
 
     def setSearchModel(self, text):
 
-        import PartGui
         from PySide import QtGui
 
         def add_line(f, dp):
@@ -445,7 +444,6 @@ class BIM_Library_TaskPanel:
     def setOnlineModel(self):
 
         from PySide import QtGui
-        import PartGui
 
         def addItems(root, d, path):
             for k, v in d.items():

--- a/src/Mod/BIM/bimcommands/BimMaterial.py
+++ b/src/Mod/BIM/bimcommands/BimMaterial.py
@@ -22,7 +22,6 @@
 
 """This module contains FreeCAD commands for the BIM workbench"""
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimNudge.py
+++ b/src/Mod/BIM/bimcommands/BimNudge.py
@@ -22,7 +22,6 @@
 
 """BIM nudge commands"""
 
-import os
 import FreeCAD
 import FreeCADGui
 
@@ -36,7 +35,7 @@ class BIM_Nudge:
     def getNudgeValue(self, mode):
         "mode can be dist, up, down, left, right. dist returns a float in mm, other modes return a 3D vector"
 
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         mw = FreeCADGui.getMainWindow()
         if mw:
@@ -136,7 +135,7 @@ class BIM_Nudge_Switch(BIM_Nudge):
         }
 
     def Activated(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         mw = FreeCADGui.getMainWindow()
         if mw:

--- a/src/Mod/BIM/bimcommands/BimOffset.py
+++ b/src/Mod/BIM/bimcommands/BimOffset.py
@@ -46,7 +46,6 @@ class BIM_Offset2D:
         return v
 
     def Activated(self):
-        import PartGui
         FreeCADGui.runCommand("Part_Offset2D")
 
 

--- a/src/Mod/BIM/bimcommands/BimPanel.py
+++ b/src/Mod/BIM/bimcommands/BimPanel.py
@@ -23,7 +23,6 @@
 """BIM Panel-related Arch_"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 
@@ -334,7 +333,6 @@ class NestTaskPanel:
     def __init__(self,obj=None):
 
         import ArchNesting
-        from PySide import QtCore, QtGui
         self.form = FreeCADGui.PySideUic.loadUi(":/ui/ArchNest.ui")
         self.form.progressBar.hide()
         self.form.ButtonPreview.setEnabled(False)

--- a/src/Mod/BIM/bimcommands/BimPipe.py
+++ b/src/Mod/BIM/bimcommands/BimPipe.py
@@ -23,7 +23,6 @@
 """BIM Panel-related Arch_"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimPreflight.py
+++ b/src/Mod/BIM/bimcommands/BimPreflight.py
@@ -80,7 +80,7 @@ class BIM_Preflight:
 class BIM_Preflight_TaskPanel:
 
     def __init__(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         self.results = {}  # to store the result message
         self.culprits = {}  # to store objects to highlight
@@ -156,12 +156,12 @@ class BIM_Preflight_TaskPanel:
                             self.customTests[butname] = func
 
     def getStandardButtons(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         return QtGui.QDialogButtonBox.Close
 
     def reject(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         QtGui.QApplication.restoreOverrideCursor()
         FreeCADGui.Control.closeDialog()
@@ -170,7 +170,7 @@ class BIM_Preflight_TaskPanel:
     def passed(self, test):
         "sets the button as passed"
 
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         getattr(self.form, test).setIcon(QtGui.QIcon(":/icons/button_valid.svg"))
         getattr(self.form, test).setText(translate("BIM", "Passed"))
@@ -181,7 +181,7 @@ class BIM_Preflight_TaskPanel:
     def failed(self, test):
         "sets the button as failed"
 
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         getattr(self.form, test).setIcon(QtGui.QIcon(":/icons/process-stop.svg"))
         getattr(self.form, test).setText("Failed")
@@ -192,7 +192,7 @@ class BIM_Preflight_TaskPanel:
     def reset(self, test):
         "reset the button"
 
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         getattr(self.form, test).setIcon(QtGui.QIcon(":/icons/button_right.svg"))
         getattr(self.form, test).setText(translate("BIM", "Test"))
@@ -293,7 +293,7 @@ class BIM_Preflight_TaskPanel:
     def testAll(self):
         "runs all tests"
 
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
         from draftutils import todo
 
         for test in tests:
@@ -698,6 +698,7 @@ class BIM_Preflight_TaskPanel:
     def testQuantities(self):
         "tests for explicit quantities export"
 
+        import Draft
         from PySide import QtCore, QtGui
 
         test = "testQuantities"

--- a/src/Mod/BIM/bimcommands/BimProfile.py
+++ b/src/Mod/BIM/bimcommands/BimProfile.py
@@ -23,7 +23,6 @@
 """BIM Panel-related Arch_"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimProjectManager.py
+++ b/src/Mod/BIM/bimcommands/BimProjectManager.py
@@ -24,7 +24,6 @@
 
 
 import os
-import sys
 import math
 import FreeCAD
 import FreeCADGui
@@ -49,7 +48,7 @@ class BIM_ProjectManager:
 
         import FreeCADGui
         import ArchBuildingPart
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         self.form = FreeCADGui.PySideUic.loadUi(":/ui/dialogProjectManager.ui")
         self.project = None
@@ -413,7 +412,7 @@ class BIM_ProjectManager:
 
     def savePreset(self):
         import Arch
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         res = QtGui.QInputDialog.getText(
             None,
@@ -648,7 +647,7 @@ class BIM_ProjectManager:
         )
 
         d.Meta = values
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         filename = QtGui.QFileDialog.getSaveFileName(
             QtGui.QApplication.activeWindow(),
@@ -670,7 +669,7 @@ class BIM_ProjectManager:
         """loads the contents of a template into the current file"""
 
         import FreeCADGui
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         filename = QtGui.QFileDialog.getOpenFileName(
             QtGui.QApplication.activeWindow(),

--- a/src/Mod/BIM/bimcommands/BimRebar.py
+++ b/src/Mod/BIM/bimcommands/BimRebar.py
@@ -23,7 +23,6 @@
 """BIM Rebar command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimReextrude.py
+++ b/src/Mod/BIM/bimcommands/BimReextrude.py
@@ -24,7 +24,6 @@
 
 """This module contains FreeCAD commands for the BIM workbench"""
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimReference.py
+++ b/src/Mod/BIM/bimcommands/BimReference.py
@@ -23,7 +23,6 @@
 """BIM Rebar command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimReorder.py
+++ b/src/Mod/BIM/bimcommands/BimReorder.py
@@ -23,7 +23,6 @@
 
 """This module contains FreeCAD commands for the BIM workbench"""
 
-import os
 import FreeCAD
 import FreeCADGui
 
@@ -57,7 +56,7 @@ class BIM_Reorder:
 class BIM_Reorder_TaskPanel:
 
     def __init__(self, obj):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         self.obj = obj
         self.form = FreeCADGui.PySideUic.loadUi(":/ui/dialogReorder.ui")

--- a/src/Mod/BIM/bimcommands/BimRoof.py
+++ b/src/Mod/BIM/bimcommands/BimRoof.py
@@ -23,7 +23,6 @@
 """BIM Roof command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 
@@ -83,4 +82,3 @@ class Arch_Roof:
 
 
 FreeCADGui.addCommand("Arch_Roof", Arch_Roof())
-

--- a/src/Mod/BIM/bimcommands/BimSchedule.py
+++ b/src/Mod/BIM/bimcommands/BimSchedule.py
@@ -23,7 +23,6 @@
 """BIM Schedule command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimSectionPlane.py
+++ b/src/Mod/BIM/bimcommands/BimSectionPlane.py
@@ -23,7 +23,6 @@
 """BIM Schedule command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimSetup.py
+++ b/src/Mod/BIM/bimcommands/BimSetup.py
@@ -396,7 +396,7 @@ class BIM_Setup:
         )
 
     def setPreset(self, preset=None):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         unit = None
         decimals = None

--- a/src/Mod/BIM/bimcommands/BimSimpleCopy.py
+++ b/src/Mod/BIM/bimcommands/BimSimpleCopy.py
@@ -47,7 +47,6 @@ class BIM_SimpleCopy:
         return v
 
     def Activated(self):
-        import PartGui
         FreeCADGui.runCommand("Part_SimpleCopy")
 
 

--- a/src/Mod/BIM/bimcommands/BimSite.py
+++ b/src/Mod/BIM/bimcommands/BimSite.py
@@ -25,7 +25,6 @@
 # TODO: Refactor the Site code so it becomes a BuildingPart too
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimSpace.py
+++ b/src/Mod/BIM/bimcommands/BimSpace.py
@@ -23,7 +23,6 @@
 """BIM Schedule command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimStairs.py
+++ b/src/Mod/BIM/bimcommands/BimStairs.py
@@ -23,7 +23,6 @@
 """BIM Schedule command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimTDPage.py
+++ b/src/Mod/BIM/bimcommands/BimTDPage.py
@@ -49,7 +49,7 @@ class BIM_TDPage:
         return v
 
     def Activated(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
         import TechDraw
 
         templatedir = FreeCAD.ParamGet(

--- a/src/Mod/BIM/bimcommands/BimTruss.py
+++ b/src/Mod/BIM/bimcommands/BimTruss.py
@@ -23,7 +23,6 @@
 """BIM Truss command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimTutorial.py
+++ b/src/Mod/BIM/bimcommands/BimTutorial.py
@@ -212,7 +212,7 @@ class BIM_Tutorial:
         self.update()
 
     def update(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtCore
 
         if not hasattr(self, "form") or not self.form or not hasattr(self, "dock"):
             return
@@ -271,7 +271,7 @@ class BIM_Tutorial:
             QtCore.QTimer.singleShot(TESTINTERVAL, self.checkGoals)
 
     def checkGoals(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtCore
 
         if not hasattr(self, "form"):
             return

--- a/src/Mod/BIM/bimcommands/BimWall.py
+++ b/src/Mod/BIM/bimcommands/BimWall.py
@@ -23,7 +23,6 @@
 """BIM wall command"""
 
 
-import os
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/BIM/bimcommands/BimWelcome.py
+++ b/src/Mod/BIM/bimcommands/BimWelcome.py
@@ -22,7 +22,6 @@
 
 """This module contains FreeCAD commands for the BIM workbench"""
 
-import os
 import FreeCAD
 import FreeCADGui
 
@@ -41,8 +40,6 @@ class BIM_Welcome:
         }
 
     def Activated(self):
-        from PySide import QtCore, QtGui
-
         self.form = FreeCADGui.PySideUic.loadUi(":ui/dialogWelcome.ui")
 
         # handle the tutorial links

--- a/src/Mod/BIM/bimcommands/BimWindows.py
+++ b/src/Mod/BIM/bimcommands/BimWindows.py
@@ -22,7 +22,6 @@
 
 """The BIM Windows Manager command"""
 
-import os
 import FreeCAD
 import FreeCADGui
 
@@ -52,7 +51,7 @@ class BIM_Windows:
 class BIM_Windows_TaskPanel:
 
     def __init__(self):
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         self.form = FreeCADGui.PySideUic.loadUi(":/ui/dialogWindows.ui")
         self.form.setWindowIcon(QtGui.QIcon(":/icons/BIM_Windows.svg"))


### PR DESCRIPTION
Following the previous BIM cleanup https://github.com/FreeCAD/FreeCAD/pull/20332
Here, unused imports from `src/Mod/BIM/bimcommands/` are removed (other directories will follow in other PRs).

This is mainly a cleanup of unused `os`, `PySide`, `PartGui` and a few others modules.
Also added a few imports that were obviously missing, or were they ?
Please do test (should be fairly safe from my preliminary tests, but you never know =D )

<hr>

<details><summary>While doing that, some issues/interrogations were reported (for future PRs). See below the list.</summary>

1. src/Mod/BIM/bimcommands/BimDiff.py:295:29: F821 undefined name 'Part'. Is an `import Part` missing ?
`shape = Part.makeCompound([a.Shape for a in additions])`

2. src/Mod/BIM/bimcommands/BimEquipment.py:92 Could it be removed ?
`class Arch_3Views: # OBSOLETE`

3. src/Mod/BIM/bimcommands/BimIfcProperties.py:585:74: F821 undefined name 'unicode'
`if (sys.version_info.major < 3) and isinstance(prop, unicode):`

4. src/Mod/BIM/bimcommands/BimLibrary.py:289:37: F821 undefined name 'tempfile'
`thumbfile = tempfile.mkstemp(suffix=".png")[1]`

5. src/Mod/BIM/bimcommands/BimLibrary.py:785 Could it be removed ?
`def getOnlineContentsWEB(self, url): # obsolete code - now using getOnlineContentsAPI`

6. src/Mod/BIM/bimcommands/BimMaterial.py:211:27: F821 undefined name 'mats' Typo ?
`for mat in self.dlg.materials:` `for om in mats:` `if om.Label == mat.Label:`

7. src/Mod/BIM/bimcommands/BimTutorial.py:87:13: F401 'draftutils.todo' imported but unused. Could it be removed ?
`from draftutils import todo` `# todo.ToDo.delay(self.load,None)`

8. src/Mod/BIM/bimcommands/BimUnclone.py:67:38: F821 undefined name 'Arch'. Is an `import Arch` missing ?
`newobj = getattr(Arch, "make" + Draft.getType(cloned))()`

9. src/Mod/BIM/bimcommands/BimViews.py:539:59: F821 undefined name 'unicode'
src/Mod/BIM/bimcommands/BimViews.py:638:63: F821 undefined name 'unicode'
`(sys.version_info.major < 3) and isinstance(item, unicode)`

</details>