### PR TITLE
[Gui] Fix Seg Fault when deleting a Link Array

### DIFF
--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2390,7 +2390,7 @@ bool ViewProviderLink::onDelete(const std::vector<std::string> &) {
     }
 
     auto link = getObject<App::Link>();
-    if (link->ElementCount.getValue() != 0) {
+    if (link && link->ElementCount.getValue() != 0) {
         auto doc = link->getDocument();
         auto elements = link->ElementList.getValues();
         for (auto element : elements) {


### PR DESCRIPTION
Test file and report https://forum.freecad.org/viewtopic.php?p=818525#p818504

This PR fixes the current seg fault when deleting a Link Array introduced by https://github.com/FreeCAD/FreeCAD/commit/dcaddb94889c33932df7f82286f83fd07ddb65bf :

```
Program received signal SIGSEGV, Segmentation fault.
#0  /usr/lib/x86_64-linux-gnu/libc.so.6(+0x45330) [0x72b856e45330]
#1  0x72b859ef2214 in App::PropertyInteger::getValue() const from /home/username/freecad-daily-build/lib/libFreeCADApp.so+0x4
#2  0x72b85ae4f6d1 in Gui::ViewProviderLink::onDelete(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0x251
#3  0x72b85a946e7b in StdCmdDelete::activated(int) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0x62b
#4  0x72b85a92e135 in Gui::Command::_invoke(int, bool) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0x215
#5  0x72b85a92e516 in Gui::Command::invoke(int, Gui::Command::TriggerSource) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0x136
#6  /usr/lib/x86_64-linux-gnu/libQt5Core.so.5(+0x312e16) [0x72b857912e16]
#7  0x72b858564f94 in QAction::triggered(bool) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5+0x44
#8  0x72b858567eab in QAction::activate(QAction::ActionEvent) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5+0xbb
#9  0x72b85a9a3adf in Gui::ShortcutManager::onTimer() from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0xff
#10  0x72b85a9a465f in Gui::ShortcutManager::checkShortcut(QObject*, QKeySequence const&) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0x52f
#11  0x72b85a9a6245 in Gui::ShortcutManager::eventFilter(QObject*, QEvent*) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0x95
#12  0x72b8578d7d5e in QCoreApplicationPrivate::sendThroughApplicationEventFilters(QObject*, QEvent*) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5+0x7e
#13  0x72b85856bd80 in QApplicationPrivate::notify_helper(QObject*, QEvent*) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5+0xc0
#14  0x72b85a8c6d98 in Gui::GUIApplication::notify(QObject*, QEvent*) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0xc8
#15  0x72b8578d8118 in QCoreApplication::notifyInternal2(QObject*, QEvent*) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5+0x128
#16  0x72b857d77b3c in QShortcutMap::dispatchEvent(QKeyEvent*) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5+0x1ac
#17  0x72b857d787b3 in QShortcutMap::tryShortcut(QKeyEvent*) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5+0x83
#18  0x72b857d1b512 in QWindowSystemInterface::handleShortcutEvent(QWindow*, unsigned long, int, QFlags<Qt::KeyboardModifier>, unsigned int, unsigned int, unsigned int, QString const&, bool, unsigned short) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5+0x192
#19  0x72b857d414d5 in QGuiApplicationPrivate::processKeyEvent(QWindowSystemInterfacePrivate::KeyEvent*) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5+0x95
#20  0x72b857d17bfc in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5+0xac
#21  /usr/lib/x86_64-linux-gnu/libQt5XcbQpa.so.5(+0x75d06) [0x72b851607d06]
#22  /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0(+0x5d5b5) [0x72b855b145b5]
#23  /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0(+0xbc717) [0x72b855b73717]
#24  /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0(g_main_context_iteration+0x33) [0x72b855b13a53]
#25  0x72b857935279 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5+0x69
#26  0x72b8578d6a7b in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5+0x13b
#27  0x72b8578df3e8 in QCoreApplication::exec() from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5+0x98
#28  0x72b85a7e7ace in Gui::Application::runApplication() from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0x6fe
#29  /home/username/freecad-daily-build/bin/FreeCAD(+0x73e3) [0x5d4bf8e3b3e3]
#30  /usr/lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca) [0x72b856e2a1ca]
#31  /usr/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b) [0x72b856e2a28b]
#32  /home/username/freecad-daily-build/bin/FreeCAD(+0x77e5) [0x5d4bf8e3b7e5]
```
