### PR TITLE
Tighten up types in Base/Tools.h math functions

### DIFF
--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -119,14 +119,16 @@ inline T clamp(T num, T lower, T upper)
     return std::clamp<T>(num, lower, upper);
 }
 
-template<class T>
-inline T sgn(T t)
+/// Returns -1, 0 or 1 depending on if the value is negative, zero or positive
+/// As this function might be used in hot paths, it uses branchless implementation
+template<typename T>
+constexpr std::enable_if_t<std::is_arithmetic_v<T> && std::is_signed_v<T>, T> sgn(T val)
 {
-    if (t == 0) {
-        return T(0);
-    }
+    int oneIfPositive = int(0 < val);
+    int oneIfNegative = int(val < 0);
+    return T(oneIfPositive - oneIfNegative);  // 0/1 - 0/1 = -1/0/1
+}
 
-    return (t > 0) ? T(1) : T(-1);
 }
 
 template<class T>

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -129,18 +129,38 @@ constexpr std::enable_if_t<std::is_arithmetic_v<T> && std::is_signed_v<T>, T> sg
     return T(oneIfPositive - oneIfNegative);  // 0/1 - 0/1 = -1/0/1
 }
 
+/// Convert degrees to radians, allow deduction for floating point types
+template<std::floating_point T>
+constexpr T toRadians(T degrees)
+{
+    constexpr auto degToRad = std::numbers::pi_v<T> / T(180);
+    return degrees * degToRad;
 }
 
-template<class T>
-inline T toRadians(T d)
+/// Convert degrees to radians, allow **explicit-only** for any arithmetic type
+template<typename T>
+    requires(std::is_arithmetic_v<T> && !std::floating_point<T>)
+constexpr T toRadians(std::type_identity_t<T> degrees)
 {
-    return static_cast<T>((d * std::numbers::pi) / 180.0);
+    using ResultT = std::conditional_t<std::is_integral_v<T>, double, T>;
+    return static_cast<T>(toRadians<ResultT>(static_cast<ResultT>(degrees)));
 }
 
-template<class T>
-inline T toDegrees(T r)
+/// Convert radians to degrees, allow deduction for floating point types
+template<std::floating_point T>
+constexpr T toDegrees(T radians)
 {
-    return static_cast<T>((r / std::numbers::pi) * 180.0);
+    constexpr auto radToDeg = T(180) / std::numbers::pi_v<T>;
+    return radians * radToDeg;
+}
+
+/// Convert radians to degrees, allow **explicit-only** for any arithmetic type
+template<typename T>
+    requires(std::is_arithmetic_v<T> && !std::floating_point<T>)
+constexpr T toDegrees(std::type_identity_t<T> radians)
+{
+    using ResultT = std::conditional_t<std::is_integral_v<T>, double, T>;
+    return static_cast<T>(toDegrees<ResultT>(static_cast<ResultT>(radians)));
 }
 
 inline float fromPercent(const long value)

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -173,7 +173,7 @@ inline long toPercent(float value)
     return std::lround(100.0 * value);
 }
 
-template<class T>
+template<std::floating_point T>
 inline T fmod(T numerator, T denominator)
 {
     T modulo = std::fmod(numerator, denominator);

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -113,9 +113,10 @@ inline manipulator<int> blanks(int n)
 // ----------------------------------------------------------------------------
 
 template<class T>
+    requires std::is_arithmetic_v<T>
 inline T clamp(T num, T lower, T upper)
 {
-    return std::max<T>(std::min<T>(upper, num), lower);
+    return std::clamp<T>(num, lower, upper);
 }
 
 template<class T>


### PR DESCRIPTION
Some compilers didn't optimize the toRadians properly (found by Jesse on discord) and due to a https://github.com/FreeCAD/FreeCAD/pull/20476#discussion_r2033239535 I dive down this rabbit hole.

This refactoring seem to work as far as I can see and stuff like `Base::toRadians(3.0)` _always_ compiles to a constant if a constant.

In addition to this I made sure `Base::toRadians(3)` doesn't compile as that would just return `0`. If this is something we want by design, it is possible to call it explicitly `Base::toRadians<int>(3)`.

Yet another thing I've done here is to make the `sgn` function without branches. I think it is quite readable too, but I'm open for discussion.

I also tighten up so the functions can't be called with the wrong types.