### PR TITLE
CAM:  Enabled coolant in the refactored_grbl post, with test

### DIFF
--- a/src/Mod/CAM/CAMTests/TestRefactoredGrblPost.py
+++ b/src/Mod/CAM/CAMTests/TestRefactoredGrblPost.py
@@ -332,3 +332,22 @@ M2
         result = gcode.splitlines()[15]
         expected = "(comment)"
         self.assertEqual(result, expected)
+
+    def test100(self):
+        """
+        Test if coolant is enabled.
+        """
+        nl = "\n"
+
+        c = Path.Command("M7")
+        c1 = Path.Command("M8")
+        c2 = Path.Command("M9")
+
+        self.profile_op.Path = Path.Path([c, c1, c2])
+
+        self.job.PostProcessorArgs = "--no-header --no-show-editor"
+        gcode = self.post.export()[0][1]
+        # print(f"--------{nl}{gcode}--------{nl}")
+        self.assertEqual(gcode.splitlines()[15], "M7")
+        self.assertEqual(gcode.splitlines()[16], "M8")
+        self.assertEqual(gcode.splitlines()[17], "M9")

--- a/src/Mod/CAM/Path/Post/scripts/refactored_grbl_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/refactored_grbl_post.py
@@ -75,6 +75,7 @@ class Refactored_Grbl(PostProcessor):
         # Set any values here that need to override the default values set
         # in the parent routine.
         #
+        values["ENABLE_COOLANT"] = True
         #
         # If this is set to True, then commands that are placed in
         # comments that look like (MC_RUN_COMMAND: blah) will be output.


### PR DESCRIPTION
This PR enables coolant-related commands in the refactored_grbl postprocessor to match the settings for the "legacy" grbl postprocessor.

It includes a test.

Please assign this PR to me.
