### PR TITLE
CAM: Fix postprocessors Help arguments --postamble and --preamble

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
@@ -68,11 +68,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="%\\nG17 G21 G40 G49 G80 G90\\nM08"',
+    help='set commands to be issued before the first command, default="%\\nG17 G21 G40 G49 G80 G90\\nM08\\n"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05 M09\\nG17 G90 G80 G40\\nM30"',
+    help='set commands to be issued after the last command, default="M05 M09\\nG17 G90 G80 G40\\nM30\\n"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
@@ -248,7 +248,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
     for line in POSTAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()

--- a/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
@@ -202,7 +202,7 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(begin preamble)\n"
-    for line in PREAMBLE.splitlines(False):
+    for line in PREAMBLE.splitlines():
         gcode += linenumber() + line + "\n"
     gcode += linenumber() + UNITS + "\n"
 
@@ -247,8 +247,8 @@ def export(objectslist, filename, argstring):
     # do the post_amble
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()

--- a/src/Mod/CAM/Path/Post/scripts/centroid_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/centroid_post.py
@@ -193,8 +193,8 @@ def export(objectslist, filename, argstring):
             ):
                 gcode += ";T{}={}\n".format(item.ToolNumber, item.Name)
         gcode += linenumber() + ";begin preamble\n"
-    for line in PREAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in PREAMBLE.splitlines():
+        gcode += linenumber() + line + "\n"
 
     gcode += linenumber() + UNITS + "\n"
 
@@ -221,8 +221,8 @@ def export(objectslist, filename, argstring):
         gcode += linenumber() + line
     for line in SAFETYBLOCK.splitlines(True):
         gcode += linenumber() + line
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + "\n"
 
     if SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
@@ -225,8 +225,8 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(T)" + "BEGIN PREAMBLE$\n"
-    for line in PREAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in PREAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
     gcode += linenumber() + UNITS + "\n"
 
     for obj in objectslist:
@@ -289,8 +289,8 @@ def export(objectslist, filename, argstring):
     # do the post_amble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(T)" + "BEGIN POSTAMBLE$\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
     # Following is required by Dynapath Controls to signify "EOF" when loading in to control
     # from external media. The control strips the "E" off as part of the load process.
     gcode += "E\n"

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
@@ -59,11 +59,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\\nG90\\nG80\\nG40"',
+    help='set commands to be issued before the first command, default="G17\\nG90\\nG80\\nG40\\n"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M09\\nM05\\nG80\\nG40\\nG17\\nG90\\nM30"',
+    help='set commands to be issued after the last command, default="M09\\nM05\\nG80\\nG40\\nG17\\nG90\\nM30\\n"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G70)"

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
@@ -226,7 +226,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(T)" + "BEGIN PREAMBLE$\n"
     for line in PREAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
     gcode += linenumber() + UNITS + "\n"
 
     for obj in objectslist:
@@ -290,7 +290,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(T)" + "BEGIN POSTAMBLE$\n"
     for line in POSTAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
     # Following is required by Dynapath Controls to signify "EOF" when loading in to control
     # from external media. The control strips the "E" off as part of the load process.
     gcode += "E\n"

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
@@ -231,8 +231,8 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(begin preamble)\n"
-    for line in PREAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in PREAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
     gcode += linenumber() + UNITS + "\n"
 
     for obj in objectslist:
@@ -255,8 +255,8 @@ def export(objectslist, filename, argstring):
 
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
 
     print("show editor: {}".format(SHOW_EDITOR))
     if FreeCAD.GuiUp and SHOW_EDITOR:

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
@@ -232,7 +232,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(begin preamble)\n"
     for line in PREAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
     gcode += linenumber() + UNITS + "\n"
 
     for obj in objectslist:
@@ -256,7 +256,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
     for line in POSTAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
 
     print("show editor: {}".format(SHOW_EDITOR))
     if FreeCAD.GuiUp and SHOW_EDITOR:

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
@@ -86,11 +86,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\\nG90\\nG80\\nG40"',
+    help='set commands to be issued before the first command, default="G17\\nG90\\nG80\\nG40\\n"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M09\\nM05\\nG80\\nG40\\nG17\\nG90\\nM30"',
+    help='set commands to be issued after the last command, default="M09\\nM05\\nG80\\nG40\\nG17\\nG90\\nM30\\n"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
@@ -235,8 +235,8 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin preamble)\n"
-    for line in PREAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in PREAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
     # verify if PREAMBLE have changed UNITS
     if "G21" in PREAMBLE:
         UNITS = "G21"
