### PR TITLE
CAM Helix, add feedrate radial correction and improve retract()

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
@@ -222,4 +222,5 @@ G0 Z20.000000"
         # test "F" param is added when using feedRateAdj
         args["feedRateAdj"] = True
         result = generator.generate(**args)
-        self.assertTrue("F" in result[-2].Parameters)
+        self.assertTrue("FeedFactor" in result[-2].Parameters)
+       

--- a/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
@@ -35,10 +35,8 @@ def _resetArgs():
     v1 = FreeCAD.Vector(5, 5, 20)
     v2 = FreeCAD.Vector(5, 5, 18)
 
-    edg = Part.makeLine(v1, v2)
-
     return {
-        "edge": edg,
+        "edge": Part.makeLine(v1, v2),
         "hole_radius": 10.0,
         "step_down": 1.0,
         "step_over": 0.5,
@@ -59,8 +57,9 @@ G2 I-2.500000 J0.000000 X2.500000 Y5.000000 Z18.500000\
 G2 I2.500000 J0.000000 X7.500000 Y5.000000 Z18.000000\
 G2 I-2.500000 J0.000000 X2.500000 Y5.000000 Z18.000000\
 G2 I2.500000 J0.000000 X7.500000 Y5.000000 Z18.000000\
-G0 X5.000000 Y5.000000 Z18.000000\
-G0 Z20.000000G0 X10.000000 Y5.000000\
+G1 X5.000000 Y5.000000\
+G0 Z20.000000\
+G0 X10.000000 Y5.000000\
 G1 Z20.000000\
 G2 I-5.000000 J0.000000 X0.000000 Y5.000000 Z19.500000\
 G2 I5.000000 J0.000000 X10.000000 Y5.000000 Z19.000000\
@@ -68,8 +67,8 @@ G2 I-5.000000 J0.000000 X0.000000 Y5.000000 Z18.500000\
 G2 I5.000000 J0.000000 X10.000000 Y5.000000 Z18.000000\
 G2 I-5.000000 J0.000000 X0.000000 Y5.000000 Z18.000000\
 G2 I5.000000 J0.000000 X10.000000 Y5.000000 Z18.000000\
-G0 X5.000000 Y5.000000 Z18.000000\
-G0 Z20.000000G0 X12.500000 Y5.000000\
+G1 X8.750000 Y5.000000G0 Z20.000000\
+G0 X12.500000 Y5.000000\
 G1 Z20.000000\
 G2 I-7.500000 J0.000000 X-2.500000 Y5.000000 Z19.500000\
 G2 I7.500000 J0.000000 X12.500000 Y5.000000 Z19.000000\
@@ -77,7 +76,8 @@ G2 I-7.500000 J0.000000 X-2.500000 Y5.000000 Z18.500000\
 G2 I7.500000 J0.000000 X12.500000 Y5.000000 Z18.000000\
 G2 I-7.500000 J0.000000 X-2.500000 Y5.000000 Z18.000000\
 G2 I7.500000 J0.000000 X12.500000 Y5.000000 Z18.000000\
-G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
+G1 X11.250000 Y5.000000\
+G0 Z20.000000"
 
     def test00(self):
         """Test Basic Helix Generator Return"""
@@ -107,6 +107,7 @@ G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
         args["tool_diameter"] = "5"
         self.assertRaises(TypeError, generator.generate, **args)
 
+    def test02(self):
         # require tool fit 2: hole diameter not greater than tool diam
         # with zero inner radius
         args = _resetArgs()
@@ -115,6 +116,7 @@ G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
         args["tool_diameter"] = 5.0
         self.assertRaises(ValueError, generator.generate, **args)
 
+    def test03(self):
         # require tool fit: actual hole diameter after taking Extra Offset into account >= tool diameter
         # 1. Extra Offset just small enough to leave room for tool should not raise an error
         args = _resetArgs()
@@ -126,15 +128,17 @@ G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
         result = generator.generate(**args)
         self.assertTrue(result)
 
+    def test03(self):
         # 2. Extra Offset does not leave room for tool, should raise an error
         args = _resetArgs()
         designed_hole_diameter = 10.0
-        extra_offset = 2.50
+        extra_offset = 2.501
         args["hole_radius"] = designed_hole_diameter / 2 - extra_offset
         args["inner_radius"] = extra_offset
         args["tool_diameter"] = 5.0
         self.assertRaises(ValueError, generator.generate, **args)
 
+    def test04(self):
         # step_over is a percent value between 0 and 1
         args = _resetArgs()
         args["step_over"] = 50
@@ -142,6 +146,7 @@ G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
         args["step_over"] = "50"
         self.assertRaises(TypeError, generator.generate, **args)
 
+    def test05(self):
         # Other argument testing
         args = _resetArgs()
         args["startAt"] = "Other"
@@ -157,16 +162,14 @@ G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
         args = _resetArgs()
         v1 = FreeCAD.Vector(5, 5, 20)
         v2 = FreeCAD.Vector(5.0001, 5, 10)
-        edg = Part.makeLine(v1, v2)
-        args["edge"] = edg
+        args["edge"] = Part.makeLine(v1, v2)
         self.assertRaises(ValueError, generator.generate, **args)
 
         # verify linear edge is vertical: Y
         args = _resetArgs()
         v1 = FreeCAD.Vector(5, 5.0001, 20)
         v2 = FreeCAD.Vector(5, 5, 10)
-        edg = Part.makeLine(v1, v2)
-        args["edge"] = edg
+        args["edge"] = Part.makeLine(v1, v2)
         self.assertRaises(ValueError, generator.generate, **args)
 
     def test08(self):
@@ -174,8 +177,7 @@ G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
         args = _resetArgs()
         v1 = FreeCAD.Vector(10, 5, 5)
         v2 = FreeCAD.Vector(20, 5, 5)
-        edg = Part.makeLine(v1, v2)
-        args["edge"] = edg
+        args["edge"] = Part.makeLine(v1, v2)
         self.assertRaises(ValueError, generator.generate, **args)
 
     def test09(self):
@@ -183,28 +185,42 @@ G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
         args = _resetArgs()
         v1 = FreeCAD.Vector(5, 5, 18)
         v2 = FreeCAD.Vector(5, 5, 20)
-        edg = Part.makeLine(v1, v2)
-        args["edge"] = edg
+        args["edge"] = Part.makeLine(v1, v2)
 
         self.assertRaises(ValueError, generator.generate, **args)
 
     def test10(self):
         """Test Helix Retraction"""
 
-        # if center is clear, the second to last move should be a rapid away
+        # if center is clear, the second to last move should be a G1 away
         # from the wall
         args = _resetArgs()
         v1 = FreeCAD.Vector(0, 0, 20)
         v2 = FreeCAD.Vector(0, 0, 18)
         edg = Part.makeLine(v1, v2)
-        args["edge"] = edg
-        args["inner_radius"] = 0.0
+        args["edge"] = Part.makeLine(v1, v2)
         args["tool_diameter"] = 5.0
         result = generator.generate(**args)
-        self.assertTrue(result[-2].Name == "G0")
+        self.assertTrue(result[-2].Name == "G1")
 
-        # if center is not clear, retraction is one straight up on the last
-        # move. the second to last move should be a G2
+        # if center is not clear, multiple helical paths
+        # retraction is one straight up on the last move.
+        # the second to last move should be a G1 pulloff to a clear radius
+        args["hole_radius"] = 14.0
+        args["inner_radius"] = 2.0
+        result = generator.generate(**args)
+        self.assertTrue(result[-2].Name == "G1")
+
+        # if center is not clear, single annular slot,
+        # retraction is one straight up on the last move.
+        #  the second to last move should be a G2 since "CW"
+        args["hole_radius"] = 7.0
         args["inner_radius"] = 2.0
         result = generator.generate(**args)
         self.assertTrue(result[-2].Name == "G2")
+
+        # test "F" param is added when using feedRateAdj
+        args["feedRateAdj"] = True
+        result = generator.generate(**args)
+        self.assertTrue("F" in result[-2].Parameters)
+       

--- a/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
@@ -223,4 +223,3 @@ G0 Z20.000000"
         args["feedRateAdj"] = True
         result = generator.generate(**args)
         self.assertTrue("F" in result[-2].Parameters)
-       

--- a/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
@@ -223,4 +223,3 @@ G0 Z20.000000"
         args["feedRateAdj"] = True
         result = generator.generate(**args)
         self.assertTrue("FeedFactor" in result[-2].Parameters)
-       

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
@@ -55,100 +55,98 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QWidget" name="widget">
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Start from</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="startSide">
+       <property name="toolTip">
+        <string>Specify if the helix operation should start at the inside and work its way outwards, or start at the outside and work its way to the center.</string>
+       </property>
+       <item>
         <property name="text">
-         <string>Start from</string>
+         <string>Inside</string>
         </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="startSide">
-        <property name="toolTip">
-         <string>Specify if the helix operation should start at the inside and work its way outwards, or start at the outside and work its way to the center.</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Inside</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Outside</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
+       </item>
+       <item>
         <property name="text">
-         <string>Direction</string>
+         <string>Outside</string>
         </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="cutMode">
-        <property name="toolTip">
-         <string>The direction for the helix, clockwise or counterclockwise.</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Climb</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Conventional</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_4">
+       </item>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Direction</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="cutMode">
+       <property name="toolTip">
+        <string>The direction for the helix, clockwise or counterclockwise.</string>
+       </property>
+       <item>
         <property name="text">
-         <string>Step over percent</string>
+         <string>Climb</string>
         </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QSpinBox" name="stepOverPercent">
-        <property name="toolTip">
-         <string>Specify the percent of the tool diameter each helix will be offset to the previous one. A step over of 100% means no overlap of the individual cuts.</string>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="singleStep">
-         <number>10</number>
-        </property>
-        <property name="value">
-         <number>100</number>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_6">
+       </item>
+       <item>
         <property name="text">
-         <string>Extra Offset</string>
+         <string>Conventional</string>
         </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="Gui::InputField" name="extraOffset">
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+       </item>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Step over percent</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QSpinBox" name="stepOverPercent">
+       <property name="toolTip">
+        <string>Specify the percent of the tool diameter each helix will be offset to the previous one. A step over of 100% means no overlap of the individual cuts.</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>100</number>
+       </property>
+       <property name="singleStep">
+        <number>10</number>
+       </property>
+       <property name="value">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Extra Offset</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="Gui::InputField" name="extraOffset">
+       <property name="unit" stdset="0">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
-  <item row="3" column="0">
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -161,7 +159,17 @@
      </property>
     </spacer>
    </item>
-   </layout>
+   <item row="2" column="0">
+    <widget class="QCheckBox" name="FeedRateCheckBox">
+     <property name="toolTip">
+      <string>Radial feed rate correction</string>
+     </property>
+     <property name="text">
+      <string>Apply feed rate correction</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
@@ -162,7 +162,7 @@
    <item row="2" column="0">
     <widget class="QCheckBox" name="FeedRateCheckBox">
      <property name="toolTip">
-      <string>Calculate spindle feed rate compensation to keep tool cutting edge speed roughly constant as helix radius varies. 
+      <string>Calculate spindle feed rate compensation to keep tool cutting edge speed roughly constant as helix radius varies.
 Reduces spindle feedrate when outer edge is cutting
 Increases spindle rate when cutting outside in to maintain tool speed on inner cuts.</string>
      </property>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
@@ -17,10 +17,10 @@
    <item row="0" column="0">
     <widget class="QFrame" name="frame">
      <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+      <enum>QFrame::Shape::StyledPanel</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+      <enum>QFrame::Shadow::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
@@ -149,7 +149,7 @@
    <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -162,7 +162,9 @@
    <item row="2" column="0">
     <widget class="QCheckBox" name="FeedRateCheckBox">
      <property name="toolTip">
-      <string>Radial feed rate correction</string>
+      <string>Calculate spindle feed rate compensation to keep tool cutting edge speed roughly constant as helix radius varies. 
+Reduces spindle feedrate when outer edge is cutting
+Increases spindle rate when cutting outside in to maintain tool speed on inner cuts.</string>
      </property>
      <property name="text">
       <string>Apply feed rate correction</string>

--- a/src/Mod/CAM/Path/Base/FeedRate.py
+++ b/src/Mod/CAM/Path/Base/FeedRate.py
@@ -69,7 +69,6 @@ def setFeedRate(commandlist, ToolController):
 
     machine = PathMachineState.MachineState()
 
-
     hFeed = ToolController.HorizFeed.Value
     vFeed = ToolController.VertFeed.Value
 
@@ -78,10 +77,10 @@ def setFeedRate(commandlist, ToolController):
             continue
 
         params = command.Parameters
-        if ("F" in params) and (command.Name in ["G2","G3"]): 
+        if ("F" in params) and (command.Name in ["G2", "G3"]):
             # adj. spindle feedrate to ensure correct chip load on cutting edge, if "F" defined
-            hFeed_adj = hFeed* params["F"]  
-            rate = math.sqrt(vFeed * vFeed + hFeed_adj * hFeed_adj ) # vector sum
+            hFeed_adj = hFeed * params["F"]
+            rate = math.sqrt(vFeed * vFeed + hFeed_adj * hFeed_adj)  # vector sum
             # TODO combined V,H feedrates for 3D-ops, ramp, pocket/contour radius ?
         else:
             if _isVertical(machine.getPosition(), command):
@@ -91,13 +90,13 @@ def setFeedRate(commandlist, ToolController):
                     else vFeed
                 )
             else:
