### PR TITLE
Draft: remove 'CTRL to snap' from tooltips

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -61,7 +61,7 @@ class Arc(gui_base_original.Creator):
         return {"Pixmap": "Draft_Arc",
                 "Accel": "A, R",
                 "MenuText": QT_TRANSLATE_NOOP("Draft_Arc", "Arc"),
-                "ToolTip": QT_TRANSLATE_NOOP("Draft_Arc", "Creates a circular arc by a center point and a radius.\nCTRL to snap, SHIFT to constrain.")}
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_Arc", "Creates a circular arc by a center point and a radius.\nSHIFT to constrain.")}
 
     def Activated(self):
         """Execute when the command is called."""
@@ -475,7 +475,7 @@ class Arc_3Points(gui_base.GuiCommandBase):
         return {"Pixmap": "Draft_Arc_3Points",
                 "Accel": "A,T",
                 "MenuText": QT_TRANSLATE_NOOP("Draft_Arc_3Points", "Arc by 3 points"),
-                "ToolTip": QT_TRANSLATE_NOOP("Draft_Arc_3Points", "Creates a circular arc by picking 3 points.\nCTRL to snap, SHIFT to constrain.")}
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_Arc_3Points", "Creates a circular arc by 3 points.\nSHIFT to constrain.")}
 
     def Activated(self):
         """Execute when the command is called."""

--- a/src/Mod/Draft/draftguitools/gui_beziers.py
+++ b/src/Mod/Draft/draftguitools/gui_beziers.py
@@ -64,7 +64,7 @@ class BezCurve(gui_lines.Line):
         return {"Pixmap": "Draft_BezCurve",
                 "Accel": "B, Z",
                 "MenuText": QT_TRANSLATE_NOOP("Draft_BezCurve", "Bézier curve"),
-                "ToolTip": QT_TRANSLATE_NOOP("Draft_BezCurve", "Creates an N-degree Bézier curve. The more points you pick, the higher the degree.\nCTRL to snap, SHIFT to constrain.")}
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_BezCurve", "Creates an N-degree Bézier curve. The more points you pick, the higher the degree.\nSHIFT to constrain.")}
 
     def Activated(self):
         """Execute when the command is called.
@@ -251,7 +251,7 @@ class CubicBezCurve(gui_lines.Line):
         return {"Pixmap": "Draft_CubicBezCurve",
                 # "Accel": "B, Z",
                 "MenuText": QT_TRANSLATE_NOOP("Draft_CubicBezCurve", "Cubic Bézier curve"),
-                "ToolTip": QT_TRANSLATE_NOOP("Draft_CubicBezCurve", "Creates a Bézier curve made of 2nd degree (quadratic) and 3rd degree (cubic) segments. Click and drag to define each segment.\nAfter the curve is created you can go back to edit each control point and set the properties of each knot.\nCTRL to snap, SHIFT to constrain.")}
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_CubicBezCurve", "Creates a Bézier curve made of 2nd degree (quadratic) and 3rd degree (cubic) segments. Click and drag to define each segment.\nAfter the curve is created you can go back to edit each control point and set the properties of each knot.\nSHIFT to constrain.")}
 
     def Activated(self):
         """Execute when the command is called.

--- a/src/Mod/Draft/draftguitools/gui_circles.py
+++ b/src/Mod/Draft/draftguitools/gui_circles.py
@@ -78,7 +78,7 @@ class Circle(gui_arcs.Arc):
         return {'Pixmap': 'Draft_Circle',
                 'Accel': "C, I",
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Circle", "Circle"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Circle", "Creates a circle (full circular arc).\nCTRL to snap, ALT to select tangent objects.")}
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_Circle", "Creates a circle (full circular arc).")}
 
 
 Gui.addCommand('Draft_Circle', Circle())

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -83,7 +83,7 @@ class Dimension(gui_base_original.Creator):
         return {'Pixmap': 'Draft_Dimension',
                 'Accel': "D, I",
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Dimension", "Dimension"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Dimension", "Creates a dimension.\n\n- Pick three points to create a simple linear dimension.\n- Select a straight line to create a linear dimension linked to that line.\n- Select an arc or circle to create a radius or diameter dimension linked to that arc.\n- Select two straight lines to create an angular dimension between them.\nCTRL to snap, SHIFT to constrain, ALT to select an edge or arc.\n\nYou may select a single line or single circular arc before launching this command\nto create the corresponding linked dimension.\nYou may also select an 'App::MeasureDistance' object before launching this command\nto turn it into a 'Draft Dimension' object.")}
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_Dimension", "Creates a dimension.\n\n- Pick three points to create a simple linear dimension.\n- Select a straight line to create a linear dimension linked to that line.\n- Select an arc or circle to create a radius or diameter dimension linked to that arc.\n- Select two straight lines to create an angular dimension between them.\nSHIFT to constrain, E or ALT to select an edge or arc.\n\nYou may select a single line or single circular arc before launching this command\nto create the corresponding linked dimension.")}
 
     def Activated(self):
         """Execute when the command is called."""

