### PR TITLE
[Doc] Fix unassociated doc strings

### DIFF
--- a/src/Mod/Import/App/SketchExportHelper.h
+++ b/src/Mod/Import/App/SketchExportHelper.h
@@ -20,7 +20,6 @@
  *                                                                         *
  ***************************************************************************/
 
-//! a class to assist with exporting sketches to dxf
 
 #include <Mod/Import/ImportGlobal.h>
 
@@ -35,6 +34,9 @@ class DocumentObject;
 namespace Import
 {
 
+/**
+ * A class to assist with exporting sketches to dxf.
+ */
 class ImportExport SketchExportHelper
 {
 public:

--- a/src/Mod/TechDraw/Gui/CommandHelpers.h
+++ b/src/Mod/TechDraw/Gui/CommandHelpers.h
@@ -22,7 +22,6 @@
  *                                                                         *
  ***************************************************************************/
 
-//! CommandHelpers is a collection of methods for common actions in commands
 
 
 #ifndef COMMANDHELPERS_H
@@ -46,6 +45,9 @@ namespace TechDraw {
 class DrawView;
 class DrawViewPart;
 
+/**
+ * CommandHelpers is a collection of methods for common actions in commands.
+ */
 namespace CommandHelpers {
 TechDraw::DrawView* firstViewInSelection(Gui::Command* cmd);
 TechDraw::DrawView* firstNonSpreadsheetInSelection(Gui::Command* cmd);


### PR DESCRIPTION
Before this commit, these doc strings were unassociated, which means that the can appear at random places.  They are now associated with their namespace an class.

The doc output before this commit where you can see that these doc strings were included in the namespace app documentation:

![screenshot-unassociated-doc-strings](https://github.com/user-attachments/assets/a052e605-1463-4d7a-8f04-e5d53aae40ea)

Related to #20503