-                if _isHorizontal(machine.getPosition(), command) :
+                if _isHorizontal(machine.getPosition(), command):
                     rate = (
                         ToolController.HorizRapid.Value
                         if command.Name in Path.Geom.CmdMoveRapid
-                        else hFeed 
+                        else hFeed
                     )
-                else : 
+                else:
                     rate = hFeed  # fallback
 
         params["F"] = rate

--- a/src/Mod/CAM/Path/Base/FeedRate.py
+++ b/src/Mod/CAM/Path/Base/FeedRate.py
@@ -69,7 +69,6 @@ def setFeedRate(commandlist, ToolController):
 
     machine = PathMachineState.MachineState()
 
-
     hFeed = ToolController.HorizFeed.Value
     vFeed = ToolController.VertFeed.Value
 
@@ -78,10 +77,10 @@ def setFeedRate(commandlist, ToolController):
             continue
 
         params = command.Parameters
-        if ("FeedFactor" in params) and (command.Name in ["G2","G3"]): 
+        if ("FeedFactor" in params) and (command.Name in ["G2", "G3"]):
             # adj. spindle feedrate to ensure correct chip load on cutting edge, if "F" defined
-            hFeed_adj = hFeed* params["FeedFactor"] 
-            rate = math.sqrt(vFeed * vFeed + hFeed_adj * hFeed_adj ) # vector sum
+            hFeed_adj = hFeed * params["FeedFactor"]
+            rate = math.sqrt(vFeed * vFeed + hFeed_adj * hFeed_adj)  # vector sum
             # TODO combined V,H feedrates for 3D-ops, ramp, pocket/contour radius ?
         else:
             if _isVertical(machine.getPosition(), command):
