### PR TITLE
Fix various typos

### DIFF
--- a/src/Doc/BuildWebDoc.cfg.in
+++ b/src/Doc/BuildWebDoc.cfg.in
@@ -2794,7 +2794,7 @@ TEMPLATE_RELATIONS     = NO
 # If the INCLUDE_GRAPH, ENABLE_PREPROCESSING and SEARCH_INCLUDES tags are set to
 # YES then Doxygen will generate a graph for each documented file showing the
 # direct and indirect include dependencies of the file with other documented
-# files. Explicit enabling an include graph, when INCLUDE_GRAPH is is set to NO,
+# files. Explicit enabling an include graph, when INCLUDE_GRAPH is set to NO,
 # can be accomplished by means of the command \includegraph. Disabling an
 # include graph can be accomplished by means of the command \hideincludegraph.
 # The default value is: YES.

--- a/src/Mod/CAM/App/Area.cpp
+++ b/src/Mod/CAM/App/Area.cpp
@@ -875,7 +875,7 @@ static inline void getEndPoints(const TopoDS_Wire& wire, gp_Pnt& p1, gp_Pnt& p2)
 }
 
 // Toponaming integration note: there's a new class called WireJoiner in Mod/Part/App/ that has been
-// imported from RT's fork. Is's an improved version of the following struct, therefor
+// imported from RT's fork. It's an improved version of the following struct, therefore
 // probably at some point this struct should be replaced with the new imported class.
 // See https://github.com/realthunder/FreeCAD/blob/LinkStable/src/Mod/Part/App/WireJoiner.h for the
 // original implementation of the class and https://github.com/FreeCAD/FreeCAD/pull/12535 for the

--- a/src/Mod/Draft/importAirfoilDAT.py
+++ b/src/Mod/Draft/importAirfoilDAT.py
@@ -132,7 +132,7 @@ def process(filename):
 
     regex = re.compile(_regex)
     afile = pyopen(filename, 'r')
-    # read the airfoil name which is always at the first line
+    # read the airfoil name which is always in the first line
     airfoilname = afile.readline().strip()
 
     coords = []

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -603,7 +603,7 @@ void PropertyPartShape::RestoreDocFile(Base::Reader &reader)
     // Now it's not possible anymore because both PropertyPartShape::loadFromFile() and
     // PropertyPartShape::loadFromStream() calls PropertyPartShape::setValue() which clears the
     // value of _Ver.
-    // Therefor we're storing the value of _Ver here so that we don't lose it.
+    // Therefore we're storing the value of _Ver here so that we don't lose it.
 
     std::string ver = _Ver;
 

--- a/src/Mod/Part/App/WireJoiner.cpp
+++ b/src/Mod/Part/App/WireJoiner.cpp
@@ -1722,7 +1722,7 @@ public:
     }
 
     // Originally here there was the definition of the method checkStack(), which does nothing and
-    // therefor has been removed. See
+    // therefore has been removed. See
     // https://github.com/realthunder/FreeCAD/blob/6f15849be2505f98927e75d0e8352185e14e7b72/src/Mod/Part/App/WireJoiner.cpp#L1366
     // for reference
 
@@ -1768,7 +1768,7 @@ public:
                 ++stack.back().iEnd;
 
                 // Originally here there was a call to the method checkStack(),
-                // which does nothing and therefor has been removed.
+                // which does nothing and therefore has been removed.
             }
         }
     }
@@ -1985,7 +1985,7 @@ public:
         auto stackEnd = stack.size();
 
         // Originally here there was a call to the method checkStack(), which does nothing and
-        // therefor has been removed.
+        // therefore has been removed.
 
         // pstart and pend is the start and end vertex of the current wire
         while (true) {
@@ -2004,7 +2004,7 @@ public:
                                         beginInfo);
 
             // Originally here there was a call to the method checkStack(), which does nothing and
