### PR TITLE
All: Replace dynamic_cast with faster alternatives

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -797,7 +797,7 @@ void Document::onChanged(const Property* prop)
     }
     else if (prop == &UseHasher) {
         for (auto obj : d->objectArray) {
-            auto geofeature = dynamic_cast<GeoFeature*>(obj);
+            auto geofeature = freecad_cast<GeoFeature*>(obj);
             if (geofeature && geofeature->getPropertyOfGeometry()) {
                 geofeature->enforceRecompute();
             }

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -428,7 +428,7 @@ void DocumentObject::getOutList(int options, std::vector<DocumentObject*>& res) 
     bool noHidden = !!(options & OutListNoHidden);
     std::size_t size = res.size();
     for (auto prop : props) {
-        auto link = dynamic_cast<PropertyLinkBase*>(prop);
+        auto link = freecad_cast<PropertyLinkBase*>(prop);
         if (link) {
             link->getLinks(res, noHidden);
         }
@@ -457,7 +457,7 @@ std::vector<App::DocumentObject*> DocumentObject::getOutListOfProperty(App::Prop
         return ret;
     }
 
-    auto link = dynamic_cast<PropertyLinkBase*>(prop);
+    auto link = freecad_cast<PropertyLinkBase*>(prop);
     if (link) {
         link->getLinks(ret);
     }
@@ -629,7 +629,7 @@ DocumentObject::getPathsByOutList(App::DocumentObject* to) const
 
 DocumentObjectGroup* DocumentObject::getGroup() const
 {
-    return dynamic_cast<DocumentObjectGroup*>(GroupExtension::getGroupOfObject(this));
+    return freecad_cast<DocumentObjectGroup*>(GroupExtension::getGroupOfObject(this));
 }
 
 bool DocumentObject::testIfLinkDAGCompatible(DocumentObject* linkTo) const
@@ -1130,7 +1130,7 @@ DocumentObject* DocumentObject::getLinkedObject(bool recursive,
         }
     }
     if (transform && mat) {
-        auto pla = dynamic_cast<PropertyPlacement*>(getPropertyByName("Placement"));
+        auto pla = freecad_cast<PropertyPlacement*>(getPropertyByName("Placement"));
         if (pla) {
             *mat *= pla->getValue().toMatrix();
         }

--- a/src/App/ExtensionContainer.h
+++ b/src/App/ExtensionContainer.h
@@ -180,7 +180,7 @@ public:
     /// find a property by its name, dynamic cased to specified type
     template<typename T>
     T* getPropertyByName(const char* name) const {
-        return dynamic_cast<T*>(this->getPropertyByName(name));
+        return freecad_cast<T*>(this->getPropertyByName(name));
     }
     /// get the name of a property
     const char* getPropertyName(const Property* prop) const override;

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -482,7 +482,7 @@ PyObject* PropertyContainerPy::getEnumerationsOfProperty(PyObject* args)
         return nullptr;
     }
 
-    PropertyEnumeration* enumProp = dynamic_cast<PropertyEnumeration*>(prop);
+    PropertyEnumeration* enumProp = freecad_cast<PropertyEnumeration*>(prop);
     if (!enumProp) {
         Py_Return;
     }

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -88,7 +88,7 @@ void PropertyLinkBase::setReturnNewElement(bool enable)
 
 void PropertyLinkBase::hasSetValue()
 {
-    auto owner = dynamic_cast<DocumentObject*>(getContainer());
+    auto owner = freecad_cast<DocumentObject*>(getContainer());
     if (owner) {
         owner->clearOutListCache();
     }
@@ -1521,7 +1521,7 @@ static bool updateLinkReference(App::PropertyLinkBase* prop,
     if (!link || !link->isAttachedToDocument()) {
         return false;
     }
-    auto owner = dynamic_cast<DocumentObject*>(prop->getContainer());
+    auto owner = freecad_cast<DocumentObject*>(prop->getContainer());
     if (owner && owner->isRestoring()) {
         return false;
     }
@@ -1846,7 +1846,7 @@ void PropertyLinkSub::Save(Base::Writer& writer) const
                     << _cSubList.size();
     writer.Stream() << "\">" << std::endl;
     writer.incInd();
-    auto owner = dynamic_cast<DocumentObject*>(getContainer());
+    auto owner = freecad_cast<DocumentObject*>(getContainer());
     bool exporting = owner && owner->isExporting();
     for (unsigned int i = 0; i < _cSubList.size(); i++) {
         const auto& shadow = _ShadowSubList[i];
@@ -2788,7 +2788,7 @@ void PropertyLinkSubList::Save(Base::Writer& writer) const
     }
     writer.Stream() << writer.ind() << "<LinkSubList count=\"" << count << "\">" << endl;
     writer.incInd();
-    auto owner = dynamic_cast<DocumentObject*>(getContainer());
+    auto owner = freecad_cast<DocumentObject*>(getContainer());
     bool exporting = owner && owner->isExporting();
     for (int i = 0; i < getSize(); i++) {
         auto obj = _lValueList[i];
@@ -2844,7 +2844,7 @@ void PropertyLinkSubList::Restore(Base::XMLReader& reader)
     SubNames.reserve(count);
     std::vector<ShadowSub> shadows;
     shadows.reserve(count);
-    DocumentObject* father = dynamic_cast<DocumentObject*>(getContainer());
+    DocumentObject* father = freecad_cast<DocumentObject*>(getContainer());
     App::Document* document = father ? father->getDocument() : nullptr;
     std::vector<int> mapped;
     bool restoreLabel = false;
@@ -3609,7 +3609,7 @@ public:
         for (auto it = links.begin(), itNext = it; it != links.end(); it = itNext) {
             ++itNext;
             auto link = *it;
-            auto obj = dynamic_cast<DocumentObject*>(link->getContainer());
+            auto obj = freecad_cast<DocumentObject*>(link->getContainer());
             if (obj && obj->getDocument() == &doc) {
                 links.erase(it);
                 // must call unlink here, so that PropertyLink::resetLink can
@@ -3654,7 +3654,7 @@ public:
     bool hasXLink(const App::Document* doc) const
     {
         for (auto link : links) {
-            auto obj = dynamic_cast<DocumentObject*>(link->getContainer());
+            auto obj = freecad_cast<DocumentObject*>(link->getContainer());
             if (obj && obj->getDocument() == doc) {
                 return true;
             }
@@ -3703,7 +3703,7 @@ void PropertyLinkBase::breakLinks(App::DocumentObject* link,
         props.clear();
         obj->getPropertyList(props);
         for (auto prop : props) {
-            auto linkProp = dynamic_cast<PropertyLinkBase*>(prop);
+            auto linkProp = freecad_cast<PropertyLinkBase*>(prop);
             if (linkProp) {
                 linkProp->breakLink(link, clear);
             }
@@ -3826,7 +3826,7 @@ void PropertyXLink::restoreLink(App::DocumentObject* lValue)
 {
     assert(!_pcLink && lValue && docInfo);
 
-    auto owner = dynamic_cast<DocumentObject*>(getContainer());
+    auto owner = freecad_cast<DocumentObject*>(getContainer());
     if (!owner || !owner->isAttachedToDocument()) {
         throw Base::RuntimeError("invalid container");
     }
@@ -3863,7 +3863,7 @@ void PropertyXLink::setValue(App::DocumentObject* lValue,
         throw Base::ValueError("Invalid object");
     }
 
-    auto owner = dynamic_cast<DocumentObject*>(getContainer());
+    auto owner = freecad_cast<DocumentObject*>(getContainer());
     if (!owner || !owner->isAttachedToDocument()) {
         throw Base::RuntimeError("invalid container");
     }
@@ -3930,7 +3930,7 @@ void PropertyXLink::setValue(std::string&& filename,
         setValue(nullptr, std::move(subs), std::move(shadows));
         return;
     }
-    auto owner = dynamic_cast<DocumentObject*>(getContainer());
+    auto owner = freecad_cast<DocumentObject*>(getContainer());
     if (!owner || !owner->isAttachedToDocument()) {
         throw Base::RuntimeError("invalid container");
     }

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1442,7 +1442,7 @@ void PropertyString::setValue(const char* newValue)
 
     std::vector<std::pair<Property*, std::unique_ptr<Property>>> propChanges;
     std::string newValueStr = newValue;
-    auto obj = dynamic_cast<DocumentObject*>(getContainer());
+    auto obj = freecad_cast<DocumentObject*>(getContainer());
     bool commit = false;
 
     if (obj && this == &obj->Label) {
@@ -1510,7 +1510,7 @@ void PropertyString::setPyObject(PyObject* value)
 void PropertyString::Save(Base::Writer& writer) const
 {
     std::string val;
-    auto obj = dynamic_cast<DocumentObject*>(getContainer());
+    auto obj = freecad_cast<DocumentObject*>(getContainer());
     writer.Stream() << writer.ind() << "<String ";
     bool exported = false;
     if (obj && obj->isAttachedToDocument() && obj->isExporting() && &obj->Label == this) {
@@ -1534,7 +1534,7 @@ void PropertyString::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("String");
     // get the value of my Attribute
-    auto obj = dynamic_cast<DocumentObject*>(getContainer());
+    auto obj = freecad_cast<DocumentObject*>(getContainer());
     if (obj && &obj->Label == this) {
         if (reader.hasAttribute("restore")) {
             int restore = reader.getAttributeAsInteger("restore");

--- a/src/Gui/ActiveObjectList.cpp
+++ b/src/Gui/ActiveObjectList.cpp
@@ -62,7 +62,7 @@ void ActiveObjectList::setHighlight(const ObjectInfo &info, HighlightMode mode, 
     auto obj = getObject(info, false);
     if (!obj)
         return;
-    auto vp = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(obj));
+    auto vp = freecad_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(obj));
     if (!vp)
         return;
 

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1346,7 +1346,7 @@ void StdCmdDelete::activated(int iMsg)
         auto editDoc = Application::Instance->editDocument();
         ViewProviderDocumentObject *vpedit = nullptr;
         if(editDoc)
-            vpedit = dynamic_cast<ViewProviderDocumentObject*>(editDoc->getInEdit());
+            vpedit = freecad_cast<ViewProviderDocumentObject*>(editDoc->getInEdit());
         if(vpedit && !vpedit->acceptDeletionsInEdit()) {
             for(auto &sel : Selection().getSelectionEx(editDoc->getDocument()->getName())) {
                 if(sel.getObject() == vpedit->getObject()) {

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -98,7 +98,7 @@ void StdCmdRandomColor::activated(int iMsg)
         // NOLINTEND
         auto objColor = Base::Color(fRed, fGrn, fBlu);
 
-        auto vpLink = dynamic_cast<ViewProviderLink*>(view);
+        auto vpLink = freecad_cast<ViewProviderLink*>(view);
         if (vpLink) {
             if (!vpLink->OverrideMaterial.getValue()) {
                 vpLink->OverrideMaterial.setValue(true);

--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -755,7 +755,7 @@ void StdCmdLinkSelectLinked::activated(int)
         Selection().addSelection(linked->getDocument()->getName(),linked->getNameInDocument(),subname.c_str());
         auto doc = Application::Instance->getDocument(linked->getDocument());
         if(doc) {
-            auto vp = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(linked));
+            auto vp = freecad_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(linked));
             doc->setActiveView(vp);
         }
     } else {

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2865,7 +2865,7 @@ static std::vector<std::string> getBoxSelection(
         if(!vis)
             continue;
 
-        auto svp = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(sobj));
+        auto svp = freecad_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(sobj));
         if(!svp)
             continue;
 
@@ -2928,7 +2928,7 @@ static void doSelect(void* ud, SoEventCallback * cb)
             if(App::GeoFeatureGroupExtension::getGroupOfObject(obj))
                 continue;
 
-            auto vp = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(obj));
+            auto vp = freecad_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(obj));
             if (!vp || !vp->isVisible())
                 continue;
 
@@ -3110,7 +3110,7 @@ bool StdCmdTreeSelectAllInstances::isActive()
     auto obj = sels[0].getObject();
     if(!obj || !obj->isAttachedToDocument())
         return false;
-    return dynamic_cast<ViewProviderDocumentObject*>(
+    return freecad_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(obj)) != nullptr;
 }
 
@@ -3123,7 +3123,7 @@ void StdCmdTreeSelectAllInstances::activated(int iMsg)
     auto obj = sels[0].getObject();
     if(!obj || !obj->isAttachedToDocument())
         return;
-    auto vpd = dynamic_cast<ViewProviderDocumentObject*>(
+    auto vpd = freecad_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(obj));
     if(!vpd)
         return;

--- a/src/Gui/DAGView/DAGModel.cpp
+++ b/src/Gui/DAGView/DAGModel.cpp
@@ -1130,7 +1130,7 @@ void Model::renameAcceptedSlot()
   assert(selections.size() == 1);
   const GraphLinkRecord &record = findRecord(selections.front(), *graphLink);
 
-  auto lineEdit = dynamic_cast<LineEdit*>(proxy->widget());
+  auto lineEdit = qobject_cast<LineEdit*>(proxy->widget());
   assert(lineEdit);
   const_cast<App::DocumentObject*>(record.DObject)->Label.setValue(lineEdit->text().toUtf8().constData()); //const hack
 

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -487,8 +487,8 @@ void DlgExpressionInput::acceptWithVarSet()
     // The value of the property is going to be the value that was originally
     // meant to be the value for the property that this dialog is targeting.
     Expression* exprSimplfied = expression->simplify();
-    auto ne = dynamic_cast<NumberExpression*>(exprSimplfied);
-    auto se = dynamic_cast<StringExpression*>(exprSimplfied);
+    auto ne = freecad_cast<NumberExpression*>(exprSimplfied);
+    auto se = freecad_cast<StringExpression*>(exprSimplfied);
     if (ne) {
         // the value is a number: directly assign it to the property instead of
         // making it an expression in the variable set

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -151,7 +151,7 @@ struct DocumentP
 
     static ViewProviderDocumentObject* throwIfCastFails(ViewProvider* p)
     {
-        if (auto vp = dynamic_cast<ViewProviderDocumentObject*>(p)) {
+        if (auto vp = freecad_cast<ViewProviderDocumentObject*>(p)) {
             return vp;
         }
 
@@ -223,7 +223,7 @@ struct DocumentP
     {
         auto svp = vp;
         if (sobj != obj) {
-            svp = dynamic_cast<ViewProviderDocumentObject*>(
+            svp = freecad_cast<ViewProviderDocumentObject*>(
                     Application::Instance->getViewProvider(sobj));
             if (!svp) {
                 std::stringstream str;
@@ -310,7 +310,7 @@ struct DocumentP
 
     void signalEditMode()
     {
-        if (auto vpd = dynamic_cast<ViewProviderDocumentObject*>(_editViewProvider)) {
+        if (auto vpd = freecad_cast<ViewProviderDocumentObject*>(_editViewProvider)) {
             vpd->getDocument()->signalInEdit(*vpd);
         }
     }
@@ -404,7 +404,7 @@ private:
                                                              const char* subname)
     {
         FC_LOG("deduced editing reference " << parentObj->getFullName() << '.' << subname);
-        auto vp = dynamic_cast<ViewProviderDocumentObject*>(
+        auto vp = freecad_cast<ViewProviderDocumentObject*>(
                 Application::Instance->getViewProvider(parentObj));
         if (!vp || !vp->getDocument()) {
             throw Base::RuntimeError("invalid view provider for parent object");
@@ -611,7 +611,7 @@ View3DInventor* Document::openEditingView3D(const ViewProviderDocumentObject* vp
 
 View3DInventor* Document::openEditingView3D(const App::DocumentObject* obj)
 {
-    if (auto vp = dynamic_cast<ViewProviderDocumentObject*>(
+    if (auto vp = freecad_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(obj))) {
         return openEditingView3D(vp);
     }
@@ -1022,8 +1022,8 @@ void Document::slotDeletedObject(const App::DocumentObject& Obj)
 void Document::beforeDelete() {
     auto editDoc = Application::Instance->editDocument();
     if(editDoc) {
-        auto vp = dynamic_cast<ViewProviderDocumentObject*>(editDoc->d->_editViewProvider);
-        auto vpp = dynamic_cast<ViewProviderDocumentObject*>(editDoc->d->_editViewProviderParent);
+        auto vp = freecad_cast<ViewProviderDocumentObject*>(editDoc->d->_editViewProvider);
+        auto vpp = freecad_cast<ViewProviderDocumentObject*>(editDoc->d->_editViewProviderParent);
         if(editDoc == this ||
            (vp && vp->getDocument()==this) ||
            (vpp && vpp->getDocument()==this))
@@ -1173,7 +1173,7 @@ void Document::slotSkipRecompute(const App::Document& doc, const std::vector<App
     App::DocumentObject *obj = nullptr;
     auto editDoc = Application::Instance->editDocument();
     if(editDoc) {
-        auto vp = dynamic_cast<ViewProviderDocumentObject*>(editDoc->getInEdit());
+        auto vp = freecad_cast<ViewProviderDocumentObject*>(editDoc->getInEdit());
         if(vp)
             obj = vp->getObject();
     }
@@ -1690,7 +1690,7 @@ void Document::RestoreDocFile(Base::Reader &reader)
                 treeRank = int(localreader->getAttributeAsInteger("treeRank"));
             }
 
-            auto pObj = dynamic_cast<ViewProviderDocumentObject*>(getViewProviderByName(name.c_str()));
+            auto pObj = freecad_cast<ViewProviderDocumentObject*>(getViewProviderByName(name.c_str()));
             // check if this feature has been registered
             if (pObj) {
                 pObj->Restore(*localreader);
@@ -1742,7 +1742,7 @@ void Document::slotStartRestoreDocument(const App::Document& doc)
 }
 
 void Document::slotFinishRestoreObject(const App::DocumentObject &obj) {
-    auto vpd = dynamic_cast<ViewProviderDocumentObject*>(getViewProvider(&obj));
+    auto vpd = freecad_cast<ViewProviderDocumentObject*>(getViewProvider(&obj));
     if(vpd) {
         vpd->setStatus(Gui::isRestoring,false);
         vpd->finishRestoring();
@@ -1961,7 +1961,7 @@ void Document::slotFinishImportObjects(const std::vector<App::DocumentObject*> &
     //     auto vp = getViewProvider(obj);
     //     if(!vp) continue;
     //     vp->setStatus(Gui::isRestoring,false);
-    //     auto vpd = dynamic_cast<ViewProviderDocumentObject*>(vp);
+    //     auto vpd = freecad_cast<ViewProviderDocumentObject*>(vp);
     //     if(vpd) vpd->finishRestoring();
     // }
 }
@@ -2422,7 +2422,7 @@ MDIView *Document::setActiveView(const ViewProviderDocumentObject* vp, Base::Typ
             else {
                 auto linked = obj->getLinkedObject(true);
                 if (linked != obj) {
-                    auto vpLinked = dynamic_cast<ViewProviderDocumentObject*>(
+                    auto vpLinked = freecad_cast<ViewProviderDocumentObject*>(
                                 Application::Instance->getViewProvider(linked));
                     if (vpLinked) {
                         view = vpLinked->getMDIView();

--- a/src/Gui/DocumentObserver.cpp
+++ b/src/Gui/DocumentObserver.cpp
@@ -199,7 +199,7 @@ ViewProviderDocumentObject* ViewProviderT::getViewProvider() const
     ViewProviderDocumentObject* obj = nullptr;
     Document* doc = getDocument();
     if (doc) {
-        obj = dynamic_cast<ViewProviderDocumentObject*>(doc->getViewProviderByName(object.c_str()));
+        obj = freecad_cast<ViewProviderDocumentObject*>(doc->getViewProviderByName(object.c_str()));
     }
     return obj;
 }

--- a/src/Gui/ExpressionBindingPy.cpp
+++ b/src/Gui/ExpressionBindingPy.cpp
@@ -43,7 +43,7 @@ ExpressionBindingPy::ExpressionBindingPy(Py::PythonClassInstance* self, Py::Tupl
     PythonWrapper wrap;
     wrap.loadWidgetsModule();
 
-    QWidget* obj = dynamic_cast<QWidget*>(wrap.toQObject(Py::Object(pyObj)));
+    QWidget* obj = qobject_cast<QWidget*>(wrap.toQObject(Py::Object(pyObj)));
     expr = asBinding(obj);
 
     if (!expr) {

--- a/src/Gui/Flag.cpp
+++ b/src/Gui/Flag.cpp
@@ -136,7 +136,7 @@ void Flag::mouseMoveEvent(QMouseEvent *e)
         move(e->globalPosition().toPoint() - dragPosition);
 #endif
         e->accept();
-        auto viewer = dynamic_cast<View3DInventorViewer*>(parentWidget());
+        auto viewer = qobject_cast<View3DInventorViewer*>(parentWidget());
         if (viewer)
             viewer->getSoRenderManager()->scheduleRedraw();
     }

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1042,7 +1042,7 @@ bool MainWindow::eventFilter(QObject* o, QEvent* e)
         if (e->type() == QEvent::WindowStateChange) {
             // notify all mdi views when the active view receives a show normal, show minimized
             // or show maximized event
-            auto view = qobject_cast<MDIView*>(o);
+            auto view = dynamic_cast<MDIView*>(o);
             if (view) { // emit this signal
                 Qt::WindowStates oldstate = static_cast<QWindowStateChangeEvent*>(e)->oldState();
                 Qt::WindowStates newstate = view->windowState();
@@ -1691,7 +1691,7 @@ void MainWindow::switchToDockedMode()
     // Search for all top-level MDI views
     QWidgetList toplevel = QApplication::topLevelWidgets();
     for (const auto & it : toplevel) {
-        auto view = qobject_cast<MDIView*>(it);
+        auto view = dynamic_cast<MDIView*>(it);
         if (view)
             view->setCurrentViewMode(MDIView::Child);
     }

--- a/src/Gui/MainWindowPy.cpp
+++ b/src/Gui/MainWindowPy.cpp
@@ -127,7 +127,7 @@ Py::Object MainWindowPy::getWindows(const Py::Tuple& args)
     if (_mw) {
         QList<QWidget*> windows = _mw->windows();
         for (auto it : windows) {
-            auto view = qobject_cast<MDIView*>(it);
+            auto view = dynamic_cast<MDIView*>(it);
             if (view) {
                 mdis.append(Py::asObject(view->getPyObject()));
             }
@@ -149,7 +149,7 @@ Py::Object MainWindowPy::getWindowsOfType(const Py::Tuple& args)
     if (_mw) {
         QList<QWidget*> windows = _mw->windows();
         for (auto it : windows) {
-            auto view = qobject_cast<MDIView*>(it);
+            auto view = dynamic_cast<MDIView*>(it);
             if (view && view->isDerivedFrom(typeId)) {
                 mdis.append(Py::asObject(view->getPyObject()));
             }

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
@@ -270,7 +270,7 @@ void DlgSettingsWorkbenchesImp::saveSettings()
     };
 
     for (int i = 0; i < ui->wbList->count(); i++) {
-        wbListItem* wbItem = dynamic_cast<wbListItem*>(ui->wbList->itemWidget(ui->wbList->item(i)));
+        wbListItem* wbItem = qobject_cast<wbListItem*>(ui->wbList->itemWidget(ui->wbList->item(i)));
         if (!wbItem)
             continue;
         std::string wbName = wbItem->objectName().toStdString();
@@ -546,7 +546,7 @@ void DlgSettingsWorkbenchesImp::wbToggled(const QString& wbName, bool enabled)
     //reorder the list of items.
     int wbIndex = 0;
     for (int i = 0; i < ui->wbList->count(); i++) {
-        wbListItem* wbItem = dynamic_cast<wbListItem*>(ui->wbList->itemWidget(ui->wbList->item(i)));
+        wbListItem* wbItem = qobject_cast<wbListItem*>(ui->wbList->itemWidget(ui->wbList->item(i)));
         if (wbItem && wbItem->objectName() == wbName) {
             wbIndex = i;
         }
@@ -555,7 +555,7 @@ void DlgSettingsWorkbenchesImp::wbToggled(const QString& wbName, bool enabled)
     int destinationIndex = ui->wbList->count();
 
     for (int i = 0; i < ui->wbList->count(); i++) {
-        wbListItem* wbItem = dynamic_cast<wbListItem*>(ui->wbList->itemWidget(ui->wbList->item(i)));
+        wbListItem* wbItem = qobject_cast<wbListItem*>(ui->wbList->itemWidget(ui->wbList->item(i)));
         if (wbItem && !wbItem->isEnabled() && (enabled || ((wbItem->objectName()).toStdString() > wbName.toStdString()))) {
             //If the wb was enabled, then it was in the disabled wbs. So it moves to the row of the currently first disabled wb
             //If the wb was disabled. Then it goes to the disabled wb where it belongs alphabetically.
@@ -574,7 +574,7 @@ void DlgSettingsWorkbenchesImp::setStartWorkbenchComboItems()
     // fills the combo box with activated workbenches.
     QStringList enabledWbs;
     for (int i = 0; i < ui->wbList->count(); i++) {
-        wbListItem* wbItem = dynamic_cast<wbListItem*>(ui->wbList->itemWidget(ui->wbList->item(i)));
+        wbListItem* wbItem = qobject_cast<wbListItem*>(ui->wbList->itemWidget(ui->wbList->item(i)));
         if (wbItem && wbItem->isEnabled()) {
             enabledWbs << wbItem->objectName();
         }
@@ -614,7 +614,7 @@ void DlgSettingsWorkbenchesImp::setStartWorkbenchComboItems()
 void DlgSettingsWorkbenchesImp::wbItemMoved()
 {
     for (int i = 0; i < ui->wbList->count(); i++) {
-        wbListItem* wbItem = dynamic_cast<wbListItem*>(ui->wbList->itemWidget(ui->wbList->item(i)));
+        wbListItem* wbItem = qobject_cast<wbListItem*>(ui->wbList->itemWidget(ui->wbList->item(i)));
         if (wbItem) {
             wbItem->setShortcutLabel(i);
         }
@@ -630,7 +630,7 @@ void DlgSettingsWorkbenchesImp::onStartWbChanged(int index)
 
     //Change wb that user can't deactivate.
     for (int i = 0; i < ui->wbList->count(); i++) {
-        wbListItem* wbItem = dynamic_cast<wbListItem*>(ui->wbList->itemWidget(ui->wbList->item(i)));
+        wbListItem* wbItem = qobject_cast<wbListItem*>(ui->wbList->itemWidget(ui->wbList->item(i)));
         if (wbItem) {
             wbItem->setStartupWb(wbItem->objectName() == wbName);
         }

--- a/src/Gui/Selection/SelectionObject.h
+++ b/src/Gui/Selection/SelectionObject.h
@@ -74,12 +74,12 @@ public:
     const App::DocumentObject* getObject() const;
     /// returns the selected DocumentObject or NULL if the object is already deleted
     template <class T>
-    const T* getObject() const { return dynamic_cast<T*>(getObject()); };
+    const T* getObject() const { return freecad_cast<T*>(getObject()); };
     /// returns the selected DocumentObject or NULL if the object is already deleted
     App::DocumentObject *getObject();
     /// returns the selected DocumentObject if it is of T type or null otherwise
     template <class T>
-    T* getObject() { return dynamic_cast<T*>(getObject()); }
+    T* getObject() { return freecad_cast<T*>(getObject()); }
 
     /// check the selected object is a special type or derived of
     bool isObjectTypeOf(const Base::Type& typeId) const;

--- a/src/Gui/TaskView/TaskImage.cpp
+++ b/src/Gui/TaskView/TaskImage.cpp
@@ -182,7 +182,7 @@ View3DInventorViewer* TaskImage::getViewer() const
     if (!feature.expired()) {
         auto vp = Application::Instance->getViewProvider(feature.get());
         auto doc = static_cast<ViewProviderDocumentObject*>(vp)->getDocument();  // NOLINT
-        auto view = dynamic_cast<View3DInventor*>(doc->getViewOfViewProvider(vp));
+        auto view = qobject_cast<View3DInventor*>(doc->getViewOfViewProvider(vp));
         if (view) {
             return view->getViewer();
         }
@@ -633,7 +633,7 @@ bool InteractiveScale::eventFilter(QObject* object, QEvent* event)
 
         /* If user press enter in the spinbox, then we validate the tool.*/
         if ((keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return)
-            && dynamic_cast<QuantitySpinBox*>(object)) {
+            && qobject_cast<QuantitySpinBox*>(object)) {
             Q_EMIT scaleRequired();
         }
 

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1582,7 +1582,7 @@ void TreeWidget::selectAllLinks(App::DocumentObject* obj) {
             TREE_ERR("invalid linked object");
             continue;
         }
-        auto vp = dynamic_cast<ViewProviderDocumentObject*>(
+        auto vp = freecad_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(link));
         if (!vp) {
             TREE_ERR("invalid view provider of the linked object");
@@ -2198,7 +2198,7 @@ bool TreeWidget::dropInDocument(QDropEvent* event, TargetItemInfo& targetInfo,
             auto doc = App::GetApplication().getDocument(info.doc.c_str());
             if (!doc) continue;
             auto obj = doc->getObject(info.obj.c_str());
-            auto vpc = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(obj));
+            auto vpc = freecad_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(obj));
             if (!vpc) {
                 FC_WARN("Cannot find dragging object " << info.obj);
                 continue;
@@ -2247,7 +2247,7 @@ bool TreeWidget::dropInDocument(QDropEvent* event, TargetItemInfo& targetInfo,
                     continue;
                 }
                 auto parent = parentDoc->getObject(info.parent.c_str());
-                auto vpp = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(parent));
+                auto vpp = freecad_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(parent));
                 if (!vpp) {
                     FC_WARN("Cannot find dragging object's parent " << info.parent);
                     continue;
@@ -2496,7 +2496,7 @@ bool TreeWidget::dropInObject(QDropEvent* event, TargetItemInfo& targetInfo,
                 continue;
             }
             auto obj = doc->getObject(info.obj.c_str());
-            auto vpc = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(obj));
+            auto vpc = freecad_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(obj));
             if (!vpc) {
                 FC_WARN("Cannot find dragging object " << info.obj);
                 continue;
@@ -2507,7 +2507,7 @@ bool TreeWidget::dropInObject(QDropEvent* event, TargetItemInfo& targetInfo,
                 auto parentDoc = App::GetApplication().getDocument(info.parentDoc.c_str());
                 if (parentDoc) {
                     auto parent = parentDoc->getObject(info.parent.c_str());
-                    vpp = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(parent));
+                    vpp = freecad_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(parent));
                 }
                 if (!vpp) {
                     FC_WARN("Cannot find dragging object's parent " << info.parent);
@@ -2819,7 +2819,7 @@ void TreeWidget::sortDroppedObjects(TargetItemInfo& targetInfo, std::vector<App:
 
         // Then we set the tree rank
         for (size_t i = 0; i < sortedObjList.size(); ++i) {
-            auto vp = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(sortedObjList[i]));
+            auto vp = freecad_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(sortedObjList[i]));
             vp->setTreeRank(i);
         }
 
@@ -3871,7 +3871,7 @@ void DocumentItem::slotInEdit(const Gui::ViewProviderDocumentObject& v)
         std::string subname;
         auto vp = doc->getInEdit(&parentVp, &subname);
         if (!parentVp)
-            parentVp = dynamic_cast<ViewProviderDocumentObject*>(vp);
+            parentVp = freecad_cast<ViewProviderDocumentObject*>(vp);
         if (parentVp)
             getTree()->editingItem = findItemByObject(true, parentVp->getObject(), subname.c_str());
     }
@@ -4260,7 +4260,7 @@ int DocumentItem::findRootIndex(App::DocumentObject* childObj) {
         return vp->getTreeRank();
     };
 
-    auto vpc = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(childObj));
+    auto vpc = freecad_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(childObj));
     int childTreeRank = getTreeRank(vpc);
 
     // find the last item

--- a/src/Gui/View3DInventorSelection.cpp
+++ b/src/Gui/View3DInventorSelection.cpp
@@ -158,7 +158,7 @@ void View3DInventorSelection::checkGroupOnTop(const SelectionChanges &Reason)
 
     if(objs.find(key.c_str())!=objs.end())
         return;
-    auto vp = dynamic_cast<ViewProviderDocumentObject*>(
+    auto vp = freecad_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(obj));
     if(!vp || !vp->isSelectable() || !vp->isShow())
         return;
@@ -168,7 +168,7 @@ void View3DInventorSelection::checkGroupOnTop(const SelectionChanges &Reason)
         if(!sobj || !sobj->isAttachedToDocument())
             return;
         if(sobj!=obj) {
-            svp = dynamic_cast<ViewProviderDocumentObject*>(
+            svp = freecad_cast<ViewProviderDocumentObject*>(
                     Application::Instance->getViewProvider(sobj));
             if(!svp || !svp->isSelectable())
                 return;
@@ -220,7 +220,7 @@ void View3DInventorSelection::checkGroupOnTop(const SelectionChanges &Reason)
             break;
         }
 
-        grpVp = dynamic_cast<ViewProviderDocumentObject*>(
+        grpVp = freecad_cast<ViewProviderDocumentObject*>(
                 Application::Instance->getViewProvider(grp));
         if (!grpVp) {
             break;

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -1011,13 +1011,13 @@ Base::BoundBox3d ViewProvider::getBoundingBox(const char *subname, bool transfor
 
     if(!view)
         view  = Application::Instance->activeView();
-    auto iview = dynamic_cast<View3DInventor*>(view);
+    auto iview = qobject_cast<View3DInventor*>(view);
     if(!iview) {
         auto doc = Application::Instance->activeDocument();
         if(doc) {
             auto views = doc->getMDIViewsOfType(View3DInventor::getClassTypeId());
             if(!views.empty())
-                iview = dynamic_cast<View3DInventor*>(views.front());
+                iview = qobject_cast<View3DInventor*>(views.front());
         }
         if(!iview) {
             FC_ERR("no view");

--- a/src/Gui/ViewProviderDocumentObject.h
+++ b/src/Gui/ViewProviderDocumentObject.h
@@ -94,7 +94,7 @@ public:
     App::DocumentObject *getObject() const {return pcObject;}
     /// Get the object of this ViewProvider object as specified type
     template <class T>
-    T *getObject() const { return dynamic_cast<T*>(pcObject); }
+    T *getObject() const { return freecad_cast<T*>(pcObject); }
     /// Asks the view provider if the given object can be deleted.
     bool canDelete(App::DocumentObject* obj) const override;
     /// Ask the view provider if it accepts object deletions while in edit

--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -86,7 +86,7 @@ QWidget* WidgetFactoryInst::createWidget (const char* sName, QWidget* parent) co
 
     try {
 #ifdef FC_DEBUG
-        const char* cName = dynamic_cast<QWidget*>(w)->metaObject()->className();
+        const char* cName = qobject_cast<QWidget*>(w)->metaObject()->className();
         Base::Console().Log("Widget of type '%s' created.\n", cName);
 #endif
     }

--- a/src/Gui/WorkbenchFactory.cpp
+++ b/src/Gui/WorkbenchFactory.cpp
@@ -46,7 +46,7 @@ void WorkbenchFactoryInst::destruct ()
 Workbench* WorkbenchFactoryInst::createWorkbench ( const char* sName ) const
 {
     auto obj = (Workbench*)Produce( sName );
-    auto wb = dynamic_cast<Workbench*>(obj);
+    auto wb = freecad_cast<Workbench*>(obj);
     if (!wb) {
         delete obj; // delete the unknown object as no workbench object
         return nullptr;

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -4746,13 +4746,13 @@ QWidget* PropertyLinkItem::createEditor(QWidget* parent,
 void PropertyLinkItem::setEditorData(QWidget* editor, const QVariant& data) const
 {
     (void)data;
-    auto ll = dynamic_cast<LinkLabel*>(editor);
+    auto ll = qobject_cast<LinkLabel*>(editor);
     return ll->updatePropertyLink();
 }
 
 QVariant PropertyLinkItem::editorData(QWidget* editor) const
 {
-    auto ll = dynamic_cast<LinkLabel*>(editor);
+    auto ll = qobject_cast<LinkLabel*>(editor);
     return ll->propertyLink();
 }
 

--- a/src/Mod/Assembly/App/AssemblyLink.cpp
+++ b/src/Mod/Assembly/App/AssemblyLink.cpp
@@ -205,7 +205,7 @@ void AssemblyLink::synchronizeComponents()
         for (auto* obj2 : assemblyLinkGroup) {
             App::DocumentObject* linkedObj;
 
-            auto* subAsmLink = dynamic_cast<AssemblyLink*>(obj2);
+            auto* subAsmLink = freecad_cast<AssemblyLink*>(obj2);
             auto* link2 = dynamic_cast<App::Link*>(obj2);
             if (subAsmLink) {
                 linkedObj = subAsmLink->getLinkedObject2(false);  // not recursive
@@ -279,8 +279,8 @@ void copyPropertyIfDifferent(App::DocumentObject* source,
                              App::DocumentObject* target,
                              const char* propertyName)
 {
-    auto sourceProp = dynamic_cast<T*>(source->getPropertyByName(propertyName));
-    auto targetProp = dynamic_cast<T*>(target->getPropertyByName(propertyName));
+    auto sourceProp = freecad_cast<T*>(source->getPropertyByName(propertyName));
+    auto targetProp = freecad_cast<T*>(target->getPropertyByName(propertyName));
     if (sourceProp && targetProp && sourceProp->getValue() != targetProp->getValue()) {
         targetProp->setValue(sourceProp->getValue());
     }
@@ -501,12 +501,12 @@ JointGroup* AssemblyLink::ensureJointGroup()
 App::DocumentObject* AssemblyLink::getLinkedObject2(bool recursive) const
 {
     auto* obj = LinkedObject.getValue();
-    auto* assembly = dynamic_cast<AssemblyObject*>(obj);
+    auto* assembly = freecad_cast<AssemblyObject*>(obj);
     if (assembly) {
         return assembly;
     }
     else {
-        auto* assemblyLink = dynamic_cast<AssemblyLink*>(obj);
+        auto* assemblyLink = freecad_cast<AssemblyLink*>(obj);
         if (assemblyLink) {
             if (recursive) {
                 return assemblyLink->getLinkedObject2(recursive);
@@ -522,14 +522,14 @@ App::DocumentObject* AssemblyLink::getLinkedObject2(bool recursive) const
 
 AssemblyObject* AssemblyLink::getLinkedAssembly() const
 {
-    return dynamic_cast<AssemblyObject*>(getLinkedObject2());
+    return freecad_cast<AssemblyObject*>(getLinkedObject2());
 }
 
 AssemblyObject* AssemblyLink::getParentAssembly() const
 {
     std::vector<App::DocumentObject*> inList = getInList();
     for (auto* obj : inList) {
-        auto* assembly = dynamic_cast<AssemblyObject*>(obj);
+        auto* assembly = freecad_cast<AssemblyObject*>(obj);
         if (assembly) {
             return assembly;
         }

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -600,7 +600,7 @@ T* AssemblyObject::getGroup()
     }
     for (auto group : groups) {
         if (hasObject(group)) {
-            return dynamic_cast<T*>(group);
+            return freecad_cast<T*>(group);
         }
     }
     return nullptr;
@@ -621,7 +621,7 @@ ViewGroup* AssemblyObject::getExplodedViewGroup() const
     }
     for (auto viewGroup : viewGroups) {
         if (hasObject(viewGroup)) {
-            return dynamic_cast<ViewGroup*>(viewGroup);
+            return freecad_cast<ViewGroup*>(viewGroup);
         }
     }
     return nullptr;
@@ -1935,7 +1935,7 @@ std::vector<AssemblyLink*> AssemblyObject::getSubAssemblies()
         doc->getObjectsOfType(Assembly::AssemblyLink::getClassTypeId());
     for (auto assembly : assemblies) {
         if (hasObject(assembly)) {
-            subAssemblies.push_back(dynamic_cast<AssemblyLink*>(assembly));
+            subAssemblies.push_back(freecad_cast<AssemblyLink*>(assembly));
         }
     }
 

--- a/src/Mod/Assembly/App/AssemblyUtils.cpp
+++ b/src/Mod/Assembly/App/AssemblyUtils.cpp
@@ -392,7 +392,7 @@ JointGroup* getJointGroup(const App::Part* part)
     }
     for (auto jointGroup : jointGroups) {
         if (part->hasObject(jointGroup)) {
-            return dynamic_cast<JointGroup*>(jointGroup);
+            return freecad_cast<JointGroup*>(jointGroup);
         }
     }
     return nullptr;

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -1064,7 +1064,7 @@ bool ViewProviderAssembly::canDelete(App::DocumentObject* objBeingDeleted) const
         addSubComponents = [&](AssemblyLink* asmLink, std::vector<App::DocumentObject*>& objs) {
             std::vector<App::DocumentObject*> assemblyLinkGroup = asmLink->Group.getValues();
             for (auto* obj : assemblyLinkGroup) {
-                auto* subAsmLink = dynamic_cast<AssemblyLink*>(obj);
+                auto* subAsmLink = freecad_cast<AssemblyLink*>(obj);
                 auto* link = dynamic_cast<App::Link*>(obj);
                 if (subAsmLink || link) {
                     if (std::ranges::find(objs, obj) == objs.end()) {

--- a/src/Mod/Assembly/Gui/ViewProviderAssemblyLink.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssemblyLink.cpp
@@ -86,7 +86,7 @@ bool ViewProviderAssemblyLink::setEdit(int mode)
 
 bool ViewProviderAssemblyLink::doubleClicked()
 {
-    auto* link = dynamic_cast<AssemblyLink*>(getObject());
+    auto* link = freecad_cast<AssemblyLink*>(getObject());
 
     if (!link) {
         return true;
@@ -94,7 +94,7 @@ bool ViewProviderAssemblyLink::doubleClicked()
     auto* assembly = link->getLinkedAssembly();
 
     auto* vpa =
-        dynamic_cast<ViewProviderAssembly*>(Gui::Application::Instance->getViewProvider(assembly));
+        freecad_cast<ViewProviderAssembly*>(Gui::Application::Instance->getViewProvider(assembly));
     if (!vpa) {
         return true;
     }

--- a/src/Mod/Fem/Gui/TaskCreateElementSet.cpp
+++ b/src/Mod/Fem/Gui/TaskCreateElementSet.cpp
@@ -455,7 +455,7 @@ TaskCreateElementSet::TaskCreateElementSet(Fem::FemSetElementNodesObject* pcObje
     // check if the Link to the FemMesh is defined
     assert(pcObject->FemMesh.getValue<Fem::FemMeshObject*>());
     MeshViewProvider =
-        dynamic_cast<ViewProviderFemMesh*>(Gui::Application::Instance->getViewProvider(
+        freecad_cast<ViewProviderFemMesh*>(Gui::Application::Instance->getViewProvider(
             pcObject->FemMesh.getValue<Fem::FemMeshObject*>()));
     assert(MeshViewProvider);
 

--- a/src/Mod/Fem/Gui/TaskCreateNodeSet.cpp
+++ b/src/Mod/Fem/Gui/TaskCreateNodeSet.cpp
@@ -75,7 +75,7 @@ TaskCreateNodeSet::TaskCreateNodeSet(Fem::FemSetNodesObject* pcObject, QWidget* 
     // check if the Link to the FemMesh is defined
     assert(pcObject->FemMesh.getValue<Fem::FemMeshObject*>());
     MeshViewProvider =
-        dynamic_cast<ViewProviderFemMesh*>(Gui::Application::Instance->getViewProvider(
+        freecad_cast<ViewProviderFemMesh*>(Gui::Application::Instance->getViewProvider(
             pcObject->FemMesh.getValue<Fem::FemMeshObject*>()));
     assert(MeshViewProvider);
 

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.h
@@ -72,7 +72,7 @@ protected:
     template<class T>
     T* getObject() const
     {
-        return dynamic_cast<T*>(getObject());
+        return freecad_cast<T*>(getObject());
     }
 
     bool blockObjectUpdates()

--- a/src/Mod/Material/Gui/DlgInspectMaterial.cpp
+++ b/src/Mod/Material/Gui/DlgInspectMaterial.cpp
@@ -208,7 +208,7 @@ void DlgInspectMaterial::updateMaterialTree(const Materials::Material& material)
     Base::Console().Log("Material '%s'\n", material.getName().toStdString().c_str());
 
     auto tree = ui->treeMaterials;
-    auto model = dynamic_cast<QStandardItemModel*>(tree->model());
+    auto model = qobject_cast<QStandardItemModel*>(tree->model());
     model->clear();
 
     addMaterial(tree, model, material);

--- a/src/Mod/Material/Gui/MaterialTreeWidget.cpp
+++ b/src/Mod/Material/Gui/MaterialTreeWidget.cpp
@@ -305,7 +305,7 @@ bool MaterialTreeWidget::findInTree(const QStandardItem& node,
 
 QModelIndex MaterialTreeWidget::findInTree(const QString& uuid)
 {
-    auto model = dynamic_cast<QStandardItemModel*>(m_materialTree->model());
+    auto model = qobject_cast<QStandardItemModel*>(m_materialTree->model());
     auto root = model->invisibleRootItem();
 
     QModelIndex index;
@@ -409,7 +409,7 @@ void MaterialTreeWidget::updateMaterialTree()
     _favorites.clear();
     _recents.clear();
 
-    auto model = dynamic_cast<QStandardItemModel*>(m_materialTree->model());
+    auto model = qobject_cast<QStandardItemModel*>(m_materialTree->model());
     model->clear();
 
     getFavorites();
@@ -539,7 +539,7 @@ void MaterialTreeWidget::fillMaterialTree()
     auto param = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Material/TreeWidget/MaterialTree");
 
-    auto model = dynamic_cast<QStandardItemModel*>(m_materialTree->model());
+    auto model = qobject_cast<QStandardItemModel*>(m_materialTree->model());
 
     if (_filterOptions.includeFavorites()) {
         auto lib = new QStandardItem(tr("Favorites"));
@@ -689,7 +689,7 @@ void MaterialTreeWidget::onSelectMaterial(const QItemSelection& selected,
 
     // Get the UUID before changing the underlying data model
     QString uuid;
-    auto model = dynamic_cast<QStandardItemModel*>(m_materialTree->model());
+    auto model = qobject_cast<QStandardItemModel*>(m_materialTree->model());
     QModelIndexList indexes = selected.indexes();
     for (auto it = indexes.begin(); it != indexes.end(); it++) {
         QStandardItem* item = model->itemFromIndex(*it);
@@ -711,7 +711,7 @@ void MaterialTreeWidget::onSelectMaterial(const QItemSelection& selected,
 
 void MaterialTreeWidget::onDoubleClick(const QModelIndex& index)
 {
-    auto model = dynamic_cast<QStandardItemModel*>(m_materialTree->model());
+    auto model = qobject_cast<QStandardItemModel*>(m_materialTree->model());
     auto item = model->itemFromIndex(index);
 
     if (item) {
@@ -739,7 +739,7 @@ void MaterialTreeWidget::saveMaterialTree()
     param->Clear();
 
     auto tree = m_materialTree;
-    auto model = dynamic_cast<QStandardItemModel*>(tree->model());
+    auto model = qobject_cast<QStandardItemModel*>(tree->model());
 
     auto root = model->invisibleRootItem();
     for (int i = 0; i < root->rowCount(); i++) {

--- a/src/Mod/Material/Gui/MaterialsEditor.cpp
+++ b/src/Mod/Material/Gui/MaterialsEditor.cpp
@@ -651,7 +651,7 @@ void MaterialsEditor::saveMaterialTree(const Base::Reference<ParameterGrp>& para
     treeParam->Clear();
 
     auto tree = ui->treeMaterials;
-    auto model = dynamic_cast<QStandardItemModel*>(tree->model());
+    auto model = qobject_cast<QStandardItemModel*>(tree->model());
 
     auto root = model->invisibleRootItem();
     for (int i = 0; i < root->rowCount(); i++) {
@@ -847,7 +847,7 @@ void MaterialsEditor::fillMaterialTree()
         "User parameter:BaseApp/Preferences/Mod/Material/Editor/MaterialTree");
 
     auto tree = ui->treeMaterials;
-    auto model = dynamic_cast<QStandardItemModel*>(tree->model());
+    auto model = qobject_cast<QStandardItemModel*>(tree->model());
 
     if (_filterOptions.includeFavorites()) {
         auto lib = new QStandardItem(tr("Favorites"));
@@ -898,7 +898,7 @@ void MaterialsEditor::createMaterialTree()
 void MaterialsEditor::refreshMaterialTree()
 {
     auto tree = ui->treeMaterials;
-    auto model = dynamic_cast<QStandardItemModel*>(tree->model());
+    auto model = qobject_cast<QStandardItemModel*>(tree->model());
     model->clear();
 
     fillMaterialTree();
@@ -1054,7 +1054,7 @@ QString MaterialsEditor::getColorHash(const QString& colorString, int colorRange
 void MaterialsEditor::updateMaterialAppearance()
 {
     QTreeView* tree = ui->treeAppearance;
-    auto treeModel = dynamic_cast<QStandardItemModel*>(tree->model());
+    auto treeModel = qobject_cast<QStandardItemModel*>(tree->model());
     treeModel->clear();
 
     QStringList headers;
@@ -1116,7 +1116,7 @@ void MaterialsEditor::updateMaterialAppearance()
 void MaterialsEditor::updateMaterialProperties()
 {
     QTreeView* tree = ui->treePhysicalProperties;
-    auto treeModel = dynamic_cast<QStandardItemModel*>(tree->model());
+    auto treeModel = qobject_cast<QStandardItemModel*>(tree->model());
     treeModel->clear();
 
     QStringList headers;
@@ -1233,7 +1233,7 @@ void MaterialsEditor::onSelectMaterial(const QItemSelection& selected,
 
     // Get the UUID before changing the underlying data model
     QString uuid;
-    auto model = dynamic_cast<QStandardItemModel*>(ui->treeMaterials->model());
+    auto model = qobject_cast<QStandardItemModel*>(ui->treeMaterials->model());
     QModelIndexList indexes = selected.indexes();
     for (auto it = indexes.begin(); it != indexes.end(); it++) {
         QStandardItem* item = model->itemFromIndex(*it);

--- a/src/Mod/Material/Gui/ModelSelect.cpp
+++ b/src/Mod/Material/Gui/ModelSelect.cpp
@@ -389,7 +389,7 @@ void ModelSelect::createModelProperties()
 void ModelSelect::updateModelProperties(std::shared_ptr<Materials::Model> model)
 {
     QTableView* table = ui->tableProperties;
-    auto tableModel = dynamic_cast<QStandardItemModel*>(table->model());
+    auto tableModel = qobject_cast<QStandardItemModel*>(table->model());
     tableModel->clear();
 
     setHeaders(tableModel);
@@ -454,7 +454,7 @@ void ModelSelect::clearMaterialModel()
     ui->tabWidget->setTabText(1, tr("Properties"));
 
     QTableView* table = ui->tableProperties;
-    auto tableModel = dynamic_cast<QStandardItemModel*>(table->model());
+    auto tableModel = qobject_cast<QStandardItemModel*>(table->model());
     tableModel->clear();
 
     setHeaders(tableModel);
@@ -465,7 +465,7 @@ void ModelSelect::onSelectModel(const QItemSelection& selected, const QItemSelec
 {
     Q_UNUSED(deselected);
 
-    auto model = dynamic_cast<QStandardItemModel*>(ui->treeModels->model());
+    auto model = qobject_cast<QStandardItemModel*>(ui->treeModels->model());
     QModelIndexList indexes = selected.indexes();
     for (auto it = indexes.begin(); it != indexes.end(); it++) {
         QStandardItem* item = model->itemFromIndex(*it);

--- a/src/Mod/Mesh/App/FeatureMeshTransform.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshTransform.cpp
@@ -42,7 +42,7 @@ Transform::Transform()
 App::DocumentObjectExecReturn* Transform::execute()
 {
     /*
-        Feature* pcFirst = dynamic_cast<Feature*>(Source.getValue());
+        Feature* pcFirst = freecad_cast<Feature*>(Source.getValue());
         if (!pcFirst || pcFirst->isError())
             return new App::DocumentObjectExecReturn("Unknown Error");
 

--- a/src/Mod/Mesh/App/FeatureMeshTransformDemolding.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshTransformDemolding.cpp
@@ -40,7 +40,7 @@ TransformDemolding::TransformDemolding()
 
 App::DocumentObjectExecReturn* TransformDemolding::execute()
 { /*
-  Feature *pcFirst  = dynamic_cast<Feature*>(Source.getValue());
+  Feature *pcFirst  = freecad_cast<Feature*>(Source.getValue());
   if (!pcFirst || pcFirst->isError())
       return new App::DocumentObjectExecReturn("Unknown Error");
 

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -1793,7 +1793,7 @@ void ViewProviderMesh::fillHoleCallback(void* ud, SoEventCallback* cb)
         // By specifying the indexed mesh node 'pcFaceSet' we make sure that the picked point is
         // really from the mesh we render and not from any other geometry
         Gui::ViewProvider* vp = view->getViewProviderByPathFromTail(point->getPath());
-        if (auto that = dynamic_cast<ViewProviderMesh*>(vp)) {
+        if (auto that = freecad_cast<ViewProviderMesh*>(vp)) {
             const SoDetail* detail = point->getDetail(that->getShapeNode());
             if (detail && detail->getTypeId() == SoFaceDetail::getClassTypeId()) {
                 // get the boundary to the picked facet
@@ -1868,7 +1868,7 @@ void ViewProviderMesh::markPartCallback(void* ud, SoEventCallback* cb)
             // By specifying the indexed mesh node 'pcFaceSet' we make sure that the picked point is
             // really from the mesh we render and not from any other geometry
             Gui::ViewProvider* vp = view->getViewProviderByPathFromTail(point->getPath());
-            if (auto that = dynamic_cast<ViewProviderMesh*>(vp)) {
+            if (auto that = freecad_cast<ViewProviderMesh*>(vp)) {
                 const SoDetail* detail = point->getDetail(that->getShapeNode());
                 if (detail && detail->getTypeId() == SoFaceDetail::getClassTypeId()) {
                     // get the boundary to the picked facet

--- a/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
@@ -325,7 +325,7 @@ void ViewProviderMeshCurvature::updateData(const App::Property* prop)
             // get the view provider of the associated mesh feature
             App::Document* rDoc = pcObject->getDocument();
             Gui::Document* pDoc = Gui::Application::Instance->getDocument(rDoc);
-            if (auto view = dynamic_cast<ViewProviderMesh*>(pDoc->getViewProvider(object))) {
+            if (auto view = freecad_cast<ViewProviderMesh*>(pDoc->getViewProvider(object))) {
                 this->pcLinkRoot->addChild(view->getHighlightNode());
 
                 auto mesh = view->getObject<Mesh::Feature>();
@@ -563,7 +563,7 @@ void ViewProviderMeshCurvature::curvatureInfoCallback(void* ud, SoEventCallback*
             // By specifying the indexed mesh node 'pcFaceSet' we make sure that the picked point is
             // really from the mesh we render and not from any other geometry
             Gui::ViewProvider* vp = view->getViewProviderByPathFromTail(point->getPath());
-            if (auto self = dynamic_cast<ViewProviderMeshCurvature*>(vp)) {
+            if (auto self = freecad_cast<ViewProviderMeshCurvature*>(vp)) {
                 const SoDetail* detail = point->getDetail(point->getPath()->getTail());
                 if (detail && detail->getTypeId() == SoFaceDetail::getClassTypeId()) {
                     const auto facedetail = static_cast<const SoFaceDetail*>(detail);  // NOLINT
@@ -597,7 +597,7 @@ void ViewProviderMeshCurvature::curvatureInfoCallback(void* ud, SoEventCallback*
         // By specifying the indexed mesh node 'pcFaceSet' we make sure that the picked point is
         // really from the mesh we render and not from any other geometry
         Gui::ViewProvider* vp = view->getViewProviderByPathFromTail(point->getPath());
-        if (auto self = dynamic_cast<ViewProviderMeshCurvature*>(vp)) {
+        if (auto self = freecad_cast<ViewProviderMeshCurvature*>(vp)) {
             const SoDetail* detail = point->getDetail(point->getPath()->getTail());
             if (detail && detail->getTypeId() == SoFaceDetail::getClassTypeId()) {
                 const auto facedetail = static_cast<const SoFaceDetail*>(detail);  // NOLINT

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -1934,17 +1934,17 @@ AttachEngine3D::_calculateAttachedPlacement(const std::vector<App::DocumentObjec
 
             switch (shape->shapeType()) {
                 case TopAbs_VERTEX: {
-                    if (auto point = dynamic_cast<GeomPoint*>(geom.get())) {
+                    if (auto point = freecad_cast<GeomPoint*>(geom.get())) {
                         placement.setPosition(point->getPoint());
                     }
                 }
                 break;
 
                 case TopAbs_EDGE: {
-                    if (auto conic = dynamic_cast<GeomConic*>(geom.get())) {
+                    if (auto conic = freecad_cast<GeomConic*>(geom.get())) {
                         placement.setPosition(conic->getLocation());
                         placement.setRotation(conic->getRotation().value_or(Base::Rotation {}));
-                    } else if (auto line = dynamic_cast<GeomCurve*>(geom.get())) {
+                    } else if (auto line = freecad_cast<GeomCurve*>(geom.get())) {
                         auto u1 = line->getFirstParameter();
                         auto u2 = line->getLastParameter();
 
@@ -1963,11 +1963,11 @@ AttachEngine3D::_calculateAttachedPlacement(const std::vector<App::DocumentObjec
                 break;
 
                 case TopAbs_FACE: {
-                    auto surface = dynamic_cast<GeomSurface*>(geom.get());
+                    auto surface = freecad_cast<GeomSurface*>(geom.get());
 
-                    if (auto sphere = dynamic_cast<GeomSphere*>(geom.get())) {
+                    if (auto sphere = freecad_cast<GeomSphere*>(geom.get())) {
                         placement.setPosition(sphere->getLocation());
-                    } else if (auto cone = dynamic_cast<GeomCone*>(geom.get())) {
+                    } else if (auto cone = freecad_cast<GeomCone*>(geom.get())) {
                         placement.setPosition(cone->getApex());
                     } else if (auto com = shape->centerOfGravity()) {
                         placement.setPosition(*com);

--- a/src/Mod/Part/App/FeatureChamfer.h
+++ b/src/Mod/Part/App/FeatureChamfer.h
@@ -29,7 +29,7 @@
 namespace Part
 {
 
-class Chamfer : public Part::FilletBase
+class PartExport Chamfer : public Part::FilletBase
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::Chamfer);
 

--- a/src/Mod/Part/App/FeatureFillet.h
+++ b/src/Mod/Part/App/FeatureFillet.h
@@ -29,7 +29,7 @@
 namespace Part
 {
 
-class Fillet : public Part::FilletBase
+class PartExport Fillet : public Part::FilletBase
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::Fillet);
 

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -1285,7 +1285,7 @@ void GeomBezierCurve::Restore(Base::XMLReader& reader)
 
 PyObject *GeomBezierCurve::getPyObject()
 {
-    return new BezierCurvePy(dynamic_cast<GeomBezierCurve*>(this->clone()));
+    return new BezierCurvePy(freecad_cast<GeomBezierCurve*>(this->clone()));
 }
 
 bool GeomBezierCurve::isSame(const Geometry &_other, double tol, double) const
@@ -2059,7 +2059,7 @@ void GeomBSplineCurve::Restore(Base::XMLReader& reader)
 
 PyObject *GeomBSplineCurve::getPyObject()
 {
-    return new BSplineCurvePy(dynamic_cast<GeomBSplineCurve*>(this->clone()));
+    return new BSplineCurvePy(freecad_cast<GeomBSplineCurve*>(this->clone()));
 }
 
 bool GeomBSplineCurve::isSame(const Geometry &_other, double tol, double atol) const
@@ -4698,7 +4698,7 @@ void GeomLineSegment::Restore    (Base::XMLReader &reader)
 
 PyObject *GeomLineSegment::getPyObject()
 {
-    return new LineSegmentPy(dynamic_cast<GeomLineSegment*>(this->clone()));
+    return new LineSegmentPy(freecad_cast<GeomLineSegment*>(this->clone()));
 }
 
 // -------------------------------------------------
@@ -4769,7 +4769,7 @@ void GeomOffsetCurve::Restore(Base::XMLReader &/*reader*/)
 
 PyObject *GeomOffsetCurve::getPyObject()
 {
-    return new OffsetCurvePy(dynamic_cast<GeomOffsetCurve*>(this->clone()));
+    return new OffsetCurvePy(freecad_cast<GeomOffsetCurve*>(this->clone()));
 }
 
 bool GeomOffsetCurve::isSame(const Geometry &_other, double tol, double atol) const

--- a/src/Mod/Part/App/PartFeatures.h
+++ b/src/Mod/Part/App/PartFeatures.h
@@ -32,7 +32,7 @@
 namespace Part
 {
 
-class RuledSurface : public Part::Feature
+class PartExport RuledSurface : public Part::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::RuledSurface);
 
@@ -64,7 +64,7 @@ private:
     static const char* OrientationEnums[];
 };
 
-class Loft : public Part::Feature
+class PartExport Loft : public Part::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::Loft);
 
@@ -96,7 +96,7 @@ private:
     static App::PropertyIntegerConstraint::Constraints Degrees;
 };
 
-class Sweep : public Part::Feature
+class PartExport Sweep : public Part::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::Sweep);
 

--- a/src/Mod/Part/App/PropertyGeometryList.cpp
+++ b/src/Mod/Part/App/PropertyGeometryList.cpp
@@ -146,7 +146,7 @@ PyObject *PropertyGeometryList::getPyObject()
 void PropertyGeometryList::setPyObject(PyObject *value)
 {
     // check container of this property to notify about changes
-    Part2DObject* part2d = dynamic_cast<Part2DObject*>(this->getContainer());
+    Part2DObject* part2d = freecad_cast<Part2DObject*>(this->getContainer());
 
     if (PySequence_Check(value)) {
         Py::Sequence sequence(value);

--- a/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
@@ -69,7 +69,7 @@ protected:
     {
         static_assert(std::is_base_of<PartDesignGui::ViewProvider, T>::value,
                 "Wrong template argument");
-        return dynamic_cast<T*>(vp);
+        return freecad_cast<T*>(vp);
     }
 
     template<typename T = App::DocumentObject> T* getObject() const
@@ -128,7 +128,7 @@ public:
     {
         static_assert(std::is_base_of<PartDesignGui::ViewProvider, T>::value,
                 "Wrong template argument");
-        return dynamic_cast<T*>(vp);
+        return freecad_cast<T*>(vp);
     }
 
     template<typename T = App::DocumentObject> T* getObject() const

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -114,7 +114,7 @@ Gui::ViewProviderCoordinateSystem* TaskRevolutionParameters::getOriginView() con
     PartDesign::Body * body = PartDesign::Body::findBodyOf(getObject());
     if (body) {
         App::Origin *origin = body->getOrigin();
-        return dynamic_cast<ViewProviderCoordinateSystem*>(
+        return freecad_cast<ViewProviderCoordinateSystem*>(
             Gui::Application::Instance->getViewProvider(origin));
      }
 

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -179,7 +179,7 @@ protected:
     PartDesign::Transformed* getObject() const;
 
     template <class T>
-    T* getObject() const { return dynamic_cast<T*>(getObject()); }
+    T* getObject() const { return freecad_cast<T*>(getObject()); }
 
     /// Get the sketch object of the first original either of the object associated with this
     /// feature or with the parent feature (MultiTransform mode)

--- a/src/Mod/Points/App/Tools.h
+++ b/src/Mod/Points/App/Tools.h
@@ -37,15 +37,15 @@ bool copyProperty(App::DocumentObject* target,
 {
     // check for properties
     if (std::all_of(std::begin(source), std::end(source), [=](auto obj) {
-            return dynamic_cast<PropertyT*>(obj->getPropertyByName(propertyName)) != nullptr;
+            return freecad_cast<PropertyT*>(obj->getPropertyByName(propertyName)) != nullptr;
         })) {
 
-        auto target_prop = dynamic_cast<PropertyT*>(
+        auto target_prop = freecad_cast<PropertyT*>(
             target->addDynamicProperty(PropertyT::getClassTypeId().getName(), propertyName));
         if (target_prop) {
             auto values = target_prop->getValues();
             for (auto it : source) {
-                auto source_prop = dynamic_cast<PropertyT*>(it->getPropertyByName(propertyName));
+                auto source_prop = freecad_cast<PropertyT*>(it->getPropertyByName(propertyName));
                 if (source_prop) {
                     auto source_values = source_prop->getValues();
                     values.insert(values.end(), source_values.begin(), source_values.end());

--- a/src/Mod/Robot/Gui/TaskTrajectory.cpp
+++ b/src/Mod/Robot/Gui/TaskTrajectory.cpp
@@ -114,7 +114,7 @@ TaskTrajectory::TaskTrajectory(Robot::RobotObject* pcRobotObject,
     // clang-format on
 
     // get the view provider
-    ViewProv = dynamic_cast<ViewProviderRobotObject*>(
+    ViewProv = freecad_cast<ViewProviderRobotObject*>(
         Gui::Application::Instance->activeDocument()->getViewProvider(pcRobotObject));
 
     setTo();

--- a/src/Mod/Sketcher/App/ExternalGeometryFacade.h
+++ b/src/Mod/Sketcher/App/ExternalGeometryFacade.h
@@ -194,7 +194,7 @@ public:
             std::is_base_of<Part::Geometry, typename std::decay<GeometryT>::type>::value>::type>
     GeometryT* getGeometry()
     {
-        return dynamic_cast<GeometryT*>(const_cast<GeometryT*>(Geo));
+        return freecad_cast<GeometryT*>(const_cast<GeometryT*>(Geo));
     }
 
     // Geometry Element
@@ -204,7 +204,7 @@ public:
             std::is_base_of<Part::Geometry, typename std::decay<GeometryT>::type>::value>::type>
     GeometryT* getGeometry() const
     {
-        return dynamic_cast<GeometryT*>(Geo);
+        return freecad_cast<GeometryT*>(Geo);
     }
 
     PyObject* getPyObject() override;

--- a/src/Mod/Sketcher/App/GeometryFacade.h
+++ b/src/Mod/Sketcher/App/GeometryFacade.h
@@ -235,7 +235,7 @@ public:
             std::is_base_of<Part::Geometry, typename std::decay<GeometryT>::type>::value>::type>
     GeometryT* getGeometry()
     {
-        return dynamic_cast<GeometryT*>(const_cast<Part::Geometry*>(Geo));
+        return freecad_cast<GeometryT*>(const_cast<Part::Geometry*>(Geo));
     }
 
     // Geometry Element

--- a/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
+++ b/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
@@ -201,7 +201,7 @@ void PropertyConstraintListItem::assignProperty(const App::Property* prop)
             else {
                 // search inside this item
                 if (namedIndex < numNamed) {
-                    child = dynamic_cast<PropertyUnitItem*>(this->child(namedIndex));
+                    child = qobject_cast<PropertyUnitItem*>(this->child(namedIndex));
                 }
 
                 if (!child) {

--- a/src/Mod/Spreadsheet/Gui/Command.cpp
+++ b/src/Mod/Spreadsheet/Gui/Command.cpp
@@ -251,7 +251,7 @@ void CmdSpreadsheetExport::activated(int iMsg)
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
             Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider(sheet);
-            auto* vps = dynamic_cast<ViewProviderSheet*>(vp);
+            auto* vps = freecad_cast<ViewProviderSheet*>(vp);
             if (vps) {
                 vps->exportAsFile();
             }

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -88,7 +88,7 @@ SheetView::SheetView(Gui::Document* pcDocument, App::DocumentObject* docObj, QWi
             this,
             &SheetView::currentChanged);
 
-    connect(dynamic_cast<SheetViewHeader*>(ui->cells->horizontalHeader()),
+    connect(qobject_cast<SheetViewHeader*>(ui->cells->horizontalHeader()),
             &SheetViewHeader::resizeFinished,
             this,
             &SheetView::columnResizeFinished);
@@ -97,7 +97,7 @@ SheetView::SheetView(Gui::Document* pcDocument, App::DocumentObject* docObj, QWi
             this,
             &SheetView::columnResized);
 
-    connect(dynamic_cast<SheetViewHeader*>(ui->cells->verticalHeader()),
+    connect(qobject_cast<SheetViewHeader*>(ui->cells->verticalHeader()),
             &SheetViewHeader::resizeFinished,
             this,
             &SheetView::rowResizeFinished);

--- a/src/Mod/Surface/App/FeatureGeomFillSurface.h
+++ b/src/Mod/Surface/App/FeatureGeomFillSurface.h
@@ -61,7 +61,7 @@ public:
     }
 };
 
-class GeomFillSurface: public Part::Spline
+class SurfaceExport GeomFillSurface: public Part::Spline
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Surface::GeomFillSurface);
 

--- a/src/Mod/TechDraw/App/DimensionReferences.h
+++ b/src/Mod/TechDraw/App/DimensionReferences.h
@@ -63,7 +63,7 @@ public:
     bool operator== (const ReferenceEntry& otherRef) const;
 
     App::DocumentObject* getObject() const;
-    template <class T> T* getObject() const { return dynamic_cast<T*>(getObject()); }
+    template <class T> T* getObject() const { return freecad_cast<T*>(getObject()); }
     void setObject(App::DocumentObject* docObj) { m_object = docObj; }
     std::string getSubName(bool longForm = false) const;
     void setSubName(const std::string& subName) { m_subName = subName; }

--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -744,7 +744,7 @@ BaseGeomPtrVector DrawComplexSection::makeSectionLineGeometry()
 {
     //    Base::Console().Message("DCS::makeSectionLineGeometry()\n");
     BaseGeomPtrVector result;
-    DrawViewPart* baseDvp = dynamic_cast<DrawViewPart*>(BaseView.getValue());
+    DrawViewPart* baseDvp = freecad_cast<DrawViewPart*>(BaseView.getValue());
     if (baseDvp) {
         TopoDS_Wire lineWire = makeSectionLineWire();
         TopoDS_Shape projectedWire =
@@ -775,7 +775,7 @@ std::pair<Base::Vector3d, Base::Vector3d> DrawComplexSection::sectionLineEnds()
     Base::Vector3d first = Base::Vector3d(gpFirst.X(), gpFirst.Y(), gpFirst.Z());
     Base::Vector3d last = Base::Vector3d(gpLast.X(), gpLast.Y(), gpLast.Z());
 
-    DrawViewPart* baseDvp = dynamic_cast<DrawViewPart*>(BaseView.getValue());
+    DrawViewPart* baseDvp = freecad_cast<DrawViewPart*>(BaseView.getValue());
     if (baseDvp) {
         first = baseDvp->projectPoint(first);
         last = baseDvp->projectPoint(last);
@@ -831,7 +831,7 @@ std::pair<Base::Vector3d, Base::Vector3d> DrawComplexSection::sectionArrowDirs()
     Base::Vector3d vDir1 = Base::convertTo<Base::Vector3d>(gDir1);
     vDir0.Normalize();
     vDir1.Normalize();
-    DrawViewPart* baseDvp = dynamic_cast<DrawViewPart*>(BaseView.getValue());
+    DrawViewPart* baseDvp = freecad_cast<DrawViewPart*>(BaseView.getValue());
     if (baseDvp) {
         vDir0 = baseDvp->projectPoint(vDir0, true);
         vDir1 = baseDvp->projectPoint(vDir1, true);
@@ -847,7 +847,7 @@ TopoDS_Wire DrawComplexSection::makeSectionLineWire()
 {
     TopoDS_Wire lineWire;
     App::DocumentObject* toolObj = CuttingToolWireObject.getValue();
-    DrawViewPart* baseDvp = dynamic_cast<DrawViewPart*>(BaseView.getValue());
+    DrawViewPart* baseDvp = freecad_cast<DrawViewPart*>(BaseView.getValue());
     if (baseDvp) {
         TopoDS_Shape toolShape = Part::Feature::getShape(toolObj);
         if (toolShape.IsNull()) {
@@ -884,7 +884,7 @@ ChangePointVector DrawComplexSection::getChangePointsFromSectionLine()
     //    Base::Console().Message("DCS::getChangePointsFromSectionLine()\n");
     ChangePointVector result;
     std::vector<gp_Pnt> allPoints;
-    DrawViewPart* baseDvp = dynamic_cast<DrawViewPart*>(BaseView.getValue());
+    DrawViewPart* baseDvp = freecad_cast<DrawViewPart*>(BaseView.getValue());
     if (baseDvp) {
         TopoDS_Wire lineWire = makeSectionLineWire();
         TopoDS_Shape projectedWire =

--- a/src/Mod/TechDraw/App/DrawDimHelper.cpp
+++ b/src/Mod/TechDraw/App/DrawDimHelper.cpp
@@ -112,7 +112,7 @@ DrawViewDimension* DrawDimHelper::makeExtentDim(DrawViewPart* dvp, std::vector<s
     Base::Interpreter().runStringArg(
         "App.activeDocument().%s.DirExtent = %d", dimName.c_str(), dimNum);
 
-    auto* dimExt = dynamic_cast<DrawViewDimExtent*>(doc->getObject(dimName.c_str()));
+    auto* dimExt = freecad_cast<DrawViewDimExtent*>(doc->getObject(dimName.c_str()));
     if (!dimExt) {
         throw Base::TypeError("Dim extent not found");
     }
@@ -174,7 +174,7 @@ void DrawDimHelper::makeExtentDim3d(DrawViewPart* dvp, ReferenceVector reference
     Base::Interpreter().runStringArg(
         "App.activeDocument().%s.DirExtent = %d", dimName.c_str(), dimNum);
 
-    auto* dimExt = dynamic_cast<DrawViewDimExtent*>(doc->getObject(dimName.c_str()));
+    auto* dimExt = freecad_cast<DrawViewDimExtent*>(doc->getObject(dimName.c_str()));
     if (!dimExt) {
         throw Base::TypeError("Dim extent not found");
     }

--- a/src/Mod/TechDraw/App/DrawGeomHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.cpp
@@ -168,7 +168,7 @@ void DrawGeomHatch::unsetupObject()
 {
 //    Base::Console().Message("DGH::unsetupObject() - status: %lu  removing: %d \n", getStatus(), isRemoving());
     App::DocumentObject* source = Source.getValue();
-    DrawView* dv = dynamic_cast<DrawView*>(source);
+    DrawView* dv = freecad_cast<DrawView*>(source);
     if (dv) {
         dv->requestPaint();
     }
@@ -211,7 +211,7 @@ std::vector<LineSet> DrawGeomHatch::makeLineSets(std::string fileSpec, std::stri
 DrawViewPart* DrawGeomHatch::getSourceView() const
 {
     App::DocumentObject* obj = Source.getValue();
-    DrawViewPart* result = dynamic_cast<DrawViewPart*>(obj);
+    DrawViewPart* result = freecad_cast<DrawViewPart*>(obj);
     return result;
 }
 

--- a/src/Mod/TechDraw/App/DrawHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawHatch.cpp
@@ -83,7 +83,7 @@ App::DocumentObjectExecReturn *DrawHatch::execute(void)
 DrawViewPart* DrawHatch::getSourceView(void) const
 {
     App::DocumentObject* obj = Source.getValue();
-    DrawViewPart* result = dynamic_cast<DrawViewPart*>(obj);
+    DrawViewPart* result = freecad_cast<DrawViewPart*>(obj);
     return result;
 }
 
@@ -183,7 +183,7 @@ void DrawHatch::unsetupObject(void)
 {
 //    Base::Console().Message("DH::unsetupObject() - status: %lu  removing: %d \n", getStatus(), isRemoving());
     App::DocumentObject* source = Source.getValue();
-    DrawView* dv = dynamic_cast<DrawView*>(source);
+    DrawView* dv = freecad_cast<DrawView*>(source);
     if (dv) {
         dv->requestPaint();
     }

--- a/src/Mod/TechDraw/App/DrawLeaderLine.cpp
+++ b/src/Mod/TechDraw/App/DrawLeaderLine.cpp
@@ -146,7 +146,7 @@ DrawView* DrawLeaderLine::getBaseView() const
         return nullptr;
     }
 
-    auto cast = dynamic_cast<DrawView*>(baseObj);
+    auto cast = freecad_cast<DrawView*>(baseObj);
     return cast;
 }
 

--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -116,7 +116,7 @@ void DrawPage::onChanged(const App::Property* prop)
         //     this is needed just to mark the Views to recompute??
         if (!isRestoring()) {
             for (auto* obj : getViews()) {
-                auto* view = dynamic_cast<DrawView*>(obj);
+                auto* view = freecad_cast<DrawView*>(obj);
                 if (view && view->ScaleType.isValue("Page")) {
                     if (std::abs(view->Scale.getValue() - Scale.getValue()) > std::numeric_limits<float>::epsilon()) {
                         view->Scale.setValue(Scale.getValue());
@@ -128,7 +128,7 @@ void DrawPage::onChanged(const App::Property* prop)
     else if (prop == &ProjectionType) {
         // touch all ortho views in the Page as they may be dependent on Projection Type  //(is this true?)
         for (auto* obj : getViews()) {
-            auto* view = dynamic_cast<DrawProjGroup*>(obj);
+            auto* view = freecad_cast<DrawProjGroup*>(obj);
             if (view && view->ProjectionType.isValue("Default")) {
                 view->ProjectionType.touch();
             }
@@ -239,7 +239,7 @@ int DrawPage::addView(App::DocumentObject* docObj, bool setPosition)
         return -1;
     }
 
-    auto* view = dynamic_cast<DrawView*>(docObj);
+    auto* view = freecad_cast<DrawView*>(docObj);
 
     if (!view) {
         auto* link = dynamic_cast<App::Link*>(docObj);
@@ -247,7 +247,7 @@ int DrawPage::addView(App::DocumentObject* docObj, bool setPosition)
             return -1;
         }
 
-        view = dynamic_cast<DrawView*>(link->getLinkedObject());
+        view = freecad_cast<DrawView*>(link->getLinkedObject());
         if (!view) {
             return -1;
         }
@@ -339,7 +339,7 @@ void DrawPage::updateAllViews()
 
     //first, make sure all the Parts have been executed so GeometryObjects exist
     for (auto& v : featViews) {
-        auto* part = dynamic_cast<DrawViewPart*>(v);
+        auto* part = freecad_cast<DrawViewPart*>(v);
         if (part) {
             //view, section, detail, dpgi
             part->recomputeFeature();
@@ -348,12 +348,12 @@ void DrawPage::updateAllViews()
     //second, do the rest of the views that may depend on a part view
     //TODO: check if we have 2 layers of dependency (ex. leader > weld > tile?)
     for (auto& v : featViews) {
-        auto* part = dynamic_cast<DrawViewPart*>(v);
+        auto* part = freecad_cast<DrawViewPart*>(v);
         if (part) {
             continue;
         }
 
-        auto* view = dynamic_cast<DrawView*>(v);
+        auto* view = freecad_cast<DrawView*>(v);
         if (view) {
             view->overrideKeepUpdated(true);
             view->recomputeFeature();

--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -356,7 +356,7 @@ void DrawProjGroup::getViewArea(std::array<DrawProjGroupItem*, MAXPROJECTIONCOUN
 App::DocumentObject* DrawProjGroup::getProjObj(const char* viewProjType) const
 {
     for (auto it : Views.getValues()) {
-        auto projPtr(dynamic_cast<DrawProjGroupItem*>(it));
+        auto projPtr(freecad_cast<DrawProjGroupItem*>(it));
         if (!projPtr) {
             //if an element in Views is not a DPGI, something really bad has happened somewhere
             Base::Console().Error("PROBLEM - DPG::getProjObj - non DPGI entry in Views! %s / %s\n",
@@ -540,7 +540,7 @@ int DrawProjGroup::purgeProjections()
     while (!Views.getValues().empty()) {
         std::vector<DocumentObject*> views = Views.getValues();
         DocumentObject* dObj = views.back();
-        auto* dpgi = dynamic_cast<DrawProjGroupItem*>(dObj);
+        auto* dpgi = freecad_cast<DrawProjGroupItem*>(dObj);
         if (dpgi) {
             std::string itemName = dpgi->Type.getValueAsString();
             removeProjection(itemName.c_str());
@@ -866,7 +866,7 @@ void DrawProjGroup::arrangeViewPointers(
 
     bool thirdAngle = (strcmp(projType, "Third Angle") == 0);
     for (auto it : Views.getValues()) {
-        auto oView(dynamic_cast<DrawProjGroupItem*>(it));
+        auto oView(freecad_cast<DrawProjGroupItem*>(it));
         if (!oView) {
             //if an element in Views is not a DPGI, something really bad has happened somewhere
             Base::Console().Error(
@@ -944,7 +944,7 @@ void DrawProjGroup::recomputeChildren()
 {
     //    Base::Console().Message("DPG::recomputeChildren() - waiting: %d\n", waitingForChildren());
     for (const auto it : Views.getValues()) {
-        auto view(dynamic_cast<DrawProjGroupItem*>(it));
+        auto view(freecad_cast<DrawProjGroupItem*>(it));
         if (!view) {
             throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
         }
@@ -959,7 +959,7 @@ void DrawProjGroup::autoPositionChildren()
     //    Base::Console().Message("DPG::autoPositionChildren() - %s - waiting: %d\n",
     //                            getNameInDocument(), waitingForChildren());
     for (const auto it : Views.getValues()) {
-        auto view(dynamic_cast<DrawProjGroupItem*>(it));
+        auto view(freecad_cast<DrawProjGroupItem*>(it));
         if (!view) {
             //if an element in Views is not a DPGI, something really bad has happened somewhere
             throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
@@ -977,7 +977,7 @@ void DrawProjGroup::updateChildrenScale()
 {
     //    Base::Console().Message("DPG::updateChildrenScale() - waiting: %d\n", waitingForChildren());
     for (const auto it : Views.getValues()) {
-        auto view(dynamic_cast<DrawProjGroupItem*>(it));
+        auto view(freecad_cast<DrawProjGroupItem*>(it));
         if (!view) {
             //if an element in Views is not a DPGI, something really bad has happened somewhere
             throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
@@ -995,7 +995,7 @@ void DrawProjGroup::updateChildrenScale()
 void DrawProjGroup::updateChildrenSource()
 {
     for (const auto it : Views.getValues()) {
-        auto view(dynamic_cast<DrawProjGroupItem*>(it));
+        auto view(freecad_cast<DrawProjGroupItem*>(it));
         if (!view) {
             //if an element in Views is not a DPGI, something really bad has happened somewhere
             Base::Console().Error(
@@ -1019,7 +1019,7 @@ void DrawProjGroup::updateChildrenSource()
 void DrawProjGroup::updateChildrenLock()
 {
     for (const auto it : Views.getValues()) {
-        auto view(dynamic_cast<DrawProjGroupItem*>(it));
+        auto view(freecad_cast<DrawProjGroupItem*>(it));
         if (!view) {
             //if an element in Views is not a DPGI, something really bad has happened somewhere
             Base::Console().Error(
@@ -1034,7 +1034,7 @@ void DrawProjGroup::updateChildrenLock()
 void DrawProjGroup::updateChildrenEnforce(void)
 {
     for (const auto it : Views.getValues()) {
-        auto view(dynamic_cast<DrawProjGroupItem*>(it));
+        auto view(freecad_cast<DrawProjGroupItem*>(it));
         if (!view) {
             //if an element in Views is not a DPGI, something really bad has happened somewhere
             Base::Console().Error(

--- a/src/Mod/TechDraw/App/DrawRichAnno.cpp
+++ b/src/Mod/TechDraw/App/DrawRichAnno.cpp
@@ -89,7 +89,7 @@ App::DocumentObjectExecReturn *DrawRichAnno::execute()
 DrawView* DrawRichAnno::getBaseView() const
 {
 //    Base::Console().Message("DRA::getBaseView() - %s\n", getNameInDocument());
-    return dynamic_cast<DrawView*>(AnnoParent.getValue());
+    return freecad_cast<DrawView*>(AnnoParent.getValue());
 }
 
 //finds the first DrawPage in this Document that claims to own this DrawRichAnno
@@ -102,7 +102,7 @@ DrawPage* DrawRichAnno::findParentPage() const
         return DrawView::findParentPage();
     }
 
-    DrawView* parent = dynamic_cast<DrawView*>(AnnoParent.getValue());
+    DrawView* parent = freecad_cast<DrawView*>(AnnoParent.getValue());
     if (parent) {
         return parent->findParentPage();
     }

--- a/src/Mod/TechDraw/App/DrawTile.cpp
+++ b/src/Mod/TechDraw/App/DrawTile.cpp
@@ -88,7 +88,7 @@ void DrawTile::handleChangedPropertyType(Base::XMLReader &reader, const char *Ty
 DrawView* DrawTile::getParent() const
 {
 //    Base::Console().Message("DT::getParent() - %s\n", getNameInDocument());
-    return dynamic_cast<DrawView*>(TileParent.getValue());
+    return freecad_cast<DrawView*>(TileParent.getValue());
 }
 
 PyObject *DrawTile::getPyObject()

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -660,7 +660,7 @@ void DrawView::setScaleAttribute()
 //! existence of the parent DrawProjGroup
 bool DrawView::isProjGroupItem(DrawViewPart* item)
 {
-    auto dpgi = dynamic_cast<DrawProjGroupItem*>(item);
+    auto dpgi = freecad_cast<DrawProjGroupItem*>(item);
     if (!dpgi) {
         return false;
     }

--- a/src/Mod/TechDraw/App/DrawViewBalloon.cpp
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.cpp
@@ -211,7 +211,7 @@ void DrawViewBalloon::handleXYLock()
 DrawView* DrawViewBalloon::getParentView() const
 {
     App::DocumentObject* obj = SourceView.getValue();
-    DrawView* result = dynamic_cast<DrawView*>(obj);
+    DrawView* result = freecad_cast<DrawView*>(obj);
     return result;
 }
 

--- a/src/Mod/TechDraw/App/DrawViewCollection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewCollection.cpp
@@ -90,7 +90,7 @@ int DrawViewCollection::addView(App::DocumentObject* docObj)
         return -1;
     }
 
-    auto* view = dynamic_cast<DrawView*>(docObj);
+    auto* view = freecad_cast<DrawView*>(docObj);
 
     if (!view) {
         auto* link = dynamic_cast<App::Link*>(docObj);
@@ -99,7 +99,7 @@ int DrawViewCollection::addView(App::DocumentObject* docObj)
         }
 
         if (link) {
-            view = dynamic_cast<DrawView*>(link->getLinkedObject());
+            view = freecad_cast<DrawView*>(link->getLinkedObject());
             if (!view) {
                 return -1;
             }
@@ -228,7 +228,7 @@ QRectF DrawViewCollection::getRect() const
 {
     QRectF result;
     for (auto& v : getViews()) {
-        auto *view = dynamic_cast<DrawView*>(v);
+        auto *view = freecad_cast<DrawView*>(v);
         if (!view) {
             throw Base::ValueError("DrawViewCollection::getRect bad View\n");
         }

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -448,7 +448,7 @@ TopoDS_Shape DrawViewDetail::projectEdgesOntoFace(TopoDS_Shape& edgeShape, TopoD
 Base::Vector3d DrawViewDetail::mapPoint3dToDetail(const Base::Vector3d& inPoint) const
 {
     auto baseObj = BaseView.getValue();
-    auto baseDvp = dynamic_cast<DrawViewPart*>(baseObj);
+    auto baseDvp = freecad_cast<DrawViewPart*>(baseObj);
     if (!baseDvp) {
         throw Base::RuntimeError("Detail has no BaseView");
     }
@@ -502,7 +502,7 @@ void DrawViewDetail::handleChangedPropertyType(Base::XMLReader &reader, const ch
 void DrawViewDetail::unsetupObject()
 {
     App::DocumentObject* baseObj = BaseView.getValue();
-    DrawView* base = dynamic_cast<DrawView*>(baseObj);
+    DrawView* base = freecad_cast<DrawView*>(baseObj);
     if (base) {
         base->requestPaint();
     }

--- a/src/Mod/TechDraw/App/DrawViewDimExtent.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimExtent.cpp
@@ -71,7 +71,7 @@ App::DocumentObjectExecReturn *DrawViewDimExtent::execute(void)
     App::DocumentObject* docObj = Source.getValue();
     if (!docObj)
         return App::DocumentObject::StdReturn;
-    DrawViewPart* dvp = dynamic_cast<DrawViewPart*>(docObj);
+    DrawViewPart* dvp = freecad_cast<DrawViewPart*>(docObj);
     if (!dvp)
         return App::DocumentObject::StdReturn;
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -729,7 +729,7 @@ double DrawViewDimension::getProjectedDimValue() const
 
     if (Type.isValue("Distance") || Type.isValue("DistanceX") || Type.isValue("DistanceY")) {
         pointPair pts = getLinearPoints();
-        auto dbv = dynamic_cast<DrawBrokenView*>(getViewPart());
+        auto dbv = freecad_cast<DrawBrokenView*>(getViewPart());
         if (dbv)  {
             // raw pts from view are inverted Y, so we need to un-invert them before mapping
             // raw pts are scaled, so we need to unscale them for mapPoint2dFromView

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -972,7 +972,7 @@ ChangePointVector DrawViewSection::getChangePointsFromSectionLine()
     //    Base::Console().Message("Dvs::getChangePointsFromSectionLine()\n");
     ChangePointVector result;
     std::vector<gp_Pnt> allPoints;
-    DrawViewPart* baseDvp = dynamic_cast<DrawViewPart*>(BaseView.getValue());
+    DrawViewPart* baseDvp = freecad_cast<DrawViewPart*>(BaseView.getValue());
     if (baseDvp) {
         std::pair<Base::Vector3d, Base::Vector3d> lineEnds = sectionLineEnds();
         // make start and end marks

--- a/src/Mod/TechDraw/App/DrawWeldSymbol.cpp
+++ b/src/Mod/TechDraw/App/DrawWeldSymbol.cpp
@@ -77,7 +77,7 @@ void DrawWeldSymbol::onSettingDocument()
 
     std::string tileName1 = doc->getUniqueObjectName("TileWeld");
     auto tile1Obj( doc->addObject( "TechDraw::DrawTileWeld", tileName1.c_str() ) );
-    DrawTileWeld* tile1 = dynamic_cast<DrawTileWeld*>(tile1Obj);
+    DrawTileWeld* tile1 = freecad_cast<DrawTileWeld*>(tile1Obj);
     if (tile1) {
         tile1->Label.setValue(DrawUtil::translateArbitrary("DrawTileWeld",  "TileWeld",  tileName1));
         tile1->TileParent.setValue(this);
@@ -85,7 +85,7 @@ void DrawWeldSymbol::onSettingDocument()
 
     std::string tileName2 = doc->getUniqueObjectName("TileWeld");
     auto tile2Obj( doc->addObject( "TechDraw::DrawTileWeld", tileName2.c_str() ) );
-    DrawTileWeld* tile2 = dynamic_cast<DrawTileWeld*>(tile2Obj);
+    DrawTileWeld* tile2 = freecad_cast<DrawTileWeld*>(tile2Obj);
     if (tile2) {
         tile2->Label.setValue(DrawUtil::translateArbitrary("DrawTileWeld",  "TileWeld",  tileName2));
         tile2->TileParent.setValue(this);

--- a/src/Mod/TechDraw/App/LandmarkDimension.cpp
+++ b/src/Mod/TechDraw/App/LandmarkDimension.cpp
@@ -165,7 +165,7 @@ DrawViewPart* LandmarkDimension::getViewPart() const
 {
     std::vector<App::DocumentObject*> refs2d = References2D.getValues();
     App::DocumentObject* obj = refs2d.front();
-    DrawViewPart* dvp = dynamic_cast<DrawViewPart*>(obj);
+    DrawViewPart* dvp = freecad_cast<DrawViewPart*>(obj);
     return dvp;
 }
 

--- a/src/Mod/TechDraw/App/PropertyGeomFormatList.cpp
+++ b/src/Mod/TechDraw/App/PropertyGeomFormatList.cpp
@@ -104,7 +104,7 @@ PyObject *PropertyGeomFormatList::getPyObject()
 void PropertyGeomFormatList::setPyObject(PyObject *value)
 {
     // check container of this property to notify about changes
-//    Part2DObject* part2d = dynamic_cast<Part2DObject*>(this->getContainer());
+//    Part2DObject* part2d = freecad_cast<Part2DObject*>(this->getContainer());
 
     if (PySequence_Check(value)) {
         Py::Sequence sequence(value);

--- a/src/Mod/TechDraw/Gui/AppTechDrawGuiPy.cpp
+++ b/src/Mod/TechDraw/Gui/AppTechDrawGuiPy.cpp
@@ -137,7 +137,7 @@ private:
                     Gui::Document* activeGui =
                         Gui::Application::Instance->getDocument(page->getDocument());
                     Gui::ViewProvider* vp = activeGui->getViewProvider(obj);
-                    ViewProviderPage* vpPage = dynamic_cast<ViewProviderPage*>(vp);
+                    ViewProviderPage* vpPage = freecad_cast<ViewProviderPage*>(vp);
                     if (!vpPage) {
                         throw Py::TypeError("TechDraw can not find Page");
                     }

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -317,7 +317,7 @@ void CmdTechDrawView::activated(int iMsg)
     std::string PageName = page->getNameInDocument();
 
     // switch to the page if it's not current active window
-    auto* vpp = dynamic_cast<ViewProviderPage*>
+    auto* vpp = freecad_cast<ViewProviderPage*>
         (Gui::Application::Instance->getViewProvider(page));
     if (vpp) {
         vpp->show();
@@ -1296,9 +1296,9 @@ void CmdTechDrawBalloon::activated(int iMsg)
     std::string PageName = page->getNameInDocument();
 
     Gui::Document* guiDoc = Gui::Application::Instance->getDocument(page->getDocument());
-    ViewProviderPage* pageVP = dynamic_cast<ViewProviderPage*>(guiDoc->getViewProvider(page));
+    ViewProviderPage* pageVP = freecad_cast<ViewProviderPage*>(guiDoc->getViewProvider(page));
     ViewProviderDrawingView* viewVP =
-        dynamic_cast<ViewProviderDrawingView*>(guiDoc->getViewProvider(objFeat));
+        freecad_cast<ViewProviderDrawingView*>(guiDoc->getViewProvider(objFeat));
 
     if (pageVP && viewVP) {
         QGVPage* viewPage = pageVP->getQGVPage();
@@ -1820,7 +1820,7 @@ void CmdTechDrawExportPageSVG::activated(int iMsg)
 
     Gui::Document* activeGui = Gui::Application::Instance->getDocument(page->getDocument());
     Gui::ViewProvider* vp = activeGui->getViewProvider(page);
-    ViewProviderPage* vpPage = dynamic_cast<ViewProviderPage*>(vp);
+    ViewProviderPage* vpPage = freecad_cast<ViewProviderPage*>(vp);
 
     if (vpPage) {
         vpPage->show();  // make sure a mdi will be available

--- a/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
@@ -1517,7 +1517,7 @@ void CmdTechDrawShowAll::activated(int iMsg)
     }
 
     Gui::ViewProvider* vp = QGIView::getViewProvider(baseFeat);
-    auto partVP = dynamic_cast<ViewProviderViewPart*>(vp);
+    auto partVP = freecad_cast<ViewProviderViewPart*>(vp);
     if (partVP) {
         bool state = partVP->ShowAllEdges.getValue();
         state = !state;

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -339,7 +339,7 @@ public:
 
     QGIDatumLabel* getDimLabel(DrawViewDimension* d)
     {
-        auto* vp = dynamic_cast<ViewProviderDimension*>(Gui::Application::Instance->getViewProvider(d));
+        auto* vp = freecad_cast<ViewProviderDimension*>(Gui::Application::Instance->getViewProvider(d));
         if (!vp) {
             return nullptr;
         }
@@ -361,7 +361,7 @@ public:
     QPointF getDimPositionToBe(QPoint pos, QPointF curPos = QPointF(), bool textToMiddle = false, Base::Vector3d dir = Base::Vector3d(),
         Base::Vector3d delta = Base::Vector3d(), DimensionType type = DimensionType::Distance, int i = 0)
     {
-        auto* vpp = dynamic_cast<ViewProviderDrawingView*>(Gui::Application::Instance->getViewProvider(partFeat));
+        auto* vpp = freecad_cast<ViewProviderDrawingView*>(Gui::Application::Instance->getViewProvider(partFeat));
         if (!vpp) { return QPointF(); }
 
 

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -120,7 +120,7 @@ void positionDimText(DrawViewDimension* dim, int indexOffset = 0);
 
 void activateHandler(TechDrawHandler* newHandler)
 {
-    auto* mdi = dynamic_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
+    auto* mdi = qobject_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
     if (!mdi) {
         return;
     }
@@ -237,7 +237,7 @@ public:
 
     void activated() override
     {
-        auto* mdi = dynamic_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
+        auto* mdi = qobject_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
         if (mdi) {
             mdi->setDimensionsSelectability(false);
         }
@@ -248,7 +248,7 @@ public:
 
     void deactivated() override
     {
-        auto* mdi = dynamic_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
+        auto* mdi = qobject_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
         if (mdi) {
             mdi->setDimensionsSelectability(true);
         }

--- a/src/Mod/TechDraw/Gui/CommandDecorate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandDecorate.cpp
@@ -328,7 +328,7 @@ void CmdTechDrawToggleFrame::activated(int iMsg)
 
     Gui::Document* activeGui = Gui::Application::Instance->getDocument(page->getDocument());
     Gui::ViewProvider* vp = activeGui->getViewProvider(page);
-    ViewProviderPage* vpPage = dynamic_cast<ViewProviderPage*>(vp);
+    ViewProviderPage* vpPage = freecad_cast<ViewProviderPage*>(vp);
 
     if (!vpPage) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("No TechDraw Page"),

--- a/src/Mod/TechDraw/Gui/CommandDecorate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandDecorate.cpp
@@ -349,7 +349,7 @@ void CmdTechDrawToggleFrame::activated(int iMsg)
 // currently looking at that page
 bool CmdTechDrawToggleFrame::isActive()
 {
-    auto mvp = dynamic_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
+    auto mvp = qobject_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
     if (!mvp) {
         return false;
     }

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -2038,7 +2038,7 @@ std::string _createBalloon(Gui::Command* cmd, TechDraw::DrawViewPart* objFeat)
     std::string featName;
     TechDraw::DrawPage* page = objFeat->findParentPage();
     Gui::Document* guiDoc = Gui::Application::Instance->getDocument(page->getDocument());
-    auto pageVP = dynamic_cast<ViewProviderPage*>(guiDoc->getViewProvider(page));
+    auto pageVP = freecad_cast<ViewProviderPage*>(guiDoc->getViewProvider(page));
     if (pageVP) {
         QGSPage* scenePage = pageVP->getQGSPage();
         featName = scenePage->getDrawPage()->getDocument()->getUniqueObjectName("Balloon");

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -353,7 +353,7 @@ TechDraw::DrawPage* DrawGuiUtil::findPage(Gui::Command* cmd, bool findAny)
             // multiple pages in document, use active page if there is one
             auto* w = Gui::getMainWindow();
             auto* mv = w->activeWindow();
-            auto* mvp = dynamic_cast<MDIViewPage*>(mv);
+            auto* mvp = qobject_cast<MDIViewPage*>(mv);
             if (mvp) {
                 QGSPage* qp = mvp->getViewProviderPage()->getQGSPage();
                 return qp->getDrawPage();

--- a/src/Mod/TechDraw/Gui/QGIDatumLabel.cpp
+++ b/src/Mod/TechDraw/Gui/QGIDatumLabel.cpp
@@ -214,7 +214,7 @@ void QGIDatumLabel::snapPosition(QPointF& pos)
                     continue;
                 }
 
-                auto* vp = dynamic_cast<ViewProviderDimension*>(Gui::Application::Instance->getViewProvider(d));
+                auto* vp = freecad_cast<ViewProviderDimension*>(Gui::Application::Instance->getViewProvider(d));
                 if (!vp) { continue; }
                 auto* qgivDi(dynamic_cast<QGIViewDimension*>(vp->getQView()));
                 if (!qgivDi) { continue; }
@@ -277,7 +277,7 @@ void QGIDatumLabel::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
         return;
     }
 
-    auto ViewProvider = dynamic_cast<ViewProviderDimension*>(
+    auto ViewProvider = freecad_cast<ViewProviderDimension*>(
         qgivDimension->getViewProvider(qgivDimension->getViewObject()));
     if (!ViewProvider) {
         qWarning() << "QGIDatumLabel::mouseDoubleClickEvent: No valid view provider";

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
@@ -155,7 +155,7 @@ void QGILeaderLine::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 //! start editor on double click
 void QGILeaderLine::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
 {
-    auto ViewProvider = dynamic_cast<ViewProviderLeader*>(getViewProvider(getLeaderFeature()));
+    auto ViewProvider = freecad_cast<ViewProviderLeader*>(getViewProvider(getLeaderFeature()));
     if (!ViewProvider) {
         qWarning() << "QGILeaderLine::mouseDoubleClickEvent: No valid view provider";
         return;
@@ -632,7 +632,7 @@ QColor QGILeaderLine::prefNormalColor()
     //    Base::Console().Message("QGILL::getNormalColor()\n");
     setNormalColor(PreferencesGui::leaderQColor());
 
-    auto vp = dynamic_cast<ViewProviderLeader*>(getViewProvider(getViewObject()));
+    auto vp = freecad_cast<ViewProviderLeader*>(getViewProvider(getViewObject()));
     if (vp) {
         QColor normal = vp->Color.getValue().asValue<QColor>();
         setNormalColor(PreferencesGui::getAccessibleQColor(normal));
@@ -659,7 +659,7 @@ void QGILeaderLine::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt
 
 bool QGILeaderLine::useOldCoords() const
 {
-    auto vp = dynamic_cast<ViewProviderLeader*>(getViewProvider(getViewObject()));
+    auto vp = freecad_cast<ViewProviderLeader*>(getViewProvider(getViewObject()));
     if (vp) {
         return vp->UseOldCoords.getValue();
     }

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -225,7 +225,7 @@ void QGIView::snapPosition(QPointF& newPosition)
         return;
     }
 
-    auto dvp = dynamic_cast<DrawViewPart*>(feature);
+    auto dvp = freecad_cast<DrawViewPart*>(feature);
     if (dvp  &&
         !dvp->hasGeometry()) {
         // too early. wait for updates to finish.
@@ -262,7 +262,7 @@ void QGIView::snapPosition(QPointF& newPosition)
             continue;
         }
         auto viewFeature = view->getViewObject();
-        auto viewDvp = dynamic_cast<DrawViewPart*>(viewFeature);
+        auto viewDvp = freecad_cast<DrawViewPart*>(viewFeature);
 
         auto viewScenePos = view->scenePos();
         if (viewDvp &&
@@ -316,7 +316,7 @@ void QGIView::snapSectionView(const TechDraw::DrawViewSection* sectionView,
     if (!baseView) {
         return;
     }
-    auto* vpdv = dynamic_cast<ViewProviderDrawingView*>(getViewProvider(baseView));
+    auto* vpdv = freecad_cast<ViewProviderDrawingView*>(getViewProvider(baseView));
     if (!vpdv) {
         return;
     }
@@ -810,7 +810,7 @@ ViewProviderPage* QGIView::getViewProviderPage(TechDraw::DrawView* dView)
         return nullptr;
     }
 
-    return dynamic_cast<ViewProviderPage*>(activeGui->getViewProvider(page));
+    return freecad_cast<ViewProviderPage*>(activeGui->getViewProvider(page));
 }
 
 //remove a child of this from scene while keeping scene indexes valid
@@ -833,7 +833,7 @@ bool QGIView::getFrameState()
 
     Gui::Document* activeGui = Gui::Application::Instance->getDocument(page->getDocument());
     Gui::ViewProvider* vp = activeGui->getViewProvider(page);
-    ViewProviderPage* vpp = dynamic_cast<ViewProviderPage*>(vp);
+    ViewProviderPage* vpp = freecad_cast<ViewProviderPage*>(vp);
     if (!vpp) return true;
 
     return vpp->getFrameState();

--- a/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
@@ -188,7 +188,7 @@ void QGIViewAnnotation::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
     if (!annotation) {
         return;
     }
-    auto ViewProvider = dynamic_cast<ViewProviderAnnotation*>(getViewProvider(annotation));
+    auto ViewProvider = freecad_cast<ViewProviderAnnotation*>(getViewProvider(annotation));
     if (!ViewProvider) {
         qWarning() << "QGIViewAnnotation::mouseDoubleClickEvent: No valid view provider";
         return;

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -149,7 +149,7 @@ void QGIBalloonLabel::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
         return;
     }
 
-    auto ViewProvider = dynamic_cast<ViewProviderBalloon*>(
+    auto ViewProvider = freecad_cast<ViewProviderBalloon*>(
         qgivBalloon->getViewProvider(qgivBalloon->getViewObject()));
     if (!ViewProvider) {
         qWarning() << "QGIBalloonLabel::mouseDoubleClickEvent: No valid view provider";
@@ -366,7 +366,7 @@ void QGIViewBalloon::setViewPartFeature(TechDraw::DrawViewBalloon* balloonFeat)
     double scale = 1.0;
     App::DocumentObject* docObj = balloonFeat->SourceView.getValue();
     if (docObj) {
-        balloonParent = dynamic_cast<DrawView*>(docObj);
+        balloonParent = freecad_cast<DrawView*>(docObj);
         if (balloonParent) {
             scale = balloonParent->getScale();
         }
@@ -547,7 +547,7 @@ void QGIViewBalloon::placeBalloon(QPointF pos)
         return;
     }
 
-    DrawView* balloonParent = dynamic_cast<DrawView*>(balloon->SourceView.getValue());
+    DrawView* balloonParent = freecad_cast<DrawView*>(balloon->SourceView.getValue());
     if (!balloonParent) {
         return;
     }
@@ -565,7 +565,7 @@ void QGIViewBalloon::placeBalloon(QPointF pos)
     QGIView* qgivParent = nullptr;
     QPointF viewPos;
     Gui::ViewProvider* objVp = QGIView::getViewProvider(balloonParent);
-    auto partVP = dynamic_cast<ViewProviderViewPart*>(objVp);
+    auto partVP = freecad_cast<ViewProviderViewPart*>(objVp);
     if (partVP) {
         qgivParent = partVP->getQView();
         if (qgivParent) {
@@ -944,7 +944,7 @@ QColor QGIViewBalloon::prefNormalColor()
     ViewProviderBalloon* vpBalloon = nullptr;
     Gui::ViewProvider* vp = getViewProvider(getBalloonFeat());
     if (vp) {
-        vpBalloon = dynamic_cast<ViewProviderBalloon*>(vp);
+        vpBalloon = freecad_cast<ViewProviderBalloon*>(vp);
         if (vpBalloon) {
             Base::Color fcColor = Preferences::getAccessibleColor(vpBalloon->Color.getValue());
             setNormalColor(fcColor.asValue<QColor>());
@@ -968,9 +968,9 @@ DrawView* QGIViewBalloon::getSourceView() const
 {
     DrawView* balloonParent = nullptr;
     App::DocumentObject* docObj = getViewObject();
-    DrawViewBalloon* dvb = dynamic_cast<DrawViewBalloon*>(docObj);
+    DrawViewBalloon* dvb = freecad_cast<DrawViewBalloon*>(docObj);
     if (dvb) {
-        balloonParent = dynamic_cast<DrawView*>(dvb->SourceView.getValue());
+        balloonParent = freecad_cast<DrawView*>(dvb->SourceView.getValue());
     }
     return balloonParent;
 }

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -2261,7 +2261,7 @@ QColor QGIViewDimension::prefNormalColor()
     ViewProviderDimension* vpDim = nullptr;
     Gui::ViewProvider* vp = getViewProvider(getDimFeat());
     if (vp) {
-        vpDim = dynamic_cast<ViewProviderDimension*>(vp);
+        vpDim = freecad_cast<ViewProviderDimension*>(vp);
         if (vpDim) {
             Base::Color fcColor = vpDim->Color.getValue();
             fcColor = Preferences::getAccessibleColor(fcColor);

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -300,7 +300,7 @@ void QGIViewPart::drawAllFaces(void)
             newFace->setHatchOffset(fGeom->PatternOffset.getValue());
             newFace->setHatchFile(fGeom->PatIncluded.getValue());
             Gui::ViewProvider* gvp = QGIView::getViewProvider(fGeom);
-            ViewProviderGeomHatch* geomVp = dynamic_cast<ViewProviderGeomHatch*>(gvp);
+            ViewProviderGeomHatch* geomVp = freecad_cast<ViewProviderGeomHatch*>(gvp);
             if (geomVp) {
                 newFace->setHatchColor(geomVp->ColorPattern.getValue());
                 newFace->setLineWeight(geomVp->WeightPattern.getValue());
@@ -321,7 +321,7 @@ void QGIViewPart::drawAllFaces(void)
 
             // get the properties from the hatch viewprovider
             Gui::ViewProvider* gvp = QGIView::getViewProvider(fHatch);
-            ViewProviderHatch* hatchVp = dynamic_cast<ViewProviderHatch*>(gvp);
+            ViewProviderHatch* hatchVp = freecad_cast<ViewProviderHatch*>(gvp);
             if (hatchVp) {
                 if (hatchVp->HatchScale.getValue() > 0.0) {
                     newFace->setHatchScale(hatchVp->HatchScale.getValue());
@@ -993,7 +993,7 @@ void QGIViewPart::highlightMoved(QGIHighlight* highlight, QPointF newPos)
     std::string highlightName = highlight->getFeatureName();
     App::Document* doc = getViewObject()->getDocument();
     App::DocumentObject* docObj = doc->getObject(highlightName.c_str());
-    auto detail = dynamic_cast<DrawViewDetail*>(docObj);
+    auto detail = freecad_cast<DrawViewDetail*>(docObj);
     if (detail) {
         auto oldAnchor = detail->AnchorPoint.getValue();
         Base::Vector3d delta = Rez::appX(DrawUtil::toVector3d(newPos)) / getViewObject()->getScale();

--- a/src/Mod/TechDraw/Gui/QGIViewSection.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSection.cpp
@@ -58,7 +58,7 @@ void QGIViewSection::drawSectionFace()
         return;
     }
 
-    ViewProviderViewSection* sectionVp = dynamic_cast<ViewProviderViewSection*>(QGIView::getViewProvider(section));
+    ViewProviderViewSection* sectionVp = freecad_cast<ViewProviderViewSection*>(QGIView::getViewProvider(section));
     if (!sectionVp) {
         return;
     }

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
@@ -112,7 +112,7 @@ void QGIViewSymbol::drawSvg()
     }
 
     auto vp = getViewProvider(viewSymbol);
-    auto vps = dynamic_cast<ViewProviderSymbol*>(vp);
+    auto vps = freecad_cast<ViewProviderSymbol*>(vp);
     if (!vp || !vps) {
         return;
     }

--- a/src/Mod/TechDraw/Gui/TaskActiveView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskActiveView.cpp
@@ -224,7 +224,7 @@ TechDraw::DrawViewImage* TaskActiveView::createActiveView()
     if (guiDoc) {
         Gui::ViewProvider* vp = guiDoc->getViewProvider(newImg);
         if (vp) {
-            auto vpImage = dynamic_cast<ViewProviderImage*>(vp);
+            auto vpImage = freecad_cast<ViewProviderImage*>(vp);
             if (vpImage) {
                 vpImage->Crop.setValue(ui->cbCrop->isChecked());
             }

--- a/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
@@ -507,7 +507,7 @@ void TaskCenterLine::enableTaskButtons(bool isEnabled)
 double TaskCenterLine::getCenterWidth()
 {
     Gui::ViewProvider* vp = QGIView::getViewProvider(m_partFeat);
-    auto partVP = dynamic_cast<ViewProviderViewPart*>(vp);
+    auto partVP = freecad_cast<ViewProviderViewPart*>(vp);
     if (!partVP) {
         return TechDraw::LineGroup::getDefaultWidth("Graphic");
     }

--- a/src/Mod/TechDraw/Gui/TaskCosVertex.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCosVertex.cpp
@@ -217,7 +217,7 @@ void TaskCosVertex::onTrackerFinished(std::vector<QPointF> pts, QGIView* qgParen
     double y = Rez::guiX(m_baseFeat->Y.getValue());
 
     DrawViewPart* dvp = m_baseFeat;
-    DrawProjGroupItem* dpgi = dynamic_cast<DrawProjGroupItem*>(dvp);
+    DrawProjGroupItem* dpgi = freecad_cast<DrawProjGroupItem*>(dvp);
     if (dpgi) {
         DrawProjGroup* dpg = dpgi->getPGroup();
         if (dpg) {

--- a/src/Mod/TechDraw/Gui/TaskDetail.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDetail.cpp
@@ -391,7 +391,7 @@ void TaskDetail::onHighlightMoved(QPointF dragEnd)
     double y = Rez::guiX(getBaseFeat()->Y.getValue());
 
     DrawViewPart* dvp = getBaseFeat();
-    DrawProjGroupItem* dpgi = dynamic_cast<DrawProjGroupItem*>(dvp);
+    DrawProjGroupItem* dpgi = freecad_cast<DrawProjGroupItem*>(dvp);
     if (dpgi) {
         DrawProjGroup* dpg = dpgi->getPGroup();
         if (!dpg) {
@@ -504,7 +504,7 @@ void TaskDetail::updateDetail()
 QPointF TaskDetail::getAnchorScene()
 {
     DrawViewPart* dvp = getBaseFeat();
-    DrawProjGroupItem* dpgi = dynamic_cast<DrawProjGroupItem*>(dvp);
+    DrawProjGroupItem* dpgi = freecad_cast<DrawProjGroupItem*>(dvp);
     DrawViewDetail* dvd = getDetailFeat();
     Base::Vector3d anchorPos = dvd->AnchorPoint.getValue();
     anchorPos.y = -anchorPos.y;

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
@@ -393,7 +393,7 @@ void TaskLeaderLine::createLeaderFeature(std::vector<Base::Vector3d> sceneDeltas
 
     if (m_lineFeat) {
         Gui::ViewProvider* vp = QGIView::getViewProvider(m_lineFeat);
-        auto leadVP = dynamic_cast<ViewProviderLeader*>(vp);
+        auto leadVP = freecad_cast<ViewProviderLeader*>(vp);
         if (leadVP) {
             Base::Color ac;
             ac.setValue<QColor>(ui->cpLineColor->color());
@@ -700,7 +700,7 @@ QGIView* TaskLeaderLine::findParentQGIV()
     }
 
     Gui::ViewProvider* gvp = QGIView::getViewProvider(m_baseFeat);
-    ViewProviderDrawingView* vpdv = dynamic_cast<ViewProviderDrawingView*>(gvp);
+    ViewProviderDrawingView* vpdv = freecad_cast<ViewProviderDrawingView*>(gvp);
     if (!vpdv) {
         return nullptr;
     }

--- a/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
@@ -460,7 +460,7 @@ TaskDlgLineDecor::TaskDlgLineDecor(TechDraw::DrawViewPart* partFeat,
         taskbox->hideGroupBox();
     }
 
-    TaskLineDecor* parent = dynamic_cast<TaskLineDecor*>(widget);
+    TaskLineDecor* parent = qobject_cast<TaskLineDecor*>(widget);
     if (parent) {
         restore = new TaskRestoreLines(partFeat, parent);
         restoreBox = new Gui::TaskView::TaskBox(Gui::BitmapFactory().pixmap("actions/TechDraw_DecorateLine"),

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
@@ -317,7 +317,7 @@ void TaskRichAnno::createAnnoFeature()
 
     if (m_annoFeat) {
         Gui::ViewProvider* vp = QGIView::getViewProvider(m_annoFeat);
-        auto annoVP = dynamic_cast<ViewProviderRichAnno*>(vp);
+        auto annoVP = freecad_cast<ViewProviderRichAnno*>(vp);
         if (annoVP) {
             Base::Color ac;
             ac.setValue<QColor>(ui->cpFrameColor->color());

--- a/src/Mod/TechDraw/Gui/TechDrawHandler.cpp
+++ b/src/Mod/TechDraw/Gui/TechDrawHandler.cpp
@@ -58,7 +58,7 @@ TechDrawHandler::~TechDrawHandler()
 
 void TechDrawHandler::activate(QGVPage* vp)
 {
-    auto* mdi = dynamic_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
+    auto* mdi = qobject_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
     if (!mdi) {
         return;
     }
@@ -79,7 +79,7 @@ void TechDrawHandler::deactivate()
     // So to prevent the menu from appearing when the tool is cleared by right mouse click
     // we set a small timer.
     QTimer::singleShot(100, []() { // 100 milliseconds delay
-        auto* mdi = dynamic_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
+        auto* mdi = qobject_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
         if (!mdi) {
             return;
         }

--- a/src/Mod/TechDraw/Gui/TemplateTextField.cpp
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.cpp
@@ -80,7 +80,7 @@ void TemplateTextField::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         ui.setFieldContent(tmplte->EditableTexts[fieldNameStr]);
 
         auto qName = QString::fromStdString(fieldNameStr);
-        auto svgTemplate = dynamic_cast<DrawSVGTemplate*>(tmplte);
+        auto svgTemplate = freecad_cast<DrawSVGTemplate*>(tmplte);
         if (svgTemplate) {
             // preset the autofill with the current value - something might have changed since this field was created
             m_autofillString = svgTemplate->getAutofillByEditableName(qName);

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -306,7 +306,7 @@ bool ViewProviderDimension::onDelete(const std::vector<std::string> & parms)
 {
     Q_UNUSED(parms)
     auto dlg = Gui::Control().activeDialog();
-    auto ourDlg = dynamic_cast<TaskDlgDimension*>(dlg);
+    auto ourDlg = qobject_cast<TaskDlgDimension*>(dlg);
     if (ourDlg)  {
         QString bodyMessage;
         QTextStream bodyMessageStream(&bodyMessage);

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -272,7 +272,7 @@ ViewProviderPage* ViewProviderDrawingView::getViewProviderPage() const
     Gui::Document* guiDoc = Gui::Application::Instance->getDocument(getViewObject()->getDocument());
     if (guiDoc) {
         Gui::ViewProvider* vp = guiDoc->getViewProvider(getViewObject()->findParentPage());
-        return dynamic_cast<ViewProviderPage*>(vp);
+        return freecad_cast<ViewProviderPage*>(vp);
     }
     return nullptr;
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -369,7 +369,7 @@ MDIViewPage* ViewProviderPage::getMDIViewPage() const
 
 DrawTemplate* ViewProviderPage::getTemplate() const
 {
-    return dynamic_cast<DrawTemplate*>(getDrawPage()->Template.getValue());
+    return freecad_cast<DrawTemplate*>(getDrawPage()->Template.getValue());
 }
 
 
@@ -378,7 +378,7 @@ QGITemplate* ViewProviderPage::getQTemplate() const
     Gui::Document* guiDoc = Gui::Application::Instance->getDocument(getDrawPage()->getDocument());
     if (guiDoc) {
         Gui::ViewProvider* vp = guiDoc->getViewProvider(getTemplate());
-        auto vpTemplate = dynamic_cast<ViewProviderTemplate*>(vp);
+        auto vpTemplate = freecad_cast<ViewProviderTemplate*>(vp);
         if (vpTemplate) {
             return vpTemplate->getQTemplate();
         }
@@ -455,7 +455,7 @@ void ViewProviderPage::setTemplateMarkers(bool state) const
     templateFeat = getDrawPage()->Template.getValue();
     Gui::Document* guiDoc = Gui::Application::Instance->getDocument(templateFeat->getDocument());
     Gui::ViewProvider* vp = guiDoc->getViewProvider(templateFeat);
-    auto* vpt = dynamic_cast<ViewProviderTemplate*>(vp);
+    auto* vpt = freecad_cast<ViewProviderTemplate*>(vp);
     if (vpt) {
         vpt->setMarkers(state);
         QGITemplate* t = vpt->getQTemplate();

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -172,7 +172,7 @@ void ViewProviderViewPart::onChanged(const App::Property* prop)
     if (auto part = getViewPart(); part && part->isDerivedFrom<TechDraw::DrawViewDetail>() &&
         prop == &(HighlightAdjust)) {
         auto detail = static_cast<DrawViewDetail*>(getViewPart());
-        auto baseDvp = dynamic_cast<DrawViewPart*>(detail->BaseView.getValue());
+        auto baseDvp = freecad_cast<DrawViewPart*>(detail->BaseView.getValue());
         if (baseDvp) {
             baseDvp->requestPaint();
         }


### PR DESCRIPTION
This is continuation for #20515.

As @benj5378 noted, `dynamic_cast` is quite slow method of upcasting due to vtable checking. FreeCAD has faster method based on our own typesystem the `freecad_cast` and Qt does have `qobject_cast`. Both should be preferred when they are possible to use. 

This PR replaces all `dynamic_casts` with more specific alternatives to hopefully increase performance a bit and to make our code base more consistent and uniform.

@FreeCAD/code-quality-working-group 