### PR TITLE
BIM: cleanup import take 6

### DIFF
--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -324,6 +324,7 @@ def splitMesh(obj,mark=True):
 def makeFace(wires,method=2,cleanup=False):
     '''makeFace(wires): makes a face from a list of wires, finding which ones are holes'''
     #print("makeFace: start:", wires)
+    import DraftGeomUtils
     import Part
 
     if not isinstance(wires,list):
@@ -1379,4 +1380,3 @@ def makeIfcSpreadsheet(archobj=None):
             FreeCAD.ActiveDocument.removeObject(ifc_spreadsheet)
     else :
         return ifc_spreadsheet
-

--- a/src/Mod/BIM/ArchCutPlane.py
+++ b/src/Mod/BIM/ArchCutPlane.py
@@ -27,7 +27,6 @@ import Draft
 import ArchCommands
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from PySide import QtCore, QtGui
     from draftutils.translate import translate
 else:
     # \cond

--- a/src/Mod/BIM/ArchEquipment.py
+++ b/src/Mod/BIM/ArchEquipment.py
@@ -29,7 +29,6 @@ import ArchComponent
 import DraftVecUtils
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from PySide import QtGui
     from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
@@ -305,4 +304,3 @@ class _ViewProviderEquipment(ArchComponent.ViewProviderComponent):
                 self.coords.point.setValues([[p.x,p.y,p.z] for p in obj.SnapPoints])
             else:
                 self.coords.point.deleteValues(0)
-

--- a/src/Mod/BIM/ArchFence.py
+++ b/src/Mod/BIM/ArchFence.py
@@ -30,7 +30,6 @@ import draftobjects.patharray as patharray
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide.QtCore import QT_TRANSLATE_NOOP
-    import PySide.QtGui as QtGui
 else:
     # \cond
     def translate(ctxt, txt):
@@ -236,6 +235,8 @@ class _Fence(ArchComponent.Component):
         return newShape.removeSplitter()
 
     def calculatePathWire(self, obj):
+        import Part
+
         if (hasattr(obj.Path.Shape, 'Wires') and obj.Path.Shape.Wires):
             return obj.Path.Shape.Wires[0]
         elif obj.Path.Shape.Edges:

--- a/src/Mod/BIM/ArchFrame.py
+++ b/src/Mod/BIM/ArchFrame.py
@@ -118,7 +118,6 @@ class _Frame(ArchComponent.Component):
                 for w in obj.Profile.Shape.Wires:
                     if not w.isClosed():
                         return
-            import math
             import DraftGeomUtils
             import Part
             baseprofile = obj.Profile.Shape.copy()
@@ -228,4 +227,3 @@ class _ViewProviderFrame(ArchComponent.ViewProviderComponent):
             if self.Object.Profile:
                 p = [self.Object.Profile]
         return ArchComponent.ViewProviderComponent.claimChildren(self)+p
-

--- a/src/Mod/BIM/ArchMaterial.py
+++ b/src/Mod/BIM/ArchMaterial.py
@@ -308,7 +308,6 @@ class _ViewProviderArchMaterial:
 
     def updateData(self, obj, prop):
         if prop == "Color":
-            from PySide import QtCore,QtGui
 
             # custom icon
             if hasattr(obj,"Color"):
@@ -895,5 +894,3 @@ class _ArchMultiMaterialTaskPanel:
     def reject(self):
         FreeCADGui.ActiveDocument.resetEdit()
         return True
-
-

--- a/src/Mod/BIM/ArchPipe.py
+++ b/src/Mod/BIM/ArchPipe.py
@@ -266,7 +266,6 @@ class _ViewProviderPipe(ArchComponent.ViewProviderComponent):
 
     def getIcon(self):
 
-        import Arch_rc
         return ":/icons/Arch_Pipe_Tree.svg"
 
 
@@ -451,5 +450,3 @@ class _ArchPipeConnector(ArchComponent.Component):
             if pipe.OffsetEnd != offset:
                 pipe.OffsetEnd = offset
                 pipe.Proxy.execute(pipe)
-
-

--- a/src/Mod/BIM/ArchPrecast.py
+++ b/src/Mod/BIM/ArchPrecast.py
@@ -1001,7 +1001,6 @@ class _PrecastTaskPanel:
         params.set_param_arch("PrecastTread",value)
 
     def retranslateUi(self, dialog):
