### PR TITLE
Gui: fix Quantity spinbox margin without an icon

### DIFF
--- a/src/Gui/QuantitySpinBox_p.h
+++ b/src/Gui/QuantitySpinBox_p.h
@@ -44,7 +44,7 @@ public:
         if (auto parentLineEdit = qobject_cast<QLineEdit*>(parent())) {
             // horizontal margin, so text will not be behind the icon
             QMargins margins = parentLineEdit->contentsMargins();
-            margins.setRight(margins.right() * 2 + sizeHint().width());
+            margins.setRight(2 * margins.right() + sizeHint().width());
             parentLineEdit->setContentsMargins(margins);
         }
         QLabel::show();

--- a/src/Gui/QuantitySpinBox_p.h
+++ b/src/Gui/QuantitySpinBox_p.h
@@ -25,6 +25,7 @@
 
 #include <QLabel>
 #include <QMouseEvent>
+#include <QLineEdit>
 
 class ExpressionLabel : public QLabel
 {
@@ -37,6 +38,16 @@ public:
             this->setToolTip(genericExpressionEditorTooltip);
         else
             this->setToolTip(expressionEditorTooltipPrefix + text);
+    }
+
+    void show() {
+        if (QLineEdit* parentLineEdit = qobject_cast<QLineEdit*>(parent())) {
+            // horizontal margin, so text will not be behind the icon
+            QMargins margins = parentLineEdit->contentsMargins();
+            margins.setRight(margins.right() * 2 + this->sizeHint().width());
+            parentLineEdit->setContentsMargins(margins);
+        }
+        QLabel::show();
     }
 
 protected:

--- a/src/Gui/QuantitySpinBox_p.h
+++ b/src/Gui/QuantitySpinBox_p.h
@@ -41,10 +41,10 @@ public:
     }
 
     void show() {
-        if (QLineEdit* parentLineEdit = qobject_cast<QLineEdit*>(parent())) {
+        if (auto parentLineEdit = qobject_cast<QLineEdit*>(parent())) {
             // horizontal margin, so text will not be behind the icon
             QMargins margins = parentLineEdit->contentsMargins();
-            margins.setRight(margins.right() * 2 + this->sizeHint().width());
+            margins.setRight(margins.right() * 2 + sizeHint().width());
             parentLineEdit->setContentsMargins(margins);
         }
         QLabel::show();

--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -50,18 +50,17 @@ ExpressionSpinBox::ExpressionSpinBox(QAbstractSpinBox* sb)
   : spinbox(sb)
 {
     lineedit = spinbox->findChild<QLineEdit*>();
+    // Set Margins
+    // https://forum.freecad.org/viewtopic.php?f=8&t=50615
+    // vertical margin, otherwise `,` is clipped to a `.` on some OSX versions
+    int margin = getMargin();
+    lineedit->setTextMargins(margin, margin, margin, margin);
+    lineedit->setAlignment(Qt::AlignVCenter);
+
     makeLabel(lineedit);
     QObject::connect(iconLabel, &ExpressionLabel::clicked, [this]() {
         this->openFormulaDialog();
     });
-
-    // Set Margins
-    // vertical to avoid this: https://forum.freecad.org/viewtopic.php?f=8&t=50615
-    // horizontal to avoid going under the icon
-    lineedit->setAlignment(Qt::AlignVCenter);
-    int iconWidth = iconLabel->sizeHint().width();
-    int margin = getMargin();
-    lineedit->setTextMargins(margin, margin, margin + iconWidth, margin);
 }
 
 ExpressionSpinBox::~ExpressionSpinBox() = default;


### PR DESCRIPTION
margin refactoring aimed to fix #20680

margins are different depending on whether there is an icon or not

![imagen](https://github.com/user-attachments/assets/1f5459f0-fdb2-4411-8a64-89856cd51b5d)

![imagen](https://github.com/user-attachments/assets/8391e119-00ba-47fb-9028-e73e075df367)

