### PR TITLE
Sketcher: Allow camera to _not_ align on edit as option

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -432,6 +432,7 @@ void SketcherSettingsDisplay::saveSettings()
     ui->checkBoxTVShowSupport->onSave();
     ui->checkBoxTVRestoreCamera->onSave();
     ui->checkBoxTVForceOrtho->onSave();
+    ui->checkBoxTVAlignView->onSave();
     ui->checkBoxTVSectionView->onSave();
 }
 
@@ -454,6 +455,8 @@ void SketcherSettingsDisplay::loadSettings()
     ui->checkBoxTVRestoreCamera->onRestore();
     ui->checkBoxTVForceOrtho->onRestore();
     this->ui->checkBoxTVForceOrtho->setEnabled(this->ui->checkBoxTVRestoreCamera->isChecked());
+    ui->checkBoxTVAlignView->onRestore();
+    this->ui->checkBoxTVAlignView->setEnabled(this->ui->checkBoxTVRestoreCamera->isChecked());
     ui->checkBoxTVSectionView->onRestore();
 }
 
@@ -482,12 +485,14 @@ void SketcherSettingsDisplay::onBtnTVApplyClicked(bool)
                                 "        sketch.ViewObject.ShowSupport = %s\n"
                                 "        sketch.ViewObject.RestoreCamera = %s\n"
                                 "        sketch.ViewObject.ForceOrtho = %s\n"
+                                "        sketch.ViewObject.AlignView = %s\n"
                                 "        sketch.ViewObject.SectionView = %s\n",
                                 this->ui->checkBoxTVHideDependent->isChecked() ? "True" : "False",
                                 this->ui->checkBoxTVShowLinks->isChecked() ? "True" : "False",
                                 this->ui->checkBoxTVShowSupport->isChecked() ? "True" : "False",
                                 this->ui->checkBoxTVRestoreCamera->isChecked() ? "True" : "False",
                                 this->ui->checkBoxTVForceOrtho->isChecked() ? "True" : "False",
+                                this->ui->checkBoxTVAlignView->isChecked() ? "True" : "False",
                                 this->ui->checkBoxTVSectionView->isChecked() ? "True" : "False");
     }
     catch (Base::PyException& e) {

--- a/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
@@ -418,6 +418,25 @@ Works only when &quot;Restore camera position after editing&quot; is enabled.</s
        </widget>
       </item>
       <item>
+       <widget class="Gui::PrefCheckBox" name="checkBoxTVAlignView">
+        <property name="toolTip">
+         <string>When entering edit mode, align the camera to the sketch.</string>
+        </property>
+        <property name="text">
+         <string>Align camera when entering edit</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>AlignView</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Sketcher/General</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="Gui::PrefCheckBox" name="checkBoxTVSectionView">
         <property name="toolTip">
          <string>Open a sketch in Section View mode by default.
@@ -527,6 +546,7 @@ Then objects are only visible behind the sketch plane.</string>
   <tabstop>checkBoxTVShowSupport</tabstop>
   <tabstop>checkBoxTVRestoreCamera</tabstop>
   <tabstop>checkBoxTVForceOrtho</tabstop>
+  <tabstop>checkBoxTVAlignView</tabstop>
   <tabstop>checkBoxTVSectionView</tabstop>
   <tabstop>btnTVApply</tabstop>
  </tabstops>
@@ -536,6 +556,8 @@ Then objects are only visible behind the sketch plane.</string>
    <sender>checkBoxTVRestoreCamera</sender>
    <signal>toggled(bool)</signal>
    <receiver>checkBoxTVForceOrtho</receiver>
+   <slot>setEnabled(bool)</slot>
+   <receiver>checkBoxTVAlignView</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -505,6 +505,7 @@ public:
     App::PropertyBool ShowSupport;
     App::PropertyBool RestoreCamera;
     App::PropertyBool ForceOrtho;
+    App::PropertyBool AlignView;
     App::PropertyBool SectionView;
     App::PropertyBool AutoColor;
     App::PropertyString EditingWorkbench;


### PR DESCRIPTION
Adds new option in sketcher settings to specify if the camera should align to the sketch when entering edit.
The default value is to align the camera to the sketch so users should see no change in behavior.

![image](https://github.com/user-attachments/assets/84b13172-f860-4f30-92a1-e93ee83e429c)

The feature is implemented in the same way as ForceOrtho under the hood.

Fixes https://github.com/FreeCAD/FreeCAD/issues/12895