### PR TITLE
Holes on sketch points

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -74,7 +74,17 @@ public:
     App::PropertyAngle          TaperedAngle;
     App::PropertyBool           UseCustomThreadClearance;
     App::PropertyLength         CustomThreadClearance;
-    App::PropertyEnumeration    BaseProfileType;
+    App::PropertyInteger        BaseProfileType;
+
+    enum BaseProfileTypeOptions {
+        OnPoints    = 1 << 0,
+        OnCircles   = 1 << 1,
+        OnArcs      = 1 << 2,
+
+        // Common combos
+        OnPointsCirclesArcs = OnPoints | OnCircles | OnArcs,
+        OnCirclesArcs = OnCircles | OnArcs
+    };
 
     /** @name methods override feature */
     //@{
@@ -126,7 +136,6 @@ private:
     static const char* ClearanceUTSEnums[];
     static const char* DrillPointEnums[];
     static const char* ThreadDirectionEnums[];
-    static const char* BaseProfileTypeEnums[];
 
     /* "None" thread profile */
     static const char* HoleCutType_None_Enums[];

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -74,6 +74,7 @@ public:
     App::PropertyAngle          TaperedAngle;
     App::PropertyBool           UseCustomThreadClearance;
     App::PropertyLength         CustomThreadClearance;
+    App::PropertyEnumeration    BaseProfileType;
 
     /** @name methods override feature */
     //@{
@@ -113,6 +114,8 @@ public:
 
 protected:
     void onChanged(const App::Property* prop) override;
+    void setupObject() override;
+
     static const App::PropertyAngle::Constraints floatAngle;
 
 private:
@@ -123,6 +126,7 @@ private:
     static const char* ClearanceUTSEnums[];
     static const char* DrillPointEnums[];
     static const char* ThreadDirectionEnums[];
+    static const char* BaseProfileTypeEnums[];
 
     /* "None" thread profile */
     static const char* HoleCutType_None_Enums[];

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -404,7 +404,7 @@ TopoDS_Shape ProfileBased::getVerifiedFace(bool silent) const {
     return TopoDS_Face();
 }
 
-TopoShape ProfileBased::getProfileShape() const
+TopoShape ProfileBased::getProfileShape(bool needSubElement) const
 {
     TopoShape shape;
     const auto& subs = Profile.getSubValues();
@@ -416,7 +416,7 @@ TopoShape ProfileBased::getProfileShape() const
         std::vector<TopoShape> shapes;
         for (auto& sub : subs) {
             shapes.push_back(
-                Part::Feature::getTopoShape(profile, sub.c_str(), /* needSubElement */ true));
+                Part::Feature::getTopoShape(profile, sub.c_str(), needSubElement));
         }
         shape = TopoShape(shape.Tag).makeElementCompound(shapes);
     }

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -944,11 +944,13 @@ double ProfileBased::getThroughAllLength() const
 {
     TopoShape profileshape;
     TopoShape base;
-    profileshape = getTopoShapeVerifiedFace();
+    profileshape = getTopoShapeVerifiedFace(true);
     base = getBaseTopoShape();
     Bnd_Box box;
     BRepBndLib::Add(base.getShape(), box);
-    BRepBndLib::Add(profileshape.getShape(), box);
+
+    if(!profileshape.isNull()) 
+        BRepBndLib::Add(profileshape.getShape(), box);
     box.SetGap(0.0);
     // The diagonal of the bounding box, plus 1%  extra to eliminate risk of
     // co-planar issues, gives a length that is guaranteed to go through all.

--- a/src/Mod/PartDesign/App/FeatureSketchBased.h
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.h
@@ -131,7 +131,7 @@ public:
 
     virtual Base::Vector3d getProfileNormal() const;
 
-    TopoShape getProfileShape() const;
+    TopoShape getProfileShape(bool needSubElement = false) const;
 
     /// retrieves the number of axes in the linked sketch (defined as construction lines)
     int getSketchAxisCount() const;

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -183,7 +183,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
         std::string(pcHole->ThreadDepthType.getValueAsString()) == "Dimension"
     );
 
-    ui->BaseProfileType->setCurrentIndex(pcHole->BaseProfileType.getValue());
+    ui->BaseProfileType->setCurrentIndex(baseProfilesOptionToComboboxIndex(pcHole->BaseProfileType.getValue()));
 
     setCutDiagram();
 
@@ -416,7 +416,7 @@ void TaskHoleParameters::holeCutTypeChanged(int index)
 void TaskHoleParameters::baseProfileTypeChanged(int index)
 {
     if (auto hole = getObject<PartDesign::Hole>()) {
-        hole->BaseProfileType.setValue(index);
+        hole->BaseProfileType.setValue(comboBoxIndexToBaseProfilesOption(index));
         recomputeFeature();
     }
 }
@@ -922,7 +922,7 @@ void TaskHoleParameters::changedObject(const App::Document&, const App::Property
         updateSpinBox(ui->ThreadDepth, hole->ThreadDepth.getValue());
     } else if(&Prop == &hole->BaseProfileType) {
         ui->BaseProfileType->setEnabled(true);
-        updateComboBox(ui->BaseProfileType, hole->BaseProfileType.getValue());
+        updateComboBox(ui->BaseProfileType, baseProfilesOptionToComboboxIndex(hole->BaseProfileType.getValue()));
     }
 }
 
@@ -1072,9 +1072,33 @@ double TaskHoleParameters::getThreadDepth() const
 {
     return ui->ThreadDepth->value().getValue();
 }
