### PR TITLE
Part: Remove `Py_UNICODE` usage from `Part.makeWireString` and `FT2FC`.

### DIFF
--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -1981,7 +1981,7 @@ private:
         double height;
         double track = 0;
 
-        Py_UNICODE *unichars = nullptr;
+        Py_UCS4 *unichars = nullptr;
         Py_ssize_t pysize;
 
         PyObject *CharList;
@@ -2014,28 +2014,11 @@ private:
             }
 
             pysize = PyUnicode_GetLength(p);
-
-#ifdef FC_OS_WIN32
-            //PyUNICODE is only 16 bits on Windows (wchar_t), so passing 32 bit UCS4
-            //will result in unknown glyph in even positions, and wrong characters in
-            //odd positions.
-            unichars = (Py_UNICODE*)PyUnicode_AsWideCharString(p, &pysize);
-#else
-            unichars = (Py_UNICODE *)PyUnicode_AsUCS4Copy(p);
-#endif
+            unichars = PyUnicode_AsUCS4Copy(p);
         }
         else if (PyUnicode_Check(intext)) {
             pysize = PyUnicode_GetLength(intext);
-
-
-#ifdef FC_OS_WIN32
-            //PyUNICODE is only 16 bits on Windows (wchar_t), so passing 32 bit UCS4
-            //will result in unknown glyph in even positions, and wrong characters in
-            //odd positions.
-            unichars = (Py_UNICODE*)PyUnicode_AsWideCharString(intext, &pysize);
-#else
-            unichars = (Py_UNICODE *)PyUnicode_AsUCS4Copy(intext);
-#endif
+            unichars = PyUnicode_AsUCS4Copy(intext);
         }
         else {
             throw Py::TypeError("** makeWireString bad text parameter");

--- a/src/Mod/Part/App/FT2FC.cpp
+++ b/src/Mod/Part/App/FT2FC.cpp
@@ -76,16 +76,14 @@
 
 using namespace Part;
 
-using UNICHAR = unsigned long;           // ul is FT2's codepoint type <=> Py_UNICODE2/4
-
 // Private function prototypes
-PyObject* getGlyphContours(FT_Face FTFace, UNICHAR currchar, double PenPos, double Scale,int charNum, double tracking);
-FT_Vector getKerning(FT_Face FTFace, UNICHAR lc, UNICHAR rc);
+PyObject* getGlyphContours(FT_Face FTFace, FT_ULong currchar, double PenPos, double Scale,int charNum, double tracking);
+FT_Vector getKerning(FT_Face FTFace, FT_ULong lc, FT_ULong rc);
 TopoDS_Wire edgesToWire(std::vector<TopoDS_Edge> Edges);
 int calcClockDir(std::vector<Base::Vector3d> points);
 
 // for compatibility with old version - separate path & filename
-PyObject* FT2FC(const Py_UNICODE *PyUString,
+PyObject* FT2FC(const Py_UCS4 *PyUString,
                 const size_t length,
                 const char *FontPath,
                 const char *FontName,
@@ -99,7 +97,7 @@ PyObject* FT2FC(const Py_UNICODE *PyUString,
 }
 
 // get string's wires (contours) in FC/OCC coords
-PyObject* FT2FC(const Py_UNICODE *PyUString,
+PyObject* FT2FC(const Py_UCS4 *PyUString,
                 const size_t length,
                 const char *FontSpec,
                 const double stringheight,                 // fc coords
@@ -114,7 +112,7 @@ PyObject* FT2FC(const Py_UNICODE *PyUString,
 
     std::stringstream ErrorMsg;
     double PenPos = 0, scalefactor;
-    UNICHAR prevchar = 0, currchar = 0;
+    FT_ULong prevchar = 0, currchar = 0;
     int  cadv;
     size_t i;
     Py::List CharList;
@@ -215,7 +213,7 @@ struct FTDC_Ctx {
   std::vector<int> wDir;
   std::vector<TopoDS_Edge> Edges;
   std::vector<Base::Vector3d> polyPoints;
-  UNICHAR currchar;
+  FT_ULong currchar;
   FT_Vector LastVert;
   Handle(Geom_Surface) surf;
 };
@@ -321,7 +319,7 @@ static FT_Outline_Funcs FTcbFuncs = {
 
 //********** FT2FC Helpers
 // get glyph outline in wires
-PyObject* getGlyphContours(FT_Face FTFace, UNICHAR currchar, double PenPos, double Scale, int charNum, double tracking) {
+PyObject* getGlyphContours(FT_Face FTFace, FT_ULong currchar, double PenPos, double Scale, int charNum, double tracking) {
    FT_Error error = 0;
    std::stringstream ErrorMsg;
    gp_Pnt origin = gp_Pnt(0.0,0.0,0.0);
@@ -393,7 +391,7 @@ PyObject* getGlyphContours(FT_Face FTFace, UNICHAR currchar, double PenPos, doub
 
 // get kerning values for this char pair
 //TODO: should check FT_HASKERNING flag? returns (0,0) if no kerning?
-FT_Vector getKerning(FT_Face FTFace, UNICHAR lc, UNICHAR rc) {
+FT_Vector getKerning(FT_Face FTFace, FT_ULong lc, FT_ULong rc) {
    FT_Vector retXY;
    FT_Error error;
    std::stringstream ErrorMsg;

--- a/src/Mod/Part/App/FT2FC.h
+++ b/src/Mod/Part/App/FT2FC.h
@@ -30,14 +30,14 @@
 #ifndef FT2FC_H
 #define FT2FC_H
 // public functions
-PyObject* FT2FC(const Py_UNICODE *unichars,
+PyObject* FT2FC(const Py_UCS4 *unichars,
                 const size_t length,
                 const char *FontPath,
                 const char *FontName,
                 const double stringheight,
                 const double tracking);
 
-PyObject* FT2FC(const Py_UNICODE *unichars,
+PyObject* FT2FC(const Py_UCS4 *unichars,
                 const size_t length,
                 const char *FontSpec,
                 const double stringheight,


### PR DESCRIPTION
Deprecated in Py 3.13 and slated for removal in Py 3.15. See also [PEP 623](https://peps.python.org/pep-0623/).