### PR TITLE
Coverity fixes: three medium-priority destructor exceptions

### DIFF
--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -261,27 +261,40 @@ ViewProviderFemPostObject::ViewProviderFemPostObject()
 
 ViewProviderFemPostObject::~ViewProviderFemPostObject()
 {
-    FemPostObjectSelectionObserver::instance().unregisterFemPostObject(this);
-    m_transpType->unref();
-    m_depthBuffer->unref();
-    m_shapeHints->unref();
-    m_coordinates->unref();
-    m_materialBinding->unref();
-    m_drawStyle->unref();
-    m_normalBinding->unref();
-    m_normals->unref();
-    m_faces->unref();
-    m_triangleStrips->unref();
-    m_markers->unref();
-    m_lines->unref();
-    m_sepMarkerLine->unref();
-    m_separator->unref();
-    m_material->unref();
-    m_matPlainEdges->unref();
-    m_switchMatEdges->unref();
-    deleteColorBar();
-    m_colorStyle->unref();
-    m_colorRoot->unref();
+    try {
+        FemPostObjectSelectionObserver::instance().unregisterFemPostObject(this);
+        m_transpType->unref();
+        m_depthBuffer->unref();
+        m_shapeHints->unref();
+        m_coordinates->unref();
+        m_materialBinding->unref();
+        m_drawStyle->unref();
+        m_normalBinding->unref();
+        m_normals->unref();
+        m_faces->unref();
+        m_triangleStrips->unref();
+        m_markers->unref();
+        m_lines->unref();
+        m_sepMarkerLine->unref();
+        m_separator->unref();
+        m_material->unref();
+        m_matPlainEdges->unref();
+        m_switchMatEdges->unref();
+        m_colorStyle->unref();
+        m_colorRoot->unref();
+        deleteColorBar();
+    }
+    catch (Base::Exception& e) {
+        Base::Console().DestructorError(
+            "ViewProviderFemPostObject",
+            "ViewProviderFemPostObject destructor threw an exception: %s\n",
+            e.what());
+    }
+    catch (...) {
+        Base::Console().DestructorError(
+            "ViewProviderFemPostObject",
+            "ViewProviderFemPostObject destructor threw an unknown exception");
+    }
 }
 
 void ViewProviderFemPostObject::deleteColorBar()

--- a/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
+++ b/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
@@ -111,13 +111,26 @@ ViewProviderInspection::ViewProviderInspection()
 
 ViewProviderInspection::~ViewProviderInspection()
 {
-    pcColorRoot->unref();
-    pcCoords->unref();
-    pcMatBinding->unref();
-    pcColorMat->unref();
-    deleteColorBar();
-    pcLinkRoot->unref();
-    pcPointStyle->unref();
+    try {
+        pcColorRoot->unref();
+        pcCoords->unref();
+        pcMatBinding->unref();
+        pcColorMat->unref();
+        pcLinkRoot->unref();
+        pcPointStyle->unref();
+        deleteColorBar();
+    }
+    catch (Base::Exception& e) {
+        Base::Console().DestructorError(
+            "ViewProviderInspection",
+            "ViewProviderInspection::deleteColorBar() threw an exception: %s\n",
+            e.what());
+    }
+    catch (...) {
+        Base::Console().DestructorError(
+            "ViewProviderInspection",
+            "ViewProviderInspection destructor threw an unknown exception");
+    }
 }
 
 void ViewProviderInspection::onChanged(const App::Property* prop)

--- a/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
@@ -126,10 +126,23 @@ ViewProviderMeshCurvature::ViewProviderMeshCurvature()
 
 ViewProviderMeshCurvature::~ViewProviderMeshCurvature()
 {
-    pcColorRoot->unref();
-    pcColorMat->unref();
-    deleteColorBar();
-    pcLinkRoot->unref();
+    try {
+        pcColorRoot->unref();
+        pcColorMat->unref();
+        pcLinkRoot->unref();
+        deleteColorBar();
+    }
+    catch (Base::Exception& e) {
+        Base::Console().DestructorError(
+            "ViewProviderMeshCurvature",
+            "ViewProviderMeshCurvature::deleteColorBar() threw an exception: %s\n",
+            e.what());
+    }
+    catch (...) {
+        Base::Console().DestructorError(
+            "ViewProviderInspection",
+            "ViewProviderInspection destructor threw an unknown exception");
+    }
 }
 
 void ViewProviderMeshCurvature::onChanged(const App::Property* prop)


### PR DESCRIPTION
Coverity flags destructors that call methods that can throw exceptions. In these three cases, while unlikely, it is at least sort of possible that is true. To resolve this without simply swallowing all of the exceptions invisibly, this PR introduces a new console output statement that is `noexcept` -- that method will `abort()` (via `assert`) in debug mode, but silently fail in release. This can be used to safely print to the console in a destructor.