### PR TITLE
MOD: remove unused variable

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -482,7 +482,6 @@ void DrawSketchHandler::seekPreselectionAutoConstraint(
     const Base::Vector2d& Dir,
     AutoConstraint::TargetType type)
 {
-    SketchObject* obj = sketchgui->getSketchObject();
     PreselectionData preSel = getPreselectionData();
 
     if (preSel.geoId != GeoEnum::GeoUndef) {


### PR DESCRIPTION
the obj variable is not used inside the function