### PR TITLE
Fixing copr build by using tito rpm management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # file types to ignore
 .*
+!/.tito/
 !/.clang-format
 !/.clang-tidy
 !/.git-blame-ignore-revs

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -1,0 +1,6 @@
+[buildconfig]
+builder = tito.builder.SubmoduleAwareBuilder
+tagger = tito.tagger.VersionTagger
+changelog_do_not_remove_cherrypick = 0
+changelog_format = %s (%ae)
+

--- a/freecad.spec
+++ b/freecad.spec
@@ -32,7 +32,7 @@
 Name:           %{name}
 Epoch:          1
 Version:        1.1.0
-Release:        pre%{?dist}
+Release:        tito%{?dist}
 Summary:        A general purpose 3D CAD modeler
 Group:          Applications/Engineering
 

--- a/freecad.spec
+++ b/freecad.spec
@@ -32,7 +32,7 @@
 Name:           %{name}
 Epoch:          1
 Version:        1.1.0
-Release:        pre_{{{git_commit_no}}}%{?dist}
+Release:        pre%{?dist}
 Summary:        A general purpose 3D CAD modeler
 Group:          Applications/Engineering
 

--- a/package/fedora/rpkg.conf
+++ b/package/fedora/rpkg.conf
@@ -1,3 +1,0 @@
-[rpkg]
-auto_pack = False
-user_macros = "${git_props:root}/rpkg.macros"

--- a/rpkg.macros
+++ b/rpkg.macros
@@ -1,4 +1,0 @@
-function git_commit_no {
-	commits=$(curl -s 'https://api.github.com/repos/FreeCAD/FreeCAD/compare/120ca87015...main' | grep "\"ahead_by\":" | sed -s 's/ //g' | sed -s 's/"ahead_by"://' | sed -s 's/,//')
-	echo -n $((commits + 1))
-}

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -74,6 +74,7 @@ endif()
 include_directories(
     ${QtCore_INCLUDE_DIRS}
     ${QtXml_INCLUDE_DIRS}
+    ${COIN3D_INCLUDE_DIR}
 )
 list(APPEND FreeCADApp_LIBS
         ${QtCore_LIBRARIES}


### PR DESCRIPTION
use tito https://github.com/rpm-software-management/tito
to build the rpm on copr
it require a config change on copr package change Build SRPM with:   to tito_test

a working copr repo is at https://copr.fedorainfracloud.org/coprs/filippor/filippor-test/package/freecad/

ti test locally
generate src.rpm with
`tito build --srpm --test`
build the generated src.rpm with mock
`mock --rebuild /tmp/tito/freecad-1.1.0-pre.git.41256.42e2fab.fc41.src.rpm`

or install the dependency and generate directly the rpm
`tito build --rpm --test`

can replace PR #20300 