### PR TITLE
Gui: inputfield only show invalid states

### DIFF
--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -89,7 +89,7 @@ InputField::InputField(QWidget * parent)
     iconLabel->setCursor(Qt::ArrowCursor);
     QFontMetrics fm(font());
     int iconSize = fm.height();
-    QPixmap pixmap = getValidationIcon(":/icons/button_valid.svg", QSize(iconSize, iconSize));
+    QPixmap pixmap = getValidationIcon(":/icons/button_invalid.svg", QSize(iconSize, iconSize));
     iconLabel->setPixmap(pixmap);
     iconLabel->hide();
     connect(this, &QLineEdit::textChanged, this, &InputField::updateIconLabel);
@@ -270,8 +270,9 @@ void InputField::newInput(const QString & text)
     }
     catch(Base::Exception &e){
         QString errorText = QString::fromLatin1(e.what());
-        QPixmap pixmap = getValidationIcon(":/icons/button_invalid.svg", iconLabel->sizeHint());
-        iconLabel->setPixmap(pixmap);
+        if (iconLabel->isHidden()) {
+            iconLabel->setVisible(true);
+        }
         Q_EMIT parseError(errorText);
         validInput = false;
         return;
@@ -282,16 +283,17 @@ void InputField::newInput(const QString & text)
 
     // check if unit fits!
     if(!actUnit.isEmpty() && !res.getUnit().isEmpty() && actUnit != res.getUnit()){
-        QPixmap pixmap = getValidationIcon(":/icons/button_invalid.svg", iconLabel->sizeHint());
-        iconLabel->setPixmap(pixmap);
+        if (iconLabel->isHidden()) {
+            iconLabel->setVisible(true);
+        }
         Q_EMIT parseError(QStringLiteral("Wrong unit"));
         validInput = false;
         return;
     }
 
-
-    QPixmap pixmap = getValidationIcon(":/icons/button_valid.svg", iconLabel->sizeHint());
-    iconLabel->setPixmap(pixmap);
+    if (iconLabel->isVisible()) {
+        iconLabel->setVisible(false);
+    }
     validInput = true;
 
     if (res.getValue() > Maximum){


### PR DESCRIPTION
as we talked in discord a while ago, only an invalid icon should be provided

![imagen](https://github.com/user-attachments/assets/8dfaae84-73dc-4361-a788-4809d3c19c2b)

this also should have better performance, and fixes the resizing and moving bug that @benj5378 shown, due to not having to re-set the pixmap