### PR TITLE
Fem: Add method to rename pipeline VTK data arrays

### DIFF
--- a/src/Mod/Fem/App/FemPostPipeline.h
+++ b/src/Mod/Fem/App/FemPostPipeline.h
@@ -98,6 +98,7 @@ public:
               Base::Unit unit,
               std::string& frame_type);
     void scale(double s);
+    void renameArrays(const std::map<std::string, std::string>& names);
 
     // load from results
     void load(FemResultObject* res);

--- a/src/Mod/Fem/App/FemPostPipelinePy.xml
+++ b/src/Mod/Fem/App/FemPostPipelinePy.xml
@@ -66,5 +66,10 @@ Load a single result object or create a multiframe result by loading multiple re
                 <UserDocu>Check if this pipeline holds a given post-processing object</UserDocu>
             </Documentation>
         </Methode>
+        <Methode Name="renameArrays">
+            <Documentation>
+                <UserDocu>Change name of data arrays</UserDocu>
+            </Documentation>
+        </Methode>
     </PythonExport>
 </GenerateModel>

--- a/src/Mod/Fem/App/FemPostPipelinePyImp.cpp
+++ b/src/Mod/Fem/App/FemPostPipelinePyImp.cpp
@@ -285,6 +285,28 @@ PyObject* FemPostPipelinePy::holdsPostObject(PyObject* args)
     return Py_BuildValue("O", (ok ? Py_True : Py_False));
 }
 
+PyObject* FemPostPipelinePy::renameArrays(PyObject* args)
+{
+    PyObject* pyObj;
+    if (!PyArg_ParseTuple(args, "O!", &(PyDict_Type), &pyObj)) {
+        return nullptr;
+    }
+
+    Py::Dict pyNames {pyObj};
+    std::map<std::string, std::string> names {};
+    for (auto&& [key, value] : pyNames) {
+        if (!key.isString() || !value.isString()) {
+            PyErr_SetString(PyExc_TypeError, "Names must be string objects");
+            return nullptr;
+        }
+        names.emplace(key.as_string(), static_cast<Py::Object>(value).as_string());
+    }
+
+    getFemPostPipelinePtr()->renameArrays(names);
+
+    Py_Return;
+}
+
 PyObject* FemPostPipelinePy::getCustomAttributes(const char* /*attr*/) const
 {
     return nullptr;


### PR DESCRIPTION
Add function to rename pipeline fields,
Use case: Since it is now possible to load `.vtm` files created from `.frd` CalculiX result files, this function is useful for assigning a more meaningful name to fields:
`pipeline.renameArrays({"T":"Temperature", "FLUX": "Heat Flux"})`

@FEA-eng