### PR TITLE
Fix doxygen structural warnings

### DIFF
--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Quadrangle_2D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Quadrangle_2D.cpp
@@ -4218,7 +4218,7 @@ bool StdMeshers_Quadrangle_2D::check()
   return isOK;
 }
 
-/*//================================================================================
+//================================================================================
 /*!
  * \brief Finds vertices at the most sharp face corners
  *  \param [in] theFace - the FACE

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -643,7 +643,7 @@ void PropertyData::visitProperties(OffsetBase offsetBase,
 /** \defgroup PropFrame Property framework
     \ingroup APP
     \brief System to access object properties
-\section Introduction
+\section propframe_intro Introduction
 The property framework introduces the ability to access attributes (member variables) of a class by name without
 knowing the class type. It's like the reflection mechanism of Java or C#.
 This ability is introduced by the App::PropertyContainer class and can be used by all derived classes.

--- a/src/Doc/CMakeLists.txt
+++ b/src/Doc/CMakeLists.txt
@@ -31,22 +31,22 @@ if(DOXYGEN_FOUND)
 
     # directory order seems important for correct macro expansion
     # (files containing macros definitions must be parsed before the files using them)
-    SET(DOXYGEN_SOURCE_DIR ${COIN3D_INCLUDE_DIRS}/Inventor/fields/SoSubField.h 
-                           ${CMAKE_SOURCE_DIR}/src/CXX 
-                           ${CMAKE_SOURCE_DIR}/src/3rdParty/zipios++ 
+    SET(DOXYGEN_SOURCE_DIR ${COIN3D_INCLUDE_DIRS}/Inventor/fields/SoSubField.h
+                           ${CMAKE_SOURCE_DIR}/src/3rdParty/PyCXX/CXX
+                           ${CMAKE_SOURCE_DIR}/src/3rdParty/zipios++
                            ${CMAKE_SOURCE_DIR}/src/3rdParty
-                           ${CMAKE_SOURCE_DIR}/src/Build 
-                           ${CMAKE_SOURCE_DIR}/src/Base 
-                           ${CMAKE_BINARY_DIR}/src/Base 
-                           ${CMAKE_SOURCE_DIR}/src/App 
-                           ${CMAKE_BINARY_DIR}/src/App 
-                           ${CMAKE_SOURCE_DIR}/src/Gui 
-                           ${CMAKE_BINARY_DIR}/src/Gui 
+                           ${CMAKE_SOURCE_DIR}/src/Build
+                           ${CMAKE_SOURCE_DIR}/src/Base
+                           ${CMAKE_BINARY_DIR}/src/Base
+                           ${CMAKE_SOURCE_DIR}/src/App
+                           ${CMAKE_BINARY_DIR}/src/App
+                           ${CMAKE_SOURCE_DIR}/src/Gui
+                           ${CMAKE_BINARY_DIR}/src/Gui
                            ${CMAKE_SOURCE_DIR}/src/Mod
                            ${CMAKE_BINARY_DIR}/src/Mod
-                           #${CMAKE_SOURCE_DIR}/src/Main #nothing to document there ATM...
+                           ${CMAKE_SOURCE_DIR}/src/Main #nothing to document there ATM...
                            ${CMAKE_SOURCE_DIR}/src/Doc
-                           ${CMAKE_BINARY_DIR}/src/Doc 
+                           ${CMAKE_BINARY_DIR}/src/Doc
     )
     STRING(REGEX REPLACE ";" " " DOXYGEN_INPUT_LIST "${DOXYGEN_SOURCE_DIR}")
 

--- a/src/Gui/Language/Translator.cpp
+++ b/src/Gui/Language/Translator.cpp
@@ -45,7 +45,7 @@ using namespace Gui;
  * The internationalization of FreeCAD makes heavy use of the internationalization
  * support of Qt. For more details refer to your Qt documentation.
  *
- * \section stepbystep Step by step
+ * \section stepbystep_language Step by step
  * To integrate a new language into FreeCAD or one of its application modules
  * you have to perform the following steps:
  *

--- a/src/Mod/CAM/App/ParamsHelper.h
+++ b/src/Mod/CAM/App/ParamsHelper.h
@@ -27,7 +27,7 @@
  * \ingroup PATH
  * Collections of macros for managing groups of parameters.
  *
- * \section Motivation
+ * \section motivation_groups_params Motivation
  *
  * For an application like FreeCAD, there are often cases where the same set of
  * parameters are referred in dozons of different places. The macros here is
@@ -61,7 +61,7 @@
  *     <your_build_dir>/src/Mod/CAM/App.CMakeFiles/Path.dir/Area.cpp.i
  * \endcode
  *
- * \section Introduction of Boost.Preprocessor
+ * \section intro_boost_preproc Introduction of Boost.Preprocessor
  *
  * The macros here make heavy use of the awesome
  * [Boost.Preprocessor](http://www.boost.org/libs/preprocessor/) (short for
@@ -1017,6 +1017,7 @@
  *      if(name1.isTouched()) return 1;
  *      if(name2.isTouched()) return 1;
  *      ...
+ * \endcode
  * \ingroup ParamProperty
  */
 #define PARAM_PROP_TOUCHED(_seq) PARAM_FOREACH(PARAM_PROP_TOUCHED_, _seq)

