### PR TITLE
Assembly: enable BOM columns to be autopopulated with given properties 

### DIFF
--- a/src/Mod/Assembly/App/BomObject.cpp
+++ b/src/Mod/Assembly/App/BomObject.cpp
@@ -279,6 +279,9 @@ std::string BomObject::getBomPropertyValue(App::DocumentObject* obj, const std::
     else if (auto propQuantity = freecad_cast<App::PropertyQuantity*>(prop)) {
         return propQuantity->getQuantityValue().getUserString();
     }
+    else if (auto propEnum = freecad_cast<App::PropertyEnumeration*>(prop)) {
+        return propEnum->getValueAsString();
+    }
     else if (auto propFloat = freecad_cast<App::PropertyFloat*>(prop)) {
         return std::to_string(propFloat->getValue());
     }

--- a/src/Mod/Assembly/App/BomObject.cpp
+++ b/src/Mod/Assembly/App/BomObject.cpp
@@ -277,9 +277,7 @@ std::string BomObject::getBomPropertyValue(App::DocumentObject* obj, const std::
         return propStr->getValue();
     }
     else if (auto propQuantity = freecad_cast<App::PropertyQuantity*>(prop)) {
-        auto unit = propQuantity->getUnit().getString();
-        auto value = std::to_string(propQuantity->getValue());
-        return value + " " + unit;
+        return propQuantity->getQuantityValue().getUserString();
     }
     else if (auto propFloat = freecad_cast<App::PropertyFloat*>(prop)) {
         return std::to_string(propFloat->getValue());

--- a/src/Mod/Assembly/App/BomObject.cpp
+++ b/src/Mod/Assembly/App/BomObject.cpp
@@ -276,16 +276,6 @@ std::string BomObject::getBomPropertyValue(App::DocumentObject* obj, const std::
     if (auto propStr = dynamic_cast<App::PropertyString*>(prop)) {
         return propStr->getValue();
     }
-    else if (auto propLength = dynamic_cast<App::PropertyLength*>(prop)) {
-        auto unit = propLength->getUnit().getString();
-        auto value = std::to_string(propLength->getValue());
-        return value + " " + unit;
-    }
-    else if (auto propVolume = dynamic_cast<App::PropertyVolume*>(prop)) {
-        auto unit = propVolume->getUnit().getString();
-        auto value = std::to_string(propVolume->getValue());
-        return value + " " + unit;
-    }
     else if (auto propQuantity = dynamic_cast<App::PropertyQuantity*>(prop)) {
         auto unit = propQuantity->getUnit().getString();
         auto value = std::to_string(propQuantity->getValue());

--- a/src/Mod/Assembly/App/BomObject.cpp
+++ b/src/Mod/Assembly/App/BomObject.cpp
@@ -273,21 +273,21 @@ std::string BomObject::getBomPropertyValue(App::DocumentObject* obj, const std::
     }
 
     // Only support a subset of property types for BOM
-    if (auto propStr = dynamic_cast<App::PropertyString*>(prop)) {
+    if (auto propStr = freecad_cast<App::PropertyString*>(prop)) {
         return propStr->getValue();
     }
-    else if (auto propQuantity = dynamic_cast<App::PropertyQuantity*>(prop)) {
+    else if (auto propQuantity = freecad_cast<App::PropertyQuantity*>(prop)) {
         auto unit = propQuantity->getUnit().getString();
         auto value = std::to_string(propQuantity->getValue());
         return value + " " + unit;
     }
-    else if (auto propFloat = dynamic_cast<App::PropertyFloat*>(prop)) {
+    else if (auto propFloat = freecad_cast<App::PropertyFloat*>(prop)) {
         return std::to_string(propFloat->getValue());
     }
-    else if (auto propInt = dynamic_cast<App::PropertyInteger*>(prop)) {
+    else if (auto propInt = freecad_cast<App::PropertyInteger*>(prop)) {
         return std::to_string(propInt->getValue());
     }
-    else if (auto propBool = dynamic_cast<App::PropertyBool*>(prop)) {
+    else if (auto propBool = freecad_cast<App::PropertyBool*>(prop)) {
         return propBool->getValue() ? "True" : "False";
     }
 

--- a/src/Mod/Assembly/App/BomObject.cpp
+++ b/src/Mod/Assembly/App/BomObject.cpp
@@ -39,6 +39,7 @@
 #include <Base/Rotation.h>
 #include <Base/Tools.h>
 #include <Base/Interpreter.h>
+#include <QObject>
 
 #include <Mod/Part/App/PartFeature.h>
 #include <Mod/PartDesign/App/Body.h>
@@ -268,7 +269,7 @@ std::string BomObject::getBomPropertyValue(App::DocumentObject* obj, std::string
 
     if (!prop) {
         Base::Console().Warning("Property not found: %s\n", baseName.c_str());
-        return "N/A";
+        return QObject::tr("N/A").toStdString();
     }
 
     // Only support a subset of property types for BOM
@@ -301,7 +302,7 @@ std::string BomObject::getBomPropertyValue(App::DocumentObject* obj, std::string
     }
 
     Base::Console().Warning("Property type not supported for: %s\n", prop->getName());
-    return "Not supported";
+    return QObject::tr("Not supported").toStdString();
 }
 
 AssemblyObject* BomObject::getAssembly()

--- a/src/Mod/Assembly/App/BomObject.cpp
+++ b/src/Mod/Assembly/App/BomObject.cpp
@@ -263,7 +263,7 @@ void BomObject::addObjectToBom(App::DocumentObject* obj, size_t row, std::string
     }
 }
 
-std::string BomObject::getBomPropertyValue(App::DocumentObject* obj, std::string baseName)
+std::string BomObject::getBomPropertyValue(App::DocumentObject* obj, const std::string& baseName)
 {
     App::Property* prop = obj->getPropertyByName(baseName.c_str());
 

--- a/src/Mod/Assembly/App/BomObject.h
+++ b/src/Mod/Assembly/App/BomObject.h
@@ -96,7 +96,7 @@ public:
     std::vector<App::DocumentObject*> obj_list;
 
 private:
-    std::string getBomPropertyValue(App::DocumentObject* obj, std::string baseName);
+    std::string getBomPropertyValue(App::DocumentObject* obj, const std::string& baseName);
 };
 
 

--- a/src/Mod/Assembly/App/BomObject.h
+++ b/src/Mod/Assembly/App/BomObject.h
@@ -94,6 +94,9 @@ public:
 
     std::vector<BomDataElement> dataElements;
     std::vector<App::DocumentObject*> obj_list;
+
+private:
+    std::string getBomPropertyValue(App::DocumentObject* obj, std::string baseName);
 };
 
 

--- a/src/Mod/Assembly/CommandCreateBom.py
+++ b/src/Mod/Assembly/CommandCreateBom.py
@@ -402,7 +402,7 @@ class TaskAssemblyCreateBom(QtCore.QObject):
             " - "
             + translate(
                 "Assembly",
-                "Custom columns : 'Description' and other custom columns you add by clicking on 'Add column' will not have their data overwritten. These columns can be renamed by double-clicking or pressing F2 (Renaming a column will currently lose its data).",
+                "Custom columns : 'Description' and other custom columns you add by clicking on 'Add column' will not have their data overwritten. If a column name starts with '.' followed by a property name (e.g. '.Length'), it will be auto-populated with that property value. These columns can be renamed by double-clicking or pressing F2 (Renaming a column will currently lose its data).",
             )
             + "\n"
             "\n"


### PR DESCRIPTION
In Assembly Bill Of Materials (BOM), provide custom columns with the ability to automatically list the value of a given property. For this to work, the column must be named starting with a dot, followed by the name of the property

This is more or less an MVP to be reviewed, commented on, and possibly to make the minimum functionality available already. On a subsequent iteration, there should probably be a dialog for individually setting the column name and its associated property.

![image](https://github.com/user-attachments/assets/6c9fa185-d300-4931-8438-82c24b2222c0)
_Dynamic properties as a source_

![image](https://github.com/user-attachments/assets/940ff13f-b8f3-46f3-8e7a-30d3440e7765)
_Column names with `.PropertyName` notation in the BOM settings_

![image](https://github.com/user-attachments/assets/154ac901-6d5e-4ce9-8a5d-18924158d266)
_BOM output with autopopulated columns based on properties_

Fixes: https://github.com/FreeCAD/FreeCAD/issues/20730

## Known issues

- Unless the property names themselves are translated, the dot column names are not translatable
- Column names cannot be decoupled from property names
- This approach is not the most optimal in terms of user friendliness and discoverability. This is mitigated by explaining how it works in the help dialog.

These can probably be addressed in a subsequent iteration with a dialog to set the column name and associated property independently. A place to save the associated property name would need to be devised (perhaps the in the `columnsNames` property?).

## Implementation details <a href="implementation-details" id="implementation-details"/>

The dot notation has been chosen as:
- It's already used in some parts of FreeCAD when referencing an object (e.g. dynamic properties)
- It clearly marks the column name as being different than the rest (autopopulated)

Only properties and not expressions are supported:
- Easier to implement => simpler, cleaner code
- Expressions are indirectly supported by adding them to a dynamic property and listing the property value

Only a subset of property types is available:
- If the type of the property specified is not supported, a translatable "_Not supported_" message is added to the relevant cell.
- If the property is not found, a translatable "_N/A_" message is added to the relevant cell.

:warning: In both cases above, a warning will be shown in the report window. Having used the feature a few times, I realize at least the "_Not supported_" warning could be removed. It can get tedious to get multiple warnings as the spreadsheet is being recomputed. The translatable messages in the spreadsheet already indicate what's happened.

When a property type supports units, it will be displayed in the user's chosen unit system.

Based on the approach from the code in the linked issue description.

## Testing

For Linux users: snap test build available at https://github.com/furgo16/FreeCAD-snap/actions/runs/14395158869. To install in parallel, without affecting any other existing FreeCAD installation:

1. Download the `snap-package` artifact from the link above
2. Uncompress it
3. Run this set of commands on the terminal:

```shell
$ sudo snap set system experimental.parallel-instances=true # Only needed once: https://snapcraft.io/docs/parallel-installs
$ sudo snap install ./$UNCOMPRESSED_SNAP.snap --dangerous --name=freecad_cnt # The `freecad_cnt` name is arbitrary, you can call it `freecad_$FOO`
$ freecad_cnt # Launch the snap package
```
