### PR TITLE
Gui: make BitmapFactory::pixmapFromSvg dpi aware

### DIFF
--- a/src/Gui/BitmapFactory.h
+++ b/src/Gui/BitmapFactory.h
@@ -87,14 +87,6 @@ public:
      */
     QPixmap pixmapFromSvg(const char* name, const QSizeF& size,
                           const ColorMap& colorMapping = ColorMap()) const;
-    /** Retrieves a pixmap by name and size created by an
-     * scalable vector graphics (SVG) and a device pixel ratio
-     *
-     * @param colorMapping - a dictionary of substitute colors.
-     * Can be used to customize icon color scheme, e.g. crosshair color
-     */
-    QPixmap pixmapFromSvg(const char* name, const QSizeF& size, qreal dpr,
-                          const ColorMap& colorMapping = ColorMap()) const;
     /** This method is provided for convenience and does the same
      * as the method above except that it creates the pixmap from
      * a byte array.
@@ -148,6 +140,8 @@ public:
 
     /// Helper method to merge a pixmap into one corner of a QIcon
     static QIcon mergePixmap (const QIcon &base, const QPixmap &px, Gui::BitmapFactoryInst::Position position);
+
+    static qreal getMaximumDPR();
 
 private:
     bool loadPixmap(const QString& path, QPixmap&) const;

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2697,10 +2697,7 @@ public:
             hotYF *= pRatio;
         }
 #endif
-        qreal cursorWidth = size.width() * pRatio;
-        qreal cursorHeight = size.height() * pRatio;
-        QPixmap px(Gui::BitmapFactory().pixmapFromSvg(svgFile, QSizeF(cursorWidth, cursorHeight)));
-        px.setDevicePixelRatio(pRatio);
+        QPixmap px(Gui::BitmapFactory().pixmapFromSvg(svgFile, size));
         return QCursor(px, hotXF, hotYF);
     }
 };

--- a/src/Gui/ToolHandler.cpp
+++ b/src/Gui/ToolHandler.cpp
@@ -120,7 +120,7 @@ void ToolHandler::setSvgCursor(const QString& cursorName,
     //
     qreal pRatio = devicePixelRatio();
     bool isRatioOne = (pRatio == 1.0);
-    qreal defaultCursorSize = isRatioOne ? 64 : 32;
+    qreal cursorSize = isRatioOne ? 64 : 32;
     qreal hotX = x;
     qreal hotY = y;
 #if !defined(Q_OS_WIN32) && !defined(Q_OS_MACOS)
@@ -129,15 +129,13 @@ void ToolHandler::setSvgCursor(const QString& cursorName,
         hotY *= pRatio;
     }
 #endif
-    qreal cursorSize = defaultCursorSize * pRatio;
 
     QPixmap pointer = Gui::BitmapFactory().pixmapFromSvg(cursorName.toStdString().c_str(),
-                                                         QSizeF(cursorSize, cursorSize),
+                                                         QSizeF{cursorSize, cursorSize},
                                                          colorMapping);
     if (isRatioOne) {
         pointer = pointer.scaled(32, 32);
     }
-    pointer.setDevicePixelRatio(pRatio);
     setCursor(pointer, hotX, hotY, false);
 }
 

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -5488,7 +5488,7 @@ void DocumentObjectItem::testStatus(bool resetStatus, QIcon& icon1, QIcon& icon2
 
         if (currentStatus & Status::External) {
             static QPixmap pxExternal;
-            int px = 12 * getMainWindow()->devicePixelRatioF();
+            constexpr int px = 12;
             if (pxExternal.isNull()) {
                 pxExternal = Gui::BitmapFactory().pixmapFromSvg("LinkOverlay",
                                                               QSize(px, px));

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -1730,7 +1730,7 @@ QIcon ViewProviderLink::getIcon() const {
 
 QPixmap ViewProviderLink::getOverlayPixmap() const {
     auto ext = getLinkExtension();
-    int px = 12 * getMainWindow()->devicePixelRatioF();
+    constexpr int px = 12;
     if(ext && ext->getLinkedObjectProperty() && ext->_getElementCountValue())
         return BitmapFactory().pixmapFromSvg("LinkArrayOverlay", QSizeF(px,px));
     else if(hasSubElement)

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1129,8 +1129,8 @@ private:
         auto colorMapping = std::map<unsigned long, unsigned long>();
         colorMapping[defaultCrosshairColor] = color;
 
-        qreal fullIconWidth = 32 * pixelRatio;
-        qreal iconWidth = 16 * pixelRatio;
+        constexpr qreal fullIconWidth = 32;
+        constexpr qreal iconWidth = 16;
         QPixmap cursorPixmap =
                     Gui::BitmapFactory().pixmapFromSvg("Sketcher_Crosshair",
                                                        QSizeF(fullIconWidth, fullIconWidth),
@@ -1143,7 +1143,6 @@ private:
         cursorPainter.end();
         int hotX = 8;
         int hotY = 8;
-        cursorPixmap.setDevicePixelRatio(pixelRatio);
         // only X11 needs hot point coordinates to be scaled
         if (qGuiApp->platformName() == QLatin1String("xcb")) {
             hotX *= pixelRatio;
@@ -1422,17 +1421,16 @@ public:
         auto colorMapping = std::map<unsigned long, unsigned long>();
         colorMapping[defaultCrosshairColor] = color;
 
-        qreal fullIconWidth = 32 * pixelRatio;
-        qreal iconWidth = 16 * pixelRatio;
-        QPixmap cursorPixmap = Gui::BitmapFactory().pixmapFromSvg("Sketcher_Crosshair", QSizeF(fullIconWidth, fullIconWidth), colorMapping),
-            icon = Gui::BitmapFactory().pixmapFromSvg("Constraint_Dimension", QSizeF(iconWidth, iconWidth));
+        constexpr qreal fullIconWidth = 32;
+        constexpr qreal iconWidth = 16;
+        QPixmap cursorPixmap = Gui::BitmapFactory().pixmapFromSvg("Sketcher_Crosshair", QSizeF(fullIconWidth, fullIconWidth), colorMapping);
+        QPixmap icon = Gui::BitmapFactory().pixmapFromSvg("Constraint_Dimension", QSizeF(iconWidth, iconWidth));
         QPainter cursorPainter;
         cursorPainter.begin(&cursorPixmap);
         cursorPainter.drawPixmap(16 * pixelRatio, 16 * pixelRatio, icon);
         cursorPainter.end();
         int hotX = 8;
         int hotY = 8;
-        cursorPixmap.setDevicePixelRatio(pixelRatio);
         // only X11 needs hot point coordinates to be scaled
         if (qGuiApp->platformName() == QLatin1String("xcb")) {
             hotX *= pixelRatio;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -406,12 +406,7 @@ DrawSketchHandler::suggestedConstraintsPixmaps(std::vector<AutoConstraint>& sugg
                 break;
         }
         if (!iconType.isEmpty()) {
-            qreal pixelRatio = 1;
-            Gui::View3DInventorViewer* viewer = getViewer();
-            if (viewer) {
-                pixelRatio = viewer->devicePixelRatio();
-            }
-            int iconWidth = 16 * pixelRatio;
+            constexpr int iconWidth = 16;
             QPixmap icon = Gui::BitmapFactory().pixmapFromSvg(iconType.toStdString().c_str(),
                                                               QSize(iconWidth, iconWidth));
             pixmaps.push_back(icon);

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -1364,12 +1364,7 @@ protected:
 
     QPixmap icon(std::string name)
     {
-        qreal pixelRatio = 1;
-        Gui::View3DInventorViewer* viewer = getViewer();
-        if (viewer) {
-            pixelRatio = viewer->devicePixelRatio();
-        }
-        int width = 16 * pixelRatio;
+        constexpr int width = 16;
         return Gui::BitmapFactory().pixmapFromSvg(name.c_str(), QSize(width, width));
     }
 

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -572,14 +572,10 @@ QPixmap QGVPage::prepareCursorPixmap(const char* iconName, QPoint& hotspot)
 {
 
     QPointF floatHotspot(hotspot);
-    double pixelRatio = getDevicePixelRatio();
 
-    // Due to impossibility to query cursor size via Qt API, we stick to (32x32)*device_pixel_ratio
+    // Due to impossibility to query cursor size via Qt API, we stick to (32x32)
     // as FreeCAD Wiki suggests - see https://wiki.freecad.org/HiDPI_support#Custom_cursor_size
-    double cursorSize = 32.0 * pixelRatio;
-
-    QPixmap pixmap = Gui::BitmapFactory().pixmapFromSvg(iconName, QSizeF(cursorSize, cursorSize));
-    pixmap.setDevicePixelRatio(pixelRatio);
+    QPixmap pixmap = Gui::BitmapFactory().pixmapFromSvg(iconName, QSizeF(32, 32));
 
     // The default (and here expected) SVG cursor graphics size is 64x64 pixels, thus we must adjust
     // the 64x64 based hotspot position for our 32x32 based cursor pixmaps accordingly
@@ -590,7 +586,7 @@ QPixmap QGVPage::prepareCursorPixmap(const char* iconName, QPoint& hotspot)
     // therefore we must take care of the transformation ourselves...
     // Refer to QTBUG-68571 - https://bugreports.qt.io/browse/QTBUG-68571
     if (qGuiApp->platformName() == QLatin1String("xcb")) {
-        floatHotspot *= pixelRatio;
+        floatHotspot *= getDevicePixelRatio();
     }
 #endif
 

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -557,17 +557,6 @@ QColor QGVPage::getBackgroundColor()
     return fcColor.asValue<QColor>();
 }
 
-double QGVPage::getDevicePixelRatio() const
-{
-    for (Gui::MDIView* view : m_vpPage->getDocument()->getMDIViews()) {
-        if (view->isDerivedFrom<Gui::View3DInventor>()) {
-            return static_cast<Gui::View3DInventor*>(view)->getViewer()->devicePixelRatio();
-        }
-    }
-
-    return 1.0;
-}
-
 QPixmap QGVPage::prepareCursorPixmap(const char* iconName, QPoint& hotspot)
 {
 
@@ -586,7 +575,7 @@ QPixmap QGVPage::prepareCursorPixmap(const char* iconName, QPoint& hotspot)
     // therefore we must take care of the transformation ourselves...
     // Refer to QTBUG-68571 - https://bugreports.qt.io/browse/QTBUG-68571
     if (qGuiApp->platformName() == QLatin1String("xcb")) {
-        floatHotspot *= getDevicePixelRatio();
+        floatHotspot *= Gui::BitmapFactoryInst::getMaximumDPR();
     }
 #endif
 

--- a/src/Mod/TechDraw/Gui/QGVPage.h
+++ b/src/Mod/TechDraw/Gui/QGVPage.h
@@ -152,7 +152,6 @@ protected:
 
     QColor getBackgroundColor();
 
-    double getDevicePixelRatio() const;
     QPixmap prepareCursorPixmap(const char* iconName, QPoint& hotspot);
 
     void drawForeground(QPainter* painter, const QRectF& rect) override;


### PR DESCRIPTION
Partially fixes https://github.com/FreeCAD/FreeCAD/issues/17602#issuecomment-2721420581

![image](https://github.com/user-attachments/assets/ee774283-095d-4eb8-89e9-6933631821bc)
These arrow icons appear to be PNGs so this PR doesn't fix their scaling issue.