### PR TITLE
CAM: Less warning with new Array Dressup

### DIFF
--- a/src/Mod/CAM/Path/Op/Gui/Array.py
+++ b/src/Mod/CAM/Path/Op/Gui/Array.py
@@ -146,6 +146,8 @@ class ObjectArray:
         self.setEditorModes(obj)
         obj.Proxy = self
 
+        self.FirstRun = True
+
     def dumps(self):
         return None
 
@@ -205,8 +207,8 @@ class ObjectArray:
         self.setEditorModes(obj)
 
     def execute(self, obj):
-        if FreeCAD.GuiUp:
-
+        if FreeCAD.GuiUp and self.FirstRun:
+            self.FirstRun = False
             QtGui.QMessageBox.warning(
                 None,
                 QT_TRANSLATE_NOOP("CAM_ArrayOp", "Operation is depreciated"),

--- a/src/Mod/CAM/Path/Op/Gui/Array.py
+++ b/src/Mod/CAM/Path/Op/Gui/Array.py
@@ -211,15 +211,15 @@ class ObjectArray:
             self.FirstRun = False
             QtGui.QMessageBox.warning(
                 None,
-                QT_TRANSLATE_NOOP("CAM_ArrayOp", "Operation is depreciated"),
+                QT_TRANSLATE_NOOP("CAM_ArrayOp", "Operation is deprecated"),
                 QT_TRANSLATE_NOOP(
                     "CAM_ArrayOp",
                     (
-                        "CAM -> Path Modification -> Array operation is depreciated "
+                        "CAM -> Path Modification -> Array operation is deprecated "
                         "and will be removed in future FreeCAD versions.\n\n"
                         "Please use CAM -> Path Dressup -> Array instead.\n\n"
                         "DO NOT USE CURRENT ARRAY OPERATION WHEN MACHINING WITH COOLANT!\n"
-                        "Due to a bug - collant will not be enabled for array paths."
+                        "Due to a bug - coolant will not be enabled for array paths."
                     ),
                 ),
             )


### PR DESCRIPTION
Old Array feature is still very useful

With each change in the parameters of the old Array, a warning is displayed
This is a little annoys
It is enough that the warning is displayed when creating new Array

![Screenshot_20250411_232751_lossy](https://github.com/user-attachments/assets/de204d24-7cbb-4a32-9e9b-0f400ce08d46)
