### PR TITLE
Fixes Tool changes not commented

### DIFF
--- a/src/Mod/CAM/Path/Post/UtilsParse.py
+++ b/src/Mod/CAM/Path/Post/UtilsParse.py
@@ -174,7 +174,7 @@ def check_for_tool_change(
                 gcode.append(f"{linenumber(values)}M5{nl}")
             for line in values["TOOL_CHANGE"].splitlines(False):
                 gcode.append(f"{linenumber(values)}{line}{nl}")
-        elif values["OUTPUT_COMMENTS"]:
+        elif values["OUTPUT_COMMENTS"] == False:
             # convert the tool change to a comment
             comment = create_comment(values, format_command_line(values, command_line))
             gcode.append(f"{linenumber(values)}{comment}{nl}")


### PR DESCRIPTION
    Fixes Tool changes not commented out in gcode.
    
    Nether the default, nor --no-tool_change Cam-output-Processor parameter was working.
    
    Adding missing "== False" fixes issue