### PR TITLE
Gui: Remove -1 min-width from dialog buttons

### DIFF
--- a/src/Gui/Stylesheets/FreeCAD Dark.qss
+++ b/src/Gui/Stylesheets/FreeCAD Dark.qss
@@ -1287,11 +1287,6 @@ QPushButton::menu-indicator {
   bottom: 4px;
 }
 
-QDialogButtonBox QPushButton {
-  /* Issue # 194 # 248 - Special case of QPushButton inside dialogs, for better UI */
-  min-width: -1;
-}
-
 /* QToolButton ------------------------------------------------------------
 
 https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtoolbutton

--- a/src/Gui/Stylesheets/FreeCAD Light.qss
+++ b/src/Gui/Stylesheets/FreeCAD Light.qss
@@ -1284,11 +1284,6 @@ QPushButton::menu-indicator {
   bottom: 4px;
 }
 
-QDialogButtonBox QPushButton {
-  /* Issue # 194 # 248 - Special case of QPushButton inside dialogs, for better UI */
-  min-width: -1;
-}
-
 /* QToolButton ------------------------------------------------------------
 
 https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtoolbutton


### PR DESCRIPTION
This ensures that minimum width from QStyle is still applied while buttons still respect minimum size hint. Setting min-width to -1 disables min width set by QStyle while simply not setting it allows Qt to apply the default one. 

This is follow up for #20241 and addresses mentioned issue with too small hitbox for buttons. 

@yomgui1 @FreeCAD/design-working-group @MisterMakerNL FYI, I tested if it still works for case with absurdly long text and it seems to do so.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/352f4c94-d3e4-47c3-a10c-efb75e365291) | ![image](https://github.com/user-attachments/assets/8382f9c0-06cc-4681-8ce5-2d2aa567ab14) |