-            // therefor has been removed.
+            // therefore has been removed.
 
             if (proceed) {
                 if (_findClosedWiresUpdateEdges(currentVertex,
@@ -2182,7 +2182,7 @@ public:
             vertexStack.push_back(currentVertex);
 
             // Originally here there was a call to the method checkStack(), which does
-            // nothing and therefor has been removed.
+            // nothing and therefore has been removed.
 
             int idxEnd = (int)wireVertices.size();
             int stackStart = (int)stack.size() - 1;
@@ -2381,7 +2381,7 @@ public:
                     edgeSet.insert(wireVertices[idxV].edgeInfo());
 
                     // Originally here there was a call to the method checkStack(), which does
-                    // nothing and therefor has been removed.
+                    // nothing and therefore has been removed.
                 }
 
                 if (!newWire) {
@@ -2425,7 +2425,7 @@ public:
             vertexStack.push_back(currentVertex);
 
             // Originally here there a call to the method checkStack(), which
-            // does nothing and therefor has been removed.
+            // does nothing and therefore has been removed.
 
             TopoDS_Wire wire;
             if (pstart.SquareDistance(currentVertex.ptOther()) > myTol2) {
@@ -2511,7 +2511,7 @@ public:
             edgeSet.insert(wireVertices[idxV].edgeInfo());
 
             // Originally here there a call to the method checkStack(), which does
-            // nothing and therefor has been removed.
+            // nothing and therefore has been removed.
         }
     }
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -10708,7 +10708,7 @@ void SketchObject::updateGeometryRefs() {
                     FC_ERR("External geometry reference corrupted in " << getFullName()
                             << " Please check.");
                     // This could happen if someone saved the sketch containing
-                    // external geometries using some rouge releases during the
+                    // external geometries using some rogue releases during the
                     // migration period. As a remedy, We re-initiate the
                     // external geometry here to trigger rebuild later, with
                     // call to rebuildExternalGeometry()

--- a/src/Mod/Spreadsheet/Gui/LineEdit.cpp
+++ b/src/Mod/Spreadsheet/Gui/LineEdit.cpp
@@ -49,7 +49,7 @@ void LineEdit::setDocumentObject(const App::DocumentObject* currentDocObj, bool 
 
     /* The code below is supposed to fix the input of an expression and to make the popup
      * functional. The input seems to be broken because of installed event filters. My solution is
-     * to readd the widget into the scene. Only a parentless widget can be added to the scene.
+     * to re-add the widget into the scene. Only a parentless widget can be added to the scene.
      * Making a widget parentless makes it lose its windowFlags, even if it is added to the scene.
      * So, the algorithm is to obtain globalPos, then to make the widget parentless,
      * to add it to the scene, setting the globalPos after. */

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
@@ -461,7 +461,7 @@ QPainterPath QGILeaderLine::makeLeaderPath(std::vector<QPointF> qPoints)
 
 //! returns the point (on the parent) to which the leader is attached.
 //! result is relative to the center of the unscaled, unrotated parent.
-//! result is is not inverted (Y grows upwards).
+//! result is not inverted (Y grows upwards).
 QPointF QGILeaderLine::getAttachFromFeature()
 {
     TechDraw::DrawLeaderLine* featLeader = getLeaderFeature();

--- a/tests/src/App/DocumentObserver.cpp
+++ b/tests/src/App/DocumentObserver.cpp
@@ -74,11 +74,11 @@ TEST_F(DISABLED_DocumentObserverTest, hasSubObject)
 
     // Assert
 
-    // The subname of subObjTWithoutSubObj doesn't contain the name of a sub object, therefor
+    // The subname of subObjTWithoutSubObj doesn't contain the name of a sub object, therefore
     // hasNoSubObj should be false
     EXPECT_FALSE(hasNoSubObj);
 
-    // The subname of subObjTWithSubObj doesn't contain the name of a sub object, therefor hasSubObj
+    // The subname of subObjTWithSubObj doesn't contain the name of a sub object, therefore hasSubObj
     // should be true
     EXPECT_TRUE(hasSubObj);
 }
@@ -118,11 +118,11 @@ TEST_F(DISABLED_DocumentObserverTest, hasSubElement)
 
     // Assert
 
-    // The subname of subObjTWithoutSubEl doesn't contain the name of a sub element, therefor
+    // The subname of subObjTWithoutSubEl doesn't contain the name of a sub element, therefore
     // hasNoSubEl should be false
     EXPECT_FALSE(hasNoSubEl);
 
-    // The subname of subObjTWithSubEl doesn't contain the name of a sub element, therefor hasSubEl
+    // The subname of subObjTWithSubEl doesn't contain the name of a sub element, therefore hasSubEl
     // should be true
     EXPECT_TRUE(hasSubEl);
 }

--- a/tests/src/App/DocumentObserver.cpp
+++ b/tests/src/App/DocumentObserver.cpp
@@ -78,8 +78,8 @@ TEST_F(DISABLED_DocumentObserverTest, hasSubObject)
     // hasNoSubObj should be false
     EXPECT_FALSE(hasNoSubObj);
 
-    // The subname of subObjTWithSubObj doesn't contain the name of a sub object, therefore hasSubObj
-    // should be true
+    // The subname of subObjTWithSubObj doesn't contain the name of a sub object, therefore
+    // hasSubObj should be true
     EXPECT_TRUE(hasSubObj);
 }
 

--- a/tests/src/Mod/Part/App/PartFeature.cpp
+++ b/tests/src/Mod/Part/App/PartFeature.cpp
@@ -111,7 +111,7 @@ TEST_F(FeaturePartTest, create)
     // without modifications
     EXPECT_STREQ(_doc->getObjectName(featureNoDoc), "Vertex");
 
-    // The feature is created in otherDoc, which doesn't have other features and thertherefor the
+    // The feature is created in otherDoc, which doesn't have other features and thertherefore the
     // feature's name will be assigned without modifications
     EXPECT_STREQ(otherDoc->getObjectName(feature), "Vertex");
 

--- a/tests/src/Mod/Part/App/WireJoiner.cpp
+++ b/tests/src/Mod/Part/App/WireJoiner.cpp
@@ -541,17 +541,17 @@ TEST_F(WireJoinerTest, setTolerance)
     wjtol.getOpenWires(wiretol, nullptr, false);
 
     wjNegatol.addShape(edgesNegatol);
-    // Setting atol to a negative value won't have effect and therefore wjNegatol.pimpl->myAngularTol
-    // will keep the default value.
-    // The tol value must be given in any case.
+    // Setting atol to a negative value won't have effect and therefore
+    // wjNegatol.pimpl->myAngularTol will keep the default value. The tol value must be given in any
+    // case.
     wjNegatol.setTolerance(-0.1, -pi);
     wjNegatol.Build();
     wjNegatol.getOpenWires(wireNegatol, nullptr, false);
 
     wjatol.addShape(edgesatol);
-    // Setting atol to a negative value won't have effect and therefore wjNegatol.pimpl->myAngularTol
-    // will keep the default value.
-    // We give also the tol value so that a closed wire can be created.
+    // Setting atol to a negative value won't have effect and therefore
+    // wjNegatol.pimpl->myAngularTol will keep the default value. We give also the tol value so that
+    // a closed wire can be created.
     wjatol.setTolerance(0.2, pi / 9);
     wjatol.Build();
     wjatol.getOpenWires(wireatol, nullptr, false);

--- a/tests/src/Mod/Part/App/WireJoiner.cpp
+++ b/tests/src/Mod/Part/App/WireJoiner.cpp
@@ -92,19 +92,19 @@ TEST_F(WireJoinerTest, addShape)
 
     wjTS.addShape(wireTS);
     wjTS.Build();
-    // The wire in wjTS is open, therefor to see the effect of wjTS.addShape() we must call
+    // The wire in wjTS is open, therefore to see the effect of wjTS.addShape() we must call
     // wjTS.getOpenWires() and put the result in wireTS
     wjTS.getOpenWires(wireTS, nullptr, false);
 
     wjvTS.addShape({edge1TS, edge2TS});
     wjvTS.Build();
-    // The wire in wjvTS is open, therefor to see the effect of wjvTS.addShape() we must call
+    // The wire in wjvTS is open, therefore to see the effect of wjvTS.addShape() we must call
     // wjvTS.getOpenWires() and put the result in wirevTS
     wjvTS.getOpenWires(wirevTS, nullptr, false);
 
     wjvTDS.addShape(edges);
     wjvTDS.Build();
-    // The wire in wjvTDS is closed, therefor to see the effect of wjvTDS.addShape() we can smply
+    // The wire in wjvTDS is closed, therefore to see the effect of wjvTDS.addShape() we can simply
     // call wjvTDS.Shape() to replace the shape in wirevTDS
     wirevTDS.setShape(wjvTDS.Shape());
 
@@ -452,12 +452,12 @@ TEST_F(WireJoinerTest, setMergeEdges)
     EXPECT_FALSE(wjNoBuild.IsDone());
 
     // In this case the number of edges is equal to 9 because all the 3 edges intersect the other 2
-    // and are therefor split in 3 edges each.
+    // and are therefore split in 3 edges each.
     EXPECT_EQ(wireNoMergeEdges.getSubTopoShapes(TopAbs_EDGE).size(), 9);
 
     // In this case the number of edges is equal to 6 because, among the 9 produced by
     // WireJoiner::WireJoinerP::splitEdges(), 3 of them are connected to more than one other edge
-    // and therefor aren't added by WireJoiner::WireJoinerP::findSuperEdges()
+    // and therefore aren't added by WireJoiner::WireJoinerP::findSuperEdges()
     EXPECT_EQ(wireMergeEdges.getSubTopoShapes(TopAbs_EDGE).size(), 6);
 }
 
@@ -524,7 +524,7 @@ TEST_F(WireJoinerTest, setTolerance)
     // WireJoiner::getOpenWires() to get the edges, if any, that aren't used to create a closed wire
 
     wjNegtol.addShape(edgesNegtol);
-    // Setting tol to a negative value won't have effect and therefor wjNegtol.pimpl->myTol will
+    // Setting tol to a negative value won't have effect and therefore wjNegtol.pimpl->myTol will
     // keep the default value.
     // It's better also to give a negative value for the argument atol otherwise setTolerance()
     // will set it to 0.0
@@ -541,7 +541,7 @@ TEST_F(WireJoinerTest, setTolerance)
     wjtol.getOpenWires(wiretol, nullptr, false);
 
     wjNegatol.addShape(edgesNegatol);
-    // Setting atol to a negative value won't have effect and therefor wjNegatol.pimpl->myAngularTol
+    // Setting atol to a negative value won't have effect and therefore wjNegatol.pimpl->myAngularTol
     // will keep the default value.
     // The tol value must be given in any case.
     wjNegatol.setTolerance(-0.1, -pi);
@@ -549,7 +549,7 @@ TEST_F(WireJoinerTest, setTolerance)
     wjNegatol.getOpenWires(wireNegatol, nullptr, false);
 
     wjatol.addShape(edgesatol);
-    // Setting atol to a negative value won't have effect and therefor wjNegatol.pimpl->myAngularTol
+    // Setting atol to a negative value won't have effect and therefore wjNegatol.pimpl->myAngularTol
     // will keep the default value.
     // We give also the tol value so that a closed wire can be created.
     wjatol.setTolerance(0.2, pi / 9);
@@ -570,7 +570,7 @@ TEST_F(WireJoinerTest, setTolerance)
     // In this case, as the gap between edge1 and edge3 is smaller than tol, a closed wire can be
     // created and it contains all the edges added with wjtol.addShape().
     EXPECT_EQ(TopoShape(wjtol.Shape()).getSubTopoShapes(TopAbs_EDGE).size(), 3);
-    // There are no open wires and therefor no edges that create them
+    // There are no open wires and therefore no edges that create them
     EXPECT_EQ(wiretol.getSubTopoShapes(TopAbs_EDGE).size(), 0);
 
     // In this case, as there's a gap between edge2, edge4 and edge5, no closed wires are created.
@@ -580,12 +580,12 @@ TEST_F(WireJoinerTest, setTolerance)
 
     // In this case, as the gap between edge2, edge4 and edge5 is smaller than tol, a closed wire
     // can be created.
-    // Because of atol, edge4 and edge5 are considerated as duplicates and therefor one of them is
+    // Because of atol, edge4 and edge5 are considerated as duplicates and therefore one of them is
     // removed by WireJoiner::WireJoinerP::add().
     // The closed wire is then created using all the edges added with wjatol.addShape() except the
     // removed one
     EXPECT_EQ(TopoShape(wjatol.Shape()).getSubTopoShapes(TopAbs_EDGE).size(), 3);
-    // There are no open wires and therefor no edges that create them
+    // There are no open wires and therefore no edges that create them
     EXPECT_EQ(wireatol.getSubTopoShapes(TopAbs_EDGE).size(), 0);
 }
 