@@ -91,15 +90,15 @@ def setFeedRate(commandlist, ToolController):
                     else vFeed
                 )
             else:
-                if _isHorizontal(machine.getPosition(), command) :
+                if _isHorizontal(machine.getPosition(), command):
                     rate = (
                         ToolController.HorizRapid.Value
                         if command.Name in Path.Geom.CmdMoveRapid
-                        else hFeed 
+                        else hFeed
                     )
-                else : 
+                else:
                     rate = hFeed  # fallback
-        params.pop("FeedFactor",None) 
+        params.pop("FeedFactor", None)
 
         params["F"] = rate
         command.Parameters = params

--- a/src/Mod/CAM/Path/Base/FeedRate.py
+++ b/src/Mod/CAM/Path/Base/FeedRate.py
@@ -69,6 +69,7 @@ def setFeedRate(commandlist, ToolController):
 
     machine = PathMachineState.MachineState()
 
+
     hFeed = ToolController.HorizFeed.Value
     vFeed = ToolController.VertFeed.Value
 
@@ -77,10 +78,10 @@ def setFeedRate(commandlist, ToolController):
             continue
 
         params = command.Parameters
-        if ("F" in params) and (command.Name in ["G2", "G3"]):
+        if ("FeedFactor" in params) and (command.Name in ["G2","G3"]): 
             # adj. spindle feedrate to ensure correct chip load on cutting edge, if "F" defined
-            hFeed_adj = hFeed * params["F"]
-            rate = math.sqrt(vFeed * vFeed + hFeed_adj * hFeed_adj)  # vector sum
+            hFeed_adj = hFeed* params["FeedFactor"] 
+            rate = math.sqrt(vFeed * vFeed + hFeed_adj * hFeed_adj ) # vector sum
             # TODO combined V,H feedrates for 3D-ops, ramp, pocket/contour radius ?
         else:
             if _isVertical(machine.getPosition(), command):
@@ -90,14 +91,15 @@ def setFeedRate(commandlist, ToolController):
                     else vFeed
                 )
             else:
-                if _isHorizontal(machine.getPosition(), command):
+                if _isHorizontal(machine.getPosition(), command) :
                     rate = (
                         ToolController.HorizRapid.Value
                         if command.Name in Path.Geom.CmdMoveRapid
-                        else hFeed
+                        else hFeed 
                     )
-                else:
+                else : 
                     rate = hFeed  # fallback
+        params.pop("FeedFactor",None) 
 
         params["F"] = rate
         command.Parameters = params

--- a/src/Mod/CAM/Path/Base/Generator/helix.py
+++ b/src/Mod/CAM/Path/Base/Generator/helix.py
@@ -23,7 +23,7 @@
 
 from numpy import ceil, linspace, isclose, delete
 import Path
-import math
+import math 
 
 __title__ = "Helix toolpath Generator"
 __author__ = "sliptonic (Brad Collette)"
