### PR TITLE
BIM change BIM_Setup dialogue default width

### DIFF
--- a/src/Mod/BIM/Resources/ui/dialogSetup.ui
+++ b/src/Mod/BIM/Resources/ui/dialogSetup.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>580</width>
+    <width>640</width>
     <height>691</height>
    </rect>
   </property>


### PR DESCRIPTION
This PR changes the default size of the BIM_Setup dialogue, so that all objects in the dialogue are fully visible.

Original width 588px:
![BIM_setup-default-width](https://github.com/user-attachments/assets/c761b343-6596-46ba-8d6b-653a159cb493)



New width 640px:
![new-width](https://github.com/user-attachments/assets/71a520b4-cc68-49b7-8c0d-362567a97bca)


Note: I did not compile a test the changes myself