### PR TITLE
CAM: Dressup combined menu in toolbar

### DIFF
--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -154,6 +154,14 @@ class CAMWorkbench(Workbench):
                 QT_TRANSLATE_NOOP("CAM_DrillingTools", "Drilling Operations"),
             ),
         )
+        dressupcmdgroup = ["CAM_DressupTools"]
+        FreeCADGui.addCommand(
+            "CAM_DressupTools",
+            PathCommandGroup(
+                dressupcmdlist,
+                QT_TRANSLATE_NOOP("CAM_DressupTools", "Dressup Operations"),
+            ),
+        )
         threedcmdgroup = threedopcmdlist
         if Path.Preferences.experimentalFeaturesEnabled():
             prepcmdlist.append("CAM_Shape")
@@ -206,7 +214,7 @@ class CAMWorkbench(Workbench):
             QT_TRANSLATE_NOOP("Workbench", "New Operations"),
             twodopcmdlist + drillingcmdgroup + engravecmdgroup + threedcmdgroup,
         )
-        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Path Modification"), modcmdlist)
+        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Path Modification"), modcmdlist + dressupcmdgroup)
         if extracmdlist:
             self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Helpful Tools"), extracmdlist)
 

--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -214,7 +214,9 @@ class CAMWorkbench(Workbench):
             QT_TRANSLATE_NOOP("Workbench", "New Operations"),
             twodopcmdlist + drillingcmdgroup + engravecmdgroup + threedcmdgroup,
         )
-        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Path Modification"), modcmdlist + dressupcmdgroup)
+        self.appendToolbar(
+            QT_TRANSLATE_NOOP("Workbench", "Path Modification"), modcmdlist + dressupcmdgroup
+        )
         if extracmdlist:
             self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Helpful Tools"), extracmdlist)
 


### PR DESCRIPTION
It is not convenient to add _Dressup_ tools to custom toolbar since all of them have one icon
Now there is a convenient access to these tools

![Screenshot_20250416_205358_lossy](https://github.com/user-attachments/assets/0b7f5133-d4ee-41f7-846b-34216c6d2b48)
