### PR TITLE
GUI: Fix Toggle Freeze Behavior

### DIFF
--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -185,6 +185,14 @@ void StdCmdToggleFreeze::activated(int iMsg)
             obj->unfreeze();
             for (auto child : obj->getInListRecursive())
                 child->unfreeze();
+            if (obj->isDerivedFrom(Base::Type::fromName("PartDesign::Body"))) {
+                for (auto child : obj->getOutListRecursive())
+                    child->unfreeze();
+            }
+            else {
+                for (auto child : obj->getOutList())
+                    child->unfreeze();
+            }
         } else {
             obj->freeze();
             for (auto parent : obj->getOutListRecursive())


### PR DESCRIPTION
Previously, the `StdCmdToggleFreeze` command only unfroze objects using `getInListRecursive()`, meaning that unfreezing an element would only affect itself or the elements that contained it.
This caused issues when using Toggle Freeze for a Body object, as it made it difficult to identify all frozen elements in a project, and the presence of frozen elements prevented the project from being saved.

Cause of the Bug
The unfreeze operation only considered outward dependencies, meaning that elements further down the hierarchy (inward dependencies) were not properly unfrozen.

Fix Implementation
Updated the `StdCmdToggleFreeze` command, so that objects are properly unfrozen when toggling freeze state.


Fix #18806 