--- a/src/Mod/Fem/feminout/convert2TetGen.py
+++ b/src/Mod/Fem/feminout/convert2TetGen.py
@@ -40,9 +40,6 @@ if FreeCAD.GuiUp:
 
     Gui = FreeCADGui  # shortcut
 
-## \addtogroup FEM
-#  @{
-
 
 def exportMeshToTetGenPoly(meshToExport, filePath, beVerbose=1):
     """Export mesh to TetGen *.poly file format"""

--- a/src/Mod/Fem/femsolver/fenics/fenics_tools.py
+++ b/src/Mod/Fem/femsolver/fenics/fenics_tools.py
@@ -257,6 +257,3 @@ class FacetFunctionFromXDMF:
 
     # TODO: write some functions to return integrals for Neumann and Robin
     # boundary conditions for the general case (i.e. vector, tensor)
-
-
-##  @}

--- a/src/Mod/Fem/femsolver/mystran/solver.py
+++ b/src/Mod/Fem/femsolver/mystran/solver.py
@@ -92,6 +92,3 @@ class ViewProxy(solverbase.ViewProxy):
 
     def getIcon(self):
         return ":/icons/FEM_SolverMystran.svg"
-
-
-##  @}

--- a/src/Mod/Fem/femsolver/z88/solver.py
+++ b/src/Mod/Fem/femsolver/z88/solver.py
@@ -111,6 +111,3 @@ class ViewProxy(solverbase.ViewProxy):
 
     def getIcon(self):
         return ":/icons/FEM_SolverZ88.svg"
-
-
-##  @}

--- a/src/Mod/Robot/App/kdl_cp/kdl.hpp
+++ b/src/Mod/Robot/App/kdl_cp/kdl.hpp
@@ -30,7 +30,7 @@
  * href="http://www.orocos.org">Orocos</a>, but that can be used
  * independently of Orocos. KDL offers different kinds of
  * functionality, grouped in the following  Modules:
- * - \subpage geomprim
+ * - \ref geomprim
  * - \ref KinematicFamily : functionality to build kinematic chains and access their kinematic and dynamic properties, such as e.g. Forward and Inverse kinematics and dynamics.
  * - \ref Motion : functionality to specify motion trajectories of frames and kinematic chains, such as e.g. Trapezoidal Velocity profiles.
  *
@@ -38,7 +38,7 @@
 **/
 /**
  * \page geomprim Geometric Primitives
- * \section Introduction 
+ * \section kdl_geometric_prims Introduction 
  * Geometric primitives are represented by the following classes.
  * - KDL::Vector
  * - KDL::Rotation


### PR DESCRIPTION
Closes https://github.com/FreeCAD/FreeCAD/issues/20366

All listed problems are solved with this PR with the exception of

```
Preprocessing freecad-main/src/3rdParty/json/single_include/nlohmann/json.hpp:24029: warning: unbalanced grouping commands
freecad-main/src/3rdParty/json/single_include/nlohmann/json.hpp:24176: warning: unbalanced grouping commands
```

This one is solved by using a configuration file that matches the Doxygen version, see https://github.com/FreeCAD/FreeCAD/issues/20365.