### PR TITLE
Eliminate use of <cmath> and <climits> macros

### DIFF
--- a/src/App/Datums.cpp
+++ b/src/App/Datums.cpp
@@ -33,10 +33,6 @@
 
 #include "Datums.h"
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 using namespace App;
 
 PROPERTY_SOURCE(App::DatumElement, App::GeoFeature)
@@ -246,11 +242,11 @@ const std::vector<LocalCoordinateSystem::SetupData>& LocalCoordinateSystem::getS
     static const std::vector<SetupData> setupData = {
         // clang-format off
         {App::Line::getClassTypeId(),  AxisRoles[0],  tr("X-axis"),   Base::Rotation()},
-        {App::Line::getClassTypeId(),  AxisRoles[1],  tr("Y-axis"),   Base::Rotation(Base::Vector3d(1, 1, 1), M_PI * 2 / 3)},
-        {App::Line::getClassTypeId(),  AxisRoles[2],  tr("Z-axis"),   Base::Rotation(Base::Vector3d(1,-1, 1), M_PI * 2 / 3)},
+        {App::Line::getClassTypeId(),  AxisRoles[1],  tr("Y-axis"),   Base::Rotation(Base::Vector3d(1, 1, 1), std::numbers::pi * 2 / 3)},
+        {App::Line::getClassTypeId(),  AxisRoles[2],  tr("Z-axis"),   Base::Rotation(Base::Vector3d(1,-1, 1), std::numbers::pi * 2 / 3)},
         {App::Plane::getClassTypeId(), PlaneRoles[0], tr("XY-plane"), Base::Rotation()},
         {App::Plane::getClassTypeId(), PlaneRoles[1], tr("XZ-plane"), Base::Rotation(1.0, 0.0, 0.0, 1.0)},
-        {App::Plane::getClassTypeId(), PlaneRoles[2], tr("YZ-plane"), Base::Rotation(Base::Vector3d(1, 1, 1), M_PI * 2 / 3)},
+        {App::Plane::getClassTypeId(), PlaneRoles[2], tr("YZ-plane"), Base::Rotation(Base::Vector3d(1, 1, 1), std::numbers::pi * 2 / 3)},
         {App::Point::getClassTypeId(), PointRoles[0], tr("Origin"),   Base::Rotation()}
         // clang-format on
     };

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -62,18 +62,6 @@ using namespace App;
 
 FC_LOG_LEVEL_INIT("Expression", true, true)
 
-#ifndef M_PI
-#define M_PI       3.14159265358979323846
-#endif
-#ifndef M_E
-#define M_E        2.71828182845904523536
-#endif
-#ifndef  DOUBLE_MAX
-# define DOUBLE_MAX 1.7976931348623157E+308    /* max decimal value of a "double"*/
-#endif
-#ifndef  DOUBLE_MIN
-# define DOUBLE_MIN 2.2250738585072014E-308    /* min decimal value of a "double"*/
-#endif
 
 #if defined(_MSC_VER)
 #define strtoll _strtoi64
@@ -2227,7 +2215,7 @@ Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std
 
         Rotation rotation = Base::Rotation(
             Vector3d(static_cast<double>(f == MROTATEX), static_cast<double>(f == MROTATEY), static_cast<double>(f == MROTATEZ)),
-            rotationAngle.getValue() * M_PI / 180.0);
+            rotationAngle.getValue() * std::numbers::pi / 180.0);
         Base::Matrix4D rotationMatrix;
         rotation.getValue(rotationMatrix);
 
@@ -2366,7 +2354,7 @@ Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std
 
         switch (f) {
         case VANGLE:
-            return Py::asObject(new QuantityPy(new Quantity(vector1.GetAngle(vector2) * 180 / M_PI, Unit::Angle)));
+            return Py::asObject(new QuantityPy(new Quantity(vector1.GetAngle(vector2) * 180 / std::numbers::pi, Unit::Angle)));
         case VCROSS:
             return Py::asObject(new Base::VectorPy(vector1.Cross(vector2)));
         case VDOT:
@@ -2425,7 +2413,7 @@ Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std
             _EXPR_THROW("Unit must be either empty or an angle.", expr);
 
         // Convert value to radians
-        value *= M_PI / 180.0;
+        value *= std::numbers::pi / 180.0;
         unit = Unit();
         break;
     case ACOS:
@@ -2434,7 +2422,7 @@ Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std
         if (!v1.isDimensionless())
             _EXPR_THROW("Unit must be empty.", expr);
         unit = Unit::Angle;
-        scaler = 180.0 / M_PI;
+        scaler = 180.0 / std::numbers::pi;
         break;
     case EXP:
     case LOG:
@@ -2466,7 +2454,7 @@ Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std
         if (v1.getUnit() != v2.getUnit())
             _EXPR_THROW("Units must be equal.",expr);
         unit = Unit::Angle;
-        scaler = 180.0 / M_PI;
+        scaler = 180.0 / std::numbers::pi;
         break;
     case MOD:
         if (e2.isNone())

--- a/src/App/ExpressionParser.l
+++ b/src/App/ExpressionParser.l
@@ -45,6 +45,8 @@ extern int column;
 
 #define COUNTCHARS do { last_column = column; column += yyleng; } while (0)
 
+#include <numbers>
+
 %}
 
 /*** Flex Declarations and Options ***/
@@ -348,8 +350,8 @@ EXPO     [eE][-+]?[0-9]+
                                if (yylval.ivalue == 1) { yylval.fvalue = 1; return ONE; } else return INTEGER;
                              }
 
-"pi"                         COUNTCHARS; yylval.constant.fvalue = M_PI; yylval.constant.name = "pi"; return CONSTANT; // constant pi
-"e"                          COUNTCHARS; yylval.constant.fvalue = M_E; yylval.constant.name = "e"; return CONSTANT; // constant e
+"pi"                         COUNTCHARS; yylval.constant.fvalue = std::numbers::pi; yylval.constant.name = "pi"; return CONSTANT; // constant pi
+"e"                          COUNTCHARS; yylval.constant.fvalue = std::numbers::e; yylval.constant.name = "e"; return CONSTANT; // constant e
 
 "None"                       COUNTCHARS; yylval.constant.fvalue = 0; yylval.constant.name = "None"; return CONSTANT;
 "True"                       COUNTCHARS; yylval.constant.fvalue = 1; yylval.constant.name = "True"; return CONSTANT;

--- a/src/App/PreCompiled.h
+++ b/src/App/PreCompiled.h
@@ -51,6 +51,7 @@
 #include <cstdio>
 #include <ctime>
 #include <cfloat>
+#include <numbers>
 
 #ifdef FC_OS_WIN32
 #include <crtdbg.h>

--- a/src/App/lex.ExpressionParser.c
+++ b/src/App/lex.ExpressionParser.c
@@ -8608,14 +8608,16 @@ extern int column;
 
 #define COUNTCHARS do { last_column = column; column += yyleng; } while (0)
 
-#line 8611 "lex.ExpressionParser.c"
+#include <numbers>
+
+#line 8613 "lex.ExpressionParser.c"
 /*** Flex Declarations and Options ***/
 /* change the name of the scanner class. */
 /* the manual says "somewhat more optimized" */
 /* no support for include files is planned */
 /* UTF-8 unicode regular expressions. */
 /* http://www.unicode.org/reports/tr44/#General_Category_Values */
-#line 8618 "lex.ExpressionParser.c"
+#line 8620 "lex.ExpressionParser.c"
 
 #define INITIAL 0
 
@@ -8626,7 +8628,7 @@ extern int column;
  */
 #include <unistd.h>
 #endif
-
+    
 #ifndef YY_EXTRA_TYPE
 #define YY_EXTRA_TYPE void *
 #endif
@@ -8830,10 +8832,10 @@ YY_DECL
 		}
 
 	{
-#line 170 "ExpressionParser.l"
+#line 172 "ExpressionParser.l"
 
 
-#line 8836 "lex.ExpressionParser.c"
+#line 8838 "lex.ExpressionParser.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -8888,689 +8890,689 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 172 "ExpressionParser.l"
+#line 174 "ExpressionParser.l"
 COUNTCHARS;
 	YY_BREAK
 case 2:
 /* rule 2 can match eol */
 YY_RULE_SETUP
-#line 173 "ExpressionParser.l"
+#line 175 "ExpressionParser.l"
 column = 0;
 	YY_BREAK
 case 3:
 /* rule 3 can match eol */
 YY_RULE_SETUP
-#line 175 "ExpressionParser.l"
+#line 177 "ExpressionParser.l"
 COUNTCHARS; yylval.string = unquote(yytext); return STRING;
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 177 "ExpressionParser.l"
+#line 179 "ExpressionParser.l"
 COUNTCHARS; return *yytext;
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 179 "ExpressionParser.l"
+#line 181 "ExpressionParser.l"
 COUNTCHARS; return EQ;
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 180 "ExpressionParser.l"
+#line 182 "ExpressionParser.l"
 COUNTCHARS; return NEQ;
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 181 "ExpressionParser.l"
+#line 183 "ExpressionParser.l"
 COUNTCHARS; return GT;
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 182 "ExpressionParser.l"
+#line 184 "ExpressionParser.l"
 COUNTCHARS; return LT;
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 183 "ExpressionParser.l"
+#line 185 "ExpressionParser.l"
 COUNTCHARS; return GTE;
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 184 "ExpressionParser.l"
+#line 186 "ExpressionParser.l"
 COUNTCHARS; return LTE;
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 186 "ExpressionParser.l"
+#line 188 "ExpressionParser.l"
 COUNTCHARS; return MINUSSIGN;
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 187 "ExpressionParser.l"
+#line 189 "ExpressionParser.l"
 COUNTCHARS; return MINUSSIGN;
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 189 "ExpressionParser.l"
+#line 191 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::NanoMetre;           yylval.quantity.unitStr = yytext; return UNIT; // nano meter
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 190 "ExpressionParser.l"
+#line 192 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MicroMetre;          yylval.quantity.unitStr = yytext; return UNIT; // micro meter
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 191 "ExpressionParser.l"
+#line 193 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MicroMetre;          yylval.quantity.unitStr = yytext; return UNIT; // micro meter    (greek micro in UTF8)
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 192 "ExpressionParser.l"
+#line 194 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliMetre;          yylval.quantity.unitStr = yytext; return UNIT; // milli meter    (internal standard length)
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 193 "ExpressionParser.l"
+#line 195 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::CentiMetre;          yylval.quantity.unitStr = yytext; return UNIT; // centi meter
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 194 "ExpressionParser.l"
+#line 196 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::DeciMetre;           yylval.quantity.unitStr = yytext; return UNIT; // deci meter
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 195 "ExpressionParser.l"
+#line 197 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Metre;               yylval.quantity.unitStr = yytext; return UNIT; // Metre
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 196 "ExpressionParser.l"
+#line 198 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloMetre;           yylval.quantity.unitStr = yytext; return UNIT; // kilo meter
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 198 "ExpressionParser.l"
+#line 200 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Liter;               yylval.quantity.unitStr = yytext; return UNIT; // Liter      dm^3
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 199 "ExpressionParser.l"
+#line 201 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliLiter;          yylval.quantity.unitStr = yytext; return UNIT; // milli Liter
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 201 "ExpressionParser.l"
+#line 203 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Hertz;               yylval.quantity.unitStr = yytext; return UNIT; // Hertz
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 202 "ExpressionParser.l"
+#line 204 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloHertz;           yylval.quantity.unitStr = yytext; return UNIT; // kilo Hertz
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 203 "ExpressionParser.l"
+#line 205 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MegaHertz;           yylval.quantity.unitStr = yytext; return UNIT; // mega Hertz
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 204 "ExpressionParser.l"
+#line 206 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::GigaHertz;           yylval.quantity.unitStr = yytext; return UNIT; // giga Hertz
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 205 "ExpressionParser.l"
+#line 207 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::TeraHertz;           yylval.quantity.unitStr = yytext; return UNIT; // tera Hertz
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 207 "ExpressionParser.l"
+#line 209 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MicroGram;           yylval.quantity.unitStr = yytext; return UNIT; // micro gram
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 208 "ExpressionParser.l"
+#line 210 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MicroGram;           yylval.quantity.unitStr = yytext; return UNIT; // micro gram
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 209 "ExpressionParser.l"
+#line 211 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliGram;           yylval.quantity.unitStr = yytext; return UNIT; // milli gram
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 210 "ExpressionParser.l"
+#line 212 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Gram;                yylval.quantity.unitStr = yytext; return UNIT; // gram
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 211 "ExpressionParser.l"
+#line 213 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloGram;            yylval.quantity.unitStr = yytext; return UNIT; // kilo gram      (internal standard for mass)
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 212 "ExpressionParser.l"
+#line 214 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Ton;                 yylval.quantity.unitStr = yytext; return UNIT; // Metric Tonne
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 214 "ExpressionParser.l"
+#line 216 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Second;              yylval.quantity.unitStr = yytext; return UNIT; // second         (internal standard time)
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 215 "ExpressionParser.l"
+#line 217 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Minute;              yylval.quantity.unitStr = yytext; return UNIT; // minute
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 216 "ExpressionParser.l"
+#line 218 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Hour;                yylval.quantity.unitStr = yytext; return UNIT; // hour
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 218 "ExpressionParser.l"
+#line 220 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Ampere;              yylval.quantity.unitStr = yytext; return UNIT; // Ampere         (internal standard electric current)
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 219 "ExpressionParser.l"
+#line 221 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliAmpere;         yylval.quantity.unitStr = yytext; return UNIT; // milli Ampere
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 220 "ExpressionParser.l"
+#line 222 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloAmpere;          yylval.quantity.unitStr = yytext; return UNIT; // kilo Ampere
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 221 "ExpressionParser.l"
+#line 223 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MegaAmpere;          yylval.quantity.unitStr = yytext; return UNIT; // mega Ampere
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 223 "ExpressionParser.l"
+#line 225 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Kelvin;              yylval.quantity.unitStr = yytext; return UNIT; // Kelvin         (internal standard thermodynamic temperature)
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 224 "ExpressionParser.l"
+#line 226 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliKelvin;         yylval.quantity.unitStr = yytext; return UNIT; // milli Kelvin
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 225 "ExpressionParser.l"
+#line 227 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MicroKelvin;         yylval.quantity.unitStr = yytext; return UNIT; // micro Kelvin
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 226 "ExpressionParser.l"
+#line 228 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MicroKelvin;         yylval.quantity.unitStr = yytext; return UNIT; // micro Kelvin
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 228 "ExpressionParser.l"
+#line 230 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Mole;                yylval.quantity.unitStr = yytext; return UNIT; // Mole           (internal standard amount of substance)
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 229 "ExpressionParser.l"
+#line 231 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliMole;           yylval.quantity.unitStr = yytext; return UNIT; // milli Mole
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 231 "ExpressionParser.l"
+#line 233 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Candela;             yylval.quantity.unitStr = yytext; return UNIT; // Candela        (internal standard luminous intensity)
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 233 "ExpressionParser.l"
+#line 235 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Inch;                yylval.quantity.unitStr = yytext; return UNIT; // inch
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 234 "ExpressionParser.l"
+#line 236 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Inch;                yylval.quantity.unitStr = yytext; return USUNIT; // inch
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 235 "ExpressionParser.l"
+#line 237 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Foot;                yylval.quantity.unitStr = yytext; return UNIT; // foot
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 236 "ExpressionParser.l"
+#line 238 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Foot;                yylval.quantity.unitStr = yytext; return USUNIT; // foot
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 237 "ExpressionParser.l"
+#line 239 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Thou;                yylval.quantity.unitStr = yytext; return UNIT; // thou (in/1000)
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 238 "ExpressionParser.l"
+#line 240 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Thou;                yylval.quantity.unitStr = yytext; return UNIT; // mil  (the thou in US)
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 239 "ExpressionParser.l"
+#line 241 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Yard;                yylval.quantity.unitStr = yytext; return UNIT; // yard
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 240 "ExpressionParser.l"
+#line 242 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Mile;                yylval.quantity.unitStr = yytext; return UNIT; // mile
 	YY_BREAK
 case 56:
 YY_RULE_SETUP
-#line 242 "ExpressionParser.l"
+#line 244 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilePerHour;         yylval.quantity.unitStr = yytext; return UNIT; // mile per hour
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 243 "ExpressionParser.l"
+#line 245 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::SquareFoot;          yylval.quantity.unitStr = yytext; return UNIT; // square foot
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 244 "ExpressionParser.l"
+#line 246 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::CubicFoot;           yylval.quantity.unitStr = yytext; return UNIT; // cubic foot
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 246 "ExpressionParser.l"
+#line 248 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Pound;               yylval.quantity.unitStr = yytext; return UNIT; // pound
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 247 "ExpressionParser.l"
+#line 249 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Pound;               yylval.quantity.unitStr = yytext; return UNIT; // pound
 	YY_BREAK
 case 61:
 YY_RULE_SETUP
-#line 248 "ExpressionParser.l"
+#line 250 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Ounce;               yylval.quantity.unitStr = yytext; return UNIT; // ounce
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 249 "ExpressionParser.l"
+#line 251 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Stone;               yylval.quantity.unitStr = yytext; return UNIT; // Stone
 	YY_BREAK
 case 63:
 YY_RULE_SETUP
-#line 250 "ExpressionParser.l"
+#line 252 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Hundredweights;      yylval.quantity.unitStr = yytext; return UNIT; // hundredweights
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 252 "ExpressionParser.l"
+#line 254 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::PoundForce;          yylval.quantity.unitStr = yytext; return UNIT; // pound
 	YY_BREAK
 case 65:
 YY_RULE_SETUP
-#line 254 "ExpressionParser.l"
+#line 256 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Newton;              yylval.quantity.unitStr = yytext; return UNIT; // Newton (kg*m/s^2)a-za-za-z
 	YY_BREAK
 case 66:
 YY_RULE_SETUP
-#line 255 "ExpressionParser.l"
+#line 257 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliNewton;         yylval.quantity.unitStr = yytext; return UNIT; // milli Newton
 	YY_BREAK
 case 67:
 YY_RULE_SETUP
-#line 256 "ExpressionParser.l"
+#line 258 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloNewton;          yylval.quantity.unitStr = yytext; return UNIT; // kilo Newton
 	YY_BREAK
 case 68:
 YY_RULE_SETUP
-#line 257 "ExpressionParser.l"
+#line 259 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MegaNewton;          yylval.quantity.unitStr = yytext; return UNIT; // mega Newton
 	YY_BREAK
 case 69:
 YY_RULE_SETUP
-#line 259 "ExpressionParser.l"
+#line 261 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Pascal;              yylval.quantity.unitStr = yytext; return UNIT; // Pascal (kg/m*s^2 or N/m^2)
 	YY_BREAK
 case 70:
 YY_RULE_SETUP
-#line 260 "ExpressionParser.l"
+#line 262 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloPascal;          yylval.quantity.unitStr = yytext; return UNIT; // kilo Pascal
 	YY_BREAK
 case 71:
 YY_RULE_SETUP
-#line 261 "ExpressionParser.l"
+#line 263 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MegaPascal;          yylval.quantity.unitStr = yytext; return UNIT; // mega Pascal
 	YY_BREAK
 case 72:
 YY_RULE_SETUP
-#line 262 "ExpressionParser.l"
+#line 264 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::GigaPascal;          yylval.quantity.unitStr = yytext; return UNIT; // giga Pascal
 	YY_BREAK
 case 73:
 YY_RULE_SETUP
-#line 264 "ExpressionParser.l"
+#line 266 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Bar;                 yylval.quantity.unitStr = yytext; return UNIT; // Bar
 	YY_BREAK
 case 74:
 YY_RULE_SETUP
-#line 265 "ExpressionParser.l"
+#line 267 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliBar;            yylval.quantity.unitStr = yytext; return UNIT; // milli Bar
 	YY_BREAK
 case 75:
 YY_RULE_SETUP
-#line 267 "ExpressionParser.l"
+#line 269 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Torr;                yylval.quantity.unitStr = yytext; return UNIT; // portion of Pascal ( 101325/760 )
 	YY_BREAK
 case 76:
 YY_RULE_SETUP
-#line 268 "ExpressionParser.l"
+#line 270 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::mTorr;               yylval.quantity.unitStr = yytext; return UNIT; //
 	YY_BREAK
 case 77:
 YY_RULE_SETUP
-#line 269 "ExpressionParser.l"
+#line 271 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::yTorr;               yylval.quantity.unitStr = yytext; return UNIT; //
 	YY_BREAK
 case 78:
 YY_RULE_SETUP
-#line 270 "ExpressionParser.l"
+#line 272 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::yTorr;               yylval.quantity.unitStr = yytext; return UNIT; //
 	YY_BREAK
 case 79:
 YY_RULE_SETUP
-#line 272 "ExpressionParser.l"
+#line 274 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::PSI;                 yylval.quantity.unitStr = yytext; return UNIT; // pounds/in^2
 	YY_BREAK
 case 80:
 YY_RULE_SETUP
-#line 273 "ExpressionParser.l"
+#line 275 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KSI;                 yylval.quantity.unitStr = yytext; return UNIT; // 1000 x pounds/in^2
 	YY_BREAK
 case 81:
 YY_RULE_SETUP
-#line 274 "ExpressionParser.l"
+#line 276 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MPSI;                yylval.quantity.unitStr = yytext; return UNIT; // 1000 ksi
 	YY_BREAK
 case 82:
 YY_RULE_SETUP
-#line 276 "ExpressionParser.l"
+#line 278 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Watt;                yylval.quantity.unitStr = yytext; return UNIT; // Watt (kg*m^2/s^3)
 	YY_BREAK
 case 83:
 YY_RULE_SETUP
-#line 277 "ExpressionParser.l"
+#line 279 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliWatt;           yylval.quantity.unitStr = yytext; return UNIT; // milli Watt
 	YY_BREAK
 case 84:
 YY_RULE_SETUP
-#line 278 "ExpressionParser.l"
+#line 280 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloWatt;            yylval.quantity.unitStr = yytext; return UNIT; // kilo Watt
 	YY_BREAK
 case 85:
 YY_RULE_SETUP
-#line 279 "ExpressionParser.l"
+#line 281 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::VoltAmpere;          yylval.quantity.unitStr = yytext; return UNIT; // VoltAmpere (kg*m^2/s^3)
 	YY_BREAK
 case 86:
 YY_RULE_SETUP
-#line 281 "ExpressionParser.l"
+#line 283 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Volt;                yylval.quantity.unitStr = yytext; return UNIT; // Volt (kg*m^2/A/s^3)
 	YY_BREAK
 case 87:
 YY_RULE_SETUP
-#line 282 "ExpressionParser.l"
+#line 284 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloVolt;            yylval.quantity.unitStr = yytext; return UNIT; // kilo Volt
 	YY_BREAK
 case 88:
 YY_RULE_SETUP
-#line 283 "ExpressionParser.l"
+#line 285 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliVolt;           yylval.quantity.unitStr = yytext; return UNIT; // milli Volt
 	YY_BREAK
 case 89:
 YY_RULE_SETUP
-#line 285 "ExpressionParser.l"
+#line 287 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MegaSiemens;         yylval.quantity.unitStr = yytext; return UNIT; // mega Siemens
 	YY_BREAK
 case 90:
 YY_RULE_SETUP
-#line 286 "ExpressionParser.l"
+#line 288 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloSiemens;         yylval.quantity.unitStr = yytext; return UNIT; // kilo Siemens
 	YY_BREAK
 case 91:
 YY_RULE_SETUP
-#line 287 "ExpressionParser.l"
+#line 289 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Siemens;             yylval.quantity.unitStr = yytext; return UNIT; // Siemens (A^2*s^3/kg/m^2)
 	YY_BREAK
 case 92:
 YY_RULE_SETUP
-#line 288 "ExpressionParser.l"
+#line 290 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliSiemens;        yylval.quantity.unitStr = yytext; return UNIT; // milli Siemens
 	YY_BREAK
 case 93:
 YY_RULE_SETUP
-#line 289 "ExpressionParser.l"
+#line 291 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MicroSiemens;        yylval.quantity.unitStr = yytext; return UNIT; // micro Siemens
 	YY_BREAK
 case 94:
 YY_RULE_SETUP
-#line 290 "ExpressionParser.l"
+#line 292 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MicroSiemens;        yylval.quantity.unitStr = yytext; return UNIT; // micro Siemens
 	YY_BREAK
 case 95:
 YY_RULE_SETUP
-#line 292 "ExpressionParser.l"
+#line 294 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Ohm;                 yylval.quantity.unitStr = yytext; return UNIT; // Ohm (kg*m^2/A^2/s^3)
 	YY_BREAK
 case 96:
 YY_RULE_SETUP
-#line 293 "ExpressionParser.l"
+#line 295 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloOhm;             yylval.quantity.unitStr = yytext; return UNIT; // kilo Ohm
 	YY_BREAK
 case 97:
 YY_RULE_SETUP
-#line 294 "ExpressionParser.l"
+#line 296 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MegaOhm;             yylval.quantity.unitStr = yytext; return UNIT; // mega Ohm
 	YY_BREAK
 case 98:
 YY_RULE_SETUP
-#line 296 "ExpressionParser.l"
+#line 298 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Coulomb;             yylval.quantity.unitStr = yytext; return UNIT; // Coulomb (A*s)
 	YY_BREAK
 case 99:
 YY_RULE_SETUP
-#line 298 "ExpressionParser.l"
+#line 300 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Tesla;               yylval.quantity.unitStr = yytext; return UNIT; // Tesla (kg/s^2/A)
 	YY_BREAK
 case 100:
 YY_RULE_SETUP
-#line 299 "ExpressionParser.l"
+#line 301 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Gauss;               yylval.quantity.unitStr = yytext; return UNIT; // Gauss (1 G = 1e-4 T)
 	YY_BREAK
 case 101:
 YY_RULE_SETUP
-#line 301 "ExpressionParser.l"
+#line 303 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Weber;               yylval.quantity.unitStr = yytext; return UNIT; // Weber (kg*m^2/s^2/A)
 	YY_BREAK
 case 102:
 YY_RULE_SETUP
-#line 303 "ExpressionParser.l"
+#line 305 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Farad;               yylval.quantity.unitStr = yytext; return UNIT; // Farad (s^4*A^2/m^2/kg)
 	YY_BREAK
 case 103:
 YY_RULE_SETUP
-#line 304 "ExpressionParser.l"
+#line 306 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliFarad;          yylval.quantity.unitStr = yytext; return UNIT; // milli Farad
 	YY_BREAK
 case 104:
 YY_RULE_SETUP
-#line 305 "ExpressionParser.l"
+#line 307 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MicroFarad;          yylval.quantity.unitStr = yytext; return UNIT; // micro Farad
 	YY_BREAK
 case 105:
 YY_RULE_SETUP
-#line 306 "ExpressionParser.l"
+#line 308 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MicroFarad;          yylval.quantity.unitStr = yytext; return UNIT; // micro Farad
 	YY_BREAK
 case 106:
 YY_RULE_SETUP
-#line 307 "ExpressionParser.l"
+#line 309 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::NanoFarad;           yylval.quantity.unitStr = yytext; return UNIT; // nano Farad
 	YY_BREAK
 case 107:
 YY_RULE_SETUP
-#line 308 "ExpressionParser.l"
+#line 310 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::PicoFarad;           yylval.quantity.unitStr = yytext; return UNIT; // pico Farad
 	YY_BREAK
 case 108:
 YY_RULE_SETUP
-#line 310 "ExpressionParser.l"
+#line 312 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Henry;               yylval.quantity.unitStr = yytext; return UNIT; // Henry (kg*m^2/s^2/A^2)
 	YY_BREAK
 case 109:
 YY_RULE_SETUP
-#line 311 "ExpressionParser.l"
+#line 313 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliHenry;          yylval.quantity.unitStr = yytext; return UNIT; // milli Henry
 	YY_BREAK
 case 110:
 YY_RULE_SETUP
-#line 312 "ExpressionParser.l"
+#line 314 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MicroHenry;          yylval.quantity.unitStr = yytext; return UNIT; // micro Henry
 	YY_BREAK
 case 111:
 YY_RULE_SETUP
-#line 313 "ExpressionParser.l"
+#line 315 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MicroHenry;          yylval.quantity.unitStr = yytext; return UNIT; // micro Henry)
 	YY_BREAK
 case 112:
 YY_RULE_SETUP
-#line 314 "ExpressionParser.l"
+#line 316 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::NanoHenry;           yylval.quantity.unitStr = yytext; return UNIT; // nano Henry
 	YY_BREAK
 case 113:
 YY_RULE_SETUP
-#line 316 "ExpressionParser.l"
+#line 318 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Joule;               yylval.quantity.unitStr = yytext; return UNIT; // Joule (kg*m^2/s^2)
 	YY_BREAK
 case 114:
 YY_RULE_SETUP
-#line 317 "ExpressionParser.l"
+#line 319 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MilliJoule;          yylval.quantity.unitStr = yytext; return UNIT; // milli Joule
 	YY_BREAK
 case 115:
 YY_RULE_SETUP
-#line 318 "ExpressionParser.l"
+#line 320 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloJoule;           yylval.quantity.unitStr = yytext; return UNIT; // kilo Joule
 	YY_BREAK
 case 116:
 YY_RULE_SETUP
-#line 319 "ExpressionParser.l"
+#line 321 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::NewtonMeter;         yylval.quantity.unitStr = yytext; return UNIT; // N*m = Joule
 	YY_BREAK
 case 117:
 YY_RULE_SETUP
-#line 320 "ExpressionParser.l"
+#line 322 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::VoltAmpereSecond;    yylval.quantity.unitStr = yytext; return UNIT; // V*A*s = Joule
 	YY_BREAK
 case 118:
 YY_RULE_SETUP
-#line 321 "ExpressionParser.l"
+#line 323 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::WattSecond;          yylval.quantity.unitStr = yytext; return UNIT; //
 	YY_BREAK
 case 119:
 YY_RULE_SETUP
-#line 322 "ExpressionParser.l"
+#line 324 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::WattSecond;          yylval.quantity.unitStr = yytext; return UNIT; // W*s = Joule
 	YY_BREAK
 case 120:
 YY_RULE_SETUP
-#line 323 "ExpressionParser.l"
+#line 325 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloWattHour;        yylval.quantity.unitStr = yytext; return UNIT; // 1 kWh = 3.6e6 J
 	YY_BREAK
 case 121:
 YY_RULE_SETUP
-#line 324 "ExpressionParser.l"
+#line 326 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::ElectronVolt;        yylval.quantity.unitStr = yytext; return UNIT; // 1 eV = 1.602176634e-19 J
 	YY_BREAK
 case 122:
 YY_RULE_SETUP
-#line 325 "ExpressionParser.l"
+#line 327 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloElectronVolt;    yylval.quantity.unitStr = yytext; return UNIT;
 	YY_BREAK
 case 123:
 YY_RULE_SETUP
-#line 326 "ExpressionParser.l"
+#line 328 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::MegaElectronVolt;    yylval.quantity.unitStr = yytext; return UNIT;
 	YY_BREAK
 case 124:
 YY_RULE_SETUP
-#line 327 "ExpressionParser.l"
+#line 329 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Calorie;             yylval.quantity.unitStr = yytext; return UNIT; // 1 cal = 4.1868 J
 	YY_BREAK
 case 125:
 YY_RULE_SETUP
-#line 328 "ExpressionParser.l"
+#line 330 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::KiloCalorie;         yylval.quantity.unitStr = yytext; return UNIT;
 	YY_BREAK
 case 126:
 YY_RULE_SETUP
-#line 330 "ExpressionParser.l"
+#line 332 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Degree;              yylval.quantity.unitStr = yytext; return UNIT; // degree         (internal standard angle)
 	YY_BREAK
 case 127:
 YY_RULE_SETUP
-#line 331 "ExpressionParser.l"
+#line 333 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Degree;              yylval.quantity.unitStr = yytext; return UNIT; // degree         (internal standard angle)
 	YY_BREAK
 case 128:
 YY_RULE_SETUP
-#line 332 "ExpressionParser.l"
+#line 334 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Radian;              yylval.quantity.unitStr = yytext; return UNIT; // radian
 	YY_BREAK
 case 129:
 YY_RULE_SETUP
-#line 333 "ExpressionParser.l"
+#line 335 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::Gon;                 yylval.quantity.unitStr = yytext; return UNIT; // gon
 	YY_BREAK
 case 130:
 YY_RULE_SETUP
-#line 334 "ExpressionParser.l"
+#line 336 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::AngMinute;           yylval.quantity.unitStr = yytext; return UNIT; // angminute
 	YY_BREAK
 case 131:
 YY_RULE_SETUP
-#line 335 "ExpressionParser.l"
+#line 337 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::AngMinute;           yylval.quantity.unitStr = yytext; return UNIT; // angminute U+2032 	&prime; &#8242; ′
 	YY_BREAK
 case 132:
 YY_RULE_SETUP
-#line 336 "ExpressionParser.l"
+#line 338 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::AngSecond;           yylval.quantity.unitStr = yytext; return UNIT; // angsecond
 	YY_BREAK
 case 133:
 YY_RULE_SETUP
-#line 337 "ExpressionParser.l"
+#line 339 "ExpressionParser.l"
 COUNTCHARS; yylval.quantity.scaler  = Quantity::AngSecond;           yylval.quantity.unitStr = yytext; return UNIT; // angsecond U+2033 	&Prime; &#8243; ″
 	YY_BREAK
 case 134:
 YY_RULE_SETUP
-#line 339 "ExpressionParser.l"
+#line 341 "ExpressionParser.l"
 COUNTCHARS; yylval.fvalue = num_change(yytext,'.',',');       return yylval.fvalue == 1 ? ONE : NUM;
 	YY_BREAK
 case 135:
 YY_RULE_SETUP
-#line 340 "ExpressionParser.l"
+#line 342 "ExpressionParser.l"
 COUNTCHARS; yylval.fvalue = num_change(yytext,',','.');       return yylval.fvalue == 1 ? ONE : NUM;
 	YY_BREAK
 case 136:
 YY_RULE_SETUP
-#line 341 "ExpressionParser.l"
+#line 343 "ExpressionParser.l"
 COUNTCHARS; yylval.fvalue = num_change(yytext,',','.');       return yylval.fvalue == 1 ? ONE : NUM;
 	YY_BREAK
 case 137:
 YY_RULE_SETUP
-#line 342 "ExpressionParser.l"
+#line 344 "ExpressionParser.l"
 { COUNTCHARS;
                                yylval.ivalue = strtoll( yytext, NULL, 10 );
                                if (yylval.ivalue == LLONG_MIN)
@@ -9582,57 +9584,57 @@ YY_RULE_SETUP
 	YY_BREAK
 case 138:
 YY_RULE_SETUP
-#line 351 "ExpressionParser.l"
-COUNTCHARS; yylval.constant.fvalue = M_PI; yylval.constant.name = "pi"; return CONSTANT; // constant pi
+#line 353 "ExpressionParser.l"
+COUNTCHARS; yylval.constant.fvalue = std::numbers::pi; yylval.constant.name = "pi"; return CONSTANT; // constant pi
 	YY_BREAK
 case 139:
 YY_RULE_SETUP
-#line 352 "ExpressionParser.l"
-COUNTCHARS; yylval.constant.fvalue = M_E; yylval.constant.name = "e"; return CONSTANT; // constant e
+#line 354 "ExpressionParser.l"
+COUNTCHARS; yylval.constant.fvalue = std::numbers::e; yylval.constant.name = "e"; return CONSTANT; // constant e
 	YY_BREAK
 case 140:
 YY_RULE_SETUP
-#line 354 "ExpressionParser.l"
+#line 356 "ExpressionParser.l"
 COUNTCHARS; yylval.constant.fvalue = 0; yylval.constant.name = "None"; return CONSTANT;
 	YY_BREAK
 case 141:
 YY_RULE_SETUP
-#line 355 "ExpressionParser.l"
+#line 357 "ExpressionParser.l"
 COUNTCHARS; yylval.constant.fvalue = 1; yylval.constant.name = "True"; return CONSTANT;
 	YY_BREAK
 case 142:
 YY_RULE_SETUP
-#line 356 "ExpressionParser.l"
+#line 358 "ExpressionParser.l"
 COUNTCHARS; yylval.constant.fvalue = 1; yylval.constant.name = "True"; return CONSTANT;
 	YY_BREAK
 case 143:
 YY_RULE_SETUP
-#line 357 "ExpressionParser.l"
+#line 359 "ExpressionParser.l"
 COUNTCHARS; yylval.constant.fvalue = 0; yylval.constant.name = "False"; return CONSTANT;
 	YY_BREAK
 case 144:
 YY_RULE_SETUP
-#line 358 "ExpressionParser.l"
+#line 360 "ExpressionParser.l"
 COUNTCHARS; yylval.constant.fvalue = 0; yylval.constant.name = "False"; return CONSTANT;
 	YY_BREAK
 case 145:
 YY_RULE_SETUP
-#line 360 "ExpressionParser.l"
+#line 362 "ExpressionParser.l"
 COUNTCHARS; yylval.string = yytext; return CELLADDRESS;
 	YY_BREAK
 case 146:
 YY_RULE_SETUP
-#line 361 "ExpressionParser.l"
+#line 363 "ExpressionParser.l"
 COUNTCHARS; yylval.string = yytext; return CELLADDRESS;
 	YY_BREAK
 case 147:
 YY_RULE_SETUP
-#line 362 "ExpressionParser.l"
+#line 364 "ExpressionParser.l"
 COUNTCHARS; yylval.string = yytext; return CELLADDRESS;
 	YY_BREAK
 case 148:
 YY_RULE_SETUP
-#line 364 "ExpressionParser.l"
+#line 366 "ExpressionParser.l"
 {
                             COUNTCHARS;
                             std::string s = yytext;
@@ -9650,15 +9652,15 @@ YY_RULE_SETUP
 	YY_BREAK
 case 149:
 YY_RULE_SETUP
-#line 379 "ExpressionParser.l"
+#line 381 "ExpressionParser.l"
 COUNTCHARS; yylval.string = yytext; return IDENTIFIER;
 	YY_BREAK
 case 150:
 YY_RULE_SETUP
-#line 380 "ExpressionParser.l"
+#line 382 "ExpressionParser.l"
 ECHO;
 	YY_BREAK
-#line 9661 "lex.ExpressionParser.c"
+#line 9663 "lex.ExpressionParser.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -10627,4 +10629,4 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 380 "ExpressionParser.l"
+#line 382 "ExpressionParser.l"

--- a/src/Base/Matrix.cpp
+++ b/src/Base/Matrix.cpp
@@ -429,7 +429,7 @@ bool Matrix4D::toAxisAngle(Vector3d& rclBase,
     rfAngle = acos(fCos);  // in [0,PI]
 
     if (rfAngle > 0.0) {
-        if (rfAngle < D_PI) {
+        if (rfAngle < std::numbers::pi) {
             rclDir.x = (dMtrx4D[2][1] - dMtrx4D[1][2]);
             rclDir.y = (dMtrx4D[0][2] - dMtrx4D[2][0]);
             rclDir.z = (dMtrx4D[1][0] - dMtrx4D[0][1]);
@@ -1013,8 +1013,8 @@ std::array<Matrix4D, 4> Matrix4D::decompose() const
     residualMatrix = rotationMatrix * residualMatrix;
     // To keep signs of the scale factors equal
     if (residualMatrix.determinant() < 0) {
-        rotationMatrix.rotZ(D_PI);
-        residualMatrix.rotZ(D_PI);
+        rotationMatrix.rotZ(std::numbers::pi);
+        residualMatrix.rotZ(std::numbers::pi);
     }
     rotationMatrix.inverseGauss();
     // extract scale

--- a/src/Base/PlacementPyImp.cpp
+++ b/src/Base/PlacementPyImp.cpp
@@ -99,7 +99,7 @@ int PlacementPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                          &angle)) {
         // NOTE: The first parameter defines the translation, the second the rotation axis
         // and the last parameter defines the rotation angle in degree.
-        Base::Rotation rot(static_cast<Base::VectorPy*>(d)->value(), angle / 180.0 * D_PI);
+        Base::Rotation rot(static_cast<Base::VectorPy*>(d)->value(), angle / 180.0 * std::numbers::pi);
         *getPlacementPtr() = Base::Placement(static_cast<Base::VectorPy*>(o)->value(), rot);
         return 0;
     }

--- a/src/Base/PreCompiled.h
+++ b/src/Base/PreCompiled.h
@@ -32,18 +32,15 @@
 #include <Python.h>
 
 // standard
-#include <fcntl.h>
-#include <cstdio>
 #include <cassert>
-#include <ctime>
 #include <cfloat>
 #include <chrono>
-#ifdef FC_OS_WIN32
-#define _USE_MATH_DEFINES
-#endif  // FC_OS_WIN32
-#include <cmath>
-#include <climits>
 #include <codecvt>
+#include <cstdio>
+#include <ctime>
+#include <fcntl.h>
+#include <limits>
+#include <numbers>
 
 #ifdef FC_OS_WIN32
 #include <direct.h>

--- a/src/Base/Quantity.cpp
+++ b/src/Base/Quantity.cpp
@@ -22,8 +22,6 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#define _USE_MATH_DEFINES
-#include <cmath>
 #include <array>
 #endif
 
@@ -443,8 +441,8 @@ const Quantity Quantity::AngSecond(1.0 / 3600.0, Unit(0, 0, 0, 0, 0, 0, 0, 1)); 
 const Quantity
     Quantity::Degree(1.0,
                      Unit(0, 0, 0, 0, 0, 0, 0, 1));  // degree         (internal standard angle)
-const Quantity Quantity::Radian(180 / M_PI, Unit(0, 0, 0, 0, 0, 0, 0, 1));  // radian
-const Quantity Quantity::Gon(360.0 / 400.0, Unit(0, 0, 0, 0, 0, 0, 0, 1));  // gon
+const Quantity Quantity::Radian(180 / std::numbers::pi, Unit(0, 0, 0, 0, 0, 0, 0, 1));  // radian
+const Quantity Quantity::Gon(360.0 / 400.0, Unit(0, 0, 0, 0, 0, 0, 0, 1));              // gon
 
 
 // === Parser & Scanner stuff ===============================================
@@ -568,7 +566,7 @@ Quantity Quantity::parse(const std::string& string)
         QuantityParser::yy_scan_string(string.c_str());
     QuantityParser::StringBufferCleaner cleaner(my_string_buffer);
     // set the global return variables
-    QuantResult = Quantity(DOUBLE_MIN);
+    QuantResult = Quantity(std::numeric_limits<double>::min());
     // run the parser
     QuantityParser::yyparse();
 

--- a/src/Base/Quantity.h
+++ b/src/Base/Quantity.h
@@ -27,14 +27,6 @@
 #include "Unit.h"
 #include <string>
 
-// NOLINTBEGIN
-#ifndef DOUBLE_MAX
-#define DOUBLE_MAX 1.7976931348623157E+308 /* max decimal value of a "double"*/
-#endif
-#ifndef DOUBLE_MIN
-#define DOUBLE_MIN 2.2250738585072014E-308 /* min decimal value of a "double"*/
-#endif
-// NOLINTEND
 
 namespace Base
 {

--- a/src/Base/QuantityLexer.c
+++ b/src/Base/QuantityLexer.c
@@ -1613,7 +1613,7 @@ YY_RULE_SETUP
 case 135:
 YY_RULE_SETUP
 #line 228 "QuantityParser.l"
-{yylval = Quantity(M_PI)          ; return NUM;} // constant pi
+{yylval = Quantity(std::numbers::pi)          ; return NUM;} // constant pi
 	YY_BREAK
 case 136:
 YY_RULE_SETUP

--- a/src/Base/QuantityParser.l
+++ b/src/Base/QuantityParser.l
@@ -225,7 +225,7 @@ CGRP     '\,'[0-9][0-9][0-9]
 ","?{DIGIT}+{EXPO}?                                 {  yylval = Quantity(num_change(yytext,',','.'));return NUM;  }
 
 
-"pi"                   {yylval = Quantity(M_PI)          ; return NUM;} // constant pi
+"pi"                   {yylval = Quantity(std::numbers::pi)          ; return NUM;} // constant pi
 "e"                    {yylval = Quantity(M_E)           ; return NUM;} // constant e
 
 "acos"                 return ACOS;

--- a/src/Base/QuantityPyImp.cpp
+++ b/src/Base/QuantityPyImp.cpp
@@ -88,7 +88,7 @@ int QuantityPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     }
 
     PyErr_Clear();  // set by PyArg_ParseTuple()
-    double f = DOUBLE_MAX;
+    double f = std::numeric_limits<double>::max();
     if (PyArg_ParseTuple(args, "dO!", &f, &(Base::UnitPy::Type), &object)) {
         *self = Quantity(f, *(static_cast<Base::UnitPy*>(object)->getUnitPtr()));
         return 0;
@@ -110,7 +110,7 @@ int QuantityPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     int i8 = 0;
     PyErr_Clear();  // set by PyArg_ParseTuple()
     if (PyArg_ParseTuple(args, "|diiiiiiii", &f, &i1, &i2, &i3, &i4, &i5, &i6, &i7, &i8)) {
-        if (f < DOUBLE_MAX) {
+        if (f < std::numeric_limits<double>::max()) {
             *self = Quantity(f,
                              Unit {static_cast<int8_t>(i1),
                                    static_cast<int8_t>(i2),
@@ -207,7 +207,7 @@ PyObject* QuantityPy::getValueAs(PyObject* args)
     }
 
     if (!quant.isValid()) {
-        double f = DOUBLE_MAX;
+        double f = std::numeric_limits<double>::max();
         int i1 = 0;
         int i2 = 0;
         int i3 = 0;
@@ -218,7 +218,7 @@ PyObject* QuantityPy::getValueAs(PyObject* args)
         int i8 = 0;
         PyErr_Clear();
         if (PyArg_ParseTuple(args, "d|iiiiiiii", &f, &i1, &i2, &i3, &i4, &i5, &i6, &i7, &i8)) {
-            if (f < DOUBLE_MAX) {
+            if (f < std::numeric_limits<double>::max()) {
                 quant = Quantity(f,
                                  Unit {static_cast<int8_t>(i1),
                                        static_cast<int8_t>(i2),

--- a/src/Base/Rotation.cpp
+++ b/src/Base/Rotation.cpp
@@ -249,7 +249,7 @@ void Rotation::setValue(const Vector3d& axis, double fAngle)
     //
     // normalization of the angle to be in [0, 2pi[
     _angle = fAngle;
-    double theAngle = fAngle - floor(fAngle / (2.0 * D_PI)) * (2.0 * D_PI);
+    double theAngle = fAngle - floor(fAngle / (2.0 * std::numbers::pi)) * (2.0 * std::numbers::pi);
     this->quat[3] = cos(theAngle / 2.0);
 
     Vector3d norm = axis;
@@ -691,9 +691,9 @@ void Rotation::setYawPitchRoll(double y, double p, double r)
 {
     // The Euler angles (yaw,pitch,roll) are in XY'Z''-notation
     // convert to radians
-    y = (y / 180.0) * D_PI;
-    p = (p / 180.0) * D_PI;
-    r = (r / 180.0) * D_PI;
+    y = (y / 180.0) * std::numbers::pi;
+    p = (p / 180.0) * std::numbers::pi;
+    r = (r / 180.0) * std::numbers::pi;
 
     double c1 = cos(y / 2.0);
     double s1 = sin(y / 2.0);
@@ -726,26 +726,26 @@ void Rotation::getYawPitchRoll(double& y, double& p, double& r) const
     if (fabs(qd2 - 1.0) <= 16 * DBL_EPSILON) {  // Tolerance copied from OCC "gp_Quaternion.cxx"
         // north pole
         y = 0.0;
-        p = D_PI / 2.0;
+        p = std::numbers::pi / 2.0;
         r = 2.0 * atan2(quat[0], quat[3]);
     }
     else if (fabs(qd2 + 1.0)
              <= 16 * DBL_EPSILON) {  // Tolerance copied from OCC "gp_Quaternion.cxx"
         // south pole
         y = 0.0;
-        p = -D_PI / 2.0;
+        p = -std::numbers::pi / 2.0;
         r = 2.0 * atan2(quat[0], quat[3]);
     }
     else {
         y = atan2(2.0 * (q01 + q23), (q00 + q33) - (q11 + q22));
-        p = qd2 > 1.0 ? D_PI / 2.0 : (qd2 < -1.0 ? -D_PI / 2.0 : asin(qd2));
+        p = qd2 > 1.0 ? std::numbers::pi / 2.0 : (qd2 < -1.0 ? -std::numbers::pi / 2.0 : asin(qd2));
         r = atan2(2.0 * (q12 + q03), (q22 + q33) - (q00 + q11));
     }
 
     // convert to degree
-    y = (y / D_PI) * 180;
-    p = (p / D_PI) * 180;
-    r = (r / D_PI) * 180;
+    y = (y / std::numbers::pi) * 180;
+    p = (p / std::numbers::pi) * 180;
+    r = (r / std::numbers::pi) * 180;
 }
 
 bool Rotation::isSame(const Rotation& q) const
@@ -984,9 +984,9 @@ void Rotation::setEulerAngles(EulerSequence theOrder,
 
     EulerSequence_Parameters o = translateEulerSequence(theOrder);
 
-    theAlpha *= D_PI / 180.0;
-    theBeta *= D_PI / 180.0;
-    theGamma *= D_PI / 180.0;
+    theAlpha *= std::numbers::pi / 180.0;
+    theBeta *= std::numbers::pi / 180.0;
+    theGamma *= std::numbers::pi / 180.0;
 
     double a = theAlpha;
     double b = theBeta;
@@ -1081,7 +1081,7 @@ void Rotation::getEulerAngles(EulerSequence theOrder,
         theGamma = aFirst;
     }
 
-    theAlpha *= 180.0 / D_PI;
-    theBeta *= 180.0 / D_PI;
-    theGamma *= 180.0 / D_PI;
+    theAlpha *= 180.0 / std::numbers::pi;
+    theBeta *= 180.0 / std::numbers::pi;
+    theGamma *= 180.0 / std::numbers::pi;
 }

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -28,6 +28,7 @@
 #include <FCGlobal.h>
 #endif
 #include <cmath>
+#include <numbers>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -127,20 +128,16 @@ inline T sgn(T t)
     return (t > 0) ? T(1) : T(-1);
 }
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 template<class T>
 inline T toRadians(T d)
 {
-    return static_cast<T>((d * M_PI) / 180.0);
+    return static_cast<T>((d * std::numbers::pi) / 180.0);
 }
 
 template<class T>
 inline T toDegrees(T r)
 {
-    return static_cast<T>((r / M_PI) * 180.0);
+    return static_cast<T>((r / std::numbers::pi) * 180.0);
 }
 
 inline float fromPercent(const long value)

--- a/src/Base/Tools2D.cpp
+++ b/src/Base/Tools2D.cpp
@@ -43,7 +43,7 @@ double Vector2d::GetAngle(const Vector2d& vec) const
     if ((fDivid < -1e-10) || (fDivid > 1e-10)) {
         fNum = (*this * vec) / fDivid;
         if (fNum < -1) {
-            return D_PI;
+            return std::numbers::pi;
         }
         if (fNum > 1) {
             return 0.0;
@@ -52,7 +52,7 @@ double Vector2d::GetAngle(const Vector2d& vec) const
         return acos(fNum);
     }
 
-    return -FLOAT_MAX;  // division by zero
+    return -std::numeric_limits<double>::max();  // division by zero
 }
 
 void Vector2d::ProjectToLine(const Vector2d& point, const Vector2d& line)
@@ -173,13 +173,13 @@ bool Line2d::Intersect(const Line2d& rclLine, Vector2d& rclV) const
         m1 = (clV2.y - clV1.y) / (clV2.x - clV1.x);
     }
     else {
-        m1 = DOUBLE_MAX;
+        m1 = std::numeric_limits<double>::max();
     }
     if (fabs(rclLine.clV2.x - rclLine.clV1.x) > 1e-10) {
         m2 = (rclLine.clV2.y - rclLine.clV1.y) / (rclLine.clV2.x - rclLine.clV1.x);
     }
     else {
-        m2 = DOUBLE_MAX;
+        m2 = std::numeric_limits<double>::max();
     }
     if (m1 == m2) { /****** RETURN ERR (parallel lines) *************/
         return false;
@@ -189,11 +189,11 @@ bool Line2d::Intersect(const Line2d& rclLine, Vector2d& rclV) const
     b2 = rclLine.clV1.y - m2 * rclLine.clV1.x;
 
     // calc intersection
-    if (m1 == DOUBLE_MAX) {
+    if (m1 == std::numeric_limits<double>::max()) {
         rclV.x = clV1.x;
         rclV.y = m2 * rclV.x + b2;
     }
-    else if (m2 == DOUBLE_MAX) {
+    else if (m2 == std::numeric_limits<double>::max()) {
         rclV.x = rclLine.clV1.x;
         rclV.y = m1 * rclV.x + b1;
     }

--- a/src/Base/Tools2D.h
+++ b/src/Base/Tools2D.h
@@ -32,15 +32,6 @@
 #include <FCGlobal.h>
 #endif
 
-// NOLINTBEGIN
-#ifndef DOUBLE_MAX
-#define DOUBLE_MAX 1.7976931348623157E+308 /* max decimal value of a "double"*/
-#endif
-#ifndef DOUBLE_MIN
-#define DOUBLE_MIN 2.2250738585072014E-308 /* min decimal value of a "double"*/
-#endif
-// NOLINTEND
-
 
 namespace Base
 {
@@ -462,8 +453,8 @@ inline bool Line2d::Contains(const Vector2d& rclV) const
 
 inline BoundBox2d::BoundBox2d()
 {
-    MinX = MinY = DOUBLE_MAX;
-    MaxX = MaxY = -DOUBLE_MAX;
+    MinX = MinY = std::numeric_limits<double>::max();
+    MaxX = MaxY = -std::numeric_limits<double>::max();
 }
 
 inline BoundBox2d::BoundBox2d(double fX1, double fY1, double fX2, double fY2)
@@ -480,7 +471,9 @@ inline bool BoundBox2d::IsValid() const
 
 inline bool BoundBox2d::IsInfinite() const
 {
-    return MaxX >= DOUBLE_MAX && MaxY >= DOUBLE_MAX && MinX <= -DOUBLE_MAX && MinY <= -DOUBLE_MAX;
+    return MaxX >= std::numeric_limits<double>::max() && MaxY >= std::numeric_limits<double>::max()
+        && MinX <= -std::numeric_limits<double>::max()
+        && MinY <= -std::numeric_limits<double>::max();
 }
 
 inline bool BoundBox2d::IsEqual(const BoundBox2d& bbox, double tolerance) const
@@ -525,8 +518,8 @@ inline Vector2d BoundBox2d::GetCenter() const
 
 inline void BoundBox2d::SetVoid()
 {
-    MinX = MinY = DOUBLE_MAX;
-    MaxX = MaxY = -DOUBLE_MAX;
+    MinX = MinY = std::numeric_limits<double>::max();
+    MaxX = MaxY = -std::numeric_limits<double>::max();
 }
 
 inline void BoundBox2d::Add(const Vector2d& v)

--- a/src/Base/Vector3D.h
+++ b/src/Base/Vector3D.h
@@ -27,74 +27,28 @@
 
 #include <cmath>
 #include <cfloat>
-
-#ifndef F_PI
-#define F_PI 3.1415926f
-#endif
-
-#ifndef D_PI
-#define D_PI 3.141592653589793
-#endif
-
-#ifndef FLOAT_MAX
-#define FLOAT_MAX 3.402823466E+38F
-#endif
-
-#ifndef FLOAT_MIN
-#define FLOAT_MIN 1.175494351E-38F
-#endif
-
-#ifndef DOUBLE_MAX
-#define DOUBLE_MAX 1.7976931348623157E+308 /* max decimal value of a "double"*/
-#endif
-
-#ifndef DOUBLE_MIN
-#define DOUBLE_MIN 2.2250738585072014E-308 /* min decimal value of a "double"*/
-#endif
-
+#include <limits>
+#include <numbers>
 
 namespace Base
 {
 template<class numT>
 struct float_traits
 {
-};
-
-template<>
-struct float_traits<float>
-{
-    using float_type = float;
-    [[nodiscard]] static constexpr float_type pi()
+    [[nodiscard]] static constexpr numT pi()
     {
-        return F_PI;
+        return std::numbers::pi_v<numT>;
     }
-    [[nodiscard]] static constexpr float_type epsilon()
+    [[nodiscard]] static constexpr numT epsilon()
     {
-        return FLT_EPSILON;
+        return std::numeric_limits<numT>::epsilon();
     }
-    [[nodiscard]] static constexpr float_type maximum()
+    [[nodiscard]] static constexpr numT maximum()
     {
-        return FLT_MAX;
+        return std::numeric_limits<numT>::max();
     }
 };
 
-template<>
-struct float_traits<double>
-{
-    using float_type = double;
-    [[nodiscard]] static constexpr float_type pi()
-    {
-        return D_PI;
-    }
-    [[nodiscard]] static constexpr float_type epsilon()
-    {
-        return DBL_EPSILON;
-    }
-    [[nodiscard]] static constexpr float_type maximum()
-    {
-        return DBL_MAX;
-    }
-};
 
 /** The Vector Base class. */
 template<class float_type>

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -71,8 +71,8 @@ InputField::InputField(QWidget * parent)
     ExpressionWidget(),
     validInput(true),
     actUnitValue(0),
-    Maximum(DOUBLE_MAX),
-    Minimum(-DOUBLE_MAX),
+    Maximum(std::numeric_limits<double>::max()),
+    Minimum(-std::numeric_limits<double>::max()),
     StepSize(1.0),
     HistorySize(5),
     SaveSize(5)

--- a/src/Gui/Inventor/SoFCBackgroundGradient.cpp
+++ b/src/Gui/Inventor/SoFCBackgroundGradient.cpp
@@ -24,11 +24,6 @@
 
 #ifndef _PreComp_
 #include <array>
-#include <boost/math/constants/constants.hpp>
-#ifdef FC_OS_WIN32
- #define _USE_MATH_DEFINES
-#endif
-#include <cmath>
 #ifdef FC_OS_MACOSX
 #include <OpenGL/gl.h>
 #else
@@ -39,17 +34,17 @@
 #include "SoFCBackgroundGradient.h"
 
 static const std::array <GLfloat[2], 32> big_circle = []{
-    static const float pi2 = boost::math::constants::two_pi<float>();
+    constexpr float pi2 = std::numbers::pi_v<float> * 2.0F;
     std::array <GLfloat[2], 32> result; int c = 0;
     for (GLfloat i = 0; i < pi2; i += pi2 / 32, c++) {
-        result[c][0] = M_SQRT2*cosf(i); result[c][1] = M_SQRT2*sinf(i);
+        result[c][0] = std::numbers::sqrt2_v<float>*cosf(i); result[c][1] = std::numbers::sqrt2_v<float>*sinf(i);
     }
     return result; }();
 static const std::array <GLfloat[2], 32> small_oval = []{
-    static const float pi2 = boost::math::constants::two_pi<float>();
+    constexpr float pi2 = std::numbers::pi_v<float> * 2.0F;
     std::array <GLfloat[2], 32> result; int c = 0;
     for (GLfloat i = 0; i < pi2; i += pi2 / 32, c++) {
-        result[c][0] = 0.3*M_SQRT2*cosf(i); result[c][1] = M_SQRT1_2*sinf(i);
+        result[c][0] = 0.3*std::numbers::sqrt2_v<float>*cosf(i); result[c][1] = (1.0F/std::numbers::sqrt2_v<float>)*sinf(i);
     }
     return result; }();
 

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -32,7 +32,6 @@
 # else
 #  include <GL/gl.h>
 # endif
-# include <boost/math/constants/constants.hpp>
 # include <Inventor/nodes/SoOrthographicCamera.h>
 # include <Inventor/events/SoEvent.h>
 # include <Inventor/events/SoLocation2Event.h>
@@ -553,7 +552,7 @@ void NaviCubeImplementation::addButtonFace(PickId pickId, const SbVec3f& directi
         case PickId::DotBackside: {
             int steps = 16;
             for (int i = 0; i < steps; i++) {
-                float angle = 2.0f * M_PI * ((float)i+0.5) / (float)steps;
+                float angle = 2.0f * std::numbers::pi * ((float)i+0.5) / (float)steps;
                 pointData.emplace_back(10. * cos(angle) + 87.);
                 pointData.emplace_back(10. * sin(angle) - 87.);
             }
@@ -659,8 +658,8 @@ void NaviCubeImplementation::setSize(int size)
 
 void NaviCubeImplementation::prepare()
 {
-    static const float pi = boost::math::constants::pi<float>();
-    static const float pi1_2 = boost::math::constants::half_pi<float>();
+    static const float pi = std::numbers::pi_v<float>;
+    static const float pi1_2 = pi/2.0F;
 
     createCubeFaceTextures();
 
@@ -817,7 +816,7 @@ void NaviCubeImplementation::drawNaviCube(bool pickMode, float opacity)
         glOrtho(-2.1, 2.1, -2.1, 2.1, NEARVAL, FARVAL);
     }
     else {
-        const float dim = NEARVAL * float(tan(M_PI / 8.0)) * 1.1;
+        const float dim = NEARVAL * float(tan(std::numbers::pi / 8.0)) * 1.1;
         glFrustum(-dim, dim, -dim, dim, NEARVAL, FARVAL);
     }
     glMatrixMode(GL_MODELVIEW);
@@ -1010,11 +1009,12 @@ SbRotation NaviCubeImplementation::getNearestOrientation(PickId pickId) {
         angle *= -1;
     }
 
-    static const float pi = boost::math::constants::pi<float>();
-    static const float pi2 = boost::math::constants::two_pi<float>();
-    static const float pi1_2 = boost::math::constants::half_pi<float>();
-    static const float pi1_3 = boost::math::constants::third_pi<float>();
-    static const float pi2_3 = boost::math::constants::two_thirds_pi<float>();
+    constexpr float pi = std::numbers::pi_v<float>;
+    constexpr float pi2 = 2.0F * pi;
+    constexpr float pi_2 = pi / 2.0F;
+    constexpr float pi_3 = pi / 3.0F;
+    constexpr float pi_4 = pi / 4.0F;
+    constexpr float pi2_3 = 2 * pi_3;
 
     // Make angle positive
     if (angle < 0) {
@@ -1030,22 +1030,22 @@ SbRotation NaviCubeImplementation::getNearestOrientation(PickId pickId) {
     // Find the angle to rotate to the nearest orientation
     if (m_Faces[pickId].type == ShapeId::Corner) {
         // 6 possible orientations for the corners
-        if (angle <= (M_PI / 6 + f)) {
+        if (angle <= (pi / 6 + f)) {
             angle = 0;
         }
-        else if (angle <= (M_PI_2 + f)) {
-            angle = pi1_3;
+        else if (angle <= (pi_2 + f)) {
+            angle = pi_3;
         }
-        else if (angle < (5 * M_PI / 6 - f)) {
+        else if (angle < (5 * pi / 6 - f)) {
             angle = pi2_3;
         }
-        else if (angle <= (M_PI + M_PI / 6 + f)) {
+        else if (angle <= (pi + pi / 6 + f)) {
             angle = pi;
         }
-        else if (angle < (M_PI + M_PI_2 - f)) {
-            angle = pi + pi1_3;
+        else if (angle < (pi + pi_2 - f)) {
+            angle = pi + pi_3;
         }
-        else if (angle < (M_PI + 5 * M_PI / 6 - f)) {
+        else if (angle < (pi + 5 * pi / 6 - f)) {
             angle = pi + pi2_3;
         }
         else {
@@ -1054,17 +1054,17 @@ SbRotation NaviCubeImplementation::getNearestOrientation(PickId pickId) {
     }
     else {
         // 4 possible orientations for the main and edge faces
-        if (angle <= (M_PI_4 + f)) {
+        if (angle <= (pi_4 + f)) {
             angle = 0;
         }
-        else if (angle <= (3 * M_PI_4 + f)) {
-            angle = pi1_2;
+        else if (angle <= (3 * pi_4 + f)) {
+            angle = pi_2;
         }
-        else if (angle < (M_PI + M_PI_4 - f)) {
+        else if (angle < (pi + pi_4 - f)) {
             angle = pi;
         }
-        else if (angle < (M_PI + 3 * M_PI_4 - f)) {
-            angle = pi + pi1_2;
+        else if (angle < (pi + 3 * pi_4 - f)) {
+            angle = pi + pi_2;
         }
         else {
             angle = 0;
@@ -1079,7 +1079,7 @@ SbRotation NaviCubeImplementation::getNearestOrientation(PickId pickId) {
 
 bool NaviCubeImplementation::mouseReleased(short x, short y)
 {
-    static const float pi = boost::math::constants::pi<float>();
+    constexpr float pi = std::numbers::pi_v<float>;
 
     setHilite(PickId::None);
     m_MouseDown = false;
@@ -1089,7 +1089,7 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
     } else {
         PickId pickId = pickFace(x, y);
         long step = Base::clamp(long(m_NaviStepByTurn), 4L, 36L);
-        float rotStepAngle = (2 * M_PI) / step;
+        float rotStepAngle = (2 * std::numbers::pi) / step;
 
         if (m_Faces[pickId].type == ShapeId::Main || m_Faces[pickId].type == ShapeId::Edge || m_Faces[pickId].type == ShapeId::Corner) {
             // Handle the cube faces

--- a/src/Gui/Navigation/NavigationAnimation.cpp
+++ b/src/Gui/Navigation/NavigationAnimation.cpp
@@ -69,8 +69,8 @@ void FixedTimeAnimation::initialize()
     SbVec3f rotationAxisPost;
     float angle;
     SbRotation(navigation->getCamera()->orientation.getValue().inverse() * targetOrientation).getValue(rotationAxisPost, angle);
-    if (angle > M_PI) {
-        angle -= float(2 * M_PI);
+    if (angle > std::numbers::pi) {
+        angle -= float(2 * std::numbers::pi);
     }
 
     // Convert post-multiplication axis to a pre-multiplication axis
@@ -130,9 +130,9 @@ SpinningAnimation::SpinningAnimation(NavigationStyle* navigation, const SbVec3f&
     : NavigationAnimation(navigation)
     , rotationAxis(axis)
 {
-    setDuration((2 * M_PI / velocity) * 1000.0);
+    setDuration((2 * std::numbers::pi / velocity) * 1000.0);
     setStartValue(0.0);
-    setEndValue(2 * M_PI);
+    setEndValue(2 * std::numbers::pi);
     setLoopCount(-1);
 }
 

--- a/src/Gui/PreCompiled.h
+++ b/src/Gui/PreCompiled.h
@@ -52,6 +52,7 @@
 #include <typeinfo>
 #include <cfloat>
 #include <climits>
+#include <numbers>
 
 #ifdef FC_OS_WIN32
 #include <Windows.h>
@@ -90,7 +91,6 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
-#include <boost/math/constants/constants.hpp>
 #include <boost/program_options.hpp>
 #include <boost/utility.hpp>
 

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -66,8 +66,8 @@ public:
       pendingEmit(false),
       checkRangeInExpression(false),
       unitValue(0),
-      maximum(DOUBLE_MAX),
-      minimum(-DOUBLE_MAX),
+      maximum(std::numeric_limits<double>::max()),
+      minimum(-std::numeric_limits<double>::max()),
       singleStep(1.0),
       q_ptr(q)
     {

--- a/src/Gui/Quarter/SoQTQuarterAdaptor.cpp
+++ b/src/Gui/Quarter/SoQTQuarterAdaptor.cpp
@@ -303,7 +303,7 @@ void SIM::Coin3D::Quarter::SoQTQuarterAdaptor::convertOrtho2Perspective(const So
 
     SbRotation camrot = in->orientation.getValue();
 
-    float focaldist = float(in->height.getValue() / (2.0*tan(M_PI / 8.0)));  // NOLINT
+    float focaldist = float(in->height.getValue() / (2.0*tan(std::numbers::pi / 8.0)));  // NOLINT
 
     SbVec3f offset(0,0,focaldist-in->focalDistance.getValue());
 
@@ -313,7 +313,7 @@ void SIM::Coin3D::Quarter::SoQTQuarterAdaptor::convertOrtho2Perspective(const So
     out->focalDistance.setValue(focaldist);
 
     // 45° is the default value of this field in SoPerspectiveCamera.
-    out->heightAngle = (float)(M_PI / 4.0);  // NOLINT
+    out->heightAngle = (float)(std::numbers::pi / 4.0);  // NOLINT
 }
 
 void SIM::Coin3D::Quarter::SoQTQuarterAdaptor::convertPerspective2Ortho(const SoPerspectiveCamera* in,
@@ -568,7 +568,7 @@ void SIM::Coin3D::Quarter::SoQTQuarterAdaptor::seeksensorCB(void* data, SoSensor
 
     bool end = (par == 1.0F);
 
-    par = (float)((1.0 - cos(M_PI * par)) * 0.5);  // NOLINT
+    par = (float)((1.0 - cos(std::numbers::pi * par)) * 0.5);  // NOLINT
 
     thisp->getSoRenderManager()->getCamera()->position = thisp->m_camerastartposition +
             (thisp->m_cameraendposition - thisp->m_camerastartposition) * par;

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -36,6 +36,7 @@
 # include <algorithm>
 # include <cfloat>
 # include <cmath>
+# include <numbers>
 # include <QFontMetrics>
 # include <QPainter>
 
@@ -62,6 +63,9 @@ using namespace Gui;
 
 namespace {
 
+constexpr float pi = std::numbers::pi_v<float>;
+constexpr float pi_2 = pi/2.0F;
+
 void glVertex(const SbVec3f& pt){
     glVertex3f(pt[0], pt[1], pt[2]);
 }
@@ -78,11 +82,11 @@ void glDrawLine(const SbVec3f& p1, const SbVec3f& p2){
     glEnd();
 }
 
-void glDrawArc(const SbVec3f& center, float radius, float startAngle=0., float endAngle=2.0*M_PI, int countSegments=0){
+void glDrawArc(const SbVec3f& center, float radius, float startAngle=0., float endAngle=2.0*pi, int countSegments=0){
     float range = endAngle - startAngle;
 
     if (countSegments == 0){
-        countSegments = std::max(6, abs(int(25.0 * range / M_PI)));
+        countSegments = std::max(6, abs(int(25.0 * range / pi)));
     }
 
     float segment = range / (countSegments-1);
@@ -546,11 +550,11 @@ private:
         float startangle = atan2f(vc1[1], vc1[0]);
         float endangle = atan2f(vc2[1], vc2[0]);
         if (endangle < startangle) {
-            endangle += 2. * M_PI;
+            endangle += 2. * pi;
         }
 
         SbVec3f textCenter;
-        if (endangle - startangle <= M_PI) {
+        if (endangle - startangle <= pi) {
             textCenter = ctr + vm * (length + imgHeight);
         } else {
             textCenter = ctr - vm * (length + 2. * imgHeight);
@@ -689,7 +693,7 @@ SbVec3f SoDatumLabel::getLabelTextCenterArcLength(const SbVec3f& ctr, const SbVe
     float endangle = atan2f(vc2[1], vc2[0]);
 
     if (endangle < startangle) {
-        endangle += 2. * M_PI;
+        endangle += 2. * pi;
     }
 
     // Text location
@@ -697,7 +701,7 @@ SbVec3f SoDatumLabel::getLabelTextCenterArcLength(const SbVec3f& ctr, const SbVe
     vm.normalize();
 
     SbVec3f textCenter;
-    if (endangle - startangle <= M_PI) {
+    if (endangle - startangle <= pi) {
         textCenter = ctr + vm * (length + this->imgHeight);
     } else {
         textCenter = ctr - vm * (length + 2. * this->imgHeight);
@@ -1192,10 +1196,10 @@ void SoDatumLabel::drawDistance(const SbVec3f* points, float scale, int srch, fl
 
     // Get magnitude of angle between horizontal
     angle = atan2f(dir[1],dir[0]);
-    if (angle > M_PI_2+M_PI/12) {
-        angle -= (float)M_PI;
-    } else if (angle <= -M_PI_2+M_PI/12) {
-        angle += (float)M_PI;
+    if (angle > pi_2+pi/12) {
+        angle -= (float)pi;
+    } else if (angle <= -pi_2+pi/12) {
+        angle += (float)pi;
     }
 
     textOffset = midpos + normal * length + dir * length2;
@@ -1291,7 +1295,7 @@ void SoDatumLabel::drawDistance(const SbVec3f* points)
         float startangle1 = this->param3.getValue();
         float radius1 = this->param5.getValue();
         SbVec3f center = points[2];
-        int countSegments = std::max(6, abs(int(50.0 * range1 / (2 * M_PI))));
+        int countSegments = std::max(6, abs(int(50.0 * range1 / (2 * pi))));
         double segment = range1 / (countSegments - 1);
 
         glBegin(GL_LINE_STRIP);
@@ -1307,7 +1311,7 @@ void SoDatumLabel::drawDistance(const SbVec3f* points)
         float startangle2 = this->param6.getValue();
         float radius2 = this->param8.getValue();
         SbVec3f center = points[3];
-        int countSegments = std::max(6, abs(int(50.0 * range2 / (2 * M_PI))));
+        int countSegments = std::max(6, abs(int(50.0 * range2 / (2 * pi))));
         double segment = range2 / (countSegments - 1);
 
         glBegin(GL_LINE_STRIP);
@@ -1342,10 +1346,10 @@ void SoDatumLabel::drawRadiusOrDiameter(const SbVec3f* points, float& angle, SbV
 
     // Get magnitude of angle between horizontal
     angle = atan2f(dir[1],dir[0]);
-    if (angle > M_PI_2+M_PI/12) {
-        angle -= (float)M_PI;
-    } else if (angle <= -M_PI_2+M_PI/12) {
-        angle += (float)M_PI;
+    if (angle > pi_2+pi/12) {
+        angle -= (float)pi;
+    } else if (angle <= -pi_2+pi/12) {
+        angle += (float)pi;
     }
 
     textOffset = pos;
@@ -1401,7 +1405,7 @@ void SoDatumLabel::drawRadiusOrDiameter(const SbVec3f* points, float& angle, SbV
     float startangle = this->param3.getValue();
     float range = this->param4.getValue();
     if (range != 0.0) {
-        int countSegments = std::max(6, abs(int(50.0 * range / (2 * M_PI))));
+        int countSegments = std::max(6, abs(int(50.0 * range / (2 * pi))));
         double segment = range / (countSegments - 1);
 
         glBegin(GL_LINE_STRIP);
@@ -1535,7 +1539,7 @@ void SoDatumLabel::drawArcLength(const SbVec3f* points, float& angle, SbVec3f& t
     float startangle = atan2f(vc1[1], vc1[0]);
     float endangle = atan2f(vc2[1], vc2[0]);
     if (endangle < startangle) {
-        endangle += 2.0F * (float)M_PI;
+        endangle += 2.0F * (float)pi;
     }
 
     float range = endangle - startangle;
@@ -1547,10 +1551,10 @@ void SoDatumLabel::drawArcLength(const SbVec3f* points, float& angle, SbVec3f& t
     dir.normalize();
     // Get magnitude of angle between horizontal
     angle = atan2f(dir[1],dir[0]);
-    if (angle > M_PI_2+M_PI/12) {
-        angle -= (float)M_PI;
-    } else if (angle <= -M_PI_2+M_PI/12) {
-        angle += (float)M_PI;
+    if (angle > pi_2+pi/12) {
+        angle -= (float)pi;
+    } else if (angle <= -pi_2+pi/12) {
+        angle += (float)pi;
     }
        // Text location
     textOffset = getLabelTextCenterArcLength(ctr, p1, p2);
@@ -1566,7 +1570,7 @@ void SoDatumLabel::drawArcLength(const SbVec3f* points, float& angle, SbVec3f& t
     SbVec3f pnt4 = p2 + (length-radius) * vm;
 
         // Draw arc
-    if (range <= M_PI) {
+    if (range <= pi) {
         glDrawArc(ctr + (length-radius)*vm, radius, startangle, endangle);
     }
     else {
@@ -1678,7 +1682,7 @@ void SoDatumLabel::drawText(SoState *state, int srcw, int srch, float angle, con
 
     // Apply a rotation and translation matrix
     glTranslatef(textOffset[0], textOffset[1], textOffset[2]);
-    glRotatef((GLfloat) angle * 180 / M_PI, 0,0,1);
+    glRotatef((GLfloat) angle * 180 / pi, 0,0,1);
     glBegin(GL_QUADS);
 
     glColor3f(1.F, 1.F, 1.F);

--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -743,7 +743,7 @@ RDragger::RDragger()
     }
 
     SO_KIT_ADD_FIELD(rotation, (SbVec3f(0.0, 0.0, 1.0), 0.0));
-    SO_KIT_ADD_FIELD(rotationIncrement, (M_PI / 8.0));
+    SO_KIT_ADD_FIELD(rotationIncrement, (std::numbers::pi / 8.0));
     SO_KIT_ADD_FIELD(rotationIncrementCount, (0));
 
     SO_KIT_INIT_INSTANCE();
@@ -808,7 +808,7 @@ SoGroup* RDragger::buildGeometry()
 
     unsigned int segments = 15;
 
-    float angleIncrement = static_cast<float>(M_PI / 2.0) / static_cast<float>(segments);
+    float angleIncrement = static_cast<float>(std::numbers::pi / 2.0) / static_cast<float>(segments);
     SbRotation rotation(SbVec3f(0.0, 0.0, 1.0), angleIncrement);
     SbVec3f point(arcRadius, 0.0, 0.0);
     for (unsigned int index = 0; index <= segments; ++index) {
@@ -965,7 +965,7 @@ void RDragger::drag()
             appendRotation(getStartMotionMatrix(), localRotation, SbVec3f(0.0, 0.0, 0.0)));
     }
 
-    Base::Quantity quantity(static_cast<double>(rotationIncrementCount.getValue()) * (180.0 / M_PI)
+    Base::Quantity quantity(static_cast<double>(rotationIncrementCount.getValue()) * (180.0 / std::numbers::pi)
                                 * rotationIncrement.getValue(),
                             Base::Unit::Angle);
 
@@ -1179,7 +1179,7 @@ SoFCCSysDragger::SoFCCSysDragger()
     SO_KIT_ADD_FIELD(translationIncrementCountZ, (0));
 
     SO_KIT_ADD_FIELD(rotation, (SbVec3f(0.0, 0.0, 1.0), 0.0));
-    SO_KIT_ADD_FIELD(rotationIncrement, (M_PI / 8.0));
+    SO_KIT_ADD_FIELD(rotationIncrement, (std::numbers::pi / 8.0));
     SO_KIT_ADD_FIELD(rotationIncrementCountX, (0));
     SO_KIT_ADD_FIELD(rotationIncrementCountY, (0));
     SO_KIT_ADD_FIELD(rotationIncrementCountZ, (0));
@@ -1272,7 +1272,7 @@ SoFCCSysDragger::SoFCCSysDragger()
 
     SoRotation* localRotation;
     SbRotation tempRotation;
-    auto angle = static_cast<float>(M_PI / 2.0);
+    auto angle = static_cast<float>(std::numbers::pi / 2.0);
     // Translator
     localRotation = SO_GET_ANY_PART(this, "xTranslatorRotation", SoRotation);
     localRotation->rotation.setValue(SbVec3f(0.0, 0.0, -1.0), angle);

--- a/src/Gui/SoTouchEvents.cpp
+++ b/src/Gui/SoTouchEvents.cpp
@@ -86,8 +86,8 @@ SoGesturePinchEvent::SoGesturePinchEvent(QPinchGesture* qpinch, QWidget *widget)
     deltaZoom = qpinch->scaleFactor();
     totalZoom = qpinch->totalScaleFactor();
 
-    deltaAngle = -unbranchAngle((qpinch->rotationAngle()-qpinch->lastRotationAngle()) / 180.0 * M_PI);
-    totalAngle = -qpinch->totalRotationAngle() / 180 * M_PI;
+    deltaAngle = -unbranchAngle((qpinch->rotationAngle()-qpinch->lastRotationAngle()) / 180.0 * std::numbers::pi);
+    totalAngle = -qpinch->totalRotationAngle() / 180 * std::numbers::pi;
 
     state = SbGestureState(qpinch->state());
 
@@ -111,7 +111,7 @@ SbBool SoGesturePinchEvent::isSoGesturePinchEvent(const SoEvent *ev) const
  */
 double SoGesturePinchEvent::unbranchAngle(double ang)
 {
-    return ang - 2.0 * M_PI * floor((ang + M_PI) / (2.0 * M_PI));
+    return ang - 2.0 * std::numbers::pi * floor((ang + std::numbers::pi) / (2.0 * std::numbers::pi));
 }
 
 

--- a/src/Gui/Transform.cpp
+++ b/src/Gui/Transform.cpp
@@ -388,7 +388,7 @@ Base::Placement Transform::getPlacementData() const
 
     if (index == 0) {
         Base::Vector3d dir = getDirection();
-        rot.setValue(Base::Vector3d(dir.x,dir.y,dir.z),ui->angle->value().getValue()*D_PI/180.0);
+        rot.setValue(Base::Vector3d(dir.x,dir.y,dir.z),ui->angle->value().getValue()*std::numbers::pi/180.0);
     }
     else if (index == 1) {
         rot.setYawPitchRoll(

--- a/src/Gui/View3DInventorRiftViewer.cpp
+++ b/src/Gui/View3DInventorRiftViewer.cpp
@@ -43,7 +43,7 @@ View3DInventorRiftViewer::View3DInventorRiftViewer() : CoinRiftWidget()
 
     rotation1     = new SoRotationXYZ   ;
     rotation1->axis.setValue(SoRotationXYZ::X);
-    rotation1->angle.setValue(-M_PI/2);
+    rotation1->angle.setValue(-std::numbers::pi/2);
     workplace->addChild(rotation1);
 
     rotation2     = new SoRotationXYZ   ;
@@ -104,7 +104,7 @@ void View3DInventorRiftViewer::setSceneGraph(SoNode *sceneGraph)
 void View3DInventorRiftViewer::keyPressEvent(QKeyEvent *event)
 {
     static const float increment = 0.02; // move two centimeter per key
-    static const float rotIncrement = M_PI/4; // move two 90° per key
+    static const float rotIncrement = std::numbers::pi/4; // move two 90° per key
 
 
     if (event->key() == Qt::Key_Plus) {

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -36,6 +36,7 @@
 # endif
 
 # include <fmt/format.h>
+#include <numbers>
 
 # include <Inventor/SbBox.h>
 # include <Inventor/SoEventManager.h>
@@ -3267,7 +3268,7 @@ void View3DInventorViewer::setCameraType(SoType type)
         // heightAngle. Setting it to 45 deg also causes an issue with a too
         // close camera but we don't have this other ugly effect.
 
-        static_cast<SoPerspectiveCamera*>(cam)->heightAngle = (float)(M_PI / 4.0);  // NOLINT
+        static_cast<SoPerspectiveCamera*>(cam)->heightAngle = std::numbers::pi_v<float> / 4.0F;  // NOLINT
     }
 
     lightRotation->rotation.connectFrom(&cam->orientation);
@@ -3426,7 +3427,7 @@ void View3DInventorViewer::viewAll()
     SoCamera* cam = this->getSoRenderManager()->getCamera();
 
     if (cam && cam->getTypeId().isDerivedFrom(SoPerspectiveCamera::getClassTypeId())) {
-        static_cast<SoPerspectiveCamera*>(cam)->heightAngle = (float)(M_PI / 4.0);  // NOLINT
+        static_cast<SoPerspectiveCamera*>(cam)->heightAngle = std::numbers::pi_v<float> / 4.0F;  // NOLINT
     }
 
     if (isAnimationEnabled()) {
@@ -3562,6 +3563,10 @@ void View3DInventorViewer::viewSelection()
 
 void View3DInventorViewer::alignToSelection()
 {
+    constexpr float pi = std::numbers::pi_v<float>;
+    constexpr float pi_2 = std::numbers::pi_v<float> / 2.0F;
+    constexpr float pi_4 = std::numbers::pi_v<float> / 4.0F;
+
     if (!getCamera()) {
         return;
     }
@@ -3634,24 +3639,24 @@ void View3DInventorViewer::alignToSelection()
         
         // Make angle positive
         if (angle < 0) {
-            angle += 2 * M_PI;
+            angle += 2 * pi;
         }
         
         // Find the angle to rotate to the nearest horizontal or vertical alignment with directionX.
         // f is a small value used to get more deterministic behavior when the camera is at directionX +- 45 degrees.
         const float f = 0.00001F;
-        
-        if (angle <= M_PI_4 + f) {
+
+        if (angle <= pi_4 + f) {
             angle = 0;
         }
-        else if (angle <= 3 * M_PI_4 + f) {
-            angle = M_PI_2;
+        else if (angle <= 3 * pi_4 + f) {
+            angle = pi_2;
         }
-        else if (angle < M_PI + M_PI_4 - f) {
-            angle = M_PI;
+        else if (angle < pi + pi_4 - f) {
+            angle = pi;
         }
-        else if (angle < M_PI + 3 * M_PI_4 - f) {
-            angle = M_PI + M_PI_2;
+        else if (angle < pi + 3 * pi_4 - f) {
+            angle = pi + pi_2;
         }
         else {
             angle = 0;
@@ -3960,7 +3965,7 @@ void View3DInventorViewer::drawAxisCross()
 
     const float NEARVAL = 0.1F;
     const float FARVAL = 10.0F;
-    const float dim = NEARVAL * float(tan(M_PI / 8.0)); // FOV is 45 deg (45/360 = 1/8)
+    const float dim = NEARVAL * tan(std::numbers::pi_v<float> / 8.0F); // FOV is 45 deg (45/360 = 1/8)
     glFrustum(-dim, dim, -dim, dim, NEARVAL, FARVAL);
 
 

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -658,7 +658,7 @@ Py::Object View3DInventorPy::viewRotateLeft()
       SbRotation rot = cam->orientation.getValue();
       SbVec3f vdir(0, 0, -1);
       rot.multVec(vdir, vdir);
-      SbRotation nrot(vdir, (float)M_PI/2);
+      SbRotation nrot(vdir, (float)std::numbers::pi/2);
       cam->orientation.setValue(rot*nrot);
     }
     catch (const Base::Exception& e) {
@@ -681,7 +681,7 @@ Py::Object View3DInventorPy::viewRotateRight()
       SbRotation rot = cam->orientation.getValue();
       SbVec3f vdir(0, 0, -1);
       rot.multVec(vdir, vdir);
-      SbRotation nrot(vdir, (float)-M_PI/2);
+      SbRotation nrot(vdir, (float)-std::numbers::pi/2);
       cam->orientation.setValue(rot*nrot);
     }
     catch (const Base::Exception& e) {

--- a/src/Gui/ViewProviderAnnotation.cpp
+++ b/src/Gui/ViewProviderAnnotation.cpp
@@ -155,7 +155,7 @@ void ViewProviderAnnotation::onChanged(const App::Property* prop)
         }
     }
     else if (prop == &Rotation) {
-        pRotationXYZ->angle = (Rotation.getValue()/360)*(2*M_PI);
+        pRotationXYZ->angle = (Rotation.getValue()/360)*(2*std::numbers::pi);
     }
     else {
         ViewProviderDocumentObject::onChanged(prop);

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -1125,7 +1125,7 @@ std::shared_ptr<ASMTJoint> AssemblyObject::makeMbdJointOfType(App::DocumentObjec
     }
     else if (type == JointType::Angle) {
         double angle = fabs(Base::toRadians(getJointDistance(joint)));
-        if (fmod(angle, 2 * M_PI) < Precision::Confusion()) {
+        if (fmod(angle, 2 * std::numbers::pi) < Precision::Confusion()) {
             return CREATE<ASMTParallelAxesJoint>::With();
         }
         else {

--- a/src/Mod/Assembly/App/PreCompiled.h
+++ b/src/Mod/Assembly/App/PreCompiled.h
@@ -37,6 +37,7 @@
 #include <cmath>
 #include <iomanip>
 #include <map>
+#include <numbers>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/Mod/Assembly/Gui/CMakeLists.txt
+++ b/src/Mod/Assembly/Gui/CMakeLists.txt
@@ -83,10 +83,6 @@ SET(AssemblyGuiIcon_SVG
 
 add_library(AssemblyGui SHARED ${AssemblyGui_SRCS} ${AssemblyGuiIcon_SVG})
 
-if(WIN32)
-    target_compile_definitions(AssemblyGui PRIVATE _USE_MATH_DEFINES)
-endif(WIN32)
-
 target_link_libraries(AssemblyGui ${AssemblyGui_LIBS})
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(AssemblyGui)

--- a/src/Mod/Assembly/Gui/PreCompiled.h
+++ b/src/Mod/Assembly/Gui/PreCompiled.h
@@ -33,6 +33,7 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <numbers>
 
 #include <vector>
 #include <sstream>

--- a/src/Mod/CAM/App/Area.cpp
+++ b/src/Mod/CAM/App/Area.cpp
@@ -452,7 +452,7 @@ void Area::addWire(CArea& area,
                 if (reversed) {
                     type = -type;
                 }
-                if (fabs(first - last) > M_PI) {
+                if (fabs(first - last) > std::numbers::pi) {
                     // Split arc(circle) larger than half circle. Because gcode
                     // can't handle full circle?
                     gp_Pnt mid = curve.Value((last - first) * 0.5 + first);
@@ -2631,7 +2631,7 @@ TopoDS_Shape Area::makePocket(int index, PARAM_ARGS(PARAM_FARG, AREA_PARAMS_POCK
                 for (int j = 0; j < steps; ++j, offset += stepover) {
                     Point p1(-r, offset), p2(r, offset);
                     if (a > Precision::Confusion()) {
-                        double r = a * M_PI / 180.0;
+                        double r = a * std::numbers::pi / 180.0;
                         p1.Rotate(r);
                         p2.Rotate(r);
                     }
@@ -4155,7 +4155,7 @@ void Area::toPath(Toolpath& path,
                             }
                         }
 
-                        if (fabs(first - last) > M_PI) {
+                        if (fabs(first - last) > std::numbers::pi) {
                             // Split arc(circle) larger than half circle.
                             gp_Pnt mid = curve.Value((last - first) * 0.5 + first);
                             addGArc(verbose,

--- a/src/Mod/CAM/App/PathSegmentWalker.cpp
+++ b/src/Mod/CAM/App/PathSegmentWalker.cpp
@@ -31,14 +31,6 @@
 
 #define ARC_MIN_SEGMENTS 20.0  // minimum # segments to interpolate an arc
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846 /* pi */
-#endif
-
-#ifndef M_PI_2
-#define M_PI_2 1.57079632679489661923 /* pi/2 */
-#endif
-
 
 namespace Path
 {
@@ -195,7 +187,7 @@ void PathSegmentWalker::walk(PathSegmentVisitor& cb, const Base::Vector3d& start
             if (nrot != lrot) {
                 double amax = std::max(fmod(fabs(a - A), 360),
                                        std::max(fmod(fabs(b - B), 360), fmod(fabs(c - C), 360)));
-                double angle = amax / 180 * M_PI;
+                double angle = amax / 180 * std::numbers::pi;
                 int segments = std::max(ARC_MIN_SEGMENTS, 3.0 / (deviation / angle));
 
                 double da = (a - A) / segments;
@@ -257,16 +249,16 @@ void PathSegmentWalker::walk(PathSegmentVisitor& cb, const Base::Vector3d& start
             Base::Vector3d anorm = (last0 - center0) % (next0 - center0);
             if (anorm.*pz < 0) {
                 if (name == "G3" || name == "G03") {
-                    angle = M_PI * 2 - angle;
+                    angle = std::numbers::pi * 2 - angle;
                 }
             }
             else if (anorm.*pz > 0) {
                 if (name == "G2" || name == "G02") {
-                    angle = M_PI * 2 - angle;
+                    angle = std::numbers::pi * 2 - angle;
                 }
             }
             else if (angle == 0) {
-                angle = M_PI * 2;
+                angle = std::numbers::pi * 2;
             }
 
             double amax = std::max(fmod(fabs(a - A), 360),
@@ -337,7 +329,7 @@ void PathSegmentWalker::walk(PathSegmentVisitor& cb, const Base::Vector3d& start
             if (nrot != lrot) {
                 double amax = std::max(fmod(fabs(a - A), 360),
                                        std::max(fmod(fabs(b - B), 360), fmod(fabs(c - C), 360)));
-                double angle = amax / 180 * M_PI;
+                double angle = amax / 180 * std::numbers::pi;
                 int segments = std::max(ARC_MIN_SEGMENTS, 3.0 / (deviation / angle));
 
                 double da = (a - A) / segments;

--- a/src/Mod/CAM/App/PreCompiled.h
+++ b/src/Mod/CAM/App/PreCompiled.h
@@ -46,6 +46,7 @@
 #include <cinttypes>
 #include <iomanip>
 #include <map>
+#include <numbers>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/Mod/CAM/App/Voronoi.cpp
+++ b/src/Mod/CAM/App/Voronoi.cpp
@@ -21,10 +21,6 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
-#ifndef _PreComp_
-#define _USE_MATH_DEFINES
-#include <math.h>
-#endif
 
 #include <Base/Vector3D.h>
 
@@ -260,10 +256,10 @@ double Voronoi::diagram_type::angleOfSegment(int i, Voronoi::diagram_type::angle
         double ang = 0;
         if (p0.x() == p1.x()) {
             if (p0.y() < p1.y()) {
-                ang = M_PI_2;
+                ang = std::numbers::pi / 2.0;
             }
             else {
-                ang = -M_PI_2;
+                ang = -std::numbers::pi / 2.0;
             }
         }
         else {
@@ -292,7 +288,7 @@ bool Voronoi::diagram_type::segmentsAreConnected(int i, int j) const
 
 void Voronoi::colorColinear(Voronoi::color_type color, double degree)
 {
-    double rad = degree * M_PI / 180;
+    double rad = degree * std::numbers::pi / 180;
 
     Voronoi::diagram_type::angle_map_t angle;
     int psize = vd->points.size();
@@ -306,11 +302,11 @@ void Voronoi::colorColinear(Voronoi::color_type color, double degree)
             double a0 = vd->angleOfSegment(i0, &angle);
             double a1 = vd->angleOfSegment(i1, &angle);
             double a = a0 - a1;
-            if (a > M_PI_2) {
-                a -= M_PI;
+            if (a > std::numbers::pi / 2.0) {
+                a -= std::numbers::pi;
             }
-            else if (a < -M_PI_2) {
-                a += M_PI;
+            else if (a < -std::numbers::pi / 2.0) {
+                a += std::numbers::pi;
             }
             if (fabs(a) < rad) {
                 it->color(color);

--- a/src/Mod/CAM/App/VoronoiEdgePyImp.cpp
+++ b/src/Mod/CAM/App/VoronoiEdgePyImp.cpp
@@ -697,11 +697,11 @@ PyObject* VoronoiEdgePy::getSegmentAngle(PyObject* args)
             double a0 = e->dia->angleOfSegment(i0);
             double a1 = e->dia->angleOfSegment(i1);
             double a = a0 - a1;
-            if (a > M_PI_2) {
-                a -= M_PI;
+            if (a > std::numbers::pi / 2.0) {
+                a -= std::numbers::pi;
             }
-            else if (a < -M_PI_2) {
-                a += M_PI;
+            else if (a < -std::numbers::pi / 2.0) {
+                a += std::numbers::pi;
             }
             return Py::new_reference_to(Py::Float(a));
         }

--- a/src/Mod/CAM/PathSimulator/App/PreCompiled.h
+++ b/src/Mod/CAM/PathSimulator/App/PreCompiled.h
@@ -30,7 +30,7 @@
 // standard
 #include <cstdio>
 #include <cassert>
-#include <iostream>
+#include <numbers>
 
 // STL
 #include <algorithm>

--- a/src/Mod/CAM/PathSimulator/AppGL/PreCompiled.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/PreCompiled.h
@@ -30,7 +30,7 @@
 // standard
 #include <cstdio>
 #include <cassert>
-#include <iostream>
+#include <numbers>
 
 // STL
 #include <algorithm>

--- a/src/Mod/CAM/libarea/Adaptive.cpp
+++ b/src/Mod/CAM/libarea/Adaptive.cpp
@@ -22,10 +22,10 @@
 
 #include "Adaptive.hpp"
 #include <iostream>
-#include <cmath>
 #include <cstring>
 #include <ctime>
 #include <algorithm>
+#include <numbers>
 
 namespace ClipperLib
 {
@@ -116,7 +116,7 @@ inline double Angle3Points(const DoublePoint& p1, const DoublePoint& p2, const D
     double t1 = atan2(p2.Y - p1.Y, p2.X - p1.X);
     double t2 = atan2(p3.Y - p2.Y, p3.X - p2.X);
     double a = fabs(t2 - t1);
-    return min(a, 2 * M_PI - a);
+    return min(a, 2 * std::numbers::pi - a);
 }
 
 inline DoublePoint DirectionV(const IntPoint& pt1, const IntPoint& pt2)
@@ -374,7 +374,7 @@ double DistancePointToPathsSqrd(const Paths& paths,
                                 size_t& clpSegmentIndex,
                                 double& clpParameter)
 {
-    double minDistSq = __DBL_MAX__;
+    double minDistSq = std::numeric_limits<double>::max();
     IntPoint clp;
     // iterate though paths
     for (Path::size_type i = 0; i < paths.size(); i++) {
@@ -768,7 +768,7 @@ bool PopPathWithClosestPoint(Paths& paths /*closest path is removed from collect
         return false;
     }
 
-    double minDistSqrd = __DBL_MAX__;
+    double minDistSqrd = std::numeric_limits<double>::max();
     size_t closestPathIndex = 0;
     long closestPointIndex = 0;
     for (size_t pathIndex = 0; pathIndex < paths.size(); pathIndex++) {
@@ -1096,8 +1096,8 @@ private:
 class Interpolation
 {
 public:
-    const double MIN_ANGLE = -M_PI / 4;
-    const double MAX_ANGLE = M_PI / 4;
+    const double MIN_ANGLE = -std::numbers::pi / 4;
+    const double MAX_ANGLE = std::numbers::pi / 4;
 
     void clear()
     {
@@ -1247,7 +1247,7 @@ public:
             }
         }
 
-        double minDistSq = __DBL_MAX__;
+        double minDistSq = std::numeric_limits<double>::max();
         size_t minPathIndex = state.currentPathIndex;
         size_t minSegmentIndex = state.currentSegmentIndex;
         double minSegmentPos = state.segmentPos;
@@ -1542,7 +1542,7 @@ double Adaptive2d::CalcCutArea(Clipper& clip,
         double minFi = fi1;
         double maxFi = fi2;
         if (maxFi < minFi) {
-            maxFi += 2 * M_PI;
+            maxFi += 2 * std::numbers::pi;
         }
 
         if (preventConventional && interPathLen >= RESOLUTION_FACTOR) {
@@ -1550,7 +1550,7 @@ double Adaptive2d::CalcCutArea(Clipper& clip,
             IntPoint midPoint(long(c2.X + toolRadiusScaled * cos(0.5 * (maxFi + minFi))),
                               long(c2.Y + toolRadiusScaled * sin(0.5 * (maxFi + minFi))));
             if (PointSideOfLine(c1, c2, midPoint) < 0) {
-                area = __DBL_MAX__;
+                area = std::numeric_limits<double>::max();
                 Perf_CalcCutAreaCirc.Stop();
                 // #ifdef DEV_MODE
                 // 	cout << "Break: @(" << double(c2.X)/scaleFactor << "," <<
@@ -2359,7 +2359,7 @@ bool Adaptive2d::MakeLeadPath(bool leadIn,
         IntPoint(currentPoint.X + nextDir.X * stepSize, currentPoint.Y + nextDir.Y * stepSize);
     Path checkPath;
     double adaptFactor = 0.4;
-    double alfa = M_PI / 64;
+    double alfa = std::numbers::pi / 64;
     double pathLen = 0;
     checkPath.push_back(nextPoint);
     for (int i = 0; i < 10000; i++) {
@@ -2802,7 +2802,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
     IntPoint clp;                 // to store closest point
     vector<DoublePoint> gyro;     // used to average tool direction
     vector<double> angleHistory;  // use to predict deflection angle
-    double angle = M_PI;
+    double angle = std::numbers::pi;
     engagePoint = toolPos;
     Interpolation interp;  // interpolation instance
 
@@ -2846,7 +2846,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             }
         }
 
-        angle = M_PI / 4;  // initial pass angle
+        angle = std::numbers::pi / 4;  // initial pass angle
         bool recalcArea = false;
         double cumulativeCutArea = 0;
         // init gyro
@@ -2919,7 +2919,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             /******************************/
             Perf_PointIterations.Start();
             int iteration;
-            double prev_error = __DBL_MAX__;
+            double prev_error = std::numeric_limits<double>::max();
             for (iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
                 total_iterations++;
                 if (iteration == 0) {
@@ -2991,7 +2991,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                 rotateStep++;
                 // if new tool pos. outside boundary rotate until back in
                 recalcArea = true;
-                newToolDir = rotate(newToolDir, M_PI / 90);
+                newToolDir = rotate(newToolDir, std::numbers::pi / 90);
                 newToolPos = IntPoint(long(toolPos.X + newToolDir.X * stepScaled),
                                       long(toolPos.Y + newToolDir.Y * stepScaled));
             }

--- a/src/Mod/CAM/libarea/Adaptive.hpp
+++ b/src/Mod/CAM/libarea/Adaptive.hpp
@@ -28,21 +28,10 @@
 #ifndef ADAPTIVE_HPP
 #define ADAPTIVE_HPP
 
-#ifndef __DBL_MAX__
-#define __DBL_MAX__ 1.7976931348623158e+308
-#endif
-
-#ifndef __LONG_MAX__
-#define __LONG_MAX__ 2147483647
-#endif
-
-#ifndef M_PI
-#define M_PI 3.141592653589793238
-#endif
 
 // #define DEV_MODE
 
-#define NTOL 1.0e-7  // numeric tolerance
+constexpr double NTOL = 1.0e-7;  // numeric tolerance
 
 namespace AdaptivePath
 {
@@ -201,8 +190,9 @@ private:  // constants for fine tuning
     const double CLEAN_PATH_TOLERANCE = 1.41;            // should be >1
     const double FINISHING_CLEAN_PATH_TOLERANCE = 1.41;  // should be >1
 
-    const long PASSES_LIMIT = __LONG_MAX__;              // limit used while debugging
-    const long POINTS_PER_PASS_LIMIT = __LONG_MAX__;     // limit used while debugging
+    const long PASSES_LIMIT = std::numeric_limits<long>::max();  // limit used while debugging
+    const long POINTS_PER_PASS_LIMIT =
+        std::numeric_limits<long>::max();                // limit used while debugging
     const clock_t PROGRESS_TICKS = CLOCKS_PER_SEC / 10;  // progress report interval
 };
 }  // namespace AdaptivePath

--- a/src/Mod/CAM/libarea/clipper.cpp
+++ b/src/Mod/CAM/libarea/clipper.cpp
@@ -45,13 +45,14 @@
 #include <stdexcept>
 #include <cstring>
 #include <cstdlib>
+#include <numbers>
 #include <ostream>
 #include <functional>
 
 namespace ClipperLib
 {
 
-static double const pi = 3.141592653589793238;
+constexpr double pi = std::numbers::pi;
 static double const two_pi = pi * 2;
 static double const def_arc_tolerance = 0.25;
 

--- a/src/Mod/Drawing/App/DrawingExport.cpp
+++ b/src/Mod/Drawing/App/DrawingExport.cpp
@@ -208,8 +208,8 @@ void SVGOutput::printCircle(const BRepAdaptor_Curve& c, std::ostream& out)
     // arc of circle
     else {
         // See also https://developer.mozilla.org/en/SVG/Tutorial/Paths
-        char xar = '0';                         // x-axis-rotation
-        char las = (l - f > D_PI) ? '1' : '0';  // large-arc-flag
+        char xar = '0';                                     // x-axis-rotation
+        char las = (l - f > std::numbers::pi) ? '1' : '0';  // large-arc-flag
         char swp = (a < 0) ? '1' : '0';  // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
         out << "<path d=\"M" << s.X() << " " << s.Y() << " A" << r << " " << r << " " << xar << " "
             << las << " " << swp << " " << e.X() << " " << e.Y() << "\" />";
@@ -255,7 +255,7 @@ void SVGOutput::printEllipse(const BRepAdaptor_Curve& c, int id, std::ostream& o
     }
     // arc of ellipse
     else {
-        char las = (l - f > D_PI) ? '1' : '0';  // large-arc-flag
+        char las = (l - f > std::numbers::pi) ? '1' : '0';  // large-arc-flag
         char swp = (a < 0) ? '1' : '0';  // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
         out << "<path d=\"M" << s.X() << " " << s.Y() << " A" << r1 << " " << r2 << " " << angle
             << " " << las << " " << swp << " " << e.X() << " " << e.Y() << "\" />" << std::endl;
@@ -502,8 +502,8 @@ void DXFOutput::printCircle(const BRepAdaptor_Curve& c, std::ostream& out)
         double bx = e.X() - p.X();
         double by = e.Y() - p.Y();
 
-        double start_angle = atan2(ay, ax) * 180 / D_PI;
-        double end_angle = atan2(by, bx) * 180 / D_PI;
+        double start_angle = atan2(ay, ax) * 180 / std::numbers::pi;
+        double end_angle = atan2(by, bx) * 180 / std::numbers::pi;
 
         if (a > 0) {
             double temp = start_angle;

--- a/src/Mod/Drawing/App/PreCompiled.h
+++ b/src/Mod/Drawing/App/PreCompiled.h
@@ -32,6 +32,7 @@
 #include <iomanip>
 #include <iostream>
 #include <iterator>
+#include <numbers>
 #include <sstream>
 
 // boost

--- a/src/Mod/Drawing/Gui/PreCompiled.h
+++ b/src/Mod/Drawing/Gui/PreCompiled.h
@@ -33,6 +33,7 @@
 
 // STL
 #include <cmath>
+#include <numbers>
 #include <sstream>
 #include <vector>
 

--- a/src/Mod/Fem/App/FemConstraintTransform.cpp
+++ b/src/Mod/Fem/App/FemConstraintTransform.cpp
@@ -119,9 +119,9 @@ Base::Rotation anglesToRotation(double xAngle, double yAngle, double zAngle)
     static Base::Vector3d a(1, 0, 0);
     static Base::Vector3d b(0, 1, 0);
     static int count = 0;
-    double xRad = xAngle * D_PI / 180.0;
-    double yRad = yAngle * D_PI / 180.0;
-    double zRad = zAngle * D_PI / 180.0;
+    double xRad = xAngle * std::numbers::pi / 180.0;
+    double yRad = yAngle * std::numbers::pi / 180.0;
+    double zRad = zAngle * std::numbers::pi / 180.0;
     if (xAngle != 0) {
         a[1] = 0;
         a[2] = 0;

--- a/src/Mod/Fem/App/PreCompiled.h
+++ b/src/Mod/Fem/App/PreCompiled.h
@@ -42,6 +42,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <numbers>
 #include <set>
 #include <sstream>
 #include <stdexcept>

--- a/src/Mod/Fem/Gui/DlgSettingsFemCcxImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemCcxImp.cpp
@@ -43,8 +43,8 @@ DlgSettingsFemCcxImp::DlgSettingsFemCcxImp(QWidget* parent)
 {
     ui->setupUi(this);
     // set ranges
-    ui->dsb_ccx_analysis_time->setMaximum(FLOAT_MAX);
-    ui->dsb_ccx_initial_time_step->setMaximum(FLOAT_MAX);
+    ui->dsb_ccx_analysis_time->setMaximum(std::numeric_limits<float>::max());
+    ui->dsb_ccx_initial_time_step->setMaximum(std::numeric_limits<float>::max());
 
     connect(ui->fc_ccx_binary_path,
             &Gui::PrefFileChooser::fileNameChanged,

--- a/src/Mod/Fem/Gui/PreCompiled.h
+++ b/src/Mod/Fem/Gui/PreCompiled.h
@@ -36,6 +36,7 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
+#include <numbers>
 
 // STL
 #include <algorithm>

--- a/src/Mod/Fem/Gui/TaskFemConstraintBearing.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintBearing.cpp
@@ -66,18 +66,18 @@ TaskFemConstraintBearing::TaskFemConstraintBearing(ViewProviderFemConstraint* Co
     this->groupLayout()->addWidget(proxy);
 
     // setup ranges
-    ui->spinDiameter->setMinimum(-FLOAT_MAX);
-    ui->spinDiameter->setMaximum(FLOAT_MAX);
-    ui->spinOtherDiameter->setMinimum(-FLOAT_MAX);
-    ui->spinOtherDiameter->setMaximum(FLOAT_MAX);
-    ui->spinCenterDistance->setMinimum(-FLOAT_MAX);
-    ui->spinCenterDistance->setMaximum(FLOAT_MAX);
-    ui->spinForce->setMinimum(-FLOAT_MAX);
-    ui->spinForce->setMaximum(FLOAT_MAX);
-    ui->spinTensionForce->setMinimum(-FLOAT_MAX);
-    ui->spinTensionForce->setMaximum(FLOAT_MAX);
-    ui->spinDistance->setMinimum(-FLOAT_MAX);
-    ui->spinDistance->setMaximum(FLOAT_MAX);
+    ui->spinDiameter->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinDiameter->setMaximum(std::numeric_limits<float>::max());
+    ui->spinOtherDiameter->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinOtherDiameter->setMaximum(std::numeric_limits<float>::max());
+    ui->spinCenterDistance->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinCenterDistance->setMaximum(std::numeric_limits<float>::max());
+    ui->spinForce->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinForce->setMaximum(std::numeric_limits<float>::max());
+    ui->spinTensionForce->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinTensionForce->setMaximum(std::numeric_limits<float>::max());
+    ui->spinDistance->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinDistance->setMaximum(std::numeric_limits<float>::max());
 
     // Get the feature data
     Fem::ConstraintBearing* pcConstraint = ConstraintView->getObject<Fem::ConstraintBearing>();

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
@@ -96,27 +96,27 @@ TaskFemConstraintContact::TaskFemConstraintContact(ViewProviderFemConstraintCont
     // Fill data into dialog elements
     ui->spbSlope->setUnit(pcConstraint->Slope.getUnit());
     ui->spbSlope->setMinimum(0);
-    ui->spbSlope->setMaximum(FLOAT_MAX);
+    ui->spbSlope->setMaximum(std::numeric_limits<float>::max());
     ui->spbSlope->setValue(pcConstraint->Slope.getQuantityValue());
     ui->spbSlope->bind(pcConstraint->Slope);
 
     ui->spbAdjust->setUnit(pcConstraint->Adjust.getUnit());
     ui->spbAdjust->setMinimum(0);
-    ui->spbAdjust->setMaximum(FLOAT_MAX);
+    ui->spbAdjust->setMaximum(std::numeric_limits<float>::max());
     ui->spbAdjust->setValue(pcConstraint->Adjust.getQuantityValue());
     ui->spbAdjust->bind(pcConstraint->Adjust);
 
     ui->ckbFriction->setChecked(friction);
 
     ui->spbFrictionCoeff->setMinimum(0);
-    ui->spbFrictionCoeff->setMaximum(FLOAT_MAX);
+    ui->spbFrictionCoeff->setMaximum(std::numeric_limits<float>::max());
     ui->spbFrictionCoeff->setValue(pcConstraint->FrictionCoefficient.getValue());
     ui->spbFrictionCoeff->setEnabled(friction);
     ui->spbFrictionCoeff->bind(pcConstraint->FrictionCoefficient);
 
     ui->spbStickSlope->setUnit(pcConstraint->StickSlope.getUnit());
     ui->spbStickSlope->setMinimum(0);
-    ui->spbStickSlope->setMaximum(FLOAT_MAX);
+    ui->spbStickSlope->setMaximum(std::numeric_limits<float>::max());
     ui->spbStickSlope->setValue(pcConstraint->StickSlope.getQuantityValue());
     ui->spbStickSlope->setEnabled(friction);
     ui->spbStickSlope->bind(pcConstraint->StickSlope);

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -74,18 +74,18 @@ TaskFemConstraintDisplacement::TaskFemConstraintDisplacement(
     this->groupLayout()->addWidget(proxy);
 
     // setup ranges
-    ui->spinxDisplacement->setMinimum(-FLOAT_MAX);
-    ui->spinxDisplacement->setMaximum(FLOAT_MAX);
-    ui->spinyDisplacement->setMinimum(-FLOAT_MAX);
-    ui->spinyDisplacement->setMaximum(FLOAT_MAX);
-    ui->spinzDisplacement->setMinimum(-FLOAT_MAX);
-    ui->spinzDisplacement->setMaximum(FLOAT_MAX);
-    ui->spinxRotation->setMinimum(-FLOAT_MAX);
-    ui->spinxRotation->setMaximum(FLOAT_MAX);
-    ui->spinyRotation->setMinimum(-FLOAT_MAX);
-    ui->spinyRotation->setMaximum(FLOAT_MAX);
-    ui->spinzRotation->setMinimum(-FLOAT_MAX);
-    ui->spinzRotation->setMaximum(FLOAT_MAX);
+    ui->spinxDisplacement->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinxDisplacement->setMaximum(std::numeric_limits<float>::max());
+    ui->spinyDisplacement->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinyDisplacement->setMaximum(std::numeric_limits<float>::max());
+    ui->spinzDisplacement->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinzDisplacement->setMaximum(std::numeric_limits<float>::max());
+    ui->spinxRotation->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinxRotation->setMaximum(std::numeric_limits<float>::max());
+    ui->spinyRotation->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinyRotation->setMaximum(std::numeric_limits<float>::max());
+    ui->spinzRotation->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinzRotation->setMaximum(std::numeric_limits<float>::max());
 
     // Get the feature data
     Fem::ConstraintDisplacement* pcConstraint =

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
@@ -145,18 +145,18 @@ TaskFemConstraintFluidBoundary::TaskFemConstraintFluidBoundary(
             &TaskFemConstraintFluidBoundary::onReferenceDeleted);
 
     // setup ranges
-    ui->spinBoundaryValue->setMinimum(-FLOAT_MAX);
-    ui->spinBoundaryValue->setMaximum(FLOAT_MAX);
+    ui->spinBoundaryValue->setMinimum(-std::numeric_limits<float>::max());
+    ui->spinBoundaryValue->setMaximum(std::numeric_limits<float>::max());
     ui->spinTurbulentIntensityValue->setMinimum(0.0);
-    ui->spinTurbulentIntensityValue->setMaximum(FLOAT_MAX);
+    ui->spinTurbulentIntensityValue->setMaximum(std::numeric_limits<float>::max());
     ui->spinTurbulentLengthValue->setMinimum(0.0);
-    ui->spinTurbulentLengthValue->setMaximum(FLOAT_MAX);
+    ui->spinTurbulentLengthValue->setMaximum(std::numeric_limits<float>::max());
     ui->spinTemperatureValue->setMinimum(-273.15);
-    ui->spinTemperatureValue->setMaximum(FLOAT_MAX);
+    ui->spinTemperatureValue->setMaximum(std::numeric_limits<float>::max());
     ui->spinHeatFluxValue->setMinimum(0.0);
-    ui->spinHeatFluxValue->setMaximum(FLOAT_MAX);
+    ui->spinHeatFluxValue->setMaximum(std::numeric_limits<float>::max());
     ui->spinHTCoeffValue->setMinimum(0.0);
-    ui->spinHTCoeffValue->setMaximum(FLOAT_MAX);
+    ui->spinHTCoeffValue->setMaximum(std::numeric_limits<float>::max());
 
     connect(ui->comboBoundaryType,
             qOverload<int>(&QComboBox::currentIndexChanged),
@@ -352,8 +352,9 @@ TaskFemConstraintFluidBoundary::TaskFemConstraintFluidBoundary(
 
     // Fill data into dialog elements
     double f = pcConstraint->BoundaryValue.getValue();
-    ui->spinBoundaryValue->setMinimum(FLOAT_MIN);  // previous set the min to ZERO is not flexible
-    ui->spinBoundaryValue->setMaximum(FLOAT_MAX);
+    ui->spinBoundaryValue->setMinimum(
+        -std::numeric_limits<float>::max());  // previous set the min to ZERO is not flexible
+    ui->spinBoundaryValue->setMaximum(std::numeric_limits<float>::max());
     ui->spinBoundaryValue->setValue(f);
     ui->listReferences->clear();
     for (std::size_t i = 0; i < Objects.size(); i++) {

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
@@ -75,7 +75,7 @@ TaskFemConstraintForce::TaskFemConstraintForce(ViewProviderFemConstraintForce* C
     // Fill data into dialog elements
     ui->spinForce->setUnit(pcConstraint->Force.getUnit());
     ui->spinForce->setMinimum(0);
-    ui->spinForce->setMaximum(FLOAT_MAX);
+    ui->spinForce->setMaximum(std::numeric_limits<float>::max());
     ui->spinForce->setValue(force);
     ui->listReferences->clear();
     for (std::size_t i = 0; i < Objects.size(); i++) {

--- a/src/Mod/Fem/Gui/TaskFemConstraintGear.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintGear.cpp
@@ -87,10 +87,10 @@ TaskFemConstraintGear::TaskFemConstraintGear(ViewProviderFemConstraint* Constrai
 
     // Fill data into dialog elements
     ui->spinDiameter->setMinimum(0);
-    ui->spinDiameter->setMaximum(FLOAT_MAX);
+    ui->spinDiameter->setMaximum(std::numeric_limits<float>::max());
     ui->spinDiameter->setValue(dia);
     ui->spinForce->setMinimum(0);
-    ui->spinForce->setMaximum(FLOAT_MAX);
+    ui->spinForce->setMaximum(std::numeric_limits<float>::max());
     ui->spinForce->setValue(force);
     ui->spinForceAngle->setMinimum(-360);
     ui->spinForceAngle->setMaximum(360);

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -119,16 +119,16 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(
     ui->sw_heatflux->setCurrentIndex(constrType->getValue());
 
     ui->qsb_ambienttemp_conv->setMinimum(0);
-    ui->qsb_ambienttemp_conv->setMaximum(FLOAT_MAX);
+    ui->qsb_ambienttemp_conv->setMaximum(std::numeric_limits<float>::max());
 
     ui->qsb_film_coef->setMinimum(0);
-    ui->qsb_film_coef->setMaximum(FLOAT_MAX);
+    ui->qsb_film_coef->setMaximum(std::numeric_limits<float>::max());
 
     ui->dsb_emissivity->setMinimum(0);
-    ui->dsb_emissivity->setMaximum(FLOAT_MAX);
+    ui->dsb_emissivity->setMaximum(std::numeric_limits<float>::max());
 
     ui->qsb_ambienttemp_rad->setMinimum(0);
-    ui->qsb_ambienttemp_rad->setMaximum(FLOAT_MAX);
+    ui->qsb_ambienttemp_rad->setMaximum(std::numeric_limits<float>::max());
 
     ui->qsb_ambienttemp_conv->setValue(pcConstraint->AmbientTemp.getQuantityValue());
     ui->qsb_film_coef->setValue(pcConstraint->FilmCoef.getQuantityValue());

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
@@ -64,7 +64,7 @@ TaskFemConstraintPressure::TaskFemConstraintPressure(
     // Fill data into dialog elements
     ui->if_pressure->setUnit(pcConstraint->Pressure.getUnit());
     ui->if_pressure->setMinimum(0);
-    ui->if_pressure->setMaximum(FLOAT_MAX);
+    ui->if_pressure->setMaximum(std::numeric_limits<float>::max());
     ui->if_pressure->setValue(pcConstraint->Pressure.getQuantityValue());
     ui->if_pressure->bind(pcConstraint->Pressure);
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintPulley.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPulley.cpp
@@ -76,15 +76,15 @@ TaskFemConstraintPulley::TaskFemConstraintPulley(ViewProviderFemConstraintPulley
 
     // Fill data into dialog elements
     ui->spinOtherDiameter->setMinimum(0);
-    ui->spinOtherDiameter->setMaximum(FLOAT_MAX);
+    ui->spinOtherDiameter->setMaximum(std::numeric_limits<float>::max());
     ui->spinOtherDiameter->setValue(otherdia);
     ui->spinCenterDistance->setMinimum(0);
-    ui->spinCenterDistance->setMaximum(FLOAT_MAX);
+    ui->spinCenterDistance->setMaximum(std::numeric_limits<float>::max());
     ui->spinCenterDistance->setValue(centerdist);
     ui->checkIsDriven->setChecked(isdriven);
-    ui->spinForce->setMinimum(-FLOAT_MAX);
+    ui->spinForce->setMinimum(-std::numeric_limits<float>::max());
     ui->spinTensionForce->setMinimum(0);
-    ui->spinTensionForce->setMaximum(FLOAT_MAX);
+    ui->spinTensionForce->setMaximum(std::numeric_limits<float>::max());
     ui->spinTensionForce->setValue(tensionforce);
 
     // Adjust ui

--- a/src/Mod/Fem/Gui/TaskFemConstraintRigidBody.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintRigidBody.cpp
@@ -137,12 +137,12 @@ TaskFemConstraintRigidBody::TaskFemConstraintRigidBody(
         App::ObjectIdentifier::parse(pcConstraint, std::string("ReferenceNode.y")));
     ui->qsb_ref_node_z->bind(
         App::ObjectIdentifier::parse(pcConstraint, std::string("ReferenceNode.z")));
-    ui->qsb_ref_node_x->setMinimum(-FLOAT_MAX);
-    ui->qsb_ref_node_x->setMaximum(FLOAT_MAX);
-    ui->qsb_ref_node_y->setMinimum(-FLOAT_MAX);
-    ui->qsb_ref_node_y->setMaximum(FLOAT_MAX);
-    ui->qsb_ref_node_z->setMinimum(-FLOAT_MAX);
-    ui->qsb_ref_node_z->setMaximum(FLOAT_MAX);
+    ui->qsb_ref_node_x->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_ref_node_x->setMaximum(std::numeric_limits<float>::max());
+    ui->qsb_ref_node_y->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_ref_node_y->setMaximum(std::numeric_limits<float>::max());
+    ui->qsb_ref_node_z->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_ref_node_z->setMaximum(std::numeric_limits<float>::max());
 
     ui->qsb_disp_x->setValue(disp.x);
     ui->qsb_disp_y->setValue(disp.y);
@@ -150,12 +150,12 @@ TaskFemConstraintRigidBody::TaskFemConstraintRigidBody(
     ui->qsb_disp_x->bind(App::ObjectIdentifier::parse(pcConstraint, std::string("Displacement.x")));
     ui->qsb_disp_y->bind(App::ObjectIdentifier::parse(pcConstraint, std::string("Displacement.y")));
     ui->qsb_disp_z->bind(App::ObjectIdentifier::parse(pcConstraint, std::string("Displacement.z")));
-    ui->qsb_disp_x->setMinimum(-FLOAT_MAX);
-    ui->qsb_disp_x->setMaximum(FLOAT_MAX);
-    ui->qsb_disp_y->setMinimum(-FLOAT_MAX);
-    ui->qsb_disp_y->setMaximum(FLOAT_MAX);
-    ui->qsb_disp_z->setMinimum(-FLOAT_MAX);
-    ui->qsb_disp_z->setMaximum(FLOAT_MAX);
+    ui->qsb_disp_x->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_disp_x->setMaximum(std::numeric_limits<float>::max());
+    ui->qsb_disp_y->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_disp_y->setMaximum(std::numeric_limits<float>::max());
+    ui->qsb_disp_z->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_disp_z->setMaximum(std::numeric_limits<float>::max());
 
     ui->spb_rot_axis_x->setValue(rotDir.x);
     ui->spb_rot_axis_y->setValue(rotDir.y);
@@ -169,14 +169,14 @@ TaskFemConstraintRigidBody::TaskFemConstraintRigidBody(
         App::ObjectIdentifier::parse(pcConstraint, std::string("Rotation.Axis.z")));
     ui->qsb_rot_angle->bind(
         App::ObjectIdentifier::parse(pcConstraint, std::string("Rotation.Angle")));
-    ui->spb_rot_axis_x->setMinimum(-FLOAT_MAX);
-    ui->spb_rot_axis_x->setMaximum(FLOAT_MAX);
-    ui->spb_rot_axis_y->setMinimum(-FLOAT_MAX);
-    ui->spb_rot_axis_y->setMaximum(FLOAT_MAX);
-    ui->spb_rot_axis_z->setMinimum(-FLOAT_MAX);
-    ui->spb_rot_axis_z->setMaximum(FLOAT_MAX);
-    ui->qsb_rot_angle->setMinimum(-FLOAT_MAX);
-    ui->qsb_rot_angle->setMaximum(FLOAT_MAX);
+    ui->spb_rot_axis_x->setMinimum(-std::numeric_limits<float>::max());
+    ui->spb_rot_axis_x->setMaximum(std::numeric_limits<float>::max());
+    ui->spb_rot_axis_y->setMinimum(-std::numeric_limits<float>::max());
+    ui->spb_rot_axis_y->setMaximum(std::numeric_limits<float>::max());
+    ui->spb_rot_axis_z->setMinimum(-std::numeric_limits<float>::max());
+    ui->spb_rot_axis_z->setMaximum(std::numeric_limits<float>::max());
+    ui->qsb_rot_angle->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_rot_angle->setMaximum(std::numeric_limits<float>::max());
 
     ui->qsb_force_x->setValue(forceX);
     ui->qsb_force_y->setValue(forceY);
@@ -184,12 +184,12 @@ TaskFemConstraintRigidBody::TaskFemConstraintRigidBody(
     ui->qsb_force_x->bind(pcConstraint->ForceX);
     ui->qsb_force_y->bind(pcConstraint->ForceY);
     ui->qsb_force_z->bind(pcConstraint->ForceZ);
-    ui->qsb_force_x->setMinimum(-FLOAT_MAX);
-    ui->qsb_force_x->setMaximum(FLOAT_MAX);
-    ui->qsb_force_y->setMinimum(-FLOAT_MAX);
-    ui->qsb_force_y->setMaximum(FLOAT_MAX);
-    ui->qsb_force_z->setMinimum(-FLOAT_MAX);
-    ui->qsb_force_z->setMaximum(FLOAT_MAX);
+    ui->qsb_force_x->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_force_x->setMaximum(std::numeric_limits<float>::max());
+    ui->qsb_force_y->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_force_y->setMaximum(std::numeric_limits<float>::max());
+    ui->qsb_force_z->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_force_z->setMaximum(std::numeric_limits<float>::max());
 
     ui->qsb_moment_x->setValue(momentX);
     ui->qsb_moment_y->setValue(momentY);
@@ -197,12 +197,12 @@ TaskFemConstraintRigidBody::TaskFemConstraintRigidBody(
     ui->qsb_moment_x->bind(pcConstraint->MomentX);
     ui->qsb_moment_y->bind(pcConstraint->MomentY);
     ui->qsb_moment_z->bind(pcConstraint->MomentZ);
-    ui->qsb_moment_x->setMinimum(-FLOAT_MAX);
-    ui->qsb_moment_x->setMaximum(FLOAT_MAX);
-    ui->qsb_moment_y->setMinimum(-FLOAT_MAX);
-    ui->qsb_moment_y->setMaximum(FLOAT_MAX);
-    ui->qsb_moment_z->setMinimum(-FLOAT_MAX);
-    ui->qsb_moment_z->setMaximum(FLOAT_MAX);
+    ui->qsb_moment_x->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_moment_x->setMaximum(std::numeric_limits<float>::max());
+    ui->qsb_moment_y->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_moment_y->setMaximum(std::numeric_limits<float>::max());
+    ui->qsb_moment_z->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_moment_z->setMaximum(std::numeric_limits<float>::max());
 
     QStringList modeList;
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
@@ -76,11 +76,11 @@ TaskFemConstraintSpring::TaskFemConstraintSpring(ViewProviderFemConstraintSpring
 
     // Fill data into dialog elements
     ui->qsb_norm->setUnit(pcConstraint->NormalStiffness.getUnit());
-    ui->qsb_norm->setMaximum(FLOAT_MAX);
+    ui->qsb_norm->setMaximum(std::numeric_limits<float>::max());
     ui->qsb_norm->setValue(pcConstraint->NormalStiffness.getQuantityValue());
 
     ui->qsb_tan->setUnit(pcConstraint->TangentialStiffness.getUnit());
-    ui->qsb_tan->setMaximum(FLOAT_MAX);
+    ui->qsb_tan->setMaximum(std::numeric_limits<float>::max());
     ui->qsb_tan->setValue(pcConstraint->TangentialStiffness.getQuantityValue());
 
     ui->cb_elmer_stiffness->clear();

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
@@ -68,9 +68,9 @@ TaskFemConstraintTemperature::TaskFemConstraintTemperature(
 
     // Fill data into dialog elements
     ui->qsb_temperature->setMinimum(0);
-    ui->qsb_temperature->setMaximum(FLOAT_MAX);
-    ui->qsb_cflux->setMinimum(-FLOAT_MAX);
-    ui->qsb_cflux->setMaximum(FLOAT_MAX);
+    ui->qsb_temperature->setMaximum(std::numeric_limits<float>::max());
+    ui->qsb_cflux->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_cflux->setMaximum(std::numeric_limits<float>::max());
 
     App::PropertyEnumeration* constrType = &pcConstraint->ConstraintType;
     QStringList qTypeList;

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
@@ -130,14 +130,14 @@ TaskFemConstraintTransform::TaskFemConstraintTransform(
     ui->qsb_rot_angle->bind(
         App::ObjectIdentifier::parse(pcConstraint, std::string("Rotation.Angle")));
 
-    ui->spb_rot_axis_x->setMinimum(-FLOAT_MAX);
-    ui->spb_rot_axis_x->setMaximum(FLOAT_MAX);
-    ui->spb_rot_axis_y->setMinimum(-FLOAT_MAX);
-    ui->spb_rot_axis_y->setMaximum(FLOAT_MAX);
-    ui->spb_rot_axis_z->setMinimum(-FLOAT_MAX);
-    ui->spb_rot_axis_z->setMaximum(FLOAT_MAX);
-    ui->qsb_rot_angle->setMinimum(-FLOAT_MAX);
-    ui->qsb_rot_angle->setMaximum(FLOAT_MAX);
+    ui->spb_rot_axis_x->setMinimum(-std::numeric_limits<float>::max());
+    ui->spb_rot_axis_x->setMaximum(std::numeric_limits<float>::max());
+    ui->spb_rot_axis_y->setMinimum(-std::numeric_limits<float>::max());
+    ui->spb_rot_axis_y->setMaximum(std::numeric_limits<float>::max());
+    ui->spb_rot_axis_z->setMinimum(-std::numeric_limits<float>::max());
+    ui->spb_rot_axis_z->setMaximum(std::numeric_limits<float>::max());
+    ui->qsb_rot_angle->setMinimum(-std::numeric_limits<float>::max());
+    ui->qsb_rot_angle->setMaximum(std::numeric_limits<float>::max());
 
     std::string transform_type = pcConstraint->TransformType.getValueAsString();
     if (transform_type == "Rectangular") {

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintFluidBoundary.cpp
@@ -145,8 +145,8 @@ void ViewProviderFemConstraintFluidBoundary::updateData(const App::Property* pro
 
             for (const auto& point : points) {
                 SbVec3f base(point.x, point.y, point.z);
-                if (forceDirection.GetAngle(normal)
-                    < M_PI_2) {  // Move arrow so it doesn't disappear inside the solid
+                if (forceDirection.GetAngle(normal) < std::numbers::pi
+                        / 2.0) {  // Move arrow so it doesn't disappear inside the solid
                     base = base + dir * scaledlength;  // OvG: Scaling
                 }
 #ifdef USE_MULTIPLE_COPY
@@ -191,7 +191,7 @@ void ViewProviderFemConstraintFluidBoundary::updateData(const App::Property* pro
 
             for (const auto& point : points) {
                 SbVec3f base(point.x, point.y, point.z);
-                if (forceDirection.GetAngle(normal) < M_PI_2) {
+                if (forceDirection.GetAngle(normal) < std::numbers::pi / 2.0) {
                     base = base + dir * scaledlength;  // OvG: Scaling
                 }
 #ifdef USE_MULTIPLE_COPY

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintForce.cpp
@@ -88,7 +88,7 @@ void ViewProviderFemConstraintForce::transformSymbol(const Base::Vector3d& point
     // Place each symbol outside the boundary
     Base::Vector3d dir = (rev ? -1.0 : 1.0) * obj->DirectionVector.getValue();
     float symTraY = dir.Dot(normal) < 0 ? -1 * symLen : 0.0f;
-    float rotAngle = rev ? F_PI : 0.0f;
+    float rotAngle = rev ? static_cast<float>(std::numbers::pi) : 0.0f;
     SbMatrix mat0, mat1;
     mat0.setTransform(SbVec3f(0, symTraY, 0),
                       SbRotation(SbVec3f(0, 0, 1), rotAngle),

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintGear.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintGear.cpp
@@ -88,7 +88,7 @@ void ViewProviderFemConstraintGear::updateData(const App::Property* prop)
             if (dia < 2 * radius) {
                 dia = 2 * radius;
             }
-            double angle = pcConstraint->ForceAngle.getValue() / 180 * M_PI;
+            double angle = pcConstraint->ForceAngle.getValue() / 180 * std::numbers::pi;
 
             SbVec3f b(base.x, base.y, base.z);
             SbVec3f ax(axis.x, axis.y, axis.z);
@@ -118,7 +118,7 @@ void ViewProviderFemConstraintGear::updateData(const App::Property* prop)
             if (dia < 2 * radius) {
                 dia = 2 * radius;
             }
-            double angle = pcConstraint->ForceAngle.getValue() / 180 * M_PI;
+            double angle = pcConstraint->ForceAngle.getValue() / 180 * std::numbers::pi;
 
             SbVec3f ax(axis.x, axis.y, axis.z);
             SbVec3f dir(direction.x, direction.y, direction.z);
@@ -143,7 +143,7 @@ void ViewProviderFemConstraintGear::updateData(const App::Property* prop)
                 direction = Base::Vector3d(0, 1, 0);
             }
             double dia = pcConstraint->Diameter.getValue();
-            double angle = pcConstraint->ForceAngle.getValue() / 180 * M_PI;
+            double angle = pcConstraint->ForceAngle.getValue() / 180 * std::numbers::pi;
 
             SbVec3f ax(axis.x, axis.y, axis.z);
             SbVec3f dir(direction.x, direction.y, direction.z);

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.cpp
@@ -82,7 +82,7 @@ void ViewProviderFemConstraintPressure::transformSymbol(const Base::Vector3d& po
                                                         SbMatrix& mat) const
 {
     auto obj = this->getObject<const Fem::ConstraintPressure>();
-    float rotAngle = obj->Reversed.getValue() ? F_PI : 0.0f;
+    float rotAngle = obj->Reversed.getValue() ? static_cast<float>(std::numbers::pi) : 0.0f;
     float s = obj->getScaleFactor();
     // Symbol length from .iv file
     float symLen = 4.0f;

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPulley.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPulley.cpp
@@ -82,7 +82,7 @@ void ViewProviderFemConstraintPulley::updateData(const App::Property* prop)
             if (dia < 2 * radius) {
                 dia = 2 * radius;
             }
-            double forceAngle = pcConstraint->ForceAngle.getValue() / 180 * M_PI;
+            double forceAngle = pcConstraint->ForceAngle.getValue() / 180 * std::numbers::pi;
             double beltAngle = pcConstraint->BeltAngle.getValue();
             double rat1 = 0.8, rat2 = 0.2;
             double f1 = pcConstraint->BeltForce1.getValue();
@@ -101,26 +101,28 @@ void ViewProviderFemConstraintPulley::updateData(const App::Property* prop)
             pShapeSep->addChild(GuiTools::createCylinder(pcConstraint->Height.getValue() * 0.8,
                                                          dia / 2));  // child 2
             SoSeparator* sep = new SoSeparator();
-            GuiTools::createPlacement(sep,
-                                      SbVec3f(dia / 2 * sin(forceAngle + beltAngle),
-                                              0,
-                                              dia / 2 * cos(forceAngle + beltAngle)),
-                                      SbRotation(SbVec3f(0, 1, 0),
-                                                 SbVec3f(sin(forceAngle + beltAngle + M_PI_2),
-                                                         0,
-                                                         cos(forceAngle + beltAngle + M_PI_2))));
+            GuiTools::createPlacement(
+                sep,
+                SbVec3f(dia / 2 * sin(forceAngle + beltAngle),
+                        0,
+                        dia / 2 * cos(forceAngle + beltAngle)),
+                SbRotation(SbVec3f(0, 1, 0),
+                           SbVec3f(sin(forceAngle + beltAngle + std::numbers::pi / 2.0),
+                                   0,
+                                   cos(forceAngle + beltAngle + std::numbers::pi / 2.0))));
             GuiTools::createPlacement(sep, SbVec3f(0, dia / 8 + dia / 2 * rat1, 0), SbRotation());
             sep->addChild(GuiTools::createArrow(dia / 8 + dia / 2 * rat1, dia / 8));
             pShapeSep->addChild(sep);  // child 3
             sep = new SoSeparator();
-            GuiTools::createPlacement(sep,
-                                      SbVec3f(-dia / 2 * sin(forceAngle - beltAngle),
-                                              0,
-                                              -dia / 2 * cos(forceAngle - beltAngle)),
-                                      SbRotation(SbVec3f(0, 1, 0),
-                                                 SbVec3f(-sin(forceAngle - beltAngle - M_PI_2),
-                                                         0,
-                                                         -cos(forceAngle - beltAngle - M_PI_2))));
+            GuiTools::createPlacement(
+                sep,
+                SbVec3f(-dia / 2 * sin(forceAngle - beltAngle),
+                        0,
+                        -dia / 2 * cos(forceAngle - beltAngle)),
+                SbRotation(SbVec3f(0, 1, 0),
+                           SbVec3f(-sin(forceAngle - beltAngle - std::numbers::pi / 2.0),
+                                   0,
+                                   -cos(forceAngle - beltAngle - std::numbers::pi / 2.0))));
             GuiTools::createPlacement(sep, SbVec3f(0, dia / 8 + dia / 2 * rat2, 0), SbRotation());
             sep->addChild(GuiTools::createArrow(dia / 8 + dia / 2 * rat2, dia / 8));
             pShapeSep->addChild(sep);  // child 4
@@ -134,7 +136,7 @@ void ViewProviderFemConstraintPulley::updateData(const App::Property* prop)
             if (dia < 2 * radius) {
                 dia = 2 * radius;
             }
-            double forceAngle = pcConstraint->ForceAngle.getValue() / 180 * M_PI;
+            double forceAngle = pcConstraint->ForceAngle.getValue() / 180 * std::numbers::pi;
             double beltAngle = pcConstraint->BeltAngle.getValue();
             double rat1 = 0.8, rat2 = 0.2;
             double f1 = pcConstraint->BeltForce1.getValue();
@@ -147,15 +149,16 @@ void ViewProviderFemConstraintPulley::updateData(const App::Property* prop)
             const SoSeparator* sep = static_cast<SoSeparator*>(pShapeSep->getChild(2));
             GuiTools::updateCylinder(sep, 0, pcConstraint->Height.getValue() * 0.8, dia / 2);
             sep = static_cast<SoSeparator*>(pShapeSep->getChild(3));
-            GuiTools::updatePlacement(sep,
-                                      0,
-                                      SbVec3f(dia / 2 * sin(forceAngle + beltAngle),
-                                              0,
-                                              dia / 2 * cos(forceAngle + beltAngle)),
-                                      SbRotation(SbVec3f(0, 1, 0),
-                                                 SbVec3f(sin(forceAngle + beltAngle + M_PI_2),
-                                                         0,
-                                                         cos(forceAngle + beltAngle + M_PI_2))));
+            GuiTools::updatePlacement(
+                sep,
+                0,
+                SbVec3f(dia / 2 * sin(forceAngle + beltAngle),
+                        0,
+                        dia / 2 * cos(forceAngle + beltAngle)),
+                SbRotation(SbVec3f(0, 1, 0),
+                           SbVec3f(sin(forceAngle + beltAngle + std::numbers::pi / 2.0),
+                                   0,
+                                   cos(forceAngle + beltAngle + std::numbers::pi / 2.0))));
             GuiTools::updatePlacement(sep,
                                       2,
                                       SbVec3f(0, dia / 8 + dia / 2 * rat1, 0),
@@ -163,15 +166,16 @@ void ViewProviderFemConstraintPulley::updateData(const App::Property* prop)
             const SoSeparator* subsep = static_cast<SoSeparator*>(sep->getChild(4));
             GuiTools::updateArrow(subsep, 0, dia / 8 + dia / 2 * rat1, dia / 8);
             sep = static_cast<SoSeparator*>(pShapeSep->getChild(4));
-            GuiTools::updatePlacement(sep,
-                                      0,
-                                      SbVec3f(-dia / 2 * sin(forceAngle - beltAngle),
-                                              0,
-                                              -dia / 2 * cos(forceAngle - beltAngle)),
-                                      SbRotation(SbVec3f(0, 1, 0),
-                                                 SbVec3f(-sin(forceAngle - beltAngle - M_PI_2),
-                                                         0,
-                                                         -cos(forceAngle - beltAngle - M_PI_2))));
+            GuiTools::updatePlacement(
+                sep,
+                0,
+                SbVec3f(-dia / 2 * sin(forceAngle - beltAngle),
+                        0,
+                        -dia / 2 * cos(forceAngle - beltAngle)),
+                SbRotation(SbVec3f(0, 1, 0),
+                           SbVec3f(-sin(forceAngle - beltAngle - std::numbers::pi / 2.0),
+                                   0,
+                                   -cos(forceAngle - beltAngle - std::numbers::pi / 2.0))));
             GuiTools::updatePlacement(sep,
                                       2,
                                       SbVec3f(0, dia / 8 + dia / 2 * rat2, 0),
@@ -187,29 +191,31 @@ void ViewProviderFemConstraintPulley::updateData(const App::Property* prop)
             if (dia < 2 * radius) {
                 dia = 2 * radius;
             }
-            double forceAngle = pcConstraint->ForceAngle.getValue() / 180 * M_PI;
+            double forceAngle = pcConstraint->ForceAngle.getValue() / 180 * std::numbers::pi;
             double beltAngle = pcConstraint->BeltAngle.getValue();
 
             const SoSeparator* sep = static_cast<SoSeparator*>(pShapeSep->getChild(3));
-            GuiTools::updatePlacement(sep,
-                                      0,
-                                      SbVec3f(dia / 2 * sin(forceAngle + beltAngle),
-                                              0,
-                                              dia / 2 * cos(forceAngle + beltAngle)),
-                                      SbRotation(SbVec3f(0, 1, 0),
-                                                 SbVec3f(sin(forceAngle + beltAngle + M_PI_2),
-                                                         0,
-                                                         cos(forceAngle + beltAngle + M_PI_2))));
+            GuiTools::updatePlacement(
+                sep,
+                0,
+                SbVec3f(dia / 2 * sin(forceAngle + beltAngle),
+                        0,
+                        dia / 2 * cos(forceAngle + beltAngle)),
+                SbRotation(SbVec3f(0, 1, 0),
+                           SbVec3f(sin(forceAngle + beltAngle + std::numbers::pi / 2.0),
+                                   0,
+                                   cos(forceAngle + beltAngle + std::numbers::pi / 2.0))));
             sep = static_cast<SoSeparator*>(pShapeSep->getChild(4));
-            GuiTools::updatePlacement(sep,
-                                      0,
-                                      SbVec3f(-dia / 2 * sin(forceAngle - beltAngle),
-                                              0,
-                                              -dia / 2 * cos(forceAngle - beltAngle)),
-                                      SbRotation(SbVec3f(0, 1, 0),
-                                                 SbVec3f(-sin(forceAngle - beltAngle - M_PI_2),
-                                                         0,
-                                                         -cos(forceAngle - beltAngle - M_PI_2))));
+            GuiTools::updatePlacement(
+                sep,
+                0,
+                SbVec3f(-dia / 2 * sin(forceAngle - beltAngle),
+                        0,
+                        -dia / 2 * cos(forceAngle - beltAngle)),
+                SbRotation(SbVec3f(0, 1, 0),
+                           SbVec3f(-sin(forceAngle - beltAngle - std::numbers::pi / 2.0),
+                                   0,
+                                   -cos(forceAngle - beltAngle - std::numbers::pi / 2.0))));
         }
     }
     else if ((prop == &pcConstraint->BeltForce1) || (prop == &pcConstraint->BeltForce2)) {

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
@@ -1189,8 +1189,8 @@ SoGroup* postCylinder()
     for (int i = 0; i < 2; ++i) {
         for (int j = 0; j < nCirc + 1; ++j) {
             points->point.set1Value(idx,
-                                    SbVec3f(std::cos(2 * M_PI / nCirc * j),
-                                            std::sin(2 * M_PI / nCirc * j),
+                                    SbVec3f(std::cos(2 * std::numbers::pi / nCirc * j),
+                                            std::sin(2 * std::numbers::pi / nCirc * j),
                                             -h / 2. + h * i));
             ++idx;
         }
@@ -1199,8 +1199,8 @@ SoGroup* postCylinder()
     for (int i = 0; i < nSide; ++i) {
         for (int j = 0; j < 2; ++j) {
             points->point.set1Value(idx,
-                                    SbVec3f(std::cos(2 * M_PI / nSide * i),
-                                            std::sin(2 * M_PI / nSide * i),
+                                    SbVec3f(std::cos(2 * std::numbers::pi / nSide * i),
+                                            std::sin(2 * std::numbers::pi / nSide * i),
                                             -h / 2. + h * j));
             ++idx;
         }
@@ -1248,19 +1248,23 @@ SoGroup* postSphere()
     int idx = 0;
     for (int i = 0; i < 4; i++) {
         for (int j = 0; j < 21; j++) {
-            points->point.set1Value(idx,
-                                    SbVec3f(std::sin(2 * M_PI / 20 * j) * std::cos(M_PI / 4 * i),
-                                            std::sin(2 * M_PI / 20 * j) * std::sin(M_PI / 4 * i),
-                                            std::cos(2 * M_PI / 20 * j)));
+            points->point.set1Value(
+                idx,
+                SbVec3f(
+                    std::sin(2 * std::numbers::pi / 20 * j) * std::cos(std::numbers::pi / 4 * i),
+                    std::sin(2 * std::numbers::pi / 20 * j) * std::sin(std::numbers::pi / 4 * i),
+                    std::cos(2 * std::numbers::pi / 20 * j)));
             ++idx;
         }
     }
     for (int i = 0; i < 4; i++) {
         for (int j = 0; j < 21; j++) {
-            points->point.set1Value(idx,
-                                    SbVec3f(std::sin(M_PI / 4 * i) * std::cos(2 * M_PI / 20 * j),
-                                            std::sin(M_PI / 4 * i) * std::sin(2 * M_PI / 20 * j),
-                                            std::cos(M_PI / 4 * i)));
+            points->point.set1Value(
+                idx,
+                SbVec3f(
+                    std::sin(std::numbers::pi / 4 * i) * std::cos(2 * std::numbers::pi / 20 * j),
+                    std::sin(std::numbers::pi / 4 * i) * std::sin(2 * std::numbers::pi / 20 * j),
+                    std::cos(std::numbers::pi / 4 * i)));
             ++idx;
         }
     }

--- a/src/Mod/Import/App/PreCompiled.h
+++ b/src/Mod/Import/App/PreCompiled.h
@@ -46,6 +46,7 @@
 #include <iostream>
 #include <list>
 #include <map>
+#include <numbers>
 #include <sstream>
 #include <vector>
 

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -977,8 +977,8 @@ void ImpExpDxfWrite::exportEllipse(BRepAdaptor_Curve& c)
     // rotation appears to be the clockwise(?) angle between major & +Y??
     double rotation = xaxis.AngleWithRef(gp_Dir(0, 1, 0), gp_Dir(0, 0, 1));
 
-    // 2*M_PI = 6.28319 is invalid(doesn't display in LibreCAD), but 2PI = 6.28318 is valid!
-    // writeEllipse(center, major, minor, rotation, 0.0, 2 * M_PI, true );
+    // 2*std::numbers::pi = 6.28319 is invalid(doesn't display in LibreCAD), but 2PI = 6.28318 is
+    // valid! writeEllipse(center, major, minor, rotation, 0.0, 2 * std::numbers::pi, true );
     writeEllipse(center, major, minor, rotation, 0.0, 6.28318, true);
 }
 
@@ -1036,8 +1036,8 @@ void ImpExpDxfWrite::exportEllipseArc(BRepAdaptor_Curve& c)
                                      // a > 0 ==> v2 is CCW from v1 (righthanded)?
                                      // a < 0 ==> v2 is CW from v1 (lefthanded)?
 
-    double startAngle = fmod(f, 2.0 * M_PI);  // revolutions
-    double endAngle = fmod(l, 2.0 * M_PI);
+    double startAngle = fmod(f, 2.0 * std::numbers::pi);  // revolutions
+    double endAngle = fmod(l, 2.0 * std::numbers::pi);
     bool endIsCW = (a < 0) ? true : false;  // if !endIsCW swap(start,end)
     // not sure if this is a hack or not. seems to make valid arcs.
     if (!endIsCW) {

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -5,13 +5,11 @@
 
 #include "PreCompiled.h"
 
-// required by windows for M_PI definition
-#define _USE_MATH_DEFINES
-#include <cmath>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <numbers>
 
 #include "dxf.h"
 #include <App/Application.h>
@@ -1584,10 +1582,10 @@ void CDxfWrite::writeAngularDimBlock(const double* textMidPoint,
     double span = fabs(endAngle - startAngle);
     double offset = span * 0.10;
     if (startAngle < 0) {
-        startAngle += 2 * M_PI;
+        startAngle += 2 * std::numbers::pi;
     }
     if (endAngle < 0) {
-        endAngle += 2 * M_PI;
+        endAngle += 2 * std::numbers::pi;
     }
     Base::Vector3d startOff(cos(startAngle + offset), sin(startAngle + offset), 0.0);
     Base::Vector3d endOff(cos(endAngle - offset), sin(endAngle - offset), 0.0);
@@ -2130,7 +2128,7 @@ bool CDxfRead::ReadEllipse()
     Base::Vector3d majorAxisEnd;  //  relative to centre
     double eccentricity = 0;
     double startAngleRadians = 0;
-    double endAngleRadians = 2 * M_PI;
+    double endAngleRadians = 2 * std::numbers::pi;
 
     Setup3DVectorAttribute(ePrimaryPoint, centre);
     Setup3DVectorAttribute(ePoint2, majorAxisEnd);

--- a/src/Mod/Import/Gui/PreCompiled.h
+++ b/src/Mod/Import/Gui/PreCompiled.h
@@ -40,9 +40,10 @@
 // standard
 #include <cassert>
 #include <iostream>
-#include <list>
+#include <numbers>
 
 // STL
+#include <list>
 #include <map>
 #include <set>
 #include <string>

--- a/src/Mod/Inspection/App/PreCompiled.h
+++ b/src/Mod/Inspection/App/PreCompiled.h
@@ -36,6 +36,7 @@
 
 // STL
 #include <numeric>
+#include <numbers>
 
 // OCC
 #include <BRepBuilderAPI_MakeVertex.hxx>

--- a/src/Mod/Inspection/Gui/PreCompiled.h
+++ b/src/Mod/Inspection/Gui/PreCompiled.h
@@ -36,6 +36,7 @@
 
 // STL
 #include <cfloat>
+#include <numbers>
 
 // Inventor
 #include <Inventor/SoPickedPoint.h>

--- a/src/Mod/JtReader/App/PreCompiled.h
+++ b/src/Mod/JtReader/App/PreCompiled.h
@@ -33,6 +33,7 @@
 
 #include <cassert>
 #include <cstdio>
+#include <numbers>
 
 // STL
 #include <algorithm>

--- a/src/Mod/Material/App/PreCompiled.h
+++ b/src/Mod/Material/App/PreCompiled.h
@@ -44,6 +44,7 @@
 // standard
 #include <cfloat>
 #include <cmath>
+#include <numbers>
 
 // STL
 #include <algorithm>

--- a/src/Mod/Material/Gui/PreCompiled.h
+++ b/src/Mod/Material/Gui/PreCompiled.h
@@ -45,6 +45,7 @@
 #include <cfloat>
 #include <cmath>
 #include <limits>
+#include <numbers>
 
 // STL
 #include <algorithm>

--- a/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/src/Mod/Measure/App/MeasureAngle.cpp
@@ -108,7 +108,7 @@ bool MeasureAngle::isPrioritizedSelection(const App::MeasureSelection& selection
     getVec(*ob2, sub2, vec2);
 
 
-    double angle = std::fmod(vec1.GetAngle(vec2), D_PI);
+    double angle = std::fmod(vec1.GetAngle(vec2), std::numbers::pi);
     return angle > Base::Precision::Angular();
 }
 

--- a/src/Mod/Measure/App/PreCompiled.h
+++ b/src/Mod/Measure/App/PreCompiled.h
@@ -32,6 +32,7 @@
 // standard
 #include <cfloat>
 #include <cmath>
+#include <numbers>
 
 // STL
 #include <algorithm>

--- a/src/Mod/Measure/Gui/PreCompiled.h
+++ b/src/Mod/Measure/Gui/PreCompiled.h
@@ -46,6 +46,7 @@
 // standard
 #include <cfloat>
 #include <cmath>
+#include <numbers>
 
 // STL
 #include <algorithm>

--- a/src/Mod/Measure/Gui/ViewProviderMeasureAngle.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureAngle.cpp
@@ -325,7 +325,7 @@ void ViewProviderMeasureAngle::redrawAnnotation()
 {
     auto obj = dynamic_cast<Measure::MeasureAngle*>(getMeasureObject());
     double angleDeg = obj->Angle.getValue();
-    constexpr double radiansPerDegree = M_PI / 180.0;
+    constexpr double radiansPerDegree = std::numbers::pi / 180.0;
     this->fieldAngle = angleDeg * radiansPerDegree;
 
     // Set matrix

--- a/src/Mod/Mesh/App/Core/Algorithm.cpp
+++ b/src/Mod/Mesh/App/Core/Algorithm.cpp
@@ -295,7 +295,7 @@ float MeshAlgorithm::GetAverageEdgeLength() const
 
 float MeshAlgorithm::GetMinimumEdgeLength() const
 {
-    float fLen = FLOAT_MAX;
+    float fLen = std::numeric_limits<float>::max();
     MeshFacetIterator cF(_rclMesh);
     for (cF.Init(); cF.More(); cF.Next()) {
         for (int i = 0; i < 3; i++) {
@@ -1461,7 +1461,7 @@ bool MeshAlgorithm::NearestPointFromPoint(const Base::Vector3f& rclPt,
     }
 
     // calc each facet
-    float fMinDist = FLOAT_MAX;
+    float fMinDist = std::numeric_limits<float>::max();
     FacetIndex ulInd = FACET_INDEX_MAX;
     MeshFacetIterator pF(_rclMesh);
     for (pF.Init(); pF.More(); pF.Next()) {

--- a/src/Mod/Mesh/App/Core/Approximation.cpp
+++ b/src/Mod/Mesh/App/Core/Approximation.cpp
@@ -143,7 +143,7 @@ float PlaneFit::Fit()
 {
     _bIsFitted = true;
     if (CountPoints() < 3) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     double sxx {0.0};
@@ -207,7 +207,7 @@ float PlaneFit::Fit()
         akMat.EigenDecomposition(rkRot, rkDiag);
     }
     catch (const std::exception&) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     // We know the Eigenvalues are ordered
@@ -215,7 +215,7 @@ float PlaneFit::Fit()
     //
     // points describe a line or even are identical
     if (rkDiag(1, 1) <= 0) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     Wm4::Vector3<double> U = rkRot.GetColumn(1);
@@ -225,7 +225,7 @@ float PlaneFit::Fit()
     // It may happen that the result have nan values
     for (int i = 0; i < 3; i++) {
         if (boost::math::isnan(W[i])) {
-            return FLOAT_MAX;
+            return std::numeric_limits<float>::max();
         }
     }
 
@@ -253,7 +253,7 @@ float PlaneFit::Fit()
 
     // In case sigma is nan
     if (boost::math::isnan(sigma)) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     // This must be caused by some round-off errors. Theoretically it's impossible
@@ -318,7 +318,7 @@ Base::Vector3f PlaneFit::GetNormal() const
 
 float PlaneFit::GetDistanceToPlane(const Base::Vector3f& rcPoint) const
 {
-    float fResult = FLOAT_MAX;
+    float fResult = std::numeric_limits<float>::max();
     if (_bIsFitted) {
         fResult = (rcPoint - _vBase) * _vDirW;
     }
@@ -332,7 +332,7 @@ float PlaneFit::GetStdDeviation() const
     // Standard deviation: SD=SQRT(VAR)
     // Standard error of the mean: SE=SD/SQRT(N)
     if (!_bIsFitted) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     float fSumXi = 0.0F, fSumXi2 = 0.0F, fMean = 0.0F, fDist = 0.0F;
@@ -356,11 +356,11 @@ float PlaneFit::GetSignedStdDeviation() const
     // of normal direction the value will be
     // positive otherwise negative
     if (!_bIsFitted) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     float fSumXi = 0.0F, fSumXi2 = 0.0F, fMean = 0.0F, fDist = 0.0F;
-    float fMinDist = FLOAT_MAX;
+    float fMinDist = std::numeric_limits<float>::max();
     float fFactor = 0.0F;
 
     float ulPtCt = float(CountPoints());
@@ -426,7 +426,7 @@ void PlaneFit::Dimension(float& length, float& width) const
 std::vector<Base::Vector3f> PlaneFit::GetLocalPoints() const
 {
     std::vector<Base::Vector3f> localPoints;
-    if (_bIsFitted && _fLastResult < FLOAT_MAX) {
+    if (_bIsFitted && _fLastResult < std::numeric_limits<float>::max()) {
         Base::Vector3d bs = Base::convertTo<Base::Vector3d>(this->_vBase);
         Base::Vector3d ex = Base::convertTo<Base::Vector3d>(this->_vDirU);
         Base::Vector3d ey = Base::convertTo<Base::Vector3d>(this->_vDirV);
@@ -507,12 +507,12 @@ double QuadraticFit::GetCoeff(std::size_t ulIndex) const
         return _fCoeff[ulIndex];
     }
 
-    return double(FLOAT_MAX);
+    return double(std::numeric_limits<float>::max());
 }
 
 float QuadraticFit::Fit()
 {
-    float fResult = FLOAT_MAX;
+    float fResult = std::numeric_limits<float>::max();
 
     if (CountPoints() > 0) {
         std::vector<Wm4::Vector3<double>> cPts;
@@ -595,14 +595,14 @@ void QuadraticFit::CalcZValues(double x, double y, double& dZ1, double& dZ2) con
         - 4 * _fCoeff[6] * _fCoeff[4] * x * x - 4 * _fCoeff[6] * _fCoeff[5] * y * y;
 
     if (fabs(_fCoeff[6]) < 0.000005) {
-        dZ1 = double(FLOAT_MAX);
-        dZ2 = double(FLOAT_MAX);
+        dZ1 = double(std::numeric_limits<float>::max());
+        dZ2 = double(std::numeric_limits<float>::max());
         return;
     }
 
     if (dDisk < 0.0) {
-        dZ1 = double(FLOAT_MAX);
-        dZ2 = double(FLOAT_MAX);
+        dZ1 = double(std::numeric_limits<float>::max());
+        dZ2 = double(std::numeric_limits<float>::max());
         return;
     }
 
@@ -620,7 +620,7 @@ SurfaceFit::SurfaceFit()
 
 float SurfaceFit::Fit()
 {
-    float fResult = FLOAT_MAX;
+    float fResult = std::numeric_limits<float>::max();
 
     if (CountPoints() > 0) {
         fResult = float(PolynomFit());
@@ -671,8 +671,8 @@ bool SurfaceFit::GetCurvatureInfo(double x, double y, double z, double& rfCurv0,
 
 double SurfaceFit::PolynomFit()
 {
-    if (PlaneFit::Fit() >= FLOAT_MAX) {
-        return double(FLOAT_MAX);
+    if (PlaneFit::Fit() >= std::numeric_limits<float>::max()) {
+        return double(std::numeric_limits<float>::max());
     }
 
     Base::Vector3d bs = Base::convertTo<Base::Vector3d>(this->_vBase);
@@ -1165,7 +1165,7 @@ void CylinderFit::SetInitialValues(const Base::Vector3f& b, const Base::Vector3f
 float CylinderFit::Fit()
 {
     if (CountPoints() < 7) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
     _bIsFitted = true;
 
@@ -1180,7 +1180,7 @@ float CylinderFit::Fit()
     }
 
     float result = cylFit.Fit();
-    if (result < FLOAT_MAX) {
+    if (result < std::numeric_limits<float>::max()) {
         Base::Vector3d base = cylFit.GetBase();
         Base::Vector3d dir = cylFit.GetAxis();
 
@@ -1284,7 +1284,7 @@ Base::Vector3f CylinderFit::GetAxis() const
 
 float CylinderFit::GetDistanceToCylinder(const Base::Vector3f& rcPoint) const
 {
-    float fResult = FLOAT_MAX;
+    float fResult = std::numeric_limits<float>::max();
     if (_bIsFitted) {
         fResult = rcPoint.DistanceToLine(_vBase, _vAxis) - _fRadius;
     }
@@ -1298,7 +1298,7 @@ float CylinderFit::GetStdDeviation() const
     // Standard deviation: SD=SQRT(VAR)
     // Standard error of the mean: SE=SD/SQRT(N)
     if (!_bIsFitted) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     float fSumXi = 0.0F, fSumXi2 = 0.0F, fMean = 0.0F, fDist = 0.0F;
@@ -1384,7 +1384,7 @@ float SphereFit::GetRadius() const
         return _fRadius;
     }
 
-    return FLOAT_MAX;
+    return std::numeric_limits<float>::max();
 }
 
 Base::Vector3f SphereFit::GetCenter() const
@@ -1400,7 +1400,7 @@ float SphereFit::Fit()
 {
     _bIsFitted = true;
     if (CountPoints() < 4) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     std::vector<Wm4::Vector3d> input;
@@ -1433,7 +1433,7 @@ float SphereFit::Fit()
     sphereFit.AddPoints(_vPoints);
     sphereFit.ComputeApproximations();
     float result = sphereFit.Fit();
-    if (result < FLOAT_MAX) {
+    if (result < std::numeric_limits<float>::max()) {
         Base::Vector3d center = sphereFit.GetCenter();
 #if defined(_DEBUG)
         Base::Console().Message("MeshCoreFit::Sphere Fit:  Center: (%0.4f, %0.4f, %0.4f),  Radius: "
@@ -1455,7 +1455,7 @@ float SphereFit::Fit()
 
 float SphereFit::GetDistanceToSphere(const Base::Vector3f& rcPoint) const
 {
-    float fResult = FLOAT_MAX;
+    float fResult = std::numeric_limits<float>::max();
     if (_bIsFitted) {
         fResult = Base::Vector3f(rcPoint - _vCenter).Length() - _fRadius;
     }
@@ -1469,7 +1469,7 @@ float SphereFit::GetStdDeviation() const
     // Standard deviation: SD=SQRT(VAR)
     // Standard error of the mean: SE=SD/SQRT(N)
     if (!_bIsFitted) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     float fSumXi = 0.0F, fSumXi2 = 0.0F, fMean = 0.0F, fDist = 0.0F;
@@ -1533,7 +1533,7 @@ float PolynomialFit::Fit()
         }
     }
     catch (const std::exception&) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     return 0.0F;

--- a/src/Mod/Mesh/App/Core/Approximation.h
+++ b/src/Mod/Mesh/App/Core/Approximation.h
@@ -201,7 +201,8 @@ protected:
     // NOLINTBEGIN
     std::list<Base::Vector3f> _vPoints; /**< Holds the points for the fit algorithm.  */
     bool _bIsFitted {false};            /**< Flag, whether the fit has been called. */
-    float _fLastResult {FLOAT_MAX};     /**< Stores the last result of the fit */
+    float _fLastResult {
+        std::numeric_limits<float>::max()}; /**< Stores the last result of the fit */
     // NOLINTEND
 };
 
@@ -224,22 +225,23 @@ public:
     Base::Vector3f GetNormal() const;
     /**
      * Fit a plane into the given points. We must have at least three non-collinear points
-     * to succeed. If the fit fails FLOAT_MAX is returned.
+     * to succeed. If the fit fails std::numeric_limits<float>::max() is returned.
      */
     float Fit() override;
     /**
      * Returns the distance from the point \a rcPoint to the fitted plane. If Fit() has not been
-     * called FLOAT_MAX is returned.
+     * called std::numeric_limits<float>::max() is returned.
      */
     float GetDistanceToPlane(const Base::Vector3f& rcPoint) const;
     /**
      * Returns the standard deviation from the points to the fitted plane. If Fit() has not been
-     * called FLOAT_MAX is returned.
+     * called std::numeric_limits<float>::max() is returned.
      */
     float GetStdDeviation() const;
     /**
      * Returns the standard deviation from the points to the fitted plane with respect to the
-     * orientation of the plane's normal. If Fit() has not been called FLOAT_MAX is returned.
+     * orientation of the plane's normal. If Fit() has not been called
+     * std::numeric_limits<float>::max() is returned.
      */
     float GetSignedStdDeviation() const;
     /**
@@ -419,17 +421,18 @@ public:
      */
     Base::Vector3f GetInitialAxisFromNormals(const std::vector<Base::Vector3f>& n) const;
     /**
-     * Fit a cylinder into the given points. If the fit fails FLOAT_MAX is returned.
+     * Fit a cylinder into the given points. If the fit fails std::numeric_limits<float>::max() is
+     * returned.
      */
     float Fit() override;
     /**
      * Returns the distance from the point \a rcPoint to the fitted cylinder. If Fit() has not been
-     * called FLOAT_MAX is returned.
+     * called std::numeric_limits<float>::max() is returned.
      */
     float GetDistanceToCylinder(const Base::Vector3f& rcPoint) const;
     /**
      * Returns the standard deviation from the points to the fitted cylinder. If Fit() has not been
-     * called FLOAT_MAX is returned.
+     * called std::numeric_limits<float>::max() is returned.
      */
     float GetStdDeviation() const;
     /**
@@ -461,17 +464,18 @@ public:
     float GetRadius() const;
     Base::Vector3f GetCenter() const;
     /**
-     * Fit a sphere into the given points. If the fit fails FLOAT_MAX is returned.
+     * Fit a sphere into the given points. If the fit fails std::numeric_limits<float>::max() is
+     * returned.
      */
     float Fit() override;
     /**
      * Returns the distance from the point \a rcPoint to the fitted sphere. If Fit() has not been
-     * called FLOAT_MAX is returned.
+     * called std::numeric_limits<float>::max() is returned.
      */
     float GetDistanceToSphere(const Base::Vector3f& rcPoint) const;
     /**
      * Returns the standard deviation from the points to the fitted sphere. If Fit() has not been
-     * called FLOAT_MAX is returned.
+     * called std::numeric_limits<float>::max() is returned.
      */
     float GetStdDeviation() const;
     /**

--- a/src/Mod/Mesh/App/Core/CylinderFit.cpp
+++ b/src/Mod/Mesh/App/Core/CylinderFit.cpp
@@ -81,7 +81,7 @@ void CylinderFit::SetApproximations(double radius,
                                     const Base::Vector3d& axis)
 {
     _bIsFitted = false;
-    _fLastResult = FLOAT_MAX;
+    _fLastResult = std::numeric_limits<float>::max();
     _numIter = 0;
     _dRadius = radius;
     _vBase = base;
@@ -94,7 +94,7 @@ void CylinderFit::SetApproximations(double radius,
 void CylinderFit::SetApproximations(const Base::Vector3d& base, const Base::Vector3d& axis)
 {
     _bIsFitted = false;
-    _fLastResult = FLOAT_MAX;
+    _fLastResult = std::numeric_limits<float>::max();
     _numIter = 0;
     _vBase = base;
     _vAxis = axis;
@@ -168,7 +168,7 @@ int CylinderFit::GetNumIterations() const
 
 float CylinderFit::GetDistanceToCylinder(const Base::Vector3f& rcPoint) const
 {
-    float fResult = FLOAT_MAX;
+    float fResult = std::numeric_limits<float>::max();
     if (_bIsFitted) {
         Base::Vector3d pt(rcPoint.x, rcPoint.y, rcPoint.z);
         fResult = static_cast<float>(pt.DistanceToLine(_vBase, _vAxis) - _dRadius);
@@ -182,7 +182,7 @@ float CylinderFit::GetStdDeviation() const
     // Variance: VAR=(N/N-1)*[(1/N)*SUM(Xi^2)-M^2]
     // Standard deviation: SD=SQRT(VAR)
     if (!_bIsFitted) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     double sumXi = 0.0;
@@ -239,7 +239,7 @@ void CylinderFit::ProjectToCylinder()
 void CylinderFit::ComputeApproximationsLine()
 {
     _bIsFitted = false;
-    _fLastResult = FLOAT_MAX;
+    _fLastResult = std::numeric_limits<float>::max();
     _numIter = 0;
     _vBase.Set(0.0, 0.0, 0.0);
     _vAxis.Set(0.0, 0.0, 0.0);
@@ -266,13 +266,13 @@ void CylinderFit::ComputeApproximationsLine()
 float CylinderFit::Fit()
 {
     _bIsFitted = false;
-    _fLastResult = FLOAT_MAX;
+    _fLastResult = std::numeric_limits<float>::max();
     _numIter = 0;
 
     // A minimum of 5 surface points is needed to define a cylinder
     const int minPts = 5;
     if (CountPoints() < minPts) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     // If approximations have not been set/computed then compute some now using the line fit method
@@ -308,7 +308,7 @@ float CylinderFit::Fit()
         // Solve the equations for the unknown corrections
         Eigen::LLT<Matrix5x5> llt(atpa);
         if (llt.info() != Eigen::Success) {
-            return FLOAT_MAX;
+            return std::numeric_limits<float>::max();
         }
         Eigen::VectorXd x = llt.solve(atpl);
 
@@ -327,7 +327,7 @@ float CylinderFit::Fit()
         // convergence
         bool vConverged {};
         if (!computeResiduals(solDir, x, residuals, sigma0, _vConvLimit, vConverged)) {
-            return FLOAT_MAX;
+            return std::numeric_limits<float>::max();
         }
         if (!vConverged) {
             cont = true;
@@ -335,13 +335,13 @@ float CylinderFit::Fit()
 
         // Update the parameters
         if (!updateParameters(solDir, x)) {
-            return FLOAT_MAX;
+            return std::numeric_limits<float>::max();
         }
     }
 
     // Check for convergence
     if (cont) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     _bIsFitted = true;

--- a/src/Mod/Mesh/App/Core/CylinderFit.h
+++ b/src/Mod/Mesh/App/Core/CylinderFit.h
@@ -94,17 +94,18 @@ public:
      */
     int GetNumIterations() const;
     /**
-     * Fit a cylinder into the given points. If the fit fails FLOAT_MAX is returned.
+     * Fit a cylinder into the given points. If the fit fails std::numeric_limits<float>::max() is
+     * returned.
      */
     float Fit() override;
     /**
      * Returns the distance from the point \a rcPoint to the fitted cylinder. If Fit() has not been
-     * called FLOAT_MAX is returned.
+     * called std::numeric_limits<float>::max() is returned.
      */
     float GetDistanceToCylinder(const Base::Vector3f& rcPoint) const;
     /**
      * Returns the standard deviation from the points to the fitted cylinder. If Fit() has not been
-     * called FLOAT_MAX is returned.
+     * called std::numeric_limits<float>::max() is returned.
      */
     float GetStdDeviation() const;
     /**

--- a/src/Mod/Mesh/App/Core/Definitions.h
+++ b/src/Mod/Mesh/App/Core/Definitions.h
@@ -41,18 +41,6 @@
  */
 #define FLOAT_EPS 1.0e-4F
 
-#ifndef FLOAT_MAX
-#define FLOAT_MAX 1e30F
-#endif
-
-#ifndef DOUBLE_MAX
-#define DOUBLE_MAX 1.7976931348623157E+308 /* max decimal value of a "double"*/
-#endif
-
-#ifndef DOUBLE_MIN
-#define DOUBLE_MIN 2.2250738585072014E-308 /* min decimal value of a "double"*/
-#endif
-
 namespace MeshCore
 {
 

--- a/src/Mod/Mesh/App/Core/Elements.cpp
+++ b/src/Mod/Mesh/App/Core/Elements.cpp
@@ -245,7 +245,7 @@ bool MeshGeomEdge::IntersectWithLine(const Base::Vector3f& rclPt,
     const float eps = 1e-06F;
     Base::Vector3f n = _aclPoints[1] - _aclPoints[0];
 
-    // check angle between edge and the line direction, FLOAT_MAX is
+    // check angle between edge and the line direction, std::numeric_limits<float>::max() is
     // returned for degenerated edges
     float fAngle = rclDir.GetAngle(n);
     if (fAngle == 0) {
@@ -392,7 +392,7 @@ void MeshGeomEdge::ClosestPointsToLine(const Base::Vector3f& linePt,
     const float eps = 1e-06F;
     Base::Vector3f edgeDir = _aclPoints[1] - _aclPoints[0];
 
-    // check angle between edge and the line direction, FLOAT_MAX is
+    // check angle between edge and the line direction, std::numeric_limits<float>::max() is
     // returned for degenerated edges
     float fAngle = lineDir.GetAngle(edgeDir);
     if (fAngle == 0) {
@@ -885,7 +885,7 @@ bool MeshGeomFacet::Foraminate(const Base::Vector3f& P,
     const float eps = 1e-06F;
     Base::Vector3f n = this->GetNormal();
 
-    // check angle between facet normal and the line direction, FLOAT_MAX is
+    // check angle between facet normal and the line direction, std::numeric_limits<float>::max() is
     // returned for degenerated facets
     float fAngle = dir.GetAngle(n);
     if (fAngle > fMaxAngle) {
@@ -1309,9 +1309,9 @@ unsigned short MeshGeomFacet::NearestEdgeToPoint(const Base::Vector3f& rclPt) co
     const Base::Vector3f& rcP2 = _aclPoints[1];
     const Base::Vector3f& rcP3 = _aclPoints[2];
 
-    float fD1 = FLOAT_MAX;
-    float fD2 = FLOAT_MAX;
-    float fD3 = FLOAT_MAX;
+    float fD1 = std::numeric_limits<float>::max();
+    float fD2 = std::numeric_limits<float>::max();
+    float fD3 = std::numeric_limits<float>::max();
 
     // 1st edge
     Base::Vector3f clDir = rcP2 - rcP1;
@@ -1383,9 +1383,9 @@ void MeshGeomFacet::NearestEdgeToPoint(const Base::Vector3f& rclPt,
     const Base::Vector3f& rcP2 = _aclPoints[1];
     const Base::Vector3f& rcP3 = _aclPoints[2];
 
-    float fD1 = FLOAT_MAX;
-    float fD2 = FLOAT_MAX;
-    float fD3 = FLOAT_MAX;
+    float fD1 = std::numeric_limits<float>::max();
+    float fD2 = std::numeric_limits<float>::max();
+    float fD3 = std::numeric_limits<float>::max();
 
     // 1st edge
     Base::Vector3f clDir = rcP2 - rcP1;

--- a/src/Mod/Mesh/App/Core/Grid.cpp
+++ b/src/Mod/Mesh/App/Core/Grid.cpp
@@ -760,7 +760,7 @@ void MeshFacetGrid::RebuildGrid()
 unsigned long MeshFacetGrid::SearchNearestFromPoint(const Base::Vector3f& rclPt) const
 {
     ElementIndex ulFacetInd = ELEMENT_INDEX_MAX;
-    float fMinDist = FLOAT_MAX;
+    float fMinDist = std::numeric_limits<float>::max();
     Base::BoundBox3f clBB = GetBoundBox();
 
     if (clBB.IsInBox(rclPt)) {  // Point lies within
@@ -1154,7 +1154,7 @@ bool MeshGridIterator::InitOnRay(const Base::Vector3f& rclPt,
     // needed in NextOnRay() to avoid an infinite loop
     _cSearchPositions.clear();
 
-    _fMaxSearchArea = FLOAT_MAX;
+    _fMaxSearchArea = std::numeric_limits<float>::max();
 
     raulElements.clear();
 

--- a/src/Mod/Mesh/App/Core/Grid.h
+++ b/src/Mod/Mesh/App/Core/Grid.h
@@ -447,7 +447,7 @@ private:
     Base::Vector3f _clPt;     /**< Base point of search ray. */
     Base::Vector3f _clDir;    /**< Direction of search ray. */
     bool _bValidRay {false};  /**< Search ray ok? */
-    float _fMaxSearchArea {FLOAT_MAX};
+    float _fMaxSearchArea {std::numeric_limits<float>::max()};
     /** Checks if a grid position is already visited by NextOnRay(). */
     struct GridElement
     {

--- a/src/Mod/Mesh/App/Core/Projection.cpp
+++ b/src/Mod/Mesh/App/Core/Projection.cpp
@@ -78,7 +78,8 @@ bool MeshProjection::connectLines(std::list<std::pair<Base::Vector3f, Base::Vect
                                   const Base::Vector3f& endPoint,
                                   std::vector<Base::Vector3f>& polyline) const
 {
-    const float fMaxDist = float(std::sqrt(FLOAT_MAX));  // max. length of a gap
+    const float fMaxDist =
+        float(std::sqrt(std::numeric_limits<float>::max()));  // max. length of a gap
     const float fMinEps = 1.0e-4F;
 
     polyline.clear();

--- a/src/Mod/Mesh/App/Core/Segmentation.cpp
+++ b/src/Mod/Mesh/App/Core/Segmentation.cpp
@@ -201,7 +201,7 @@ std::vector<float> PlaneSurfaceFit::Parameters() const
 // --------------------------------------------------------
 
 CylinderSurfaceFit::CylinderSurfaceFit()
-    : radius(FLOAT_MAX)
+    : radius(std::numeric_limits<float>::max())
     , fitter(new CylinderFit)
 {
     axis.Set(0, 0, 0);
@@ -266,7 +266,7 @@ float CylinderSurfaceFit::Fit()
     }
 
     float fit = fitter->Fit();
-    if (fit < FLOAT_MAX) {
+    if (fit < std::numeric_limits<float>::max()) {
         basepoint = fitter->GetBase();
         axis = fitter->GetAxis();
         radius = fitter->GetRadius();
@@ -309,7 +309,7 @@ std::vector<float> CylinderSurfaceFit::Parameters() const
 // --------------------------------------------------------
 
 SphereSurfaceFit::SphereSurfaceFit()
-    : radius(FLOAT_MAX)
+    : radius(std::numeric_limits<float>::max())
     , fitter(new SphereFit)
 {
     center.Set(0, 0, 0);
@@ -367,7 +367,7 @@ float SphereSurfaceFit::Fit()
     }
 
     float fit = fitter->Fit();
-    if (fit < FLOAT_MAX) {
+    if (fit < std::numeric_limits<float>::max()) {
         center = fitter->GetCenter();
         radius = fitter->GetRadius();
     }

--- a/src/Mod/Mesh/App/Core/Simplify.h
+++ b/src/Mod/Mesh/App/Core/Simplify.h
@@ -14,10 +14,6 @@
 #include <vector>
 
 
-#ifndef _USE_MATH_DEFINES
-#define _USE_MATH_DEFINES
-#endif
-
 using vec3f = Base::Vector3f;
 
 class SymmetricMatrix {

--- a/src/Mod/Mesh/App/Core/SphereFit.cpp
+++ b/src/Mod/Mesh/App/Core/SphereFit.cpp
@@ -41,7 +41,7 @@ SphereFit::SphereFit()
 void SphereFit::SetApproximations(double radius, const Base::Vector3d& center)
 {
     _bIsFitted = false;
-    _fLastResult = FLOAT_MAX;
+    _fLastResult = std::numeric_limits<float>::max();
     _numIter = 0;
     _dRadius = radius;
     _vCenter = center;
@@ -92,7 +92,7 @@ int SphereFit::GetNumIterations() const
 
 float SphereFit::GetDistanceToSphere(const Base::Vector3f& rcPoint) const
 {
-    float fResult = FLOAT_MAX;
+    float fResult = std::numeric_limits<float>::max();
     if (_bIsFitted) {
         fResult = Base::Vector3d((double)rcPoint.x - _vCenter.x,
                                  (double)rcPoint.y - _vCenter.y,
@@ -109,7 +109,7 @@ float SphereFit::GetStdDeviation() const
     // Variance: VAR=(N/N-1)*[(1/N)*SUM(Xi^2)-M^2]
     // Standard deviation: SD=SQRT(VAR)
     if (!_bIsFitted) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     double sumXi = 0.0, sumXi2 = 0.0, dist = 0.0;
@@ -156,7 +156,7 @@ void SphereFit::ProjectToSphere()
 void SphereFit::ComputeApproximations()
 {
     _bIsFitted = false;
-    _fLastResult = FLOAT_MAX;
+    _fLastResult = std::numeric_limits<float>::max();
     _numIter = 0;
     _vCenter.Set(0.0, 0.0, 0.0);
     _dRadius = 0.0;
@@ -182,12 +182,12 @@ void SphereFit::ComputeApproximations()
 float SphereFit::Fit()
 {
     _bIsFitted = false;
-    _fLastResult = FLOAT_MAX;
+    _fLastResult = std::numeric_limits<float>::max();
     _numIter = 0;
 
     // A minimum of 4 surface points is needed to define a sphere
     if (CountPoints() < 4) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     // If approximations have not been set/computed then compute some now
@@ -212,7 +212,7 @@ float SphereFit::Fit()
         // Solve the equations for the unknown corrections
         Eigen::LLT<Matrix4x4> llt(atpa);
         if (llt.info() != Eigen::Success) {
-            return FLOAT_MAX;
+            return std::numeric_limits<float>::max();
         }
         Eigen::VectorXd x = llt.solve(atpl);
 
@@ -227,7 +227,7 @@ float SphereFit::Fit()
         // convergence
         bool vConverged {};
         if (!computeResiduals(x, residuals, sigma0, _vConvLimit, vConverged)) {
-            return FLOAT_MAX;
+            return std::numeric_limits<float>::max();
         }
         if (!vConverged) {
             cont = true;
@@ -242,7 +242,7 @@ float SphereFit::Fit()
 
     // Check for convergence
     if (cont) {
-        return FLOAT_MAX;
+        return std::numeric_limits<float>::max();
     }
 
     _bIsFitted = true;

--- a/src/Mod/Mesh/App/Core/SphereFit.h
+++ b/src/Mod/Mesh/App/Core/SphereFit.h
@@ -72,17 +72,18 @@ public:
      */
     void ComputeApproximations();
     /**
-     * Fit a sphere onto the given points. If the fit fails FLOAT_MAX is returned.
+     * Fit a sphere onto the given points. If the fit fails std::numeric_limits<float>::max() is
+     * returned.
      */
     float Fit() override;
     /**
      * Returns the distance from the point \a rcPoint to the fitted sphere. If Fit() has not been
-     * called FLOAT_MAX is returned.
+     * called std::numeric_limits<float>::max() is returned.
      */
     float GetDistanceToSphere(const Base::Vector3f& rcPoint) const;
     /**
      * Returns the standard deviation from the points to the fitted sphere. If Fit() has not been
-     * called FLOAT_MAX is returned.
+     * called std::numeric_limits<float>::max() is returned.
      */
     float GetStdDeviation() const;
     /**

--- a/src/Mod/Mesh/App/Core/Tools.h
+++ b/src/Mod/Mesh/App/Core/Tools.h
@@ -209,7 +209,7 @@ public:
 
     // NOLINTBEGIN
     Index nearest_index;
-    float nearest_dist {FLOAT_MAX};
+    float nearest_dist {std::numeric_limits<float>::max()};
     // NOLINTEND
 
 private:

--- a/src/Mod/Mesh/App/Core/TopoAlgorithm.cpp
+++ b/src/Mod/Mesh/App/Core/TopoAlgorithm.cpp
@@ -1250,7 +1250,7 @@ void MeshTopoAlgorithm::SplitFacet(FacetIndex ulFacetPos,
 
 void MeshTopoAlgorithm::SplitFacetOnOneEdge(FacetIndex ulFacetPos, const Base::Vector3f& rP)
 {
-    float fMinDist = FLOAT_MAX;
+    float fMinDist = std::numeric_limits<float>::max();
     unsigned short iEdgeNo = USHRT_MAX;
     MeshFacet& rFace = _rclMesh._aclFacetArray[ulFacetPos];
 
@@ -1282,7 +1282,8 @@ void MeshTopoAlgorithm::SplitFacetOnTwoEdges(FacetIndex ulFacetPos,
 {
     // search for the matching edges
     unsigned short iEdgeNo1 = USHRT_MAX, iEdgeNo2 = USHRT_MAX;
-    float fMinDist1 = FLOAT_MAX, fMinDist2 = FLOAT_MAX;
+    float fMinDist1 = std::numeric_limits<float>::max(),
+          fMinDist2 = std::numeric_limits<float>::max();
     MeshFacet& rFace = _rclMesh._aclFacetArray[ulFacetPos];
 
     for (unsigned short i = 0; i < 3; i++) {

--- a/src/Mod/Mesh/App/Core/Triangulation.cpp
+++ b/src/Mod/Mesh/App/Core/Triangulation.cpp
@@ -144,7 +144,7 @@ Base::Matrix4D AbstractPolygonTriangulator::GetTransformToFitPlane() const
         planeFit.AddPoint(point);
     }
 
-    if (planeFit.Fit() >= FLOAT_MAX) {
+    if (planeFit.Fit() >= std::numeric_limits<float>::max()) {
         throw Base::RuntimeError("Plane fit failed");
     }
 
@@ -215,7 +215,7 @@ void AbstractPolygonTriangulator::PostProcessing(const std::vector<Base::Vector3
         polyFit.AddPoint(pt);
     }
 
-    if (polyFit.CountPoints() >= uMinPts && polyFit.Fit() < FLOAT_MAX) {
+    if (polyFit.CountPoints() >= uMinPts && polyFit.Fit() < std::numeric_limits<float>::max()) {
         for (auto& newpoint : _newpoints) {
             newpoint.z = static_cast<float>(polyFit.Value(newpoint.x, newpoint.y));
         }

--- a/src/Mod/Mesh/App/FeatureMeshSegmentByMesh.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshSegmentByMesh.cpp
@@ -119,7 +119,7 @@ App::DocumentObjectExecReturn* SegmentByMesh::execute()
         // now we have too many facets since we have (invisible) facets near to the back clipping
         // plane, so we need the nearest facet to the front clipping plane
         //
-        float fDist = FLOAT_MAX;
+        float fDist = std::numeric_limits<float>::max();
         MeshCore::FacetIndex uIdx = MeshCore::FACET_INDEX_MAX;
         MeshFacetIterator cFIt(rMeshKernel);
 

--- a/src/Mod/Mesh/App/MeshFeaturePyImp.cpp
+++ b/src/Mod/Mesh/App/MeshFeaturePyImp.cpp
@@ -73,7 +73,7 @@ PyObject* MeshFeaturePy::harmonizeNormals(PyObject* args)
 PyObject* MeshFeaturePy::smooth(PyObject* args)
 {
     int iter = 1;
-    float d_max = FLOAT_MAX;
+    float d_max = std::numeric_limits<float>::max();
     if (!PyArg_ParseTuple(args, "|if", &iter, &d_max)) {
         return nullptr;
     }

--- a/src/Mod/Mesh/App/PreCompiled.h
+++ b/src/Mod/Mesh/App/PreCompiled.h
@@ -43,15 +43,16 @@
 #include <cmath>
 #include <cstdio>
 #include <fcntl.h>
-#include <fstream>
-#include <ios>
 
 // STL
 #include <algorithm>
 #include <iomanip>
+#include <ios>
 #include <iostream>
+#include <fstream>
 #include <list>
 #include <map>
+#include <numbers>
 #include <queue>
 #include <set>
 #include <sstream>

--- a/src/Mod/Mesh/Gui/PreCompiled.h
+++ b/src/Mod/Mesh/Gui/PreCompiled.h
@@ -38,14 +38,15 @@
 #ifdef _PreComp_
 
 // standard
-#include <ios>
 #include <cfloat>
 
 // STL
 #include <algorithm>
 #include <iomanip>
+#include <ios>
 #include <list>
 #include <map>
+#include <numbers>
 #include <random>
 #include <sstream>
 #include <string>

--- a/src/Mod/Mesh/Gui/SegmentationBestFit.cpp
+++ b/src/Mod/Mesh/Gui/SegmentationBestFit.cpp
@@ -57,7 +57,7 @@ public:
         std::vector<float> values;
         MeshCore::PlaneFit fit;
         fit.AddPoints(pts.points);
-        if (fit.Fit() < FLOAT_MAX) {
+        if (fit.Fit() < std::numeric_limits<float>::max()) {
             Base::Vector3f base = fit.GetBase();
             Base::Vector3f axis = fit.GetNormal();
             values.push_back(base.x);
@@ -90,7 +90,7 @@ public:
 #endif
         }
 
-        if (fit.Fit() < FLOAT_MAX) {
+        if (fit.Fit() < std::numeric_limits<float>::max()) {
             Base::Vector3f base, top;
             fit.GetBounding(base, top);
             Base::Vector3f axis = fit.GetAxis();
@@ -145,7 +145,7 @@ public:
         std::vector<float> values;
         MeshCore::SphereFit fit;
         fit.AddPoints(pts.points);
-        if (fit.Fit() < FLOAT_MAX) {
+        if (fit.Fit() < std::numeric_limits<float>::max()) {
             Base::Vector3f base = fit.GetCenter();
             float radius = fit.GetRadius();
             values.push_back(base.x);

--- a/src/Mod/MeshPart/App/CurveProjector.cpp
+++ b/src/Mod/MeshPart/App/CurveProjector.cpp
@@ -180,7 +180,7 @@ void CurveProjectorShape::projectCurve(const TopoDS_Edge& aEdge,
                         / ((cP1 - cP0) * (cP1 - cP0));
                     // is the Point on the Edge of the facet?
                     if (l < 0.0 || l > 1.0) {
-                        PointOnEdge[i] = Base::Vector3f(FLOAT_MAX, 0, 0);
+                        PointOnEdge[i] = Base::Vector3f(std::numeric_limits<float>::max(), 0, 0);
                     }
                     else {
                         cSplitPoint = (1 - l) * cP0 + l * cP1;
@@ -191,11 +191,11 @@ void CurveProjectorShape::projectCurve(const TopoDS_Edge& aEdge,
                     // no intersection
                 }
                 else if (Alg.NbPoints() == 0) {
-                    PointOnEdge[i] = Base::Vector3f(FLOAT_MAX, 0, 0);
+                    PointOnEdge[i] = Base::Vector3f(std::numeric_limits<float>::max(), 0, 0);
                     // more the one intersection (@ToDo)
                 }
                 else if (Alg.NbPoints() > 1) {
-                    PointOnEdge[i] = Base::Vector3f(FLOAT_MAX, 0, 0);
+                    PointOnEdge[i] = Base::Vector3f(std::numeric_limits<float>::max(), 0, 0);
                     Base::Console().Log("MeshAlgos::projectCurve(): More then one intersection in "
                                         "Facet %lu, Edge %d\n",
                                         uCurFacetIdx,
@@ -234,7 +234,7 @@ bool CurveProjectorShape::findStartPoint(const MeshKernel& MeshK,
                                          MeshCore::FacetIndex& FaceIndex)
 {
     Base::Vector3f TempResultPoint;
-    float MinLength = FLOAT_MAX;
+    float MinLength = std::numeric_limits<float>::max();
     bool bHit = false;
 
     // go through the whole Mesh
@@ -363,7 +363,7 @@ bool CurveProjectorSimple::findStartPoint(const MeshKernel& MeshK,
                                           MeshCore::FacetIndex& FaceIndex)
 {
     Base::Vector3f TempResultPoint;
-    float MinLength = FLOAT_MAX;
+    float MinLength = std::numeric_limits<float>::max();
     bool bHit = false;
 
     // go through the whole Mesh
@@ -465,11 +465,11 @@ void CurveProjectorWithToolMesh::makeToolMesh(const TopoDS_Edge& aEdge,
 
 
     // build up the new mesh
-    Base::Vector3f lp(FLOAT_MAX, 0, 0), ln, p1, p2, p3, p4, p5, p6;
+    Base::Vector3f lp(std::numeric_limits<float>::max(), 0, 0), ln, p1, p2, p3, p4, p5, p6;
     float ToolSize = 0.2f;
 
     for (const auto& It2 : LineSegs) {
-        if (lp.x != FLOAT_MAX) {
+        if (lp.x != std::numeric_limits<float>::max()) {
             p1 = lp + (ln * (-ToolSize));
             p2 = lp + (ln * ToolSize);
             p3 = lp;

--- a/src/Mod/MeshPart/App/MeshFlatteningLscmRelax.cpp
+++ b/src/Mod/MeshPart/App/MeshFlatteningLscmRelax.cpp
@@ -30,10 +30,6 @@
 #include <vector>
 #endif
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846f
-#endif
-
 #include <Eigen/SparseCholesky>
 
 #include "MeshFlatteningLscmRelax.h"
@@ -649,7 +645,7 @@ void LscmRelax::rotate_by_min_bound_area()
     // rotate vector by 90 degree and find min area
     for (int i = 0; i < n + 1; i++ )
     {
-        phi = i * M_PI / n;
+        phi = i * std::numbers::pi / n;
         Eigen::VectorXd x_proj = this->flat_vertices.transpose() * Vector2(std::cos(phi), std::sin(phi));
         Eigen::VectorXd y_proj = this->flat_vertices.transpose() * Vector2(-std::sin(phi), std::cos(phi));
         double x_distance = x_proj.maxCoeff() - x_proj.minCoeff();
@@ -663,7 +659,7 @@ void LscmRelax::rotate_by_min_bound_area()
         }
     }
     Eigen::Matrix<double, 2, 2> rot;
-    min_phi += x_dominant * M_PI / 2;
+    min_phi += x_dominant * std::numbers::pi / 2;
     rot << std::cos(min_phi), std::sin(min_phi), -std::sin(min_phi), std::cos(min_phi);
     this->flat_vertices = rot * this->flat_vertices;
 }

--- a/src/Mod/MeshPart/App/PreCompiled.h
+++ b/src/Mod/MeshPart/App/PreCompiled.h
@@ -36,13 +36,14 @@
 
 // standard
 #include <cmath>
-#include <iostream>
 
 // STL
 #include <algorithm>
 #include <array>
+#include <iostream>
 #include <map>
 #include <memory>
+#include <numbers>
 #include <set>
 #include <sstream>
 #include <stdexcept>

--- a/src/Mod/MeshPart/Gui/PreCompiled.h
+++ b/src/Mod/MeshPart/Gui/PreCompiled.h
@@ -35,6 +35,7 @@
 
 // STL
 #include <cfloat>
+#include <numbers>
 #include <sstream>
 
 // Qt Toolkit

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -1912,7 +1912,7 @@ AttachEngine3D::_calculateAttachedPlacement(const std::vector<App::DocumentObjec
                 Base::Vector3d(dirs[2].X(), dirs[2].Y(), dirs[2].Z()),
                 orderString);
             if (this->mapReverse) {
-                rot = rot * Base::Rotation(Base::Vector3d(0, 1, 0), D_PI);
+                rot = rot * Base::Rotation(Base::Vector3d(0, 1, 0), std::numbers::pi);
             }
 
             Base::Placement plm = Base::Placement(

--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -244,11 +244,11 @@ ExtrusionParameters Extrusion::computeFinalParameters()
 
     result.solid = this->Solid.getValue();
 
-    result.taperAngleFwd = this->TaperAngle.getValue() * M_PI / 180.0;
-    if (fabs(result.taperAngleFwd) > M_PI * 0.5 - Precision::Angular())
+    result.taperAngleFwd = this->TaperAngle.getValue() * std::numbers::pi / 180.0;
+    if (fabs(result.taperAngleFwd) > std::numbers::pi * 0.5 - Precision::Angular())
         throw Base::ValueError("Magnitude of taper angle matches or exceeds 90 degrees. That is too much.");
-    result.taperAngleRev = this->TaperAngleRev.getValue() * M_PI / 180.0;
-    if (fabs(result.taperAngleRev) > M_PI * 0.5 - Precision::Angular())
+    result.taperAngleRev = this->TaperAngleRev.getValue() * std::numbers::pi / 180.0;
+    if (fabs(result.taperAngleRev) > std::numbers::pi * 0.5 - Precision::Angular())
         throw Base::ValueError("Magnitude of taper angle matches or exceeds 90 degrees. That is too much.");
 
     result.faceMakerClass = this->FaceMakerClass.getValue();

--- a/src/Mod/Part/App/FeatureRevolution.cpp
+++ b/src/Mod/Part/App/FeatureRevolution.cpp
@@ -143,7 +143,7 @@ App::DocumentObjectExecReturn *Revolution::execute()
         gp_Ax1 revAx(pnt, dir);
 
         //read out revolution angle
-        double angle = Angle.getValue()/180.0f*M_PI;
+        double angle = Angle.getValue()/180.0f*std::numbers::pi;
         if (fabs(angle) < Precision::Angular())
             angle = angle_edge;
 

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -2640,7 +2640,7 @@ GeomCurve* GeomCircle::createArc(double first, double last) const
 GeomBSplineCurve* GeomCircle::toNurbs(double first, double last) const
 {
     // for an arc of circle use the generic method
-    if (first != 0 || last != 2*M_PI) {
+    if (first != 0 || last != 2*std::numbers::pi) {
         return GeomConic::toNurbs(first, last);
     }
 
@@ -2674,8 +2674,8 @@ GeomBSplineCurve* GeomCircle::toNurbs(double first, double last) const
 
     TColStd_Array1OfReal knots(1, 3);
     knots(1) = 0;
-    knots(2) = M_PI;
-    knots(3) = 2*M_PI;
+    knots(2) = std::numbers::pi;
+    knots(3) = 2*std::numbers::pi;
 
     Handle(Geom_BSplineCurve) spline = new Geom_BSplineCurve(poles, weights,knots, mults, 3,
         Standard_False, Standard_True);
@@ -2906,9 +2906,9 @@ void GeomArcOfCircle::getRange(double& u, double& v, bool emulateCCWXY) const
         }
 
         if (v < u)
-            v += 2*M_PI;
-        if (v-u > 2*M_PI)
-            v -= 2*M_PI;
+            v += 2*std::numbers::pi;
+        if (v-u > 2*std::numbers::pi)
+            v -= 2*std::numbers::pi;
     }
 }
 
@@ -3086,7 +3086,7 @@ GeomCurve* GeomEllipse::createArc(double first, double last) const
 GeomBSplineCurve* GeomEllipse::toNurbs(double first, double last) const
 {
     // for an arc of ellipse use the generic method
-    if (first != 0 || last != 2*M_PI) {
+    if (first != 0 || last != 2*std::numbers::pi) {
         return GeomConic::toNurbs(first, last);
     }
 
@@ -3465,9 +3465,9 @@ void GeomArcOfEllipse::getRange(double& u, double& v, bool emulateCCWXY) const
             std::swap(u,v);
             u = -u; v = -v;
             if (v < u)
-                v += 2*M_PI;
-            if (v-u > 2*M_PI)
-                v -= 2*M_PI;
+                v += 2*std::numbers::pi;
+            if (v-u > 2*std::numbers::pi)
+                v -= 2*std::numbers::pi;
         }
     }
 }
@@ -5409,7 +5409,7 @@ gp_Vec GeomCone::getDN(double u, double v, int Nu, int Nv) const
     {
        gp_XYZ Xdir = Pos.XDirection().XYZ();
        gp_XYZ Ydir = Pos.YDirection().XYZ();
-       Standard_Real Um = U + Nu * M_PI_2;  // M_PI * 0.5
+       Standard_Real Um = U + Nu * std::numbers::pi/2.0;  // std::numbers::pi * 0.5
        Xdir.Multiply(cos(Um));
        Ydir.Multiply(sin(Um));
        Xdir.Add(Ydir);
@@ -6228,11 +6228,11 @@ GeomArcOfCircle *createFilletGeometry(const GeomLineSegment *lineSeg1, const Geo
     if (endAngle < startAngle)
         std::swap(startAngle, endAngle);
 
-    if (endAngle > 2*M_PI )
-        endAngle -= 2*M_PI;
+    if (endAngle > 2*std::numbers::pi )
+        endAngle -= 2*std::numbers::pi;
 
     if (startAngle < 0 )
-        endAngle += 2*M_PI;
+        endAngle += 2*std::numbers::pi;
 
     // Create Arc Segment
     GeomArcOfCircle *arc = new GeomArcOfCircle();

--- a/src/Mod/Part/App/PreCompiled.h
+++ b/src/Mod/Part/App/PreCompiled.h
@@ -52,6 +52,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <numbers>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/src/Mod/Part/App/Tools.cpp
+++ b/src/Mod/Part/App/Tools.cpp
@@ -23,6 +23,7 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 # include <cassert>
+#include <numbers>
 # include <BRep_Tool.hxx>
 # include <BRepAdaptor_Curve.hxx>
 # include <BRepAdaptor_Surface.hxx>
@@ -773,9 +774,9 @@ bool Part::Tools::isConcave(const TopoDS_Face &face, const gp_Pnt &pointOfVue, c
 
             // check normals orientation
     gp_Dir dirdU(dU);
-    result = (dirdU.Angle(direction) - M_PI_2) <= Precision::Confusion();
+    result = (dirdU.Angle(direction) - std::numbers::pi_v<Standard_Real> / 2.0) <= Precision::Confusion();
     gp_Dir dirdV(dV);
-    result = result || ((dirdV.Angle(direction) - M_PI_2) <= Precision::Confusion());
+    result = result || ((dirdV.Angle(direction) - std::numbers::pi_v<Standard_Real> / 2.0) <= Precision::Confusion());
 
     return result;
 }

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -2004,7 +2004,7 @@ TopoDS_Shape TopoShape::makeTube(double radius, double tol, int cont, int maxdeg
 
     //circular profile
     Handle(Geom_Circle) aCirc = new Geom_Circle (gp::XOY(), theRadius);
-    aCirc->Rotate (gp::OZ(), M_PI/2.);
+    aCirc->Rotate (gp::OZ(), std::numbers::pi/2.);
 
     //perpendicular section
     Handle(Law_Function) myEvol = ::CreateBsFunction (myPath->FirstParameter(), myPath->LastParameter(), theRadius);
@@ -2140,24 +2140,24 @@ TopoDS_Shape TopoShape::makeHelix(Standard_Real pitch, Standard_Real height,
     }
 
     gp_Pnt2d aPnt(0, 0);
-    gp_Dir2d aDir(2. * M_PI, pitch);
+    gp_Dir2d aDir(2. * std::numbers::pi, pitch);
     Standard_Real coneDir = 1.0;
     if (leftHanded) {
-        aDir.SetCoord(-2. * M_PI, pitch);
+        aDir.SetCoord(-2. * std::numbers::pi, pitch);
         coneDir = -1.0;
     }
     gp_Ax2d aAx2d(aPnt, aDir);
 
     Handle(Geom2d_Line) line = new Geom2d_Line(aAx2d);
     gp_Pnt2d beg = line->Value(0);
-    gp_Pnt2d end = line->Value(sqrt(4.0*M_PI*M_PI+pitch*pitch)*(height/pitch));
+    gp_Pnt2d end = line->Value(sqrt(4.0*std::numbers::pi*std::numbers::pi+pitch*pitch)*(height/pitch));
 
     if (newStyle) {
         // See discussion at 0001247: Part Conical Helix Height/Pitch Incorrect
         if (angle >= Precision::Confusion()) {
             // calculate end point for conical helix
             Standard_Real v = height / cos(angle);
-            Standard_Real u = coneDir * (height/pitch) * 2.0 * M_PI;
+            Standard_Real u = coneDir * (height/pitch) * 2.0 * std::numbers::pi;
             gp_Pnt2d cend(u, v);
             end = cend;
         }
@@ -2206,10 +2206,10 @@ TopoDS_Shape TopoShape::makeLongHelix(Standard_Real pitch, Standard_Real height,
     Standard_Real partTurn = turns - wholeTurns;
 
     gp_Pnt2d aPnt(0, 0);
-    gp_Dir2d aDir(2. * M_PI, pitch);
+    gp_Dir2d aDir(2. * std::numbers::pi, pitch);
     Standard_Real coneDir = 1.0;
     if (leftHanded) {
-        aDir.SetCoord(-2. * M_PI, pitch);
+        aDir.SetCoord(-2. * std::numbers::pi, pitch);
         coneDir = -1.0;
     }
     gp_Ax2d aAx2d(aPnt, aDir);
@@ -2223,10 +2223,10 @@ TopoDS_Shape TopoShape::makeLongHelix(Standard_Real pitch, Standard_Real height,
 
     for (unsigned long i = 0; i < wholeTurns; i++) {
         if (isCylinder) {
-            end = line->Value(sqrt(4.0*M_PI*M_PI+pitch*pitch)*(i+1));
+            end = line->Value(sqrt(4.0*std::numbers::pi*std::numbers::pi+pitch*pitch)*(i+1));
         }
         else {
-            u = coneDir * (i+1) * 2.0 * M_PI;
+            u = coneDir * (i+1) * 2.0 * std::numbers::pi;
             v = ((i+1) * pitch) / cos(angle);
             end = gp_Pnt2d(u, v);
         }
@@ -2238,10 +2238,10 @@ TopoDS_Shape TopoShape::makeLongHelix(Standard_Real pitch, Standard_Real height,
 
     if (partTurn > Precision::Confusion()) {
         if (isCylinder) {
-            end = line->Value(sqrt(4.0*M_PI*M_PI+pitch*pitch)*turns);
+            end = line->Value(sqrt(4.0*std::numbers::pi*std::numbers::pi+pitch*pitch)*turns);
         }
         else {
-            u = coneDir * turns * 2.0 * M_PI;
+            u = coneDir * turns * 2.0 * std::numbers::pi;
             v = height / cos(angle);
             end = gp_Pnt2d(u, v);
         }
@@ -2283,9 +2283,9 @@ TopoDS_Shape TopoShape::makeSpiralHelix(Standard_Real radiusbottom, Standard_Rea
 
     gp_Pnt2d beg(0, 0);
     gp_Pnt2d end(0, 0);
-    gp_Vec2d dir(breakperiod * 2.0 * M_PI, 1 / nbPeriods);
+    gp_Vec2d dir(breakperiod * 2.0 * std::numbers::pi, 1 / nbPeriods);
     if (leftHanded == Standard_True)
-        dir = gp_Vec2d(-breakperiod * 2.0 * M_PI, 1 / nbPeriods);
+        dir = gp_Vec2d(-breakperiod * 2.0 * std::numbers::pi, 1 / nbPeriods);
     Handle(Geom2d_TrimmedCurve) segm;
     TopoDS_Edge edgeOnSurf;
     BRepBuilderAPI_MakeWire mkWire;
@@ -2332,21 +2332,21 @@ TopoDS_Shape TopoShape::makeThread(Standard_Real pitch,
     Handle(Geom_CylindricalSurface) aCyl2 = new Geom_CylindricalSurface(cylAx2 , radius+depth);
 
     //Threading : Define 2D Curves
-    gp_Pnt2d aPnt(2. * M_PI , height / 2.);
-    gp_Dir2d aDir(2. * M_PI , height / 4.);
+    gp_Pnt2d aPnt(2. * std::numbers::pi , height / 2.);
+    gp_Dir2d aDir(2. * std::numbers::pi , height / 4.);
     gp_Ax2d aAx2d(aPnt , aDir);
 
-    Standard_Real aMajor = 2. * M_PI;
+    Standard_Real aMajor = 2. * std::numbers::pi;
     Standard_Real aMinor = pitch;
 
     Handle(Geom2d_Ellipse) anEllipse1 = new Geom2d_Ellipse(aAx2d , aMajor , aMinor);
     Handle(Geom2d_Ellipse) anEllipse2 = new Geom2d_Ellipse(aAx2d , aMajor , aMinor / 4);
 
-    Handle(Geom2d_TrimmedCurve) aArc1 = new Geom2d_TrimmedCurve(anEllipse1 , 0 , M_PI);
-    Handle(Geom2d_TrimmedCurve) aArc2 = new Geom2d_TrimmedCurve(anEllipse2 , 0 , M_PI);
+    Handle(Geom2d_TrimmedCurve) aArc1 = new Geom2d_TrimmedCurve(anEllipse1 , 0 , std::numbers::pi);
+    Handle(Geom2d_TrimmedCurve) aArc2 = new Geom2d_TrimmedCurve(anEllipse2 , 0 , std::numbers::pi);
 
     gp_Pnt2d anEllipsePnt1 = anEllipse1->Value(0);
-    gp_Pnt2d anEllipsePnt2 = anEllipse1->Value(M_PI);
+    gp_Pnt2d anEllipsePnt2 = anEllipse1->Value(std::numbers::pi);
 
     Handle(Geom2d_TrimmedCurve) aSegment = GCE2d_MakeSegment(anEllipsePnt1 , anEllipsePnt2);
 

--- a/src/Mod/Part/App/modelRefine.cpp
+++ b/src/Mod/Part/App/modelRefine.cpp
@@ -613,8 +613,8 @@ bool wireEncirclesAxis(const TopoDS_Wire& wire, const Handle(Geom_CylindricalSur
 
     // For an exact calculation, only two results would be possible:
     // totalArc = 0.0: The wire does not encircle the axis
-    // totalArc = 2 * M_PI * radius: The wire encircles the axis
-    return (fabs(totalArc) > M_PI * radius);
+    // totalArc = 2 * std::numbers::pi * radius: The wire encircles the axis
+    return (fabs(totalArc) > std::numbers::pi * radius);
 }
 
 TopoDS_Face FaceTypedCylinder::buildFace(const FaceVectorType &faces) const

--- a/src/Mod/Part/Gui/DlgRevolution.cpp
+++ b/src/Mod/Part/Gui/DlgRevolution.cpp
@@ -307,7 +307,7 @@ bool DlgRevolution::validate()
 
     //check angle
     if (!axisLinkHasAngle){
-        if (fabs(this->getAngle() / 180.0 * M_PI) < Precision::Angular()) {
+        if (fabs(this->getAngle() / 180.0 * std::numbers::pi) < Precision::Angular()) {
             QMessageBox::critical(this, windowTitle(),
                 tr("Revolution angle span is zero. It must be non-zero."));
             ui->angle->setFocus();

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -24,11 +24,6 @@
 
 #ifndef _PreComp_
 
-// to avoid compiler warnings of redefining contents of basic.h
-// later by #include <Gui/ViewProvider.h>
-# define _USE_MATH_DEFINES
-# include <cmath>
-
 # include <gp_Ax2.hxx>
 # include <gp_Circ.hxx>
 # include <gp_Dir.hxx>

--- a/src/Mod/Part/Gui/PreCompiled.h
+++ b/src/Mod/Part/Gui/PreCompiled.h
@@ -51,6 +51,7 @@
 // STL
 #include <algorithm>
 #include <map>
+#include <numbers>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/Mod/Part/Gui/PropertyEnumAttacherItem.cpp
+++ b/src/Mod/Part/Gui/PropertyEnumAttacherItem.cpp
@@ -22,12 +22,7 @@
 
 
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
-# ifdef _MSC_VER
-#  define _USE_MATH_DEFINES
-#  include <cmath>
-# endif //_MSC_VER
 #endif // _PreComp_
 
 #include <Gui/Application.h>

--- a/src/Mod/Part/Gui/SectionCutting.cpp
+++ b/src/Mod/Part/Gui/SectionCutting.cpp
@@ -21,14 +21,7 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
-
-// to avoid compiler warnings of redefining contents of basic.h
-// later by #include <Gui/ViewProviderGeometryObject.h>
-# define _USE_MATH_DEFINES  // NOLINT
-# include <cmath>
-
 # include <Inventor/actions/SoGetBoundingBoxAction.h>
 # include <Inventor/nodes/SoCamera.h>
 # include <Inventor/nodes/SoOrthographicCamera.h>

--- a/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
@@ -23,10 +23,6 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# ifdef _MSC_VER
-#  define _USE_MATH_DEFINES
-#  include <cmath>
-# endif
 # include <QAction>
 # include <QMenu>
 #endif

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -976,7 +976,7 @@ void ViewProviderPartExt::updateVisual()
         //deflection = std::min(deflection, 20.0);
 
         // create or use the mesh on the data structure
-        Standard_Real AngDeflectionRads = AngularDeflection.getValue() / 180.0 * M_PI;
+        Standard_Real AngDeflectionRads = AngularDeflection.getValue() / 180.0 * std::numbers::pi;
 
         IMeshTools_Parameters meshParams;
         meshParams.Deflection = deflection;

--- a/src/Mod/Part/Gui/ViewProviderReference.cpp
+++ b/src/Mod/Part/Gui/ViewProviderReference.cpp
@@ -23,11 +23,6 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-// to avoid compiler warnings of redefining contents of basic.h
-// later by #include "ViewProvider.h"
-# define _USE_MATH_DEFINES
-# include <cmath>
-
 # include <Inventor/nodes/SoGroup.h>
 # include <Inventor/nodes/SoMaterial.h>
 # include <Inventor/nodes/SoShapeHints.h>

--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -244,7 +244,7 @@ App::DocumentObjectExecReturn *Draft::execute()
                     if (c.GetType() != GeomAbs_Line)
                         throw Base::TypeError("Neutral plane reference edge must be linear");
                     double a = c.Line().Angle(gp_Lin(c.Value(c.FirstParameter()), pullDirection));
-                    if (std::fabs(a - M_PI_2) > Precision::Confusion())
+                    if (std::fabs(a - std::numbers::pi/2.0) > Precision::Confusion())
                         throw Base::ValueError("Neutral plane reference edge must be normal to pull direction");
                     neutralPlane = gp_Pln(c.Value(c.FirstParameter()), pullDirection);
                 } else {

--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -717,8 +717,8 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             Part::ExtrusionParameters params;
             params.dir = dir;
             params.solid = makeface;
-            params.taperAngleFwd = this->TaperAngle.getValue() * M_PI / 180.0;
-            params.taperAngleRev = this->TaperAngle2.getValue() * M_PI / 180.0;
+            params.taperAngleFwd = this->TaperAngle.getValue() * std::numbers::pi / 180.0;
+            params.taperAngleRev = this->TaperAngle2.getValue() * std::numbers::pi / 180.0;
             if (L2 == 0.0 && Midplane.getValue()) {
                 params.lengthFwd = L / 2;
                 params.lengthRev = L / 2;
@@ -732,8 +732,8 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             }
             if (std::fabs(params.taperAngleFwd) >= Precision::Angular()
                 || std::fabs(params.taperAngleRev) >= Precision::Angular()) {
-                if (fabs(params.taperAngleFwd) > M_PI * 0.5 - Precision::Angular()
-                    || fabs(params.taperAngleRev) > M_PI * 0.5 - Precision::Angular()) {
+                if (fabs(params.taperAngleFwd) > std::numbers::pi * 0.5 - Precision::Angular()
+                    || fabs(params.taperAngleRev) > std::numbers::pi * 0.5 - Precision::Angular()) {
                     return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
                         "Exception",
                         "Magnitude of taper angle matches or exceeds 90 degrees"));

--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -270,7 +270,7 @@ void Groove::generateRevolution(TopoDS_Shape& revol,
             angleOffset = angle2 * -1.0;
         }
         else if (method == RevolMethod::ThroughAll) {
-            angleTotal = 2 * M_PI;
+            angleTotal = 2 * std::numbers::pi;
         }
         else if (midplane) {
             // Rotate the face by half the angle to get Groove symmetric to sketch plane

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -442,13 +442,13 @@ TopoDS_Shape Helix::generateHelixPath(double breakAtTurn)
     // because of the radius factor we used above, we must reverse after the
     // startOffset movement (that brings the path back to the desired position)
     if (reversed) {
-        mov.SetRotation(gp_Ax1(origo, dir_axis2), M_PI);
+        mov.SetRotation(gp_Ax1(origo, dir_axis2), std::numbers::pi);
         TopLoc_Location loc(mov);
         path.Move(loc);
     }
 
     if (turned) {  // turn the helix so that the starting point aligns with the profile
-        mov.SetRotation(gp_Ax1(origo, dir_axis1), M_PI);
+        mov.SetRotation(gp_Ax1(origo, dir_axis1), std::numbers::pi);
         TopLoc_Location loc(mov);
         path.Move(loc);
     }
@@ -495,7 +495,7 @@ double Helix::safePitch()
         }
     }
 
-    double angle = Angle.getValue() / 180.0 * M_PI;
+    double angle = Angle.getValue() / 180.0 * std::numbers::pi;
     gp_Dir direction(axisVec.x, axisVec.y, axisVec.z);
     gp_Dir directionStart(startVec.x, startVec.y, startVec.z);
     TopoDS_Shape sketchshape = getVerifiedFace();

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -2244,7 +2244,7 @@ TopoDS_Shape Hole::makeThread(const gp_Vec& xDir, const gp_Vec& zDir, double len
         //      | base-sharpV             Rmaj     H
 
         // the little adjustment of p1 and p4 is here to prevent coincidencies
-        double marginX = std::tan(62.5 * M_PI / 180.0) * marginZ;
+        double marginX = std::tan(62.5 * std::numbers::pi / 180.0) * marginZ;
 
         gp_Pnt p1 = toPnt(
             (RmajC - 5 * H / 6 + marginX) * xDir
@@ -2281,7 +2281,7 @@ TopoDS_Shape Hole::makeThread(const gp_Vec& xDir, const gp_Vec& zDir, double len
         //       | base-sharpV    Rmaj
 
         // the little adjustment of p1 and p4 is here to prevent coincidencies
-        double marginX = std::tan(60.0 * M_PI / 180.0) * marginZ;
+        double marginX = std::tan(60.0 * std::numbers::pi / 180.0) * marginZ;
         gp_Pnt p1 = toPnt(
             (RmajC - h + marginX) * xDir
             + marginZ * zDir
@@ -2343,7 +2343,7 @@ TopoDS_Shape Hole::makeThread(const gp_Vec& xDir, const gp_Vec& zDir, double len
 
     // Reverse the direction of the helix. So that it goes into the material
     gp_Trsf mov;
-    mov.SetRotation(gp_Ax1(origo, dir_axis2), M_PI);
+    mov.SetRotation(gp_Ax1(origo, dir_axis2), std::numbers::pi);
     TopLoc_Location loc1(mov);
     helix.Move(loc1);
 

--- a/src/Mod/PartDesign/Gui/PreCompiled.h
+++ b/src/Mod/PartDesign/Gui/PreCompiled.h
@@ -38,6 +38,8 @@
 #include <windows.h>
 #endif
 
+#include <numbers>
+
 // Boost
 #include <boost/core/ignore_unused.hpp>
 

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -327,7 +327,7 @@ void fixSketchSupport (Sketcher::SketchObject* sketch)
         // Offset to base plane
         // Find out which direction we need to offset
         double a = sketchVector.GetAngle(pnt);
-        if ((a < -M_PI_2) || (a > M_PI_2))
+        if ((a < -std::numbers::pi/2.0) || (a > std::numbers::pi/2.0))
             offset *= -1.0;
 
         std::string Datum = doc->getUniqueObjectName("DatumPlane");

--- a/src/Mod/PartDesign/Gui/ViewProviderAddSub.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderAddSub.cpp
@@ -121,7 +121,7 @@ void ViewProviderAddSub::updateAddSubShapeIndicator() {
         Standard_Real deflection = ((xMax-xMin)+(yMax-yMin)+(zMax-zMin))/300.0 * Deviation.getValue();
 
         // create or use the mesh on the data structure
-        Standard_Real AngDeflectionRads = AngularDeflection.getValue() / 180.0 * M_PI;
+        Standard_Real AngDeflectionRads = AngularDeflection.getValue() / 180.0 * std::numbers::pi;
         BRepMesh_IncrementalMesh(cShape, deflection, Standard_False, AngDeflectionRads, Standard_True);
 
         // We must reset the location here because the transformation data

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -228,7 +228,7 @@ void ViewProviderTransformed::showRejectedShape(TopoDS_Shape shape)
 
         // create or use the mesh on the data structure
         // Note: This DOES have an effect on shape
-        Standard_Real AngDeflectionRads = AngularDeflection.getValue() / 180.0 * M_PI;
+        Standard_Real AngDeflectionRads = AngularDeflection.getValue() / 180.0 * std::numbers::pi;
         BRepMesh_IncrementalMesh(shape, deflection, Standard_False, AngDeflectionRads, Standard_True);
 
         // We must reset the location here because the transformation data

--- a/src/Mod/Points/App/CMakeLists.txt
+++ b/src/Mod/Points/App/CMakeLists.txt
@@ -14,9 +14,17 @@ target_include_directories(
     SYSTEM
     PUBLIC
     ${EIGEN3_INCLUDE_DIR}
-    ${CMAKE_BINARY_DIR}/src/3rdParty/libE57Format
-    ${CMAKE_SOURCE_DIR}/src/3rdParty/libE57Format/include
 )
+
+if(NOT FREECAD_USE_EXTERNAL_E57FORMAT)
+    target_include_directories(
+        Points
+        SYSTEM
+        PUBLIC
+        ${CMAKE_BINARY_DIR}/src/3rdParty/libE57Format
+        ${CMAKE_SOURCE_DIR}/src/3rdParty/libE57Format/include
+    )
+endif()
 
 set(Points_LIBS
     FreeCADApp
@@ -67,7 +75,9 @@ if(FREECAD_USE_PCH)
 endif(FREECAD_USE_PCH)
 
 target_sources(Points PRIVATE ${Points_SRCS} ${Points_Scripts})
-link_directories(${CMAKE_BINARY_DIR}/src/3rdParty/libE57Format)
+if(NOT FREECAD_USE_EXTERNAL_E57FORMAT)
+    link_directories(${CMAKE_BINARY_DIR}/src/3rdParty/libE57Format)
+endif()
 
 target_link_libraries(Points E57Format ${Points_LIBS})
 if (FREECAD_WARN_ERROR)

--- a/src/Mod/Points/App/PointsGrid.cpp
+++ b/src/Mod/Points/App/PointsGrid.cpp
@@ -808,7 +808,7 @@ bool PointsGridIterator::InitOnRay(const Base::Vector3d& rclPt,
     // needed in NextOnRay() to avoid an infinite loop
     _cSearchPositions.clear();
 
-    _fMaxSearchArea = FLOAT_MAX;
+    _fMaxSearchArea = std::numeric_limits<float>::max();
 
     raulElements.clear();
 

--- a/src/Mod/Points/App/PointsGrid.h
+++ b/src/Mod/Points/App/PointsGrid.h
@@ -293,7 +293,7 @@ private:
     Base::Vector3d _clPt;       /**< Base point of search ray. */
     Base::Vector3d _clDir;      /**< Direction of search ray. */
     bool _bValidRay {false};    /**< Search ray ok? */
-    float _fMaxSearchArea {FLOAT_MAX};
+    float _fMaxSearchArea {std::numeric_limits<float>::max()};
     /** Checks if a grid position is already visited by NextOnRay(). */
     struct GridElement
     {

--- a/src/Mod/Points/App/PreCompiled.h
+++ b/src/Mod/Points/App/PreCompiled.h
@@ -42,6 +42,7 @@
 #include <cmath>
 #include <iostream>
 #include <memory>
+#include <numbers>
 #include <set>
 #include <sstream>
 #include <vector>

--- a/src/Mod/Points/Gui/PreCompiled.h
+++ b/src/Mod/Points/Gui/PreCompiled.h
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <numbers>
 
 // boost
 #include <boost/math/special_functions/fpclassify.hpp>

--- a/src/Mod/ReverseEngineering/App/PreCompiled.h
+++ b/src/Mod/ReverseEngineering/App/PreCompiled.h
@@ -42,6 +42,7 @@
 
 // standard
 #include <map>
+#include <numbers>
 
 // boost
 #include <boost/math/special_functions/fpclassify.hpp>

--- a/src/Mod/ReverseEngineering/App/RegionGrowing.cpp
+++ b/src/Mod/ReverseEngineering/App/RegionGrowing.cpp
@@ -88,7 +88,7 @@ void RegionGrowing::perform(int ksearch)
     reg.setInputCloud(cloud);
     // reg.setIndices (indices);
     reg.setInputNormals(normals);
-    reg.setSmoothnessThreshold(3.0 / 180.0 * M_PI);
+    reg.setSmoothnessThreshold(3.0 / 180.0 * std::numbers::pi);
     reg.setCurvatureThreshold(1.0);
 
     std::vector<pcl::PointIndices> clusters;
@@ -142,7 +142,7 @@ void RegionGrowing::perform(const std::vector<Base::Vector3f>& myNormals)
     reg.setInputCloud(cloud);
     // reg.setIndices (indices);
     reg.setInputNormals(normals);
-    reg.setSmoothnessThreshold(3.0 / 180.0 * M_PI);
+    reg.setSmoothnessThreshold(3.0 / 180.0 * std::numbers::pi);
     reg.setCurvatureThreshold(1.0);
 
     std::vector<pcl::PointIndices> clusters;

--- a/src/Mod/ReverseEngineering/App/SurfaceTriangulation.cpp
+++ b/src/Mod/ReverseEngineering/App/SurfaceTriangulation.cpp
@@ -114,9 +114,9 @@ void SurfaceTriangulation::perform(int ksearch)
     gp3.setSearchRadius(searchRadius);
     gp3.setMu(mu);
     gp3.setMaximumNearestNeighbors(100);
-    gp3.setMaximumSurfaceAngle(M_PI / 4);  // 45 degrees
-    gp3.setMinimumAngle(M_PI / 18);        // 10 degrees
-    gp3.setMaximumAngle(2 * M_PI / 3);     // 120 degrees
+    gp3.setMaximumSurfaceAngle(std::numbers::pi / 4);  // 45 degrees
+    gp3.setMinimumAngle(std::numbers::pi / 18);        // 10 degrees
+    gp3.setMaximumAngle(2 * std::numbers::pi / 3);     // 120 degrees
     gp3.setNormalConsistency(false);
     gp3.setConsistentVertexOrdering(true);
 
@@ -171,9 +171,9 @@ void SurfaceTriangulation::perform(const std::vector<Base::Vector3f>& normals)
     gp3.setSearchRadius(searchRadius);
     gp3.setMu(mu);
     gp3.setMaximumNearestNeighbors(100);
-    gp3.setMaximumSurfaceAngle(M_PI / 4);  // 45 degrees
-    gp3.setMinimumAngle(M_PI / 18);        // 10 degrees
-    gp3.setMaximumAngle(2 * M_PI / 3);     // 120 degrees
+    gp3.setMaximumSurfaceAngle(std::numbers::pi / 4);  // 45 degrees
+    gp3.setMinimumAngle(std::numbers::pi / 18);        // 10 degrees
+    gp3.setMaximumAngle(2 * std::numbers::pi / 3);     // 120 degrees
     gp3.setNormalConsistency(true);
     gp3.setConsistentVertexOrdering(true);
 

--- a/src/Mod/ReverseEngineering/Gui/Command.cpp
+++ b/src/Mod/ReverseEngineering/Gui/Command.cpp
@@ -272,7 +272,7 @@ void CmdApproxCylinder::activated(int)
             fit.SetInitialValues(base, axis);
         }
 
-        if (fit.Fit() < FLOAT_MAX) {
+        if (fit.Fit() < std::numeric_limits<float>::max()) {
             Base::Vector3f base, top;
             fit.GetBounding(base, top);
             float height = Base::Distance(base, top);
@@ -329,7 +329,7 @@ void CmdApproxSphere::activated(int)
         const MeshCore::MeshKernel& kernel = mesh.getKernel();
         MeshCore::SphereFit fit;
         fit.AddPoints(kernel.GetPoints());
-        if (fit.Fit() < FLOAT_MAX) {
+        if (fit.Fit() < std::numeric_limits<float>::max()) {
             Base::Vector3f base = fit.GetCenter();
 
             std::stringstream str;
@@ -378,7 +378,7 @@ void CmdApproxPolynomial::activated(int)
         const MeshCore::MeshKernel& kernel = mesh.getKernel();
         MeshCore::SurfaceFit fit;
         fit.AddPoints(kernel.GetPoints());
-        if (fit.Fit() < FLOAT_MAX) {
+        if (fit.Fit() < std::numeric_limits<float>::max()) {
             Base::BoundBox3f bbox = fit.GetBoundings();
             std::vector<Base::Vector3d> poles =
                 fit.toBezier(bbox.MinX, bbox.MaxX, bbox.MinY, bbox.MaxY);

--- a/src/Mod/ReverseEngineering/Gui/FitBSplineSurface.cpp
+++ b/src/Mod/ReverseEngineering/Gui/FitBSplineSurface.cpp
@@ -122,7 +122,7 @@ void FitBSplineSurfaceWidget::onMakePlacementClicked()
                                });
                 MeshCore::PlaneFit fit;
                 fit.AddPoints(data);
-                if (fit.Fit() < FLOAT_MAX) {
+                if (fit.Fit() < std::numeric_limits<float>::max()) {
                     Base::Vector3f base = fit.GetBase();
                     Base::Vector3f dirU = fit.GetDirU();
                     Base::Vector3f norm = fit.GetNormal();

--- a/src/Mod/ReverseEngineering/Gui/PreCompiled.h
+++ b/src/Mod/ReverseEngineering/Gui/PreCompiled.h
@@ -37,6 +37,7 @@
 
 // standard
 #include <algorithm>
+#include <numbers>
 #include <sstream>
 
 // OpenCasCade

--- a/src/Mod/ReverseEngineering/Gui/Segmentation.cpp
+++ b/src/Mod/ReverseEngineering/Gui/Segmentation.cpp
@@ -115,7 +115,7 @@ void Segmentation::accept()
                 std::vector<MeshCore::PointIndex> indexes = kernel.GetFacetPoints(jt);
                 MeshCore::PlaneFit fit;
                 fit.AddPoints(kernel.GetPoints(indexes));
-                if (fit.Fit() < FLOAT_MAX) {
+                if (fit.Fit() < std::numeric_limits<float>::max()) {
                     Base::Vector3f base = fit.GetBase();
                     Base::Vector3f axis = fit.GetNormal();
                     MeshCore::AbstractSurfaceFit* fitter =

--- a/src/Mod/ReverseEngineering/Gui/SegmentationManual.cpp
+++ b/src/Mod/ReverseEngineering/Gui/SegmentationManual.cpp
@@ -215,7 +215,7 @@ void SegmentationManual::onPlaneDetectClicked()
 
         MeshCore::PlaneFit fit;
         fit.AddPoints(points);
-        if (fit.Fit() < FLOAT_MAX) {
+        if (fit.Fit() < std::numeric_limits<float>::max()) {
             Base::Vector3f base = fit.GetBase();
             Base::Vector3f axis = fit.GetNormal();
             return new MeshCore::PlaneSurfaceFit(base, axis);
@@ -239,7 +239,7 @@ void SegmentationManual::onCylinderDetectClicked()
             Base::Vector3f axis = fit.GetInitialAxisFromNormals(normal);
             fit.SetInitialValues(base, axis);
         }
-        if (fit.Fit() < FLOAT_MAX) {
+        if (fit.Fit() < std::numeric_limits<float>::max()) {
             Base::Vector3f base = fit.GetBase();
             Base::Vector3f axis = fit.GetAxis();
             float radius = fit.GetRadius();
@@ -259,7 +259,7 @@ void SegmentationManual::onSphereDetectClicked()
 
         MeshCore::SphereFit fit;
         fit.AddPoints(points);
-        if (fit.Fit() < FLOAT_MAX) {
+        if (fit.Fit() < std::numeric_limits<float>::max()) {
             Base::Vector3f base = fit.GetCenter();
             float radius = fit.GetRadius();
             return new MeshCore::SphereSurfaceFit(base, radius);

--- a/src/Mod/Robot/App/PreCompiled.h
+++ b/src/Mod/Robot/App/PreCompiled.h
@@ -40,6 +40,7 @@
 
 // STL
 #include <memory>
+#include <numbers>
 #include <sstream>
 
 // kdl_cp

--- a/src/Mod/Robot/App/kdl_cp/chainiksolverpos_nr_jl.cpp
+++ b/src/Mod/Robot/App/kdl_cp/chainiksolverpos_nr_jl.cpp
@@ -22,15 +22,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "chainiksolverpos_nr_jl.hpp"
+#include <numbers>
 
-// FreeCAD change
-#ifndef M_PI
-    #define M_PI    3.14159265358979323846 /* pi */
-#endif
-
-#ifndef M_PI_2
-    #define M_PI_2  1.57079632679489661923 /* pi/2 */
-#endif
 
 namespace KDL
 {
@@ -60,14 +53,14 @@ namespace KDL
                 for(unsigned int j=0; j<q_min.rows(); j++) {
                   if(q_out(j) < q_min(j))
                     //q_out(j) = q_min(j); // FreeCAD change
-                    q_out(j) = q_out(j) + M_PI *2;
+                    q_out(j) = q_out(j) + std::numbers::pi *2;
                 }
 
 
                 for(unsigned int j=0; j<q_max.rows(); j++) {
                     if(q_out(j) > q_max(j))
                       //q_out(j) = q_max(j); // FreeCAD change
-                      q_out(j) = q_out(j) - M_PI *2;
+                      q_out(j) = q_out(j) - std::numbers::pi *2;
                 }
             }
 

--- a/src/Mod/Robot/App/kdl_cp/frames.cpp
+++ b/src/Mod/Robot/App/kdl_cp/frames.cpp
@@ -26,9 +26,7 @@
  ***************************************************************************/
 
 #include "frames.hpp"
-
-#define _USE_MATH_DEFINES  // For MSVC
-#include <math.h>
+#include <numbers>
 
 namespace KDL {
 
@@ -244,7 +242,7 @@ void Rotation::GetRPY(double& roll,double& pitch,double& yaw) const
     {
 		double epsilon=1E-12;
 		pitch = atan2(-data[6], sqrt( sqr(data[0]) +sqr(data[3]) )  );
-        if ( fabs(pitch) > (M_PI/2.0-epsilon) ) {
+        if ( fabs(pitch) > (std::numbers::pi/2.0-epsilon) ) {
             yaw = atan2(	-data[1], data[4]);
             roll  = 0.0 ;
         } else {
@@ -358,7 +356,7 @@ double Rotation::GetRotAngle(Vector& axis,double eps) const {
 		return 0;
 	}
 	if (ca < -1+t) {
-		// The case of angles consisting of multiples of M_PI:
+		// The case of angles consisting of multiples of std::numbers::pi:
 		// two solutions, choose a positive Z-component of the axis
 		double x = sqrt( (data[0]+1.0)/2);
 		double y = sqrt( (data[4]+1.0)/2);

--- a/src/Mod/Robot/App/kdl_cp/path_roundedcomposite.hpp
+++ b/src/Mod/Robot/App/kdl_cp/path_roundedcomposite.hpp
@@ -96,7 +96,7 @@ class Path_RoundedComposite : public Path
 		 * - 3101 if the eq. radius <= 0
 		 * - 3102 if the first segment in a rounding has zero length.
 		 * - 3103 if the second segment in a rounding has zero length.
-		 * - 3104 if the angle between the first and the second segment is close to M_PI.
+		 * - 3104 if the angle between the first and the second segment is close to std::numbers::pi.
 		 *         (meaning that the segments are on top of each other)
 		 * - 3105 if the distance needed for the rounding is larger then the first segment.
 		 * - 3106 if the distance needed for the rounding is larger then the second segment.

--- a/src/Mod/Robot/Gui/PreCompiled.h
+++ b/src/Mod/Robot/Gui/PreCompiled.h
@@ -46,6 +46,7 @@
 #ifdef _PreComp_
 
 // STL
+#include <numbers>
 #include <sstream>
 
 // Qt

--- a/src/Mod/Robot/Gui/ViewProviderRobotObject.cpp
+++ b/src/Mod/Robot/Gui/ViewProviderRobotObject.cpp
@@ -269,33 +269,33 @@ void ViewProviderRobotObject::updateData(const App::Property* prop)
         }
         if (Axis1Node) {
             Axis1Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0),
-                                         robObj->Axis1.getValue() * (M_PI / 180));
+                                         robObj->Axis1.getValue() * (std::numbers::pi / 180));
         }
         if (Axis2Node) {
             Axis2Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0),
-                                         robObj->Axis2.getValue() * (M_PI / 180));
+                                         robObj->Axis2.getValue() * (std::numbers::pi / 180));
         }
         if (Axis3Node) {
             Axis3Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0),
-                                         robObj->Axis3.getValue() * (M_PI / 180));
+                                         robObj->Axis3.getValue() * (std::numbers::pi / 180));
         }
         if (Axis4Node) {
             Axis4Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0),
-                                         robObj->Axis4.getValue() * (M_PI / 180));
+                                         robObj->Axis4.getValue() * (std::numbers::pi / 180));
         }
         if (Axis5Node) {
             Axis5Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0),
-                                         robObj->Axis5.getValue() * (M_PI / 180));
+                                         robObj->Axis5.getValue() * (std::numbers::pi / 180));
         }
         if (Axis6Node) {
             Axis6Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0),
-                                         robObj->Axis6.getValue() * (M_PI / 180));
+                                         robObj->Axis6.getValue() * (std::numbers::pi / 180));
         }
     }
     else if (prop == &robObj->Axis1) {
         if (Axis1Node) {
             Axis1Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0),
-                                         robObj->Axis1.getValue() * (M_PI / 180));
+                                         robObj->Axis1.getValue() * (std::numbers::pi / 180));
             if (toolShape) {
                 toolShape->setTransformation(
                     (robObj->Tcp.getValue() * (robObj->ToolBase.getValue().inverse())).toMatrix());
@@ -305,7 +305,7 @@ void ViewProviderRobotObject::updateData(const App::Property* prop)
     else if (prop == &robObj->Axis2) {
         if (Axis2Node) {
             Axis2Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0),
-                                         robObj->Axis2.getValue() * (M_PI / 180));
+                                         robObj->Axis2.getValue() * (std::numbers::pi / 180));
             if (toolShape) {
                 toolShape->setTransformation(
                     (robObj->Tcp.getValue() * (robObj->ToolBase.getValue().inverse())).toMatrix());
@@ -315,7 +315,7 @@ void ViewProviderRobotObject::updateData(const App::Property* prop)
     else if (prop == &robObj->Axis3) {
         if (Axis3Node) {
             Axis3Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0),
-                                         robObj->Axis3.getValue() * (M_PI / 180));
+                                         robObj->Axis3.getValue() * (std::numbers::pi / 180));
             if (toolShape) {
                 toolShape->setTransformation(
                     (robObj->Tcp.getValue() * (robObj->ToolBase.getValue().inverse())).toMatrix());
@@ -325,7 +325,7 @@ void ViewProviderRobotObject::updateData(const App::Property* prop)
     else if (prop == &robObj->Axis4) {
         if (Axis4Node) {
             Axis4Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0),
-                                         robObj->Axis4.getValue() * (M_PI / 180));
+                                         robObj->Axis4.getValue() * (std::numbers::pi / 180));
             if (toolShape) {
                 toolShape->setTransformation(
                     (robObj->Tcp.getValue() * (robObj->ToolBase.getValue().inverse())).toMatrix());
@@ -335,7 +335,7 @@ void ViewProviderRobotObject::updateData(const App::Property* prop)
     else if (prop == &robObj->Axis5) {
         if (Axis5Node) {
             Axis5Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0),
-                                         robObj->Axis5.getValue() * (M_PI / 180));
+                                         robObj->Axis5.getValue() * (std::numbers::pi / 180));
             if (toolShape) {
                 toolShape->setTransformation(
                     (robObj->Tcp.getValue() * (robObj->ToolBase.getValue().inverse())).toMatrix());
@@ -345,7 +345,7 @@ void ViewProviderRobotObject::updateData(const App::Property* prop)
     else if (prop == &robObj->Axis6) {
         if (Axis6Node) {
             Axis6Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0),
-                                         robObj->Axis6.getValue() * (M_PI / 180));
+                                         robObj->Axis6.getValue() * (std::numbers::pi / 180));
             if (toolShape) {
                 toolShape->setTransformation(
                     (robObj->Tcp.getValue() * (robObj->ToolBase.getValue().inverse())).toMatrix());
@@ -400,22 +400,22 @@ void ViewProviderRobotObject::setAxisTo(float A1,
     if (Axis1Node) {
         // FIXME Ugly hack for the wrong transformation of the Kuka 500 robot VRML the minus sign on
         // Axis 1
-        Axis1Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0), A1 * (M_PI / 180));
+        Axis1Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0), A1 * (std::numbers::pi / 180));
     }
     if (Axis2Node) {
-        Axis2Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0), A2 * (M_PI / 180));
+        Axis2Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0), A2 * (std::numbers::pi / 180));
     }
     if (Axis3Node) {
-        Axis3Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0), A3 * (M_PI / 180));
+        Axis3Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0), A3 * (std::numbers::pi / 180));
     }
     if (Axis4Node) {
-        Axis4Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0), A4 * (M_PI / 180));
+        Axis4Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0), A4 * (std::numbers::pi / 180));
     }
     if (Axis5Node) {
-        Axis5Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0), A5 * (M_PI / 180));
+        Axis5Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0), A5 * (std::numbers::pi / 180));
     }
     if (Axis6Node) {
-        Axis6Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0), A6 * (M_PI / 180));
+        Axis6Node->rotation.setValue(SbVec3f(0.0, 1.0, 0.0), A6 * (std::numbers::pi / 180));
     }
     // update tool position
     if (toolShape) {

--- a/src/Mod/Sandbox/App/PreCompiled.h
+++ b/src/Mod/Sandbox/App/PreCompiled.h
@@ -40,13 +40,13 @@
 // standard
 #include <cstdio>
 #include <cassert>
-#include <iostream>
 
 // STL
 #include <algorithm>
 #include <iostream>
 #include <list>
 #include <map>
+#include <numbers>
 #include <queue>
 #include <set>
 #include <sstream>

--- a/src/Mod/Sandbox/Gui/PreCompiled.h
+++ b/src/Mod/Sandbox/Gui/PreCompiled.h
@@ -52,6 +52,7 @@
 #include <iostream>
 #include <list>
 #include <map>
+#include <numbers>
 #include <queue>
 #include <set>
 #include <sstream>

--- a/src/Mod/Sketcher/App/PreCompiled.h
+++ b/src/Mod/Sketcher/App/PreCompiled.h
@@ -36,6 +36,7 @@
 #include <cmath>
 #include <iostream>
 #include <memory>
+#include <numbers>
 #include <sstream>
 #include <vector>
 

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -3132,28 +3132,28 @@ int Sketch::addAngleAtPointConstraint(int geoId1,
         // the desired angle value (and we are to decide if 180* should be added to it)
         double angleDesire = 0.0;
         if (cTyp == Tangent) {
-            angleOffset = -M_PI / 2;
+            angleOffset = -std::numbers::pi / 2;
             angleDesire = 0.0;
         }
         if (cTyp == Perpendicular) {
             angleOffset = 0;
-            angleDesire = M_PI / 2;
+            angleDesire = std::numbers::pi / 2;
         }
 
         if (*value
             == 0.0) {  // autodetect tangency internal/external (and same for perpendicularity)
             double angleErr = GCSsys.calculateAngleViaPoint(*crv1, *crv2, p) - angleDesire;
             // bring angleErr to -pi..pi
-            if (angleErr > M_PI) {
-                angleErr -= M_PI * 2;
+            if (angleErr > std::numbers::pi) {
+                angleErr -= std::numbers::pi * 2;
             }
-            if (angleErr < -M_PI) {
-                angleErr += M_PI * 2;
+            if (angleErr < -std::numbers::pi) {
+                angleErr += std::numbers::pi * 2;
             }
 
             // the autodetector
-            if (fabs(angleErr) > M_PI / 2) {
-                angleDesire += M_PI;
+            if (fabs(angleErr) > std::numbers::pi / 2) {
+                angleDesire += std::numbers::pi;
             }
 
             *angle = angleDesire;
@@ -4542,7 +4542,7 @@ bool Sketch::updateNonDrivingConstraints()
             }
             else if ((*it).constr->Type == Angle) {
 
-                (*it).constr->setValue(std::fmod(*((*it).value), 2.0 * M_PI));
+                (*it).constr->setValue(std::fmod(*((*it).value), 2.0 * std::numbers::pi));
             }
             else if ((*it).constr->Type == Diameter && (*it).constr->First >= 0) {
 

--- a/src/Mod/Sketcher/App/SketchAnalysis.cpp
+++ b/src/Mod/Sketcher/App/SketchAnalysis.cpp
@@ -591,7 +591,7 @@ void SketchAnalysis::analyseMissingPointOnPointCoincident(double angleprecision)
                 if (fabs(tgv1 * tgv2) > fabs(cos(angleprecision))) {
                     vc.Type = Sketcher::Tangent;
                 }
-                else if (fabs(tgv1 * tgv2) < fabs(cos(M_PI / 2 - angleprecision))) {
+                else if (fabs(tgv1 * tgv2) < fabs(cos(std::numbers::pi / 2 - angleprecision))) {
                     vc.Type = Sketcher::Perpendicular;
                 }
             }
@@ -726,7 +726,8 @@ void SketchAnalysis::makeMissingVerticalHorizontalOneByOne()
 
 bool SketchAnalysis::checkVertical(Base::Vector3d dir, double angleprecision)
 {
-    return (dir.x == 0. && dir.y != 0.) || (fabs(dir.y / dir.x) > tan(M_PI / 2 - angleprecision));
+    return (dir.x == 0. && dir.y != 0.)
+        || (fabs(dir.y / dir.x) > tan(std::numbers::pi / 2 - angleprecision));
 }
 
 bool SketchAnalysis::checkHorizontal(Base::Vector3d dir, double angleprecision)

--- a/src/Mod/Sketcher/App/SketchAnalysis.h
+++ b/src/Mod/Sketcher/App/SketchAnalysis.h
@@ -94,7 +94,7 @@ public:
     int detectMissingPointOnPointConstraints(double precision = Precision::Confusion() * 1000,
                                              bool includeconstruction = true);
     /// Point on Point constraint simple routine Analyse step (see constructor)
-    void analyseMissingPointOnPointCoincident(double angleprecision = M_PI / 8);
+    void analyseMissingPointOnPointCoincident(double angleprecision = std::numbers::pi / 8);
     /// Point on Point constraint simple routine Get step (see constructor)
     std::vector<ConstraintIds>& getMissingPointOnPointConstraints()
     {
@@ -113,7 +113,7 @@ public:
     void makeMissingPointOnPointCoincidentOneByOne();
 
     /// Vertical/Horizontal constraints simple routine Detect step (see constructor)
-    int detectMissingVerticalHorizontalConstraints(double angleprecision = M_PI / 8);
+    int detectMissingVerticalHorizontalConstraints(double angleprecision = std::numbers::pi / 8);
     /// Vertical/Horizontal constraints simple routine Get step (see constructor)
     std::vector<ConstraintIds>& getMissingVerticalHorizontalConstraints()
     {
@@ -168,7 +168,7 @@ public:
     ///
     /// It applies coincidents - vertical/horizontal constraints and equality constraints.
     int autoconstraint(double precision = Precision::Confusion() * 1000,
-                       double angleprecision = M_PI / 8,
+                       double angleprecision = std::numbers::pi / 8,
                        bool includeconstruction = true);
 
     // helper functions, which may be used by more complex methods, and/or called directly by user

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1143,7 +1143,7 @@ void SketchObject::reverseAngleConstraintToSupplementary(Constraint* constr, int
     }
     else {
         double actAngle = constr->getValue();
-        constr->setValue(M_PI - actAngle);
+        constr->setValue(std::numbers::pi - actAngle);
     }
 }
 
@@ -3248,12 +3248,12 @@ int SketchObject::fillet(int GeoId1, int GeoId2, const Base::Vector3d& refPnt1,
             std::swap(startAngle, endAngle);
         }
 
-        if (endAngle > 2 * M_PI) {
-            endAngle -= 2 * M_PI;
+        if (endAngle > 2 * std::numbers::pi) {
+            endAngle -= 2 * std::numbers::pi;
         }
 
         if (startAngle < 0) {
-            endAngle += 2 * M_PI;
+            endAngle += 2 * std::numbers::pi;
         }
 
         // Create Arc Segment
@@ -4980,8 +4980,8 @@ std::vector<Part::Geometry*> SketchObject::getSymmetric(const std::vector<int>& 
                 Base::Vector3d scp =
                     cp + 2.0 * (cp.Perpendicular(refGeoLine->getStartPoint(), vectline) - cp);
 
-                double theta1 = Base::fmod(atan2(sep.y - scp.y, sep.x - scp.x), 2.f * M_PI);
-                double theta2 = Base::fmod(atan2(ssp.y - scp.y, ssp.x - scp.x), 2.f * M_PI);
+                double theta1 = Base::fmod(atan2(sep.y - scp.y, sep.x - scp.x), 2.f * std::numbers::pi);
+                double theta2 = Base::fmod(atan2(ssp.y - scp.y, ssp.x - scp.x), 2.f * std::numbers::pi);
 
                 geoaoc->setCenter(scp);
                 geoaoc->setRange(theta1, theta2, true);
@@ -5028,12 +5028,12 @@ std::vector<Part::Geometry*> SketchObject::getSymmetric(const std::vector<int>& 
 
                 double theta1, theta2;
                 geosymaoe->getRange(theta1, theta2, true);
-                theta1 = 2.0 * M_PI - theta1;
-                theta2 = 2.0 * M_PI - theta2;
+                theta1 = 2.0 * std::numbers::pi - theta1;
+                theta2 = 2.0 * std::numbers::pi - theta2;
                 std::swap(theta1, theta2);
                 if (theta1 < 0) {
-                    theta1 += 2.0 * M_PI;
-                    theta2 += 2.0 * M_PI;
+                    theta1 += 2.0 * std::numbers::pi;
+                    theta2 += 2.0 * std::numbers::pi;
                 }
 
                 geosymaoe->setRange(theta1, theta2, true);
@@ -5178,8 +5178,8 @@ std::vector<Part::Geometry*> SketchObject::getSymmetric(const std::vector<int>& 
                 Base::Vector3d sep = ep + 2.0 * (refpoint - ep);
                 Base::Vector3d scp = cp + 2.0 * (refpoint - cp);
 
-                double theta1 = Base::fmod(atan2(ssp.y - scp.y, ssp.x - scp.x), 2.f * M_PI);
-                double theta2 = Base::fmod(atan2(sep.y - scp.y, sep.x - scp.x), 2.f * M_PI);
+                double theta1 = Base::fmod(atan2(ssp.y - scp.y, ssp.x - scp.x), 2.f * std::numbers::pi);
+                double theta2 = Base::fmod(atan2(sep.y - scp.y, sep.x - scp.x), 2.f * std::numbers::pi);
 
                 geoaoc->setCenter(scp);
                 geoaoc->setRange(theta1, theta2, true);
@@ -8641,11 +8641,11 @@ void processEdge(const TopoDS_Edge& edge,
                     int tours = 0;
                     double startAngle = baseAngle + alpha;
                     // bring startAngle back in [-pi/2 , 3pi/2[
-                    while (startAngle < -M_PI / 2.0 && tours < 10) {
-                        startAngle = baseAngle + ++tours * 2.0 * M_PI + alpha;
+                    while (startAngle < -std::numbers::pi / 2.0 && tours < 10) {
+                        startAngle = baseAngle + ++tours * 2.0 * std::numbers::pi + alpha;
                     }
-                    while (startAngle >= 3.0 * M_PI / 2.0 && tours > -10) {
-                        startAngle = baseAngle + --tours * 2.0 * M_PI + alpha;
+                    while (startAngle >= 3.0 * std::numbers::pi / 2.0 && tours > -10) {
+                        startAngle = baseAngle + --tours * 2.0 * std::numbers::pi + alpha;
                     }
 
                     // apply same offset to end angle
@@ -8661,7 +8661,7 @@ void processEdge(const TopoDS_Edge& edge,
                                 // P2 = P2 already defined
                                 P1 = ProjPointOnPlane_XYZ(beg, sketchPlane);
                             }
-                            else if (endAngle < M_PI) {
+                            else if (endAngle < std::numbers::pi) {
                                 // P2 = P2, already defined
                                 P1 = ProjPointOnPlane_XYZ(end, sketchPlane);
                             }
@@ -8671,16 +8671,16 @@ void processEdge(const TopoDS_Edge& edge,
                             }
                         }
                     }
-                    else if (startAngle < M_PI) {
-                        if (endAngle < M_PI) {
+                    else if (startAngle < std::numbers::pi) {
+                        if (endAngle < std::numbers::pi) {
                             P1 = ProjPointOnPlane_XYZ(beg, sketchPlane);
                             P2 = ProjPointOnPlane_XYZ(end, sketchPlane);
                         }
-                        else if (endAngle < 2.0 * M_PI - startAngle) {
+                        else if (endAngle < 2.0 * std::numbers::pi - startAngle) {
                             P2 = ProjPointOnPlane_XYZ(beg, sketchPlane);
                             // P1 = P1, already defined
                         }
-                        else if (endAngle < 2.0 * M_PI) {
+                        else if (endAngle < 2.0 * std::numbers::pi) {
                             P2 = ProjPointOnPlane_XYZ(end, sketchPlane);
                             // P1 = P1, already defined
                         }
@@ -8690,15 +8690,15 @@ void processEdge(const TopoDS_Edge& edge,
                         }
                     }
                     else {
-                        if (endAngle < 2 * M_PI) {
+                        if (endAngle < 2 * std::numbers::pi) {
                             P1 = ProjPointOnPlane_XYZ(beg, sketchPlane);
                             P2 = ProjPointOnPlane_XYZ(end, sketchPlane);
                         }
-                        else if (endAngle < 4 * M_PI - startAngle) {
+                        else if (endAngle < 4 * std::numbers::pi - startAngle) {
                             P1 = ProjPointOnPlane_XYZ(beg, sketchPlane);
                             // P2 = P2, already defined
                         }
-                        else if (endAngle < 3 * M_PI) {
+                        else if (endAngle < 3 * std::numbers::pi) {
                             // P1 = P1, already defined
                             P2 = ProjPointOnPlane_XYZ(end, sketchPlane);
                         }
@@ -8818,7 +8818,7 @@ void processEdge(const TopoDS_Edge& edge,
         gp_Vec2d PB = ProjVecOnPlane_UV(origAxisMinor, sketchPlane);
         double t_max = 2.0 * PA.Dot(PB) / (PA.SquareMagnitude() - PB.SquareMagnitude());
         t_max = 0.5 * atan(t_max);// gives new major axis is most cases, but not all
-        double t_min = t_max + 0.5 * M_PI;
+        double t_min = t_max + 0.5 * std::numbers::pi;
 
         // ON_max = OM(t_max) gives the point, which projected on the sketch plane,
         //     becomes the apoapse of the projected ellipse.
@@ -9313,7 +9313,7 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
                             processEdge(edge, geos, gPlane, invPlm, mov, sketchPlane, invRot, sketchAx3, aProjFace);
                         }
 
-                        if (fabs(dnormal.Angle(snormal) - M_PI_2) < Precision::Confusion()) {
+                        if (fabs(dnormal.Angle(snormal) - std::numbers::pi/2.0F) < Precision::Confusion()) {
                             // The face is normal to the sketch plane
                             // We don't want to keep the projection of all the edges of the face.
                             // We need a single line that goes from min to max of all the projections.
@@ -11359,25 +11359,25 @@ bool SketchObject::AutoLockTangencyAndPerpty(Constraint* cstr, bool bForce, bool
             // the desired angle value (and we are to decide if 180* should be added to it)
             double angleDesire = 0.0;
             if (cstr->Type == Tangent) {
-                angleOffset = -M_PI / 2;
+                angleOffset = -std::numbers::pi / 2;
                 angleDesire = 0.0;
             }
             if (cstr->Type == Perpendicular) {
                 angleOffset = 0;
-                angleDesire = M_PI / 2;
+                angleDesire = std::numbers::pi / 2;
             }
 
             double angleErr = calculateAngleViaPoint(geoId1, geoId2, p.x, p.y) - angleDesire;
 
             // bring angleErr to -pi..pi
-            if (angleErr > M_PI)
-                angleErr -= M_PI * 2;
-            if (angleErr < -M_PI)
-                angleErr += M_PI * 2;
+            if (angleErr > std::numbers::pi)
+                angleErr -= std::numbers::pi * 2;
+            if (angleErr < -std::numbers::pi)
+                angleErr += std::numbers::pi * 2;
 
             // the autodetector
-            if (fabs(angleErr) > M_PI / 2)
-                angleDesire += M_PI;
+            if (fabs(angleErr) > std::numbers::pi / 2)
+                angleDesire += std::numbers::pi;
 
             // external tangency. The angle stored is offset by Pi/2 so that a value of 0.0 is
             // invalid and treated as "undecided".

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -841,13 +841,13 @@ public:
 public:
     // Analyser functions
     int autoConstraint(double precision = Precision::Confusion() * 1000,
-                       double angleprecision = M_PI / 20,
+                       double angleprecision = std::numbers::pi / 20,
                        bool includeconstruction = true);
 
     int detectMissingPointOnPointConstraints(double precision = Precision::Confusion() * 1000,
                                              bool includeconstruction = true);
-    void analyseMissingPointOnPointCoincident(double angleprecision = M_PI / 8);
-    int detectMissingVerticalHorizontalConstraints(double angleprecision = M_PI / 8);
+    void analyseMissingPointOnPointCoincident(double angleprecision = std::numbers::pi / 8);
+    int detectMissingVerticalHorizontalConstraints(double angleprecision = std::numbers::pi / 8);
     int detectMissingEqualityConstraints(double precision);
 
     std::vector<ConstraintIds>& getMissingPointOnPointConstraints();

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -1918,7 +1918,7 @@ PyObject* SketchObjectPy::insertBSplineKnot(PyObject* args)
 PyObject* SketchObjectPy::autoconstraint(PyObject* args)
 {
     double precision = Precision::Confusion() * 1000;
-    double angleprecision = M_PI / 8;
+    double angleprecision = std::numbers::pi / 8;
     PyObject* includeconstruction = Py_True;
 
 
@@ -1960,7 +1960,7 @@ PyObject* SketchObjectPy::detectMissingPointOnPointConstraints(PyObject* args)
 
 PyObject* SketchObjectPy::detectMissingVerticalHorizontalConstraints(PyObject* args)
 {
-    double angleprecision = M_PI / 8;
+    double angleprecision = std::numbers::pi / 8;
 
     if (!PyArg_ParseTuple(args, "|d", &angleprecision)) {
         return nullptr;
@@ -1984,7 +1984,7 @@ PyObject* SketchObjectPy::detectMissingEqualityConstraints(PyObject* args)
 
 PyObject* SketchObjectPy::analyseMissingPointOnPointCoincident(PyObject* args)
 {
-    double angleprecision = M_PI / 8;
+    double angleprecision = std::numbers::pi / 8;
 
     if (!PyArg_ParseTuple(args, "|d", &angleprecision)) {
         return nullptr;

--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -24,10 +24,9 @@
 #pragma warning(disable : 4251)
 #endif
 
-#define _USE_MATH_DEFINES
-#include <cmath>
-
 #include <algorithm>
+#include <numbers>
+
 #define DEBUG_DERIVS 0
 #if DEBUG_DERIVS
 #include <cassert>
@@ -3536,10 +3535,10 @@ void ConstraintArcLength::errorgrad(double* err, double* grad, double* param)
     double startA = *arc.startAngle;
     // Assume positive angles and CCW arc
     while (startA < 0.) {
-        startA += 2. * M_PI;
+        startA += 2. * std::numbers::pi;
     }
     while (endA < startA) {
-        endA += 2. * M_PI;
+        endA += 2. * std::numbers::pi;
     }
     if (err) {
         *err = rad * (endA - startA) - *distance();

--- a/src/Mod/Sketcher/App/planegcs/Geo.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Geo.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include <cassert>
+#include <cmath>
 
 #include "Geo.h"
 

--- a/src/Mod/Sketcher/App/planegcs/Geo.h
+++ b/src/Mod/Sketcher/App/planegcs/Geo.h
@@ -24,8 +24,8 @@
 #define PLANEGCS_GEO_H
 
 #include "Util.h"
-#include <boost/math/constants/constants.hpp>
 #include "../../SketcherGlobal.h"
+#include <numbers>
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4251)
@@ -53,7 +53,7 @@ public:
 };
 
 using VEC_P = std::vector<Point>;
-static constexpr double pi = boost::math::constants::pi<double>();
+static constexpr double pi = std::numbers::pi;
 static constexpr double pi_2 = pi / 2.0;
 static constexpr double pi_18 = pi / 18.0;
 

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -114,10 +114,10 @@ void finishDatumConstraint(Gui::Command* cmd,
 
     if (lastConstraintType == Radius || lastConstraintType == Diameter) {
         labelPosition = hGrp->GetFloat("RadiusDiameterConstraintDisplayBaseAngle", 15.0)
-            * (M_PI / 180);// Get radius/diameter constraint display angle
+            * (std::numbers::pi / 180);// Get radius/diameter constraint display angle
         labelPositionRandomness =
             hGrp->GetFloat("RadiusDiameterConstraintDisplayAngleRandomness", 0.0)
-            * (M_PI / 180);// Get randomness
+            * (std::numbers::pi / 180);// Get randomness
 
         // Adds a random value around the base angle, so that possibly overlapping labels get likely
         // a different position.

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -1218,14 +1218,14 @@ public:
             Base::Vector2d endpoint = onSketchPos;
 
             if (snapMode == SnapMode::Snap5Degree) {
-                angle = round(angle / (M_PI / 36)) * M_PI / 36;
+                angle = round(angle / (std::numbers::pi / 36)) * std::numbers::pi / 36;
                 endpoint = EditCurve[0] + length * Base::Vector2d(cos(angle), sin(angle));
             }
 
             if (showCursorCoords()) {
                 SbString text;
                 std::string lengthString = lengthToDisplayFormat(length, 1);
-                std::string angleString = angleToDisplayFormat(angle * 180.0 / M_PI, 1);
+                std::string angleString = angleToDisplayFormat(angle * 180.0 / std::numbers::pi, 1);
                 text.sprintf(" (%s, %s)", lengthString.c_str(), angleString.c_str());
                 setPositionText(endpoint, text);
             }
@@ -1794,14 +1794,14 @@ public:
             Base::Vector2d endpoint = onSketchPos;
 
             if (snapMode == SnapMode::Snap5Degree) {
-                angle = round(angle / (M_PI / 36)) * M_PI / 36;
+                angle = round(angle / (std::numbers::pi / 36)) * std::numbers::pi / 36;
                 endpoint = EditCurve[0] + length * Base::Vector2d(cos(angle), sin(angle));
             }
 
             if (showCursorCoords()) {
                 SbString text;
                 std::string lengthString = lengthToDisplayFormat(length, 1);
-                std::string angleString = angleToDisplayFormat(angle * 180.0 / M_PI, 1);
+                std::string angleString = angleToDisplayFormat(angle * 180.0 / std::numbers::pi, 1);
                 text.sprintf(" (%s, %s)", lengthString.c_str(), angleString.c_str());
                 setPositionText(endpoint, text);
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -550,18 +550,18 @@ int DrawSketchHandler::seekAutoConstraint(std::vector<AutoConstraint>& suggested
 
     // Number of Degree of deviation from horizontal or vertical lines
     const double angleDev = 2;
-    const double angleDevRad = angleDev * M_PI / 180.;
+    const double angleDevRad = angleDev * std::numbers::pi / 180.;
 
     AutoConstraint constr;
     constr.Type = Sketcher::None;
     constr.GeoId = GeoEnum::GeoUndef;
     constr.PosId = PointPos::none;
     double angle = std::abs(atan2(Dir.y, Dir.x));
-    if (angle < angleDevRad || (M_PI - angle) < angleDevRad) {
+    if (angle < angleDevRad || (std::numbers::pi - angle) < angleDevRad) {
         // Suggest horizontal constraint
         constr.Type = Sketcher::Horizontal;
     }
-    else if (std::abs(angle - M_PI_2) < angleDevRad) {
+    else if (std::abs(angle - std::numbers::pi / 2.0) < angleDevRad) {
         // Suggest vertical constraint
         constr.Type = Sketcher::Vertical;
     }
@@ -665,7 +665,7 @@ int DrawSketchHandler::seekAutoConstraint(std::vector<AutoConstraint>& suggested
 
                 double angle = atan2(projPnt.y, projPnt.x);
                 while (angle < startAngle) {
-                    angle += 2 * D_PI;  // Bring it to range of arc
+                    angle += 2 * std::numbers::pi;  // Bring it to range of arc
                 }
 
                 // if the point is on correct side of arc
@@ -714,10 +714,10 @@ int DrawSketchHandler::seekAutoConstraint(std::vector<AutoConstraint>& suggested
                         aoe->getMinorRadius()
                             * ((tmpPos.x - center.x) * majdir.x + (tmpPos.y - center.y) * majdir.y))
                         - startAngle,
-                    2.f * M_PI);
+                    2.f * std::numbers::pi);
 
                 while (angle < startAngle) {
-                    angle += 2 * D_PI;  // Bring it to range of arc
+                    angle += 2 * std::numbers::pi;  // Bring it to range of arc
                 }
 
                 // if the point is on correct side of arc
@@ -978,7 +978,7 @@ void DrawSketchHandler::drawDirectionAtCursor(const Base::Vector2d& position,
 
     SbString text;
     std::string lengthString = lengthToDisplayFormat(length, 1);
-    std::string angleString = angleToDisplayFormat(angle * 180.0 / M_PI, 1);
+    std::string angleString = angleToDisplayFormat(angle * 180.0 / std::numbers::pi, 1);
     text.sprintf(" (%s, %s)", lengthString.c_str(), angleString.c_str());
     setPositionText(position, text);
 }
@@ -1009,7 +1009,7 @@ void DrawSketchHandler::drawDoubleAtCursor(const Base::Vector2d& position,
     SbString text;
     std::string doubleString = unit == Base::Unit::Length
         ? lengthToDisplayFormat(val, 1)
-        : angleToDisplayFormat(val * 180.0 / M_PI, 1);
+        : angleToDisplayFormat(val * 180.0 / std::numbers::pi, 1);
     text.sprintf(" (%s)", doubleString.c_str());
     setPositionText(position, text);
 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -132,7 +132,7 @@ private:
                 if (constructionMethod() == ConstructionMethod::Center) {
                     secondPoint = onSketchPos;
                     double angle1 = (onSketchPos - centerPoint).Angle() - startAngle;
-                    double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * M_PI;
+                    double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * std::numbers::pi;
                     arcAngle = abs(angle1 - arcAngle) < abs(angle2 - arcAngle) ? angle1 : angle2;
 
                     if (arcAngle > 0) {
@@ -183,7 +183,7 @@ private:
                         }
                         startAngle = std::max(angle1, angle2);
                         endAngle = std::min(angle1, angle2);
-                        arcAngle = 2 * M_PI - (startAngle - endAngle);
+                        arcAngle = 2 * std::numbers::pi - (startAngle - endAngle);
                     }
                 }
 
@@ -562,7 +562,7 @@ void DSHArcControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchPo
                 if (onViewParameters[OnViewParameter::Fifth]->isSet) {
                     double arcAngle =
                         Base::toRadians(onViewParameters[OnViewParameter::Fifth]->getValue());
-                    if (fmod(fabs(arcAngle), 2 * M_PI) < Precision::Confusion()) {
+                    if (fmod(fabs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()) {
                         unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
                         return;
                     }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -78,7 +78,7 @@ public:
             double rx0 = onSketchPos.x - EditCurve[0].x;
             double ry0 = onSketchPos.y - EditCurve[0].y;
             for (int i = 0; i < 16; i++) {
-                double angle = i * M_PI / 16.0;
+                double angle = i * std::numbers::pi / 16.0;
                 double rx1 = rx0 * cos(angle) + ry0 * sin(angle);
                 double ry1 = -rx0 * sin(angle) + ry0 * cos(angle);
                 EditCurve[1 + i] = Base::Vector2d(EditCurve[0].x + rx1, EditCurve[0].y + ry1);
@@ -115,7 +115,7 @@ public:
                 / (sin(angleatpoint) * cos(phi));
 
             for (int i = 1; i < 16; i++) {
-                double angle = i * M_PI / 16.0;
+                double angle = i * std::numbers::pi / 16.0;
                 double rx1 = a * cos(angle) * cos(phi) - b * sin(angle) * sin(phi);
                 double ry1 = a * cos(angle) * sin(phi) + b * sin(angle) * cos(phi);
                 EditCurve[1 + i] = Base::Vector2d(EditCurve[0].x + rx1, EditCurve[0].y + ry1);
@@ -161,7 +161,7 @@ public:
                                          + (onSketchPos.y - centerPoint.y) * sin(phi)))
                 - startAngle;
 
-            double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * M_PI;
+            double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * std::numbers::pi;
             arcAngle = abs(angle1 - arcAngle) < abs(angle2 - arcAngle) ? angle1 : angle2;
 
             for (int i = 0; i < 34; i++) {
@@ -178,7 +178,8 @@ public:
                 SbString text;
                 std::string aString = lengthToDisplayFormat(a, 1);
                 std::string bString = lengthToDisplayFormat(b, 1);
-                std::string angleString = angleToDisplayFormat(arcAngle * 180.0 / M_PI, 1);
+                std::string angleString =
+                    angleToDisplayFormat(arcAngle * 180.0 / std::numbers::pi, 1);
                 text.sprintf(" (R%s, R%s, %s)",
                              aString.c_str(),
                              bString.c_str(),
@@ -245,7 +246,7 @@ public:
                                          + (endPoint.y - centerPoint.y) * sin(phi)))
                 - startAngle;
 
-            double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * M_PI;
+            double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * std::numbers::pi;
             arcAngle = abs(angle1 - arcAngle) < abs(angle2 - arcAngle) ? angle1 : angle2;
 
             bool isOriginalArcCCW = true;
@@ -281,8 +282,8 @@ public:
                 perp.Scale(abs(b));
                 majAxisPoint = centerPoint + perp;
                 minAxisPoint = centerPoint + minAxisDir;
-                endAngle += M_PI / 2;
-                startAngle += M_PI / 2;
+                endAngle += std::numbers::pi / 2;
+                startAngle += std::numbers::pi / 2;
             }
 
             int currentgeoid = getHighestCurveIndex();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -103,7 +103,7 @@ public:
             if (!boost::math::isnan(b)) {
                 for (int i = 15; i >= -15; i--) {
                     // P(U) = O + MajRad*Cosh(U)*XDir + MinRad*Sinh(U)*YDir
-                    // double angle = i*M_PI/16.0;
+                    // double angle = i*std::numbers::pi/16.0;
                     double angle = i * angleatpoint / 15;
                     double rx = a * cosh(angle) * cos(phi) - b * sinh(angle) * sin(phi);
                     double ry = a * cosh(angle) * sin(phi) + b * sinh(angle) * cos(phi);
@@ -150,7 +150,7 @@ public:
 
             /*double angle1 = angleatpoint - startAngle;
 
-            double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * M_PI ;
+            double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * std::numbers::pi ;
             arcAngle = abs(angle1-arcAngle) < abs(angle2-arcAngle) ? angle1 : angle2;*/
 
             arcAngle = angleatpoint - startAngle;
@@ -290,8 +290,8 @@ public:
                 perp.Scale(abs(b));
                 majAxisPoint = centerPoint + perp;
                 minAxisPoint = centerPoint + minAxisDir;
-                endAngle += M_PI / 2;
-                startAngle += M_PI / 2;
+                endAngle += std::numbers::pi / 2;
+                startAngle += std::numbers::pi / 2;
             }
 
             int currentgeoid = getHighestCurveIndex();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
@@ -133,7 +133,7 @@ private:
                 startAngle = startAngleBackup;
 
                 double angle1 = (onSketchPos - centerPoint).Angle() - startAngle;
-                double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * M_PI;
+                double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * std::numbers::pi;
                 arcAngle = abs(angle1 - arcAngle) < abs(angle2 - arcAngle) ? angle1 : angle2;
 
                 reverseIfNecessary();
@@ -331,14 +331,16 @@ private:
                                       isConstructionMode());
 
                 addArcToShapeGeometry(toVector3d(startPoint),
-                                      angleReversed ? endAngle : startAngle + M_PI,
-                                      angleReversed ? endAngle + M_PI : startAngle + 2 * M_PI,
+                                      angleReversed ? endAngle : startAngle + std::numbers::pi,
+                                      angleReversed ? endAngle + std::numbers::pi
+                                                    : startAngle + 2 * std::numbers::pi,
                                       r,
                                       isConstructionMode());
 
                 addArcToShapeGeometry(toVector3d(endPoint),
-                                      angleReversed ? startAngle + M_PI : endAngle,
-                                      angleReversed ? startAngle + 2 * M_PI : M_PI + endAngle,
+                                      angleReversed ? startAngle + std::numbers::pi : endAngle,
+                                      angleReversed ? startAngle + 2 * std::numbers::pi
+                                                    : std::numbers::pi + endAngle,
                                       r,
                                       isConstructionMode());
 
@@ -635,7 +637,7 @@ void DSHArcSlotControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
             if (onViewParameters[OnViewParameter::Fifth]->isSet) {
                 double arcAngle =
                     Base::toRadians(onViewParameters[OnViewParameter::Fifth]->getValue());
-                if (fmod(fabs(arcAngle), 2 * M_PI) < Precision::Confusion()) {
+                if (fmod(fabs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()) {
                     unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
                 }
                 else {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
@@ -142,8 +142,8 @@ public:
                  */
                 bool inCurve = (projection.Length() < recenteredLine.Length()
                                 && projection.GetAngle(recenteredLine)
-                                    < 0.1);  // Two possible values here, M_PI and 0, but 0.1 is to
-                                             // avoid floating point problems.
+                                    < 0.1);  // Two possible values here, std::numbers::pi and 0,
+                                             // but 0.1 is to avoid floating point problems.
                 if (inCurve) {
                     Increment = SavedExtendFromStart
                         ? -1 * projection.Length()
@@ -185,8 +185,8 @@ public:
                     bool isCCWFromStart = crossProduct(angle, startAngle) < 0;
                     if (outOfArc) {
                         if (isCCWFromStart) {
-                            modStartAngle -= 2 * M_PI - angleToStartAngle;
-                            modArcAngle += 2 * M_PI - angleToStartAngle;
+                            modStartAngle -= 2 * std::numbers::pi - angleToStartAngle;
+                            modArcAngle += 2 * std::numbers::pi - angleToStartAngle;
                         }
                         else {
                             modStartAngle -= angleToStartAngle;
@@ -199,8 +199,8 @@ public:
                             modArcAngle -= angleToStartAngle;
                         }
                         else {
-                            modStartAngle += 2 * M_PI - angleToStartAngle;
-                            modArcAngle -= 2 * M_PI - angleToStartAngle;
+                            modStartAngle += 2 * std::numbers::pi - angleToStartAngle;
+                            modArcAngle -= 2 * std::numbers::pi - angleToStartAngle;
                         }
                     }
                 }
@@ -208,7 +208,7 @@ public:
                     bool isCWFromEnd = crossProduct(angle, endAngle) >= 0;
                     if (outOfArc) {
                         if (isCWFromEnd) {
-                            modArcAngle += 2 * M_PI - angleToEndAngle;
+                            modArcAngle += 2 * std::numbers::pi - angleToEndAngle;
                         }
                         else {
                             modArcAngle += angleToEndAngle;
@@ -219,7 +219,7 @@ public:
                             modArcAngle -= angleToEndAngle;
                         }
                         else {
-                            modArcAngle -= 2 * M_PI - angleToEndAngle;
+                            modArcAngle -= 2 * std::numbers::pi - angleToEndAngle;
                         }
                     }
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -647,15 +647,15 @@ void DSHLineController::addConstraints()
 
     auto constraintp4angle = [&]() {
         double angle = Base::toRadians(p4);
-        if (fabs(angle - M_PI) < Precision::Confusion()
-            || fabs(angle + M_PI) < Precision::Confusion()
+        if (fabs(angle - std::numbers::pi) < Precision::Confusion()
+            || fabs(angle + std::numbers::pi) < Precision::Confusion()
             || fabs(angle) < Precision::Confusion()) {
             Gui::cmdAppObjectArgs(obj,
                                   "addConstraint(Sketcher.Constraint('Horizontal',%d)) ",
                                   firstCurve);
         }
-        else if (fabs(angle - M_PI / 2) < Precision::Confusion()
-                 || fabs(angle + M_PI / 2) < Precision::Confusion()) {
+        else if (fabs(angle - std::numbers::pi / 2) < Precision::Confusion()
+                 || fabs(angle + std::numbers::pi / 2) < Precision::Confusion()) {
             Gui::cmdAppObjectArgs(obj,
                                   "addConstraint(Sketcher.Constraint('Vertical',%d)) ",
                                   firstCurve);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -222,7 +222,8 @@ public:
                 if (showCursorCoords()) {
                     SbString text;
                     std::string lengthString = lengthToDisplayFormat(length, 1);
-                    std::string angleString = angleToDisplayFormat(angle * 180.0 / M_PI, 1);
+                    std::string angleString =
+                        angleToDisplayFormat(angle * 180.0 / std::numbers::pi, 1);
                     text.sprintf(" (%s, %s)", lengthString.c_str(), angleString.c_str());
                     setPositionText(EditCurve[1], text);
                 }
@@ -289,14 +290,14 @@ public:
                     arcAngle = 0.f;
                 }
                 if (arcRadius >= 0 && arcAngle > 0) {
-                    arcAngle -= 2 * M_PI;
+                    arcAngle -= 2 * std::numbers::pi;
                 }
                 if (arcRadius < 0 && arcAngle < 0) {
-                    arcAngle += 2 * M_PI;
+                    arcAngle += 2 * std::numbers::pi;
                 }
 
                 if (SnapMode == SNAP_MODE_45Degree) {
-                    arcAngle = round(arcAngle / (M_PI / 4)) * M_PI / 4;
+                    arcAngle = round(arcAngle / (std::numbers::pi / 4)) * std::numbers::pi / 4;
                 }
 
                 endAngle = startAngle + arcAngle;
@@ -316,7 +317,8 @@ public:
                 if (showCursorCoords()) {
                     SbString text;
                     std::string radiusString = lengthToDisplayFormat(std::abs(arcRadius), 1);
-                    std::string angleString = angleToDisplayFormat(arcAngle * 180.0 / M_PI, 1);
+                    std::string angleString =
+                        angleToDisplayFormat(arcAngle * 180.0 / std::numbers::pi, 1);
                     text.sprintf(" (R%s, %s)", radiusString.c_str(), angleString.c_str());
                     setPositionText(onSketchPos, text);
                 }
@@ -536,8 +538,8 @@ public:
 
                     // #3974: if in radians, the printf %f defaults to six decimals, which leads to
                     // loss of precision
-                    double arcAngle =
-                        abs(round((endAngle - startAngle) / (M_PI / 4)) * 45);  // in degrees
+                    double arcAngle = abs(round((endAngle - startAngle) / (std::numbers::pi / 4))
+                                          * 45);  // in degrees
 
                     Gui::cmdAppObjectArgs(sketchgui->getObject(),
                                           "addConstraint(Sketcher.Constraint('Angle',%i,App.Units."

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -242,7 +242,8 @@ private:
             return;
         }
 
-        double angleOfSeparation = 2.0 * M_PI / static_cast<double>(numberOfCorners);  // NOLINT
+        double angleOfSeparation =
+            2.0 * std::numbers::pi / static_cast<double>(numberOfCorners);  // NOLINT
         double cos_v = cos(angleOfSeparation);
         double sin_v = sin(angleOfSeparation);
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -144,8 +144,8 @@ private:
                         corner2 = Base::Vector2d(corner1.x, onSketchPos.y);
                         cornersReversed = true;
                     }
-                    angle123 = M_PI / 2;
-                    angle412 = M_PI / 2;
+                    angle123 = std::numbers::pi / 2;
+                    angle412 = std::numbers::pi / 2;
                 }
                 else if (constructionMethod() == ConstructionMethod::CenterAndCorner) {
                     toolWidgetManager.drawDirectionAtCursor(onSketchPos, center);
@@ -162,8 +162,8 @@ private:
                         corner2 = Base::Vector2d(corner1.x, onSketchPos.y);
                         cornersReversed = true;
                     }
-                    angle123 = M_PI / 2;
-                    angle412 = M_PI / 2;
+                    angle123 = std::numbers::pi / 2;
+                    angle412 = std::numbers::pi / 2;
                 }
                 else if (constructionMethod() == ConstructionMethod::ThreePoints) {
                     toolWidgetManager.drawDirectionAtCursor(onSketchPos, corner1);
@@ -174,8 +174,8 @@ private:
                     perpendicular.y = (corner2 - corner1).x;
                     corner3 = corner2 + perpendicular;
                     corner4 = corner1 + perpendicular;
-                    angle123 = M_PI / 2;
-                    angle412 = M_PI / 2;
+                    angle123 = std::numbers::pi / 2;
+                    angle412 = std::numbers::pi / 2;
                     corner2Initial = corner2;
                     side = getPointSideOfVector(corner3, corner2 - corner1, corner1);
                 }
@@ -189,8 +189,8 @@ private:
                     perpendicular.y = (onSketchPos - center).x;
                     corner2 = center + perpendicular;
                     corner4 = center - perpendicular;
-                    angle123 = M_PI / 2;
-                    angle412 = M_PI / 2;
+                    angle123 = std::numbers::pi / 2;
+                    angle412 = std::numbers::pi / 2;
                     side = getPointSideOfVector(corner2, corner3 - corner1, corner1);
                 }
 
@@ -247,7 +247,7 @@ private:
                             acos((a.x * b.x + a.y * b.y)
                                  / (sqrt(a.x * a.x + a.y * a.y) * sqrt(b.x * b.x + b.y * b.y)));
                     }
-                    angle412 = M_PI - angle123;
+                    angle412 = std::numbers::pi - angle123;
                     if (roundCorners) {
                         radius = std::min(length, width) / 6  // NOLINT
                             * std::min(sqrt(1 - cos(angle412) * cos(angle412)),
@@ -276,7 +276,7 @@ private:
                             acos((a.x * b.x + a.y * b.y)
                                  / (sqrt(a.x * a.x + a.y * a.y) * sqrt(b.x * b.x + b.y * b.y)));
                     }
-                    angle123 = M_PI - angle412;
+                    angle123 = std::numbers::pi - angle412;
                     if (roundCorners) {
                         radius = std::min(length, width) / 6  // NOLINT
                             * std::min(sqrt(1 - cos(angle412) * cos(angle412)),
@@ -677,7 +677,7 @@ private:
         width = vecW.Length();
         angle = vecL.Angle();
         if (length < Precision::Confusion() || width < Precision::Confusion()
-            || fmod(fabs(angle123), M_PI) < Precision::Confusion()) {
+            || fmod(fabs(angle123), std::numbers::pi) < Precision::Confusion()) {
             return;
         }
 
@@ -740,7 +740,7 @@ private:
     {
         // center points required later for special case of round corner frame with
         // radiusFrame = 0.
-        double end = angle - M_PI / 2;
+        double end = angle - std::numbers::pi / 2;
 
         Base::Vector2d b1 = (vecL + vecW) / (vecL + vecW).Length();
         Base::Vector2d b2 = (vecL - vecW) / (vecL - vecW).Length();
@@ -749,16 +749,32 @@ private:
         center3 = toVector3d(corner3 - b1 * L2);
         center4 = toVector3d(corner4 + b2 * L1);
 
-        addArcToShapeGeometry(center1, end - M_PI + angle412, end, radius, isConstructionMode());
-        addArcToShapeGeometry(center2, end, end - M_PI - angle123, radius, isConstructionMode());
-        addArcToShapeGeometry(center3, end + angle412, end - M_PI, radius, isConstructionMode());
-        addArcToShapeGeometry(center4, end - M_PI, end - angle123, radius, isConstructionMode());
+        addArcToShapeGeometry(center1,
+                              end - std::numbers::pi + angle412,
+                              end,
+                              radius,
+                              isConstructionMode());
+        addArcToShapeGeometry(center2,
+                              end,
+                              end - std::numbers::pi - angle123,
+                              radius,
+                              isConstructionMode());
+        addArcToShapeGeometry(center3,
+                              end + angle412,
+                              end - std::numbers::pi,
+                              radius,
+                              isConstructionMode());
+        addArcToShapeGeometry(center4,
+                              end - std::numbers::pi,
+                              end - angle123,
+                              radius,
+                              isConstructionMode());
     }
 
     void
     createSecondRectangleGeometries(Base::Vector2d vecL, Base::Vector2d vecW, double L1, double L2)
     {
-        double end = angle - M_PI / 2;
+        double end = angle - std::numbers::pi / 2;
 
         if (radius < Precision::Confusion()) {
             radiusFrame = 0.;
@@ -800,22 +816,22 @@ private:
             Base::Vector2d b2 = (vecL - vecW) / (vecL - vecW).Length();
 
             addArcToShapeGeometry(toVector3d(frameCorner1 + b1 * L2F),
-                                  end - M_PI + angle412,
+                                  end - std::numbers::pi + angle412,
                                   end,
                                   radiusFrame,
                                   isConstructionMode());
             addArcToShapeGeometry(toVector3d(frameCorner2 - b2 * L1F),
                                   end,
-                                  end - M_PI - angle123,
+                                  end - std::numbers::pi - angle123,
                                   radiusFrame,
                                   isConstructionMode());
             addArcToShapeGeometry(toVector3d(frameCorner3 - b1 * L2F),
                                   end + angle412,
-                                  end - M_PI,
+                                  end - std::numbers::pi,
                                   radiusFrame,
                                   isConstructionMode());
             addArcToShapeGeometry(toVector3d(frameCorner4 + b2 * L1F),
-                                  end - M_PI,
+                                  end - std::numbers::pi,
                                   end - angle123,
                                   radiusFrame,
                                   isConstructionMode());
@@ -1313,7 +1329,7 @@ private:
                                   firstCurve + 1,
                                   Sketcher::PointPos::none,
                                   firstCurve + 3);
-            if (fabs(angle123 - M_PI / 2) < Precision::Confusion()) {
+            if (fabs(angle123 - std::numbers::pi / 2) < Precision::Confusion()) {
                 addToShapeConstraints(Sketcher::Perpendicular,
                                       firstCurve,
                                       Sketcher::PointPos::none,
@@ -1932,7 +1948,7 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 if (onViewParameters[OnViewParameter::Sixth]->isSet) {
                     double angle =
                         Base::toRadians(onViewParameters[OnViewParameter::Sixth]->getValue());
-                    if (fmod(angle, M_PI) < Precision::Confusion()) {
+                    if (fmod(angle, std::numbers::pi) < Precision::Confusion()) {
                         unsetOnViewParameter(onViewParameters[OnViewParameter::Sixth].get());
                         return;
                     }
@@ -1944,8 +1960,8 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
 
                     int sign = handler->side != sign1 ? 1 : -1;
 
-                    double angle123 =
-                        (handler->corner2Initial - handler->corner1).Angle() + M_PI + sign * angle;
+                    double angle123 = (handler->corner2Initial - handler->corner1).Angle()
+                        + std::numbers::pi + sign * angle;
 
                     onSketchPos.x = handler->corner2Initial.x + cos(angle123) * width;
                     onSketchPos.y = handler->corner2Initial.y + sin(angle123) * width;
@@ -1969,12 +1985,12 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 if (onViewParameters[OnViewParameter::Sixth]->isSet) {
                     double c =
                         Base::toRadians(onViewParameters[OnViewParameter::Sixth]->getValue());
-                    if (fmod(c, M_PI) < Precision::Confusion()) {
+                    if (fmod(c, std::numbers::pi) < Precision::Confusion()) {
                         unsetOnViewParameter(onViewParameters[OnViewParameter::Sixth].get());
                         return;
                     }
 
-                    double a = asin(width * sin(M_PI - c)
+                    double a = asin(width * sin(std::numbers::pi - c)
                                     / (handler->corner3 - handler->corner1).Length());
 
                     int sign1 = handler->getPointSideOfVector(onSketchPos,
@@ -2569,15 +2585,15 @@ void DSHRectangleController::addConstraints()
 
     if (handler->constructionMethod() == ConstructionMethod::ThreePoints) {
         if (angleSet) {
-            if (fabs(angle - M_PI) < Precision::Confusion()
-                || fabs(angle + M_PI) < Precision::Confusion()
+            if (fabs(angle - std::numbers::pi) < Precision::Confusion()
+                || fabs(angle + std::numbers::pi) < Precision::Confusion()
                 || fabs(angle) < Precision::Confusion()) {
                 Gui::cmdAppObjectArgs(obj,
                                       "addConstraint(Sketcher.Constraint('Horizontal',%d)) ",
                                       firstCurve);
             }
-            else if (fabs(angle - M_PI / 2) < Precision::Confusion()
-                     || fabs(angle + M_PI / 2) < Precision::Confusion()) {
+            else if (fabs(angle - std::numbers::pi / 2) < Precision::Confusion()
+                     || fabs(angle + std::numbers::pi / 2) < Precision::Confusion()) {
                 Gui::cmdAppObjectArgs(obj,
                                       "addConstraint(Sketcher.Constraint('Vertical',%d)) ",
                                       firstCurve);
@@ -2591,7 +2607,7 @@ void DSHRectangleController::addConstraints()
             }
         }
         if (innerAngleSet) {
-            if (fabs(innerAngle - M_PI / 2) > Precision::Confusion()) {
+            if (fabs(innerAngle - std::numbers::pi / 2) > Precision::Confusion()) {
                 // if 90? then perpendicular already created.
                 Gui::cmdAppObjectArgs(obj,
                                       "addConstraint(Sketcher.Constraint('Angle',%d,%d,%d,%d,%f)) ",
@@ -2617,7 +2633,7 @@ void DSHRectangleController::addConstraints()
                                    obj);
         }
         if (innerAngleSet) {
-            if (fabs(innerAngle - M_PI / 2) > Precision::Confusion()) {
+            if (fabs(innerAngle - std::numbers::pi / 2) > Precision::Confusion()) {
                 // if 90? then perpendicular already created.
                 Gui::cmdAppObjectArgs(obj,
                                       "addConstraint(Sketcher.Constraint('Angle',%d,%d,%d,%d,%f)) ",

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -103,7 +103,7 @@ private:
                 endpoint = centerPoint + length * Base::Vector2d(cos(endAngle), sin(endAngle));
 
                 double angle1 = endAngle - startAngle;
-                double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * M_PI;
+                double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * std::numbers::pi;
                 totalAngle = abs(angle1 - totalAngle) < abs(angle2 - totalAngle) ? angle1 : angle2;
 
                 CreateAndDrawShapeGeometry();
@@ -408,10 +408,11 @@ private:
                             // the new geometry.
                             /*if (cstr->Type == DistanceX || cstr->Type == DistanceY) {
                                 //DistanceX/Y can be applied only if the rotation if 90 or 180.
-                                if (fabs(fmod(individualAngle, M_PI)) < Precision::Confusion()) {
+                                if (fabs(fmod(individualAngle, std::numbers::pi)) <
+                            Precision::Confusion()) {
                                     // ok and nothing to do actually
                                 }
-                                else if (fabs(fmod(individualAngle, M_PI * 0.5)) <
+                                else if (fabs(fmod(individualAngle, std::numbers::pi * 0.5)) <
                             Precision::Confusion()) { cstr->Type = cstr->Type == DistanceX ?
                             DistanceY : DistanceX;
                                 }
@@ -567,7 +568,7 @@ void DSHRotateControllerBase::doEnforceControlParameters(Base::Vector2d& onSketc
 
                 double arcAngle =
                     Base::toRadians(onViewParameters[OnViewParameter::Third]->getValue());
-                if (fmod(fabs(arcAngle), 2 * M_PI) < Precision::Confusion()) {
+                if (fmod(fabs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()) {
                     unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
                     return;
                 }
@@ -580,7 +581,7 @@ void DSHRotateControllerBase::doEnforceControlParameters(Base::Vector2d& onSketc
 
                 double arcAngle =
                     Base::toRadians(onViewParameters[OnViewParameter::Fourth]->getValue());
-                if (fmod(fabs(arcAngle), 2 * M_PI) < Precision::Confusion()) {
+                if (fmod(fabs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()) {
                     unsetOnViewParameter(onViewParameters[OnViewParameter::Fourth].get());
                     return;
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
@@ -248,14 +248,14 @@ private:
         }
 
         Part::GeomArcOfCircle* arc1 = addArcToShapeGeometry(toVector3d(startPoint),
-                                                            M_PI / 2 + angle,
-                                                            1.5 * M_PI + angle,
+                                                            std::numbers::pi / 2 + angle,
+                                                            1.5 * std::numbers::pi + angle,
                                                             radius,
                                                             isConstructionMode());
 
         Part::GeomArcOfCircle* arc2 = addArcToShapeGeometry(toVector3d(secondPoint),
-                                                            1.5 * M_PI + angle,
-                                                            M_PI / 2 + angle,
+                                                            1.5 * std::numbers::pi + angle,
+                                                            std::numbers::pi / 2 + angle,
                                                             radius,
                                                             isConstructionMode());
 
@@ -326,10 +326,11 @@ private:
         isHorizontal = false;
         isVertical = false;
 
-        if (fmod(fabs(angle), M_PI) < Precision::Confusion()) {
+        if (fmod(fabs(angle), std::numbers::pi) < Precision::Confusion()) {
             isHorizontal = true;
         }
-        else if (fmod(fabs(angle + M_PI / 2), M_PI) < Precision::Confusion()) {
+        else if (fmod(fabs(angle + std::numbers::pi / 2), std::numbers::pi)
+                 < Precision::Confusion()) {
             isVertical = true;
         }
     }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
@@ -584,7 +584,8 @@ void DSHTranslateControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
             }
 
             if (onViewParameters[OnViewParameter::Fourth]->isSet) {
-                double angle = onViewParameters[OnViewParameter::Fourth]->getValue() * M_PI / 180;
+                double angle =
+                    onViewParameters[OnViewParameter::Fourth]->getValue() * std::numbers::pi / 180;
                 onSketchPos.x = handler->referencePoint.x + cos(angle) * length;
                 onSketchPos.y = handler->referencePoint.y + sin(angle) * length;
             }
@@ -607,7 +608,8 @@ void DSHTranslateControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
             }
 
             if (onViewParameters[OnViewParameter::Sixth]->isSet) {
-                double angle = onViewParameters[OnViewParameter::Sixth]->getValue() * M_PI / 180;
+                double angle =
+                    onViewParameters[OnViewParameter::Sixth]->getValue() * std::numbers::pi / 180;
                 onSketchPos.x = handler->referencePoint.x + cos(angle) * length;
                 onSketchPos.y = handler->referencePoint.y + sin(angle) * length;
             }
@@ -647,7 +649,7 @@ void DSHTranslateController::adaptParameters(Base::Vector2d onSketchPos)
             Base::Vector2d vec2d = Base::Vector2d(handler->firstTranslationVector.x,
                                                   handler->firstTranslationVector.y);
             double angle = vec2d.Angle();
-            double range = angle * 180 / M_PI;
+            double range = angle * 180 / std::numbers::pi;
 
             if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
                 setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
@@ -669,7 +671,7 @@ void DSHTranslateController::adaptParameters(Base::Vector2d onSketchPos)
             Base::Vector2d vec2d = Base::Vector2d(handler->secondTranslationVector.x,
                                                   handler->secondTranslationVector.y);
             double angle = vec2d.Angle();
-            double range = angle * 180 / M_PI;
+            double range = angle * 180 / std::numbers::pi;
 
             if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
                 setOnViewParameterValue(OnViewParameter::Sixth, range, Base::Unit::Angle);

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -262,7 +262,7 @@ Restart:
                                 const Part::GeomCircle* circle =
                                     static_cast<const Part::GeomCircle*>(geo);
                                 ra = circle->getRadius();
-                                angle = M_PI / 4;
+                                angle = std::numbers::pi / 4;
                                 midpos = circle->getCenter();
                             }
                             else if (geo->is<Part::GeomArcOfCircle>()) {
@@ -281,7 +281,7 @@ Restart:
                                 rb = ellipse->getMinorRadius();
                                 Base::Vector3d majdir = ellipse->getMajorAxisDir();
                                 angle = atan2(majdir.y, majdir.x);
-                                angleplus = M_PI / 4;
+                                angleplus = std::numbers::pi / 4;
                                 midpos = ellipse->getCenter();
                             }
                             else if (geo->is<Part::GeomArcOfEllipse>()) {
@@ -460,7 +460,7 @@ Restart:
 
                         norm1.Normalize();
                         dir1 = norm1;
-                        dir1.RotateZ(-M_PI / 2.0);
+                        dir1.RotateZ(-std::numbers::pi / 2.0);
                     }
                     else if (Constr->FirstPos == Sketcher::PointPos::none) {
 
@@ -485,7 +485,9 @@ Restart:
                         else if (geo1->is<Part::GeomCircle>()) {
                             const Part::GeomCircle* circle =
                                 static_cast<const Part::GeomCircle*>(geo1);
-                            norm1 = Base::Vector3d(cos(M_PI / 4), sin(M_PI / 4), 0);
+                            norm1 = Base::Vector3d(cos(std::numbers::pi / 4),
+                                                   sin(std::numbers::pi / 4),
+                                                   0);
                             dir1 = Base::Vector3d(-norm1.y, norm1.x, 0);
                             midpos1 = circle->getCenter() + circle->getRadius() * norm1;
                         }
@@ -514,7 +516,9 @@ Restart:
                         else if (geo2->is<Part::GeomCircle>()) {
                             const Part::GeomCircle* circle =
                                 static_cast<const Part::GeomCircle*>(geo2);
-                            norm2 = Base::Vector3d(cos(M_PI / 4), sin(M_PI / 4), 0);
+                            norm2 = Base::Vector3d(cos(std::numbers::pi / 4),
+                                                   sin(std::numbers::pi / 4),
+                                                   0);
                             dir2 = Base::Vector3d(-norm2.y, norm2.x, 0);
                             midpos2 = circle->getCenter() + circle->getRadius() * norm2;
                         }
@@ -576,7 +580,7 @@ Restart:
                                 const Part::GeomCircle* circle =
                                     static_cast<const Part::GeomCircle*>(geo1);
                                 r1a = circle->getRadius();
-                                angle1 = M_PI / 4;
+                                angle1 = std::numbers::pi / 4;
                                 midpos1 = circle->getCenter();
                             }
                             else if (geo1->is<Part::GeomArcOfCircle>()) {
@@ -595,7 +599,7 @@ Restart:
                                 r1b = ellipse->getMinorRadius();
                                 Base::Vector3d majdir = ellipse->getMajorAxisDir();
                                 angle1 = atan2(majdir.y, majdir.x);
-                                angle1plus = M_PI / 4;
+                                angle1plus = std::numbers::pi / 4;
                                 midpos1 = ellipse->getCenter();
                             }
                             else if (geo1->is<Part::GeomArcOfEllipse>()) {
@@ -641,7 +645,7 @@ Restart:
                                 const Part::GeomCircle* circle =
                                     static_cast<const Part::GeomCircle*>(geo2);
                                 r2a = circle->getRadius();
-                                angle2 = M_PI / 4;
+                                angle2 = std::numbers::pi / 4;
                                 midpos2 = circle->getCenter();
                             }
                             else if (geo2->is<Part::GeomArcOfCircle>()) {
@@ -660,7 +664,7 @@ Restart:
                                 r2b = ellipse->getMinorRadius();
                                 Base::Vector3d majdir = ellipse->getMajorAxisDir();
                                 angle2 = atan2(majdir.y, majdir.x);
-                                angle2plus = M_PI / 4;
+                                angle2plus = std::numbers::pi / 4;
                                 midpos2 = ellipse->getCenter();
                             }
                             else if (geo2->is<Part::GeomArcOfEllipse>()) {
@@ -968,7 +972,7 @@ Restart:
                                 // otherwise We still use findHelperAngles before to find if helper
                                 // is needed.
                                 helperStartAngle1 = endAngle;
-                                helperRange1 = 2 * M_PI - (endAngle - startAngle);
+                                helperRange1 = 2 * std::numbers::pi - (endAngle - startAngle);
 
                                 numPoints++;
                             }
@@ -991,7 +995,7 @@ Restart:
 
                             if (helperRange2 != 0.) {
                                 helperStartAngle2 = endAngle;
-                                helperRange2 = 2 * M_PI - (endAngle - startAngle);
+                                helperRange2 = 2 * std::numbers::pi - (endAngle - startAngle);
 
                                 numPoints++;
                             }
@@ -1089,7 +1093,7 @@ Restart:
                         // getSolvedSketch().calculateNormalAtPoint(Constr->Second, pos.x, pos.y);
                         norm.Normalize();
                         Base::Vector3d dir = norm;
-                        dir.RotateZ(-M_PI / 2.0);
+                        dir.RotateZ(-std::numbers::pi / 2.0);
 
                         relPos = seekConstraintPosition(
                             pos,
@@ -1385,12 +1389,13 @@ Restart:
                             // TODO: Check
                             // dir1 = getSolvedSketch().calculateNormalAtPoint(Constr->First,
                             // p.x, p.y);
-                            dir1.RotateZ(-M_PI / 2);  // convert to vector of tangency by rotating
+                            dir1.RotateZ(-std::numbers::pi
+                                         / 2);  // convert to vector of tangency by rotating
                             dir2 = getNormal(geolistfacade, Constr->Second, p);
                             // TODO: Check
                             // dir2 = getSolvedSketch().calculateNormalAtPoint(Constr->Second,
                             // p.x, p.y);
-                            dir2.RotateZ(-M_PI / 2);
+                            dir2.RotateZ(-std::numbers::pi / 2);
 
                             startangle = atan2(dir1.y, dir1.x);
                             range = atan2(dir1.x * dir2.y - dir1.y * dir2.x,
@@ -1634,24 +1639,24 @@ void EditModeConstraintCoinManager::findHelperAngles(double& helperStartAngle,
 {
     double margin = 0.2;  // about 10deg
     if (angle < 0) {
-        angle = angle + 2 * M_PI;
+        angle = angle + 2 * std::numbers::pi;
     }
     // endAngle can be more than 2*pi as its startAngle + arcAngle
-    if (endAngle > 2 * M_PI && angle < endAngle - 2 * M_PI) {
-        angle = angle + 2 * M_PI;
+    if (endAngle > 2 * std::numbers::pi && angle < endAngle - 2 * std::numbers::pi) {
+        angle = angle + 2 * std::numbers::pi;
     }
     if (!(angle > startAngle && angle < endAngle)) {
-        if ((angle < startAngle && startAngle - angle < angle + 2 * M_PI - endAngle)
-            || (angle > endAngle && startAngle + 2 * M_PI - angle < angle - endAngle)) {
+        if ((angle < startAngle && startAngle - angle < angle + 2 * std::numbers::pi - endAngle)
+            || (angle > endAngle && startAngle + 2 * std::numbers::pi - angle < angle - endAngle)) {
             if (angle > startAngle) {
-                angle -= 2 * M_PI;
+                angle -= 2 * std::numbers::pi;
             }
             helperStartAngle = angle - margin;
             helperRange = startAngle - angle + margin;
         }
         else {
             if (angle < endAngle) {
-                angle += 2 * M_PI;
+                angle += 2 * std::numbers::pi;
             }
             helperStartAngle = endAngle;
             helperRange = angle - endAngle + margin;

--- a/src/Mod/Sketcher/Gui/PreCompiled.h
+++ b/src/Mod/Sketcher/Gui/PreCompiled.h
@@ -42,6 +42,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <numbers>
 #include <vector>
 
 // Boost

--- a/src/Mod/Sketcher/Gui/SnapManager.cpp
+++ b/src/Mod/Sketcher/Gui/SnapManager.cpp
@@ -122,7 +122,8 @@ void SnapManager::ParameterObserver::updateSnapAngleParameter(const std::string&
 {
     ParameterGrp::handle hGrp = getParameterGrpHandle();
 
-    client.snapAngle = fmod(hGrp->GetFloat(parametername.c_str(), 5.) * M_PI / 180, 2 * M_PI);
+    client.snapAngle = fmod(hGrp->GetFloat(parametername.c_str(), 5.) * std::numbers::pi / 180,
+                            2 * std::numbers::pi);
 }
 
 void SnapManager::ParameterObserver::subscribeToParameters()
@@ -222,7 +223,7 @@ bool SnapManager::snapAtAngle(double& x, double& y)
     double length = (pointToOverride - referencePoint).Length();
 
     double angle1 = (pointToOverride - referencePoint).Angle();
-    double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * M_PI;
+    double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * std::numbers::pi;
     lastMouseAngle = abs(angle1 - lastMouseAngle) < abs(angle2 - lastMouseAngle) ? angle1 : angle2;
 
     double angle = round(lastMouseAngle / snapAngle) * snapAngle;
@@ -368,10 +369,10 @@ bool SnapManager::snapToArcMiddle(Base::Vector3d& pointToOverride, const Part::G
     double u, v;
     arc->getRange(u, v, true);
     if (v < u) {
-        v += 2 * M_PI;
+        v += 2 * std::numbers::pi;
     }
     double angle = v - u;
-    int revert = angle < M_PI ? 1 : -1;
+    int revert = angle < std::numbers::pi ? 1 : -1;
 
     /*To know if we are close to the middle of the arc, we are going to compare the angle of the
      * (mouse cursor - center) to the angle of the middle of the arc. If it's less than 10% of the

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -432,7 +432,7 @@ double SketcherGui::GetPointAngle(const Base::Vector2d& p1, const Base::Vector2d
 {
     double dX = p2.x - p1.x;
     double dY = p2.y - p1.y;
-    return dY >= 0 ? atan2(dY, dX) : atan2(dY, dX) + 2 * M_PI;
+    return dY >= 0 ? atan2(dY, dX) : atan2(dY, dX) + 2 * std::numbers::pi;
 }
 
 // Set the two points on circles at minimal distance

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2029,9 +2029,9 @@ void ViewProviderSketch::moveAngleConstraint(Sketcher::Constraint* constr, int c
             Base::Vector3d p = getSolvedSketch().getPoint(constr->Third, constr->ThirdPos);
             p0 = Base::Vector3d(p.x, p.y, 0);
             Base::Vector3d dir1 = getSolvedSketch().calculateNormalAtPoint(constr->First, p.x, p.y);
-            dir1.RotateZ(-M_PI / 2);// convert to vector of tangency by rotating
+            dir1.RotateZ(-std::numbers::pi / 2);// convert to vector of tangency by rotating
             Base::Vector3d dir2 = getSolvedSketch().calculateNormalAtPoint(constr->Second, p.x, p.y);
-            dir2.RotateZ(-M_PI / 2);
+            dir2.RotateZ(-std::numbers::pi / 2);
 
             Base::Vector3d vec = Base::Vector3d(toPos.x, toPos.y, 0) - p0;
             factor = factor * Base::sgn<double>((dir1 + dir2) * vec);
@@ -3996,7 +3996,7 @@ double ViewProviderSketch::getRotation(SbVec3f pos0, SbVec3f pos1) const
         getCoordsOnSketchPlane(pos0, vol.getProjectionDirection(), x0, y0);
         getCoordsOnSketchPlane(pos1, vol.getProjectionDirection(), x1, y1);
 
-        return -atan2((y1 - y0), (x1 - x0)) * 180 / M_PI;
+        return -atan2((y1 - y0), (x1 - x0)) * 180 / std::numbers::pi;
     }
     catch (const Base::ZeroDivisionError&) {
         return 0;

--- a/src/Mod/Spreadsheet/App/PreCompiled.h
+++ b/src/Mod/Spreadsheet/App/PreCompiled.h
@@ -42,6 +42,7 @@
 #include <iomanip>
 #include <map>
 #include <memory>
+#include <numbers>
 #include <set>
 #include <sstream>
 #include <string>

--- a/src/Mod/Spreadsheet/Gui/PreCompiled.h
+++ b/src/Mod/Spreadsheet/Gui/PreCompiled.h
@@ -41,6 +41,7 @@
 
 // STL
 #include <sstream>
+#include <numbers>
 
 #ifdef FC_OS_WIN32
 #include <windows.h>

--- a/src/Mod/Surface/App/PreCompiled.h
+++ b/src/Mod/Surface/App/PreCompiled.h
@@ -28,6 +28,7 @@
 #ifdef _PreComp_
 
 // STL
+#include <numbers>
 #include <string>
 
 // opencascade

--- a/src/Mod/Surface/Gui/PreCompiled.h
+++ b/src/Mod/Surface/Gui/PreCompiled.h
@@ -28,6 +28,7 @@
 #ifdef _PreComp_
 
 // STL
+#include <numbers>
 #include <sstream>
 
 // Qt

--- a/src/Mod/TechDraw/App/CenterLine.cpp
+++ b/src/Mod/TechDraw/App/CenterLine.cpp
@@ -392,7 +392,7 @@ std::pair<Base::Vector3d, Base::Vector3d> CenterLine::rotatePointsAroundMid(cons
                                   const double angleDeg)
 {
     std::pair<Base::Vector3d, Base::Vector3d> result;
-    double angleRad = angleDeg * M_PI / 180.0;
+    double angleRad = angleDeg * std::numbers::pi / 180.0;
 
     result.first.x = ((p1.x - mid.x) * cos(angleRad)) - ((p1.y - mid.y) * sin(angleRad)) + mid.x;
     result.first.y = ((p1.x - mid.x) * sin(angleRad)) + ((p1.y - mid.y) * cos(angleRad)) + mid.y;

--- a/src/Mod/TechDraw/App/CosmeticVertex.cpp
+++ b/src/Mod/TechDraw/App/CosmeticVertex.cpp
@@ -166,7 +166,7 @@ Base::Vector3d CosmeticVertex::rotatedAndScaled(const double scale, const double
         // invert the Y coordinate so the rotation math works out
         // the stored point is inverted
         scaledPoint = DU::invertY(scaledPoint);
-        scaledPoint.RotateZ(rotDegrees * M_PI / DegreesHalfCircle);
+        scaledPoint.RotateZ(rotDegrees * std::numbers::pi / DegreesHalfCircle);
         scaledPoint = DU::invertY(scaledPoint);
     }
     return scaledPoint;
@@ -182,7 +182,7 @@ Base::Vector3d CosmeticVertex::makeCanonicalPoint(DrawViewPart* dvp, Base::Vecto
     Base::Vector3d result = point;
     if (rotDeg != 0.0) {
         // unrotate the point
-        double rotRad = rotDeg * M_PI / DegreesHalfCircle;
+        double rotRad = rotDeg * std::numbers::pi / DegreesHalfCircle;
         // we always rotate around the origin.
         result.RotateZ(-rotRad);
     }

--- a/src/Mod/TechDraw/App/DrawBrokenView.cpp
+++ b/src/Mod/TechDraw/App/DrawBrokenView.cpp
@@ -1113,7 +1113,7 @@ Base::Vector3d  DrawBrokenView::makePerpendicular(Base::Vector3d inDir) const
     gp_Pnt origin(0.0, 0.0, 0.0);
     auto dir = getProjectionCS().Direction();
     gp_Ax1 axis(origin, dir);
-    auto gRotated = gDir.Rotated(axis,  M_PI_2);
+    auto gRotated = gDir.Rotated(axis, std::numbers::pi_v<Standard_Real>/2.0F);
     return Base::convertTo<Base::Vector3d>(gRotated);
 }
 

--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -98,12 +98,9 @@
 #include <gp_Dir.hxx>
 #include <gp_Pln.hxx>
 #include <gp_Pnt.hxx>
+#include <sstream>
 #endif
 
-#define _USE_MATH_DEFINES
-#include <cmath>
-
-#include <sstream>
 
 #include <App/Application.h>
 #include <App/Document.h>
@@ -387,7 +384,7 @@ void DrawComplexSection::makeAlignedPieces(const TopoDS_Shape& rawShape)
         }
         //we only want to reverse the segment normal if it is not perpendicular to section normal
         if (segmentNormal.Dot(gProjectionUnit) != 0.0
-            && segmentNormal.Angle(gProjectionUnit) <= M_PI_2) {
+            && segmentNormal.Angle(gProjectionUnit) <= std::numbers::pi_v<Standard_Real>/2.0F) {
             segmentNormal.Reverse();
         }
 
@@ -957,7 +954,7 @@ gp_Vec DrawComplexSection::projectVector(const gp_Vec& vec) const
 // being slightly wrong.  see https://forum.freecad.org/viewtopic.php?t=79017&sid=612a62a60f5db955ee071a7aaa362dbb
 bool DrawComplexSection::validateOffsetProfile(TopoDS_Wire profile, Base::Vector3d direction, double angleThresholdDeg) const
 {
-    double angleThresholdRad = angleThresholdDeg * M_PI / 180.0;  // 5 degrees
+    double angleThresholdRad = angleThresholdDeg * std::numbers::pi / 180.0;  // 5 degrees
     TopExp_Explorer explEdges(profile, TopAbs_EDGE);
     for (; explEdges.More(); explEdges.Next()) {
         std::pair<Base::Vector3d, Base::Vector3d> segmentEnds = getSegmentEnds(TopoDS::Edge(explEdges.Current()));

--- a/src/Mod/TechDraw/App/DrawGeomHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.cpp
@@ -399,12 +399,12 @@ std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hatchLine, B
     double interval = hatchLine.getInterval() * scale;
     double offset = hatchLine.getOffset() * scale;
     double angle = hatchLine.getAngle() + rotation;
-    origin.RotateZ(rotation * M_PI / 180.);
+    origin.RotateZ(rotation * std::numbers::pi / 180.);
 
     if (scale == 0. || interval == 0.)
         return {};
 
-    Base::Vector3d hatchDirection(cos(angle * M_PI / 180.), sin(angle * M_PI / 180.), 0.);
+    Base::Vector3d hatchDirection(cos(angle * std::numbers::pi / 180.), sin(angle * std::numbers::pi / 180.), 0.);
     Base::Vector3d hatchPerpendicular(-hatchDirection.y, hatchDirection.x, 0.);
     Base::Vector3d hatchIntervalAndOffset = offset * hatchDirection + interval * hatchPerpendicular;
 

--- a/src/Mod/TechDraw/App/DrawLeaderLine.cpp
+++ b/src/Mod/TechDraw/App/DrawLeaderLine.cpp
@@ -375,7 +375,7 @@ std::vector<Base::Vector3d>  DrawLeaderLine::getScaledAndRotatedPoints(bool doSc
 
     double rotationRad{0.0};
     if (doRotate) {
-        rotationRad = dvp->Rotation.getValue() * M_PI / DegreesHalfCircle;
+        rotationRad = dvp->Rotation.getValue() * std::numbers::pi / DegreesHalfCircle;
     }
 
     std::vector<Base::Vector3d> pointsAll = WayPoints.getValues();
@@ -409,7 +409,7 @@ DrawLeaderLine::makeCanonicalPoints(const std::vector<Base::Vector3d>& inPoints,
 
     double rotationRad{0.0};
     if (doRotate) {
-        rotationRad = - dvp->Rotation.getValue() * M_PI / DegreesHalfCircle;
+        rotationRad = - dvp->Rotation.getValue() * std::numbers::pi / DegreesHalfCircle;
     }
 
     std::vector<Base::Vector3d> result;

--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -1146,9 +1146,9 @@ void DrawProjGroup::spin(const SpinDirection& spindirection)
 {
     double angle;
     if (spindirection == SpinDirection::CW)
-        angle = M_PI / 2.0;// Top -> Right -> Bottom -> Left -> Top
+        angle = std::numbers::pi / 2.0;// Top -> Right -> Bottom -> Left -> Top
     if (spindirection == SpinDirection::CCW)
-        angle = -M_PI / 2.0;// Top -> Left -> Bottom -> Right -> Top
+        angle = -std::numbers::pi / 2.0;// Top -> Left -> Bottom -> Right -> Top
 
     spin(angle);
 }

--- a/src/Mod/TechDraw/App/DrawProjectSplit.cpp
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.cpp
@@ -348,7 +348,7 @@ std::string edgeSortItem::dump()
     std::string result;
     std::stringstream builder;
     builder << "edgeSortItem - s: " << DrawUtil::formatVector(start)  << " e: " << DrawUtil::formatVector(end) <<
-                              " sa: " << startAngle * 180.0/M_PI << " ea: " << endAngle* 180.0/M_PI << " idx: " << idx;
+                              " sa: " << startAngle * 180.0/std::numbers::pi << " ea: " << endAngle* 180.0/std::numbers::pi << " idx: " << idx;
     return builder.str();
 }
 

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -203,7 +203,7 @@ double DrawUtil::angleWithX(Base::Vector3d inVec)
 {
     double result = atan2(inVec.y, inVec.x);
     if (result < 0) {
-        result += 2.0 * M_PI;
+        result += 2.0 * std::numbers::pi;
     }
 
     return result;
@@ -225,7 +225,7 @@ double DrawUtil::angleWithX(TopoDS_Edge e, bool reverse)
     }
     double result = atan2(u.y, u.x);
     if (result < 0) {
-        result += 2.0 * M_PI;
+        result += 2.0 * std::numbers::pi;
     }
 
     return result;
@@ -251,7 +251,7 @@ double DrawUtil::angleWithX(TopoDS_Edge e, TopoDS_Vertex v, double tolerance)
     c->D1(param, paramPoint, derivative);
     double angle = atan2(derivative.Y(), derivative.X());
     if (angle < 0) {//map from [-PI:PI] to [0:2PI]
-        angle += 2.0 * M_PI;
+        angle += 2.0 * std::numbers::pi;
     }
     return angle;
 }
@@ -1059,7 +1059,7 @@ Base::Vector3d  DrawUtil::toAppSpace(const DrawViewPart& dvp, const Base::Vector
 
     // remove the effect of the Rotation property
     double rotDeg = dvp.Rotation.getValue();
-    double rotRad = rotDeg * M_PI / 180.0;
+    double rotRad = rotDeg * std::numbers::pi / 180.0;
     if (rotDeg != 0.0) {
         // we always rotate around the origin.
         appPoint.RotateZ(-rotRad);
@@ -1396,10 +1396,10 @@ double DrawUtil::sqr(double x)
 
 void DrawUtil::angleNormalize(double& fi)
 {
-    while (fi <= -M_PI) {
+    while (fi <= -std::numbers::pi) {
         fi += M_2PI;
     }
-    while (fi > M_PI) {
+    while (fi > std::numbers::pi) {
         fi -= M_2PI;
     }
 }
@@ -1419,7 +1419,7 @@ double DrawUtil::angleDifference(double fi1, double fi2, bool reflex)
 
     fi1 -= fi2;
 
-    if ((fi1 > +M_PI || fi1 <= -M_PI) != reflex) {
+    if ((fi1 > +std::numbers::pi || fi1 <= -std::numbers::pi) != reflex) {
         fi1 += fi1 > 0.0 ? -M_2PI : +M_2PI;
     }
 
@@ -1573,7 +1573,7 @@ void DrawUtil::intervalMarkCircular(std::vector<std::pair<double, bool>>& markin
     angleNormalize(start);
 
     double end = start + length;
-    if (end > M_PI) {
+    if (end > std::numbers::pi) {
         end -= M_2PI;
     }
 
@@ -1790,7 +1790,7 @@ void DrawUtil::findCircularArcRectangleIntersections(const Base::Vector2d& circl
     if (arcRotation < 0.0) {
         arcRotation = -arcRotation;
         arcBaseAngle -= arcRotation;
-        if (arcBaseAngle <= -M_PI) {
+        if (arcBaseAngle <= -std::numbers::pi) {
             arcBaseAngle += M_2PI;
         }
     }

--- a/src/Mod/TechDraw/App/DrawUtil.h
+++ b/src/Mod/TechDraw/App/DrawUtil.h
@@ -51,7 +51,7 @@
 
 
 #ifndef M_2PI
-#define M_2PI ((M_PI)*2.0)
+#define M_2PI ((std::numbers::pi)*2.0)
 #endif
 
 constexpr double DegreesHalfCircle{180.0};

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -986,7 +986,7 @@ double DrawViewPart::getSizeAlongVector(Base::Vector3d alignmentVector)
     if (getEdgeCompound().IsNull()) {
         return 1.0;
     }
-    TopoDS_Shape rotatedShape = ShapeUtils::rotateShape(getEdgeCompound(), OXYZ, alignmentAngle * 180.0 / M_PI);
+    TopoDS_Shape rotatedShape = ShapeUtils::rotateShape(getEdgeCompound(), OXYZ, alignmentAngle * 180.0 / std::numbers::pi);
     Bnd_Box shapeBox;
     shapeBox.SetGap(0.0);
     BRepBndLib::AddOptimal(rotatedShape, shapeBox);
@@ -1105,7 +1105,7 @@ gp_Ax2 DrawViewPart::getRotatedCS(const Base::Vector3d basePoint) const
     //    Base::Console().Message("DVP::getRotatedCS() - %s - %s\n", getNameInDocument(), Label.getValue());
     gp_Ax2 unrotated = getProjectionCS(basePoint);
     gp_Ax1 rotationAxis(Base::convertTo<gp_Pnt>(basePoint), unrotated.Direction());
-    double angleRad = Rotation.getValue() * M_PI / 180.0;
+    double angleRad = Rotation.getValue() * std::numbers::pi / 180.0;
     gp_Ax2 rotated = unrotated.Rotated(rotationAxis, -angleRad);
     return rotated;
 }
@@ -1302,9 +1302,9 @@ void DrawViewPart::spin(const SpinDirection& spindirection)
 {
     double angle;
     if (spindirection == SpinDirection::CW)
-        angle = M_PI / 2.0;// Top -> Right -> Bottom -> Left -> Top
+        angle = std::numbers::pi / 2.0;// Top -> Right -> Bottom -> Left -> Top
     if (spindirection == SpinDirection::CCW)
-        angle = -M_PI / 2.0;// Top -> Left -> Bottom -> Right -> Top
+        angle = -std::numbers::pi / 2.0;// Top -> Left -> Bottom -> Right -> Top
 
     spin(angle);
 }
@@ -1338,7 +1338,7 @@ std::pair<Base::Vector3d, Base::Vector3d> DrawViewPart::getDirsFromFront(ProjDir
     gp_Dir gNewDir;
     gp_Dir gNewXDir;
 
-    double angle = M_PI / 2.0;//90*
+    double angle = std::numbers::pi / 2.0;//90*
 
     if (viewType == ProjDirection::Right) {
         newCS = anchorCS.Rotated(gUpAxis, angle);

--- a/src/Mod/TechDraw/App/EdgeWalker.cpp
+++ b/src/Mod/TechDraw/App/EdgeWalker.cpp
@@ -556,7 +556,7 @@ std::string embedItem::dump()
     std::stringstream builder;
     builder << "embedItem - vertex: " << iVertex  << " incidenceList: ";
     for (auto& ii : incidenceList) {
-        builder << " e:" << ii.iEdge << "/a:" << (ii.angle * (180.0/M_PI)) << "/ed:" << ii.eDesc;
+        builder << " e:" << ii.iEdge << "/a:" << (ii.angle * (180.0/std::numbers::pi)) << "/ed:" << ii.eDesc;
     }
     return builder.str();
 }

--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -657,7 +657,7 @@ Ellipse::Ellipse(Base::Vector3d c, double mnr, double mjr)
         Base::Console().Message("G:Ellipse - failed to make Ellipse\n");
     }
     const Handle(Geom_Ellipse) gEllipse = me.Value();
-    BRepBuilderAPI_MakeEdge mkEdge(gEllipse, 0.0, 2 * M_PI);
+    BRepBuilderAPI_MakeEdge mkEdge(gEllipse, 0.0, 2 * std::numbers::pi);
     if (mkEdge.IsDone()) {
         occEdge = mkEdge.Edge();
     }
@@ -686,10 +686,10 @@ AOE::AOE(const TopoDS_Edge &e) : Ellipse(e)
                               e.GetMessageString());
     }
 
-    startAngle = fmod(f, 2.0*M_PI);
-    endAngle = fmod(l, 2.0*M_PI);
+    startAngle = fmod(f, 2.0*std::numbers::pi);
+    endAngle = fmod(l, 2.0*std::numbers::pi);
     cw = (a < 0) ? true: false;
-    largeArc = (l-f > M_PI) ? true : false;
+    largeArc = (l-f > std::numbers::pi) ? true : false;
 
     startPnt = Base::Vector3d(s.X(), s.Y(), s.Z());
     endPnt = Base::Vector3d(ePt.X(), ePt.Y(), ePt.Z());
@@ -722,7 +722,7 @@ Circle::Circle(Base::Vector3d c, double r)
     double angle2 = 360.0;
 
     Handle(Geom_Circle) hCircle = new Geom_Circle (circle);
-    BRepBuilderAPI_MakeEdge aMakeEdge(hCircle, angle1*(M_PI/180), angle2*(M_PI/180));
+    BRepBuilderAPI_MakeEdge aMakeEdge(hCircle, angle1*(std::numbers::pi/180), angle2*(std::numbers::pi/180));
     TopoDS_Edge edge = aMakeEdge.Edge();
     occEdge = edge;
 }
@@ -794,12 +794,12 @@ AOC::AOC(const TopoDS_Edge &e) : Circle(e)
     // this is the wrong determination of cw/ccw.  needs to be determined by edge.
     double a = v3.DotCross(v1, v2);    //error if v1 = v2?
 
-    startAngle = fmod(f, 2.0*M_PI);
-    endAngle = fmod(l, 2.0*M_PI);
+    startAngle = fmod(f, 2.0*std::numbers::pi);
+    endAngle = fmod(l, 2.0*std::numbers::pi);
 
 
     cw = (a < 0) ? true: false;
-    largeArc = (fabs(l-f) > M_PI) ? true : false;
+    largeArc = (fabs(l-f) > std::numbers::pi) ? true : false;
 
     startPnt = Base::convertTo<Base::Vector3d>(s);
     endPnt = Base::convertTo<Base::Vector3d>(ePt);
@@ -823,7 +823,7 @@ AOC::AOC(Base::Vector3d c, double r, double sAng, double eAng) : Circle()
     circle.SetRadius(r);
 
     Handle(Geom_Circle) hCircle = new Geom_Circle (circle);
-    BRepBuilderAPI_MakeEdge aMakeEdge(hCircle, sAng*(M_PI/180), eAng*(M_PI/180));
+    BRepBuilderAPI_MakeEdge aMakeEdge(hCircle, sAng*(std::numbers::pi/180), eAng*(std::numbers::pi/180));
     TopoDS_Edge edge = aMakeEdge.Edge();
     occEdge = edge;
 
@@ -844,10 +844,10 @@ AOC::AOC(Base::Vector3d c, double r, double sAng, double eAng) : Circle()
     // this cw flag is a problem.  we should just declare that arcs are always ccw and flip the start and end angles.
     double a = v3.DotCross(v1, v2);    //error if v1 = v2?
 
-    startAngle = fmod(f, 2.0*M_PI);
-    endAngle = fmod(l, 2.0*M_PI);
+    startAngle = fmod(f, 2.0*std::numbers::pi);
+    endAngle = fmod(l, 2.0*std::numbers::pi);
     cw = (a < 0) ? true: false;
-    largeArc = (fabs(l-f) > M_PI) ? true : false;
+    largeArc = (fabs(l-f) > std::numbers::pi) ? true : false;
 
     startPnt = Base::convertTo<Base::Vector3d>(s);
     endPnt = Base::convertTo<Base::Vector3d>(ePt);
@@ -866,7 +866,7 @@ AOC::AOC() : Circle()
     endPnt = Base::Vector3d(0.0, 0.0, 0.0);
     midPnt = Base::Vector3d(0.0, 0.0, 0.0);
     startAngle = 0.0;
-    endAngle = 2.0 * M_PI;
+    endAngle = 2.0 * std::numbers::pi;
     cw = false;
     largeArc = false;
 
@@ -1095,7 +1095,7 @@ double Generic::slope()
 {
     Base::Vector3d v = asVector();
     if (v.x == 0.0) {
-        return DOUBLE_MAX;
+        return std::numeric_limits<double>::max();
     } else {
         return v.y/v.x;
     }
@@ -1146,11 +1146,11 @@ BSpline::BSpline(const TopoDS_Edge &e)
 
     startAngle = atan2(startPnt.y, startPnt.x);
     if (startAngle < 0) {
-         startAngle += 2.0 * M_PI;
+         startAngle += 2.0 * std::numbers::pi;
     }
     endAngle = atan2(endPnt.y, endPnt.x);
     if (endAngle < 0) {
-         endAngle += 2.0 * M_PI;
+         endAngle += 2.0 * std::numbers::pi;
     }
 
     Standard_Real tol3D = 0.001;                                   //1/1000 of a mm? screen can't resolve this
@@ -1473,7 +1473,7 @@ TopoDS_Edge GeometryUtils::edgeFromCircle(TechDraw::CirclePtr c)
     circle.SetAxis(axis);
     circle.SetRadius(c->radius);
     Handle(Geom_Circle) hCircle = new Geom_Circle (circle);
-    BRepBuilderAPI_MakeEdge aMakeEdge(hCircle, 0.0, 2.0 * M_PI);
+    BRepBuilderAPI_MakeEdge aMakeEdge(hCircle, 0.0, 2.0 * std::numbers::pi);
     return aMakeEdge.Edge();
 }
 

--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -759,24 +759,24 @@ TechDraw::DrawViewDetail* GeometryObject::isParentDetail()
 
 bool GeometryObject::isWithinArc(double theta, double first, double last, bool cw) const
 {
-    if (fabs(last - first) >= 2 * M_PI) {
+    if (fabs(last - first) >= 2 * std::numbers::pi) {
         return true;
     }
 
     // Put params within [0, 2*pi) - not totally sure this is necessary
-    theta = fmod(theta, 2 * M_PI);
+    theta = fmod(theta, 2 * std::numbers::pi);
     if (theta < 0) {
-        theta += 2 * M_PI;
+        theta += 2 * std::numbers::pi;
     }
 
-    first = fmod(first, 2 * M_PI);
+    first = fmod(first, 2 * std::numbers::pi);
     if (first < 0) {
-        first += 2 * M_PI;
+        first += 2 * std::numbers::pi;
     }
 
-    last = fmod(last, 2 * M_PI);
+    last = fmod(last, 2 * std::numbers::pi);
     if (last < 0) {
-        last += 2 * M_PI;
+        last += 2 * std::numbers::pi;
     }
 
     if (cw) {

--- a/src/Mod/TechDraw/App/HatchLine.cpp
+++ b/src/Mod/TechDraw/App/HatchLine.cpp
@@ -396,7 +396,7 @@ double PATLineSpec::getSlope()
     } else if (angle < -90.0) {
         angle = (180 + angle);
     }
-    return tan(angle * M_PI/180.0);
+    return tan(angle * std::numbers::pi/180.0);
 }
 
 bool PATLineSpec::isDashed()
@@ -413,7 +413,7 @@ double PATLineSpec::getIntervalX()
         return getInterval();
     } else {
         double perpAngle = fabs(getAngle() - 90.0);
-        return fabs(getInterval() / cos(perpAngle * M_PI/180.0));
+        return fabs(getInterval() / cos(perpAngle * std::numbers::pi/180.0));
     }
 }
 
@@ -426,7 +426,7 @@ double PATLineSpec::getIntervalY()
         return 0.0;
     } else {
         double perpAngle = fabs(getAngle() - 90.0);
-        return fabs(getInterval() * tan(perpAngle * M_PI/180.0));
+        return fabs(getInterval() * tan(perpAngle * std::numbers::pi/180.0));
     }
 }
 

--- a/src/Mod/TechDraw/App/PreCompiled.h
+++ b/src/Mod/TechDraw/App/PreCompiled.h
@@ -40,6 +40,7 @@
 #include <iostream>
 #include <limits>
 #include <map>
+#include <numbers>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/Mod/TechDraw/App/ShapeUtils.cpp
+++ b/src/Mod/TechDraw/App/ShapeUtils.cpp
@@ -273,7 +273,7 @@ TopoDS_Shape ShapeUtils::rotateShape(const TopoDS_Shape& input, const gp_Ax2& vi
     }
 
     gp_Ax1 rotAxis = viewAxis.Axis();
-    double rotation = rotAngle * M_PI / 180.0;
+    double rotation = rotAngle * std::numbers::pi / 180.0;
 
     try {
         gp_Trsf tempTransform;

--- a/src/Mod/TechDraw/App/TechDrawExport.cpp
+++ b/src/Mod/TechDraw/App/TechDrawExport.cpp
@@ -220,7 +220,7 @@ void SVGOutput::printCircle(const BRepAdaptor_Curve& c, std::ostream& out)
     else {
         // See also https://developer.mozilla.org/en/SVG/Tutorial/Paths
         char xar = '0'; // x-axis-rotation
-        char las = (l-f > M_PI) ? '1' : '0'; // large-arc-flag
+        char las = (l-f > std::numbers::pi) ? '1' : '0'; // large-arc-flag
         char swp = (a < 0) ? '1' : '0'; // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
         out << "<path d=\"M" << s.X() <<  " " << s.Y()
             << " A" << r << " " << r << " "
@@ -267,7 +267,7 @@ void SVGOutput::printEllipse(const BRepAdaptor_Curve& c, int id, std::ostream& o
     }
     // arc of ellipse
     else {
-        char las = (l-f > M_PI) ? '1' : '0'; // large-arc-flag
+        char las = (l-f > std::numbers::pi) ? '1' : '0'; // large-arc-flag
         char swp = (a < 0) ? '1' : '0'; // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
         out << "<path d=\"M" << s.X() <<  " " << s.Y()
             << " A" << r1 << " " << r2 << " "
@@ -521,7 +521,7 @@ void DXFOutput::printCircle(const BRepAdaptor_Curve& c, std::ostream& out)
     else {
         // See also https://developer.mozilla.org/en/SVG/Tutorial/Paths
         /*char xar = '0'; // x-axis-rotation
-        char las = (l-f > M_PI) ? '1' : '0'; // large-arc-flag
+        char las = (l-f > std::numbers::pi) ? '1' : '0'; // large-arc-flag
         char swp = (a < 0) ? '1' : '0'; // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
         out << "<path d=\"M" << s.X() <<  " " << s.Y()
             << " A" << r << " " << r << " "
@@ -532,8 +532,8 @@ void DXFOutput::printCircle(const BRepAdaptor_Curve& c, std::ostream& out)
 	double bx = e.X() - p.X();
 	double by = e.Y() - p.Y();
 
-	double start_angle = atan2(ay, ax) * 180 / M_PI;
-	double end_angle = atan2(by, bx) * 180 / M_PI;
+	double start_angle = atan2(ay, ax) * 180 / std::numbers::pi;
+	double end_angle = atan2(by, bx) * 180 / std::numbers::pi;
 
 	if (a > 0) {
 		double temp = start_angle;
@@ -583,7 +583,7 @@ void DXFOutput::printEllipse(const BRepAdaptor_Curve& c, int /*id*/, std::ostrea
         gp_Dir xaxis = ellp.XAxis().Direction();
         Standard_Real angle = xaxis.Angle(gp_Dir(1, 0,0));
         angle = Base::toDegrees<double>(angle);
-        char las = (l-f > D_PI) ? '1' : '0'; // large-arc-flag
+        char las = (l-f > std::numbers::pi) ? '1' : '0'; // large-arc-flag
         char swp = (a < 0) ? '1' : '0'; // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
         out << "<path d=\"M" << s.X() <<  " " << s.Y()
             << " A" << r1 << " " << r2 << " "

--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -2050,7 +2050,7 @@ void execCreateHorizChamferDimension(Gui::Command* cmd) {
     std::vector<dimVertex> allVertexes;
     allVertexes = _getVertexInfo(objFeat, subNames);
     if (!allVertexes.empty() && allVertexes.size() > 1) {
-        const auto Pi180 = 180.0 / M_PI;
+        const auto Pi180 = 180.0 / std::numbers::pi;
         TechDraw::DrawViewDimension* dim;
         dim = _createLinDimension(objFeat, allVertexes[0].name, allVertexes[1].name, "DistanceX");
         float yMax = std::max(abs(allVertexes[0].point.y), abs(allVertexes[1].point.y)) + 7.0;
@@ -2119,7 +2119,7 @@ void execCreateVertChamferDimension(Gui::Command* cmd) {
     std::vector<dimVertex> allVertexes;
     allVertexes = _getVertexInfo(objFeat, subNames);
     if (!allVertexes.empty() && allVertexes.size() > 1) {
-        const auto Pi180 = 180.0 / M_PI;
+        const auto Pi180 = 180.0 / std::numbers::pi;
         TechDraw::DrawViewDimension* dim;
         dim = _createLinDimension(objFeat, allVertexes[0].name, allVertexes[1].name, "DistanceY");
         float xMax = std::max(abs(allVertexes[0].point.x), abs(allVertexes[1].point.x)) + 7.0;

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -2099,7 +2099,7 @@ double _getAngle(Base::Vector3d center, Base::Vector3d point)
 {
     constexpr double DegreesHalfCircle{180.0};
     Base::Vector3d vecCP = point - center;
-    double angle = DU::angleWithX(vecCP) * DegreesHalfCircle / M_PI;
+    double angle = DU::angleWithX(vecCP) * DegreesHalfCircle / std::numbers::pi;
     return angle;
 }
 

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -832,7 +832,7 @@ void DrawGuiUtil::rotateToAlign(DrawViewPart* view, const Base::Vector2d& oldDir
 
     double toRotate = newDirection.GetAngle(oldDirection);
     // Radians to degrees
-    toRotate = toRotate * 180 / M_PI;
+    toRotate = toRotate * 180 / std::numbers::pi;
 
     // Rotate least amount possible
     if(toRotate > 90) {

--- a/src/Mod/TechDraw/Gui/PathBuilder.cpp
+++ b/src/Mod/TechDraw/Gui/PathBuilder.cpp
@@ -327,11 +327,11 @@ void PathBuilder::pathArc(QPainterPath& path, double rx, double ry, double x_axi
 
     th_arc = th1 - th0;
     if (th_arc < 0 && sweep_flag)
-        th_arc += 2 * M_PI;
+        th_arc += 2 * std::numbers::pi;
     else if (th_arc > 0 && !sweep_flag)
-        th_arc -= 2 * M_PI;
+        th_arc -= 2 * std::numbers::pi;
 
-    n_segs = qCeil(qAbs(th_arc / (M_PI * 0.5 + 0.001)));
+    n_segs = qCeil(qAbs(th_arc / (std::numbers::pi * 0.5 + 0.001)));
 
     path.moveTo(curx, cury);
 

--- a/src/Mod/TechDraw/Gui/PreCompiled.h
+++ b/src/Mod/TechDraw/Gui/PreCompiled.h
@@ -40,12 +40,13 @@
 // standard
 #include <cassert>
 #include <cmath>
-#include <iostream>
-#include <sstream>
 
 // STL
 #include <algorithm>
+#include <iostream>
+#include <numbers>
 #include <regex>
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/src/Mod/TechDraw/Gui/QGIHighlight.cpp
+++ b/src/Mod/TechDraw/Gui/QGIHighlight.cpp
@@ -125,7 +125,7 @@ void QGIHighlight::makeReference()
     QRectF r(m_start, m_end);
     double radius = r.width() / 2.0;
     QPointF center = r.center();
-    double angleRad = m_referenceAngle * M_PI / 180.0;
+    double angleRad = m_referenceAngle * std::numbers::pi / 180.0;
     double posX = center.x() + cos(angleRad) * radius + horizOffset;
     double posY = center.y() - sin(angleRad) * radius - vertOffset;
     m_reference->setPos(posX, posY);

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
@@ -589,7 +589,7 @@ Base::Vector3d  QGILeaderLine::getAttachPoint()
     double yPos = Rez::guiX(featLeader->Y.getValue());
     Base::Vector3d vAttachPoint{xPos, yPos};
     vAttachPoint = vAttachPoint * baseScale;
-    double rotationRad = parent->Rotation.getValue() * M_PI / DegreesHalfCircle;
+    double rotationRad = parent->Rotation.getValue() * std::numbers::pi / DegreesHalfCircle;
     if (rotationRad != 0.0) {
         vAttachPoint.RotateZ(rotationRad);
     }

--- a/src/Mod/TechDraw/Gui/QGISectionLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.cpp
@@ -402,9 +402,9 @@ double QGISectionLine::getArrowRotation(Base::Vector3d arrowDir)
     arrowDir.Normalize();
     double angle = atan2f(arrowDir.y, arrowDir.x);
     if (angle < 0.0) {
-        angle = 2 * M_PI + angle;
+        angle = 2 * std::numbers::pi + angle;
     }
-    double arrowRotation = 360.0 - angle * (180.0/M_PI);   //convert to Qt rotation (clockwise degrees)
+    double arrowRotation = 360.0 - angle * (180.0/std::numbers::pi);   //convert to Qt rotation (clockwise degrees)
     return arrowRotation;
 }
 

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -696,14 +696,14 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
         double radius = sqrt(pow((textHeight / 2.0), 2) + pow((textWidth / 2.0), 2));
         radius = radius * scale;
         radius += Rez::guiX(3.0);
-        offsetLR = (tan(30 * M_PI / 180) * radius);
+        offsetLR = (tan(30 * std::numbers::pi / 180) * radius);
         QPolygonF triangle;
-        double startAngle = -M_PI / 2;
+        double startAngle = -std::numbers::pi / 2;
         double angle = startAngle;
         for (int i = 0; i < 4; i++) {
             triangle +=
                 QPointF(lblCenter.x + (radius * cos(angle)), lblCenter.y + (radius * sin(angle)));
-            angle += (2 * M_PI / 3);
+            angle += (2 * std::numbers::pi / 3);
         }
         balloonPath.moveTo(lblCenter.x + (radius * cos(startAngle)),
                            lblCenter.y + (radius * sin(startAngle)));
@@ -737,12 +737,12 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
         radius += Rez::guiX(1.0);
         offsetLR = radius;
         QPolygonF triangle;
-        double startAngle = -2 * M_PI / 3;
+        double startAngle = -2 * std::numbers::pi / 3;
         double angle = startAngle;
         for (int i = 0; i < 7; i++) {
             triangle +=
                 QPointF(lblCenter.x + (radius * cos(angle)), lblCenter.y + (radius * sin(angle)));
-            angle += (2 * M_PI / 6);
+            angle += (2 * std::numbers::pi / 6);
         }
         balloonPath.moveTo(lblCenter.x + (radius * cos(startAngle)),
                            lblCenter.y + (radius * sin(startAngle)));
@@ -805,7 +805,7 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
             dirballoonLinesLine = (arrowTipPosInParent - dLineStart).Normalize();
         }
 
-        float arAngle = atan2(dirballoonLinesLine.y, dirballoonLinesLine.x) * 180 / M_PI;
+        float arAngle = atan2(dirballoonLinesLine.y, dirballoonLinesLine.x) * 180 / std::numbers::pi;
 
         if ((endType == ArrowType::FILLED_TRIANGLE) && (prefOrthoPyramid())) {
             if (arAngle < 0.0) {
@@ -824,7 +824,7 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
             else {
                 arAngle = 0;
             }
-            double radAngle = arAngle * M_PI / 180.0;
+            double radAngle = arAngle * std::numbers::pi / 180.0;
             double sinAngle = sin(radAngle);
             double cosAngle = cos(radAngle);
             xAdj = Rez::guiX(arrowAdj * cosAngle);

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -22,13 +22,7 @@
 
 #include "PreCompiled.h"
 
-#ifdef FC_OS_WIN32
-# define _USE_MATH_DEFINES //resolves Windows & M_PI issues
-#endif
-
 #ifndef _PreComp_
-# include <cmath>
-
 # include <QApplication>
 # include <QGraphicsRectItem>
 # include <QGraphicsScene>
@@ -443,7 +437,7 @@ double QGIViewDimension::getAnglePlacementFactor(double testAngle, double endAng
     if (startRotation > 0.0) {
         startRotation = -startRotation;
         endAngle -= startRotation;
-        if (endAngle > M_PI) {
+        if (endAngle > std::numbers::pi) {
             endAngle -= M_2PI;
         }
     }
@@ -456,7 +450,7 @@ double QGIViewDimension::getAnglePlacementFactor(double testAngle, double endAng
         return +1.0;
     }
 
-    testAngle += M_PI;
+    testAngle += std::numbers::pi;
     if (testAngle > endAngle) {
         testAngle -= M_2PI;
     }
@@ -472,7 +466,7 @@ int QGIViewDimension::compareAngleStraightness(double straightAngle, double left
                                                double rightAngle, double leftStrikeFactor,
                                                double rightStrikeFactor)
 {
-    double leftDelta = DrawUtil::angleComposition(M_PI, straightAngle - leftAngle);
+    double leftDelta = DrawUtil::angleComposition(std::numbers::pi, straightAngle - leftAngle);
     double rightDelta = DrawUtil::angleComposition(rightAngle, -straightAngle);
 
     if (fabs(leftDelta - rightDelta) <= Precision::Confusion()) {
@@ -492,7 +486,7 @@ int QGIViewDimension::compareAngleStraightness(double straightAngle, double left
 double QGIViewDimension::getIsoStandardLinePlacement(double labelAngle)
 {
     // According to ISO 129-1 Standard Figure 23, the bordering angle is 1/2 PI, resp. -1/2 PI
-    return labelAngle < -M_PI / 2.0 || labelAngle > +M_PI / 2.0 ? +1.0 : -1.0;
+    return labelAngle < -std::numbers::pi / 2.0 || labelAngle > +std::numbers::pi / 2.0 ? +1.0 : -1.0;
 }
 
 Base::Vector2d QGIViewDimension::getIsoRefOutsetPoint(const Base::BoundBox2d& labelRectangle,
@@ -599,7 +593,7 @@ double QGIViewDimension::computeLineAndLabelAngles(const Base::Vector2d& rotatio
     double devAngle = getIsoStandardLinePlacement(rawAngle) * asin(lineLabelDistance / rawDistance);
     lineAngle = DrawUtil::angleComposition(lineAngle, devAngle);
 
-    labelAngle = devAngle < 0.0 ? lineAngle : DrawUtil::angleComposition(lineAngle, M_PI);
+    labelAngle = devAngle < 0.0 ? lineAngle : DrawUtil::angleComposition(lineAngle, std::numbers::pi);
 
     return devAngle;
 }
@@ -689,7 +683,7 @@ double QGIViewDimension::normalizeStartPosition(double& startPosition, double& l
 {
     if (startPosition > 0.0) {
         startPosition = -startPosition;
-        lineAngle += M_PI;
+        lineAngle += std::numbers::pi;
         return -1.0;
     }
 
@@ -872,7 +866,7 @@ bool QGIViewDimension::constructDimensionArc(
 
     // Add the arrow tails - these are drawn always
     double tailDelta =
-        arcRadius >= Precision::Confusion() ? getDefaultArrowTailLength() / arcRadius : M_PI_4;
+        arcRadius >= Precision::Confusion() ? getDefaultArrowTailLength() / arcRadius : std::numbers::pi/4.0;
     double placementFactor = flipArrows ? +1.0 : -1.0;
 
     DrawUtil::intervalMarkCircular(outputMarking, endAngle,
@@ -1067,7 +1061,7 @@ void QGIViewDimension::drawDimensionLine(QPainterPath& painterPath,
 
     double arrowAngles[2];
     arrowAngles[0] = lineAngle;
-    arrowAngles[1] = lineAngle + M_PI;
+    arrowAngles[1] = lineAngle + std::numbers::pi;
 
     drawArrows(arrowCount, arrowPositions, arrowAngles, flipArrows, forcePointStyle);
 }
@@ -1082,7 +1076,7 @@ void QGIViewDimension::drawDimensionArc(QPainterPath& painterPath, const Base::V
 
     // Split the rest of 2PI minus the angle and assign joint offset so > 0 is closer to end arc side
     double jointRotation = handednessFactor * (jointAngle - endAngle);
-    if (fabs(jointRotation - startRotation * 0.5) > M_PI) {
+    if (fabs(jointRotation - startRotation * 0.5) > std::numbers::pi) {
         jointRotation += jointRotation < 0.0 ? +M_2PI : -M_2PI;
     }
 
@@ -1099,8 +1093,8 @@ void QGIViewDimension::drawDimensionArc(QPainterPath& painterPath, const Base::V
         + Base::Vector2d::FromPolar(arcRadius, endAngle + handednessFactor * startRotation);
 
     double arrowAngles[2];
-    arrowAngles[0] = endAngle + handednessFactor * M_PI_2;
-    arrowAngles[1] = endAngle + handednessFactor * (startRotation - M_PI_2);
+    arrowAngles[0] = endAngle + handednessFactor * std::numbers::pi/2.0;
+    arrowAngles[1] = endAngle + handednessFactor * (startRotation - std::numbers::pi/2.0);
 
     drawArrows(arrowCount, arrowPositions, arrowAngles, flipArrows);
 }
@@ -1170,9 +1164,9 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d& startPoint,
         // Orient the leader line angle correctly towards the target point
         double angles[2];
         angles[0] =
-            jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
+            jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngle, std::numbers::pi) : lineAngle;
         angles[1] =
-            jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
+            jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngle, std::numbers::pi) : lineAngle;
 
         // Select the placement, where the label is not obscured by the leader line
         // or (if both behave the same) the one that  bends the reference line less
@@ -1226,7 +1220,7 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d& startPoint,
         // We may rotate the label so no leader and reference lines are needed
         double placementFactor = getIsoStandardLinePlacement(lineAngle);
         labelAngle =
-            placementFactor > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
+            placementFactor > 0.0 ? DrawUtil::angleComposition(lineAngle, std::numbers::pi) : lineAngle;
 
         // Find out the projection of label center on the line with given angle
         Base::Vector2d labelProjection(
@@ -1234,7 +1228,7 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d& startPoint,
             + Base::Vector2d::FromPolar(
                 placementFactor
                     * (labelRectangle.Height() * 0.5 + getIsoDimensionLineSpacing()),
-                lineAngle + M_PI_2));
+                lineAngle + std::numbers::pi/2.0));
 
         // Compute the dimensional line start and end crossings with (virtual) extension lines
         //check for isometric direction and if iso compute non-perpendicular intersection of dim line and ext lines
@@ -1288,14 +1282,14 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d& startPoint,
 
         Base::Vector2d extensionOrigin;
         Base::Vector2d extensionTarget(computeExtensionLinePoints(
-            endPoint, endCross, lineAngle + M_PI_2, getDefaultExtensionLineOverhang(), gapSize,
+            endPoint, endCross, lineAngle + std::numbers::pi/2.0, getDefaultExtensionLineOverhang(), gapSize,
             extensionOrigin));
         //draw 1st extension line
         distancePath.moveTo(toQtGui(extensionOrigin));
         distancePath.lineTo(toQtGui(extensionTarget));
 
         if (arrowCount > 1) {
-            extensionTarget = computeExtensionLinePoints(startPoint, startCross, lineAngle + M_PI_2,
+            extensionTarget = computeExtensionLinePoints(startPoint, startCross, lineAngle + std::numbers::pi/2.0,
                                                          getDefaultExtensionLineOverhang(), gapSize,
                                                          extensionOrigin);
             //draw second extension line
@@ -1377,9 +1371,9 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d& startPoint,
         // Orient the leader line angle correctly towards the target point
         double angles[2];
         angles[0] =
-            jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
+            jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngle, std::numbers::pi) : lineAngle;
         angles[1] =
-            jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
+            jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngle, std::numbers::pi) : lineAngle;
 
         // Select the placement, where the label is not obscured by the leader line
         // or (if both behave the same) the one that  bends the reference line less
@@ -1436,7 +1430,7 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d& startPoint,
         // We may rotate the label so no leader and reference lines are needed
         double placementFactor = getIsoStandardLinePlacement(lineAngle);
         labelAngle =
-            placementFactor > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
+            placementFactor > 0.0 ? DrawUtil::angleComposition(lineAngle, std::numbers::pi) : lineAngle;
 
         // Find out the projection of label center on the line with given angle
         Base::Vector2d labelProjection(
@@ -1444,7 +1438,7 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d& startPoint,
             + Base::Vector2d::FromPolar(
                 placementFactor
                     * (labelRectangle.Height() * 0.5 + getIsoDimensionLineSpacing()),
-                lineAngle + M_PI_2));
+                lineAngle + std::numbers::pi/2.0));
 
         // Compute the dimensional line start and end crossings with (virtual) extension lines
         startCross =
@@ -1499,14 +1493,14 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d& startPoint,
 
         Base::Vector2d extensionOrigin;
         Base::Vector2d extensionTarget(computeExtensionLinePoints(
-            endPoint, endCross, lineAngle + M_PI_2, getDefaultExtensionLineOverhang(), gapSize,
+            endPoint, endCross, lineAngle + std::numbers::pi/2.0, getDefaultExtensionLineOverhang(), gapSize,
             extensionOrigin));
         //draw 1st extension line
         distancePath.moveTo(toQtGui(extensionOrigin));
         distancePath.lineTo(toQtGui(extensionTarget));
 
         if (arrowCount > 1) {
-            extensionTarget = computeExtensionLinePoints(startPoint, startCross, lineAngle + M_PI_2,
+            extensionTarget = computeExtensionLinePoints(startPoint, startCross, lineAngle + std::numbers::pi/2.0,
                                                          getDefaultExtensionLineOverhang(), gapSize,
                                                          extensionOrigin);
             //draw second extension line
@@ -1558,10 +1552,10 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d& centerPoint,
 
         // Orient the leader line angle correctly towards the point on arc
         if (angleFactors[0] < 0.0) {
-            lineAngles[0] = DrawUtil::angleComposition(lineAngles[0], M_PI);
+            lineAngles[0] = DrawUtil::angleComposition(lineAngles[0], std::numbers::pi);
         }
         if (angleFactors[1] < 0.0) {
-            lineAngles[1] = DrawUtil::angleComposition(lineAngles[1], M_PI);
+            lineAngles[1] = DrawUtil::angleComposition(lineAngles[1], std::numbers::pi);
         }
 
         // Find the positions where the reference line attaches to the dimension line
@@ -1600,9 +1594,9 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d& centerPoint,
 
                 if (compareAngleStraightness(
                         0.0,
-                        jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngles[0], M_PI)
+                        jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngles[0], std::numbers::pi)
                                                 : lineAngles[0],
-                        jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngles[1], M_PI)
+                        jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngles[1], std::numbers::pi)
                                                 : lineAngles[1],
                         strikeFactors[0], strikeFactors[1])
                     > 0) {
@@ -1653,7 +1647,7 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d& centerPoint,
         // Is there point on the arc, where line from center intersects it perpendicularly?
         double angleFactor = getAnglePlacementFactor(lineAngle, endAngle, startRotation);
         if (angleFactor < 0.0) {
-            lineAngle = DrawUtil::angleComposition(lineAngle, M_PI);
+            lineAngle = DrawUtil::angleComposition(lineAngle, std::numbers::pi);
         }
 
         Base::Vector2d arcPoint;
@@ -1673,7 +1667,7 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d& centerPoint,
                                                  labelRectangle.Height() * 0.5
                                                      + getIsoDimensionLineSpacing(),
                                                  lineAngle, labelAngle);
-            lineAngle = DrawUtil::angleComposition(lineAngle, M_PI);
+            lineAngle = DrawUtil::angleComposition(lineAngle, std::numbers::pi);
 
             labelPosition = -cos(devAngle) * ((labelCenter - arcPoint).Length());
         }
@@ -1693,7 +1687,7 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d& centerPoint,
         // Is there point on the arc, where line from center intersects it perpendicularly?
         double angleFactor = getAnglePlacementFactor(lineAngle, endAngle, startRotation);
         if (angleFactor < 0) {
-            lineAngle = DrawUtil::angleComposition(lineAngle, M_PI);
+            lineAngle = DrawUtil::angleComposition(lineAngle, std::numbers::pi);
         }
 
         Base::Vector2d arcPoint;
@@ -1779,7 +1773,7 @@ void QGIViewDimension::drawAreaExecutive(const Base::Vector2d& centerPoint, doub
                                             labelRectangle.Height() * 0.5 + getIsoDimensionLineSpacing(),
                                             lineAngle, labelAngle);
 
-        lineAngle = lineAngle - M_PI;
+        lineAngle = lineAngle - std::numbers::pi;
         double labelPosition = -cos(devAngle) * ((labelCenter - centerPoint).Length());
 
         drawDimensionLine(areaPath, centerPoint, lineAngle, 0.0, labelPosition, labelRectangle, 1, standardStyle, flipArrow, forcePointStyle);
@@ -1818,7 +1812,7 @@ void QGIViewDimension::drawDistance(TechDraw::DrawViewDimension* dimension,
         lineAngle = 0.0;
     }
     else if (strcmp(dimensionType, "DistanceY") == 0) {
-        lineAngle = M_PI_2;
+        lineAngle = std::numbers::pi/2.0;
     }
     else {
         lineAngle = (fromQtApp(linePoints.second()) - fromQtApp(linePoints.first())).Angle();
@@ -1831,9 +1825,9 @@ void QGIViewDimension::drawDistance(TechDraw::DrawViewDimension* dimension,
 
     if (dimension->AngleOverride.getValue()) {
         drawDistanceOverride(fromQtApp(linePoints.first()), fromQtApp(linePoints.second()),
-                             dimension->LineAngle.getValue() * M_PI / 180.0, labelRectangle,
+                             dimension->LineAngle.getValue() * std::numbers::pi / 180.0, labelRectangle,
                              standardStyle, renderExtent, flipArrows,
-                             dimension->ExtensionAngle.getValue() * M_PI / 180.0);
+                             dimension->ExtensionAngle.getValue() * std::numbers::pi / 180.0);
     }
     else {
         drawDistanceExecutive(fromQtApp(linePoints.extensionLineFirst()), fromQtApp(linePoints.extensionLineSecond()),
@@ -1862,7 +1856,7 @@ void QGIViewDimension::drawRadius(TechDraw::DrawViewDimension* dimension,
         }
     }
     else {// A circle arc covers the whole plane
-        endAngle = M_PI;
+        endAngle = std::numbers::pi;
         startRotation = -M_2PI;
     }
 
@@ -1941,9 +1935,9 @@ void QGIViewDimension::drawDiameter(TechDraw::DrawViewDimension* dimension,
             int selected = 0;
             if (compareAngleStraightness(
                     0.0,
-                    jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngles[0], M_PI)
+                    jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngles[0], std::numbers::pi)
                                             : lineAngles[0],
-                    jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngles[1], M_PI)
+                    jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngles[1], std::numbers::pi)
                                             : lineAngles[1],
                     strikeFactors[0], strikeFactors[1])
                 > 0) {
@@ -2006,8 +2000,8 @@ void QGIViewDimension::drawDiameter(TechDraw::DrawViewDimension* dimension,
         Base::Vector2d startPoint(curveCenter);
         Base::Vector2d endPoint(curveCenter);
 
-        if ((lineAngle >= M_PI_4 && lineAngle <= 3.0 * M_PI_4)
-            || (lineAngle <= -M_PI_4 && lineAngle >= -3.0 * M_PI_4)) {
+        if ((lineAngle >= std::numbers::pi/4.0 && lineAngle <= 3.0 * std::numbers::pi/4.0)
+            || (lineAngle <= -std::numbers::pi/4.0 && lineAngle >= -3.0 * std::numbers::pi/4.0)) {
             // Horizontal dimension line
             startPoint.x -= curveRadius;
             endPoint.x += curveRadius;
@@ -2016,10 +2010,10 @@ void QGIViewDimension::drawDiameter(TechDraw::DrawViewDimension* dimension,
         else {// Vertical dimension line
             startPoint.y -= curveRadius;
             endPoint.y += curveRadius;
-            lineAngle = M_PI_2;
+            lineAngle = std::numbers::pi/2.0;
         }
 
-        //        lineAngle = DrawUtil::angleComposition((labelCenter - curveCenter).Angle(), +M_PI_2);
+        //        lineAngle = DrawUtil::angleComposition((labelCenter - curveCenter).Angle(), +std::numbers::pi/2.0);
         //        startPoint = curveCenter - Base::Vector2d::FromPolar(curveRadius, lineAngle);
         //        endPoint = curveCenter + Base::Vector2d::FromPolar(curveRadius, lineAngle);
 
@@ -2031,7 +2025,7 @@ void QGIViewDimension::drawDiameter(TechDraw::DrawViewDimension* dimension,
             ? ViewProviderDimension::REND_EXTENT_REDUCED
             : ViewProviderDimension::REND_EXTENT_NORMAL;
 
-        drawRadiusExecutive(curveCenter, Rez::guiX(curvePoints.midArc, true), curveRadius, M_PI,
+        drawRadiusExecutive(curveCenter, Rez::guiX(curvePoints.midArc, true), curveRadius, std::numbers::pi,
                             -M_2PI, labelRectangle, getDefaultExtensionLineOverhang(),
                             standardStyle, renderExtent, flipArrows);
     }
@@ -2105,10 +2099,10 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension* dimension,
         jointRotations[1] = handednessFactor * (jointAngles[1] - endAngle);
 
         // Compare the offset with half of the rest of 2PI minus the angle and eventually fix the values
-        if (fabs(jointRotations[0] - startRotation * 0.5) > M_PI) {
+        if (fabs(jointRotations[0] - startRotation * 0.5) > std::numbers::pi) {
             jointRotations[0] += jointRotations[0] < 0.0 ? +M_2PI : -M_2PI;
         }
-        if (fabs(jointRotations[1] - startRotation * 0.5) > M_PI) {
+        if (fabs(jointRotations[1] - startRotation * 0.5) > std::numbers::pi) {
             jointRotations[1] += jointRotations[1] < 0.0 ? +M_2PI : -M_2PI;
         }
 
@@ -2133,9 +2127,9 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension* dimension,
         if (compareAngleStraightness(
                 0.0,
                 DrawUtil::angleComposition(
-                    jointAngles[0], handednessFactor * jointRotations[0] > 0.0 ? -M_PI_2 : +M_PI_2),
+                    jointAngles[0], handednessFactor * jointRotations[0] > 0.0 ? -std::numbers::pi/2.0 : +std::numbers::pi/2.0),
                 DrawUtil::angleComposition(
-                    jointAngles[1], handednessFactor * jointRotations[1] > 0.0 ? -M_PI_2 : +M_PI_2),
+                    jointAngles[1], handednessFactor * jointRotations[1] > 0.0 ? -std::numbers::pi/2.0 : +std::numbers::pi/2.0),
                 strikeFactors[0], strikeFactors[1])
             > 0) {
             selected = 1;
@@ -2160,10 +2154,10 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension* dimension,
         Base::Vector2d labelDirection(labelCenter - angleVertex);
         double radiusAngle = labelDirection.Angle();
 
-        labelAngle = DrawUtil::angleComposition(radiusAngle, M_PI_2);
+        labelAngle = DrawUtil::angleComposition(radiusAngle, std::numbers::pi/2.0);
         double placementFactor = getIsoStandardLinePlacement(labelAngle);
         labelAngle =
-            placementFactor > 0.0 ? DrawUtil::angleComposition(labelAngle, M_PI) : labelAngle;
+            placementFactor > 0.0 ? DrawUtil::angleComposition(labelAngle, std::numbers::pi) : labelAngle;
 
         arcRadius = labelDirection.Length()
             - placementFactor
@@ -2454,11 +2448,11 @@ void QGIViewDimension::setPens()
     aHead2->setWidth(m_lineWidth);
 }
 
-double QGIViewDimension::toDeg(double angle) { return angle * 180 / M_PI; }
+double QGIViewDimension::toDeg(double angle) { return angle * 180 / std::numbers::pi; }
 
 double QGIViewDimension::toQtRad(double angle) { return -angle; }
 
-double QGIViewDimension::toQtDeg(double angle) { return -angle * 180.0 / M_PI; }
+double QGIViewDimension::toQtDeg(double angle) { return -angle * 180.0 / std::numbers::pi; }
 
 void QGIViewDimension::makeMarkC(double xPos, double yPos, QColor color) const
 {

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -964,7 +964,7 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
         highlight->setPos(0.0, 0.0);//sb setPos(center.x, center.y)?
 
         Base::Vector3d center = viewDetail->AnchorPoint.getValue() * viewPart->getScale();
-        double rotationRad = viewPart->Rotation.getValue() * M_PI / 180.0;
+        double rotationRad = viewPart->Rotation.getValue() * std::numbers::pi / 180.0;
         center.RotateZ(rotationRad);
 
         double radius = viewDetail->Radius.getValue() * viewPart->getScale();

--- a/src/Mod/TechDraw/Gui/QGIWeldSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/QGIWeldSymbol.cpp
@@ -549,7 +549,7 @@ std::pair<Base::Vector3d, Base::Vector3d> QGIWeldSymbol::getLocalAxes()
 {
     auto localX = getLeader()->lastSegmentDirection();
     auto localY = DU::invertY(localX);
-    localY.RotateZ(M_PI_2);
+    localY.RotateZ(std::numbers::pi/2.0);
     localY.Normalize();
     localY = DU::invertY(localY);
     return {localX, localY};

--- a/src/Mod/TechDraw/Gui/QGTracker.cpp
+++ b/src/Mod/TechDraw/Gui/QGTracker.cpp
@@ -183,7 +183,7 @@ QPointF QGTracker::snapToAngle(QPointF dumbPt)
         return dumbPt;
 
     QPointF result(dumbPt);
-    double angleIncr = M_PI / 8.0;   //15*
+    double angleIncr = std::numbers::pi / 8.0;   //15*
     //mirror last clicked point and event point to get sensible coords
     QPointF last(m_points.back().x(), -m_points.back().y());
     QPointF pt(dumbPt.x(), -dumbPt.y());
@@ -192,7 +192,7 @@ QPointF QGTracker::snapToAngle(QPointF dumbPt)
     QPointF qVec = last - pt;    //vec from end of track to end of tail
     double actual = atan2(-qVec.y(), qVec.x());
     if (actual < 0.0) {
-        actual = (2 * M_PI) + actual;          //map to +ve angle
+        actual = (2 * std::numbers::pi) + actual;          //map to +ve angle
     }
 
     double intPart;

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
@@ -193,7 +193,7 @@ void TaskComplexSection::setUiEdit()
         ui->leBaseView->setText(QString::fromStdString(m_baseView->getNameInDocument()));
         Base::Vector3d projectedViewDirection = m_baseView->projectPoint(sectionNormalVec, false);
         double viewAngle = atan2(-projectedViewDirection.y, -projectedViewDirection.x);
-        m_compass->setDialAngle(viewAngle * 180.0 / M_PI);
+        m_compass->setDialAngle(viewAngle * 180.0 / std::numbers::pi);
         m_viewDirectionWidget->setValueNoNotify(projectedViewDirection * -1.0);
     }
     else {
@@ -308,7 +308,7 @@ void TaskComplexSection::slotViewDirectionChanged(Base::Vector3d newDirection)
     }
     projectedViewDirection.Normalize();
     double viewAngle = atan2(projectedViewDirection.y, projectedViewDirection.x);
-    m_compass->setDialAngle(viewAngle * 180.0 / M_PI);
+    m_compass->setDialAngle(viewAngle * 180.0 / std::numbers::pi);
     checkAll(false);
     applyAligned();
 }
@@ -318,7 +318,7 @@ void TaskComplexSection::slotViewDirectionChanged(Base::Vector3d newDirection)
 void TaskComplexSection::slotChangeAngle(double newAngle)
 {
     //    Base::Console().Message("TCS::slotAngleChanged(%.3f)\n", newAngle);
-    double angleRadians = newAngle * M_PI / 180.0;
+    double angleRadians = newAngle * std::numbers::pi / 180.0;
     double unitX = cos(angleRadians);
     double unitY = sin(angleRadians);
     Base::Vector3d localUnit(unitX, unitY, 0.0);

--- a/src/Mod/TechDraw/Gui/TaskCosmeticLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCosmeticLine.cpp
@@ -113,7 +113,7 @@ void TaskCosmeticLine::setUiPrimary()
     setWindowTitle(QObject::tr("Create Cosmetic Line"));
 
     // double rotDeg = m_partFeat->Rotation.getValue();
-    // double rotRad = rotDeg * M_PI / 180.0;
+    // double rotRad = rotDeg * std::numbers::pi / 180.0;
     Base::Vector3d centroid = m_partFeat->getCurrentCentroid();
     Base::Vector3d p1, p2;
     if (m_is3d.front()) {

--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -372,14 +372,14 @@ void TaskDimension::onDimUseDefaultClicked()
     Base::Vector2d first2(points.first().x, -points.first().y);
     Base::Vector2d second2(points.second().x, -points.second().y);
     double lineAngle = (second2 - first2).Angle();
-    ui->dsbDimAngle->setValue(lineAngle * 180.0 / M_PI);
+    ui->dsbDimAngle->setValue(lineAngle * 180.0 / std::numbers::pi);
 }
 
 void TaskDimension::onDimUseSelectionClicked()
 {
     std::pair<double, bool> result = getAngleFromSelection();
     if (result.second) {
-        ui->dsbDimAngle->setValue(result.first * 180.0 / M_PI);
+        ui->dsbDimAngle->setValue(result.first * 180.0 / std::numbers::pi);
     }
 }
 
@@ -392,13 +392,13 @@ void TaskDimension::onExtUseDefaultClicked()
     Base::Vector2d lineDirection = second2 - first2;
     Base::Vector2d extensionDirection(-lineDirection.y, lineDirection.x);
     double extensionAngle = extensionDirection.Angle();
-    ui->dsbExtAngle->setValue(extensionAngle * 180.0 / M_PI);
+    ui->dsbExtAngle->setValue(extensionAngle * 180.0 / std::numbers::pi);
 }
 void TaskDimension::onExtUseSelectionClicked()
 {
     std::pair<double, bool> result = getAngleFromSelection();
     if (result.second) {
-        ui->dsbExtAngle->setValue(result.first * 180.0 / M_PI);
+        ui->dsbExtAngle->setValue(result.first * 180.0 / std::numbers::pi);
     }
 }
 

--- a/src/Mod/TechDraw/Gui/TaskSectionView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.cpp
@@ -180,7 +180,7 @@ void TaskSectionView::setUiEdit()
     Base::Vector3d projectedViewDirection = m_base->projectPoint(sectionNormalVec, false);
     projectedViewDirection.Normalize();
     double viewAngle = atan2(-projectedViewDirection.y, -projectedViewDirection.x);
-    m_compass->setDialAngle(viewAngle * 180.0 / M_PI);
+    m_compass->setDialAngle(viewAngle * 180.0 / std::numbers::pi);
     m_viewDirectionWidget->setValueNoNotify(sectionNormalVec * -1.0);
 }
 
@@ -272,7 +272,7 @@ void TaskSectionView::slotViewDirectionChanged(Base::Vector3d newDirection)
     Base::Vector3d projectedViewDirection = m_base->projectPoint(newDirection, false);
     projectedViewDirection.Normalize();
     double viewAngle = atan2(projectedViewDirection.y, projectedViewDirection.x);
-    m_compass->setDialAngle(viewAngle * 180.0 / M_PI);
+    m_compass->setDialAngle(viewAngle * 180.0 / std::numbers::pi);
     checkAll(false);
     directionChanged(true);
     applyAligned();
@@ -281,7 +281,7 @@ void TaskSectionView::slotViewDirectionChanged(Base::Vector3d newDirection)
 //the CompassWidget reports that the view direction angle has changed
 void TaskSectionView::slotChangeAngle(double newAngle)
 {
-    double angleRadians = newAngle * M_PI / 180.0;
+    double angleRadians = newAngle * std::numbers::pi / 180.0;
     double unitX = cos(angleRadians);
     double unitY = sin(angleRadians);
     Base::Vector3d localUnit(unitX, unitY, 0.0);

--- a/src/Mod/TechDraw/Gui/ViewProviderCosmeticExtension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderCosmeticExtension.cpp
@@ -22,12 +22,7 @@
 
 
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
-# ifdef _MSC_VER
-#  define _USE_MATH_DEFINES
-#  include <cmath>
-# endif //_MSC_VER
 #endif
 
 #include <Mod/TechDraw/App/CosmeticExtension.h>

--- a/tests/src/Base/Tools.cpp
+++ b/tests/src/Base/Tools.cpp
@@ -39,16 +39,16 @@ TEST(Tools, TestSignum)
 TEST(Tools, TestRadian)
 {
     EXPECT_EQ(Base::toRadians<int>(90), 1);
-    EXPECT_DOUBLE_EQ(Base::toRadians<double>(180), M_PI);
-    EXPECT_DOUBLE_EQ(Base::toRadians<double>(90.0), M_PI / 2.0);
+    EXPECT_DOUBLE_EQ(Base::toRadians<double>(180), std::numbers::pi);
+    EXPECT_DOUBLE_EQ(Base::toRadians<double>(90.0), std::numbers::pi / 2.0);
     EXPECT_DOUBLE_EQ(Base::toRadians<double>(0.0), 0.0);
 }
 
 TEST(Tools, TestDegree)
 {
     EXPECT_EQ(Base::toDegrees<int>(3), 171);
-    EXPECT_DOUBLE_EQ(Base::toDegrees<double>(M_PI), 180.0);
-    EXPECT_DOUBLE_EQ(Base::toDegrees<double>(M_PI / 2.0), 90.0);
+    EXPECT_DOUBLE_EQ(Base::toDegrees<double>(std::numbers::pi), 180.0);
+    EXPECT_DOUBLE_EQ(Base::toDegrees<double>(std::numbers::pi / 2.0), 90.0);
     EXPECT_DOUBLE_EQ(Base::toDegrees<double>(0.0), 0.0);
 }
 

--- a/tests/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -54,8 +54,8 @@ TEST_F(ConstraintsTest, tangentBSplineAndArc)  // NOLINT
     arcEnd.y = &arcEndY;
     arcCenter.x = &arcCenterX;
     arcCenter.y = &arcCenterY;
-    double arcRadius = 5.0, arcStartAngle = 0.0, arcEndAngle = M_PI / 2;
-    double desiredAngle = M_PI;
+    double arcRadius = 5.0, arcStartAngle = 0.0, arcEndAngle = std::numbers::pi / 2;
+    double desiredAngle = std::numbers::pi;
     double bSplineStartX = 0.0, bSplineEndX = 16.0;
     double bSplineStartY = 10.0, bSplineEndY = -10.0;
     GCS::Point bSplineStart, bSplineEnd;


### PR DESCRIPTION
I didn't really intend to do this now, but a couple of these macros were interfering with the compilation of a new version of libE57Format, so I figured it was time. 

The macros in question are mostly `M_PI`, `M_E`, `DBL_MAX`, and `FLT_MAX`, but there were a couple uses of other related macros, and LOTS of internal definitions of these and similar. The goal here is to find and eliminate all of them in our first-party code.

C++20 gives us `std::numbers`, and we already had `std::numeric_limits`. My basic process was to eliminate all instances of `_USE_MATH_DEFINES` (which is what triggers MSVC to add them), delete all the instances I could find of these macros, and then clean up any compilation that then failed. I also got rid of the few uses we had of `boost/math/constants`.

This is draft while I get Linux compilation sorted, but feel free to look through the changes and make sure I didn't screw up