### PR TITLE
FEM: fix source typos

### DIFF
--- a/src/Mod/Fem/femexamples/ccx_cantilever_prescribeddisplacement.py
+++ b/src/Mod/Fem/femexamples/ccx_cantilever_prescribeddisplacement.py
@@ -80,7 +80,7 @@ def setup(doc=None, solvertype="ccxtools"):
     geom_obj = doc.Box
 
     # constraint displacement
-    con_disp = ObjectsFem.makeConstraintDisplacement(doc, name="ConstraintDisplacmentPrescribed")
+    con_disp = ObjectsFem.makeConstraintDisplacement(doc, name="ConstraintDisplacementPrescribed")
     con_disp.References = [(geom_obj, "Face2")]
     con_disp.zFree = False
     con_disp.zDisplacement = -250.0

--- a/src/Mod/Fem/femexamples/constraint_transform_beam_hinged.py
+++ b/src/Mod/Fem/femexamples/constraint_transform_beam_hinged.py
@@ -155,7 +155,7 @@ def setup(doc=None, solvertype="ccxtools"):
     analysis.addObject(con_pressure)
 
     # constraint displacement
-    con_disp = ObjectsFem.makeConstraintDisplacement(doc, name="FemConstraintDisplacment")
+    con_disp = ObjectsFem.makeConstraintDisplacement(doc, name="FemConstraintDisplacement")
     con_disp.References = [(geom_obj, "Face4"), (geom_obj, "Face5")]
     con_disp.xFree = False
     con_disp.xDisplacement = 0.0

--- a/src/Mod/Fem/femexamples/rc_wall_2d.py
+++ b/src/Mod/Fem/femexamples/rc_wall_2d.py
@@ -158,7 +158,7 @@ def setup(doc=None, solvertype="ccxtools"):
     analysis.addObject(con_force)
 
     # constraint displacement
-    con_disp = ObjectsFem.makeConstraintDisplacement(doc, "ConstraintDisplacmentPrescribed")
+    con_disp = ObjectsFem.makeConstraintDisplacement(doc, "ConstraintDisplacementPrescribed")
     con_disp.References = [(geom_obj, "Face1")]
     con_disp.zFree = False
     con_disp.zDisplacement = 0

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_prescribeddisplacement.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_prescribeddisplacement.inp
@@ -346,8 +346,8 @@ Evolumes
 
 ***********************************************************
 ** constraints displacement node sets
-** ConstraintDisplacmentPrescribed
-*NSET,NSET=ConstraintDisplacmentPrescribed
+** ConstraintDisplacementPrescribed
+*NSET,NSET=ConstraintDisplacementPrescribed
 1,
 2,
 3,
@@ -395,9 +395,9 @@ ConstraintFixed,3
 
 ***********************************************************
 ** Displacement constraint applied
-** ConstraintDisplacmentPrescribed
+** ConstraintDisplacementPrescribed
 *BOUNDARY
-ConstraintDisplacmentPrescribed,3,3,-250.0
+ConstraintDisplacementPrescribed,3,3,-250.0
 
 
 ***********************************************************
@@ -411,7 +411,7 @@ S, E
 *NODE PRINT, NSET=ConstraintFixed, TOTALS=ONLY
 RF
 ** reaction forces for Constraint displacement constraining translation
-*NODE PRINT, NSET=ConstraintDisplacmentPrescribed, TOTALS=ONLY
+*NODE PRINT, NSET=ConstraintDisplacementPrescribed, TOTALS=ONLY
 RF
 
 *OUTPUT, FREQUENCY=1

--- a/src/Mod/Fem/femtest/data/calculix/constraint_transform_beam_hinged.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_transform_beam_hinged.inp
@@ -3257,8 +3257,8 @@ Evolumes
 
 ***********************************************************
 ** constraints displacement node sets
-** FemConstraintDisplacment
-*NSET,NSET=FemConstraintDisplacment
+** FemConstraintDisplacement
+*NSET,NSET=FemConstraintDisplacement
 4,
 5,
 7,
@@ -3648,9 +3648,9 @@ Evolumes
 
 ***********************************************************
 ** Displacement constraint applied
-** FemConstraintDisplacment
+** FemConstraintDisplacement
 *BOUNDARY
-FemConstraintDisplacment,1,1,0.0
+FemConstraintDisplacement,1,1,0.0
 
 
 ***********************************************************
@@ -3785,7 +3785,7 @@ U
 S, E
 ** outputs --> dat file
 ** reaction forces for Constraint displacement constraining translation
-*NODE PRINT, NSET=FemConstraintDisplacment, TOTALS=ONLY
+*NODE PRINT, NSET=FemConstraintDisplacement, TOTALS=ONLY
 RF
 
 *OUTPUT, FREQUENCY=1


### PR DESCRIPTION
ConstraintDisplacmentPrescribed → ConstraintDisplacementPrescribed  
FemConstraintDisplacment → FemConstraintDisplacement

This has not been tested. Unsure if this is a breaking change.