### PR TITLE
[Core] Fix visibility icons VarSets/Spreadsheet

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -5534,7 +5534,9 @@ void DocumentObjectItem::testStatus(bool resetStatus, QIcon& icon1, QIcon& icon2
                 QPainter pt;
                 pt.begin(&px);
                 pt.setPen(Qt::NoPen);
-                pt.drawPixmap(0, 0, px_org.width(), px_org.height(), (currentStatus & Status::Visible) ? pxVisible : pxInvisible);
+                if (strlen(object()->DisplayMode.getValueAsString()) != 0) {
+                    pt.drawPixmap(0, 0, px_org.width(), px_org.height(), (currentStatus & Status::Visible) ? pxVisible : pxInvisible);
+                }
                 pt.drawPixmap(px_org.width() + spacing, 0, px_org.width(), px_org.height(), px_org);
                 pt.end();
 

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
@@ -147,11 +147,6 @@ std::vector<App::DocumentObject*> ViewProviderFemAnalysis::claimChildren() const
     return Gui::ViewProviderDocumentObjectGroup::claimChildren();
 }
 
-std::vector<std::string> ViewProviderFemAnalysis::getDisplayModes() const
-{
-    return {"Analysis"};
-}
-
 void ViewProviderFemAnalysis::hide()
 {
     Gui::ViewProviderDocumentObjectGroup::hide();

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.h
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.h
@@ -75,8 +75,6 @@ public:
 
     void setupContextMenu(QMenu*, QObject*, const char*) override;
 
-    /// list of all possible display modes
-    std::vector<std::string> getDisplayModes() const override;
     /// shows solid in the tree
     bool isShow() const override
     {

--- a/src/Mod/Fem/Gui/ViewProviderSolver.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderSolver.cpp
@@ -46,11 +46,6 @@ ViewProviderSolver::ViewProviderSolver()
 
 ViewProviderSolver::~ViewProviderSolver() = default;
 
-std::vector<std::string> ViewProviderSolver::getDisplayModes() const
-{
-    return {"Solver"};
-}
-
 bool ViewProviderSolver::onDelete(const std::vector<std::string>&)
 {
     // warn the user if the object has unselected children

--- a/src/Mod/Fem/Gui/ViewProviderSolver.h
+++ b/src/Mod/Fem/Gui/ViewProviderSolver.h
@@ -53,8 +53,6 @@ public:
     {
         return Visibility.getValue();
     }
-    /// A list of all possible display modes
-    std::vector<std::string> getDisplayModes() const override;
 
     // handling when object is deleted
     bool onDelete(const std::vector<std::string>&) override;

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -59,18 +59,6 @@ ViewProviderSheet::~ViewProviderSheet()
     }
 }
 
-void ViewProviderSheet::setDisplayMode(const char* ModeName)
-{
-    ViewProviderDocumentObject::setDisplayMode(ModeName);
-}
-
-std::vector<std::string> ViewProviderSheet::getDisplayModes() const
-{
-    std::vector<std::string> StrList;
-    StrList.emplace_back("Spreadsheet");
-    return StrList;
-}
-
 QIcon ViewProviderSheet::getIcon() const
 {
     return QIcon(QLatin1String(":icons/Spreadsheet.svg"));

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.h
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.h
@@ -46,12 +46,10 @@ public:
     /// destructor.
     ~ViewProviderSheet() override;
 
-    void setDisplayMode(const char* ModeName) override;
     bool useNewSelectionModel() const override
     {
         return false;
     }
-    std::vector<std::string> getDisplayModes() const override;
 
     bool doubleClicked() override;
     void setupContextMenu(QMenu* menu, QObject* receiver, const char* member) override;


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/16816

It uses the DisplayMode to differentiate between document objects that can be toggled for visibility or not.

Is an alternative to https://github.com/FreeCAD/FreeCAD/pull/16817.

Since @FlachyJoe proposed the same as I did, I had some confidence in this solution.

However, now that I see the result on TechDraw pages, I'm not so sure whether the DisplayMode should be the criterion to differentiate:

![screenshot](https://github.com/user-attachments/assets/105be0f7-d400-435a-9bd2-483efddbdc13)

This PR removes various displaymodes from FEM objects that are not rendered and the Spreadsheet that is also not rendered. However, although the TechDraw document objects are not rendered by Coin and hence don't have a displaymode, it does make sense to have a visibility icon for these objects. This is because a dimension, template or view can be toggled on or off on the page or not. 