--- a/src/Mod/Draft/draftguitools/gui_ellipses.py
+++ b/src/Mod/Draft/draftguitools/gui_ellipses.py
@@ -57,7 +57,7 @@ class Ellipse(gui_base_original.Creator):
         return {'Pixmap': 'Draft_Ellipse',
                 'Accel': "E, L",
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Ellipse", "Ellipse"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Ellipse", "Creates an ellipse. CTRL to snap.")}
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_Ellipse", "Creates an ellipse.")}
 
     def Activated(self):
         """Execute when the command is called."""

--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -61,7 +61,7 @@ class Line(gui_base_original.Creator):
         return {'Pixmap': 'Draft_Line',
                 'Accel': "L,I",
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Line", "Line"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Line", "Creates a 2-point line. CTRL to snap, SHIFT to constrain.")}
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_Line", "Creates a 2-point line.\nSHIFT to constrain.")}
 
     def Activated(self, name=QT_TRANSLATE_NOOP("draft", "Line"), icon="Draft_Line", task_title=None):
         """Execute when the command is called."""
@@ -308,7 +308,7 @@ class Wire(Line):
         return {'Pixmap': 'Draft_Wire',
                 'Accel': "P, L",
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Wire", "Polyline"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Wire", "Creates a multiple-points line (polyline). CTRL to snap, SHIFT to constrain.")}
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_Wire", "Creates a multiple-points line (polyline).\nSHIFT to constrain.")}
 
     def Activated(self):
         """Execute when the command is called."""

--- a/src/Mod/Draft/draftguitools/gui_move.py
+++ b/src/Mod/Draft/draftguitools/gui_move.py
@@ -53,7 +53,7 @@ class Move(gui_base_original.Modifier):
         return {"Pixmap": "Draft_Move",
                 "Accel": "M, V",
                 "MenuText": QT_TRANSLATE_NOOP("Draft_Move", "Move"),
-                "ToolTip": QT_TRANSLATE_NOOP("Draft_Move", "Moves the selected objects from one base point to another point.\nIf the \"copy\" option is active, it will create displaced copies.\nCTRL to snap, SHIFT to constrain.")}
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_Move", "Moves the selected objects.\nIf the \"copy\" option is active, it will create displaced copies.\nSHIFT to constrain. Hold ALT and click to create a copy with each click.")}
 
     def Activated(self):
         """Execute when the command is called."""

--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -61,7 +61,7 @@ class Offset(gui_base_original.Modifier):
         return {'Pixmap': 'Draft_Offset',
                 'Accel': "O, S",
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Offset", "Offset"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Offset", "Offsets of the selected object.\nIt can also create an offset copy of the original object.\nCTRL to snap, SHIFT to constrain. Hold ALT and click to create a copy with each click.")}
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_Offset", "Offsets of the selected object.\nIt can also create an offset copy of the original object.\nSHIFT to constrain. Hold ALT and click to create a copy with each click.")}
 
     def Activated(self):
         """Execute when the command is called."""

--- a/src/Mod/Draft/draftguitools/gui_polygons.py
+++ b/src/Mod/Draft/draftguitools/gui_polygons.py
@@ -55,7 +55,7 @@ class Polygon(gui_base_original.Creator):
         return {'Pixmap': 'Draft_Polygon',
                 'Accel': "P, G",
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Polygon", "Polygon"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Polygon", "Creates a regular polygon (triangle, square, pentagon, ...), by defining the number of sides and the circumscribed radius.\nCTRL to snap, SHIFT to constrain")}
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_Polygon", "Creates a regular polygon (triangle, square, pentagon, ...).\nSHIFT to constrain")}
 
     def Activated(self):
         """Execute when the command is called."""

