### PR TITLE
CAM: fix context menu callbacks for Qt6

### DIFF
--- a/src/Mod/CAM/Path/Base/Gui/IconViewProvider.py
+++ b/src/Mod/CAM/Path/Base/Gui/IconViewProvider.py
@@ -95,8 +95,11 @@ class ViewProvider(object):
 
         edit = translate("Path", "Edit")
         action = QtGui.QAction(edit, menu)
-        action.triggered.connect(self.setEdit)
+        action.triggered.connect(self._editInContextMenuTriggered)
         menu.addAction(action)
+
+    def _editInContextMenuTriggered(self, checked):
+        self.setEdit()
 
 
 _factory = {}

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -345,8 +345,11 @@ class ViewProvider:
         for action in menu.actions():
             menu.removeAction(action)
         action = QtGui.QAction(translate("CAM_Job", "Edit"), menu)
-        action.triggered.connect(self.setEdit)
+        action.triggered.connect(self._editInContextMenuTriggered)
         menu.addAction(action)
+
+    def _editInContextMenuTriggered(self, checked):
+        self.setEdit()
 
 
 class MaterialDialog(QtWidgets.QDialog):

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -187,8 +187,11 @@ class ViewProvider(object):
         for action in menu.actions():
             menu.removeAction(action)
         action = QtGui.QAction(translate("PathOp", "Edit"), menu)
-        action.triggered.connect(self.setEdit)
+        action.triggered.connect(self._editInContextMenuTriggered)
         menu.addAction(action)
+
+    def _editInContextMenuTriggered(self, checked):
+        self.setEdit()
 
 
 class TaskPanelPage(object):

--- a/src/Mod/CAM/Path/Tool/Gui/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Gui/Controller.py
@@ -114,8 +114,11 @@ class ViewProvider:
         for action in menu.actions():
             menu.removeAction(action)
         action = QtGui.QAction(translate("CAM", "Edit"), menu)
-        action.triggered.connect(self.setEdit)
+        action.triggered.connect(self._editInContextMenuTriggered)
         menu.addAction(action)
+
+    def _editInContextMenuTriggered(self, checked):
+        self.setEdit()
 
     def claimChildren(self):
         obj = self.vobj.Object


### PR DESCRIPTION
This fixes #20519.

Some analysis of the problem:

The `QAction.triggered` signal has an optional parameter `checked=False` in both Qt5 and Qt6:
https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QAction.html#PySide2.QtWidgets.PySide2.QtWidgets.QAction.triggered
https://doc.qt.io/qtforpython-6/PySide6/QtGui/QAction.html#PySide6.QtGui.QAction.triggered

In PySide2, the callback method `setEdit(self, vobj=None, mode=0)` was handled like `setEdit()`
whereas in PySide6, the callback is called like `setEdit(checked)`.

A callback method `my_callback(self, my_param)` is called as `my_callback(checked)` in both Qt5 and Qt6.
And callback method `my_callback(self)` is called as `my_callback()` in both Qt5 and Qt6.
The different behavior is only when there are more parameters in the callback.