### PR TITLE
CMake: use job pools to restrict number of concurrent compilers and linkers.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,6 +14,14 @@
             "type": "BOOL",
             "value": "ON"
           },
+          "CMAKE_JOB_POOL_COMPILE": {
+            "type": "STRING",
+            "value": "compile_jobs"
+          },
+          "CMAKE_JOB_POOL_LINK": {
+            "type": "STRING",
+            "value": "link_jobs"
+          },
           "CMAKE_POLICY_VERSION_MINIMUM": {
             "type": "STRING",
             "value": "3.5"

--- a/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
+++ b/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
@@ -9,6 +9,13 @@ macro(CompilerChecksAndSetups)
 
     # ================================================================================
 
+    # Use a heuristic of 1 GiB of RAM needed per compiler job and limit to
+    # a single link job. Modern linkers are multithreaded and running them concurrently
+    # can exhaust resources.
+    cmake_host_system_information(RESULT avail_mem_MiB QUERY TOTAL_PHYSICAL_MEMORY)
+    math(EXPR max_compile_procs "${avail_mem_MiB} / 1024")
+    set_property(GLOBAL PROPERTY JOB_POOLS compile_jobs=${max_compile_procs} link_jobs=1)
+
     # Allow developers to use Boost < 1.74
     if (NOT BOOST_MIN_VERSION)
         set(BOOST_MIN_VERSION 1.74)


### PR DESCRIPTION
When using Ninja build system, CMake can specify job pools for number of concurrent compilers and concurrent linkers.  This PR employes the heuristic of max number of compilers as available physical ram / 1 GiB and a single linker instance to prevent using excessive RAM.  Modern linkers are multithreaded and should not be run concurrently due to risk of resource exhaustion.