### PR TITLE
GUI: Eliminate implicit capture of this via =

### DIFF
--- a/src/Gui/TaskCSysDragger.cpp
+++ b/src/Gui/TaskCSysDragger.cpp
@@ -264,7 +264,7 @@ void TaskTransform::setupGui()
         connect(rotationSpinBox,
                 qOverload<double>(&QuantitySpinBox::valueChanged),
                 this,
-                [=](double) {
+                [this,rotationSpinBox](double) {
                     onRotationChange(rotationSpinBox);
                 });
     }


### PR DESCRIPTION
Per clang: "implicit capture of 'this' with a capture default of '=' is deprecated"