### PR TITLE
FEM: myStudyId not needed when SMESH >= 9

### DIFF
--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -88,7 +88,9 @@ TYPESYSTEM_SOURCE(Fem::FemMesh, Base::Persistence)
 
 FemMesh::FemMesh()
     : myMesh(nullptr)
+#if SMESH_VERSION_MAJOR < 9
     , myStudyId(0)
+#endif
 {
 #if SMESH_VERSION_MAJOR >= 9
     myMesh = getGenerator()->CreateMesh(false);
@@ -99,7 +101,9 @@ FemMesh::FemMesh()
 
 FemMesh::FemMesh(const FemMesh& mesh)
     : myMesh(nullptr)
+#if SMESH_VERSION_MAJOR < 9
     , myStudyId(0)
+#endif
 {
 #if SMESH_VERSION_MAJOR >= 9
     myMesh = getGenerator()->CreateMesh(false);

--- a/src/Mod/Fem/App/FemMesh.h
+++ b/src/Mod/Fem/App/FemMesh.h
@@ -224,7 +224,9 @@ private:
     /// positioning matrix
     Base::Matrix4D _Mtrx;
     SMESH_Mesh* myMesh;
+#if SMESH_VERSION_MAJOR < 9
     const int myStudyId;
+#endif
 
     std::list<SMESH_HypothesisPtr> hypoth;
     static SMESH_Gen* _mesh_gen;


### PR DESCRIPTION
Put guards not just around its use, but also its creation. Alternate solution would be to annotate it as `[[maybe_unused]]`, but my feeling is that would make it "sticky" and we'd tend not to remove it later on when it was truly unneeded. This way a search for the appropriate SMESH version check will lead to its eventual elimination. I'm happy to code this the other way if preferred.