### PR TITLE
Materials: Model Manager External Interface

### DIFF
--- a/src/Mod/Material/App/CMakeLists.txt
+++ b/src/Mod/Material/App/CMakeLists.txt
@@ -24,6 +24,12 @@ include_directories(
 )
 link_directories(${YAML_CPP_LIBRARY_DIR})
 
+if(BUILD_MATERIAL_EXTERNAL)
+    include_directories(
+        ${CMAKE_SOURCE_DIR}/src/3rdParty/lru-cache/include
+    )
+endif(BUILD_MATERIAL_EXTERNAL)
+
 set(Materials_LIBS
     FreeCADApp
 )
@@ -139,6 +145,8 @@ if(BUILD_MATERIAL_EXTERNAL)
     list(APPEND Materials_SRCS
         ExternalManager.cpp
         ExternalManager.h
+        ModelManagerExternal.cpp
+        ModelManagerExternal.h
     )
 endif(BUILD_MATERIAL_EXTERNAL)
 

--- a/src/Mod/Material/App/ExternalManager.cpp
+++ b/src/Mod/Material/App/ExternalManager.cpp
@@ -116,7 +116,7 @@ void ExternalManager::instantiate()
 
         Py::Callable managerClass(mod.getAttr(_className));
         _managerObject = managerClass.apply();
