### PR TITLE
Fix/snap todegrees

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -23,6 +23,7 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
+#include <cmath>
 #include <limits>
 #include <string>
 #include <vector>
@@ -1140,7 +1141,7 @@ protected:
             TechDraw::pointPair pp = dim->getLinearPoints();
             float dx = pp.first().x - pp.second().x;
             float dy = pp.first().y - pp.second().y;
-            int alpha = round(Base::toDegrees(abs(atan(type == "DistanceY" ? (dx / dy) : (dy / dx)))));
+            int alpha = std::round(Base::toDegrees(std::abs<float>(std::atan(type == "DistanceY" ? (dx / dy) : (dy / dx)))));
             std::string sAlpha = std::to_string(alpha);
             std::string formatSpec = dim->FormatSpec.getStrValue();
             formatSpec = formatSpec + " x" + sAlpha + "°";

--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -2063,7 +2063,7 @@ void execCreateHorizChamferDimension(Gui::Command* cmd) {
         dim->Y.setValue(-yMax);
         float dx = allVertexes[0].point.x - allVertexes[1].point.x;
         float dy = allVertexes[0].point.y - allVertexes[1].point.y;
-        float alpha = round(Base::toDegrees(abs(atan(dy / dx))));
+        float alpha = std::round(Base::toDegrees(std::abs<float>(std::atan(dy / dx))));
         std::string sAlpha = std::to_string((int)alpha);
         std::string formatSpec = dim->FormatSpec.getStrValue();
         formatSpec = formatSpec + " x" + sAlpha + "°";

--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -24,6 +24,7 @@
 #ifndef _PreComp_
 # include <QApplication>
 # include <QMessageBox>
+# include <cmath>
 # include <sstream>
 # include <BRepGProp.hxx>
 # include <GProp_GProps.hxx>
@@ -2130,7 +2131,7 @@ void execCreateVertChamferDimension(Gui::Command* cmd) {
         dim->Y.setValue(-mid.y);
         float dx = allVertexes[0].point.x - allVertexes[1].point.x;
         float dy = allVertexes[0].point.y - allVertexes[1].point.y;
-        float alpha = round(Base::toDegrees(abs(atan(dx / dy))));
+        float alpha = std::round(Base::toDegrees(std::abs<float>(std::atan(dx / dy))));
         std::string sAlpha = std::to_string((int)alpha);
         std::string formatSpec = dim->FormatSpec.getStrValue();
         formatSpec = formatSpec + " x" + sAlpha + "°";


### PR DESCRIPTION
As reported here, there where more issues: https://github.com/FreeCAD/FreeCAD/pull/20823#issuecomment-2810486432

There are a few `Base::toDegrees(atan2(ay, ax));` in the codebase that might fail, but I'd like to see if that is the case, hence not changing those.