### PR TITLE
Gui: Show Placement Indicator - several fixes

### DIFF
--- a/src/Gui/ViewProviderDragger.cpp
+++ b/src/Gui/ViewProviderDragger.cpp
@@ -53,6 +53,7 @@
 #include <ViewProviderLink.h>
 #include <App/DocumentObjectGroup.h>
 #include <Base/Tools.h>
+#include <Inventor/So3DAnnotation.h>
 
 using namespace Gui;
 
@@ -341,7 +342,11 @@ void ViewProviderDragger::attach(App::DocumentObject* pcObject)
     getAnnotation()->addChild(pcPlacement);
 
     auto* pcAxisCrossKit = new Gui::SoFCPlacementIndicatorKit();
-    pcPlacement->addChild(pcAxisCrossKit);
+
+    auto* pcAnnotation = new So3DAnnotation();
+    pcAnnotation->addChild(pcAxisCrossKit);
+
+    pcPlacement->addChild(pcAnnotation);
 }
 
 void ViewProviderDragger::updateDraggerPosition()

--- a/src/Gui/ViewProviderDragger.cpp
+++ b/src/Gui/ViewProviderDragger.cpp
@@ -62,11 +62,6 @@ PROPERTY_SOURCE(Gui::ViewProviderDragger, Gui::ViewProviderDocumentObject)
 ViewProviderDragger::ViewProviderDragger()
 {
     ADD_PROPERTY_TYPE(TransformOrigin, ({}), nullptr, App::Prop_Hidden, nullptr);
-    ADD_PROPERTY_TYPE(ShowPlacement,
-                      (false),
-                      "Display Options",
-                      App::Prop_None,
-                      "If true, placement of object is additionally rendered.");
 
     pcPlacement = new SoSwitch;
     pcPlacement->whichChild = SO_SWITCH_NONE;
@@ -107,9 +102,6 @@ void ViewProviderDragger::onChanged(const App::Property* property)
 {
     if (property == &TransformOrigin) {
         updateDraggerPosition();
-    }
-    else if (property == &ShowPlacement || property == &Visibility) {
-        pcPlacement->whichChild = (ShowPlacement.getValue() && Visibility.getValue()) ? SO_SWITCH_ALL : SO_SWITCH_NONE;
     }
 
     ViewProviderDocumentObject::onChanged(property);

--- a/src/Gui/ViewProviderDragger.cpp
+++ b/src/Gui/ViewProviderDragger.cpp
@@ -108,8 +108,8 @@ void ViewProviderDragger::onChanged(const App::Property* property)
     if (property == &TransformOrigin) {
         updateDraggerPosition();
     }
-    else if (property == &ShowPlacement) {
-        pcPlacement->whichChild = ShowPlacement.getValue() ? SO_SWITCH_ALL : SO_SWITCH_NONE;
+    else if (property == &ShowPlacement || property == &Visibility) {
+        pcPlacement->whichChild = (ShowPlacement.getValue() && Visibility.getValue()) ? SO_SWITCH_ALL : SO_SWITCH_NONE;
     }
 
     ViewProviderDocumentObject::onChanged(property);

--- a/src/Gui/ViewProviderDragger.h
+++ b/src/Gui/ViewProviderDragger.h
@@ -56,10 +56,6 @@ public:
     /// destructor.
     ~ViewProviderDragger() override;
 
-    /// Property controlling visibility of the placement indicator, useful for displaying origin
-    /// position of attached Document Object.
-    App::PropertyBool ShowPlacement;
-
     /// Origin used when object is transformed. It temporarily changes the origin of object.
     /// Dragger is normally placed at the transform origin, unless explicitly overridden via
     /// ViewProviderDragger#setDraggerPlacement() method.

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -184,6 +184,7 @@ ViewProviderPartExt::ViewProviderPartExt()
     Lighting.setEnums(LightingEnums);
     ADD_PROPERTY_TYPE(DrawStyle,((long int)0), osgroup, App::Prop_None, "Defines the style of the edges in the 3D view.");
     DrawStyle.setEnums(DrawStyleEnums);
+    ADD_PROPERTY_TYPE(ShowPlacement,(false), "Display Options", App::Prop_None, "If true, placement of object is additionally rendered.");
 
     coords = new SoCoordinate3();
     coords->ref();
@@ -373,6 +374,9 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
         else
             pcLineStyle->linePattern = 0xff88;
     }
+    else if (prop == &ShowPlacement) {
+        pcPlacement->whichChild = (ShowPlacement.getValue() && Visibility.getValue()) ? SO_SWITCH_ALL : SO_SWITCH_NONE;
+    }
     else {
         // if the object was invisible and has been changed, recreate the visual
         if (prop == &Visibility && (isUpdateForced() || Visibility.getValue()) && VisualTouched) {
@@ -385,6 +389,7 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
                     App::Property::NoModify, &ShapeAppearance);
             // The material has to be checked again (#0001736)
             onChanged(&ShapeAppearance);
+            onChanged(&ShowPlacement);
         }
     }
 

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -76,6 +76,8 @@ public:
     App::PropertyAngle AngularDeflection;
     App::PropertyEnumeration Lighting;
     App::PropertyEnumeration DrawStyle;
+    /// Property controlling visibility of the placement indicator, useful for displaying origin
+    /// position of attached Document Object.
     App::PropertyBool ShowPlacement;
     // Points
     App::PropertyFloatConstraint PointSize;

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -238,7 +238,7 @@ QIcon ViewProvider::mergeColorfulOverlayIcons (const QIcon & orig) const
     return Gui::ViewProvider::mergeColorfulOverlayIcons (mergedicon);
 }
 
-bool ViewProvider::onDelete(const std::vector<std::string> &)
+bool ViewProvider::onDelete(const std::vector<std::string>&)
 {
     PartDesign::Feature* feature = getObject<PartDesign::Feature>();
 

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -282,6 +282,7 @@ void ViewProviderBody::unifyVisualProperty(const App::Property* prop) {
         prop == &Selectable ||
         prop == &DisplayModeBody ||
         prop == &PointColorArray ||
+        prop == &ShowPlacement ||
         prop == &LineColorArray) {
         return;
     }


### PR DESCRIPTION
This PR fixes #19894:
1. Indicator is now visible only when object is visible
2. Indicator is now shown on top of the object
3. Indicator is not not available for features of body as body is one object.