-        from PySide import QtGui
         self.form.setWindowTitle(translate("Arch", "Precast elements"))
         self.labelSlabType.setText(translate("Arch", "Slab type"))
         self.labelChamfer.setText(translate("Arch", "Chamfer"))
@@ -1404,7 +1403,6 @@ class _DentsTaskPanel:
             self.valueOffset.setText(FreeCAD.Units.Quantity(float(s[6]),FreeCAD.Units.Length).UserString)
 
     def retranslateUi(self, dialog):
-        from PySide import QtGui
         self.form.setWindowTitle(translate("Arch", "Precast options"))
         self.labelDents.setText(translate("Arch", "Dents list"))
         self.buttonAdd.setText(translate("Arch", "Add dent"))

--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -416,7 +416,7 @@ def getSVG(source,
         if should_update_svg_cache:
             svgcache = ""
             # render using the TechDraw module
-            import TechDraw, Part
+            import TechDraw
             if vshapes:
                 baseshape = Part.makeCompound(vshapes)
                 style = {'stroke':       "SVGLINECOLOR",
@@ -1348,4 +1348,3 @@ class SectionPlaneTaskPanel:
         self.resizeButton.setToolTip(QtGui.QApplication.translate("Arch", "Resizes the plane to fit the objects in the list above", None))
         self.recenterButton.setText(QtGui.QApplication.translate("Arch", "Center", None))
         self.recenterButton.setToolTip(QtGui.QApplication.translate("Arch", "Centers the plane on the objects in the list above", None))
-

--- a/src/Mod/BIM/ArchVRM.py
+++ b/src/Mod/BIM/ArchVRM.py
@@ -428,6 +428,7 @@ class Renderer:
 
     def join(self,otype):
         "joins the objects of same type"
+        import Draft
         import Part
         walls = []
         structs = []

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -19,7 +19,6 @@
 #*                                                                         *
 #***************************************************************************
 
-import os
 
 import FreeCAD
 import ArchCommands
@@ -434,7 +433,6 @@ class _Window(ArchComponent.Component):
 
         import Part
         import DraftGeomUtils
-        import math
         pl = obj.Placement
         base = None
         self.sshapes = []
@@ -1417,6 +1415,3 @@ class _ArchWindowTaskPanel:
 
         if self.obj:
             self.obj.ViewObject.Proxy.invertHinge()
-
-
-

--- a/src/Mod/BIM/BimStatus.py
+++ b/src/Mod/BIM/BimStatus.py
@@ -24,7 +24,6 @@
 
 """This module contains FreeCAD commands for the BIM workbench"""
 
-import os
 import FreeCAD
 import FreeCADGui
 
@@ -37,7 +36,6 @@ translate = FreeCAD.Qt.translate
 def setStatusIcons(show=True):
     "shows or hides the BIM icons in the status bar"
 
-    import FreeCADGui
     from PySide import QtCore, QtGui
 
     nudgeLabelsI = [


### PR DESCRIPTION
Following the previous BIM cleanups https://github.com/FreeCAD/FreeCAD/pull/20332, https://github.com/FreeCAD/FreeCAD/pull/20341, https://github.com/FreeCAD/FreeCAD/pull/20345, https://github.com/FreeCAD/FreeCAD/pull/20346 and https://github.com/FreeCAD/FreeCAD/pull/20348
Here, unused imports from `src/Mod/BIM/` (at the "root" of the BIM module) are removed (other cleanups will follow in other PRs).

This is mainly a cleanup of unused `PySide` and other redundant modules.
Also a few missing imports were added.
Please do test (should be fairly safe from my preliminary tests, but you never know =D )

<hr>

<details><summary>While doing that, some issues/interrogations were reported (for future PRs). See below the list.</summary>

1. src/Mod/BIM/ArchBuildingPart.py:936:20: F821 undefined name 'makeBuildingPart'
`nobj = makeBuildingPart()`

2. src/Mod/BIM/ArchNesting.py:455:34: F821 undefined name 'fitpol'
`for f in fitpol.Faces:`

3. src/Mod/BIM/ArchRoof.py:112:47: F821 undefined name 'isPtOnEdge'
src/Mod/BIM/ArchRoof.py:115:47: F821 undefined name 'isPtOnEdge'
`if infinite1 is False and not isPtOnEdge(intp, edge1):`

4. src/Mod/BIM/OfflineRenderingUtils.py:911:14: F821 undefined name 'sc'. Should it be `scene` ?
`wa.apply(sc)`

Saw some other undefined names and unused assigned variables as well, but will be for later PRs.

</details>