### PR TITLE
Draft/BIM: Change Continue behavior and caching among commands

### DIFF
--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -295,7 +295,6 @@ class _CommandStructure:
             self.Length = params.get_param_arch("StructureLength")
             self.Height = params.get_param_arch("StructureHeight")
         self.Profile = None
-        self.continueCmd = False
         self.bpoint = None
         self.bmode = False
         self.precastvalues = None
@@ -338,6 +337,7 @@ class _CommandStructure:
             title=translate("Arch","Base point of column")+":"
         FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
         FreeCADGui.Snapper.getPoint(callback=self.getPoint,movecallback=self.update,extradlg=[self.taskbox(),self.precast.form,self.dents.form],title=title)
+        FreeCADGui.draftToolBar.continueCmd.show()
 
     def getPoint(self,point=None,obj=None):
 
@@ -423,7 +423,7 @@ class _CommandStructure:
         FreeCAD.ActiveDocument.recompute()
         # gui_utils.end_all_events()  # Causes a crash on Linux.
         self.tracker.finalize()
-        if self.continueCmd:
+        if FreeCADGui.draftToolBar.continueCmd.isChecked():
             self.Activated()
 
     def _createItemlist(self, baselist):
@@ -505,21 +505,10 @@ class _CommandStructure:
         grid.addWidget(self.vHeight,6,1,1,1)
 
         # horizontal button
-        value5 = QtGui.QPushButton(translate("Arch","Switch Length/Height"))
-        grid.addWidget(value5,7,0,1,1)
-        value6 = QtGui.QPushButton(translate("Arch","Switch Length/Width"))
-        grid.addWidget(value6,7,1,1,1)
-
-        # continue button
-        label4 = QtGui.QLabel(translate("Arch","Con&tinue"))
-        value4 = QtGui.QCheckBox()
-        value4.setObjectName("ContinueCmd")
-        value4.setLayoutDirection(QtCore.Qt.RightToLeft)
-        label4.setBuddy(value4)
-        self.continueCmd = params.get_param("ContinueMode")
-        value4.setChecked(self.continueCmd)
-        grid.addWidget(label4,8,0,1,1)
-        grid.addWidget(value4,8,1,1,1)
+        value4 = QtGui.QPushButton(translate("Arch","Switch Length/Height"))
+        grid.addWidget(value4,7,0,1,1)
+        value5 = QtGui.QPushButton(translate("Arch","Switch Length/Width"))
+        grid.addWidget(value5,7,1,1,1)
 
         # connect slots
         QtCore.QObject.connect(self.valuec,QtCore.SIGNAL("currentIndexChanged(int)"),self.setCategory)
@@ -527,9 +516,8 @@ class _CommandStructure:
         QtCore.QObject.connect(self.vLength,QtCore.SIGNAL("valueChanged(double)"),self.setLength)
         QtCore.QObject.connect(self.vWidth,QtCore.SIGNAL("valueChanged(double)"),self.setWidth)
         QtCore.QObject.connect(self.vHeight,QtCore.SIGNAL("valueChanged(double)"),self.setHeight)
-        QtCore.QObject.connect(value4,QtCore.SIGNAL("stateChanged(int)"),self.setContinue)
-        QtCore.QObject.connect(value5,QtCore.SIGNAL("pressed()"),self.rotateLH)
-        QtCore.QObject.connect(value6,QtCore.SIGNAL("pressed()"),self.rotateLW)
+        QtCore.QObject.connect(value4,QtCore.SIGNAL("pressed()"),self.rotateLH)
+        QtCore.QObject.connect(value5,QtCore.SIGNAL("pressed()"),self.rotateLW)
         QtCore.QObject.connect(self.modeb,QtCore.SIGNAL("toggled(bool)"),self.switchLH)
 
         # restore preset
@@ -601,11 +589,6 @@ class _CommandStructure:
             params.set_param_arch("StructureHeight",d)
         else:
             params.set_param_arch("StructureLength",d)
-
-    def setContinue(self,i):
-
-        self.continueCmd = bool(i)
-        params.set_param("ContinueMode", bool(i))
 
     def setCategory(self,i):
 

