### PR TITLE
TechDraw: Section task: Fix spinbox

### DIFF
--- a/src/Mod/TechDraw/Gui/Widgets/CompassWidget.cpp
+++ b/src/Mod/TechDraw/Gui/Widgets/CompassWidget.cpp
@@ -68,16 +68,10 @@ bool CompassWidget::eventFilter(QObject* target, QEvent* event)
     if (target == dsbAngle) {
         if (event->type() == QEvent::KeyPress) {
             QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
-            if (keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter) {
-                dsbAngle->interpretText();
-                slotSpinBoxEnter(dsbAngle->rawValue());
+            const auto isEnter = keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter;
+            if (dsbAngle->isNormalized() && isEnter) {
                 return true;
             }
-        }
-        else if (event->type() == QEvent::FocusOut) {
-            dsbAngle->interpretText();
-            slotSpinBoxEnter(dsbAngle->rawValue());
-            return true;
         }
     }
     return QWidget::eventFilter(target, event);

--- a/src/Mod/TechDraw/Gui/Widgets/CompassWidget.cpp
+++ b/src/Mod/TechDraw/Gui/Widgets/CompassWidget.cpp
@@ -69,7 +69,7 @@ bool CompassWidget::eventFilter(QObject* target, QEvent* event)
         if (event->type() == QEvent::KeyPress) {
             QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
             const auto isEnter = keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter;
-            if (dsbAngle->isNormalized() && isEnter) {
+            if (isEnter && dsbAngle->isNormalized()) {
                 return true;
             }
         }

--- a/src/Mod/TechDraw/Gui/Widgets/CompassWidget.cpp
+++ b/src/Mod/TechDraw/Gui/Widgets/CompassWidget.cpp
@@ -133,15 +133,8 @@ void CompassWidget::buildWidget()
     dsbAngle = new Gui::QuantitySpinBox(this);
     dsbAngle->setObjectName(QStringLiteral("dsbAngle"));
     dsbAngle->setUnit(Base::Unit::Angle);
-    sizePolicy2.setHeightForWidth(dsbAngle->sizePolicy().hasHeightForWidth());
-    dsbAngle->setSizePolicy(sizePolicy2);
-    dsbAngle->setMinimumSize(QSize(75, 26));
-    dsbAngle->setMouseTracking(true);
-    dsbAngle->setFocusPolicy(Qt::ClickFocus);
-    dsbAngle->setAlignment(Qt::AlignRight | Qt::AlignTrailing | Qt::AlignVCenter);
-    dsbAngle->setKeyboardTracking(false);
-    dsbAngle->setMaximum(360.000000000000000);
-    dsbAngle->setMinimum(-360.000000000000000);
+    connect(dsbAngle, QOverload<double>::of(&Gui::QuantitySpinBox::valueChanged),
+        this, &CompassWidget::slotSpinBoxEnter);
 
     compassControlLayout->addWidget(dsbAngle);
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/20412

by removing the `setKeyboardTracking` as it does not look like it's really of any use
Also removes custom formating of the spinbox. Better use same formating accross the application.
Also removes min/max: they bring nothing. Why prevent user from inputing 423 ? He may have done a calculation that gives him this amount and don't want to modulus it.

Add connection so that changing the spinbox value updates the widget directly. Note it does not update the view since that still needs you to click on update.

@kadet1090 @WandererFan 