-long TaskHoleParameters::getBaseProfileType() const
+int TaskHoleParameters::getBaseProfileType() const
 {
-    return ui->BaseProfileType->currentIndex();
+    return comboBoxIndexToBaseProfilesOption(ui->BaseProfileType->currentIndex());
+}
+int TaskHoleParameters::comboBoxIndexToBaseProfilesOption(int index) const
+{
+    // Translate combobox index to bitmask value
+    // More options could be made available
+    if(index == 0) {
+        return PartDesign::Hole::BaseProfileTypeOptions::OnCirclesArcs;
+    } else if(index == 1) {
+        return PartDesign::Hole::BaseProfileTypeOptions::OnPointsCirclesArcs;
+    } else {
+        Base::Console().Error("Unexpected hole base profile combobox index: %i", index);
+        return 0;
+    }
+}
+int TaskHoleParameters::baseProfilesOptionToComboboxIndex(int baseprofilesoptions) const
+{
+    if(baseprofilesoptions == PartDesign::Hole::BaseProfileTypeOptions::OnCirclesArcs) {
+        return 0;
+    } else if(baseprofilesoptions == PartDesign::Hole::BaseProfileTypeOptions::OnPointsCirclesArcs) {
+        return 1;
+    } else {
+        Base::Console().Error("Unexpected hole base profile bitmask: %i", baseprofilesoptions);
+        return -1;
+    }
 }
 void TaskHoleParameters::apply()
 {

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -183,6 +183,8 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
         std::string(pcHole->ThreadDepthType.getValueAsString()) == "Dimension"
     );
 
+    ui->BaseProfileType->setCurrentIndex(pcHole->BaseProfileType.getValue());
+
     setCutDiagram();
 
     // clang-format off
@@ -240,6 +242,8 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
             this, &TaskHoleParameters::threadDepthTypeChanged);
     connect(ui->ThreadDepth, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
             this, &TaskHoleParameters::threadDepthChanged);
+    connect(ui->BaseProfileType, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &TaskHoleParameters::baseProfileTypeChanged);
     // clang-format on
 
     getViewObject()->show();
@@ -321,7 +325,6 @@ void TaskHoleParameters::threadDepthTypeChanged(int index)
         recomputeFeature();
     }
 }
-
 void TaskHoleParameters::threadDepthChanged(double value)
 {
     if (auto hole = getObject<PartDesign::Hole>()) {
@@ -409,6 +412,13 @@ void TaskHoleParameters::holeCutTypeChanged(int index)
         );
     }
     setCutDiagram();
+}
+void TaskHoleParameters::baseProfileTypeChanged(int index)
+{
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->BaseProfileType.setValue(index);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::setCutDiagram()
@@ -910,6 +920,9 @@ void TaskHoleParameters::changedObject(const App::Document&, const App::Property
     else if (&Prop == &hole->ThreadDepth) {
         ui->ThreadDepth->setEnabled(true);
         updateSpinBox(ui->ThreadDepth, hole->ThreadDepth.getValue());
+    } else if(&Prop == &hole->BaseProfileType) {
+        ui->BaseProfileType->setEnabled(true);
+        updateComboBox(ui->BaseProfileType, hole->BaseProfileType.getValue());
     }
 }
 
@@ -1059,7 +1072,10 @@ double TaskHoleParameters::getThreadDepth() const
 {
     return ui->ThreadDepth->value().getValue();
 }
-
+long TaskHoleParameters::getBaseProfileType() const
+{
+    return ui->BaseProfileType->currentIndex();
+}
 void TaskHoleParameters::apply()
 {
     auto hole = getObject<PartDesign::Hole>();
@@ -1125,6 +1141,9 @@ void TaskHoleParameters::apply()
     }
     if (!hole->Tapered.isReadOnly()) {
         FCMD_OBJ_CMD(hole, "Tapered = " << getTapered());
+    }
+    if (!hole->BaseProfileType.isReadOnly()) {
+        FCMD_OBJ_CMD(hole, "BaseProfileType = " << getBaseProfileType());
     }
 
     isApplying = false;

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -79,7 +79,9 @@ public:
     bool getModelThread() const;
     long getThreadDepthType() const;
     double getThreadDepth() const;
-    long getBaseProfileType() const;
+    int getBaseProfileType() const;
+    int comboBoxIndexToBaseProfilesOption(int index) const;
+    int baseProfilesOptionToComboboxIndex(int baseprofilesoptions) const;
 
 private Q_SLOTS:
     void threadedChanged();

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -79,6 +79,7 @@ public:
     bool getModelThread() const;
     long getThreadDepthType() const;
     double getThreadDepth() const;
+    long getBaseProfileType() const;
 
 private Q_SLOTS:
     void threadedChanged();
@@ -108,6 +109,7 @@ private Q_SLOTS:
     void updateViewChanged(bool isChecked);
     void threadDepthTypeChanged(int index);
     void threadDepthChanged(double value);
+    void baseProfileTypeChanged(int index);
     void setCutDiagram();
 
 private:

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -1074,6 +1074,31 @@ Note that the calculation can take some time</string>
      </layout>
     </widget>
    </item>
+   <item>
+    <layout class="QHBoxLayout" name="BaseProfileLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Base profile types</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="BaseProfileType">
+       <item>
+        <property name="text">
+         <string>Circles and arcs</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Points, circles and arcs</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
  <customwidgets>


### PR DESCRIPTION
Center holes on sketch points as well as circles and arcs. Each possible base profile geometry (point, circle, arc) has a flag. New hole features get a bit mask that allows point, circles and arcs while hole feature made before this version get a bit mask that allows for circles and arcs only. The bitmask can be modified via a new dropdown in the ui:

![Screenshot_circlesarcs](https://github.com/user-attachments/assets/6394b0d1-5aa6-4a67-a765-b6c54a650bbe)
![Screenshot_pointscirclesarcs](https://github.com/user-attachments/assets/93c8c89e-1471-43cd-959f-0bbeb930ce0a)
