### PR TITLE
Update Eigen Requirement

### DIFF
--- a/cMake/FindEigen3.cmake
+++ b/cMake/FindEigen3.cmake
@@ -1,8 +1,8 @@
 # - Try to find Eigen3 lib
 #
 # This module supports requiring a minimum version, e.g. you can do
-#   find_package(Eigen3 3.1.2)
-# to require version 3.1.2 or newer of Eigen3.
+#   find_package(Eigen3 3.4.0)
+# to require version 3.4.0 or newer of Eigen3.
 #
 # Once done this will define
 #
@@ -17,7 +17,7 @@
 
 if(NOT Eigen3_FIND_VERSION)
   set(Eigen3_FIND_VERSION_MAJOR 3)
-  set(Eigen3_FIND_VERSION_MINOR 0)
+  set(Eigen3_FIND_VERSION_MINOR 4)
   set(Eigen3_FIND_VERSION_PATCH 0)
   set(Eigen3_FIND_VERSION "${Eigen3_FIND_VERSION_MAJOR}.${Eigen3_FIND_VERSION_MINOR}.${Eigen3_FIND_VERSION_PATCH}")
 endif(NOT Eigen3_FIND_VERSION)

--- a/cMake/FreeCAD_Helpers/SetupEigen.cmake
+++ b/cMake/FreeCAD_Helpers/SetupEigen.cmake
@@ -11,19 +11,10 @@ macro(SetupEigen)
                 "=================\n")
     endif(NOT EIGEN3_FOUND)
 
-    if (EIGEN3_FOUND AND ${EIGEN3_VERSION} VERSION_LESS "3.3.1")
+    if (EIGEN3_FOUND AND ${EIGEN3_VERSION} VERSION_LESS "3.4.0")
         message(WARNING "Disable module flatmesh because it requires "
-                        "minimum Eigen3 version 3.3.1 but version ${EIGEN3_VERSION} was found")
+                        "minimum Eigen3 version 3.4.0 but version ${EIGEN3_VERSION} was found")
         set (BUILD_FLAT_MESH OFF)
-    endif()
-
-    # Older versions raise the warning -Wdeprecated-copy with clang10/gcc10
-    if (EIGEN3_FOUND AND ${EIGEN3_VERSION} VERSION_LESS "3.3.8")
-        unset(_flag_found CACHE)
-        check_cxx_compiler_flag("-Wno-deprecated-copy" _flag_found)
-        if (_flag_found)
-            set (EIGEN3_NO_DEPRECATED_COPY "-Wno-deprecated-copy")
-        endif ()
     endif()
 
 endmacro(SetupEigen)


### PR DESCRIPTION
ubuntu 22.04 use eigen 3.4. The minimum eigen version is raised to 3.4. Old cmake eigen  code is also removed.