### PR TITLE
CAM: Fixes PickStartPoint

### DIFF
--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -51,6 +51,7 @@
         <file>icons/CAM_Simulator.svg</file>
         <file>icons/CAM_SimulatorGL.svg</file>
         <file>icons/CAM_Slot.svg</file>
+        <file>icons/CAM_StartPoint.svg</file>
         <file>icons/CAM_Stop.svg</file>
         <file>icons/CAM_Tapping.svg</file>
         <file>icons/CAM_ThreadMilling.svg</file>

--- a/src/Mod/CAM/Gui/Resources/icons/CAM_StartPoint.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/CAM_StartPoint.svg
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   viewBox="0 0 16.933333 16.933334"
+   version="1.1"
+   id="svg8"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient3">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="0"
+         id="stop1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1"
+         id="stop2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1;"
+         offset="0"
+         id="stop6" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5969">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5967" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient6"
+       id="radialGradient7"
+       cx="7.8876033"
+       cy="286.57697"
+       fx="7.8876033"
+       fy="286.57697"
+       r="6.1166241"
+       gradientTransform="matrix(1,0,0,1.0003089,0,-0.08849432)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient6"
+       id="linearGradient2"
+       x1="4.4678578"
+       y1="282.99539"
+       x2="14.767755"
+       y2="292.10928"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3"
+       id="linearGradient3898"
+       x1="37.429146"
+       y1="41.590584"
+       x2="24.483221"
+       y2="4.9104676"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="0"
+         id="stop3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1"
+         id="stop4" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4"
+       id="linearGradient3856"
+       x1="22.84341"
+       y1="4.8241611"
+       x2="30.783579"
+       y2="28.644661"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0.57899503,-278.01443)"
+     style="display:inline">
+    <g
+       id="g4428-3"
+       transform="matrix(0.0386382,0,0,0.03863832,-58.284885,263.11938)"
+       style="display:inline;stroke-width:1">
+      <path
+         style="display:inline;fill:none;stroke:#555753;stroke-width:8.27356;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3044"
+         d="m 53.611551,28.644661 c 0,13.703853 -11.109167,24.813021 -24.81302,24.813021 -13.703853,0 -24.8130211,-11.109168 -24.8130211,-24.813021 0,-13.703853 11.1091681,-24.8130208 24.8130211,-24.8130208 13.703853,0 24.81302,11.1091678 24.81302,24.8130208 z"
+         transform="matrix(6.6234045,0,0,6.6191713,1521.886,414.91855)" />
+      <path
+         style="fill:none;stroke:#babdb6;stroke-width:4.13678;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3044-2"
+         d="m 53.611551,28.644661 c 0,13.703853 -11.109167,24.813021 -24.81302,24.813021 -13.703853,0 -24.8130211,-11.109168 -24.8130211,-24.813021 0,-13.703853 11.1091681,-24.8130208 24.8130211,-24.8130208 13.703853,0 24.81302,11.1091678 24.81302,24.8130208 z"
+         transform="matrix(6.6234045,0,0,6.6191713,1521.886,414.91855)" />
+      <path
+         style="fill:none;stroke:url(#linearGradient3898);stroke-width:2.15765;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3044-2-4-1"
+         d="m 53.611551,28.644661 c 0,13.703853 -11.109167,24.813021 -24.81302,24.813021 -13.703853,0 -24.8130211,-11.109168 -24.8130211,-24.813021 0,-13.703853 11.1091681,-24.8130208 24.8130211,-24.8130208 13.703853,0 24.81302,11.1091678 24.81302,24.8130208 z"
+         transform="matrix(6.34735,0,0,6.34735,1529.8339,422.80776)" />
+      <path
+         style="fill:none;stroke:url(#linearGradient3856);stroke-width:1.98504;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3044-2-4"
+         d="m 53.611551,28.644661 c 0,13.703853 -11.109167,24.813021 -24.81302,24.813021 -13.703853,0 -24.8130211,-11.109168 -24.8130211,-24.813021 0,-13.703853 11.1091681,-24.8130208 24.8130211,-24.8130208 13.703853,0 24.81302,11.1091678 24.81302,24.8130208 z"
+         transform="matrix(6.899293,0,0,6.8992932,1513.9387,406.99753)" />
+    </g>
+    <g
+       id="g1">
+      <path
+         style="display:inline;fill:none;fill-opacity:1;stroke:#0b1521;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 15.825172,286.4811 H -0.04982836"
+         id="path9"
+         transform="rotate(-90,7.8876997,286.4811)" />
+      <path
+         style="display:inline;fill:none;fill-opacity:1;stroke:#0b1521;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 15.825172,286.4811 H -0.04982836"
+         id="path5" />
+      <path
+         style="display:inline;fill:#ffff00;fill-opacity:1;stroke:#3465a4;stroke-width:1.05833;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 15.825233,286.4811 H -0.04982836"
+         id="path10"
+         transform="rotate(-90,7.8876997,286.4811)" />
+      <path
+         style="display:inline;fill:#ffff00;fill-opacity:1;stroke:#3465a4;stroke-width:1.05833334;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 15.825233,286.4811 H -0.04982836"
+         id="path2"
+         transform="translate(1.2990436e-8)" />
+      <path
+         style="display:inline;fill:#ffff00;fill-opacity:1;stroke:#729fcf;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 15.825233,286.21651 H -0.04982836"
+         id="path8" />
+      <path
+         style="display:inline;fill:#ffff00;fill-opacity:1;stroke:#729fcf;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 15.825233,286.21651 H -0.04982836"
+         id="path11"
+         transform="rotate(-90,7.8876997,286.4811)" />
+    </g>
+  </g>
+  <path
+     style="fill:#d3d7cf;stroke:#0b1521;stroke-width:2.11667;stroke-dasharray:none;stroke-dashoffset:0;paint-order:fill markers stroke"
+     d="m 8.4666684,12.170828 3.2e-5,-7.4083234"
+     id="path7" />
+  <path
+     style="fill:#d3d7cf;stroke:#0b1521;stroke-width:2.11666;stroke-dasharray:none;stroke-dashoffset:0;paint-order:fill markers stroke"
+     d="m 12.170828,8.4666849 -7.4083234,-3.2e-5"
+     id="path12" />
+  <path
+     style="fill:#d3d7cf;stroke:#3465a4;stroke-width:1.05833;stroke-dasharray:none;stroke-dashoffset:0;paint-order:fill markers stroke"
+     d="m 8.4666651,10.318749 3.3e-6,-3.7041651"
+     id="path13" />
+  <path
+     style="fill:#d3d7cf;stroke:#3465a4;stroke-width:1.05833;stroke-dasharray:none;stroke-dashoffset:0;paint-order:fill markers stroke"
+     d="m 10.318749,8.4666681 -3.7041648,-3.3e-6"
+     id="path14" />
+  <path
+     style="fill:#d3d7cf;stroke:#729fcf;stroke-width:0.529167;stroke-dasharray:none;stroke-dashoffset:0;paint-order:fill markers stroke"
+     d="m 8.2020834,10.318749 3.3e-6,-3.7041651"
+     id="path15" />
+  <path
+     style="fill:#d3d7cf;stroke:#729fcf;stroke-width:0.529167;stroke-dasharray:none;stroke-dashoffset:0;paint-order:fill markers stroke"
+     d="m 10.318749,8.2020867 -3.7041648,-3.3e-6"
+     id="path16" />
+</svg>

