### PR TITLE
CI: Update to LibPack 3.1.1

### DIFF
--- a/.github/workflows/actions/windows/getLibpack/action.yml
+++ b/.github/workflows/actions/windows/getLibpack/action.yml
@@ -41,11 +41,11 @@ inputs:
   libpackdownloadurl:
     description: "URL where to download libpack"
     required: false
-    default: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.1.0/LibPack-1.1.0-v3.1.0-Release.7z
+    default: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.1.1.1/LibPack-1.1.0-v3.1.1.1-Release.7z
   libpackname:
     description: "Libpack name (once downloaded)"
     required: false
-    default: LibPack-1.1.0-v3.1.0-Release
+    default: LibPack-1.1.0-v3.1.1.1-Release
 
 runs:
   using: "composite"


### PR DESCRIPTION
Changes from 3.1.0 are that all libraries are compiled with the C++20 standard enabled, and versions are updated as follows:
* boost 1.86.0 → 1.87.0
* harfbuzz 10.1.0 → 10.4.0
* ifcopenshell 0.8.0 → 0.8.1.post1
* libpng 1.6.40 → 1.6.47
* libE57Format added
* pcre2 10.44 → 10.45
* Python 3.12.7 → 3.12.10
* Qt and Pyside 6.8.1 → 6.8.3
* vtk 9.3.1 → 9.4.1 (Python support added)
* zlib 1.3 → 1.3.1

Note that after merging this may require the GitHub cache of the LibPack to be cleared in order to actually force download of the new one.