### PR TITLE
Enable pcl by default on non windows systems

### DIFF
--- a/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
+++ b/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
@@ -178,7 +178,7 @@ macro(InitializeFreeCADBuildOptions)
     endif(MSVC)
     if(NOT MSVC)
         option(BUILD_FEM_NETGEN "Build the FreeCAD FEM module with the NETGEN mesher" OFF)
-        option(FREECAD_USE_PCL "Build the features that use PCL libs" OFF)
+        option(FREECAD_USE_PCL "Build the features that use PCL libs" ON)
     endif(NOT MSVC)
 
     # if this is set override some options

--- a/package/ubuntu/install-apt-packages.sh
+++ b/package/ubuntu/install-apt-packages.sh
@@ -33,6 +33,7 @@ packages=(
   libocct-visualization-dev
   libopencv-dev
   libproj-dev
+  libpcl-dev
   libpyside2-dev
   libqt5opengl5-dev
   libqt5svg5-dev


### PR DESCRIPTION
as mentioned in https://github.com/FreeCAD/FreeCAD/pull/20248#issuecomment-2735216005 ubuntu CI wasn't building with pcl, it seems that pcl is reasonably available nowadays so it should be ok to enable by default, this should also encourage downstream packagers to include this and they can always choose to disable this if it's not available in their platform.