### PR TITLE
cmake: remove distutils usage for python < 3.10

### DIFF
--- a/src/Ext/freecad/CMakeLists.txt
+++ b/src/Ext/freecad/CMakeLists.txt
@@ -1,15 +1,6 @@
-if (${Python3_VERSION} VERSION_LESS "3.10")
-    # deprecated distutils package still required for ubuntu 20.04 and similar
-    # see https://bugs.launchpad.net/ubuntu/+source/python3.8/+bug/2039511
-    # TODO: remove this once we drop support for 20.04
-    EXECUTE_PROCESS(COMMAND ${Python3_EXECUTABLE} -c
-        "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True))"
-        OUTPUT_VARIABLE python_libs OUTPUT_STRIP_TRAILING_WHITESPACE )
-else()
-    EXECUTE_PROCESS(COMMAND ${Python3_EXECUTABLE} -c
-        "from sysconfig import get_path; print(get_path('purelib'))"
-        OUTPUT_VARIABLE python_libs OUTPUT_STRIP_TRAILING_WHITESPACE )
-endif()
+EXECUTE_PROCESS(COMMAND ${Python3_EXECUTABLE} -c
+    "from sysconfig import get_path; print(get_path('purelib'))"
+    OUTPUT_VARIABLE python_libs OUTPUT_STRIP_TRAILING_WHITESPACE )
 
 SET(PYTHON_MAIN_DIR ${python_libs})
 

--- a/src/Mod/CAM/libarea/CMakeLists.txt
+++ b/src/Mod/CAM/libarea/CMakeLists.txt
@@ -137,19 +137,9 @@ endif()
 SET_BIN_DIR(area area /Mod/CAM)
 SET_PYTHON_PREFIX_SUFFIX(area)
 
-# this figures out where to install the Python modules
-if (${Python3_VERSION} VERSION_LESS "3.10")
-    # deprecated distutils package still required for ubuntu 20.04 and similar
-    # see https://bugs.launchpad.net/ubuntu/+source/python3.8/+bug/2039511
-    # TODO: remove this once we drop support for 20.04
-    EXECUTE_PROCESS(COMMAND ${Python3_EXECUTABLE} -c
-        "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True))"
-        OUTPUT_VARIABLE Python_site_packages OUTPUT_STRIP_TRAILING_WHITESPACE )
-else()
-    EXECUTE_PROCESS(COMMAND ${Python3_EXECUTABLE} -c
-        "from sysconfig import get_path; print(get_path('platlib'))"
-        OUTPUT_VARIABLE Python_site_packages OUTPUT_STRIP_TRAILING_WHITESPACE )
-endif()
+EXECUTE_PROCESS(COMMAND ${Python3_EXECUTABLE} -c
+    "from sysconfig import get_path; print(get_path('platlib'))"
+    OUTPUT_VARIABLE Python_site_packages OUTPUT_STRIP_TRAILING_WHITESPACE )
 
 message(STATUS "area module (for Path Workbench) will be installed to: " ${CMAKE_INSTALL_LIBDIR})
 


### PR DESCRIPTION
can be removed now that we dropped support for ubuntu 20.04