### PR TITLE
CAM: Multiline POSTAMBLE and PREAMBLE arguments in old postprocessors

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
@@ -156,9 +156,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
@@ -68,11 +68,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\nG90"',
+    help='set commands to be issued before the first command, default="%\\nG17 G21 G40 G49 G80 G90\\nM08"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\nG17 G90\nM2"',
+    help='set commands to be issued after the last command, default="M05 M09\\nG17 G90 G80 G40\\nM30"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
@@ -156,9 +156,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
@@ -59,11 +59,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\nG90\nG80\nG40"',
+    help='set commands to be issued before the first command, default="G17\\nG90\\nG80\\nG40"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M09\nM05\nG80\nG40\nG17\nG90\nM30"',
+    help='set commands to be issued after the last command, default="M09\\nM05\\nG80\\nG40\\nG17\\nG90\\nM30"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G70)"

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
@@ -173,9 +173,9 @@ def processArguments(argstring):
         if args.precision is not None:
             PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.inches:
             UNITS = "G70"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
@@ -173,9 +173,9 @@ def processArguments(argstring):
         if args.precision is not None:
             PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.inches:
             UNITS = "G70"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
@@ -176,9 +176,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
@@ -86,11 +86,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\nG90\nG80\nG40"',
+    help='set commands to be issued before the first command, default="G17\\nG90\\nG80\\nG40"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M09\nM05\nG80\nG40\nG17\nG90\nM30"',
+    help='set commands to be issued after the last command, default="M09\\nM05\\nG80\\nG40\\nG17\\nG90\\nM30"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
@@ -176,9 +176,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
@@ -179,9 +179,9 @@ def processArguments(argstring):
             SHOW_EDITOR = False
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
@@ -179,9 +179,9 @@ def processArguments(argstring):
             SHOW_EDITOR = False
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/fangling_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fangling_post.py
@@ -156,9 +156,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/fangling_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fangling_post.py
@@ -65,11 +65,11 @@ parser.add_argument(
 )
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
-    "--preamble", help='set commands to be issued before the first command, default="G17\nG90"'
+    "--preamble", help='set commands to be issued before the first command, default="G90"'
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M5\nG17 G90\nM2"',
+    help='set commands to be issued after the last command, default="M8\\nG90 G40\\nM2"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/fangling_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fangling_post.py
@@ -156,9 +156,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -161,9 +161,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -161,9 +161,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -60,11 +60,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\nG90"',
+    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\nG17 G90\nM2"',
+    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM6 T0\\nM2"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/grbl_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/grbl_post.py
@@ -127,7 +127,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M5\nG17 G90\n;M2"',
+    help='set commands to be issued after the last command, default="M5\\nG17 G90\\nM2"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/grbl_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/grbl_post.py
@@ -215,9 +215,9 @@ def processArguments(argstring):
             SHOW_EDITOR = True
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.no_translate_drill:
             TRANSLATE_DRILL_CYCLES = False
         if args.translate_drill:

--- a/src/Mod/CAM/Path/Post/scripts/grbl_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/grbl_post.py
@@ -215,9 +215,9 @@ def processArguments(argstring):
             SHOW_EDITOR = True
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.no_translate_drill:
             TRANSLATE_DRILL_CYCLES = False
         if args.translate_drill:

--- a/src/Mod/CAM/Path/Post/scripts/jtech_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/jtech_post.py
@@ -155,9 +155,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/jtech_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/jtech_post.py
@@ -155,9 +155,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/jtech_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/jtech_post.py
@@ -56,11 +56,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="M05 S0\nG90"',
+    help='set commands to be issued before the first command, default="M05 S0\\nG90"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05 S0\nM2"',
+    help='set commands to be issued after the last command, default="M05 S0\\nM2"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -148,9 +148,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -56,11 +56,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\nG90"',
+    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\nG17 G90\nM2"',
+    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM2"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -148,9 +148,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
@@ -148,9 +148,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
@@ -56,11 +56,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\nG90"',
+    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\nG17 G90\nM2"',
+    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM2"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
@@ -148,9 +148,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/marlin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/marlin_post.py
@@ -262,9 +262,9 @@ def processArguments(argstring):
         if args.show_editor:
             SHOW_EDITOR = True
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.no_translate_drill:
             TRANSLATE_DRILL_CYCLES = False
         if args.translate_drill:

