### PR TITLE
[Core] Add a frame for the value field in the Add Property dialog for VarSets.

### DIFF
--- a/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
@@ -261,7 +261,7 @@ void DlgAddPropertyVarSet::addEditor(PropertyEditor::PropertyItem* propertyItem,
 {
     editor.reset(propertyItem->createEditor(this, [this]() {
         this->valueChanged();
-    }));
+    }, PropertyEditor::FrameOption::WithFrame));
     editor->blockSignals(true);
     propertyItem->setEditorData(
             editor.get(),

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -74,6 +74,7 @@ constexpr const int lowPrec = 2;
 constexpr const int highPrec = 16;
 }  // namespace
 
+
 PropertyItemFactory& PropertyItemFactory::instance()
 {
     static PropertyItemFactory inst;
@@ -490,7 +491,8 @@ void PropertyItem::setValue(const QVariant& /*value*/)
 {}
 
 QWidget* PropertyItem::createEditor(QWidget* /*parent*/,
-                                    const std::function<void()>& /*method*/) const
+                                    const std::function<void()>& /*method*/,
+                                    FrameOption /*frameOption*/) const
 {
     return nullptr;
 }
@@ -839,10 +841,11 @@ void PropertyStringItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyStringItem::createEditor(QWidget* parent,
-                                          const std::function<void()>& method) const
+                                          const std::function<void()>& method,
+                                          FrameOption frameOption) const
 {
     auto le = new ExpLineEdit(parent);
-    le->setFrame(false);
+    le->setFrame(frameOptionToBool(frameOption));
     le->setReadOnly(isReadOnly());
     QObject::connect(le, &ExpLineEdit::textChanged, method);
     if (isBound()) {
@@ -886,10 +889,12 @@ void PropertyFontItem::setValue(const QVariant& value)
     }
 }
 
-QWidget* PropertyFontItem::createEditor(QWidget* parent, const std::function<void()>& method) const
+QWidget* PropertyFontItem::createEditor(QWidget* parent,
+                                        const std::function<void()>& method,
+                                        FrameOption frameOption) const
 {
     auto cb = new QComboBox(parent);
-    cb->setFrame(false);
+    cb->setFrame(frameOptionToBool(frameOption));
     cb->setDisabled(isReadOnly());
     QObject::connect(cb, &QComboBox::textActivated, method);
     return cb;
@@ -919,10 +924,12 @@ QVariant PropertyFontItem::editorData(QWidget* editor) const
 PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertySeparatorItem)
 
 QWidget* PropertySeparatorItem::createEditor(QWidget* parent,
-                                             const std::function<void()>& method) const
+                                             const std::function<void()>& method,
+                                             FrameOption frameOption) const
 {
     Q_UNUSED(parent);
     Q_UNUSED(method);
+    Q_UNUSED(frameOption);
     return nullptr;
 }
 
@@ -950,10 +957,11 @@ void PropertyIntegerItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyIntegerItem::createEditor(QWidget* parent,
-                                           const std::function<void()>& method) const
+                                           const std::function<void()>& method,
+                                           FrameOption frameOption) const
 {
     auto sb = new Gui::IntSpinBox(parent);
-    sb->setFrame(false);
+    sb->setFrame(frameOptionToBool(frameOption));
     sb->setReadOnly(isReadOnly());
     QObject::connect(sb, qOverload<int>(&Gui::IntSpinBox::valueChanged), method);
 
@@ -1016,10 +1024,11 @@ void PropertyIntegerConstraintItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyIntegerConstraintItem::createEditor(QWidget* parent,
-                                                     const std::function<void()>& method) const
+                                                     const std::function<void()>& method,
+                                                     FrameOption frameOption) const
 {
     auto sb = new Gui::IntSpinBox(parent);
-    sb->setFrame(false);
+    sb->setFrame(frameOptionToBool(frameOption));
     sb->setReadOnly(isReadOnly());
     QObject::connect(sb, qOverload<int>(&Gui::IntSpinBox::valueChanged), method);
 
@@ -1110,10 +1119,12 @@ void PropertyFloatItem::setValue(const QVariant& value)
     }
 }
 
