### PR TITLE
[Core] Allow setting visibility toggling in the ViewProvider

### DIFF
--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -29,7 +29,7 @@
 
 # imports the one and only
 import FreeCAD, FreeCADGui
-from enum import IntEnum
+from enum import IntEnum, Enum
 
 # shortcuts
 Gui = FreeCADGui
@@ -51,6 +51,11 @@ Gui.Selection.ResolveMode = ResolveMode
 class SelectionStyle(IntEnum):
     NormalSelection = 0
     GreedySelection = 1
+
+# The values must match with that of the Python enum class in ViewProvider.pyi
+class ToggleVisibilityMode(Enum):
+    CanToggleVisibility = "CanToggleVisibility"
+    NoToggleVisibility = "NoToggleVisibility"
 
 Gui.Selection.SelectionStyle = SelectionStyle
 

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -5534,7 +5534,9 @@ void DocumentObjectItem::testStatus(bool resetStatus, QIcon& icon1, QIcon& icon2
                 QPainter pt;
                 pt.begin(&px);
                 pt.setPen(Qt::NoPen);
-                pt.drawPixmap(0, 0, px_org.width(), px_org.height(), (currentStatus & Status::Visible) ? pxVisible : pxInvisible);
+                if (object()->canToggleVisibility()) {
+                    pt.drawPixmap(0, 0, px_org.width(), px_org.height(), (currentStatus & Status::Visible) ? pxVisible : pxInvisible);
+                }
                 pt.drawPixmap(px_org.width() + spacing, 0, px_org.width(), px_org.height(), px_org);
                 pt.end();
 

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -93,6 +93,7 @@ PROPERTY_SOURCE_ABSTRACT(Gui::ViewProvider, App::TransactionalObject)
 
 ViewProvider::ViewProvider()
     : overrideMode("As Is")
+    , toggleVisibilityMode(ToggleVisibilityMode::CanToggleVisibility)
 {
     setStatus(UpdateData, true);
 

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -121,6 +121,11 @@ class GuiExport ViewProvider : public App::TransactionalObject
     PROPERTY_HEADER_WITH_OVERRIDE(Gui::ViewProvider);
 
 public:
+    enum class ToggleVisibilityMode : bool {
+        CanToggleVisibility = true,
+        NoToggleVisibility = false
+    };
+
     /// constructor.
     ViewProvider();
 
@@ -246,6 +251,22 @@ public:
     //@{
     /// deliver the icon shown in the tree view
     virtual QIcon getIcon() const;
+
+    /**
+     * @brief Whether the viewprovider should allow to toggle the visibility.
+     *
+     * Some document objects are not rendered and for those document objects,
+     * it makes no sense to be able to toggle the visibility.  Examples are
+     * VarSet and Spreadsheet.
+     *
+     * Note that "rendered" should be seen broadly here.  Objects such as
+     * TechDraw pages, templates, views, and dimensions are not rendered by
+     * Coin but are "rendered" on the TechDraw page and hence this function can
+     * return true for those items.
+     */
+    bool canToggleVisibility() const {
+        return toggleVisibilityMode == ToggleVisibilityMode::CanToggleVisibility;
+    }
 
      /** @name Methods used by the Tree
      * If you want to take control over the
@@ -571,6 +592,8 @@ protected:
     /// Turn on mode switch
     virtual void setModeSwitch();
 
+    void setToggleVisibility(ToggleVisibilityMode mode) { toggleVisibilityMode = mode; }
+
 protected:
     /// The root Separator of the ViewProvider
     SoSeparator *pcRoot;
@@ -584,6 +607,10 @@ protected:
     ViewProviderPy* pyViewObject{nullptr};
     std::string overrideMode;
     std::bitset<32> StatusBits;
+    /// whether visibility can toggled
+    ToggleVisibilityMode toggleVisibilityMode;
+
+    friend class ViewProviderPy;
 
 private:
     int _iActualMode{-1};

--- a/src/Gui/ViewProvider.pyi
+++ b/src/Gui/ViewProvider.pyi
@@ -2,6 +2,7 @@ from Base.Metadata import constmethod
 from Base.BoundBox import BoundBox
 from App.ExtensionContainer import ExtensionContainer
 from typing import Any, Final, List, Optional
+import enum
 
 
 class ViewProvider(ExtensionContainer):
@@ -11,6 +12,11 @@ class ViewProvider(ExtensionContainer):
     Author: Werner Mayer (wmayer@users.sourceforge.net)
     Licence: LGPL
     """
+
+    class ToggleVisibilityMode(enum.Enum):
+        CanToggleVisibility = "CanToggleVisibility"
+        NoToggleVisibility = "NoToggleVisibility"
+
 
     def addProperty(
         self,
@@ -367,3 +373,7 @@ class ViewProvider(ExtensionContainer):
 
     DropPrefix: Final[str] = ""
     """Subname referencing the sub-object for holding dropped object."""
+
+    ToggleVisibility: ToggleVisibilityMode = ToggleVisibilityMode.CanToggleVisibility
+    """Get/set whether the viewprovider can toggle the visibility of
+    the object."""

--- a/src/Gui/ViewProviderPyImp.cpp
+++ b/src/Gui/ViewProviderPyImp.cpp
@@ -706,3 +706,34 @@ Py::String ViewProviderPy::getDropPrefix() const
 {
     return {getViewProviderPtr()->getDropPrefix()};
 }
+
+void ViewProviderPy::setToggleVisibility(Py::Object arg)
+{
+    std::string val;
+
+    if (PyObject_HasAttrString(arg.ptr(), "value")) {
+        // we are dealing with the enum
+        val = Py::String(arg.getAttr("value"));
+    }
+    else {
+        // we are dealing with a string
+        val = Py::String(arg);
+    }
+
+    if (val == "CanToggleVisibility") {
+        getViewProviderPtr()->setToggleVisibility(ViewProvider::ToggleVisibilityMode::CanToggleVisibility);
+    }
+    else if (val == "NoToggleVisibility") {
+        getViewProviderPtr()->setToggleVisibility(ViewProvider::ToggleVisibilityMode::NoToggleVisibility);
+    }
+    else {
+        throw Py::ValueError("Invalid ToggleVisibility mode. Use 'CanToggleVisibility' or 'NoToggleVisibility'.");
+    }
+}
+
+Py::Object ViewProviderPy::getToggleVisibility() const
+{
+    bool canToggleVisibility = getViewProviderPtr()->canToggleVisibility();
+
+    return Py::String(canToggleVisibility ? "CanToggleVisibility" : "NoToggleVisibility");
+}

--- a/src/Gui/ViewProviderVarSet.cpp
+++ b/src/Gui/ViewProviderVarSet.cpp
@@ -37,6 +37,7 @@ PROPERTY_SOURCE(Gui::ViewProviderVarSet, Gui::ViewProviderDocumentObject)
 
 ViewProviderVarSet::ViewProviderVarSet()
 {
+    setToggleVisibility(ToggleVisibilityMode::NoToggleVisibility);
     sPixmap = "VarSet";
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
@@ -101,6 +101,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemAnalysis, Gui::ViewProviderDocumentObject
 
 ViewProviderFemAnalysis::ViewProviderFemAnalysis()
 {
+    setToggleVisibility(ToggleVisibilityMode::NoToggleVisibility);
     sPixmap = "FEM_Analysis";
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
@@ -147,11 +147,6 @@ std::vector<App::DocumentObject*> ViewProviderFemAnalysis::claimChildren() const
     return Gui::ViewProviderDocumentObjectGroup::claimChildren();
 }
 
-std::vector<std::string> ViewProviderFemAnalysis::getDisplayModes() const
-{
-    return {"Analysis"};
-}
-
 void ViewProviderFemAnalysis::hide()
 {
     Gui::ViewProviderDocumentObjectGroup::hide();

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.h
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.h
@@ -75,8 +75,6 @@ public:
 
     void setupContextMenu(QMenu*, QObject*, const char*) override;
 
-    /// list of all possible display modes
-    std::vector<std::string> getDisplayModes() const override;
     /// shows solid in the tree
     bool isShow() const override
     {

--- a/src/Mod/Fem/Gui/ViewProviderSolver.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderSolver.cpp
@@ -41,6 +41,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderSolver, Gui::ViewProviderDocumentObject)
 
 ViewProviderSolver::ViewProviderSolver()
 {
+    setToggleVisibility(ToggleVisibilityMode::NoToggleVisibility);
     sPixmap = "FEM_SolverStandard";
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderSolver.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderSolver.cpp
@@ -46,11 +46,6 @@ ViewProviderSolver::ViewProviderSolver()
 
 ViewProviderSolver::~ViewProviderSolver() = default;
 
-std::vector<std::string> ViewProviderSolver::getDisplayModes() const
-{
-    return {"Solver"};
-}
-
 bool ViewProviderSolver::onDelete(const std::vector<std::string>&)
 {
     // warn the user if the object has unselected children

--- a/src/Mod/Fem/Gui/ViewProviderSolver.h
+++ b/src/Mod/Fem/Gui/ViewProviderSolver.h
@@ -53,8 +53,6 @@ public:
     {
         return Visibility.getValue();
     }
-    /// A list of all possible display modes
-    std::vector<std::string> getDisplayModes() const override;
 
     // handling when object is deleted
     bool onDelete(const std::vector<std::string>&) override;

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -50,7 +50,10 @@ using namespace Spreadsheet;
 
 PROPERTY_SOURCE(SpreadsheetGui::ViewProviderSheet, Gui::ViewProviderDocumentObject)
 
-ViewProviderSheet::ViewProviderSheet() = default;
+ViewProviderSheet::ViewProviderSheet()
+{
+    setToggleVisibility(ToggleVisibilityMode::NoToggleVisibility);
+}
 
 ViewProviderSheet::~ViewProviderSheet()
 {

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -59,18 +59,6 @@ ViewProviderSheet::~ViewProviderSheet()
     }
 }
 
-void ViewProviderSheet::setDisplayMode(const char* ModeName)
-{
-    ViewProviderDocumentObject::setDisplayMode(ModeName);
-}
-
-std::vector<std::string> ViewProviderSheet::getDisplayModes() const
-{
-    std::vector<std::string> StrList;
-    StrList.emplace_back("Spreadsheet");
-    return StrList;
-}
-
 QIcon ViewProviderSheet::getIcon() const
 {
     return QIcon(QLatin1String(":icons/Spreadsheet.svg"));

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.h
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.h
@@ -46,12 +46,10 @@ public:
     /// destructor.
     ~ViewProviderSheet() override;
 
-    void setDisplayMode(const char* ModeName) override;
     bool useNewSelectionModel() const override
     {
         return false;
     }
-    std::vector<std::string> getDisplayModes() const override;
 
     bool doubleClicked() override;
     void setupContextMenu(QMenu* menu, QObject* receiver, const char* member) override;


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/16816.

This is an alternative to https://github.com/FreeCAD/FreeCAD/pull/20573. Instead of basing toggling visibility on the DisplayMode, this PR extends the ViewProvider API to allow for viewproviders to disable toggling visibility.

This PR has a C++ and Python interface. Disabling toggling visibility in Python can be done in the following way:

```python
class ViewProviderMyObject(object):

    def __init__(self, vobj):
        vobj.ToggleVisibility = ToggleVisibilityMode.NoToggleVisibility
        ...
```
I believe the proposed interface is idiomatic for FreeCAD and all is implemented with enums for readability.