@@ -310,8 +310,8 @@ def export(objectslist, filename, argstring):
     # do the post_amble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + "\n"
 
     # show the gCode result dialog
     if FreeCAD.GuiUp and SHOW_EDITOR:

--- a/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
@@ -236,7 +236,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin preamble)\n"
     for line in PREAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
     # verify if PREAMBLE have changed UNITS
     if "G21" in PREAMBLE:
         UNITS = "G21"

--- a/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
@@ -114,11 +114,11 @@ parser.add_argument(
 )
 parser.add_argument(
     "--preamble",
-    help="set commands to be issued before the first command",
+    help='set commands to be issued before the first command, default=""',
 )
 parser.add_argument(
     "--postamble",
-    help="set commands to be issued after the last command",
+    help='set commands to be issued after the last command, default="M5\\n"',
 )
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument("--inches", action="store_true", help="convert output for US imperial mode")

--- a/src/Mod/CAM/Path/Post/scripts/fablin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fablin_post.py
@@ -160,8 +160,8 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(begin preamble)\n"
-    for line in PREAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in PREAMBLE.splitlines():
+        gcode += linenumber() + line + "\n"
 
     for obj in objectslist:
 
@@ -183,8 +183,8 @@ def export(objectslist, filename, argstring):
 
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + "\n"
 
     if SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()

--- a/src/Mod/CAM/Path/Post/scripts/fangling_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fangling_post.py
@@ -207,7 +207,7 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(begin preamble)\n"
-    for line in PREAMBLE.splitlines(False):
+    for line in PREAMBLE.splitlines():
         gcode += linenumber() + line + "\n"
     gcode += linenumber() + UNITS + "\n"
 
@@ -251,8 +251,8 @@ def export(objectslist, filename, argstring):
     # do the post_amble
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + "\n"
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()

--- a/src/Mod/CAM/Path/Post/scripts/fangling_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fangling_post.py
@@ -65,11 +65,11 @@ parser.add_argument(
 )
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
-    "--preamble", help='set commands to be issued before the first command, default="G90"'
+    "--preamble", help='set commands to be issued before the first command, default="G90\\n"'
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M8\\nG90 G40\\nM2"',
+    help='set commands to be issued after the last command, default="M8\\nG90 G40\\nM2\\n"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -60,11 +60,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90"',
+    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90\\n"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM6 T0\\nM2"',
+    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM6 T0\\nM2\\n"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -220,7 +220,7 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(BEGIN PREAMBLE)\n"
-    for line in PREAMBLE.splitlines(False):
+    for line in PREAMBLE.splitlines():
         gcode += linenumber() + line + "\n"
     gcode += linenumber() + UNITS + "\n"
 
@@ -276,8 +276,8 @@ def export(objectslist, filename, argstring):
     # do the post_amble
     if OUTPUT_COMMENTS:
         gcode += "(BEGIN POSTAMBLE)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + "\n"
     gcode += "%\n"
 
     if FreeCAD.GuiUp and SHOW_EDITOR:

--- a/src/Mod/CAM/Path/Post/scripts/grbl_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/grbl_post.py
@@ -123,11 +123,11 @@ parser.add_argument(
 )
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17 G90"',
+    help='set commands to be issued before the first command, default="G17 G90\\n"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M5\\nG17 G90\\nM2"',
+    help='set commands to be issued after the last command, default="M5\\nG17 G90\\nM2\\n"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/grbl_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/grbl_post.py
@@ -283,8 +283,8 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin preamble)\n"
-    for line in PREAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in PREAMBLE.splitlines():
+        gcode += linenumber() + line + "\n"
     # verify if PREAMBLE have changed MOTION_MODE or UNITS
     if "G90" in PREAMBLE:
         MOTION_MODE = "G90"
@@ -370,8 +370,8 @@ def export(objectslist, filename, argstring):
         gcode += linenumber() + "(Block-enable: 1)\n"
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + "\n"
 
     # show the gCode result dialog
     if FreeCAD.GuiUp and SHOW_EDITOR:

--- a/src/Mod/CAM/Path/Post/scripts/jtech_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/jtech_post.py
@@ -56,11 +56,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="M05 S0\\nG90"',
+    help='set commands to be issued before the first command, default="M05 S0\\nG90\\n"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05 S0\\nM2"',
+    help='set commands to be issued after the last command, default="M05 S0\\nM2\\n"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/jtech_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/jtech_post.py
@@ -198,7 +198,7 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(begin preamble)\n"
-    for line in PREAMBLE.splitlines(False):
+    for line in PREAMBLE.splitlines():
         gcode += linenumber() + line + "\n"
     gcode += linenumber() + UNITS + "\n"
 