@@ -87,7 +87,7 @@ def generate(
         raise TypeError("inner_radius must be a float")
 
     if inner_radius < -tool_diameter / 2:
-        # inner_radius also depends on StartRadius
+		# inner_radius also depends on StartRadius
         raise ValueError(
             "inner_radius {0} with a tool of diameter {1} gives a negative helix radius !".format(
                 inner_radius, tool_diameter
@@ -140,21 +140,21 @@ def generate(
         Path.Log.debug("(annular clearance or entire hole)\n")
         outer_path_radius = hole_radius - tool_radius
         inner_path_radius = inner_radius + tool_radius
-
+        
         if abs((outer_path_radius - inner_path_radius) / step_over_distance) < 1e-5:
-            radii = [outer_path_radius]  # below tolerance cutoff, just use outer radius
+            radii = [outer_path_radius] # below tolerance cutoff, just use outer radius
         else:
-            nr = int(ceil((outer_path_radius - inner_path_radius) / step_over_distance) + 1)
-            radii = linspace(outer_path_radius, inner_path_radius, nr)
-            if (startAt == "Outside") and (inner_radius <= 0):
-                radii = delete(radii, -1)  # cutting air. useful for spacing
+            nr = int( ceil((outer_path_radius - inner_path_radius ) / step_over_distance) +1 )
+            radii = linspace(outer_path_radius, inner_path_radius , nr)
+            if (startAt == "Outside") and (inner_radius <= 0): 
+                radii = delete(radii,-1)  # cutting air. useful for spacing
 
     Path.Log.debug("Radii: {}".format(radii))
     # calculate the number of full and partial turns required
     # Each full turn is two 180 degree arcs. Zsteps is equally spaced step
     # down values
-    turncount = max(int(ceil((startPoint.z - endPoint.z) / step_down)), 2)
-    zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount + 1)
+    turncount = max(int(ceil((startPoint.z - endPoint.z) / step_down)) ,2)
+    zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount+1)
 
     def helix_cut_r(r):
         commandlist = []
@@ -162,26 +162,17 @@ def generate(
         commandlist.append(Path.Command("G0", {"X": startPoint.x + r, "Y": startPoint.y}))
         commandlist.append(Path.Command("G1", {"Z": startPoint.z}))
 
-        # FeedRateCheckbox.checked
-        if not feedRateAdj:
-            feedRateRatio = 0
+        #FeedRateCheckbox.checked
+        if not feedRateAdj : feedRateRatio = 0
         else:
-            if (startAt == "Inside") or (
-                r == radii[0]
-            ):  # first cut, always adj for outer wall chip-load
-                feedRateRatio = r / (
-                    r + tool_radius
-                )  # classic (hole_rad-tool_rad)/hole_rad adjustment
+            if (startAt=="Inside") or (r == radii[0]): # first cut, always adj for outer wall chip-load
+                feedRateRatio = r/(r+tool_radius)  # classic (hole_rad-tool_rad)/hole_rad adjustment
             else:
-                if tool_radius > 200 * r:
-                    feedRateRatio = 200  # prevent div zero
-                else:
-                    feedRateRatio = (
-                        r + tool_radius
-                    ) / r  # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
+                if tool_radius > 200*r : feedRateRatio = 200 # prevent div zero
+                else: feedRateRatio = (r+tool_radius)/r # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
+
 
         # Note: if (r == -tool_radius), helix is plugne, hence VH_gradient==0; feedrate==vFeed , OK
-        print("rad = ", r, ",  feedRateRatio = ", feedRateRatio)
         for i in range(1, turncount + 1):
             commandlist.append(
                 Path.Command(
@@ -195,8 +186,7 @@ def generate(
                     },
                 )
             )
-            if feedRateAdj:
-                commandlist[-1].Parameters["F"] = feedRateRatio
+            if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
             commandlist.append(
                 Path.Command(
                     arc_cmd,
@@ -209,8 +199,7 @@ def generate(
                     },
                 )
             )
-            if feedRateAdj:
-                commandlist[-1].Parameters["F"] = feedRateRatio
+            if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
         commandlist.append(
             Path.Command(
                 arc_cmd,
@@ -220,11 +209,10 @@ def generate(
                     "Z": endPoint.z,
                     "I": -r,
                     "J": 0.0,
-                },
+               },
             )
         )
-        if feedRateAdj:
-            commandlist[-1].Parameters["F"] = feedRateRatio
+        if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
         commandlist.append(
             Path.Command(
                 arc_cmd,
@@ -237,8 +225,7 @@ def generate(
                 },
             )
         )
-        if feedRateAdj:
-            commandlist[-1].Parameters["F"] = feedRateRatio
+        if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
         return commandlist
 
     def retract():
@@ -280,3 +267,5 @@ def generate(
         commands.extend(retract())
         prev_r = r
     return commands
+
+ 

--- a/src/Mod/CAM/Path/Base/Generator/helix.py
+++ b/src/Mod/CAM/Path/Base/Generator/helix.py
@@ -23,7 +23,7 @@
 
 from numpy import ceil, linspace, isclose, delete
 import Path
-import math 
+import math
 
 __title__ = "Helix toolpath Generator"
 __author__ = "sliptonic (Brad Collette)"
@@ -87,7 +87,7 @@ def generate(
         raise TypeError("inner_radius must be a float")
 
     if inner_radius < -tool_diameter / 2:
-		# inner_radius also depends on StartRadius
+        # inner_radius also depends on StartRadius
         raise ValueError(
             "inner_radius {0} with a tool of diameter {1} gives a negative helix radius !".format(
                 inner_radius, tool_diameter
@@ -141,20 +141,22 @@ def generate(
         outer_path_radius = hole_radius - tool_radius
         inner_path_radius = inner_radius + tool_radius
 
-        if abs(outer_path_radius-inner_path_radius) < Path.Preferences.defaultGeometryTolerance():
-            radii = [outer_path_radius] # below tolerance cutoff, just use outer radius
+        if abs(outer_path_radius - inner_path_radius) < Path.Preferences.defaultGeometryTolerance():
+            radii = [outer_path_radius]  # below tolerance cutoff, just use outer radius
         else:
-            num_steps = int( ceil((outer_path_radius - inner_path_radius ) / step_over_distance) +1 )
-            radii = linspace(outer_path_radius, inner_path_radius , num_steps)
-            if (startAt == "Outside") and (inner_radius <= 0): 
-                radii = delete(radii,-1)  # remove air cutt, but inner_radius<0 useful for setting step spacing
+            num_steps = int(ceil((outer_path_radius - inner_path_radius) / step_over_distance) + 1)
+            radii = linspace(outer_path_radius, inner_path_radius, num_steps)
+            if (startAt == "Outside") and (inner_radius <= 0):
+                radii = delete(
+                    radii, -1
+                )  # remove air cutt, but inner_radius<0 useful for setting step spacing
 
     Path.Log.debug("Radii: {}".format(radii))
     # calculate the number of full and partial turns required
     # Each full turn is two 180 degree arcs. Zsteps is equally spaced step
     # down values
-    turncount = max(int(ceil((startPoint.z - endPoint.z) / step_down)) ,2)
-    zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount+1)
+    turncount = max(int(ceil((startPoint.z - endPoint.z) / step_down)), 2)
+    zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount + 1)
 
     def helix_cut_r(r):
         commandlist = []
@@ -162,15 +164,23 @@ def generate(
         commandlist.append(Path.Command("G0", {"X": startPoint.x + r, "Y": startPoint.y}))
         commandlist.append(Path.Command("G1", {"Z": startPoint.z}))
 
-        #FeedRateCheckbox.checked
-        if not feedRateAdj : feedRateRatio = 0
+        # FeedRateCheckbox.checked
+        if not feedRateAdj:
+            feedRateRatio = 0
         else:
-            if (startAt=="Inside") or (r == radii[0]): # first cut, always adj for outer wall chip-load
-                feedRateRatio = r/(r+tool_radius)  # classic (hole_rad-tool_rad)/hole_rad adjustment
+            if (startAt == "Inside") or (
+                r == radii[0]
+            ):  # first cut, always adj for outer wall chip-load
+                feedRateRatio = r / (
+                    r + tool_radius
+                )  # classic (hole_rad-tool_rad)/hole_rad adjustment
             else:
-                if tool_radius > 200*r : feedRateRatio = 200 # prevent div zero
-                else: feedRateRatio = (r+tool_radius)/r # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
-
+                if tool_radius > 200 * r:
+                    feedRateRatio = 200  # prevent div zero
+                else:
+                    feedRateRatio = (
+                        r + tool_radius
+                    ) / r  # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
 
         # Note: if (r == -tool_radius), helix is plugne, hence VH_gradient==0; feedrate==vFeed , OK
         for i in range(1, turncount + 1):
@@ -186,7 +196,8 @@ def generate(
                     },
                 )
             )
-            if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
+            if feedRateAdj:
+                commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
             commandlist.append(
                 Path.Command(
                     arc_cmd,
@@ -199,7 +210,8 @@ def generate(
                     },
                 )
             )
-            if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
+            if feedRateAdj:
+                commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
         commandlist.append(
             Path.Command(
                 arc_cmd,
@@ -209,10 +221,11 @@ def generate(
                     "Z": endPoint.z,
                     "I": -r,
                     "J": 0.0,
-               },
+                },
             )
         )
-        if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
+        if feedRateAdj:
+            commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
         commandlist.append(
             Path.Command(
                 arc_cmd,
@@ -225,7 +238,8 @@ def generate(
                 },
             )
         )
-        if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
+        if feedRateAdj:
+            commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
         return commandlist
 
     def retract():
@@ -267,5 +281,3 @@ def generate(
         commands.extend(retract())
         prev_r = r
     return commands
-
- 

--- a/src/Mod/CAM/Path/Base/Generator/helix.py
+++ b/src/Mod/CAM/Path/Base/Generator/helix.py
@@ -23,7 +23,7 @@
 
 from numpy import ceil, linspace, isclose, delete
 import Path
-import math 
+import math
 
 __title__ = "Helix toolpath Generator"
 __author__ = "sliptonic (Brad Collette)"
@@ -87,7 +87,7 @@ def generate(
         raise TypeError("inner_radius must be a float")
 
     if inner_radius < -tool_diameter / 2:
-		# inner_radius also depends on StartRadius
+        # inner_radius also depends on StartRadius
         raise ValueError(
             "inner_radius {0} with a tool of diameter {1} gives a negative helix radius !".format(
                 inner_radius, tool_diameter
@@ -140,21 +140,21 @@ def generate(
         Path.Log.debug("(annular clearance or entire hole)\n")
         outer_path_radius = hole_radius - tool_radius
         inner_path_radius = inner_radius + tool_radius
-        
+
         if abs((outer_path_radius - inner_path_radius) / step_over_distance) < 1e-5:
-            radii = [outer_path_radius] # below tolerance cutoff, just use outer radius
+            radii = [outer_path_radius]  # below tolerance cutoff, just use outer radius
         else:
-            nr = int( ceil((outer_path_radius - inner_path_radius ) / step_over_distance) +1 )
-            radii = linspace(outer_path_radius, inner_path_radius , nr)
-            if (startAt == "Outside") and (inner_radius <= 0): 
-                radii = delete(radii,-1)  # cutting air. useful for spacing
+            nr = int(ceil((outer_path_radius - inner_path_radius) / step_over_distance) + 1)
+            radii = linspace(outer_path_radius, inner_path_radius, nr)
+            if (startAt == "Outside") and (inner_radius <= 0):
+                radii = delete(radii, -1)  # cutting air. useful for spacing
 
     Path.Log.debug("Radii: {}".format(radii))
     # calculate the number of full and partial turns required
     # Each full turn is two 180 degree arcs. Zsteps is equally spaced step
     # down values
-    turncount = max(int(ceil((startPoint.z - endPoint.z) / step_down)) ,2)
-    zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount+1)
+    turncount = max(int(ceil((startPoint.z - endPoint.z) / step_down)), 2)
+    zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount + 1)
 
     def helix_cut_r(r):
         commandlist = []
@@ -162,15 +162,23 @@ def generate(
         commandlist.append(Path.Command("G0", {"X": startPoint.x + r, "Y": startPoint.y}))
         commandlist.append(Path.Command("G1", {"Z": startPoint.z}))
 
-        #FeedRateCheckbox.checked
-        if not feedRateAdj : feedRateRatio = 0
+        # FeedRateCheckbox.checked
+        if not feedRateAdj:
+            feedRateRatio = 0
         else:
-            if (startAt=="Inside") or (r == radii[0]): # first cut, always adj for outer wall chip-load
-                feedRateRatio = r/(r+tool_radius)  # classic (hole_rad-tool_rad)/hole_rad adjustment
+            if (startAt == "Inside") or (
+                r == radii[0]
+            ):  # first cut, always adj for outer wall chip-load
+                feedRateRatio = r / (
+                    r + tool_radius
+                )  # classic (hole_rad-tool_rad)/hole_rad adjustment
             else:
-                if tool_radius > 200*r : feedRateRatio = 200 # prevent div zero
-                else: feedRateRatio = (r+tool_radius)/r # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
-
+                if tool_radius > 200 * r:
+                    feedRateRatio = 200  # prevent div zero
+                else:
+                    feedRateRatio = (
+                        r + tool_radius
+                    ) / r  # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
 
         # Note: if (r == -tool_radius), helix is plugne, hence VH_gradient==0; feedrate==vFeed , OK
         for i in range(1, turncount + 1):
@@ -186,7 +194,8 @@ def generate(
                     },
                 )
             )
-            if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
+            if feedRateAdj:
+                commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
             commandlist.append(
                 Path.Command(
                     arc_cmd,
@@ -199,7 +208,8 @@ def generate(
                     },
                 )
             )
-            if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
+            if feedRateAdj:
+                commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
         commandlist.append(
             Path.Command(
                 arc_cmd,
@@ -209,10 +219,11 @@ def generate(
                     "Z": endPoint.z,
                     "I": -r,
                     "J": 0.0,
-               },
+                },
             )
         )
-        if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
+        if feedRateAdj:
+            commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
         commandlist.append(
             Path.Command(
                 arc_cmd,
@@ -225,7 +236,8 @@ def generate(
                 },
             )
         )
-        if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
+        if feedRateAdj:
+            commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
         return commandlist
 
     def retract():
@@ -267,5 +279,3 @@ def generate(
         commands.extend(retract())
         prev_r = r
     return commands
-
- 

--- a/src/Mod/CAM/Path/Base/Generator/helix.py
+++ b/src/Mod/CAM/Path/Base/Generator/helix.py
@@ -21,8 +21,9 @@
 # ***************************************************************************
 
 
-from numpy import ceil, linspace, isclose
+from numpy import ceil, linspace, isclose, delete
 import Path
+import math 
 
 __title__ = "Helix toolpath Generator"
 __author__ = "sliptonic (Brad Collette)"
@@ -47,6 +48,7 @@ def generate(
     inner_radius=0.0,
     direction="CW",
     startAt="Outside",
+    feedRateAdj=False,
 ):
     """generate(edge, hole_radius, inner_radius, step_over) ... generate helix commands.
     hole_radius, inner_radius: outer and inner radius of the hole
@@ -68,11 +70,12 @@ def generate(
             tool_diameter,
             direction,
             startAt,
+            feedRateAdj,
         )
     )
 
-    # inner_radius contains not a radius but the value from Extra Offset, which is the distance between the hole radius as designed and the hole radius to be cut.
-    # hole_radius contains the designed hole radius - inner_radius.
+    # hole_radius contains the designed hole radius - OffsetExtra.
+    # inner_radius contains the start radius + OffsetExtra.
 
     if type(hole_radius) not in [float, int]:
         raise TypeError("Invalid type for hole radius")
@@ -83,20 +86,28 @@ def generate(
     if type(inner_radius) not in [float, int]:
         raise TypeError("inner_radius must be a float")
 
+    if inner_radius < -tool_diameter / 2:
+		# inner_radius also depends on StartRadius
+        raise ValueError(
+            "inner_radius {0} with a tool of diameter {1} gives a negative helix radius !".format(
+                inner_radius, tool_diameter
+            )
+        )
+
     if type(tool_diameter) not in [float, int]:
         raise TypeError("tool_diameter must be a float")
 
-    if not hole_radius * 2 > tool_diameter:
+    if not hole_radius * 2 >= tool_diameter:  # will allow plunge cut, zero radius helix
         raise ValueError(
             "Cannot helix a hole of diameter {0} with a tool of diameter {1}".format(
                 2 * hole_radius, tool_diameter
             )
         )
 
-    elif startAt not in ["Inside", "Outside"]:
+    if startAt not in ["Inside", "Outside"]:
         raise ValueError("Invalid value for parameter 'startAt'")
 
-    elif direction not in ["CW", "CCW"]:
+    if direction not in ["CW", "CCW"]:
         raise ValueError("Invalid value for parameter 'direction'")
 
     if type(step_over) not in [float, int]:
@@ -115,39 +126,54 @@ def generate(
     if startPoint.z < endPoint.z:
         raise ValueError("start point is below end point")
 
+    tool_radius = tool_diameter / 2
     if hole_radius <= tool_diameter:
-        Path.Log.debug("(single helix mode)\n")
-        radii = [hole_radius - tool_diameter / 2]
-        if radii[0] <= 0:
+        Path.Log.debug("(single helix path)\n")
+        radii = [hole_radius - tool_radius]
+        if radii[0] < 0:
             raise ValueError(
-                "Cannot helix a hole of diameter {0} with a tool of diameter {1}".format(
+                "Cannot creatre a helical path of diameter {0} with a tool of diameter {1}".format(
                     2 * hole_radius, tool_diameter
                 )
             )
-        outer_radius = hole_radius
-
-    else:  # inner_radius > 0:
-        Path.Log.debug("(annulus mode / full hole)\n")
-        outer_radius = hole_radius - tool_diameter / 2
-        step_radius = inner_radius + tool_diameter / 2
-        if abs((outer_radius - step_radius) / step_over_distance) < 1e-5:
-            radii = [(outer_radius + inner_radius) / 2]
+    else:  # inner_radius >= 0:
+        Path.Log.debug("(annular clearance or entire hole)\n")
+        outer_path_radius = hole_radius - tool_radius
+        inner_path_radius = inner_radius + tool_radius
+        
+        if abs((outer_path_radius - inner_path_radius) / step_over_distance) < 1e-5:
+            radii = [outer_path_radius] # below tolerance cutoff, just use outer radius
         else:
-            nr = max(int(ceil((outer_radius - inner_radius) / step_over_distance)), 2)
-            radii = linspace(outer_radius, step_radius, nr)
+            nr = int( ceil((outer_path_radius - inner_path_radius ) / step_over_distance) +1 )
+            radii = linspace(outer_path_radius, inner_path_radius , nr)
+            if (startAt == "Outside") and (inner_radius <= 0): 
+                radii = delete(radii,-1)  # cutting air. useful for spacing
 
     Path.Log.debug("Radii: {}".format(radii))
     # calculate the number of full and partial turns required
     # Each full turn is two 180 degree arcs. Zsteps is equally spaced step
     # down values
-    turncount = max(int(ceil((startPoint.z - endPoint.z) / step_down)), 2)
-    zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount + 1)
+    turncount = max(int(ceil((startPoint.z - endPoint.z) / step_down)) ,2)
+    zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount+1)
 
     def helix_cut_r(r):
         commandlist = []
         arc_cmd = "G2" if direction == "CW" else "G3"
         commandlist.append(Path.Command("G0", {"X": startPoint.x + r, "Y": startPoint.y}))
         commandlist.append(Path.Command("G1", {"Z": startPoint.z}))
+
+        #FeedRateCheckbox.checked
+        if not feedRateAdj : feedRateRatio = 0
+        else:
+            if (startAt=="Inside") or (r == radii[0]): # first cut, always adj for outer wall chip-load
+                feedRateRatio = r/(r+tool_radius)  # classic (hole_rad-tool_rad)/hole_rad adjustment
+            else:
+                if tool_radius > 200*r : feedRateRatio = 200 # prevent div zero
+                else: feedRateRatio = (r+tool_radius)/r # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
+
+
+        # Note: if (r == -tool_radius), helix is plugne, hence VH_gradient==0; feedrate==vFeed , OK
+        print ("rad = ",r,",  feedRateRatio = ", feedRateRatio)
         for i in range(1, turncount + 1):
             commandlist.append(
                 Path.Command(
@@ -161,6 +187,7 @@ def generate(
                     },
                 )
             )
+            if feedRateAdj: commandlist[-1].Parameters["F"] = feedRateRatio
             commandlist.append(
                 Path.Command(
                     arc_cmd,
@@ -173,6 +200,7 @@ def generate(
                     },
                 )
             )
+            if feedRateAdj: commandlist[-1].Parameters["F"] = feedRateRatio
         commandlist.append(
             Path.Command(
                 arc_cmd,
@@ -182,9 +210,10 @@ def generate(
                     "Z": endPoint.z,
                     "I": -r,
                     "J": 0.0,
-                },
+               },
             )
         )
+        if feedRateAdj: commandlist[-1].Parameters["F"] = feedRateRatio
         commandlist.append(
             Path.Command(
                 arc_cmd,
@@ -197,31 +226,33 @@ def generate(
                 },
             )
         )
+        if feedRateAdj: commandlist[-1].Parameters["F"] = feedRateRatio
         return commandlist
 
     def retract():
-        # try to move to a safe place to retract without leaving a dwell
-        # mark
+        # try to move to a safe place to retract without leaving a dwell mark
         retractcommands = []
-        # Calculate retraction
-        if hole_radius <= tool_diameter:  # simple case where center is clear
-            center_clear = True
-
-        elif startAt == "Inside" and inner_radius == 0.0:  # middle is clear
-            center_clear = True
+        if tool_diameter >= hole_radius:
+            center_clear = True  # single cut operation
         else:
-            center_clear = False
+            center_clear = (startAt == "Inside") and (inner_radius <= 0.0)
+            # hole centre is already clear (hole inner radius<=tool_radius)
 
-        if center_clear:
+        # use G1 since tool tip still in contact with workpiece.
+        if center_clear and (prev_r is None):
+            retractcommands.append(Path.Command("G1", {"X": endPoint.x, "Y": endPoint.y}))
+        elif prev_r is not None:
+            dwell_r = (r + prev_r) / 2
             retractcommands.append(
-                Path.Command("G0", {"X": endPoint.x, "Y": endPoint.y, "Z": endPoint.z})
+                Path.Command(
+                    "G1",
+                    {
+                        "X": endPoint.x + dwell_r,
+                        "Y": endPoint.y,
+                    },
+                )
             )
-
-        # Technical Debt.
-        # If the operation is clearing multiple passes in annulus mode (inner
-        # radius > 0.0 and len(radii) > 1) then there is a derivable
-        # safe place which does not touch the inner or outer wall on all radii except
-        # the first.  This is left as a future improvement.
+            # else annular slot, no pulloff, just retract along wall
 
         retractcommands.append(Path.Command("G0", {"Z": startPoint.z}))
 
@@ -231,8 +262,11 @@ def generate(
         radii = radii[::-1]
 
     commands = []
+    prev_r = None
     for r in radii:
         commands.extend(helix_cut_r(r))
         commands.extend(retract())
-
+        prev_r = r
     return commands
+
+ 

--- a/src/Mod/CAM/Path/Base/Generator/helix.py
+++ b/src/Mod/CAM/Path/Base/Generator/helix.py
@@ -23,7 +23,7 @@
 
 from numpy import ceil, linspace, isclose, delete
 import Path
-import math 
+import math
 
 __title__ = "Helix toolpath Generator"
 __author__ = "sliptonic (Brad Collette)"
@@ -87,7 +87,7 @@ def generate(
         raise TypeError("inner_radius must be a float")
 
     if inner_radius < -tool_diameter / 2:
-		# inner_radius also depends on StartRadius
+        # inner_radius also depends on StartRadius
         raise ValueError(
             "inner_radius {0} with a tool of diameter {1} gives a negative helix radius !".format(
                 inner_radius, tool_diameter
@@ -140,21 +140,21 @@ def generate(
         Path.Log.debug("(annular clearance or entire hole)\n")
         outer_path_radius = hole_radius - tool_radius
         inner_path_radius = inner_radius + tool_radius
-        
+
         if abs((outer_path_radius - inner_path_radius) / step_over_distance) < 1e-5:
-            radii = [outer_path_radius] # below tolerance cutoff, just use outer radius
+            radii = [outer_path_radius]  # below tolerance cutoff, just use outer radius
         else:
-            nr = int( ceil((outer_path_radius - inner_path_radius ) / step_over_distance) +1 )
-            radii = linspace(outer_path_radius, inner_path_radius , nr)
-            if (startAt == "Outside") and (inner_radius <= 0): 
-                radii = delete(radii,-1)  # cutting air. useful for spacing
+            nr = int(ceil((outer_path_radius - inner_path_radius) / step_over_distance) + 1)
+            radii = linspace(outer_path_radius, inner_path_radius, nr)
+            if (startAt == "Outside") and (inner_radius <= 0):
+                radii = delete(radii, -1)  # cutting air. useful for spacing
 
     Path.Log.debug("Radii: {}".format(radii))
     # calculate the number of full and partial turns required
     # Each full turn is two 180 degree arcs. Zsteps is equally spaced step
     # down values
-    turncount = max(int(ceil((startPoint.z - endPoint.z) / step_down)) ,2)
-    zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount+1)
+    turncount = max(int(ceil((startPoint.z - endPoint.z) / step_down)), 2)
+    zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount + 1)
 
     def helix_cut_r(r):
         commandlist = []
@@ -162,18 +162,26 @@ def generate(
         commandlist.append(Path.Command("G0", {"X": startPoint.x + r, "Y": startPoint.y}))
         commandlist.append(Path.Command("G1", {"Z": startPoint.z}))
 
-        #FeedRateCheckbox.checked
-        if not feedRateAdj : feedRateRatio = 0
+        # FeedRateCheckbox.checked
+        if not feedRateAdj:
+            feedRateRatio = 0
         else:
-            if (startAt=="Inside") or (r == radii[0]): # first cut, always adj for outer wall chip-load
-                feedRateRatio = r/(r+tool_radius)  # classic (hole_rad-tool_rad)/hole_rad adjustment
+            if (startAt == "Inside") or (
+                r == radii[0]
+            ):  # first cut, always adj for outer wall chip-load
+                feedRateRatio = r / (
+                    r + tool_radius
+                )  # classic (hole_rad-tool_rad)/hole_rad adjustment
             else:
-                if tool_radius > 200*r : feedRateRatio = 200 # prevent div zero
-                else: feedRateRatio = (r+tool_radius)/r # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
-
+                if tool_radius > 200 * r:
+                    feedRateRatio = 200  # prevent div zero
+                else:
+                    feedRateRatio = (
+                        r + tool_radius
+                    ) / r  # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
 
         # Note: if (r == -tool_radius), helix is plugne, hence VH_gradient==0; feedrate==vFeed , OK
-        print ("rad = ",r,",  feedRateRatio = ", feedRateRatio)
+        print("rad = ", r, ",  feedRateRatio = ", feedRateRatio)
         for i in range(1, turncount + 1):
             commandlist.append(
                 Path.Command(
@@ -187,7 +195,8 @@ def generate(
                     },
                 )
             )
-            if feedRateAdj: commandlist[-1].Parameters["F"] = feedRateRatio
+            if feedRateAdj:
+                commandlist[-1].Parameters["F"] = feedRateRatio
             commandlist.append(
                 Path.Command(
                     arc_cmd,
@@ -200,7 +209,8 @@ def generate(
                     },
                 )
             )
-            if feedRateAdj: commandlist[-1].Parameters["F"] = feedRateRatio
+            if feedRateAdj:
+                commandlist[-1].Parameters["F"] = feedRateRatio
         commandlist.append(
             Path.Command(
                 arc_cmd,
@@ -210,10 +220,11 @@ def generate(
                     "Z": endPoint.z,
                     "I": -r,
                     "J": 0.0,
-               },
+                },
             )
         )
-        if feedRateAdj: commandlist[-1].Parameters["F"] = feedRateRatio
+        if feedRateAdj:
+            commandlist[-1].Parameters["F"] = feedRateRatio
         commandlist.append(
             Path.Command(
                 arc_cmd,
@@ -226,7 +237,8 @@ def generate(
                 },
             )
         )
-        if feedRateAdj: commandlist[-1].Parameters["F"] = feedRateRatio
+        if feedRateAdj:
+            commandlist[-1].Parameters["F"] = feedRateRatio
         return commandlist
 
     def retract():
@@ -268,5 +280,3 @@ def generate(
         commands.extend(retract())
         prev_r = r
     return commands
-
- 

--- a/src/Mod/CAM/Path/Base/Generator/helix.py
+++ b/src/Mod/CAM/Path/Base/Generator/helix.py
@@ -23,7 +23,7 @@
 
 from numpy import ceil, linspace, isclose, delete
 import Path
-import math
+import math 
 
 __title__ = "Helix toolpath Generator"
 __author__ = "sliptonic (Brad Collette)"
@@ -87,7 +87,7 @@ def generate(
         raise TypeError("inner_radius must be a float")
 
     if inner_radius < -tool_diameter / 2:
-        # inner_radius also depends on StartRadius
+		# inner_radius also depends on StartRadius
         raise ValueError(
             "inner_radius {0} with a tool of diameter {1} gives a negative helix radius !".format(
                 inner_radius, tool_diameter
@@ -141,20 +141,20 @@ def generate(
         outer_path_radius = hole_radius - tool_radius
         inner_path_radius = inner_radius + tool_radius
 
-        if abs((outer_path_radius - inner_path_radius) / step_over_distance) < 1e-5:
-            radii = [outer_path_radius]  # below tolerance cutoff, just use outer radius
+        if abs(outer_path_radius-inner_path_radius) < Path.Preferences.defaultGeometryTolerance():
+            radii = [outer_path_radius] # below tolerance cutoff, just use outer radius
         else:
-            nr = int(ceil((outer_path_radius - inner_path_radius) / step_over_distance) + 1)
-            radii = linspace(outer_path_radius, inner_path_radius, nr)
-            if (startAt == "Outside") and (inner_radius <= 0):
-                radii = delete(radii, -1)  # cutting air. useful for spacing
+            num_steps = int( ceil((outer_path_radius - inner_path_radius ) / step_over_distance) +1 )
+            radii = linspace(outer_path_radius, inner_path_radius , num_steps)
+            if (startAt == "Outside") and (inner_radius <= 0): 
+                radii = delete(radii,-1)  # remove air cutt, but inner_radius<0 useful for setting step spacing
 
     Path.Log.debug("Radii: {}".format(radii))
     # calculate the number of full and partial turns required
     # Each full turn is two 180 degree arcs. Zsteps is equally spaced step
     # down values
-    turncount = max(int(ceil((startPoint.z - endPoint.z) / step_down)), 2)
-    zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount + 1)
+    turncount = max(int(ceil((startPoint.z - endPoint.z) / step_down)) ,2)
+    zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount+1)
 
     def helix_cut_r(r):
         commandlist = []
@@ -162,23 +162,15 @@ def generate(
         commandlist.append(Path.Command("G0", {"X": startPoint.x + r, "Y": startPoint.y}))
         commandlist.append(Path.Command("G1", {"Z": startPoint.z}))
 
-        # FeedRateCheckbox.checked
-        if not feedRateAdj:
-            feedRateRatio = 0
+        #FeedRateCheckbox.checked
+        if not feedRateAdj : feedRateRatio = 0
         else:
-            if (startAt == "Inside") or (
-                r == radii[0]
-            ):  # first cut, always adj for outer wall chip-load
-                feedRateRatio = r / (
-                    r + tool_radius
-                )  # classic (hole_rad-tool_rad)/hole_rad adjustment
+            if (startAt=="Inside") or (r == radii[0]): # first cut, always adj for outer wall chip-load
+                feedRateRatio = r/(r+tool_radius)  # classic (hole_rad-tool_rad)/hole_rad adjustment
             else:
-                if tool_radius > 200 * r:
-                    feedRateRatio = 200  # prevent div zero
-                else:
-                    feedRateRatio = (
-                        r + tool_radius
-                    ) / r  # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
+                if tool_radius > 200*r : feedRateRatio = 200 # prevent div zero
+                else: feedRateRatio = (r+tool_radius)/r # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
+
 
         # Note: if (r == -tool_radius), helix is plugne, hence VH_gradient==0; feedrate==vFeed , OK
         for i in range(1, turncount + 1):
@@ -194,8 +186,7 @@ def generate(
                     },
                 )
             )
-            if feedRateAdj:
-                commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
+            if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
             commandlist.append(
                 Path.Command(
                     arc_cmd,
@@ -208,8 +199,7 @@ def generate(
                     },
                 )
             )
-            if feedRateAdj:
-                commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
+            if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
         commandlist.append(
             Path.Command(
                 arc_cmd,
@@ -219,11 +209,10 @@ def generate(
                     "Z": endPoint.z,
                     "I": -r,
                     "J": 0.0,
-                },
+               },
             )
         )
-        if feedRateAdj:
-            commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
+        if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
         commandlist.append(
             Path.Command(
                 arc_cmd,
@@ -236,8 +225,7 @@ def generate(
                 },
             )
         )
-        if feedRateAdj:
-            commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
+        if feedRateAdj: commandlist[-1].Parameters["FeedFactor"] = feedRateRatio
         return commandlist
 
     def retract():
@@ -279,3 +267,5 @@ def generate(
         commands.extend(retract())
         prev_r = r
     return commands
+
+ 

--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -178,13 +178,13 @@ class ObjectOp(PathOp.ObjectOp):
                             {
                                 "x": pos.x,
                                 "y": pos.y,
-                                "r": self.holeDiameter(obj, base, sub),
+                                "d": self.holeDiameter(obj, base, sub),
                             }
                         )
 
         if haveLocations(self, obj):
             for location in obj.Locations:
-                holes.append({"x": location.x, "y": location.y, "r": 0})
+                holes.append({"x": location.x, "y": location.y, "d": 0})
 
         if len(holes) > 0:
             self.circularHoleExecute(obj, holes)

--- a/src/Mod/CAM/Path/Op/Gui/Helix.py
+++ b/src/Mod/CAM/Path/Op/Gui/Helix.py
@@ -89,7 +89,7 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
             FreeCAD.Units.Quantity(obj.OffsetExtra.Value, FreeCAD.Units.Length).UserString
         )
         self.form.FeedRateCheckBox.setCheckState(
-            QtCore.Qt.Checked if obj.FeedRateAdj  else QtCore.Qt.Unchecked
+            QtCore.Qt.Checked if obj.FeedRateAdj else QtCore.Qt.Unchecked
         )
 
     def getSignalsForUpdate(self, obj):

--- a/src/Mod/CAM/Path/Op/Gui/Helix.py
+++ b/src/Mod/CAM/Path/Op/Gui/Helix.py
@@ -72,6 +72,7 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
 
         self.updateToolController(obj, self.form.toolController)
         self.updateCoolant(obj, self.form.coolantController)
+        obj.FeedRateAdj = self.form.FeedRateCheckBox.checkState() == QtCore.Qt.Checked
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
@@ -87,6 +88,9 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         self.form.extraOffset.setText(
             FreeCAD.Units.Quantity(obj.OffsetExtra.Value, FreeCAD.Units.Length).UserString
         )
+        self.form.FeedRateCheckBox.setCheckState(
+            QtCore.Qt.Checked if obj.FeedRateAdj  else QtCore.Qt.Unchecked
+        )
 
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
@@ -98,6 +102,7 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         signals.append(self.form.startSide.currentIndexChanged)
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.coolantController.currentIndexChanged)
+        signals.append(self.form.FeedRateCheckBox.stateChanged)
 
         return signals
 

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -276,7 +276,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "inner_radius": obj.StartRadius.Value + obj.OffsetExtra.Value,
             "direction": obj.Direction,
             "startAt": obj.StartSide,
-            "feedRateAdj":obj.FeedRateAdj,
+            "feedRateAdj": obj.FeedRateAdj,
         }
 
         for hole in holes:

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -30,7 +30,7 @@ import Path
 import Path.Base.FeedRate as PathFeedRate
 import Path.Op.Base as PathOp
 import Path.Op.CircularHoleBase as PathCircularHoleBase
-
+from math import sqrt
 
 __title__ = "CAM Helix Operation"
 __author__ = "Lorenz Hüdepohl"
@@ -184,6 +184,15 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 "Extra value to stay away from final profile- good for roughing toolpath",
             ),
         )
+        obj.addProperty(
+            "App::PropertyBool",
+            "FeedRateAdj",
+            "Helix Drill",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Apply radial feed-rate adjustment to correct tooltip speed",
+            ),
+        )
 
         ENUMS = self.helixOpPropertyEnumerations()
         for n in ENUMS:
@@ -207,6 +216,17 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 QT_TRANSLATE_NOOP(
                     "App::Property",
                     "Extra value to stay away from final profile- good for roughing toolpath",
+                ),
+            )
+
+        if not hasattr(obj, "FeedRateAdj"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "FeedRateAdj",
+                "Helix Drill",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Apply radial feed-rate adjustment to correct tooltip speed",
                 ),
             )
 
@@ -256,10 +276,11 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "inner_radius": obj.StartRadius.Value + obj.OffsetExtra.Value,
             "direction": obj.Direction,
             "startAt": obj.StartSide,
+            "feedRateAdj":obj.FeedRateAdj,
         }
 
         for hole in holes:
-            args["hole_radius"] = (hole["r"] / 2) - (obj.OffsetExtra.Value)
+            args["hole_radius"] = (hole["d"] / 2) - (obj.OffsetExtra.Value)
             startPoint = FreeCAD.Vector(hole["x"], hole["y"], obj.StartDepth.Value)
             endPoint = FreeCAD.Vector(hole["x"], hole["y"], obj.FinalDepth.Value)
             args["edge"] = Part.makeLine(startPoint, endPoint)
@@ -295,6 +316,7 @@ def SetupProperties():
     setup.append("StartSide")
     setup.append("StepOver")
     setup.append("StartRadius")
+    setup.append("FeedRateAdj")
     return setup
 
 


### PR DESCRIPTION
Incorporates changes to helix retract() previously reviewed and discussed in: 
CAM: Improved retraction between helical paths #20340

Adds new dlg option for radial adjustment of spindle feed rate parameter "F" 

As radius changes from on helix to the next in multiple cut helix operations the spindle feedrate is adjusted for the radial difference between cutting edge of tool and spindle path radius. 

The aim is to give roughly constant tool cutting speed across all helices, allowing one ToolController
Spindle feedrate is reduced when cutting outer edge and increase when cutting inwards to maintain tool tip speed. 

The effect can be a ratio of 2 or more when tool diam is near hole diameter. 
A cutoff is set at 200 to avoid div zero condition.

The issue is explained here if required. 
https://www.youtube.com/watch?v=6wLU97gVo5k

