### PR TITLE
Fem: Remove unused variables in FemPost*

### DIFF
--- a/src/Mod/Fem/App/FemPostBranchFilter.h
+++ b/src/Mod/Fem/App/FemPostBranchFilter.h
@@ -64,7 +64,6 @@ protected:
 private:
     static const char* OutputEnums[];
 
-    bool m_transform_used = false;
     void setupPipeline();
 
     vtkSmartPointer<vtkAppendFilter> m_append;

--- a/src/Mod/Fem/App/FemPostPipeline.h
+++ b/src/Mod/Fem/App/FemPostPipeline.h
@@ -133,7 +133,6 @@ private:
 
     bool m_block_property = false;
     bool m_data_updated = false;
-    bool m_use_transform = false;
     void updateData();
 
 


### PR DESCRIPTION
This unused variable is a little concerning because there's a pattern here that seems suspicious: the base class also has a private variable with this name and type, and a spot check indicates that other derived classes do as well. @marioalexis84 do you know what's going on here? This strikes me as an unusual design.