### PR TITLE
Draft: Simplify working plane view observer callback

### DIFF
--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -1788,19 +1788,7 @@ if FreeCAD.GuiUp:
         except Exception:
             pass
 
-    def _view_observer_callback(sub_win):
-        if sub_win is None:
-            return
-        view = gui_utils.get_3d_view()
-        if view is None:
-            return
-        if not hasattr(FreeCADGui, "draftToolBar"):
-            return
-        tray = FreeCADGui.draftToolBar.tray
-        if tray is None:
-            return
-        if FreeCADGui.draftToolBar.tray.isVisible() is False:
-            return
+    def _view_observer_callback():
         ToDo.delay(_update_gui, None)
 
     _view_observer_active = False
@@ -1812,7 +1800,7 @@ if FreeCAD.GuiUp:
         if not _view_observer_active:
             mdi.subWindowActivated.connect(_view_observer_callback)
             _view_observer_active = True
-            _view_observer_callback(mdi.activeSubWindow())  # Trigger initial update.
+            _view_observer_callback()  # Trigger initial update.
 
     def _view_observer_stop():
         mw = FreeCADGui.getMainWindow()


### PR DESCRIPTION
The old callback contained unnecessary checks that prevented the working plane from working correctly if the Tray was missing.
