### PR TITLE
Mod: Fix Material Library naming issue

### DIFF
--- a/src/Mod/Material/App/MaterialLibrary.cpp
+++ b/src/Mod/Material/App/MaterialLibrary.cpp
@@ -211,7 +211,7 @@ std::shared_ptr<Material> MaterialLibrary::saveMaterial(const std::shared_ptr<Ma
         stream.setGenerateByteOrderMark(true);
 
         // Write the contents
-        material->setName(info.baseName());
+        material->setName(info.fileName().remove(QStringLiteral(".FCMat"), Qt::CaseInsensitive));
         material->setLibrary(getptr());
         material->setDirectory(getRelativePath(path));
         material->save(stream, overwrite, saveAsCopy, saveInherited);


### PR DESCRIPTION
fixes #20005 :
Updated info.baseName() to info.fileName().remove(QStringLiteral(".FCMat"), Qt::CaseInsensitive) in MaterialLibrary.cpp to ensure that only the ".FCMat" extension is removed from the file name.
Previously, the implementation removed everything after the first dot, which could unintentionally modify file names when saving a material. This fix ensures that only the specific ".FCMat" extension is stripped while preserving the rest of the file name.
@davesrocketshop 