-QWidget* PropertyFloatItem::createEditor(QWidget* parent, const std::function<void()>& method) const
+QWidget* PropertyFloatItem::createEditor(QWidget* parent,
+                                         const std::function<void()>& method,
+                                         FrameOption frameOption) const
 {
     auto sb = new Gui::DoubleSpinBox(parent);
-    sb->setFrame(false);
+    sb->setFrame(frameOptionToBool(frameOption));
     sb->setDecimals(decimals());
     sb->setReadOnly(isReadOnly());
     QObject::connect(sb, qOverload<double>(&Gui::DoubleSpinBox::valueChanged), method);
@@ -1176,10 +1187,12 @@ void PropertyUnitItem::setValue(const QVariant& value)
     }
 }
 
-QWidget* PropertyUnitItem::createEditor(QWidget* parent, const std::function<void()>& method) const
+QWidget* PropertyUnitItem::createEditor(QWidget* parent,
+                                        const std::function<void()>& method,
+                                        FrameOption frameOption) const
 {
     auto infield = new Gui::QuantitySpinBox(parent);
-    infield->setFrame(false);
+    infield->setFrame(frameOptionToBool(frameOption));
     infield->setMinimumHeight(0);
     infield->setReadOnly(isReadOnly());
 
@@ -1274,11 +1287,12 @@ void PropertyFloatConstraintItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyFloatConstraintItem::createEditor(QWidget* parent,
-                                                   const std::function<void()>& method) const
+                                                   const std::function<void()>& method,
+                                                   FrameOption frameOption) const
 {
     auto sb = new Gui::DoubleSpinBox(parent);
     sb->setDecimals(decimals());
-    sb->setFrame(false);
+    sb->setFrame(frameOptionToBool(frameOption));
     sb->setReadOnly(isReadOnly());
     QObject::connect(sb, qOverload<double>(&Gui::DoubleSpinBox::valueChanged), method);
 
@@ -1367,10 +1381,12 @@ void PropertyBoolItem::setValue(const QVariant& value)
     }
 }
 
-QWidget* PropertyBoolItem::createEditor(QWidget* parent, const std::function<void()>& method) const
+QWidget* PropertyBoolItem::createEditor(QWidget* parent,
+                                        const std::function<void()>& method,
+                                        FrameOption frameOption) const
 {
     auto cb = new QComboBox(parent);
-    cb->setFrame(false);
+    cb->setFrame(frameOptionToBool(frameOption));
     cb->addItem(QLatin1String("false"));
     cb->addItem(QLatin1String("true"));
     cb->setDisabled(isReadOnly());
@@ -1486,10 +1502,11 @@ void PropertyVectorItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyVectorItem::createEditor(QWidget* parent,
-                                          const std::function<void()>& /*method*/) const
+                                          const std::function<void()>& /*method*/,
+                                          FrameOption frameOption) const
 {
     auto le = new VectorLineEdit(decimals(), parent);
-    le->setFrame(false);
+    le->setFrame(frameOptionToBool(frameOption));
     le->setReadOnly(true);
 
     if (isBound()) {
@@ -1708,7 +1725,8 @@ void PropertyVectorListItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyVectorListItem::createEditor(QWidget* parent,
-                                              const std::function<void()>& method) const
+                                              const std::function<void()>& method,
+                                              FrameOption /*frameOption*/) const
 {
     auto pe = new VectorListWidget(decimals(), parent);
     QObject::connect(pe, &VectorListWidget::valueChanged, method);
@@ -1797,10 +1815,11 @@ void PropertyVectorDistanceItem::setEditorData(QWidget* editor, const QVariant& 
 }
 
 QWidget* PropertyVectorDistanceItem::createEditor(QWidget* parent,
-                                                  const std::function<void()>& /*method*/) const
+                                                  const std::function<void()>& /*method*/,
+                                                  FrameOption frameOption) const
 {
     auto le = new VectorLineEdit(decimals(), parent);
-    le->setFrame(false);
+    le->setFrame(frameOptionToBool(frameOption));
     le->setReadOnly(true);
 
     if (isBound()) {
@@ -2022,10 +2041,11 @@ void PropertyMatrixItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyMatrixItem::createEditor(QWidget* parent,
-                                          const std::function<void()>& /*method*/) const
+                                          const std::function<void()>& /*method*/,
+                                          FrameOption frameOption) const
 {
     auto le = new QLineEdit(parent);
-    le->setFrame(false);
+    le->setFrame(frameOptionToBool(frameOption));
     le->setReadOnly(true);
     return le;
 }
@@ -2528,10 +2548,12 @@ void PropertyRotationItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyRotationItem::createEditor(QWidget* parent,
-                                            const std::function<void()>& method) const
+                                            const std::function<void()>& method,
+                                            FrameOption frameOption) const
 {
     Q_UNUSED(parent)
     Q_UNUSED(method)
+    Q_UNUSED(frameOption)
     return nullptr;
 }
 
@@ -2850,7 +2872,8 @@ void PropertyPlacementItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyPlacementItem::createEditor(QWidget* parent,
-                                             const std::function<void()>& method) const
+                                             const std::function<void()>& method,
+                                             FrameOption /*frameOption*/) const
 {
     auto pe = new PlacementEditor(this->propertyName(), parent);
     QObject::connect(pe, &PlacementEditor::valueChanged, method);
@@ -3095,7 +3118,9 @@ QStringList PropertyEnumItem::getCommonModes() const
     return commonModes;
 }
 
