### PR TITLE
Avoid using `count` and `std::find` where `contains` and `isEmpty` express intent better

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -865,7 +865,7 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
             // It is possible that the newly opened document depends on an existing
             // document, which will be included with the above call to
             // Document::getDependentDocuments(). Make sure to exclude that.
-            if(!newDocs.count(doc)) {
+            if(!newDocs.contains(doc)) {
                 it = docs.erase(it);
                 continue;
             }
@@ -2352,7 +2352,7 @@ void parseProgramOptions(int ac, char ** av, const std::string& exe, boost::prog
         throw Base::UnknownProgramOption(str.str());
     }
 
-    if (vm.count("help")) {
+    if (vm.contains("help")) {
         std::stringstream str;
         str << exe << '\n' << '\n';
         str << "For a detailed description see https://www.freecad.org/wiki/Start_up_and_Configuration" << '\n'<<'\n';
@@ -2361,7 +2361,7 @@ void parseProgramOptions(int ac, char ** av, const std::string& exe, boost::prog
         throw Base::ProgramInformation(str.str());
     }
 
-    if (vm.count("response-file")) {
+    if (vm.contains("response-file")) {
         // Load the file and tokenize it
         std::ifstream ifs(vm["response-file"].as<std::string>().c_str());
         if (!ifs) {
@@ -2387,14 +2387,14 @@ void parseProgramOptions(int ac, char ** av, const std::string& exe, boost::prog
 
 void processProgramOptions(const boost::program_options::variables_map& vm, std::map<std::string,std::string>& mConfig)
 {
-    if (vm.count("version") && !vm.count("verbose")) {
+    if (vm.contains("version") && !vm.contains("verbose")) {
         std::stringstream str;
         str << mConfig["ExeName"] << " " << mConfig["ExeVersion"]
             << " Revision: " << mConfig["BuildRevision"] << '\n';
         throw Base::ProgramInformation(str.str());
     }
 
-    if (vm.count("module-path")) {
+    if (vm.contains("module-path")) {
         auto  Mods = vm["module-path"].as< std::vector<std::string> >();
         std::string temp;
         for (const auto & It : Mods)
@@ -2403,7 +2403,7 @@ void processProgramOptions(const boost::program_options::variables_map& vm, std:
         mConfig["AdditionalModulePaths"] = temp;
     }
 
-    if (vm.count("macro-path")) {
+    if (vm.contains("macro-path")) {
         std::vector<std::string> Macros = vm["macro-path"].as< std::vector<std::string> >();
         std::string temp;
         for (const auto & It : Macros)
@@ -2412,13 +2412,13 @@ void processProgramOptions(const boost::program_options::variables_map& vm, std:
         mConfig["AdditionalMacroPaths"] = std::move(temp);
     }
 
-    if (vm.count("python-path")) {
+    if (vm.contains("python-path")) {
         auto  Paths = vm["python-path"].as< std::vector<std::string> >();
         for (const auto & It : Paths)
             Base::Interpreter().addPythonPath(It.c_str());
     }
 
-    if (vm.count("disable-addon")) {
+    if (vm.contains("disable-addon")) {
         auto Addons = vm["disable-addon"].as< std::vector<std::string> >();
         std::string temp;
         for (const auto & It : Addons) {
@@ -2428,7 +2428,7 @@ void processProgramOptions(const boost::program_options::variables_map& vm, std:
         mConfig["DisabledAddons"] = temp;
     }
 
-    if (vm.count("input-file")) {
+    if (vm.contains("input-file")) {
         auto  files(vm["input-file"].as< std::vector<std::string> >());
         int OpenFileCount=0;
         for (const auto & It : files) {
@@ -2443,34 +2443,34 @@ void processProgramOptions(const boost::program_options::variables_map& vm, std:
         mConfig["OpenFileCount"] = buffer.str();
     }
 
-    if (vm.count("output")) {
+    if (vm.contains("output")) {
         mConfig["SaveFile"] = vm["output"].as<std::string>();
     }
 
-    if (vm.count("hidden")) {
+    if (vm.contains("hidden")) {
         mConfig["StartHidden"] = "1";
     }
 
-    if (vm.count("write-log")) {
+    if (vm.contains("write-log")) {
         mConfig["LoggingFile"] = "1";
         mConfig["LoggingFileName"] = mConfig["UserAppData"] + mConfig["ExeName"] + ".log";
     }
 
-    if (vm.count("log-file")) {
+    if (vm.contains("log-file")) {
         mConfig["LoggingFile"] = "1";
         mConfig["LoggingFileName"] = vm["log-file"].as<std::string>();
     }
 
-    if (vm.count("user-cfg")) {
+    if (vm.contains("user-cfg")) {
         mConfig["UserParameter"] = vm["user-cfg"].as<std::string>();
     }
 
-    if (vm.count("system-cfg")) {
+    if (vm.contains("system-cfg")) {
         mConfig["SystemParameter"] = vm["system-cfg"].as<std::string>();
     }
 
-    if (vm.count("run-test") || vm.count("run-open")) {
-        std::string testCase = vm.count("run-open") ? vm["run-open"].as<std::string>() : vm["run-test"].as<std::string>();
+    if (vm.contains("run-test") || vm.contains("run-open")) {
+        std::string testCase = vm.contains("run-open") ? vm["run-open"].as<std::string>() : vm["run-test"].as<std::string>();
 
         if ( "0" == testCase) {
             testCase = "TestApp.All";
@@ -2481,14 +2481,14 @@ void processProgramOptions(const boost::program_options::variables_map& vm, std:
         mConfig["TestCase"] = std::move(testCase);
         mConfig["RunMode"] = "Internal";
         mConfig["ScriptFileName"] = "FreeCADTest";
-        mConfig["ExitTests"] = vm.count("run-open") == 0  ? "yes" : "no";
+        mConfig["ExitTests"] = vm.contains("run-open") ? "no" : "yes";
     }
 
-    if (vm.count("single-instance")) {
+    if (vm.contains("single-instance")) {
         mConfig["SingleInstance"] = "1";
     }
 
-    if (vm.count("dump-config")) {
+    if (vm.contains("dump-config")) {
         std::stringstream str;
         for (const auto & it : mConfig) {
             str << it.first << "=" << it.second << '\n';
@@ -2496,7 +2496,7 @@ void processProgramOptions(const boost::program_options::variables_map& vm, std:
         throw Base::ProgramInformation(str.str());
     }
 
-    if (vm.count("get-config")) {
+    if (vm.contains("get-config")) {
         auto configKey = vm["get-config"].as<std::string>();
         std::stringstream str;
         std::map<std::string,std::string>::iterator pos;
@@ -2508,7 +2508,7 @@ void processProgramOptions(const boost::program_options::variables_map& vm, std:
         throw Base::ProgramInformation(str.str());
     }
 
-    if (vm.count("set-config")) {
+    if (vm.contains("set-config")) {
         auto  configKeyValue = vm["set-config"].as< std::vector<std::string> >();
         for (const auto& it : configKeyValue) {
             auto pos = it.find('=');
@@ -2572,7 +2572,7 @@ void Application::initConfig(int argc, char ** argv)
         BOOST_SCOPE_EXIT_ALL(&) {
             // console-mode needs to be set (if possible) also in case parseProgramOptions
             // throws, as it's needed when reporting such exceptions
-            if (vm.count("console")) {
+            if (vm.contains("console")) {
                 mConfig["Console"] = "1";
                 mConfig["RunMode"] = "Cmd";
             }
@@ -2580,14 +2580,14 @@ void Application::initConfig(int argc, char ** argv)
         parseProgramOptions(argc, argv, mConfig["ExeName"], vm);
     }
 
-    if (vm.count("keep-deprecated-paths")) {
+    if (vm.contains("keep-deprecated-paths")) {
         mConfig["KeepDeprecatedPaths"] = "1";
     }
 
     // extract home paths
     ExtractUserPath();
 
-    if (vm.count("safe-mode")) {
+    if (vm.contains("safe-mode")) {
         SafeMode::StartSafeMode();
     }
 
@@ -2654,7 +2654,7 @@ void Application::initConfig(int argc, char ** argv)
         _pConsoleObserverFile = nullptr;
 
     // Banner ===========================================================
-    if (mConfig["RunMode"] != "Cmd" && !(vm.count("verbose") && vm.count("version"))) {
+    if (mConfig["RunMode"] != "Cmd" && !(vm.contains("verbose") && vm.contains("version"))) {
         // Remove banner if FreeCAD is invoked via the -c command as regular
         // Python interpreter
         if (mConfig["Verbose"] != "Strict")
@@ -2766,7 +2766,7 @@ void Application::initConfig(int argc, char ** argv)
 
     logStatus();
 
-    if (vm.count("verbose") && vm.count("version")) {
+    if (vm.contains("verbose") && vm.contains("version")) {
         Application::_pcSingleton = new Application(mConfig);
         throw Base::ProgramInformation(Application::verboseVersionEmitMessage);
     }
@@ -3290,7 +3290,7 @@ std::tuple<QString, QString, QString, QString> getStandardPaths()
 
 void Application::ExtractUserPath()
 {
-    bool keepDeprecatedPaths = mConfig.count("KeepDeprecatedPaths") > 0;
+    bool keepDeprecatedPaths = mConfig.contains("KeepDeprecatedPaths");
 
     // std paths
     mConfig["BinPath"] = mConfig["AppHomePath"] + "bin" + PATHSEP;

--- a/src/App/Branding.cpp
+++ b/src/App/Branding.cpp
@@ -92,7 +92,7 @@ Branding::XmlConfig Branding::getUserDefines() const
         while (!child.isNull()) {
             std::string name = child.localName().toLatin1().constData();
             std::string value = child.text().toUtf8().constData();
-            if (std::ranges::find(filter, name) != filter.end()) {
+            if (filter.contains(name)) {
                 cfg[name] = std::move(value);
             }
             child = child.nextSiblingElement();

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2465,7 +2465,7 @@ bool Document::afterRestore(const std::vector<DocumentObject*>& objArray, bool c
             // partial document touched, signal full reload
             return false;
         }
-        else if (!d->touchedObjs.count(obj)) {
+        else if (!d->touchedObjs.contains(obj)) {
             obj->purgeTouched();
         }
 
@@ -3065,7 +3065,7 @@ int Document::recompute(const std::vector<App::DocumentObject*>& objs,
             for (size_t i = 0; i < topoSortedObjects.size(); ++i) {
                 auto obj = topoSortedObjects[i];
                 obj->setStatus(ObjectStatus::Recompute2, false);
-                if (!filter.count(obj) && obj->isTouched()) {
+                if (!filter.contains(obj) && obj->isTouched()) {
                     if (passes > 0) {
                         FC_ERR(obj->getFullName() << " still touched after recompute");
                     }

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -581,7 +581,7 @@ bool _isInInListRecursive(const DocumentObject* act, const DocumentObject* check
 
 bool DocumentObject::isInInListRecursive(DocumentObject* linkTo) const
 {
-    return this == linkTo || getInListEx(true).count(linkTo);
+    return this == linkTo || getInListEx(true).contains(linkTo);
 }
 
 bool DocumentObject::isInInList(DocumentObject* linkTo) const
@@ -644,7 +644,7 @@ bool DocumentObject::testIfLinkDAGCompatible(const std::vector<DocumentObject*>&
     auto inLists = getInListEx(true);
     inLists.emplace(const_cast<DocumentObject*>(this));
     for (auto obj : linksTo) {
-        if (inLists.count(obj)) {
+        if (inLists.contains(obj)) {
             return false;
         }
     }

--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -256,9 +256,15 @@ bool DynamicProperty::addProperty(Property* prop)
         return false;
     }
     auto& index = props.get<0>();
+#if BOOST_VERSION < 107500
     if (index.count(prop->getName())) {
         return false;
     }
+#else
+    if (index.contains(prop->getName())) {
+        return false;
+    }
+#endif
     index.emplace(prop,
                   std::string(),
                   prop->getName(),

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -997,7 +997,7 @@ ExpressionPtr Expression::importSubNames(const std::map<std::string,std::string>
                 if(it!=nameMap.end())
                     subNameMap.emplace(std::make_pair(obj,std::string()),it->second);
                 auto key = std::make_pair(obj,path.getSubObjectName());
-                if(key.second.empty() || subNameMap.count(key))
+                if(key.second.empty() || subNameMap.contains(key))
                     continue;
                 std::string imported = PropertyLinkBase::tryImportSubName(
                                obj,key.second.c_str(),owner->getDocument(), nameMap);

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -134,7 +134,7 @@ Base::Placement GeoFeatureGroupExtension::recursiveGroupPlacement(
         auto parent = link->getExtensionByType<GeoFeatureGroupExtension>(true);
         if (parent && parent->hasObject(group->getExtendedObject())) {
             // Cyclic dependencies detected
-            if (history.count(parent) > 0) {
+            if (history.contains(parent)) {
                 break;
             }
             return recursiveGroupPlacement(parent, history) * group->placement().getValue();

--- a/src/App/Graphviz.cpp
+++ b/src/App/Graphviz.cpp
@@ -290,7 +290,7 @@ void Document::exportGraphviz(std::ostream& out) const
         {
 
             // don't add objects twice
-            if (std::ranges::find(objects, docObj) != objects.end()) {
+            if (objects.contains(docObj)) {
                 return;
             }
 

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -880,7 +880,7 @@ bool LinkBaseExtension::setupCopyOnChange(
             if (!gname || !boost::starts_with(gname, _GroupPrefix)) {
                 continue;
             }
-            if (!newProps.count(prop)) {
+            if (!newProps.contains(prop)) {
                 parent->removeDynamicProperty(prop->getName());
             }
         }
@@ -1833,7 +1833,7 @@ void LinkBaseExtension::updateGroup()
         }
     }
     for (auto it = plainGroupConns.begin(); it != plainGroupConns.end();) {
-        if (!groupSet.count(it->first)) {
+        if (!groupSet.contains(it->first)) {
             it = plainGroupConns.erase(it);
         }
         else {

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -873,7 +873,7 @@ PropertyExpressionEngine::validateExpression(const ObjectIdentifier& path,
     auto inList = pathDocObj->getInListEx(true);
     for (auto& v : expr->getDepObjects()) {
         auto docObj = v.first;
-        if (!v.second && inList.count(docObj)) {
+        if (!v.second && inList.contains(docObj)) {
             std::stringstream ss;
             ss << "cyclic reference to " << docObj->getFullName();
             return ss.str();
@@ -1008,7 +1008,7 @@ bool PropertyExpressionEngine::adjustLink(const std::set<DocumentObject*>& inLis
     }
     bool found = false;
     for (auto& v : _Deps) {
-        if (inList.count(v.first)) {
+        if (inList.contains(v.first)) {
             found = true;
             break;
         }

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -2107,7 +2107,7 @@ adjustLinkSubs(App::PropertyLinkBase* prop,
                 break;
             }
             if (!newLink) {
-                if (inList.count(sobj)) {
+                if (inList.contains(sobj)) {
                     continue;
                 }
                 newLink = sobj;
@@ -2138,7 +2138,7 @@ bool PropertyLinkSub::adjustLink(const std::set<App::DocumentObject*>& inList)
     if (_pcScope == LinkScope::Hidden) {
         return false;
     }
-    if (!_pcLinkSub || !_pcLinkSub->isAttachedToDocument() || !inList.count(_pcLinkSub)) {
+    if (!_pcLinkSub || !_pcLinkSub->isAttachedToDocument() || !inList.contains(_pcLinkSub)) {
         return false;
     }
     auto subs = _cSubList;
@@ -3229,7 +3229,7 @@ bool PropertyLinkSubList::adjustLink(const std::set<App::DocumentObject*>& inLis
     for (std::string& sub : subs) {
         ++idx;
         auto& link = links[idx];
-        if (!link || !link->isAttachedToDocument() || !inList.count(link)) {
+        if (!link || !link->isAttachedToDocument() || !inList.contains(link)) {
             continue;
         }
         touched = true;
@@ -3240,7 +3240,7 @@ bool PropertyLinkSubList::adjustLink(const std::set<App::DocumentObject*>& inLis
                 pos = std::string::npos;
                 break;
             }
-            if (!inList.count(sobj)) {
+            if (!inList.contains(sobj)) {
                 link = sobj;
                 sub = sub.substr(pos + 1);
                 break;
@@ -4657,7 +4657,7 @@ bool PropertyXLink::adjustLink(const std::set<App::DocumentObject*>& inList)
     if (_pcScope == LinkScope::Hidden) {
         return false;
     }
-    if (!_pcLink || !_pcLink->isAttachedToDocument() || !inList.count(_pcLink)) {
+    if (!_pcLink || !_pcLink->isAttachedToDocument() || !inList.contains(_pcLink)) {
         return false;
     }
     auto subs = _SubList;
@@ -5479,7 +5479,7 @@ bool PropertyXLinkSubList::adjustLink(const std::set<App::DocumentObject*>& inLi
             ++count;
             continue;
         }
-        if (inList.count(obj) && adjustLinkSubs(this, inList, obj, l._SubList, &values)) {
+        if (inList.contains(obj) && adjustLinkSubs(this, inList, obj, l._SubList, &values)) {
             touched = true;
         }
     }

--- a/src/App/Transactions.cpp
+++ b/src/App/Transactions.cpp
@@ -141,7 +141,11 @@ bool Transaction::isEmpty() const
 
 bool Transaction::hasObject(const TransactionalObject* Obj) const
 {
+#if BOOST_VERSION < 107500
     return !!_Objects.get<1>().count(Obj);
+#else
+    return !!_Objects.get<1>().contains(Obj);
+#endif
 }
 
 void Transaction::addOrRemoveProperty(TransactionalObject* Obj, const Property* pcProp, bool add)

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2602,7 +2602,7 @@ App::Document* Application::reopen(App::Document* doc)
         if (name == v.first->FileName.getValue()) {
             doc = const_cast<App::Document*>(v.first);
         }
-        if (untouchedDocs.count(v.second)) {
+        if (untouchedDocs.contains(v.second)) {
             if (!v.second->isModified()) {
                 continue;
             }

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1977,7 +1977,7 @@ const Command* Gui::CommandManager::checkAcceleratorForConflicts(const char* acc
     if (newCombo.isEmpty())
         return nullptr;
     auto newSequence = QKeySequence::fromString(newCombo);
-    if (newSequence.count() == 0)
+    if (newSequence.isEmpty())
         return nullptr;
 
     // Does this command shortcut conflict with other commands already defined?
@@ -1998,7 +1998,7 @@ const Command* Gui::CommandManager::checkAcceleratorForConflicts(const char* acc
         if (existingCombo.isEmpty())
             continue;
         auto existingSequence = QKeySequence::fromString(existingCombo);
-        if (existingSequence.count() == 0)
+        if (existingSequence.isEmpty())
             continue;
 
         // Exact match

--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -403,7 +403,7 @@ static void linkConvert(bool unlink) {
             auto obj = info.obj.getObject();
             if(!parent || !obj || !parentVp)
                 continue;
-            if(!recomputeSet.count(parent))
+            if(!recomputeSet.contains(parent))
                 recomputeSet.emplace(parent,parent);
             auto doc = parent->getDocument();
             App::DocumentObject *replaceObj;

--- a/src/Gui/DAGView/DAGModel.cpp
+++ b/src/Gui/DAGView/DAGModel.cpp
@@ -1096,7 +1096,7 @@ void Model::contextMenuEvent(QGraphicsSceneContextMenuEvent* event)
         contextMenu.addAction(editingFinishedAction);
     }
 
-    if (contextMenu.actions().count() > 0)
+    if (!contextMenu.actions().isEmpty())
         contextMenu.exec(event->screenPos());
   }
 

--- a/src/Gui/Dialogs/DlgObjectSelection.cpp
+++ b/src/Gui/Dialogs/DlgObjectSelection.cpp
@@ -280,7 +280,7 @@ void DlgObjectSelection::setItemState(App::DocumentObject *obj,
     if (ui->checkBoxAutoDeps->isChecked() && state == Qt::Checked) {
         // If an object is newly checked, check all its dependencies
         for (auto o : obj->getOutListRecursive()) {
-            if (!depSet.count(o) || itemChanged.count(o))
+            if (!depSet.contains(o) || itemChanged.contains(o))
                 continue;
             auto itItem = itemMap.find(o);
             if (itItem == itemMap.end() || itItem->second[0]->checkState(0) == state)
@@ -304,7 +304,7 @@ void DlgObjectSelection::setItemState(App::DocumentObject *obj,
         // If an object toggles state, we need to revisit all its in-list
         // object to update the partial/full checked state.
         for (auto o : obj->getInList()) {
-            if (!depSet.count(o) ||itemChanged.count(o))
+            if (!depSet.contains(o) || itemChanged.contains(o))
                 continue;
             auto it = itemMap.find(o);
             if (it == itemMap.end() || it->second[0]->checkState(0) == state)
@@ -312,7 +312,7 @@ void DlgObjectSelection::setItemState(App::DocumentObject *obj,
             int count = 0;
             int selcount = 0;
             for (auto sibling : o->getOutList()) {
-                if (!depSet.count(sibling))
+                if (!depSet.contains(sibling))
                     continue;
                 ++count;
                 auto it = itemMap.find(sibling);
@@ -511,7 +511,7 @@ void DlgObjectSelection::checkItemChanged() {
         std::sort(outlist.begin(), outlist.end());
 
         for (const auto &v : itemMap) {
-            if (itemChanged.count(v.first) == 0 && v.second[0]->checkState(0) == Qt::Unchecked)
+            if (!itemChanged.contains(v.first) && v.second[0]->checkState(0) == Qt::Unchecked)
                 continue;
             if (auto obj = v.first.getObject()) {
                 if (!std::binary_search(outlist.begin(), outlist.end(), obj))
@@ -598,7 +598,7 @@ void DlgObjectSelection::onItemSelectionChanged() {
     for (auto obj : sels)
         obj->getInListEx(inlist, true);
     for (auto it = inlist.begin(); it != inlist.end();) {
-        if (!depSet.count(*it) || std::binary_search(sels.begin(), sels.end(), *it))
+        if (!depSet.contains(*it) || std::binary_search(sels.begin(), sels.end(), *it))
             it = inlist.erase(it);
         else
             ++it;

--- a/src/Gui/Dialogs/DlgOnlineHelpImp.cpp
+++ b/src/Gui/Dialogs/DlgOnlineHelpImp.cpp
@@ -98,7 +98,7 @@ void DlgOnlineHelpImp::changeEvent(QEvent *e)
 void DlgOnlineHelpImp::onLineEditDownloadFileNameSelected( const QString& url )
 {
     QDir dir(url);
-    if (dir.exists() && dir.count() == 0) {
+    if (dir.exists() && dir.isEmpty()) {
         QMessageBox::critical(this, tr("Access denied"), tr("Access denied to '%1'\n\n"
             "Specify another directory, please.").arg(url));
     }

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1047,7 +1047,7 @@ void Document::slotChangedObject(const App::DocumentObject& Obj, const App::Prop
                     && (Prop.isDerivedFrom<App::PropertyPlacement>()
                         // Issue ID 0004230 : getName() can return null in which case strstr() crashes
                         || (Prop.getName() && strstr(Prop.getName(),"Scale")))
-                    && d->_editObjs.count(&Obj))
+                    && d->_editObjs.contains(&Obj))
             {
                 Base::Matrix4D mat;
                 auto sobj = d->_editViewProviderParent->getObject()->getSubObject(
@@ -1294,7 +1294,7 @@ static bool checkCanonicalPath(const std::map<App::Document*, bool> &docs)
         auto &d = paths[info.canonicalFilePath()];
         d.push_back(doc);
         if (!warn && d.size() > 1) {
-            if (docs.count(d.front()) || docs.count(d.back()))
+            if (docs.contains(d.front()) || docs.contains(d.back()))
                 warn = true;
         }
     }
@@ -1315,7 +1315,7 @@ static bool checkCanonicalPath(const std::map<App::Document*, bool> &docs)
     for (auto &v : paths) {
         if (v.second.size() <= 1) continue;
         for (auto doc : v.second) {
-            if (docs.count(doc)) {
+            if (docs.contains(doc)) {
                 FC_WARN("Physical path: " << v.first.toUtf8().constData());
                 for (auto d : v.second)
                     FC_WARN("  Document: " << docName(d).toUtf8().constData()

--- a/src/Gui/DocumentRecovery.cpp
+++ b/src/Gui/DocumentRecovery.cpp
@@ -484,7 +484,7 @@ DocumentRecoveryPrivate::XmlConfig DocumentRecoveryPrivate::readXmlFile(const QS
         while (!child.isNull()) {
             QString name = child.localName();
             const QString value = child.text();
-            if (std::ranges::find(filter, name) != filter.end())
+            if (filter.contains(name))
                 cfg[name] = value;
             child = child.nextSiblingElement();
         }

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -341,7 +341,7 @@ public:
             if (idx >= 0 && idx < objSize) {
                 obj = objs[idx / 2];
                 // if they are in the ignore list skip
-                if (inList.count(obj)) {
+                if (inList.contains(obj)) {
                     return;
                 }
             }
@@ -430,7 +430,7 @@ public:
             const auto& objs = doc->getObjects();
             objSize = (int)objs.size() * 2;
             // if invalid index, or in the ignore list bail out
-            if (idx < 0 || idx >= objSize || inList.count(obj)) {
+            if (idx < 0 || idx >= objSize || inList.contains(obj)) {
                 return;
             }
             obj = objs[idx / 2];

--- a/src/Gui/MDIViewPyWrap.cpp
+++ b/src/Gui/MDIViewPyWrap.cpp
@@ -66,7 +66,7 @@ public:
         Base::PyGILStateLocker lock;
         PythonWrapper wrap;
         wrap.loadWidgetsModule();
-        if (func.count("widget") == 0) {
+        if (!func.contains("widget")) {
             throw Py::AttributeError("Object has no attribute 'widget'");
         }
         Py::Callable target(func.at("widget"));

--- a/src/Gui/MenuManager.cpp
+++ b/src/Gui/MenuManager.cpp
@@ -62,7 +62,7 @@ std::string MenuItem::command() const
 
 bool MenuItem::hasItems() const
 {
-    return _items.count() > 0;
+    return !_items.isEmpty();
 }
 
 MenuItem* MenuItem::findItem(const std::string& name)

--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -1179,7 +1179,7 @@ public:
                 if (dockWidget == dock
                         || !dockWidget->isVisible()
                         || dockWidget->isFloating()
-                        || _overlayMap.count(dockWidget))
+                        || _overlayMap.contains(dockWidget))
                     continue;
                 if (dockWidget->rect().contains(dockWidget->mapFromGlobal(pos))) {
                     dstDock = dockWidget;

--- a/src/Gui/PropertyView.cpp
+++ b/src/Gui/PropertyView.cpp
@@ -214,7 +214,7 @@ void PropertyView::slotRollback() {
 
 void PropertyView::slotChangePropertyData(const App::Property& prop)
 {
-    if (propertyEditorData->propOwners.count(prop.getContainer())) {
+    if (propertyEditorData->propOwners.contains(prop.getContainer())) {
         propertyEditorData->updateProperty(prop);
         timer->start(ViewParams::instance()->getPropertyViewTimer());
     }
@@ -222,7 +222,7 @@ void PropertyView::slotChangePropertyData(const App::Property& prop)
 
 void PropertyView::slotChangePropertyView(const Gui::ViewProvider&, const App::Property& prop)
 {
-    if (propertyEditorView->propOwners.count(prop.getContainer())) {
+    if (propertyEditorView->propOwners.contains(prop.getContainer())) {
         propertyEditorView->updateProperty(prop);
         timer->start(ViewParams::instance()->getPropertyViewTimer());
     }
@@ -239,8 +239,8 @@ void PropertyView::slotAppendDynamicProperty(const App::Property& prop)
         return;
 
     App::PropertyContainer* parent = prop.getContainer();
-    if (propertyEditorData->propOwners.count(parent)
-            || propertyEditorView->propOwners.count(parent))
+    if (propertyEditorData->propOwners.contains(parent)
+            || propertyEditorView->propOwners.contains(parent))
     {
         timer->start(ViewParams::instance()->getPropertyViewTimer());
     }
@@ -249,9 +249,9 @@ void PropertyView::slotAppendDynamicProperty(const App::Property& prop)
 void PropertyView::slotRemoveDynamicProperty(const App::Property& prop)
 {
     App::PropertyContainer* parent = prop.getContainer();
-    if(propertyEditorData->propOwners.count(parent))
+    if(propertyEditorData->propOwners.contains(parent))
         propertyEditorData->removeProperty(prop);
-    else if(propertyEditorView->propOwners.count(parent))
+    else if(propertyEditorView->propOwners.contains(parent))
         propertyEditorView->removeProperty(prop);
     else
         return;
@@ -261,13 +261,13 @@ void PropertyView::slotRemoveDynamicProperty(const App::Property& prop)
 void PropertyView::slotChangePropertyEditor(const App::Document &, const App::Property& prop)
 {
     App::PropertyContainer* parent = prop.getContainer();
-    if (propertyEditorData->propOwners.count(parent)
-            || propertyEditorView->propOwners.count(parent))
+    if (propertyEditorData->propOwners.contains(parent)
+            || propertyEditorView->propOwners.contains(parent))
         timer->start(ViewParams::instance()->getPropertyViewTimer());
 }
 
 void PropertyView::slotDeleteDocument(const Gui::Document &doc) {
-    if(propertyEditorData->propOwners.count(doc.getDocument())) {
+    if(propertyEditorData->propOwners.contains(doc.getDocument())) {
         propertyEditorView->buildUp();
         propertyEditorData->buildUp();
         clearPropertyItemSelection();
@@ -276,7 +276,7 @@ void PropertyView::slotDeleteDocument(const Gui::Document &doc) {
 }
 
 void PropertyView::slotDeletedViewObject(const Gui::ViewProvider &vp) {
-    if(propertyEditorView->propOwners.count(&vp)) {
+    if(propertyEditorView->propOwners.contains(&vp)) {
         propertyEditorView->buildUp();
         propertyEditorData->buildUp();
         clearPropertyItemSelection();
@@ -285,7 +285,7 @@ void PropertyView::slotDeletedViewObject(const Gui::ViewProvider &vp) {
 }
 
 void PropertyView::slotDeletedObject(const App::DocumentObject &obj) {
-    if(propertyEditorData->propOwners.count(&obj)) {
+    if(propertyEditorData->propOwners.contains(&obj)) {
         propertyEditorView->buildUp();
         propertyEditorData->buildUp();
         clearPropertyItemSelection();

--- a/src/Gui/Selection/SoFCSelectionContext.cpp
+++ b/src/Gui/Selection/SoFCSelectionContext.cpp
@@ -104,7 +104,7 @@ int SoFCSelectionContext::merge(int status, SoFCSelectionContextBasePtr &output,
 
     std::vector<int> remove;
     for(auto idx : ret->selectionIndex) {
-        if(!ctx->selectionIndex.count(idx))
+        if(!ctx->selectionIndex.contains(idx))
             remove.push_back(idx);
     }
 
@@ -216,7 +216,7 @@ int SoFCSelectionContextEx::merge(int status, SoFCSelectionContextBasePtr &outpu
     auto ret = std::dynamic_pointer_cast<SoFCSelectionContextEx>(output);
     assert(ret);
     for(auto &v : ctx->colors) {
-        if(ret->colors.count(v.first))
+        if(ret->colors.contains(v.first))
             continue;
         if(!status) {
             status = 1;

--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -78,7 +78,7 @@ const std::string & ToolBarItem::command() const
 
 bool ToolBarItem::hasItems() const
 {
-    return _items.count() > 0;
+    return !_items.isEmpty();
 }
 
 ToolBarItem* ToolBarItem::findItem(const std::string& name)

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1177,7 +1177,7 @@ void TreeWidget::contextMenuEvent(QContextMenuEvent* e)
         header()->setVisible(action->isChecked()||internalNameAction->isChecked());
     });
 
-    if (contextMenu.actions().count() > 0) {
+    if (!contextMenu.actions().isEmpty()) {
         try {
             contextMenu.exec(QCursor::pos());
         }
@@ -2573,7 +2573,7 @@ bool TreeWidget::dropInObject(QDropEvent* event, TargetItemInfo& targetInfo,
                 }
             }
 
-            if (inList.count(obj)) {
+            if (inList.contains(obj)) {
                 FC_THROWM(Base::RuntimeError, "Dependency loop detected for " << obj->getFullName());
             }
 
@@ -3059,7 +3059,7 @@ void TreeWidget::onUpdateStatus()
                 continue;
             if (obj->isError())
                 errors.push_back(obj);
-            if (docItem->ObjectMap.count(obj))
+            if (docItem->ObjectMap.contains(obj))
                 continue;
             auto vpd = freecad_cast<ViewProviderDocumentObject*>(gdoc->getViewProvider(obj));
             if (vpd)
@@ -4447,7 +4447,7 @@ void TreeWidget::updateChildren(App::DocumentObject* obj,
         // and thus, its property change will not be propagated through
         // recomputation. So we have to manually check for each links here.
         for (auto link : App::GetApplication().getLinksTo(obj, App::GetLinkRecursive)) {
-            if (ChangedObjects.count(link))
+            if (ChangedObjects.contains(link))
                 continue;
             std::vector<App::DocumentObject*> linkedChildren;
             DocumentObjectDataPtr found;
@@ -4475,7 +4475,7 @@ void TreeWidget::updateChildren(App::DocumentObject* obj,
         //if the item is in a GeoFeatureGroup we may need to update that too, as the claim children
         //of the geofeaturegroup depends on what the childs claim
         auto grp = App::GeoFeatureGroupExtension::getGroupOfObject(obj);
-        if (grp && !ChangedObjects.count(grp)) {
+        if (grp && !ChangedObjects.contains(grp)) {
             auto iter = ObjectTable.find(grp);
             if (iter != ObjectTable.end())
                 updateChildren(grp, iter->second, true, false);

--- a/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
+++ b/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
@@ -104,7 +104,7 @@ std::vector<App::DocumentObject*> ViewProviderGeoFeatureGroupExtension::extensio
     for(auto obj : model) {
         if(!obj || !obj->isAttachedToDocument())
             continue;
-        if(outSet.count(obj))
+        if(outSet.contains(obj))
             obj->setStatus(App::ObjectStatus::GeoExcluded,true);
         else {
             obj->setStatus(App::ObjectStatus::GeoExcluded,false);

--- a/src/Mod/CAM/App/Command.cpp
+++ b/src/Mod/CAM/App/Command.cpp
@@ -91,7 +91,7 @@ bool Command::has(const std::string& attr) const
 {
     std::string a(attr);
     boost::to_upper(a);
-    return Parameters.count(a) > 0;
+    return Parameters.contains(a);
 }
 
 std::string Command::toGCode(int precision, bool padzero) const

--- a/src/Mod/CAM/App/CommandPyImp.cpp
+++ b/src/Mod/CAM/App/CommandPyImp.cpp
@@ -281,7 +281,7 @@ PyObject* CommandPy::getCustomAttributes(const char* attr) const
     if (satt.length() == 1) {
         if (isalpha(satt[0])) {
             boost::to_upper(satt);
-            if (getCommandPtr()->Parameters.count(satt)) {
+            if (getCommandPtr()->Parameters.contains(satt)) {
                 return PyFloat_FromDouble(getCommandPtr()->Parameters[satt]);
             }
             Py_INCREF(Py_None);

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -189,7 +189,7 @@ bool ImpExpDxfRead::OnReadBlock(const std::string& name, int flags)
         // and don't want to be complaining about unhandled entity types.
         // Note that if it *is* for a hatch we could actually import it and use it to draw a hatch.
     }
-    else if (Blocks.count(name) > 0) {
+    else if (Blocks.contains(name)) {
         ImportError("Duplicate block name '%s'\n", name);
     }
     else {

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2689,7 +2689,7 @@ bool CDxfRead::ReadSection()
 }
 void CDxfRead::ProcessLayerReference(CDxfRead* object, void* target)
 {
-    if (object->Layers.count(object->m_record_data) == 0) {
+    if (!object->Layers.contains(object->m_record_data)) {
         object->ImportError("First reference to missing Layer '%s'", object->m_record_data);
         // Synthesize the Layer so we don't get the same error again.
         // We need to take copies of the string arguments because MakeLayer uses them as move

--- a/src/Mod/Material/App/MaterialLibrary.cpp
+++ b/src/Mod/Material/App/MaterialLibrary.cpp
@@ -92,7 +92,7 @@ MaterialLibrary::getMaterialTree(const std::shared_ptr<Materials::MaterialFilter
         for (auto& itp : list) {
             if (!itp.isEmpty()) {
                 // Add the folder only if it's not already there
-                if (node->count(itp) == 0) {
+                if (!node->contains(itp)) {
                     auto mapPtr = std::make_shared<
                         std::map<QString, std::shared_ptr<MaterialTreeNode>>>();
                     std::shared_ptr<MaterialTreeNode> child =
@@ -125,7 +125,7 @@ MaterialLibrary::getMaterialTree(const std::shared_ptr<Materials::MaterialFilter
     //             auto node = materialTree;
     //             for (auto& itp : list) {
     //                 // Add the folder only if it's not already there
-    //                 if (node->count(itp) == 0) {
+    //                 if (!node->contains(itp)) {
     //                     std::shared_ptr<std::map<QString, std::shared_ptr<MaterialTreeNode>>>
     //                         mapPtr = std::make_shared<
     //                             std::map<QString, std::shared_ptr<MaterialTreeNode>>>();

--- a/src/Mod/Material/App/ModelLibrary.cpp
+++ b/src/Mod/Material/App/ModelLibrary.cpp
@@ -87,7 +87,7 @@ ModelLibrary::getModelTree(ModelFilter filter) const
             std::shared_ptr<std::map<QString, std::shared_ptr<ModelTreeNode>>> node = modelTree;
             for (auto& itp : list) {
                 // Add the folder only if it's not already there
-                if (node->count(itp) == 0) {
+                if (!node->contains(itp)) {
                     auto mapPtr =
                         std::make_shared<std::map<QString, std::shared_ptr<ModelTreeNode>>>();
                     std::shared_ptr<ModelTreeNode> child = std::make_shared<ModelTreeNode>();

--- a/src/Mod/Material/App/ModelLoader.cpp
+++ b/src/Mod/Material/App/ModelLoader.cpp
@@ -163,7 +163,7 @@ void ModelLoader::dereference(const QString& uuid,
     auto childProperties = childYaml[childBase];
     for (auto it = childProperties.begin(); it != childProperties.end(); it++) {
         std::string name = it->first.as<std::string>();
-        if (exclude.count(QString::fromStdString(name)) == 0) {
+        if (!exclude.contains(QString::fromStdString(name))) {
             // showYaml(it->second);
             if (!parentProperties[name]) {
                 parentProperties[name] = it->second;
@@ -261,7 +261,7 @@ void ModelLoader::addToTree(std::shared_ptr<ModelEntry> model,
     auto yamlProperties = yamlModel[base];
     for (auto it = yamlProperties.begin(); it != yamlProperties.end(); it++) {
         std::string propName = it->first.as<std::string>();
-        if (exclude.count(QString::fromStdString(propName)) == 0) {
+        if (!exclude.contains(QString::fromStdString(propName))) {
             // showYaml(it->second);
             auto yamlProp = yamlProperties[propName];
             auto propDisplayName = yamlValue(yamlProp, "DisplayName", "");
@@ -304,7 +304,7 @@ void ModelLoader::addToTree(std::shared_ptr<ModelEntry> model,
             }
 
             auto key = std::pair<QString, QString>(uuid, QString::fromStdString(propName));
-            if (inheritances->count(key) > 0) {
+            if (inheritances->contains(key)) {
                 property.setInheritance((*inheritances)[key]);
             }
 

--- a/src/Mod/Material/Gui/MaterialSave.cpp
+++ b/src/Mod/Material/Gui/MaterialSave.cpp
@@ -404,7 +404,7 @@ void MaterialSave::onSelectModel(const QItemSelection& selected, const QItemSele
     _filename = QString(ui->editFilename->text());  // No filename by default
     auto model = static_cast<QStandardItemModel*>(ui->treeMaterials->model());
     QModelIndexList indexes = selected.indexes();
-    if (indexes.count() == 0) {
+    if (indexes.isEmpty()) {
         _selectedPath = QStringLiteral("/") + _libraryName;
         _selectedFull = _selectedPath;
         _selectedUUID = QString();

--- a/src/Mod/Part/App/TopoShapeCache.cpp
+++ b/src/Mod/Part/App/TopoShapeCache.cpp
@@ -151,6 +151,10 @@ int TopoShapeCache::Ancestry::count() const
     return shapes.Extent();
 }
 
+bool TopoShapeCache::Ancestry::empty() const
+{
+    return shapes.IsEmpty();
+}
 
 TopoShapeCache::TopoShapeCache(const TopoDS_Shape& tds)
     : shape(tds.Located(TopLoc_Location()))

--- a/src/Mod/Part/App/TopoShapeCache.h
+++ b/src/Mod/Part/App/TopoShapeCache.h
@@ -114,6 +114,7 @@ public:
         int find(const TopoDS_Shape& parent, const TopoDS_Shape& subShape);
         TopoDS_Shape find(const TopoDS_Shape& parent, int index);
         int count() const;
+        bool empty() const;
 
         friend TopoShapeCache;
     };

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -860,7 +860,7 @@ void TopoShape::mapSubElementForShape(const TopoShape& other, const char* op)
     for (auto type : types) {
         auto& shapeMap = _cache->getAncestry(type);
         auto& otherMap = other._cache->getAncestry(type);
-        if ((shapeMap.count() == 0) || (otherMap.count() == 0)) {
+        if ((shapeMap.empty()) || (otherMap.empty())) {
             continue;
         }
 
@@ -1450,7 +1450,7 @@ TopoShape& TopoShape::makeShapeWithElementMap(const TopoDS_Shape& shape,
                 continue;
             }
             auto& otherMap = incomingShape._cache->getAncestry(info.type);
-            if (otherMap.count() == 0) {
+            if (otherMap.empty()) {
                 continue;
             }
             for (int i = 1; i <= otherMap.count(); i++) {

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -952,7 +952,7 @@ void TaskAttacher::updateListOfModes()
     //first up, remember currently selected mode.
     eMapMode curMode = mmDeactivated;
     auto sel = ui->listOfModes->selectedItems();
-    if (sel.count() > 0)
+    if (!sel.isEmpty())
         curMode = modesInList[ui->listOfModes->row(sel[0])];
 
     //obtain list of available modes:
@@ -1054,7 +1054,7 @@ void TaskAttacher::selectMapMode(eMapMode mmode) {
 Attacher::eMapMode TaskAttacher::getActiveMapMode()
 {
     auto sel = ui->listOfModes->selectedItems();
-    if (sel.count() > 0)
+    if (!sel.isEmpty())
         return modesInList[ui->listOfModes->row(sel[0])];
     else {
         if (this->lastSuggestResult.message == SuggestResult::srOK)

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1105,7 +1105,7 @@ void TaskSketcherConstraints::changeFilteredVisibility(bool show, ActionTarget t
             processItem = !item->isHidden();
         }
         else if (target == ActionTarget::Selected) {
-            if (std::ranges::find(selecteditems, item) != selecteditems.end())
+            if (selecteditems.contains(item))
                 processItem = true;
         }
 

--- a/src/Mod/Spreadsheet/Gui/qtcolorpicker.cpp
+++ b/src/Mod/Spreadsheet/Gui/qtcolorpicker.cpp
@@ -851,7 +851,7 @@ void ColorPickerPopup::showEvent(QShowEvent *)
     }
 
     if (!foundSelected) {
-    if (items.count() == 0)
+    if (items.isEmpty())
         setFocus();
     else
         widgetAt[0][0]->setFocus();


### PR DESCRIPTION
By using `contains()` and `isEmpty()` instead of `count()` and `std::find()` we express the intent better and avoid a lot of implicit conversions from `int` to `bool`.