### PR TITLE
PartDesign: Fix #20205 where Placement changes at Suppression

### DIFF
--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -98,11 +98,10 @@ App::DocumentObjectExecReturn* Feature::recompute()
         FC_ERR("Failed to recompute suppressed feature " << getFullName());
     }
 
+    Shape.setValue(getBaseTopoShape(true));
+
     if (!failed) {
         updateSuppressedShape();
-    }
-    else {
-        Shape.setValue(getBaseTopoShape(true));
     }
     return App::DocumentObject::StdReturn;
 }
@@ -121,7 +120,6 @@ void Feature::setMaterialToBodyMaterial()
 
 void Feature::updateSuppressedShape()
 {
-    auto baseShape = getBaseTopoShape(true);
     TopoShape res(getID());
     TopoShape shape = Shape.getShape();
     shape.setPlacement(Base::Placement());
@@ -139,7 +137,6 @@ void Feature::updateSuppressedShape()
         res.makeElementCompound(generated);
         res.setPlacement(Placement.getValue());
     }
-    Shape.setValue(baseShape);
     SuppressedShape.setValue(res);
 }
 
@@ -195,6 +192,13 @@ void Feature::onChanged(const App::Property *prop)
                     != ShapeMaterial.getValue().getUUID()) {
                     body->ShapeMaterial.setValue(ShapeMaterial.getValue());
                 }
+            }
+        } else if (prop == &Suppressed){
+            if (Suppressed.getValue()) {
+                SuppressedPlacement = Placement.getValue();
+            } else {
+                Placement.setValue(SuppressedPlacement);
+                SuppressedPlacement = Base::Placement();
             }
         }
     }

--- a/src/Mod/PartDesign/App/Feature.h
+++ b/src/Mod/PartDesign/App/Feature.h
@@ -60,6 +60,8 @@ public:
 
     /// Keep a copy of suppressed shapes so that we can restore them (and maybe display them)
     Part::PropertyPartShape SuppressedShape;
+    /// Keep a copy of the placement before suppression to restore it back when unsuppressed, fix #20205
+    Base::Placement SuppressedPlacement;
     App::DocumentObjectExecReturn* recompute() override;
 
     short mustExecute() const override;


### PR DESCRIPTION
Fix #20205

Keep trace of the original placement and restore it when the feature is unsuppressed.