@@ -665,7 +665,7 @@ TEST_F(WireJoinerTest, getOpenWires)
 
     // Assert
 
-    // All the edges added with wjNoOpenWires.addShape() are used to create a closed wire, therefor
+    // All the edges added with wjNoOpenWires.addShape() are used to create a closed wire, therefore
     // wireNoOpenWires should be null
     EXPECT_TRUE(wireNoOpenWires.isNull());
 
@@ -673,7 +673,7 @@ TEST_F(WireJoinerTest, getOpenWires)
     // except those ones that are split, and all the edges generated by splitting an edge with
     // another one.
     // edge1 and edge2 are left untouched, while edge4 is split in two at the intersection point
-    // (1.0, 1.0, 0.0), therefor 4 edges.
+    // (1.0, 1.0, 0.0), therefore 4 edges.
     EXPECT_EQ(wireOriginal.getSubTopoShapes(TopAbs_EDGE).size(), 4);
 
     // In this case wireNoOriginal should contain only the edges generated by splitting one of them
@@ -753,7 +753,7 @@ TEST_F(WireJoinerTest, getResultWires)
 
     // Assert
 
-    // All the edges added with wjNoResultWires.addShape() can't create a closed wire, therefor
+    // All the edges added with wjNoResultWires.addShape() can't create a closed wire, therefore
     // wireNoResultWires shouldn't have any edges
     // It's not possible to get an useful result from wireNoResultWires.isNull() because
     // WireJoiner::WireJoinerP::compound is always created by
