### PR TITLE
Gui: Added classic trackball orbit style 

### DIFF
--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -64,7 +64,8 @@ public:
     enum OrbitStyle {
         Turntable,
         Trackball,
-        FreeTurntable
+        FreeTurntable,
+        TrackballClassic,
     };
 
     static constexpr float defaultSphereRadius = 0.8F;
@@ -98,6 +99,9 @@ public:
         }
         if (orbit == FreeTurntable) {
             return getFreeTurntable(point1, point2);
+        }
+        if (orbit == TrackballClassic) {
+            return getTrackballClassic(point1, point2);
         }
 
         return rot;
@@ -162,6 +166,22 @@ private:
         xrot.setValue(xaxis, -dif[0]);
 
         return zrot * xrot;
+    }
+
+    SbRotation getTrackballClassic(const SbVec3f &point1, const SbVec3f &point2) const
+    {
+        // Classic trackball
+        SbRotation zrot;
+        SbRotation yrot;
+        SbVec3f dif = point1 - point2;
+
+        SbVec3f zaxis(1,0,0);
+        zrot.setValue(zaxis, dif[1]);
+
+        SbVec3f yaxis(0,1,0);
+        yrot.setValue(yaxis, -dif[0]);
+
+        return zrot * yrot;
     }
 
 private:
@@ -888,7 +908,7 @@ void NavigationStyle::spin(const SbVec2f & pointerpos)
     float sensitivity = getSensitivity();
 
     // Adjust the spin projector sphere to the screen position of the rotation center when the mouse intersects an object
-    if (getOrbitStyle() == Trackball && rotationCenterMode & RotationCenterMode::ScenePointAtCursor && rotationCenterFound && rotationCenterIsScenePointAtCursor) {
+    if ((getOrbitStyle() == Trackball || getOrbitStyle() == TrackballClassic) && rotationCenterMode & RotationCenterMode::ScenePointAtCursor && rotationCenterFound && rotationCenterIsScenePointAtCursor) {
         const auto pointOnScreen = viewer->getPointOnViewport(rotationCenter);
         const auto sphereCenter = 2 * normalizePixelPos(pointOnScreen) - SbVec2f {1, 1};
 

--- a/src/Gui/Navigation/NavigationStyle.h
+++ b/src/Gui/Navigation/NavigationStyle.h
@@ -103,7 +103,8 @@ public:
     enum OrbitStyle {
         Turntable,
         Trackball,
-        FreeTurntable
+        FreeTurntable,
+        TrackballClassic
     };
 
     enum class RotationCenterMode {

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.ui
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.ui
@@ -475,7 +475,8 @@ Select a set and then press the button to view said configurations.</string>
          <string>Rotation orbit style.
 Trackball: moving the mouse horizontally will rotate the part around the y-axis
 Turntable: the part will be rotated around the z-axis (with constrained axes).
-Free Turntable: the part will be rotated around the z-axis.</string>
+Free Turntable: the part will be rotated around the z-axis.
+Trackball Classic: moving the mouse will rotate the part allowing precession</string>
         </property>
         <property name="currentIndex">
          <number>1</number>
@@ -493,6 +494,11 @@ Free Turntable: the part will be rotated around the z-axis.</string>
         <item>
          <property name="text">
           <string>Free Turntable</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Trackball Classic</string>
          </property>
         </item>
        </widget>

--- a/src/Mod/Tux/NavigationIndicatorGui.py
+++ b/src/Mod/Tux/NavigationIndicatorGui.py
@@ -612,6 +612,7 @@ def retranslateUi():
     aTurntable.setText(translate("NavigationIndicator", "Turntable"))
     aFreeTurntable.setText(translate("NavigationIndicator", "Free Turntable"))
     aTrackball.setText(translate("NavigationIndicator", "Trackball"))
+    aTrackballClassic.setText(translate("NavigationIndicator", "Trackball Classic"))
     a0.setText(translate("NavigationIndicator", "Undefined"))
 
 
@@ -642,10 +643,14 @@ aTrackball.setCheckable(True)
 aFreeTurntable = QtGui.QAction(gOrbit)
 aFreeTurntable.setObjectName("NavigationIndicator_FreeTurntable")
 aFreeTurntable.setCheckable(True)
+aTrackballClassic = QtGui.QAction(gOrbit)
+aTrackballClassic.setObjectName("NavigationIndicator_TrackballClassic")
+aTrackballClassic.setCheckable(True)
 
 menuOrbit.addAction(aTurntable)
 menuOrbit.addAction(aTrackball)
 menuOrbit.addAction(aFreeTurntable)
+menuOrbit.addAction(aTrackballClassic)
 
 menuSettings.addMenu(menuOrbit)
 menuSettings.addSeparator()
@@ -789,6 +794,8 @@ def onOrbit():
         pView.SetInt("OrbitStyle", 1)
     elif aFreeTurntable.isChecked():
         pView.SetInt("OrbitStyle", 2)
+    elif aTrackballClassic.isChecked():
+        pView.SetInt("OrbitStyle", 3)
 
 
 def onOrbitShow():
@@ -802,6 +809,8 @@ def onOrbitShow():
         aTrackball.setChecked(True)
     elif OrbitStyle == 2:
         aFreeTurntable.setChecked(True)
+    elif OrbitStyle == 3:
+        aTrackballClassic.setChecked(True)
     gOrbit.blockSignals(False)
 
 


### PR DESCRIPTION
This PR adds a `TrackballClassic` orbit style that mimics the default orbit behavior of other CAD applications.

https://github.com/user-attachments/assets/23c1b7e8-7286-461e-b474-377574e3b532

This forum thread from November talks about such an orbit style: https://forum.freecad.org/viewtopic.php?t=91769

I'm open to any better name suggestions, trackball classic was chosen to line up with the naming here: https://theshamblog.com/virtual-trackballs-a-taxonomy-and-new-method/

This has the same files changed #8048 does. It seems like this changes some translated strings that will need to be updated, but I'm not sure what the process for that looks like.