### PR TITLE
Draft: fix Dim Auto Flip Text angle checks

### DIFF
--- a/src/Mod/Draft/draftmake/make_dimension.py
+++ b/src/Mod/Draft/draftmake/make_dimension.py
@@ -64,7 +64,7 @@ def _get_flip_text_lin(p1, p2, wp, normal):
     tol = 1e-4  # high tolerance
     if math.isclose(ang, 0, abs_tol=tol):
         return False
-    if math.isclose(ang, math.pi, abs_tol=tol):
+    if math.isclose(abs(ang), math.pi, abs_tol=tol):
         return True
     if math.isclose(ang, math.pi/2, abs_tol=tol):
         return False
@@ -92,7 +92,7 @@ def _get_flip_text_ang(cen, sta, end, normal):
     tol = 1e-4  # high tolerance
     if math.isclose(ang, 0, abs_tol=tol):
         return True
-    if math.isclose(ang, math.pi, abs_tol=tol):
+    if math.isclose(abs(ang), math.pi, abs_tol=tol):
         return False
     if ang > 0:
         return False


### PR DESCRIPTION
When checking angles Dim Auto Flip Text did not consider that angles can be almost -180 degrees and should then be treated the same as 180 degree angles.
