### PR TITLE
App: Use the legacy macOS version functionality for About FreeCAD dialog

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -64,6 +64,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QProcessEnvironment>
+#include <QRegularExpression>
 #include <QSettings>
 #include <QStandardPaths>
 #include <Inventor/C/basic.h>

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -127,7 +127,6 @@
 #include "OriginGroupExtension.h"
 #include "OriginGroupExtensionPy.h"
 #include "SuppressibleExtension.h"
-#include "SuppressibleExtensionPy.h"
 #include "Part.h"
 #include "GeoFeaturePy.h"
 #include "Placement.h"

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -3541,7 +3541,6 @@ std::string Application::FindHomePath(const char* sCall)
 QString Application::prettyProductInfoWrapper()
 {
     auto productName = QSysInfo::prettyProductName();
-#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
 #ifdef FC_OS_MACOSX
     auto macosVersionFile =
         QStringLiteral("/System/Library/CoreServices/.SystemVersionPlatform.plist");
@@ -3564,7 +3563,6 @@ QString Application::prettyProductInfoWrapper()
             }
         }
     }
-#endif
 #endif
 #ifdef FC_OS_WIN64
     QSettings regKey {


### PR DESCRIPTION
The Qt version gating for determining OS version for the About FreeCAD dialog resulted in a loss of information. This PR uses the legacy approach which retains the version information details.

Fixes #20836.