### PR TITLE
Base: Use explicit pointer syntax for freecad_cast

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1630,9 +1630,9 @@ std::vector<App::DocumentObject*> Document::importObjects(Base::XMLReader& reade
             o->setStatus(App::ObjImporting, true);
             FC_LOG("importing " << o->getFullName());
             if (auto propUUID =
-                    freecad_cast<PropertyUUID>(o->getPropertyByName("_ObjectUUID"))) {
+                    freecad_cast<PropertyUUID*>(o->getPropertyByName("_ObjectUUID"))) {
                 auto propSource =
-                    freecad_cast<PropertyUUID>(o->getPropertyByName("_SourceUUID"));
+                    freecad_cast<PropertyUUID*>(o->getPropertyByName("_SourceUUID"));
                 if (!propSource) {
                     propSource = static_cast<PropertyUUID*>(
                         o->addDynamicProperty("App::PropertyUUID",
@@ -2439,7 +2439,7 @@ bool Document::afterRestore(const std::vector<DocumentObject*>& objArray, bool c
             // refresh properties in case the object changes its property list
             obj->getPropertyList(props);
             for (auto prop : props) {
-                auto link = freecad_cast<PropertyLinkBase>(prop);
+                auto link = freecad_cast<PropertyLinkBase*>(prop);
                 int res;
                 std::string errMsg;
                 if (link && (res = link->checkRestore(&errMsg))) {
@@ -3987,7 +3987,7 @@ Document::importLinks(const std::vector<App::DocumentObject*>& objArray)
         propList.clear();
         obj->getPropertyList(propList);
         for (auto prop : propList) {
-            auto linkProp = freecad_cast<PropertyLinkBase>(prop);
+            auto linkProp = freecad_cast<PropertyLinkBase*>(prop);
             if (linkProp && !prop->testStatus(Property::Immutable) && !obj->isReadOnly(prop)) {
                 auto copy = linkProp->CopyOnImportExternal(nameMap);
                 if (copy) {

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -949,7 +949,7 @@ DocumentObject* DocumentObject::getSubObject(const char* subname,
     // objects (think of the claimed children of a Fusion). But I do think we
     // should change that.
     if (transform && mat) {
-        auto pla = freecad_cast<PropertyPlacement>(getPropertyByName("Placement"));
+        auto pla = freecad_cast<PropertyPlacement*>(getPropertyByName("Placement"));
         if (pla) {
             *mat *= pla->getValue().toMatrix();
         }
@@ -1476,7 +1476,7 @@ bool DocumentObject::adjustRelativeLinks(const std::set<App::DocumentObject*>& i
     std::vector<Property*> props;
     getPropertyList(props);
     for (auto prop : props) {
-        auto linkProp = freecad_cast<PropertyLinkBase>(prop);
+        auto linkProp = freecad_cast<PropertyLinkBase*>(prop);
         if (linkProp && linkProp->adjustLink(inList)) {
             touched = true;
         }
@@ -1495,7 +1495,7 @@ bool DocumentObject::adjustRelativeLinks(const std::set<App::DocumentObject*>& i
 
 std::string DocumentObject::getElementMapVersion(const App::Property* _prop, bool restored) const
 {
-    auto prop = freecad_cast<const PropertyComplexGeoData>(_prop);
+    auto prop = freecad_cast<const PropertyComplexGeoData*>(_prop);
     if (!prop) {
         return std::string();
     }
@@ -1504,7 +1504,7 @@ std::string DocumentObject::getElementMapVersion(const App::Property* _prop, boo
 
 bool DocumentObject::checkElementMapVersion(const App::Property* _prop, const char* ver) const
 {
-    auto prop = freecad_cast<const PropertyComplexGeoData>(_prop);
+    auto prop = freecad_cast<const PropertyComplexGeoData*>(_prop);
     if (!prop) {
         return false;
     }

--- a/src/App/DocumentObserver.h
+++ b/src/App/DocumentObserver.h
@@ -148,12 +148,12 @@ public:
     template<typename T>
     inline T* getObjectAs() const
     {
-        return freecad_cast<T>(getObject());
+        return freecad_cast<T*>(getObject());
     }
     template<typename T>
     inline T* getPropertyAs() const
     {
-        return freecad_cast<T>(getProperty());
+        return freecad_cast<T*>(getProperty());
     }
 
 private:
@@ -409,7 +409,7 @@ public:
     template<typename T>
     inline T* get() const noexcept
     {
-        return freecad_cast<T>(_get());
+        return freecad_cast<T*>(_get());
     }
 
 private:

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1478,7 +1478,7 @@ Expression *OperatorExpression::simplify() const
     Expression * v2 = right->simplify();
 
     // Both arguments reduced to numerics? Then evaluate and return answer
-    if (freecad_cast<NumberExpression>(v1) && freecad_cast<NumberExpression>(v2)) {
+    if (freecad_cast<NumberExpression*>(v1) && freecad_cast<NumberExpression*>(v2)) {
         delete v1;
         delete v2;
         return eval();
@@ -1499,7 +1499,7 @@ void OperatorExpression::_toString(std::ostream &s, bool persistent,int) const
     Operator leftOperator(NONE), rightOperator(NONE);
 
     needsParens = false;
-    if (freecad_cast<OperatorExpression>(left))
+    if (freecad_cast<OperatorExpression*>(left))
         leftOperator = static_cast<OperatorExpression*>(left)->op;
     if (left->priority() < priority()) // Check on operator priority first
         needsParens = true;
@@ -1571,7 +1571,7 @@ void OperatorExpression::_toString(std::ostream &s, bool persistent,int) const
     }
 
     needsParens = false;
-    if (freecad_cast<OperatorExpression>(right))
+    if (freecad_cast<OperatorExpression*>(right))
         rightOperator = static_cast<OperatorExpression*>(right)->op;
     if (right->priority() < priority()) // Check on operator priority first
         needsParens = true;
@@ -2012,11 +2012,11 @@ Py::Object FunctionExpression::evalAggregate(
                 if (!p)
                     continue;
 
-                if ((qp = freecad_cast<PropertyQuantity>(p)))
+                if ((qp = freecad_cast<PropertyQuantity*>(p)))
                     c->collect(qp->getQuantityValue());
-                else if ((fp = freecad_cast<PropertyFloat>(p)))
+                else if ((fp = freecad_cast<PropertyFloat*>(p)))
                     c->collect(Quantity(fp->getValue()));
-                else if ((ip = freecad_cast<PropertyInteger>(p)))
+                else if ((ip = freecad_cast<PropertyInteger*>(p)))
                     c->collect(Quantity(ip->getValue()));
                 else
                     _EXPR_THROW("Invalid property type for aggregate.", owner);
@@ -2614,7 +2614,7 @@ Expression *FunctionExpression::simplify() const
     for (auto it : args) {
         Expression * v = it->simplify();
 
-        if (freecad_cast<NumberExpression>(v))
+        if (freecad_cast<NumberExpression*>(v))
             ++numerics;
         a.push_back(v);
     }
@@ -2869,16 +2869,16 @@ void VariableExpression::addComponent(Component *c) {
         }
         long l1=0,l2=0,l3=1;
         if(c->e3) {
-            auto n3 = freecad_cast<NumberExpression>(c->e3);
+            auto n3 = freecad_cast<NumberExpression*>(c->e3);
             if(!n3 || !essentiallyEqual(n3->getValue(),(double)l3))
                 break;
         }
         if(c->e1) {
-            auto n1 = freecad_cast<NumberExpression>(c->e1);
+            auto n1 = freecad_cast<NumberExpression*>(c->e1);
             if(!n1) {
                 if(c->e2 || c->e3)
                     break;
-                auto s = freecad_cast<StringExpression>(c->e1);
+                auto s = freecad_cast<StringExpression*>(c->e1);
                 if(!s)
                     break;
                 var << ObjectIdentifier::MapComponent(
@@ -2895,7 +2895,7 @@ void VariableExpression::addComponent(Component *c) {
                 return;
             }
         }
-        auto n2 = freecad_cast<NumberExpression>(c->e2);
+        auto n2 = freecad_cast<NumberExpression*>(c->e2);
         if(n2 && essentiallyInteger(n2->getValue(),l2)) {
             var << ObjectIdentifier::RangeComponent(l1,l2,l3);
             return;
@@ -3195,7 +3195,7 @@ Py::Object ConditionalExpression::_getPyValue() const {
 Expression *ConditionalExpression::simplify() const
 {
     std::unique_ptr<Expression> e(condition->simplify());
-    NumberExpression * v = freecad_cast<NumberExpression>(e.get());
+    NumberExpression * v = freecad_cast<NumberExpression*>(e.get());
 
     if (!v)
         return new ConditionalExpression(owner, condition->simplify(), trueExpr->simplify(), falseExpr->simplify());
@@ -3752,11 +3752,11 @@ UnitExpression * ExpressionParser::parseUnit(const App::DocumentObject *owner, c
     Expression * simplified = ScanResult->simplify();
 
     if (!unitExpression) {
-        OperatorExpression * fraction = freecad_cast<OperatorExpression>(ScanResult);
+        OperatorExpression * fraction = freecad_cast<OperatorExpression*>(ScanResult);
 
         if (fraction && fraction->getOperator() == OperatorExpression::DIV) {
-            NumberExpression * nom = freecad_cast<NumberExpression>(fraction->getLeft());
-            UnitExpression * denom = freecad_cast<UnitExpression>(fraction->getRight());
+            NumberExpression * nom = freecad_cast<NumberExpression*>(fraction->getLeft());
+            UnitExpression * denom = freecad_cast<UnitExpression*>(fraction->getRight());
 
             // If not initially a unit expression, but value is equal to 1, it means the expression is something like 1/unit
             if (denom && nom && essentiallyEqual(nom->getValue(), 1.0))
@@ -3766,13 +3766,13 @@ UnitExpression * ExpressionParser::parseUnit(const App::DocumentObject *owner, c
     delete ScanResult;
 
     if (unitExpression) {
-        NumberExpression * num = freecad_cast<NumberExpression>(simplified);
+        NumberExpression * num = freecad_cast<NumberExpression*>(simplified);
 
         if (num) {
            simplified = new UnitExpression(num->getOwner(), num->getQuantity());
             delete num;
         }
-        return freecad_cast<UnitExpression>(simplified);
+        return freecad_cast<UnitExpression*>(simplified);
     }
     else {
         delete simplified;

--- a/src/App/Expression.h
+++ b/src/App/Expression.h
@@ -84,7 +84,7 @@ template<class P> class ExpressionModifier : public ExpressionVisitor {
 public:
     explicit ExpressionModifier(P & _prop)
         : prop(_prop)
-        , propLink(freecad_cast<App::PropertyLinkBase>(&prop))
+        , propLink(freecad_cast<App::PropertyLinkBase*>(&prop))
         , signaller(_prop,false)
     {}
 

--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -160,11 +160,11 @@ DocumentObject* GeoFeature::resolveElement(const DocumentObject* obj,
         return nullptr;
     }
     auto linked = sobj->getLinkedObject(true);
-    auto geo = freecad_cast<GeoFeature>(linked);
+    auto geo = freecad_cast<GeoFeature*>(linked);
     if (!geo && linked) {
         auto ext = linked->getExtensionByType<LinkBaseExtension>(true);
         if (ext) {
-            geo = freecad_cast<GeoFeature>(ext->getTrueLinkedObject(true));
+            geo = freecad_cast<GeoFeature*>(ext->getTrueLinkedObject(true));
         }
     }
     if (geoFeature) {

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -285,7 +285,7 @@ std::vector<DocumentObject*> GeoFeatureGroupExtension::getScopedObjectsFromLink(
     }
 
     std::vector<App::DocumentObject*> result;
-    auto link = freecad_cast<PropertyLinkBase>(prop);
+    auto link = freecad_cast<PropertyLinkBase*>(prop);
     if (link && link->getScope() == scope) {
         link->getLinks(result);
     }

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -414,7 +414,7 @@ bool GroupExtension::extensionGetSubObject(DocumentObject*& ret,
 {
     const char* dot;
     if (!subname || *subname == 0) {
-        auto obj = freecad_cast<const DocumentObject>(getExtendedContainer());
+        auto obj = freecad_cast<const DocumentObject*>(getExtendedContainer());
         ret = const_cast<DocumentObject*>(obj);
         return true;
     }

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -286,7 +286,7 @@ void LinkBaseExtension::setProperty(int idx, Property* prop)
         }
         case PropLinkCopyOnChangeSource:
         case PropLinkCopyOnChangeGroup:
-            if (auto linkProp = freecad_cast<PropertyLinkBase>(prop)) {
+            if (auto linkProp = freecad_cast<PropertyLinkBase*>(prop)) {
                 linkProp->setScope(LinkScope::Global);
             }
             // fall through
@@ -356,7 +356,7 @@ App::DocumentObjectExecReturn* LinkBaseExtension::extensionExecute()
         if (!linked) {
             std::ostringstream ss;
             ss << "Link broken!";
-            auto xlink = freecad_cast<PropertyXLink>(getLinkedObjectProperty());
+            auto xlink = freecad_cast<PropertyXLink*>(getLinkedObjectProperty());
             if (xlink) {
                 const char* objname = xlink->getObjectName();
                 if (!Base::Tools::isNullOrEmpty(objname)) {
@@ -389,7 +389,7 @@ App::DocumentObjectExecReturn* LinkBaseExtension::extensionExecute()
                 || !container->getDocument()->getObjectByID(_LinkOwner.getValue()))) {
             // Check if this is an element link. Do not invoke appLinkExecute()
             // if so, because it will be called from the link array.
-            proxy = freecad_cast<PropertyPythonObject>(
+            proxy = freecad_cast<PropertyPythonObject*>(
                 linked->getPropertyByName("Proxy"));
         }
         if (proxy) {
@@ -491,7 +491,7 @@ LinkBaseExtension::getOnChangeCopyObjects(std::vector<App::DocumentObject*>* exc
             continue;
         }
         auto prop =
-            freecad_cast<PropertyMap>(obj->getPropertyByName("_CopyOnChangeControl"));
+            freecad_cast<PropertyMap*>(obj->getPropertyByName("_CopyOnChangeControl"));
         static std::map<std::string, std::string> dummy;
         const auto& map = prop && prop->getContainer() == obj ? prop->getValues() : dummy;
         const char* v = "";
@@ -526,7 +526,7 @@ void LinkBaseExtension::setOnChangeCopyObject(App::DocumentObject* obj, OnChange
     bool exclude = flags.testFlag(OnChangeCopyOptions::Exclude);
     bool external = parent->getDocument() != obj->getDocument();
     auto prop =
-        freecad_cast<PropertyMap>(obj->getPropertyByName("_CopyOnChangeControl"));
+        freecad_cast<PropertyMap*>(obj->getPropertyByName("_CopyOnChangeControl"));
 
     if (external == exclude && !prop) {
         return;
@@ -583,7 +583,7 @@ void LinkBaseExtension::syncCopyOnChange()
     // dependencies.
     LinkGroup* copyOnChangeGroup = nullptr;
     if (auto prop = getLinkCopyOnChangeGroupProperty()) {
-        copyOnChangeGroup = freecad_cast<LinkGroup>(prop->getValue());
+        copyOnChangeGroup = freecad_cast<LinkGroup*>(prop->getValue());
         if (!copyOnChangeGroup) {
             // Create the LinkGroup if not exist
             auto group = new LinkGroup;
@@ -601,7 +601,7 @@ void LinkBaseExtension::syncCopyOnChange()
                     continue;
                 }
                 auto prop =
-                    freecad_cast<PropertyUUID>(obj->getPropertyByName("_SourceUUID"));
+                    freecad_cast<PropertyUUID*>(obj->getPropertyByName("_SourceUUID"));
                 if (prop && prop->getContainer() == obj) {
                     oldObjs.emplace_back(prop);
                 }
@@ -665,7 +665,7 @@ void LinkBaseExtension::syncCopyOnChange()
 
     std::map<Base::Uuid, App::DocumentObjectT> newObjs;
     for (auto obj : copiedObjs) {
-        auto prop = freecad_cast<PropertyUUID>(obj->getPropertyByName("_SourceUUID"));
+        auto prop = freecad_cast<PropertyUUID*>(obj->getPropertyByName("_SourceUUID"));
         if (prop) {
             newObjs.insert(std::make_pair(prop->getValue(), obj));
         }
@@ -673,7 +673,7 @@ void LinkBaseExtension::syncCopyOnChange()
 
     std::vector<std::pair<App::DocumentObject*, App::DocumentObject*>> replacements;
     for (const auto& objT : oldObjs) {
-        auto prop = freecad_cast<PropertyUUID>(objT.getProperty());
+        auto prop = freecad_cast<PropertyUUID*>(objT.getProperty());
         if (!prop) {
             continue;
         }
@@ -707,7 +707,7 @@ void LinkBaseExtension::syncCopyOnChange()
                     if (prop->getContainer() != o) {
                         continue;
                     }
-                    auto linkProp = freecad_cast<App::PropertyLinkBase>(prop);
+                    auto linkProp = freecad_cast<App::PropertyLinkBase*>(prop);
                     if (!linkProp) {
                         continue;
                     }
@@ -1739,7 +1739,7 @@ void LinkBaseExtension::parseSubName() const
     bool hasSubElement = !mySubElements.empty();
     mySubElements.clear();
     mySubName.clear();
-    auto xlink = freecad_cast<const PropertyXLink>(getLinkedObjectProperty());
+    auto xlink = freecad_cast<const PropertyXLink*>(getLinkedObjectProperty());
     if (!xlink || xlink->getSubValues().empty()) {
         if (hasSubElement) {
             mySubElements.emplace_back("");
@@ -1896,7 +1896,7 @@ void LinkBaseExtension::update(App::DocumentObject* parent, const Property* prop
             std::vector<Base::Vector3d> scales;
             scales.reserve(objs.size());
             for (auto obj : objs) {
-                auto element = freecad_cast<LinkElement>(obj);
+                auto element = freecad_cast<LinkElement*>(obj);
                 if (element) {
                     placements.push_back(element->Placement.getValue());
                     scales.push_back(element->getScaleVector());
@@ -1990,7 +1990,7 @@ void LinkBaseExtension::update(App::DocumentObject* parent, const Property* prop
                     // It is possible to have orphan LinkElement here due to,
                     // for example, undo and redo. So we try to re-claim the
                     // children element first.
-                    auto obj = freecad_cast<LinkElement>(doc->getObject(name.c_str()));
+                    auto obj = freecad_cast<LinkElement*>(doc->getObject(name.c_str()));
                     if (obj
                         && (!obj->_LinkOwner.getValue() || obj->_LinkOwner.getValue() == ownerID)) {
                         obj->Visibility.setValue(false);
@@ -2034,7 +2034,7 @@ void LinkBaseExtension::update(App::DocumentObject* parent, const Property* prop
                 auto owner = getContainer();
                 long ownerID = owner ? owner->getID() : 0;
                 while (objs.size() > elementCount) {
-                    auto element = freecad_cast<LinkElement>(objs.back());
+                    auto element = freecad_cast<LinkElement*>(objs.back());
                     if (element && element->_LinkOwner.getValue() == ownerID) {
                         tmpObjs.push_back(objs.back());
                     }
@@ -2201,13 +2201,13 @@ void LinkBaseExtension::syncElementList()
 {
     auto transform = getLinkTransformProperty();
     auto link = getLinkedObjectProperty();
-    auto xlink = freecad_cast<const PropertyXLink>(link);
+    auto xlink = freecad_cast<const PropertyXLink*>(link);
 
     auto owner = getContainer();
     auto ownerID = owner ? owner->getID() : 0;
     auto elements = getElementListValue();
     for (auto i : elements) {
-        auto element = freecad_cast<LinkElement>(i);
+        auto element = freecad_cast<LinkElement*>(i);
         if (!element
             || (element->_LinkOwner.getValue() && element->_LinkOwner.getValue() != ownerID)) {
             continue;
@@ -2251,7 +2251,7 @@ void LinkBaseExtension::onExtendedDocumentRestored()
         hasOldSubElement = false;
         // SubElements was stored as a PropertyStringList. It is now migrated to be
         // stored inside PropertyXLink.
-        auto xlink = freecad_cast<PropertyXLink>(getLinkedObjectProperty());
+        auto xlink = freecad_cast<PropertyXLink*>(getLinkedObjectProperty());
         if (!xlink) {
             FC_ERR("Failed to restore SubElements for " << parent->getFullName());
         }
@@ -2393,7 +2393,7 @@ void LinkBaseExtension::setLink(int index,
                     link->Label.setValue(linked->Label.getValue());
                 }
                 auto pla =
-                    freecad_cast<PropertyPlacement>(obj->getPropertyByName("Placement"));
+                    freecad_cast<PropertyPlacement*>(obj->getPropertyByName("Placement"));
                 if (pla) {
                     link->Placement.setValue(pla->getValue());
                 }
@@ -2424,7 +2424,7 @@ void LinkBaseExtension::setLink(int index,
 
     // Here means we are assigning a Link
 
-    auto xlink = freecad_cast<PropertyXLink>(linkProp);
+    auto xlink = freecad_cast<PropertyXLink*>(linkProp);
     if (obj) {
         if (!obj->isAttachedToDocument()) {
             LINK_THROW(Base::ValueError, "Invalid document object");

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -119,7 +119,7 @@ ObjectIdentifier::ObjectIdentifier(const App::PropertyContainer* _owner,
     , _hash(0)
 {
     if (_owner) {
-        const DocumentObject* docObj = freecad_cast<const DocumentObject>(_owner);
+        const DocumentObject* docObj = freecad_cast<const DocumentObject*>(_owner);
         if (!docObj) {
             FC_THROWM(Base::RuntimeError, "Property must be owned by a document object.");
         }
@@ -145,7 +145,7 @@ ObjectIdentifier::ObjectIdentifier(const App::PropertyContainer* _owner, bool lo
     , _hash(0)
 {
     if (_owner) {
-        const DocumentObject* docObj = freecad_cast<const DocumentObject>(_owner);
+        const DocumentObject* docObj = freecad_cast<const DocumentObject*>(_owner);
         if (!docObj) {
             FC_THROWM(Base::RuntimeError, "Property must be owned by a document object.");
         }
@@ -166,7 +166,7 @@ ObjectIdentifier::ObjectIdentifier(const Property& prop, int index)
     , localProperty(false)
     , _hash(0)
 {
-    DocumentObject* docObj = freecad_cast<DocumentObject>(prop.getContainer());
+    DocumentObject* docObj = freecad_cast<DocumentObject*>(prop.getContainer());
 
     if (!docObj) {
         FC_THROWM(Base::TypeError, "Property must be owned by a document object.");
@@ -1364,7 +1364,7 @@ ObjectIdentifier ObjectIdentifier::relativeTo(const ObjectIdentifier& other) con
 ObjectIdentifier ObjectIdentifier::parse(const DocumentObject* docObj, const std::string& str)
 {
     std::unique_ptr<Expression> expr(ExpressionParser::parse(docObj, str.c_str()));
-    VariableExpression* v = freecad_cast<VariableExpression>(expr.get());
+    VariableExpression* v = freecad_cast<VariableExpression*>(expr.get());
 
     if (v) {
         return v->getPath();
@@ -1853,12 +1853,12 @@ ObjectIdentifier::access(const ResolveResults& result, Py::Object* value, Depend
         }
         if (prop && prop->getContainer() != obj) {
             auto linkTouched =
-                freecad_cast<PropertyBool>(obj->getPropertyByName("_LinkTouched"));
+                freecad_cast<PropertyBool*>(obj->getPropertyByName("_LinkTouched"));
             if (linkTouched) {
                 propName = linkTouched->getName();
             }
             else {
-                auto propOwner = freecad_cast<DocumentObject>(prop->getContainer());
+                auto propOwner = freecad_cast<DocumentObject*>(prop->getContainer());
                 if (propOwner) {
                     obj = propOwner;
                 }

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -247,7 +247,7 @@ PyObject* PropertyContainerPy::setPropertyStatus(PyObject* args)
         return nullptr;
     }
 
-    auto linkProp = freecad_cast<App::PropertyLinkBase>(prop);
+    auto linkProp = freecad_cast<App::PropertyLinkBase*>(prop);
     std::bitset<32> status(prop->getStatus());
 
     std::vector<Py::Object> items;
@@ -326,7 +326,7 @@ PyObject* PropertyContainerPy::getPropertyStatus(PyObject* args)
             return nullptr;
         }
 
-        auto linkProp = freecad_cast<App::PropertyLinkBase>(prop);
+        auto linkProp = freecad_cast<App::PropertyLinkBase*>(prop);
         if (linkProp && linkProp->testFlag(App::PropertyLinkBase::LinkAllowPartial)) {
             ret.append(Py::String("AllowPartial"));
         }

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -408,7 +408,7 @@ void PropertyExpressionEngine::buildGraphStructures(
 
 ObjectIdentifier PropertyExpressionEngine::canonicalPath(const ObjectIdentifier& p) const
 {
-    DocumentObject* docObj = freecad_cast<DocumentObject>(getContainer());
+    DocumentObject* docObj = freecad_cast<DocumentObject*>(getContainer());
 
     // Am I owned by a DocumentObject?
     if (!docObj) {
@@ -448,7 +448,7 @@ size_t PropertyExpressionEngine::numExpressions() const
 
 void PropertyExpressionEngine::afterRestore()
 {
-    DocumentObject* docObj = freecad_cast<DocumentObject>(getContainer());
+    DocumentObject* docObj = freecad_cast<DocumentObject*>(getContainer());
     if (restoredExpressions && docObj) {
         Base::FlagToggler<bool> flag(restoring);
         AtomicPropertyChange signaller(*this);
@@ -669,7 +669,7 @@ PropertyExpressionEngine::computeEvaluationOrder(ExecuteOption option)
 DocumentObjectExecReturn* App::PropertyExpressionEngine::execute(ExecuteOption option,
                                                                  bool* touched)
 {
-    DocumentObject* docObj = freecad_cast<DocumentObject>(getContainer());
+    DocumentObject* docObj = freecad_cast<DocumentObject*>(getContainer());
 
     if (!docObj) {
         throw Base::RuntimeError("PropertyExpressionEngine must be owned by a DocumentObject.");
@@ -739,7 +739,7 @@ DocumentObjectExecReturn* App::PropertyExpressionEngine::execute(ExecuteOption o
             throw Base::RuntimeError("Path does not resolve to a property.");
         }
 
-        DocumentObject* parent = freecad_cast<DocumentObject>(prop->getContainer());
+        DocumentObject* parent = freecad_cast<DocumentObject*>(prop->getContainer());
 
         /* Make sure property belongs to the same container as this PropertyExpressionEngine */
         if (parent != docObj) {
@@ -808,7 +808,7 @@ void PropertyExpressionEngine::getPathsToDocumentObject(
     DocumentObject* obj,
     std::vector<App::ObjectIdentifier>& paths) const
 {
-    DocumentObject* owner = freecad_cast<DocumentObject>(getContainer());
+    DocumentObject* owner = freecad_cast<DocumentObject*>(getContainer());
 
     if (!owner || owner == obj) {
         return;

--- a/src/App/PropertyGeo.cpp
+++ b/src/App/PropertyGeo.cpp
@@ -1301,7 +1301,7 @@ std::string PropertyComplexGeoData::getElementMapVersion(bool) const
     if (!data) {
         return std::string();
     }
-    auto owner = freecad_cast<DocumentObject>(getContainer());
+    auto owner = freecad_cast<DocumentObject*>(getContainer());
     std::ostringstream ss;
     if (owner && owner->getDocument() && owner->getDocument()->getStringHasher() == data->Hasher) {
         ss << "1.";
@@ -1319,7 +1319,7 @@ bool PropertyComplexGeoData::checkElementMapVersion(const char* ver) const
     if (!data) {
         return false;
     }
-    auto owner = freecad_cast<DocumentObject>(getContainer());
+    auto owner = freecad_cast<DocumentObject*>(getContainer());
     std::ostringstream ss;
     const char* prefix;
     if (owner && owner->getDocument() && owner->getDocument()->getStringHasher() == data->Hasher) {
@@ -1340,7 +1340,7 @@ void PropertyComplexGeoData::afterRestore()
     auto data = getComplexData();
     if (data && data->isRestoreFailed()) {
         data->resetRestoreFailure();
-        auto owner = freecad_cast<DocumentObject>(getContainer());
+        auto owner = freecad_cast<DocumentObject*>(getContainer());
         if (owner && owner->getDocument()
             && !owner->getDocument()->testStatus(App::Document::PartialDoc)) {
             owner->getDocument()->addRecomputeObject(owner);

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -249,7 +249,7 @@ static std::string propertyName(const Property* prop)
         return {};
     }
     if (!prop->getContainer() || !prop->hasName()) {
-        auto xlink = freecad_cast<const PropertyXLink>(prop);
+        auto xlink = freecad_cast<const PropertyXLink*>(prop);
         if (xlink) {
             return propertyName(xlink->parent());
         }
@@ -976,7 +976,7 @@ void PropertyLinkList::setValues(const std::vector<DocumentObject*>& value)
         return;
     }
 
-    auto parent = freecad_cast<App::DocumentObject>(getContainer());
+    auto parent = freecad_cast<App::DocumentObject*>(getContainer());
     for (auto obj : value) {
         if (!obj || !obj->isAttachedToDocument()) {
             throw Base::ValueError("PropertyLinkList: invalid document object");
@@ -1321,7 +1321,7 @@ void PropertyLinkSub::setValue(App::DocumentObject* lValue,
                                std::vector<std::string>&& subs,
                                std::vector<ShadowSub>&& shadows)
 {
-    auto parent = freecad_cast<App::DocumentObject>(getContainer());
+    auto parent = freecad_cast<App::DocumentObject*>(getContainer());
     if (lValue) {
         if (!lValue->isAttachedToDocument()) {
             throw Base::ValueError("PropertyLinkSub: invalid document object");
@@ -2216,7 +2216,7 @@ int PropertyLinkSubList::getSize() const
 
 void PropertyLinkSubList::setValue(DocumentObject* lValue, const char* SubName)
 {
-    auto parent = freecad_cast<App::DocumentObject>(getContainer());
+    auto parent = freecad_cast<App::DocumentObject*>(getContainer());
     verifyObject(lValue, parent);
 
     // maintain backlinks
@@ -2255,7 +2255,7 @@ void PropertyLinkSubList::setValue(DocumentObject* lValue, const char* SubName)
 void PropertyLinkSubList::setValues(const std::vector<DocumentObject*>& lValue,
                                     const std::vector<const char*>& lSubNames)
 {
-    auto parent = freecad_cast<App::DocumentObject>(getContainer());
+    auto parent = freecad_cast<App::DocumentObject*>(getContainer());
     for (auto obj : lValue) {
         verifyObject(obj, parent);
     }
@@ -2316,7 +2316,7 @@ void PropertyLinkSubList::setValues(std::vector<DocumentObject*>&& lValue,
                                     std::vector<std::string>&& lSubNames,
                                     std::vector<ShadowSub>&& ShadowSubList)
 {
-    auto parent = freecad_cast<App::DocumentObject>(getContainer());
+    auto parent = freecad_cast<App::DocumentObject*>(getContainer());
     for (auto obj : lValue) {
         verifyObject(obj, parent);
     }
@@ -2411,7 +2411,7 @@ void PropertyLinkSubList::addValue(App::DocumentObject* obj,
                                    const std::vector<std::string>& subs,
                                    bool reset)
 {
-    auto parent = freecad_cast<App::DocumentObject>(getContainer());
+    auto parent = freecad_cast<App::DocumentObject*>(getContainer());
     verifyObject(obj, parent);
 
     // maintain backlinks.
@@ -2729,7 +2729,7 @@ void PropertyLinkSubList::updateElementReference(DocumentObject* feature, bool r
         unregisterElementReference();
     }
     _ShadowSubList.resize(_lSubList.size());
-    auto owner = freecad_cast<DocumentObject>(getContainer());
+    auto owner = freecad_cast<DocumentObject*>(getContainer());
     if (owner && owner->isRestoring()) {
         return;
     }
@@ -3370,7 +3370,7 @@ public:
 
         if (info->pcDoc) {
             // make sure to attach only external object
-            auto owner = freecad_cast<DocumentObject>(l->getContainer());
+            auto owner = freecad_cast<DocumentObject*>(l->getContainer());
             if (owner && owner->getDocument() == info->pcDoc) {
                 return info;
             }
@@ -4332,7 +4332,7 @@ void PropertyXLink::Restore(Base::XMLReader& reader)
 Property*
 PropertyXLink::CopyOnImportExternal(const std::map<std::string, std::string>& nameMap) const
 {
-    auto owner = freecad_cast<const DocumentObject>(getContainer());
+    auto owner = freecad_cast<const DocumentObject*>(getContainer());
     if (!owner || !owner->getDocument() || !_pcLink || !_pcLink->isAttachedToDocument()) {
         return nullptr;
     }
@@ -5735,7 +5735,7 @@ void PropertyXLinkContainer::Save(Base::Writer& writer) const
     writer.Stream() << writer.ind() << "<XLinks count=\"" << _XLinks.size();
 
     std::map<App::Document*, int> docSet;
-    auto owner = freecad_cast<App::DocumentObject>(getContainer());
+    auto owner = freecad_cast<App::DocumentObject*>(getContainer());
     if (owner && !owner->isExporting()) {
         // Document name and label can change on restore, we shall record the
         // current document name and label and pair it with the associated
@@ -5878,7 +5878,7 @@ bool PropertyXLinkContainer::isLinkedToDocument(const App::Document& doc) const
 
 void PropertyXLinkContainer::updateDeps(std::map<DocumentObject*, bool>&& newDeps)
 {
-    auto owner = freecad_cast<App::DocumentObject>(getContainer());
+    auto owner = freecad_cast<App::DocumentObject*>(getContainer());
     if (!owner || !owner->isAttachedToDocument()) {
         return;
     }

--- a/src/Base/BaseClass.h
+++ b/src/Base/BaseClass.h
@@ -184,30 +184,29 @@ public:
 template<typename T>
 bool BaseClass::is() const
 {
-    static_assert(std::is_base_of<BaseClass, T>::value, "T must be derived from Base::BaseClass");
+    static_assert(std::is_base_of_v<BaseClass, T>, "T must be derived from Base::BaseClass");
     return getTypeId() == T::getClassTypeId();
 }
 
 template<typename T>
 bool BaseClass::isDerivedFrom() const
 {
-    static_assert(std::is_base_of<BaseClass, T>::value, "T must be derived from Base::BaseClass");
+    static_assert(std::is_base_of_v<BaseClass, T>, "T must be derived from Base::BaseClass");
     return getTypeId().isDerivedFrom(T::getClassTypeId());
 }
 
 /**
  * Template that works just like dynamic_cast, but expects the argument to
  * inherit from Base::BaseClass.
- *
  */
-template<typename T>
-T* freecad_cast(Base::BaseClass* type)
+template<typename T, typename U = std::remove_pointer_t<T>>
+    requires(std::is_pointer_v<T>)
+T freecad_cast(Base::BaseClass* type)
 {
-    static_assert(std::is_base_of<Base::BaseClass, T>::value,
-                  "T must be derived from Base::BaseClass");
+    static_assert(std::is_base_of_v<Base::BaseClass, U>, "T must be derived from Base::BaseClass");
 
-    if (type && type->isDerivedFrom(T::getClassTypeId())) {
-        return static_cast<T*>(type);
+    if (type && type->isDerivedFrom(U::getClassTypeId())) {
+        return static_cast<T>(type);
     }
 
     return nullptr;
@@ -216,16 +215,15 @@ T* freecad_cast(Base::BaseClass* type)
 /**
  * Template that works just like dynamic_cast, but expects the argument to
  * inherit from a const Base::BaseClass.
- *
  */
-template<typename T>
-const T* freecad_cast(const Base::BaseClass* type)
+template<typename T, typename U = std::remove_pointer_t<T>>
+    requires(std::is_pointer_v<T>)
+const U* freecad_cast(const Base::BaseClass* type)
 {
-    static_assert(std::is_base_of<Base::BaseClass, T>::value,
-                  "T must be derived from Base::BaseClass");
+    static_assert(std::is_base_of_v<Base::BaseClass, U>, "T must be derived from Base::BaseClass");
 
-    if (type && type->isDerivedFrom(T::getClassTypeId())) {
-        return static_cast<const T*>(type);
+    if (type && type->isDerivedFrom(U::getClassTypeId())) {
+        return static_cast<const U*>(type);
     }
 
     return nullptr;

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -159,7 +159,7 @@ public:
     void newObject(const ViewProvider& vp)
     {
         auto vpd =
-            freecad_cast<ViewProviderDocumentObject>(const_cast<ViewProvider*>(&vp));
+            freecad_cast<ViewProviderDocumentObject*>(const_cast<ViewProvider*>(&vp));
         if (vpd && vpd->getObject()) {
             map[vpd->getObject()] = vpd;
         }
@@ -167,7 +167,7 @@ public:
     void deleteObject(const ViewProvider& vp)
     {
         auto vpd =
-            freecad_cast<ViewProviderDocumentObject>(const_cast<ViewProvider*>(&vp));
+            freecad_cast<ViewProviderDocumentObject*>(const_cast<ViewProvider*>(&vp));
         if (vpd && vpd->getObject()) {
             map.erase(vpd->getObject());
         }

--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -398,7 +398,7 @@ static void linkConvert(bool unlink) {
         for(auto &v : infos) {
             auto &info = v.second;
             auto parent = info.parent.getObject();
-            auto parentVp = freecad_cast<ViewProviderDocumentObject>(
+            auto parentVp = freecad_cast<ViewProviderDocumentObject*>(
                     Application::Instance->getViewProvider(parent));
             auto obj = info.obj.getObject();
             if(!parent || !obj || !parentVp)
@@ -418,7 +418,7 @@ static void linkConvert(bool unlink) {
                     FC_THROWM(Base::RuntimeError,"Failed to create link");
                 link->setLink(-1,obj);
                 link->Label.setValue(obj->Label.getValue());
-                auto pla = freecad_cast<App::PropertyPlacement>(
+                auto pla = freecad_cast<App::PropertyPlacement*>(
                         obj->getPropertyByName("Placement"));
                 if(pla)
                     link->Placement.setValue(pla->getValue());
@@ -662,7 +662,7 @@ static App::DocumentObject *getSelectedLink(bool finalLink, std::string *subname
     auto sobj = sels[0].pObject->getSubObject(sels[0].SubName);
     if(!sobj)
         return nullptr;
-    auto vp = freecad_cast<ViewProviderDocumentObject>(
+    auto vp = freecad_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(sobj));
     if(!vp)
         return nullptr;

--- a/src/Gui/DAGView/DAGModel.cpp
+++ b/src/Gui/DAGView/DAGModel.cpp
@@ -146,7 +146,7 @@ Model::Model(QObject *parentIn, const Gui::Document &documentIn) : QGraphicsScen
   //NOLINTEND
 
   for (auto obj : documentIn.getDocument()->getObjects()) {
-    auto vpd = freecad_cast<Gui::ViewProviderDocumentObject>(documentIn.getViewProvider(obj));
+    auto vpd = freecad_cast<Gui::ViewProviderDocumentObject*>(documentIn.getViewProvider(obj));
     if (vpd)
       slotNewObject(*vpd);
   }

--- a/src/Gui/DemoMode.cpp
+++ b/src/Gui/DemoMode.cpp
@@ -145,7 +145,7 @@ void DemoMode::hideEvent(QHideEvent*)
 Gui::View3DInventor* DemoMode::activeView() const
 {
     if (Document* doc = Application::Instance->activeDocument()) {
-        return freecad_cast<Gui::View3DInventor>(doc->getActiveView());
+        return freecad_cast<Gui::View3DInventor*>(doc->getActiveView());
     }
 
     return nullptr;

--- a/src/Gui/Dialogs/DlgAddProperty.cpp
+++ b/src/Gui/Dialogs/DlgAddProperty.cpp
@@ -82,13 +82,13 @@ DlgAddProperty::DlgAddProperty(QWidget* parent,
 DlgAddProperty::~DlgAddProperty() = default;
 
 static std::string containerName(const App::PropertyContainer *c) {
-    auto doc = freecad_cast<App::Document>(c);
+    auto doc = freecad_cast<App::Document*>(c);
     if(doc)
         return doc->getName();
-    auto obj = freecad_cast<App::DocumentObject>(c);
+    auto obj = freecad_cast<App::DocumentObject*>(c);
     if(obj)
         return obj->getFullName();
-    auto vpd = freecad_cast<ViewProviderDocumentObject>(c);
+    auto vpd = freecad_cast<ViewProviderDocumentObject*>(c);
     if(vpd)
         return vpd->getObject()->getFullName();
     return "?";

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -286,7 +286,7 @@ void DlgExpressionInput::checkExpression(const QString& text)
             //set default palette as we may have read text right now
             ui->msg->setPalette(ui->okBtn->palette());
 
-            auto * n = freecad_cast<NumberExpression>(result.get());
+            auto * n = freecad_cast<NumberExpression*>(result.get());
             if (n) {
                 Base::Quantity value = n->getQuantity();
                 if (!value.isValid()) {
@@ -554,7 +554,7 @@ static void addGroupsVarSetComboBox(App::VarSet* varSet, QTreeWidgetItem* varSet
 static void addVarSetsVarSetComboBox(std::vector<App::VarSet*>& varSets, QTreeWidgetItem* docItem)
 {
     for (auto varSet : varSets) {
-        auto vp = freecad_cast<Gui::ViewProviderDocumentObject>(
+        auto vp = freecad_cast<Gui::ViewProviderDocumentObject*>(
                 Gui::Application::Instance->getViewProvider(varSet));
         // the item will be automatically destroyed when the docItem will be destroyed
         auto item = new QTreeWidgetItem(docItem);

--- a/src/Gui/Dialogs/DlgObjectSelection.cpp
+++ b/src/Gui/Dialogs/DlgObjectSelection.cpp
@@ -194,7 +194,7 @@ QTreeWidgetItem *DlgObjectSelection::getItem(App::DocumentObject *obj,
         if (!items.empty())
             return items[0];
         item = new QTreeWidgetItem(ui->treeWidget);
-        auto vp = freecad_cast<ViewProviderDocumentObject>(
+        auto vp = freecad_cast<ViewProviderDocumentObject*>(
                 Gui::Application::Instance->getViewProvider(obj));
         if (vp) item->setIcon(0, vp->getIcon());
         App::SubObjectT objT(obj, "");

--- a/src/Gui/Dialogs/DlgPropertyLink.cpp
+++ b/src/Gui/Dialogs/DlgPropertyLink.cpp
@@ -272,7 +272,7 @@ void DlgPropertyLink::init(const App::DocumentObjectT& prop, bool tryFilter)
 
     ui->searchBox->setDocumentObject(owner);
 
-    auto propLink = freecad_cast<App::PropertyLinkBase>(objProp.getProperty());
+    auto propLink = freecad_cast<App::PropertyLinkBase*>(objProp.getProperty());
     if (!propLink) {
         return;
     }
@@ -580,7 +580,7 @@ void DlgPropertyLink::onItemSelectionChanged()
         focus = ui->treeWidget->hasFocus();
         auto doc = Gui::Application::Instance->getDocument(sobjs.front().getDocumentName().c_str());
         if (doc) {
-            auto vp = freecad_cast<Gui::ViewProviderDocumentObject>(
+            auto vp = freecad_cast<Gui::ViewProviderDocumentObject*>(
                 doc->getViewProvider(obj));
             if (vp) {
                 // If the view provider uses a special window for rendering, switch to it
@@ -1016,7 +1016,7 @@ QTreeWidgetItem* DlgPropertyLink::createItem(App::DocumentObject* obj, QTreeWidg
         return nullptr;
     }
 
-    auto vp = freecad_cast<ViewProviderDocumentObject>(
+    auto vp = freecad_cast<ViewProviderDocumentObject*>(
         Application::Instance->getViewProvider(obj));
     if (!vp) {
         return nullptr;
@@ -1047,7 +1047,7 @@ QTreeWidgetItem* DlgPropertyLink::createItem(App::DocumentObject* obj, QTreeWidg
 
     QByteArray proxyType;
     auto prop =
-        freecad_cast<App::PropertyPythonObject>(obj->getPropertyByName("Proxy"));
+        freecad_cast<App::PropertyPythonObject*>(obj->getPropertyByName("Proxy"));
     if (prop) {
         Base::PyGILStateLocker lock;
         Py::Object proxy = prop->getValue();

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1932,7 +1932,7 @@ void Document::importObjects(const std::vector<App::DocumentObject*>& obj, Base:
             Gui::ViewProvider* pObj = this->getViewProviderByName(name.c_str());
             if (pObj) {
                 pObj->setStatus(Gui::isRestoring,true);
-                auto vpd = freecad_cast<ViewProviderDocumentObject>(pObj);
+                auto vpd = freecad_cast<ViewProviderDocumentObject*>(pObj);
                 if(vpd) vpd->startRestoring();
                 pObj->Restore(*localreader);
                 if (expanded && vpd)

--- a/src/Gui/DocumentObserver.h
+++ b/src/Gui/DocumentObserver.h
@@ -120,7 +120,7 @@ public:
     template<typename T>
     inline T* getObjectAs() const
     {
-        return freecad_cast<T>(getViewProvider());
+        return freecad_cast<T*>(getViewProvider());
     }
 
 private:
@@ -215,7 +215,7 @@ public:
     template<typename T>
     inline T* get() const noexcept
     {
-        return freecad_cast<T>(_get());
+        return freecad_cast<T*>(_get());
     }
 
 private:

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -120,7 +120,7 @@ void InputField::bind(const App::ObjectIdentifier &_path)
 {
     ExpressionBinding::bind(_path);
 
-    auto * prop = freecad_cast<PropertyQuantity>(getPath().getProperty());
+    auto * prop = freecad_cast<PropertyQuantity*>(getPath().getProperty());
 
     if (prop)
         actQuantity = Base::Quantity(prop->getValue());
@@ -259,7 +259,7 @@ void InputField::newInput(const QString & text)
 
             std::unique_ptr<Expression> evalRes(getExpression()->eval());
 
-            auto * value = freecad_cast<NumberExpression>(evalRes.get());
+            auto * value = freecad_cast<NumberExpression*>(evalRes.get());
             if (value) {
                 res.setValue(value->getValue());
                 res.setUnit(value->getUnit());

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -139,7 +139,7 @@ public:
             if (expr) {
 
                 std::unique_ptr<Expression> res(expr->eval());
-                NumberExpression * n = freecad_cast<NumberExpression>(res.get());
+                NumberExpression * n = freecad_cast<NumberExpression*>(res.get());
                 if (n){
                     result = n->getQuantity();
                     value = result.getValue();

--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -102,7 +102,7 @@ void ExpressionSpinBox::showInvalidExpression(const QString& tip)
 void ExpressionSpinBox::showValidExpression(ExpressionSpinBox::Number number)
 {
     std::unique_ptr<Expression> result(getExpression()->eval());
-    auto * value = freecad_cast<NumberExpression>(result.get());
+    auto * value = freecad_cast<NumberExpression*>(result.get());
 
     if (value) {
         switch (number) {
@@ -186,7 +186,7 @@ void ExpressionSpinBox::openFormulaDialog()
 {
     Q_ASSERT(isBound());
 
-    auto * qprop = freecad_cast<PropertyQuantity>(getPath().getProperty());
+    auto * qprop = freecad_cast<PropertyQuantity*>(getPath().getProperty());
     Unit unit;
 
     if (qprop)

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1918,14 +1918,14 @@ namespace {
                     if (topObj) {
                         auto sobj = topObj->getSubObject(info.topSubname.c_str(), nullptr, &mat);
                         if (sobj == obj) {
-                            propPlacement = freecad_cast<App::PropertyPlacement>(
+                            propPlacement = freecad_cast<App::PropertyPlacement*>(
                                 obj->getPropertyByName("Placement"));
                         }
                     }
                 }
             }
             else {
-                propPlacement = freecad_cast<App::PropertyPlacement>(
+                propPlacement = freecad_cast<App::PropertyPlacement*>(
                     obj->getPropertyByName("Placement"));
                 if (propPlacement)
                     mat = propPlacement->getValue().toMatrix();
@@ -2484,7 +2484,7 @@ bool TreeWidget::dropInObject(QDropEvent* event, TargetItemInfo& targetInfo,
         for (auto& info : infos) {
             auto& subname = info.subname;
             targetObj = targetDoc->getObject(target.c_str());
-            vp = freecad_cast<ViewProviderDocumentObject>( Application::Instance->getViewProvider(targetObj));
+            vp = freecad_cast<ViewProviderDocumentObject*>( Application::Instance->getViewProvider(targetObj));
             if (!vp) {
                 FC_ERR("Cannot find drop target object " << target);
                 break;
@@ -2652,7 +2652,7 @@ bool TreeWidget::dropInObject(QDropEvent* event, TargetItemInfo& targetInfo,
                     (!info.dragging && sobj->getLinkedObject(false) == obj))
                 {
                     if (!info.dragging)
-                        propPlacement = freecad_cast<App::PropertyPlacement>(
+                        propPlacement = freecad_cast<App::PropertyPlacement*>(
                             sobj->getPropertyByName("Placement"));
                     if (propPlacement) {
                         newMat *= propPlacement->getValue().inverse().toMatrix();
@@ -2791,7 +2791,7 @@ void TreeWidget::sortDroppedObjects(TargetItemInfo& targetInfo, std::vector<App:
         auto targetItemObj = static_cast<DocumentObjectItem*>(targetInfo.targetItem);
         App::DocumentObject* targetObj = targetItemObj->object()->getObject();
 
-        auto propGroup = freecad_cast<App::PropertyLinkList>(targetObj->getPropertyByName("Group"));
+        auto propGroup = freecad_cast<App::PropertyLinkList*>(targetObj->getPropertyByName("Group"));
         if (!propGroup) {
             return;
         }
@@ -3061,7 +3061,7 @@ void TreeWidget::onUpdateStatus()
                 errors.push_back(obj);
             if (docItem->ObjectMap.count(obj))
                 continue;
-            auto vpd = freecad_cast<ViewProviderDocumentObject>(gdoc->getViewProvider(obj));
+            auto vpd = freecad_cast<ViewProviderDocumentObject*>(gdoc->getViewProvider(obj));
             if (vpd)
                 docItem->createNewItem(*vpd);
         }
@@ -3746,7 +3746,7 @@ void TreeWidget::selectLinkedObject(App::DocumentObject* linked) {
     if (!isSelectionAttached() || isSelectionBlocked())
         return;
 
-    auto linkedVp = freecad_cast<ViewProviderDocumentObject>(
+    auto linkedVp = freecad_cast<ViewProviderDocumentObject*>(
         Application::Instance->getViewProvider(linked));
     if (!linkedVp) {
         TREE_ERR("invalid linked view provider");
@@ -3962,7 +3962,7 @@ bool DocumentItem::createNewItem(const Gui::ViewProviderDocumentObject& obj,
 }
 
 ViewProviderDocumentObject* DocumentItem::getViewProvider(App::DocumentObject* obj) {
-    return freecad_cast<ViewProviderDocumentObject>(
+    return freecad_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(obj));
 }
 

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -547,7 +547,7 @@ int ViewProviderDocumentObject::replaceObject(
     std::vector<App::Property*> props;
     obj->getPropertyList(props);
     for(auto prop : props) {
-        auto linkProp = freecad_cast<App::PropertyLinkBase>(prop);
+        auto linkProp = freecad_cast<App::PropertyLinkBase*>(prop);
         if(!linkProp)
             continue;
         std::unique_ptr<App::Property> copy(linkProp->CopyOnLinkReplace(obj, oldObj,newObj));
@@ -567,7 +567,7 @@ int ViewProviderDocumentObject::replaceObject(
             std::vector<App::Property*> props;
             o->getPropertyList(props);
             for(auto prop : props) {
-                auto linkProp = freecad_cast<App::PropertyLinkBase>(prop);
+                auto linkProp = freecad_cast<App::PropertyLinkBase*>(prop);
                 if(!linkProp)
                     continue;
                 std::unique_ptr<App::Property> copy(linkProp->CopyOnLinkReplace(obj,oldObj,newObj));
@@ -691,7 +691,7 @@ ViewProviderDocumentObject *ViewProviderDocumentObject::getLinkedViewProvider(
     auto linked = pcObject->getLinkedObject(recursive);
     if(!linked || linked == pcObject)
         return self;
-    auto res = freecad_cast<ViewProviderDocumentObject>(
+    auto res = freecad_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(linked));
     if(!res)
         res = self;

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -745,7 +745,7 @@ void ViewProviderLinkObserver::extensionBeforeDelete() {
 void ViewProviderLinkObserver::extensionReattach(App::DocumentObject *) {
     if(linkInfo) {
         linkInfo->pcLinked =
-            freecad_cast<ViewProviderDocumentObject>(getExtendedContainer());
+            freecad_cast<ViewProviderDocumentObject*>(getExtendedContainer());
         linkInfo->update();
     }
 }
@@ -755,7 +755,7 @@ void ViewProviderLinkObserver::extensionOnChanged(const App::Property *prop) {
 }
 
 void ViewProviderLinkObserver::extensionModeSwitchChange() {
-    auto owner = freecad_cast<ViewProviderDocumentObject>(getExtendedContainer());
+    auto owner = freecad_cast<ViewProviderDocumentObject*>(getExtendedContainer());
     if(owner && linkInfo)
         linkInfo->updateSwitch();
 }
@@ -1026,7 +1026,7 @@ void LinkView::setMaterial(int index, const App::Material *material) {
 }
 
 void LinkView::setLink(App::DocumentObject *obj, const std::vector<std::string> &subs) {
-    setLinkViewObject(freecad_cast<ViewProviderDocumentObject>(
+    setLinkViewObject(freecad_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(obj)),subs);
 
 }
@@ -1743,7 +1743,7 @@ QPixmap ViewProviderLink::getOverlayPixmap() const {
 
 void ViewProviderLink::onChanged(const App::Property* prop) {
     if(prop==&ChildViewProvider) {
-        childVp = freecad_cast<ViewProviderDocumentObject>(ChildViewProvider.getObject().get());
+        childVp = freecad_cast<ViewProviderDocumentObject*>(ChildViewProvider.getObject().get());
         if(childVp && getObject()) {
             if(strcmp(childVp->getTypeId().getName(),getObject()->getViewProviderName())!=0
                     && !childVp->allowOverride(*getObject()))
@@ -1864,7 +1864,7 @@ void ViewProviderLink::updateDataPrivate(App::LinkBaseExtension *ext, const App:
         }
     }else if(prop == ext->getLinkCopyOnChangeGroupProperty()) {
         if (auto group = ext->getLinkCopyOnChangeGroupValue()) {
-            auto vp = freecad_cast<ViewProviderDocumentObject>(
+            auto vp = freecad_cast<ViewProviderDocumentObject*>(
                     Application::Instance->getViewProvider(group));
             if (vp) {
                 vp->hide();
@@ -1915,7 +1915,7 @@ void ViewProviderLink::updateDataPrivate(App::LinkBaseExtension *ext, const App:
     }else if(prop == ext->_getShowElementProperty()) {
         if(!ext->_getShowElementValue()) {
 
-            auto linked = freecad_cast<ViewProviderDocumentObject>(getLinkedView(true,ext));
+            auto linked = freecad_cast<ViewProviderDocumentObject*>(getLinkedView(true,ext));
             if(linked && linked->getDocument()==getDocument())
                 linked->hide();
 
@@ -1929,9 +1929,9 @@ void ViewProviderLink::updateDataPrivate(App::LinkBaseExtension *ext, const App:
                 bool hasMaterial = false;
                 materials.reserve(elements.size());
                 for(size_t i=0;i<elements.size();++i) {
-                    auto element = freecad_cast<App::LinkElement>(elements[i]);
+                    auto element = freecad_cast<App::LinkElement*>(elements[i]);
                     if(!element) continue;
-                    auto vp = freecad_cast<ViewProviderLink>(
+                    auto vp = freecad_cast<ViewProviderLink*>(
                             Application::Instance->getViewProvider(element));
                     if(!vp) continue;
                     overrideMaterial = overrideMaterial || vp->OverrideMaterial.getValue();
@@ -2016,7 +2016,7 @@ void ViewProviderLink::updateElementList(App::LinkBaseExtension *ext) {
         int i=-1;
         for(auto obj : elements) {
             ++i;
-            auto vp = freecad_cast<ViewProviderLink>(
+            auto vp = freecad_cast<ViewProviderLink*>(
                     Application::Instance->getViewProvider(obj));
             if(!vp) continue;
             if(OverrideMaterialList.getSize()>i)
@@ -2234,7 +2234,7 @@ bool ViewProviderLink::canDropObjectEx(App::DocumentObject *obj,
     if(!hasSubName && linkView->isLinked()) {
         auto linked = getLinkedView(false,ext);
         if(linked) {
-            auto linkedVdp = freecad_cast<ViewProviderDocumentObject>(linked);
+            auto linkedVdp = freecad_cast<ViewProviderDocumentObject*>(linked);
             if(linkedVdp) {
                 if(linkedVdp->getObject()==obj || linkedVdp->getObject()==owner)
                     return false;
@@ -2243,7 +2243,7 @@ bool ViewProviderLink::canDropObjectEx(App::DocumentObject *obj,
         }
     }
     if(obj->getDocument() != getObject()->getDocument() &&
-       !freecad_cast<App::PropertyXLink>(ext->getLinkedObjectProperty()))
+       !freecad_cast<App::PropertyXLink*>(ext->getLinkedObjectProperty()))
         return false;
 
     return true;
@@ -2600,7 +2600,7 @@ void ViewProviderLink::_setupContextMenu(
         App::LinkBaseExtension *ext, QMenu* menu, QObject* receiver, const char* member)
 {
     if(linkEdit(ext)) {
-        if (auto linkvp = freecad_cast<ViewProviderLink>(linkView->getLinkedView()))
+        if (auto linkvp = freecad_cast<ViewProviderLink*>(linkView->getLinkedView()))
             linkvp->_setupContextMenu(ext, menu, receiver, member);
         else
             linkView->getLinkedView()->setupContextMenu(menu,receiver,member);
@@ -2743,7 +2743,7 @@ bool ViewProviderLink::initDraggingPlacement() {
     {
         App::PropertyPlacement *propPla = nullptr;
         if(ext->getLinkTransformValue() && ext->getLinkedObjectValue()) {
-            propPla = freecad_cast<App::PropertyPlacement>(
+            propPla = freecad_cast<App::PropertyPlacement*>(
                     ext->getLinkedObjectValue()->getPropertyByName("Placement"));
         }
         if(propPla) {
@@ -2828,7 +2828,7 @@ ViewProvider *ViewProviderLink::startEditing(int mode) {
         FC_ERR("no linked object");
         return nullptr;
     }
-    auto vpd = freecad_cast<ViewProviderDocumentObject>(
+    auto vpd = freecad_cast<ViewProviderDocumentObject*>(
                 Application::Instance->getViewProvider(linked));
     if(!vpd) {
         FC_ERR("no linked viewprovider");
@@ -3018,7 +3018,7 @@ std::map<std::string, Base::Color> ViewProviderLink::getElementColors(const char
             auto link = vp->getObject()->getLinkedObject(false);
             if(!link || link==vp->getObject())
                 break;
-            auto next = freecad_cast<ViewProviderLink>(
+            auto next = freecad_cast<ViewProviderLink*>(
                     Application::Instance->getViewProvider(link));
             if(!next)
                 break;
@@ -3341,7 +3341,7 @@ ViewProviderDocumentObject *ViewProviderLink::getLinkedViewProvider(
         linked = ext->getTrueLinkedObject(recursive);
     if(!linked)
         return self;
-    auto res = freecad_cast<ViewProviderDocumentObject>(
+    auto res = freecad_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(linked));
     if(res)
         return res;

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -319,9 +319,9 @@ void PropertyEditor::openEditor(const QModelIndex& index)
     }
     auto prop = items[0];
     auto parent = prop->getContainer();
-    auto obj = freecad_cast<App::DocumentObject>(parent);
+    auto obj = freecad_cast<App::DocumentObject*>(parent);
     if (!obj) {
-        auto view = freecad_cast<ViewProviderDocumentObject>(parent);
+        auto view = freecad_cast<ViewProviderDocumentObject*>(parent);
         if (view) {
             obj = view->getObject();
         }

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -158,7 +158,7 @@ void PropertyItem::setPropertyData(const std::vector<App::Property*>& items)
         try {
             // Check for 'DocumentObject' as parent because otherwise 'ObjectIdentifier' raises an
             // exception
-            auto* docObj = freecad_cast<App::DocumentObject>(prop.getContainer());
+            auto* docObj = freecad_cast<App::DocumentObject*>(prop.getContainer());
             if (docObj && !docObj->isReadOnly(&prop)) {
                 App::ObjectIdentifier id(prop);
                 std::vector<App::ObjectIdentifier> paths;
@@ -4558,7 +4558,7 @@ void LinkLabel::updatePropertyLink()
 {
     QString text;
     auto owner = objProp.getObject();
-    auto prop = freecad_cast<App::PropertyLinkBase>(objProp.getProperty());
+    auto prop = freecad_cast<App::PropertyLinkBase*>(objProp.getProperty());
 
     link = QVariant();
 
@@ -4673,7 +4673,7 @@ QVariant PropertyLinkItem::data(int column, int role) const
 
 QVariant PropertyLinkItem::value(const App::Property* prop) const
 {
-    auto propLink = freecad_cast<App::PropertyLinkBase>(prop);
+    auto propLink = freecad_cast<App::PropertyLinkBase*>(prop);
     if (!propLink) {
         return {};
     }

--- a/src/Mod/CAM/Gui/ViewProviderPath.cpp
+++ b/src/Mod/CAM/Gui/ViewProviderPath.cpp
@@ -111,7 +111,7 @@ public:
         }
         Base::Matrix4D linkMat;
         auto linked = sobj->getLinkedObject(true, &linkMat, false);
-        auto vp = freecad_cast<ViewProviderPath>(Application::Instance->getViewProvider(linked));
+        auto vp = freecad_cast<ViewProviderPath*>(Application::Instance->getViewProvider(linked));
         if (!vp) {
             setArrow();
             return;

--- a/src/Mod/Drawing/App/FeatureViewSpreadsheet.cpp
+++ b/src/Mod/Drawing/App/FeatureViewSpreadsheet.cpp
@@ -186,13 +186,13 @@ App::DocumentObjectExecReturn* FeatureViewSpreadsheet::execute(void)
             App::Property* prop = sheet->getPropertyByName(address.toString().c_str());
             std::stringstream field;
             if (prop) {
-                if (auto* p = freecad_cast<App::PropertyQuantity>(prop)) {
+                if (auto* p = freecad_cast<App::PropertyQuantity*>(prop)) {
                     field << p->getValue();
                 }
-                else if (auto p = freecad_cast<App::PropertyFloat>(prop)) {
+                else if (auto p = freecad_cast<App::PropertyFloat*>(prop)) {
                     field << p->getValue();
                 }
-                else if (auto p = freecad_cast<App::PropertyString>(prop)) {
+                else if (auto p = freecad_cast<App::PropertyString*>(prop)) {
                     field << p->getValue();
                 }
                 else {

--- a/src/Mod/Fem/App/FemPostFilter.cpp
+++ b/src/Mod/Fem/App/FemPostFilter.cpp
@@ -616,7 +616,7 @@ void FemPostClipFilter::onChanged(const Property* prop)
 {
     if (prop == &Function) {
 
-        if (auto* value = freecad_cast<FemPostFunction>(Function.getValue())) {
+        if (auto* value = freecad_cast<FemPostFunction*>(Function.getValue())) {
             m_clipper->SetClipFunction(value->getImplicitFunction());
             m_extractor->SetImplicitFunction(value->getImplicitFunction());
         }
@@ -1078,7 +1078,7 @@ FemPostCutFilter::~FemPostCutFilter() = default;
 void FemPostCutFilter::onChanged(const Property* prop)
 {
     if (prop == &Function) {
-        if (auto* value = freecad_cast<FemPostFunction>(Function.getValue())) {
+        if (auto* value = freecad_cast<FemPostFunction*>(Function.getValue())) {
             m_cutter->SetCutFunction(value->getImplicitFunction());
         }
         else {

--- a/src/Mod/Fem/App/FemPostPipeline.cpp
+++ b/src/Mod/Fem/App/FemPostPipeline.cpp
@@ -459,7 +459,7 @@ void FemPostPipeline::onChanged(const Property* prop)
             value = frames[Frame.getValue()];
         }
         for (const auto& obj : Group.getValues()) {
-            if (auto* postFilter = freecad_cast<FemPostFilter>(obj)) {
+            if (auto* postFilter = freecad_cast<FemPostFilter*>(obj)) {
                 postFilter->Frame.setValue(value);
             }
         }

--- a/src/Mod/Fem/Gui/TaskPostBoxes.h
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.h
@@ -83,7 +83,7 @@ public:
     template<class T>
     T* getObject() const
     {
-        return freecad_cast<T>(getObject());
+        return freecad_cast<T*>(getObject());
     }
     QMetaObject::Connection connSelectPoint;
 
@@ -159,7 +159,7 @@ protected:
     template<class T>
     T* getObject() const
     {
-        return freecad_cast<T>(getObject());
+        return freecad_cast<T*>(getObject());
     }
     template<typename T>
     T* getTypedObject() const

--- a/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.cpp
@@ -94,8 +94,8 @@ ViewProviderFemAnalysis* getAnalyzeView(App::DocumentObject* obj)
     ViewProviderFemAnalysis* analyzeView = nullptr;
     App::DocumentObject* grp = App::GroupExtension::getGroupOfObject(obj);
 
-    if (Fem::FemAnalysis* analyze = freecad_cast<Fem::FemAnalysis>(grp)) {
-        analyzeView = freecad_cast<ViewProviderFemAnalysis>(
+    if (Fem::FemAnalysis* analyze = freecad_cast<Fem::FemAnalysis*>(grp)) {
+        analyzeView = freecad_cast<ViewProviderFemAnalysis*>(
             Gui::Application::Instance->getViewProvider(analyze));
     }
 

--- a/src/Mod/Import/App/ImportOCAF2.cpp
+++ b/src/Mod/Import/App/ImportOCAF2.cpp
@@ -478,7 +478,7 @@ bool ImportOCAF2::createGroup(App::Document* doc,
             auto link = doc->addObject<App::Link>("Link");
             link->Label.setValue(child->Label.getValue());
             link->setLink(-1, child);
-            auto pla = freecad_cast<App::PropertyPlacement>(child->getPropertyByName("Placement"));
+            auto pla = freecad_cast<App::PropertyPlacement*>(child->getPropertyByName("Placement"));
             if (pla) {
                 link->Placement.setValue(pla->getValue());
             }

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -249,7 +249,7 @@ void TaskMeasure::update()
         App::DocumentObject* sub = ob->getSubObject(sel.SubName);
 
         // Resolve App::Link
-        if (auto link = freecad_cast<App::Link>(sub)) {
+        if (auto link = freecad_cast<App::Link*>(sub)) {
             sub = link->getLinkedObject(true);
         }
 

--- a/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
@@ -237,8 +237,8 @@ SbMatrix ViewProviderMeasureDistance::getMatrix()
         return {};
     }
 
-    auto prop1 = freecad_cast<App::PropertyVector>(pcObject->getPropertyByName("Position1"));
-    auto prop2 = freecad_cast<App::PropertyVector>(pcObject->getPropertyByName("Position2"));
+    auto prop1 = freecad_cast<App::PropertyVector*>(pcObject->getPropertyByName("Position1"));
+    auto prop2 = freecad_cast<App::PropertyVector*>(pcObject->getPropertyByName("Position2"));
 
     if (!prop1 || !prop2) {
         return {};
@@ -456,8 +456,8 @@ void ViewProviderMeasureDistance::redrawAnnotation()
         return;
     }
 
-    auto prop1 = freecad_cast<App::PropertyVector>(pcObject->getPropertyByName("Position1"));
-    auto prop2 = freecad_cast<App::PropertyVector>(pcObject->getPropertyByName("Position2"));
+    auto prop1 = freecad_cast<App::PropertyVector*>(pcObject->getPropertyByName("Position1"));
+    auto prop2 = freecad_cast<App::PropertyVector*>(pcObject->getPropertyByName("Position2"));
 
     if (!prop1 || !prop2) {
         return;

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -386,12 +386,12 @@ void ViewProviderMesh::setOpenEdgeColorFrom(const Base::Color& c)
 
 const Mesh::PropertyMeshKernel& ViewProviderMesh::getMeshProperty() const
 {
-    return freecad_cast<Mesh::Feature>(getObject())->Mesh;
+    return freecad_cast<Mesh::Feature*>(getObject())->Mesh;
 }
 
 Mesh::PropertyMeshKernel& ViewProviderMesh::getMeshProperty()
 {
-    return freecad_cast<Mesh::Feature>(getObject())->Mesh;
+    return freecad_cast<Mesh::Feature*>(getObject())->Mesh;
 }
 
 const Mesh::MeshObject& ViewProviderMesh::getMeshObject() const
@@ -2420,14 +2420,15 @@ void ViewProviderMesh::highlightColors()
 {
     const Mesh::MeshObject& rMesh = getMeshObject();
     {
-        auto prop = freecad_cast<App::PropertyColorList>(pcObject->getPropertyByName("FaceColors"));
+        auto prop =
+            freecad_cast<App::PropertyColorList*>(pcObject->getPropertyByName("FaceColors"));
         if (prop && prop->getSize() == int(rMesh.countFacets())) {
             setColorPerFace(prop);
         }
     }
     {
         auto prop =
-            freecad_cast<App::PropertyColorList>(pcObject->getPropertyByName("VertexColors"));
+            freecad_cast<App::PropertyColorList*>(pcObject->getPropertyByName("VertexColors"));
         if (prop && prop->getSize() == int(rMesh.countPoints())) {
             setColorPerVertex(prop);
         }
@@ -2438,14 +2439,15 @@ bool ViewProviderMesh::canHighlightColors() const
 {
     const Mesh::MeshObject& rMesh = getMeshObject();
     {
-        auto prop = freecad_cast<App::PropertyColorList>(pcObject->getPropertyByName("FaceColors"));
+        auto prop =
+            freecad_cast<App::PropertyColorList*>(pcObject->getPropertyByName("FaceColors"));
         if (prop && prop->getSize() == int(rMesh.countFacets())) {
             return true;
         }
     }
     {
         auto prop =
-            freecad_cast<App::PropertyColorList>(pcObject->getPropertyByName("VertexColors"));
+            freecad_cast<App::PropertyColorList*>(pcObject->getPropertyByName("VertexColors"));
         if (prop && prop->getSize() == int(rMesh.countPoints())) {
             return true;
         }

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -374,7 +374,7 @@ void Tessellation::setFaceColors(int method, App::Document* doc, App::DocumentOb
                 Gui::Application::Instance->getViewProvider(doc->getActiveObject());
             auto vpmesh = dynamic_cast<MeshGui::ViewProviderMesh*>(vpm);
 
-            auto svp = freecad_cast<PartGui::ViewProviderPartExt>(
+            auto svp = freecad_cast<PartGui::ViewProviderPartExt*>(
                 Gui::Application::Instance->getViewProvider(obj));
             if (vpmesh && svp) {
                 std::vector<Base::Color> diff_col = svp->ShapeAppearance.getDiffuseColors();
@@ -463,7 +463,7 @@ QString Tessellation::getStandardParameters(App::DocumentObject* obj) const
         param += QStringLiteral(",Segments=True");
     }
 
-    auto svp = freecad_cast<PartGui::ViewProviderPartExt>(
+    auto svp = freecad_cast<PartGui::ViewProviderPartExt*>(
         Gui::Application::Instance->getViewProvider(obj));
     if (ui->groupsFaceColors->isChecked() && svp) {
         // TODO: currently, we can only retrieve part feature

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -168,7 +168,7 @@ static inline bool getProp(bool force,
                            const char* name,
                            const char* doc)
 {
-    prop = freecad_cast<T>(owner->getDynamicPropertyByName(name));
+    prop = freecad_cast<T*>(owner->getDynamicPropertyByName(name));
     if (prop || !force) {
         return false;
     }
@@ -573,7 +573,7 @@ AttachExtension::Properties AttachExtension::getInitedProperties(bool base)
 
 App::PropertyPlacement& AttachExtension::getPlacement() const
 {
-    auto pla = freecad_cast<App::PropertyPlacement>(
+    auto pla = freecad_cast<App::PropertyPlacement*>(
         getExtendedObject()->getPropertyByName("Placement"));
     if (!pla) {
         throw Base::RuntimeError("AttachExtension cannot find placement property");

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -215,9 +215,9 @@ bool Geometry::hasSameExtensions(const Geometry& other) const
     size_t index = 0;
     for (const auto& ext : extensions) {
         if (auto persistExt =
-                freecad_cast<const GeometryPersistenceExtension>(ext.get())) {
+                freecad_cast<const GeometryPersistenceExtension*>(ext.get())) {
             for (; index < other.extensions.size(); ++index) {
-                if (auto extOther = freecad_cast<const GeometryPersistenceExtension>(
+                if (auto extOther = freecad_cast<const GeometryPersistenceExtension*>(
                         other.extensions[index].get())) {
                     if (!persistExt->isSame(*extOther)) {
                         return false;
@@ -232,7 +232,7 @@ bool Geometry::hasSameExtensions(const Geometry& other) const
         }
     }
     for (; index < other.extensions.size(); ++index) {
-        if (freecad_cast<const GeometryPersistenceExtension>(
+        if (freecad_cast<const GeometryPersistenceExtension*>(
                 other.extensions[index].get())) {
             return false;
         }

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -166,7 +166,7 @@ App::ElementNamePair Feature::getElementName(const char* name,
     // This function is overridden to provide higher level shape topo names that
     // are generated on demand, e.g. Wire, Shell, Solid, etc.
 
-    auto prop = freecad_cast<PropertyPartShape>(getPropertyOfGeometry());
+    auto prop = freecad_cast<PropertyPartShape*>(getPropertyOfGeometry());
     if (!prop) {
         return App::GeoFeature::getElementName(name, type);
     }
@@ -1686,7 +1686,7 @@ bool Feature::isElementMappingDisabled(App::PropertyContainer* container)
 //    if (prop && prop->getValue()) {
 //        return true;
 //    }
-//    if (auto obj = freecad_cast<App::DocumentObject>(container)) {
+//    if (auto obj = freecad_cast<App::DocumentObject*>(container)) {
 //        if (auto doc = obj->getDocument()) {
 //            if (auto prop = propDisableMapping(doc, /*forced*/ false)) {
 //                return prop->getValue();

--- a/src/Mod/Part/App/PropertyGeometryList.cpp
+++ b/src/Mod/Part/App/PropertyGeometryList.cpp
@@ -191,7 +191,7 @@ void PropertyGeometryList::trySaveGeometry(Geometry * geom, Base::Writer &writer
         geom->Save(writer);
         for( auto & ext : geom->getExtensions() ) {
             auto extension = ext.lock();
-            auto gpe = freecad_cast<GeometryMigrationPersistenceExtension>(extension.get());
+            auto gpe = freecad_cast<GeometryMigrationPersistenceExtension*>(extension.get());
             if (gpe)
                 gpe->postSave(writer);
         }
@@ -232,7 +232,7 @@ void PropertyGeometryList::Save(Writer &writer) const
                                         << _lValueList[i]->getTypeId().getName() << "\"";
         for (auto &e : _lValueList[i]->getExtensions() ) {
             auto ext = e.lock();
-            if (auto gpe = freecad_cast<GeometryMigrationPersistenceExtension>(ext.get())) {
+            if (auto gpe = freecad_cast<GeometryMigrationPersistenceExtension*>(ext.get())) {
                 gpe->preSave(writer);
             }
         }

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -67,7 +67,7 @@ void PropertyPartShape::setValue(const TopoShape& sh)
 {
     aboutToSetValue();
     _Shape = sh;
-    auto obj = freecad_cast<App::DocumentObject>(getContainer());
+    auto obj = freecad_cast<App::DocumentObject*>(getContainer());
     if(obj) {
         auto tag = obj->getID();
         if(_Shape.Tag && tag!=_Shape.Tag) {
@@ -109,7 +109,7 @@ const TopoShape& PropertyPartShape::getShape() const
     //        res.Tag = -1;
     //    else if (!res.Tag) {
     if (!_Shape.Tag) {
-        if (auto parent = freecad_cast<App::DocumentObject>(getContainer())) {
+        if (auto parent = freecad_cast<App::DocumentObject*>(getContainer())) {
             _Shape.Tag = parent->getID();
         }
     }
@@ -219,7 +219,7 @@ App::Property *PropertyPartShape::Copy() const
 
 void PropertyPartShape::Paste(const App::Property &from)
 {
-    auto prop = freecad_cast<const PropertyPartShape>(&from);
+    auto prop = freecad_cast<const PropertyPartShape*>(&from);
     if(prop) {
         setValue(prop->_Shape);
         _Ver = prop->_Ver;
@@ -249,7 +249,7 @@ void PropertyPartShape::beforeSave() const
 {
     _HasherIndex = 0;
     _SaveHasher = false;
-    auto owner = freecad_cast<App::DocumentObject>(getContainer());
+    auto owner = freecad_cast<App::DocumentObject*>(getContainer());
     if(owner && !_Shape.isNull() && _Shape.getElementMapSize()>0) {
         auto ret = owner->getDocument()->addStringHasher(_Shape.Hasher);
         _HasherIndex = ret.second;
@@ -323,7 +323,7 @@ void PropertyPartShape::Restore(Base::XMLReader &reader)
 {
     reader.readElement("Part");
 
-    auto owner = freecad_cast<App::DocumentObject>(getContainer());
+    auto owner = freecad_cast<App::DocumentObject*>(getContainer());
     _Ver = "?";
     bool has_ver = reader.hasAttribute("ElementMap");
     if (has_ver)
@@ -943,7 +943,7 @@ void PropertyShapeCache::setPyObject(PyObject *value) {
  * @return The shape cache, or null if we aren't creating and it doesn't exist
  */
 PropertyShapeCache *PropertyShapeCache::get(const App::DocumentObject *obj, bool create) {
-    auto prop = freecad_cast<PropertyShapeCache>(
+    auto prop = freecad_cast<PropertyShapeCache*>(
         obj->getDynamicPropertyByName(SHAPE_CACHE_NAME));
     if(prop && prop->getContainer()==obj)
         return prop;

--- a/src/Mod/Part/Gui/CommandSimple.cpp
+++ b/src/Mod/Part/Gui/CommandSimple.cpp
@@ -154,12 +154,12 @@ void CmdPartPointsFromMesh::activated(int iMsg)
 
     double distance{1.0};
     auto found = std::find_if(geoms.begin(), geoms.end(), [](App::DocumentObject* obj) {
-        return freecad_cast<Part::Feature>(obj);
+        return freecad_cast<Part::Feature*>(obj);
     });
 
     if (found != geoms.end()) {
 
-        double defaultDistance = getDefaultDistance(freecad_cast<Part::Feature>(*found));
+        double defaultDistance = getDefaultDistance(freecad_cast<Part::Feature*>(*found));
 
         double STD_OCC_TOLERANCE = 1e-6;
 

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -194,7 +194,7 @@ bool Body::isSolidFeature(const App::DocumentObject *obj)
             // Datum objects are not solid
             return false;
         }
-        if (auto transFeature = freecad_cast<PartDesign::Transformed>(obj)) {
+        if (auto transFeature = freecad_cast<PartDesign::Transformed*>(obj)) {
             // Transformed Features inside a MultiTransform are not solid features
             return !transFeature->isMultiTransformChild();
         }

--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -389,7 +389,7 @@ TopoShape Feature::makeTopoShapeFromPlane(const App::DocumentObject* obj)
 
 Body* Feature::getFeatureBody() const {
 
-    auto body = freecad_cast<Body>(_Body.getValue());
+    auto body = freecad_cast<Body*>(_Body.getValue());
     if(body)
         return body;
 

--- a/src/Mod/PartDesign/App/FeatureDressUp.cpp
+++ b/src/Mod/PartDesign/App/FeatureDressUp.cpp
@@ -310,7 +310,7 @@ void DressUp::getAddSubShape(Part::TopoShape &addShape, Part::TopoShape &subShap
                 // feature (which must be of type FeatureAddSub), and skipping
                 // any consecutive DressUp in-between.
                 for(Feature *current=this; ;current=static_cast<DressUp*>(base)) {
-                    base = freecad_cast<FeatureAddSub>(current->getBaseObject(true));
+                    base = freecad_cast<FeatureAddSub*>(current->getBaseObject(true));
                     if(!base)
                         FC_THROWM(Base::CADKernelError,
                                 "Cannot find additive or subtractive support for " << getFullName());

--- a/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
+++ b/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
@@ -52,7 +52,7 @@ void MultiTransform::positionBySupport()
     PartDesign::Transformed::positionBySupport();
     std::vector<App::DocumentObject*> transFeatures = Transformations.getValues();
     for (auto f : transFeatures) {
-        auto transFeature = freecad_cast<PartDesign::Transformed>(f);
+        auto transFeature = freecad_cast<PartDesign::Transformed*>(f);
         if (!transFeature) {
             throw Base::TypeError("Transformation features must be subclasses of Transformed");
         }
@@ -85,7 +85,7 @@ MultiTransform::getTransformations(const std::vector<App::DocumentObject*> origi
         // Find centre of gravity of first original
         // FIXME: This method will NOT give the expected result for more than one original!
         if (auto addFeature =
-                freecad_cast<PartDesign::FeatureAddSub>(originals.front())) {
+                freecad_cast<PartDesign::FeatureAddSub*>(originals.front())) {
             TopoDS_Shape original = addFeature->AddSubShape.getShape().getShape();
 
             GProp_GProps props;
@@ -98,7 +98,7 @@ MultiTransform::getTransformations(const std::vector<App::DocumentObject*> origi
     std::list<gp_Pnt> cogs;
 
     for (auto const& f : transFeatures) {
-        auto transFeature = freecad_cast<PartDesign::Transformed>(f);
+        auto transFeature = freecad_cast<PartDesign::Transformed*>(f);
         if (!transFeature) {
             throw Base::TypeError("Transformation features must be subclasses of Transformed");
         }

--- a/src/Mod/PartDesign/App/FeatureScaled.cpp
+++ b/src/Mod/PartDesign/App/FeatureScaled.cpp
@@ -72,7 +72,7 @@ Scaled::getTransformations(const std::vector<App::DocumentObject*> originals)
     if (!originals.empty()) {
         // Find centre of gravity of first original
         // FIXME: This method will NOT give the expected result for more than one original!
-        if (auto feature = freecad_cast<PartDesign::FeatureAddSub>(originals.front())) {
+        if (auto feature = freecad_cast<PartDesign::FeatureAddSub*>(originals.front())) {
             TopoDS_Shape original = feature->AddSubShape.getShape().getShape();
 
             GProp_GProps props;

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -1449,7 +1449,7 @@ Base::Vector3d ProfileBased::getProfileNormal() const {
 
     // If the shape is a line, then return an arbitrary direction that is perpendicular to the line
     auto geom = Part::Geometry::fromShape(shape.getSubShape(TopAbs_EDGE, 1), true);
-    auto geomLine = freecad_cast<Part::GeomLine>(geom.get());
+    auto geomLine = freecad_cast<Part::GeomLine*>(geom.get());
     if (geomLine) {
         Base::Vector3d dir = geomLine->getDir();
         double x = std::fabs(dir.x);

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -95,7 +95,7 @@ Part::Feature* Transformed::getBaseObject(bool silent) const
     // first
     App::DocumentObject* firstOriginal = originals.empty() ? nullptr : originals.front();
     if (firstOriginal) {
-        rv = freecad_cast<Part::Feature>(firstOriginal);
+        rv = freecad_cast<Part::Feature*>(firstOriginal);
         if (!rv) {
             err = QT_TRANSLATE_NOOP("Exception",
                                     "Transformation feature Linked object is not a Part object");
@@ -117,19 +117,19 @@ App::DocumentObject* Transformed::getSketchObject() const
     std::vector<DocumentObject*> originals = Originals.getValues();
     DocumentObject const* firstOriginal = !originals.empty() ? originals.front() : nullptr;
 
-    if (auto feature = freecad_cast<PartDesign::ProfileBased>(firstOriginal)) {
+    if (auto feature = freecad_cast<PartDesign::ProfileBased*>(firstOriginal)) {
         return feature->getVerifiedSketch(true);
     }
-    if (freecad_cast<PartDesign::FeatureAddSub>(firstOriginal)) {
+    if (freecad_cast<PartDesign::FeatureAddSub*>(firstOriginal)) {
         return nullptr;
     }
-    if (auto pattern = freecad_cast<LinearPattern>(this)) {
+    if (auto pattern = freecad_cast<LinearPattern*>(this)) {
         return pattern->Direction.getValue();
     }
-    if (auto pattern = freecad_cast<PolarPattern>(this)) {
+    if (auto pattern = freecad_cast<PolarPattern*>(this)) {
         return pattern->Axis.getValue();
     }
-    if (auto pattern = freecad_cast<Mirrored>(this)) {
+    if (auto pattern = freecad_cast<Mirrored*>(this)) {
         return pattern->MirrorPlane.getValue();
     }
 
@@ -147,7 +147,7 @@ bool Transformed::isMultiTransformChild() const
     // because the dependencies are only established after creation.
     /*
     for (auto const* obj : getInList()) {
-        auto mt = freecad_cast<PartDesign::MultiTransform>(obj);
+        auto mt = freecad_cast<PartDesign::MultiTransform*>(obj);
         if (!mt) {
             continue;
         }
@@ -175,7 +175,7 @@ void Transformed::handleChangedPropertyType(Base::XMLReader& reader,
     // The property 'Angle' of PolarPattern has changed from PropertyFloat
     // to PropertyAngle and the property 'Length' has changed to PropertyLength.
     Base::Type inputType = Base::Type::fromName(TypeName);
-    if (auto property = freecad_cast<App::PropertyFloat>(prop);
+    if (auto property = freecad_cast<App::PropertyFloat*>(prop);
         property != nullptr && inputType.isDerivedFrom(App::PropertyFloat::getClassTypeId())) {
         // Do not directly call the property's Restore method in case the implementation
         // has changed. So, create a temporary PropertyFloat object and assign the value.
@@ -214,7 +214,7 @@ App::DocumentObjectExecReturn* Transformed::execute()
     // there
     auto eraseIter =
         std::remove_if(originals.begin(), originals.end(), [](App::DocumentObject const* obj) {
-            auto feature = freecad_cast<PartDesign::Feature>(obj);
+            auto feature = freecad_cast<PartDesign::Feature*>(obj);
             return feature != nullptr && feature->Suppressed.getValue();
         });
     originals.erase(eraseIter, originals.end());
@@ -298,7 +298,7 @@ App::DocumentObjectExecReturn* Transformed::execute()
                 Part::TopoShape fuseShape;
                 Part::TopoShape cutShape;
 
-                auto feature = freecad_cast<PartDesign::FeatureAddSub>(original);
+                auto feature = freecad_cast<PartDesign::FeatureAddSub*>(original);
                 if (!feature) {
                     return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
                         "Exception",

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -718,7 +718,7 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
         if (!forced) {
             bool hit = true;
             for (auto& v : mats) {
-                auto prop = freecad_cast<App::PropertyMatrix>(
+                auto prop = freecad_cast<App::PropertyMatrix*>(
                     getDynamicPropertyByName(cacheName(v.first)));
                 if (!prop || prop->getValue() != v.second) {
                     hit = false;

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -677,7 +677,7 @@ bool importExternalElements(App::PropertyLinkSub& prop, std::vector<App::SubObje
     if (!prop.getName() || !prop.getName()[0]) {
         FC_THROWM(Base::RuntimeError, "Invalid property");
     }
-    auto editObj = freecad_cast<App::DocumentObject>(prop.getContainer());
+    auto editObj = freecad_cast<App::DocumentObject*>(prop.getContainer());
     if (!editObj) {
         FC_THROWM(Base::RuntimeError, "Editing object not found");
     }
@@ -784,7 +784,7 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
 
         // Populate the subs parameter by checking for external elements before
         // we construct our command.
-        auto ProfileFeature = freecad_cast<PartDesign::ProfileBased>(Feat);
+        auto ProfileFeature = freecad_cast<PartDesign::ProfileBased*>(Feat);
 
         std::vector<std::string>& cmdSubs = const_cast<vector<std::string>&>(subs);
         if (subs.size() == 0) {

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -391,7 +391,7 @@ TaskFeaturePick::makeCopy(App::DocumentObject* obj, std::string sub, bool indepe
 
             // we are a independent copy, therefore no external geometry was copied. WE therefore
             // can delete all constraints
-            if (auto* sketchObj = freecad_cast<Sketcher::SketchObject>(obj)) {
+            if (auto* sketchObj = freecad_cast<Sketcher::SketchObject*>(obj)) {
                 sketchObj->delConstraintsToExternal();
             }
         }

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -192,7 +192,7 @@ void ViewProvider::onChanged(const App::Property* prop) {
             for(App::DocumentObject* obj : body->Group.getValues()) {
 
                 if(obj->isDerivedFrom<PartDesign::Feature>() && obj != getObject()) {
-                   auto vpd = freecad_cast<Gui::ViewProviderDocumentObject>(
+                   auto vpd = freecad_cast<Gui::ViewProviderDocumentObject*>(
                            Gui::Application::Instance->getViewProvider(obj));
                    if(vpd && vpd->Visibility.getValue())
                        vpd->Visibility.setValue(false);

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -413,7 +413,7 @@ void ViewProviderSubShapeBinder::updatePlacement(bool transaction) {
 
 std::vector<App::DocumentObject*> ViewProviderSubShapeBinder::claimChildren() const {
     std::vector<App::DocumentObject*> ret;
-    auto self = freecad_cast<PartDesign::SubShapeBinder>(getObject());
+    auto self = freecad_cast<PartDesign::SubShapeBinder*>(getObject());
     if (self && self->ClaimChildren.getValue() && self->Support.getValue()) {
         std::set<App::DocumentObject*> objSet;
         for (auto& l : self->Support.getSubListValues()) {

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -8234,7 +8234,7 @@ static Part::Geometry *fitArcs(std::vector<std::unique_ptr<Part::Geometry> > &ar
     double m = 0.0;
     Base::Vector3d center;
     for (auto &geo : arcs) {
-        if (auto arc = freecad_cast<Part::GeomArcOfCircle>(geo.get())) {
+        if (auto arc = freecad_cast<Part::GeomArcOfCircle*>(geo.get())) {
             if (radius == 0.0) {
                 radius = arc->getRadius();
                 center = arc->getCenter();

--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -250,14 +250,14 @@ bool Cell::getStringContent(std::string& s, bool persistent) const
         if (expression->hasComponent()) {
             s = "=" + expression->toString(persistent);
         }
-        else if (freecad_cast<App::StringExpression>(expression.get())) {
+        else if (freecad_cast<App::StringExpression*>(expression.get())) {
             s = static_cast<App::StringExpression*>(expression.get())->getText();
             s = "'" + s;
         }
-        else if (freecad_cast<App::ConstantExpression>(expression.get())) {
+        else if (freecad_cast<App::ConstantExpression*>(expression.get())) {
             s = "=" + expression->toString();
         }
-        else if (freecad_cast<App::NumberExpression>(expression.get())) {
+        else if (freecad_cast<App::NumberExpression*>(expression.get())) {
             s = expression->toString();
         }
         else {
@@ -274,7 +274,7 @@ bool Cell::getStringContent(std::string& s, bool persistent) const
 
 void Cell::afterRestore()
 {
-    auto expr = freecad_cast<StringExpression>(expression.get());
+    auto expr = freecad_cast<StringExpression*>(expression.get());
     if (expr) {
         setContent(expr->getText().c_str());
     }
@@ -331,10 +331,10 @@ void Cell::setContent(const char* value)
                 try {
                     ExpressionPtr parsedExpr(App::ExpressionParser::parse(owner->sheet(), value));
 
-                    if (const auto fraction = freecad_cast<OperatorExpression>(parsedExpr.get())) {
+                    if (const auto fraction = freecad_cast<OperatorExpression*>(parsedExpr.get())) {
                         if (fraction->getOperator() == OperatorExpression::UNIT) {
-                            const auto left = freecad_cast<NumberExpression>(fraction->getLeft());
-                            const auto right = freecad_cast<UnitExpression>(fraction->getRight());
+                            const auto left = freecad_cast<NumberExpression*>(fraction->getLeft());
+                            const auto right = freecad_cast<UnitExpression*>(fraction->getRight());
                             if (left && right) {
                                 newExpr = std::move(parsedExpr);
                             }
@@ -345,22 +345,22 @@ void Cell::setContent(const char* value)
 
                             // check for numbers in (de)nominator
                             const bool isNumberNom =
-                                freecad_cast<NumberExpression>(fraction->getLeft());
+                                freecad_cast<NumberExpression*>(fraction->getLeft());
                             const bool isNumberDenom =
-                                freecad_cast<NumberExpression>(fraction->getRight());
+                                freecad_cast<NumberExpression*>(fraction->getRight());
 
                             // check for numbers with units in (de)nominator
                             const auto opNom =
-                                freecad_cast<OperatorExpression>(fraction->getLeft());
+                                freecad_cast<OperatorExpression*>(fraction->getLeft());
                             const auto opDenom =
-                                freecad_cast<OperatorExpression>(fraction->getRight());
+                                freecad_cast<OperatorExpression*>(fraction->getRight());
                             const bool isQuantityNom =
                                 opNom && opNom->getOperator() == OperatorExpression::UNIT;
                             const bool isQuantityDenom =
                                 opDenom && opDenom->getOperator() == OperatorExpression::UNIT;
 
                             // check for units in denomainator
-                            const auto uDenom = freecad_cast<UnitExpression>(fraction->getRight());
+                            const auto uDenom = freecad_cast<UnitExpression*>(fraction->getRight());
                             const bool isUnitDenom = uDenom && uDenom->is<UnitExpression>();
 
                             const bool isNomValid = isNumberNom || isQuantityNom;
@@ -371,7 +371,8 @@ void Cell::setContent(const char* value)
                             }
                         }
                     }
-                    else if (const auto number = freecad_cast<NumberExpression>(parsedExpr.get())) {
+                    else if (const auto number =
+                                 freecad_cast<NumberExpression*>(parsedExpr.get())) {
                         // NumbersExpressions can accept more than can be parsed with strtod.
                         //   Example: 12.34 and 12,34 are both valid NumberExpressions
                         newExpr = std::move(parsedExpr);

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -378,7 +378,7 @@ void PropertySheet::Paste(const Property& from)
 
     if (!spanChanges.empty()) {
         mergedCells = froms.mergedCells;
-        if (auto sheet = freecad_cast<Sheet>(getContainer())) {
+        if (auto sheet = freecad_cast<Sheet*>(getContainer())) {
             for (const auto& addr : spanChanges) {
                 sheet->cellSpanChanged(addr);
             }
@@ -1476,7 +1476,7 @@ void PropertySheet::recomputeDependants(const App::DocumentObject* owner, const 
         // Check for hidden reference. Because a hidden reference is not
         // protected by cyclic dependency checking, we need to take special
         // care to prevent it from misbehave.
-        Sheet* sheet = freecad_cast<Sheet>(getContainer());
+        Sheet* sheet = freecad_cast<Sheet*>(getContainer());
         if (!sheet || sheet->testStatus(App::ObjectStatus::Recompute2) || !owner
             || owner->testStatus(App::ObjectStatus::Recompute2)) {
             return;
@@ -2078,7 +2078,7 @@ PropertySheet::BindingType PropertySheet::getBinding(const Range& range,
 
             if (expr->getFunction() == FunctionExpression::TUPLE && expr->getArgs().size() == 3) {
                 if (pTarget) {
-                    if (auto e = freecad_cast<VariableExpression>(expr->getArgs()[0])) {
+                    if (auto e = freecad_cast<VariableExpression*>(expr->getArgs()[0])) {
                         *pTarget = e->getPath();
                     }
                 }
@@ -2117,7 +2117,7 @@ void PropertySheet::setPathValue(const ObjectIdentifier& path, const boost::any&
             && Py::Object(seq[1].ptr()).isString() && Py::Object(seq[2].ptr()).isString()) {
             AtomicPropertyChange signaller(*this, false);
             auto other = static_cast<PropertySheetPy*>(seq[0].ptr())->getPropertySheetPtr();
-            auto otherOwner = freecad_cast<App::DocumentObject>(other->getContainer());
+            auto otherOwner = freecad_cast<App::DocumentObject*>(other->getContainer());
             if (!otherOwner) {
                 FC_THROWM(Base::RuntimeError,
                           "Invalid binding of '" << other->getFullName() << " in "
@@ -2287,7 +2287,7 @@ void PropertySheet::getLinksTo(std::vector<App::ObjectIdentifier>& identifiers,
     auto subObject = objT.getSubObject();
     auto subElement = objT.getOldElementName();
 
-    auto owner = freecad_cast<App::DocumentObject>(getContainer());
+    auto owner = freecad_cast<App::DocumentObject*>(getContainer());
     for (const auto& [cellName, cellExpression] : data) {
         if (auto expr = cellExpression->getExpression()) {
             const auto& deps = expr->getDeps(option);

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -344,16 +344,16 @@ bool Sheet::exportToFile(const std::string& filename,
 
         std::stringstream field;
 
-        if (auto p = freecad_cast<PropertyQuantity>(prop)) {
+        if (auto p = freecad_cast<PropertyQuantity*>(prop)) {
             field << p->getValue();
         }
-        else if (auto p = freecad_cast<PropertyFloat>(prop)) {
+        else if (auto p = freecad_cast<PropertyFloat*>(prop)) {
             field << p->getValue();
         }
-        else if (auto p = freecad_cast<PropertyInteger>(prop)) {
+        else if (auto p = freecad_cast<PropertyInteger*>(prop)) {
             field << p->getValue();
         }
-        else if (auto p = freecad_cast<PropertyString>(prop)) {
+        else if (auto p = freecad_cast<PropertyString*>(prop)) {
             field << p->getValue();
         }
         else {
@@ -593,7 +593,7 @@ Property* Sheet::setFloatProperty(CellAddress key, double value)
             this->removeDynamicProperty(name.c_str());
             propAddress.erase(prop);
         }
-        floatProp = freecad_cast<PropertyFloat>(
+        floatProp = freecad_cast<PropertyFloat*>(
             addDynamicProperty("App::PropertyFloat",
                                name.c_str(),
                                nullptr,
@@ -621,7 +621,7 @@ Property* Sheet::setIntegerProperty(CellAddress key, long value)
             this->removeDynamicProperty(name.c_str());
             propAddress.erase(prop);
         }
-        intProp = freecad_cast<PropertyInteger>(
+        intProp = freecad_cast<PropertyInteger*>(
             addDynamicProperty("App::PropertyInteger",
                                name.c_str(),
                                nullptr,
@@ -666,7 +666,7 @@ Property* Sheet::setQuantityProperty(CellAddress key, double value, const Base::
                                          nullptr,
                                          nullptr,
                                          Prop_ReadOnly | Prop_Hidden | Prop_NoPersist);
-        quantityProp = freecad_cast<PropertySpreadsheetQuantity>(p);
+        quantityProp = freecad_cast<PropertySpreadsheetQuantity*>(p);
     }
     else {
         quantityProp = static_cast<PropertySpreadsheetQuantity*>(prop);
@@ -695,14 +695,14 @@ Property* Sheet::setStringProperty(CellAddress key, const std::string& value)
 {
     std::string name = key.toString(CellAddress::Cell::ShowRowColumn);
     Property* prop = props.getDynamicPropertyByName(name.c_str());
-    PropertyString* stringProp = freecad_cast<PropertyString>(prop);
+    PropertyString* stringProp = freecad_cast<PropertyString*>(prop);
 
     if (!stringProp) {
         if (prop) {
             this->removeDynamicProperty(name.c_str());
             propAddress.erase(prop);
         }
-        stringProp = freecad_cast<PropertyString>(
+        stringProp = freecad_cast<PropertyString*>(
             addDynamicProperty("App::PropertyString",
                                name.c_str(),
                                nullptr,
@@ -720,14 +720,14 @@ Property* Sheet::setObjectProperty(CellAddress key, Py::Object object)
 {
     std::string name = key.toString(CellAddress::Cell::ShowRowColumn);
     Property* prop = props.getDynamicPropertyByName(name.c_str());
-    PropertyPythonObject* pyProp = freecad_cast<PropertyPythonObject>(prop);
+    PropertyPythonObject* pyProp = freecad_cast<PropertyPythonObject*>(prop);
 
     if (!pyProp) {
         if (prop) {
             this->removeDynamicProperty(name.c_str());
             propAddress.erase(prop);
         }
-        pyProp = freecad_cast<PropertyPythonObject>(
+        pyProp = freecad_cast<PropertyPythonObject*>(
             addDynamicProperty("App::PropertyPythonObject",
                                name.c_str(),
                                nullptr,
@@ -794,10 +794,10 @@ void Sheet::updateProperty(CellAddress key)
 
         /* Eval returns either NumberExpression or StringExpression, or
          * PyObjectExpression objects */
-        auto number = freecad_cast<NumberExpression>(output.get());
+        auto number = freecad_cast<NumberExpression*>(output.get());
         if (number) {
             long l;
-            auto constant = freecad_cast<ConstantExpression>(output.get());
+            auto constant = freecad_cast<ConstantExpression*>(output.get());
             if (constant && !constant->isNumber()) {
                 Base::PyGILStateLocker lock;
                 setObjectProperty(key, constant->getPyValue());
@@ -813,13 +813,13 @@ void Sheet::updateProperty(CellAddress key)
             }
         }
         else {
-            auto str_expr = freecad_cast<StringExpression>(output.get());
+            auto str_expr = freecad_cast<StringExpression*>(output.get());
             if (str_expr) {
                 setStringProperty(key, str_expr->getText().c_str());
             }
             else {
                 Base::PyGILStateLocker lock;
-                auto py_expr = freecad_cast<PyObjectExpression>(output.get());
+                auto py_expr = freecad_cast<PyObjectExpression*>(output.get());
                 if (py_expr) {
                     setObjectProperty(key, py_expr->getPyValue());
                 }

--- a/src/Mod/Spreadsheet/Gui/Command.cpp
+++ b/src/Mod/Spreadsheet/Gui/Command.cpp
@@ -71,7 +71,7 @@ void CmdSpreadsheetMergeCells::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -101,7 +101,7 @@ bool CmdSpreadsheetMergeCells::isActive()
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             return (sheetView->selectedIndexesRaw().size() > 1);
@@ -132,7 +132,7 @@ void CmdSpreadsheetSplitCell::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -157,7 +157,7 @@ bool CmdSpreadsheetSplitCell::isActive()
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             QModelIndex current = sheetView->currentIndex();
@@ -246,7 +246,7 @@ void CmdSpreadsheetExport::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -263,7 +263,7 @@ bool CmdSpreadsheetExport::isActive()
 {
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
-        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView>(activeWindow)) {
+        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView*>(activeWindow)) {
             return true;
         }
     }
@@ -292,7 +292,7 @@ void CmdSpreadsheetAlignLeft::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -320,7 +320,7 @@ bool CmdSpreadsheetAlignLeft::isActive()
 {
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
-        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView>(activeWindow)) {
+        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView*>(activeWindow)) {
             return true;
         }
     }
@@ -349,7 +349,7 @@ void CmdSpreadsheetAlignCenter::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -377,7 +377,7 @@ bool CmdSpreadsheetAlignCenter::isActive()
 {
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
-        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView>(activeWindow)) {
+        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView*>(activeWindow)) {
             return true;
         }
     }
@@ -406,7 +406,7 @@ void CmdSpreadsheetAlignRight::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -434,7 +434,7 @@ bool CmdSpreadsheetAlignRight::isActive()
 {
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
-        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView>(activeWindow)) {
+        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView*>(activeWindow)) {
             return true;
         }
     }
@@ -463,7 +463,7 @@ void CmdSpreadsheetAlignTop::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -491,7 +491,7 @@ bool CmdSpreadsheetAlignTop::isActive()
 {
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
-        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView>(activeWindow)) {
+        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView*>(activeWindow)) {
             return true;
         }
     }
@@ -520,7 +520,7 @@ void CmdSpreadsheetAlignBottom::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -548,7 +548,7 @@ bool CmdSpreadsheetAlignBottom::isActive()
 {
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
-        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView>(activeWindow)) {
+        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView*>(activeWindow)) {
             return true;
         }
     }
@@ -577,7 +577,7 @@ void CmdSpreadsheetAlignVCenter::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -605,7 +605,7 @@ bool CmdSpreadsheetAlignVCenter::isActive()
 {
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
-        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView>(activeWindow)) {
+        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView*>(activeWindow)) {
             return true;
         }
     }
@@ -635,7 +635,7 @@ void CmdSpreadsheetStyleBold::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -689,7 +689,7 @@ bool CmdSpreadsheetStyleBold::isActive()
 {
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
-        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView>(activeWindow)) {
+        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView*>(activeWindow)) {
             return true;
         }
     }
@@ -719,7 +719,7 @@ void CmdSpreadsheetStyleItalic::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -773,7 +773,7 @@ bool CmdSpreadsheetStyleItalic::isActive()
 {
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
-        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView>(activeWindow)) {
+        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView*>(activeWindow)) {
             return true;
         }
     }
@@ -803,7 +803,7 @@ void CmdSpreadsheetStyleUnderline::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -857,7 +857,7 @@ bool CmdSpreadsheetStyleUnderline::isActive()
 {
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
-        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView>(activeWindow)) {
+        if (activeWindow && freecad_cast<SpreadsheetGui::SheetView*>(activeWindow)) {
             return true;
         }
     }
@@ -887,7 +887,7 @@ void CmdSpreadsheetSetAlias::activated(int iMsg)
     if (getActiveGuiDocument()) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -921,7 +921,7 @@ bool CmdSpreadsheetSetAlias::isActive()
 
         if (activeWindow) {
             SpreadsheetGui::SheetView* sheetView =
-                freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+                freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
             if (sheetView) {
                 QModelIndexList selection = sheetView->selectedIndexes();

--- a/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
@@ -168,10 +168,10 @@ void DlgBindSheet::accept()
                 if (!doc) {
                     FC_THROWM(Base::RuntimeError, "Cannot find document " << docname);
                 }
-                obj = freecad_cast<Sheet>(doc->getObject(sep + 1));
+                obj = freecad_cast<Sheet*>(doc->getObject(sep + 1));
             }
             else {
-                obj = freecad_cast<Sheet>(sheet->getDocument()->getObject(ref));
+                obj = freecad_cast<Sheet*>(sheet->getDocument()->getObject(ref));
             }
             if (!obj) {
                 FC_THROWM(Base::RuntimeError, "Cannot find Spreadsheet '" << ref << "'");

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
@@ -140,7 +140,7 @@ App::Property* DlgSheetConf::prepare(CellAddress& from,
     if (cell && cell->getExpression()) {
         auto expr = cell->getExpression();
         if (expr->isDerivedFrom<FunctionExpression>()) {
-            auto fexpr = freecad_cast<FunctionExpression>(cell->getExpression());
+            auto fexpr = freecad_cast<FunctionExpression*>(cell->getExpression());
             if (fexpr
                 && (fexpr->getFunction() == FunctionExpression::HREF
                     || fexpr->getFunction() == FunctionExpression::HIDDENREF)
@@ -148,11 +148,11 @@ App::Property* DlgSheetConf::prepare(CellAddress& from,
                 expr = fexpr->getArgs().front();
             }
         }
-        auto vexpr = freecad_cast<VariableExpression>(expr);
+        auto vexpr = freecad_cast<VariableExpression*>(expr);
         if (vexpr) {
-            auto prop = freecad_cast<PropertyEnumeration>(vexpr->getPath().getProperty());
+            auto prop = freecad_cast<PropertyEnumeration*>(vexpr->getPath().getProperty());
             if (prop) {
-                auto obj = freecad_cast<DocumentObject>(prop->getContainer());
+                auto obj = freecad_cast<DocumentObject*>(prop->getContainer());
                 if (obj && prop->hasName()) {
                     path = ObjectIdentifier(sheet);
                     path.setDocumentObjectName(obj, true);

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -146,7 +146,7 @@ void ViewProviderSheet::setupContextMenu(QMenu* menu, QObject* receiver, const c
 
 Sheet* ViewProviderSheet::getSpreadsheetObject() const
 {
-    return freecad_cast<Sheet>(pcObject);
+    return freecad_cast<Sheet*>(pcObject);
 }
 
 void ViewProviderSheet::beforeDelete()

--- a/src/Mod/Spreadsheet/Gui/Workbench.cpp
+++ b/src/Mod/Spreadsheet/Gui/Workbench.cpp
@@ -129,7 +129,7 @@ void WorkbenchHelper::setForegroundColor(const QColor& color)
     if (doc) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();
@@ -163,7 +163,7 @@ void WorkbenchHelper::setBackgroundColor(const QColor& color)
     if (doc) {
         Gui::MDIView* activeWindow = Gui::getMainWindow()->activeWindow();
         SpreadsheetGui::SheetView* sheetView =
-            freecad_cast<SpreadsheetGui::SheetView>(activeWindow);
+            freecad_cast<SpreadsheetGui::SheetView*>(activeWindow);
 
         if (sheetView) {
             Sheet* sheet = sheetView->getSheet();

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -390,49 +390,49 @@ bool QGSPage::attachView(App::DocumentObject* obj)
 
     QGIView* qview(nullptr);
 
-    if (auto o = freecad_cast<TechDraw::DrawViewSection>(obj)) {
+    if (auto o = freecad_cast<TechDraw::DrawViewSection*>(obj)) {
         qview = addViewSection(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawViewPart>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawViewPart*>(obj)) {
         qview = addViewPart(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawProjGroup>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawProjGroup*>(obj)) {
         qview = addProjectionGroup(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawViewCollection>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawViewCollection*>(obj)) {
         qview = addDrawView(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawViewDimension>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawViewDimension*>(obj)) {
         qview = addViewDimension(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawViewBalloon>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawViewBalloon*>(obj)) {
         qview = addViewBalloon(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawViewAnnotation>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawViewAnnotation*>(obj)) {
         qview = addAnnotation(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawViewSymbol>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawViewSymbol*>(obj)) {
         qview = addDrawViewSymbol(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawViewClip>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawViewClip*>(obj)) {
         qview = addDrawViewClip(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawViewSpreadsheet>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawViewSpreadsheet*>(obj)) {
         qview = addDrawViewSpreadsheet(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawViewImage>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawViewImage*>(obj)) {
         qview = addDrawViewImage(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawLeaderLine>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawLeaderLine*>(obj)) {
         qview = addViewLeader(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawRichAnno>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawRichAnno*>(obj)) {
         qview = addRichAnno(o);
     }
-    else if (auto o = freecad_cast<TechDraw::DrawWeldSymbol>(obj)) {
+    else if (auto o = freecad_cast<TechDraw::DrawWeldSymbol*>(obj)) {
         qview = addWeldSymbol(o);
     }
-    else if (freecad_cast<TechDraw::DrawHatch>(obj)) {
+    else if (freecad_cast<TechDraw::DrawHatch*>(obj)) {
         //Hatch is not attached like other Views (since it isn't really a View)
         return true;
     }

--- a/src/Tools/params_utils.py
+++ b/src/Tools/params_utils.py
@@ -1197,7 +1197,7 @@ class Property:
             )
         cog.out(
             f"""
-    if (auto prop = freecad_cast<{self.type_name}>(
+    if (auto prop = freecad_cast<{self.type_name}*>(
             obj->getPropertyByName("{self.name}")))
     {{
         if (prop->getContainer() == obj)


### PR DESCRIPTION
All other casts in language specify full type, our type is the only one that does not require explicitly stating that we are casting pointer types. This is problematic for cases with auto `auto extrude = freecad_cast<FeatureExtrude>(feature);` - one might expect it to be `FeatureExtrude` while in reality it is `FeatureExtrude*`.