### PR TITLE
Draft: Update checked state of grid button when switching the grid

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -43,6 +43,7 @@ import FreeCADGui
 import Draft
 import DraftVecUtils
 from FreeCAD import Vector
+from draftutils import grid_observer
 from draftutils import gui_utils
 from draftutils import params
 from draftutils import utils
@@ -1349,6 +1350,16 @@ class gridTracker(Tracker):
         self.displayHumanFigure(wp)
         self.setAxesColor(wp)
         self.on()
+
+    def on(self):
+        """Set the visibility to True and update the checked state grid button."""
+        super().on()
+        grid_observer._update_grid_gui()
+
+    def off(self):
+        """Set the visibility to False and update the checked state grid button."""
+        super().off()
+        grid_observer._update_grid_gui()
 
     def getClosestNode(self, point):
         """Return the closest node from the given point."""

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -1352,12 +1352,12 @@ class gridTracker(Tracker):
         self.on()
 
     def on(self):
-        """Set the visibility to True and update the checked state grid button."""
+        """Set the visibility to True and update the checked state of the grid button."""
         super().on()
         grid_observer._update_grid_gui()
 
     def off(self):
-        """Set the visibility to False and update the checked state grid button."""
+        """Set the visibility to False and update the checked state of the grid button."""
         super().off()
         grid_observer._update_grid_gui()
 


### PR DESCRIPTION
The checked state of the grid button was not updated when the grid was only displayed during Draft commands.
