### PR TITLE
Base: Initialize tp_versions_used in PyTypeObject (3.13)

### DIFF
--- a/src/Base/PyObjectBase.cpp
+++ b/src/Base/PyObjectBase.cpp
@@ -169,7 +169,9 @@ static PyTypeObject PyBaseProxyType = {
 #if PY_VERSION_HEX >= 0x030c0000
     ,0                                                      /*tp_watched */
 #endif
-
+#if PY_VERSION_HEX >= 0x030d0000
+    ,0                                                      /*tp_versions_used*/
+#endif
 };
 
 PyTypeObject PyObjectBase::Type = {
@@ -227,6 +229,9 @@ PyTypeObject PyObjectBase::Type = {
     ,0                                            //NOLINT  /*tp_vectorcall */
 #if PY_VERSION_HEX >= 0x030c0000
     ,0                                                      /*tp_watched */
+#endif
+#if PY_VERSION_HEX >= 0x030d0000
+    ,0                                                      /*tp_versions_used*/
 #endif
 };
 


### PR DESCRIPTION
This field is undocumented at https://docs.python.org/3.13/extending/newtypes.html, but exists in the source code for 3.13 (see https://github.com/python/cpython/blob/3.13/Include/cpython/object.h#L232) and gives a compiler warning if left uninitialized.