### PR TITLE
BIM: cleanup import take 5

### DIFF
--- a/src/Mod/BIM/utils/ifctree.py
+++ b/src/Mod/BIM/utils/ifctree.py
@@ -34,7 +34,7 @@ my ryzen9 machine, for 2700 objects. Larger files like the King Arch file
 
 import FreeCAD
 import ifcopenshell
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide import QtWidgets
 import time
 
 


### PR DESCRIPTION
Following the previous BIM cleanups https://github.com/FreeCAD/FreeCAD/pull/20332, https://github.com/FreeCAD/FreeCAD/pull/20341, https://github.com/FreeCAD/FreeCAD/pull/20345 and https://github.com/FreeCAD/FreeCAD/pull/20346
Here, unused import from `src/Mod/BIM/utils/` is removed (other cleanups will follow in other PRs).

This is mainly a cleanup of unused PySide, following [info from the wiki](https://wiki.freecad.org/PySide), there is no need to declare `PySide2` or `PySide6` as `PySide` should normally be sufficient.
Please do test nevertheless =D