### PR TITLE
[Core] Fix Color transparency misinterpretation

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -691,7 +691,7 @@ std::map<std::string,Base::Color> ViewProviderPartExt::getElementColors(const ch
             }
             if(size && singleColor) {
                 color = ShapeAppearance.getDiffuseColor(0);
-                color.setTransparency(Base::fromPercent(100.0F));
+                color.setTransparency(Base::fromPercent(0.0F));
                 ret.clear();
             }
             ret["Face"] = color;


### PR DESCRIPTION
Apparently the culprit for export color/transparency is this hardcoded line that sets transparency to 100%. I tested the change in my local build and it works, but to be honest I don't know if this affects other things.

ref: #20621 

@davesrocketshop  