### PR TITLE
[CAM] fix estlcam postprocessor file saving issues

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
@@ -327,10 +327,11 @@ def export(objectslist, filename, argstring):
 
     print("Done postprocessing.")
 
-    # write the file
-    gfile = pyopen(filename, "w")
-    gfile.write(final)
-    gfile.close()
+    if filename != "-":
+        with pyopen(filename, "w") as gfile:
+            gfile.write(final)
+
+    return final
 
 
 def linenumber():


### PR DESCRIPTION

Fix estlcam postprocessor file handling and return value. Depending on system (Win/MacOS) it was crashing on file write in different places.

Reported bug: https://github.com/FreeCAD/FreeCAD/issues/20323