### PR TITLE
Gui: Fix saving light sources

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsLightSources.ui
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.ui
@@ -164,7 +164,7 @@
          <cstring>AmbientLightIntensity</cstring>
         </property>
         <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
+         <cstring>View/LightSources</cstring>
         </property>
        </widget>
       </item>
@@ -181,7 +181,7 @@
          <cstring>BacklightColor</cstring>
         </property>
         <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
+         <cstring>View/LightSources</cstring>
         </property>
        </widget>
       </item>
@@ -267,7 +267,7 @@
          <cstring>AmbientLightColor</cstring>
         </property>
         <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
+         <cstring>View/LightSources</cstring>
         </property>
        </widget>
       </item>
@@ -293,7 +293,7 @@
          <cstring>HeadlightIntensity</cstring>
         </property>
         <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
+         <cstring>View/LightSources</cstring>
         </property>
        </widget>
       </item>
@@ -332,7 +332,7 @@
          <cstring>BacklightIntensity</cstring>
         </property>
         <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
+         <cstring>View/LightSources</cstring>
         </property>
        </widget>
       </item>
@@ -367,7 +367,7 @@
          <cstring>FillLightIntensity</cstring>
         </property>
         <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
+         <cstring>View/LightSources</cstring>
         </property>
        </widget>
       </item>
@@ -404,7 +404,7 @@
          <cstring>FillLightColor</cstring>
         </property>
         <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
+         <cstring>View/LightSources</cstring>
         </property>
        </widget>
       </item>
@@ -431,7 +431,7 @@
          <cstring>HeadlightColor</cstring>
         </property>
         <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
+         <cstring>View/LightSources</cstring>
         </property>
        </widget>
       </item>

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -45,22 +45,27 @@ using namespace Gui;
 View3DSettings::View3DSettings(ParameterGrp::handle hGrp,
                                View3DInventorViewer* view)
     : hGrp(hGrp)
+    , hLightSourcesGrp(hGrp->GetGroup("LightSources"))
     , _viewers{view}
 {
     hGrp->Attach(this);
+    hLightSourcesGrp->Attach(this);
 }
 
 View3DSettings::View3DSettings(ParameterGrp::handle hGrp,
                                const std::vector<View3DInventorViewer *>& view)
     : hGrp(hGrp)
+    , hLightSourcesGrp(hGrp->GetGroup("LightSources"))
     , _viewers(view)
 {
     hGrp->Attach(this);
+    hLightSourcesGrp->Attach(this);
 }
 
 View3DSettings::~View3DSettings()
 {
     hGrp->Detach(this);
+    hLightSourcesGrp->Detach(this);
 }
 
 int View3DSettings::stopAnimatingIfDeactivated() const

--- a/src/Gui/View3DSettings.h
+++ b/src/Gui/View3DSettings.h
@@ -54,6 +54,8 @@ public:
 
 private:
     ParameterGrp::handle hGrp;
+    ParameterGrp::handle hLightSourcesGrp;
+
     std::vector<View3DInventorViewer*> _viewers;
 };
 


### PR DESCRIPTION
As it seems the dialog saved settings in old place and because listener listened for the old place also the lights were updated only when applied through settings. Now it should be correct.

Fixes: #20159 