--- a/src/Mod/BIM/bimcommands/BimBeam.py
+++ b/src/Mod/BIM/bimcommands/BimBeam.py
@@ -38,6 +38,7 @@ class BIM_Beam(ArchStructure._CommandStructure):
     def __init__(self):
         super().__init__()
         self.beammode = True
+        self.featureName = "Beam"
 
     def IsActive(self):
         v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")

--- a/src/Mod/BIM/bimcommands/BimColumn.py
+++ b/src/Mod/BIM/bimcommands/BimColumn.py
@@ -38,6 +38,7 @@ class BIM_Column(ArchStructure._CommandStructure):
     def __init__(self):
         super().__init__()
         self.beammode = False
+        self.featureName = "Column"
 
     def IsActive(self):
         v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")

--- a/src/Mod/BIM/bimcommands/BimWall.py
+++ b/src/Mod/BIM/bimcommands/BimWall.py
@@ -75,7 +75,7 @@ class Arch_Wall:
         self.MultiMat = None
         self.Length = None
         self.lengthValue = 0
-        self.continueCmd = False
+        self.featureName = "Wall"
         self.Width = params.get_param_arch("WallWidth")
         self.Height = params.get_param_arch("WallHeight")
         self.JOIN_WALLS_SKETCHES = params.get_param_arch("joinWallSketches")
@@ -118,6 +118,7 @@ class Arch_Wall:
             FreeCADGui.Snapper.getPoint(callback=self.getPoint,
                                         extradlg=self.taskbox(),
                                         title=translate("Arch","First point of wall")+":")