-QWidget* PropertyEnumItem::createEditor(QWidget* parent, const std::function<void()>& method) const
+QWidget* PropertyEnumItem::createEditor(QWidget* parent,
+                                        const std::function<void()>& method,
+                                        FrameOption frameOption) const
 {
     QStringList commonModes = getCommonModes();
     if (commonModes.isEmpty()) {
@@ -3106,7 +3131,7 @@ QWidget* PropertyEnumItem::createEditor(QWidget* parent, const std::function<voi
 
     if (!enumItems) {
         auto cb = new QComboBox(parent);
-        cb->setFrame(false);
+        cb->setFrame(frameOptionToBool(frameOption));
         cb->setDisabled(isReadOnly());
         cb->addItems(commonModes);
         QObject::connect(cb, qOverload<int>(&QComboBox::activated), method);
@@ -3160,7 +3185,8 @@ PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyStringListItem)
 PropertyStringListItem::PropertyStringListItem() = default;
 
 QWidget* PropertyStringListItem::createEditor(QWidget* parent,
-                                              const std::function<void()>& method) const
+                                              const std::function<void()>& method,
+                                              FrameOption /*frameOption*/) const
 {
     auto le = new Gui::LabelEditor(parent);
     le->setAutoFillBackground(true);
@@ -3234,7 +3260,8 @@ PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyFloatListItem)
 PropertyFloatListItem::PropertyFloatListItem() = default;
 
 QWidget* PropertyFloatListItem::createEditor(QWidget* parent,
-                                             const std::function<void()>& method) const
+                                             const std::function<void()>& method,
+                                             FrameOption /*frameOption*/) const
 {
     auto le = new Gui::LabelEditor(parent);
     le->setAutoFillBackground(true);
@@ -3311,7 +3338,8 @@ PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyIntegerListItem)
 PropertyIntegerListItem::PropertyIntegerListItem() = default;
 
 QWidget* PropertyIntegerListItem::createEditor(QWidget* parent,
-                                               const std::function<void()>& method) const
+                                               const std::function<void()>& method,
+                                               FrameOption /*frameOption*/) const
 {
     auto le = new Gui::LabelEditor(parent);
     le->setAutoFillBackground(true);
@@ -3426,7 +3454,9 @@ void PropertyColorItem::setValue(const QVariant& value)
     setPropertyValue(data);
 }
 
