### PR TITLE
[Core] Show units in the VarSet add property dialog

### DIFF
--- a/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
@@ -251,7 +251,9 @@ void DlgAddPropertyVarSet::addEditor(PropertyEditor::PropertyItem* propertyItem,
     editor.reset(propertyItem->createEditor(this, [this]() {
         this->valueChanged();
     }));
-    propertyItem->setEditorData(editor.get(), QVariant());
+    propertyItem->setEditorData(
+            editor.get(),
+            propertyItem->data(PropertyEditor::PropertyItem::ValueColumn, Qt::EditRole));
     editor->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     editor->setObjectName(QStringLiteral("editor"));
     auto formLayout = qobject_cast<QFormLayout*>(layout());

--- a/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
@@ -153,7 +153,7 @@ static void printFocusChain(QWidget *widget) {
     QWidget* start = widget;
     int i = 0;
     do {
-        FC_ERR(" " << widget->objectName().toStdString();
+        FC_ERR(" " << widget->objectName().toStdString());
         widget = widget->nextInFocusChain();
         i++;
     } while (widget != nullptr && i < 30 && start != widget);
@@ -245,12 +245,24 @@ static PropertyEditor::PropertyItem *createPropertyItem(App::Property *prop)
     return item;
 }
 
+void DlgAddPropertyVarSet::removeSelectionEditor()
+{
+    // If the editor has a lineedit, then Qt selects the string inside it when
+    // the editor is created.  This interferes with the editor getting focus.
+    // For example, units will then be selected as well, whereas this is not
+    // the behavior we want.  We therefore deselect the text in the lineedit.
+    if (auto lineEdit = editor->findChild<QLineEdit*>()) {
+        lineEdit->deselect();
+    }
+}
+
 void DlgAddPropertyVarSet::addEditor(PropertyEditor::PropertyItem* propertyItem,
                                      [[maybe_unused]]std::string& type)
 {
     editor.reset(propertyItem->createEditor(this, [this]() {
         this->valueChanged();
     }));
+    editor->blockSignals(true);
     propertyItem->setEditorData(
             editor.get(),
             propertyItem->data(PropertyEditor::PropertyItem::ValueColumn, Qt::EditRole));
@@ -261,6 +273,9 @@ void DlgAddPropertyVarSet::addEditor(PropertyEditor::PropertyItem* propertyItem,
 
     QWidget::setTabOrder(ui->comboBoxType, editor.get());
     QWidget::setTabOrder(editor.get(), ui->checkBoxAdd);
+
+    removeSelectionEditor();
+    editor->blockSignals(false);
 
     // FC_ERR("add editor");
     // printFocusChain(editor.get());

--- a/src/Gui/Dialogs/DlgAddPropertyVarSet.h
+++ b/src/Gui/Dialogs/DlgAddPropertyVarSet.h
@@ -92,6 +92,7 @@ private:
     void clearCurrentProperty();
 
     void removeEditor();
+    void removeSelectionEditor();
     void addEditor(PropertyEditor::PropertyItem* propertyItem, std::string& type);
 
     bool isTypeWithEditor(const std::string& type);

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -295,7 +295,7 @@ int PropertyItem::childCount() const
 
 int PropertyItem::columnCount() const
 {
-    return 2;
+    return PropertyItem::ColumnCount;
 }
 
 void PropertyItem::setReadOnly(bool ro)
@@ -649,7 +649,7 @@ void PropertyItem::setPropertyValue(const QString& value)
     setPropertyValue(value.toStdString());
 }
 
-QVariant PropertyItem::dataProperty(int role) const
+QVariant PropertyItem::dataPropertyName(int role) const
 {
     if (role == Qt::ForegroundRole && linked) {
         return QVariant::fromValue(QColor(0x20, 0xaa, 0x20));  // NOLINT
@@ -742,9 +742,8 @@ QVariant PropertyItem::dataValue(int role) const
 
 QVariant PropertyItem::data(int column, int role) const
 {
-    // property name
-    if (column == 0) {
-        return dataProperty(role);
+    if (column == PropertyItem::NameColumn) {
+        return dataPropertyName(role);
     }
 
     return dataValue(role);

--- a/src/Gui/propertyeditor/PropertyItem.h
+++ b/src/Gui/propertyeditor/PropertyItem.h
@@ -130,6 +130,12 @@ class GuiExport PropertyItem: public QObject, public ExpressionBinding
     PROPERTYITEM_HEADER
 
 public:
+    enum Column {
+        NameColumn = 0,
+        ValueColumn = 1,
+        ColumnCount
+    };
+
     ~PropertyItem() override;
 
     /** Sets the current property objects. */
@@ -216,7 +222,7 @@ protected:
     void onChange() override;
 
 private:
-    QVariant dataProperty(int role) const;
+    QVariant dataPropertyName(int role) const;
     QVariant dataValue(int role) const;
     QString toString(const Py::Object&) const;
     QString asNone(const Py::Object&) const;


### PR DESCRIPTION
Closes #15557

@FreeCAD/code-quality-working-group. I made a small refactor in `PropertyItem.cpp` in https://github.com/FreeCAD/FreeCAD/commit/4bbc59d3094a109b7fa8945375f98725675e841f for some code that puzzled me a bit when reading. What do you think of the way I return the column count in this enum?