### PR TITLE
TechDraw: Potential fix for snap builds, specify type

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -24,6 +24,7 @@
 #ifndef _PreComp_
 # include <QApplication>
 # include <QMessageBox>
+# include <cmath>
 # include <sstream>
 # include <BRepGProp.hxx>
 # include <GProp_GProps.hxx>
@@ -2130,7 +2131,7 @@ void execCreateVertChamferDimension(Gui::Command* cmd) {
         dim->Y.setValue(-mid.y);
         float dx = allVertexes[0].point.x - allVertexes[1].point.x;
         float dy = allVertexes[0].point.y - allVertexes[1].point.y;
-        float alpha = round(Base::toDegrees(abs(atan(dx / dy))));
+        float alpha = std::round(Base::toDegrees(std::abs<float>(std::atan(dx / dy))));
         std::string sAlpha = std::to_string((int)alpha);
         std::string formatSpec = dim->FormatSpec.getStrValue();
         formatSpec = formatSpec + " x" + sAlpha + "°";


### PR DESCRIPTION
Should fix #20820 

The problem can be seen here: https://github.com/FreeCAD/FreeCAD-snap/actions/runs/14482259726/job/40621422608#step:3:9555
```
:: /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp: In function ‘void execCreateHorizChamferDimension(Gui::Command*)’:
:: /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:2065:44: error: no matching function for call to ‘toDegrees(int)’
::  2065 |         float alpha = round(Base::toDegrees(abs(atan(dy / dx))));
::       |                             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
:: In file included from /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:36:
:: /root/parts/freecad/src/src/Base/Tools.h:151:13: note: candidate: ‘template<class T>  requires  floating_point<T> constexpr T Base::toDegrees(T)’
::   151 | constexpr T toDegrees(T radians)
::       |             ^~~~~~~~~
:: /root/parts/freecad/src/src/Base/Tools.h:151:13: note:   template argument deduction/substitution failed:
:: /root/parts/freecad/src/src/Base/Tools.h:151:13: note: constraints not satisfied
:: In file included from /usr/include/c++/11/compare:39,
::                  from /usr/include/c++/11/bits/stl_pair.h:65,
::                  from /usr/include/c++/11/utility:70,
::                  from /snap/kde-qt5-core22-sdk/1/usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:47,
::                  from /snap/kde-qt5-core22-sdk/1/usr/include/x86_64-linux-gnu/qt5/QtGui/qtguiglobal.h:43,
::                  from /snap/kde-qt5-core22-sdk/1/usr/include/x86_64-linux-gnu/qt5/QtWidgets/qtwidgetsglobal.h:43,
::                  from /snap/kde-qt5-core22-sdk/1/usr/include/x86_64-linux-gnu/qt5/QtWidgets/qapplication.h:43,
::                  from /snap/kde-qt5-core22-sdk/1/usr/include/x86_64-linux-gnu/qt5/QtWidgets/QApplication:1,
::                  from /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:25:
:: /usr/include/c++/11/concepts: In substitution of ‘template<class T>  requires  floating_point<T> constexpr T Base::toDegrees(T) [with T = int]’:
:: /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:2065:44:   required from here
:: /usr/include/c++/11/concepts:109:13:   required for the satisfaction of ‘floating_point<T>’ [with T = int]
:: /usr/include/c++/11/concepts:109:30: note: the expression ‘is_floating_point_v<_Tp> [with _Tp = int]’ evaluated to ‘false’
::   109 |     concept floating_point = is_floating_point_v<_Tp>;
::       |                              ^~~~~~~~~~~~~~~~~~~~~~~~
:: In file included from /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:36:
:: /root/parts/freecad/src/src/Base/Tools.h:160:13: note: candidate: ‘template<class T>  requires (is_arithmetic_v<T>) && !(floating_point<T>) constexpr T Base::toDegrees(std::type_identity_t<T>)’
::   160 | constexpr T toDegrees(std::type_identity_t<T> radians)
::       |             ^~~~~~~~~
:: /root/parts/freecad/src/src/Base/Tools.h:160:13: note:   template argument deduction/substitution failed:
:: /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:2065:44: note:   couldn’t deduce template parameter ‘T’
::  2065 |         float alpha = round(Base::toDegrees(abs(atan(dy / dx))));
::       |                             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
:: /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp: In function ‘void execCreateVertChamferDimension(Gui::Command*)’:
:: /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:2133:44: error: no matching function for call to ‘toDegrees(int)’
::  2133 |         float alpha = round(Base::toDegrees(abs(atan(dx / dy))));
::       |                             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
:: In file included from /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:36:
:: /root/parts/freecad/src/src/Base/Tools.h:151:13: note: candidate: ‘template<class T>  requires  floating_point<T> constexpr T Base::toDegrees(T)’
::   151 | constexpr T toDegrees(T radians)
::       |             ^~~~~~~~~
:: /root/parts/freecad/src/src/Base/Tools.h:151:13: note:   template argument deduction/substitution failed:
:: /root/parts/freecad/src/src/Base/Tools.h:151:13: note: constraints not satisfied
:: In file included from /usr/include/c++/11/compare:39,
::                  from /usr/include/c++/11/bits/stl_pair.h:65,
::                  from /usr/include/c++/11/utility:70,
::                  from /snap/kde-qt5-core22-sdk/1/usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:47,
::                  from /snap/kde-qt5-core22-sdk/1/usr/include/x86_64-linux-gnu/qt5/QtGui/qtguiglobal.h:43,
::                  from /snap/kde-qt5-core22-sdk/1/usr/include/x86_64-linux-gnu/qt5/QtWidgets/qtwidgetsglobal.h:43,
::                  from /snap/kde-qt5-core22-sdk/1/usr/include/x86_64-linux-gnu/qt5/QtWidgets/qapplication.h:43,
::                  from /snap/kde-qt5-core22-sdk/1/usr/include/x86_64-linux-gnu/qt5/QtWidgets/QApplication:1,
::                  from /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:25:
:: /usr/include/c++/11/concepts: In substitution of ‘template<class T>  requires  floating_point<T> constexpr T Base::toDegrees(T) [with T = int]’:
:: /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:2133:44:   required from here
:: /usr/include/c++/11/concepts:109:13:   required for the satisfaction of ‘floating_point<T>’ [with T = int]
:: /usr/include/c++/11/concepts:109:30: note: the expression ‘is_floating_point_v<_Tp> [with _Tp = int]’ evaluated to ‘false’
::   109 |     concept floating_point = is_floating_point_v<_Tp>;
::       |                              ^~~~~~~~~~~~~~~~~~~~~~~~
:: In file included from /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:36:
:: /root/parts/freecad/src/src/Base/Tools.h:160:13: note: candidate: ‘template<class T>  requires (is_arithmetic_v<T>) && !(floating_point<T>) constexpr T Base::toDegrees(std::type_identity_t<T>)’
::   160 | constexpr T toDegrees(std::type_identity_t<T> radians)
::       |             ^~~~~~~~~
:: /root/parts/freecad/src/src/Base/Tools.h:160:13: note:   template argument deduction/substitution failed:
:: /root/parts/freecad/src/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:2133:44: note:   couldn’t deduce template parameter ‘T’
::  2133 |         float alpha = round(Base::toDegrees(abs(atan(dx / dy))));
::       |                             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
```

Specifying type for abs should help it finding which type to use. I put it there instead of in toDegrees to make sure it isn't using integer math in abs.
This problem is most likely due to an old compiler in snap but it doesn't hurt being explicit.