### PR TITLE
Fixing ambiguous python shebang in installed script freecad-thumbnailer [skip ci]

### DIFF
--- a/src/Tools/freecad-thumbnailer.in
+++ b/src/Tools/freecad-thumbnailer.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 """Support file to show FreeCAD thumbnails on Free Desktop Environments (like GNOME or KDE)
 
 Installation:


### PR DESCRIPTION
The newly added XDG installable script fails `brp-mangle-shebangs`. Fixing ambiguity by giving explicit python version, i.e. 3. 