### PR TITLE
3Dconnexion - Fixed crashing on some commands

### DIFF
--- a/src/Gui/3Dconnexion/navlib/NavlibCmds.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibCmds.cpp
@@ -153,7 +153,9 @@ long NavlibInterface::SetActiveCommand(std::string commandId)
             if (!std::string(command->getName()).compare(parsedData.commandName)) {
                 if (parsedData.actionIndex == -1) {
                     Gui::Action* pAction = command->getAction();
-                    pAction->action()->trigger();
+                    if (pAction != nullptr) {
+                        pAction->action()->trigger();
+                    }
                 }
                 else
                     command->invoke(parsedData.actionIndex);


### PR DESCRIPTION
I have added a missing sanity check for the action pointer, which is used to invoke an application's command by 3Dconnexion device.