+            FreeCADGui.draftToolBar.continueCmd.show()
 
     def getPoint(self,point=None,obj=None):
         """Callback for clicks during interactive mode.
@@ -194,7 +195,7 @@ class Arch_Wall:
             FreeCAD.ActiveDocument.recompute()
             # gui_utils.end_all_events()  # Causes a crash on Linux.
             self.tracker.finalize()
-            if self.continueCmd:
+            if FreeCADGui.draftToolBar.continueCmd.isChecked():
                 self.Activated()
 
     def addDefault(self):
@@ -319,31 +320,20 @@ class Arch_Wall:
         grid.addWidget(label3,4,0,1,1)
         grid.addWidget(value3,4,1,1,1)
 
-        label4 = QtGui.QLabel(translate("Arch","Con&tinue"))
+        label4 = QtGui.QLabel(translate("Arch","Use sketches"))
         value4 = QtGui.QCheckBox()
-        value4.setObjectName("ContinueCmd")
+        value4.setObjectName("UseSketches")
         value4.setLayoutDirection(QtCore.Qt.RightToLeft)
         label4.setBuddy(value4)
-        self.continueCmd = params.get_param("ContinueMode")
-        value4.setChecked(self.continueCmd)
+        value4.setChecked(params.get_param_arch("WallSketches"))
         grid.addWidget(label4,5,0,1,1)
         grid.addWidget(value4,5,1,1,1)
-
-        label5 = QtGui.QLabel(translate("Arch","Use sketches"))
-        value5 = QtGui.QCheckBox()
-        value5.setObjectName("UseSketches")
-        value5.setLayoutDirection(QtCore.Qt.RightToLeft)
-        label5.setBuddy(value5)
-        value5.setChecked(params.get_param_arch("WallSketches"))
-        grid.addWidget(label5,6,0,1,1)
-        grid.addWidget(value5,6,1,1,1)
 
         self.Length.valueChanged.connect(self.setLength)
         value1.valueChanged.connect(self.setWidth)
         value2.valueChanged.connect(self.setHeight)
         value3.currentIndexChanged.connect(self.setAlign)
-        value4.stateChanged.connect(self.setContinue)
-        value5.stateChanged.connect(self.setUseSketch)
+        value4.stateChanged.connect(self.setUseSketch)
         self.Length.returnPressed.connect(value1.setFocus)
         self.Length.returnPressed.connect(value1.selectAll)
         value1.returnPressed.connect(value2.setFocus)
@@ -396,16 +386,6 @@ class Arch_Wall:
         from draftutils import params
         self.Align = ["Center","Left","Right"][i]
         params.set_param_arch("WallAlignment",i)
-
-    def setContinue(self,i):
-        """Simple callback to set if the interactive mode will restart when finished.
-
-        This allows for several walls to be placed one after another.
-        """
-
-        from draftutils import params
-        self.continueCmd = bool(i)
-        params.set_param("ContinueMode", bool(i))
 
     def setUseSketch(self,i):
         """Simple callback to set if walls should based on sketches."""

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -391,7 +391,7 @@ class DraftToolBar:
         self.relativeMode = params.get_param("RelativeMode")
         self.globalMode = params.get_param("GlobalMode")
         self.makeFaceMode = params.get_param("MakeFaceMode")
-        self.continueMode = params.get_param(self.sourceCmd.featureName, "Mod/Draft/ContinueMode")
+        self.continueMode = params.get_param(self.sourceCmd.featureName, "Mod/Draft/ContinueMode", silent=True)
         self.chainedMode = params.get_param("ChainedMode")
 
         # Note: The order of the calls to self._checkbox() below controls

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -391,7 +391,10 @@ class DraftToolBar:
         self.relativeMode = params.get_param("RelativeMode")
         self.globalMode = params.get_param("GlobalMode")
         self.makeFaceMode = params.get_param("MakeFaceMode")
-        self.continueMode = params.get_param(self.sourceCmd.featureName, "Mod/Draft/ContinueMode", silent=True)
+
+        feature_name = getattr(FreeCAD.activeDraftCommand, "featureName", None)
+        self.continueMode = params.get_param(feature_name, "Mod/ContinueMode", silent=True)
+
         self.chainedMode = params.get_param("ChainedMode")
 
         # Note: The order of the calls to self._checkbox() below controls
@@ -930,7 +933,7 @@ class DraftToolBar:
 #---------------------------------------------------------------------------
 
     def setContinue(self, val):
-        params.set_param(self.sourceCmd.featureName, bool(val), "Mod/Draft/ContinueMode")
+        params.set_param(FreeCAD.activeDraftCommand.featureName, bool(val), "Mod/ContinueMode")
         self.continueMode = bool(val)
         self.chainedModeCmd.setEnabled(not val)
 

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -390,7 +390,7 @@ class DraftToolBar:
         self.relativeMode = params.get_param("RelativeMode")
         self.globalMode = params.get_param("GlobalMode")
         self.makeFaceMode = params.get_param("MakeFaceMode")
-        self.continueMode = params.get_param("ContinueMode")
+        self.continueMode = params.get_param(self.sourceCmd.featureName, "Mod/Draft/ContinueMode")
 
         # Note: The order of the calls to self._checkbox() below controls
         #       the position of the checkboxes in the task panel.
@@ -399,7 +399,7 @@ class DraftToolBar:
         self.isRelative = self._checkbox("isRelative", self.layout, checked=self.relativeMode)
         self.isGlobal = self._checkbox("isGlobal", self.layout, checked=self.globalMode)
         self.makeFace = self._checkbox("makeFace", self.layout, checked=self.makeFaceMode)
-        self.continueCmd = self._checkbox("continueCmd", self.layout, checked=self.continueMode)
+        self.continueCmd = self._checkbox("continueCmd", self.layout, checked=bool(self.continueMode))
 
         # update checkboxes without parameters and without internal modes:
         self.occOffset = self._checkbox("occOffset", self.layout, checked=False)
@@ -920,7 +920,7 @@ class DraftToolBar:
 #---------------------------------------------------------------------------
 
     def setContinue(self, val):
-        params.set_param("ContinueMode", bool(val))
+        params.set_param(self.sourceCmd.featureName, bool(val), "Mod/Draft/ContinueMode")
         self.continueMode = bool(val)
 
     # val=-1 is used to temporarily switch to relativeMode and disable the checkbox.

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -393,7 +393,7 @@ class DraftToolBar:
         self.makeFaceMode = params.get_param("MakeFaceMode")
 
         feature_name = getattr(FreeCAD.activeDraftCommand, "featureName", None)
-        self.continueMode = params.get_param(feature_name, "Mod/ContinueMode", silent=True)
+        self.continueMode = params.get_param(feature_name, "Mod/Draft/ContinueMode", silent=True)
 
         self.chainedMode = params.get_param("ChainedMode")
 
@@ -933,7 +933,7 @@ class DraftToolBar:
 #---------------------------------------------------------------------------
 
     def setContinue(self, val):
-        params.set_param(FreeCAD.activeDraftCommand.featureName, bool(val), "Mod/ContinueMode")
+        params.set_param(FreeCAD.activeDraftCommand.featureName, bool(val), "Mod/Draft/ContinueMode")
         self.continueMode = bool(val)
         self.chainedModeCmd.setEnabled(not val)
 

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -74,7 +74,8 @@ class Dimension(gui_base_original.Creator):
     def __init__(self):
         super().__init__()
         self.max = 2
-        self.cont = None
+        self.chain = None
+        self.contMode = None
         self.dir = None
         self.featureName = "Dimension"
 
@@ -88,13 +89,14 @@ class Dimension(gui_base_original.Creator):
 
     def Activated(self):
         """Execute when the command is called."""
-        if self.cont:
+        if self.chain and not self.contMode:
             self.finish()
         else:
             super().Activated(name=self.featureName)
             if self.ui:
                 self.ui.pointUi(title=translate("draft", self.featureName), icon="Draft_Dimension")
                 self.ui.continueCmd.show()
+                self.ui.chainedModeCmd.show()
                 self.ui.selectButton.show()
                 self.altdown = False
                 self.call = self.view.addEventCallback("SoEvent", self.action)
@@ -160,7 +162,8 @@ class Dimension(gui_base_original.Creator):
     def finish(self, cont=False):
         """Terminate the operation."""
         self.end_callbacks(self.call)
-        self.cont = None
+        self.chain = None
+        self.contMode = None
         self.dir = None
         if self.ui:
             self.dimtrack.finalize()
@@ -284,8 +287,9 @@ class Dimension(gui_base_original.Creator):
             # Linear dimension, not linked to any edge
             self.create_linear_dimension()
 
-        if self.ui.continueMode:
-            self.cont = self.node[2]
+        if self.ui.chainedMode or self.ui.continueMode:
+            if self.ui.chainedMode:
+                self.chain = self.node[2]
             if not self.dir:
                 if self.link:
                     v1 = self.link[0].Shape.Vertexes[self.link[1]].Point
@@ -340,7 +344,7 @@ class Dimension(gui_base_original.Creator):
                         ed = ob.Shape.Edges[num]
                         v1 = ed.Vertexes[0].Point
                         v2 = ed.Vertexes[-1].Point
-                        self.dimtrack.update([v1, v2, self.cont])
+                        self.dimtrack.update([v1, v2, self.chain])
             else:
                 if self.node and (len(self.edges) < 2):
                     self.dimtrack.on()
@@ -414,7 +418,7 @@ class Dimension(gui_base_original.Creator):
                 # update the dimline
                 if self.node and not self.arcmode:
                     self.dimtrack.update(self.node
-                                         + [self.point] + [self.cont])
+                                         + [self.point] + [self.chain])
             gui_tool_utils.redraw3DView()
         elif arg["Type"] == "SoMouseButtonEvent":
             if (arg["State"] == "DOWN") and (arg["Button"] == "BUTTON1"):
@@ -494,10 +498,10 @@ class Dimension(gui_base_original.Creator):
                         self.dimtrack.on()
                         if self.planetrack:
                             self.planetrack.set(self.node[0])
-                    elif len(self.node) == 2 and self.cont:
-                        self.node.append(self.cont)
+                    elif len(self.node) == 2 and self.chain:
+                        self.node.append(self.chain)
                         self.createObject()
-                        if not self.cont:
+                        if not self.chain:
                             self.finish()
                     elif len(self.node) == 3:
                         # for unlinked arc mode:
@@ -507,7 +511,10 @@ class Dimension(gui_base_original.Creator):
                         #     cen = self.node[0].add(v)
                         #     self.node = [self.node[0], self.node[1], cen]
                         self.createObject()
-                        if not self.cont:
+                        if self.ui.continueMode:
+                            self.contMode = True
+                            self.Activated()
+                        elif not self.chain:
                             self.finish()
                     elif self.angledata:
                         self.node.append(self.point)
@@ -527,7 +534,7 @@ class Dimension(gui_base_original.Creator):
             self.dimtrack.on()
         elif len(self.node) == 3:
             self.createObject()
-            if not self.cont:
+            if not self.chain:
                 self.finish()
 
     def set_constraint_node(self):

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -76,6 +76,7 @@ class Dimension(gui_base_original.Creator):
         self.max = 2
         self.cont = None
         self.dir = None
+        self.featureName = "Dimension"
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -90,9 +91,9 @@ class Dimension(gui_base_original.Creator):
         if self.cont:
             self.finish()
         else:
-            super().Activated(name="Dimension")
+            super().Activated(name=self.featureName)
             if self.ui:
-                self.ui.pointUi(title=translate("draft", "Dimension"), icon="Draft_Dimension")
+                self.ui.pointUi(title=translate("draft", self.featureName), icon="Draft_Dimension")
                 self.ui.continueCmd.show()
                 self.ui.selectButton.show()
                 self.altdown = False

--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -416,6 +416,7 @@ def _get_param_dictionary():
         "FilletRadius":                ("float",     100.0),
         "FilletChamferMode":           ("bool",      False),
         "FilletDeleteMode":            ("bool",      False),
+        "ChainedMode":                 ("bool",      False),
         "GlobalMode":                  ("bool",      False),
         "GridHideInOtherWorkbenches":  ("bool",      True),
         "HatchPatternFile":            ("string",    hatch_pattern_file),

--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -405,7 +405,6 @@ def _get_param_dictionary():
         "AnnotationStyleEditorHeight": ("int",       450),
         "AnnotationStyleEditorWidth":  ("int",       450),
         "CenterPlaneOnView":           ("bool",      False),
-        "ContinueMode":                ("bool",      False),
         "CopyMode":                    ("bool",      False),
         "DefaultAnnoDisplayMode":      ("int",       0),
         "DefaultDisplayMode":          ("int",       0),
@@ -441,6 +440,26 @@ def _get_param_dictionary():
         "SubelementMode":              ("bool",      False),
         "SvgLinesBlack":               ("bool",      True),
         "useSupport":                  ("bool",      False),
+    }
+
+    param_dict["Mod/Draft/ContinueMode"] = {
+        "Line": ("bool", False),
+        "Polyline": ("bool", False),
+        "Arc": ("bool", False),
+        "Arc_3Points": ("bool", False),
+        "Circle": ("bool", False),
+        "Ellipse": ("bool", False),
+        "Rectangle": ("bool", False),
+        "Polygon": ("bool", False),
+        "Bspline": ("bool", False),
+        "CubicBezCurve": ("bool", False),
+        "BezCurve": ("bool", False),
+        "Point": ("bool", False),
+        "Text": ("bool", False),
+        "Dimension": ("bool", False),
+
+        "Move": ("bool", False),
+        "Copy": ("bool", False),
     }
 
     # Arch parameters that are not in the preferences:

--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -443,7 +443,8 @@ def _get_param_dictionary():
         "useSupport":                  ("bool",      False),
     }
 
-    param_dict["Mod/Draft/ContinueMode"] = {
+    param_dict["Mod/ContinueMode"] = {
+        # Draft
         "Line": ("bool", False),
         "Polyline": ("bool", False),
         "Arc": ("bool", False),
@@ -459,8 +460,15 @@ def _get_param_dictionary():
         "Text": ("bool", False),
         "Dimension": ("bool", False),
 
+        # Standard operations (Draft)
         "Move": ("bool", False),
         "Copy": ("bool", False),
+        
+        # Arch/BIM
+        "Wall": ("bool", False),
+        "Column": ("bool", False),
+        "Beam": ("bool", False),
+        "Panel": ("bool", False),
     }
 
     # Arch parameters that are not in the preferences:

--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -404,6 +404,7 @@ def _get_param_dictionary():
     param_dict["Mod/Draft"] = {
         "AnnotationStyleEditorHeight": ("int",       450),
         "AnnotationStyleEditorWidth":  ("int",       450),
+        "ChainedMode":                 ("bool",      False),
         "CenterPlaneOnView":           ("bool",      False),
         "CopyMode":                    ("bool",      False),
         "DefaultAnnoDisplayMode":      ("int",       0),
@@ -416,7 +417,6 @@ def _get_param_dictionary():
         "FilletRadius":                ("float",     100.0),
         "FilletChamferMode":           ("bool",      False),
         "FilletDeleteMode":            ("bool",      False),
-        "ChainedMode":                 ("bool",      False),
         "GlobalMode":                  ("bool",      False),
         "GridHideInOtherWorkbenches":  ("bool",      True),
         "HatchPatternFile":            ("string",    hatch_pattern_file),
@@ -443,7 +443,7 @@ def _get_param_dictionary():
         "useSupport":                  ("bool",      False),
     }
 
-    param_dict["Mod/ContinueMode"] = {
+    param_dict["Mod/Draft/ContinueMode"] = {
         # Draft
         "Line": ("bool", False),
         "Polyline": ("bool", False),
@@ -463,6 +463,7 @@ def _get_param_dictionary():
         # Standard operations (Draft)
         "Move": ("bool", False),
         "Copy": ("bool", False),
+        "Rotate": ("bool", False),
         
         # Arch/BIM
         "Wall": ("bool", False),

--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -654,7 +654,7 @@ def _get_param_dictionary():
 PARAM_DICT = _get_param_dictionary()
 
 
-def get_param(entry, path="Mod/Draft", ret_default=False):
+def get_param(entry, path="Mod/Draft", ret_default=False, silent=False):
     """Return a stored parameter value or its default.
 
     Parameters
