### PR TITLE
Enable Weekly Builds

### DIFF
--- a/.github/workflows/sub_weeklyBuild.yml
+++ b/.github/workflows/sub_weeklyBuild.yml
@@ -1,7 +1,7 @@
 name: Weekly Build
 on:
   schedule:
-   - cron: "0 1,3,5,7,9,11,13,15,17,19,21,23 * * *"
+   - cron: "42 18 * * 1"
 
 permissions:
   contents: write
@@ -25,24 +25,24 @@ jobs:
           echo "BUILD_TAG=${BUILD_TAG}" >> "$GITHUB_ENV"
           echo "build_tag=${BUILD_TAG}" >> "$GITHUB_OUTPUT"
 
-      # - name: Upload Source
-      #   env:
-      #     GH_TOKEN: ${{ github.token }}
-      #   run: |
-      #     python3 package/rattler-build/scripts/make_version_file.py ../freecad_version.txt
-      #     git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      #     git config user.name 'github-actions[bot]'
-      #     git apply package/rattler-build/scripts/disable_git_info.patch
-      #     git commit -a -m "Disable git info write to Version.h"
-      #     git archive HEAD -o freecad_source_${BUILD_TAG}.tar
-      #     git submodule foreach --recursive \
-      #       "git archive HEAD --prefix=\$path/ -o \$sha1.tar && \
-      #        tar -A -f \$toplevel/freecad_source_${BUILD_TAG}.tar \$sha1.tar && \
-      #        rm \$sha1.tar"
-      #     gzip freecad_source_${BUILD_TAG}.tar
-      #     sha256sum freecad_source_${BUILD_TAG}.tar.gz > freecad_source_${BUILD_TAG}.tar.gz-SHA256.txt
-      #     gh release create ${BUILD_TAG} --title "Weekly Build ${BUILD_TAG}" --notes "Weekly Build ${BUILD_TAG}" --prerelease || true
-      #     gh release upload --clobber ${BUILD_TAG} "freecad_source_${BUILD_TAG}.tar.gz" "freecad_source_${BUILD_TAG}.tar.gz-SHA256.txt"
+      - name: Upload Source
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 package/rattler-build/scripts/make_version_file.py ../freecad_version.txt
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git apply package/rattler-build/scripts/disable_git_info.patch
+          git commit -a -m "Disable git info write to Version.h"
+          git archive HEAD -o freecad_source_${BUILD_TAG}.tar
+          git submodule foreach --recursive \
+            "git archive HEAD --prefix=\$path/ -o \$sha1.tar && \
+             tar -A -f \$toplevel/freecad_source_${BUILD_TAG}.tar \$sha1.tar && \
+             rm \$sha1.tar"
+          gzip freecad_source_${BUILD_TAG}.tar
+          sha256sum freecad_source_${BUILD_TAG}.tar.gz > freecad_source_${BUILD_TAG}.tar.gz-SHA256.txt
+          gh release create ${BUILD_TAG} --title "Weekly Build ${BUILD_TAG}" --notes "Weekly Build ${BUILD_TAG}" --prerelease || true
+          gh release upload --clobber ${BUILD_TAG} "freecad_source_${BUILD_TAG}.tar.gz" "freecad_source_${BUILD_TAG}.tar.gz-SHA256.txt"
 
   build:
     needs: tag_build
@@ -127,7 +127,7 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGN_RELEASE: "true"
           TARGET_PLATFORM: ${{ matrix.target }}
-          UPLOAD_RELEASE: "false"
+          UPLOAD_RELEASE: "true"
         run: |
           cd package/rattler-build
           pixi install


### PR DESCRIPTION
This reverts commit 0747a4f4a167b1f54df0ec6694d45ce01e4e20fd.

The weekly builds will take place Monday evening at 18:42 PM UTC.  This is more than 3 hours after the weekly PR meeting to give opportunity to accept PRs before the weekly build.