### PR TITLE
Prevent user to remove core properties

### DIFF
--- a/src/App/DocumentObject.pyi
+++ b/src/App/DocumentObject.pyi
@@ -71,10 +71,11 @@ class DocumentObject(ExtensionContainer):
         attr: int = 0,
         read_only: bool = False,
         hidden: bool = False,
+        locked: bool = False,
         enum_vals: list = []
     ) -> "DocumentObject":
         """
-        addProperty(type: string, name: string, group="", doc="", attr=0, read_only=False, hidden=False, enum_vals=[]) -- Add a generic property.
+        addProperty(type: string, name: string, group="", doc="", attr=0, read_only=False, hidden=False, locked = False, enum_vals=[]) -- Add a generic property.
         """
         ...
 

--- a/src/App/DocumentObjectPyImp.cpp
+++ b/src/App/DocumentObjectPyImp.cpp
@@ -91,21 +91,21 @@ PyObject* DocumentObjectPy::addProperty(PyObject* args, PyObject* kwd)
 {
     char *sType, *sName = nullptr, *sGroup = nullptr, *sDoc = nullptr;
     short attr = 0;
-    std::string sDocStr;
-    PyObject *ro = Py_False, *hd = Py_False;
+    PyObject *ro = Py_False, *hd = Py_False, *lk = Py_False;
     PyObject* enumVals = nullptr;
-    const std::array<const char*, 9> kwlist {"type",
+    const std::array<const char*, 10> kwlist {"type",
                                              "name",
                                              "group",
                                              "doc",
                                              "attr",
                                              "read_only",
                                              "hidden",
+                                             "locked",
                                              "enum_vals",
                                              nullptr};
     if (!Base::Wrapped_ParseTupleAndKeywords(args,
                                              kwd,
-                                             "ss|sethO!O!O",
+                                             "ss|sethO!O!O!O",
                                              kwlist,
                                              &sType,
                                              &sName,
@@ -117,22 +117,21 @@ PyObject* DocumentObjectPy::addProperty(PyObject* args, PyObject* kwd)
                                              &ro,
                                              &PyBool_Type,
                                              &hd,
+                                             &PyBool_Type,
+                                             &lk,
                                              &enumVals)) {
         return nullptr;
-    }
-
-    if (sDoc) {
-        sDocStr = sDoc;
-        PyMem_Free(sDoc);
     }
 
     Property* prop = getDocumentObjectPtr()->addDynamicProperty(sType,
                                                                 sName,
                                                                 sGroup,
-                                                                sDocStr.c_str(),
+                                                                sDoc,
                                                                 attr,
                                                                 Base::asBoolean(ro),
                                                                 Base::asBoolean(hd));
+
+    prop->setStatus(Property::LockDynamic, Base::asBoolean(lk));
 
     // enum support
     auto* propEnum = dynamic_cast<App::PropertyEnumeration*>(prop);

--- a/src/Gui/ViewProvider.pyi
+++ b/src/Gui/ViewProvider.pyi
@@ -20,16 +20,18 @@ class ViewProvider(ExtensionContainer):
 
     def addProperty(
         self,
+        *,
         type: str,
         name: str,
         group: str,
         doc: str,
         attr: int = 0,
-        ro: bool = False,
-        hd: bool = False,
+        read_only: bool = False,
+        hidden: bool = False,
+        locked: bool = False,
     ) -> "ViewProvider":
         """
-        addProperty(type, name, group, doc, attr=0, ro=False, hd=False) -> ViewProvider
+        addProperty(type, name, group, doc, attr=0, read_only=False, hidden=False, locked=False) -> ViewProvider
 
         Add a generic property.
 
@@ -41,10 +43,12 @@ class ViewProvider(ExtensionContainer):
             Property group. Optional.
         attr : int
             Property attributes.
-        ro : bool
+        read_only : bool
             Read only property.
-        hd : bool
+        hidden : bool
             Hidden property.
+        locked : bool
+            Locked property.
         """
         ...
 

--- a/src/Gui/ViewProviderPyImp.cpp
+++ b/src/Gui/ViewProviderPyImp.cpp
@@ -60,33 +60,56 @@ std::string ViewProviderPy::representation() const
     return "<View provider object>";
 }
 
-PyObject*  ViewProviderPy::addProperty(PyObject *args)
+PyObject* ViewProviderPy::addProperty(PyObject* args, PyObject* kwd)
 {
-    char *sType,*sName=nullptr,*sGroup=nullptr,*sDoc=nullptr;
-    short attr=0;
-    std::string sDocStr;
-    PyObject *ro = Py_False, *hd = Py_False;
-    if (!PyArg_ParseTuple(args, "s|ssethO!O!", &sType,&sName,&sGroup,"utf-8",&sDoc,&attr,
-        &PyBool_Type, &ro, &PyBool_Type, &hd))
+    char *sType, *sName = nullptr, *sGroup = nullptr, *sDoc = nullptr;
+    short attr = 0;
+    PyObject *ro = Py_False, *hd = Py_False, *lk = Py_False;
+    PyObject* enumVals = nullptr;
+    const std::array<const char*, 10> kwlist {"type",
+                                              "name",
+                                              "group",
+                                              "doc",
+                                              "attr",
+                                              "read_only",
+                                              "hidden",
+                                              "locked",
+                                              "enum_vals",
+                                              nullptr};
+    if (!Base::Wrapped_ParseTupleAndKeywords(args,
+                                             kwd,
+                                             "ss|sethO!O!O!O",
+                                             kwlist,
+                                             &sType,
+                                             &sName,
+                                             &sGroup,
+                                             "utf-8",
+                                             &sDoc,
+                                             &attr,
+                                             &PyBool_Type,
+                                             &ro,
+                                             &PyBool_Type,
+                                             &hd,
+                                             &PyBool_Type,
+                                             &lk,
+                                             &enumVals)) {
         return nullptr;
-
-    if (sDoc) {
-        sDocStr = sDoc;
-        PyMem_Free(sDoc);
     }
 
-    App::Property* prop=nullptr;
-    try {
-        prop = getViewProviderPtr()->addDynamicProperty(sType,sName,sGroup,sDocStr.c_str(),attr,
-            Base::asBoolean(ro), Base::asBoolean(hd));
-    }
-    catch (const Base::Exception& e) {
-        throw Py::RuntimeError(e.what());
-    }
-    if (!prop) {
-        std::stringstream str;
-        str << "No property found of type '" << sType << "'" << std::ends;
-        throw Py::TypeError(str.str());
+    App::Property* prop = getViewProviderPtr()->addDynamicProperty(sType,
+                                                                sName,
+                                                                sGroup,
+                                                                sDoc,
+                                                                attr,
+                                                                Base::asBoolean(ro),
+                                                                Base::asBoolean(hd));
+
+    prop->setStatus(App::Property::LockDynamic, Base::asBoolean(lk));
+
+            // enum support
+    auto* propEnum = freecad_cast<App::PropertyEnumeration*>(prop);
+    if (propEnum && enumVals) {
+        propEnum->setPyObject(enumVals);
     }
 
     return Py::new_reference_to(this);

--- a/src/Mod/Assembly/CommandCreateSimulation.py
+++ b/src/Mod/Assembly/CommandCreateSimulation.py
@@ -105,6 +105,7 @@ class Simulation:
                     "App::Property",
                     "Simulation start time.",
                 ),
+                locked=True,
             )
 
         if not hasattr(feaPy, "bTimeEnd"):
@@ -116,6 +117,7 @@ class Simulation:
                     "App::Property",
                     "Simulation end time.",
                 ),
+                locked=True,
             )
 
         if not hasattr(feaPy, "cTimeStepOutput"):
@@ -127,6 +129,7 @@ class Simulation:
                     "App::Property",
                     "Simulation time step for output.",
                 ),
+                locked=True,
             )
 
         if not hasattr(feaPy, "fGlobalErrorTolerance"):
@@ -138,6 +141,7 @@ class Simulation:
                     "App::Property",
                     "Integration global error tolerance.",
                 ),
+                locked=True,
             )
 
         if not hasattr(feaPy, "jFramesPerSecond"):
@@ -149,6 +153,7 @@ class Simulation:
                     "App::Property",
                     "Frames Per Second.",
                 ),
+                locked=True,
             )
 
         feaPy.aTimeStart = 0.0
@@ -200,6 +205,7 @@ class ViewProviderSimulation:
                 QT_TRANSLATE_NOOP(
                     "App::Property", "The number of decimals to use for calculated texts"
                 ),
+                locked=True,
             )
             vpDoc.Decimals = 9
 
@@ -296,6 +302,7 @@ class Motion:
                 "Joint",
                 "Motion",
                 QT_TRANSLATE_NOOP("App::Property", "The joint that is moved by the motion"),
+                locked=True,
             )
 
         if not hasattr(feaPy, "Formula"):
@@ -307,6 +314,7 @@ class Motion:
                     "App::Property",
                     "This is the formula of the motion. For example '1.0*time'.",
                 ),
+                locked=True,
             )
 
         if not hasattr(feaPy, "MotionType"):
@@ -315,6 +323,7 @@ class Motion:
                 "MotionType",
                 "Motion",
                 QT_TRANSLATE_NOOP("App::Property", "The type of the motion"),
+                locked=True,
             )
 
     def dumps(self):

--- a/src/Mod/Assembly/CommandCreateView.py
+++ b/src/Mod/Assembly/CommandCreateView.py
@@ -252,6 +252,7 @@ class ExplodedViewStep:
                 "References",
                 "Exploded Move",
                 QT_TRANSLATE_NOOP("App::Property", "The objects moved by the move"),
+                locked=True,
             )
 
         if not hasattr(evStep, "MovementTransform"):
@@ -263,6 +264,7 @@ class ExplodedViewStep:
                     "App::Property",
                     "This is the movement of the move. The end placement is the result of the start placement * this placement.",
                 ),
+                locked=True,
             )
 
         if not hasattr(evStep, "MoveType"):
@@ -271,6 +273,7 @@ class ExplodedViewStep:
                 "MoveType",
                 "Exploded Move",
                 QT_TRANSLATE_NOOP("App::Property", "The type of the move"),
+                locked=True,
             )
 
     def migrationScript(self, evStep):
@@ -286,6 +289,7 @@ class ExplodedViewStep:
                 "References",
                 "Exploded Move",
                 QT_TRANSLATE_NOOP("App::Property", "The objects moved by the move"),
+                locked=True,
             )
 
             rootObj = None

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -179,6 +179,7 @@ class Joint:
             "JointType",
             "Joint",
             QT_TRANSLATE_NOOP("App::Property", "The type of the joint"),
+            locked=True,
         )
         joint.JointType = JointTypes  # sets the list
         joint.JointType = JointTypes[type_index]  # set the initial value
@@ -203,6 +204,7 @@ class Joint:
                 "Reference1",
                 "Joint Connector 1",
                 QT_TRANSLATE_NOOP("App::Property", "The first reference of the joint"),
+                locked=True,
             )
 
         if not hasattr(joint, "Placement1"):
@@ -214,6 +216,7 @@ class Joint:
                     "App::Property",
                     "This is the local coordinate system within Reference1's object that will be used for the joint.",
                 ),
+                locked=True,
             )
 
         if not hasattr(joint, "Detach1"):
@@ -225,6 +228,7 @@ class Joint:
                     "App::Property",
                     "This prevents Placement1 from recomputing, enabling custom positioning of the placement.",
                 ),
+                locked=True,
             )
 
         if not hasattr(joint, "Offset1"):
@@ -236,6 +240,7 @@ class Joint:
                     "App::Property",
                     "This is the attachment offset of the first connector of the joint.",
                 ),
+                locked=True,
             )
 
         # Second Joint Connector
@@ -245,6 +250,7 @@ class Joint:
                 "Reference2",
                 "Joint Connector 2",
                 QT_TRANSLATE_NOOP("App::Property", "The second reference of the joint"),
+                locked=True,
             )
 
         if not hasattr(joint, "Placement2"):
@@ -256,6 +262,7 @@ class Joint:
                     "App::Property",
                     "This is the local coordinate system within Reference2's object that will be used for the joint.",
                 ),
+                locked=True,
             )
 
         if not hasattr(joint, "Detach2"):
@@ -267,6 +274,7 @@ class Joint:
                     "App::Property",
                     "This prevents Placement2 from recomputing, enabling custom positioning of the placement.",
                 ),
+                locked=True,
             )
 
         if not hasattr(joint, "Offset2"):
@@ -278,6 +286,7 @@ class Joint:
                     "App::Property",
                     "This is the attachment offset of the second connector of the joint.",
                 ),
+                locked=True,
             )
 
         # Other properties
@@ -290,6 +299,7 @@ class Joint:
                     "App::Property",
                     "This is the distance of the joint. It is used only by the Distance joint and Rack and Pinion (pitch radius), Screw and Gears and Belt (radius1)",
                 ),
+                locked=True,
             )
 
         if not hasattr(joint, "Distance2"):
@@ -301,6 +311,7 @@ class Joint:
                     "App::Property",
                     "This is the second distance of the joint. It is used only by the gear joint to store the second radius.",
                 ),
+                locked=True,
             )
 
         if not hasattr(joint, "Activated"):
@@ -312,6 +323,7 @@ class Joint:
                     "App::Property",
                     "This indicates if the joint is active.",
                 ),
+                locked=True,
             )
             joint.Activated = True
 
@@ -324,6 +336,7 @@ class Joint:
                     "App::Property",
                     "Enable the minimum length limit of the joint.",
                 ),
+                locked=True,
             )
             joint.EnableLengthMin = False
 
@@ -336,6 +349,7 @@ class Joint:
                     "App::Property",
                     "Enable the maximum length limit of the joint.",
                 ),
+                locked=True,
             )
             joint.EnableLengthMax = False
 
@@ -348,6 +362,7 @@ class Joint:
                     "App::Property",
                     "Enable the minimum angle limit of the joint.",
                 ),
+                locked=True,
             )
             joint.EnableAngleMin = False
 
@@ -360,6 +375,7 @@ class Joint:
                     "App::Property",
                     "Enable the minimum length of the joint.",
                 ),
+                locked=True,
             )
             joint.EnableAngleMax = False
 
@@ -372,6 +388,7 @@ class Joint:
                     "App::Property",
                     "This is the minimum limit for the length between both coordinate systems (along their Z axis).",
                 ),
+                locked=True,
             )
 
         if not hasattr(joint, "LengthMax"):
@@ -383,6 +400,7 @@ class Joint:
                     "App::Property",
                     "This is the maximum limit for the length between both coordinate systems (along their Z axis).",
                 ),
+                locked=True,
             )
 
         if not hasattr(joint, "AngleMin"):
@@ -394,6 +412,7 @@ class Joint:
                     "App::Property",
                     "This is the minimum limit for the angle between both coordinate systems (between their X axis).",
                 ),
+                locked=True,
             )
 
         if not hasattr(joint, "AngleMax"):
@@ -405,6 +424,7 @@ class Joint:
                     "App::Property",
                     "This is the maximum limit for the angle between both coordinate systems (between their X axis).",
                 ),
+                locked=True,
             )
 
     def migrationScript(self, joint):
@@ -423,6 +443,7 @@ class Joint:
                 "Object1",
                 "Joint Connector 1",
                 QT_TRANSLATE_NOOP("App::Property", "The first object of the joint"),
+                locked=True,
             )
 
             joint.Object1 = [obj1, [el1, vtx1]]
@@ -442,6 +463,7 @@ class Joint:
                 "Object2",
                 "Joint Connector 2",
                 QT_TRANSLATE_NOOP("App::Property", "The second object of the joint"),
+                locked=True,
             )
 
             joint.Object2 = [obj2, [el2, vtx2]]
@@ -455,6 +477,7 @@ class Joint:
                         reference_attr,
                         connector_label,
                         QT_TRANSLATE_NOOP("App::Property", f"The {order} reference of the joint"),
+                        locked=True,
                     )
 
                     obj = getattr(joint, object_attr)
@@ -501,6 +524,7 @@ class Joint:
                     "App::Property",
                     "This is the attachment offset of the first connector of the joint.",
                 ),
+                locked=True,
             )
 
             joint.addProperty(
@@ -511,6 +535,7 @@ class Joint:
                     "App::Property",
                     "This is the attachment offset of the second connector of the joint.",
                 ),
+                locked=True,
             )
 
             joint.Offset2 = App.Placement(current_offset, App.Rotation(current_rotation, 0, 0))
@@ -966,6 +991,7 @@ class GroundedJoint:
             "ObjectToGround",
             "Ground",
             QT_TRANSLATE_NOOP("App::Property", "The object to ground"),
+            locked=True,
         )
 
         joint.ObjectToGround = obj_to_ground

--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -147,7 +147,7 @@ def makeBuilding(objectslist=None,baseobj=None,name=None):
     obj.IfcType = "Building"
     obj.CompositionType = "ELEMENT"
     t = QT_TRANSLATE_NOOP("App::Property","The type of this building")
-    obj.addProperty("App::PropertyEnumeration","BuildingType","Building",t)
+    obj.addProperty("App::PropertyEnumeration","BuildingType","Building",t, locked=True)
     obj.BuildingType = ArchBuildingPart.BuildingTypes
     if FreeCAD.GuiUp:
         obj.ViewObject.ShowLevel = False
@@ -196,7 +196,7 @@ def convertFloors(floor=None):
                 nobj.IfcType = "Building"
                 nobj.CompositionType = "ELEMENT"
                 t = QT_TRANSLATE_NOOP("App::Property","The type of this building")
-                nobj.addProperty("App::PropertyEnumeration","BuildingType","Building",t)
+                nobj.addProperty("App::PropertyEnumeration","BuildingType","Building",t, locked=True)
                 nobj.BuildingType = ArchBuildingPart.BuildingTypes
             label = obj.Label
             for parent in obj.InList:

--- a/src/Mod/BIM/ArchAxis.py
+++ b/src/Mod/BIM/ArchAxis.py
@@ -72,22 +72,22 @@ class _Axis:
 
         pl = obj.PropertiesList
         if not "Distances" in pl:
-            obj.addProperty("App::PropertyFloatList","Distances","Axis", QT_TRANSLATE_NOOP("App::Property","The intervals between axes"))
+            obj.addProperty("App::PropertyFloatList","Distances","Axis", QT_TRANSLATE_NOOP("App::Property","The intervals between axes"), locked=True)
         if not "Angles" in pl:
-            obj.addProperty("App::PropertyFloatList","Angles","Axis", QT_TRANSLATE_NOOP("App::Property","The angles of each axis"))
+            obj.addProperty("App::PropertyFloatList","Angles","Axis", QT_TRANSLATE_NOOP("App::Property","The angles of each axis"), locked=True)
         if not "Labels" in pl:
-            obj.addProperty("App::PropertyStringList","Labels","Axis", QT_TRANSLATE_NOOP("App::Property","The label of each axis"))
+            obj.addProperty("App::PropertyStringList","Labels","Axis", QT_TRANSLATE_NOOP("App::Property","The label of each axis"), locked=True)
         if not "CustomNumber" in pl:
-            obj.addProperty("App::PropertyString","CustomNumber","Axis", QT_TRANSLATE_NOOP("App::Property","An optional custom bubble number"))
+            obj.addProperty("App::PropertyString","CustomNumber","Axis", QT_TRANSLATE_NOOP("App::Property","An optional custom bubble number"), locked=True)
         if not "Length" in pl:
-            obj.addProperty("App::PropertyLength","Length","Axis", QT_TRANSLATE_NOOP("App::Property","The length of the axes"))
+            obj.addProperty("App::PropertyLength","Length","Axis", QT_TRANSLATE_NOOP("App::Property","The length of the axes"), locked=True)
             obj.Length=3000
         if not "Placement" in pl:
-            obj.addProperty("App::PropertyPlacement","Placement","Base","")
+            obj.addProperty("App::PropertyPlacement","Placement","Base","", locked=True)
         if not "Shape" in pl:
-            obj.addProperty("Part::PropertyPartShape","Shape","Base","")
+            obj.addProperty("Part::PropertyPartShape","Shape","Base","", locked=True)
         if not "Limit" in pl:
-            obj.addProperty("App::PropertyLength","Limit","Axis", QT_TRANSLATE_NOOP("App::Property","If not zero, the axes are not represented as one full line but as two lines of the given length"))
+            obj.addProperty("App::PropertyLength","Limit","Axis", QT_TRANSLATE_NOOP("App::Property","If not zero, the axes are not represented as one full line but as two lines of the given length"), locked=True)
             obj.Limit=0
         self.Type = "Axis"
 
@@ -185,38 +185,38 @@ class _ViewProviderAxis:
         ts = params.get_param("textheight") * params.get_param("DefaultAnnoScaleMultiplier")
         pl = vobj.PropertiesList
         if not "BubbleSize" in pl:
-            vobj.addProperty("App::PropertyLength","BubbleSize","Axis", QT_TRANSLATE_NOOP("App::Property","The size of the axis bubbles"))
+            vobj.addProperty("App::PropertyLength","BubbleSize","Axis", QT_TRANSLATE_NOOP("App::Property","The size of the axis bubbles"), locked=True)
             vobj.BubbleSize = ts * 1.42
         if not "NumberingStyle" in pl:
-            vobj.addProperty("App::PropertyEnumeration","NumberingStyle","Axis", QT_TRANSLATE_NOOP("App::Property","The numbering style"))
+            vobj.addProperty("App::PropertyEnumeration","NumberingStyle","Axis", QT_TRANSLATE_NOOP("App::Property","The numbering style"), locked=True)
             vobj.NumberingStyle = ["1,2,3","01,02,03","001,002,003","A,B,C","a,b,c","I,II,III","L0,L1,L2"]
             vobj.NumberingStyle = "1,2,3"
         if not "DrawStyle" in pl:
-            vobj.addProperty("App::PropertyEnumeration","DrawStyle","Axis",QT_TRANSLATE_NOOP("App::Property","The type of line to draw this axis"))
+            vobj.addProperty("App::PropertyEnumeration","DrawStyle","Axis",QT_TRANSLATE_NOOP("App::Property","The type of line to draw this axis"), locked=True)
             vobj.DrawStyle = ["Solid","Dashed","Dotted","Dashdot"]
         vobj.DrawStyle = "Dashdot"
         if not "BubblePosition" in pl:
-            vobj.addProperty("App::PropertyEnumeration","BubblePosition","Axis",QT_TRANSLATE_NOOP("App::Property","Where to add bubbles to this axis: Start, end, both or none"))
+            vobj.addProperty("App::PropertyEnumeration","BubblePosition","Axis",QT_TRANSLATE_NOOP("App::Property","Where to add bubbles to this axis: Start, end, both or none"), locked=True)
             vobj.BubblePosition = ["Start","End","Both","None","Arrow left","Arrow right","Bar left","Bar right"]
         if not "LineWidth" in pl:
-            vobj.addProperty("App::PropertyFloat","LineWidth","Axis",QT_TRANSLATE_NOOP("App::Property","The line width to draw this axis"))
+            vobj.addProperty("App::PropertyFloat","LineWidth","Axis",QT_TRANSLATE_NOOP("App::Property","The line width to draw this axis"), locked=True)
             vobj.LineWidth = 1
         if not "LineColor" in pl:
-            vobj.addProperty("App::PropertyColor","LineColor","Axis",QT_TRANSLATE_NOOP("App::Property","The color of this axis"))
+            vobj.addProperty("App::PropertyColor","LineColor","Axis",QT_TRANSLATE_NOOP("App::Property","The color of this axis"), locked=True)
         vobj.LineColor = ArchCommands.getDefaultColor("Helpers")
         if not "StartNumber" in pl:
-            vobj.addProperty("App::PropertyInteger","StartNumber","Axis",QT_TRANSLATE_NOOP("App::Property","The number of the first axis"))
+            vobj.addProperty("App::PropertyInteger","StartNumber","Axis",QT_TRANSLATE_NOOP("App::Property","The number of the first axis"), locked=True)
             vobj.StartNumber = 1
         if not "FontName" in pl:
-            vobj.addProperty("App::PropertyFont","FontName","Axis",QT_TRANSLATE_NOOP("App::Property","The font to use for texts"))
+            vobj.addProperty("App::PropertyFont","FontName","Axis",QT_TRANSLATE_NOOP("App::Property","The font to use for texts"), locked=True)
             vobj.FontName = params.get_param("textfont")
         if not "FontSize" in pl:
-            vobj.addProperty("App::PropertyLength","FontSize","Axis",QT_TRANSLATE_NOOP("App::Property","The font size"))
+            vobj.addProperty("App::PropertyLength","FontSize","Axis",QT_TRANSLATE_NOOP("App::Property","The font size"), locked=True)
             vobj.FontSize = ts
         if not "ShowLabel" in pl:
             vobj.addProperty("App::PropertyBool","ShowLabel","Axis",QT_TRANSLATE_NOOP("App::Property","If true, show the labels"))
         if not "LabelOffset" in pl:
-            vobj.addProperty("App::PropertyPlacement","LabelOffset","Axis",QT_TRANSLATE_NOOP("App::Property","A transformation to apply to each label"))
+            vobj.addProperty("App::PropertyPlacement","LabelOffset","Axis",QT_TRANSLATE_NOOP("App::Property","A transformation to apply to each label"), locked=True)
 
     def onDocumentRestored(self,vobj):
 

--- a/src/Mod/BIM/ArchAxisSystem.py
+++ b/src/Mod/BIM/ArchAxisSystem.py
@@ -65,9 +65,9 @@ class _AxisSystem:
 
         pl = obj.PropertiesList
         if not "Axes" in pl:
-            obj.addProperty("App::PropertyLinkList","Axes","AxisSystem", QT_TRANSLATE_NOOP("App::Property","The axes this system is made of"))
+            obj.addProperty("App::PropertyLinkList","Axes","AxisSystem", QT_TRANSLATE_NOOP("App::Property","The axes this system is made of"), locked=True)
         if not "Placement" in pl:
-            obj.addProperty("App::PropertyPlacement","Placement","AxisSystem",QT_TRANSLATE_NOOP("App::Property","The placement of this axis system"))
+            obj.addProperty("App::PropertyPlacement","Placement","AxisSystem",QT_TRANSLATE_NOOP("App::Property","The placement of this axis system"), locked=True)
         self.Type = "AxisSystem"
 
     def onDocumentRestored(self,obj):

--- a/src/Mod/BIM/ArchBuilding.py
+++ b/src/Mod/BIM/ArchBuilding.py
@@ -282,7 +282,7 @@ class _Building(ArchFloor._Floor):
 
         pl = obj.PropertiesList
         if not "BuildingType" in pl:
-            obj.addProperty("App::PropertyEnumeration","BuildingType","Arch",QT_TRANSLATE_NOOP("App::Property","The type of this building"))
+            obj.addProperty("App::PropertyEnumeration","BuildingType","Arch",QT_TRANSLATE_NOOP("App::Property","The type of this building"), locked=True)
             obj.BuildingType = BuildingTypes
         obj.setEditorMode('Height',2)
         self.Type = "Building"

--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -218,28 +218,28 @@ class BuildingPart(ArchIFC.IfcProduct):
 
         pl = obj.PropertiesList
         if not "Height" in pl:
-            obj.addProperty("App::PropertyLength","Height","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The height of this object"))
+            obj.addProperty("App::PropertyLength","Height","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The height of this object"), locked=True)
         if not "HeightPropagate" in pl:
-            obj.addProperty("App::PropertyBool","HeightPropagate","Children",QT_TRANSLATE_NOOP("App::Property","If true, the height value propagates to contained objects if the height of those objects is set to 0"))
+            obj.addProperty("App::PropertyBool","HeightPropagate","Children",QT_TRANSLATE_NOOP("App::Property","If true, the height value propagates to contained objects if the height of those objects is set to 0"), locked=True)
             obj.HeightPropagate = True
         if not "LevelOffset" in pl:
-            obj.addProperty("App::PropertyDistance","LevelOffset","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The level of the (0,0,0) point of this level"))
+            obj.addProperty("App::PropertyDistance","LevelOffset","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The level of the (0,0,0) point of this level"), locked=True)
         if not "Area" in pl:
-            obj.addProperty("App::PropertyArea","Area", "BuildingPart",QT_TRANSLATE_NOOP("App::Property","The computed floor area of this floor"))
+            obj.addProperty("App::PropertyArea","Area", "BuildingPart",QT_TRANSLATE_NOOP("App::Property","The computed floor area of this floor"), locked=True)
         if not "Description" in pl:
-            obj.addProperty("App::PropertyString","Description","Component",QT_TRANSLATE_NOOP("App::Property","An optional description for this component"))
+            obj.addProperty("App::PropertyString","Description","Component",QT_TRANSLATE_NOOP("App::Property","An optional description for this component"), locked=True)
         if not "Tag" in pl:
-            obj.addProperty("App::PropertyString","Tag","Component",QT_TRANSLATE_NOOP("App::Property","An optional tag for this component"))
+            obj.addProperty("App::PropertyString","Tag","Component",QT_TRANSLATE_NOOP("App::Property","An optional tag for this component"), locked=True)
         if not "Shape" in pl:
-            obj.addProperty("Part::PropertyPartShape","Shape","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The shape of this object"))
+            obj.addProperty("Part::PropertyPartShape","Shape","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The shape of this object"), locked=True)
         if not "SavedInventor" in pl:
-            obj.addProperty("App::PropertyFileIncluded","SavedInventor","BuildingPart",QT_TRANSLATE_NOOP("App::Property","This property stores an OpenInventor representation for this object"))
+            obj.addProperty("App::PropertyFileIncluded","SavedInventor","BuildingPart",QT_TRANSLATE_NOOP("App::Property","This property stores an OpenInventor representation for this object"), locked=True)
             obj.setEditorMode("SavedInventor",2)
         if not "OnlySolids" in pl:
-            obj.addProperty("App::PropertyBool","OnlySolids","BuildingPart",QT_TRANSLATE_NOOP("App::Property","If true, only solids will be collected by this object when referenced from other files"))
+            obj.addProperty("App::PropertyBool","OnlySolids","BuildingPart",QT_TRANSLATE_NOOP("App::Property","If true, only solids will be collected by this object when referenced from other files"), locked=True)
             obj.OnlySolids = True
         if not "MaterialsTable" in pl:
-            obj.addProperty("App::PropertyMap","MaterialsTable","BuildingPart",QT_TRANSLATE_NOOP("App::Property","A MaterialName:SolidIndexesList map that relates material names with solid indexes to be used when referencing this object from other files"))
+            obj.addProperty("App::PropertyMap","MaterialsTable","BuildingPart",QT_TRANSLATE_NOOP("App::Property","A MaterialName:SolidIndexesList map that relates material names with solid indexes to be used when referencing this object from other files"), locked=True)
 
         self.Type = "BuildingPart"
 
@@ -442,87 +442,87 @@ class ViewProviderBuildingPart:
 
         pl = vobj.PropertiesList
         if not "LineWidth" in pl:
-            vobj.addProperty("App::PropertyFloat","LineWidth","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The line width of this object"))
+            vobj.addProperty("App::PropertyFloat","LineWidth","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The line width of this object"), locked=True)
             vobj.LineWidth = 1
         if not "OverrideUnit" in pl:
-            vobj.addProperty("App::PropertyString","OverrideUnit","BuildingPart",QT_TRANSLATE_NOOP("App::Property","An optional unit to express levels"))
+            vobj.addProperty("App::PropertyString","OverrideUnit","BuildingPart",QT_TRANSLATE_NOOP("App::Property","An optional unit to express levels"), locked=True)
         if not "DisplayOffset" in pl:
-            vobj.addProperty("App::PropertyPlacement","DisplayOffset","BuildingPart",QT_TRANSLATE_NOOP("App::Property","A transformation to apply to the level mark"))
+            vobj.addProperty("App::PropertyPlacement","DisplayOffset","BuildingPart",QT_TRANSLATE_NOOP("App::Property","A transformation to apply to the level mark"), locked=True)
             vobj.DisplayOffset = FreeCAD.Placement(FreeCAD.Vector(0,0,0),FreeCAD.Rotation(FreeCAD.Vector(1,0,0),90))
         if not "ShowLevel" in pl:
-            vobj.addProperty("App::PropertyBool","ShowLevel","BuildingPart",QT_TRANSLATE_NOOP("App::Property","If true, show the level"))
+            vobj.addProperty("App::PropertyBool","ShowLevel","BuildingPart",QT_TRANSLATE_NOOP("App::Property","If true, show the level"), locked=True)
             vobj.ShowLevel = True
         if not "ShowUnit" in pl:
-            vobj.addProperty("App::PropertyBool","ShowUnit","BuildingPart",QT_TRANSLATE_NOOP("App::Property","If true, show the unit on the level tag"))
+            vobj.addProperty("App::PropertyBool","ShowUnit","BuildingPart",QT_TRANSLATE_NOOP("App::Property","If true, show the unit on the level tag"), locked=True)
         if not "OriginOffset" in pl:
-            vobj.addProperty("App::PropertyBool","OriginOffset","BuildingPart",QT_TRANSLATE_NOOP("App::Property","If true, display offset will affect the origin mark too"))
+            vobj.addProperty("App::PropertyBool","OriginOffset","BuildingPart",QT_TRANSLATE_NOOP("App::Property","If true, display offset will affect the origin mark too"), locked=True)
         if not "ShowLabel" in pl:
-            vobj.addProperty("App::PropertyBool","ShowLabel","BuildingPart",QT_TRANSLATE_NOOP("App::Property","If true, the object's label is displayed"))
+            vobj.addProperty("App::PropertyBool","ShowLabel","BuildingPart",QT_TRANSLATE_NOOP("App::Property","If true, the object's label is displayed"), locked=True)
             vobj.ShowLabel = True
         if not "FontName" in pl:
-            vobj.addProperty("App::PropertyFont","FontName","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The font to be used for texts"))
+            vobj.addProperty("App::PropertyFont","FontName","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The font to be used for texts"), locked=True)
             vobj.FontName = params.get_param("textfont")
         if not "FontSize" in pl:
-            vobj.addProperty("App::PropertyLength","FontSize","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The font size of texts"))
+            vobj.addProperty("App::PropertyLength","FontSize","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The font size of texts"), locked=True)
             vobj.FontSize = params.get_param("textheight") * params.get_param("DefaultAnnoScaleMultiplier")
         if not "DiffuseColor" in pl:
-            vobj.addProperty("App::PropertyColorList","DiffuseColor","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The individual face colors"))
+            vobj.addProperty("App::PropertyColorList","DiffuseColor","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The individual face colors"), locked=True)
 
         # Interaction properties
         if not "SetWorkingPlane" in pl:
-            vobj.addProperty("App::PropertyBool","SetWorkingPlane","Interaction",QT_TRANSLATE_NOOP("App::Property","If true, when activated, the working plane will automatically adapt to this level"))
+            vobj.addProperty("App::PropertyBool","SetWorkingPlane","Interaction",QT_TRANSLATE_NOOP("App::Property","If true, when activated, the working plane will automatically adapt to this level"), locked=True)
             vobj.SetWorkingPlane = True
         if not "AutoWorkingPlane" in pl:
-            vobj.addProperty("App::PropertyBool","AutoWorkingPlane","Interaction",QT_TRANSLATE_NOOP("App::Property","If set to True, the working plane will be kept on Auto mode"))
+            vobj.addProperty("App::PropertyBool","AutoWorkingPlane","Interaction",QT_TRANSLATE_NOOP("App::Property","If set to True, the working plane will be kept on Auto mode"), locked=True)
         if not "ViewData" in pl:
-            vobj.addProperty("App::PropertyFloatList","ViewData","Interaction",QT_TRANSLATE_NOOP("App::Property","Camera position data associated with this object"))
+            vobj.addProperty("App::PropertyFloatList","ViewData","Interaction",QT_TRANSLATE_NOOP("App::Property","Camera position data associated with this object"), locked=True)
             vobj.setEditorMode("ViewData",2)
         if not "RestoreView" in pl:
-            vobj.addProperty("App::PropertyBool","RestoreView","Interaction",QT_TRANSLATE_NOOP("App::Property","If set, the view stored in this object will be restored on double-click"))
+            vobj.addProperty("App::PropertyBool","RestoreView","Interaction",QT_TRANSLATE_NOOP("App::Property","If set, the view stored in this object will be restored on double-click"), locked=True)
         if not "DoubleClickActivates" in pl:
-            vobj.addProperty("App::PropertyBool","DoubleClickActivates","Interaction",QT_TRANSLATE_NOOP("App::Property","If True, double-clicking this object in the tree activates it"))
+            vobj.addProperty("App::PropertyBool","DoubleClickActivates","Interaction",QT_TRANSLATE_NOOP("App::Property","If True, double-clicking this object in the tree activates it"), locked=True)
 
         # inventor saving
         if not "SaveInventor" in pl:
-            vobj.addProperty("App::PropertyBool","SaveInventor","Interaction",QT_TRANSLATE_NOOP("App::Property","If this is enabled, the OpenInventor representation of this object will be saved in the FreeCAD file, allowing to reference it in other files in lightweight mode."))
+            vobj.addProperty("App::PropertyBool","SaveInventor","Interaction",QT_TRANSLATE_NOOP("App::Property","If this is enabled, the OpenInventor representation of this object will be saved in the FreeCAD file, allowing to reference it in other files in lightweight mode."), locked=True)
         if not "SavedInventor" in pl:
-            vobj.addProperty("App::PropertyFileIncluded","SavedInventor","Interaction",QT_TRANSLATE_NOOP("App::Property","A slot to save the OpenInventor representation of this object, if enabled"))
+            vobj.addProperty("App::PropertyFileIncluded","SavedInventor","Interaction",QT_TRANSLATE_NOOP("App::Property","A slot to save the OpenInventor representation of this object, if enabled"), locked=True)
             vobj.setEditorMode("SavedInventor",2)
 
         # children properties
         if not "ChildrenOverride" in pl:
-            vobj.addProperty("App::PropertyBool","ChildrenOverride","Children",QT_TRANSLATE_NOOP("App::Property","If true, show the objects contained in this Building Part will adopt these line, color and transparency settings"))
+            vobj.addProperty("App::PropertyBool","ChildrenOverride","Children",QT_TRANSLATE_NOOP("App::Property","If true, show the objects contained in this Building Part will adopt these line, color and transparency settings"), locked=True)
         if not "ChildrenLineWidth" in pl:
-            vobj.addProperty("App::PropertyFloat","ChildrenLineWidth","Children",QT_TRANSLATE_NOOP("App::Property","The line width of child objects"))
+            vobj.addProperty("App::PropertyFloat","ChildrenLineWidth","Children",QT_TRANSLATE_NOOP("App::Property","The line width of child objects"), locked=True)
             vobj.ChildrenLineWidth = params.get_param_view("DefaultShapeLineWidth")
         if not "ChildrenLineColor" in pl:
-            vobj.addProperty("App::PropertyColor","ChildrenLineColor","Children",QT_TRANSLATE_NOOP("App::Property","The line color of child objects"))
+            vobj.addProperty("App::PropertyColor","ChildrenLineColor","Children",QT_TRANSLATE_NOOP("App::Property","The line color of child objects"), locked=True)
             vobj.ChildrenLineColor = params.get_param_view("DefaultShapeLineColor") & 0xFFFFFF00
         if not "ChildrenShapeColor" in pl:
-            vobj.addProperty("App::PropertyMaterial","ChildrenShapeColor","Children",QT_TRANSLATE_NOOP("App::Property","The shape appearance of child objects"))
+            vobj.addProperty("App::PropertyMaterial","ChildrenShapeColor","Children",QT_TRANSLATE_NOOP("App::Property","The shape appearance of child objects"), locked=True)
             vobj.ChildrenShapeColor = params.get_param_view("DefaultShapeColor") & 0xFFFFFF00
         if not "ChildrenTransparency" in pl:
-            vobj.addProperty("App::PropertyPercent","ChildrenTransparency","Children",QT_TRANSLATE_NOOP("App::Property","The transparency of child objects"))
+            vobj.addProperty("App::PropertyPercent","ChildrenTransparency","Children",QT_TRANSLATE_NOOP("App::Property","The transparency of child objects"), locked=True)
             vobj.ChildrenTransparency = params.get_param_view("DefaultShapeTransparency")
 
         # clip properties
         if not "CutView" in pl:
-            vobj.addProperty("App::PropertyBool","CutView","Clip",QT_TRANSLATE_NOOP("App::Property","Cut the view above this level"))
+            vobj.addProperty("App::PropertyBool","CutView","Clip",QT_TRANSLATE_NOOP("App::Property","Cut the view above this level"), locked=True)
         if not "CutMargin" in pl:
-            vobj.addProperty("App::PropertyLength","CutMargin","Clip",QT_TRANSLATE_NOOP("App::Property","The distance between the level plane and the cut line"))
+            vobj.addProperty("App::PropertyLength","CutMargin","Clip",QT_TRANSLATE_NOOP("App::Property","The distance between the level plane and the cut line"), locked=True)
             vobj.CutMargin = 1600
         if not "AutoCutView" in pl:
-            vobj.addProperty("App::PropertyBool","AutoCutView","Clip",QT_TRANSLATE_NOOP("App::Property","Turn cutting on when activating this level"))
+            vobj.addProperty("App::PropertyBool","AutoCutView","Clip",QT_TRANSLATE_NOOP("App::Property","Turn cutting on when activating this level"), locked=True)
 
         # autogroup properties
         if not "AutogroupSize" in pl:
-            vobj.addProperty("App::PropertyIntegerList","AutogroupSize","AutoGroup",QT_TRANSLATE_NOOP("App::Property","The capture box for newly created objects expressed as [XMin,YMin,ZMin,XMax,YMax,ZMax]"))
+            vobj.addProperty("App::PropertyIntegerList","AutogroupSize","AutoGroup",QT_TRANSLATE_NOOP("App::Property","The capture box for newly created objects expressed as [XMin,YMin,ZMin,XMax,YMax,ZMax]"), locked=True)
         if not "AutogroupBox" in pl:
-            vobj.addProperty("App::PropertyBool","AutogroupBox","AutoGroup",QT_TRANSLATE_NOOP("App::Property","Turns auto group box on/off"))
+            vobj.addProperty("App::PropertyBool","AutogroupBox","AutoGroup",QT_TRANSLATE_NOOP("App::Property","Turns auto group box on/off"), locked=True)
         if not "AutogroupAutosize" in pl:
-            vobj.addProperty("App::PropertyBool","AutogroupAutosize","AutoGroup",QT_TRANSLATE_NOOP("App::Property","Automatically set size from contents"))
+            vobj.addProperty("App::PropertyBool","AutogroupAutosize","AutoGroup",QT_TRANSLATE_NOOP("App::Property","Automatically set size from contents"), locked=True)
         if not "AutogroupMargin" in pl:
-            vobj.addProperty("App::PropertyLength","AutogroupMargin","AutoGroup",QT_TRANSLATE_NOOP("App::Property","A margin to use when autosize is turned on"))
+            vobj.addProperty("App::PropertyLength","AutogroupMargin","AutoGroup",QT_TRANSLATE_NOOP("App::Property","A margin to use when autosize is turned on"), locked=True)
 
     def onDocumentRestored(self,vobj):
 

--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -199,44 +199,44 @@ class Component(ArchIFC.IfcProduct):
 
         pl = obj.PropertiesList
         if not "Base" in pl:
-            obj.addProperty("App::PropertyLink","Base","Component",QT_TRANSLATE_NOOP("App::Property","The base object this component is built upon"))
+            obj.addProperty("App::PropertyLink","Base","Component",QT_TRANSLATE_NOOP("App::Property","The base object this component is built upon"), locked=True)
         if not "CloneOf" in pl:
-            obj.addProperty("App::PropertyLink","CloneOf","Component",QT_TRANSLATE_NOOP("App::Property","The object this component is cloning"))
+            obj.addProperty("App::PropertyLink","CloneOf","Component",QT_TRANSLATE_NOOP("App::Property","The object this component is cloning"), locked=True)
         if not "Additions" in pl:
-            obj.addProperty("App::PropertyLinkList","Additions","Component",QT_TRANSLATE_NOOP("App::Property","Other shapes that are appended to this object"))
+            obj.addProperty("App::PropertyLinkList","Additions","Component",QT_TRANSLATE_NOOP("App::Property","Other shapes that are appended to this object"), locked=True)
         if not "Subtractions" in pl:
-            obj.addProperty("App::PropertyLinkList","Subtractions","Component",QT_TRANSLATE_NOOP("App::Property","Other shapes that are subtracted from this object"))
+            obj.addProperty("App::PropertyLinkList","Subtractions","Component",QT_TRANSLATE_NOOP("App::Property","Other shapes that are subtracted from this object"), locked=True)
         if not "Description" in pl:
-            obj.addProperty("App::PropertyString","Description","Component",QT_TRANSLATE_NOOP("App::Property","An optional description for this component"))
+            obj.addProperty("App::PropertyString","Description","Component",QT_TRANSLATE_NOOP("App::Property","An optional description for this component"), locked=True)
         if not "Tag" in pl:
-            obj.addProperty("App::PropertyString","Tag","Component",QT_TRANSLATE_NOOP("App::Property","An optional tag for this component"))
+            obj.addProperty("App::PropertyString","Tag","Component",QT_TRANSLATE_NOOP("App::Property","An optional tag for this component"), locked=True)
         if not "StandardCode" in pl:
-            obj.addProperty("App::PropertyString","StandardCode","Component",QT_TRANSLATE_NOOP("App::Property","An optional standard (OmniClass, etc...) code for this component"))
+            obj.addProperty("App::PropertyString","StandardCode","Component",QT_TRANSLATE_NOOP("App::Property","An optional standard (OmniClass, etc...) code for this component"), locked=True)
         if not "Material" in pl:
-            obj.addProperty("App::PropertyLink","Material","Component",QT_TRANSLATE_NOOP("App::Property","A material for this object"))
+            obj.addProperty("App::PropertyLink","Material","Component",QT_TRANSLATE_NOOP("App::Property","A material for this object"), locked=True)
         if "BaseMaterial" in pl:
             obj.Material = obj.BaseMaterial
             obj.removeProperty("BaseMaterial")
             FreeCAD.Console.PrintMessage("Upgrading "+obj.Label+" BaseMaterial property to Material\n")
         if not "MoveBase" in pl:
-            obj.addProperty("App::PropertyBool","MoveBase","Component",QT_TRANSLATE_NOOP("App::Property","Specifies if moving this object moves its base instead"))
+            obj.addProperty("App::PropertyBool","MoveBase","Component",QT_TRANSLATE_NOOP("App::Property","Specifies if moving this object moves its base instead"), locked=True)
             obj.MoveBase = params.get_param_arch("MoveBase")
         if not "MoveWithHost" in pl:
-            obj.addProperty("App::PropertyBool","MoveWithHost","Component",QT_TRANSLATE_NOOP("App::Property","Specifies if this object must move together when its host is moved"))
+            obj.addProperty("App::PropertyBool","MoveWithHost","Component",QT_TRANSLATE_NOOP("App::Property","Specifies if this object must move together when its host is moved"), locked=True)
             obj.MoveWithHost = params.get_param_arch("MoveWithHost")
         if not "VerticalArea" in pl:
-            obj.addProperty("App::PropertyArea","VerticalArea","Component",QT_TRANSLATE_NOOP("App::Property","The area of all vertical faces of this object"))
+            obj.addProperty("App::PropertyArea","VerticalArea","Component",QT_TRANSLATE_NOOP("App::Property","The area of all vertical faces of this object"), locked=True)
             obj.setEditorMode("VerticalArea",1)
         if not "HorizontalArea" in pl:
-            obj.addProperty("App::PropertyArea","HorizontalArea","Component",QT_TRANSLATE_NOOP("App::Property","The area of the projection of this object onto the XY plane"))
+            obj.addProperty("App::PropertyArea","HorizontalArea","Component",QT_TRANSLATE_NOOP("App::Property","The area of the projection of this object onto the XY plane"), locked=True)
             obj.setEditorMode("HorizontalArea",1)
         if not "PerimeterLength" in pl:
-            obj.addProperty("App::PropertyLength","PerimeterLength","Component",QT_TRANSLATE_NOOP("App::Property","The perimeter length of the horizontal area"))
+            obj.addProperty("App::PropertyLength","PerimeterLength","Component",QT_TRANSLATE_NOOP("App::Property","The perimeter length of the horizontal area"), locked=True)
             obj.setEditorMode("PerimeterLength",1)
         if not "HiRes" in pl:
-            obj.addProperty("App::PropertyLink","HiRes","Component",QT_TRANSLATE_NOOP("App::Property","An optional higher-resolution mesh or shape for this object"))
+            obj.addProperty("App::PropertyLink","HiRes","Component",QT_TRANSLATE_NOOP("App::Property","An optional higher-resolution mesh or shape for this object"), locked=True)
         if not "Axis" in pl:
-            obj.addProperty("App::PropertyLink","Axis","Component",QT_TRANSLATE_NOOP("App::Property","An optional axis or axis system on which this object should be duplicated"))
+            obj.addProperty("App::PropertyLink","Axis","Component",QT_TRANSLATE_NOOP("App::Property","An optional axis or axis system on which this object should be duplicated"), locked=True)
 
         self.Subvolume = None
         #self.MoveWithHost = False
@@ -1196,7 +1196,7 @@ class ViewProviderComponent:
         """
 
         if not "UseMaterialColor" in vobj.PropertiesList:
-            vobj.addProperty("App::PropertyBool","UseMaterialColor","Component",QT_TRANSLATE_NOOP("App::Property","Use the material color as this object's shape color, if available"))
+            vobj.addProperty("App::PropertyBool","UseMaterialColor","Component",QT_TRANSLATE_NOOP("App::Property","Use the material color as this object's shape color, if available"), locked=True)
             vobj.UseMaterialColor = params.get_param_arch("UseMaterialColor")
 
     def updateData(self,obj,prop):

--- a/src/Mod/BIM/ArchCurtainWall.py
+++ b/src/Mod/BIM/ArchCurtainWall.py
@@ -91,21 +91,21 @@ class CurtainWall(ArchComponent.Component):
         vsize = 50
         hsize = 50
         if not "Host" in pl:
-            obj.addProperty("App::PropertyLink","Host","CurtainWall",QT_TRANSLATE_NOOP("App::Property","An optional host object for this curtain wall"))
+            obj.addProperty("App::PropertyLink","Host","CurtainWall",QT_TRANSLATE_NOOP("App::Property","An optional host object for this curtain wall"), locked=True)
         if not "Height" in pl:
             obj.addProperty("App::PropertyLength","Height","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The height of the curtain wall, if based on an edge"))
+                            QT_TRANSLATE_NOOP("App::Property","The height of the curtain wall, if based on an edge"), locked=True)
             obj.Height = params.get_param_arch("WallHeight")
         if not "VerticalMullionNumber" in pl:
             obj.addProperty("App::PropertyInteger","VerticalMullionNumber","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The number of vertical mullions"))
+                            QT_TRANSLATE_NOOP("App::Property","The number of vertical mullions"), locked=True)
             obj.setEditorMode("VerticalMullionNumber",1)
         if not "VerticalMullionAlignment" in pl:
             obj.addProperty("App::PropertyBool","VerticalMullionAlignment","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","If the profile of the vertical mullions get aligned with the surface or not"))
+                            QT_TRANSLATE_NOOP("App::Property","If the profile of the vertical mullions get aligned with the surface or not"), locked=True)
         if not "VerticalSections" in pl:
             obj.addProperty("App::PropertyInteger","VerticalSections","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The number of vertical sections of this curtain wall"))
+                            QT_TRANSLATE_NOOP("App::Property","The number of vertical sections of this curtain wall"), locked=True)
             obj.VerticalSections = 1
         if "VerticalMullionSize" in pl:
             # obsolete
@@ -113,25 +113,25 @@ class CurtainWall(ArchComponent.Component):
             obj.removeProperty("VerticalMullionSize")
         if not "VerticalMullionHeight" in pl:
             obj.addProperty("App::PropertyLength","VerticalMullionHeight","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The height of the vertical mullions profile, if no profile is used"))
+                            QT_TRANSLATE_NOOP("App::Property","The height of the vertical mullions profile, if no profile is used"), locked=True)
             obj.VerticalMullionHeight = vsize
         if not "VerticalMullionWidth" in pl:
             obj.addProperty("App::PropertyLength","VerticalMullionWidth","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The width of the vertical mullions profile, if no profile is used"))
+                            QT_TRANSLATE_NOOP("App::Property","The width of the vertical mullions profile, if no profile is used"), locked=True)
             obj.VerticalMullionWidth = vsize
         if not "VerticalMullionProfile" in pl:
             obj.addProperty("App::PropertyLink","VerticalMullionProfile","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","A profile for vertical mullions (disables vertical mullion size)"))
+                            QT_TRANSLATE_NOOP("App::Property","A profile for vertical mullions (disables vertical mullion size)"), locked=True)
         if not "HorizontalMullionNumber" in pl:
             obj.addProperty("App::PropertyInteger","HorizontalMullionNumber","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The number of horizontal mullions"))
+                            QT_TRANSLATE_NOOP("App::Property","The number of horizontal mullions"), locked=True)
             obj.setEditorMode("HorizontalMullionNumber",1)
         if not "HorizontalMullionAlignment" in pl:
             obj.addProperty("App::PropertyBool","HorizontalMullionAlignment","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","If the profile of the horizontal mullions gets aligned with the surface or not"))
+                            QT_TRANSLATE_NOOP("App::Property","If the profile of the horizontal mullions gets aligned with the surface or not"), locked=True)
         if not "HorizontalSections" in pl:
             obj.addProperty("App::PropertyInteger","HorizontalSections","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The number of horizontal sections of this curtain wall"))
+                            QT_TRANSLATE_NOOP("App::Property","The number of horizontal sections of this curtain wall"), locked=True)
             obj.HorizontalSections = 1
         if "HorizontalMullionSize" in pl:
             # obsolete
@@ -139,50 +139,50 @@ class CurtainWall(ArchComponent.Component):
             obj.removeProperty("HorizontalMullionSize")
         if not "HorizontalMullionHeight" in pl:
             obj.addProperty("App::PropertyLength","HorizontalMullionHeight","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The height of the horizontal mullions profile, if no profile is used"))
+                            QT_TRANSLATE_NOOP("App::Property","The height of the horizontal mullions profile, if no profile is used"), locked=True)
             obj.HorizontalMullionHeight = hsize
         if not "HorizontalMullionWidth" in pl:
             obj.addProperty("App::PropertyLength","HorizontalMullionWidth","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The width of the horizontal mullions profile, if no profile is used"))
+                            QT_TRANSLATE_NOOP("App::Property","The width of the horizontal mullions profile, if no profile is used"), locked=True)
             obj.HorizontalMullionWidth = hsize
         if not "HorizontalMullionProfile" in pl:
             obj.addProperty("App::PropertyLink","HorizontalMullionProfile","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","A profile for horizontal mullions (disables horizontal mullion size)"))
+                            QT_TRANSLATE_NOOP("App::Property","A profile for horizontal mullions (disables horizontal mullion size)"), locked=True)
         if not "DiagonalMullionNumber" in pl:
             obj.addProperty("App::PropertyInteger","DiagonalMullionNumber","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The number of diagonal mullions"))
+                            QT_TRANSLATE_NOOP("App::Property","The number of diagonal mullions"), locked=True)
             obj.setEditorMode("DiagonalMullionNumber",1)
         if not "DiagonalMullionSize" in pl:
             obj.addProperty("App::PropertyLength","DiagonalMullionSize","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The size of the diagonal mullions, if any, if no profile is used"))
+                            QT_TRANSLATE_NOOP("App::Property","The size of the diagonal mullions, if any, if no profile is used"), locked=True)
             obj.DiagonalMullionSize = 50
         if not "DiagonalMullionProfile" in pl:
             obj.addProperty("App::PropertyLink","DiagonalMullionProfile","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","A profile for diagonal mullions, if any (disables horizontal mullion size)"))
+                            QT_TRANSLATE_NOOP("App::Property","A profile for diagonal mullions, if any (disables horizontal mullion size)"), locked=True)
         if not "PanelNumber" in pl:
             obj.addProperty("App::PropertyInteger","PanelNumber","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The number of panels"))
+                            QT_TRANSLATE_NOOP("App::Property","The number of panels"), locked=True)
             obj.setEditorMode("PanelNumber",1)
         if not "PanelThickness" in pl:
             obj.addProperty("App::PropertyLength","PanelThickness","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The thickness of the panels"))
+                            QT_TRANSLATE_NOOP("App::Property","The thickness of the panels"), locked=True)
             obj.PanelThickness = 20
         if not "SwapHorizontalVertical" in pl:
             obj.addProperty("App::PropertyBool","SwapHorizontalVertical","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","Swaps horizontal and vertical lines"))
+                            QT_TRANSLATE_NOOP("App::Property","Swaps horizontal and vertical lines"), locked=True)
         if not "Refine" in pl:
             obj.addProperty("App::PropertyBool","Refine","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","Perform subtractions between components so none overlap"))
+                            QT_TRANSLATE_NOOP("App::Property","Perform subtractions between components so none overlap"), locked=True)
         if not "CenterProfiles" in pl:
             obj.addProperty("App::PropertyBool","CenterProfiles","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","Centers the profile over the edges or not"))
+                            QT_TRANSLATE_NOOP("App::Property","Centers the profile over the edges or not"), locked=True)
             obj.CenterProfiles = True
         if not "VerticalDirection" in pl:
             obj.addProperty("App::PropertyVector","VerticalDirection","CurtainWall",
-                            QT_TRANSLATE_NOOP("App::Property","The vertical direction reference to be used by this object to deduce vertical/horizontal directions. Keep it close to the actual vertical direction of your curtain wall"))
+                            QT_TRANSLATE_NOOP("App::Property","The vertical direction reference to be used by this object to deduce vertical/horizontal directions. Keep it close to the actual vertical direction of your curtain wall"), locked=True)
             obj.VerticalDirection = FreeCAD.Vector(0,0,1)
         if not "OverrideEdges" in pl:  # PropertyStringList
-            obj.addProperty("App::PropertyStringList","OverrideEdges","CurtainWall",QT_TRANSLATE_NOOP("App::Property","Input are index numbers of edges of Base ArchSketch/Sketch geometries (in Edit mode).  Selected edges are used to create the shape of this Arch Curtain Wall (instead of using all edges by default).  [ENHANCED by ArchSketch] GUI 'Edit Curtain Wall' Tool is provided in external Add-on ('SketchArch') to let users to select the edges interactively.  'Toponaming-Tolerant' if ArchSketch is used in Base (and SketchArch Add-on is installed).  Warning : Not 'Toponaming-Tolerant' if just Sketch is used. Property is ignored if Base ArchSketch provided the selected edges."))
+            obj.addProperty("App::PropertyStringList","OverrideEdges","CurtainWall",QT_TRANSLATE_NOOP("App::Property","Input are index numbers of edges of Base ArchSketch/Sketch geometries (in Edit mode).  Selected edges are used to create the shape of this Arch Curtain Wall (instead of using all edges by default).  [ENHANCED by ArchSketch] GUI 'Edit Curtain Wall' Tool is provided in external Add-on ('SketchArch') to let users to select the edges interactively.  'Toponaming-Tolerant' if ArchSketch is used in Base (and SketchArch Add-on is installed).  Warning : Not 'Toponaming-Tolerant' if just Sketch is used. Property is ignored if Base ArchSketch provided the selected edges."), locked=True)
 
         self.Type = "CurtainWall"
 

--- a/src/Mod/BIM/ArchEquipment.py
+++ b/src/Mod/BIM/ArchEquipment.py
@@ -186,15 +186,15 @@ class _Equipment(ArchComponent.Component):
 
         pl = obj.PropertiesList
         if not "Model" in pl:
-            obj.addProperty("App::PropertyString","Model","Equipment",QT_TRANSLATE_NOOP("App::Property","The model description of this equipment"))
+            obj.addProperty("App::PropertyString","Model","Equipment",QT_TRANSLATE_NOOP("App::Property","The model description of this equipment"), locked=True)
         if not "ProductURL" in pl:
-            obj.addProperty("App::PropertyString","ProductURL","Equipment",QT_TRANSLATE_NOOP("App::Property","The URL of the product page of this equipment"))
+            obj.addProperty("App::PropertyString","ProductURL","Equipment",QT_TRANSLATE_NOOP("App::Property","The URL of the product page of this equipment"), locked=True)
         if not "StandardCode" in pl:
-            obj.addProperty("App::PropertyString","StandardCode","Equipment",QT_TRANSLATE_NOOP("App::Property","A standard code (MasterFormat, OmniClass,...)"))
+            obj.addProperty("App::PropertyString","StandardCode","Equipment",QT_TRANSLATE_NOOP("App::Property","A standard code (MasterFormat, OmniClass,...)"), locked=True)
         if not "SnapPoints" in pl:
-            obj.addProperty("App::PropertyVectorList","SnapPoints","Equipment",QT_TRANSLATE_NOOP("App::Property","Additional snap points for this equipment"))
+            obj.addProperty("App::PropertyVectorList","SnapPoints","Equipment",QT_TRANSLATE_NOOP("App::Property","Additional snap points for this equipment"), locked=True)
         if not "EquipmentPower" in pl:
-            obj.addProperty("App::PropertyFloat","EquipmentPower","Equipment",QT_TRANSLATE_NOOP("App::Property","The electric power needed by this equipment in Watts"))
+            obj.addProperty("App::PropertyFloat","EquipmentPower","Equipment",QT_TRANSLATE_NOOP("App::Property","The electric power needed by this equipment in Watts"), locked=True)
         obj.setEditorMode("VerticalArea",2)
         obj.setEditorMode("HorizontalArea",2)
         obj.setEditorMode("PerimeterLength",2)

--- a/src/Mod/BIM/ArchFence.py
+++ b/src/Mod/BIM/ArchFence.py
@@ -62,24 +62,24 @@ class _Fence(ArchComponent.Component):
 
         if not "Section" in pl:
             obj.addProperty("App::PropertyLink", "Section", "Fence", QT_TRANSLATE_NOOP(
-                "App::Property", "A single section of the fence"))
+                "App::Property", "A single section of the fence"), locked=True)
 
         if not "Post" in pl:
             obj.addProperty("App::PropertyLink", "Post", "Fence", QT_TRANSLATE_NOOP(
-                "App::Property", "A single fence post"))
+                "App::Property", "A single fence post"), locked=True)
 
         if not "Path" in pl:
             obj.addProperty("App::PropertyLink", "Path", "Fence", QT_TRANSLATE_NOOP(
-                "App::Property", "The Path the fence should follow"))
+                "App::Property", "The Path the fence should follow"), locked=True)
 
         if not "NumberOfSections" in pl:
             obj.addProperty("App::PropertyInteger", "NumberOfSections", "Fence", QT_TRANSLATE_NOOP(
-                "App::Property", "The number of sections the fence is built of"))
+                "App::Property", "The number of sections the fence is built of"), locked=True)
             obj.setEditorMode("NumberOfSections", 1)
 
         if not "NumberOfPosts" in pl:
             obj.addProperty("App::PropertyInteger", "NumberOfPosts", "Fence", QT_TRANSLATE_NOOP(
-                "App::Property", "The number of posts used to build the fence"))
+                "App::Property", "The number of posts used to build the fence"), locked=True)
             obj.setEditorMode("NumberOfPosts", 1)
 
         self.Type = "Fence"
@@ -263,7 +263,7 @@ class _ViewProviderFence(ArchComponent.ViewProviderComponent):
 
         if not "UseOriginalColors" in pl:
             vobj.addProperty("App::PropertyBool", "UseOriginalColors", "Fence", QT_TRANSLATE_NOOP(
-                "App::Property", "When true, the fence will be colored like the original post and section."))
+                "App::Property", "When true, the fence will be colored like the original post and section."), locked=True)
 
     def attach(self, vobj):
         self.setProperties(vobj)

--- a/src/Mod/BIM/ArchFloor.py
+++ b/src/Mod/BIM/ArchFloor.py
@@ -210,12 +210,12 @@ class _Floor(ArchIFC.IfcProduct):
         ArchIFC.IfcProduct.setProperties(self, obj)
         pl = obj.PropertiesList
         if not "Height" in pl:
-            obj.addProperty("App::PropertyLength","Height","Floor",QT_TRANSLATE_NOOP("App::Property","The height of this object"))
+            obj.addProperty("App::PropertyLength","Height","Floor",QT_TRANSLATE_NOOP("App::Property","The height of this object"), locked=True)
         if not "Area" in pl:
-            obj.addProperty("App::PropertyArea","Area", "Floor",QT_TRANSLATE_NOOP("App::Property","The computed floor area of this floor"))
+            obj.addProperty("App::PropertyArea","Area", "Floor",QT_TRANSLATE_NOOP("App::Property","The computed floor area of this floor"), locked=True)
         if not hasattr(obj,"Placement"):
             # obj can be a Part Feature and already has a placement
-            obj.addProperty("App::PropertyPlacement","Placement","Base",QT_TRANSLATE_NOOP("App::Property","The placement of this object"))
+            obj.addProperty("App::PropertyPlacement","Placement","Base",QT_TRANSLATE_NOOP("App::Property","The placement of this object"), locked=True)
         self.Type = "Floor"
 
     def onDocumentRestored(self,obj):

--- a/src/Mod/BIM/ArchFrame.py
+++ b/src/Mod/BIM/ArchFrame.py
@@ -65,23 +65,23 @@ class _Frame(ArchComponent.Component):
 
         pl = obj.PropertiesList
         if not "Profile" in pl:
-            obj.addProperty("App::PropertyLink","Profile","Frame",QT_TRANSLATE_NOOP("App::Property","The profile used to build this frame"))
+            obj.addProperty("App::PropertyLink","Profile","Frame",QT_TRANSLATE_NOOP("App::Property","The profile used to build this frame"), locked=True)
         if not "Align" in pl:
-            obj.addProperty("App::PropertyBool","Align","Frame",QT_TRANSLATE_NOOP("App::Property","Specifies if the profile must be aligned with the extrusion wires"))
+            obj.addProperty("App::PropertyBool","Align","Frame",QT_TRANSLATE_NOOP("App::Property","Specifies if the profile must be aligned with the extrusion wires"), locked=True)
             obj.Align = True
         if not "Offset" in pl:
-            obj.addProperty("App::PropertyVectorDistance","Offset","Frame",QT_TRANSLATE_NOOP("App::Property","An offset vector between the base sketch and the frame"))
+            obj.addProperty("App::PropertyVectorDistance","Offset","Frame",QT_TRANSLATE_NOOP("App::Property","An offset vector between the base sketch and the frame"), locked=True)
         if not "BasePoint" in pl:
-            obj.addProperty("App::PropertyInteger","BasePoint","Frame",QT_TRANSLATE_NOOP("App::Property","Crossing point of the path on the profile."))
+            obj.addProperty("App::PropertyInteger","BasePoint","Frame",QT_TRANSLATE_NOOP("App::Property","Crossing point of the path on the profile."), locked=True)
         if not "ProfilePlacement" in pl:
-            obj.addProperty("App::PropertyPlacement","ProfilePlacement","Frame",QT_TRANSLATE_NOOP("App::Property","An optional additional placement to add to the profile before extruding it"))
+            obj.addProperty("App::PropertyPlacement","ProfilePlacement","Frame",QT_TRANSLATE_NOOP("App::Property","An optional additional placement to add to the profile before extruding it"), locked=True)
         if not "Rotation" in pl:
-            obj.addProperty("App::PropertyAngle","Rotation","Frame",QT_TRANSLATE_NOOP("App::Property","The rotation of the profile around its extrusion axis"))
+            obj.addProperty("App::PropertyAngle","Rotation","Frame",QT_TRANSLATE_NOOP("App::Property","The rotation of the profile around its extrusion axis"), locked=True)
         if not "Edges" in pl:
-            obj.addProperty("App::PropertyEnumeration","Edges","Frame",QT_TRANSLATE_NOOP("App::Property","The type of edges to consider"))
+            obj.addProperty("App::PropertyEnumeration","Edges","Frame",QT_TRANSLATE_NOOP("App::Property","The type of edges to consider"), locked=True)
             obj.Edges = ["All edges","Vertical edges","Horizontal edges","Bottom horizontal edges","Top horizontal edges"]
         if not "Fuse" in pl:
-            obj.addProperty("App::PropertyBool","Fuse","Frame",QT_TRANSLATE_NOOP("App::Property","If true, geometry is fused, otherwise a compound"))
+            obj.addProperty("App::PropertyBool","Fuse","Frame",QT_TRANSLATE_NOOP("App::Property","If true, geometry is fused, otherwise a compound"), locked=True)
         self.Type = "Frame"
 
     def onDocumentRestored(self,obj):

--- a/src/Mod/BIM/ArchGrid.py
+++ b/src/Mod/BIM/ArchGrid.py
@@ -64,30 +64,30 @@ class ArchGrid:
 
         pl = obj.PropertiesList
         if not "Rows" in pl:
-            obj.addProperty("App::PropertyInteger","Rows","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The number of rows'))
+            obj.addProperty("App::PropertyInteger","Rows","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The number of rows'), locked=True)
         if not "Columns" in pl:
-            obj.addProperty("App::PropertyInteger","Columns","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The number of columns'))
+            obj.addProperty("App::PropertyInteger","Columns","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The number of columns'), locked=True)
         if not "RowSize" in pl:
-            obj.addProperty("App::PropertyFloatList","RowSize","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The sizes of rows'))
+            obj.addProperty("App::PropertyFloatList","RowSize","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The sizes of rows'), locked=True)
         if not "ColumnSize" in pl:
-            obj.addProperty("App::PropertyFloatList","ColumnSize","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The sizes of columns'))
+            obj.addProperty("App::PropertyFloatList","ColumnSize","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The sizes of columns'), locked=True)
         if not "Spans" in pl:
-            obj.addProperty("App::PropertyStringList","Spans","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The span ranges of cells that are merged together'))
+            obj.addProperty("App::PropertyStringList","Spans","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The span ranges of cells that are merged together'), locked=True)
         if not "PointsOutput" in pl:
-            obj.addProperty("App::PropertyEnumeration","PointsOutput","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The type of 3D points produced by this grid object'))
+            obj.addProperty("App::PropertyEnumeration","PointsOutput","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The type of 3D points produced by this grid object'), locked=True)
             obj.PointsOutput = ["Vertices","Edges","Vertical Edges","Horizontal Edges","Faces"]
         if not "Width" in pl:
-            obj.addProperty("App::PropertyLength","Width","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The total width of this grid'))
+            obj.addProperty("App::PropertyLength","Width","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The total width of this grid'), locked=True)
         if not "Height" in pl:
-            obj.addProperty("App::PropertyLength","Height","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The total height of this grid'))
+            obj.addProperty("App::PropertyLength","Height","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The total height of this grid'), locked=True)
         if not "AutoWidth" in pl:
-            obj.addProperty("App::PropertyLength","AutoWidth","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'Creates automatic column divisions (set to 0 to disable)'))
+            obj.addProperty("App::PropertyLength","AutoWidth","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'Creates automatic column divisions (set to 0 to disable)'), locked=True)
         if not "AutoHeight" in pl:
-            obj.addProperty("App::PropertyLength","AutoHeight","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'Creates automatic row divisions (set to 0 to disable)'))
+            obj.addProperty("App::PropertyLength","AutoHeight","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'Creates automatic row divisions (set to 0 to disable)'), locked=True)
         if not "Reorient" in pl:
-            obj.addProperty("App::PropertyBool","Reorient","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'When in edge midpoint mode, if this grid must reorient its children along edge normals or not'))
+            obj.addProperty("App::PropertyBool","Reorient","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'When in edge midpoint mode, if this grid must reorient its children along edge normals or not'), locked=True)
         if not "HiddenFaces" in pl:
-            obj.addProperty("App::PropertyIntegerList","HiddenFaces","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The indices of faces to hide'))
+            obj.addProperty("App::PropertyIntegerList","HiddenFaces","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The indices of faces to hide'), locked=True)
         self.Type = "Grid"
 
     def onDocumentRestored(self,obj):

--- a/src/Mod/BIM/ArchIFC.py
+++ b/src/Mod/BIM/ArchIFC.py
@@ -68,14 +68,14 @@ class IfcRoot:
         """
 
         if not "IfcData" in obj.PropertiesList:
-            obj.addProperty("App::PropertyMap","IfcData","IFC",QT_TRANSLATE_NOOP("App::Property","IFC data"))
+            obj.addProperty("App::PropertyMap","IfcData","IFC",QT_TRANSLATE_NOOP("App::Property","IFC data"), locked=True)
 
         if not "IfcType" in obj.PropertiesList:
-            obj.addProperty("App::PropertyEnumeration","IfcType","IFC",QT_TRANSLATE_NOOP("App::Property","The type of this object"))
+            obj.addProperty("App::PropertyEnumeration","IfcType","IFC",QT_TRANSLATE_NOOP("App::Property","The type of this object"), locked=True)
             obj.IfcType = self.getCanonicalisedIfcTypes()
 
         if not "IfcProperties" in obj.PropertiesList:
-            obj.addProperty("App::PropertyMap","IfcProperties","IFC",QT_TRANSLATE_NOOP("App::Property","IFC properties of this object"))
+            obj.addProperty("App::PropertyMap","IfcProperties","IFC",QT_TRANSLATE_NOOP("App::Property","IFC properties of this object"), locked=True)
 
         self.migrateDeprecatedAttributes(obj)
 

--- a/src/Mod/BIM/ArchMaterial.py
+++ b/src/Mod/BIM/ArchMaterial.py
@@ -168,17 +168,17 @@ class _ArchMaterial:
     def setProperties(self,obj):
 
         if not "Description" in obj.PropertiesList:
-            obj.addProperty("App::PropertyString","Description","Material",QT_TRANSLATE_NOOP("App::Property","A description for this material"))
+            obj.addProperty("App::PropertyString","Description","Material",QT_TRANSLATE_NOOP("App::Property","A description for this material"), locked=True)
         if not "StandardCode" in obj.PropertiesList:
-            obj.addProperty("App::PropertyString","StandardCode","Material",QT_TRANSLATE_NOOP("App::Property","A standard code (MasterFormat, OmniClass,...)"))
+            obj.addProperty("App::PropertyString","StandardCode","Material",QT_TRANSLATE_NOOP("App::Property","A standard code (MasterFormat, OmniClass,...)"), locked=True)
         if not "ProductURL" in obj.PropertiesList:
-            obj.addProperty("App::PropertyString","ProductURL","Material",QT_TRANSLATE_NOOP("App::Property","A URL where to find information about this material"))
+            obj.addProperty("App::PropertyString","ProductURL","Material",QT_TRANSLATE_NOOP("App::Property","A URL where to find information about this material"), locked=True)
         if not "Transparency" in obj.PropertiesList:
-            obj.addProperty("App::PropertyPercent","Transparency","Material",QT_TRANSLATE_NOOP("App::Property","The transparency value of this material"))
+            obj.addProperty("App::PropertyPercent","Transparency","Material",QT_TRANSLATE_NOOP("App::Property","The transparency value of this material"), locked=True)
         if not "Color" in obj.PropertiesList:
-            obj.addProperty("App::PropertyColor","Color","Material",QT_TRANSLATE_NOOP("App::Property","The color of this material"))
+            obj.addProperty("App::PropertyColor","Color","Material",QT_TRANSLATE_NOOP("App::Property","The color of this material"), locked=True)
         if not "SectionColor" in obj.PropertiesList:
-            obj.addProperty("App::PropertyColor","SectionColor","Material",QT_TRANSLATE_NOOP("App::Property","The color of this material when cut"))
+            obj.addProperty("App::PropertyColor","SectionColor","Material",QT_TRANSLATE_NOOP("App::Property","The color of this material when cut"), locked=True)
 
     def isSameColor(self,c1,c2):
 
@@ -624,10 +624,10 @@ class _ArchMultiMaterial:
     def __init__(self,obj):
         self.Type = "MultiMaterial"
         obj.Proxy = self
-        obj.addProperty("App::PropertyString","Description","Arch",QT_TRANSLATE_NOOP("App::Property","A description for this material"))
-        obj.addProperty("App::PropertyStringList","Names","Arch",QT_TRANSLATE_NOOP("App::Property","The list of layer names"))
-        obj.addProperty("App::PropertyLinkList","Materials","Arch",QT_TRANSLATE_NOOP("App::Property","The list of layer materials"))
-        obj.addProperty("App::PropertyFloatList","Thicknesses","Arch",QT_TRANSLATE_NOOP("App::Property","The list of layer thicknesses"))
+        obj.addProperty("App::PropertyString","Description","Arch",QT_TRANSLATE_NOOP("App::Property","A description for this material"), locked=True)
+        obj.addProperty("App::PropertyStringList","Names","Arch",QT_TRANSLATE_NOOP("App::Property","The list of layer names"), locked=True)
+        obj.addProperty("App::PropertyLinkList","Materials","Arch",QT_TRANSLATE_NOOP("App::Property","The list of layer materials"), locked=True)
+        obj.addProperty("App::PropertyFloatList","Thicknesses","Arch",QT_TRANSLATE_NOOP("App::Property","The list of layer thicknesses"), locked=True)
 
     def dumps(self):
         if hasattr(self,"Type"):

--- a/src/Mod/BIM/ArchPanel.py
+++ b/src/Mod/BIM/ArchPanel.py
@@ -74,36 +74,36 @@ class _Panel(ArchComponent.Component):
 
         pl = obj.PropertiesList
         if not "Length" in pl:
-            obj.addProperty("App::PropertyLength","Length","Panel",   QT_TRANSLATE_NOOP("App::Property","The length of this element, if not based on a profile"))
+            obj.addProperty("App::PropertyLength","Length","Panel",   QT_TRANSLATE_NOOP("App::Property","The length of this element, if not based on a profile"), locked=True)
         if not "Width" in pl:
-            obj.addProperty("App::PropertyLength","Width","Panel",    QT_TRANSLATE_NOOP("App::Property","The width of this element, if not based on a profile"))
+            obj.addProperty("App::PropertyLength","Width","Panel",    QT_TRANSLATE_NOOP("App::Property","The width of this element, if not based on a profile"), locked=True)
         if not "Thickness" in pl:
-            obj.addProperty("App::PropertyLength","Thickness","Panel",QT_TRANSLATE_NOOP("App::Property","The thickness or extrusion depth of this element"))
+            obj.addProperty("App::PropertyLength","Thickness","Panel",QT_TRANSLATE_NOOP("App::Property","The thickness or extrusion depth of this element"), locked=True)
         if not "Sheets" in pl:
-            obj.addProperty("App::PropertyInteger","Sheets","Panel",  QT_TRANSLATE_NOOP("App::Property","The number of sheets to use"))
+            obj.addProperty("App::PropertyInteger","Sheets","Panel",  QT_TRANSLATE_NOOP("App::Property","The number of sheets to use"), locked=True)
             obj.Sheets = 1
         if not "Offset" in pl:
-            obj.addProperty("App::PropertyDistance","Offset","Panel",   QT_TRANSLATE_NOOP("App::Property","The offset between this panel and its baseline"))
+            obj.addProperty("App::PropertyDistance","Offset","Panel",   QT_TRANSLATE_NOOP("App::Property","The offset between this panel and its baseline"), locked=True)
         if not "WaveLength" in pl:
-            obj.addProperty("App::PropertyLength","WaveLength","Panel", QT_TRANSLATE_NOOP("App::Property","The length of waves for corrugated elements"))
+            obj.addProperty("App::PropertyLength","WaveLength","Panel", QT_TRANSLATE_NOOP("App::Property","The length of waves for corrugated elements"), locked=True)
         if not "WaveHeight" in pl:
-            obj.addProperty("App::PropertyLength","WaveHeight","Panel", QT_TRANSLATE_NOOP("App::Property","The height of waves for corrugated elements"))
+            obj.addProperty("App::PropertyLength","WaveHeight","Panel", QT_TRANSLATE_NOOP("App::Property","The height of waves for corrugated elements"), locked=True)
         if not "WaveOffset" in pl:
-            obj.addProperty("App::PropertyDistance","WaveOffset","Panel", QT_TRANSLATE_NOOP("App::Property","The horizontal offset of waves for corrugated elements"))
+            obj.addProperty("App::PropertyDistance","WaveOffset","Panel", QT_TRANSLATE_NOOP("App::Property","The horizontal offset of waves for corrugated elements"), locked=True)
         if not "WaveDirection" in pl:
-            obj.addProperty("App::PropertyAngle","WaveDirection","Panel", QT_TRANSLATE_NOOP("App::Property","The direction of waves for corrugated elements"))
+            obj.addProperty("App::PropertyAngle","WaveDirection","Panel", QT_TRANSLATE_NOOP("App::Property","The direction of waves for corrugated elements"), locked=True)
         if not "WaveType" in pl:
-            obj.addProperty("App::PropertyEnumeration","WaveType","Panel", QT_TRANSLATE_NOOP("App::Property","The type of waves for corrugated elements"))
+            obj.addProperty("App::PropertyEnumeration","WaveType","Panel", QT_TRANSLATE_NOOP("App::Property","The type of waves for corrugated elements"), locked=True)
             obj.WaveType = ["Curved","Trapezoidal","Spikes"]
         if not "WaveBottom" in pl:
-            obj.addProperty("App::PropertyBool","WaveBottom","Panel", QT_TRANSLATE_NOOP("App::Property","If the wave also affects the bottom side or not"))
+            obj.addProperty("App::PropertyBool","WaveBottom","Panel", QT_TRANSLATE_NOOP("App::Property","If the wave also affects the bottom side or not"), locked=True)
         if not "Area" in pl:
-            obj.addProperty("App::PropertyArea","Area","Panel",       QT_TRANSLATE_NOOP("App::Property","The area of this panel"))
+            obj.addProperty("App::PropertyArea","Area","Panel",       QT_TRANSLATE_NOOP("App::Property","The area of this panel"), locked=True)
         if not "FaceMaker" in pl:
-            obj.addProperty("App::PropertyEnumeration","FaceMaker","Panel",QT_TRANSLATE_NOOP("App::Property","The facemaker type to use to build the profile of this object"))
+            obj.addProperty("App::PropertyEnumeration","FaceMaker","Panel",QT_TRANSLATE_NOOP("App::Property","The facemaker type to use to build the profile of this object"), locked=True)
             obj.FaceMaker = ["None","Simple","Cheese","Bullseye"]
         if not "Normal" in pl:
-            obj.addProperty("App::PropertyVector","Normal","Panel",QT_TRANSLATE_NOOP("App::Property","The normal extrusion direction of this object (keep (0,0,0) for automatic normal)"))
+            obj.addProperty("App::PropertyVector","Normal","Panel",QT_TRANSLATE_NOOP("App::Property","The normal extrusion direction of this object (keep (0,0,0) for automatic normal)"), locked=True)
         self.Type = "Panel"
         obj.setEditorMode("VerticalArea",2)
         obj.setEditorMode("HorizontalArea",2)
@@ -505,27 +505,27 @@ class PanelCut(Draft.DraftObject):
 
         pl = obj.PropertiesList
         if not "Source" in pl:
-            obj.addProperty("App::PropertyLink","Source","PanelCut",QT_TRANSLATE_NOOP("App::Property","The linked object"))
+            obj.addProperty("App::PropertyLink","Source","PanelCut",QT_TRANSLATE_NOOP("App::Property","The linked object"), locked=True)
         if not "TagText" in pl:
-            obj.addProperty("App::PropertyString","TagText","PanelCut",QT_TRANSLATE_NOOP("App::Property","The text to display. Can be %tag%, %label% or %description% to display the panel tag or label"))
+            obj.addProperty("App::PropertyString","TagText","PanelCut",QT_TRANSLATE_NOOP("App::Property","The text to display. Can be %tag%, %label% or %description% to display the panel tag or label"), locked=True)
             obj.TagText = "%tag%"
         if not "TagSize" in pl:
-            obj.addProperty("App::PropertyLength","TagSize","PanelCut",QT_TRANSLATE_NOOP("App::Property","The size of the tag text"))
+            obj.addProperty("App::PropertyLength","TagSize","PanelCut",QT_TRANSLATE_NOOP("App::Property","The size of the tag text"), locked=True)
             obj.TagSize = 10
         if not "TagPosition" in pl:
-            obj.addProperty("App::PropertyVector","TagPosition","PanelCut",QT_TRANSLATE_NOOP("App::Property","The position of the tag text. Keep (0,0,0) for center position"))
+            obj.addProperty("App::PropertyVector","TagPosition","PanelCut",QT_TRANSLATE_NOOP("App::Property","The position of the tag text. Keep (0,0,0) for center position"), locked=True)
         if not "TagRotation" in pl:
-            obj.addProperty("App::PropertyAngle","TagRotation","PanelCut",QT_TRANSLATE_NOOP("App::Property","The rotation of the tag text"))
+            obj.addProperty("App::PropertyAngle","TagRotation","PanelCut",QT_TRANSLATE_NOOP("App::Property","The rotation of the tag text"), locked=True)
         if not "FontFile" in pl:
-            obj.addProperty("App::PropertyFile","FontFile","PanelCut",QT_TRANSLATE_NOOP("App::Property","The font of the tag text"))
+            obj.addProperty("App::PropertyFile","FontFile","PanelCut",QT_TRANSLATE_NOOP("App::Property","The font of the tag text"), locked=True)
             obj.FontFile = params.get_param("FontFile")
         if not "MakeFace" in pl:
-            obj.addProperty("App::PropertyBool","MakeFace","PanelCut",QT_TRANSLATE_NOOP("App::Property","If True, the object is rendered as a face, if possible."))
+            obj.addProperty("App::PropertyBool","MakeFace","PanelCut",QT_TRANSLATE_NOOP("App::Property","If True, the object is rendered as a face, if possible."), locked=True)
         if not "AllowedAngles" in pl:
-            obj.addProperty("App::PropertyFloatList","AllowedAngles","PanelCut",QT_TRANSLATE_NOOP("App::Property","The allowed angles this object can be rotated to when placed on sheets"))
+            obj.addProperty("App::PropertyFloatList","AllowedAngles","PanelCut",QT_TRANSLATE_NOOP("App::Property","The allowed angles this object can be rotated to when placed on sheets"), locked=True)
         self.Type = "PanelCut"
         if not "CutOffset" in pl:
-            obj.addProperty("App::PropertyDistance","CutOffset","PanelCut",QT_TRANSLATE_NOOP("App::Property","An offset value to move the cut plane from the center point"))
+            obj.addProperty("App::PropertyDistance","CutOffset","PanelCut",QT_TRANSLATE_NOOP("App::Property","An offset value to move the cut plane from the center point"), locked=True)
 
     def onDocumentRestored(self,obj):
 
@@ -698,9 +698,9 @@ class ViewProviderPanelCut(Draft.ViewProviderDraft):
 
         pl = vobj.PropertiesList
         if not "Margin" in pl:
-            vobj.addProperty("App::PropertyLength","Margin","Arch",QT_TRANSLATE_NOOP("App::Property","A margin inside the boundary"))
+            vobj.addProperty("App::PropertyLength","Margin","Arch",QT_TRANSLATE_NOOP("App::Property","A margin inside the boundary"), locked=True)
         if not "ShowMargin" in pl:
-            vobj.addProperty("App::PropertyBool","ShowMargin","Arch",QT_TRANSLATE_NOOP("App::Property","Turns the display of the margin on/off"))
+            vobj.addProperty("App::PropertyBool","ShowMargin","Arch",QT_TRANSLATE_NOOP("App::Property","Turns the display of the margin on/off"), locked=True)
 
     def onDocumentRestored(self,vobj):
 
@@ -786,37 +786,37 @@ class PanelSheet(Draft.DraftObject):
 
         pl = obj.PropertiesList
         if not "Group" in pl:
-            obj.addProperty("App::PropertyLinkList","Group","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The linked Panel cuts"))
+            obj.addProperty("App::PropertyLinkList","Group","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The linked Panel cuts"), locked=True)
         if not "TagText" in pl:
-            obj.addProperty("App::PropertyString","TagText","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The tag text to display"))
+            obj.addProperty("App::PropertyString","TagText","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The tag text to display"), locked=True)
         if not "TagSize" in pl:
-            obj.addProperty("App::PropertyLength","TagSize","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The size of the tag text"))
+            obj.addProperty("App::PropertyLength","TagSize","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The size of the tag text"), locked=True)
             obj.TagSize = 10
         if not "TagPosition" in pl:
-            obj.addProperty("App::PropertyVector","TagPosition","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The position of the tag text. Keep (0,0,0) for center position"))
+            obj.addProperty("App::PropertyVector","TagPosition","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The position of the tag text. Keep (0,0,0) for center position"), locked=True)
         if not "TagRotation" in pl:
-            obj.addProperty("App::PropertyAngle","TagRotation","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The rotation of the tag text"))
+            obj.addProperty("App::PropertyAngle","TagRotation","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The rotation of the tag text"), locked=True)
         if not "FontFile" in pl:
-            obj.addProperty("App::PropertyFile","FontFile","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The font of the tag text"))
+            obj.addProperty("App::PropertyFile","FontFile","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The font of the tag text"), locked=True)
             obj.FontFile = params.get_param("FontFile")
         if not "Width" in pl:
-            obj.addProperty("App::PropertyLength","Width","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The width of the sheet"))
+            obj.addProperty("App::PropertyLength","Width","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The width of the sheet"), locked=True)
             obj.Width = params.get_param_arch("PanelLength")
         if not "Height" in pl:
-            obj.addProperty("App::PropertyLength","Height","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The height of the sheet"))
+            obj.addProperty("App::PropertyLength","Height","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The height of the sheet"), locked=True)
             obj.Height = params.get_param_arch("PanelWidth")
         if not "FillRatio" in pl:
-            obj.addProperty("App::PropertyPercent","FillRatio","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The fill ratio of this sheet"))
+            obj.addProperty("App::PropertyPercent","FillRatio","PanelSheet",QT_TRANSLATE_NOOP("App::Property","The fill ratio of this sheet"), locked=True)
             obj.setEditorMode("FillRatio",2)
         if not "MakeFace" in pl:
-            obj.addProperty("App::PropertyBool","MakeFace","PanelSheet",QT_TRANSLATE_NOOP("App::Property","If True, the object is rendered as a face, if possible."))
+            obj.addProperty("App::PropertyBool","MakeFace","PanelSheet",QT_TRANSLATE_NOOP("App::Property","If True, the object is rendered as a face, if possible."), locked=True)
         if not "GrainDirection" in pl:
-            obj.addProperty("App::PropertyAngle","GrainDirection","PanelSheet",QT_TRANSLATE_NOOP("App::Property","Specifies an angle for the wood grain (Clockwise, 0 is North)"))
+            obj.addProperty("App::PropertyAngle","GrainDirection","PanelSheet",QT_TRANSLATE_NOOP("App::Property","Specifies an angle for the wood grain (Clockwise, 0 is North)"), locked=True)
         if not "Scale" in pl:
-            obj.addProperty("App::PropertyFloat","Scale","PanelSheet", QT_TRANSLATE_NOOP("App::Property","Specifies the scale applied to each panel view."))
+            obj.addProperty("App::PropertyFloat","Scale","PanelSheet", QT_TRANSLATE_NOOP("App::Property","Specifies the scale applied to each panel view."), locked=True)
             obj.Scale = 1.0
         if not "Rotations" in pl:
-            obj.addProperty("App::PropertyFloatList","Rotations","PanelSheet", QT_TRANSLATE_NOOP("App::Property","A list of possible rotations for the nester"))
+            obj.addProperty("App::PropertyFloatList","Rotations","PanelSheet", QT_TRANSLATE_NOOP("App::Property","A list of possible rotations for the nester"), locked=True)
         self.Type = "PanelSheet"
 
     def onDocumentRestored(self, obj):
@@ -961,11 +961,11 @@ class ViewProviderPanelSheet(Draft.ViewProviderDraft):
 
         pl = vobj.PropertiesList
         if not "Margin" in pl:
-            vobj.addProperty("App::PropertyLength","Margin","PanelSheet",QT_TRANSLATE_NOOP("App::Property","A margin inside the boundary"))
+            vobj.addProperty("App::PropertyLength","Margin","PanelSheet",QT_TRANSLATE_NOOP("App::Property","A margin inside the boundary"), locked=True)
         if not "ShowMargin" in pl:
-            vobj.addProperty("App::PropertyBool","ShowMargin","PanelSheet",QT_TRANSLATE_NOOP("App::Property","Turns the display of the margin on/off"))
+            vobj.addProperty("App::PropertyBool","ShowMargin","PanelSheet",QT_TRANSLATE_NOOP("App::Property","Turns the display of the margin on/off"), locked=True)
         if not "ShowGrain" in pl:
-            vobj.addProperty("App::PropertyBool","ShowGrain","PanelSheet",QT_TRANSLATE_NOOP("App::Property","Turns the display of the wood grain texture on/off"))
+            vobj.addProperty("App::PropertyBool","ShowGrain","PanelSheet",QT_TRANSLATE_NOOP("App::Property","Turns the display of the wood grain texture on/off"), locked=True)
 
     def onDocumentRestored(self,vobj):
 

--- a/src/Mod/BIM/ArchPipe.py
+++ b/src/Mod/BIM/ArchPipe.py
@@ -73,25 +73,25 @@ class _ArchPipe(ArchComponent.Component):
 
         pl = obj.PropertiesList
         if not "Diameter" in pl:
-            obj.addProperty("App::PropertyLength", "Diameter",     "Pipe", QT_TRANSLATE_NOOP("App::Property","The diameter of this pipe, if not based on a profile"))
+            obj.addProperty("App::PropertyLength", "Diameter",     "Pipe", QT_TRANSLATE_NOOP("App::Property","The diameter of this pipe, if not based on a profile"), locked=True)
         if not "Width" in pl:
-            obj.addProperty("App::PropertyLength", "Width",        "Pipe", QT_TRANSLATE_NOOP("App::Property","The width of this pipe, if not based on a profile"))
+            obj.addProperty("App::PropertyLength", "Width",        "Pipe", QT_TRANSLATE_NOOP("App::Property","The width of this pipe, if not based on a profile"), locked=True)
             obj.setPropertyStatus("Width", "Hidden")
         if not "Height" in pl:
-            obj.addProperty("App::PropertyLength", "Height",        "Pipe", QT_TRANSLATE_NOOP("App::Property","The height of this pipe, if not based on a profile"))
+            obj.addProperty("App::PropertyLength", "Height",        "Pipe", QT_TRANSLATE_NOOP("App::Property","The height of this pipe, if not based on a profile"), locked=True)
             obj.setPropertyStatus("Height", "Hidden")
         if not "Length" in pl:
-            obj.addProperty("App::PropertyLength", "Length",       "Pipe", QT_TRANSLATE_NOOP("App::Property","The length of this pipe, if not based on an edge"))
+            obj.addProperty("App::PropertyLength", "Length",       "Pipe", QT_TRANSLATE_NOOP("App::Property","The length of this pipe, if not based on an edge"), locked=True)
         if not "Profile" in pl:
-            obj.addProperty("App::PropertyLink",   "Profile",      "Pipe", QT_TRANSLATE_NOOP("App::Property","An optional closed profile to base this pipe on"))
+            obj.addProperty("App::PropertyLink",   "Profile",      "Pipe", QT_TRANSLATE_NOOP("App::Property","An optional closed profile to base this pipe on"), locked=True)
         if not "OffsetStart" in pl:
-            obj.addProperty("App::PropertyLength", "OffsetStart",  "Pipe", QT_TRANSLATE_NOOP("App::Property","Offset from the start point"))
+            obj.addProperty("App::PropertyLength", "OffsetStart",  "Pipe", QT_TRANSLATE_NOOP("App::Property","Offset from the start point"), locked=True)
         if not "OffsetEnd" in pl:
-            obj.addProperty("App::PropertyLength", "OffsetEnd",    "Pipe", QT_TRANSLATE_NOOP("App::Property","Offset from the end point"))
+            obj.addProperty("App::PropertyLength", "OffsetEnd",    "Pipe", QT_TRANSLATE_NOOP("App::Property","Offset from the end point"), locked=True)
         if not "WallThickness" in pl:
-            obj.addProperty("App::PropertyLength", "WallThickness","Pipe", QT_TRANSLATE_NOOP("App::Property","The wall thickness of this pipe, if not based on a profile"))
+            obj.addProperty("App::PropertyLength", "WallThickness","Pipe", QT_TRANSLATE_NOOP("App::Property","The wall thickness of this pipe, if not based on a profile"), locked=True)
         if not "ProfileType" in pl:
-            obj.addProperty("App::PropertyEnumeration", "ProfileType", "Pipe", QT_TRANSLATE_NOOP("App::Property","If not based on a profile, this controls the profile of this pipe"))
+            obj.addProperty("App::PropertyEnumeration", "ProfileType", "Pipe", QT_TRANSLATE_NOOP("App::Property","If not based on a profile, this controls the profile of this pipe"), locked=True)
             obj.ProfileType = ["Circle", "Square", "Rectangle"]
         self.Type = "Pipe"
 
@@ -287,11 +287,11 @@ class _ArchPipeConnector(ArchComponent.Component):
 
         pl = obj.PropertiesList
         if not "Radius" in pl:
-            obj.addProperty("App::PropertyLength",      "Radius",        "PipeConnector", QT_TRANSLATE_NOOP("App::Property","The curvature radius of this connector"))
+            obj.addProperty("App::PropertyLength",      "Radius",        "PipeConnector", QT_TRANSLATE_NOOP("App::Property","The curvature radius of this connector"), locked=True)
         if not "Pipes" in pl:
-            obj.addProperty("App::PropertyLinkList",    "Pipes",         "PipeConnector", QT_TRANSLATE_NOOP("App::Property","The pipes linked by this connector"))
+            obj.addProperty("App::PropertyLinkList",    "Pipes",         "PipeConnector", QT_TRANSLATE_NOOP("App::Property","The pipes linked by this connector"), locked=True)
         if not "ConnectorType" in pl:
-            obj.addProperty("App::PropertyEnumeration", "ConnectorType", "PipeConnector", QT_TRANSLATE_NOOP("App::Property","The type of this connector"))
+            obj.addProperty("App::PropertyEnumeration", "ConnectorType", "PipeConnector", QT_TRANSLATE_NOOP("App::Property","The type of this connector"), locked=True)
             obj.ConnectorType = ["Corner","Tee"]
             obj.setEditorMode("ConnectorType",1)
         self.Type = "PipeConnector"

--- a/src/Mod/BIM/ArchPrecast.py
+++ b/src/Mod/BIM/ArchPrecast.py
@@ -68,13 +68,13 @@ class _Precast(ArchComponent.Component):
 
         pl = obj.PropertiesList
         if not "Length" in pl:
-            obj.addProperty("App::PropertyDistance","Length","Structure",QT_TRANSLATE_NOOP("App::Property","The length of this element"))
+            obj.addProperty("App::PropertyDistance","Length","Structure",QT_TRANSLATE_NOOP("App::Property","The length of this element"), locked=True)
         if not "Width" in pl:
-            obj.addProperty("App::PropertyDistance","Width","Structure",QT_TRANSLATE_NOOP("App::Property","The width of this element"))
+            obj.addProperty("App::PropertyDistance","Width","Structure",QT_TRANSLATE_NOOP("App::Property","The width of this element"), locked=True)
         if not "Height" in pl:
-            obj.addProperty("App::PropertyDistance","Height","Structure",QT_TRANSLATE_NOOP("App::Property","The height of this element"))
+            obj.addProperty("App::PropertyDistance","Height","Structure",QT_TRANSLATE_NOOP("App::Property","The height of this element"), locked=True)
         if not "Nodes" in pl:
-            obj.addProperty("App::PropertyVectorList","Nodes","Structure",QT_TRANSLATE_NOOP("App::Property","The structural nodes of this element"))
+            obj.addProperty("App::PropertyVectorList","Nodes","Structure",QT_TRANSLATE_NOOP("App::Property","The structural nodes of this element"), locked=True)
         self.Type = "Precast"
 
     def onDocumentRestored(self,obj):
@@ -102,13 +102,13 @@ class _PrecastBeam(_Precast):
 
         pl = obj.PropertiesList
         if not "Chamfer" in pl:
-            obj.addProperty("App::PropertyDistance","Chamfer","Beam",QT_TRANSLATE_NOOP("App::Property","The size of the chamfer of this element"))
+            obj.addProperty("App::PropertyDistance","Chamfer","Beam",QT_TRANSLATE_NOOP("App::Property","The size of the chamfer of this element"), locked=True)
         if not "DentLength" in pl:
-            obj.addProperty("App::PropertyDistance","DentLength","Beam",QT_TRANSLATE_NOOP("App::Property","The dent length of this element"))
+            obj.addProperty("App::PropertyDistance","DentLength","Beam",QT_TRANSLATE_NOOP("App::Property","The dent length of this element"), locked=True)
         if not "DentHeight" in pl:
-            obj.addProperty("App::PropertyDistance","DentHeight","Beam",QT_TRANSLATE_NOOP("App::Property","The dent height of this element"))
+            obj.addProperty("App::PropertyDistance","DentHeight","Beam",QT_TRANSLATE_NOOP("App::Property","The dent height of this element"), locked=True)
         if not "Dents" in pl:
-            obj.addProperty("App::PropertyStringList","Dents","Beam",QT_TRANSLATE_NOOP("App::Property","The dents of this element"))
+            obj.addProperty("App::PropertyStringList","Dents","Beam",QT_TRANSLATE_NOOP("App::Property","The dents of this element"), locked=True)
 
     def onDocumentRestored(self,obj):
 
@@ -224,9 +224,9 @@ class _PrecastIbeam(_Precast):
 
         pl = obj.PropertiesList
         if not "Chamfer" in pl:
-            obj.addProperty("App::PropertyDistance","Chamfer","Beam",QT_TRANSLATE_NOOP("App::Property","The chamfer length of this element"))
+            obj.addProperty("App::PropertyDistance","Chamfer","Beam",QT_TRANSLATE_NOOP("App::Property","The chamfer length of this element"), locked=True)
         if not "BeamBase" in pl:
-            obj.addProperty("App::PropertyDistance","BeamBase","Beam",QT_TRANSLATE_NOOP("App::Property","The base length of this element"))
+            obj.addProperty("App::PropertyDistance","BeamBase","Beam",QT_TRANSLATE_NOOP("App::Property","The base length of this element"), locked=True)
 
     def onDocumentRestored(self,obj):
 
@@ -290,17 +290,17 @@ class _PrecastPillar(_Precast):
 
         pl = obj.PropertiesList
         if not "Chamfer" in pl:
-            obj.addProperty("App::PropertyDistance","Chamfer","Column",QT_TRANSLATE_NOOP("App::Property","The size of the chamfer of this element"))
+            obj.addProperty("App::PropertyDistance","Chamfer","Column",QT_TRANSLATE_NOOP("App::Property","The size of the chamfer of this element"), locked=True)
         if not "GrooveDepth" in pl:
-            obj.addProperty("App::PropertyDistance","GrooveDepth","Column",QT_TRANSLATE_NOOP("App::Property","The groove depth of this element"))
+            obj.addProperty("App::PropertyDistance","GrooveDepth","Column",QT_TRANSLATE_NOOP("App::Property","The groove depth of this element"), locked=True)
         if not "GrooveHeight" in pl:
-            obj.addProperty("App::PropertyDistance","GrooveHeight","Column",QT_TRANSLATE_NOOP("App::Property","The groove height of this element"))
+            obj.addProperty("App::PropertyDistance","GrooveHeight","Column",QT_TRANSLATE_NOOP("App::Property","The groove height of this element"), locked=True)
         if not "GrooveSpacing" in pl:
-            obj.addProperty("App::PropertyDistance","GrooveSpacing","Column",QT_TRANSLATE_NOOP("App::Property","The spacing between the grooves of this element"))
+            obj.addProperty("App::PropertyDistance","GrooveSpacing","Column",QT_TRANSLATE_NOOP("App::Property","The spacing between the grooves of this element"), locked=True)
         if not "GrooveNumber" in pl:
-            obj.addProperty("App::PropertyInteger","GrooveNumber","Column",QT_TRANSLATE_NOOP("App::Property","The number of grooves of this element"))
+            obj.addProperty("App::PropertyInteger","GrooveNumber","Column",QT_TRANSLATE_NOOP("App::Property","The number of grooves of this element"), locked=True)
         if not "Dents" in pl:
-            obj.addProperty("App::PropertyStringList","Dents","Column",QT_TRANSLATE_NOOP("App::Property","The dents of this element"))
+            obj.addProperty("App::PropertyStringList","Dents","Column",QT_TRANSLATE_NOOP("App::Property","The dents of this element"), locked=True)
 
     def onDocumentRestored(self,obj):
 
@@ -431,11 +431,11 @@ class _PrecastPanel(_Precast):
 
         pl = obj.PropertiesList
         if not "Chamfer" in pl:
-            obj.addProperty("App::PropertyDistance","Chamfer","Panel",QT_TRANSLATE_NOOP("App::Property","The size of the chamfer of this element"))
+            obj.addProperty("App::PropertyDistance","Chamfer","Panel",QT_TRANSLATE_NOOP("App::Property","The size of the chamfer of this element"), locked=True)
         if not "DentWidth" in pl:
-            obj.addProperty("App::PropertyDistance","DentWidth","Panel",QT_TRANSLATE_NOOP("App::Property","The dent width of this element"))
+            obj.addProperty("App::PropertyDistance","DentWidth","Panel",QT_TRANSLATE_NOOP("App::Property","The dent width of this element"), locked=True)
         if not "DentHeight" in pl:
-            obj.addProperty("App::PropertyDistance","DentHeight","Panel",QT_TRANSLATE_NOOP("App::Property","The dent height of this element"))
+            obj.addProperty("App::PropertyDistance","DentHeight","Panel",QT_TRANSLATE_NOOP("App::Property","The dent height of this element"), locked=True)
 
     def onDocumentRestored(self,obj):
 
@@ -542,18 +542,18 @@ class _PrecastSlab(_Precast):
 
         pl = obj.PropertiesList
         if not "SlabType" in pl:
-            obj.addProperty("App::PropertyEnumeration","SlabType","Slab",QT_TRANSLATE_NOOP("App::Property","The type of this slab"))
+            obj.addProperty("App::PropertyEnumeration","SlabType","Slab",QT_TRANSLATE_NOOP("App::Property","The type of this slab"), locked=True)
             obj.SlabType = ["Champagne","Hat"]
         if not "SlabBase" in pl:
-            obj.addProperty("App::PropertyDistance","SlabBase","Slab",QT_TRANSLATE_NOOP("App::Property","The size of the base of this element"))
+            obj.addProperty("App::PropertyDistance","SlabBase","Slab",QT_TRANSLATE_NOOP("App::Property","The size of the base of this element"), locked=True)
         if not "HoleNumber" in pl:
-            obj.addProperty("App::PropertyInteger","HoleNumber","Slab",QT_TRANSLATE_NOOP("App::Property","The number of holes in this element"))
+            obj.addProperty("App::PropertyInteger","HoleNumber","Slab",QT_TRANSLATE_NOOP("App::Property","The number of holes in this element"), locked=True)
         if not "HoleMajor" in pl:
-            obj.addProperty("App::PropertyDistance","HoleMajor","Slab",QT_TRANSLATE_NOOP("App::Property","The major radius of the holes of this element"))
+            obj.addProperty("App::PropertyDistance","HoleMajor","Slab",QT_TRANSLATE_NOOP("App::Property","The major radius of the holes of this element"), locked=True)
         if not "HoleMinor" in pl:
-            obj.addProperty("App::PropertyDistance","HoleMinor","Slab",QT_TRANSLATE_NOOP("App::Property","The minor radius of the holes of this element"))
+            obj.addProperty("App::PropertyDistance","HoleMinor","Slab",QT_TRANSLATE_NOOP("App::Property","The minor radius of the holes of this element"), locked=True)
         if not "HoleSpacing" in pl:
-            obj.addProperty("App::PropertyDistance","HoleSpacing","Slab",QT_TRANSLATE_NOOP("App::Property","The spacing between the holes of this element"))
+            obj.addProperty("App::PropertyDistance","HoleSpacing","Slab",QT_TRANSLATE_NOOP("App::Property","The spacing between the holes of this element"), locked=True)
 
     def onDocumentRestored(self,obj):
 
@@ -653,13 +653,13 @@ class _PrecastStairs(_Precast):
 
         pl = obj.PropertiesList
         if not "DownLength" in pl:
-            obj.addProperty("App::PropertyDistance","DownLength","Stairs",QT_TRANSLATE_NOOP("App::Property","The length of the down floor of this element"))
+            obj.addProperty("App::PropertyDistance","DownLength","Stairs",QT_TRANSLATE_NOOP("App::Property","The length of the down floor of this element"), locked=True)
         if not "RiserNumber" in pl:
-            obj.addProperty("App::PropertyInteger","RiserNumber","Stairs",QT_TRANSLATE_NOOP("App::Property","The number of risers in this element"))
+            obj.addProperty("App::PropertyInteger","RiserNumber","Stairs",QT_TRANSLATE_NOOP("App::Property","The number of risers in this element"), locked=True)
         if not "Riser" in pl:
-            obj.addProperty("App::PropertyDistance","Riser","Stairs",QT_TRANSLATE_NOOP("App::Property","The riser height of this element"))
+            obj.addProperty("App::PropertyDistance","Riser","Stairs",QT_TRANSLATE_NOOP("App::Property","The riser height of this element"), locked=True)
         if not "Tread" in pl:
-            obj.addProperty("App::PropertyDistance","Tread","Stairs",QT_TRANSLATE_NOOP("App::Property","The tread depth of this element"))
+            obj.addProperty("App::PropertyDistance","Tread","Stairs",QT_TRANSLATE_NOOP("App::Property","The tread depth of this element"), locked=True)
 
     def onDocumentRestored(self,obj):
 

--- a/src/Mod/BIM/ArchProfile.py
+++ b/src/Mod/BIM/ArchProfile.py
@@ -126,8 +126,8 @@ class _ProfileC(_Profile):
 
     def __init__(self,obj, profile):
         self.cleanProperties(obj)
-        obj.addProperty("App::PropertyLength","OutDiameter","Draft",QT_TRANSLATE_NOOP("App::Property","Outside Diameter")).OutDiameter = profile[4]
-        obj.addProperty("App::PropertyLength","Thickness","Draft",QT_TRANSLATE_NOOP("App::Property","Wall thickness")).Thickness = profile[5]
+        obj.addProperty("App::PropertyLength","OutDiameter","Draft",QT_TRANSLATE_NOOP("App::Property","Outside Diameter"), locked=True).OutDiameter = profile[4]
+        obj.addProperty("App::PropertyLength","Thickness","Draft",QT_TRANSLATE_NOOP("App::Property","Wall thickness"), locked=True).Thickness = profile[5]
         _Profile.__init__(self,obj,profile)
 
     def execute(self,obj):
@@ -151,10 +151,10 @@ class _ProfileH(_Profile):
 
     def __init__(self,obj, profile):
         self.cleanProperties(obj)
-        obj.addProperty("App::PropertyLength","Width","Draft",QT_TRANSLATE_NOOP("App::Property","Width of the beam")).Width = profile[4]
-        obj.addProperty("App::PropertyLength","Height","Draft",QT_TRANSLATE_NOOP("App::Property","Height of the beam")).Height = profile[5]
-        obj.addProperty("App::PropertyLength","WebThickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the web")).WebThickness = profile[6]
-        obj.addProperty("App::PropertyLength","FlangeThickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the flanges")).FlangeThickness = profile[7]
+        obj.addProperty("App::PropertyLength","Width","Draft",QT_TRANSLATE_NOOP("App::Property","Width of the beam"), locked=True).Width = profile[4]
+        obj.addProperty("App::PropertyLength","Height","Draft",QT_TRANSLATE_NOOP("App::Property","Height of the beam"), locked=True).Height = profile[5]
+        obj.addProperty("App::PropertyLength","WebThickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the web"), locked=True).WebThickness = profile[6]
+        obj.addProperty("App::PropertyLength","FlangeThickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the flanges"), locked=True).FlangeThickness = profile[7]
         _Profile.__init__(self,obj,profile)
 
     def execute(self,obj):
@@ -185,8 +185,8 @@ class _ProfileR(_Profile):
 
     def __init__(self,obj, profile):
         self.cleanProperties(obj)
-        obj.addProperty("App::PropertyLength","Width","Draft",QT_TRANSLATE_NOOP("App::Property","Width of the beam")).Width = profile[4]
-        obj.addProperty("App::PropertyLength","Height","Draft",QT_TRANSLATE_NOOP("App::Property","Height of the beam")).Height = profile[5]
+        obj.addProperty("App::PropertyLength","Width","Draft",QT_TRANSLATE_NOOP("App::Property","Width of the beam"), locked=True).Width = profile[4]
+        obj.addProperty("App::PropertyLength","Height","Draft",QT_TRANSLATE_NOOP("App::Property","Height of the beam"), locked=True).Height = profile[5]
         _Profile.__init__(self,obj,profile)
 
     def execute(self,obj):
@@ -209,9 +209,9 @@ class _ProfileRH(_Profile):
 
     def __init__(self,obj, profile):
         self.cleanProperties(obj)
-        obj.addProperty("App::PropertyLength","Width","Draft",QT_TRANSLATE_NOOP("App::Property","Width of the beam")).Width = profile[4]
-        obj.addProperty("App::PropertyLength","Height","Draft",QT_TRANSLATE_NOOP("App::Property","Height of the beam")).Height = profile[5]
-        obj.addProperty("App::PropertyLength","Thickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the sides")).Thickness = profile[6]
+        obj.addProperty("App::PropertyLength","Width","Draft",QT_TRANSLATE_NOOP("App::Property","Width of the beam"), locked=True).Width = profile[4]
+        obj.addProperty("App::PropertyLength","Height","Draft",QT_TRANSLATE_NOOP("App::Property","Height of the beam"), locked=True).Height = profile[5]
+        obj.addProperty("App::PropertyLength","Thickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the sides"), locked=True).Thickness = profile[6]
         _Profile.__init__(self,obj,profile)
 
     def execute(self,obj):
@@ -242,10 +242,10 @@ class _ProfileU(_Profile):
 
     def __init__(self,obj, profile):
         self.cleanProperties(obj)
-        obj.addProperty("App::PropertyLength","Width","Draft",QT_TRANSLATE_NOOP("App::Property","Width of the beam")).Width = profile[4]
-        obj.addProperty("App::PropertyLength","Height","Draft",QT_TRANSLATE_NOOP("App::Property","Height of the beam")).Height = profile[5]
-        obj.addProperty("App::PropertyLength","WebThickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the webs")).WebThickness = profile[6]
-        obj.addProperty("App::PropertyLength","FlangeThickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the flange")).FlangeThickness = profile[7]
+        obj.addProperty("App::PropertyLength","Width","Draft",QT_TRANSLATE_NOOP("App::Property","Width of the beam"), locked=True).Width = profile[4]
+        obj.addProperty("App::PropertyLength","Height","Draft",QT_TRANSLATE_NOOP("App::Property","Height of the beam"), locked=True).Height = profile[5]
+        obj.addProperty("App::PropertyLength","WebThickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the webs"), locked=True).WebThickness = profile[6]
+        obj.addProperty("App::PropertyLength","FlangeThickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the flange"), locked=True).FlangeThickness = profile[7]
         _Profile.__init__(self,obj,profile)
 
     def execute(self,obj):
@@ -272,9 +272,9 @@ class _ProfileL(_Profile):
 
     def __init__(self, obj, profile):
         self.cleanProperties(obj)
-        obj.addProperty("App::PropertyLength","Width","Draft",QT_TRANSLATE_NOOP("App::Property","Width of the beam")).Width = profile[4]
-        obj.addProperty("App::PropertyLength","Height","Draft",QT_TRANSLATE_NOOP("App::Property","Height of the beam")).Height = profile[5]
-        obj.addProperty("App::PropertyLength","Thickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the legs")).Thickness = profile[6]
+        obj.addProperty("App::PropertyLength","Width","Draft",QT_TRANSLATE_NOOP("App::Property","Width of the beam"), locked=True).Width = profile[4]
+        obj.addProperty("App::PropertyLength","Height","Draft",QT_TRANSLATE_NOOP("App::Property","Height of the beam"), locked=True).Height = profile[5]
+        obj.addProperty("App::PropertyLength","Thickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the legs"), locked=True).Thickness = profile[6]
         _Profile.__init__(self,obj,profile)
 
     def execute(self,obj):
@@ -299,10 +299,10 @@ class _ProfileT(_Profile):
 
     def __init__(self, obj, profile):
         self.cleanProperties(obj)
-        obj.addProperty("App::PropertyLength","Width","Draft",QT_TRANSLATE_NOOP("App::Property","Width of the beam")).Width = profile[4]
-        obj.addProperty("App::PropertyLength","Height","Draft",QT_TRANSLATE_NOOP("App::Property","Height of the beam")).Height = profile[5]
-        obj.addProperty("App::PropertyLength","WebThickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the web")).WebThickness = profile[6]
-        obj.addProperty("App::PropertyLength","FlangeThickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the flanges")).FlangeThickness = profile[7]
+        obj.addProperty("App::PropertyLength","Width","Draft",QT_TRANSLATE_NOOP("App::Property","Width of the beam"), locked=True).Width = profile[4]
+        obj.addProperty("App::PropertyLength","Height","Draft",QT_TRANSLATE_NOOP("App::Property","Height of the beam"), locked=True).Height = profile[5]
+        obj.addProperty("App::PropertyLength","WebThickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the web"), locked=True).WebThickness = profile[6]
+        obj.addProperty("App::PropertyLength","FlangeThickness","Draft",QT_TRANSLATE_NOOP("App::Property","Thickness of the flanges"), locked=True).FlangeThickness = profile[7]
         _Profile.__init__(self,obj,profile)
 
     def execute(self,obj):

--- a/src/Mod/BIM/ArchRebar.py
+++ b/src/Mod/BIM/ArchRebar.py
@@ -75,33 +75,33 @@ class _Rebar(ArchComponent.Component):
 
         pl = obj.PropertiesList
         if not "Diameter" in pl:
-            obj.addProperty("App::PropertyLength","Diameter","Rebar",QT_TRANSLATE_NOOP("App::Property","The diameter of the bar"))
+            obj.addProperty("App::PropertyLength","Diameter","Rebar",QT_TRANSLATE_NOOP("App::Property","The diameter of the bar"), locked=True)
         if not "OffsetStart" in pl:
-            obj.addProperty("App::PropertyDistance","OffsetStart","Rebar",QT_TRANSLATE_NOOP("App::Property","The distance between the border of the beam and the first bar (concrete cover)."))
+            obj.addProperty("App::PropertyDistance","OffsetStart","Rebar",QT_TRANSLATE_NOOP("App::Property","The distance between the border of the beam and the first bar (concrete cover)."), locked=True)
         if not "OffsetEnd" in pl:
-            obj.addProperty("App::PropertyDistance","OffsetEnd","Rebar",QT_TRANSLATE_NOOP("App::Property","The distance between the border of the beam and the last bar (concrete cover)."))
+            obj.addProperty("App::PropertyDistance","OffsetEnd","Rebar",QT_TRANSLATE_NOOP("App::Property","The distance between the border of the beam and the last bar (concrete cover)."), locked=True)
         if not "Amount" in pl:
-            obj.addProperty("App::PropertyInteger","Amount","Rebar",QT_TRANSLATE_NOOP("App::Property","The amount of bars"))
+            obj.addProperty("App::PropertyInteger","Amount","Rebar",QT_TRANSLATE_NOOP("App::Property","The amount of bars"), locked=True)
         if not "Spacing" in pl:
-            obj.addProperty("App::PropertyLength","Spacing","Rebar",QT_TRANSLATE_NOOP("App::Property","The spacing between the bars"))
+            obj.addProperty("App::PropertyLength","Spacing","Rebar",QT_TRANSLATE_NOOP("App::Property","The spacing between the bars"), locked=True)
             obj.setEditorMode("Spacing", 1)
         if not "Distance" in pl:
-            obj.addProperty("App::PropertyLength","Distance","Rebar",QT_TRANSLATE_NOOP("App::Property","The total distance to span the rebars over. Keep 0 to automatically use the host shape size."))
+            obj.addProperty("App::PropertyLength","Distance","Rebar",QT_TRANSLATE_NOOP("App::Property","The total distance to span the rebars over. Keep 0 to automatically use the host shape size."), locked=True)
         if not "Direction" in pl:
-            obj.addProperty("App::PropertyVector","Direction","Rebar",QT_TRANSLATE_NOOP("App::Property","The direction to use to spread the bars. Keep (0,0,0) for automatic direction."))
+            obj.addProperty("App::PropertyVector","Direction","Rebar",QT_TRANSLATE_NOOP("App::Property","The direction to use to spread the bars. Keep (0,0,0) for automatic direction."), locked=True)
         if not "Rounding" in pl:
-            obj.addProperty("App::PropertyFloat","Rounding","Rebar",QT_TRANSLATE_NOOP("App::Property","The fillet to apply to the angle of the base profile. This value is multiplied by the bar diameter."))
+            obj.addProperty("App::PropertyFloat","Rounding","Rebar",QT_TRANSLATE_NOOP("App::Property","The fillet to apply to the angle of the base profile. This value is multiplied by the bar diameter."), locked=True)
         if not "PlacementList" in pl:
-            obj.addProperty("App::PropertyPlacementList","PlacementList","Rebar",QT_TRANSLATE_NOOP("App::Property","List of placement of all the bars"))
+            obj.addProperty("App::PropertyPlacementList","PlacementList","Rebar",QT_TRANSLATE_NOOP("App::Property","List of placement of all the bars"), locked=True)
         if not "Host" in pl:
-            obj.addProperty("App::PropertyLink","Host","Rebar",QT_TRANSLATE_NOOP("App::Property","The structure object that hosts this rebar"))
+            obj.addProperty("App::PropertyLink","Host","Rebar",QT_TRANSLATE_NOOP("App::Property","The structure object that hosts this rebar"), locked=True)
         if not "CustomSpacing" in pl:
-            obj.addProperty("App::PropertyString", "CustomSpacing", "Rebar", QT_TRANSLATE_NOOP("App::Property","The custom spacing of rebar"))
+            obj.addProperty("App::PropertyString", "CustomSpacing", "Rebar", QT_TRANSLATE_NOOP("App::Property","The custom spacing of rebar"), locked=True)
         if not "Length" in pl:
-            obj.addProperty("App::PropertyDistance", "Length", "Rebar", QT_TRANSLATE_NOOP("App::Property","Length of a single rebar"))
+            obj.addProperty("App::PropertyDistance", "Length", "Rebar", QT_TRANSLATE_NOOP("App::Property","Length of a single rebar"), locked=True)
             obj.setEditorMode("Length", 1)
         if not "TotalLength" in pl:
-            obj.addProperty("App::PropertyDistance", "TotalLength", "Rebar", QT_TRANSLATE_NOOP("App::Property","Total length of all rebars"))
+            obj.addProperty("App::PropertyDistance", "TotalLength", "Rebar", QT_TRANSLATE_NOOP("App::Property","Total length of all rebars"), locked=True)
             obj.setEditorMode("TotalLength", 1)
         if not "Mark" in pl:
             obj.addProperty(
@@ -109,6 +109,7 @@ class _Rebar(ArchComponent.Component):
                 "Mark",
                 "Rebar",
                 QT_TRANSLATE_NOOP("App::Property", "The rebar mark"),
+                locked=True,
             )
         self.Type = "Rebar"
 
@@ -404,7 +405,7 @@ class _ViewProviderRebar(ArchComponent.ViewProviderComponent):
 
         pl = vobj.PropertiesList
         if not "RebarShape" in pl:
-            vobj.addProperty("App::PropertyString","RebarShape","Rebar",QT_TRANSLATE_NOOP("App::Property","Shape of rebar")).RebarShape
+            vobj.addProperty("App::PropertyString","RebarShape","Rebar",QT_TRANSLATE_NOOP("App::Property","Shape of rebar"), locked=True).RebarShape
             vobj.setEditorMode("RebarShape",2)
 
     def onDocumentRestored(self,vobj):

--- a/src/Mod/BIM/ArchReference.py
+++ b/src/Mod/BIM/ArchReference.py
@@ -73,13 +73,13 @@ class ArchReference:
         pl = obj.PropertiesList
         if not "File" in pl:
             t = QT_TRANSLATE_NOOP("App::Property","The base file this component is built upon")
-            obj.addProperty("App::PropertyFile","File","Reference",t)
+            obj.addProperty("App::PropertyFile","File","Reference",t, locked=True)
         if not "Part" in pl:
             t = QT_TRANSLATE_NOOP("App::Property","The part to use from the base file")
-            obj.addProperty("App::PropertyString","Part","Reference",t)
+            obj.addProperty("App::PropertyString","Part","Reference",t, locked=True)
         if not "ReferenceMode" in pl:
             t = QT_TRANSLATE_NOOP("App::Property","The way the referenced objects are included in the current document. 'Normal' includes the shape, 'Transient' discards the shape when the object is switched off (smaller filesize), 'Lightweight' does not import the shape but only the OpenInventor representation")
-            obj.addProperty("App::PropertyEnumeration","ReferenceMode","Reference",t)
+            obj.addProperty("App::PropertyEnumeration","ReferenceMode","Reference",t, locked=True)
             obj.ReferenceMode = ["Normal","Transient","Lightweight"]
             if "TransientReference" in pl:
                 if obj.TransientReference:
@@ -89,7 +89,7 @@ class ArchReference:
                 FreeCAD.Console.PrintMessage(translate("Arch","Upgrading")+" "+obj.Label+" "+t+"\n")
         if not "FuseArch" in pl:
             t = QT_TRANSLATE_NOOP("App::Property","Fuse objects of same material")
-            obj.addProperty("App::PropertyBool","FuseArch", "Reference", t)
+            obj.addProperty("App::PropertyBool","FuseArch", "Reference", t, locked=True)
         self.Type = "Reference"
 
 
@@ -526,11 +526,11 @@ class ViewProviderArchReference:
         pl = vobj.PropertiesList
         if not "TimeStamp" in pl:
             t = QT_TRANSLATE_NOOP("App::Property","The latest time stamp of the linked file")
-            vobj.addProperty("App::PropertyFloat","TimeStamp","Reference",t)
+            vobj.addProperty("App::PropertyFloat","TimeStamp","Reference",t, locked=True)
             vobj.setEditorMode("TimeStamp",2)
         if not "UpdateColors" in pl:
             t = QT_TRANSLATE_NOOP("App::Property","If true, the colors from the linked file will be kept updated")
-            vobj.addProperty("App::PropertyBool","UpdateColors","Reference",t)
+            vobj.addProperty("App::PropertyBool","UpdateColors","Reference",t, locked=True)
             vobj.UpdateColors = True
 
 

--- a/src/Mod/BIM/ArchRoof.py
+++ b/src/Mod/BIM/ArchRoof.py
@@ -162,59 +162,70 @@ class _Roof(ArchComponent.Component):
             obj.addProperty("App::PropertyFloatList",
                             "Angles",
                             "Roof",
-                            QT_TRANSLATE_NOOP("App::Property", "The list of angles of the roof segments"))
+                            QT_TRANSLATE_NOOP("App::Property", "The list of angles of the roof segments"),
+                            locked=True)
         if not "Runs" in pl:
             obj.addProperty("App::PropertyFloatList",
                             "Runs",
                             "Roof",
-                            QT_TRANSLATE_NOOP("App::Property", "The list of horizontal length projections of the roof segments"))
+                            QT_TRANSLATE_NOOP("App::Property", "The list of horizontal length projections of the roof segments"),
+                            locked=True)
         if not "IdRel" in pl:
             obj.addProperty("App::PropertyIntegerList",
                             "IdRel",
                             "Roof",
-                            QT_TRANSLATE_NOOP("App::Property", "The list of IDs of the relative profiles of the roof segments"))
+                            QT_TRANSLATE_NOOP("App::Property", "The list of IDs of the relative profiles of the roof segments"),
+                            locked=True)
         if not "Thickness" in pl:
             obj.addProperty("App::PropertyFloatList",
                             "Thickness",
                             "Roof",
-                            QT_TRANSLATE_NOOP("App::Property", "The list of thicknesses of the roof segments"))
+                            QT_TRANSLATE_NOOP("App::Property", "The list of thicknesses of the roof segments"),
+                            locked=True)
         if not "Overhang" in pl:
             obj.addProperty("App::PropertyFloatList",
                             "Overhang",
                             "Roof",
-                            QT_TRANSLATE_NOOP("App::Property", "The list of overhangs of the roof segments"))
+                            QT_TRANSLATE_NOOP("App::Property", "The list of overhangs of the roof segments"),
+                            locked=True)
         if not "Heights" in pl:
             obj.addProperty("App::PropertyFloatList",
                             "Heights",
                             "Roof",
-                            QT_TRANSLATE_NOOP("App::Property", "The list of calculated heights of the roof segments"))
+                            QT_TRANSLATE_NOOP("App::Property", "The list of calculated heights of the roof segments"),
+                            locked=True)
         if not "Face" in pl:
             obj.addProperty("App::PropertyInteger",
                             "Face",
                             "Roof",
-                            QT_TRANSLATE_NOOP("App::Property", "The face number of the base object used to build the roof"))
+                            QT_TRANSLATE_NOOP("App::Property", "The face number of the base object used to build the roof"),
+                            locked=True)
         if not "RidgeLength" in pl:
             obj.addProperty("App::PropertyLength",
                             "RidgeLength",
                             "Roof",
-                            QT_TRANSLATE_NOOP("App::Property", "The total length of the ridges and hips of the roof"))
+                            QT_TRANSLATE_NOOP("App::Property", "The total length of the ridges and hips of the roof"),
+                            locked=True)
             obj.setEditorMode("RidgeLength",1)
         if not "BorderLength" in pl:
             obj.addProperty("App::PropertyLength",
                             "BorderLength",
                             "Roof",
-                            QT_TRANSLATE_NOOP("App::Property", "The total length of the borders of the roof"))
+                            QT_TRANSLATE_NOOP("App::Property", "The total length of the borders of the roof"),
+                            locked=True)
             obj.setEditorMode("BorderLength",1)
         if not "Flip" in pl:
             obj.addProperty("App::PropertyBool",
                             "Flip",
                             "Roof",
-                            QT_TRANSLATE_NOOP("App::Property", "Specifies if the direction of the roof should be flipped"))
+                            QT_TRANSLATE_NOOP("App::Property", "Specifies if the direction of the roof should be flipped"),
+                            locked=True)
         if not "Subvolume" in pl:
             obj.addProperty("App::PropertyLink",
                             "Subvolume",
                             "Roof",
-                            QT_TRANSLATE_NOOP("App::Property", "An optional object that defines a volume to be subtracted from walls. If field is set - it has a priority over auto-generated subvolume"))
+                            QT_TRANSLATE_NOOP("App::Property", "An optional object that defines a volume to be subtracted from walls. If field is set - it has a priority over auto-generated subvolume"),
+                            locked=True)
         self.Type = "Roof"
 
     def onDocumentRestored(self, obj):

--- a/src/Mod/BIM/ArchSchedule.py
+++ b/src/Mod/BIM/ArchSchedule.py
@@ -115,21 +115,21 @@ class _ArchSchedule:
     def setProperties(self,obj):
 
         if not "Operation" in obj.PropertiesList:
-            obj.addProperty("App::PropertyStringList","Operation",         "Schedule",QT_TRANSLATE_NOOP("App::Property","The operation column"))
+            obj.addProperty("App::PropertyStringList","Operation",         "Schedule",QT_TRANSLATE_NOOP("App::Property","The operation column"), locked=True)
         if not "Value" in obj.PropertiesList:
-            obj.addProperty("App::PropertyStringList","Value",             "Schedule",QT_TRANSLATE_NOOP("App::Property","The values column"))
+            obj.addProperty("App::PropertyStringList","Value",             "Schedule",QT_TRANSLATE_NOOP("App::Property","The values column"), locked=True)
         if not "Unit" in obj.PropertiesList:
-            obj.addProperty("App::PropertyStringList","Unit",              "Schedule",QT_TRANSLATE_NOOP("App::Property","The units column"))
+            obj.addProperty("App::PropertyStringList","Unit",              "Schedule",QT_TRANSLATE_NOOP("App::Property","The units column"), locked=True)
         if not "Objects" in obj.PropertiesList:
-            obj.addProperty("App::PropertyStringList","Objects",           "Schedule",QT_TRANSLATE_NOOP("App::Property","The objects column"))
+            obj.addProperty("App::PropertyStringList","Objects",           "Schedule",QT_TRANSLATE_NOOP("App::Property","The objects column"), locked=True)
         if not "Filter" in obj.PropertiesList:
-            obj.addProperty("App::PropertyStringList","Filter",            "Schedule",QT_TRANSLATE_NOOP("App::Property","The filter column"))
+            obj.addProperty("App::PropertyStringList","Filter",            "Schedule",QT_TRANSLATE_NOOP("App::Property","The filter column"), locked=True)
         if not "CreateSpreadsheet" in obj.PropertiesList:
-            obj.addProperty("App::PropertyBool",      "CreateSpreadsheet", "Schedule",QT_TRANSLATE_NOOP("App::Property","If True, a spreadsheet containing the results is recreated when needed"))
+            obj.addProperty("App::PropertyBool",      "CreateSpreadsheet", "Schedule",QT_TRANSLATE_NOOP("App::Property","If True, a spreadsheet containing the results is recreated when needed"), locked=True)
         if not "DetailedResults" in obj.PropertiesList:
-            obj.addProperty("App::PropertyBool",      "DetailedResults",   "Schedule",QT_TRANSLATE_NOOP("App::Property","If True, additional lines with each individual object are added to the results"))
+            obj.addProperty("App::PropertyBool",      "DetailedResults",   "Schedule",QT_TRANSLATE_NOOP("App::Property","If True, additional lines with each individual object are added to the results"), locked=True)
         if not "AutoUpdate" in obj.PropertiesList:
-            obj.addProperty("App::PropertyBool",      "AutoUpdate",        "Schedule",QT_TRANSLATE_NOOP("App::Property","If True, the schedule and the associated spreadsheet are updated whenever the document is recomputed"))
+            obj.addProperty("App::PropertyBool",      "AutoUpdate",        "Schedule",QT_TRANSLATE_NOOP("App::Property","If True, the schedule and the associated spreadsheet are updated whenever the document is recomputed"), locked=True)
             obj.AutoUpdate = True
 
         # To add the doc observer:
@@ -141,7 +141,8 @@ class _ArchSchedule:
                 "App::PropertyLink",
                 "Schedule",
                 "Arch",
-                QT_TRANSLATE_NOOP("App::Property", "The BIM Schedule that uses this spreadsheet"))
+                QT_TRANSLATE_NOOP("App::Property", "The BIM Schedule that uses this spreadsheet"),
+                locked=True)
         sp.Schedule = obj
 
     def getSpreadSheet(self, obj, force=False):

--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -817,21 +817,21 @@ class _SectionPlane:
 
         pl = obj.PropertiesList
         if not "Placement" in pl:
-            obj.addProperty("App::PropertyPlacement","Placement","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The placement of this object"))
+            obj.addProperty("App::PropertyPlacement","Placement","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The placement of this object"), locked=True)
         if not "Shape" in pl:
-            obj.addProperty("Part::PropertyPartShape","Shape","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The shape of this object"))
+            obj.addProperty("Part::PropertyPartShape","Shape","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The shape of this object"), locked=True)
         if not "Objects" in pl:
-            obj.addProperty("App::PropertyLinkList","Objects","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The objects that must be considered by this section plane. Empty means the whole document."))
+            obj.addProperty("App::PropertyLinkList","Objects","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The objects that must be considered by this section plane. Empty means the whole document."), locked=True)
         if not "OnlySolids" in pl:
-            obj.addProperty("App::PropertyBool","OnlySolids","SectionPlane",QT_TRANSLATE_NOOP("App::Property","If false, non-solids will be cut too, with possible wrong results."))
+            obj.addProperty("App::PropertyBool","OnlySolids","SectionPlane",QT_TRANSLATE_NOOP("App::Property","If false, non-solids will be cut too, with possible wrong results."), locked=True)
             obj.OnlySolids = True
         if not "Clip" in pl:
-            obj.addProperty("App::PropertyBool","Clip","SectionPlane",QT_TRANSLATE_NOOP("App::Property","If True, resulting views will be clipped to the section plane area."))
+            obj.addProperty("App::PropertyBool","Clip","SectionPlane",QT_TRANSLATE_NOOP("App::Property","If True, resulting views will be clipped to the section plane area."), locked=True)
         if not "UseMaterialColorForFill" in pl:
-            obj.addProperty("App::PropertyBool","UseMaterialColorForFill","SectionPlane",QT_TRANSLATE_NOOP("App::Property","If true, the color of the objects material will be used to fill cut areas."))
+            obj.addProperty("App::PropertyBool","UseMaterialColorForFill","SectionPlane",QT_TRANSLATE_NOOP("App::Property","If true, the color of the objects material will be used to fill cut areas."), locked=True)
             obj.UseMaterialColorForFill = False
         if not "Depth" in pl:
-            obj.addProperty("App::PropertyLength","Depth","SectionPlane",QT_TRANSLATE_NOOP("App::Property","Geometry further than this value will be cut off. Keep zero for unlimited."))
+            obj.addProperty("App::PropertyLength","Depth","SectionPlane",QT_TRANSLATE_NOOP("App::Property","Geometry further than this value will be cut off. Keep zero for unlimited."), locked=True)
         self.Type = "SectionPlane"
 
     def onDocumentRestored(self,obj):
@@ -894,43 +894,43 @@ class _ViewProviderSectionPlane:
             d = vobj.DisplaySize.Value
             vobj.removeProperty("DisplaySize")
         if not "DisplayLength" in pl:
-            vobj.addProperty("App::PropertyLength","DisplayLength","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The display length of this section plane"))
+            vobj.addProperty("App::PropertyLength","DisplayLength","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The display length of this section plane"), locked=True)
             if d:
                 vobj.DisplayLength = d
             else:
                 vobj.DisplayLength = 1000
         if not "DisplayHeight" in pl:
-            vobj.addProperty("App::PropertyLength","DisplayHeight","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The display height of this section plane"))
+            vobj.addProperty("App::PropertyLength","DisplayHeight","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The display height of this section plane"), locked=True)
             if d:
                 vobj.DisplayHeight = d
             else:
                 vobj.DisplayHeight = 1000
         if not "ArrowSize" in pl:
-            vobj.addProperty("App::PropertyLength","ArrowSize","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The size of the arrows of this section plane"))
+            vobj.addProperty("App::PropertyLength","ArrowSize","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The size of the arrows of this section plane"), locked=True)
             vobj.ArrowSize = 50
         if not "Transparency" in pl:
-            vobj.addProperty("App::PropertyPercent","Transparency","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The transparency of this object"))
+            vobj.addProperty("App::PropertyPercent","Transparency","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The transparency of this object"), locked=True)
             vobj.Transparency = 85
         if not "LineWidth" in pl:
-            vobj.addProperty("App::PropertyFloat","LineWidth","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The line width of this object"))
+            vobj.addProperty("App::PropertyFloat","LineWidth","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The line width of this object"), locked=True)
             vobj.LineWidth = 1
         if not "CutDistance" in pl:
-            vobj.addProperty("App::PropertyLength","CutDistance","SectionPlane",QT_TRANSLATE_NOOP("App::Property","Show the cut in the 3D view"))
+            vobj.addProperty("App::PropertyLength","CutDistance","SectionPlane",QT_TRANSLATE_NOOP("App::Property","Show the cut in the 3D view"), locked=True)
         if not "LineColor" in pl:
-            vobj.addProperty("App::PropertyColor","LineColor","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The color of this object"))
+            vobj.addProperty("App::PropertyColor","LineColor","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The color of this object"), locked=True)
             vobj.LineColor = ArchCommands.getDefaultColor("Helpers")
         if not "CutView" in pl:
-            vobj.addProperty("App::PropertyBool","CutView","SectionPlane",QT_TRANSLATE_NOOP("App::Property","Show the cut in the 3D view"))
+            vobj.addProperty("App::PropertyBool","CutView","SectionPlane",QT_TRANSLATE_NOOP("App::Property","Show the cut in the 3D view"), locked=True)
         if not "CutMargin" in pl:
-            vobj.addProperty("App::PropertyLength","CutMargin","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The distance between the cut plane and the actual view cut (keep this a very small value but not zero)"))
+            vobj.addProperty("App::PropertyLength","CutMargin","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The distance between the cut plane and the actual view cut (keep this a very small value but not zero)"), locked=True)
             vobj.CutMargin = 1
         if not "ShowLabel" in pl:
-            vobj.addProperty("App::PropertyBool","ShowLabel","SectionPlane",QT_TRANSLATE_NOOP("App::Property","Show the label in the 3D view"))
+            vobj.addProperty("App::PropertyBool","ShowLabel","SectionPlane",QT_TRANSLATE_NOOP("App::Property","Show the label in the 3D view"), locked=True)
         if not "FontName" in pl:
-            vobj.addProperty("App::PropertyFont","FontName", "SectionPlane",QT_TRANSLATE_NOOP("App::Property","The name of the font"))
+            vobj.addProperty("App::PropertyFont","FontName", "SectionPlane",QT_TRANSLATE_NOOP("App::Property","The name of the font"), locked=True)
             vobj.FontName = params.get_param("textfont")
         if not "FontSize" in pl:
-            vobj.addProperty("App::PropertyLength","FontSize","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The size of the text font"))
+            vobj.addProperty("App::PropertyLength","FontSize","SectionPlane",QT_TRANSLATE_NOOP("App::Property","The size of the text font"), locked=True)
             vobj.FontSize = params.get_param("textheight") * params.get_param("DefaultAnnoScaleMultiplier")
 
 

--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -523,59 +523,59 @@ class _Site(ArchIFC.IfcProduct):
 
         pl = obj.PropertiesList
         if not "Terrain" in pl:
-            obj.addProperty("App::PropertyLink","Terrain","Site",QT_TRANSLATE_NOOP("App::Property","The base terrain of this site"))
+            obj.addProperty("App::PropertyLink","Terrain","Site",QT_TRANSLATE_NOOP("App::Property","The base terrain of this site"), locked=True)
         if not "Address" in pl:
-            obj.addProperty("App::PropertyString","Address","Site",QT_TRANSLATE_NOOP("App::Property","The street and house number of this site, with postal box or apartment number if needed"))
+            obj.addProperty("App::PropertyString","Address","Site",QT_TRANSLATE_NOOP("App::Property","The street and house number of this site, with postal box or apartment number if needed"), locked=True)
         if not "PostalCode" in pl:
-            obj.addProperty("App::PropertyString","PostalCode","Site",QT_TRANSLATE_NOOP("App::Property","The postal or zip code of this site"))
+            obj.addProperty("App::PropertyString","PostalCode","Site",QT_TRANSLATE_NOOP("App::Property","The postal or zip code of this site"), locked=True)
         if not "City" in pl:
-            obj.addProperty("App::PropertyString","City","Site",QT_TRANSLATE_NOOP("App::Property","The city of this site"))
+            obj.addProperty("App::PropertyString","City","Site",QT_TRANSLATE_NOOP("App::Property","The city of this site"), locked=True)
         if not "Region" in pl:
-            obj.addProperty("App::PropertyString","Region","Site",QT_TRANSLATE_NOOP("App::Property","The region, province or county of this site"))
+            obj.addProperty("App::PropertyString","Region","Site",QT_TRANSLATE_NOOP("App::Property","The region, province or county of this site"), locked=True)
         if not "Country" in pl:
-            obj.addProperty("App::PropertyString","Country","Site",QT_TRANSLATE_NOOP("App::Property","The country of this site"))
+            obj.addProperty("App::PropertyString","Country","Site",QT_TRANSLATE_NOOP("App::Property","The country of this site"), locked=True)
         if not "Latitude" in pl:
-            obj.addProperty("App::PropertyFloat","Latitude","Site",QT_TRANSLATE_NOOP("App::Property","The latitude of this site"))
+            obj.addProperty("App::PropertyFloat","Latitude","Site",QT_TRANSLATE_NOOP("App::Property","The latitude of this site"), locked=True)
         if not "Longitude" in pl:
-            obj.addProperty("App::PropertyFloat","Longitude","Site",QT_TRANSLATE_NOOP("App::Property","The latitude of this site"))
+            obj.addProperty("App::PropertyFloat","Longitude","Site",QT_TRANSLATE_NOOP("App::Property","The latitude of this site"), locked=True)
         if not "Declination" in pl:
-            obj.addProperty("App::PropertyAngle","Declination","Site",QT_TRANSLATE_NOOP("App::Property","Angle between the true North and the North direction in this document"))
+            obj.addProperty("App::PropertyAngle","Declination","Site",QT_TRANSLATE_NOOP("App::Property","Angle between the true North and the North direction in this document"), locked=True)
         if "NorthDeviation"in pl:
             obj.Declination = obj.NorthDeviation.Value
             obj.removeProperty("NorthDeviation")
         if not "Elevation" in pl:
-            obj.addProperty("App::PropertyLength","Elevation","Site",QT_TRANSLATE_NOOP("App::Property","The elevation of level 0 of this site"))
+            obj.addProperty("App::PropertyLength","Elevation","Site",QT_TRANSLATE_NOOP("App::Property","The elevation of level 0 of this site"), locked=True)
         if not "Url" in pl:
-            obj.addProperty("App::PropertyString","Url","Site",QT_TRANSLATE_NOOP("App::Property","A URL that shows this site in a mapping website"))
+            obj.addProperty("App::PropertyString","Url","Site",QT_TRANSLATE_NOOP("App::Property","A URL that shows this site in a mapping website"), locked=True)
         if not "Additions" in pl:
-            obj.addProperty("App::PropertyLinkList","Additions","Site",QT_TRANSLATE_NOOP("App::Property","Other shapes that are appended to this object"))
+            obj.addProperty("App::PropertyLinkList","Additions","Site",QT_TRANSLATE_NOOP("App::Property","Other shapes that are appended to this object"), locked=True)
         if not "Subtractions" in pl:
-            obj.addProperty("App::PropertyLinkList","Subtractions","Site",QT_TRANSLATE_NOOP("App::Property","Other shapes that are subtracted from this object"))
+            obj.addProperty("App::PropertyLinkList","Subtractions","Site",QT_TRANSLATE_NOOP("App::Property","Other shapes that are subtracted from this object"), locked=True)
         if not "ProjectedArea" in pl:
-            obj.addProperty("App::PropertyArea","ProjectedArea","Site",QT_TRANSLATE_NOOP("App::Property","The area of the projection of this object onto the XY plane"))
+            obj.addProperty("App::PropertyArea","ProjectedArea","Site",QT_TRANSLATE_NOOP("App::Property","The area of the projection of this object onto the XY plane"), locked=True)
         if not "Perimeter" in pl:
-            obj.addProperty("App::PropertyLength","Perimeter","Site",QT_TRANSLATE_NOOP("App::Property","The perimeter length of the projected area"))
+            obj.addProperty("App::PropertyLength","Perimeter","Site",QT_TRANSLATE_NOOP("App::Property","The perimeter length of the projected area"), locked=True)
         if not "AdditionVolume" in pl:
-            obj.addProperty("App::PropertyVolume","AdditionVolume","Site",QT_TRANSLATE_NOOP("App::Property","The volume of earth to be added to this terrain"))
+            obj.addProperty("App::PropertyVolume","AdditionVolume","Site",QT_TRANSLATE_NOOP("App::Property","The volume of earth to be added to this terrain"), locked=True)
         if not "SubtractionVolume" in pl:
-            obj.addProperty("App::PropertyVolume","SubtractionVolume","Site",QT_TRANSLATE_NOOP("App::Property","The volume of earth to be removed from this terrain"))
+            obj.addProperty("App::PropertyVolume","SubtractionVolume","Site",QT_TRANSLATE_NOOP("App::Property","The volume of earth to be removed from this terrain"), locked=True)
         if not "ExtrusionVector" in pl:
-            obj.addProperty("App::PropertyVector","ExtrusionVector","Site",QT_TRANSLATE_NOOP("App::Property","An extrusion vector to use when performing boolean operations"))
+            obj.addProperty("App::PropertyVector","ExtrusionVector","Site",QT_TRANSLATE_NOOP("App::Property","An extrusion vector to use when performing boolean operations"), locked=True)
             obj.ExtrusionVector = FreeCAD.Vector(0,0,-100000)
         if not "RemoveSplitter" in pl:
-            obj.addProperty("App::PropertyBool","RemoveSplitter","Site",QT_TRANSLATE_NOOP("App::Property","Remove splitters from the resulting shape"))
+            obj.addProperty("App::PropertyBool","RemoveSplitter","Site",QT_TRANSLATE_NOOP("App::Property","Remove splitters from the resulting shape"), locked=True)
         if not "OriginOffset" in pl:
-            obj.addProperty("App::PropertyVector","OriginOffset","Site",QT_TRANSLATE_NOOP("App::Property","An optional offset between the model (0,0,0) origin and the point indicated by the geocoordinates"))
+            obj.addProperty("App::PropertyVector","OriginOffset","Site",QT_TRANSLATE_NOOP("App::Property","An optional offset between the model (0,0,0) origin and the point indicated by the geocoordinates"), locked=True)
         if not hasattr(obj,"Group"):
             obj.addExtension("App::GroupExtensionPython")
         if not "IfcType" in pl:
-            obj.addProperty("App::PropertyEnumeration","IfcType","IFC",QT_TRANSLATE_NOOP("App::Property","The type of this object"))
+            obj.addProperty("App::PropertyEnumeration","IfcType","IFC",QT_TRANSLATE_NOOP("App::Property","The type of this object"), locked=True)
             obj.IfcType = ArchIFC.IfcTypes
             obj.IcfType = "Site"
         if not "TimeZone" in pl:
-            obj.addProperty("App::PropertyInteger","TimeZone","Site",QT_TRANSLATE_NOOP("App::Property","The time zone where this site is located"))
+            obj.addProperty("App::PropertyInteger","TimeZone","Site",QT_TRANSLATE_NOOP("App::Property","The time zone where this site is located"), locked=True)
         if not "EPWFile" in pl:
-            obj.addProperty("App::PropertyFileIncluded","EPWFile","Site",QT_TRANSLATE_NOOP("App::Property","An optional EPW File for the location of this site. Refer to the Site documentation to know how to obtain one"))
+            obj.addProperty("App::PropertyFileIncluded","EPWFile","Site",QT_TRANSLATE_NOOP("App::Property","An optional EPW File for the location of this site. Refer to the Site documentation to know how to obtain one"), locked=True)
         self.Type = "Site"
 
     def onDocumentRestored(self,obj):
@@ -779,30 +779,30 @@ class _ViewProviderSite:
 
         pl = vobj.PropertiesList
         if not "WindRose" in pl:
-            vobj.addProperty("App::PropertyBool","WindRose","Site",QT_TRANSLATE_NOOP("App::Property","Show wind rose diagram or not. Uses solar diagram scale. Needs Ladybug module"))
+            vobj.addProperty("App::PropertyBool","WindRose","Site",QT_TRANSLATE_NOOP("App::Property","Show wind rose diagram or not. Uses solar diagram scale. Needs Ladybug module"), locked=True)
         if not "SolarDiagram" in pl:
-            vobj.addProperty("App::PropertyBool","SolarDiagram","Site",QT_TRANSLATE_NOOP("App::Property","Show solar diagram or not"))
+            vobj.addProperty("App::PropertyBool","SolarDiagram","Site",QT_TRANSLATE_NOOP("App::Property","Show solar diagram or not"), locked=True)
         if not "SolarDiagramScale" in pl:
-            vobj.addProperty("App::PropertyFloat","SolarDiagramScale","Site",QT_TRANSLATE_NOOP("App::Property","The scale of the solar diagram"))
+            vobj.addProperty("App::PropertyFloat","SolarDiagramScale","Site",QT_TRANSLATE_NOOP("App::Property","The scale of the solar diagram"), locked=True)
             vobj.SolarDiagramScale = 1
         if not "SolarDiagramPosition" in pl:
-            vobj.addProperty("App::PropertyVector","SolarDiagramPosition","Site",QT_TRANSLATE_NOOP("App::Property","The position of the solar diagram"))
+            vobj.addProperty("App::PropertyVector","SolarDiagramPosition","Site",QT_TRANSLATE_NOOP("App::Property","The position of the solar diagram"), locked=True)
         if not "SolarDiagramColor" in pl:
-            vobj.addProperty("App::PropertyColor","SolarDiagramColor","Site",QT_TRANSLATE_NOOP("App::Property","The color of the solar diagram"))
+            vobj.addProperty("App::PropertyColor","SolarDiagramColor","Site",QT_TRANSLATE_NOOP("App::Property","The color of the solar diagram"), locked=True)
             vobj.SolarDiagramColor = (0.16,0.16,0.25)
         if not "Orientation" in pl:
             vobj.addProperty("App::PropertyEnumeration", "Orientation", "Site", QT_TRANSLATE_NOOP(
-                "App::Property", "When set to 'True North' the whole geometry will be rotated to match the true north of this site"))
+                "App::Property", "When set to 'True North' the whole geometry will be rotated to match the true north of this site"), locked=True)
             vobj.Orientation = ["Project North", "True North"]
             vobj.Orientation = "Project North"
         if not "Compass" in pl:
-            vobj.addProperty("App::PropertyBool", "Compass", "Compass", QT_TRANSLATE_NOOP("App::Property", "Show compass or not"))
+            vobj.addProperty("App::PropertyBool", "Compass", "Compass", QT_TRANSLATE_NOOP("App::Property", "Show compass or not"), locked=True)
         if not "CompassRotation" in pl:
-            vobj.addProperty("App::PropertyAngle", "CompassRotation", "Compass", QT_TRANSLATE_NOOP("App::Property", "The rotation of the Compass relative to the Site"))
+            vobj.addProperty("App::PropertyAngle", "CompassRotation", "Compass", QT_TRANSLATE_NOOP("App::Property", "The rotation of the Compass relative to the Site"), locked=True)
         if not "CompassPosition" in pl:
-            vobj.addProperty("App::PropertyVector", "CompassPosition", "Compass", QT_TRANSLATE_NOOP("App::Property", "The position of the Compass relative to the Site placement"))
+            vobj.addProperty("App::PropertyVector", "CompassPosition", "Compass", QT_TRANSLATE_NOOP("App::Property", "The position of the Compass relative to the Site placement"), locked=True)
         if not "UpdateDeclination" in pl:
-            vobj.addProperty("App::PropertyBool", "UpdateDeclination", "Compass", QT_TRANSLATE_NOOP("App::Property", "Update the Declination value based on the compass rotation"))
+            vobj.addProperty("App::PropertyBool", "UpdateDeclination", "Compass", QT_TRANSLATE_NOOP("App::Property", "Update the Declination value based on the compass rotation"), locked=True)
 
     def getIcon(self):
         """Return the path to the appropriate icon.

--- a/src/Mod/BIM/ArchSketchObject.py
+++ b/src/Mod/BIM/ArchSketchObject.py
@@ -45,7 +45,7 @@ class ArchSketch(ArchSketchObject):
             if "Hosts" not in prop:
                 fp.addProperty("App::PropertyLinkList","Hosts","Window",
                                QT_TRANSLATE_NOOP("App::Property",
-                               "The objects that host this window"))
+                               "The objects that host this window"), locked=True)
                                # Arch Window's code
 
 #from ArchSketchObjectExt import ArchSketch  # Doesn't work

--- a/src/Mod/BIM/ArchSpace.py
+++ b/src/Mod/BIM/ArchSpace.py
@@ -198,38 +198,38 @@ class _Space(ArchComponent.Component):
 
         pl = obj.PropertiesList
         if not "Boundaries" in pl:
-            obj.addProperty("App::PropertyLinkSubList","Boundaries",    "Space",QT_TRANSLATE_NOOP("App::Property","The objects that make the boundaries of this space object"))
+            obj.addProperty("App::PropertyLinkSubList","Boundaries",    "Space",QT_TRANSLATE_NOOP("App::Property","The objects that make the boundaries of this space object"), locked=True)
         if not "Area" in pl:
-            obj.addProperty("App::PropertyArea",       "Area",          "Space",QT_TRANSLATE_NOOP("App::Property","Identical to Horizontal Area"))
+            obj.addProperty("App::PropertyArea",       "Area",          "Space",QT_TRANSLATE_NOOP("App::Property","Identical to Horizontal Area"), locked=True)
         if not "FinishFloor" in pl:
-            obj.addProperty("App::PropertyString",     "FinishFloor",   "Space",QT_TRANSLATE_NOOP("App::Property","The finishing of the floor of this space"))
+            obj.addProperty("App::PropertyString",     "FinishFloor",   "Space",QT_TRANSLATE_NOOP("App::Property","The finishing of the floor of this space"), locked=True)
         if not "FinishWalls" in pl:
-            obj.addProperty("App::PropertyString",     "FinishWalls",   "Space",QT_TRANSLATE_NOOP("App::Property","The finishing of the walls of this space"))
+            obj.addProperty("App::PropertyString",     "FinishWalls",   "Space",QT_TRANSLATE_NOOP("App::Property","The finishing of the walls of this space"), locked=True)
         if not "FinishCeiling" in pl:
-            obj.addProperty("App::PropertyString",     "FinishCeiling", "Space",QT_TRANSLATE_NOOP("App::Property","The finishing of the ceiling of this space"))
+            obj.addProperty("App::PropertyString",     "FinishCeiling", "Space",QT_TRANSLATE_NOOP("App::Property","The finishing of the ceiling of this space"), locked=True)
         if not "Group" in pl:
-            obj.addProperty("App::PropertyLinkList",   "Group",         "Space",QT_TRANSLATE_NOOP("App::Property","Objects that are included inside this space, such as furniture"))
+            obj.addProperty("App::PropertyLinkList",   "Group",         "Space",QT_TRANSLATE_NOOP("App::Property","Objects that are included inside this space, such as furniture"), locked=True)
         if not "SpaceType" in pl:
-            obj.addProperty("App::PropertyEnumeration","SpaceType",     "Space",QT_TRANSLATE_NOOP("App::Property","The type of this space"))
+            obj.addProperty("App::PropertyEnumeration","SpaceType",     "Space",QT_TRANSLATE_NOOP("App::Property","The type of this space"), locked=True)
             obj.SpaceType = SpaceTypes
         if not "FloorThickness" in pl:
-            obj.addProperty("App::PropertyLength",     "FloorThickness","Space",QT_TRANSLATE_NOOP("App::Property","The thickness of the floor finish"))
+            obj.addProperty("App::PropertyLength",     "FloorThickness","Space",QT_TRANSLATE_NOOP("App::Property","The thickness of the floor finish"), locked=True)
         if not "NumberOfPeople" in pl:
-            obj.addProperty("App::PropertyInteger",    "NumberOfPeople","Space",QT_TRANSLATE_NOOP("App::Property","The number of people who typically occupy this space"))
+            obj.addProperty("App::PropertyInteger",    "NumberOfPeople","Space",QT_TRANSLATE_NOOP("App::Property","The number of people who typically occupy this space"), locked=True)
         if not "LightingPower" in pl:
-            obj.addProperty("App::PropertyFloat",      "LightingPower", "Space",QT_TRANSLATE_NOOP("App::Property","The electric power needed to light this space in Watts"))
+            obj.addProperty("App::PropertyFloat",      "LightingPower", "Space",QT_TRANSLATE_NOOP("App::Property","The electric power needed to light this space in Watts"), locked=True)
         if not "EquipmentPower" in pl:
-            obj.addProperty("App::PropertyFloat",      "EquipmentPower","Space",QT_TRANSLATE_NOOP("App::Property","The electric power needed by the equipment of this space in Watts"))
+            obj.addProperty("App::PropertyFloat",      "EquipmentPower","Space",QT_TRANSLATE_NOOP("App::Property","The electric power needed by the equipment of this space in Watts"), locked=True)
         if not "AutoPower" in pl:
-            obj.addProperty("App::PropertyBool",       "AutoPower",     "Space",QT_TRANSLATE_NOOP("App::Property","If True, Equipment Power will be automatically filled by the equipment included in this space"))
+            obj.addProperty("App::PropertyBool",       "AutoPower",     "Space",QT_TRANSLATE_NOOP("App::Property","If True, Equipment Power will be automatically filled by the equipment included in this space"), locked=True)
         if not "Conditioning" in pl:
-            obj.addProperty("App::PropertyEnumeration","Conditioning",  "Space",QT_TRANSLATE_NOOP("App::Property","The type of air conditioning of this space"))
+            obj.addProperty("App::PropertyEnumeration","Conditioning",  "Space",QT_TRANSLATE_NOOP("App::Property","The type of air conditioning of this space"), locked=True)
             obj.Conditioning = ConditioningTypes
         if not "Internal" in pl:
-            obj.addProperty("App::PropertyBool",       "Internal",      "Space",QT_TRANSLATE_NOOP("App::Property","Specifies if this space is internal or external"))
+            obj.addProperty("App::PropertyBool",       "Internal",      "Space",QT_TRANSLATE_NOOP("App::Property","Specifies if this space is internal or external"), locked=True)
             obj.Internal = True
         if not "AreaCalculationType" in pl:
-            obj.addProperty("App::PropertyEnumeration", "AreaCalculationType",  "Space",QT_TRANSLATE_NOOP("App::Property","Defines the calculation type for the horizontal area and its perimeter length"))
+            obj.addProperty("App::PropertyEnumeration", "AreaCalculationType",  "Space",QT_TRANSLATE_NOOP("App::Property","Defines the calculation type for the horizontal area and its perimeter length"), locked=True)
             obj.AreaCalculationType = AreaCalculationType
         self.Type = "Space"
 
@@ -445,34 +445,34 @@ class _ViewProviderSpace(ArchComponent.ViewProviderComponent):
 
         pl = vobj.PropertiesList
         if not "Text" in pl:
-            vobj.addProperty("App::PropertyStringList",    "Text",        "Space",QT_TRANSLATE_NOOP("App::Property","The text to show. Use $area, $label, $longname, $description or any other property name preceded with $ (case insensitive), or $floor, $walls, $ceiling for finishes, to insert the respective data"))
+            vobj.addProperty("App::PropertyStringList",    "Text",        "Space",QT_TRANSLATE_NOOP("App::Property","The text to show. Use $area, $label, $longname, $description or any other property name preceded with $ (case insensitive), or $floor, $walls, $ceiling for finishes, to insert the respective data"), locked=True)
             vobj.Text = ["$label","$area"]
         if not "FontName" in pl:
-            vobj.addProperty("App::PropertyFont",          "FontName",    "Space",QT_TRANSLATE_NOOP("App::Property","The name of the font"))
+            vobj.addProperty("App::PropertyFont",          "FontName",    "Space",QT_TRANSLATE_NOOP("App::Property","The name of the font"), locked=True)
             vobj.FontName = params.get_param("textfont")
         if not "TextColor" in pl:
-            vobj.addProperty("App::PropertyColor",         "TextColor",   "Space",QT_TRANSLATE_NOOP("App::Property","The color of the area text"))
+            vobj.addProperty("App::PropertyColor",         "TextColor",   "Space",QT_TRANSLATE_NOOP("App::Property","The color of the area text"), locked=True)
             vobj.TextColor = (0.0,0.0,0.0,1.0)
         if not "FontSize" in pl:
-            vobj.addProperty("App::PropertyLength",        "FontSize",    "Space",QT_TRANSLATE_NOOP("App::Property","The size of the text font"))
+            vobj.addProperty("App::PropertyLength",        "FontSize",    "Space",QT_TRANSLATE_NOOP("App::Property","The size of the text font"), locked=True)
             vobj.FontSize = params.get_param("textheight") * params.get_param("DefaultAnnoScaleMultiplier")
         if not "FirstLine" in pl:
-            vobj.addProperty("App::PropertyLength",        "FirstLine",   "Space",QT_TRANSLATE_NOOP("App::Property","The size of the first line of text"))
+            vobj.addProperty("App::PropertyLength",        "FirstLine",   "Space",QT_TRANSLATE_NOOP("App::Property","The size of the first line of text"), locked=True)
             vobj.FirstLine = params.get_param("textheight") * params.get_param("DefaultAnnoScaleMultiplier")
         if not "LineSpacing" in pl:
-            vobj.addProperty("App::PropertyFloat",         "LineSpacing", "Space",QT_TRANSLATE_NOOP("App::Property","The space between the lines of text"))
+            vobj.addProperty("App::PropertyFloat",         "LineSpacing", "Space",QT_TRANSLATE_NOOP("App::Property","The space between the lines of text"), locked=True)
             vobj.LineSpacing = 1.0
         if not "TextPosition" in pl:
-            vobj.addProperty("App::PropertyVectorDistance","TextPosition","Space",QT_TRANSLATE_NOOP("App::Property","The position of the text. Leave (0,0,0) for automatic position"))
+            vobj.addProperty("App::PropertyVectorDistance","TextPosition","Space",QT_TRANSLATE_NOOP("App::Property","The position of the text. Leave (0,0,0) for automatic position"), locked=True)
         if not "TextAlign" in pl:
-            vobj.addProperty("App::PropertyEnumeration",   "TextAlign",   "Space",QT_TRANSLATE_NOOP("App::Property","The justification of the text"))
+            vobj.addProperty("App::PropertyEnumeration",   "TextAlign",   "Space",QT_TRANSLATE_NOOP("App::Property","The justification of the text"), locked=True)
             vobj.TextAlign = ["Left","Center","Right"]
             vobj.TextAlign = "Center"
         if not "Decimals" in pl:
-            vobj.addProperty("App::PropertyInteger",       "Decimals",    "Space",QT_TRANSLATE_NOOP("App::Property","The number of decimals to use for calculated texts"))
+            vobj.addProperty("App::PropertyInteger",       "Decimals",    "Space",QT_TRANSLATE_NOOP("App::Property","The number of decimals to use for calculated texts"), locked=True)
             vobj.Decimals = params.get_param("dimPrecision")
         if not "ShowUnit" in pl:
-            vobj.addProperty("App::PropertyBool",          "ShowUnit",    "Space",QT_TRANSLATE_NOOP("App::Property","Show the unit suffix"))
+            vobj.addProperty("App::PropertyBool",          "ShowUnit",    "Space",QT_TRANSLATE_NOOP("App::Property","Show the unit suffix"), locked=True)
             vobj.ShowUnit = params.get_param("showUnit")
 
     def onDocumentRestored(self,vobj):

--- a/src/Mod/BIM/ArchStairs.py
+++ b/src/Mod/BIM/ArchStairs.py
@@ -78,71 +78,71 @@ class _Stairs(ArchComponent.Component):
 
         # base properties
         if not "Length" in pl:
-            obj.addProperty("App::PropertyLength","Length","Stairs",QT_TRANSLATE_NOOP("App::Property","The length of these stairs, if no baseline is defined"))
+            obj.addProperty("App::PropertyLength","Length","Stairs",QT_TRANSLATE_NOOP("App::Property","The length of these stairs, if no baseline is defined"), locked=True)
         if not "Width" in pl:
-            obj.addProperty("App::PropertyLength","Width","Stairs",QT_TRANSLATE_NOOP("App::Property","The width of these stairs"))
+            obj.addProperty("App::PropertyLength","Width","Stairs",QT_TRANSLATE_NOOP("App::Property","The width of these stairs"), locked=True)
         if not "Height" in pl:
-            obj.addProperty("App::PropertyLength","Height","Stairs",QT_TRANSLATE_NOOP("App::Property","The total height of these stairs"))
+            obj.addProperty("App::PropertyLength","Height","Stairs",QT_TRANSLATE_NOOP("App::Property","The total height of these stairs"), locked=True)
         if not "Align" in pl:
-            obj.addProperty("App::PropertyEnumeration","Align","Stairs",QT_TRANSLATE_NOOP("App::Property","The alignment of these stairs on their baseline, if applicable"))
+            obj.addProperty("App::PropertyEnumeration","Align","Stairs",QT_TRANSLATE_NOOP("App::Property","The alignment of these stairs on their baseline, if applicable"), locked=True)
             obj.Align = ['Left','Right','Center']
 
         # TODO - To be combined into Width when PropertyLengthList is available
         if not "WidthOfLanding" in pl:
-            obj.addProperty("App::PropertyFloatList","WidthOfLanding","Stairs",QT_TRANSLATE_NOOP("App::Property","The width of a Landing (Second edge and after - First edge follows Width property)"))
+            obj.addProperty("App::PropertyFloatList","WidthOfLanding","Stairs",QT_TRANSLATE_NOOP("App::Property","The width of a Landing (Second edge and after - First edge follows Width property)"), locked=True)
 
         # steps and risers properties
 
         if not "NumberOfSteps" in pl:
-            obj.addProperty("App::PropertyInteger","NumberOfSteps","Steps",QT_TRANSLATE_NOOP("App::Property","The number of risers in these stairs"))
+            obj.addProperty("App::PropertyInteger","NumberOfSteps","Steps",QT_TRANSLATE_NOOP("App::Property","The number of risers in these stairs"), locked=True)
         if not "TreadDepth" in pl:
-            obj.addProperty("App::PropertyLength","TreadDepth","Steps",QT_TRANSLATE_NOOP("App::Property","The depth of the treads of these stairs"))
+            obj.addProperty("App::PropertyLength","TreadDepth","Steps",QT_TRANSLATE_NOOP("App::Property","The depth of the treads of these stairs"), locked=True)
             obj.setEditorMode("TreadDepth",1)
         if not "RiserHeight" in pl:
-            obj.addProperty("App::PropertyLength","RiserHeight","Steps",QT_TRANSLATE_NOOP("App::Property","The height of the risers of these stairs"))
+            obj.addProperty("App::PropertyLength","RiserHeight","Steps",QT_TRANSLATE_NOOP("App::Property","The height of the risers of these stairs"), locked=True)
             obj.setEditorMode("RiserHeight",1)
         if not "Nosing" in pl:
-            obj.addProperty("App::PropertyLength","Nosing","Steps",QT_TRANSLATE_NOOP("App::Property","The size of the nosing"))
+            obj.addProperty("App::PropertyLength","Nosing","Steps",QT_TRANSLATE_NOOP("App::Property","The size of the nosing"), locked=True)
         if not "TreadThickness" in pl:
-            obj.addProperty("App::PropertyLength","TreadThickness","Steps",QT_TRANSLATE_NOOP("App::Property","The thickness of the treads"))
+            obj.addProperty("App::PropertyLength","TreadThickness","Steps",QT_TRANSLATE_NOOP("App::Property","The thickness of the treads"), locked=True)
         if not "BlondelRatio" in pl:
-            obj.addProperty("App::PropertyFloat","BlondelRatio","Steps",QT_TRANSLATE_NOOP("App::Property","The Blondel ratio indicates comfortable stairs and should be between 62 and 64cm or 24.5 and 25.5in"))
+            obj.addProperty("App::PropertyFloat","BlondelRatio","Steps",QT_TRANSLATE_NOOP("App::Property","The Blondel ratio indicates comfortable stairs and should be between 62 and 64cm or 24.5 and 25.5in"), locked=True)
             obj.setEditorMode("BlondelRatio",1)
 
         if not "RiserThickness" in pl:
-            obj.addProperty("App::PropertyLength","RiserThickness","Steps",QT_TRANSLATE_NOOP("App::Property","The thickness of the risers"))
+            obj.addProperty("App::PropertyLength","RiserThickness","Steps",QT_TRANSLATE_NOOP("App::Property","The thickness of the risers"), locked=True)
 
         if not hasattr(obj,"LandingDepth"):
-            obj.addProperty("App::PropertyLength","LandingDepth","Steps",QT_TRANSLATE_NOOP("App::Property","The depth of the landing of these stairs"))
+            obj.addProperty("App::PropertyLength","LandingDepth","Steps",QT_TRANSLATE_NOOP("App::Property","The depth of the landing of these stairs"), locked=True)
 
         if not hasattr(obj,"TreadDepthEnforce"):
-            obj.addProperty("App::PropertyLength","TreadDepthEnforce","Steps",QT_TRANSLATE_NOOP("App::Property","The depth of the treads of these stairs - Enforced regardless of Length or edge's Length"))
+            obj.addProperty("App::PropertyLength","TreadDepthEnforce","Steps",QT_TRANSLATE_NOOP("App::Property","The depth of the treads of these stairs - Enforced regardless of Length or edge's Length"), locked=True)
         if not hasattr(obj,"RiserHeightEnforce"):
-            obj.addProperty("App::PropertyLength","RiserHeightEnforce","Steps",QT_TRANSLATE_NOOP("App::Property","The height of the risers of these stairs - Enforced regardless of Height or edge's Height"))
+            obj.addProperty("App::PropertyLength","RiserHeightEnforce","Steps",QT_TRANSLATE_NOOP("App::Property","The height of the risers of these stairs - Enforced regardless of Height or edge's Height"), locked=True)
 
         if not hasattr(obj,"Flight"):
-            obj.addProperty("App::PropertyEnumeration","Flight","Structure",QT_TRANSLATE_NOOP("App::Property","The direction of flight after landing"))
+            obj.addProperty("App::PropertyEnumeration","Flight","Structure",QT_TRANSLATE_NOOP("App::Property","The direction of flight after landing"), locked=True)
             obj.Flight = ["Straight","HalfTurnLeft","HalfTurnRight"]
 
         # Segment and Parts properties
         if not hasattr(obj,"LastSegment"):
-            obj.addProperty("App::PropertyLink","LastSegment","Segment and Parts","Last Segment (Flight or Landing) of Arch Stairs connecting to This Segment")
+            obj.addProperty("App::PropertyLink","LastSegment","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","Last Segment (Flight or Landing) of Arch Stairs connecting to This Segment"), locked=True)
         if not hasattr(obj,"AbsTop"):
-            obj.addProperty("App::PropertyVector","AbsTop","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'absolute' top level of a flight of stairs leads to"))
+            obj.addProperty("App::PropertyVector","AbsTop","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'absolute' top level of a flight of stairs leads to"), locked=True)
             obj.setEditorMode("AbsTop",1)
         if not hasattr(obj,"OutlineLeft"):
-            obj.addProperty("App::PropertyVectorList","OutlineLeft","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' of stairs")) # Used for Outline of Railing
+            obj.addProperty("App::PropertyVectorList","OutlineLeft","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' of stairs"), locked=True) # Used for Outline of Railing
             obj.setEditorMode("OutlineLeft",1)
         if not hasattr(obj,"OutlineRight"):
-            obj.addProperty("App::PropertyVectorList","OutlineRight","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' of stairs"))
+            obj.addProperty("App::PropertyVectorList","OutlineRight","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' of stairs"), locked=True)
             obj.setEditorMode("OutlineRight",1)
 
         # Can't accept 'None' in list, need NaN
         #if not hasattr(obj,"OutlineRailArcLeft"):
-            #obj.addProperty("App::PropertyVectorList","OutlineRailArcLeft","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' 'arc points' of stairs railing"))
+            #obj.addProperty("App::PropertyVectorList","OutlineRailArcLeft","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' 'arc points' of stairs railing"), locked=True)
             #obj.setEditorMode("OutlineRailArcLeft",1)
         #if not hasattr(obj,"OutlineRailArcRight"):
-            #obj.addProperty("App::PropertyVectorList","OutlineRailArcRight","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'right outline' 'arc points of stairs railing"))
+            #obj.addProperty("App::PropertyVectorList","OutlineRailArcRight","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'right outline' 'arc points of stairs railing"), locked=True)
             #obj.setEditorMode("OutlineRailArcRight",1)
         if not hasattr(self,"OutlineRailArcLeft"):
             self.OutlineRailArcLeft = []
@@ -150,23 +150,23 @@ class _Stairs(ArchComponent.Component):
             self.OutlineRailArcRight = []
 
         if not hasattr(obj,"RailingLeft"):
-            obj.addProperty("App::PropertyLinkHidden","RailingLeft","Segment and Parts","Name of Railing object (left) created")
+            obj.addProperty("App::PropertyLinkHidden","RailingLeft","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","Name of Railing object (left) created"), locked=True)
         if not hasattr(obj,"RailingRight"):
-            obj.addProperty("App::PropertyLinkHidden","RailingRight","Segment and Parts","Name of Railing object (right) created")
+            obj.addProperty("App::PropertyLinkHidden","RailingRight","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","Name of Railing object (right) created"), locked=True)
 
         if not hasattr(obj,"OutlineLeftAll"):
-            obj.addProperty("App::PropertyVectorList","OutlineLeftAll","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' of all segments of stairs"))
+            obj.addProperty("App::PropertyVectorList","OutlineLeftAll","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' of all segments of stairs"), locked=True)
             obj.setEditorMode("OutlineLeftAll",1) # Used for Outline of Railing
         if not hasattr(obj,"OutlineRightAll"):
-            obj.addProperty("App::PropertyVectorList","OutlineRightAll","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'right outline' of all segments of stairs"))
+            obj.addProperty("App::PropertyVectorList","OutlineRightAll","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'right outline' of all segments of stairs"), locked=True)
             obj.setEditorMode("OutlineRightAll",1)
 
         # Can't accept 'None' in list, need NaN
         #if not hasattr(obj,"OutlineRailArcLeftAll"):
-            #obj.addProperty("App::PropertyVectorList","OutlineRailArcLeftAll","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' 'arc points' of all segments of stairs railing"))
+            #obj.addProperty("App::PropertyVectorList","OutlineRailArcLeftAll","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' 'arc points' of all segments of stairs railing"), locked=True)
             #obj.setEditorMode("OutlineRailArcLeftAll",1) # Used for Outline of Railing
         #if not hasattr(obj,"OutlineRailArcRightAll"):
-            #obj.addProperty("App::PropertyVectorList","OutlineRailArcRightAll","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'right outline' 'arc points' of all segments of stairs railing"))
+            #obj.addProperty("App::PropertyVectorList","OutlineRailArcRightAll","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'right outline' 'arc points' of all segments of stairs railing"), locked=True)
             #obj.setEditorMode("OutlineRailArcRightAll",1)
         if not hasattr(self,"OutlineRailArcLeftAll"):
             self.OutlineRailArcLeftAll = []
@@ -174,41 +174,41 @@ class _Stairs(ArchComponent.Component):
             self.OutlineRailArcRightAll = []
 
         if not hasattr(obj,"RailingHeightLeft"):
-            obj.addProperty("App::PropertyLength","RailingHeightLeft","Segment and Parts","Height of Railing on Left hand side from Stairs or Landing ")
+            obj.addProperty("App::PropertyLength","RailingHeightLeft","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","Height of Railing on Left hand side from Stairs or Landing"), locked=True)
         if not hasattr(obj,"RailingHeightRight"):
-            obj.addProperty("App::PropertyLength","RailingHeightRight","Segment and Parts","Height of Railing on Right hand side from Stairs or Landing ")
+            obj.addProperty("App::PropertyLength","RailingHeightRight","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","Height of Railing on Right hand side from Stairs or Landing "), locked=True)
         if not hasattr(obj,"RailingOffsetLeft"):
-            obj.addProperty("App::PropertyLength","RailingOffsetLeft","Segment and Parts","Offset of Railing on Left hand side from stairs or landing Edge ")
+            obj.addProperty("App::PropertyLength","RailingOffsetLeft","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","Offset of Railing on Left hand side from stairs or landing Edge "), locked=True)
         if not hasattr(obj,"RailingOffsetRight"):
-            obj.addProperty("App::PropertyLength","RailingOffsetRight","Segment and Parts","Offset of Railing on Right hand side from stairs or landing Edge ")
+            obj.addProperty("App::PropertyLength","RailingOffsetRight","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","Offset of Railing on Right hand side from stairs or landing Edge "), locked=True)
 
         # structural properties
         if not "Landings" in pl:
-            obj.addProperty("App::PropertyEnumeration","Landings","Structure",QT_TRANSLATE_NOOP("App::Property","The type of landings of these stairs"))
+            obj.addProperty("App::PropertyEnumeration","Landings","Structure",QT_TRANSLATE_NOOP("App::Property","The type of landings of these stairs"), locked=True)
             obj.Landings = ["None","At center","At each corner"]
         if not "Winders" in pl:
-            obj.addProperty("App::PropertyEnumeration","Winders","Structure",QT_TRANSLATE_NOOP("App::Property","The type of winders in these stairs"))
+            obj.addProperty("App::PropertyEnumeration","Winders","Structure",QT_TRANSLATE_NOOP("App::Property","The type of winders in these stairs"), locked=True)
             obj.Winders = ["None","All","Corners strict","Corners relaxed"]
         if not "Structure" in pl:
-            obj.addProperty("App::PropertyEnumeration","Structure","Structure",QT_TRANSLATE_NOOP("App::Property","The type of structure of these stairs"))
+            obj.addProperty("App::PropertyEnumeration","Structure","Structure",QT_TRANSLATE_NOOP("App::Property","The type of structure of these stairs"), locked=True)
             obj.Structure = ["None","Massive","One stringer","Two stringers"]
         if not "StructureThickness" in pl:
-            obj.addProperty("App::PropertyLength","StructureThickness","Structure",QT_TRANSLATE_NOOP("App::Property","The thickness of the massive structure or of the stringers"))
+            obj.addProperty("App::PropertyLength","StructureThickness","Structure",QT_TRANSLATE_NOOP("App::Property","The thickness of the massive structure or of the stringers"), locked=True)
         if not "StringerWidth" in pl:
-            obj.addProperty("App::PropertyLength","StringerWidth","Structure",QT_TRANSLATE_NOOP("App::Property","The width of the stringers"))
+            obj.addProperty("App::PropertyLength","StringerWidth","Structure",QT_TRANSLATE_NOOP("App::Property","The width of the stringers"), locked=True)
         if not "StructureOffset" in pl:
-            obj.addProperty("App::PropertyLength","StructureOffset","Structure",QT_TRANSLATE_NOOP("App::Property","The offset between the border of the stairs and the structure"))
+            obj.addProperty("App::PropertyLength","StructureOffset","Structure",QT_TRANSLATE_NOOP("App::Property","The offset between the border of the stairs and the structure"), locked=True)
         if not "StringerOverlap" in pl:
-            obj.addProperty("App::PropertyLength","StringerOverlap","Structure",QT_TRANSLATE_NOOP("App::Property","The overlap of the stringers above the bottom of the treads"))
+            obj.addProperty("App::PropertyLength","StringerOverlap","Structure",QT_TRANSLATE_NOOP("App::Property","The overlap of the stringers above the bottom of the treads"), locked=True)
         if not "DownSlabThickness" in pl:
-            obj.addProperty("App::PropertyLength","DownSlabThickness","Structure",QT_TRANSLATE_NOOP("App::Property","The thickness of the lower floor slab"))
+            obj.addProperty("App::PropertyLength","DownSlabThickness","Structure",QT_TRANSLATE_NOOP("App::Property","The thickness of the lower floor slab"), locked=True)
         if not "UpSlabThickness" in pl:
-            obj.addProperty("App::PropertyLength","UpSlabThickness","Structure",QT_TRANSLATE_NOOP("App::Property","The thickness of the upper floor slab"))
+            obj.addProperty("App::PropertyLength","UpSlabThickness","Structure",QT_TRANSLATE_NOOP("App::Property","The thickness of the upper floor slab"), locked=True)
         if not "ConnectionDownStartStairs" in pl:
-            obj.addProperty("App::PropertyEnumeration","ConnectionDownStartStairs","Structure",QT_TRANSLATE_NOOP("App::Property","The type of connection between the lower floor slab and the start of the stairs"))
+            obj.addProperty("App::PropertyEnumeration","ConnectionDownStartStairs","Structure",QT_TRANSLATE_NOOP("App::Property","The type of connection between the lower floor slab and the start of the stairs"), locked=True)
             obj.ConnectionDownStartStairs = ["HorizontalCut","VerticalCut","HorizontalVerticalCut"]
         if not "ConnectionEndStairsUp" in pl:
-            obj.addProperty("App::PropertyEnumeration","ConnectionEndStairsUp","Structure",QT_TRANSLATE_NOOP("App::Property","The type of connection between the end of the stairs and the upper floor slab"))
+            obj.addProperty("App::PropertyEnumeration","ConnectionEndStairsUp","Structure",QT_TRANSLATE_NOOP("App::Property","The type of connection between the end of the stairs and the upper floor slab"), locked=True)
             obj.ConnectionEndStairsUp = ["toFlightThickness","toSlabThickness"]
 
         # additional stairs properties
@@ -1118,7 +1118,7 @@ class _Stairs(ArchComponent.Component):
         # TODO
         # Upgrade obj if it is from an older version of FreeCAD
         if not hasattr(obj, "StringerOverlap"):
-            obj.addProperty("App::PropertyLength","StringerOverlap","Structure",QT_TRANSLATE_NOOP("App::Property","The overlap of the stringers above the bottom of the treads"))
+            obj.addProperty("App::PropertyLength","StringerOverlap","Structure",QT_TRANSLATE_NOOP("App::Property","The overlap of the stringers above the bottom of the treads"), locked=True)
 
         # general data
         if not numberofsteps:

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -673,45 +673,45 @@ class _Structure(ArchComponent.Component):
 
         pl = obj.PropertiesList
         if not "Tool" in pl:
-            obj.addProperty("App::PropertyLinkSubList", "Tool", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "An optional extrusion path for this element"))
+            obj.addProperty("App::PropertyLinkSubList", "Tool", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "An optional extrusion path for this element"), locked=True)
         if not "ComputedLength" in pl:
-            obj.addProperty("App::PropertyDistance", "ComputedLength", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "The computed length of the extrusion path"), 1)
+            obj.addProperty("App::PropertyDistance", "ComputedLength", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "The computed length of the extrusion path"), 1, locked=True)
         if not "ToolOffsetFirst" in pl:
-            obj.addProperty("App::PropertyDistance", "ToolOffsetFirst", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "Start offset distance along the extrusion path (positive: extend, negative: trim)"))
+            obj.addProperty("App::PropertyDistance", "ToolOffsetFirst", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "Start offset distance along the extrusion path (positive: extend, negative: trim)"), locked=True)
         if not "ToolOffsetLast" in pl:
-            obj.addProperty("App::PropertyDistance", "ToolOffsetLast", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "End offset distance along the extrusion path (positive: extend, negative: trim)"))
+            obj.addProperty("App::PropertyDistance", "ToolOffsetLast", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "End offset distance along the extrusion path (positive: extend, negative: trim)"), locked=True)
         if not "BasePerpendicularToTool" in pl:
-            obj.addProperty("App::PropertyBool", "BasePerpendicularToTool", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "Automatically align the Base of the Structure perpendicular to the Tool axis"))
+            obj.addProperty("App::PropertyBool", "BasePerpendicularToTool", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "Automatically align the Base of the Structure perpendicular to the Tool axis"), locked=True)
         if not "BaseOffsetX" in pl:
-            obj.addProperty("App::PropertyDistance", "BaseOffsetX", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "X offset between the Base origin and the Tool axis (only used if BasePerpendicularToTool is True)"))
+            obj.addProperty("App::PropertyDistance", "BaseOffsetX", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "X offset between the Base origin and the Tool axis (only used if BasePerpendicularToTool is True)"), locked=True)
         if not "BaseOffsetY" in pl:
-            obj.addProperty("App::PropertyDistance", "BaseOffsetY", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "Y offset between the Base origin and the Tool axis (only used if BasePerpendicularToTool is True)"))
+            obj.addProperty("App::PropertyDistance", "BaseOffsetY", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "Y offset between the Base origin and the Tool axis (only used if BasePerpendicularToTool is True)"), locked=True)
         if not "BaseMirror" in pl:
-            obj.addProperty("App::PropertyBool", "BaseMirror", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "Mirror the Base along its Y axis (only used if BasePerpendicularToTool is True)"))
+            obj.addProperty("App::PropertyBool", "BaseMirror", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "Mirror the Base along its Y axis (only used if BasePerpendicularToTool is True)"), locked=True)
         if not "BaseRotation" in pl:
-            obj.addProperty("App::PropertyAngle", "BaseRotation", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "Base rotation around the Tool axis (only used if BasePerpendicularToTool is True)"))
+            obj.addProperty("App::PropertyAngle", "BaseRotation", "ExtrusionPath", QT_TRANSLATE_NOOP("App::Property", "Base rotation around the Tool axis (only used if BasePerpendicularToTool is True)"), locked=True)
         if not "Length" in pl:
-            obj.addProperty("App::PropertyLength","Length","Structure",QT_TRANSLATE_NOOP("App::Property","The length of this element, if not based on a profile"))
+            obj.addProperty("App::PropertyLength","Length","Structure",QT_TRANSLATE_NOOP("App::Property","The length of this element, if not based on a profile"), locked=True)
         if not "Width" in pl:
-            obj.addProperty("App::PropertyLength","Width","Structure",QT_TRANSLATE_NOOP("App::Property","The width of this element, if not based on a profile"))
+            obj.addProperty("App::PropertyLength","Width","Structure",QT_TRANSLATE_NOOP("App::Property","The width of this element, if not based on a profile"), locked=True)
         if not "Height" in pl:
-            obj.addProperty("App::PropertyLength","Height","Structure",QT_TRANSLATE_NOOP("App::Property","The height or extrusion depth of this element. Keep 0 for automatic"))
+            obj.addProperty("App::PropertyLength","Height","Structure",QT_TRANSLATE_NOOP("App::Property","The height or extrusion depth of this element. Keep 0 for automatic"), locked=True)
         if not "Normal" in pl:
-            obj.addProperty("App::PropertyVector","Normal","Structure",QT_TRANSLATE_NOOP("App::Property","The normal extrusion direction of this object (keep (0,0,0) for automatic normal)"))
+            obj.addProperty("App::PropertyVector","Normal","Structure",QT_TRANSLATE_NOOP("App::Property","The normal extrusion direction of this object (keep (0,0,0) for automatic normal)"), locked=True)
         if not "Nodes" in pl:
-            obj.addProperty("App::PropertyVectorList","Nodes","Structure",QT_TRANSLATE_NOOP("App::Property","The structural nodes of this element"))
+            obj.addProperty("App::PropertyVectorList","Nodes","Structure",QT_TRANSLATE_NOOP("App::Property","The structural nodes of this element"), locked=True)
         if not "Profile" in pl:
-            obj.addProperty("App::PropertyString","Profile","Structure",QT_TRANSLATE_NOOP("App::Property","A description of the standard profile this element is based upon"))
+            obj.addProperty("App::PropertyString","Profile","Structure",QT_TRANSLATE_NOOP("App::Property","A description of the standard profile this element is based upon"), locked=True)
         if not "NodesOffset" in pl:
-            obj.addProperty("App::PropertyDistance","NodesOffset","Structure",QT_TRANSLATE_NOOP("App::Property","Offset distance between the centerline and the nodes line"))
+            obj.addProperty("App::PropertyDistance","NodesOffset","Structure",QT_TRANSLATE_NOOP("App::Property","Offset distance between the centerline and the nodes line"), locked=True)
         if not "FaceMaker" in pl:
-            obj.addProperty("App::PropertyEnumeration","FaceMaker","Structure",QT_TRANSLATE_NOOP("App::Property","The facemaker type to use to build the profile of this object"))
+            obj.addProperty("App::PropertyEnumeration","FaceMaker","Structure",QT_TRANSLATE_NOOP("App::Property","The facemaker type to use to build the profile of this object"), locked=True)
             obj.FaceMaker = ["None","Simple","Cheese","Bullseye"]
         if not "ArchSketchData" in pl:
-            obj.addProperty("App::PropertyBool","ArchSketchData","Structure",QT_TRANSLATE_NOOP("App::Property","Use Base ArchSketch (if used) data (e.g. widths, aligns, offsets) instead of Wall's properties"))
+            obj.addProperty("App::PropertyBool","ArchSketchData","Structure",QT_TRANSLATE_NOOP("App::Property","Use Base ArchSketch (if used) data (e.g. widths, aligns, offsets) instead of Wall's properties"), locked=True)
             obj.ArchSketchData = True
         if not "ArchSketchEdges" in pl:  # PropertyStringList
-            obj.addProperty("App::PropertyStringList","ArchSketchEdges","Structure",QT_TRANSLATE_NOOP("App::Property","Selected edges (or group of edges) of the base ArchSketch, to use in creating the shape of this BIM Structure (instead of using all the Base shape's edges by default).  Input are index numbers of edges or groups."))
+            obj.addProperty("App::PropertyStringList","ArchSketchEdges","Structure",QT_TRANSLATE_NOOP("App::Property","Selected edges (or group of edges) of the base ArchSketch, to use in creating the shape of this BIM Structure (instead of using all the Base shape's edges by default).  Input are index numbers of edges or groups."), locked=True)
         else:
             # test if the property was added but as IntegerList, then update;
             type = obj.getTypeIdOfProperty('ArchSketchEdges')
@@ -719,10 +719,10 @@ class _Structure(ArchComponent.Component):
                 oldIntValue = obj.ArchSketchEdges
                 newStrValue = [str(x) for x in oldIntValue]
                 obj.removeProperty("ArchSketchEdges")
-                obj.addProperty("App::PropertyStringList","ArchSketchEdges","Structure",QT_TRANSLATE_NOOP("App::Property","Selected edges (or group of edges) of the base ArchSketch, to use in creating the shape of this BIM Structure (instead of using all the Base shape's edges by default).  Input are index numbers of edges or groups."))
+                obj.addProperty("App::PropertyStringList","ArchSketchEdges","Structure",QT_TRANSLATE_NOOP("App::Property","Selected edges (or group of edges) of the base ArchSketch, to use in creating the shape of this BIM Structure (instead of using all the Base shape's edges by default).  Input are index numbers of edges or groups."), locked=True)
                 obj.ArchSketchEdges = newStrValue
         if not hasattr(obj,"ArchSketchPropertySet"):
-            obj.addProperty("App::PropertyEnumeration","ArchSketchPropertySet","Structure",QT_TRANSLATE_NOOP("App::Property","Select User Defined PropertySet to use in creating variant shape, with same ArchSketch "))
+            obj.addProperty("App::PropertyEnumeration","ArchSketchPropertySet","Structure",QT_TRANSLATE_NOOP("App::Property","Select User Defined PropertySet to use in creating variant shape, with same ArchSketch "), locked=True)
             obj.ArchSketchPropertySet = ['Default']
         if not hasattr(self,"ArchSkPropSetPickedUuid"):
             self.ArchSkPropSetPickedUuid = ''
@@ -1186,17 +1186,17 @@ class _ViewProviderStructure(ArchComponent.ViewProviderComponent):
 
         pl = vobj.PropertiesList
         if not "ShowNodes" in pl:
-            vobj.addProperty("App::PropertyBool","ShowNodes","Nodes",QT_TRANSLATE_NOOP("App::Property","If the nodes are visible or not")).ShowNodes = False
+            vobj.addProperty("App::PropertyBool","ShowNodes","Nodes",QT_TRANSLATE_NOOP("App::Property","If the nodes are visible or not"), locked=True).ShowNodes = False
         if not "NodeLine" in pl:
-            vobj.addProperty("App::PropertyFloat","NodeLine","Nodes",QT_TRANSLATE_NOOP("App::Property","The width of the nodes line"))
+            vobj.addProperty("App::PropertyFloat","NodeLine","Nodes",QT_TRANSLATE_NOOP("App::Property","The width of the nodes line"), locked=True)
         if not "NodeSize" in pl:
-            vobj.addProperty("App::PropertyFloat","NodeSize","Nodes",QT_TRANSLATE_NOOP("App::Property","The size of the node points"))
+            vobj.addProperty("App::PropertyFloat","NodeSize","Nodes",QT_TRANSLATE_NOOP("App::Property","The size of the node points"), locked=True)
             vobj.NodeSize = 6
         if not "NodeColor" in pl:
-            vobj.addProperty("App::PropertyColor","NodeColor","Nodes",QT_TRANSLATE_NOOP("App::Property","The color of the nodes line"))
+            vobj.addProperty("App::PropertyColor","NodeColor","Nodes",QT_TRANSLATE_NOOP("App::Property","The color of the nodes line"), locked=True)
             vobj.NodeColor = (1.0,1.0,1.0,1.0)
         if not "NodeType" in pl:
-            vobj.addProperty("App::PropertyEnumeration","NodeType","Nodes",QT_TRANSLATE_NOOP("App::Property","The type of structural node"))
+            vobj.addProperty("App::PropertyEnumeration","NodeType","Nodes",QT_TRANSLATE_NOOP("App::Property","The type of structural node"), locked=True)
             vobj.NodeType = ["Linear","Area"]
 
     def onDocumentRestored(self,vobj):
@@ -1495,7 +1495,7 @@ class StructureTaskPanel(ArchComponent.ComponentTaskPanel):
         if self.Object.getTypeIdOfProperty("Tool") != "App::PropertyLinkSubList":
             # Upgrade property Tool from App::PropertyLink to App::PropertyLinkSubList (note: Undo/Redo fails)
             self.Object.removeProperty("Tool")
-            self.Object.addProperty("App::PropertyLinkSubList", "Tool", "Structure", QT_TRANSLATE_NOOP("App::Property", "An optional extrusion path for this element"))
+            self.Object.addProperty("App::PropertyLinkSubList", "Tool", "Structure", QT_TRANSLATE_NOOP("App::Property", "An optional extrusion path for this element"), locked=True)
         self.Object.Tool = objectList
         QtCore.QObject.disconnect(self.selectToolButton, QtCore.SIGNAL("clicked()"), self.setToolFromSelection)
         QtCore.QObject.connect(self.selectToolButton, QtCore.SIGNAL("clicked()"), self.setSelectionFromTool)
@@ -1530,9 +1530,9 @@ class _StructuralSystem(ArchComponent.Component): # OBSOLETE - All Arch objects 
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
-        obj.addProperty("App::PropertyLinkList","Axes","Arch",QT_TRANSLATE_NOOP("App::Property","Axes systems this structure is built on"))
-        obj.addProperty("App::PropertyIntegerList","Exclude","Arch",QT_TRANSLATE_NOOP("App::Property","The element numbers to exclude when this structure is based on axes"))
-        obj.addProperty("App::PropertyBool","Align","Arch",QT_TRANSLATE_NOOP("App::Property","If true the element are aligned with axes")).Align = False
+        obj.addProperty("App::PropertyLinkList","Axes","Arch",QT_TRANSLATE_NOOP("App::Property","Axes systems this structure is built on"), locked=True)
+        obj.addProperty("App::PropertyIntegerList","Exclude","Arch",QT_TRANSLATE_NOOP("App::Property","The element numbers to exclude when this structure is based on axes"), locked=True)
+        obj.addProperty("App::PropertyBool","Align","Arch",QT_TRANSLATE_NOOP("App::Property","If true the element are aligned with axes"), locked=True).Align = False
         self.Type = "StructuralSystem"
 
     def execute(self,obj):

--- a/src/Mod/BIM/ArchTruss.py
+++ b/src/Mod/BIM/ArchTruss.py
@@ -70,60 +70,60 @@ class Truss(ArchComponent.Component):
         pl = obj.PropertiesList
         if not "TrussAngle" in pl:
             obj.addProperty("App::PropertyAngle","TrussAngle","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","The angle of the truss"))
+                            QT_TRANSLATE_NOOP("App::Property","The angle of the truss"), locked=True)
             obj.setEditorMode("TrussAngle",1)
         if not "SlantType" in pl:
             obj.addProperty("App::PropertyEnumeration","SlantType","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","The slant type of this truss"))
+                            QT_TRANSLATE_NOOP("App::Property","The slant type of this truss"), locked=True)
             obj.SlantType = ["Simple","Double"]
         if not "Normal" in pl:
             obj.addProperty("App::PropertyVector","Normal","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","The normal direction of this truss"))
+                            QT_TRANSLATE_NOOP("App::Property","The normal direction of this truss"), locked=True)
             obj.Normal = FreeCAD.Vector(0,0,1)
         if not "HeightStart" in pl:
             obj.addProperty("App::PropertyLength","HeightStart","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","The height of the truss at the start position"))
+                            QT_TRANSLATE_NOOP("App::Property","The height of the truss at the start position"), locked=True)
             obj.HeightStart = 100
         if not "HeightEnd" in pl:
             obj.addProperty("App::PropertyLength","HeightEnd","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","The height of the truss at the end position"))
+                            QT_TRANSLATE_NOOP("App::Property","The height of the truss at the end position"), locked=True)
             obj.HeightEnd = 200
         if not "StrutStartOffset" in pl:
             obj.addProperty("App::PropertyDistance","StrutStartOffset","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","An optional start offset for the top strut"))
+                            QT_TRANSLATE_NOOP("App::Property","An optional start offset for the top strut"), locked=True)
         if not "StrutEndOffset" in pl:
             obj.addProperty("App::PropertyDistance","StrutEndOffset","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","An optional end offset for the top strut"))
+                            QT_TRANSLATE_NOOP("App::Property","An optional end offset for the top strut"), locked=True)
         if not "StrutHeight" in pl:
             obj.addProperty("App::PropertyLength","StrutHeight","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","The height of the main top and bottom elements of the truss"))
+                            QT_TRANSLATE_NOOP("App::Property","The height of the main top and bottom elements of the truss"), locked=True)
             obj.StrutHeight = 10
         if not "StrutWidth" in pl:
             obj.addProperty("App::PropertyLength","StrutWidth","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","The width of the main top and bottom elements of the truss"))
+                            QT_TRANSLATE_NOOP("App::Property","The width of the main top and bottom elements of the truss"), locked=True)
             obj.StrutWidth = 5
         if not "RodType" in pl:
             obj.addProperty("App::PropertyEnumeration","RodType","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","The type of the middle element of the truss"))
+                            QT_TRANSLATE_NOOP("App::Property","The type of the middle element of the truss"), locked=True)
             obj.RodType = ["Round","Square"]
         if not "RodDirection" in pl:
             obj.addProperty("App::PropertyEnumeration","RodDirection","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","The direction of the rods"))
+                            QT_TRANSLATE_NOOP("App::Property","The direction of the rods"), locked=True)
             obj.RodDirection = ["Forward","Backward"]
         if not "RodSize" in pl:
             obj.addProperty("App::PropertyLength","RodSize","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","The diameter or side of the rods"))
+                            QT_TRANSLATE_NOOP("App::Property","The diameter or side of the rods"), locked=True)
             obj.RodSize = 2
         if not "RodSections" in pl:
             obj.addProperty("App::PropertyInteger","RodSections","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","The number of rod sections"))
+                            QT_TRANSLATE_NOOP("App::Property","The number of rod sections"), locked=True)
             obj.RodSections = 3
         if not "RodEnd" in pl:
             obj.addProperty("App::PropertyBool","RodEnd","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","If the truss has a rod at its endpoint or not"))
+                            QT_TRANSLATE_NOOP("App::Property","If the truss has a rod at its endpoint or not"), locked=True)
         if not "RodMode" in pl:
             obj.addProperty("App::PropertyEnumeration","RodMode","Truss",
-                            QT_TRANSLATE_NOOP("App::Property","How to draw the rods"))
+                            QT_TRANSLATE_NOOP("App::Property","How to draw the rods"), locked=True)
             obj.RodMode = rodmodes
         self.Type = "Truss"
 

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -166,63 +166,63 @@ class _Wall(ArchComponent.Component):
 
         lp = obj.PropertiesList
         if not "Length" in lp:
-            obj.addProperty("App::PropertyLength","Length","Wall",QT_TRANSLATE_NOOP("App::Property","The length of this wall. Read-only if this wall is not based on an unconstrained sketch with a single edge, or on a Draft Wire with a single edge. Refer to wiki for details how length is deduced."))
+            obj.addProperty("App::PropertyLength","Length","Wall",QT_TRANSLATE_NOOP("App::Property","The length of this wall. Read-only if this wall is not based on an unconstrained sketch with a single edge, or on a Draft Wire with a single edge. Refer to wiki for details how length is deduced."), locked=True)
         if not "Width" in lp:
-            obj.addProperty("App::PropertyLength","Width","Wall",QT_TRANSLATE_NOOP("App::Property","The width of this wall. Not used if this wall is based on a face. Disabled and ignored if Base object (ArchSketch) provides the information."))
+            obj.addProperty("App::PropertyLength","Width","Wall",QT_TRANSLATE_NOOP("App::Property","The width of this wall. Not used if this wall is based on a face. Disabled and ignored if Base object (ArchSketch) provides the information."), locked=True)
 
         # To be combined into Width when PropertyLengthList is available
         if not "OverrideWidth" in lp:
-            obj.addProperty("App::PropertyFloatList","OverrideWidth","Wall",QT_TRANSLATE_NOOP("App::Property","This overrides Width attribute to set width of each segment of wall.  Disabled and ignored if Base object (ArchSketch) provides Widths information, with getWidths() method  (If a value is zero, the value of 'Width' will be followed).  [ENHANCEMENT by ArchSketch] GUI 'Edit Wall Segment Width' Tool is provided in external SketchArch Add-on to let users to set the values interactively.  'Toponaming-Tolerant' if ArchSketch is used in Base (and SketchArch Add-on is installed).  Warning : Not 'Toponaming-Tolerant' if just Sketch is used."))			# see DraftGeomUtils.offsetwire()
+            obj.addProperty("App::PropertyFloatList","OverrideWidth","Wall",QT_TRANSLATE_NOOP("App::Property","This overrides Width attribute to set width of each segment of wall.  Disabled and ignored if Base object (ArchSketch) provides Widths information, with getWidths() method  (If a value is zero, the value of 'Width' will be followed).  [ENHANCEMENT by ArchSketch] GUI 'Edit Wall Segment Width' Tool is provided in external SketchArch Add-on to let users to set the values interactively.  'Toponaming-Tolerant' if ArchSketch is used in Base (and SketchArch Add-on is installed).  Warning : Not 'Toponaming-Tolerant' if just Sketch is used."), locked=True)			# see DraftGeomUtils.offsetwire()
         if not "OverrideAlign" in lp:
-            obj.addProperty("App::PropertyStringList","OverrideAlign","Wall",QT_TRANSLATE_NOOP("App::Property","This overrides Align attribute to set align of each segment of wall.  Disabled and ignored if Base object (ArchSketch) provides Aligns information, with getAligns() method  (If a value is not 'Left, Right, Center', the value of 'Align' will be followed).  [ENHANCEMENT by ArchSketch] GUI 'Edit Wall Segment Align' Tool is provided in external SketchArch Add-on to let users to set the values interactively.  'Toponaming-Tolerant' if ArchSketch is used in Base (and SketchArch Add-on is installed).  Warning : Not 'Toponaming-Tolerant' if just Sketch is used."))			# see DraftGeomUtils.offsetwire()
+            obj.addProperty("App::PropertyStringList","OverrideAlign","Wall",QT_TRANSLATE_NOOP("App::Property","This overrides Align attribute to set align of each segment of wall.  Disabled and ignored if Base object (ArchSketch) provides Aligns information, with getAligns() method  (If a value is not 'Left, Right, Center', the value of 'Align' will be followed).  [ENHANCEMENT by ArchSketch] GUI 'Edit Wall Segment Align' Tool is provided in external SketchArch Add-on to let users to set the values interactively.  'Toponaming-Tolerant' if ArchSketch is used in Base (and SketchArch Add-on is installed).  Warning : Not 'Toponaming-Tolerant' if just Sketch is used."), locked=True)			# see DraftGeomUtils.offsetwire()
         if not "OverrideOffset" in lp:
-            obj.addProperty("App::PropertyFloatList","OverrideOffset","Wall",QT_TRANSLATE_NOOP("App::Property","This overrides Offset attribute to set offset of each segment of wall.  Disabled and ignored if Base object (ArchSketch) provides Offsets information, with getOffsets() method  (If a value is zero, the value of 'Offset' will be followed).  [ENHANCED by ArchSketch] GUI 'Edit Wall Segment Offset' Tool is provided in external Add-on ('SketchArch') to let users to select the edges interactively.  'Toponaming-Tolerant' if ArchSketch is used in Base (and SketchArch Add-on is installed).  Warning : Not 'Toponaming-Tolerant' if just Sketch is used. Property is ignored if Base ArchSketch provided the selected edges. "))			# see DraftGeomUtils.offsetwire()
+            obj.addProperty("App::PropertyFloatList","OverrideOffset","Wall",QT_TRANSLATE_NOOP("App::Property","This overrides Offset attribute to set offset of each segment of wall.  Disabled and ignored if Base object (ArchSketch) provides Offsets information, with getOffsets() method  (If a value is zero, the value of 'Offset' will be followed).  [ENHANCED by ArchSketch] GUI 'Edit Wall Segment Offset' Tool is provided in external Add-on ('SketchArch') to let users to select the edges interactively.  'Toponaming-Tolerant' if ArchSketch is used in Base (and SketchArch Add-on is installed).  Warning : Not 'Toponaming-Tolerant' if just Sketch is used. Property is ignored if Base ArchSketch provided the selected edges. "), locked=True)			# see DraftGeomUtils.offsetwire()
         if not "Height" in lp:
-            obj.addProperty("App::PropertyLength","Height","Wall",QT_TRANSLATE_NOOP("App::Property","The height of this wall. Keep 0 for automatic. Not used if this wall is based on a solid"))
+            obj.addProperty("App::PropertyLength","Height","Wall",QT_TRANSLATE_NOOP("App::Property","The height of this wall. Keep 0 for automatic. Not used if this wall is based on a solid"), locked=True)
         if not "Area" in lp:
-            obj.addProperty("App::PropertyArea","Area","Wall",QT_TRANSLATE_NOOP("App::Property","The area of this wall as a simple Height * Length calculation"))
+            obj.addProperty("App::PropertyArea","Area","Wall",QT_TRANSLATE_NOOP("App::Property","The area of this wall as a simple Height * Length calculation"), locked=True)
             obj.setEditorMode("Area",1)
         if not "Align" in lp:
-            obj.addProperty("App::PropertyEnumeration","Align","Wall",QT_TRANSLATE_NOOP("App::Property","The alignment of this wall on its base object, if applicable. Disabled and ignored if Base object (ArchSketch) provides the information."))
+            obj.addProperty("App::PropertyEnumeration","Align","Wall",QT_TRANSLATE_NOOP("App::Property","The alignment of this wall on its base object, if applicable. Disabled and ignored if Base object (ArchSketch) provides the information."), locked=True)
             obj.Align = ['Left','Right','Center']
         if not "Normal" in lp:
-            obj.addProperty("App::PropertyVector","Normal","Wall",QT_TRANSLATE_NOOP("App::Property","The normal extrusion direction of this object (keep (0,0,0) for automatic normal)"))
+            obj.addProperty("App::PropertyVector","Normal","Wall",QT_TRANSLATE_NOOP("App::Property","The normal extrusion direction of this object (keep (0,0,0) for automatic normal)"), locked=True)
         if not "Face" in lp:
-            obj.addProperty("App::PropertyInteger","Face","Wall",QT_TRANSLATE_NOOP("App::Property","The face number of the base object used to build this wall"))
+            obj.addProperty("App::PropertyInteger","Face","Wall",QT_TRANSLATE_NOOP("App::Property","The face number of the base object used to build this wall"), locked=True)
         if not "Offset" in lp:
-            obj.addProperty("App::PropertyDistance","Offset","Wall",QT_TRANSLATE_NOOP("App::Property","The offset between this wall and its baseline (only for left and right alignments). Disabled and ignored if Base object (ArchSketch) provides the information."))
+            obj.addProperty("App::PropertyDistance","Offset","Wall",QT_TRANSLATE_NOOP("App::Property","The offset between this wall and its baseline (only for left and right alignments). Disabled and ignored if Base object (ArchSketch) provides the information."), locked=True)
 
         # See getExtrusionData(), removeSplitters are no longer used
         #if not "Refine" in lp:
-        #    obj.addProperty("App::PropertyEnumeration","Refine","Wall",QT_TRANSLATE_NOOP("App::Property","Select whether or not and the method to remove splitter of the Wall. Currently Draft removeSplitter and Part removeSplitter available but may not work on complex sketch."))
+        #    obj.addProperty("App::PropertyEnumeration","Refine","Wall",QT_TRANSLATE_NOOP("App::Property","Select whether or not and the method to remove splitter of the Wall. Currently Draft removeSplitter and Part removeSplitter available but may not work on complex sketch."), locked=True)
         #    obj.Refine = ['No','DraftRemoveSplitter','PartRemoveSplitter']
         # TODO - To implement in Arch Component ?
 
         if not "MakeBlocks" in lp:
-            obj.addProperty("App::PropertyBool","MakeBlocks","Blocks",QT_TRANSLATE_NOOP("App::Property","Enable this to make the wall generate blocks"))
+            obj.addProperty("App::PropertyBool","MakeBlocks","Blocks",QT_TRANSLATE_NOOP("App::Property","Enable this to make the wall generate blocks"), locked=True)
         if not "BlockLength" in lp:
-            obj.addProperty("App::PropertyLength","BlockLength","Blocks",QT_TRANSLATE_NOOP("App::Property","The length of each block"))
+            obj.addProperty("App::PropertyLength","BlockLength","Blocks",QT_TRANSLATE_NOOP("App::Property","The length of each block"), locked=True)
         if not "BlockHeight" in lp:
-            obj.addProperty("App::PropertyLength","BlockHeight","Blocks",QT_TRANSLATE_NOOP("App::Property","The height of each block"))
+            obj.addProperty("App::PropertyLength","BlockHeight","Blocks",QT_TRANSLATE_NOOP("App::Property","The height of each block"), locked=True)
         if not "OffsetFirst" in lp:
-            obj.addProperty("App::PropertyLength","OffsetFirst","Blocks",QT_TRANSLATE_NOOP("App::Property","The horizontal offset of the first line of blocks"))
+            obj.addProperty("App::PropertyLength","OffsetFirst","Blocks",QT_TRANSLATE_NOOP("App::Property","The horizontal offset of the first line of blocks"), locked=True)
         if not "OffsetSecond" in lp:
-            obj.addProperty("App::PropertyLength","OffsetSecond","Blocks",QT_TRANSLATE_NOOP("App::Property","The horizontal offset of the second line of blocks"))
+            obj.addProperty("App::PropertyLength","OffsetSecond","Blocks",QT_TRANSLATE_NOOP("App::Property","The horizontal offset of the second line of blocks"), locked=True)
         if not "Joint" in lp:
-            obj.addProperty("App::PropertyLength","Joint","Blocks",QT_TRANSLATE_NOOP("App::Property","The size of the joints between each block"))
+            obj.addProperty("App::PropertyLength","Joint","Blocks",QT_TRANSLATE_NOOP("App::Property","The size of the joints between each block"), locked=True)
         if not "CountEntire" in lp:
-            obj.addProperty("App::PropertyInteger","CountEntire","Blocks",QT_TRANSLATE_NOOP("App::Property","The number of entire blocks"))
+            obj.addProperty("App::PropertyInteger","CountEntire","Blocks",QT_TRANSLATE_NOOP("App::Property","The number of entire blocks"), locked=True)
             obj.setEditorMode("CountEntire",1)
         if not "CountBroken" in lp:
-            obj.addProperty("App::PropertyInteger","CountBroken","Blocks",QT_TRANSLATE_NOOP("App::Property","The number of broken blocks"))
+            obj.addProperty("App::PropertyInteger","CountBroken","Blocks",QT_TRANSLATE_NOOP("App::Property","The number of broken blocks"), locked=True)
             obj.setEditorMode("CountBroken",1)
         if not "ArchSketchData" in lp:
-            obj.addProperty("App::PropertyBool","ArchSketchData","Wall",QT_TRANSLATE_NOOP("App::Property","Use Base ArchSketch (if used) data (e.g. widths, aligns, offsets) instead of Wall's properties"))
+            obj.addProperty("App::PropertyBool","ArchSketchData","Wall",QT_TRANSLATE_NOOP("App::Property","Use Base ArchSketch (if used) data (e.g. widths, aligns, offsets) instead of Wall's properties"), locked=True)
             obj.ArchSketchData = True
         if not "ArchSketchEdges" in lp:
-            obj.addProperty("App::PropertyStringList","ArchSketchEdges","Wall",QT_TRANSLATE_NOOP("App::Property","Selected edges (or group of edges) of the base Sketch/ArchSketch, to use in creating the shape of this Arch Wall (instead of using all the Base Sketch/ArchSketch's edges by default).  Input are index numbers of edges or groups.  Disabled and ignored if Base object (ArchSketch) provides selected edges (as Wall Axis) information, with getWallBaseShapeEdgesInfo() method.  [ENHANCEMENT by ArchSketch] GUI 'Edit Wall Segment' Tool is provided in external SketchArch Add-on to let users to (de)select the edges interactively.  'Toponaming-Tolerant' if ArchSketch is used in Base (and SketchArch Add-on is installed).  Warning : Not 'Toponaming-Tolerant' if just Sketch is used."))
+            obj.addProperty("App::PropertyStringList","ArchSketchEdges","Wall",QT_TRANSLATE_NOOP("App::Property","Selected edges (or group of edges) of the base Sketch/ArchSketch, to use in creating the shape of this Arch Wall (instead of using all the Base Sketch/ArchSketch's edges by default).  Input are index numbers of edges or groups.  Disabled and ignored if Base object (ArchSketch) provides selected edges (as Wall Axis) information, with getWallBaseShapeEdgesInfo() method.  [ENHANCEMENT by ArchSketch] GUI 'Edit Wall Segment' Tool is provided in external SketchArch Add-on to let users to (de)select the edges interactively.  'Toponaming-Tolerant' if ArchSketch is used in Base (and SketchArch Add-on is installed).  Warning : Not 'Toponaming-Tolerant' if just Sketch is used."), locked=True)
         if not hasattr(obj,"ArchSketchPropertySet"):
-            obj.addProperty("App::PropertyEnumeration","ArchSketchPropertySet","Wall",QT_TRANSLATE_NOOP("App::Property","Select User Defined PropertySet to use in creating variant shape, layers of the Arch Wall with same ArchSketch "))
+            obj.addProperty("App::PropertyEnumeration","ArchSketchPropertySet","Wall",QT_TRANSLATE_NOOP("App::Property","Select User Defined PropertySet to use in creating variant shape, layers of the Arch Wall with same ArchSketch "), locked=True)
             obj.ArchSketchPropertySet = ['Default']
         if not hasattr(self,"ArchSkPropSetPickedUuid"):  # 'obj.Proxy', 'self' not works ?
             self.ArchSkPropSetPickedUuid = ''

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -125,41 +125,41 @@ class _Window(ArchComponent.Component):
 
         lp = obj.PropertiesList
         if not "Hosts" in lp:
-            obj.addProperty("App::PropertyLinkList","Hosts","Window",QT_TRANSLATE_NOOP("App::Property","The objects that host this window"))
+            obj.addProperty("App::PropertyLinkList","Hosts","Window",QT_TRANSLATE_NOOP("App::Property","The objects that host this window"), locked=True)
         if not "WindowParts" in lp:
-            obj.addProperty("App::PropertyStringList","WindowParts","Window",QT_TRANSLATE_NOOP("App::Property","The components of this window"))
+            obj.addProperty("App::PropertyStringList","WindowParts","Window",QT_TRANSLATE_NOOP("App::Property","The components of this window"), locked=True)
             obj.setEditorMode("WindowParts",2)
         if not "HoleDepth" in lp:
-            obj.addProperty("App::PropertyLength","HoleDepth","Window",QT_TRANSLATE_NOOP("App::Property","The depth of the hole that this window makes in its host object. If 0, the value will be calculated automatically."))
+            obj.addProperty("App::PropertyLength","HoleDepth","Window",QT_TRANSLATE_NOOP("App::Property","The depth of the hole that this window makes in its host object. If 0, the value will be calculated automatically."), locked=True)
         if not "Subvolume" in lp:
-            obj.addProperty("App::PropertyLink","Subvolume","Window",QT_TRANSLATE_NOOP("App::Property","An optional object that defines a volume to be subtracted from hosts of this window"))
+            obj.addProperty("App::PropertyLink","Subvolume","Window",QT_TRANSLATE_NOOP("App::Property","An optional object that defines a volume to be subtracted from hosts of this window"), locked=True)
         if not "Width" in lp:
-            obj.addProperty("App::PropertyLength","Width","Window",QT_TRANSLATE_NOOP("App::Property","The width of this window"))
+            obj.addProperty("App::PropertyLength","Width","Window",QT_TRANSLATE_NOOP("App::Property","The width of this window"), locked=True)
         if not "Height" in lp:
-            obj.addProperty("App::PropertyLength","Height","Window",QT_TRANSLATE_NOOP("App::Property","The height of this window"))
+            obj.addProperty("App::PropertyLength","Height","Window",QT_TRANSLATE_NOOP("App::Property","The height of this window"), locked=True)
         if not "Normal" in lp:
-            obj.addProperty("App::PropertyVector","Normal","Window",QT_TRANSLATE_NOOP("App::Property","The normal direction of this window"))
+            obj.addProperty("App::PropertyVector","Normal","Window",QT_TRANSLATE_NOOP("App::Property","The normal direction of this window"), locked=True)
         if not "Preset" in lp:
-            obj.addProperty("App::PropertyInteger","Preset","Window",QT_TRANSLATE_NOOP("App::Property","The preset number this window is based on"))
+            obj.addProperty("App::PropertyInteger","Preset","Window",QT_TRANSLATE_NOOP("App::Property","The preset number this window is based on"), locked=True)
             obj.setEditorMode("Preset",2)
         if not "Frame" in lp:
-            obj.addProperty("App::PropertyLength","Frame","Window",QT_TRANSLATE_NOOP("App::Property","The frame size of this window"))
+            obj.addProperty("App::PropertyLength","Frame","Window",QT_TRANSLATE_NOOP("App::Property","The frame size of this window"), locked=True)
         if not "Offset" in lp:
-            obj.addProperty("App::PropertyLength","Offset","Window",QT_TRANSLATE_NOOP("App::Property","The offset size of this window"))
+            obj.addProperty("App::PropertyLength","Offset","Window",QT_TRANSLATE_NOOP("App::Property","The offset size of this window"), locked=True)
         if not "Area" in lp:
-            obj.addProperty("App::PropertyArea","Area","Window",QT_TRANSLATE_NOOP("App::Property","The area of this window"))
+            obj.addProperty("App::PropertyArea","Area","Window",QT_TRANSLATE_NOOP("App::Property","The area of this window"), locked=True)
         if not "LouvreWidth" in lp:
-            obj.addProperty("App::PropertyLength","LouvreWidth","Window",QT_TRANSLATE_NOOP("App::Property","The width of louvre elements"))
+            obj.addProperty("App::PropertyLength","LouvreWidth","Window",QT_TRANSLATE_NOOP("App::Property","The width of louvre elements"), locked=True)
         if not "LouvreSpacing" in lp:
-            obj.addProperty("App::PropertyLength","LouvreSpacing","Window",QT_TRANSLATE_NOOP("App::Property","The space between louvre elements"))
+            obj.addProperty("App::PropertyLength","LouvreSpacing","Window",QT_TRANSLATE_NOOP("App::Property","The space between louvre elements"), locked=True)
         if not "Opening" in lp:
-            obj.addProperty("App::PropertyPercent","Opening","Window",QT_TRANSLATE_NOOP("App::Property","Opens the subcomponents that have a hinge defined"))
+            obj.addProperty("App::PropertyPercent","Opening","Window",QT_TRANSLATE_NOOP("App::Property","Opens the subcomponents that have a hinge defined"), locked=True)
         if not "HoleWire" in lp:
-            obj.addProperty("App::PropertyInteger","HoleWire","Window",QT_TRANSLATE_NOOP("App::Property","The number of the wire that defines the hole. If 0, the value will be calculated automatically"))
+            obj.addProperty("App::PropertyInteger","HoleWire","Window",QT_TRANSLATE_NOOP("App::Property","The number of the wire that defines the hole. If 0, the value will be calculated automatically"), locked=True)
         if not "SymbolPlan" in lp:
-            obj.addProperty("App::PropertyBool","SymbolPlan","Window",QT_TRANSLATE_NOOP("App::Property","Shows plan opening symbols if available"))
+            obj.addProperty("App::PropertyBool","SymbolPlan","Window",QT_TRANSLATE_NOOP("App::Property","Shows plan opening symbols if available"), locked=True)
         if not "SymbolElevation" in lp:
-            obj.addProperty("App::PropertyBool","SymbolElevation","Window",QT_TRANSLATE_NOOP("App::Property","Show elevation opening symbols if available"))
+            obj.addProperty("App::PropertyBool","SymbolElevation","Window",QT_TRANSLATE_NOOP("App::Property","Show elevation opening symbols if available"), locked=True)
         obj.setEditorMode("VerticalArea",2)
         obj.setEditorMode("HorizontalArea",2)
         obj.setEditorMode("PerimeterLength",2)
@@ -1130,7 +1130,7 @@ class _ArchWindowTaskPanel:
             val = int(val)
             if self.obj:
                 if not hasattr(self.obj,"HoleWire"):
-                    self.obj.addProperty("App::PropertyInteger","HoleWire","Arch",QT_TRANSLATE_NOOP("App::Property","The number of the wire that defines the hole. A value of 0 means automatic"))
+                    self.obj.addProperty("App::PropertyInteger","HoleWire","Arch",QT_TRANSLATE_NOOP("App::Property","The number of the wire that defines the hole. A value of 0 means automatic"), locked=True)
                 self.obj.HoleWire = val
 
     def getIcon(self,obj):

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -605,7 +605,7 @@ class BIM_Classification:
                                     obj.StandardCode = code
                             elif hasattr(obj, "IfcClass"):
                                 if not "Classification" in obj.PropertiesList:
-                                    obj.addProperty("App::PropertyString", "Classification", "IFC")
+                                    obj.addProperty("App::PropertyString", "Classification", "IFC", locked=True)
                                 if code != obj.Classification:
                                     if not changed:
                                         FreeCAD.ActiveDocument.openTransaction(
@@ -634,7 +634,7 @@ class BIM_Classification:
                     self.isEditing.StandardCode = code
                 else:
                     if not "Classification" in self.isEditing.PropertiesList:
-                        self.isEditing.addProperty("App::PropertyString", "Classification", "IFC")
+                        self.isEditing.addProperty("App::PropertyString", "Classification", "IFC", locked=True)
                     self.isEditing.Classification = code
                 if hasattr(self.isEditing.ViewObject, "Proxy") and hasattr(
                     self.isEditing.ViewObject.Proxy, "setTaskValue"

--- a/src/Mod/BIM/bimcommands/BimIfcProperties.py
+++ b/src/Mod/BIM/bimcommands/BimIfcProperties.py
@@ -415,6 +415,7 @@ class BIM_IfcProperties:
                             QT_TRANSLATE_NOOP(
                                 "App::Property", "IFC properties of this object"
                             ),
+                            locked=True,
                         )
                     if hasattr(obj, "IfcProperties"):
                         obj.IfcProperties = values[1]

--- a/src/Mod/BIM/bimcommands/BimIfcQuantities.py
+++ b/src/Mod/BIM/bimcommands/BimIfcQuantities.py
@@ -210,7 +210,7 @@ class BIM_IfcQuantities:
             qname = val[i]
             qtype = QTO_TYPES[val[i+1]]
             if not qname in obj.PropertiesList:
-                obj.addProperty(qtype, qname, "Quantities", val[i+1])
+                obj.addProperty(qtype, qname, "Quantities", val[i+1], locked=True)
                 qval = 0
                 i = self.get_row(obj.Name)
                 if i > -1:

--- a/src/Mod/BIM/bimcommands/BimLayers.py
+++ b/src/Mod/BIM/bimcommands/BimLayers.py
@@ -171,7 +171,7 @@ class BIM_Layers:
                     obj = Draft.make_layer(self.model.item(row, 1).text())
                     # By default BIM layers should not swallow their children otherwise
                     # they will disappear from the tree root
-                    obj.ViewObject.addProperty("App::PropertyBool", "HideChildren", "Layer")
+                    obj.ViewObject.addProperty("App::PropertyBool", "HideChildren", "Layer", locked=True)
                     obj.ViewObject.HideChildren = True
                 else:
                     from nativeifc import ifc_tools

--- a/src/Mod/BIM/importers/importIFC.py
+++ b/src/Mod/BIM/importers/importIFC.py
@@ -823,7 +823,7 @@ def insert(srcfile, docname, skip=[], only=[], root=None, preferences=None):
                         # fix property type if needed
 
                         obj.removeProperty("IfcProperties")
-                        obj.addProperty("App::PropertyLink","IfcProperties","Component","Stores IFC properties as a spreadsheet")
+                        obj.addProperty("App::PropertyLink","IfcProperties","Component","Stores IFC properties as a spreadsheet", locked=True)
 
                     ifc_spreadsheet = Arch.makeIfcSpreadsheet()
                     n = 2

--- a/src/Mod/BIM/importers/importSH3DHelper.py
+++ b/src/Mod/BIM/importers/importSH3DHelper.py
@@ -471,7 +471,7 @@ class SH3DImporter:
             description (str): a short description of the property to add
         """
         if name not in obj.PropertiesList:
-            obj.addProperty(property_type, name, group, description)
+            obj.addProperty(property_type, name, group, description, locked=True)
 
     def add_fc_objects(self, obj):
         """Register `obj`.

--- a/src/Mod/BIM/nativeifc/ifc_classification.py
+++ b/src/Mod/BIM/nativeifc/ifc_classification.py
@@ -99,7 +99,7 @@ def show_classification(obj):
             for rel in ref.ClassificationRefForObjects:
                 if element in rel.RelatedObjects:
                     if not "Classification" in obj.PropertiesList:
-                        obj.addProperty("App::PropertyString", "Classification", "IFC")
+                        obj.addProperty("App::PropertyString", "Classification", "IFC", locked=True)
                     sname = system.Name
                     cname = ref.Name or ref.Identification
                     obj.Classification = sname + " " + cname

--- a/src/Mod/BIM/nativeifc/ifc_geometry.py
+++ b/src/Mod/BIM/nativeifc/ifc_geometry.py
@@ -49,12 +49,12 @@ def add_geom_properties(obj):
                     ext = rep.Items[0]
                     if "ExtrusionDepth" not in obj.PropertiesList:
                         obj.addProperty(
-                            "App::PropertyLength", "ExtrusionDepth", "Geometry"
+                            "App::PropertyLength", "ExtrusionDepth", "Geometry", locked=True
                         )
                     obj.ExtrusionDepth = ext.Depth * scaling
                     if "ExtrusionDirection" not in obj.PropertiesList:
                         obj.addProperty(
-                            "App::PropertyVector", "ExtrusionDirection", "Geometry"
+                            "App::PropertyVector", "ExtrusionDirection", "Geometry", locked=True
                         )
                     obj.ExtrusionDirection = FreeCAD.Vector(
                         ext.ExtrudedDirection.DirectionRatios
@@ -64,12 +64,12 @@ def add_geom_properties(obj):
                     if ext.SweptArea.is_a("IfcRectangleProfileDef"):
                         if "RectangleLength" not in obj.PropertiesList:
                             obj.addProperty(
-                                "App::PropertyLength", "RectangleLength", "Geometry"
+                                "App::PropertyLength", "RectangleLength", "Geometry", locked=True
                             )
                         obj.RectangleLength = ext.SweptArea.XDim * scaling
                         if "RectangleWidth" not in obj.PropertiesList:
                             obj.addProperty(
-                                "App::PropertyLength", "RectangleWidth", "Geometry"
+                                "App::PropertyLength", "RectangleWidth", "Geometry", locked=True
                             )
                         obj.RectangleWidth = ext.SweptArea.YDim * scaling
 
@@ -81,6 +81,7 @@ def add_geom_properties(obj):
                                     "App::PropertyVectorList",
                                     "PolylinePoints",
                                     "Geometry",
+                                    locked=True,
                                 )
                             points = [
                                 p.Coordinates for p in ext.SweptArea.OuterCurve.Points
@@ -103,14 +104,14 @@ def add_geom_properties(obj):
                             "WebThickness",
                         ]:
                             if hasattr(ext.SweptArea, p):
-                                obj.addProperty("App::PropertyLength", p, "Geometry")
+                                obj.addProperty("App::PropertyLength", p, "Geometry", locked=True)
                                 value = getattr(ext.SweptArea, p)
                                 if not value:
                                     value = 0
                                 value = value * scaling
                                 setattr(obj, p, value)
                             obj.addProperty(
-                                "App::PropertyString", "ProfileName", "Geometry"
+                                "App::PropertyString", "ProfileName", "Geometry", locked=True
                             )
                             obj.ProfileName = ext.SweptArea.ProfileName
 
@@ -129,6 +130,7 @@ def add_geom_properties(obj):
                                             "App::PropertyPosition",
                                             "AxisStart",
                                             "Geometry",
+                                            locked=True,
                                         )
                                     obj.AxisStart = FreeCAD.Vector(
                                         pol.Points[0].Coordinates
@@ -138,6 +140,7 @@ def add_geom_properties(obj):
                                             "App::PropertyPosition",
                                             "AxisEnd",
                                             "Geometry",
+                                            locked=True,
                                         )
                                     obj.AxisEnd = FreeCAD.Vector(
                                         pol.Points[1].Coordinates

--- a/src/Mod/BIM/nativeifc/ifc_materials.py
+++ b/src/Mod/BIM/nativeifc/ifc_materials.py
@@ -72,7 +72,7 @@ def show_material(obj):
     if not material:
         return
     if not hasattr(obj, "Material"):
-        obj.addProperty("App::PropertyLink", "Material", "IFC")
+        obj.addProperty("App::PropertyLink", "Material", "IFC", locked=True)
     project = ifc_tools.get_project(obj)
     matobj = create_material(material, project, recursive=True)
     obj.Material = matobj

--- a/src/Mod/BIM/nativeifc/ifc_psets.py
+++ b/src/Mod/BIM/nativeifc/ifc_psets.py
@@ -166,7 +166,7 @@ def show_psets(obj):
                         value = [value]
                 else:
                     print(pname, gname, obj.PropertiesList)
-                    obj.addProperty(ftype, pname, gname, ttip)
+                    obj.addProperty(ftype, pname, gname, ttip, locked=True)
             if pname in obj.PropertiesList:
                 setattr(obj, pname, value)
 

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -138,7 +138,7 @@ def convert_document(document, filename=None, shapemode=0, strategy=0, silent=Fa
     """
 
     if "Proxy" not in document.PropertiesList:
-        document.addProperty("App::PropertyPythonObject", "Proxy")
+        document.addProperty("App::PropertyPythonObject", "Proxy", locked=True)
     document.setPropertyStatus("Proxy", "Transient")
     document.Proxy = ifc_objects.document_object()
     ifcfile, project, full = setup_project(document, filename, shapemode, silent)
@@ -165,9 +165,9 @@ def setup_project(proj, filename, shapemode, silent):
     full = False
     d = "The path to the linked IFC file"
     if "IfcFilePath" not in proj.PropertiesList:
-        proj.addProperty("App::PropertyFile", "IfcFilePath", "Base", d)
+        proj.addProperty("App::PropertyFile", "IfcFilePath", "Base", d, locked=True)
     if "Modified" not in proj.PropertiesList:
-        proj.addProperty("App::PropertyBool", "Modified", "Base")
+        proj.addProperty("App::PropertyBool", "Modified", "Base", locked=True)
     proj.setPropertyStatus("Modified", "Hidden")
     if filename:
         # opening existing file
@@ -185,7 +185,7 @@ def setup_project(proj, filename, shapemode, silent):
     proj.Proxy.ifcfile = ifcfile
     add_properties(proj, ifcfile, project, shapemode=shapemode)
     if "Schema" not in proj.PropertiesList:
-        proj.addProperty("App::PropertyEnumeration", "Schema", "Base")
+        proj.addProperty("App::PropertyEnumeration", "Schema", "Base", locked=True)
     # bug in FreeCAD - to avoid a crash, pre-populate the enum with one value
     proj.Schema = [ifcfile.wrapped_data.schema_name()]
     proj.Schema = ifcfile.wrapped_data.schema_name()
@@ -564,7 +564,7 @@ def add_object(document, otype=None, oname="IfcObject"):
         obj = document.addObject("App::FeaturePython", oname, proxy, None, False)
         if obj.ViewObject:
             view_layer.ViewProviderLayer(obj.ViewObject)
-            obj.ViewObject.addProperty("App::PropertyBool", "HideChildren", "Layer")
+            obj.ViewObject.addProperty("App::PropertyBool", "HideChildren", "Layer", locked=True)
             obj.ViewObject.HideChildren = True
     elif otype == "group":
         vproxy = ifc_viewproviders.ifc_vp_group()
@@ -610,9 +610,9 @@ def add_properties(
     else:
         obj.Label = "_" + ifcentity.is_a()
     if isinstance(obj, FreeCAD.DocumentObject) and "Group" not in obj.PropertiesList:
-        obj.addProperty("App::PropertyLinkList", "Group", "Base")
+        obj.addProperty("App::PropertyLinkList", "Group", "Base", locked=True)
     if "ShapeMode" not in obj.PropertiesList:
-        obj.addProperty("App::PropertyEnumeration", "ShapeMode", "Base")
+        obj.addProperty("App::PropertyEnumeration", "ShapeMode", "Base", locked=True)
         shapemodes = [
             "Shape",
             "Coin",
@@ -625,7 +625,7 @@ def add_properties(
         if not obj.isDerivedFrom("Part::Feature"):
             obj.setPropertyStatus("ShapeMode", "Hidden")
     if ifcentity.is_a("IfcProduct"):
-        obj.addProperty("App::PropertyLink", "Type", "IFC")
+        obj.addProperty("App::PropertyLink", "Type", "IFC", locked=True)
     attr_defs = ifcentity.wrapped_data.declaration().as_entity().all_attributes()
     try:
         info_ifcentity = ifcentity.get_info()
@@ -650,7 +650,7 @@ def add_properties(
         if attr == "Class":
             # main enum property, not saved to file
             if attr not in obj.PropertiesList:
-                obj.addProperty("App::PropertyEnumeration", attr, "IFC")
+                obj.addProperty("App::PropertyEnumeration", attr, "IFC", locked=True)
                 obj.setPropertyStatus(attr, "Transient")
             # to avoid bug/crash: we populate first the property with only the
             # class, then we add the sibling classes
@@ -659,7 +659,7 @@ def add_properties(
             setattr(obj, attr, get_ifc_classes(obj, value))
             # companion hidden propertym that gets saved to file
             if "IfcClass" not in obj.PropertiesList:
-                obj.addProperty("App::PropertyString", "IfcClass", "IFC")
+                obj.addProperty("App::PropertyString", "IfcClass", "IFC", locked=True)
                 obj.setPropertyStatus("IfcClass", "Hidden")
             setattr(obj, "IfcClass", value)
         elif attr_def and "IfcLengthMeasure" in str(attr_def.type_of_attribute()):
@@ -668,17 +668,17 @@ def add_properties(
                 setattr(obj, attr, value * (1 / get_scale(ifcfile)))
         elif isinstance(value, int):
             if attr not in obj.PropertiesList:
-                obj.addProperty("App::PropertyInteger", attr, "IFC")
+                obj.addProperty("App::PropertyInteger", attr, "IFC", locked=True)
                 if attr == "StepId":
                     obj.setPropertyStatus(attr, "ReadOnly")
             setattr(obj, attr, value)
         elif isinstance(value, float):
             if attr not in obj.PropertiesList:
-                obj.addProperty("App::PropertyFloat", attr, "IFC")
+                obj.addProperty("App::PropertyFloat", attr, "IFC", locked=True)
             setattr(obj, attr, value)
         elif data_type == "boolean":
             if attr not in obj.PropertiesList:
-                obj.addProperty("App::PropertyBool", attr, "IFC")
+                obj.addProperty("App::PropertyBool", attr, "IFC", locked=True)
             if not value or value in ["UNKNOWN", "FALSE"]:
                 value = False
             elif not isinstance(value, bool):
@@ -688,15 +688,15 @@ def add_properties(
         elif isinstance(value, ifcopenshell.entity_instance):
             if links:
                 if attr not in obj.PropertiesList:
-                    obj.addProperty("App::PropertyLink", attr, "IFC")
+                    obj.addProperty("App::PropertyLink", attr, "IFC", locked=True)
         elif isinstance(value, (list, tuple)) and value:
             if isinstance(value[0], ifcopenshell.entity_instance):
                 if links:
                     if attr not in obj.PropertiesList:
-                        obj.addProperty("App::PropertyLinkList", attr, "IFC")
+                        obj.addProperty("App::PropertyLinkList", attr, "IFC", locked=True)
         elif data_type == "enum":
             if attr not in obj.PropertiesList:
-                obj.addProperty("App::PropertyEnumeration", attr, "IFC")
+                obj.addProperty("App::PropertyEnumeration", attr, "IFC", locked=True)
             items = ifcopenshell.util.attribute.get_enum_items(attr_def)
             if value not in items:
                 for v in ("UNDEFINED", "NOTDEFINED", "USERDEFINED"):
@@ -711,14 +711,14 @@ def add_properties(
                 setattr(obj, attr, value)
                 setattr(obj, attr, items)
         elif attr in ["RefLongitude", "RefLatitude"]:
-            obj.addProperty("App::PropertyFloat", attr, "IFC")
+            obj.addProperty("App::PropertyFloat", attr, "IFC", locked=True)
             if value is not None:
                 # convert from list of 4 ints
                 value = value[0] + value[1]/60. + value[2]/3600. + value[3]/3600.e6
                 setattr(obj, attr, value)
         else:
             if attr not in obj.PropertiesList:
-                obj.addProperty("App::PropertyString", attr, "IFC")
+                obj.addProperty("App::PropertyString", attr, "IFC", locked=True)
             if value is not None:
                 setattr(obj, attr, str(value))
     # annotation properties
@@ -726,14 +726,14 @@ def add_properties(
         axisdata = ifc_export.get_axis(ifcentity)
         if axisdata:
             if "Placement" not in obj.PropertiesList:
-                obj.addProperty("App::PropertyPlacement", "Placement", "Base")
+                obj.addProperty("App::PropertyPlacement", "Placement", "Base", locked=True)
             if "CustomText" in obj.PropertiesList:
                 obj.setPropertyStatus("CustomText", "Hidden")
                 obj.setExpression("CustomText", "AxisTag")
             if "Length" not in obj.PropertiesList:
-                obj.addProperty("App::PropertyLength","Length","Axis")
+                obj.addProperty("App::PropertyLength","Length","Axis", locked=True)
             if "Text" not in obj.PropertiesList:
-                obj.addProperty("App::PropertyStringList", "Text", "Base")
+                obj.addProperty("App::PropertyStringList", "Text", "Base", locked=True)
             obj.Text = [text.Literal]
             obj.Placement = ifc_export.get_placement(ifcentity.ObjectPlacement, ifcfile)
             obj.Length = axisdata[1]
@@ -741,18 +741,18 @@ def add_properties(
         sectionplane = ifc_export.get_sectionplane(ifcentity)
         if sectionplane:
             if "Placement" not in obj.PropertiesList:
-                obj.addProperty("App::PropertyPlacement", "Placement", "Base")
+                obj.addProperty("App::PropertyPlacement", "Placement", "Base", locked=True)
             if "Depth" not in obj.PropertiesList:
-                obj.addProperty("App::PropertyLength","Depth","SectionPlane")
+                obj.addProperty("App::PropertyLength","Depth","SectionPlane", locked=True)
             obj.Placement = sectionplane[0]
             if len(sectionplane) > 3:
                 obj.Depth = sectionplane[3]
             vobj = obj.ViewObject
             if vobj:
                 if "DisplayLength" not in vobj.PropertiesList:
-                    vobj.addProperty("App::PropertyLength","DisplayLength","SectionPlane")
+                    vobj.addProperty("App::PropertyLength","DisplayLength","SectionPlane", locked=True)
                 if "DisplayHeight" not in vobj.PropertiesList:
-                    vobj.addProperty("App::PropertyLength","DisplayHeight","SectionPlane")
+                    vobj.addProperty("App::PropertyLength","DisplayHeight","SectionPlane", locked=True)
                 if len(sectionplane) > 1:
                     vobj.DisplayLength = sectionplane[1]
                 if len(sectionplane) > 2:
@@ -761,11 +761,11 @@ def add_properties(
             dim = ifc_export.get_dimension(ifcentity)
             if dim and len(dim) >= 3:
                 if "Start" not in obj.PropertiesList:
-                    obj.addProperty("App::PropertyVectorDistance", "Start", "Base")
+                    obj.addProperty("App::PropertyVectorDistance", "Start", "Base", locked=True)
                 if "End" not in obj.PropertiesList:
-                    obj.addProperty("App::PropertyVectorDistance", "End", "Base")
+                    obj.addProperty("App::PropertyVectorDistance", "End", "Base", locked=True)
                 if "Dimline" not in obj.PropertiesList:
-                    obj.addProperty("App::PropertyVectorDistance", "Dimline", "Base")
+                    obj.addProperty("App::PropertyVectorDistance", "Dimline", "Base", locked=True)
                 obj.Start = dim[1]
                 obj.End = dim[2]
                 if len(dim) > 3:
@@ -778,9 +778,9 @@ def add_properties(
                 text = ifc_export.get_text(ifcentity)
                 if text:
                     if "Placement" not in obj.PropertiesList:
-                        obj.addProperty("App::PropertyPlacement", "Placement", "Base")
+                        obj.addProperty("App::PropertyPlacement", "Placement", "Base", locked=True)
                     if "Text" not in obj.PropertiesList:
-                        obj.addProperty("App::PropertyStringList", "Text", "Base")
+                        obj.addProperty("App::PropertyStringList", "Text", "Base", locked=True)
                     obj.Text = [text.Literal]
                     obj.Placement = ifc_export.get_placement(ifcentity.ObjectPlacement, ifcfile)
     elif ifcentity.is_a("IfcControl"):

--- a/src/Mod/BIM/utils/ifctree.py
+++ b/src/Mod/BIM/utils/ifctree.py
@@ -98,24 +98,24 @@ def create(ifcentity):
             if hasattr(obj, attr):
                 continue
             elif isinstance(value, int):
-                obj.addProperty("App::PropertyInteger", attr, "IFC")
+                obj.addProperty("App::PropertyInteger", attr, "IFC", locked=True)
                 setattr(obj, attr, value)
             elif isinstance(value, float):
-                obj.addProperty("App::PropertyFloat", attr, "IFC")
+                obj.addProperty("App::PropertyFloat", attr, "IFC", locked=True)
                 setattr(obj, attr, value)
             elif isinstance(value, ifcopenshell.entity_instance):
                 value = create(value)
-                obj.addProperty("App::PropertyLink", attr, "IFC")
+                obj.addProperty("App::PropertyLink", attr, "IFC", locked=True)
                 setattr(obj, attr, value)
             elif isinstance(value, (list, tuple)) and value:
                 if isinstance(value[0], ifcopenshell.entity_instance):
                     nvalue = []
                     for elt in value:
                         nvalue.append(create(elt))
-                    obj.addProperty("App::PropertyLinkList", attr, "IFC")
+                    obj.addProperty("App::PropertyLinkList", attr, "IFC", locked=True)
                     setattr(obj, attr, nvalue)
             else:
-                obj.addProperty("App::PropertyString", attr, "IFC")
+                obj.addProperty("App::PropertyString", attr, "IFC", locked=True)
                 if value is not None:
                     setattr(obj, attr, str(value))
     for parent in ifcfile.get_inverse(ifcentity):

--- a/src/Mod/Draft/draftobjects/array.py
+++ b/src/Mod/Draft/draftobjects/array.py
@@ -97,7 +97,7 @@ class Array(DraftLink):
         if "Base" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                                      "The base object that will be duplicated")
-            obj.addProperty("App::PropertyLink", "Base", "Objects", _tip)
+            obj.addProperty("App::PropertyLink", "Base", "Objects", _tip, locked=True)
             obj.Base = None
 
         if "ArrayType" not in properties:
@@ -116,7 +116,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyEnumeration",
                             "ArrayType",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.ArrayType = ['ortho', 'polar', 'circular']
 
         if "Fuse" not in properties:
@@ -127,7 +128,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyBool",
                             "Fuse",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Fuse = False
 
         if "Count" not in properties:
@@ -140,7 +142,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyInteger",
                             "Count",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Count = 0
             obj.setEditorMode("Count", 1)  # Read only
 
@@ -151,7 +154,8 @@ class Array(DraftLink):
                 obj.addProperty("App::PropertyPlacementList",
                                 "PlacementList",
                                 "Objects",
-                                _tip)
+                                _tip,
+                                locked=True)
                 obj.PlacementList = []
 
     def set_ortho_properties(self, obj):
@@ -164,7 +168,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyInteger",
                             "NumberX",
                             "Orthogonal array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.NumberX = 2
 
         if "NumberY" not in properties:
@@ -173,7 +178,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyInteger",
                             "NumberY",
                             "Orthogonal array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.NumberY = 2
 
         if "NumberZ" not in properties:
@@ -182,7 +188,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyInteger",
                             "NumberZ",
                             "Orthogonal array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.NumberZ = 1
 
         if "IntervalX" not in properties:
@@ -192,7 +199,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyVectorDistance",
                             "IntervalX",
                             "Orthogonal array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.IntervalX = App.Vector(50, 0, 0)
 
         if "IntervalY" not in properties:
@@ -202,7 +210,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyVectorDistance",
                             "IntervalY",
                             "Orthogonal array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.IntervalY = App.Vector(0, 50, 0)
 
         if "IntervalZ" not in properties:
@@ -212,7 +221,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyVectorDistance",
                             "IntervalZ",
                             "Orthogonal array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.IntervalZ = App.Vector(0, 0, 50)
 
     def set_polar_circular_properties(self, obj):
@@ -227,7 +237,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyVector",
                             "Axis",
                             "Polar/circular array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Axis = App.Vector(0, 0, 1)
 
         if "Center" not in properties:
@@ -238,7 +249,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyVectorDistance",
                             "Center",
                             "Polar/circular array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Center = App.Vector(0, 0, 0)
 
         # The AxisReference property must be attached after Axis and Center
@@ -257,7 +269,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyLinkGlobal",
                             "AxisReference",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.AxisReference = None
 
     def set_polar_properties(self, obj):
@@ -270,7 +283,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyInteger",
                             "NumberPolar",
                             "Polar array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.NumberPolar = 5
 
         if "IntervalAxis" not in properties:
@@ -280,7 +294,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyVectorDistance",
                             "IntervalAxis",
                             "Polar array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.IntervalAxis = App.Vector(0, 0, 0)
 
         if "Angle" not in properties:
@@ -289,7 +304,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyAngle",
                             "Angle",
                             "Polar array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Angle = 360
 
     def set_circular_properties(self, obj):
@@ -302,7 +318,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyDistance",
                             "RadialDistance",
                             "Circular array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.RadialDistance = 50
 
         if "TangentialDistance" not in properties:
@@ -312,7 +329,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyDistance",
                             "TangentialDistance",
                             "Circular array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.TangentialDistance = 25
 
         if "NumberCircles" not in properties:
@@ -322,7 +340,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyInteger",
                             "NumberCircles",
                             "Circular array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.NumberCircles = 3
 
         if "Symmetry" not in properties:
@@ -333,7 +352,8 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyInteger",
                             "Symmetry",
                             "Circular array",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Symmetry = 1
 
     def set_link_properties(self, obj):
@@ -348,7 +368,8 @@ class Array(DraftLink):
                 obj.addProperty("App::PropertyBool",
                                 "ExpandArray",
                                 "Objects",
-                                _tip)
+                                _tip,
+                                locked=True)
                 obj.ExpandArray = False
 
     def linkSetup(self, obj):

--- a/src/Mod/Draft/draftobjects/bezcurve.py
+++ b/src/Mod/Draft/draftobjects/bezcurve.py
@@ -43,31 +43,31 @@ class BezCurve(DraftObject):
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The points of the Bezier curve")
-        obj.addProperty("App::PropertyVectorList", "Points", "Draft", _tip)
+        obj.addProperty("App::PropertyVectorList", "Points", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The degree of the Bezier function")
-        obj.addProperty("App::PropertyInteger", "Degree", "Draft", _tip)
+        obj.addProperty("App::PropertyInteger", "Degree", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "Continuity")
-        obj.addProperty("App::PropertyIntegerList", "Continuity", "Draft", _tip)
+        obj.addProperty("App::PropertyIntegerList", "Continuity", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "If the Bezier curve should be closed or not")
-        obj.addProperty("App::PropertyBool", "Closed", "Draft", _tip)
+        obj.addProperty("App::PropertyBool", "Closed", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "Create a face if this curve is closed")
-        obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip)
+        obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The length of this object")
-        obj.addProperty("App::PropertyLength", "Length", "Draft", _tip)
+        obj.addProperty("App::PropertyLength", "Length", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The area of this object")
-        obj.addProperty("App::PropertyArea", "Area", "Draft", _tip)
+        obj.addProperty("App::PropertyArea", "Area", "Draft", _tip, locked=True)
 
         obj.MakeFace = params.get_param("MakeFaceMode")
         obj.Closed = False

--- a/src/Mod/Draft/draftobjects/block.py
+++ b/src/Mod/Draft/draftobjects/block.py
@@ -41,7 +41,7 @@ class Block(DraftObject):
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The components of this block")
-        obj.addProperty("App::PropertyLinkList","Components", "Draft", _tip)
+        obj.addProperty("App::PropertyLinkList","Components", "Draft", _tip, locked=True)
 
     def onDocumentRestored(self, obj):
         super().onDocumentRestored(obj)

--- a/src/Mod/Draft/draftobjects/bspline.py
+++ b/src/Mod/Draft/draftobjects/bspline.py
@@ -43,18 +43,18 @@ class BSpline(DraftObject):
 
         _tip =  QT_TRANSLATE_NOOP("App::Property",
                 "The points of the B-spline")
-        obj.addProperty("App::PropertyVectorList","Points", "Draft", _tip)
+        obj.addProperty("App::PropertyVectorList","Points", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "If the B-spline is closed or not")
-        obj.addProperty("App::PropertyBool","Closed", "Draft", _tip)
+        obj.addProperty("App::PropertyBool","Closed", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "Create a face if this spline is closed")
-        obj.addProperty("App::PropertyBool","MakeFace", "Draft",_tip)
+        obj.addProperty("App::PropertyBool","MakeFace", "Draft",_tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "The area of this object")
-        obj.addProperty("App::PropertyArea","Area", "Draft", _tip)
+        obj.addProperty("App::PropertyArea","Area", "Draft", _tip, locked=True)
 
         obj.MakeFace = params.get_param("MakeFaceMode")
         obj.Closed = False
@@ -70,7 +70,7 @@ class BSpline(DraftObject):
     def assureProperties(self, obj): # for Compatibility with older versions
         if not hasattr(obj, "Parameterization"):
             _tip = QT_TRANSLATE_NOOP("App::Property","Parameterization factor")
-            obj.addProperty("App::PropertyFloat", "Parameterization", "Draft", _tip)
+            obj.addProperty("App::PropertyFloat", "Parameterization", "Draft", _tip, locked=True)
             obj.Parameterization = 1.0
             self.knotSeq = []
 

--- a/src/Mod/Draft/draftobjects/circle.py
+++ b/src/Mod/Draft/draftobjects/circle.py
@@ -43,24 +43,24 @@ class Circle(DraftObject):
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Start angle of the arc")
         obj.addProperty("App::PropertyAngle", "FirstAngle",
-                        "Draft", _tip)
+                        "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "End angle of the arc (for a full circle, \
                 give it same value as First Angle)")
         obj.addProperty("App::PropertyAngle","LastAngle",
-                        "Draft", _tip)
+                        "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Radius of the circle")
         obj.addProperty("App::PropertyLength", "Radius",
-                        "Draft", _tip)
+                        "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Create a face")
         obj.addProperty("App::PropertyBool", "MakeFace",
-                        "Draft", _tip)
+                        "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "The area of this object")
         obj.addProperty("App::PropertyArea", "Area",
-                        "Draft", _tip)
+                        "Draft", _tip, locked=True)
 
         obj.MakeFace = params.get_param("MakeFaceMode")
 

--- a/src/Mod/Draft/draftobjects/clone.py
+++ b/src/Mod/Draft/draftobjects/clone.py
@@ -49,19 +49,19 @@ class Clone(DraftObject):
         pl = obj.PropertiesList
         if not "Objects" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property", "The objects included in this clone")
-            obj.addProperty("App::PropertyLinkListGlobal", "Objects", "Draft", _tip)
+            obj.addProperty("App::PropertyLinkListGlobal", "Objects", "Draft", _tip, locked=True)
         if not "Scale" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property", "The scale factor of this clone")
-            obj.addProperty("App::PropertyVector", "Scale", "Draft", _tip)
+            obj.addProperty("App::PropertyVector", "Scale", "Draft", _tip, locked=True)
             obj.Scale = App.Vector(1, 1, 1)
         if not "Fuse" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                                      "If Clones includes several objects,\n"
                                      "set True for fusion or False for compound")
-            obj.addProperty("App::PropertyBool", "Fuse", "Draft", _tip)
+            obj.addProperty("App::PropertyBool", "Fuse", "Draft", _tip, locked=True)
         if not "ForceCompound" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Always create a compound")
-            obj.addProperty("App::PropertyBool", "ForceCompound", "Draft", _tip)
+            obj.addProperty("App::PropertyBool", "ForceCompound", "Draft", _tip, locked=True)
 
     def onDocumentRestored(self, obj):
         super().onDocumentRestored(obj)

--- a/src/Mod/Draft/draftobjects/dimension.py
+++ b/src/Mod/Draft/draftobjects/dimension.py
@@ -135,7 +135,8 @@ class DimensionBase(DraftAnnotation):
             obj.addProperty("App::PropertyVector",
                             "Normal",
                             "Dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Normal = App.Vector(0, 0, 1)
 
         # TODO: remove Support property as it is not used at all.
@@ -148,7 +149,8 @@ class DimensionBase(DraftAnnotation):
             obj.addProperty("App::PropertyLink",
                             "Support",
                             "Dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Support = None
 
         if "LinkedGeometry" not in properties:
@@ -165,7 +167,8 @@ class DimensionBase(DraftAnnotation):
             obj.addProperty("App::PropertyLinkSubList",
                             "LinkedGeometry",
                             "Dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.LinkedGeometry = []
 
         if "Dimline" not in properties:
@@ -188,7 +191,8 @@ class DimensionBase(DraftAnnotation):
             obj.addProperty("App::PropertyVectorDistance",
                             "Dimline",
                             "Dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Dimline = App.Vector(0, 1, 0)
 
     def update_properties_0v21(self, obj, vobj):
@@ -234,7 +238,8 @@ class LinearDimension(DimensionBase):
             obj.addProperty("App::PropertyVectorDistance",
                             "Start",
                             "Linear/radial dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Start = App.Vector(0, 0, 0)
 
         if "End" not in properties:
@@ -248,7 +253,8 @@ class LinearDimension(DimensionBase):
             obj.addProperty("App::PropertyVectorDistance",
                             "End",
                             "Linear/radial dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.End = App.Vector(1, 0, 0)
 
         if "Direction" not in properties:
@@ -260,7 +266,8 @@ class LinearDimension(DimensionBase):
             obj.addProperty("App::PropertyVector",
                             "Direction",
                             "Linear/radial dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
 
         if "Distance" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property",
@@ -277,7 +284,8 @@ class LinearDimension(DimensionBase):
             obj.addProperty("App::PropertyLength",
                             "Distance",
                             "Linear/radial dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Distance = 0
 
         if "Diameter" not in properties:
@@ -288,7 +296,8 @@ class LinearDimension(DimensionBase):
             obj.addProperty("App::PropertyBool",
                             "Diameter",
                             "Radial dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Diameter = False
 
     def onDocumentRestored(self, obj):
@@ -521,7 +530,8 @@ class AngularDimension(DimensionBase):
             obj.addProperty("App::PropertyAngle",
                             "FirstAngle",
                             "Angular dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.FirstAngle = 0
 
         if "LastAngle" not in properties:
@@ -532,7 +542,8 @@ class AngularDimension(DimensionBase):
             obj.addProperty("App::PropertyAngle",
                             "LastAngle",
                             "Angular dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.LastAngle = 90
 
         if "Center" not in properties:
@@ -547,7 +558,8 @@ class AngularDimension(DimensionBase):
             obj.addProperty("App::PropertyVectorDistance",
                             "Center",
                             "Angular dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Center = App.Vector(0, 0, 0)
 
         if "Angle" not in properties:
@@ -561,7 +573,8 @@ class AngularDimension(DimensionBase):
             obj.addProperty("App::PropertyAngle",
                             "Angle",
                             "Angular dimension",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Angle = 0
 
     def onDocumentRestored(self, obj):

--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -100,7 +100,8 @@ class DraftLink(DraftObject):
             obj.addProperty("App::PropertyBool",
                             "AlwaysSyncPlacement",
                             "Draft",
-                            _tip)
+                            _tip,
+                            locked=True)
 
         if hasattr(obj, 'ShowElement'):
             # Rename 'ShowElement' property to 'ExpandArray' to avoid conflict
@@ -113,7 +114,8 @@ class DraftLink(DraftObject):
             obj.addProperty("App::PropertyBool",
                             "ExpandArray",
                             "Draft",
-                            _tip)
+                            _tip,
+                            locked=True)
 
             obj.ExpandArray = showElement
             obj.configLinkProperty(ShowElement='ExpandArray')
@@ -129,16 +131,18 @@ class DraftLink(DraftObject):
         if not hasattr(obj, 'LinkTransform'):
             obj.addProperty('App::PropertyBool',
                             'LinkTransform',
-                            ' Link')
+                            ' Link',
+                            locked=True)
 
         if not hasattr(obj, 'ColoredElements'):
             obj.addProperty('App::PropertyLinkSubHidden',
                             'ColoredElements',
-                            ' Link')
+                            ' Link',
+                            locked=True)
             obj.setPropertyStatus('ColoredElements', 'Hidden')
 
         if not hasattr(obj,'LinkCopyOnChange'):
-            obj.addProperty("App::PropertyEnumeration","LinkCopyOnChange"," Link")
+            obj.addProperty("App::PropertyEnumeration","LinkCopyOnChange"," Link",locked=True)
 
         obj.configLinkProperty('LinkCopyOnChange','LinkTransform','ColoredElements')
 

--- a/src/Mod/Draft/draftobjects/ellipse.py
+++ b/src/Mod/Draft/draftobjects/ellipse.py
@@ -42,23 +42,23 @@ class Ellipse(DraftObject):
         super().__init__(obj, "Ellipse")
 
         _tip = QT_TRANSLATE_NOOP("App::Property","Start angle of the elliptical arc")
-        obj.addProperty("App::PropertyAngle", "FirstAngle", "Draft", _tip)
+        obj.addProperty("App::PropertyAngle", "FirstAngle", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","End angle of the elliptical arc \n\
                 (for a full circle, give it same value as First Angle)")
-        obj.addProperty("App::PropertyAngle", "LastAngle", "Draft", _tip)
+        obj.addProperty("App::PropertyAngle", "LastAngle", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","Minor radius of the ellipse")
-        obj.addProperty("App::PropertyLength", "MinorRadius", "Draft", _tip)
+        obj.addProperty("App::PropertyLength", "MinorRadius", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","Major radius of the ellipse")
-        obj.addProperty("App::PropertyLength", "MajorRadius", "Draft", _tip)
+        obj.addProperty("App::PropertyLength", "MajorRadius", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","Create a face")
-        obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip)
+        obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","Area of this object")
-        obj.addProperty("App::PropertyArea", "Area","Draft", _tip)
+        obj.addProperty("App::PropertyArea", "Area","Draft", _tip, locked=True)
 
         obj.MakeFace = params.get_param("MakeFaceMode")
 

--- a/src/Mod/Draft/draftobjects/facebinder.py
+++ b/src/Mod/Draft/draftobjects/facebinder.py
@@ -44,22 +44,22 @@ class Facebinder(DraftObject):
         super().__init__(obj, "Facebinder")
 
         _tip = QT_TRANSLATE_NOOP("App::Property","Linked faces")
-        obj.addProperty("App::PropertyLinkSubList", "Faces", "Draft", _tip)
+        obj.addProperty("App::PropertyLinkSubList", "Faces", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","Specifies if splitter lines must be removed")
-        obj.addProperty("App::PropertyBool","RemoveSplitter", "Draft", _tip)
+        obj.addProperty("App::PropertyBool","RemoveSplitter", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","An optional extrusion value to be applied to all faces")
-        obj.addProperty("App::PropertyDistance","Extrusion", "Draft" , _tip)
+        obj.addProperty("App::PropertyDistance","Extrusion", "Draft" , _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","An optional offset value to be applied to all faces")
-        obj.addProperty("App::PropertyDistance","Offset", "Draft" , _tip)
+        obj.addProperty("App::PropertyDistance","Offset", "Draft" , _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","This specifies if the shapes sew")
-        obj.addProperty("App::PropertyBool","Sew", "Draft", _tip)
+        obj.addProperty("App::PropertyBool","Sew", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","The area of the faces of this Facebinder")
-        obj.addProperty("App::PropertyArea","Area", "Draft", _tip)
+        obj.addProperty("App::PropertyArea","Area", "Draft", _tip, locked=True)
         obj.setEditorMode("Area", 1)
 
     def onDocumentRestored(self, obj):

--- a/src/Mod/Draft/draftobjects/fillet.py
+++ b/src/Mod/Draft/draftobjects/fillet.py
@@ -50,7 +50,8 @@ class Fillet(DraftObject):
             obj.addProperty("App::PropertyVectorDistance",
                             "Start",
                             "Draft",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Start = App.Vector(0, 0, 0)
 
         if not hasattr(obj, "End"):
@@ -58,7 +59,8 @@ class Fillet(DraftObject):
             obj.addProperty("App::PropertyVectorDistance",
                             "End",
                             "Draft",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.End = App.Vector(0, 0, 0)
 
         if not hasattr(obj, "Length"):
@@ -66,7 +68,8 @@ class Fillet(DraftObject):
             obj.addProperty("App::PropertyLength",
                             "Length",
                             "Draft",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Length = 0
 
         if not hasattr(obj, "FilletRadius"):
@@ -74,7 +77,8 @@ class Fillet(DraftObject):
             obj.addProperty("App::PropertyLength",
                             "FilletRadius",
                             "Draft",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.FilletRadius = 0
 
         # TODO: these two properties should link two straight lines

--- a/src/Mod/Draft/draftobjects/hatch.py
+++ b/src/Mod/Draft/draftobjects/hatch.py
@@ -46,22 +46,22 @@ class Hatch(DraftObject):
         pl = obj.PropertiesList
         if not "Base" in pl:
             obj.addProperty("App::PropertyLink","Base","Hatch",
-                            QT_TRANSLATE_NOOP("App::Property","The base object used by this object"))
+                            QT_TRANSLATE_NOOP("App::Property","The base object used by this object"), locked=True)
         if not "File" in pl:
             obj.addProperty("App::PropertyFile","File","Hatch",
-                            QT_TRANSLATE_NOOP("App::Property","The PAT file used by this object"))
+                            QT_TRANSLATE_NOOP("App::Property","The PAT file used by this object"), locked=True)
         if not "Pattern" in pl:
             obj.addProperty("App::PropertyString","Pattern","Hatch",
-                            QT_TRANSLATE_NOOP("App::Property","The pattern name used by this object"))
+                            QT_TRANSLATE_NOOP("App::Property","The pattern name used by this object"), locked=True)
         if not "Scale" in pl:
             obj.addProperty("App::PropertyFloat","Scale","Hatch",
-                            QT_TRANSLATE_NOOP("App::Property","The pattern scale used by this object"))
+                            QT_TRANSLATE_NOOP("App::Property","The pattern scale used by this object"), locked=True)
         if not "Rotation" in pl:
             obj.addProperty("App::PropertyAngle","Rotation","Hatch",
-                            QT_TRANSLATE_NOOP("App::Property","The pattern rotation used by this object"))
+                            QT_TRANSLATE_NOOP("App::Property","The pattern rotation used by this object"), locked=True)
         if not "Translate" in pl:
             obj.addProperty("App::PropertyBool","Translate","Hatch",
-                            QT_TRANSLATE_NOOP("App::Property","If set to False, hatch is applied as is to the faces, without translation (this might give wrong results for non-XY faces)"))
+                            QT_TRANSLATE_NOOP("App::Property","If set to False, hatch is applied as is to the faces, without translation (this might give wrong results for non-XY faces)"), locked=True)
             obj.Translate = True
         self.Type = "Hatch"
 

--- a/src/Mod/Draft/draftobjects/label.py
+++ b/src/Mod/Draft/draftobjects/label.py
@@ -67,7 +67,8 @@ class Label(DraftAnnotation):
             obj.addProperty("App::PropertyVector",
                             "TargetPoint",
                             "Target",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.TargetPoint = App.Vector(2, -1, 0)
 
         if "Target" not in properties:
@@ -81,7 +82,8 @@ class Label(DraftAnnotation):
             obj.addProperty("App::PropertyLinkSub",
                             "Target",
                             "Target",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Target = None
 
     def set_leader_properties(self, obj):
@@ -111,7 +113,8 @@ class Label(DraftAnnotation):
             obj.addProperty("App::PropertyVectorList",
                             "Points",
                             "Leader",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Points = []
 
         if "StraightDirection" not in properties:
@@ -126,7 +129,8 @@ class Label(DraftAnnotation):
             obj.addProperty("App::PropertyEnumeration",
                             "StraightDirection",
                             "Leader",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.StraightDirection = ["Horizontal", "Vertical", "Custom"]
 
         if "StraightDistance" not in properties:
@@ -144,7 +148,8 @@ class Label(DraftAnnotation):
             obj.addProperty("App::PropertyDistance",
                             "StraightDistance",
                             "Leader",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.StraightDistance = 1
 
     def set_label_properties(self, obj):
@@ -158,7 +163,8 @@ class Label(DraftAnnotation):
             obj.addProperty("App::PropertyPlacement",
                             "Placement",
                             "Label",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Placement = App.Placement()
 
         if "CustomText" not in properties:
@@ -168,7 +174,8 @@ class Label(DraftAnnotation):
             obj.addProperty("App::PropertyStringList",
                             "CustomText",
                             "Label",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.CustomText = "Label"
 
         if "Text" not in properties:
@@ -183,7 +190,8 @@ class Label(DraftAnnotation):
             obj.addProperty("App::PropertyStringList",
                             "Text",
                             "Label",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.setEditorMode("Text", 1)  # Read only
 
         # TODO: maybe here we can define a second and third 'label type'
@@ -218,7 +226,8 @@ class Label(DraftAnnotation):
             obj.addProperty("App::PropertyEnumeration",
                             "LabelType",
                             "Label",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.LabelType = get_label_types()
 
     def onDocumentRestored(self, obj):

--- a/src/Mod/Draft/draftobjects/layer.py
+++ b/src/Mod/Draft/draftobjects/layer.py
@@ -61,7 +61,8 @@ class Layer:
             obj.addProperty("App::PropertyLinkListHidden",
                             "Group",
                             "Layer",
-                            _tip)
+                            _tip,
+                            locked=True)
 
     def onDocumentRestored(self, obj):
         """Execute code when the document is restored."""

--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -216,7 +216,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyLinkGlobal",
                             "Base",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Base = None
 
         if "PathObject" not in properties:
@@ -224,7 +225,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyLinkGlobal",
                             "PathObject",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.PathObject = None
 
         # TODO: the 'PathSubelements' property must be changed,
@@ -239,7 +241,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyLinkSubListGlobal",
                             "PathSubelements",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.PathSubelements = []
 
         if "Fuse" not in properties:
@@ -250,7 +253,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyBool",
                             "Fuse",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Fuse = False
 
         if self.use_link and "ExpandArray" not in properties:
@@ -258,7 +262,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyBool",
                             "ExpandArray",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.ExpandArray = False
             obj.setPropertyStatus('Shape', 'Transient')
 
@@ -269,7 +274,8 @@ class PathArray(DraftLink):
                 obj.addProperty("App::PropertyPlacementList",
                                 "PlacementList",
                                 "Objects",
-                                _tip)
+                                _tip,
+                                locked=True)
                 obj.PlacementList = []
 
     def set_align_properties(self, obj, properties):
@@ -279,7 +285,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyVectorDistance",
                             "ExtraTranslation",
                             "Alignment",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.ExtraTranslation = App.Vector(0, 0, 0)
 
         if "TangentVector" not in properties:
@@ -287,7 +294,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyVector",
                             "TangentVector",
                             "Alignment",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.TangentVector = App.Vector(1, 0, 0)
 
         if "ForceVertical" not in properties:
@@ -295,7 +303,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyBool",
                             "ForceVertical",
                             "Alignment",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.ForceVertical = False
 
         if "VerticalVector" not in properties:
@@ -303,7 +312,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyVector",
                             "VerticalVector",
                             "Alignment",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.VerticalVector = App.Vector(0, 0, 1)
 
         if "AlignMode" not in properties:
@@ -311,7 +321,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyEnumeration",
                             "AlignMode",
                             "Alignment",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.AlignMode = ["Original", "Frenet", "Tangent"]
             obj.AlignMode = "Original"
 
@@ -320,7 +331,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyBool",
                             "ReversePath",
                             "Alignment",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.ReversePath = False
 
         # The Align property must be attached after other align properties
@@ -330,7 +342,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyBool",
                             "Align",
                             "Alignment",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Align = False
 
     def set_spacing_properties(self, obj, properties):
@@ -340,7 +353,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyInteger",
                             "Count",
                             "Spacing",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Count = 4
 
         if "SpacingMode" not in properties:
@@ -354,7 +368,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyEnumeration",
                             "SpacingMode",
                             "Spacing",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.SpacingMode = ["Fixed count", "Fixed spacing", "Fixed count and spacing"]
             obj.SpacingMode = "Fixed count"
 
@@ -363,7 +378,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyLength",
                             "SpacingUnit",
                             "Spacing",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.SpacingUnit = 20.0
             obj.setPropertyStatus("SpacingUnit", "Hidden")
 
@@ -372,7 +388,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyBool",
                             "UseSpacingPattern",
                             "Spacing",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.UseSpacingPattern = False
 
         if "SpacingPattern" not in properties:
@@ -380,7 +397,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyFloatList",
                             "SpacingPattern",
                             "Spacing",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.SpacingPattern = [1, 2]
             obj.setPropertyStatus("SpacingPattern", "Hidden")
 
@@ -389,7 +407,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyLength",
                             "StartOffset",
                             "Spacing",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.StartOffset = 0.0
 
         if "EndOffset" not in properties:
@@ -397,7 +416,8 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyLength",
                             "EndOffset",
                             "Spacing",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.EndOffset = 0.0
 
     def linkSetup(self, obj):

--- a/src/Mod/Draft/draftobjects/pathtwistedarray.py
+++ b/src/Mod/Draft/draftobjects/pathtwistedarray.py
@@ -84,14 +84,16 @@ class PathTwistedArray(DraftLink):
             obj.addProperty("App::PropertyLink",
                             "Base",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property","The base object that will be duplicated."))
+                            QT_TRANSLATE_NOOP("App::Property","The base object that will be duplicated."),
+                            locked=True)
             obj.Base = None
 
         if "PathObject" not in properties:
             obj.addProperty("App::PropertyLink",
                             "PathObject",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property","The object along which the copies will be distributed. It must contain 'Edges'."))
+                            QT_TRANSLATE_NOOP("App::Property","The object along which the copies will be distributed. It must contain 'Edges'."),
+                            locked=True)
             obj.PathObject = None
 
         if "Fuse" not in properties:
@@ -102,28 +104,32 @@ class PathTwistedArray(DraftLink):
             obj.addProperty("App::PropertyBool",
                             "Fuse",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Fuse = False
 
         if "Count" not in properties:
             obj.addProperty("App::PropertyInteger",
                             "Count",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property","Number of copies to create."))
+                            QT_TRANSLATE_NOOP("App::Property","Number of copies to create."),
+                            locked=True)
             obj.Count = 15
 
         if "RotationFactor" not in properties:
             obj.addProperty("App::PropertyFloat",
                             "RotationFactor",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property","Rotation factor of the twisted array."))
+                            QT_TRANSLATE_NOOP("App::Property","Rotation factor of the twisted array."),
+                            locked=True)
             obj.RotationFactor = 0.25
 
         if self.use_link and "ExpandArray" not in properties:
             obj.addProperty("App::PropertyBool",
                             "ExpandArray",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property","Show the individual array elements (only for Link arrays)"))
+                            QT_TRANSLATE_NOOP("App::Property","Show the individual array elements (only for Link arrays)"),
+                            locked=True)
             obj.ExpandArray = False
             obj.setPropertyStatus('Shape', 'Transient')
 
@@ -134,7 +140,8 @@ class PathTwistedArray(DraftLink):
                 obj.addProperty("App::PropertyPlacementList",
                                 "PlacementList",
                                 "Objects",
-                                _tip)
+                                _tip,
+                                locked=True)
                 obj.PlacementList = []
 
     def linkSetup(self, obj):

--- a/src/Mod/Draft/draftobjects/point.py
+++ b/src/Mod/Draft/draftobjects/point.py
@@ -42,13 +42,13 @@ class Point(DraftObject):
         super().__init__(obj, "Point")
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "X Location")
-        obj.addProperty("App::PropertyDistance", "X", "Draft", _tip)
+        obj.addProperty("App::PropertyDistance", "X", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Y Location")
-        obj.addProperty("App::PropertyDistance", "Y", "Draft", _tip)
+        obj.addProperty("App::PropertyDistance", "Y", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Z Location")
-        obj.addProperty("App::PropertyDistance", "Z", "Draft", _tip)
+        obj.addProperty("App::PropertyDistance", "Z", "Draft", _tip, locked=True)
 
         obj.X = x
         obj.Y = y

--- a/src/Mod/Draft/draftobjects/pointarray.py
+++ b/src/Mod/Draft/draftobjects/pointarray.py
@@ -67,7 +67,8 @@ class PointArray(DraftLink):
             obj.addProperty("App::PropertyLink",
                             "Base",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Base = None
 
         if "PointObject" not in properties:
@@ -75,7 +76,8 @@ class PointArray(DraftLink):
             obj.addProperty("App::PropertyLink",
                             "PointObject",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.PointObject = None
 
         if "Fuse" not in properties:
@@ -86,7 +88,8 @@ class PointArray(DraftLink):
             obj.addProperty("App::PropertyBool",
                             "Fuse",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Fuse = False
 
         if "Count" not in properties:
@@ -94,7 +97,8 @@ class PointArray(DraftLink):
             obj.addProperty("App::PropertyInteger",
                             "Count",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Count = 0
             obj.setEditorMode("Count", 1)  # Read only
 
@@ -103,7 +107,8 @@ class PointArray(DraftLink):
             obj.addProperty("App::PropertyPlacement",
                             "ExtraPlacement",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.ExtraPlacement = App.Placement()
 
         if self.use_link and "ExpandArray" not in properties:
@@ -111,7 +116,8 @@ class PointArray(DraftLink):
             obj.addProperty("App::PropertyBool",
                             "ExpandArray",
                             "Objects",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.setPropertyStatus('Shape', 'Transient')
 
         if not self.use_link:
@@ -121,7 +127,8 @@ class PointArray(DraftLink):
                 obj.addProperty("App::PropertyPlacementList",
                                 "PlacementList",
                                 "Objects",
-                                _tip)
+                                _tip,
+                                locked=True)
                 obj.PlacementList = []
 
     def execute(self, obj):

--- a/src/Mod/Draft/draftobjects/polygon.py
+++ b/src/Mod/Draft/draftobjects/polygon.py
@@ -45,31 +45,31 @@ class Polygon(DraftObject):
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "Number of faces")
-        obj.addProperty("App::PropertyInteger", "FacesNumber", "Draft", _tip)
+        obj.addProperty("App::PropertyInteger", "FacesNumber", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "Radius of the control circle")
-        obj.addProperty("App::PropertyLength", "Radius", "Draft", _tip)
+        obj.addProperty("App::PropertyLength", "Radius", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "How the polygon must be drawn from the control circle")
-        obj.addProperty("App::PropertyEnumeration", "DrawMode", "Draft", _tip)
+        obj.addProperty("App::PropertyEnumeration", "DrawMode", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "Radius to use to fillet the corners")
-        obj.addProperty("App::PropertyLength", "FilletRadius", "Draft", _tip)
+        obj.addProperty("App::PropertyLength", "FilletRadius", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "Size of the chamfer to give to the corners")
-        obj.addProperty("App::PropertyLength", "ChamferSize", "Draft", _tip)
+        obj.addProperty("App::PropertyLength", "ChamferSize", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "Create a face")
-        obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip)
+        obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The area of this object")
-        obj.addProperty("App::PropertyArea", "Area", "Draft", _tip)
+        obj.addProperty("App::PropertyArea", "Area", "Draft", _tip, locked=True)
 
         obj.MakeFace = params.get_param("MakeFaceMode")
         obj.DrawMode = ['inscribed','circumscribed']

--- a/src/Mod/Draft/draftobjects/rectangle.py
+++ b/src/Mod/Draft/draftobjects/rectangle.py
@@ -43,28 +43,28 @@ class Rectangle(DraftObject):
         super().__init__(obj, "Rectangle")
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Length of the rectangle")
-        obj.addProperty("App::PropertyDistance", "Length", "Draft", _tip)
+        obj.addProperty("App::PropertyDistance", "Length", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Height of the rectangle")
-        obj.addProperty("App::PropertyDistance", "Height", "Draft", _tip)
+        obj.addProperty("App::PropertyDistance", "Height", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Radius to use to fillet the corners")
-        obj.addProperty("App::PropertyLength", "FilletRadius", "Draft", _tip)
+        obj.addProperty("App::PropertyLength", "FilletRadius", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Size of the chamfer to give to the corners")
-        obj.addProperty("App::PropertyLength", "ChamferSize", "Draft", _tip)
+        obj.addProperty("App::PropertyLength", "ChamferSize", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Create a face")
-        obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip)
+        obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Horizontal subdivisions of this rectangle")
-        obj.addProperty("App::PropertyInteger", "Rows", "Draft", _tip)
+        obj.addProperty("App::PropertyInteger", "Rows", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Vertical subdivisions of this rectangle")
-        obj.addProperty("App::PropertyInteger", "Columns", "Draft", _tip)
+        obj.addProperty("App::PropertyInteger", "Columns", "Draft", _tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "The area of this object")
-        obj.addProperty("App::PropertyArea", "Area", "Draft", _tip)
+        obj.addProperty("App::PropertyArea", "Area", "Draft", _tip, locked=True)
 
         obj.MakeFace = params.get_param("MakeFaceMode")
         obj.Length=1

--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -61,85 +61,85 @@ class Shape2DView(DraftObject):
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "The base object this 2D view must represent")
             obj.addProperty("App::PropertyLink", "Base",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
         if not "Projection" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "The projection vector of this object")
             obj.addProperty("App::PropertyVector", "Projection",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
             obj.Projection = App.Vector(0,0,1)
         if not "ProjectionMode" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "The way the viewed object must be projected")
             obj.addProperty("App::PropertyEnumeration", "ProjectionMode",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
             obj.ProjectionMode = ["Solid", "Individual Faces",
                                   "Cutlines", "Cutfaces","Solid faces"]
         if not "FaceNumbers" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "The indices of the faces to be projected in Individual Faces mode")
             obj.addProperty("App::PropertyIntegerList", "FaceNumbers",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
         if not "HiddenLines" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "Show hidden lines")
             obj.addProperty("App::PropertyBool", "HiddenLines",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
             obj.HiddenLines = False
         if not "FuseArch" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "Fuse wall and structure objects of same type and material")
             obj.addProperty("App::PropertyBool", "FuseArch",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
         if not "Tessellation" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "Tessellate Ellipses and B-splines into line segments")
             obj.addProperty("App::PropertyBool", "Tessellation",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
             obj.Tessellation = False
         if not "InPlace" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "For Cutlines and Cutfaces modes, this leaves the faces at the cut location")
             obj.addProperty("App::PropertyBool", "InPlace",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
             obj.InPlace = True
         if not "SegmentLength" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "Length of line segments if tessellating Ellipses or B-splines into line segments")
             obj.addProperty("App::PropertyFloat", "SegmentLength",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
             obj.SegmentLength = .05
         if not "VisibleOnly" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "If this is True, this object will include only visible objects")
             obj.addProperty("App::PropertyBool", "VisibleOnly",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
             obj.VisibleOnly = False
         if not "ExclusionPoints" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "A list of exclusion points. Any edge touching any of those points will not be drawn.")
             obj.addProperty("App::PropertyVectorList", "ExclusionPoints",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
         if not "ExclusionNames" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "A list of exclusion object names. Any object viewed that matches a name from the list will not be drawn.")
             obj.addProperty("App::PropertyStringList", "ExclusionNames",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
         if not "OnlySolids" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "If this is True, only solid geometry is handled. This overrides the base object's Only Solids property")
             obj.addProperty("App::PropertyBool", "OnlySolids",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
         if not "Clip" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "If this is True, the contents are clipped to the borders of the section plane, if applicable. This overrides the base object's Clip property")
             obj.addProperty("App::PropertyBool", "Clip",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
         if not "AutoUpdate" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
                     "This object will be recomputed only if this is True.")
             obj.addProperty("App::PropertyBool", "AutoUpdate",
-                            "Draft", _tip)
+                            "Draft", _tip, locked=True)
             obj.AutoUpdate = True
 
     def getProjected(self,obj,shape,direction):

--- a/src/Mod/Draft/draftobjects/shapestring.py
+++ b/src/Mod/Draft/draftobjects/shapestring.py
@@ -53,19 +53,19 @@ class ShapeString(DraftObject):
 
         if "String" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Text string")
-            obj.addProperty("App::PropertyString", "String", "Draft", _tip)
+            obj.addProperty("App::PropertyString", "String", "Draft", _tip, locked=True)
 
         if "FontFile" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Font file name")
-            obj.addProperty("App::PropertyFile", "FontFile", "Draft", _tip)
+            obj.addProperty("App::PropertyFile", "FontFile", "Draft", _tip, locked=True)
 
         if "Size" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Height of text")
-            obj.addProperty("App::PropertyLength", "Size", "Draft", _tip)
+            obj.addProperty("App::PropertyLength", "Size", "Draft", _tip, locked=True)
 
         if "Justification" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Horizontal and vertical alignment")
-            obj.addProperty("App::PropertyEnumeration", "Justification", "Draft", _tip)
+            obj.addProperty("App::PropertyEnumeration", "Justification", "Draft", _tip, locked=True)
             obj.Justification = ["Top-Left", "Top-Center", "Top-Right",
                                  "Middle-Left", "Middle-Center", "Middle-Right",
                                  "Bottom-Left", "Bottom-Center", "Bottom-Right"]
@@ -73,33 +73,33 @@ class ShapeString(DraftObject):
 
         if "JustificationReference" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Height reference used for justification")
-            obj.addProperty("App::PropertyEnumeration", "JustificationReference", "Draft", _tip)
+            obj.addProperty("App::PropertyEnumeration", "JustificationReference", "Draft", _tip, locked=True)
             obj.JustificationReference = ["Cap Height", "Shape Height"]
             obj.JustificationReference = "Cap Height"
 
         if "KeepLeftMargin" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Keep left margin and leading white space when justification is left")
-            obj.addProperty("App::PropertyBool", "KeepLeftMargin", "Draft", _tip).KeepLeftMargin = False
+            obj.addProperty("App::PropertyBool", "KeepLeftMargin", "Draft", _tip, locked=True).KeepLeftMargin = False
 
         if "ScaleToSize" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Scale to ensure cap height is equal to size")
-            obj.addProperty("App::PropertyBool", "ScaleToSize", "Draft", _tip).ScaleToSize = True
+            obj.addProperty("App::PropertyBool", "ScaleToSize", "Draft", _tip, locked=True).ScaleToSize = True
 
         if "Tracking" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Inter-character spacing")
-            obj.addProperty("App::PropertyDistance", "Tracking", "Draft", _tip)
+            obj.addProperty("App::PropertyDistance", "Tracking", "Draft", _tip, locked=True)
 
         if "ObliqueAngle" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Oblique (slant) angle")
-            obj.addProperty("App::PropertyAngle", "ObliqueAngle", "Draft", _tip)
+            obj.addProperty("App::PropertyAngle", "ObliqueAngle", "Draft", _tip, locked=True)
 
         if "MakeFace" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Fill letters with faces")
-            obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip).MakeFace = True
+            obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip, locked=True).MakeFace = True
 
         if "Fuse" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Fuse faces if faces overlap, usually not required (can be very slow)")
-            obj.addProperty("App::PropertyBool", "Fuse", "Draft", _tip).Fuse = False
+            obj.addProperty("App::PropertyBool", "Fuse", "Draft", _tip, locked=True).Fuse = False
 
     def onDocumentRestored(self, obj):
         super().onDocumentRestored(obj)

--- a/src/Mod/Draft/draftobjects/text.py
+++ b/src/Mod/Draft/draftobjects/text.py
@@ -56,7 +56,8 @@ class Text(DraftAnnotation):
             obj.addProperty("App::PropertyPlacement",
                             "Placement",
                             "Base",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Placement = App.Placement()
 
         if "Text" not in properties:
@@ -68,7 +69,8 @@ class Text(DraftAnnotation):
             obj.addProperty("App::PropertyStringList",
                             "Text",
                             "Base",
-                            _tip)
+                            _tip,
+                            locked=True)
             obj.Text = []
 
     def onDocumentRestored(self,obj):

--- a/src/Mod/Draft/draftobjects/wire.py
+++ b/src/Mod/Draft/draftobjects/wire.py
@@ -46,51 +46,51 @@ class Wire(DraftObject):
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The vertices of the wire")
-        obj.addProperty("App::PropertyVectorList","Points", "Draft",_tip)
+        obj.addProperty("App::PropertyVectorList","Points", "Draft",_tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "If the wire is closed or not")
-        obj.addProperty("App::PropertyBool","Closed", "Draft",_tip)
+        obj.addProperty("App::PropertyBool","Closed", "Draft",_tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The base object is the wire, it's formed from 2 objects")
-        obj.addProperty("App::PropertyLink","Base", "Draft",_tip)
+        obj.addProperty("App::PropertyLink","Base", "Draft",_tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The tool object is the wire, it's formed from 2 objects")
-        obj.addProperty("App::PropertyLink","Tool", "Draft",_tip)
+        obj.addProperty("App::PropertyLink","Tool", "Draft",_tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The start point of this line")
-        obj.addProperty("App::PropertyVectorDistance","Start", "Draft",_tip)
+        obj.addProperty("App::PropertyVectorDistance","Start", "Draft",_tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The end point of this line")
-        obj.addProperty("App::PropertyVectorDistance","End", "Draft",_tip)
+        obj.addProperty("App::PropertyVectorDistance","End", "Draft",_tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The length of this line")
-        obj.addProperty("App::PropertyLength","Length", "Draft",_tip)
+        obj.addProperty("App::PropertyLength","Length", "Draft",_tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "Radius to use to fillet the corners")
-        obj.addProperty("App::PropertyLength","FilletRadius", "Draft",_tip)
+        obj.addProperty("App::PropertyLength","FilletRadius", "Draft",_tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "Size of the chamfer to give to the corners")
-        obj.addProperty("App::PropertyLength","ChamferSize", "Draft",_tip)
+        obj.addProperty("App::PropertyLength","ChamferSize", "Draft",_tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "Create a face if this object is closed")
-        obj.addProperty("App::PropertyBool","MakeFace", "Draft",_tip)
+        obj.addProperty("App::PropertyBool","MakeFace", "Draft",_tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The number of subdivisions of each edge")
-        obj.addProperty("App::PropertyInteger","Subdivisions", "Draft",_tip)
+        obj.addProperty("App::PropertyInteger","Subdivisions", "Draft",_tip, locked=True)
 
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The area of this object")
-        obj.addProperty("App::PropertyArea","Area", "Draft",_tip)
+        obj.addProperty("App::PropertyArea","Area", "Draft",_tip, locked=True)
 
         obj.MakeFace = params.get_param("MakeFaceMode")
         obj.Closed = False

--- a/src/Mod/Draft/draftobjects/wpproxy.py
+++ b/src/Mod/Draft/draftobjects/wpproxy.py
@@ -40,9 +40,9 @@ class WorkingPlaneProxy:
         obj.Proxy = self
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "The placement of this object")
-        obj.addProperty("App::PropertyPlacement", "Placement", "Base", _tip)
+        obj.addProperty("App::PropertyPlacement", "Placement", "Base", _tip, locked=True)
 
-        obj.addProperty("Part::PropertyPartShape","Shape","Base","")
+        obj.addProperty("Part::PropertyPartShape","Shape","Base","", locked=True)
 
         obj.addExtension("Part::AttachExtensionPython")
         obj.changeAttacherType("Attacher::AttachEnginePlane")

--- a/src/Mod/Draft/draftviewproviders/view_base.py
+++ b/src/Mod/Draft/draftviewproviders/view_base.py
@@ -106,7 +106,8 @@ class ViewProviderDraft(object):
                              "Pattern",
                              "Draft",
                              QT_TRANSLATE_NOOP("App::Property",
-                                               "Defines an SVG pattern."))
+                                               "Defines an SVG pattern."),
+                             locked=True)
             patterns = list(utils.svg_patterns())
             patterns.sort()
             vobj.Pattern = ["None"] + patterns
@@ -116,7 +117,8 @@ class ViewProviderDraft(object):
                              "PatternSize",
                              "Draft",
                              QT_TRANSLATE_NOOP("App::Property",
-                                               "Defines the size of the SVG pattern."))
+                                               "Defines the size of the SVG pattern."),
+                             locked=True)
             vobj.PatternSize = params.get_param("HatchPatternSize")
 
     def dumps(self):

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -124,7 +124,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyLength",
                              "TextSpacing",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.TextSpacing = params.get_param("dimspacing")
 
         if "FlipText" not in properties:
@@ -133,7 +134,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyBool",
                              "FlipText",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.FlipText = False
 
         if "TextPosition" not in properties:
@@ -143,7 +145,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyVectorDistance",
                              "TextPosition",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.TextPosition = App.Vector(0, 0, 0)
 
         if "Override" not in properties:
@@ -154,7 +157,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyString",
                              "Override",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.Override = ''
 
     def set_units_properties(self, vobj, properties):
@@ -167,7 +171,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyInteger",
                              "Decimals",
                              "Units",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.Decimals = params.get_param("dimPrecision")
 
         if "ShowUnit" not in properties:
@@ -176,7 +181,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyBool",
                              "ShowUnit",
                              "Units",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.ShowUnit = params.get_param("showUnit")
 
         if "UnitOverride" not in properties:
@@ -187,7 +193,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyString",
                              "UnitOverride",
                              "Units",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.UnitOverride = params.get_param("overrideUnit")
 
     def set_graphics_properties(self, vobj, properties):
@@ -200,7 +207,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyLength",
                              "ArrowSize",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.ArrowSize = params.get_param("arrowsize")
 
         if "ArrowType" not in properties:
@@ -209,7 +217,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyEnumeration",
                              "ArrowType",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.ArrowType = utils.ARROW_TYPES
             vobj.ArrowType = utils.ARROW_TYPES[params.get_param("dimsymbol")]
 
@@ -219,7 +228,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyBool",
                              "FlipArrows",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.FlipArrows = False
 
         if "DimOvershoot" not in properties:
@@ -230,7 +240,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyDistance",
                              "DimOvershoot",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.DimOvershoot = params.get_param("dimovershoot")
 
         if "ExtLines" not in properties:
@@ -239,7 +250,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyDistance",
                              "ExtLines",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.ExtLines = params.get_param("extlines")
 
         if "ExtOvershoot" not in properties:
@@ -249,7 +261,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyDistance",
                              "ExtOvershoot",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.ExtOvershoot = params.get_param("extovershoot")
 
         if "ShowLine" not in properties:
@@ -258,7 +271,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyBool",
                              "ShowLine",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.ShowLine = params.get_param("DimShowLine")
 
     def getIcon(self):

--- a/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
+++ b/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
@@ -85,7 +85,8 @@ class ViewProviderDraftAnnotation(object):
             vobj.addProperty("App::PropertyFloat",
                              "ScaleMultiplier",
                              "Annotation",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.ScaleMultiplier = params.get_param("DefaultAnnoScaleMultiplier")
 
         if "AnnotationStyle" not in properties:
@@ -101,7 +102,8 @@ class ViewProviderDraftAnnotation(object):
             vobj.addProperty("App::PropertyEnumeration",
                              "AnnotationStyle",
                              "Annotation",
-                             _tip)
+                             _tip,
+                             locked=True)
             styles = []
             for key in vobj.Object.Document.Meta.keys():
                 if key.startswith("Draft_Style_"):
@@ -117,7 +119,8 @@ class ViewProviderDraftAnnotation(object):
             vobj.addProperty("App::PropertyFont",
                              "FontName",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.FontName = params.get_param("textfont")
 
         if "FontSize" not in properties:
@@ -126,7 +129,8 @@ class ViewProviderDraftAnnotation(object):
             vobj.addProperty("App::PropertyLength",
                              "FontSize",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.FontSize = params.get_param("textheight")
 
         if "TextColor" not in properties:
@@ -135,7 +139,8 @@ class ViewProviderDraftAnnotation(object):
             vobj.addProperty("App::PropertyColor",
                              "TextColor",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.TextColor = params.get_param("DefaultTextColor") | 0x000000FF
 
     def set_units_properties(self, vobj, properties):
@@ -148,7 +153,8 @@ class ViewProviderDraftAnnotation(object):
             vobj.addProperty("App::PropertyFloat",
                              "LineWidth",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.LineWidth = params.get_param("DefaultAnnoLineWidth")
 
         if "LineColor" not in properties:
@@ -156,7 +162,8 @@ class ViewProviderDraftAnnotation(object):
             vobj.addProperty("App::PropertyColor",
                              "LineColor",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.LineColor = params.get_param("DefaultAnnoLineColor") | 0x000000FF
 
     def dumps(self):

--- a/src/Mod/Draft/draftviewproviders/view_label.py
+++ b/src/Mod/Draft/draftviewproviders/view_label.py
@@ -58,7 +58,8 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyEnumeration",
                              "TextAlignment",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.TextAlignment = ["Top", "Middle", "Bottom"]
             vobj.TextAlignment = "Bottom"
 
@@ -69,7 +70,8 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyInteger",
                              "MaxChars",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
 
         if "Justification" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property",
@@ -77,7 +79,8 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyEnumeration",
                              "Justification",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.Justification = ["Left", "Center", "Right"]
 
         if "LineSpacing" not in properties:
@@ -86,7 +89,8 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyFloat",
                              "LineSpacing",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.LineSpacing = params.get_param("LineSpacing")
 
     def set_graphics_properties(self, vobj, properties):
@@ -99,7 +103,8 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyLength",
                              "ArrowSize",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.ArrowSize = params.get_param("arrowsize")
 
         if "ArrowType" not in properties:
@@ -108,7 +113,8 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyEnumeration",
                              "ArrowType",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.ArrowType = utils.ARROW_TYPES
             vobj.ArrowType = utils.ARROW_TYPES[params.get_param("dimsymbol")]
 
@@ -119,7 +125,8 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyEnumeration",
                              "Frame",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.Frame = ["None", "Rectangle"]
 
         if "Line" not in properties:
@@ -128,7 +135,8 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyBool",
                              "Line",
                              "Graphics",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.Line = True
 
     def getIcon(self):

--- a/src/Mod/Draft/draftviewproviders/view_layer.py
+++ b/src/Mod/Draft/draftviewproviders/view_layer.py
@@ -67,7 +67,8 @@ class ViewProviderLayer:
             vobj.addProperty("App::PropertyBool",
                              "OverrideLineColorChildren",
                              "Layer",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.OverrideLineColorChildren = True
 
         if "OverrideShapeAppearanceChildren" not in properties:
@@ -78,7 +79,8 @@ class ViewProviderLayer:
             vobj.addProperty("App::PropertyBool",
                              "OverrideShapeAppearanceChildren",
                              "Layer",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.OverrideShapeAppearanceChildren = True
 
         if "UsePrintColor" not in properties:
@@ -89,7 +91,8 @@ class ViewProviderLayer:
             vobj.addProperty("App::PropertyBool",
                              "UsePrintColor",
                              "Print",
-                             _tip)
+                             _tip,
+                             locked=True)
 
     def set_visual_properties(self, vobj, properties):
         """Set visual properties only if they don't already exist."""
@@ -100,7 +103,8 @@ class ViewProviderLayer:
             vobj.addProperty("App::PropertyColor",
                              "LineColor",
                              "Layer",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.LineColor = params.get_param_view("DefaultShapeLineColor") | 0x000000FF
 
         if "ShapeColor" not in properties:
@@ -111,7 +115,8 @@ class ViewProviderLayer:
                              "ShapeColor",
                              "Layer",
                              _tip,
-                             4)  # Hidden
+                             4,
+                             locked=True)  # Hidden
             vobj.ShapeColor = params.get_param_view("DefaultShapeColor") | 0x000000FF
 
         if "ShapeAppearance" not in properties:
@@ -121,7 +126,8 @@ class ViewProviderLayer:
             vobj.addProperty("App::PropertyMaterialList",
                              "ShapeAppearance",
                              "Layer",
-                             _tip)
+                             _tip,
+                             locked=True)
             material = App.Material()
             material.DiffuseColor = params.get_param_view("DefaultShapeColor") | 0x000000FF
             vobj.ShapeAppearance = (material, )
@@ -133,7 +139,8 @@ class ViewProviderLayer:
             vobj.addProperty("App::PropertyFloat",
                              "LineWidth",
                              "Layer",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.LineWidth = params.get_param_view("DefaultShapeLineWidth")
 
         if "DrawStyle" not in properties:
@@ -143,7 +150,8 @@ class ViewProviderLayer:
             vobj.addProperty("App::PropertyEnumeration",
                              "DrawStyle",
                              "Layer",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.DrawStyle = utils.DRAW_STYLES
             vobj.DrawStyle = params.get_param("DefaultDrawStyle")
 
@@ -154,7 +162,8 @@ class ViewProviderLayer:
             vobj.addProperty("App::PropertyPercent",
                              "Transparency",
                              "Layer",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.Transparency = params.get_param_view("DefaultShapeTransparency")
 
         if "LinePrintColor" not in properties:
@@ -165,7 +174,8 @@ class ViewProviderLayer:
             vobj.addProperty("App::PropertyColor",
                              "LinePrintColor",
                              "Print",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.LinePrintColor = params.get_param("DefaultPrintColor")
 
     def getIcon(self):

--- a/src/Mod/Draft/draftviewproviders/view_rectangle.py
+++ b/src/Mod/Draft/draftviewproviders/view_rectangle.py
@@ -37,9 +37,9 @@ class ViewProviderRectangle(ViewProviderDraft):
     def __init__(self,vobj):
         super(ViewProviderRectangle, self).__init__(vobj)
 
-        _tip = "Defines a texture image (overrides hatch patterns)"
+        _tip = QT_TRANSLATE_NOOP("App::Property","Defines a texture image (overrides hatch patterns)")
         vobj.addProperty("App::PropertyFile","TextureImage",
-                         "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                         "Draft", _tip, locked=True)
 
 
 # Alias for compatibility with v0.18 and earlier

--- a/src/Mod/Draft/draftviewproviders/view_text.py
+++ b/src/Mod/Draft/draftviewproviders/view_text.py
@@ -54,7 +54,8 @@ class ViewProviderText(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyEnumeration",
                              "Justification",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.Justification = ["Left", "Center", "Right"]
 
         if "LineSpacing" not in properties:
@@ -63,7 +64,8 @@ class ViewProviderText(ViewProviderDraftAnnotation):
             vobj.addProperty("App::PropertyFloat",
                              "LineSpacing",
                              "Text",
-                             _tip)
+                             _tip,
+                             locked=True)
             vobj.LineSpacing = params.get_param("LineSpacing")
 
     def getIcon(self):

--- a/src/Mod/Draft/draftviewproviders/view_wire.py
+++ b/src/Mod/Draft/draftviewproviders/view_wire.py
@@ -60,27 +60,30 @@ class ViewProviderWire(ViewProviderDraft):
         super(ViewProviderWire, self)._set_properties(vobj)
 
         if not hasattr(vobj, "EndArrow"):
-            _tip = "Displays a Dimension symbol at the end of the wire."
+            _tip = QT_TRANSLATE_NOOP("App::Property", "Displays a Dimension symbol at the end of the wire.")
             vobj.addProperty("App::PropertyBool",
                              "EndArrow",
                              "Draft",
-                             QT_TRANSLATE_NOOP("App::Property", _tip))
+                             _tip,
+                             locked=True)
             vobj.EndArrow = False
 
         if not hasattr(vobj, "ArrowSize"):
-            _tip = "Arrow size"
+            _tip = QT_TRANSLATE_NOOP("App::Property", "Arrow size")
             vobj.addProperty("App::PropertyLength",
                              "ArrowSize",
                              "Draft",
-                             QT_TRANSLATE_NOOP("App::Property", _tip))
+                             _tip,
+                             locked=True)
             vobj.ArrowSize = params.get_param("arrowsize")
 
         if not hasattr(vobj, "ArrowType"):
-            _tip = "Arrow type"
+            _tip = QT_TRANSLATE_NOOP("App::Property", "Arrow type")
             vobj.addProperty("App::PropertyEnumeration",
                              "ArrowType",
                              "Draft",
-                             QT_TRANSLATE_NOOP("App::Property", _tip))
+                             _tip,
+                             locked=True)
             vobj.ArrowType = utils.ARROW_TYPES
             vobj.ArrowType = utils.ARROW_TYPES[params.get_param("dimsymbol")]
 

--- a/src/Mod/Draft/draftviewproviders/view_wpproxy.py
+++ b/src/Mod/Draft/draftviewproviders/view_wpproxy.py
@@ -44,27 +44,29 @@ class ViewProviderWorkingPlaneProxy:
         # ViewData: 0,1,2: position; 3,4,5,6: rotation; 7: near dist; 8: far dist, 9:aspect ratio;
         # 10: focal dist; 11: height (ortho) or height angle (persp); 12: ortho (0) or persp (1)
 
-        _tip = "The display length of this section plane"
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The display length of this section plane")
         vobj.addProperty("App::PropertyLength", "DisplaySize",
-                         "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                         "Draft", _tip,
+                         locked=True)
 
-        _tip = "The size of the arrows of this section plane"
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The size of the arrows of this section plane")
         vobj.addProperty("App::PropertyLength", "ArrowSize",
-                         "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                         "Draft", _tip,
+                         locked=True)
 
-        vobj.addProperty("App::PropertyPercent","Transparency","Base","")
+        vobj.addProperty("App::PropertyPercent","Transparency","Base","",locked=True)
 
-        vobj.addProperty("App::PropertyFloat","LineWidth","Base","")
+        vobj.addProperty("App::PropertyFloat","LineWidth","Base","",locked=True)
 
-        vobj.addProperty("App::PropertyColor","LineColor","Base","")
+        vobj.addProperty("App::PropertyColor","LineColor","Base","",locked=True)
 
-        vobj.addProperty("App::PropertyFloatList","ViewData","Base","")
+        vobj.addProperty("App::PropertyFloatList","ViewData","Base","",locked=True)
 
-        vobj.addProperty("App::PropertyBool","RestoreView","Base","")
+        vobj.addProperty("App::PropertyBool","RestoreView","Base","",locked=True)
 
-        vobj.addProperty("App::PropertyMap","VisibilityMap","Base","")
+        vobj.addProperty("App::PropertyMap","VisibilityMap","Base","",locked=True)
 
-        vobj.addProperty("App::PropertyBool","RestoreState","Base","")
+        vobj.addProperty("App::PropertyBool","RestoreState","Base","",locked=True)
 
         vobj.DisplaySize = 100
         vobj.ArrowSize = 5

--- a/src/Mod/Fem/femsolver/calculix/solver.py
+++ b/src/Mod/Fem/femsolver/calculix/solver.py
@@ -66,7 +66,11 @@ class _BaseSolverCalculix:
     def add_attributes(self, obj):
         if not hasattr(obj, "AnalysisType"):
             obj.addProperty(
-                "App::PropertyEnumeration", "AnalysisType", "Fem", "Type of the analysis"
+                "App::PropertyEnumeration",
+                "AnalysisType",
+                "Fem",
+                "Type of the analysis",
+                locked=True,
             )
             obj.AnalysisType = ANALYSIS_TYPES
             obj.AnalysisType = ANALYSIS_TYPES[0]
@@ -78,6 +82,7 @@ class _BaseSolverCalculix:
                 "GeometricalNonlinearity",
                 "Fem",
                 "Set geometrical nonlinearity",
+                locked=True,
             )
             obj.GeometricalNonlinearity = choices_geom_nonlinear
             obj.GeometricalNonlinearity = choices_geom_nonlinear[0]
@@ -89,6 +94,7 @@ class _BaseSolverCalculix:
                 "MaterialNonlinearity",
                 "Fem",
                 "Set material nonlinearity",
+                locked=True,
             )
             obj.MaterialNonlinearity = choices_material_nonlinear
             obj.MaterialNonlinearity = choices_material_nonlinear[0]
@@ -99,6 +105,7 @@ class _BaseSolverCalculix:
                 "EigenmodesCount",
                 "Fem",
                 "Number of modes for frequency calculations",
+                locked=True,
             )
             obj.EigenmodesCount = (10, 1, 100, 1)
 
@@ -108,6 +115,7 @@ class _BaseSolverCalculix:
                 "EigenmodeLowLimit",
                 "Fem",
                 "Low frequency limit for eigenmode calculations",
+                locked=True,
             )
             obj.EigenmodeLowLimit = (0.0, 0.0, 1000000.0, 10000.0)
 
@@ -117,6 +125,7 @@ class _BaseSolverCalculix:
                 "EigenmodeHighLimit",
                 "Fem",
                 "High frequency limit for eigenmode calculations",
+                locked=True,
             )
             obj.EigenmodeHighLimit = (1000000.0, 0.0, 1000000.0, 10000.0)
 
@@ -129,6 +138,7 @@ class _BaseSolverCalculix:
                 "IterationsMaximum",
                 "Fem",
                 help_string_IterationsMaximum,
+                locked=True,
             )
             obj.IterationsMaximum = 2000
 
@@ -142,28 +152,43 @@ class _BaseSolverCalculix:
                 "BucklingFactors",
                 "Fem",
                 "Calculates the lowest buckling modes to the corresponding buckling factors",
+                locked=True,
             )
             obj.BucklingFactors = 1
 
         if not hasattr(obj, "TimeInitialStep"):
             obj.addProperty(
-                "App::PropertyFloatConstraint", "TimeInitialStep", "Fem", "Initial time steps"
+                "App::PropertyFloatConstraint",
+                "TimeInitialStep",
+                "Fem",
+                "Initial time steps",
+                locked=True,
             )
             obj.TimeInitialStep = 0.01
 
         if not hasattr(obj, "TimeEnd"):
-            obj.addProperty("App::PropertyFloatConstraint", "TimeEnd", "Fem", "End time analysis")
+            obj.addProperty(
+                "App::PropertyFloatConstraint", "TimeEnd", "Fem", "End time analysis", locked=True
+            )
             obj.TimeEnd = 1.0
 
         if not hasattr(obj, "TimeMinimumStep"):
             obj.addProperty(
-                "App::PropertyFloatConstraint", "TimeMinimumStep", "Fem", "Minimum time step"
+                "App::PropertyFloatConstraint",
+                "TimeMinimumStep",
+                "Fem",
+                "Minimum time step",
+                locked=True,
             )
             obj.TimeMinimumStep = 0.00001
 
         if not hasattr(obj, "TimeMaximumStep"):
             obj.addProperty(
-                "App::PropertyFloatConstraint", "TimeMaximumStep", "Fem", "Maximum time step"
+                "App::PropertyFloatConstraint",
+                "TimeMaximumStep",
+                "Fem",
+                "Maximum time step",
+                locked=True,
             )
             obj.TimeMaximumStep = 1.0
 
@@ -173,6 +198,7 @@ class _BaseSolverCalculix:
                 "ThermoMechSteadyState",
                 "Fem",
                 "Choose between steady state thermo mech or transient thermo mech analysis",
+                locked=True,
             )
             obj.ThermoMechSteadyState = True
 
@@ -182,12 +208,17 @@ class _BaseSolverCalculix:
                 "IterationsControlParameterTimeUse",
                 "Fem",
                 "Use the user defined time incrementation control parameter",
+                locked=True,
             )
             obj.IterationsControlParameterTimeUse = False
 
         if not hasattr(obj, "SplitInputWriter"):
             obj.addProperty(
-                "App::PropertyBool", "SplitInputWriter", "Fem", "Split writing of ccx input file"
+                "App::PropertyBool",
+                "SplitInputWriter",
+                "Fem",
+                "Split writing of ccx input file",
+                locked=True,
             )
             obj.SplitInputWriter = False
 
@@ -211,6 +242,7 @@ class _BaseSolverCalculix:
                 "IterationsControlParameterIter",
                 "Fem",
                 "User defined time incrementation iterations control parameter",
+                locked=True,
             )
             obj.IterationsControlParameterIter = control_parameter_iterations
 
@@ -230,6 +262,7 @@ class _BaseSolverCalculix:
                 "IterationsControlParameterCutb",
                 "Fem",
                 "User defined time incrementation cutbacks control parameter",
+                locked=True,
             )
             obj.IterationsControlParameterCutb = control_parameter_cutback
 
@@ -243,6 +276,7 @@ class _BaseSolverCalculix:
                 "IterationsUserDefinedIncrementations",
                 "Fem",
                 stringIterationsUserDefinedIncrementations,
+                locked=True,
             )
             obj.IterationsUserDefinedIncrementations = False
 
@@ -256,6 +290,7 @@ class _BaseSolverCalculix:
                 "IterationsUserDefinedTimeStepLength",
                 "Fem",
                 help_string_IterationsUserDefinedTimeStepLength,
+                locked=True,
             )
             obj.IterationsUserDefinedTimeStepLength = False
 
@@ -269,7 +304,11 @@ class _BaseSolverCalculix:
                 "iterativecholesky",
             ]
             obj.addProperty(
-                "App::PropertyEnumeration", "MatrixSolverType", "Fem", "Type of solver to use"
+                "App::PropertyEnumeration",
+                "MatrixSolverType",
+                "Fem",
+                "Type of solver to use",
+                locked=True,
             )
             obj.MatrixSolverType = known_ccx_solver_types
             obj.MatrixSolverType = known_ccx_solver_types[0]
@@ -280,6 +319,7 @@ class _BaseSolverCalculix:
                 "BeamShellResultOutput3D",
                 "Fem",
                 "Output 3D results for 1D and 2D analysis ",
+                locked=True,
             )
             obj.BeamShellResultOutput3D = True
 
@@ -289,6 +329,7 @@ class _BaseSolverCalculix:
                 "BeamReducedIntegration",
                 "Fem",
                 "Set to True to use beam elements with reduced integration",
+                locked=True,
             )
             obj.BeamReducedIntegration = True
 
@@ -298,12 +339,15 @@ class _BaseSolverCalculix:
                 "OutputFrequency",
                 "Fem",
                 "Set the output frequency in increments",
+                locked=True,
             )
             obj.OutputFrequency = 1
 
         if not hasattr(obj, "ModelSpace"):
             model_space_types = ["3D", "plane stress", "plane strain", "axisymmetric"]
-            obj.addProperty("App::PropertyEnumeration", "ModelSpace", "Fem", "Type of model space")
+            obj.addProperty(
+                "App::PropertyEnumeration", "ModelSpace", "Fem", "Type of model space", locked=True
+            )
             obj.ModelSpace = model_space_types
 
         if not hasattr(obj, "ThermoMechType"):
@@ -313,6 +357,7 @@ class _BaseSolverCalculix:
                 "ThermoMechType",
                 "Fem",
                 "Type of thermomechanical analysis",
+                locked=True,
             )
             obj.ThermoMechType = thermomech_types
 
@@ -322,6 +367,7 @@ class _BaseSolverCalculix:
                 "BucklingAccuracy",
                 "Fem",
                 "Accuracy for buckling analysis",
+                locked=True,
             )
             obj.BucklingAccuracy = 0.01
 

--- a/src/Mod/Fem/femsolver/elmer/equations/deformation.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/deformation.py
@@ -45,37 +45,53 @@ class Proxy(nonlinear.Proxy, equationbase.DeformationProxy):
         super().__init__(obj)
 
         obj.addProperty(
-            "App::PropertyBool", "CalculatePangle", "Deformation", "Compute principal stress angles"
+            "App::PropertyBool",
+            "CalculatePangle",
+            "Deformation",
+            "Compute principal stress angles",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "CalculatePrincipal",
             "Deformation",
             "Compute principal stress components",
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyBool", "CalculateStrains", "Deformation", "Compute the strain tensor"
+            "App::PropertyBool",
+            "CalculateStrains",
+            "Deformation",
+            "Compute the strain tensor",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "CalculateStresses",
             "Deformation",
             "Compute stress tensor and vanMises",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "InitializeStateVariables",
             "Deformation",
             "See Elmer manual for info",
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyBool", "MixedFormulation", "Deformation", "See Elmer manual for info"
+            "App::PropertyBool",
+            "MixedFormulation",
+            "Deformation",
+            "See Elmer manual for info",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "NeoHookeanMaterial",
             "Deformation",
             ("Uses the neo-Hookean material model"),
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
@@ -85,12 +101,14 @@ class Proxy(nonlinear.Proxy, equationbase.DeformationProxy):
                 "Computes solution according to plane\nstress situation.\n"
                 "Applies only for 2D geometry."
             ),
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyString",
             "Variable",
             "Deformation",
             "Only for a 2D model change the '3' to '2'",
+            locked=True,
         )
 
         obj.Priority = 10

--- a/src/Mod/Fem/femsolver/elmer/equations/elasticity.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/elasticity.py
@@ -55,34 +55,53 @@ class Proxy(linear.Proxy, equationbase.ElasticityProxy):
         super().__init__(obj)
 
         obj.addProperty(
-            "App::PropertyBool", "CalculatePangle", "Elasticity", "Compute principal stress angles"
+            "App::PropertyBool",
+            "CalculatePangle",
+            "Elasticity",
+            "Compute principal stress angles",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "CalculatePrincipal",
             "Elasticity",
             "Compute principal stress components",
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyBool", "CalculateStrains", "Elasticity", "Compute the strain tensor"
+            "App::PropertyBool",
+            "CalculateStrains",
+            "Elasticity",
+            "Compute the strain tensor",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "CalculateStresses",
             "Elasticity",
             "Compute stress tensor and vanMises",
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyBool", "ConstantBulkSystem", "Elasticity", "See Elmer manual for info"
+            "App::PropertyBool",
+            "ConstantBulkSystem",
+            "Elasticity",
+            "See Elmer manual for info",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "DisplaceMesh",
             "Elasticity",
             ("If mesh is deformed by displacement field.\nSet to False for 'Eigen Analysis'."),
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyBool", "EigenAnalysis", "Eigen Values", "If true, modal analysis"
+            "App::PropertyBool",
+            "EigenAnalysis",
+            "Eigen Values",
+            "If true, modal analysis",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
@@ -92,12 +111,14 @@ class Proxy(linear.Proxy, equationbase.ElasticityProxy):
                 "Should be true if eigen system is complex\n"
                 "Must be false for a damped eigen value analysis."
             ),
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "EigenSystemComputeResiduals",
             "Eigen Values",
             "Computes residuals of eigen value system",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
@@ -107,18 +128,21 @@ class Proxy(linear.Proxy, equationbase.ElasticityProxy):
                 "Set a damped eigen analysis. Can only be\n"
                 "used if 'Linear Solver Type' is 'Iterative'."
             ),
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyIntegerConstraint",
             "EigenSystemMaxIterations",
             "Eigen Values",
             "Max iterations for iterative eigensystem solver",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyEnumeration",
             "EigenSystemSelect",
             "Eigen Values",
             "Which eigenvalues are computed",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyFloat",
@@ -128,21 +152,28 @@ class Proxy(linear.Proxy, equationbase.ElasticityProxy):
                 "Convergence tolerance for iterative eigensystem solve\n"
                 "Default is 100 times the 'Linear Tolerance'"
             ),
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyInteger",
             "EigenSystemValues",
             "Eigen Values",
             "Number of lowest eigen modes",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "FixDisplacement",
             "Elasticity",
             "If displacements or forces are set,\nthereby model lumping is used",
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyBool", "GeometricStiffness", "Elasticity", "Consider geometric stiffness"
+            "App::PropertyBool",
+            "GeometricStiffness",
+            "Elasticity",
+            "Consider geometric stiffness",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
@@ -152,19 +183,24 @@ class Proxy(linear.Proxy, equationbase.ElasticityProxy):
                 "Computation of incompressible material in connection\n"
                 "with viscoelastic Maxwell material and a custom 'Variable'"
             ),
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "MaxwellMaterial",
             "Elasticity",
             "Compute viscoelastic material model",
+            locked=True,
         )
-        obj.addProperty("App::PropertyBool", "ModelLumping", "Elasticity", "Use model lumping")
+        obj.addProperty(
+            "App::PropertyBool", "ModelLumping", "Elasticity", "Use model lumping", locked=True
+        )
         obj.addProperty(
             "App::PropertyFile",
             "ModelLumpingFilename",
             "Elasticity",
             "File to save results from model lumping to",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
@@ -174,9 +210,14 @@ class Proxy(linear.Proxy, equationbase.ElasticityProxy):
                 "If true, 'Eigen Analysis' is stability analysis.\n"
                 "Otherwise modal analysis is performed."
             ),
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyBool", "UpdateTransientSystem", "Elasticity", "See Elmer manual for info"
+            "App::PropertyBool",
+            "UpdateTransientSystem",
+            "Elasticity",
+            "See Elmer manual for info",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyString",
@@ -186,6 +227,7 @@ class Proxy(linear.Proxy, equationbase.ElasticityProxy):
                 "Only change this if 'Incompressible' is set to true\n"
                 "according to the Elmer manual."
             ),
+            locked=True,
         )
 
         obj.addProperty(
@@ -196,6 +238,7 @@ class Proxy(linear.Proxy, equationbase.ElasticityProxy):
                 "Computes solution according to plane\nstress situation.\n"
                 "Applies only for 2D geometry."
             ),
+            locked=True,
         )
 
         obj.EigenSystemValues = 5

--- a/src/Mod/Fem/femsolver/elmer/equations/elasticity_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/elasticity_writer.py
@@ -110,6 +110,7 @@ class ElasticityWriter:
                     "Only change this if 'Incompressible' is set to true\n"
                     "according to the Elmer manual."
                 ),
+                locked=True,
             )
             equation.Variable = "Displacement"
         if hasattr(equation, "Bubbles"):
@@ -117,7 +118,11 @@ class ElasticityWriter:
             equation.removeProperty("Bubbles")
         if not hasattr(equation, "ConstantBulkSystem"):
             equation.addProperty(
-                "App::PropertyBool", "ConstantBulkSystem", "Elasticity", "See Elmer manual for info"
+                "App::PropertyBool",
+                "ConstantBulkSystem",
+                "Elasticity",
+                "See Elmer manual for info",
+                locked=True,
             )
         if not hasattr(equation, "DisplaceMesh"):
             equation.addProperty(
@@ -128,6 +133,7 @@ class ElasticityWriter:
                     "If mesh is deformed by displacement field.\n"
                     "Set to False for 'Eigen Analysis'."
                 ),
+                locked=True,
             )
             # DisplaceMesh is true except if DoFrequencyAnalysis is true
             equation.DisplaceMesh = True
@@ -138,7 +144,11 @@ class ElasticityWriter:
             # DoFrequencyAnalysis was renamed to EigenAnalysis
             # to follow the Elmer manual
             equation.addProperty(
-                "App::PropertyBool", "EigenAnalysis", "Eigen Values", "If true, modal analysis"
+                "App::PropertyBool",
+                "EigenAnalysis",
+                "Eigen Values",
+                "If true, modal analysis",
+                locked=True,
             )
             if hasattr(equation, "DoFrequencyAnalysis"):
                 equation.EigenAnalysis = equation.DoFrequencyAnalysis
@@ -152,6 +162,7 @@ class ElasticityWriter:
                     "Should be true if eigen system is complex\n"
                     "Must be false for a damped eigen value analysis."
                 ),
+                locked=True,
             )
             equation.EigenSystemComplex = True
         if not hasattr(equation, "EigenSystemComputeResiduals"):
@@ -160,6 +171,7 @@ class ElasticityWriter:
                 "EigenSystemComputeResiduals",
                 "Eigen Values",
                 "Computes residuals of eigen value system",
+                locked=True,
             )
         if not hasattr(equation, "EigenSystemDamped"):
             equation.addProperty(
@@ -170,6 +182,7 @@ class ElasticityWriter:
                     "Set a damped eigen analysis. Can only be\n"
                     "used if 'Linear Solver Type' is 'Iterative'."
                 ),
+                locked=True,
             )
         if not hasattr(equation, "EigenSystemMaxIterations"):
             equation.addProperty(
@@ -177,6 +190,7 @@ class ElasticityWriter:
                 "EigenSystemMaxIterations",
                 "Eigen Values",
                 "Max iterations for iterative eigensystem solver",
+                locked=True,
             )
             equation.EigenSystemMaxIterations = (300, 1, int(1e8), 1)
         if not hasattr(equation, "EigenSystemSelect"):
@@ -185,6 +199,7 @@ class ElasticityWriter:
                 "EigenSystemSelect",
                 "Eigen Values",
                 "Which eigenvalues are computed",
+                locked=True,
             )
             equation.EigenSystemSelect = elasticity.EIGEN_SYSTEM_SELECT
             equation.EigenSystemSelect = "Smallest Magnitude"
@@ -197,6 +212,7 @@ class ElasticityWriter:
                     "Convergence tolerance for iterative eigensystem solve\n"
                     "Default is 100 times the 'Linear Tolerance'"
                 ),
+                locked=True,
             )
             equation.setExpression("EigenSystemTolerance", str(100 * equation.LinearTolerance))
         if not hasattr(equation, "EigenSystemValues"):
@@ -207,6 +223,7 @@ class ElasticityWriter:
                 "EigenSystemValues",
                 "Eigen Values",
                 "Number of lowest eigen modes",
+                locked=True,
             )
             if hasattr(equation, "EigenmodesCount"):
                 equation.EigenSystemValues = equation.EigenmodesCount
@@ -217,6 +234,7 @@ class ElasticityWriter:
                 "FixDisplacement",
                 "Elasticity",
                 "If displacements or forces are set,\nthereby model lumping is used",
+                locked=True,
             )
         if not hasattr(equation, "GeometricStiffness"):
             equation.addProperty(
@@ -224,6 +242,7 @@ class ElasticityWriter:
                 "GeometricStiffness",
                 "Elasticity",
                 "Consider geometric stiffness",
+                locked=True,
             )
         if not hasattr(equation, "Incompressible"):
             equation.addProperty(
@@ -234,6 +253,7 @@ class ElasticityWriter:
                     "Computation of incompressible material in connection\n"
                     "with viscoelastic Maxwell material and a custom 'Variable'"
                 ),
+                locked=True,
             )
         if not hasattr(equation, "MaxwellMaterial"):
             equation.addProperty(
@@ -241,10 +261,11 @@ class ElasticityWriter:
                 "MaxwellMaterial",
                 "Elasticity",
                 "Compute viscoelastic material model",
+                locked=True,
             )
         if not hasattr(equation, "ModelLumping"):
             equation.addProperty(
-                "App::PropertyBool", "ModelLumping", "Elasticity", "Use model lumping"
+                "App::PropertyBool", "ModelLumping", "Elasticity", "Use model lumping", locked=True
             )
         if not hasattr(equation, "ModelLumpingFilename"):
             equation.addProperty(
@@ -252,6 +273,7 @@ class ElasticityWriter:
                 "ModelLumpingFilename",
                 "Elasticity",
                 "File to save results from model lumping to",
+                locked=True,
             )
         if not hasattr(equation, "PlaneStress"):
             equation.addProperty(
@@ -262,6 +284,7 @@ class ElasticityWriter:
                     "Computes solution according to plane\nstress situation.\n"
                     "Applies only for 2D geometry."
                 ),
+                locked=True,
             )
         if not hasattr(equation, "StabilityAnalysis"):
             equation.addProperty(
@@ -272,6 +295,7 @@ class ElasticityWriter:
                     "If true, 'Eigen Analysis' is stability analysis.\n"
                     "Otherwise modal analysis is performed."
                 ),
+                locked=True,
             )
         if not hasattr(equation, "UpdateTransientSystem"):
             equation.addProperty(
@@ -279,6 +303,7 @@ class ElasticityWriter:
                 "UpdateTransientSystem",
                 "Elasticity",
                 "See Elmer manual for info",
+                locked=True,
             )
 
     def handleElasticityConstants(self):

--- a/src/Mod/Fem/femsolver/elmer/equations/electricforce.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/electricforce.py
@@ -54,6 +54,7 @@ class Proxy(linear.Proxy, equationbase.ElectricforceProxy):
                 "That solver is only executed after solution converged\n"
                 "To execute always, change to 'Always'"
             ),
+            locked=True,
         )
 
         obj.ExecSolver = SOLVER_EXEC_METHODS

--- a/src/Mod/Fem/femsolver/elmer/equations/electricforce_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/electricforce_writer.py
@@ -61,6 +61,7 @@ class EFwriter:
                     "That solver is only executed after solution converged\n"
                     "To execute always, change to 'Always'"
                 ),
+                locked=True,
             )
             equation.ExecSolver = electricforce.SOLVER_EXEC_METHODS
             equation.ExecSolver = "After Timestep"

--- a/src/Mod/Fem/femsolver/elmer/equations/electrostatic.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/electrostatic.py
@@ -45,17 +45,27 @@ class Proxy(linear.Proxy, equationbase.ElectrostaticProxy):
     def __init__(self, obj):
         super().__init__(obj)
 
-        obj.addProperty("App::PropertyBool", "CalculateCapacitanceMatrix", "Electrostatic", "")
-        obj.addProperty("App::PropertyBool", "CalculateElectricEnergy", "Electrostatic", "")
-        obj.addProperty("App::PropertyBool", "CalculateElectricField", "Electrostatic", "")
-        obj.addProperty("App::PropertyBool", "CalculateElectricFlux", "Electrostatic", "")
-        obj.addProperty("App::PropertyBool", "CalculateSurfaceCharge", "Electrostatic", "")
+        obj.addProperty(
+            "App::PropertyBool", "CalculateCapacitanceMatrix", "Electrostatic", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyBool", "CalculateElectricEnergy", "Electrostatic", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyBool", "CalculateElectricField", "Electrostatic", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyBool", "CalculateElectricFlux", "Electrostatic", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyBool", "CalculateSurfaceCharge", "Electrostatic", "", locked=True
+        )
         """
         obj.addProperty(
             "App::PropertyInteger",
             "CapacitanceBodies",
             "Electrostatic",
-            ""
+            "", locked=True
         )
         """
         obj.addProperty(
@@ -66,12 +76,14 @@ class Proxy(linear.Proxy, equationbase.ElectrostaticProxy):
                 "File where capacitance matrix is being saved\n"
                 "Only used if 'CalculateCapacitanceMatrix' is true"
             ),
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "ConstantWeights",
             "Electrostatic",
             "Use constant weighting for results",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyFloat",
@@ -81,6 +93,7 @@ class Proxy(linear.Proxy, equationbase.ElectrostaticProxy):
                 "Potential difference in Volt for which capacitance is\n"
                 "calculated if 'CalculateCapacitanceMatrix' is false"
             ),
+            locked=True,
         )
 
         obj.CapacitanceMatrixFilename = "cmatrix.dat"

--- a/src/Mod/Fem/femsolver/elmer/equations/electrostatic_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/electrostatic_writer.py
@@ -81,6 +81,7 @@ class ESwriter:
                     "File where capacitance matrix is being saved\n"
                     "Only used if 'CalculateCapacitanceMatrix' is true"
                 ),
+                locked=True,
             )
             equation.CapacitanceMatrixFilename = "cmatrix.dat"
         if not hasattr(equation, "ConstantWeights"):
@@ -89,6 +90,7 @@ class ESwriter:
                 "ConstantWeights",
                 "Electrostatic",
                 "Use constant weighting for results",
+                locked=True,
             )
         if not hasattr(equation, "PotentialDifference"):
             equation.addProperty(
@@ -99,6 +101,7 @@ class ESwriter:
                     "Potential difference in Volt for which capacitance is\n"
                     "calculated if 'CalculateCapacitanceMatrix' is false"
                 ),
+                locked=True,
             )
             equation.PotentialDifference = 0.0
 

--- a/src/Mod/Fem/femsolver/elmer/equations/equation.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/equation.py
@@ -50,6 +50,7 @@ class Proxy(equationbase.BaseProxy):
                 "The equation with highest number\n"
                 "will be solved first."
             ),
+            locked=True,
         )
 
 

--- a/src/Mod/Fem/femsolver/elmer/equations/flow.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/flow.py
@@ -56,8 +56,11 @@ class Proxy(nonlinear.Proxy, equationbase.FlowProxy):
                 "Set to true for incompressible flow for more stable\n"
                 "discretization when Reynolds number increases"
             ),
+            locked=True,
         )
-        obj.addProperty("App::PropertyEnumeration", "FlowModel", "Flow", "Flow model to be used")
+        obj.addProperty(
+            "App::PropertyEnumeration", "FlowModel", "Flow", "Flow model to be used", locked=True
+        )
         obj.addProperty(
             "App::PropertyBool",
             "GradpDiscretization",
@@ -66,13 +69,22 @@ class Proxy(nonlinear.Proxy, equationbase.FlowProxy):
                 "If true pressure Dirichlet boundary conditions can be used.\n"
                 "Also mass flux is available as a natural boundary condition."
             ),
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyString", "Variable", "Flow", "Only for a 2D model change the '3' to '2'"
+            "App::PropertyString",
+            "Variable",
+            "Flow",
+            "Only for a 2D model change the '3' to '2'",
+            locked=True,
         )
 
         obj.addProperty(
-            "App::PropertyEnumeration", "Convection", "Equation", "Type of convection to be used"
+            "App::PropertyEnumeration",
+            "Convection",
+            "Equation",
+            "Type of convection to be used",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
@@ -82,6 +94,7 @@ class Proxy(nonlinear.Proxy, equationbase.FlowProxy):
                 "Magnetic induction equation will be solved\n"
                 "along with the Navier-Stokes equations"
             ),
+            locked=True,
         )
         obj.FlowModel = FLOW_MODEL
         obj.FlowModel = "Full"

--- a/src/Mod/Fem/femsolver/elmer/equations/flow_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/flow_writer.py
@@ -73,6 +73,7 @@ class Flowwriter:
                 "Convection",
                 "Equation",
                 "Type of convection to be used",
+                locked=True,
             )
             equation.Convection = flow.CONVECTION_TYPE
             equation.Convection = "Computed"
@@ -85,10 +86,15 @@ class Flowwriter:
                     "Set to true for incompressible flow for more stable\n"
                     "discretization when Reynolds number increases"
                 ),
+                locked=True,
             )
         if not hasattr(equation, "FlowModel"):
             equation.addProperty(
-                "App::PropertyEnumeration", "FlowModel", "Flow", "Flow model to be used"
+                "App::PropertyEnumeration",
+                "FlowModel",
+                "Flow",
+                "Flow model to be used",
+                locked=True,
             )
             equation.FlowModel = flow.FLOW_MODEL
             equation.FlowModel = "Full"
@@ -101,6 +107,7 @@ class Flowwriter:
                     "If true pressure Dirichlet boundary conditions can be used.\n"
                     "Also mass flux is available as a natural boundary condition."
                 ),
+                locked=True,
             )
         if not hasattr(equation, "MagneticInduction"):
             equation.addProperty(
@@ -111,6 +118,7 @@ class Flowwriter:
                     "Magnetic induction equation will be solved\n"
                     "along with the Navier-Stokes equations"
                 ),
+                locked=True,
             )
         if not hasattr(equation, "Variable"):
             equation.addProperty(
@@ -118,6 +126,7 @@ class Flowwriter:
                 "Variable",
                 "Flow",
                 "Only for a 2D model change the '3' to '2'",
+                locked=True,
             )
             equation.Variable = "Flow Solution[Velocity:3 Pressure:1]"
 

--- a/src/Mod/Fem/femsolver/elmer/equations/flux.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/flux.py
@@ -57,28 +57,45 @@ class Proxy(linear.Proxy, equationbase.FluxProxy):
                 "Enforces continuity within the same material\n"
                 "in the 'Discontinuous Galerkin' discretization"
             ),
+            locked=True,
         )
-        obj.addProperty("App::PropertyBool", "CalculateFlux", "Flux", "Computes flux vector")
         obj.addProperty(
-            "App::PropertyBool", "CalculateFluxAbs", "Flux", "Computes absolute of flux vector"
+            "App::PropertyBool", "CalculateFlux", "Flux", "Computes flux vector", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyBool",
+            "CalculateFluxAbs",
+            "Flux",
+            "Computes absolute of flux vector",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "CalculateFluxMagnitude",
             "Flux",
             "Computes magnitude of flux vector field",
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyBool", "CalculateGrad", "Flux", "Select calculation of gradient"
+            "App::PropertyBool",
+            "CalculateGrad",
+            "Flux",
+            "Select calculation of gradient",
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyBool", "CalculateGradAbs", "Flux", "Computes absolute of gradient field"
+            "App::PropertyBool",
+            "CalculateGradAbs",
+            "Flux",
+            "Computes absolute of gradient field",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "CalculateGradMagnitude",
             "Flux",
             "Computes magnitude of gradient field",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
@@ -88,6 +105,7 @@ class Proxy(linear.Proxy, equationbase.FluxProxy):
                 "Enable if standard Galerkin approximation leads to\n"
                 "unphysical results when there are discontinuities"
             ),
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
@@ -97,15 +115,21 @@ class Proxy(linear.Proxy, equationbase.FluxProxy):
                 "If true, negative values of computed magnitude fields\n"
                 "are a posteriori set to zero."
             ),
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyEnumeration",
             "FluxCoefficient",
             "Flux",
             "Proportionality coefficient\nto compute the flux",
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyEnumeration", "FluxVariable", "Flux", "Variable name for flux calculation"
+            "App::PropertyEnumeration",
+            "FluxVariable",
+            "Flux",
+            "Variable name for flux calculation",
+            locked=True,
         )
 
         obj.CalculateFlux = True

--- a/src/Mod/Fem/femsolver/elmer/equations/flux_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/flux_writer.py
@@ -79,13 +79,18 @@ class Fluxwriter:
                     "Enforces continuity within the same material\n"
                     "in the 'Discontinuous Galerkin' discretization"
                 ),
+                locked=True,
             )
         if hasattr(equation, "Bubbles"):
             # Bubbles was removed because it is unused by Elmer for the flux solver
             equation.removeProperty("Bubbles")
         if not hasattr(equation, "CalculateFluxAbs"):
             equation.addProperty(
-                "App::PropertyBool", "CalculateFluxAbs", "Flux", "Computes absolute of flux vector"
+                "App::PropertyBool",
+                "CalculateFluxAbs",
+                "Flux",
+                "Computes absolute of flux vector",
+                locked=True,
             )
         if not hasattr(equation, "CalculateFluxMagnitude"):
             equation.addProperty(
@@ -93,6 +98,7 @@ class Fluxwriter:
                 "CalculateFluxMagnitude",
                 "Flux",
                 "Computes magnitude of flux vector field",
+                locked=True,
             )
         if not hasattr(equation, "CalculateGradAbs"):
             equation.addProperty(
@@ -100,6 +106,7 @@ class Fluxwriter:
                 "CalculateGradAbs",
                 "Flux",
                 "Computes absolute of gradient field",
+                locked=True,
             )
         if not hasattr(equation, "CalculateGradMagnitude"):
             equation.addProperty(
@@ -107,6 +114,7 @@ class Fluxwriter:
                 "CalculateGradMagnitude",
                 "Flux",
                 "Computes magnitude of gradient field",
+                locked=True,
             )
         if not hasattr(equation, "DiscontinuousGalerkin"):
             equation.addProperty(
@@ -117,6 +125,7 @@ class Fluxwriter:
                     "Enable if standard Galerkin approximation leads to\n"
                     "unphysical results when there are discontinuities"
                 ),
+                locked=True,
             )
         if not hasattr(equation, "EnforcePositiveMagnitude"):
             equation.addProperty(
@@ -127,6 +136,7 @@ class Fluxwriter:
                     "If true, negative values of computed magnitude fields\n"
                     "are a posteriori set to zero."
                 ),
+                locked=True,
             )
         tempFluxCoefficient = ""
         if hasattr(equation, "FluxCoefficient"):
@@ -141,6 +151,7 @@ class Fluxwriter:
                 "FluxCoefficient",
                 "Flux",
                 "Name of proportionality coefficient\nto compute the flux",
+                locked=True,
             )
             equation.FluxCoefficient = flux.COEFFICIENTS
             if tempFluxCoefficient:
@@ -159,6 +170,7 @@ class Fluxwriter:
                     "FluxVariable",
                     "Flux",
                     "Variable name for flux calculation",
+                    locked=True,
                 )
                 equation.FluxVariable = flux.VARIABLES
                 equation.FluxVariable = tempFluxVariable

--- a/src/Mod/Fem/femsolver/elmer/equations/heat.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/heat.py
@@ -50,12 +50,20 @@ class Proxy(nonlinear.Proxy, equationbase.HeatProxy):
 
         # according to the Elmer models manual Bubbles is by default True
         # and Stabilize is False (Stabilize is added in linear.py)
-        obj.addProperty("App::PropertyBool", "Bubbles", "Heat", "")
+        obj.addProperty("App::PropertyBool", "Bubbles", "Heat", "", locked=True)
         obj.addProperty(
-            "App::PropertyEnumeration", "Convection", "Equation", "Type of convection to be used"
+            "App::PropertyEnumeration",
+            "Convection",
+            "Equation",
+            "Type of convection to be used",
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyEnumeration", "PhaseChangeModel", "Equation", "Model for phase change"
+            "App::PropertyEnumeration",
+            "PhaseChangeModel",
+            "Equation",
+            "Model for phase change",
+            locked=True,
         )
 
         obj.Bubbles = True

--- a/src/Mod/Fem/femsolver/elmer/equations/heat_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/heat_writer.py
@@ -81,12 +81,17 @@ class Heatwriter:
                 "Convection",
                 "Equation",
                 "Type of convection to be used",
+                locked=True,
             )
             equation.Convection = heat.CONVECTION_TYPE
             equation.Convection = "None"
         if not hasattr(equation, "PhaseChangeModel"):
             equation.addProperty(
-                "App::PropertyEnumeration", "PhaseChangeModel", "Equation", "Model for phase change"
+                "App::PropertyEnumeration",
+                "PhaseChangeModel",
+                "Equation",
+                "Model for phase change",
+                locked=True,
             )
             equation.PhaseChangeModel = heat.PHASE_CHANGE_MODEL
             equation.PhaseChangeModel = "None"

--- a/src/Mod/Fem/femsolver/elmer/equations/linear.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/linear.py
@@ -53,18 +53,30 @@ class Proxy(equation.Proxy):
             "BiCGstablDegree",
             "Linear System",
             "Polynom degree for iterative method 'BiCGstabl'",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyIntegerConstraint",
             "IdrsParameter",
             "Linear System",
             "Parameter for iterative method 'Idrs'",
+            locked=True,
         )
-        obj.addProperty("App::PropertyEnumeration", "LinearDirectMethod", "Linear System", "")
-        obj.addProperty("App::PropertyIntegerConstraint", "LinearIterations", "Linear System", "")
-        obj.addProperty("App::PropertyEnumeration", "LinearIterativeMethod", "Linear System", "")
-        obj.addProperty("App::PropertyEnumeration", "LinearPreconditioning", "Linear System", "")
-        obj.addProperty("App::PropertyEnumeration", "LinearSolverType", "Linear System", "")
+        obj.addProperty(
+            "App::PropertyEnumeration", "LinearDirectMethod", "Linear System", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyIntegerConstraint", "LinearIterations", "Linear System", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyEnumeration", "LinearIterativeMethod", "Linear System", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyEnumeration", "LinearPreconditioning", "Linear System", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyEnumeration", "LinearSolverType", "Linear System", "", locked=True
+        )
         obj.addProperty(
             "App::PropertyBool",
             "LinearSystemSolverDisabled",
@@ -74,15 +86,19 @@ class Proxy(equation.Proxy):
                 "Only use for special cases\n"
                 "and consult the Elmer docs."
             ),
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyFloat",
             "LinearTolerance",
             "Linear System",
             "Linear preconditioning method",
+            locked=True,
         )
-        obj.addProperty("App::PropertyBool", "Stabilize", "Base", "")
-        obj.addProperty("App::PropertyFloat", "SteadyStateTolerance", "Steady State", "")
+        obj.addProperty("App::PropertyBool", "Stabilize", "Base", "", locked=True)
+        obj.addProperty(
+            "App::PropertyFloat", "SteadyStateTolerance", "Steady State", "", locked=True
+        )
 
         obj.BiCGstablDegree = (2, 2, 10, 1)
         obj.IdrsParameter = (2, 1, 10, 1)

--- a/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic.py
@@ -49,12 +49,14 @@ class Proxy(nonlinear.Proxy, equationbase.MagnetodynamicProxy):
             "IsHarmonic",
             "Magnetodynamic",
             "If the magnetic source is harmonically driven",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyFrequency",
             "AngularFrequency",
             "Magnetodynamic",
             "Frequency of the driving current",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
@@ -63,67 +65,79 @@ class Proxy(nonlinear.Proxy, equationbase.MagnetodynamicProxy):
             "Must be True if basis functions for edge element interpolation\n"
             "are selected to be members of optimal edge element family\n"
             "or if second-order approximation is used.",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "QuadraticApproximation",
             "Magnetodynamic",
             "Enables second-order approximation of driving current",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "StaticConductivity",
             "Magnetodynamic",
             "See Elmer models manual for info",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "FixInputCurrentDensity",
             "Magnetodynamic",
             "Ensures divergence-freeness of current density",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "AutomatedSourceProjectionBCs",
             "Magnetodynamic",
             "See Elmer models manual for info",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "UseLagrangeGauge",
             "Magnetodynamic",
             "See Elmer models manual for info",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyFloat",
             "LagrangeGaugePenalizationCoefficient",
             "Magnetodynamic",
             "See Elmer models manual for info",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "UseTreeGauge",
             "Magnetodynamic",
             "See Elmer models manual for info\nWill be ignored if 'UsePiolaTransform' is True",
+            locked=True,
         )
-        obj.addProperty("App::PropertyBool", "LinearSystemRefactorize", "Linear System", "")
+        obj.addProperty(
+            "App::PropertyBool", "LinearSystemRefactorize", "Linear System", "", locked=True
+        )
 
         obj.IsHarmonic = False
         obj.AngularFrequency = 0
         obj.Priority = 10
 
         # the post processor options
-        obj.addProperty("App::PropertyBool", "CalculateCurrentDensity", "Results", "")
-        obj.addProperty("App::PropertyBool", "CalculateElectricField", "Results", "")
-        obj.addProperty("App::PropertyBool", "CalculateElementalFields", "Results", "")
-        obj.addProperty("App::PropertyBool", "CalculateHarmonicLoss", "Results", "")
-        obj.addProperty("App::PropertyBool", "CalculateJouleHeating", "Results", "")
-        obj.addProperty("App::PropertyBool", "CalculateMagneticFieldStrength", "Results", "")
-        obj.addProperty("App::PropertyBool", "CalculateMaxwellStress", "Results", "")
-        obj.addProperty("App::PropertyBool", "CalculateNodalFields", "Results", "")
-        obj.addProperty("App::PropertyBool", "CalculateNodalForces", "Results", "")
-        obj.addProperty("App::PropertyBool", "CalculateNodalHeating", "Results", "")
-        obj.addProperty("App::PropertyBool", "DiscontinuousBodies", "Results", "")
+        obj.addProperty("App::PropertyBool", "CalculateCurrentDensity", "Results", "", locked=True)
+        obj.addProperty("App::PropertyBool", "CalculateElectricField", "Results", "", locked=True)
+        obj.addProperty("App::PropertyBool", "CalculateElementalFields", "Results", "", locked=True)
+        obj.addProperty("App::PropertyBool", "CalculateHarmonicLoss", "Results", "", locked=True)
+        obj.addProperty("App::PropertyBool", "CalculateJouleHeating", "Results", "", locked=True)
+        obj.addProperty(
+            "App::PropertyBool", "CalculateMagneticFieldStrength", "Results", "", locked=True
+        )
+        obj.addProperty("App::PropertyBool", "CalculateMaxwellStress", "Results", "", locked=True)
+        obj.addProperty("App::PropertyBool", "CalculateNodalFields", "Results", "", locked=True)
+        obj.addProperty("App::PropertyBool", "CalculateNodalForces", "Results", "", locked=True)
+        obj.addProperty("App::PropertyBool", "CalculateNodalHeating", "Results", "", locked=True)
+        obj.addProperty("App::PropertyBool", "DiscontinuousBodies", "Results", "", locked=True)
         obj.CalculateCurrentDensity = False
         obj.CalculateElectricField = False
         # FIXME: at the moment FreeCAD's post processor cannot display elementary field

--- a/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic2D.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic2D.py
@@ -49,30 +49,54 @@ class Proxy(nonlinear.Proxy, equationbase.Magnetodynamic2DProxy):
             "IsHarmonic",
             "Magnetodynamic2D",
             "If the magnetic source is harmonically driven",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyFrequency",
             "AngularFrequency",
             "Magnetodynamic2D",
             "Frequency of the driving current",
+            locked=True,
         )
         obj.IsHarmonic = False
         obj.AngularFrequency = 0
         obj.Priority = 10
 
         # the post processor options
-        obj.addProperty("App::PropertyBool", "CalculateCurrentDensity", "Magnetodynamic2D", "")
-        obj.addProperty("App::PropertyBool", "CalculateElectricField", "Magnetodynamic2D", "")
-        obj.addProperty("App::PropertyBool", "CalculateElementalFields", "Magnetodynamic2D", "")
-        obj.addProperty("App::PropertyBool", "CalculateHarmonicLoss", "Magnetodynamic2D", "")
-        obj.addProperty("App::PropertyBool", "CalculateJouleHeating", "Magnetodynamic2D", "")
         obj.addProperty(
-            "App::PropertyBool", "CalculateMagneticFieldStrength", "Magnetodynamic2D", ""
+            "App::PropertyBool", "CalculateCurrentDensity", "Magnetodynamic2D", "", locked=True
         )
-        obj.addProperty("App::PropertyBool", "CalculateMaxwellStress", "Magnetodynamic2D", "")
-        obj.addProperty("App::PropertyBool", "CalculateNodalFields", "Magnetodynamic2D", "")
-        obj.addProperty("App::PropertyBool", "CalculateNodalForces", "Magnetodynamic2D", "")
-        obj.addProperty("App::PropertyBool", "CalculateNodalHeating", "Magnetodynamic2D", "")
+        obj.addProperty(
+            "App::PropertyBool", "CalculateElectricField", "Magnetodynamic2D", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyBool", "CalculateElementalFields", "Magnetodynamic2D", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyBool", "CalculateHarmonicLoss", "Magnetodynamic2D", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyBool", "CalculateJouleHeating", "Magnetodynamic2D", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyBool",
+            "CalculateMagneticFieldStrength",
+            "Magnetodynamic2D",
+            "",
+            locked=True,
+        )
+        obj.addProperty(
+            "App::PropertyBool", "CalculateMaxwellStress", "Magnetodynamic2D", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyBool", "CalculateNodalFields", "Magnetodynamic2D", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyBool", "CalculateNodalForces", "Magnetodynamic2D", "", locked=True
+        )
+        obj.addProperty(
+            "App::PropertyBool", "CalculateNodalHeating", "Magnetodynamic2D", "", locked=True
+        )
         obj.CalculateCurrentDensity = False
         obj.CalculateElectricField = False
         # FIXME: at the moment FreeCAD's post processor cannot display elementary field

--- a/src/Mod/Fem/femsolver/elmer/equations/nonlinear.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/nonlinear.py
@@ -47,17 +47,25 @@ class Proxy(linear.Proxy):
             "NonlinearIterations",
             "Nonlinear System",
             "Maximum number of iterations",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyIntegerConstraint",
             "NonlinearNewtonAfterIterations",
             "Nonlinear System",
             "",
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyFloat", "NonlinearNewtonAfterTolerance", "Nonlinear System", ""
+            "App::PropertyFloat",
+            "NonlinearNewtonAfterTolerance",
+            "Nonlinear System",
+            "",
+            locked=True,
         )
-        obj.addProperty("App::PropertyFloat", "NonlinearTolerance", "Nonlinear System", "")
+        obj.addProperty(
+            "App::PropertyFloat", "NonlinearTolerance", "Nonlinear System", "", locked=True
+        )
         obj.addProperty(
             "App::PropertyFloatConstraint",
             "RelaxationFactor",
@@ -66,6 +74,7 @@ class Proxy(linear.Proxy):
                 "Value below 1.0 might be necessary to achieve convergence\n"
                 "Typical values are in the range [0.3, 1.0]"
             ),
+            locked=True,
         )
 
         obj.NonlinearIterations = (20, 1, int(1e6), 10)

--- a/src/Mod/Fem/femsolver/elmer/equations/staticcurrent.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/staticcurrent.py
@@ -44,43 +44,58 @@ class Proxy(nonlinear.Proxy, equationbase.StaticCurrentProxy):
     def __init__(self, obj):
         super().__init__(obj)
 
-        obj.addProperty("App::PropertyBool", "CalculateVolumeCurrent", "StaticCurrent", "")
+        obj.addProperty(
+            "App::PropertyBool", "CalculateVolumeCurrent", "StaticCurrent", "", locked=True
+        )
         obj.CalculateVolumeCurrent = True
-        obj.addProperty("App::PropertyBool", "CalculateJouleHeating", "StaticCurrent", "")
+        obj.addProperty(
+            "App::PropertyBool", "CalculateJouleHeating", "StaticCurrent", "", locked=True
+        )
         obj.addProperty(
             "App::PropertyBool",
             "ConstantWeights",
             "StaticCurrent",
             "Used to turn constant weighting on for the results",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "CalculateNodalHeating",
             "StaticCurrent",
             "Calculate nodal heating that may be used to couple the heat equation optimally when using conforming finite element meshes",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "HeatSource",
             "StaticCurrent",
             "Use Joule heating as a heat source in combination with heat equation",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "PowerControl",
             "StaticCurrent",
             "Apply power control with the desired heating power",
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyBool",
             "CurrentControl",
             "StaticCurrent",
             "Apply current control with the desired current",
+            locked=True,
         )
         obj.addProperty(
-            "App::PropertyElectricCurrent", "Current", "StaticCurrent", "Current control value"
+            "App::PropertyElectricCurrent",
+            "Current",
+            "StaticCurrent",
+            "Current control value",
+            locked=True,
         )
-        obj.addProperty("App::PropertyPower", "Power", "StaticCurrent", "Power control value")
+        obj.addProperty(
+            "App::PropertyPower", "Power", "StaticCurrent", "Power control value", locked=True
+        )
 
 
 class ViewProxy(nonlinear.ViewProxy, equationbase.StaticCurrentViewProxy):

--- a/src/Mod/Fem/femsolver/elmer/solver.py
+++ b/src/Mod/Fem/femsolver/elmer/solver.py
@@ -88,7 +88,9 @@ class Proxy(solverbase.Proxy):
     def __init__(self, obj):
         super().__init__(obj)
 
-        obj.addProperty("App::PropertyEnumeration", "CoordinateSystem", "Coordinate System", "")
+        obj.addProperty(
+            "App::PropertyEnumeration", "CoordinateSystem", "Coordinate System", "", locked=True
+        )
         obj.CoordinateSystem = COORDINATE_SYSTEM
         obj.CoordinateSystem = "Cartesian"
 
@@ -97,6 +99,7 @@ class Proxy(solverbase.Proxy):
             "BDFOrder",
             "Timestepping",
             "Order of time stepping method 'BDF'",
+            locked=True,
         )
         # according to the Elmer manual recommended is order 2
         # possible range is 1 - 5
@@ -107,6 +110,7 @@ class Proxy(solverbase.Proxy):
             "OutputIntervals",
             "Timestepping",
             "After how many time steps a result file is output",
+            locked=True,
         )
         obj.OutputIntervals = [1]
 
@@ -115,6 +119,7 @@ class Proxy(solverbase.Proxy):
             "TimestepIntervals",
             "Timestepping",
             ("List of times if 'Simulation Type'\nis either 'Scanning' or 'Transient'"),
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyFloatList",
@@ -124,6 +129,7 @@ class Proxy(solverbase.Proxy):
                 "List of time steps sizes if 'Simulation Type'\n"
                 "is either 'Scanning' or 'Transient'"
             ),
+            locked=True,
         )
         # there is no universal default, it all depends on the analysis, however
         # we have to set something and set 10 seconds in steps of 0.1s
@@ -139,6 +145,7 @@ class Proxy(solverbase.Proxy):
             "SteadyStateMaxIterations",
             "Type",
             "Maximal steady state iterations",
+            locked=True,
         )
         obj.SteadyStateMaxIterations = 1
 
@@ -147,20 +154,29 @@ class Proxy(solverbase.Proxy):
             "SteadyStateMinIterations",
             "Type",
             "Minimal steady state iterations",
+            locked=True,
         )
         obj.SteadyStateMinIterations = 0
 
-        obj.addProperty("App::PropertyLink", "ElmerResult", "Base", "", 4 | 8)
+        obj.addProperty("App::PropertyLink", "ElmerResult", "Base", "", 4 | 8, locked=True)
 
-        obj.addProperty("App::PropertyLink", "ElmerOutput", "Base", "", 4 | 8)
+        obj.addProperty("App::PropertyLink", "ElmerOutput", "Base", "", 4 | 8, locked=True)
 
         obj.addProperty(
-            "App::PropertyBool", "BinaryOutput", "Result File", "Save result in binary format"
+            "App::PropertyBool",
+            "BinaryOutput",
+            "Result File",
+            "Save result in binary format",
+            locked=True,
         )
         obj.BinaryOutput = False
 
         obj.addProperty(
-            "App::PropertyBool", "SaveGeometryIndex", "Result File", "Save geometry IDs"
+            "App::PropertyBool",
+            "SaveGeometryIndex",
+            "Result File",
+            "Save geometry IDs",
+            locked=True,
         )
         obj.SaveGeometryIndex = False
 
@@ -170,14 +186,22 @@ class Proxy(solverbase.Proxy):
             obj.getPropertyByName("BinaryOutput")
         except FreeCAD.Base.PropertyError:
             obj.addProperty(
-                "App::PropertyBool", "BinaryOutput", "Result File", "Save result in binary format"
+                "App::PropertyBool",
+                "BinaryOutput",
+                "Result File",
+                "Save result in binary format",
+                locked=True,
             )
             obj.BinaryOutput = False
         try:
             obj.getPropertyByName("SaveGeometryIndex")
         except FreeCAD.Base.PropertyError:
             obj.addProperty(
-                "App::PropertyBool", "SaveGeometryIndex", "Result File", "Save geometry IDs"
+                "App::PropertyBool",
+                "SaveGeometryIndex",
+                "Result File",
+                "Save geometry IDs",
+                locked=True,
             )
             obj.SaveGeometryIndex = False
 

--- a/src/Mod/Fem/femsolver/elmer/writer.py
+++ b/src/Mod/Fem/femsolver/elmer/writer.py
@@ -350,7 +350,7 @@ class Writer:
         # updates older simulations
         if not hasattr(self.solver, "CoordinateSystem"):
             solver.addProperty(
-                "App::PropertyEnumeration", "CoordinateSystem", "Coordinate System", ""
+                "App::PropertyEnumeration", "CoordinateSystem", "Coordinate System", "", locked=True
             )
             solver.CoordinateSystem = solverClass.COORDINATE_SYSTEM
             solver.CoordinateSystem = "Cartesian"
@@ -360,6 +360,7 @@ class Writer:
                 "BDFOrder",
                 "Timestepping",
                 "Order of time stepping method 'BDF'",
+                locked=True,
             )
             solver.BDFOrder = (2, 1, 5, 1)
         if not hasattr(self.solver, "OutputIntervals"):
@@ -368,10 +369,13 @@ class Writer:
                 "OutputIntervals",
                 "Timestepping",
                 "After how many time steps a result file is output",
+                locked=True,
             )
             solver.OutputIntervals = [1]
         if not hasattr(self.solver, "SimulationType"):
-            solver.addProperty("App::PropertyEnumeration", "SimulationType", "Type", "")
+            solver.addProperty(
+                "App::PropertyEnumeration", "SimulationType", "Type", "", locked=True
+            )
             solver.SimulationType = solverClass.SIMULATION_TYPE
             solver.SimulationType = "Steady State"
         if not hasattr(self.solver, "TimestepIntervals"):
@@ -383,6 +387,7 @@ class Writer:
                     "List of maximum optimization rounds if 'Simulation Type'\n"
                     "is either 'Scanning' or 'Transient'"
                 ),
+                locked=True,
             )
             solver.TimestepIntervals = [100]
         if not hasattr(self.solver, "TimestepSizes"):
@@ -394,6 +399,7 @@ class Writer:
                     "List of time steps of optimization if 'Simulation Type'\n"
                     "is either 'Scanning' or 'Transient'"
                 ),
+                locked=True,
             )
             solver.TimestepSizes = [0.1]
 
@@ -661,6 +667,7 @@ class Writer:
                     "Only use for special cases\n"
                     "and consult the Elmer docs."
                 ),
+                locked=True,
             )
         if not hasattr(equation, "IdrsParameter"):
             equation.addProperty(
@@ -668,6 +675,7 @@ class Writer:
                 "IdrsParameter",
                 "Linear System",
                 "Parameter for iterative method 'Idrs'",
+                locked=True,
             )
             equation.IdrsParameter = (2, 1, 10, 1)
 

--- a/src/Mod/Fem/femsolver/equationbase.py
+++ b/src/Mod/Fem/femsolver/equationbase.py
@@ -40,7 +40,7 @@ class BaseProxy:
 
     def __init__(self, obj):
         obj.Proxy = self
-        obj.addProperty("App::PropertyLinkSubList", "References", "Base", "")
+        obj.addProperty("App::PropertyLinkSubList", "References", "Base", "", locked=True)
 
     def execute(self, obj):
         return True

--- a/src/Mod/Fem/femsolver/mystran/solver.py
+++ b/src/Mod/Fem/femsolver/mystran/solver.py
@@ -59,7 +59,9 @@ class Proxy(solverbase.Proxy):
 
         # mystran_prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Fem/Mystran")
 
-        obj.addProperty("App::PropertyEnumeration", "AnalysisType", "Fem", "Type of the analysis")
+        obj.addProperty(
+            "App::PropertyEnumeration", "AnalysisType", "Fem", "Type of the analysis", locked=True
+        )
         obj.AnalysisType = ANALYSIS_TYPES
         obj.AnalysisType = ANALYSIS_TYPES[0]
 

--- a/src/Mod/Measure/MeasureCOM.py
+++ b/src/Mod/Measure/MeasureCOM.py
@@ -58,12 +58,14 @@ class MeasureCOM(MeasureBasePython):
             "Element",
             "",
             QT_TRANSLATE_NOOP("App::Property", "Element to measure"),
+            locked=True,
         )
         obj.addProperty(
             "App::PropertyPosition",
             "Result",
             "",
             QT_TRANSLATE_NOOP("App::PropertyVector", "The result location"),
+            locked=True,
         )
 
     @classmethod

--- a/src/Mod/OpenSCAD/OpenSCADFeatures.py
+++ b/src/Mod/OpenSCAD/OpenSCADFeatures.py
@@ -169,8 +169,8 @@ static char * openscadlogo_xpm[] = {
 
 class OpenSCADPlaceholder:
     def __init__(self,obj,children=None,arguments=None):
-        obj.addProperty("App::PropertyLinkList",'Children','OpenSCAD',"Base Objects")
-        obj.addProperty("App::PropertyString",'Arguments','OpenSCAD',"Arguments")
+        obj.addProperty("App::PropertyLinkList",'Children','OpenSCAD',"Base Objects", locked=True)
+        obj.addProperty("App::PropertyString",'Arguments','OpenSCAD',"Arguments", locked=True)
         obj.Proxy = self
         if children:
             obj.Children = children
@@ -189,10 +189,10 @@ class Resize:
         self.Target = target
         self.Vector = vector
         #obj.addProperty("App::PropertyPythonObject","Object","Resize", \
-        #                "Object to be resized").Object = target
-        obj.addProperty("Part::PropertyPartShape","Shape","Resize", "Shape of the Resize")
+        #                "Object to be resized", locked=True).Object = target
+        obj.addProperty("Part::PropertyPartShape","Shape","Resize", "Shape of the Resize", locked=True)
         obj.addProperty("App::PropertyVector","Vector","Resize",
-                        " Resize Vector").Vector = FreeCAD.Vector(vector)
+                        " Resize Vector", locked=True).Vector = FreeCAD.Vector(vector)
         obj.Proxy = self
 
     def execute(self, fp):
@@ -213,8 +213,8 @@ class Resize:
 class MatrixTransform:
     def __init__(self, obj,matrix=None,child=None):
         obj.addProperty("App::PropertyLink","Base","Base",
-                        "The base object that must be tranfsformed")
-        obj.addProperty("App::PropertyMatrix","Matrix","Matrix", "Transformation Matrix")
+                        "The base object that must be tranfsformed", locked=True)
+        obj.addProperty("App::PropertyMatrix","Matrix","Matrix", "Transformation Matrix", locked=True)
         obj.Proxy = self
         obj.Matrix = matrix
         obj.Base = child
@@ -240,7 +240,7 @@ class MatrixTransform:
 class ImportObject:
     def __init__(self, obj,child=None):
         obj.addProperty("App::PropertyLink", "Base", "Base",
-                        "The base object that must be tranfsformed")
+                        "The base object that must be tranfsformed", locked=True)
         obj.Proxy = self
         obj.Base = child
 
@@ -258,7 +258,7 @@ class RefineShape:
     '''return a refined shape'''
     def __init__(self, obj, child=None):
         obj.addProperty("App::PropertyLink", "Base", "Base",
-                        "The base object that must be refined")
+                        "The base object that must be refined", locked=True)
         obj.Proxy = self
         obj.Base = child
 
@@ -277,10 +277,10 @@ class IncreaseTolerance:
     in the current implementation its' placement is linked'''
     def __init__(self,obj,child,tolerance=0):
         obj.addProperty("App::PropertyLink", "Base", "Base",
-                        "The base object that wire must be extracted")
-        obj.addProperty("App::PropertyDistance","Vertex","Tolerance","Vertexes tolerance (0 default)")
-        obj.addProperty("App::PropertyDistance","Edge","Tolerance","Edges tolerance (0 default)")
-        obj.addProperty("App::PropertyDistance","Face","Tolerance","Faces tolerance (0 default)")
+                        "The base object that wire must be extracted", locked=True)
+        obj.addProperty("App::PropertyDistance","Vertex","Tolerance","Vertexes tolerance (0 default)", locked=True)
+        obj.addProperty("App::PropertyDistance","Edge","Tolerance","Edges tolerance (0 default)", locked=True)
+        obj.addProperty("App::PropertyDistance","Face","Tolerance","Faces tolerance (0 default)", locked=True)
         obj.Base = child
         obj.Vertex = tolerance
         obj.Edge = tolerance
@@ -311,7 +311,7 @@ class GetWire:
     '''return the first wire from a given shape'''
     def __init__(self, obj, child=None):
         obj.addProperty("App::PropertyLink","Base","Base",
-                        "The base object that wire must be extracted")
+                        "The base object that wire must be extracted", locked=True)
         obj.Proxy = self
         obj.Base = child
 
@@ -328,10 +328,10 @@ class GetWire:
 
 class Frustum:
     def __init__(self, obj,r1=1,r2=2,n=3,h=4):
-        obj.addProperty("App::PropertyInteger","FacesNumber","Base","Number of faces")
-        obj.addProperty("App::PropertyDistance","Radius1","Base","Radius of lower the inscribed control circle")
-        obj.addProperty("App::PropertyDistance","Radius2","Base","Radius of upper the inscribed control circle")
-        obj.addProperty("App::PropertyDistance","Height","Base","Height of the Frustum")
+        obj.addProperty("App::PropertyInteger","FacesNumber","Base","Number of faces", locked=True)
+        obj.addProperty("App::PropertyDistance","Radius1","Base","Radius of lower the inscribed control circle", locked=True)
+        obj.addProperty("App::PropertyDistance","Radius2","Base","Radius of upper the inscribed control circle", locked=True)
+        obj.addProperty("App::PropertyDistance","Height","Base","Height of the Frustum", locked=True)
 
         obj.FacesNumber = n
         obj.Radius1 = r1
@@ -372,11 +372,11 @@ class Twist:
     def __init__(self, obj, child=None, h=1.0, angle=0.0, scale=[1.0,1.0]):
         import FreeCAD
         obj.addProperty("App::PropertyLink","Base","Base",
-                        "The base object that must be transformed")
-        obj.addProperty("App::PropertyQuantity","Angle","Base","Twist Angle")
+                        "The base object that must be transformed", locked=True)
+        obj.addProperty("App::PropertyQuantity","Angle","Base","Twist Angle", locked=True)
         obj.Angle = FreeCAD.Units.Angle # assign the Angle unit
-        obj.addProperty("App::PropertyDistance","Height","Base","Height of the Extrusion")
-        obj.addProperty("App::PropertyFloatList","Scale","Base","Scale to apply during the Extrusion")
+        obj.addProperty("App::PropertyDistance","Height","Base","Height of the Extrusion", locked=True)
+        obj.addProperty("App::PropertyFloatList","Scale","Base","Scale to apply during the Extrusion", locked=True)
 
         obj.Base = child
         obj.Angle = angle
@@ -441,9 +441,9 @@ class Twist:
 class PrismaticToroid:
     def __init__(self, obj,child=None,angle=360.0,n=3):
         obj.addProperty("App::PropertyLink","Base","Base",
-                        "The 2D face that will be swept")
-        obj.addProperty("App::PropertyAngle","Angle","Base","Angle to sweep through")
-        obj.addProperty("App::PropertyInteger","Segments","Base","Number of segments per 360° (OpenSCAD's \"$fn\")")
+                        "The 2D face that will be swept", locked=True)
+        obj.addProperty("App::PropertyAngle","Angle","Base","Angle to sweep through", locked=True)
+        obj.addProperty("App::PropertyInteger","Segments","Base","Number of segments per 360° (OpenSCAD's \"$fn\")", locked=True)
 
         obj.Base = child
         obj.Angle =  angle
@@ -517,8 +517,8 @@ class PrismaticToroid:
 class OffsetShape:
     def __init__(self, obj,child=None,offset=1.0):
         obj.addProperty("App::PropertyLink","Base","Base",
-                        "The base object that must be transformed")
-        obj.addProperty("App::PropertyDistance","Offset","Base","Offset outwards")
+                        "The base object that must be transformed", locked=True)
+        obj.addProperty("App::PropertyDistance","Offset","Base","Offset outwards", locked=True)
 
         obj.Base = child
         obj.Offset = offset
@@ -530,9 +530,9 @@ class OffsetShape:
 
 class CGALFeature:
     def __init__(self,obj,opname=None,children=None,arguments=None):
-        obj.addProperty("App::PropertyLinkList",'Children','OpenSCAD',"Base Objects")
-        obj.addProperty("App::PropertyString",'Arguments','OpenSCAD',"Arguments")
-        obj.addProperty("App::PropertyString",'Operation','OpenSCAD',"Operation")
+        obj.addProperty("App::PropertyLinkList",'Children','OpenSCAD',"Base Objects", locked=True)
+        obj.addProperty("App::PropertyString",'Arguments','OpenSCAD',"Arguments", locked=True)
+        obj.addProperty("App::PropertyString",'Operation','OpenSCAD',"Operation", locked=True)
         obj.Proxy = self
         if opname:
             obj.Operation = opname

--- a/src/Mod/Part/BOPTools/JoinFeatures.py
+++ b/src/Mod/Part/BOPTools/JoinFeatures.py
@@ -114,13 +114,13 @@ class FeatureConnect:
     """The PartJoinFeature object."""
 
     def __init__(self,obj):
-        obj.addProperty("App::PropertyLinkList","Objects","Connect","Object to be connected.")
+        obj.addProperty("App::PropertyLinkList","Objects","Connect","Object to be connected.", locked=True)
         obj.addProperty("App::PropertyBool","Refine","Connect",
-                        "True = refine resulting shape. False = output as is.")
+                        "True = refine resulting shape. False = output as is.", locked=True)
         obj.Refine = getParamRefine()
         obj.addProperty("App::PropertyLength","Tolerance","Connect",
                         "Tolerance when intersecting (fuzzy value). "
-                        "In addition to tolerances of the shapes.")
+                        "In addition to tolerances of the shapes.", locked=True)
 
         obj.Proxy = self
         self.Type = "FeatureConnect"
@@ -224,14 +224,14 @@ class FeatureEmbed:
     """The Part Embed object."""
 
     def __init__(self,obj):
-        obj.addProperty("App::PropertyLink","Base","Embed","Object to embed into.")
-        obj.addProperty("App::PropertyLink","Tool","Embed","Object to be embedded.")
+        obj.addProperty("App::PropertyLink","Base","Embed","Object to embed into.", locked=True)
+        obj.addProperty("App::PropertyLink","Tool","Embed","Object to be embedded.", locked=True)
         obj.addProperty("App::PropertyBool","Refine","Embed",
-                        "True = refine resulting shape. False = output as is.")
+                        "True = refine resulting shape. False = output as is.", locked=True)
         obj.Refine = getParamRefine()
         obj.addProperty("App::PropertyLength","Tolerance","Embed",
                         "Tolerance when intersecting (fuzzy value). "
-                        "In addition to tolerances of the shapes.")
+                        "In addition to tolerances of the shapes.", locked=True)
 
         obj.Proxy = self
         self.Type = "FeatureEmbed"
@@ -319,13 +319,13 @@ class FeatureCutout:
     """The Part Cutout object."""
 
     def __init__(self,obj):
-        obj.addProperty("App::PropertyLink","Base","Cutout","Object to be cut.")
-        obj.addProperty("App::PropertyLink","Tool","Cutout","Object to make cutout for.")
+        obj.addProperty("App::PropertyLink","Base","Cutout","Object to be cut.", locked=True)
+        obj.addProperty("App::PropertyLink","Tool","Cutout","Object to make cutout for.", locked=True)
         obj.addProperty("App::PropertyBool","Refine","Cutout",
-                        "True = refine resulting shape. False = output as is.")
+                        "True = refine resulting shape. False = output as is.", locked=True)
         obj.Refine = getParamRefine()
         obj.addProperty("App::PropertyLength","Tolerance","Cutout",
-                        "Tolerance when intersecting (fuzzy value). In addition to tolerances of the shapes.")
+                        "Tolerance when intersecting (fuzzy value). In addition to tolerances of the shapes.", locked=True)
 
         obj.Proxy = self
         self.Type = "FeatureCutout"

--- a/src/Mod/Part/BOPTools/SplitFeatures.py
+++ b/src/Mod/Part/BOPTools/SplitFeatures.py
@@ -65,15 +65,15 @@ class FeatureBooleanFragments:
     """The BooleanFragments feature object."""
 
     def __init__(self,obj):
-        obj.addProperty("App::PropertyLinkList","Objects","BooleanFragments","Object to compute intersections between.")
+        obj.addProperty("App::PropertyLinkList","Objects","BooleanFragments","Object to compute intersections between.", locked=True)
         obj.addProperty("App::PropertyEnumeration","Mode","BooleanFragments",
                         "- Standard: wires, shells, compsolids remain in one piece.\n"
                         "- Split: wires, shells, compsolids are split.\n"
-                        "- CompSolid: make compsolid from solid fragments.")
+                        "- CompSolid: make compsolid from solid fragments.", locked=True)
         obj.Mode = ["Standard", "Split", "CompSolid"]
         obj.addProperty("App::PropertyLength","Tolerance","BooleanFragments",
                         "Tolerance when intersecting (fuzzy value). "
-                        "In addition to tolerances of the shapes.")
+                        "In addition to tolerances of the shapes.", locked=True)
 
         obj.Proxy = self
         self.Type = "FeatureBooleanFragments"
@@ -222,16 +222,16 @@ class FeatureSlice:
     """The Slice feature object."""
 
     def __init__(self,obj):
-        obj.addProperty("App::PropertyLink","Base","Slice","Object to be sliced.")
-        obj.addProperty("App::PropertyLinkList","Tools","Slice","Objects that slice.")
+        obj.addProperty("App::PropertyLink","Base","Slice","Object to be sliced.", locked=True)
+        obj.addProperty("App::PropertyLinkList","Tools","Slice","Objects that slice.", locked=True)
         obj.addProperty("App::PropertyEnumeration","Mode","Slice",
                         "- Standard: wires, shells, compsolids remain in one piece.\n"
                         "- Split: wires, shells, compsolids are split.\n"
-                        "- CompSolid: make compsolid from solid fragments.")
+                        "- CompSolid: make compsolid from solid fragments.", locked=True)
         obj.Mode = ["Standard", "Split", "CompSolid"]
         obj.addProperty("App::PropertyLength","Tolerance","Slice",
                         "Tolerance when intersecting (fuzzy value). "
-                        "In addition to tolerances of the shapes.")
+                        "In addition to tolerances of the shapes.", locked=True)
 
         obj.Proxy = self
         self.Type = "FeatureSlice"
@@ -408,10 +408,10 @@ class FeatureXOR:
     """The XOR feature object."""
 
     def __init__(self,obj):
-        obj.addProperty("App::PropertyLinkList","Objects","XOR","Object to compute intersections between.")
+        obj.addProperty("App::PropertyLinkList","Objects","XOR","Object to compute intersections between.", locked=True)
         obj.addProperty("App::PropertyLength","Tolerance","XOR",
                         "Tolerance when intersecting (fuzzy value). "
-                        "In addition to tolerances of the shapes.")
+                        "In addition to tolerances of the shapes.", locked=True)
 
         obj.Proxy = self
         self.Type = "FeatureXOR"

--- a/src/Mod/Part/BOPTools/ToleranceFeatures.py
+++ b/src/Mod/Part/BOPTools/ToleranceFeatures.py
@@ -106,11 +106,11 @@ class FeatureToleranceSet:
     """The PartToleranceSetFeature object."""
 
     def __init__(self,obj):
-        obj.addProperty("App::PropertyLinkList","Objects","ToleranceSet","Objects to have tolerance adjusted.")
+        obj.addProperty("App::PropertyLinkList","Objects","ToleranceSet","Objects to have tolerance adjusted.", locked=True)
         obj.addProperty("App::PropertyBool","Refine","ToleranceSet",
-                        "True = refine resulting shape. False = output as is.")
-        obj.addProperty("App::PropertyLength","minTolerance","ToleranceSet", "0.1 nm")
-        obj.addProperty("App::PropertyLength","maxTolerance","ToleranceSet", "0")
+                        "True = refine resulting shape. False = output as is.", locked=True)
+        obj.addProperty("App::PropertyLength","minTolerance","ToleranceSet", "0.1 nm", locked=True)
+        obj.addProperty("App::PropertyLength","maxTolerance","ToleranceSet", "0", locked=True)
         obj.Refine = getParamRefine()
 
         obj.Proxy = self
@@ -118,7 +118,7 @@ class FeatureToleranceSet:
 
     def onDocumentRestored(self, obj):
         if not hasattr(obj, 'maxTolerance'):
-            obj.addProperty("App::PropertyLength","maxTolerance","ToleranceSet", "0")
+            obj.addProperty("App::PropertyLength","maxTolerance","ToleranceSet", "0", locked=True)
 
     def execute(self,selfobj):
         shapes = []

--- a/src/Mod/Part/BasicShapes/Shapes.py
+++ b/src/Mod/Part/BasicShapes/Shapes.py
@@ -42,9 +42,9 @@ def makeTube(outerRadius, innerRadius, height):
 class TubeFeature:
     def __init__(self, obj):
         obj.Proxy = self
-        obj.addProperty("App::PropertyLength","OuterRadius","Tube","Outer radius").OuterRadius = 5.0
-        obj.addProperty("App::PropertyLength","InnerRadius","Tube","Inner radius").InnerRadius = 2.0
-        obj.addProperty("App::PropertyLength","Height","Tube", "Height of the tube").Height = 10.0
+        obj.addProperty("App::PropertyLength","OuterRadius","Tube","Outer radius", locked=True).OuterRadius = 5.0
+        obj.addProperty("App::PropertyLength","InnerRadius","Tube","Inner radius", locked=True).InnerRadius = 2.0
+        obj.addProperty("App::PropertyLength","Height","Tube", "Height of the tube", locked=True).Height = 10.0
         obj.addExtension("Part::AttachExtensionPython")
 
     def execute(self, fp):

--- a/src/Mod/Part/CompoundTools/CompoundFilter.py
+++ b/src/Mod/Part/CompoundTools/CompoundFilter.py
@@ -49,13 +49,13 @@ class _CompoundFilter:
     """The CompoundFilter object."""
 
     def __init__(self, obj):
-        obj.addProperty("App::PropertyLink", "Base", "CompoundFilter", "Compound to be filtered")
+        obj.addProperty("App::PropertyLink", "Base", "CompoundFilter", "Compound to be filtered", locked=True)
 
         obj.addProperty("App::PropertyEnumeration",
                         "FilterType",
                         "CompoundFilter",
                         "Type of filter method to use; some of these methods "
-                        "require, or are affected by, a 'Stencil' object.")
+                        "require, or are affected by, a 'Stencil' object.", locked=True)
         obj.FilterType = ['bypass', 'specific items', 'collision-pass',
                           'window-volume', 'window-area', 'window-length',
                           'window-distance']
@@ -65,24 +65,24 @@ class _CompoundFilter:
         obj.addProperty("App::PropertyString", "items", "CompoundFilter",
                         "Indices of the pieces to be returned.\n"
                         "These are numbers separated by a semicolon, '1;3;5'.\n"
-                        "A range can also be provided using a colon, '1;4;8:10'.")
+                        "A range can also be provided using a colon, '1;4;8:10'.", locked=True)
 
         obj.addProperty("App::PropertyLink", "Stencil", "CompoundFilter",
-                        "Object that defines filtering")
+                        "Object that defines filtering", locked=True)
 
         obj.addProperty("App::PropertyFloat", "WindowFrom", "CompoundFilter",
-                        "Value of threshold, expressed as a percentage of maximum value.")
+                        "Value of threshold, expressed as a percentage of maximum value.", locked=True)
         obj.WindowFrom = 80.0
         obj.addProperty("App::PropertyFloat", "WindowTo", "CompoundFilter",
-                        "Value of threshold, expressed as a percentage of maximum value.")
+                        "Value of threshold, expressed as a percentage of maximum value.", locked=True)
         obj.WindowTo = 100.0
 
         obj.addProperty("App::PropertyFloat", "OverrideMaxVal", "CompoundFilter",
-                        "Volume threshold, expressed as percentage of the volume of largest child")
+                        "Volume threshold, expressed as percentage of the volume of largest child", locked=True)
         obj.OverrideMaxVal = 0
 
         obj.addProperty("App::PropertyBool", "Invert", "CompoundFilter",
-                        "Output shapes that are rejected by the filter, instead")
+                        "Output shapes that are rejected by the filter, instead", locked=True)
         obj.Invert = False
 
         self.Type = "CompoundFilter"
@@ -214,7 +214,7 @@ class _ViewProviderCompoundFilter:
                          "DontUnhideOnDelete",
                          "CompoundFilter",
                          "When this object is deleted, Base and Stencil are unhidden. "
-                         "This flag stops it from happening.")
+                         "This flag stops it from happening.", locked=True)
         vobj.setEditorMode("DontUnhideOnDelete", 2)  # set hidden
 
     def getIcon(self):

--- a/src/Mod/Part/JoinFeatures.py
+++ b/src/Mod/Part/JoinFeatures.py
@@ -65,16 +65,16 @@ class _PartJoinFeature:
             "App::PropertyEnumeration",
             "Mode",
             "Join",
-            "The mode of operation. bypass = make compound (fast)",
+            "The mode of operation. bypass = make compound (fast)", locked=True,
         )
         obj.Mode = ["bypass", "Connect", "Embed", "Cutout"]
-        obj.addProperty("App::PropertyLink", "Base", "Join", "First object")
-        obj.addProperty("App::PropertyLink", "Tool", "Join", "Second object")
+        obj.addProperty("App::PropertyLink", "Base", "Join", "First object", locked=True)
+        obj.addProperty("App::PropertyLink", "Tool", "Join", "Second object", locked=True)
         obj.addProperty(
             "App::PropertyBool",
             "Refine",
             "Join",
-            "True = refine resulting shape. False = output as is.",
+            "True = refine resulting shape. False = output as is.", locked=True,
         )
 
         obj.Proxy = self

--- a/src/Mod/PartDesign/InvoluteGearFeature.py
+++ b/src/Mod/PartDesign/InvoluteGearFeature.py
@@ -86,7 +86,7 @@ class _InvoluteGear:
     def _ensure_properties(self, obj, is_restore):
         def ensure_property(type_, name, doc, default):
             if not hasattr(obj, name):
-                obj.addProperty(type_, name, "Gear", doc)
+                obj.addProperty(type_, name, "Gear", doc, locked=True)
                 if callable(default):
                     setattr(obj, name, default())
                 else:

--- a/src/Mod/PartDesign/Scripts/DistanceBolt.py
+++ b/src/Mod/PartDesign/Scripts/DistanceBolt.py
@@ -14,10 +14,10 @@ from FreeCAD import Base
 class DistanceBolt:
     def __init__(self, obj):
         ''' Add the properties: Length, Edges, Radius, Height '''
-        obj.addProperty("App::PropertyInteger","Edges","Bolt","Number of edges of the outline").Edges=6
-        obj.addProperty("App::PropertyLength","Length","Bolt","Length of the edges of the outline").Length=10.0
-        obj.addProperty("App::PropertyLength","Radius","Bolt","Radius of the inner circle").Radius=4.0
-        obj.addProperty("App::PropertyLength","Height","Bolt","Height of the extrusion").Height=20.0
+        obj.addProperty("App::PropertyInteger","Edges","Bolt","Number of edges of the outline", locked=True).Edges=6
+        obj.addProperty("App::PropertyLength","Length","Bolt","Length of the edges of the outline", locked=True).Length=10.0
+        obj.addProperty("App::PropertyLength","Radius","Bolt","Radius of the inner circle", locked=True).Radius=4.0
+        obj.addProperty("App::PropertyLength","Height","Bolt","Height of the extrusion", locked=True).Height=20.0
         obj.Proxy = self
 
     def onChanged(self, fp, prop):

--- a/src/Mod/PartDesign/Scripts/Epitrochoid.py
+++ b/src/Mod/PartDesign/Scripts/Epitrochoid.py
@@ -10,10 +10,10 @@ from FreeCAD import Base
 class Epitrochoid:
     def __init__(self, obj):
         ''' Add the properties: Radius1, Radius2, Distance, Segments '''
-        obj.addProperty("App::PropertyLength","Radius1","Epitrochoid","Interior radius").Radius1=60.0
-        obj.addProperty("App::PropertyLength","Radius2","Epitrochoid","Exterior radius").Radius2=20.0
-        obj.addProperty("App::PropertyLength","Distance","Epitrochoid","Distance").Distance=10.0
-        obj.addProperty("App::PropertyInteger","Segments","Epitrochoid","Number of the line segments").Segments=72
+        obj.addProperty("App::PropertyLength","Radius1","Epitrochoid","Interior radius", locked=True).Radius1=60.0
+        obj.addProperty("App::PropertyLength","Radius2","Epitrochoid","Exterior radius", locked=True).Radius2=20.0
+        obj.addProperty("App::PropertyLength","Distance","Epitrochoid","Distance", locked=True).Distance=10.0
+        obj.addProperty("App::PropertyInteger","Segments","Epitrochoid","Number of the line segments", locked=True).Segments=72
         obj.Proxy = self
 
     def onChanged(self, fp, prop):

--- a/src/Mod/PartDesign/Scripts/Parallelepiped.py
+++ b/src/Mod/PartDesign/Scripts/Parallelepiped.py
@@ -14,9 +14,9 @@ from FreeCAD import Base
 class Parallelepiped:
     def __init__(self, obj):
         ''' Add the properties: Length, Edges, Radius, Height '''
-        obj.addProperty("App::PropertyVector","A","Parallelepiped","Vector").A=Base.Vector(1,0,0)
-        obj.addProperty("App::PropertyVector","B","Parallelepiped","Vector").B=Base.Vector(0,1,0)
-        obj.addProperty("App::PropertyVector","C","Parallelepiped","Vector").C=Base.Vector(0,0,1)
+        obj.addProperty("App::PropertyVector","A","Parallelepiped","Vector", locked=True).A=Base.Vector(1,0,0)
+        obj.addProperty("App::PropertyVector","B","Parallelepiped","Vector", locked=True).B=Base.Vector(0,1,0)
+        obj.addProperty("App::PropertyVector","C","Parallelepiped","Vector", locked=True).C=Base.Vector(0,0,1)
         obj.Proxy = self
 
     def onChanged(self, fp, prop):
@@ -43,9 +43,9 @@ class Parallelepiped:
 
 class BoxCylinder:
     def __init__(self, obj):
-        obj.addProperty("App::PropertyFloat","Length","BoxCylinder","Length").Length=10.0
-        obj.addProperty("App::PropertyFloat","Width","BoxCylinder","Width").Width=10.0
-        obj.addProperty("App::PropertyLink","Source","BoxCylinder","Source").Source=None
+        obj.addProperty("App::PropertyFloat","Length","BoxCylinder","Length", locked=True).Length=10.0
+        obj.addProperty("App::PropertyFloat","Width","BoxCylinder","Width", locked=True).Width=10.0
+        obj.addProperty("App::PropertyLink","Source","BoxCylinder","Source", locked=True).Source=None
         obj.Proxy = self
 
     def onChanged(self, fp, prop):

--- a/src/Mod/PartDesign/Scripts/RadialCopy.py
+++ b/src/Mod/PartDesign/Scripts/RadialCopy.py
@@ -26,9 +26,9 @@ def makeCopy(shape, radius, angle):
 
 class RadialCopy:
     def __init__(self, obj):
-        obj.addProperty("App::PropertyLength","Radius","","Radius").Radius=10.0
-        obj.addProperty("App::PropertyLength","Angle" ,"","Angle").Angle=20.0
-        obj.addProperty("App::PropertyLink","Source" ,"","Source shape").Source=None
+        obj.addProperty("App::PropertyLength","Radius","","Radius", locked=True).Radius=10.0
+        obj.addProperty("App::PropertyLength","Angle" ,"","Angle", locked=True).Angle=20.0
+        obj.addProperty("App::PropertyLink","Source" ,"","Source shape", locked=True).Source=None
         obj.Proxy = self
 
 #   def onChanged(self, fp, prop):

--- a/src/Mod/PartDesign/Scripts/Spring.py
+++ b/src/Mod/PartDesign/Scripts/Spring.py
@@ -9,10 +9,10 @@ from FreeCAD import Base
 class MySpring:
    def __init__(self, obj):
       ''' Add the properties: Pitch, Diameter, Height, BarDiameter '''
-      obj.addProperty("App::PropertyLength", "Pitch", "MySpring", "Pitch of the helix").Pitch = 5.0
-      obj.addProperty("App::PropertyLength", "Diameter", "MySpring", "Diameter of the helix").Diameter = 6.0
-      obj.addProperty("App::PropertyLength", "Height", "MySpring", "Height of the helix").Height = 30.0
-      obj.addProperty("App::PropertyLength", "BarDiameter", "MySpring", "Diameter of the bar").BarDiameter = 3.0
+      obj.addProperty("App::PropertyLength", "Pitch", "MySpring", "Pitch of the helix", locked=True).Pitch = 5.0
+      obj.addProperty("App::PropertyLength", "Diameter", "MySpring", "Diameter of the helix", locked=True).Diameter = 6.0
+      obj.addProperty("App::PropertyLength", "Height", "MySpring", "Height of the helix", locked=True).Height = 30.0
+      obj.addProperty("App::PropertyLength", "BarDiameter", "MySpring", "Diameter of the bar", locked=True).BarDiameter = 3.0
       obj.Proxy = self
 
    def onChanged(self, fp, prop):

--- a/src/Mod/PartDesign/SprocketFeature.py
+++ b/src/Mod/PartDesign/SprocketFeature.py
@@ -136,7 +136,7 @@ class Sprocket:
             "App::PropertyEnumeration",
             "SprocketReference",
             "Sprocket",
-            "Sprocket Reference",
+            "Sprocket Reference", locked=True,
         )
         obj.SprocketReference = list(self.sprockRef)
         obj.Proxy = self
@@ -148,7 +148,7 @@ class Sprocket:
     def _ensure_properties(self, obj, is_restore):
         def ensure_property(type_, name, doc, default):
             if not hasattr(obj, name):
-                obj.addProperty(type_, name, "Sprocket")
+                obj.addProperty(type_, name, "Sprocket", locked=True)
                 if callable(default):
                     setattr(obj, name, default())
                 else:

--- a/src/Mod/Points/pointscommands/commands.py
+++ b/src/Mod/Points/pointscommands/commands.py
@@ -58,7 +58,7 @@ def make_points_from_geometry(geometries, distance):
         if len(points_and_normals[1]) > 0 and len(points_and_normals[0]) == len(
             points_and_normals[1]
         ):
-            points.addProperty("Points::PropertyNormalList", "Normal")
+            points.addProperty("Points::PropertyNormalList", "Normal", locked=True)
             points.Normal = points_and_normals[1]
 
         points.purgeTouched()

--- a/src/Mod/TemplatePyMod/DocumentObject.py
+++ b/src/Mod/TemplatePyMod/DocumentObject.py
@@ -277,9 +277,9 @@ class Box(DocumentObject):
 
     #-----------------------------INIT----------------------------------------
     def init(self):
-        self.addProperty("App::PropertyLength","Length","Box","Length of the box").Length=1.0
-        self.addProperty("App::PropertyLength","Width","Box","Width of the box").Width=1.0
-        self.addProperty("App::PropertyLength","Height","Box", "Height of the box").Height=1.0
+        self.addProperty("App::PropertyLength","Length","Box","Length of the box", locked=True).Length=1.0
+        self.addProperty("App::PropertyLength","Width","Box","Width of the box", locked=True).Width=1.0
+        self.addProperty("App::PropertyLength","Height","Box", "Height of the box", locked=True).Height=1.0
 
     #-----------------------------BEHAVIOR------------------------------------
     def propertyChanged(self,prop):

--- a/src/Mod/TemplatePyMod/FeaturePython.py
+++ b/src/Mod/TemplatePyMod/FeaturePython.py
@@ -17,9 +17,9 @@ class Box(PartFeature):
 	def __init__(self, obj):
 		PartFeature.__init__(self, obj)
 		''' Add some custom properties to our box feature '''
-		obj.addProperty("App::PropertyLength","Length","Box","Length of the box").Length=1.0
-		obj.addProperty("App::PropertyLength","Width","Box","Width of the box").Width=1.0
-		obj.addProperty("App::PropertyLength","Height","Box", "Height of the box").Height=1.0
+                obj.addProperty("App::PropertyLength","Length","Box","Length of the box", locked=True).Length=1.0
+                obj.addProperty("App::PropertyLength","Width","Box","Width of the box", locked=True).Width=1.0
+                obj.addProperty("App::PropertyLength","Height","Box", "Height of the box", locked=True).Height=1.0
 
 	def onChanged(self, fp, prop):
 		''' Print the name of the property that has changed '''
@@ -120,8 +120,8 @@ def makeBox():
 class Line:
 	def __init__(self, obj):
 		''' Add two point properties '''
-		obj.addProperty("App::PropertyVector","p1","Line","Start point")
-		obj.addProperty("App::PropertyVector","p2","Line","End point").p2=FreeCAD.Vector(1,0,0)
+                obj.addProperty("App::PropertyVector","p1","Line","Start point", locked=True)
+                obj.addProperty("App::PropertyVector","p2","Line","End point", locked=True).p2=FreeCAD.Vector(1,0,0)
 		obj.Proxy = self
 
 	def execute(self, fp):
@@ -150,10 +150,10 @@ def makeLine():
 class Octahedron:
 	def __init__(self, obj):
 		"Add some custom properties to our box feature"
-		obj.addProperty("App::PropertyLength","Length","Octahedron","Length of the octahedron").Length=1.0
-		obj.addProperty("App::PropertyLength","Width","Octahedron","Width of the octahedron").Width=1.0
-		obj.addProperty("App::PropertyLength","Height","Octahedron", "Height of the octahedron").Height=1.0
-		obj.addProperty("Part::PropertyPartShape","Shape","Octahedron", "Shape of the octahedron")
+                obj.addProperty("App::PropertyLength","Length","Octahedron","Length of the octahedron", locked=True).Length=1.0
+                obj.addProperty("App::PropertyLength","Width","Octahedron","Width of the octahedron", locked=True).Width=1.0
+                obj.addProperty("App::PropertyLength","Height","Octahedron", "Height of the octahedron", locked=True).Height=1.0
+                obj.addProperty("Part::PropertyPartShape","Shape","Octahedron", "Shape of the octahedron", locked=True)
 		obj.Proxy = self
  
 	def execute(self, fp):
@@ -186,7 +186,7 @@ class Octahedron:
 class ViewProviderOctahedron:
 	def __init__(self, obj):
 		"Set this object to the proxy object of the actual view provider"
-		obj.addProperty("App::PropertyColor","Color","Octahedron","Color of the octahedron").Color=(1.0,0.0,0.0)
+                obj.addProperty("App::PropertyColor","Color","Octahedron","Color of the octahedron", locked=True).Color=(1.0,0.0,0.0)
 		obj.Proxy = self
  
 	def attach(self, obj):
@@ -525,8 +525,8 @@ def makeMesh():
 class Molecule:
 	def __init__(self, obj):
 		''' Add two point properties '''
-		obj.addProperty("App::PropertyVector","p1","Line","Start point")
-		obj.addProperty("App::PropertyVector","p2","Line","End point").p2=FreeCAD.Vector(5,0,0)
+                obj.addProperty("App::PropertyVector","p1","Line","Start point", locked=True)
+                obj.addProperty("App::PropertyVector","p2","Line","End point", locked=True).p2=FreeCAD.Vector(5,0,0)
 
 		obj.Proxy = self
 
@@ -577,7 +577,7 @@ def makeMolecule():
 
 class CircleSet:
 	def __init__(self, obj):
-		obj.addProperty("Part::PropertyPartShape","Shape","Circle","Shape")
+                obj.addProperty("Part::PropertyPartShape","Shape","Circle","Shape", locked=True)
 		obj.Proxy = self
 
 	def execute(self, fp):
@@ -640,8 +640,8 @@ def makeCircleSet():
 class EnumTest:
 	def __init__(self, obj):
 		''' Add enum properties '''
-		obj.addProperty("App::PropertyEnumeration","Enum","","Enumeration").Enum=["One","Two","Three"]
-		obj.addProperty("App::PropertyEnumeration","Enum2","","Enumeration2").Enum2=["One","Two","Three"]
+                obj.addProperty("App::PropertyEnumeration","Enum","","Enumeration", locked=True).Enum=["One","Two","Three"]
+                obj.addProperty("App::PropertyEnumeration","Enum2","","Enumeration2", locked=True).Enum2=["One","Two","Three"]
 		obj.Proxy = self
 
 	def execute(self, fp):
@@ -650,8 +650,8 @@ class EnumTest:
 class ViewProviderEnumTest:
 	def __init__(self, obj):
 		''' Set this object to the proxy object of the actual view provider '''
-		obj.addProperty("App::PropertyEnumeration","Enum3","","Enumeration3").Enum3=["One","Two","Three"]
-		obj.addProperty("App::PropertyEnumeration","Enum4","","Enumeration4").Enum4=["One","Two","Three"]
+                obj.addProperty("App::PropertyEnumeration","Enum3","","Enumeration3", locked=True).Enum3=["One","Two","Three"]
+                obj.addProperty("App::PropertyEnumeration","Enum4","","Enumeration4", locked=True).Enum4=["One","Two","Three"]
 		obj.Proxy = self
 
 	def updateData(self, fp, prop):
@@ -674,10 +674,10 @@ def makeEnumTest():
 class DistanceBolt:
 	def __init__(self, obj):
 		''' Add the properties: Length, Edges, Radius, Height '''
-		obj.addProperty("App::PropertyInteger","Edges","Bolt","Number of edges of the outline").Edges=6
-		obj.addProperty("App::PropertyLength","Length","Bolt","Length of the edges of the outline").Length=10.0
-		obj.addProperty("App::PropertyLength","Radius","Bolt","Radius of the inner circle").Radius=4.0
-		obj.addProperty("App::PropertyLength","Height","Bolt","Height of the extrusion").Height=20.0
+                obj.addProperty("App::PropertyInteger","Edges","Bolt","Number of edges of the outline", locked=True).Edges=6
+                obj.addProperty("App::PropertyLength","Length","Bolt","Length of the edges of the outline", locked=True).Length=10.0
+                obj.addProperty("App::PropertyLength","Radius","Bolt","Radius of the inner circle", locked=True).Radius=4.0
+                obj.addProperty("App::PropertyLength","Height","Bolt","Height of the extrusion", locked=True).Height=20.0
 		obj.Proxy = self
 
 	def onChanged(self, fp, prop):

--- a/src/Mod/TemplatePyMod/Texture.py
+++ b/src/Mod/TemplatePyMod/Texture.py
@@ -6,7 +6,7 @@ from pivy import coin
 class Texture:
 	def __init__(self, obj, source):
 		"Add some custom properties to our box feature"
-		obj.addProperty("App::PropertyLink","Source","Texture", "Link to the shape").Source = source
+                obj.addProperty("App::PropertyLink","Source","Texture", "Link to the shape", locked=True).Source = source
 		obj.Proxy = self
 
 	def onChanged(self, fp, prop):
@@ -17,7 +17,7 @@ class Texture:
 
 class ViewProviderTexture:
 	def __init__(self, obj):
-		obj.addProperty("App::PropertyPath","File","Texture", "File name to the texture resource")
+                obj.addProperty("App::PropertyPath","File","Texture", "File name to the texture resource", locked=True)
 		self.obj = obj
 		obj.Proxy = self
 


### PR DESCRIPTION
Add a new locked keyword argument to the  DocumentObject.addProperty python function. Default is False, when True the LockDynamic status is set so the end-user can't remove the property.

The whole python code of internal workbenches use this new argument.

Fix https://github.com/FreeCAD/FreeCAD/issues/18499

Replace #19508 