### PR TITLE
fix: fedora build

### DIFF
--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -74,6 +74,7 @@ endif()
 include_directories(
     ${QtCore_INCLUDE_DIRS}
     ${QtXml_INCLUDE_DIRS}
+    ${Coin_INCLUDE_DIR}
 )
 list(APPEND FreeCADApp_LIBS
         ${QtCore_LIBRARIES}


### PR DESCRIPTION
build is failing with error
```
Building CXX object src/App/CMakeFiles/FreeCADApp.dir/Application.cpp.o
cd /builddir/build/BUILD/FreeCAD-rpkg.0.git.11300.b0f98acd-build/FreeCAD/build/src/App && /usr/bin/g++ -DBOOST_DATE_TIME_DYN_LINK -DBOOST_DATE_TIME_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DDOCDIR=\"/usr/share/doc/FreeCAD\" -DFMT_SHARED -DFreeCADApp_EXPORTS -DHAVE_CONFIG_H -DLIBRARYDIR=\"lib64\" -DPYCXX_6_2_COMPATIBILITY -DQT_CORE_LIB -DQT_NO_DEBUG -DQT_NO_KEYWORDS -DQT_XML_LIB -DRESOURCEDIR=\"/usr/share/FreeCAD\" -D_OCC64 -I/builddir/build/BUILD/FreeCAD-rpkg.0.git.11300.b0f98acd-build/FreeCAD/build/src/App/FreeCADApp_autogen/include -I/builddir/build/BUILD/FreeCAD-rpkg.0.git.11300.b0f98acd-build/FreeCAD/build -I/builddir/build/BUILD/FreeCAD-rpkg.0.git.11300.b0f98acd-build/FreeCAD/build/src -I/builddir/build/BUILD/FreeCAD-rpkg.0.git.11300.b0f98acd-build/FreeCAD/src -I/builddir/build/BUILD/FreeCAD-rpkg.0.git.11300.b0f98acd-build/FreeCAD/build/src/App -isystem /usr/include/qt6/QtCore -isystem /usr/include/qt6 -isystem /usr/include/qt6/QtXml -isystem /usr/include/python3.13 -isystem /builddir/build/BUILD/FreeCAD-rpkg.0.git.11300.b0f98acd-build/FreeCAD/src/3rdParty -isystem /usr/lib64/qt6/mkspecs/linux-g++ -Wall -Wextra -Wno-write-strings -fdiagnostics-color -Wno-error=cast-function-type -std=gnu++20 -fPIC -I/usr/include/openmpi-x86_64 -MD -MT src/App/CMakeFiles/FreeCADApp.dir/Application.cpp.o -MF CMakeFiles/FreeCADApp.dir/Application.cpp.o.d -o CMakeFiles/FreeCADApp.dir/Application.cpp.o -c /builddir/build/BUILD/FreeCAD-rpkg.0.git.11300.b0f98acd-build/FreeCAD/src/App/Application.cpp
/builddir/build/BUILD/FreeCAD-rpkg.0.git.11300.b0f98acd-build/FreeCAD/src/App/Application.cpp:69:10: fatal error: Inventor/C/basic.h: No such file or directory
   69 | #include <Inventor/C/basic.h>
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
```
the <Inventor/C/basic.h> include in App/Application.cpp
was  added in 
commit https://github.com/FreeCAD/FreeCAD/commit/989a06ea63d51f8ece7b53807e329f47778f9c27 (origin/main, origin/HEAD, main)
Author: Alex Tran [56737137+xelathan@users.noreply.github.com](mailto:56737137+xelathan@users.noreply.github.com)
Date: Tue Apr 15 23:29:07 2025 -0700

App: Running FreeCAD in verbose mode information to reflect Gui -> Help -> About Dialog info (#20487)

fixed by adding COIN3D_INCLUDE_DIR in App directory