--- a/src/Mod/Draft/draftguitools/gui_rectangles.py
+++ b/src/Mod/Draft/draftguitools/gui_rectangles.py
@@ -52,7 +52,7 @@ class Rectangle(gui_base_original.Creator):
         return {'Pixmap': 'Draft_Rectangle',
                 'Accel': "R, E",
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Rectangle", "Rectangle"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Rectangle", "Creates a 2-point rectangle. CTRL to snap.")}
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_Rectangle", "Creates a 2-point rectangle.")}
 
     def Activated(self):
         """Execute when the command is called."""

--- a/src/Mod/Draft/draftguitools/gui_rotate.py
+++ b/src/Mod/Draft/draftguitools/gui_rotate.py
@@ -55,7 +55,7 @@ class Rotate(gui_base_original.Modifier):
         return {"Pixmap": "Draft_Rotate",
                 "Accel": "R, O",
                 "MenuText": QT_TRANSLATE_NOOP("Draft_Rotate", "Rotate"),
-                "ToolTip": QT_TRANSLATE_NOOP("Draft_Rotate", "Rotates the selected objects. Choose the center of rotation, then the initial angle, and then the final angle.\nIf the \"copy\" option is active, it will create rotated copies.\nCTRL to snap, SHIFT to constrain. Hold ALT and click to create a copy with each click.")}
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_Rotate", "Rotates the selected objects. Choose the center of rotation, then the initial angle, and then the final angle.\nIf the \"copy\" option is active, it will create rotated copies.\nSHIFT to constrain. Hold ALT and click to create a copy with each click.")}
 
     def Activated(self):
         """Execute when the command is called."""

--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -65,7 +65,7 @@ class Scale(gui_base_original.Modifier):
         return {"Pixmap": "Draft_Scale",
                 "Accel": "S, C",
                 "MenuText": QT_TRANSLATE_NOOP("Draft_Scale", "Scale"),
-                "ToolTip": QT_TRANSLATE_NOOP("Draft_Scale", "Scales the selected objects from a base point.\nCTRL to snap, SHIFT to constrain, ALT to copy.")}
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_Scale", "Scales the selected objects from a base point.\nSHIFT to constrain.")}
 
     def Activated(self):
         """Execute when the command is called."""

--- a/src/Mod/Draft/draftguitools/gui_splines.py
+++ b/src/Mod/Draft/draftguitools/gui_splines.py
@@ -58,7 +58,7 @@ class BSpline(gui_lines.Line):
         return {'Pixmap': 'Draft_BSpline',
                 'Accel': "B, S",
                 'MenuText': QT_TRANSLATE_NOOP("Draft_BSpline", "B-spline"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_BSpline", "Creates a multiple-point B-spline. CTRL to snap, SHIFT to constrain.")}
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_BSpline", "Creates a multiple-point B-spline.\nSHIFT to constrain.")}
 
     def Activated(self):
         """Execute when the command is called.

--- a/src/Mod/Draft/draftguitools/gui_texts.py
+++ b/src/Mod/Draft/draftguitools/gui_texts.py
@@ -58,7 +58,7 @@ class Text(gui_base_original.Creator):
         return {'Pixmap': 'Draft_Text',
                 'Accel': "T, E",
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Text", "Text"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Text", "Creates a multi-line annotation. CTRL to snap.")}
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_Text", "Creates a multi-line annotation.")}
 
     def Activated(self):
         """Execute when the command is called."""

--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -76,7 +76,7 @@ class Trimex(gui_base_original.Modifier):
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Trimex", "Trimex"),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Trimex",
                     "Trims or extends the selected object, or extrudes single"
-                    + " faces.\nCTRL snaps, SHIFT constrains to current segment"
+                    + " faces.\nSHIFT constrains to current segment"
                     + " or to normal, ALT inverts.")}
 
     def Activated(self):


### PR DESCRIPTION
The 'CTRL to snap' option is not the default, it should therefore not be included in the tooltips.

Additionally:
* Some obsolete info was removed.
* Some minor improvements,
