### PR TITLE
BIM: cleanup import take 3

### DIFF
--- a/src/Mod/BIM/importers/importGBXML.py
+++ b/src/Mod/BIM/importers/importGBXML.py
@@ -23,6 +23,8 @@ __title__  = "FreeCAD GbXml exporter"
 __author__ = "Yorik van Havre"
 __url__    = "https://www.freecad.org"
 
+from builtins import open as pyopen
+
 import FreeCAD
 import Draft
 

--- a/src/Mod/BIM/importers/importIFCHelper.py
+++ b/src/Mod/BIM/importers/importIFCHelper.py
@@ -19,7 +19,6 @@
 # *                                                                         *
 # ***************************************************************************
 """Helper functions that are used by IFC importer and exporter."""
-import sys
 import math
 
 import FreeCAD

--- a/src/Mod/BIM/importers/importIFClegacy.py
+++ b/src/Mod/BIM/importers/importIFClegacy.py
@@ -26,7 +26,7 @@
 ############################################################################
 
 
-import FreeCAD, Arch, Draft, os, sys, time, Part, DraftVecUtils, uuid, math, re
+import FreeCAD, Arch, Draft, os, time, Part, DraftVecUtils, uuid, math, re
 from builtins import open as pyopen
 from draftutils import params
 from draftutils.translate import translate
@@ -1779,7 +1779,7 @@ class IfcDocument:
 
 def explorer(filename,schema="IFC2X3_TC1.exp"):
     "returns a PySide dialog showing the contents of an IFC file"
-    from PySide import QtCore,QtGui
+    from PySide import QtGui
     ifc = IfcDocument(filename,schema)
     schema = IfcSchema(schema)
     tree = QtGui.QTreeWidget()

--- a/src/Mod/BIM/importers/importSH3D.py
+++ b/src/Mod/BIM/importers/importSH3D.py
@@ -24,7 +24,6 @@ __author__ = "Yorik van Havre"
 __url__    = "https://www.freecad.org"
 
 import os
-import xml.sax
 import zipfile
 
 import FreeCAD

--- a/src/Mod/BIM/importers/importSHP.py
+++ b/src/Mod/BIM/importers/importSHP.py
@@ -144,11 +144,6 @@ def checkShapeFileLibrary():
                 f = pyopen(fp,"wb")
                 f.write(b)
                 f.close()
-                try:
-                    import shapefile
-                except Exception:
-                    FreeCAD.Console.PrintError(translate("Arch","Could not download shapefile module. Aborting.")+"\n")
-                    return False
             else:
                 FreeCAD.Console.PrintError(translate("Arch","Shapefile module not downloaded. Aborting.")+"\n")
                 return False


### PR DESCRIPTION
Following the previous BIM cleanups https://github.com/FreeCAD/FreeCAD/pull/20332 and https://github.com/FreeCAD/FreeCAD/pull/20341
Here, unused imports from `src/Mod/BIM/importers/` are removed (other directories will follow in other PRs).

This is mainly a cleanup of unused `sys`, `PySide` and a few others modules.
@rostskadat could you please confirm the `xml.sax` can be safely removed from importSH3D.py, as the comment on importSH3DHelper.py:210 suggests so.
Also added an `open` import that was probably missing.
Please do test (should be fairly safe from my preliminary tests, but you never know =D )

Saw many undefined names and unused assigned variables as well, but will be for later PRs.