### PR TITLE
TechDraw: Return text fields directly as childs of QGISVGTemplate

### DIFF
--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -204,17 +204,30 @@ void QGISVGTemplate::updateView(bool update)
     draw();
 }
 
+std::vector<TemplateTextField*> QGISVGTemplate::getTextFields()
+{
+    constexpr int TemplateTextFieldType {QGraphicsItem::UserType + 160};
+    std::vector<TemplateTextField*> result;
+    result.reserve(childItems().size());
+
+    QList<QGraphicsItem*> templateChildren = childItems();
+    for (auto& child : templateChildren) {
+        if (child->type() == TemplateTextFieldType) {
+            result.push_back(dynamic_cast<TemplateTextField*>(child));
+        }
+    }
+
+    return result;
+}
+
 void QGISVGTemplate::clearClickHandles()
 {
     prepareGeometryChange();
-    constexpr int TemplateTextFieldType{QGraphicsItem::UserType + 160};
-    auto templateChildren = childItems();
-    for (auto& child : templateChildren) {
-        if (child->type() == TemplateTextFieldType) {
-            child->hide();
-            scene()->removeItem(child);
-            delete child;
-        }
+    std::vector<TemplateTextField*> textFields = getTextFields(); 
+    for (auto& textField : textFields) {
+        textField->hide();
+        scene()->removeItem(textField);
+        delete textField;
      }
 }
 
@@ -317,7 +330,6 @@ void QGISVGTemplate::createClickHandles()
         item->setZValue(ZVALUE::SVGTEMPLATE + 1);
 
         addToGroup(item);
-        textFields.push_back(item);
     }
 }
 

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -213,7 +213,7 @@ std::vector<TemplateTextField*> QGISVGTemplate::getTextFields()
     QList<QGraphicsItem*> templateChildren = childItems();
     for (auto& child : templateChildren) {
         if (child->type() == TemplateTextFieldType) {
-            result.push_back(dynamic_cast<TemplateTextField*>(child));
+            result.push_back(static_cast<TemplateTextField*>(child));
         }
     }
 

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.h
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.h
@@ -60,6 +60,7 @@ public:
     void updateView(bool update = false) override;
 
     TechDraw::DrawSVGTemplate* getSVGTemplate();
+    std::vector<TemplateTextField*> getTextFields() override;
 
 protected:
     void openFile(const QFile& file);

--- a/src/Mod/TechDraw/Gui/QGITemplate.h
+++ b/src/Mod/TechDraw/Gui/QGITemplate.h
@@ -60,7 +60,7 @@ public:
     inline qreal getY() { return y() * -1; }
 
     virtual void updateView(bool update = false);
-    std::vector<TemplateTextField *> getTextFields() { return textFields; };
+    virtual std::vector<TemplateTextField *> getTextFields() { return textFields; };
 
     virtual void draw() = 0;
 


### PR DESCRIPTION
As the title says. I've noticed during reproducing of https://github.com/FreeCAD/FreeCAD/issues/18921, that
after in `PagePrinter::renderPage` we call `setTemplateMarkers`
twice, which results in deleting `childItems` allocated memory
(in `setTemplateMarkers`->`setMarkers`->`updateView`->`clearClickHandles`),
and then we are calling `setTemplateMarkers` (also in `PagePrinter::renderPage`) second time,
accessing `textFields` in `setMarkers` method, which still contain hanging pointers
from the previous deallocation. This results in segfaults as we iterate through `textFields`.

So, instead of keeping sychronization between childs of QGISVGTemplate
and textFields vector - this patch removes this variable at all and uses
childs directly to return text fields.

FYI @benj5378 