### PR TITLE
Gui: Python console function signature call tip

### DIFF
--- a/src/Gui/CallTips.cpp
+++ b/src/Gui/CallTips.cpp
@@ -728,7 +728,7 @@ void CallTipsList::callTipItemActivated(QListWidgetItem *item)
        * Try to find out if call needs arguments.
        * For this we search the parameters if there are no arguments
        */
-      QRegularExpression argumentMatcher(QLatin1String(R"(\(\s*\))"));
+      QRegularExpression argumentMatcher(QLatin1String(R"(\(\s*self\s*,\s*/\))"));
       if (!argumentMatcher.match( callTip.parameter ).hasMatch())
       {
         // if arguments are needed, we just move the cursor one left, to between the parentheses.

--- a/src/Gui/CallTips.cpp
+++ b/src/Gui/CallTips.cpp
@@ -398,22 +398,28 @@ void CallTipsList::extractTipsFromObject(Py::Object& obj, Py::List& list, QMap<Q
             CallTip tip;
             QString str = QString::fromLatin1(name.c_str());
             tip.name = str;
+            tip.parameter = QString::fromStdString(attrname.as_std_string());
 
             if (attr.isCallable()) {
+                tip.parameter += extractSignature(attr);
                 PyObject* basetype = Base::getTypeAsObject(&PyBaseObject_Type);
                 if (PyObject_IsSubclass(attr.ptr(), basetype) == 1) {
                     tip.type = CallTip::Class;
+                    tip.parameter = QString::fromStdString("(class) ") + tip.parameter;
                 }
                 else {
                     PyErr_Clear(); // PyObject_IsSubclass might set an exception
                     tip.type = CallTip::Method;
+                    tip.parameter = QString::fromStdString("(function) def ") + tip.parameter;
                 }
             }
             else if (PyModule_Check(attr.ptr())) {
                 tip.type = CallTip::Module;
+                tip.parameter = QString::fromStdString("(module) ") + tip.parameter;
             }
             else {
                 tip.type = CallTip::Member;
+                tip.parameter = QString::fromStdString("(member) ") + tip.parameter;
             }
 
             if (str == QLatin1String("__doc__") && attr.isString()) {
@@ -426,7 +432,6 @@ void CallTipsList::extractTipsFromObject(Py::Object& obj, Py::List& list, QMap<Q
                     if (pos < 0)
                         pos = qMin(longdoc.length(), 70);
                     tip.description = stripWhiteSpace(longdoc);
-                    tip.parameter = longdoc.left(pos);
                 }
             }
             else if (attr.hasAttr("__doc__")) {
@@ -439,7 +444,6 @@ void CallTipsList::extractTipsFromObject(Py::Object& obj, Py::List& list, QMap<Q
                     if (pos < 0)
                         pos = qMin(longdoc.length(), 70);
                     tip.description = stripWhiteSpace(longdoc);
-                    tip.parameter = longdoc.left(pos);
                 }
             }
 
@@ -722,11 +726,10 @@ void CallTipsList::callTipItemActivated(QListWidgetItem *item)
 
       /**
        * Try to find out if call needs arguments.
-       * For this we search the description for appropriate hints ...
+       * For this we search the parameters if there are no arguments
        */
-      QRegularExpression argumentMatcher( QRegularExpression::escape( callTip.name ) + QLatin1String(R"(\s*\(\s*\w+.*\))") );
-      argumentMatcher.setPatternOptions( QRegularExpression::InvertedGreedinessOption ); //< set regex non-greedy!
-      if (argumentMatcher.match( callTip.description ).hasMatch())
+      QRegularExpression argumentMatcher(QLatin1String(R"(\(\s*\))"));
+      if (!argumentMatcher.match( callTip.parameter ).hasMatch())
       {
         // if arguments are needed, we just move the cursor one left, to between the parentheses.
         cursor.movePosition( QTextCursor::Left, QTextCursor::MoveAnchor, 1 );
@@ -741,7 +744,8 @@ void CallTipsList::callTipItemActivated(QListWidgetItem *item)
 
     QPoint p(posX, posY);
     p = textEdit->mapToGlobal(p);
-    QToolTip::showText( p, callTip.parameter );
+
+    QToolTip::showText(p, callTip.parameter);
 }
 
 QString CallTipsList::stripWhiteSpace(const QString& str) const
@@ -782,6 +786,18 @@ QString CallTipsList::stripWhiteSpace(const QString& str) const
     }
 
     return stripped;
+}
+
+QString CallTipsList::extractSignature(const Py::Object& obj) const {
+    Py::Callable callable(obj);
+    Py::Module pInspect("inspect");
+    Py::Callable signatureFunc(pInspect.getAttr("signature"));
+
+    Py::Tuple args(1);
+    args[0] = callable;
+    Py::Object signature = signatureFunc.apply(args);
+
+    return QString::fromStdString(signature.as_string());
 }
 
 #include "moc_CallTips.cpp"

--- a/src/Gui/CallTips.h
+++ b/src/Gui/CallTips.h
@@ -76,6 +76,7 @@ private:
     void extractTipsFromObject(Py::Object&, Py::List&, QMap<QString, CallTip>&) const;
     void extractTipsFromProperties(Py::Object&, QMap<QString, CallTip>&) const;
     QString stripWhiteSpace(const QString&) const;
+    QString extractSignature(const Py::Object&) const;
     Py::Object getAttrWorkaround(Py::Object&, Py::String&) const;
 
 private:


### PR DESCRIPTION
See: #20273 

Currently, the docstrings of the Python APIs are in an inconsistent state. Some docstrings include the function signature in the first line of the docstring while others leave it out.

This is problematic as we currently rely on the parsing the docstring for displaying the correct function signature while the user is interacting with the Python console and for moving their cursor accordingly if the function call has arguments that need to be specified.

The PR aims to address this by not relying on the parsing the docstrings, rather using python embeddings to import the `inspect` module and call `signature` on the `Py::Object`. From there the function signature is extracted, displayed on the `QToolTip`. The cursor is also moved accordingly: if the function has arguments then it goes in between `()`; otherwise its placed at the end.

[Screencast from 04-02-2025 09:27:17 PM.webm](https://github.com/user-attachments/assets/bb1fc396-600b-41e4-9ecd-617350e04651)

Extra:
Not totally related to this PR, but it would be nice to add more function annotations to the python APIs since it would enhance the tooltip info as well, specifically with argument and return type labels. e.g. `def add(x: int, y: int) -> int:`

And it would be nice if the docstrings could be unified by displaying the function signature in the first line for all of them or leave it out for all.