@@ -668,13 +668,17 @@ def get_param(entry, path="Mod/Draft", ret_default=False):
     ret_default: bool, optional
         Defaults to `False`.
         If `True`, always return the default value even if a stored value is available.
+    silent: bool, optional
+        Defaults to `False`.
+        If `True`, do not log anything if entry wasn't found.
 
     Returns
     -------
     bool, float, int or str (if successful) or `None`.
     """
     if path not in PARAM_DICT or entry not in PARAM_DICT[path]:
-        print(f"draftutils.params.get_param: Unable to find '{entry}' in '{path}'")
+        if not silent:
+            print(f"draftutils.params.get_param: Unable to find '{entry}' in '{path}'")
         return None
     param_grp = App.ParamGet("User parameter:BaseApp/Preferences/" + path)
     typ, default = PARAM_DICT[path][entry]


### PR DESCRIPTION
**Draft:**
Currently, if we select `"Continue"` mode for Draft, it retriggers the command for
almost every command but not for `Dimension` command. Also, if we select `"Continue"` in
one of the tools, it is cached globally for every single one of them instead of
being cached separately.

So, those series of patches introduce series of things:
- changes `Continue` option name to `Chained Mode`, but leaves
the option with new behavior for `Dimension` command.
- changes caching of this option, so every tool has it enabled
separately, i.e. we enable for `Dimension` - it's not enabled for Rectangle
- `Continue` option for `Dimension` now retriggers the command, whereas
for `Chained Mode` it keeps old behavior.

Short demo Draft:
https://github.com/user-attachments/assets/5daf9e5a-541d-44b5-bbfb-d709a969ea05

##########################################
**BIM:**
Currently, if we select `"Continue"` mode for BIM, it retriggers the
command, but it is not unique between commands and selecting it in one
place results in selecting it also in another place. Also, the place of
`Continue` is far below in the Tasks submenu.

So, this patch does a few things:
- removes additional "Continue" mode in BIM/Arch Mod, connecting to
  Draft's "Continue" mode directly (since we share those parts of GUI
  anyways)
- caches "Continue" mode separately between commands
- by doing the first point, this patch also moves "Continue" mode
  further above in the "Tasks" submenu

Short demo BIM:
https://github.com/user-attachments/assets/f0ea76f4-0778-4740-aaef-e6f8249915d1

Resolves: https://github.com/FreeCAD/FreeCAD/issues/19155
Resolves: https://github.com/FreeCAD/FreeCAD/issues/19153