-QWidget* PropertyColorItem::createEditor(QWidget* parent, const std::function<void()>& method) const
+QWidget* PropertyColorItem::createEditor(QWidget* parent,
+                                         const std::function<void()>& method,
+                                         FrameOption /*frameOption*/) const
 {
     auto cb = new Gui::ColorButton(parent);
     cb->setDisabled(isReadOnly());
@@ -3772,7 +3802,8 @@ void PropertyMaterialItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyMaterialItem::createEditor(QWidget* parent,
-                                            const std::function<void()>& method) const
+                                            const std::function<void()>& method,
+                                            FrameOption /*frameOption*/) const
 {
     auto cb = new Gui::ColorButton(parent);
     cb->setDisabled(isReadOnly());
@@ -4279,7 +4310,8 @@ void PropertyMaterialListItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyMaterialListItem::createEditor(QWidget* parent,
-                                                const std::function<void()>& method) const
+                                                const std::function<void()>& method,
+                                                FrameOption /*frameOption*/) const
 {
     auto cb = new Gui::ColorButton(parent);
     cb->setDisabled(isReadOnly());
@@ -4361,7 +4393,9 @@ QVariant PropertyFileItem::toolTip(const App::Property* prop) const
     return value(prop);
 }
 
-QWidget* PropertyFileItem::createEditor(QWidget* parent, const std::function<void()>& method) const
+QWidget* PropertyFileItem::createEditor(QWidget* parent,
+                                        const std::function<void()>& method,
+                                        FrameOption /*frameOption*/) const
 {
     auto fc = new Gui::FileChooser(parent);
     fc->setAutoFillBackground(true);
@@ -4415,7 +4449,9 @@ QVariant PropertyPathItem::toolTip(const App::Property* prop) const
     return value(prop);
 }
 
-QWidget* PropertyPathItem::createEditor(QWidget* parent, const std::function<void()>& method) const
+QWidget* PropertyPathItem::createEditor(QWidget* parent,
+                                        const std::function<void()>& method,
+                                        FrameOption /*frameOption*/) const
 {
     auto fc = new Gui::FileChooser(parent);
     fc->setMode(FileChooser::Directory);
@@ -4464,7 +4500,8 @@ QVariant PropertyTransientFileItem::toolTip(const App::Property* prop) const
 }
 
 QWidget* PropertyTransientFileItem::createEditor(QWidget* parent,
-                                                 const std::function<void()>& method) const
+                                                 const std::function<void()>& method,
+                                                 FrameOption /*frameOption*/) const
 {
     auto fc = new Gui::FileChooser(parent);
     fc->setAutoFillBackground(true);
@@ -4692,7 +4729,9 @@ void PropertyLinkItem::setValue(const QVariant& value)
     setPropertyValue(DlgPropertyLink::linksToPython(links));
 }
 
