### PR TITLE
Gui: Check return value from getDetail()

### DIFF
--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -1534,8 +1534,9 @@ bool LinkView::linkGetDetailPath(const char *subname, SoFullPath *path, SoDetail
             return true;
 
         if(info.isLinked()) {
-            info.linkInfo->getDetail(false,childType,subname,det,path);
-            return true;
+            if (info.linkInfo->getDetail(false,childType,subname,det,path)) {
+                return true;
+            }
         }
     }
     if(isLinked()) {


### PR DESCRIPTION
Coverity issue 251377. Every other use of this method follows this idiom, update the last call to match. It is unlikely to matter since it is itself protected by a call to `isLinked()`, but for the sake of consistency I propose we update.