### PR TITLE
Sketcher: Auto-scroll to selected geometry elements

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1373,10 +1373,7 @@ void TaskSketcherConstraints::onSelectionChanged(const Gui::SelectionChanges& ms
                                 auto tmpBlock = ui->listWidgetConstraints->blockSignals(true);
                                 item->setSelected(select);
                                 ui->listWidgetConstraints->blockSignals(tmpBlock);
-                                if (select && ui->listWidgetConstraints->model()) { // scrollTo only on select, not de-select
-                                    QModelIndex index = ui->listWidgetConstraints->model()->index(i, 0);
-                                    ui->listWidgetConstraints->scrollTo(index, QAbstractItemView::PositionAtCenter);
-                                }
+                                SketcherGui::scrollTo(ui->listWidgetConstraints, i, select);
                                 break;
                             }
                         }

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -1435,6 +1435,7 @@ void TaskSketcherElements::onSelectionChanged(const Gui::SelectionChanges& msg)
                                 if (item->ElementNbr == ElementId) {
                                     item->isLineSelected = select;
                                     modified_item = item;
+                                    SketcherGui::scrollTo(ui->listWidgetElements, i, select);
                                     break;
                                 }
                             }

--- a/src/Mod/Sketcher/Gui/Utils.h
+++ b/src/Mod/Sketcher/Gui/Utils.h
@@ -210,6 +210,14 @@ bool areCollinear(const Base::Vector2d& p1, const Base::Vector2d& p2, const Base
 
 int indexOfGeoId(const std::vector<int>& vec, int elem);
 
+inline void scrollTo(QListWidget* list, int i, bool select)
+{
+    if (select && list->model()) {  // scrollTo only on select, not de-select
+        QModelIndex index = list->model()->index(i, 0);
+        list->scrollTo(index, QAbstractItemView::PositionAtCenter);
+    }
+}
+
 }  // namespace SketcherGui
 
 /// converts a 2D vector into a 3D vector in the XY plane

--- a/src/Mod/Sketcher/Gui/Utils.h
+++ b/src/Mod/Sketcher/Gui/Utils.h
@@ -27,6 +27,7 @@
 #include <Base/Tools.h>
 #include <Base/Tools2D.h>
 #include <Mod/Sketcher/App/GeoEnum.h>
+#include <QListWidget>
 
 #include "AutoConstraint.h"
 #include "ViewProviderSketchGeometryExtension.h"


### PR DESCRIPTION
Currently if user selects a geometry element on sketch, listview is not scrolling to it.

So, this patch moves the previously added logic to constraints into a separate helper function call and calls it for Geometry Elements as well, resulting in scrolling in both lists - constraints and elements.

Demo:
https://github.com/user-attachments/assets/84b11d57-6070-4ef4-8559-549b33667063

Resolves: https://github.com/FreeCAD/FreeCAD/issues/20842
