### PR TITLE
Base: Eliminate use of deprecated PyWeakref_GetObject

### DIFF
--- a/src/Base/PyObjectBase.cpp
+++ b/src/Base/PyObjectBase.cpp
@@ -259,7 +259,16 @@ PyObject* createWeakRef(PyObjectBase* ptr)
 PyObjectBase* getFromWeakRef(PyObject* ref)
 {
     if (ref) {
+#if PY_VERSION_HEX >= 0x030d0000
+        ::PyObject* proxy;
+        int returnCode = PyWeakref_GetRef(ref, &proxy);
+        if (returnCode != 1) {
+            return nullptr;
+        }
+        Py_DECREF(proxy);
+#else
         PyObject* proxy = PyWeakref_GetObject(ref);
+#endif
         if (proxy && PyObject_TypeCheck(proxy, &PyBaseProxyType)) {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             return static_cast<PyObjectBase*>(reinterpret_cast<PyBaseProxy*>(proxy)->baseobject);


### PR DESCRIPTION
Deprecated in Py 3.13 (slated for removal in Py 3.15).