### PR TITLE
PD: Eliminate unused variable in FeatureHole

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -2168,9 +2168,7 @@ TopoShape Hole::findHoles(std::vector<TopoShape> &holes,
 {
     TopoShape result(0);
 
-    int i = 0;
     for(const auto &profileEdge : profileshape.getSubTopoShapes(TopAbs_EDGE)) {
-        ++i;
         Standard_Real c_start;
         Standard_Real c_end;
         TopoDS_Edge edge = TopoDS::Edge(profileEdge.getShape());


### PR DESCRIPTION
I looked around to see if there was any indication that this counter was actually needed and not being used by accident, but I didn't see anything obvious. More pairs of eyes would be appreciated.