### PR TITLE
Do not specify a version in FindOCC.cmake

### DIFF
--- a/cMake/FindOCC.cmake
+++ b/cMake/FindOCC.cmake
@@ -9,7 +9,7 @@
 
 # we first try to find opencascade directly:
 if (NOT OCCT_CMAKE_FALLBACK)
-    find_package(OpenCASCADE "7.5.1" CONFIG QUIET)
+    find_package(OpenCASCADE CONFIG QUIET)
     get_property(flags DIRECTORY PROPERTY COMPILE_DEFINITIONS)
     # OCCT 7.5 adds this define that causes hundreds of compiler warnings with Qt5.x, so remove it again
     list(FILTER flags EXCLUDE REGEX [[GL_GLEXT_LEGACY]])


### PR DESCRIPTION
PR https://github.com/FreeCAD/FreeCAD/pull/20084 broke the daily snap builds

<details>

https://github.com/FreeCAD/FreeCAD-snap/actions/runs/14003413007/job/39213830371#step:4:1163

```
:: -- Could NOT find OCC (missing: OCC_INCLUDE_DIR)
:: CMake Error at cMake/FreeCAD_Helpers/SetupOpenCasCade.cmake:4 (message):
::   ================================================================
::
::   OpenCASCADE not found!
::
::   ================================================================
::
:: Call Stack (most recent call first):
::   CMakeLists.txt:87 (SetupOpenCasCade)
::
::
:: -- Configuring incomplete, errors occurred!
Failed to run the build script for part 'freecad'.

:: + cmake /home/runner/work/FreeCAD-snap/FreeCAD-snap/parts/freecad/src -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.10 -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.10.so -DFREECAD_USE_PYBIND11=ON -DFREECAD_USE_QT_FILEDIALOG=ON -DBUILD_FLAT_MESH=ON '-DCMAKE_FIND_ROOT_PATH=/home/runner/work/FreeCAD-snap/FreeCAD-snap/stage;/snap/kde-qt5-core22-sdk/current;/snap/kf5-core22-sdk/current/usr'
:: CMake Error at cMake/FreeCAD_Helpers/SetupOpenCasCade.cmake:4 (message):
::   ================================================================
::   OpenCASCADE not found!
::   ================================================================
```

</details>

By specifying the version for [`find_package()` ](https://cmake.org/cmake/help/v3.22/command/find_package.html#version-selection) as 7.5.1, CMake fails to configure if that version is not found. The snap package uses a newer OCCT (7.7.1), and thus the configuration step fails

I've tested this change to fix the issue by building a snap based on it: https://github.com/furgo16/FreeCAD-snap/actions/runs/14004527851. The build suceeds.