### PR TITLE
Use longest edge in face for horizontal/vertical alignment

### DIFF
--- a/src/App/Datums.cpp
+++ b/src/App/Datums.cpp
@@ -62,10 +62,11 @@ DatumElement::DatumElement(bool hideRole)
 
 DatumElement::~DatumElement() = default;
 
-bool DatumElement::getCameraAlignmentDirection(Base::Vector3d& direction, const char* subname) const
+bool DatumElement::getCameraAlignmentDirection(Base::Vector3d& directionZ, Base::Vector3d& directionX, const char* subname) const
 {
     Q_UNUSED(subname);
-    Placement.getValue().getRotation().multVec(baseDir, direction);
+    Q_UNUSED(directionX);
+    Placement.getValue().getRotation().multVec(baseDir, directionZ);
 
     return true;
 }
@@ -144,11 +145,13 @@ LocalCoordinateSystem::LocalCoordinateSystem()
 
 LocalCoordinateSystem::~LocalCoordinateSystem() = default;
 
-bool LocalCoordinateSystem::getCameraAlignmentDirection(Base::Vector3d& direction,
+bool LocalCoordinateSystem::getCameraAlignmentDirection(Base::Vector3d& directionZ,
+                                                        Base::Vector3d& directionX,
                                                         const char* subname) const
 {
     Q_UNUSED(subname);
-    Placement.getValue().getRotation().multVec(Base::Vector3d(0., 0., 1.), direction);
+    Q_UNUSED(directionX);
+    Placement.getValue().getRotation().multVec(Base::Vector3d(0., 0., 1.), directionZ);
 
     return true;
 }

--- a/src/App/Datums.cpp
+++ b/src/App/Datums.cpp
@@ -65,8 +65,12 @@ DatumElement::~DatumElement() = default;
 bool DatumElement::getCameraAlignmentDirection(Base::Vector3d& directionZ, Base::Vector3d& directionX, const char* subname) const
 {
     Q_UNUSED(subname);
-    Q_UNUSED(directionX);
+    
     Placement.getValue().getRotation().multVec(baseDir, directionZ);
+
+    if (baseDir == Base::Vector3d::UnitZ) {
+        Placement.getValue().getRotation().multVec(Base::Vector3d::UnitX, directionX);
+    }
 
     return true;
 }
@@ -150,8 +154,9 @@ bool LocalCoordinateSystem::getCameraAlignmentDirection(Base::Vector3d& directio
                                                         const char* subname) const
 {
     Q_UNUSED(subname);
-    Q_UNUSED(directionX);
-    Placement.getValue().getRotation().multVec(Base::Vector3d(0., 0., 1.), directionZ);
+
+    Placement.getValue().getRotation().multVec(Base::Vector3d::UnitZ, directionZ);
+    Placement.getValue().getRotation().multVec(Base::Vector3d::UnitX, directionX);
 
     return true;
 }

--- a/src/App/Datums.h
+++ b/src/App/Datums.h
@@ -55,7 +55,7 @@ public:
     Base::Vector3d getDirection() const;
     Base::Vector3d getBaseDirection() const;
 
-    bool getCameraAlignmentDirection(Base::Vector3d& direction, const char* subname) const override;
+    bool getCameraAlignmentDirection(Base::Vector3d& directionZ, Base::Vector3d& directionX, const char* subname) const override;
 
     /// Returns true if this DatumElement is part of a App::Origin.
     bool isOriginFeature() const;
@@ -119,7 +119,7 @@ public:
         return "Gui::ViewProviderCoordinateSystem";
     }
 
-    bool getCameraAlignmentDirection(Base::Vector3d& direction, const char* subname) const override;
+    bool getCameraAlignmentDirection(Base::Vector3d& directionZ, Base::Vector3d& directionX, const char* subname) const override;
 
     /** @name Axis and plane access
      * This functions returns casted axis and planes objects and asserts they are set correctly

--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -213,10 +213,11 @@ void GeoFeature::setMaterialAppearance(const App::Material& material)
     Q_UNUSED(material)
 }
 
-bool GeoFeature::getCameraAlignmentDirection(Base::Vector3d& direction, const char* subname) const
+bool GeoFeature::getCameraAlignmentDirection(Base::Vector3d& directionZ, Base::Vector3d& directionX, const char* subname) const
 {
     Q_UNUSED(subname)
-    Q_UNUSED(direction)
+    Q_UNUSED(directionZ)
+    Q_UNUSED(directionX)
     return false;
 }
 

--- a/src/App/GeoFeature.h
+++ b/src/App/GeoFeature.h
@@ -151,11 +151,13 @@ public:
     /**
      * @brief Virtual function to get the camera alignment direction
      *
-     * Finds a direction to align the camera with.
+     * Finds a directionZ to align the camera with.
+     * May also find an optional directionX which could be used for horizontal or vertical alignment.
      *
-     * @return bool whether or not a direction is found.
+     * @return bool whether or not a directionZ is found.
      */
-    virtual bool getCameraAlignmentDirection(Base::Vector3d& direction,
+    virtual bool getCameraAlignmentDirection(Base::Vector3d& directionZ,
+                                             Base::Vector3d& directionX,
                                              const char* subname = nullptr) const;
     /** Search sub element using internal cached geometry
      *

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3592,11 +3592,13 @@ void View3DInventorViewer::alignToSelection()
     const auto geoFeatureSubName = !splitSubName.empty() ? splitSubName.back() : "";
 
     Base::Vector3d alignmentZ;
-    if (geoFeature->getCameraAlignmentDirection(alignmentZ, geoFeatureSubName.c_str())) {
+    Base::Vector3d alignmentX (0, 0, 0);
+    if (geoFeature->getCameraAlignmentDirection(alignmentZ, alignmentX, geoFeatureSubName.c_str())) {
 
-        // Find the x alignment
-        Base::Vector3d alignmentX;
-        Base::Rotation(Base::Vector3d(0, 0, -1), alignmentZ).multVec(Base::Vector3d(1, 0, 0), alignmentX);
+        // Find a x alignment if the geoFeature did not suggest any
+        if (alignmentX == Base::Vector3d (0, 0, 0)) {
+            Base::Rotation(-Base::Vector3d::UnitZ, alignmentZ).multVec(Base::Vector3d::UnitX, alignmentX);
+        }
 
         // Convert to global coordinates
         globalRotation.multVec(alignmentZ, alignmentZ);

--- a/src/Mod/Part/App/PartFeature.h
+++ b/src/Mod/Part/App/PartFeature.h
@@ -153,7 +153,7 @@ public:
 
     static bool isElementMappingDisabled(App::PropertyContainer *container);
 
-    bool getCameraAlignmentDirection(Base::Vector3d &direction, const char *subname) const override;
+    bool getCameraAlignmentDirection(Base::Vector3d &directionZ, Base::Vector3d &directionX, const char *subname) const override;
 
     static void guessNewLink(std::string &replacementName, DocumentObject *base, const char *oldLink);
 


### PR DESCRIPTION
As mentioned in #20088, this PR implements the use of the longest straight edge in a face for horizontal or vertical alignment when using the align to selection tool.