-QWidget* PropertyLinkItem::createEditor(QWidget* parent, const std::function<void()>& method) const
+QWidget* PropertyLinkItem::createEditor(QWidget* parent,
+                                        const std::function<void()>& method,
+                                        FrameOption /*frameOption*/) const
 {
     if (propertyItems.empty()) {
         return nullptr;
@@ -4727,7 +4766,8 @@ PropertyItemEditorFactory::PropertyItemEditorFactory() = default;
 
 PropertyItemEditorFactory::~PropertyItemEditorFactory() = default;
 
-QWidget* PropertyItemEditorFactory::createEditor(int /*type*/, QWidget* /*parent*/) const
+QWidget* PropertyItemEditorFactory::createEditor(int /*type*/,
+                                                 QWidget* /*parent*/) const
 {
     // do not allow to create any editor widgets because we do that in subclasses of PropertyItem
     return nullptr;

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -845,7 +845,7 @@ QWidget* PropertyStringItem::createEditor(QWidget* parent,
                                           FrameOption frameOption) const
 {
     auto le = new ExpLineEdit(parent);
-    le->setFrame(frameOptionToBool(frameOption));
+    le->setFrame(static_cast<bool>(frameOption));
     le->setReadOnly(isReadOnly());
     QObject::connect(le, &ExpLineEdit::textChanged, method);
     if (isBound()) {
@@ -894,7 +894,7 @@ QWidget* PropertyFontItem::createEditor(QWidget* parent,
                                         FrameOption frameOption) const
 {
     auto cb = new QComboBox(parent);
-    cb->setFrame(frameOptionToBool(frameOption));
+    cb->setFrame(static_cast<bool>(frameOption));
     cb->setDisabled(isReadOnly());
     QObject::connect(cb, &QComboBox::textActivated, method);
     return cb;
@@ -961,7 +961,7 @@ QWidget* PropertyIntegerItem::createEditor(QWidget* parent,
                                            FrameOption frameOption) const
 {
     auto sb = new Gui::IntSpinBox(parent);
-    sb->setFrame(frameOptionToBool(frameOption));
+    sb->setFrame(static_cast<bool>(frameOption));
     sb->setReadOnly(isReadOnly());
     QObject::connect(sb, qOverload<int>(&Gui::IntSpinBox::valueChanged), method);
 
@@ -1028,7 +1028,7 @@ QWidget* PropertyIntegerConstraintItem::createEditor(QWidget* parent,
                                                      FrameOption frameOption) const
 {
     auto sb = new Gui::IntSpinBox(parent);
-    sb->setFrame(frameOptionToBool(frameOption));
+    sb->setFrame(static_cast<bool>(frameOption));
     sb->setReadOnly(isReadOnly());
     QObject::connect(sb, qOverload<int>(&Gui::IntSpinBox::valueChanged), method);
 
@@ -1124,7 +1124,7 @@ QWidget* PropertyFloatItem::createEditor(QWidget* parent,
                                          FrameOption frameOption) const
 {
     auto sb = new Gui::DoubleSpinBox(parent);
-    sb->setFrame(frameOptionToBool(frameOption));
+    sb->setFrame(static_cast<bool>(frameOption));
     sb->setDecimals(decimals());
     sb->setReadOnly(isReadOnly());
     QObject::connect(sb, qOverload<double>(&Gui::DoubleSpinBox::valueChanged), method);
@@ -1192,7 +1192,7 @@ QWidget* PropertyUnitItem::createEditor(QWidget* parent,
                                         FrameOption frameOption) const
 {
     auto infield = new Gui::QuantitySpinBox(parent);
-    infield->setFrame(frameOptionToBool(frameOption));
+    infield->setFrame(static_cast<bool>(frameOption));
     infield->setMinimumHeight(0);
     infield->setReadOnly(isReadOnly());
 
@@ -1292,7 +1292,7 @@ QWidget* PropertyFloatConstraintItem::createEditor(QWidget* parent,
 {
     auto sb = new Gui::DoubleSpinBox(parent);
     sb->setDecimals(decimals());
-    sb->setFrame(frameOptionToBool(frameOption));
+    sb->setFrame(static_cast<bool>(frameOption));
     sb->setReadOnly(isReadOnly());
     QObject::connect(sb, qOverload<double>(&Gui::DoubleSpinBox::valueChanged), method);
 
@@ -1386,7 +1386,7 @@ QWidget* PropertyBoolItem::createEditor(QWidget* parent,
                                         FrameOption frameOption) const
 {
     auto cb = new QComboBox(parent);
-    cb->setFrame(frameOptionToBool(frameOption));
+    cb->setFrame(static_cast<bool>(frameOption));
     cb->addItem(QLatin1String("false"));
     cb->addItem(QLatin1String("true"));
     cb->setDisabled(isReadOnly());
@@ -1506,7 +1506,7 @@ QWidget* PropertyVectorItem::createEditor(QWidget* parent,
                                           FrameOption frameOption) const
 {
     auto le = new VectorLineEdit(decimals(), parent);
-    le->setFrame(frameOptionToBool(frameOption));
+    le->setFrame(static_cast<bool>(frameOption));
     le->setReadOnly(true);
 
     if (isBound()) {
@@ -1819,7 +1819,7 @@ QWidget* PropertyVectorDistanceItem::createEditor(QWidget* parent,
                                                   FrameOption frameOption) const
 {
     auto le = new VectorLineEdit(decimals(), parent);
-    le->setFrame(frameOptionToBool(frameOption));
+    le->setFrame(static_cast<bool>(frameOption));
     le->setReadOnly(true);
 
     if (isBound()) {
@@ -2045,7 +2045,7 @@ QWidget* PropertyMatrixItem::createEditor(QWidget* parent,
                                           FrameOption frameOption) const
 {
     auto le = new QLineEdit(parent);
-    le->setFrame(frameOptionToBool(frameOption));
+    le->setFrame(static_cast<bool>(frameOption));
     le->setReadOnly(true);
     return le;
 }
@@ -3131,7 +3131,7 @@ QWidget* PropertyEnumItem::createEditor(QWidget* parent,
 
     if (!enumItems) {
         auto cb = new QComboBox(parent);
-        cb->setFrame(frameOptionToBool(frameOption));
+        cb->setFrame(static_cast<bool>(frameOption));
         cb->setDisabled(isReadOnly());
         cb->addItems(commonModes);
         QObject::connect(cb, qOverload<int>(&QComboBox::activated), method);

--- a/src/Gui/propertyeditor/PropertyItem.h
+++ b/src/Gui/propertyeditor/PropertyItem.h
@@ -87,6 +87,15 @@ class PropertyItem;
 class PropertyModel;
 class PropertyEditorWidget;
 
+enum class FrameOption {
+    NoFrame,
+    WithFrame
+};
+
+inline bool frameOptionToBool(FrameOption option) {
+    return option == FrameOption::WithFrame;
+}
+
 /**
  * The PropertyItemFactory provides methods for the dynamic creation of property items.
  * \author Werner Mayer
@@ -150,7 +159,9 @@ public:
 
     /** Creates the appropriate editor for this item and sets the editor to the value of
      * overrideValue(). */
-    virtual QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const;
+    virtual QWidget* createEditor(QWidget* parent,
+                                  const std::function<void()>& method,
+                                  FrameOption frameOption = FrameOption::NoFrame) const;
     virtual void setEditorData(QWidget* editor, const QVariant& data) const;
     virtual QVariant editorData(QWidget* editor) const;
     virtual bool isSeparator() const
@@ -253,7 +264,9 @@ class GuiExport PropertyStringItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -274,7 +287,9 @@ class GuiExport PropertyFontItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -299,7 +314,9 @@ class GuiExport PropertySeparatorItem: public PropertyItem
     {
         return true;
     }
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
 
     int row() const override
     {
@@ -320,7 +337,9 @@ class GuiExport PropertyIntegerItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -342,7 +361,9 @@ class GuiExport PropertyIntegerConstraintItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -380,7 +401,9 @@ class GuiExport PropertyFloatItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -402,7 +425,9 @@ class GuiExport PropertyUnitItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -454,7 +479,9 @@ class GuiExport PropertyFloatConstraintItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -520,7 +547,9 @@ class GuiExport PropertyBoolItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -547,7 +576,9 @@ class GuiExport PropertyVectorItem: public PropertyItem
     PROPERTYITEM_HEADER
     // clang-format on
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -626,7 +657,9 @@ class GuiExport PropertyVectorListItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -654,7 +687,9 @@ class GuiExport PropertyVectorDistanceItem: public PropertyItem
     PROPERTYITEM_HEADER
     // clang-format on
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -715,7 +750,9 @@ class GuiExport PropertyMatrixItem: public PropertyItem
     PROPERTYITEM_HEADER
     // clang-format on
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -815,7 +852,9 @@ class GuiExport PropertyRotationItem: public PropertyItem
     PROPERTYITEM_HEADER
     // clang-format on
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -875,7 +914,9 @@ class GuiExport PropertyPlacementItem: public PropertyItem
     PROPERTYITEM_HEADER
     // clang-format on
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -918,7 +959,9 @@ class GuiExport PropertyEnumItem: public PropertyItem
     PROPERTYITEM_HEADER
     // clang-format on
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -961,7 +1004,9 @@ class GuiExport PropertyStringListItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -983,7 +1028,9 @@ class GuiExport PropertyFloatListItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -1005,7 +1052,9 @@ class GuiExport PropertyIntegerListItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -1027,7 +1076,9 @@ class GuiExport PropertyColorItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -1058,7 +1109,9 @@ class GuiExport PropertyMaterialItem: public PropertyItem
     PROPERTYITEM_HEADER
     // clang-format on
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -1109,7 +1162,9 @@ class GuiExport PropertyMaterialListItem: public PropertyItem
     PROPERTYITEM_HEADER
     // clang-format on
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -1156,7 +1211,9 @@ class GuiExport PropertyFileItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -1178,7 +1235,9 @@ class GuiExport PropertyPathItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -1200,7 +1259,9 @@ class GuiExport PropertyTransientFileItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 
@@ -1268,7 +1329,9 @@ class GuiExport PropertyLinkItem: public PropertyItem
     Q_OBJECT
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption = FrameOption::NoFrame) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 

--- a/src/Gui/propertyeditor/PropertyItem.h
+++ b/src/Gui/propertyeditor/PropertyItem.h
@@ -87,15 +87,10 @@ class PropertyItem;
 class PropertyModel;
 class PropertyEditorWidget;
 
-enum class FrameOption {
-    NoFrame,
-    WithFrame
+enum class FrameOption : bool {
+    NoFrame=false,
+    WithFrame=true
 };
-
-inline bool frameOptionToBool(FrameOption option) {
-    return option == FrameOption::WithFrame;
-}
-
 /**
  * The PropertyItemFactory provides methods for the dynamic creation of property items.
  * \author Werner Mayer

--- a/src/Mod/Fem/Gui/PropertyFemMeshItem.cpp
+++ b/src/Mod/Fem/Gui/PropertyFemMeshItem.cpp
@@ -129,10 +129,12 @@ void PropertyFemMeshItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyFemMeshItem::createEditor(QWidget* parent,
-                                           const std::function<void()>& method) const
+                                           const std::function<void()>& method,
+                                           FrameOption frameOption) const
 {
     Q_UNUSED(parent);
     Q_UNUSED(method);
+    Q_UNUSED(frameOption);
     return nullptr;
 }
 

--- a/src/Mod/Fem/Gui/PropertyFemMeshItem.h
+++ b/src/Mod/Fem/Gui/PropertyFemMeshItem.h
@@ -28,6 +28,8 @@
 namespace FemGui
 {
 
+using FrameOption = Gui::PropertyEditor::FrameOption;
+
 /**
  * Display data of an FEM mesh.
  * \author Werner Mayer
@@ -44,7 +46,9 @@ class PropertyFemMeshItem: public Gui::PropertyEditor::PropertyItem
     Q_PROPERTY(int Groups READ countGroups CONSTANT)
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 

--- a/src/Mod/Mesh/Gui/PropertyEditorMesh.cpp
+++ b/src/Mod/Mesh/Gui/PropertyEditorMesh.cpp
@@ -89,10 +89,12 @@ void PropertyMeshKernelItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyMeshKernelItem::createEditor(QWidget* parent,
-                                              const std::function<void()>& method) const
+                                              const std::function<void()>& method,
+                                              FrameOption frameOption) const
 {
     Q_UNUSED(parent);
     Q_UNUSED(method);
+    Q_UNUSED(frameOption);
     return nullptr;
 }
 

--- a/src/Mod/Mesh/Gui/PropertyEditorMesh.h
+++ b/src/Mod/Mesh/Gui/PropertyEditorMesh.h
@@ -32,6 +32,8 @@
 namespace MeshGui
 {
 
+using FrameOption = Gui::PropertyEditor::FrameOption;
+
 /**
  * Display data of a mesh kernel.
  * \author Werner Mayer
@@ -45,7 +47,9 @@ class MeshGuiExport PropertyMeshKernelItem: public Gui::PropertyEditor::Property
     PROPERTYITEM_HEADER
 
     // clang-format off
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption) const override;
     // clang-format on
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;

--- a/src/Mod/Part/Gui/PropertyEnumAttacherItem.cpp
+++ b/src/Mod/Part/Gui/PropertyEnumAttacherItem.cpp
@@ -40,7 +40,8 @@ PROPERTYITEM_SOURCE(PartGui::PropertyEnumAttacherItem)
 PropertyEnumAttacherItem::PropertyEnumAttacherItem() = default;
 
 QWidget* PropertyEnumAttacherItem::createEditor(QWidget* parent,
-                                                const std::function<void()>& method) const
+                                                const std::function<void()>& method,
+                                                FrameOption /*frameOption*/) const
 {
     Gui::LabelButton* modeEditor = new Gui::LabelButton(parent);
     QObject::connect(modeEditor, &Gui::LabelButton::valueChanged, method);

--- a/src/Mod/Part/Gui/PropertyEnumAttacherItem.h
+++ b/src/Mod/Part/Gui/PropertyEnumAttacherItem.h
@@ -30,6 +30,8 @@
 namespace PartGui
 {
 
+using FrameOption = Gui::PropertyEditor::FrameOption;
+
 /**
 * Custom editor item for PropertyEnumeration to open Attacher task
 */
@@ -40,7 +42,9 @@ class PartGuiExport PropertyEnumAttacherItem: public Gui::PropertyEditor::Proper
 public:
     PROPERTYITEM_HEADER
 
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 

--- a/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
+++ b/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
@@ -373,7 +373,7 @@ QWidget* PropertyConstraintListItem::createEditor(QWidget* parent,
 {
     Q_UNUSED(method);
     QLineEdit* le = new QLineEdit(parent);
-    le->setFrame(frameOptionToBool(frameOption));
+    le->setFrame(static_cast<bool>(frameOption));
     le->setReadOnly(true);
     return le;
 }

--- a/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
+++ b/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
@@ -368,11 +368,12 @@ void PropertyConstraintListItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyConstraintListItem::createEditor(QWidget* parent,
-                                                  const std::function<void()>& method) const
+                                                  const std::function<void()>& method,
+                                                  FrameOption frameOption) const
 {
     Q_UNUSED(method);
     QLineEdit* le = new QLineEdit(parent);
-    le->setFrame(false);
+    le->setFrame(frameOptionToBool(frameOption));
     le->setReadOnly(true);
     return le;
 }

--- a/src/Mod/Sketcher/Gui/PropertyConstraintListItem.h
+++ b/src/Mod/Sketcher/Gui/PropertyConstraintListItem.h
@@ -31,6 +31,8 @@
 namespace SketcherGui
 {
 
+using FrameOption = Gui::PropertyEditor::FrameOption;
+
 class PropertyConstraintListItem: public Gui::PropertyEditor::PropertyItem
 {
     Q_OBJECT
@@ -38,7 +40,9 @@ class PropertyConstraintListItem: public Gui::PropertyEditor::PropertyItem
 
     ~PropertyConstraintListItem() override;
     void assignProperty(const App::Property* prop) override;
-    QWidget* createEditor(QWidget* parent, const std::function<void()>& method) const override;
+    QWidget* createEditor(QWidget* parent,
+                          const std::function<void()>& method,
+                          FrameOption frameOption) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
 


### PR DESCRIPTION
Fixes #14632 

This PR contains two commits. The first ensures that editors can be created with a frame. The second makes use of that functionality in the Add Property VarSet dialog.