-        if (_managerObject.hasAttr("APIVersion")) {
+        if (!_managerObject.isNull() && _managerObject.hasAttr("APIVersion")) {
             _instantiated = true;
         }
 

--- a/src/Mod/Material/App/Library.cpp
+++ b/src/Mod/Material/App/Library.cpp
@@ -34,6 +34,14 @@ using namespace Materials;
 
 TYPESYSTEM_SOURCE(Materials::Library, Base::BaseClass)
 
+Library::Library(const Library& other)
+    : _name(other._name)
+    , _directory(other._directory)
+    , _iconPath(other._iconPath)
+    , _readOnly(other._readOnly)
+    , _timestamp(other._timestamp)
+{}
+
 Library::Library(const QString& libraryName, const QString& icon, bool readOnly)
     : _name(libraryName)
     , _iconPath(icon)

--- a/src/Mod/Material/App/Library.cpp
+++ b/src/Mod/Material/App/Library.cpp
@@ -34,14 +34,6 @@ using namespace Materials;
 
 TYPESYSTEM_SOURCE(Materials::Library, Base::BaseClass)
 
-Library::Library(const Library& other)
-    : _name(other._name)
-    , _directory(other._directory)
-    , _iconPath(other._iconPath)
-    , _readOnly(other._readOnly)
-    , _timestamp(other._timestamp)
-{}
-
 Library::Library(const QString& libraryName, const QString& icon, bool readOnly)
     : _name(libraryName)
     , _iconPath(icon)

--- a/src/Mod/Material/App/Library.h
+++ b/src/Mod/Material/App/Library.h
@@ -38,7 +38,7 @@ class MaterialsExport Library: public Base::BaseClass
 
 public:
     Library() = default;
-    Library(const Library &other);
+    Library(const Library &other) = default;
     Library(const QString& libraryName, const QString& icon, bool readOnly = true);
     Library(const QString& libraryName,
             const QString& icon,

--- a/src/Mod/Material/App/Library.h
+++ b/src/Mod/Material/App/Library.h
@@ -38,6 +38,7 @@ class MaterialsExport Library: public Base::BaseClass
 
 public:
     Library() = default;
+    Library(const Library &other);
     Library(const QString& libraryName, const QString& icon, bool readOnly = true);
     Library(const QString& libraryName,
             const QString& icon,

--- a/src/Mod/Material/App/MaterialManager.cpp
+++ b/src/Mod/Material/App/MaterialManager.cpp
@@ -202,7 +202,7 @@ std::shared_ptr<MaterialLibrary> MaterialManager::getLibrary(const QString& name
     return _localManager->getLibrary(name);
 }
 
-void MaterialManager::createLibrary(const QString& libraryName, const QString& icon, bool readOnly)
+void MaterialManager::createLibrary(const QString& /*libraryName*/, const QString& /*icon*/, bool /*readOnly*/)
 {
     throw CreationError("Local library requires a path");
 }
@@ -244,7 +244,7 @@ MaterialManager::libraryMaterials(const QString& libraryName,
     return _localManager->libraryMaterials(libraryName, filter, options);
 }
 
-bool MaterialManager::isLocalLibrary(const QString& libraryName)
+bool MaterialManager::isLocalLibrary(const QString& /*libraryName*/)
 {
     return true;
 }

--- a/src/Mod/Material/App/ModelLibrary.cpp
+++ b/src/Mod/Material/App/ModelLibrary.cpp
@@ -22,6 +22,7 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 #include <string>
+#include <QLatin1Char>
 #endif
 
 #include <QFileInfo>
@@ -80,7 +81,7 @@ ModelLibrary::getModelTree(ModelFilter filter) const
 
         auto model = ModelManager::getManager().getModel(getName(), uuid);
         if (ModelManager::passFilter(filter, model->getType())) {
-            QStringList list = path.split(QStringLiteral("/"));
+            QStringList list = path.split(QLatin1Char('/'));
 
             // Start at the root
             std::shared_ptr<std::map<QString, std::shared_ptr<ModelTreeNode>>> node = modelTree;

--- a/src/Mod/Material/App/ModelLibrary.cpp
+++ b/src/Mod/Material/App/ModelLibrary.cpp
@@ -38,21 +38,105 @@ using namespace Materials;
 
 TYPESYSTEM_SOURCE(Materials::ModelLibrary, Materials::Library)
 
+ModelLibrary::ModelLibrary(const Library& other)
+    : Library(other)
+    , _local(false)
+{}
+
 ModelLibrary::ModelLibrary(const QString& libraryName,
                            const QString& dir,
                            const QString& icon,
                            bool readOnly)
     : Library(libraryName, dir, icon, readOnly)
-{
-    _modelPathMap = std::make_unique<std::map<QString, std::shared_ptr<Model>>>();
-}
+    , _local(false)
+{}
 
 ModelLibrary::ModelLibrary()
+    : _local(false)
 {
+}
+
+bool ModelLibrary::isLocal() const
+{
+    return _local;
+}
+
+void ModelLibrary::setLocal(bool local)
+{
+    _local = local;
+}
+
+std::shared_ptr<std::map<QString, std::shared_ptr<ModelTreeNode>>>
+ModelLibrary::getModelTree(ModelFilter filter) const
+{
+    std::shared_ptr<std::map<QString, std::shared_ptr<ModelTreeNode>>> modelTree =
+        std::make_shared<std::map<QString, std::shared_ptr<ModelTreeNode>>>();
+
+    auto models = ModelManager::getManager().libraryModels(getName());
+    for (auto& it : *models) {
+        auto uuid = std::get<0>(it);
+        auto path = std::get<1>(it);
+        auto filename = std::get<2>(it);
+
+        auto model = ModelManager::getManager().getModel(getName(), uuid);
+        if (ModelManager::passFilter(filter, model->getType())) {
+            QStringList list = path.split(QStringLiteral("/"));
+
+            // Start at the root
+            std::shared_ptr<std::map<QString, std::shared_ptr<ModelTreeNode>>> node = modelTree;
+            for (auto& itp : list) {
+                // Add the folder only if it's not already there
+                if (node->count(itp) == 0) {
+                    auto mapPtr =
+                        std::make_shared<std::map<QString, std::shared_ptr<ModelTreeNode>>>();
+                    std::shared_ptr<ModelTreeNode> child = std::make_shared<ModelTreeNode>();
+                    child->setFolder(mapPtr);
+                    (*node)[itp] = child;
+                    node = mapPtr;
+                }
+                else {
+                    node = (*node)[itp]->getFolder();
+                }
+            }
+            std::shared_ptr<ModelTreeNode> child = std::make_shared<ModelTreeNode>();
+            child->setUUID(uuid);
+            child->setData(model);
+            (*node)[filename] = child;
+        }
+    }
+
+    return modelTree;
+}
+
+TYPESYSTEM_SOURCE(Materials::ModelLibraryLocal, Materials::ModelLibrary)
+
+ModelLibraryLocal::ModelLibraryLocal(const Library& other)
+    : ModelLibrary(other)
+{
+    setLocal(true);
+
     _modelPathMap = std::make_unique<std::map<QString, std::shared_ptr<Model>>>();
 }
 
-std::shared_ptr<Model> ModelLibrary::getModelByPath(const QString& path) const
+ModelLibraryLocal::ModelLibraryLocal(const QString& libraryName,
+                                     const QString& dir,
+                                     const QString& icon,
+                                     bool readOnly)
+    : ModelLibrary(libraryName, dir, icon, readOnly)
+{
+    setLocal(true);
+
+    _modelPathMap = std::make_unique<std::map<QString, std::shared_ptr<Model>>>();
+}
+
+ModelLibraryLocal::ModelLibraryLocal()
+{
+    setLocal(true);
+
+    _modelPathMap = std::make_unique<std::map<QString, std::shared_ptr<Model>>>();
+}
+
+std::shared_ptr<Model> ModelLibraryLocal::getModelByPath(const QString& path) const
 {
     QString filePath = getRelativePath(path);
     try {
@@ -64,7 +148,7 @@ std::shared_ptr<Model> ModelLibrary::getModelByPath(const QString& path) const
     }
 }
 
-std::shared_ptr<Model> ModelLibrary::addModel(const Model& model, const QString& path)
+std::shared_ptr<Model> ModelLibraryLocal::addModel(const Model& model, const QString& path)
 {
     QString filePath = getRelativePath(path);
     QFileInfo info(filePath);
@@ -76,47 +160,4 @@ std::shared_ptr<Model> ModelLibrary::addModel(const Model& model, const QString&
     (*_modelPathMap)[filePath] = newModel;
 
     return newModel;
-}
-
-std::shared_ptr<std::map<QString, std::shared_ptr<ModelTreeNode>>>
-ModelLibrary::getModelTree(ModelFilter filter) const
-{
-    std::shared_ptr<std::map<QString, std::shared_ptr<ModelTreeNode>>> modelTree =
-        std::make_shared<std::map<QString, std::shared_ptr<ModelTreeNode>>>();
-
-    for (auto& it : *_modelPathMap) {
-        auto filename = it.first;
-        auto model = it.second;
-
-        if (ModelManager::passFilter(filter, model->getType())) {
-            QStringList list = filename.split(QStringLiteral("/"));
-
-            // Start at the root
-            std::shared_ptr<std::map<QString, std::shared_ptr<ModelTreeNode>>> node = modelTree;
-            for (auto& itp : list) {
-                if (ModelManager::isModel(itp)) {
-                    std::shared_ptr<ModelTreeNode> child = std::make_shared<ModelTreeNode>();
-                    child->setUUID(model->getUUID());
-                    child->setData(model);
-                    (*node)[itp] = child;
-                }
-                else {
-                    // Add the folder only if it's not already there
-                    if (node->count(itp) == 0) {
-                        auto mapPtr =
-                            std::make_shared<std::map<QString, std::shared_ptr<ModelTreeNode>>>();
-                        std::shared_ptr<ModelTreeNode> child = std::make_shared<ModelTreeNode>();
-                        child->setFolder(mapPtr);
-                        (*node)[itp] = child;
-                        node = mapPtr;
-                    }
-                    else {
-                        node = (*node)[itp]->getFolder();
-                    }
-                }
-            }
-        }
-    }
-
-    return modelTree;
 }

--- a/src/Mod/Material/App/ModelLibrary.h
+++ b/src/Mod/Material/App/ModelLibrary.h
@@ -35,6 +35,7 @@
 #include "Library.h"
 #include "MaterialValue.h"
 #include "Model.h"
+
 namespace Materials
 {
 
@@ -45,11 +46,43 @@ class MaterialsExport ModelLibrary: public Library,
 
 public:
     ModelLibrary();
+    ModelLibrary(const Library& other);
     ModelLibrary(const QString& libraryName,
                  const QString& dir,
                  const QString& icon,
                  bool readOnly = true);
+    ModelLibrary(const ModelLibrary& other) = delete;
     ~ModelLibrary() override = default;
+
+    bool isLocal() const;
+    void setLocal(bool local);
+
+    std::shared_ptr<std::map<QString, std::shared_ptr<ModelTreeNode>>>
+    getModelTree(ModelFilter filter) const;
+
+    // Use this to get a shared_ptr for *this
+    std::shared_ptr<ModelLibrary> getptr()
+    {
+        return shared_from_this();
+    }
+
+private:
+    bool _local;
+};
+
+class MaterialsExport ModelLibraryLocal: public ModelLibrary
+{
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
+
+public:
+    ModelLibraryLocal();
+    ModelLibraryLocal(const Library& other);
+    ModelLibraryLocal(const QString& libraryName,
+                 const QString& dir,
+                 const QString& icon,
+                 bool readOnly = true);
+    ModelLibraryLocal(const ModelLibraryLocal& other) = delete;
+    ~ModelLibraryLocal() override = default;
 
     bool operator==(const ModelLibrary& library) const
     {
@@ -63,16 +96,7 @@ public:
 
     std::shared_ptr<Model> addModel(const Model& model, const QString& path);
 
-    // Use this to get a shared_ptr for *this
-    std::shared_ptr<ModelLibrary> getptr()
-    {
-        return shared_from_this();
-    }
-    std::shared_ptr<std::map<QString, std::shared_ptr<ModelTreeNode>>>
-    getModelTree(ModelFilter filter) const;
-
 private:
-    ModelLibrary(const ModelLibrary&);
 
     std::unique_ptr<std::map<QString, std::shared_ptr<Model>>> _modelPathMap;
 };
@@ -80,5 +104,6 @@ private:
 }  // namespace Materials
 
 Q_DECLARE_METATYPE(std::shared_ptr<Materials::ModelLibrary>)
+Q_DECLARE_METATYPE(std::shared_ptr<Materials::ModelLibraryLocal>)
 
 #endif  // MATERIAL_MODELLIBRARY_H

--- a/src/Mod/Material/App/ModelLoader.h
+++ b/src/Mod/Material/App/ModelLoader.h
@@ -29,6 +29,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include "Model.h"
+#include "ModelLibrary.h"
 
 namespace Materials
 {
@@ -36,7 +37,7 @@ namespace Materials
 class ModelEntry
 {
 public:
-    ModelEntry(const std::shared_ptr<ModelLibrary>& library,
+    ModelEntry(const std::shared_ptr<ModelLibraryLocal>& library,
                const QString& baseName,
                const QString& modelName,
                const QString& dir,
@@ -44,7 +45,7 @@ public:
                const YAML::Node& modelData);
     virtual ~ModelEntry() = default;
 
-    std::shared_ptr<ModelLibrary> getLibrary() const
+    std::shared_ptr<ModelLibraryLocal> getLibrary() const
     {
         return _library;
     }
@@ -85,7 +86,7 @@ public:
 private:
     ModelEntry();
 
-    std::shared_ptr<ModelLibrary> _library;
+    std::shared_ptr<ModelLibraryLocal> _library;
     QString _base;
     QString _name;
     QString _directory;
@@ -98,7 +99,7 @@ class ModelLoader
 {
 public:
     ModelLoader(std::shared_ptr<std::map<QString, std::shared_ptr<Model>>> modelMap,
-                std::shared_ptr<std::list<std::shared_ptr<ModelLibrary>>> libraryList);
+                std::shared_ptr<std::list<std::shared_ptr<ModelLibraryLocal>>> libraryList);
     virtual ~ModelLoader() = default;
 
     static const QString getUUIDFromPath(const QString& path);
@@ -120,13 +121,13 @@ private:
                      std::map<std::pair<QString, QString>, QString>* inheritances);
     std::shared_ptr<ModelEntry> getModelFromPath(std::shared_ptr<ModelLibrary> library,
                                                  const QString& path) const;
-    void addLibrary(std::shared_ptr<ModelLibrary> model);
-    void loadLibrary(std::shared_ptr<ModelLibrary> library);
+    void addLibrary(std::shared_ptr<ModelLibraryLocal> model);
+    void loadLibrary(std::shared_ptr<ModelLibraryLocal> library);
     void loadLibraries();
 
     static std::unique_ptr<std::map<QString, std::shared_ptr<ModelEntry>>> _modelEntryMap;
     std::shared_ptr<std::map<QString, std::shared_ptr<Model>>> _modelMap;
-    std::shared_ptr<std::list<std::shared_ptr<ModelLibrary>>> _libraryList;
+    std::shared_ptr<std::list<std::shared_ptr<ModelLibraryLocal>>> _libraryList;
 };
 
 }  // namespace Materials

--- a/src/Mod/Material/App/ModelManager.h
+++ b/src/Mod/Material/App/ModelManager.h
@@ -39,7 +39,7 @@ namespace Materials
 class ModelManagerLocal;
 class ModelManagerExternal;
 
-class MaterialsExport ModelManager: public Base::BaseClass
+class MaterialsExport ModelManager: public Base::BaseClass, ParameterGrp::ObserverType
 {
     TYPESYSTEM_HEADER_WITH_OVERRIDE();
 
@@ -51,8 +51,10 @@ public:
     static void cleanup();
     void refresh();
 
+    // Library management
     std::shared_ptr<std::list<std::shared_ptr<ModelLibrary>>> getLibraries();
     std::shared_ptr<std::list<std::shared_ptr<ModelLibrary>>> getLocalLibraries();
+    std::shared_ptr<ModelLibrary> getLibrary(const QString& name) const;
     void createLibrary(const QString& libraryName, const QString& icon, bool readOnly = true);
     void createLocalLibrary(const QString& libraryName,
                        const QString& directory,
@@ -65,20 +67,36 @@ public:
     libraryModels(const QString& libraryName);
     bool isLocalLibrary(const QString& libraryName);
 
-    std::shared_ptr<std::map<QString, std::shared_ptr<Model>>> getModels();
-    std::shared_ptr<std::map<QString, std::shared_ptr<Model>>> getLocalModels();
+    // Folder management
+
+    // Tree management
     std::shared_ptr<std::map<QString, std::shared_ptr<ModelTreeNode>>>
     getModelTree(std::shared_ptr<ModelLibrary> library, ModelFilter filter = ModelFilter_None) const
     {
         return library->getModelTree(filter);
     }
+
+    // Model management
+    std::shared_ptr<std::map<QString, std::shared_ptr<Model>>> getModels();
+    std::shared_ptr<std::map<QString, std::shared_ptr<Model>>> getLocalModels();
     std::shared_ptr<Model> getModel(const QString& uuid) const;
+    std::shared_ptr<Model> getModel(const QString& libraryName, const QString& uuid) const;
     std::shared_ptr<Model> getModelByPath(const QString& path) const;
     std::shared_ptr<Model> getModelByPath(const QString& path, const QString& lib) const;
-    std::shared_ptr<ModelLibrary> getLibrary(const QString& name) const;
 
     static bool isModel(const QString& file);
     static bool passFilter(ModelFilter filter, Model::ModelType modelType);
+
+    /// Observer message from the ParameterGrp
+    void OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::MessageType Reason) override;
+
+#if defined(BUILD_MATERIAL_EXTERNAL)
+    void migrateToExternal(const std::shared_ptr<Materials::ModelLibrary>& library);
+    void validateMigration(const std::shared_ptr<Materials::ModelLibrary>& library);
+
+    // Cache functions
+    static double modelHitRate();
+#endif
 
 private:
     ModelManager();
@@ -86,7 +104,13 @@ private:
 
     static ModelManager* _manager;
     static std::unique_ptr<ModelManagerLocal> _localManager;
+#if defined(BUILD_MATERIAL_EXTERNAL)
+    static std::unique_ptr<ModelManagerExternal> _externalManager;
+#endif
     static QMutex _mutex;
+    static bool _useExternal;
+
+    ParameterGrp::handle _hGrp;
 };
 
 }  // namespace Materials

--- a/src/Mod/Material/App/ModelManagerExternal.cpp
+++ b/src/Mod/Material/App/ModelManagerExternal.cpp
@@ -1,0 +1,187 @@
+/***************************************************************************
+ *   Copyright (c) 2024 David Carter <dcarter@david.carter.ca>             *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+#endif
+
+#include <QMutexLocker>
+
+#include <App/Application.h>
+
+#include "Model.h"
+#include "ModelLoader.h"
+#include "ModelManagerExternal.h"
+#include "ExternalManager.h"
+
+using namespace Materials;
+
+QMutex ModelManagerExternal::_mutex;
+LRU::Cache<std::string, std::shared_ptr<Model>> ModelManagerExternal::_cache(DEFAULT_CACHE_SIZE);
+
+TYPESYSTEM_SOURCE(Materials::ModelManagerExternal, Base::BaseClass)
+
+ModelManagerExternal::ModelManagerExternal()
+{
+    initCache();
+}
+
+void ModelManagerExternal::initCache()
+{
+    QMutexLocker locker(&_mutex);
+
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Material/ExternalInterface");
+    auto cacheSize = hGrp->GetInt("ModelCacheSize", DEFAULT_CACHE_SIZE);
+    _cache.capacity(cacheSize);
+
+    _cache.monitor();
+}
+
+void ModelManagerExternal::cleanup()
+{
+}
+
+void ModelManagerExternal::refresh()
+{
+    resetCache();
+}
+
+//=====
+//
+// Library management
+//
+//=====
+
+std::shared_ptr<std::list<std::shared_ptr<ModelLibrary>>> ModelManagerExternal::getLibraries()
+{
+    auto libraryList = std::make_shared<std::list<std::shared_ptr<ModelLibrary>>>();
+    try {
+        auto externalLibraries = ExternalManager::getManager()->libraries();
+        for (auto& entry : *externalLibraries) {
+            auto library = std::make_shared<ModelLibrary>(*entry);
+            libraryList->push_back(library);
+        }
+    }
+    catch (const LibraryNotFound& e) {
+    }
+    catch (const ConnectionError& e) {
+    }
+
+    return libraryList;
+}
+
+std::shared_ptr<ModelLibrary> ModelManagerExternal::getLibrary(const QString& name) const
+{
+    try {
+        auto lib = ExternalManager::getManager()->getLibrary(name);
+        auto library = std::make_shared<ModelLibrary>(*lib);
+        return library;
+    }
+    catch (const LibraryNotFound& e) {
+        throw LibraryNotFound(e);
+    }
+    catch (const ConnectionError& e) {
+        throw LibraryNotFound(e.what());
+    }
+}
+
+void ModelManagerExternal::createLibrary(const QString& libraryName,
+                                      const QString& icon,
+                                      bool readOnly)
+{
+    ExternalManager::getManager()->createLibrary(libraryName, icon, readOnly);
+}
+
+std::shared_ptr<std::vector<std::tuple<QString, QString, QString>>>
+ModelManagerExternal::libraryModels(const QString& libraryName)
+{
+    return ExternalManager::getManager()->libraryModels(libraryName);
+}
+
+//=====
+//
+// Model management
+//
+//=====
+
+std::shared_ptr<Model> ModelManagerExternal::getModel(const QString& uuid)
+{
+    if (_cache.contains(uuid.toStdString())) {
+        return _cache.lookup(uuid.toStdString());
+    }
+    try
+    {
+        auto model = ExternalManager::getManager()->getModel(uuid);
+        _cache.emplace(uuid.toStdString(), model);
+        return model;
+    }
+    catch (const ModelNotFound& e) {
+        _cache.emplace(uuid.toStdString(), nullptr);
+        return nullptr;
+    }
+    catch (const ConnectionError& e) {
+        _cache.emplace(uuid.toStdString(), nullptr);
+        return nullptr;
+    }
+}
+
+std::shared_ptr<std::map<QString, std::shared_ptr<Model>>> ModelManagerExternal::getModels()
+{
+    // TODO: Implement an external call
+    return std::make_shared<std::map<QString, std::shared_ptr<Model>>>();
+}
+
+void ModelManagerExternal::addModel(const QString& libraryName,
+                                    const QString& path,
+                                    const std::shared_ptr<Model>& model)
+{
+    _cache.erase(model->getUUID().toStdString());
+    ExternalManager::getManager()->addModel(libraryName, path, model);
+}
+
+void ModelManagerExternal::migrateModel(const QString& libraryName,
+                                    const QString& path,
+                                    const std::shared_ptr<Model>& model)
+{
+    _cache.erase(model->getUUID().toStdString());
+    ExternalManager::getManager()->migrateModel(libraryName, path, model);
+}
+
+//=====
+//
+// Cache management
+//
+//=====
+
+void ModelManagerExternal::resetCache()
+{
+    _cache.clear();
+}
+
+double ModelManagerExternal::modelHitRate()
+{
+    auto hitRate = _cache.stats().hit_rate();
+    if (std::isnan(hitRate)) {
+        return 0;
+    }
+    return hitRate;
+}


### PR DESCRIPTION
Implement the ModelManagerExternal class for the external Materials interface.

This is part of the ongoing merges of code to support external material interfaces. In this PR the ModelManagerExternal class is implemented, along with changes to supporting classes required for this class.

![Managers](https://github.com/user-attachments/assets/dbc755a8-0fc1-41c6-a978-2ca55e8ce3b9)
