### PR TITLE
BIM: Improve grid handling for some commands

### DIFF
--- a/src/Mod/BIM/bimcommands/BimCurtainwall.py
+++ b/src/Mod/BIM/bimcommands/BimCurtainwall.py
@@ -67,6 +67,7 @@ class Arch_CurtainWall:
             FreeCAD.ActiveDocument.recompute()
         else:
             # interactive line drawing
+            FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
             self.points = []
             import WorkingPlane
             WorkingPlane.get_working_plane()
@@ -79,11 +80,15 @@ class Arch_CurtainWall:
 
         if point is None:
             # cancelled
+            FreeCAD.activeDraftCommand = None
+            FreeCADGui.Snapper.off()
             return
         self.points.append(point)
         if len(self.points) == 1:
             FreeCADGui.Snapper.getPoint(last=self.points[0],callback=self.getPoint)
         elif len(self.points) == 2:
+            FreeCAD.activeDraftCommand = None
+            FreeCADGui.Snapper.off()
             FreeCADGui.Control.closeDialog()
             FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Curtain Wall"))
             FreeCADGui.addModule("Draft")

--- a/src/Mod/BIM/bimcommands/BimImagePlane.py
+++ b/src/Mod/BIM/bimcommands/BimImagePlane.py
@@ -61,6 +61,7 @@ class BIM_ImagePlane:
             translate("BIM", "Image file (*.png *.jpg *.bmp)"),
         )
         if filename:
+            FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
             self.filename = filename
             im = QtGui.QImage(self.filename)
             self.proportion = float(im.height()) / float(im.width())
@@ -90,6 +91,8 @@ class BIM_ImagePlane:
 
         if not point:
             # cancelled
+            FreeCAD.activeDraftCommand = None
+            FreeCADGui.Snapper.off()
             self.tracker.off()
             return
         elif not self.basepoint:
@@ -102,6 +105,8 @@ class BIM_ImagePlane:
             )
         else:
             # this is our second point
+            FreeCAD.activeDraftCommand = None
+            FreeCADGui.Snapper.off()
             self.tracker.off()
             midpoint = self.basepoint.add(
                 self.opposite.sub(self.basepoint).multiply(0.5)
@@ -111,7 +116,7 @@ class BIM_ImagePlane:
             length = DraftVecUtils.project(diagonal, FreeCAD.DraftWorkingPlane.u).Length
             height = DraftVecUtils.project(diagonal, FreeCAD.DraftWorkingPlane.v).Length
             FreeCAD.ActiveDocument.openTransaction("Create image plane")
-            image = FreeCAD.activeDocument().addObject(
+            image = FreeCAD.ActiveDocument.addObject(
                 "Image::ImagePlane", "ImagePlane"
             )
             image.Label = os.path.splitext(os.path.basename(self.filename))[0]

--- a/src/Mod/BIM/bimcommands/BimPanel.py
+++ b/src/Mod/BIM/bimcommands/BimPanel.py
@@ -88,8 +88,9 @@ class Arch_Panel:
             return
 
         # interactive mode
-        WorkingPlane.get_working_plane()
 
+        FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
+        WorkingPlane.get_working_plane()
         self.points = []
         self.tracker = DraftTrackers.boxTracker()
         self.tracker.width(self.Width)
@@ -105,6 +106,9 @@ class Arch_Panel:
         "this function is called by the snapper when it has a 3D point"
 
         import DraftVecUtils
+
+        FreeCAD.activeDraftCommand = None
+        FreeCADGui.Snapper.off()
         self.tracker.finalize()
         if point is None:
             FreeCAD.activeDraftCommand = None

--- a/src/Mod/BIM/bimcommands/BimPanel.py
+++ b/src/Mod/BIM/bimcommands/BimPanel.py
@@ -97,7 +97,6 @@ class Arch_Panel:
         self.tracker.height(self.Thickness)
         self.tracker.length(self.Length)
         self.tracker.on()
-        FreeCAD.activeDraftCommand = self
         FreeCADGui.Snapper.getPoint(callback=self.getPoint,movecallback=self.update,extradlg=self.taskbox())
         FreeCADGui.draftToolBar.continueCmd.show()
 
@@ -111,7 +110,6 @@ class Arch_Panel:
         FreeCADGui.Snapper.off()
         self.tracker.finalize()
         if point is None:
-            FreeCAD.activeDraftCommand = None
             return
         FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Panel"))
         FreeCADGui.addModule("Arch")
@@ -127,7 +125,6 @@ class Arch_Panel:
             FreeCADGui.doCommand('s.Placement.Rotation = FreeCAD.Rotation(FreeCAD.Vector(1.00,0.00,0.00),90.00)')
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()
-        FreeCAD.activeDraftCommand = None
         if FreeCADGui.draftToolBar.continueCmd.isChecked():
             self.Activated()
 

--- a/src/Mod/BIM/bimcommands/BimProfile.py
+++ b/src/Mod/BIM/bimcommands/BimProfile.py
@@ -52,6 +52,8 @@ class Arch_Profile:
     def Activated(self):
 
         import ArchProfile
+
+        FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
         self.Profile = None
         self.Categories = []
         self.Presets = ArchProfile.readPresets()
@@ -109,6 +111,8 @@ class Arch_Profile:
 
         "this function is called by the snapper when it has a 3D point"
 
+        FreeCAD.activeDraftCommand = None
+        FreeCADGui.Snapper.off()
         if not point:
             return
         if not self.Profile:

--- a/src/Mod/BIM/bimcommands/BimTruss.py
+++ b/src/Mod/BIM/bimcommands/BimTruss.py
@@ -60,8 +60,10 @@ class Arch_Truss:
             self.createTruss(basename)
         else:
             # interactive line drawing
-            self.points = []
             import WorkingPlane
+
+            FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
+            self.points = []
             WorkingPlane.get_working_plane()
             if hasattr(FreeCADGui,"Snapper"):
                 FreeCADGui.Snapper.getPoint(callback=self.getPoint)
@@ -72,11 +74,15 @@ class Arch_Truss:
 
         if point is None:
             # cancelled
+            FreeCAD.activeDraftCommand = None
+            FreeCADGui.Snapper.off()
             return
         self.points.append(point)
         if len(self.points) == 1:
             FreeCADGui.Snapper.getPoint(last=self.points[0],callback=self.getPoint)
         elif len(self.points) == 2:
+            FreeCAD.activeDraftCommand = None
+            FreeCADGui.Snapper.off()
             self.createTruss()
 
     def createTruss(self, basename=""):

--- a/src/Mod/BIM/bimcommands/BimWindow.py
+++ b/src/Mod/BIM/bimcommands/BimWindow.py
@@ -127,8 +127,9 @@ class Arch_Window:
                     return
 
         # interactive mode
-        self.wp = WorkingPlane.get_working_plane()
 
+        FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
+        self.wp = WorkingPlane.get_working_plane()
         self.tracker = DraftTrackers.boxTracker()
         self.tracker.length(self.Width)
         self.tracker.width(self.W1)
@@ -160,6 +161,9 @@ class Arch_Window:
         from draftutils import gui_utils
         from draftutils.messages import _wrn
         from ArchWindowPresets import WindowPresets
+
+        FreeCAD.activeDraftCommand = None
+        FreeCADGui.Snapper.off()
         self.tracker.off()
         if point is None:
             return


### PR DESCRIPTION
The updated commands did not handle the 2 grid options ("always", "only during commands") correctly. The proposed code follows the example of BimWall.py and ArchStructure.py where this issue has already been addressed.

Additionally: updated workingplane code in BimBox.py