@@ -801,7 +801,7 @@ TEST_F(WireJoinerTest, Build)
 
     // Assert
 
-    // theRange isn't used in WireJoiner::Build() and therefor not attached to any indicator.
+    // theRange isn't used in WireJoiner::Build() and therefore not attached to any indicator.
     // For more reference see
     // https://dev.opencascade.org/doc/occt-7.6.0/refman/html/class_message___progress_range.html
     // and
@@ -878,7 +878,7 @@ TEST_F(WireJoinerTest, Generated)
     // Assert
 
     // There aren't calls to WireJoiner::WireJoinerP::aHistory->AddGenerated() or similar methods in
-    // WireJoiner::WireJoinerP, therefor nothing is returned by calling
+    // WireJoiner::WireJoinerP, therefore nothing is returned by calling
     // WireJoiner::WireJoinerP::aHistory->Generated().
     // There's a call to WireJoiner::WireJoinerP::aHistory->Merge() that uses the history produced
     // by a ShapeFix_Wire object in WireJoiner::WireJoinerP::makeCleanWire() that however looks
@@ -921,11 +921,11 @@ TEST_F(WireJoinerTest, IsDeleted)
     EXPECT_FALSE(wjIsDeleted.IsDeleted(edge2));
     EXPECT_FALSE(wjIsDeleted.IsDeleted(edge3));
 
