### PR TITLE
Draft: close task panels on doc close

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -48,7 +48,6 @@ SET (Draft_geoutils
 
 SET(Draft_tests
     drafttests/__init__.py
-    drafttests/README.md
     drafttests/auxiliary.py
     drafttests/draft_test_objects.py
     drafttests/test_airfoildat.py
@@ -65,22 +64,24 @@ SET(Draft_tests
     drafttests/test_oca.py
     drafttests/test_pivy.py
     drafttests/test_svg.py
+    drafttests/README.md
 )
 
 SET(Draft_utilities
     draftutils/__init__.py
+    draftutils/doc_observer.py
+    draftutils/grid_observer.py
     draftutils/groups.py
-    draftutils/init_tools.py
-    draftutils/init_draft_statusbar.py
-    draftutils/params.py
-    draftutils/units.py
-    draftutils/utils.py
     draftutils/gui_utils.py
+    draftutils/init_draft_statusbar.py
+    draftutils/init_tools.py
+    draftutils/messages.py
+    draftutils/params.py
     draftutils/todo.py
     draftutils/translate.py
-    draftutils/messages.py
+    draftutils/units.py
+    draftutils/utils.py
     draftutils/README.md
-    draftutils/grid_observer.py
 )
 
 SET(Draft_functions

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -157,6 +157,8 @@ class DraftWorkbench(FreeCADGui.Workbench):
         WorkingPlane._view_observer_start()  # Updates the draftToolBar when switching views.
         from draftutils import grid_observer
         grid_observer._view_observer_setup()
+        from draftutils import doc_observer
+        doc_observer._doc_observer_start()
         FreeCAD.Console.PrintLog("Draft workbench activated.\n")
 
     def Deactivated(self):
@@ -171,6 +173,8 @@ class DraftWorkbench(FreeCADGui.Workbench):
         WorkingPlane._view_observer_stop()
         from draftutils import grid_observer
         grid_observer._view_observer_setup()
+        from draftutils import doc_observer
+        doc_observer._doc_observer_stop()
         FreeCAD.Console.PrintLog("Draft workbench deactivated.\n")
 
     def ContextMenu(self, recipient):

--- a/src/Mod/Draft/draftguitools/gui_circulararray.py
+++ b/src/Mod/Draft/draftguitools/gui_circulararray.py
@@ -32,8 +32,6 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
-import Draft
-import Draft_rc  # include resources, icons, ui files
 from draftguitools import gui_base
 from draftutils import gui_utils
 from draftutils import todo
@@ -41,19 +39,14 @@ from draftutils.messages import _log
 from draftutils.translate import translate
 from drafttaskpanels import task_circulararray
 
-# The module is used to prevent complaints from code checkers (flake8)
-bool(Draft_rc.__name__)
-
 
 class CircularArray(gui_base.GuiCommandBase):
     """Gui command for the CircularArray tool."""
 
     def __init__(self):
-        super().__init__()
-        self.command_name = "Circular array"
+        super().__init__(name="CircularArray")
         self.location = None
         self.mouse_event = None
-        self.view = None
         self.callback_move = None
         self.callback_click = None
         self.ui = None
@@ -61,9 +54,9 @@ class CircularArray(gui_base.GuiCommandBase):
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        return {'Pixmap': 'Draft_CircularArray',
-               'MenuText': QT_TRANSLATE_NOOP("Draft_CircularArray", "Circular array"),
-               'ToolTip': QT_TRANSLATE_NOOP("Draft_CircularArray", "Creates copies of the selected object, and places the copies in a radial pattern\ncreating various circular layers.\n\nThe array can be turned into an orthogonal or a polar array by changing its type.")}
+        return {"Pixmap": "Draft_CircularArray",
+                "MenuText": QT_TRANSLATE_NOOP("Draft_CircularArray", "Circular array"),
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_CircularArray", "Creates copies of the selected object, and places the copies in a radial pattern\ncreating various circular layers.\n\nThe array can be turned into an orthogonal or a polar array by changing its type.")}
 
     def Activated(self):
         """Execute when the command is called.
@@ -71,11 +64,10 @@ class CircularArray(gui_base.GuiCommandBase):
         We add callbacks that connect the 3D view with
         the widgets of the task panel.
         """
-        _log("GuiCommand: {}".format(self.command_name))
+        super().Activated()
 
         self.location = coin.SoLocation2Event.getClassTypeId()
         self.mouse_event = coin.SoMouseButtonEvent.getClassTypeId()
-        self.view = Draft.get3DView()
         self.callback_move = \
             self.view.addEventCallbackPivy(self.location, self.move)
         self.callback_click = \
@@ -135,7 +127,7 @@ class CircularArray(gui_base.GuiCommandBase):
         self.callback_click = None
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
-            self.finish()
+        self.finish()
 
 
 Gui.addCommand('Draft_CircularArray', CircularArray())

--- a/src/Mod/Draft/draftguitools/gui_orthoarray.py
+++ b/src/Mod/Draft/draftguitools/gui_orthoarray.py
@@ -32,8 +32,6 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
-import Draft
-import Draft_rc  # include resources, icons, ui files
 from draftguitools import gui_base
 from draftutils import gui_utils
 from draftutils import todo
@@ -41,19 +39,14 @@ from draftutils.messages import _log
 from draftutils.translate import translate
 from drafttaskpanels import task_orthoarray
 
-# The module is used to prevent complaints from code checkers (flake8)
-bool(Draft_rc.__name__)
-
 
 class OrthoArray(gui_base.GuiCommandBase):
     """Gui command for the OrthoArray tool."""
 
     def __init__(self):
-        super().__init__()
-        self.command_name = "Orthogonal array"
+        super().__init__(name="OrthoArray")
         # self.location = None
         self.mouse_event = None
-        self.view = None
         # self.callback_move = None
         self.callback_click = None
         self.ui = None
@@ -71,11 +64,10 @@ class OrthoArray(gui_base.GuiCommandBase):
         We add callbacks that connect the 3D view with
         the widgets of the task panel.
         """
-        _log("GuiCommand: {}".format(self.command_name))
+        super().Activated()
 
         # self.location = coin.SoLocation2Event.getClassTypeId()
         self.mouse_event = coin.SoMouseButtonEvent.getClassTypeId()
-        self.view = Draft.get3DView()
         # self.callback_move = \
         #     self.view.addEventCallbackPivy(self.location, self.move)
         self.callback_click = \
@@ -120,7 +112,7 @@ class OrthoArray(gui_base.GuiCommandBase):
         self.callback_click = None
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
-            self.finish()
+        self.finish()
 
 
 Gui.addCommand('Draft_OrthoArray', OrthoArray())

--- a/src/Mod/Draft/draftguitools/gui_polararray.py
+++ b/src/Mod/Draft/draftguitools/gui_polararray.py
@@ -32,8 +32,6 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
-import Draft
-import Draft_rc  # include resources, icons, ui files
 from draftguitools import gui_base
 from draftutils import gui_utils
 from draftutils import todo
@@ -41,19 +39,14 @@ from draftutils.messages import _log
 from draftutils.translate import translate
 from drafttaskpanels import task_polararray
 
-# The module is used to prevent complaints from code checkers (flake8)
-bool(Draft_rc.__name__)
-
 
 class PolarArray(gui_base.GuiCommandBase):
     """Gui command for the PolarArray tool."""
 
     def __init__(self):
-        super().__init__()
-        self.command_name = "Polar array"
+        super().__init__(name="PolarArray")
         self.location = None
         self.mouse_event = None
-        self.view = None
         self.callback_move = None
         self.callback_click = None
         self.ui = None
@@ -61,9 +54,9 @@ class PolarArray(gui_base.GuiCommandBase):
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        return {'Pixmap': 'Draft_PolarArray',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_PolarArray", "Polar array"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_PolarArray", "Creates copies of the selected object, and places the copies in a polar pattern\ndefined by a center of rotation and its angle.\n\nThe array can be turned into an orthogonal or a circular array by changing its type.")}
+        return {"Pixmap": "Draft_PolarArray",
+                "MenuText": QT_TRANSLATE_NOOP("Draft_PolarArray", "Polar array"),
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_PolarArray", "Creates copies of the selected object, and places the copies in a polar pattern\ndefined by a center of rotation and its angle.\n\nThe array can be turned into an orthogonal or a circular array by changing its type.")}
 
     def Activated(self):
         """Execute when the command is called.
@@ -71,11 +64,10 @@ class PolarArray(gui_base.GuiCommandBase):
         We add callbacks that connect the 3D view with
         the widgets of the task panel.
         """
-        _log("GuiCommand: {}".format(self.command_name))
+        super().Activated()
 
         self.location = coin.SoLocation2Event.getClassTypeId()
         self.mouse_event = coin.SoMouseButtonEvent.getClassTypeId()
-        self.view = Draft.get3DView()
         self.callback_move = \
             self.view.addEventCallbackPivy(self.location, self.move)
         self.callback_click = \
@@ -135,7 +127,7 @@ class PolarArray(gui_base.GuiCommandBase):
         self.callback_click = None
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
-            self.finish()
+        self.finish()
 
 
 Gui.addCommand('Draft_PolarArray', PolarArray())

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -142,7 +142,6 @@ class ShapeStringTaskPanelCmd(ShapeStringTaskPanel):
 
     def reject(self):
         """Run when clicking the Cancel button."""
-        Gui.ActiveDocument.resetEdit()
         self.sourceCmd.finish()
         self.platWinDialog("Restore")
         return True
@@ -160,15 +159,14 @@ class ShapeStringTaskPanelCmd(ShapeStringTaskPanel):
         z = App.Units.Quantity(self.form.sbZ.text()).Value
         ssBase = App.Vector(x, y, z)
         try:
-            qr, sup, points, fil = self.sourceCmd.getStrings()
             Gui.addModule("Draft")
+            Gui.addModule("WorkingPlane")
             self.sourceCmd.commit(translate('draft', 'Create ShapeString'),
                                   ['ss = Draft.make_shapestring(String=' + String + ', FontFile=' + FFile + ', Size=' + Size + ', Tracking=' + Tracking + ')',
-                                   'plm = FreeCAD.Placement()',
-                                   'plm.Base = ' + toString(ssBase),
-                                   'plm.Rotation.Q = ' + qr,
-                                   'ss.Placement = plm',
-                                   'ss.AttachmentSupport = ' + sup,
+                                   'pl = FreeCAD.Placement()',
+                                   'pl.Base = ' + toString(ssBase),
+                                   'pl.Rotation = WorkingPlane.get_working_plane().get_placement().Rotation',
+                                   'ss.Placement = pl',
                                    'Draft.autogroup(ss)',
                                    'FreeCAD.ActiveDocument.recompute()'])
         except Exception:

--- a/src/Mod/Draft/draftutils/doc_observer.py
+++ b/src/Mod/Draft/draftutils/doc_observer.py
@@ -1,0 +1,42 @@
+import FreeCAD as App
+
+if App.GuiUp:
+    import FreeCADGui as Gui
+    from draftutils.todo import ToDo
+
+    class _Draft_DocObserver():
+
+        # See: /src/Gui/DocumentObserverPython.h
+
+        def slotDeletedDocument(self, gui_doc):
+            _finish_command_on_doc_close(gui_doc)
+
+    _doc_observer = None
+
+    def _doc_observer_start():
+        global _doc_observer
+        if _doc_observer is None:
+            _doc_observer = _Draft_DocObserver()
+            Gui.addDocumentObserver(_doc_observer)
+
+    def _doc_observer_stop():
+        global _doc_observer
+        try:
+            if _doc_observer is not None:
+                Gui.removeDocumentObserver(_doc_observer)
+        except:
+            pass
+        _doc_observer = None
+
+    def _finish_command_on_doc_close(gui_doc):
+        """Finish the active Draft or BIM command if the related document has been
+        closed. Only works for commands that have set `App.activeDraftCommand.doc`
+        and use a task panel.
+        """
+        if getattr(App, "activeDraftCommand", None) \
+                and getattr(App.activeDraftCommand, "doc", None) == gui_doc.Document \
+                and getattr(App.activeDraftCommand, "ui", None):
+            if hasattr(App.activeDraftCommand.ui, "reject"):
+                ToDo.delay(App.activeDraftCommand.ui.reject, None)
+            elif hasattr(App.activeDraftCommand.ui, "escape"):
+                ToDo.delay(App.activeDraftCommand.ui.escape, None)


### PR DESCRIPTION
Related: #17952.

This PR introduces a document observer to close task panels on doc close.

For now it is for the Draft Workbench only. The BIM Workbench will be dealt with in a future PR.

The basic code is simple, but to make things works some additional things were addressed:
* gui_base.py: the GuiCommandBase class was enhanced to handle App.activeDraftCommand, self.doc, self.view and self.planetracker. Strictly speaking only the first 2 are required for this PR.
* gui_base.py: self.command_name was changed to self.featureName for compatibility with gui_base_original.py. Not required for this PR.
* gui_arcs.py, gui_circulararray.py, gui_polararray.py and gui_orthoarray.py: updated in relation to the GuiCommandBase class.
* gui_arcs.py Arc_3Points: The command now has a ui property and shows a plane tracker. Only the first is required for this PR.
* gui_shapestrings.py: This command had two ui attributes: self.ui and self.task. This was problematic. To fix this the base class of the command was changed from gui_base_original.Creator to gui_base.GuiCommandBase. As a result the getStrings method is no longer available meaning that the useSupport parameter is ignored when creating a ShapeString. But since that mechanism does not work properly anyway, I feel that this is acceptable. Should many users complain the functionality can of course be reintroduced.
