### PR TITLE
BIM: cleanup import take 4

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_commands.py
+++ b/src/Mod/BIM/nativeifc/ifc_commands.py
@@ -155,7 +155,7 @@ class IFC_MakeProject:
     def Activated(self):
         from importers import exportIFC  # lazy loading
         from . import ifc_tools
-        from PySide import QtCore, QtGui
+        from PySide import QtGui
 
         doc = FreeCAD.ActiveDocument
         objs = FreeCADGui.Selection.getSelection()

--- a/src/Mod/BIM/nativeifc/ifc_selftest.py
+++ b/src/Mod/BIM/nativeifc/ifc_selftest.py
@@ -22,8 +22,6 @@
 
 """Unit test for the Native IFC module"""
 
-import os
-import time
 import tempfile
 import FreeCAD
 import Draft

--- a/src/Mod/BIM/nativeifc/ifc_status.py
+++ b/src/Mod/BIM/nativeifc/ifc_status.py
@@ -100,7 +100,7 @@ def on_add_property():
     sel = FreeCADGui.Selection.getSelection()
     if not sel:
         return
-    from PySide import QtCore, QtGui  # lazy loading
+    from PySide import QtGui  # lazy loading
     from . import ifc_psets
     obj = sel[0]
     psets = list(set([obj.getGroupOfProperty(p) for p in obj.PropertiesList]))
@@ -179,7 +179,6 @@ def on_add_pset():
     sel = FreeCADGui.Selection.getSelection()
     if not sel:
         return
-    from PySide import QtCore, QtGui  # lazy loading
     from . import ifc_psets
     obj = sel[0]
     mw = FreeCADGui.getMainWindow()
@@ -273,7 +272,7 @@ def on_new():
 def set_menu(locked=False):
     """Sets the File menu items"""
 
-    from PySide import QtCore, QtGui  # lazy loading
+    from PySide import QtGui  # lazy loading
 
     # switch Std_Save and IFC_Save
     mw = FreeCADGui.getMainWindow()
@@ -452,7 +451,6 @@ def lock_document():
 def find_toplevel(objs):
     """Finds the top-level objects from the list"""
 
-    import Draft
     # filter out any object that depend on another from the list
     nobjs = []
     for obj in objs:
@@ -473,6 +471,8 @@ def find_toplevel(objs):
 
 def filter_out(objs):
     """Filter out objects that should not be converted to IFC"""
+
+    import Draft
 
     nobjs = []
     for obj in objs:

--- a/src/Mod/BIM/nativeifc/ifc_tree.py
+++ b/src/Mod/BIM/nativeifc/ifc_tree.py
@@ -80,7 +80,7 @@ def show_geometry_tree(element):
     import Arch_rc
     import FreeCADGui  # lazy import
     from . import ifc_tools
-    from PySide import QtGui, QtWidgets
+    from PySide import QtWidgets
 
     if isinstance(element, FreeCAD.DocumentObject):
         element = ifc_tools.get_ifc_element(element)
@@ -147,7 +147,7 @@ def show_properties(current, previous):
 
     import FreeCADGui
     from . import ifc_tools  # lazy loading
-    from PySide import QtCore, QtGui, QtWidgets
+    from PySide import QtCore, QtWidgets
 
     ifcid = int(current.text(0).split("=", 1)[0].strip(" ").strip("#"))
     sel = FreeCADGui.Selection.getSelection()

--- a/src/Mod/BIM/nativeifc/ifc_viewproviders.py
+++ b/src/Mod/BIM/nativeifc/ifc_viewproviders.py
@@ -86,7 +86,7 @@ class ifc_vp_object:
         from . import ifc_psets
         from . import ifc_materials
         from . import ifc_types
-        from PySide import QtCore, QtGui  # lazy import
+        from PySide import QtGui  # lazy import
 
         if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
             return
@@ -419,7 +419,7 @@ class ifc_vp_document(ifc_vp_object):
 
     def setupContextMenu(self, vobj, menu):
 
-        from PySide import QtCore, QtGui  # lazy import
+        from PySide import QtGui  # lazy import
 
         if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
             return
@@ -463,7 +463,7 @@ class ifc_vp_document(ifc_vp_object):
     def replace_file(self, obj, newfile):
         """Asks the user if the attached file path needs to be replaced"""
 
-        from PySide import QtCore, QtGui  # lazy import
+        from PySide import QtGui  # lazy import
 
         msg = "Replace the stored IFC file path in object "
         msg += self.Object.Label + " with the new one: "
@@ -484,7 +484,7 @@ class ifc_vp_document(ifc_vp_object):
             return False
 
     def schema_warning(self):
-        from PySide import QtCore, QtGui  # lazy import
+        from PySide import QtGui  # lazy import
 
         msg = "Warning: This operation will change the whole IFC file contents "
         msg += "and will not give versionable results. It is best to not do "
@@ -516,7 +516,7 @@ class ifc_vp_group:
         self.Object = vobj.Object
 
     def getIcon(self):
-        from PySide import QtCore, QtGui  # lazy loading
+        from PySide import QtGui  # lazy loading
         import Draft_rc
         import Arch_rc
 
@@ -602,7 +602,7 @@ class ifc_vp_material:
     def setupContextMenu(self, vobj, menu):
         from . import ifc_tools  # lazy import
         from . import ifc_psets
-        from PySide import QtCore, QtGui  # lazy import
+        from PySide import QtGui  # lazy import
 
         if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
             return
@@ -660,7 +660,7 @@ def get_filepath(project):
     """Saves the associated IFC file to another file"""
 
     from . import ifc_tools  # lazy import
-    from PySide import QtCore, QtGui  # lazy import
+    from PySide import QtGui  # lazy import
 
     sf = QtGui.QFileDialog.getSaveFileName(
         None,


### PR DESCRIPTION
Following the previous BIM cleanups https://github.com/FreeCAD/FreeCAD/pull/20332, https://github.com/FreeCAD/FreeCAD/pull/20341 and https://github.com/FreeCAD/FreeCAD/pull/20345
Here, unused imports from `src/Mod/BIM/nativeifc/` are removed (other directories will follow in other PRs).

This is mainly a cleanup of unused PySide and a few others modules.
Also added a `Draft` import that was probably missing.
Please do test (should be fairly safe from my preliminary tests, but you never know =D )

Saw many undefined names and unused assigned variables as well, but will be for later PRs.