### PR TITLE
Core: Do not raise ReportView while showing it

### DIFF
--- a/src/Gui/DockWindowManager.cpp
+++ b/src/Gui/DockWindowManager.cpp
@@ -405,7 +405,7 @@ void DockWindowManager::removeDockWindow(QWidget* widget)
 /**
  * If the corresponding dock widget isn't visible then activate it.
  */
-void DockWindowManager::activate(QWidget* widget)
+void DockWindowManager::activate(QWidget* widget, bool setFocus)
 {
     QDockWidget* dw = nullptr;
     QWidget* par = widget->parentWidget();
@@ -424,7 +424,8 @@ void DockWindowManager::activate(QWidget* widget)
         dw->toggleViewAction()->activate(QAction::Trigger);
     }
 
-    dw->raise();
+    if (setFocus)
+        dw->raise();
 }
 
 /**

--- a/src/Gui/DockWindowManager.h
+++ b/src/Gui/DockWindowManager.h
@@ -91,7 +91,7 @@ public:
     /// Returns a list of all widgets which set to a QDockWidget.
     QList<QWidget*> getDockWindows() const;
     /// If the corresponding dock widget isn't visible then activate it
-    void activate(QWidget* widget);
+    void activate(QWidget* widget, bool setFocus = true);
 
     void saveState();
     void loadState();

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -310,8 +310,8 @@ ReportOutputObserver::ReportOutputObserver(ReportOutput *report)
 
 void ReportOutputObserver::showReportView()
 {
-    // get the QDockWidget parent of the report view
-    DockWindowManager::instance()->activate(reportView);
+    // get the QDockWidget parent of the report view but don't set focus on it
+    DockWindowManager::instance()->activate(reportView, false);
 }
 
 bool ReportOutputObserver::eventFilter(QObject *obj, QEvent *event)


### PR DESCRIPTION
Right now user has a couple of options to be able to show Report View everytime something is being logged or error pops up, but this gets irritating as the `ReportView` may get focused everytime we get a message.

So, this patch changes this by introducing additional `setFocus` flag that does raise a window inside DockWidget, depending if we want it or not.

NOTE: Maybe we would want to raise the window in `DockWidget` anyways, depending if the message is an error or warning? Let me know.

Demo:
https://github.com/user-attachments/assets/375ebb60-d60c-4572-8e81-ae04b555b376

Resolves: https://github.com/FreeCAD/FreeCAD/issues/20865