### PR TITLE
Fix typos

### DIFF
--- a/src/Mod/BIM/ArchSpace.py
+++ b/src/Mod/BIM/ArchSpace.py
@@ -442,7 +442,7 @@ class _ViewProviderSpace(ArchComponent.ViewProviderComponent):
 
         pl = vobj.PropertiesList
         if not "Text" in pl:
-            vobj.addProperty("App::PropertyStringList",    "Text",        "Space",QT_TRANSLATE_NOOP("App::Property","The text to show. Use $area, $label, $longname, $description or any other propery name preceded with $ (case insensitive), or $floor, $walls, $ceiling for finishes, to insert the respective data"))
+            vobj.addProperty("App::PropertyStringList",    "Text",        "Space",QT_TRANSLATE_NOOP("App::Property","The text to show. Use $area, $label, $longname, $description or any other property name preceded with $ (case insensitive), or $floor, $walls, $ceiling for finishes, to insert the respective data"))
             vobj.Text = ["$label","$area"]
         if not "FontName" in pl:
             vobj.addProperty("App::PropertyFont",          "FontName",    "Space",QT_TRANSLATE_NOOP("App::Property","The name of the font"))

--- a/src/Mod/BIM/importers/importSH3DHelper.py
+++ b/src/Mod/BIM/importers/importSH3DHelper.py
@@ -1511,9 +1511,9 @@ class WallHandler(BaseHandler):
 
     def _set_baseboard_properties(self, obj, elm):
         # Baseboard are a little bit special:
-        # Since their placement and other characteristics are dependant of
+        # Since their placement and other characteristics are dependent on
         # the wall elements to be created (such as doorOrWndows), their
-        # creation is delayed until the
+        # creation is delayed until then
         for baseboard in elm.findall('baseboard'):
             side = baseboard.get('attribute')
             self.setp(obj, "App::PropertyQuantity", f"{side}Thickness", f"The thickness of the {side} baseboard", dim_sh2fc(float(baseboard.get("thickness"))))

--- a/src/Mod/Fem/App/FemPostBranchFilter.cpp
+++ b/src/Mod/Fem/App/FemPostBranchFilter.cpp
@@ -44,14 +44,14 @@ FemPostBranchFilter::FemPostBranchFilter()
                       (long(0)),
                       "Pipeline",
                       App::Prop_None,
