### PR TITLE
BIM: adjust BIM_Classification tooltip

### DIFF
--- a/src/Mod/BIM/Resources/ui/dialogClassification.ui
+++ b/src/Mod/BIM/Resources/ui/dialogClassification.ui
@@ -173,7 +173,7 @@
             </size>
            </property>
            <property name="toolTip">
-            <string>Apply the selected class to selected materials</string>
+            <string>Apply the selected class to selected objects</string>
            </property>
            <property name="text">
             <string>&lt;&lt; Apply to selected</string>


### PR DESCRIPTION
The tooltip changed from:
_Apply the selected class to selected material_
to
_Apply the selected class to selected objects_

to better describe the functionality.

![classification-manager-tooltip](https://github.com/user-attachments/assets/3bc7d1cf-25af-4d74-b179-1f3b5414256e)