-    // edge4 is a duplicate of edge3 and therefor deleted
+    // edge4 is a duplicate of edge3 and therefore deleted
     EXPECT_TRUE(wjIsDeleted.IsDeleted(edge4));
 
     // edge5 is smaller that the smallest shape that can be considered with the given value of
-    // tolerance and therefor deleted
+    // tolerance and therefore deleted
     EXPECT_TRUE(wjIsDeleted.IsDeleted(edge5));
 }
 


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,addmin,ake,aline,alle,alledges,alocation,als,ang,anid,anormal,anull,aply,apoints,ba,beginn,behaviour,bloaded,bottome,brushin,bu,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childrens,childs,colour,colours,commen,connexion,currenty,documentin,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,findn,fle,freez,graphin,groupe,hist,iff,incrementin,indexin,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,itsel,kilometre,leadin,localy,lod,mantatory,matc,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oce,oder,ontop,orgin,orginx,orginy,ot,pard,parm,parms,pres,programm,que,rady,recurrance,renderin,re-use,re-used,re-using,rin,ro,rougly,sectionin,seperator,sergent,serie,shs,sinc,siz,som,stpo,strack,substraction,te,technic,thist,thru,tread,tru,ue,uint,unter,uupper,uptodate,vas,vertexes,vew,wallthickness,whitespaces -S "./.git,*.po,*.ts,*.pdf,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./src/Base/StackWalker.cpp,./build/doc/SourceDoc,./tools/build/WindowsInstaller/lang,./src/Mod/TechDraw/Templates/locale"`