### PR TITLE
Check for a null scene object

### DIFF
--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -2135,6 +2135,9 @@ Py::Object View3DInventorPy::getSceneGraph()
 {
     try {
         SoNode* scene = getView3DInventorPtr()->getViewer()->getSceneGraph();
+        if (scene == nullptr) {
+            return Py::None();
+        }
         PyObject* proxy = nullptr;
         proxy = Base::Interpreter().createSWIGPointerObj("pivy.coin", "SoSeparator *", static_cast<void*>(scene), 1);
         scene->ref();


### PR DESCRIPTION
Under certain unusual circumstances getSceneGraph can be called when the scene is null, causing a native exception when the scene's reference count is incremented. This changes the code to return python None in this condition, allowing the calling code to handle the no-scene case itself.

Fixes #18679
At least it fixes the immediate cause of the issue. It does not address the whole issue of the use of the delay mechanism.