@@ -221,8 +221,8 @@ def export(objectslist, filename, argstring):
     # do the post_amble
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + "\n"
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -56,11 +56,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90"',
+    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90\\n"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM2"',
+    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM2\\n"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -196,7 +196,7 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(begin preamble)\n"
-    for line in PREAMBLE.splitlines(False):
+    for line in PREAMBLE.splitlines():
         gcode += linenumber() + line + "\n"
     gcode += linenumber() + UNITS + "\n"
 
@@ -252,8 +252,8 @@ def export(objectslist, filename, argstring):
     # do the post_amble
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         final = gcode

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -253,7 +253,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
     for line in POSTAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         final = gcode

--- a/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
@@ -196,7 +196,7 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(begin preamble)\n"
-    for line in PREAMBLE.splitlines(False):
+    for line in PREAMBLE.splitlines():
         gcode += linenumber() + line + "\n"
     gcode += linenumber() + UNITS + "\n"
 
@@ -255,8 +255,8 @@ def export(objectslist, filename, argstring):
     # do the post_amble
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()

--- a/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
@@ -56,11 +56,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90"',
+    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90\\n"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM2"',
+    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM2\\n"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
@@ -256,7 +256,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
     for line in POSTAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()

--- a/src/Mod/CAM/Path/Post/scripts/marlin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/marlin_post.py
@@ -156,7 +156,7 @@ parser.add_argument(
     "--preamble", help='set commands to be issued before the first command, default=""'
 )
 parser.add_argument(
-    "--postamble", help='set commands to be issued after the last command, default="M5"'
+    "--postamble", help='set commands to be issued after the last command, default="M5\\n"'
 )
 parser.add_argument("--tool-change", action="store_true", help="Insert M6 for all tool changes")
 parser.add_argument(

--- a/src/Mod/CAM/Path/Post/scripts/marlin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/marlin_post.py
@@ -335,7 +335,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin preamble)\n"
     for line in PREAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
 
     # Write these settings AFTER the preamble,
     # to prevent the preamble from changing these:
@@ -410,7 +410,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin postamble)\n"
     for line in POSTAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
 
     # Optionally add a final XYZ position to the end of the gcode:
     if RETURN_TO:

--- a/src/Mod/CAM/Path/Post/scripts/marlin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/marlin_post.py
@@ -334,8 +334,8 @@ def export(objectslist, filename, argstring):
     # Write the preamble:
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin preamble)\n"
-    for line in PREAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in PREAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
 
     # Write these settings AFTER the preamble,
     # to prevent the preamble from changing these:
@@ -409,8 +409,8 @@ def export(objectslist, filename, argstring):
         gcode += linenumber() + "(Block-enable: 1)\n"
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
 
     # Optionally add a final XYZ position to the end of the gcode:
     if RETURN_TO:

--- a/src/Mod/CAM/Path/Post/scripts/rrf_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/rrf_post.py
@@ -332,8 +332,8 @@ def export(objectslist, filename, argstring):
     # Write the preamble:
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin preamble)\n"
-    for line in PREAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in PREAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
 
     # Write these settings AFTER the preamble,
     # to prevent the preamble from changing these:
@@ -407,8 +407,8 @@ def export(objectslist, filename, argstring):
         gcode += linenumber() + "(Block-enable: 1)\n"
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
 
     # Optionally add a final XYZ position to the end of the gcode:
     if RETURN_TO:

--- a/src/Mod/CAM/Path/Post/scripts/rrf_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/rrf_post.py
@@ -154,7 +154,7 @@ parser.add_argument(
     "--preamble", help='set commands to be issued before the first command, default=""'
 )
 parser.add_argument(
-    "--postamble", help='set commands to be issued after the last command, default="M5"'
+    "--postamble", help='set commands to be issued after the last command, default="M5\\n"'
 )
 parser.add_argument("--tool-change", action="store_true", help="Insert M6 for all tool changes")
 parser.add_argument(

--- a/src/Mod/CAM/Path/Post/scripts/rrf_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/rrf_post.py
@@ -333,7 +333,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin preamble)\n"
     for line in PREAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
 
     # Write these settings AFTER the preamble,
     # to prevent the preamble from changing these:
@@ -408,7 +408,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(Begin postamble)\n"
     for line in POSTAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
 
     # Optionally add a final XYZ position to the end of the gcode:
     if RETURN_TO:

