### PR TITLE
Automatically switch to the edge selection mode when creating a surface

### DIFF
--- a/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
+++ b/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
@@ -338,6 +338,11 @@ void GeomFillSurface::open()
     checkOpenCommand();
     this->vp->highlightReferences(true);
     Gui::Selection().clearSelection();
+
+    // if the surface is not yet created then automatically start "AppendEdge" mode
+    if (editedObject->Shape.getShape().isNull()) {
+        ui->buttonEdgeAdd->setChecked(true);
+    }
 }
 
 void GeomFillSurface::clearSelection()

--- a/src/Mod/Surface/Gui/TaskSections.cpp
+++ b/src/Mod/Surface/Gui/TaskSections.cpp
@@ -368,6 +368,11 @@ void SectionsPanel::open()
                                   true);
 
     Gui::Selection().clearSelection();
+
+    // if the surface is not yet created then automatically start "AppendEdge" mode
+    if (editedObject->Shape.getShape().isNull()) {
+        ui->buttonEdgeAdd->setChecked(true);
+    }
 }
 
 void SectionsPanel::clearSelection()


### PR DESCRIPTION
Small convenience change to "Fill boundary curves" and "Sections" surface tools. 
This PR make em behave same as Filling tool. After activating tool no need to click on "Add edge" button - you can select edges strait away. When open existing surface for edit - selection mode disabled as before the change, so it affect only initial tool activation.