### PR TITLE
Fem: Simplify label in material task panel

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/Material.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/Material.ui
@@ -340,7 +340,10 @@
         <item row="2" column="0">
          <widget class="QLabel" name="label_expansion_reference_temperature">
           <property name="text">
-           <string>Expansion Reference Temperature:</string>
+           <string>Reference Temperature:</string>
+          </property>
+          <property name="toolTip">
+           <string>Reference temperature for thermal expansion</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Change the Expansion Reference Temperature label, so as not to crop the box quantities when trying to shrink the material panel.
A tooltip has been added to clarify that this is the expansion reference temperature.

Before:
![image](https://github.com/user-attachments/assets/efecbb6f-12db-4f05-8582-105d5b2e1ec4)

After:
![image](https://github.com/user-attachments/assets/a7e542a2-54fe-4b70-a01a-afe5e10b1f45)

@FEA-eng 