### PR TITLE
Tools: Add PyCXX includes to generated Python binding files.

### DIFF
--- a/src/Base/PyObjectBase.h
+++ b/src/Base/PyObjectBase.h
@@ -25,36 +25,11 @@
 
 // clang-format off
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
-// Std. configurations
-
-// (re-)defined in pyconfig.h
-#if defined (_POSIX_C_SOURCE)
-#   undef    _POSIX_C_SOURCE
-#endif
-#if defined (_XOPEN_SOURCE)
-#   undef    _XOPEN_SOURCE
-#endif
-
-// needed header
-#undef slots
-#include <Python.h>
-#ifdef FC_OS_MACOSX
-#undef toupper
-#undef tolower
-#undef isupper
-#undef islower
-#undef isspace
-#undef isalpha
-#undef isalnum
-#endif
-#define slots
 #include <bitset>
 #include <cstring>
-
-#include "Exception.h"
-
 #include <CXX/Objects.hxx>
 
+#include "Exception.h"
 
 /** Python static class macro for definition
  * sets up a static function entry in a class inheriting

--- a/src/Tools/bindings/templates/templateClassPyExport.py
+++ b/src/Tools/bindings/templates/templateClassPyExport.py
@@ -122,6 +122,7 @@ class TemplateClassPyExport(template.ModelTemplate):
 #ifndef @self.export.Namespace.upper().replace("::", "_")@_@self.export.Name.upper()@_H
 #define @self.export.Namespace.upper().replace("::", "_")@_@self.export.Name.upper()@_H
 
+#include <CXX/Objects.hxx>
 #include <@self.export.FatherInclude@>
 #include <@self.export.Include@>
 #include <string>


### PR DESCRIPTION
Also cleans up Python includes in `PyObjectBase.h`.