### PR TITLE
Sketcher: Prevent bad constraint names

### DIFF
--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -50,6 +50,19 @@ using namespace SketcherGui;
 
 /* TRANSLATOR SketcherGui::EditDatumDialog */
 
+bool SketcherGui::checkConstraintName(const Sketcher::SketchObject* sketch, std::string constraintName)
+{
+    if (constraintName != Base::Tools::getIdentifier(constraintName)) {
+        Gui::NotifyUserError(
+            sketch, QT_TRANSLATE_NOOP("Notifications", "Value Error"),
+            QT_TRANSLATE_NOOP("Notifications", "Invalid constraint name (must only contain alphanumericals and underscores, and must not start with digit)"));
+        return false;
+    }
+
+    return true;
+}
+
+
 EditDatumDialog::EditDatumDialog(ViewProviderSketch* vp, int ConstrNbr)
     : ConstrNbr(ConstrNbr)
     , success(false)
@@ -214,14 +227,11 @@ void EditDatumDialog::accepted()
             }
 
             std::string constraintName = ui_ins_datum->name->text().trimmed().toStdString();
-            if (constraintName != sketch->Constraints[ConstrNbr]->Name) {
-                if (constraintName != Base::Tools::getIdentifier(constraintName)) {
-                    Gui::NotifyUserError(
-                        sketch,
-                        QT_TRANSLATE_NOOP("Notifications", "Value Error"),
-                        "Invalid constraint name (must only contain alphanumericals, underscores, "
-                        "and must not start with digit)");
-                    constraintName.clear();
+            std::string currConstraintName = sketch->Constraints[ConstrNbr]->Name;
+            printf("datum");
+            if (constraintName != currConstraintName) {
+                if (!SketcherGui::checkConstraintName(sketch, constraintName)) {
+                    constraintName = currConstraintName;
                 }
 
                 Gui::cmdAppObjectArgs(sketch,

--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -213,15 +213,21 @@ void EditDatumDialog::accepted()
                 }
             }
 
-            QString constraintName = ui_ins_datum->name->text().trimmed();
-            if (constraintName.toStdString() != sketch->Constraints[ConstrNbr]->Name) {
-                std::string escapedstr =
-                    Base::Tools::escapedUnicodeFromUtf8(constraintName.toUtf8().constData());
-                escapedstr = Base::Tools::escapeQuotesFromString(escapedstr);
+            std::string constraintName = ui_ins_datum->name->text().trimmed().toStdString();
+            if (constraintName != sketch->Constraints[ConstrNbr]->Name) {
+                if (constraintName != Base::Tools::getIdentifier(constraintName)) {
+                    Gui::NotifyUserError(
+                        sketch,
+                        QT_TRANSLATE_NOOP("Notifications", "Value Error"),
+                        "Invalid constraint name (must only contain alphanumericals, underscores, "
+                        "and must not start with digit)");
+                    constraintName.clear();
+                }
+
                 Gui::cmdAppObjectArgs(sketch,
                                       "renameConstraint(%d, u'%s')",
                                       ConstrNbr,
-                                      escapedstr.c_str());
+                                      constraintName.c_str());
             }
 
             Gui::Command::commitCommand();

--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -50,12 +50,16 @@ using namespace SketcherGui;
 
 /* TRANSLATOR SketcherGui::EditDatumDialog */
 
-bool SketcherGui::checkConstraintName(const Sketcher::SketchObject* sketch, std::string constraintName)
+bool SketcherGui::checkConstraintName(const Sketcher::SketchObject* sketch,
+                                      std::string constraintName)
 {
     if (constraintName != Base::Tools::getIdentifier(constraintName)) {
         Gui::NotifyUserError(
-            sketch, QT_TRANSLATE_NOOP("Notifications", "Value Error"),
-            QT_TRANSLATE_NOOP("Notifications", "Invalid constraint name (must only contain alphanumericals and underscores, and must not start with digit)"));
+            sketch,
+            QT_TRANSLATE_NOOP("Notifications", "Value Error"),
+            QT_TRANSLATE_NOOP("Notifications",
+                              "Invalid constraint name (must only contain alphanumericals and "
+                              "underscores, and must not start with digit)"));
         return false;
     }
 

--- a/src/Mod/Sketcher/Gui/EditDatumDialog.h
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.h
@@ -38,6 +38,8 @@ namespace SketcherGui
 class ViewProviderSketch;
 class Ui_InsertDatum;
 
+bool checkConstraintName(const Sketcher::SketchObject* sketch, std::string constraintName);
+
 class EditDatumDialog: public QObject
 {
     Q_OBJECT

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1224,12 +1224,17 @@ void TaskSketcherConstraints::onListWidgetConstraintsItemChanged(QListWidgetItem
     // otherwise a checkbox change will trigger a rename on the first execution, bloating the
     // constraint icons with the default constraint name "constraint1, constraint2"
     if (newName != currConstraintName && !basename.empty()) {
-        std::string escapedstr = Base::Tools::escapedUnicodeFromUtf8(newName.c_str());
+        if (newName != Base::Tools::getIdentifier(newName)) {
+            Gui::NotifyUserError(
+                sketch, QT_TRANSLATE_NOOP("Notifications", "Value Error"),
+                "Invalid constraint name (must only contain alphanumericals, underscores, and must not start with digit)");
+            newName = currConstraintName;
+        }
 
         Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Rename sketch constraint"));
         try {
             Gui::cmdAppObjectArgs(
-                sketch, "renameConstraint(%d, u'%s')", it->ConstraintNbr, escapedstr.c_str());
+                sketch, "renameConstraint(%d, u'%s')", it->ConstraintNbr, newName.c_str());
             Gui::Command::commitCommand();
         }
         catch (const Base::Exception& e) {

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1223,11 +1223,9 @@ void TaskSketcherConstraints::onListWidgetConstraintsItemChanged(QListWidgetItem
     // b) that the text in the widget item, basename, is not ""
     // otherwise a checkbox change will trigger a rename on the first execution, bloating the
     // constraint icons with the default constraint name "constraint1, constraint2"
+    printf("task");
     if (newName != currConstraintName && !basename.empty()) {
-        if (newName != Base::Tools::getIdentifier(newName)) {
-            Gui::NotifyUserError(
-                sketch, QT_TRANSLATE_NOOP("Notifications", "Value Error"),
-                "Invalid constraint name (must only contain alphanumericals, underscores, and must not start with digit)");
+        if (!SketcherGui::checkConstraintName(sketch, newName)) {
             newName = currConstraintName;
         }
 


### PR DESCRIPTION
Whenever a constraint name contains a space (for example), it becomes impossible to reference it by name in an expression.

I added checks to ensure that constraint names only contain alphanumericals and underscores so that they can always be used in expressions.

Fixes: https://github.com/FreeCAD/FreeCAD/issues/19767