-                      "Selects what the output of the branch itself is\n"
-                      "In passthrough the branchs output is equal its imput.\n"
-                      "In append, all child filter outputs gets appended as the branches output");
+                      "Selects what the output of the branch itself is.\n"
+                      "In passthrough, the branch's output is equal to its input.\n"
+                      "In append, all child filter outputs get appended as the branch's output");
 
     Output.setEnums(OutputEnums);
 
     /* We always have a passthrough filter. This allows to connect our children
-     * dependend on the Mode setting, without worrying about the connection to our input
+     * dependent on the Mode setting, without worrying about the connection to our input
      * filter. We do not care if the input filter changes, as this is affecting only the passthrough
      * input and does not affect our child connections.
      * Dependent on our output mode, the passthrough is also used as output, but potentially

--- a/src/Mod/Fem/App/FemPostPipeline.cpp
+++ b/src/Mod/Fem/App/FemPostPipeline.cpp
@@ -185,8 +185,8 @@ int FemFrameSourceAlgorithm::RequestData(vtkInformation*,
         auto time = outInfo->Get(vtkStreamingDemandDrivenPipeline::UPDATE_TIME_STEP());
         auto frames = getFrameValues();
 
-        // we have float values, so be aware of roundign erros. lets subtract the searched time and
-        // then use the smalles value
+        // we have float values, so be aware of rounding errors. lets subtract the searched time and
+        // then use the smallest value
         for (auto& frame : frames) {
             frame = std::abs(frame - time);
         }
@@ -257,7 +257,7 @@ bool FemPostPipeline::allowObject(App::DocumentObject* obj)
         return true;
     }
 
-    // and all standart Post objects the group can handle
+    // and all standard Post objects the group can handle
     return FemPostGroupExtension::allowObject(obj);
 }
 
@@ -360,7 +360,7 @@ void FemPostPipeline::scale(double s)
 
 App::DocumentObjectExecReturn* FemPostPipeline::execute()
 {
-    // we fake a recalculated data oject, so that the viewprovider updates
+    // we fake a recalculated data object, so that the viewprovider updates
     // the visualization. We do not want to do this in onChange, as it
     // could theoretically be long running
     if (m_data_updated) {
@@ -487,7 +487,7 @@ void FemPostPipeline::onChanged(const Property* prop)
             FemPostFilter* nextFilter = obj;
             nextFilter->getFilterInput()->RemoveAllInputConnections(0);
 
-            // handle input modes (Parallel is seperated, alll other settings are serial, just in
+            // handle input modes (Parallel is separated, all other settings are serial, just in
             // case an old document is loaded with "custom" mode, idx 2)
             if (Mode.getValue() == Fem::PostGroupMode::Parallel) {
                 // parallel: all filters get out input

--- a/src/Mod/Fem/App/FemPostPipelinePyImp.cpp
+++ b/src/Mod/Fem/App/FemPostPipelinePyImp.cpp
@@ -222,7 +222,7 @@ PyObject* FemPostPipelinePy::load(PyObject* args)
         }
         else {
             std::string error = std::string(
-                "Multistep load requries 4 arguments: ResultList, ValueList, unit, type");
+                "Multistep load requires 4 arguments: ResultList, ValueList, unit, type");
             throw Base::TypeError(error);
         }
     }

--- a/src/Mod/Fem/Gui/ViewProviderFemPostBranchFilter.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostBranchFilter.h
@@ -50,7 +50,7 @@ public:
 protected:
     virtual void setupTaskDialog(TaskDlgPost* dlg) override;
 
-    // change default group drag/drop behaviour sligthly
+    // change default group drag/drop behaviour slightly
     bool acceptReorderingObjects() const override;
     bool canDragObjectToTarget(App::DocumentObject* obj,
                                App::DocumentObject* target) const override;

--- a/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.h
@@ -56,7 +56,7 @@ protected:
     void updateFunctionSize();
     virtual void setupTaskDialog(TaskDlgPost* dlg) override;
 
-    // change default group drag/drop behaviour sligthly
+    // change default group drag/drop behaviour slightly
     bool acceptReorderingObjects() const override;
     bool canDragObjectToTarget(App::DocumentObject* obj,
                                App::DocumentObject* target) const override;

--- a/src/Mod/Fem/femresult/resulttools.py
+++ b/src/Mod/Fem/femresult/resulttools.py
@@ -71,7 +71,7 @@ def purge_results(analysis):
     # result pipeline and filter
     for m in analysis.Group:
         if is_of_type(m, "Fem::FemPostPipeline"):
-            # delete the pipeline itself (it removes all fiters itself)
+            # delete the pipeline itself (it removes all filters itself)
             analysis.Document.removeObject(m.Name)
     analysis.Document.recompute()
 

--- a/src/Mod/Material/App/Exceptions.h
+++ b/src/Mod/Material/App/Exceptions.h
@@ -34,7 +34,7 @@ class Uninitialized: public Base::Exception
 {
 public:
     Uninitialized()
-        : Base::Exception("Uninitalized")
+        : Base::Exception("Uninitialized")
     {}
     explicit Uninitialized(const char* msg)
         : Base::Exception(msg)
@@ -244,7 +244,7 @@ class UnknownValueType: public Base::Exception
 {
 public:
     UnknownValueType()
-        : Base::Exception("Unkown value type")
+        : Base::Exception("Unknown value type")
     {}
     explicit UnknownValueType(const char* msg)
         : Base::Exception(msg)

--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -567,7 +567,7 @@ private:
 
         TechDraw::GeometryObjectPtr gObj = dvp->getGeometryObject();
         if (!gObj) {
-            // this test might be redundent here since we already checked hasGeometry.
+            // this test might be redundant here since we already checked hasGeometry.
             Base::Console().Message("TechDraw: %s has no geometry object!\n", dvp->Label.getValue());
             return;
         }

--- a/src/Mod/TechDraw/Gui/ViewProviderAnnotation.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderAnnotation.cpp
@@ -135,7 +135,7 @@ bool ViewProviderAnnotation::setEdit(int ModNum)
     // setting the current item also opens the editor
     dataPropView->setCurrentIndex(index);
     dataPropView->activated(index);
-    // there is a button in the editor wigdet that opens a plain text dialog
+    // there is a button in the editor widget that opens a plain text dialog
     auto button = dataPropView->findChild<QPushButton*>();
     if (button) {
         button->click();

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -710,7 +710,7 @@ class DocumentImportCases(unittest.TestCase):
             params.set_param("dxfCreateDraft", wasCreateDraft)
             params.set_param("dxfCreateSketch", wasCreateSketch)
         doc = FreeCAD.getDocument("ImportedDocName")
-        # This doc should ahve 3 objects: The Layers containter, the DXF layer called 0, and one Line
+        # This doc should have 3 objects: The Layers container, the DXF layer called 0, and one Line
         self.assertEqual(len(doc.Objects), 3)
         FreeCAD.closeDocument("ImportedDocName")
 


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,addmin,ake,aline,alle,alledges,alocation,als,ang,anid,anormal,aply,apoints,ba,beginn,behaviour,bloaded,bottome,brushin,bu,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childrens,childs,colour,colours,commen,connexion,currenty,documentin,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,findn,fle,freez,graphin,hist,iff,incrementin,indexin,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,itsel,kilometre,leadin,localy,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oce,oder,ontop,orgin,orginx,orginy,ot,pard,parm,parms,pres,programm,que,rady,recurrance,renderin,rin,ro,rougly,sectionin,seperator,serie,shs,sinc,siz,som,strack,substraction,te,technic,thist,thru,tread,tru,ue,uint,unter,uptodate,vas,vertexes,vew,wallthickness,whitespaces -S "./.git,*.po,*.ts,*.pdf,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./src/Base/StackWalker.cpp,./build/doc/SourceDoc,./tools/build/WindowsInstaller/lang,./src/Mod/TechDraw/Templates/locale"`