### PR TITLE
Preferences: Fixed a bug in 'Animation curve type' label position

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsAdvanced.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsAdvanced.cpp
@@ -554,7 +554,6 @@ void DlgSettingsAdvanced::setOffset1(qreal t)
         QPoint pos(width(), 0);
         this->b1 = width() - label->fontMetrics().boundingRect(label->text()).width() - 5;
     }
-    label->move(this->a1 * (1-t) + this->b1 * t, label->y());
 }
 
 void DlgSettingsAdvanced::onCurveChange(int index)


### PR DESCRIPTION
Deleted a line in DlgSettingsAdvanced.cpp that made the label move after selecting a animation curve type. Fixes #18376.