### PR TITLE
App: Prevent exceptions in destructors

### DIFF
--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -3731,7 +3731,11 @@ PropertyXLink::PropertyXLink(bool _allowPartial, PropertyLinkBase* parent)
 
 PropertyXLink::~PropertyXLink()
 {
-    unlink();
+    try {
+        unlink();
+    } catch (std::bad_weak_ptr &) {
+        FC_WARN("Bad pointer exception caught when destroying PropertyXLink\n");
+    }
 }
 
 void PropertyXLink::setSyncSubObject(bool enable)

--- a/src/App/PropertyPythonObject.cpp
+++ b/src/App/PropertyPythonObject.cpp
@@ -48,7 +48,11 @@ PropertyPythonObject::~PropertyPythonObject()
     // this is needed because the release of the pickled object may need the
     // GIL. Thus, we grab the GIL and replace the pickled with an empty object
     Base::PyGILStateLocker lock;
-    this->object = Py::Object();
+    try {
+        this->object = Py::Object();
+    } catch (Py::TypeError &) {
+        Base::Console().Warning("Py::TypeError Exception caught while destroying PropertyPythonObject\n");
+    }
 }
 
 void PropertyPythonObject::setValue(const Py::Object& py)


### PR DESCRIPTION
Coverity issues 251332 and 356538. These destructors call methods that could throw exceptions. Catch them and convert to console print statements to prevent calls to `terminate()`. An argument could be made that actually calling `terminate()` would be fine here since these exceptions should be basically impossible to hit, but I think it's best to at least attempt to recover gracefully from whatever terrible thing has happened.