### PR TITLE
Material: Remove unused parameters/functions

### DIFF
--- a/src/Mod/Material/App/MaterialManager.cpp
+++ b/src/Mod/Material/App/MaterialManager.cpp
@@ -239,10 +239,6 @@ MaterialManager::libraryMaterials(const QString& libraryName,
     return _localManager->libraryMaterials(libraryName, filter, options);
 }
 
-bool MaterialManager::isLocalLibrary()
-{
-    return true;
-}
 
 //=====
 //

--- a/src/Mod/Material/App/MaterialManager.cpp
+++ b/src/Mod/Material/App/MaterialManager.cpp
@@ -202,11 +202,6 @@ std::shared_ptr<MaterialLibrary> MaterialManager::getLibrary(const QString& name
     return _localManager->getLibrary(name);
 }
 
-void MaterialManager::createLibrary(const QString& libraryName, const QString& icon, bool readOnly)
-{
-    throw CreationError("Local library requires a path");
-}
-
 void MaterialManager::createLocalLibrary(const QString& libraryName,
                                          const QString& directory,
                                          const QString& icon,
@@ -244,7 +239,7 @@ MaterialManager::libraryMaterials(const QString& libraryName,
     return _localManager->libraryMaterials(libraryName, filter, options);
 }
 
-bool MaterialManager::isLocalLibrary(const QString& libraryName)
+bool MaterialManager::isLocalLibrary()
 {
     return true;
 }

--- a/src/Mod/Material/App/MaterialManager.h
+++ b/src/Mod/Material/App/MaterialManager.h
@@ -71,8 +71,9 @@ public:
     // Library management
     std::shared_ptr<std::list<std::shared_ptr<MaterialLibrary>>> getLibraries();
     std::shared_ptr<std::list<std::shared_ptr<MaterialLibrary>>> getLocalLibraries();
-    std::shared_ptr<MaterialLibrary> getLibrary(const QString& name) const;
-    void createLibrary(const QString& libraryName, const QString& icon, bool readOnly = true);
+    std::shared_ptr<MaterialLibrary> getLibrary(const QString& name) 
+    
+const;
     void createLocalLibrary(const QString& libraryName,
                             const QString& directory,
                             const QString& icon,
@@ -86,7 +87,7 @@ public:
     libraryMaterials(const QString& libraryName,
                      const std::shared_ptr<MaterialFilter>& filter,
                      const MaterialFilterOptions& options);
-    bool isLocalLibrary(const QString& libraryName);
+    bool isLocalLibrary();
 
     // Folder management
     std::shared_ptr<std::list<QString>>

--- a/src/Mod/Material/App/MaterialManager.h
+++ b/src/Mod/Material/App/MaterialManager.h
@@ -87,7 +87,6 @@ const;
     libraryMaterials(const QString& libraryName,
                      const std::shared_ptr<MaterialFilter>& filter,
                      const MaterialFilterOptions& options);
-    bool isLocalLibrary();
 
     // Folder management
     std::shared_ptr<std::list<QString>>

--- a/src/Mod/Material/App/ModelManager.cpp
+++ b/src/Mod/Material/App/ModelManager.cpp
@@ -126,11 +126,6 @@ ModelManager::libraryModels(const QString& libraryName)
     return _localManager->libraryModels(libraryName);
 }
 
-bool ModelManager::isLocalLibrary()
-{
-    return true;
-}
-
 std::shared_ptr<std::map<QString, std::shared_ptr<Model>>> ModelManager::getModels()
 {
     return _localManager->getModels();

--- a/src/Mod/Material/App/ModelManager.cpp
+++ b/src/Mod/Material/App/ModelManager.cpp
@@ -96,8 +96,6 @@ std::shared_ptr<std::list<std::shared_ptr<ModelLibrary>>> ModelManager::getLocal
     return _localManager->getLibraries();
 }
 
-void ModelManager::createLibrary(const QString& libraryName, const QString& icon, bool readOnly)
-{}
 
 void ModelManager::createLocalLibrary(const QString& libraryName,
                                       const QString& directory,
@@ -128,7 +126,7 @@ ModelManager::libraryModels(const QString& libraryName)
     return _localManager->libraryModels(libraryName);
 }
 
-bool ModelManager::isLocalLibrary(const QString& libraryName)
+bool ModelManager::isLocalLibrary()
 {
     return true;
 }

--- a/src/Mod/Material/App/ModelManager.h
+++ b/src/Mod/Material/App/ModelManager.h
@@ -63,7 +63,6 @@ public:
     void removeLibrary(const QString& libraryName);
     std::shared_ptr<std::vector<std::tuple<QString, QString, QString>>>
     libraryModels(const QString& libraryName);
-    bool isLocalLibrary();
 
     std::shared_ptr<std::map<QString, std::shared_ptr<Model>>> getModels();
     std::shared_ptr<std::map<QString, std::shared_ptr<Model>>> getLocalModels();

--- a/src/Mod/Material/App/ModelManager.h
+++ b/src/Mod/Material/App/ModelManager.h
@@ -53,7 +53,7 @@ public:
 
     std::shared_ptr<std::list<std::shared_ptr<ModelLibrary>>> getLibraries();
     std::shared_ptr<std::list<std::shared_ptr<ModelLibrary>>> getLocalLibraries();
-    void createLibrary(const QString& libraryName, const QString& icon, bool readOnly = true);
+
     void createLocalLibrary(const QString& libraryName,
                        const QString& directory,
                        const QString& icon,
@@ -63,7 +63,7 @@ public:
     void removeLibrary(const QString& libraryName);
     std::shared_ptr<std::vector<std::tuple<QString, QString, QString>>>
     libraryModels(const QString& libraryName);
-    bool isLocalLibrary(const QString& libraryName);
+    bool isLocalLibrary();
 
     std::shared_ptr<std::map<QString, std::shared_ptr<Model>>> getModels();
     std::shared_ptr<std::map<QString, std::shared_ptr<Model>>> getLocalModels();


### PR DESCRIPTION
Due compile warnings  unused parameters functions are removed. One of the class constructors has also been removed.