### PR TITLE
Draft: show and hide Tray with delay

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1631,7 +1631,7 @@ class DraftToolBar:
     def Activated(self):
         self.setWatchers()
         if hasattr(self,"tray"):
-            self.tray.show()
+            todo.delay(self.tray.show, None)
 
     def Deactivated(self):
         if (FreeCAD.activeDraftCommand is not None):
@@ -1640,7 +1640,7 @@ class DraftToolBar:
         FreeCADGui.Control.clearTaskWatcher()
         #self.tray = None
         if hasattr(self,"tray"):
-            self.tray.hide()
+            todo.delay(self.tray.hide, None)
 
     def reset_ui_values(self):
         """Method to reset task panel values"""


### PR DESCRIPTION
Without this delay the Tray may not display if Draft is the start-up workbench.

When the Draft workbench is autoloaded the Tray is shown and then immediately hidden. Because of this, hiding the tray must also happen with a delay.
