### PR TITLE
Update MainGui.cpp

### DIFF
--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -179,9 +179,6 @@ int main(int argc, char** argv)
         }
         argv_.push_back(0);  // 0-terminated string
     }
-
-    // https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5
-    _putenv("QT_QPA_PLATFORM=windows:darkmode=1");
 #endif
 
     // Name and Version of the Application


### PR DESCRIPTION
So in QT 6.5> Darkmode variable works a bit differently as can be read here:
https://github.com/FreeCAD/FreeCAD/issues/15346#issuecomment-2774508501
https://github.com/FreeCAD/FreeCAD/issues/15346#issuecomment-2776642462
So it seems like it works as default like it worked with darkmode=1.
This PR will result in a white title bar in lower QT versions, but this is not a big deal.

The proposed "better" solution from QT is to let QT detect if there is a dark color palette active and then change the title bar. Which sounds good, but I really don't think that users who use a dark-style windows will want a light Freecad and visa versa, it just makes things unnecessary complicated. 