--- a/src/Mod/CAM/Path/Post/scripts/marlin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/marlin_post.py
@@ -262,9 +262,9 @@ def processArguments(argstring):
         if args.show_editor:
             SHOW_EDITOR = True
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.no_translate_drill:
             TRANSLATE_DRILL_CYCLES = False
         if args.translate_drill:

--- a/src/Mod/CAM/Path/Post/scripts/rrf_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/rrf_post.py
@@ -260,9 +260,9 @@ def processArguments(argstring):
         if args.show_editor:
             SHOW_EDITOR = True
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.no_translate_drill:
             TRANSLATE_DRILL_CYCLES = False
         if args.translate_drill:

--- a/src/Mod/CAM/Path/Post/scripts/rrf_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/rrf_post.py
@@ -260,9 +260,9 @@ def processArguments(argstring):
         if args.show_editor:
             SHOW_EDITOR = True
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.no_translate_drill:
             TRANSLATE_DRILL_CYCLES = False
         if args.translate_drill:

--- a/src/Mod/CAM/Path/Post/scripts/smoothie_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/smoothie_post.py
@@ -68,11 +68,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="4", help="number of digits of precision, default=4")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\nG90"',
+    help='set commands to be issued before the first command, default="G17\\nG90"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\nG17 G90\nM2"',
+    help='set commands to be issued after the last command, default="M05\\nG17 G90\\nM2"',
 )
 parser.add_argument("--IP_ADDR", help="IP Address for machine target machine")
 parser.add_argument(

--- a/src/Mod/CAM/Path/Post/scripts/smoothie_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/smoothie_post.py
@@ -172,9 +172,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/smoothie_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/smoothie_post.py
@@ -172,9 +172,9 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/uccnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/uccnc_post.py
@@ -336,14 +336,14 @@ def processArguments(argstring):
         PRECISION = args.precision
 
         if args.preamble is not None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         elif OUTPUT_COMMENTS:
             PREAMBLE = PREAMBLE_DEFAULT
         else:
             PREAMBLE = PREAMBLE_DEFAULT_NO_COMMENT
 
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         elif OUTPUT_COMMENTS:
             POSTAMBLE = POSTAMBLE_DEFAULT
         else:

--- a/src/Mod/CAM/Path/Post/scripts/uccnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/uccnc_post.py
@@ -336,14 +336,14 @@ def processArguments(argstring):
         PRECISION = args.precision
 
         if args.preamble is not None:
-            PREAMBLE = args.preamble.replace('\\n', '\n')
+            PREAMBLE = args.preamble.replace("\\n", "\n")
         elif OUTPUT_COMMENTS:
             PREAMBLE = PREAMBLE_DEFAULT
         else:
             PREAMBLE = PREAMBLE_DEFAULT_NO_COMMENT
 
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         elif OUTPUT_COMMENTS:
             POSTAMBLE = POSTAMBLE_DEFAULT
         else:

--- a/src/Mod/CAM/Path/Post/scripts/wedm_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/wedm_post.py
@@ -208,7 +208,7 @@ def processArguments(argstring):
         if args.preamble is not None:
             PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"

--- a/src/Mod/CAM/Path/Post/scripts/wedm_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/wedm_post.py
@@ -68,11 +68,11 @@ parser.add_argument("--precision", default="3", help="number of digits of precis
 parser.add_argument("--fixed-length", default="0", help="use fixed length coordinates, default=0")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\nG90"',
+    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\nG17 G90\nM2"',
+    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM2"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/wedm_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/wedm_post.py
@@ -208,7 +208,7 @@ def processArguments(argstring):
         if args.preamble is not None:
             PREAMBLE = args.preamble.replace("\\n", "\n")
         if args.postamble is not None:
-            POSTAMBLE = args.postamble.replace('\\n', '\n')
+            POSTAMBLE = args.postamble.replace("\\n", "\n")
         if args.inches:
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"


### PR DESCRIPTION
This changes allow to use `\n` with `--postamble` and `--preamble` arguments with old postprocessors

Example:
`--postamble='M5\nG17 G54 G40 G49 G80 G90\nM2\nM0\nM47'`

Result gcode output before changes:

```
(begin postamble)
M5\nG17 G54 G40 G49 G80 G90\nM2\nM0\nM47
```

Result g-code output after changes:

```
(begin postamble)
M5
G17 G54 G40 G49 G80 G90
M2
M0
M47
```
https://forum.freecad.org/viewtopic.php?t=28579
https://forum.freecad.org/viewtopic.php?t=96157
https://forum.freecad.org/viewtopic.php?t=86950