### PR TITLE
Build: force CMake to 3.31.6 version in CI

### DIFF
--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.16.x'
+          cmake-version: '3.31.6'
       - name: CMake Configure
         uses: ./.github/workflows/actions/linux/configure
         with:

--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -107,6 +107,10 @@ jobs:
           ccache -s
           ccache -z
           ccache -p
+      - name: Install cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.16.x'
       - name: CMake Configure
         uses: ./.github/workflows/actions/linux/configure
         with:

--- a/.github/workflows/sub_buildWindows.yml
+++ b/.github/workflows/sub_buildWindows.yml
@@ -98,6 +98,10 @@ jobs:
           . $env:ccachebindir\ccache -s
           . $env:ccachebindir\ccache -z
           . $env:ccachebindir\ccache -p
+      - name: Install cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.6'
       - name: Configuring CMake
         run: >
           cmake -B"${{ env.builddir }}" .


### PR DESCRIPTION
GitHub just changed CMake version on their CI that kabooms everyones CIs.
- https://github.com/actions/runner-images/issues/11926


Installing CMake with `apt install` doesn't override the path used in the CMake. So let's use https://github.com/marketplace/actions/actions-setup-cmake and fix the CI for now.