### PR TITLE
importSVG Overhaul

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -23,6 +23,7 @@ SET(Draft_import
     importDWG.py
     importOCA.py
     importSVG.py
+    SVGPath.py
 )
 
 SET (Draft_geoutils

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -55,6 +55,7 @@ from draftutils.utils import ARROW_TYPES as arrowtypes
 from draftutils.utils import (type_check,
                               typecheck,
                               precision,
+                              precisionSVG,
                               tolerance)
 
 from draftutils.utils import (get_real_name,

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -55,7 +55,6 @@ from draftutils.utils import ARROW_TYPES as arrowtypes
 from draftutils.utils import (type_check,
                               typecheck,
                               precision,
-                              precisionSVG,
                               tolerance)
 
 from draftutils.utils import (get_real_name,

--- a/src/Mod/Draft/Resources/ui/preferences-svg.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-svg.ui
@@ -44,7 +44,7 @@
         <item>
          <widget class="Gui::PrefComboBox" name="gui::prefcombobox_3">
           <property name="toolTip">
-           <string>Method chosen for importing SVG object color to FreeCAD</string>
+           <string>Method chosen for importing SVG object colors to FreeCAD</string>
           </property>
           <property name="currentIndex">
            <number>0</number>
@@ -56,18 +56,13 @@
            <cstring>Mod/Draft</cstring>
           </property>
           <item>
-           <property name="text">
-            <string>None (fastest)</string>
-           </property>
+          <property name="text">
+            <string>Use default style from Part/PartDesign</string>
+          </property>
           </item>
           <item>
            <property name="text">
-            <string>Use default color and linewidth</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Original color and linewidth</string>
+            <string>Use original svg style</string>
            </property>
           </item>
          </widget>

--- a/src/Mod/Draft/Resources/ui/preferences-svg.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-svg.ui
@@ -98,6 +98,56 @@ One unit in the SVG file will translate as one millimeter.</string>
         </item>
        </layout>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Mathematical precision (cruical for closed wires)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+	       <widget class="Gui::PrefSpinBox" name="spinBox_precisionSVG">
+	        <property name="minimumSize">
+	         <size>
+	          <width>140</width>
+	          <height>0</height>
+	         </size>
+	        </property>
+	        <property name="toolTip">
+	         <string>The number of decimals used in internal coordinate operations (for example 3 = 0.001).
+	Values between 3 and 5 are usually considered the best trade-off.</string>
+	        </property>
+	        <property name="maximum">
+	         <number>10</number>
+	        </property>
+	        <property name="value">
+	         <number>4</number>
+	        </property>
+	        <property name="prefEntry" stdset="0">
+	         <cstring>precisionSVG</cstring>
+	        </property>
+	        <property name="prefPath" stdset="0">
+	         <cstring>Mod/Draft</cstring>
+	        </property>
+	       </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Mod/Draft/Resources/ui/preferences-svg.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-svg.ui
@@ -96,6 +96,45 @@ One unit in the SVG file will translate as one millimeter.</string>
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="Gui::PrefCheckBox" name="checkBox">
+          <property name="toolTip">
+           <string>If face generation results in a degenerated face
+a raw Wire from the original Shape is added.</string>
+          </property>
+          <property name="text">
+           <string>Add wires for invalid faces</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>svgAddWireForInvalidFace</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefCheckBox" name="checkBox">
+          <property name="toolTip">
+           <string>Check to cut shapes following the even/odd svg fill rule.</string>
+          </property>
+          <property name="text">
+           <string>Make Cuts</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>svgMakeCuts</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>
@@ -103,7 +142,7 @@ One unit in the SVG file will translate as one millimeter.</string>
         <item>
          <widget class="QLabel" name="label_3">
           <property name="text">
-           <string>Mathematical precision (cruical for closed wires)</string>
+           <string>Coordinate precision (cruical for detecting closed paths)</string>
           </property>
          </widget>
         </item>
@@ -136,10 +175,10 @@ One unit in the SVG file will translate as one millimeter.</string>
 	         <number>10</number>
 	        </property>
 	        <property name="value">
-	         <number>4</number>
+	         <number>3</number>
 	        </property>
 	        <property name="prefEntry" stdset="0">
-	         <cstring>precisionSVG</cstring>
+	         <cstring>svgPrecision</cstring>
 	        </property>
 	        <property name="prefPath" stdset="0">
 	         <cstring>Mod/Draft</cstring>

--- a/src/Mod/Draft/SVGPath.py
+++ b/src/Mod/Draft/SVGPath.py
@@ -1,0 +1,769 @@
+import re
+import math
+from Draft import precisionSVG
+from FreeCAD import Vector, Matrix
+from DraftVecUtils import equals, isNull, angle
+from draftutils.messages import _err, _msg, _wrn
+
+from Part import (
+    Arc,
+    BezierCurve,
+    BSplineCurve,
+    Ellipse,
+    Face,
+    LineSegment,
+    Shape,
+    Edge,
+    Wire,
+    Compound,
+    OCCError
+)
+
+def _precision_step(precision):
+    return 10**(-precision)
+
+def _arc_end_to_center(lastvec, currentvec, rx, ry,
+                      x_rotation=0.0, correction=False):
+    '''Calculate the possible centers for an arc in endpoint parameterization.
+
+    Calculate (positive and negative) possible centers for an arc given in
+    ``endpoint parametrization``.
+    See http://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes
+
+    the sweepflag is interpreted as: sweepflag <==>  arc is travelled clockwise
+
+    Parameters
+    ----------
+    lastvec : Base::Vector3
+        First point of the arc.
+    currentvec : Base::Vector3
+        End point (current) of the arc.
+    rx : float
+        Radius of the ellipse, semi-major axis in the X direction.
+    ry : float
+        Radius of the ellipse, semi-minor axis in the Y direction.
+    x_rotation : float
+        Default is 0. Rotation around the Z axis, in radians (CCW).
+    correction : bool, optional
+        Default is `False`. If it is `True`, the radii will be scaled
+        by a factor.
+
+    Returns
+    -------
+    list, (float, float)
+        A tuple that consists of one list, and a tuple of radii.
+    [(positive), (negative)], (rx, ry)
+        The first element of the list is the positive tuple,
+        the second is the negative tuple.
+    [(Base::Vector3, float, float),
+    (Base::Vector3, float, float)], (float, float)
+        Types
+    [(vcenter+, angle1+, angledelta+),
+    (vcenter-, angle1-, angledelta-)], (rx, ry)
+        The first element of the list is the positive tuple,
+        consisting of center, angle, and angle increment;
+        the second element is the negative tuple.
+    '''
+    # scalefacsign = 1 if (largeflag != sweepflag) else -1
+    rx = float(rx)
+    ry = float(ry)
+    v0 = lastvec.sub(currentvec)
+    v0.multiply(0.5)
+    m1 = Matrix()
+    m1.rotateZ(-x_rotation)  # eq. 5.1
+    v1 = m1.multiply(v0)
+    if correction:
+        eparam = v1.x**2 / rx**2 + v1.y**2 / ry**2
+        if eparam > 1:
+            eproot = math.sqrt(eparam)
+            rx = eproot * rx
+            ry = eproot * ry
+    denom = rx**2 * v1.y**2 + ry**2 * v1.x**2
+    numer = rx**2 * ry**2 - denom
+    results = []
+
+    # If the division is very small, set the scaling factor to zero,
+    # otherwise try to calculate it by taking the square root
+    if abs(numer/denom) < 1.0e-7:
+        scalefacpos = 0
+    else:
+        try:
+            scalefacpos = math.sqrt(numer/denom)
+        except ValueError:
+            _msg("sqrt({0}/{1})".format(numer, denom))
+            scalefacpos = 0
+
+    # Calculate two values because the square root may be positive or negative
+    for scalefacsign in (1, -1):
+        scalefac = scalefacpos * scalefacsign
+        # Step2 eq. 5.2
+        vcx1 = Vector(v1.y * rx/ry, -v1.x * ry/rx, 0).multiply(scalefac)
+        m2 = Matrix()
+        m2.rotateZ(x_rotation)
+        centeroff = currentvec.add(lastvec)
+        centeroff.multiply(0.5)
+        vcenter = m2.multiply(vcx1).add(centeroff)  # Step3 eq. 5.3
+        # angle1 = Vector(1, 0, 0).getAngle(Vector((v1.x - vcx1.x)/rx,
+        #                                          (v1.y - vcx1.y)/ry,
+        #                                          0))  # eq. 5.5
+        # angledelta = Vector((v1.x - vcx1.x)/rx,
+        #                     (v1.y - vcx1.y)/ry,
+        #                     0).getAngle(Vector((-v1.x - vcx1.x)/rx,
+        #                                        (-v1.y - vcx1.y)/ry,
+        #                                        0))  # eq. 5.6
+        # we need the right sign for the angle
+        angle1 = angle(Vector(1, 0, 0),
+                       Vector((v1.x - vcx1.x)/rx,
+                              (v1.y - vcx1.y)/ry,
+                              0))  # eq. 5.5
+        angledelta = angle(Vector((v1.x - vcx1.x)/rx,
+                                  (v1.y - vcx1.y)/ry,
+                                  0),
+                           Vector((-v1.x - vcx1.x)/rx,
+                                  (-v1.y - vcx1.y)/ry,
+                                  0))  # eq. 5.6
+        results.append((vcenter, angle1, angledelta))
+
+        if rx < 0 or ry < 0:
+            _wrn("Warning: 'rx' or 'ry' is negative, check the SVG file")
+
+    return results, (rx, ry)
+
+
+def _arc_center_to_end(center, rx, ry, angle1, angledelta, xrotation=0.0):
+    '''Calculate start and end points, and flags of an arc.
+
+    Calculate start and end points, and flags of an arc given in
+    ``center parametrization``.
+    See http://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes
+
+    Parameters
+    ----------
+    center : Base::Vector3
+        Coordinates of the center of the ellipse.
+    rx : float
+        Radius of the ellipse, semi-major axis in the X direction
+    ry : float
+        Radius of the ellipse, semi-minor axis in the Y direction
+    angle1 : float
+        Initial angle in radians
+    angledelta : float
+        Additional angle in radians
+    xrotation : float, optional
+        Default 0. Rotation around the Z axis
+
+    Returns
+    -------
+    v1, v2, largerc, sweep
+        Tuple indicating the end points of the arc, and two boolean values
+        indicating whether the arc is less than 180 degrees or not,
+        and whether the angledelta is negative.
+    '''
+    vr1 = Vector(rx * math.cos(angle1), ry * math.sin(angle1), 0)
+    vr2 = Vector(rx * math.cos(angle1 + angledelta),
+                 ry * math.sin(angle1 + angledelta),
+                 0)
+    mxrot = Matrix()
+    mxrot.rotateZ(xrotation)
+    v1 = mxrot.multiply(vr1).add(center)
+    v2 = mxrot.multiply(vr2).add(center)
+    fa = ((abs(angledelta) / math.pi) % 2) > 1  # < 180 deg
+    fs = angledelta < 0
+    return v1, v2, fa, fs
+
+
+def _approx_bspline(
+    curve: BezierCurve,
+    num: int = 10,
+    tol: float = 1e-7,
+) -> BSplineCurve | BezierCurve:
+    _p0, d0 = curve.getD1(curve.FirstParameter)
+    _p1, d1 = curve.getD1(curve.LastParameter)
+    if (d0.Length < tol) or (d1.Length < tol):
+        tan1 = curve.tangent(curve.FirstParameter)[0]
+        tan2 = curve.tangent(curve.LastParameter)[0]
+        pts = curve.discretize(num)
+        bs = BSplineCurve()
+        try:
+            bs.interpolate(Points=pts, InitialTangent=tan1, FinalTangent=tan2)
+            return bs
+        except OCCError:
+            pass
+    return curve
+
+
+def _make_wire(path : list[Edge], precision : int, checkclosed : bool=False, donttry : bool=False):
+    '''Try to make a wire out of the list of edges.
+
+    If the wire functions fail or the wire is not closed,
+    if required the TopoShapeCompoundPy::connectEdgesToWires()
+    function is used.
+
+    Parameters
+    ----------
+    path : list[Edge]
+        A collection of edges
+    checkclosed : bool, optional
+        Default is `False`.
+    donttry : bool, optional
+        Default is `False`. If it's `True` it won't try to check
+        for a closed path.
+
+    Returns
+    -------
+    Part::Wire
+        A wire created from the ordered edges.
+    Part::Compound
+        A compound made of the edges, but unable to form a wire.
+    '''
+    if not donttry:
+        try:
+            sh = Wire(path)
+            # sh = Wire(path)
+            isok = (not checkclosed) or sh.isClosed()
+            if len(sh.Edges) != len(path):
+                isok = False
+        # BRep_API: command not done
+        except OCCError:
+            isok = False
+    if donttry or not isok:
+        # Code from wmayer forum p15549 to fix the tolerance problem
+        # original tolerance = 0.00001
+        comp = Compound(path)
+        _sh = comp.connectEdgesToWires(False, _precision_step(precision))
+        sh = _sh.Wires[0]
+        if len(sh.Edges) != len(path):
+            _wrn("Unable to form a wire")
+            sh = comp
+    return sh
+
+
+class FaceTreeNode:
+    '''
+    Building Block of a tree structure holding one-closed-wire faces 
+    sorted after their enclosure of each other.
+    This class only works with faces that have exactly one closed wire
+    '''
+    face     : Face
+    children : list
+    name     : str
+
+    
+    def __init__(self, face=None, name="root"):
+        super().__init__()
+        self.face = face
+        self.name = name
+        self.children = [] 
+
+      
+    def insert (self, face, name):
+        ''' 
+        takes a single-wire named face, and inserts it into the tree 
+        depending on its enclosure in/of already added faces.
+
+        Parameters
+        ----------
+        face : Face
+               single closed wire face to be added to the tree
+        name : str
+               face identifier       
+        ''' 
+        for node in self.children:
+            if  node.face.Area > face.Area:
+                # new face could be encompassed
+                if (face.distToShape(node.face)[0] == 0.0 and 
+                    face.Wires[0].distToShape(node.face.Wires[0])[0] != 0.0):
+                    # it is encompassed - enter next tree layer
+                    node.insert(face, name)
+                    return
+            else:
+                # new face could encompass
+                if (node.face.distToShape(face)[0] == 0.0 and
+                    node.face.Wires[0].distToShape(face.Wires[0])[0] != 0.0):
+                    # it does encompass the current child nodes face
+                    # create new node from face
+                    new = FaceTreeNode(face, name)
+                    # swap the new one with the child node 
+                    self.children.remove(node)
+                    self.children.append(new)
+                    # add former child node as child to the new node
+                    new.children.append(node)
+                    return
+        # the face is not encompassing and is not encompassed (from) any
+        # other face, we add it as new child 
+        new = FaceTreeNode(face, name)
+        self.children.append(new)
+
+     
+    def makeCuts(self):
+        ''' 
+        recursively traverse the tree and cuts all faces in even 
+        numbered tree levels with their direct childrens faces. 
+        Additionally the tree is shrunk by removing the odd numbered 
+        tree levels.                 
+        '''
+        result = self.face
+        if not result:
+            for node in self.children:
+                node.makeCuts()
+        else:
+            new_children = []
+            for node in self.children:
+                result = result.cut(node.face)
+                for subnode in node.children:
+                    subnode.makeCuts()
+                    new_children.append(subnode)
+            self.children = new_children
+            self.face = result
+
+           
+    def flatten(self):
+        ''' creates a flattened list of face-name tuples from the facetree
+            content
+        '''
+        result = []
+        result.append((self.name, self.face))
+        for node in self.children:
+            result.extend(node.flatten())
+        return result  
+        
+  
+  
+class SvgPathElement:
+
+    path : list[dict]
+
+    def __init__(self, precision : int, interpol_pts : int, origin : Vector = Vector(0, 0, 0)):
+        self.precision = precision
+        self.interpol_pts = interpol_pts
+        self.path = [{"type": "start", "last_v": origin }]
+        
+    def add_move(self, x : float, y : float, relative : bool) -> None:
+        if relative:
+            last_v = self.path[-1]["last_v"].add(Vector(x, -y, 0))
+        else:
+            last_v = Vector(x, -y, 0)
+        # if we're at the beginning of a wire we overwrite the start vector
+        if self.path[-1]["type"] == "start":
+            self.path[-1]["last_v"] = last_v
+        else:
+            self.path.append({"type": "start", "last_v": last_v})
+
+    def add_lines(self, coords: list[float], relative: bool) -> None:
+        last_v = self.path[-1]["last_v"]
+        for x, y in zip(coords[0::2], coords[1::2]):
+            if relative:
+                last_v = last_v.add(Vector(x, -y, 0))
+            else:
+                last_v = Vector(x, -y, 0)
+            self.path.append({"type": "line", "last_v": last_v})
+
+    def add_horizontals(self, x_coords: list[float], relative: bool) -> None:
+        last_v = self.path[-1]["last_v"]
+        for x in x_coords:
+            if relative:
+                last_v = Vector(x + last_v.x, last_v.y, 0)
+            else:
+                last_v = Vector(x, last_v.y, 0)
+            self.path.append({"type": "line", "last_v": last_v})
+
+    def add_verticals(self, y_coords: list[float], relative: bool) -> None:
+        last_v = self.path[-1]["last_v"]
+        if relative:
+            for y in y_coords:
+                last_v = Vector(last_v.x, last_v.y - y, 0)
+                self.path.append({"type": "line", "last_v": last_v})
+        else:
+            for y in y_coords:
+                last_v = Vector(last_v.x, -y, 0)
+                self.path.append({"type": "line", "last_v": last_v})
+
+    def add_arcs(self, args: list[float], relative: bool) -> None:
+        p_iter = zip(
+            args[0::7], args[1::7], args[2::7], args[3::7],
+            args[4::7], args[5::7], args[6::7], strict=False,
+        )
+        for rx, ry, x_rotation, large_flag, sweep_flag, x, y in p_iter:
+            # support for large-arc and x-rotation is missing
+            if relative:
+                last_v = self.path[-1]["last_v"].add(Vector(x, -y, 0))
+            else:
+                last_v = Vector(x, -y, 0)
+            self.path.append({
+                "type": "arc",
+                "rx": rx,
+                "ry": ry,
+                "x_rotation": x_rotation,
+                "large_flag": large_flag != 0,
+                "sweep_flag": sweep_flag != 0,
+                "last_v": last_v
+            })
+
+    def add_cubic_beziers(self, args: list[float], relative: bool, smooth: bool) -> None:
+        last_v = self.path[-1]["last_v"]
+        if smooth:
+            p_iter = list(
+                zip(
+                    args[2::4], args[3::4],
+                    args[0::4], args[1::4],
+                    args[2::4], args[3::4], strict=False )
+            )
+        else:
+            p_iter = list(
+                zip(
+                    args[0::6], args[1::6],
+                    args[2::6], args[3::6],
+                    args[4::6], args[5::6], strict=False )
+            )
+        for p1x, p1y, p2x, p2y, x, y in p_iter:
+            if smooth:
+                if self.path[-1]["type"] == "cbezier":
+                    pole1 = last_v.sub(self.path[-1]["pole2"]).add(last_v)
+                else:
+                    pole1 = last_v
+            else:
+                if relative:
+                    pole1 = last_v.add(Vector(p1x, -p1y, 0))
+                else:
+                    pole1 = Vector(p1x, -p1y, 0)
+            if relative:
+                pole2 = last_v.add(Vector(p2x, -p2y, 0))
+                last_v = last_v.add(Vector(x, -y, 0))
+            else:
+                pole2 = Vector(p2x, -p2y, 0)
+                last_v = Vector(x, -y, 0)
+
+            self.path.append({
+                "type": "cbezier",
+                "pole1": pole1,
+                "pole2": pole2,
+                "last_v": last_v
+            })
+
+    def add_quadratic_beziers(self, args: list[float], relative: bool, smooth: bool):
+        last_v = self.path[-1]["last_v"]
+        if smooth:
+            p_iter = list( zip( args[1::2], args[1::2],
+                                args[0::2], args[1::2], strict=False ) )
+        else:
+            p_iter = list( zip( args[0::4], args[1::4],
+                                args[2::4], args[3::4], strict=False ) )
+        for px, py, x, y in p_iter:
+            if smooth:
+                if self.path[-1]["type"] == "qbezier":
+                    pole = last_v.sub(self.path[-1]["pole"]).add(last_v)
+                else:
+                    pole = last_v
+            else:
+                if relative:
+                    pole = last_v.add(Vector(px, -py, 0))
+                else:
+                    pole = Vector(px, -py, 0)
+            if relative:
+                last_v = last_v.add(Vector(x, -y, 0))
+            else:
+                last_v = Vector(x, -y, 0)
+
+            self.path.append({
+                "type": "qbezier",
+                "pole": pole,
+                "last_v": last_v 
+            })
+
+    def add_close(self):
+        last_v  = self.path[-1]["last_v"]
+        first_v = self.__get_last_start()
+        if not equals(last_v, first_v, self.precision):
+            self.path.append({"type": "line", "last_v": first_v})
+        # assume that a close command finalizes a subpath
+        self.path.append({"type": "start", "last_v": first_v})
+
+    def __get_last_start(self) -> Vector:
+        """
+        Return the startpoint of the last SubPath.
+        """
+        for pds in reversed(self.path):
+            if pds["type"] == "start":
+                return pds["last_v"]
+        return Vector(0, 0, 0)
+
+    def __correct_last_v(self, pds: dict, last_v: Vector) -> None:
+        """
+        Correct the endpoint of the given path dataset to the 
+        given vector and move possibly associated members accordingly.
+        """
+        delta = last_v.sub(pds["last_v"])
+        # we won't move last_v if it's already correct or if the delta 
+        # is substantially greater than what rounding errors could accumulate,
+        # so we assume the path is intended to be open. 
+        if (delta.x == 0 and delta.y == 0 and delta.z == 0 or
+            not isNull(delta, self.precision)):
+            return
+        
+        # for cbeziers we also relocate the second pole
+        if pds["type"] == "cbezier":
+                pds["pole2"] = pds["pole2"].add(delta)
+        # for qbeziers we also relocate the pole by half of the delta
+        elif pds["type"] == "qbezier":
+                pds["pole"] = pds["pole"].add(delta.scale(0.5, 0.5, 0))
+        # all data types have last_v
+        pds["last_v"] = last_v
+
+
+    def correct_endpoints(self):
+        """ 
+        Correct the endpoints of all subpaths and move possibly 
+        associated members accordingly.
+        """
+        start = None
+        last = None
+        for pds in self.path:
+            if pds["type"] == "start":
+                if start:
+                    # there is already a start
+                    if last:
+                        # and there are edges behind us. 
+                        # we correct the last to the start vector
+                        self.__correct_last_v(last, start["last_v"])
+                        last = None
+                start = pds
+                continue
+            last = pds
+        if start and last and start != last:
+            self.__correct_last_v(last, start["last_v"])
+
+
+    def create_edges(self) -> list[list[Edge]]:
+        """
+        Creates shapes from prepared path datasets and returns them in an 
+        ordered list of lists of edges, where each 1st order list entry
+        represents a single continuous (and probably closed) sub-path.
+        """
+        result = []
+        edges = None
+        last_v = Vector(0, 0, 0)
+        for pds in self.path:
+            next_v = pds["last_v"]
+            match pds["type"]:
+                case "start":
+                    if edges and len(edges) > 0 :
+                        result.append(edges)
+                    edges = []
+                case "line":
+                    if equals(last_v, next_v, self.precision):
+                        # line segment too short, skip it
+                        next_v = last_v
+                    else:
+                        edges.append(LineSegment(last_v, next_v).toShape())
+                case "arc":
+                    rx = pds["rx"]
+                    ry = pds["ry"]
+                    x_rotation = pds["x_rotation"]
+                    large_flag = pds["large_flag"]
+                    sweep_flag = pds["sweep_flag"]
+                    # Calculate the possible centers for an arc
+                    # in 'endpoint parameterization'.
+                    _x_rot = math.radians(-x_rotation)
+                    (solution, (rx, ry)) = _arc_end_to_center(
+                        last_v, next_v,
+                        rx, ry,
+                        _x_rot,
+                        correction=True
+                    )
+                    # Choose one of the two solutions
+                    neg_sol = large_flag != sweep_flag
+                    v_center, angle1, angle_delta = solution[neg_sol]
+                    if ry > rx:
+                        rx, ry = ry, rx
+                        swap_axis = True
+                    else:
+                        swap_axis = False
+                    e1 = Ellipse(v_center, rx, ry)
+                    if sweep_flag:
+                        angle1 = angle1 + angle_delta
+                        angle_delta = -angle_delta
+
+                    d90 = math.radians(90)
+                    e1a = Arc(e1, angle1 - swap_axis * d90, angle1 + angle_delta - swap_axis * d90)
+                    seg = e1a.toShape()
+                    if swap_axis:
+                        seg.rotate(v_center, Vector(0, 0, 1), 90)
+                    _precision = _precision_step(self.precision)
+                    if abs(x_rotation) > _precision:
+                        seg.rotate(v_center, Vector(0, 0, 1), -x_rotation)
+                    if sweep_flag:
+                        seg.reverse()
+                    edges.append(seg)
+
+                case "cbezier":
+                    pole1 = pds["pole1"]
+                    pole2 = pds["pole2"]
+                    _precision = _precision_step(self.precision + 2)
+                    _d1 = pole1.distanceToLine(last_v, next_v)
+                    _d2 = pole2.distanceToLine(last_v, next_v)
+                    if _d1 < _precision and _d2 < _precision:
+                        # poles and endpints are all on a line
+                        if equals(last_v, next_v, self.precision):
+                            # in this case we don't accept (nearly) zero
+                            # distance betwen start and end (skip it).
+                            next_v = last_v
+                        else:
+                            seg = LineSegment(last_v, next_v).toShape()
+                            edges.append(seg)
+                    else:
+                        b = BezierCurve()
+                        b.setPoles([last_v, pole1, pole2, next_v])
+                        seg = _approx_bspline(b, self.interpol_pts).toShape()
+                        edges.append(seg)
+                case "qbezier":
+                    if equals(last_v, next_v, self.precision):
+                        # segment too small - skipping.
+                        next_v = last_v
+                    else:
+                        pole = pds["pole"]
+                        _precision = _precision_step(self.precision + 2)
+                        _distance = pole.distanceToLine(last_v, next_v)
+                        if _distance < _precision:
+                            # pole is on the line
+                            _seg = LineSegment(last_v, next_v)
+                            seg = _seg.toShape()
+                        else:
+                            b = BezierCurve()
+                            b.setPoles([last_v, pole, next_v])
+                            seg = _approx_bspline(b, self.interpol_pts).toShape()
+                        edges.append(seg)
+                case _:
+                    _msg("Illegal path_data type. {}".format(pds['type']))
+                    return []
+            last_v = next_v
+        if not edges is None and len(edges) > 0 :
+            result.append(edges)
+        return result
+
+        
+
+class SvgPathParser:
+    """Parse SVG path data and create FreeCAD Shapes."""
+
+    commands : list[tuple]
+    pointsre : re.Pattern
+    data     : dict
+    shapes   : list[list[Shape]]
+    faces    : FaceTreeNode  
+    name     : str
+
+    def __init__(self, data, name):
+        super().__init__()
+        """Evaluate path data and initialize."""
+        _op = '([mMlLhHvVaAcCqQsStTzZ])'
+        _op2 = '([^mMlLhHvVaAcCqQsStTzZ]*)'
+        _command = '\\s*?' + _op + '\\s*?' + _op2 + '\\s*?'
+        pathcommandsre = re.compile(_command, re.DOTALL)
+    
+        _num = '[-+]?[0-9]*\\.?[0-9]+'
+        _exp = '([eE][-+]?[0-9]+)?'
+        _arg = '(' + _num + _exp + ')'
+        self.commands = pathcommandsre.findall(' '.join(data['d']))
+        self.argsre = re.compile(_arg, re.DOTALL)
+        self.data = data
+        self.paths = []
+        self.shapes = []
+        self.faces = None
+        self.name = name
+     
+        
+    def parse(self):
+        ''' 
+        Creates lists of SvgPathElements from raw svg path 
+        data. It's supposed to be called direct after SvgPath Object
+        creation.
+        '''
+        path = SvgPathElement(precisionSVG(), 10)
+        self.paths = []
+        for d, argsstr in self.commands:
+            relative = d.islower()
+            
+            _args = self.argsre.findall(argsstr.replace(',', ' '))
+            args = [float(number) for number, exponent in _args]
+
+            if d in "Mm":
+                path.add_move(args.pop(0), args.pop(0), relative)
+            if d in "LlMm":
+                path.add_lines(args, relative)
+            elif d in "Hh":
+                path.add_horizontals(args, relative)
+            elif d in "Vv":
+                path.add_verticals(args, relative)
+            elif d in "Aa":
+                path.add_arcs(args, relative)
+            elif d in "Cc":
+                path.add_cubic_beziers(args, relative, False)
+            elif d in "Ss":
+                path.add_cubic_beziers(args, relative, True)
+            elif d in "Qq":
+                path.add_quadratic_beziers(args, relative, False)
+            elif d in "Tt":
+                path.add_quadratic_beziers(args, relative, True)
+            elif d in "Zz":
+                path.add_close()
+                
+        path.correct_endpoints();
+        self.shapes = path.create_edges()
+        
+        
+    def create_faces(self, fill=True, cut=True):
+        ''' 
+        Generate Faces from lists of Shapes.
+        If shapes form a closed wire and the fill Attribute is set, we 
+        generate a closed Face. Otherwise we treat the shape as pure wire.
+        
+        Parameters
+        ----------
+        fill : Object/bool
+               if True or not None Faces are generated from closed shapes.
+        '''
+        precision = precisionSVG()
+        cnt = 0;
+        openShapes = []
+        self.faces = FaceTreeNode()
+        for sh in self.shapes:                               
+            # The path should be closed by now
+            # sh = make_wire(path, self.precision, True)
+            add_wire = True
+            wr = make_wire(sh, precision, checkclosed=True)
+            wrcpy = wr.copy();
+            if fill and len(wr.Wires) == 1 and wr.Wires[0].isClosed():
+                try:
+                    face = Face(wr)
+                    if not face.isValid():
+                        face.fix(1e-6, 0, 1)
+                    else:
+                        add_wire = False
+                    if not (face.Area < 10 * (precision_step(precision) ** 2)):
+                        self.faces.insert(face, self.name + "_f" + str(cnt))
+                        cnt += 1
+                except:
+                    _msg("Failed to make a shape from path '{}'. This Path will be discarded.".format(self.name))
+            if add_wire:
+                if wrcpy.Length > precision_step(precision):
+                    openShapes.append((self.name + "_w" + str(cnt-1), wrcpy))
+
+        self.shapes = openShapes
+
+
+    def doCuts(self):
+        ''' Exposes the FaceTreeNode.makeCuts function of the tree containing 
+            closed wire faces.
+            This function is called after creating closed Faces with
+            'createFaces' in order to hollow faces encompassing others.
+        '''      
+        self.faces.makeCuts()
+
+
+    def getShapeList(self):
+        ''' Returns the resulting list of tuples containing name and face of 
+            each created element.
+        ''' 
+        result = self.faces.flatten()
+        result.extend(self.shapes)             
+        return result

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -224,7 +224,7 @@ def precisionSVG():
     Returns
     -------
     int
-        params.get_param("precisionSVG")
+        params.get_param("svgPrecision")
     """
     return params.get_param("precisionSVG")
 

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -206,7 +206,7 @@ def precision():
     return params.get_param("precision")
 
 
-def precisionSVG():
+def svg_precision():
     """Return the precision value for SVG import from the parameter database.
 
     It is the number of decimal places that a float will have.
@@ -226,7 +226,7 @@ def precisionSVG():
     int
         params.get_param("svgPrecision")
     """
-    return params.get_param("precisionSVG")
+    return params.get_param("svgPrecision")
 
 
 def tolerance():

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -206,6 +206,29 @@ def precision():
     return params.get_param("precision")
 
 
+def precisionSVG():
+    """Return the precision value for SVG import from the parameter database.
+
+    It is the number of decimal places that a float will have.
+    Example
+    ::
+        precision=5, 0.12345
+        precision=4, 0.1234
+        precision=3, 0.123
+
+    Due to floating point operations there may be rounding errors.
+    Therefore, this precision number is used to round up values
+    so that all operations are consistent.
+    By default the precision is 3 decimal places.
+
+    Returns
+    -------
+    int
+        params.get_param("precisionSVG")
+    """
+    return params.get_param("precisionSVG")
+
+
 def tolerance():
     """Return a tolerance based on the precision() value
 

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -60,6 +60,7 @@ from DraftVecUtils import equals
 from FreeCAD import Vector
 from draftutils import params
 from draftutils import utils
+from draftutils.utils import svg_precision
 from draftutils.translate import translate
 from draftutils.messages import _err, _msg, _wrn
 from draftutils.utils import pyopen
@@ -463,6 +464,8 @@ class svgHandler(xml.sax.ContentHandler):
         """Retrieve Draft parameters and initialize."""
         self.style = params.get_param("svgstyle")
         self.disableUnitScaling = params.get_param("svgDisableUnitScaling")
+        self.make_cuts = params.get_param("svgMakeCuts")
+        self.add_wire_for_invalid_face = params.get_param("svgAddWireForInvalidFace")
         self.count = 0
         self.transform = None
         self.grouptransform = []
@@ -529,6 +532,7 @@ class svgHandler(xml.sax.ContentHandler):
             Dictionary of content of the elements
         """
         self.count += 1
+        precision = svg_precision()
 
         _msg('processing element {0}: {1}'.format(self.count, name))
         _msg('existing group transform: {}'.format(self.grouptransform))
@@ -748,8 +752,9 @@ class svgHandler(xml.sax.ContentHandler):
             if "d" in data:
                 svgPath = SvgPathParser(data, pathname)
                 svgPath.parse()
-                svgPath.create_faces(self.fill)
-                svgPath.doCuts()
+                svgPath.create_faces(self.fill, self.add_wire_for_invalid_face)
+                if self.make_cuts:
+                    svgPath.doCuts()
                 shapes = svgPath.getShapeList()
                 for named_shape in shapes:
                     self.__addFaceToDoc(named_shape)
@@ -764,7 +769,7 @@ class svgHandler(xml.sax.ContentHandler):
             if "y" not in data:
                 data["y"] = 0
             # Negative values are invalid
-            _precision = 10**(-Draft.precisionSVG())
+            _precision = 10**(-precision)
             if ('rx' not in data or data['rx'] < _precision) \
                     and ('ry' not in data or data['ry'] < _precision):
                 # if True:
@@ -836,7 +841,7 @@ class svgHandler(xml.sax.ContentHandler):
                 for esh1, esh2 in zip(esh[-1:] + esh[:-1], esh):
                     p1 = esh1.Vertexes[-1].Point
                     p2 = esh2.Vertexes[0].Point
-                    if not equals(p1, p2, Draft.precisionSVG()):
+                    if not equals(p1, p2, precision):
                         # straight segments
                         _sh = Part.LineSegment(p1, p2).toShape()
                         edges.append(_sh)
@@ -887,7 +892,7 @@ class svgHandler(xml.sax.ContentHandler):
                     points = points + points[:2]  # emulate closepath
                 for svgx, svgy in zip(points[2::2], points[3::2]):
                     currentvec = Vector(svgx, -svgy, 0)
-                    if not equals(lastvec, currentvec, Draft.precisionSVG()):
+                    if not equals(lastvec, currentvec, precision):
                         seg = Part.LineSegment(lastvec, currentvec).toShape()
                         # print("polyline seg ", lastvec, currentvec)
                         lastvec = currentvec


### PR DESCRIPTION
### Abstract
The builtin svg import functionality, which is part of Draft workbench, could be more error tolerant, could support cuts in shapes and should produce paths that are easy to process.

Therefore this PR wants to add:

1. robustness against non-matching start- and endpoints due to accumulated rounding errors when using relative coordinates
2. better filtering of invalid or nonsensical data, eg. zero-length or microscopic short edges 
3. optional cuts of sub-paths enclosing other sub-paths 
4. apply matrix transformations while keeping degeneration of created edges as low as possible.

To achieve that the import process is segmented in several phases:

1. init
2. parse
3. optimize/correct
4. create faces
5. cut (optional)

Phase 2, 'parse', creates a set of metadata for each path segment. Phase 3 optimizes and corrects the metadata, while Phase 4 creates Faces. from the corrected metadata.

Following a short introduction to the four PR subjects.

### Robustness for matching start- and endpoints
The huge majority of paths people want to import are closed paths. Unfortunately there are many ways to create paths in svg that look like they are closed, while mathematically spoken they are not. And even the most careful svg creator may end up with a file that defines both, start and endpoint on almost the same spot, but differing on a minimal scale.
This can be alleviated by using a precision attribute controlling how many fractional digits are considered for identity and geometric tests.

### Filtering of invalid or nonsensical data
This PR divides the svg parsing process in several phases. First a list of metadata about sub-paths is generated from svg. Already in this early process too tiny edges are filtered. 
But there are special cases, like cubic beziers that can have zero distance between start and end while maintaining full validity. For this reason detecting invalid or nonsensical data is also part of the following edge generating phase.  Eg. if beziers have no curve they are replaced with line segments. 
The last optimization for each closed wire is correcting start- and endpoint if they are supposed to be identical but aren't.

### Optional cuts of sub-paths enclosing other sub-paths 
Often svg paths have holes or cutouts. They follow the svg fill parameter and its [fill-rule property](https://www.w3.org/TR/SVG11/painting.html#FillRuleProperty). This PR adds the option to cut paths following the evenodd svg fill rule (see link).
Unfortunately evenodd was the low hanging fruit but not the default for svg objects. So there will be complaints about differences between svg output and freeCAD import. 
Implementing the default fill rule (nonzero) will (hopefully) be added in a later PR.

### Apply matrix transformations while avoiding degeneration
Paths generated with svg import often break standard procedures like champfer or fillet. That's due to the fact that any imported path is subject to a matrix transformation that is applied in a way that produces edge degeneration. Eg. straight lines degenerate to straight first order bsplines.
In 2015 there was a [Bug Report](https://tracker.freecad.org/view.php?id=2062) complaining about differences in the size of generated objects compared to its size defined in the svg file. Long story short, the bug report suggests that the svg file was ambiguous/broken, which resulted in a wrong transformation applied. Despite that on behalf of this bug report a cruical piece of code got reverted which introduced unnecessary degenerations to all generated paths. Eg. [this Issue](https://github.com/FreeCAD/FreeCAD/issues/20264) is most possibly result of the mentioned degeneration.
This PR reactivates and 'refreshes' the code that avoids degenerations, but was disabled 2015.

