### PR TITLE
Property View: Auto expand/collapse and 1 time expand/collapse functionality

### DIFF
--- a/src/Gui/propertyeditor/PropertyEditor.h
+++ b/src/Gui/propertyeditor/PropertyEditor.h
@@ -78,6 +78,8 @@ public:
                  bool checkDocument = false);
     void updateProperty(const App::Property&);
     void removeProperty(const App::Property&);
+    void setAutomaticCollapse(bool);
+    bool isAutomaticCollapse(bool) const;
     void setAutomaticExpand(bool);
     bool isAutomaticExpand(bool) const;
     void setAutomaticDocumentUpdate(bool);
@@ -143,6 +145,7 @@ private:
     QStringList selectedProperty;
     PropertyModel::PropertyList propList;
     std::unordered_set<const App::PropertyContainer*> propOwners;
+    bool autocollapse;
     bool autoexpand;
     bool autoupdate;
     bool committing;


### PR DESCRIPTION
See: #19088

This PR adds auto expanding /collapsing in the `PropertyView` along with 1 time temporary expanding/collapsing functionality.

`PropertyView` can either have no auto expanding and collapsing checked, either one checked, but both cannot be checked at the same time. When auto expanding/collapsing is toggled, this change will be permanent to the `PropertyView`.

For the 1 time expand/collapse, the change is temporary so clicking away and back will reset the `PropertyView` to the default state.

[Screencast from 03-29-2025 06:31:01 PM.webm](https://github.com/user-attachments/assets/9419710f-6e0a-43dd-a54d-b504afd2ec15)