--- a/src/Mod/CAM/Path/Post/scripts/smoothie_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/smoothie_post.py
@@ -68,11 +68,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="4", help="number of digits of precision, default=4")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\\nG90"',
+    help='set commands to be issued before the first command, default="G17\\nG90\\n"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\\nG17 G90\\nM2"',
+    help='set commands to be issued after the last command, default="M05\\nG17 G90\\nM2\\n"',
 )
 parser.add_argument("--IP_ADDR", help="IP Address for machine target machine")
 parser.add_argument(

--- a/src/Mod/CAM/Path/Post/scripts/smoothie_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/smoothie_post.py
@@ -229,7 +229,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(begin preamble)\n"
     for line in PREAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
     gcode += linenumber() + UNITS + "\n"
 
     for obj in objectslist:
@@ -253,7 +253,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
     for line in POSTAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
 
     if SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()

--- a/src/Mod/CAM/Path/Post/scripts/smoothie_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/smoothie_post.py
@@ -228,8 +228,8 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + "(begin preamble)\n"
-    for line in PREAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in PREAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
     gcode += linenumber() + UNITS + "\n"
 
     for obj in objectslist:
@@ -252,8 +252,8 @@ def export(objectslist, filename, argstring):
 
     if OUTPUT_COMMENTS:
         gcode += "(begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
 
     if SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()

--- a/src/Mod/CAM/Path/Post/scripts/uccnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/uccnc_post.py
@@ -443,7 +443,7 @@ def export(objectslist, filename, argstring):
         #    if isinstance(obj.Proxy, Path.Tool.Controller.ToolController):
         #        gcode += append("(T{}={})\n".format(obj.ToolNumber, item.Name))
         # error: global name 'PathScripts' is not defined
-    for line in PREAMBLE.splitlines(False):
+    for line in PREAMBLE.splitlines():
         gcode += append(line + "\n")
     if OUTPUT_COMMENTS:
         gcode += append("(preamble: done)\n")

--- a/src/Mod/CAM/Path/Post/scripts/uccnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/uccnc_post.py
@@ -256,11 +256,11 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\nG90\nG54"',
+    help='set commands to be issued before the first command, default="G17\\nG54\\G40\\nG49\\nG90\\nG80\\n"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\nM30"',
+    help='set commands to be issued after the last command, default="M05\\nG17\\nG54\\nG0\\nG90\\nG80\\nM30\\n"',
 )
 parser.add_argument("--inches", action="store_true", help="lengths in [in], G20")
 parser.add_argument("--metric", action="store_true", help="lengths in [mm], G21")

--- a/src/Mod/CAM/Path/Post/scripts/wedm_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/wedm_post.py
@@ -271,7 +271,7 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + COMMENT_CHAR + "(begin preamble)\n"
-    for line in PREAMBLE.splitlines(False):
+    for line in PREAMBLE.splitlines():
         gcode += linenumber() + line + "\n"
     if not OMIT_UNITS:
         gcode += linenumber() + UNITS + ENDLINE + "\n"
@@ -353,8 +353,8 @@ def export(objectslist, filename, argstring):
     # do the post_amble
     if OUTPUT_COMMENTS:
         gcode += linenumber() + COMMENT_CHAR + "(begin postamble)\n"
-    for line in POSTAMBLE.splitlines(True):
-        gcode += linenumber() + line
+    for line in POSTAMBLE.splitlines():
+        gcode += linenumber() + line + '\n'
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         final = gcode

--- a/src/Mod/CAM/Path/Post/scripts/wedm_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/wedm_post.py
@@ -68,11 +68,11 @@ parser.add_argument("--precision", default="3", help="number of digits of precis
 parser.add_argument("--fixed-length", default="0", help="use fixed length coordinates, default=0")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90"',
+    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90\\n"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM2"',
+    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM2\\n"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/wedm_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/wedm_post.py
@@ -354,7 +354,7 @@ def export(objectslist, filename, argstring):
     if OUTPUT_COMMENTS:
         gcode += linenumber() + COMMENT_CHAR + "(begin postamble)\n"
     for line in POSTAMBLE.splitlines():
-        gcode += linenumber() + line + '\n'
+        gcode += linenumber() + line + "\n"
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         final = gcode


### PR DESCRIPTION
Default **PREAMBLE** and **POSTAMBLE** arguments contains line break in the end

E.g. mach3 will pass last line if not finished by line break `\n`
So need to insert `\n` in the end of custom arguments

![Screenshot_20250414_185649_lossy](https://github.com/user-attachments/assets/92ee155e-0492-4563-8c13-fa19bb958611)