--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -320,6 +320,8 @@ class CAMWorkbench(Workbench):
                 menuAppended = True
             if isinstance(obj.Proxy, Path.Op.Base.ObjectOp):
                 self.appendContextMenu("", ["CAM_OperationCopy", "CAM_OpActiveToggle"])
+                if hasattr(obj, "StartPoint"):
+                    self.appendContextMenu("", ["CAM_SetStartPoint"])
                 menuAppended = True
             if obj.isDerivedFrom("Path::Feature"):
                 if (

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -1306,12 +1306,18 @@ class CommandSetStartPoint:
         return obj and hasattr(obj, "StartPoint")
 
     def setpoint(self, point, o):
-        obj = FreeCADGui.Selection.getSelection()[0]
+        FreeCADGui.Snapper.grid.off()
+        obj = self.obj
         obj.StartPoint.x = point.x
         obj.StartPoint.y = point.y
         obj.StartPoint.z = obj.ClearanceHeight.Value
+        obj.UseStartPoint = True
+        obj.recompute()
+        textPoint = f"{obj.StartPoint.x:.2f}, {obj.StartPoint.y:.2f}, {obj.StartPoint.z:.2f}"
+        print(f"Set start point for operation {obj.Label} >>> {textPoint}")
 
     def Activated(self):
+        self.obj = FreeCADGui.Selection.getSelection()[0]
         if not hasattr(FreeCADGui, "Snapper"):
             import DraftTools
         FreeCADGui.Snapper.getPoint(callback=self.setpoint)


### PR DESCRIPTION
_PickStartPoint_ tool useful for select start point of the Path in 3dView
Get error while try to use it
<details>
  <summary>Errors</summary>

```
21:39:29  Cannot find icon: CAM_StartPoint
21:39:29  Cannot find icon: Test1
21:39:32  Cannot find icon: CAM_StartPoint
21:39:38  Cannot find icon: CAM_StartPoint
21:39:46  <class 'IndexError'>
21:39:46  Traceback (most recent call last):
21:39:46    File "/home/user/freecad_build/FreeCAD/build/Mod/Draft/draftguitools/gui_snapper.py", line 1418, in click
    accept()
    ~~~~~~^^
21:39:46    File "/home/user/freecad_build/FreeCAD/build/Mod/Draft/draftguitools/gui_snapper.py", line 1441, in accept
    callback(self.pt, obj)
    ~~~~~~~~^^^^^^^^^^^^^^
21:39:46    File "/home/user/freecad_build/FreeCAD/build/Mod/CAM/Path/Op/Gui/Base.py", line 1309, in setpoint
    obj = FreeCADGui.Selection.getSelection()[0]
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
21:39:46  IndexError: list index out of range
```

</details>

- Fixed error `<class 'IndexError'>` while try to apply _PickStartPoint_

Using `FreeCADGui.Selection.getSelection` after `Snapper.getPoint()` leads to error because the selection is empty after _Snapper_
So put  `getSelection()` before `Snapper.getPoint()`

- Automatically set property _UseStartPoint = True_ for Path object after apply _PickStartPoint_

- Added `recompute()`

- Added _PickStartPoint_ tool to toolbar and menu

- Added icon _CAM_StartPoint_ (taken from TechDraw workbench)

![Screenshot_20250418_184042_lossy](https://github.com/user-attachments/assets/90924e73-5c87-49c8-bd3d-09b0f029efe4)

https://streamable.com/4rszlt
https://forum.freecad.org/viewtopic.php?t=96404
