### PR TITLE
Gui: rename TaskCSysDragger to TaskTransformDragger

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -431,7 +431,7 @@ SET(Gui_UIC_SRCS
     SceneInspector.ui
     InputVector.ui
     Placement.ui
-    TaskCSysDragger.ui
+    TaskTransform.ui
     TextureMapping.ui
     TaskView/TaskAppearance.ui
     TaskView/TaskOrientation.ui
@@ -517,7 +517,7 @@ SET(Dialog_CPP_SRCS
     Dialogs/DlgExpressionInput.cpp
     TaskDlgRelocation.cpp
     Dialogs/DlgCheckableMessageBox.cpp
-    TaskCSysDragger.cpp
+    TaskTransform.cpp
     Dialogs/DlgUndoRedo.cpp
     InputVector.cpp
     Placement.cpp
@@ -558,7 +558,7 @@ SET(Dialog_HPP_SRCS
     Dialogs/DlgCheckableMessageBox.h
     Dialogs/DlgExpressionInput.h
     TaskDlgRelocation.h
-    TaskCSysDragger.h
+    TaskTransform.h
     Dialogs/DlgUndoRedo.h
     InputVector.h
     Placement.h

--- a/src/Gui/TaskTransform.cpp
+++ b/src/Gui/TaskTransform.cpp
@@ -37,7 +37,7 @@
 #include <Base/ServiceProvider.h>
 #include <Base/Tools.h>
 
-#include "Document.h"  // must be before TaskCSysDragger.h
+#include "Document.h"  // must be before TaskTransform.h
 #include "Application.h"
 #include "BitmapFactory.h"
 #include "Command.h"
@@ -46,8 +46,8 @@
 #include "ViewProviderDragger.h"
 #include "TaskView/TaskView.h"
 
-#include "TaskCSysDragger.h"
-#include "ui_TaskCSysDragger.h"
+#include "TaskTransform.h"
+#include "ui_TaskTransform.h"
 
 #include <Inventor/nodes/SoPickStyle.h>
 
@@ -90,7 +90,7 @@ TaskTransform::TaskTransform(Gui::ViewProviderDragger* vp,
     , subObjectPlacementProvider(subObjectPlacemenProvider)
     , centerOfMassProvider(centerOfMassProvider)
     , dragger(dragger)
-    , ui(new Ui_TaskCSysDragger)
+    , ui(new Ui_TaskTransformDialog)
 {
     blockSelection(true);
 
@@ -708,14 +708,14 @@ void TaskTransform::onRotationChange(QuantitySpinBox* changed)
     resetReferencePlacement();
 }
 
-TaskCSysDragger::TaskCSysDragger(ViewProviderDragger* vp, SoTransformDragger* dragger)
+TaskTransformDialog::TaskTransformDialog(ViewProviderDragger* vp, SoTransformDragger* dragger)
     : vp(vp)
 {
     transform = new TaskTransform(vp, dragger);
     Content.push_back(transform);
 }
 
-void TaskCSysDragger::open()
+void TaskTransformDialog::open()
 {
     // we can't have user switching camera types while dragger is shown.
     Gui::Application::Instance->commandManager()
@@ -732,7 +732,7 @@ void TaskCSysDragger::open()
         QT_TRANSLATE_NOOP("Command", "Transform"));
 }
 
-bool TaskCSysDragger::accept()
+bool TaskTransformDialog::accept()
 {
     if (auto documentObject = vp->getObject()) {
         Gui::Document* document =
@@ -746,7 +746,7 @@ bool TaskCSysDragger::accept()
     return Gui::TaskView::TaskDialog::accept();
 }
 
-bool TaskCSysDragger::reject()
+bool TaskTransformDialog::reject()
 {
     if (auto documentObject = vp->getObject()) {
         Gui::Document* document =
@@ -760,4 +760,4 @@ bool TaskCSysDragger::reject()
     return Gui::TaskView::TaskDialog::reject();
 }
 
-#include "moc_TaskCSysDragger.cpp"
+#include "moc_TaskTransform.cpp"

--- a/src/Gui/TaskTransform.h
+++ b/src/Gui/TaskTransform.h
@@ -21,8 +21,8 @@
  ***************************************************************************/
 
 
-#ifndef TASKCSYSDRAGGER_H
-#define TASKCSYSDRAGGER_H
+#ifndef TASK_TRANSFORM_DRAGGER_H
+#define TASK_TRANSFORM_DRAGGER_H
 
 #include "TaskView/TaskDialog.h"
 #include "TaskView/TaskView.h"
@@ -43,7 +43,7 @@ namespace Gui
 class QuantitySpinBox;
 class SoTransformDragger;
 class ViewProviderDragger;
-class Ui_TaskCSysDragger;
+class Ui_TaskTransformDialog;
 
 class TaskTransform : public Gui::TaskView::TaskBox, public Gui::SelectionObserver
 {
@@ -136,7 +136,7 @@ private:
 
     CoinPtr<SoTransformDragger> dragger;
 
-    Ui_TaskCSysDragger *ui;
+    Ui_TaskTransformDialog *ui;
 
     SelectionMode selectionMode { SelectionMode::None };
     PlacementMode placementMode { PlacementMode::ObjectOrigin };
@@ -150,13 +150,13 @@ private:
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/History/Dragger");
 };
 
-class TaskCSysDragger: public Gui::TaskView::TaskDialog
+class TaskTransformDialog: public Gui::TaskView::TaskDialog
 {
     Q_OBJECT
 
 public:
-    TaskCSysDragger(ViewProviderDragger* vp, SoTransformDragger* dragger);
-    ~TaskCSysDragger() override = default;
+    TaskTransformDialog(ViewProviderDragger* vp, SoTransformDragger* dragger);
+    ~TaskTransformDialog() override = default;
 
     QDialogButtonBox::StandardButtons getStandardButtons() const override
     {
@@ -173,4 +173,4 @@ private:
 };
 }  // namespace Gui
 
-#endif  // TASKCSYSDRAGGER_H
+#endif  // TASK_TRANSFORM_DRAGGER_H

--- a/src/Gui/TaskTransform.ui
+++ b/src/Gui/TaskTransform.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Gui::TaskCSysDragger</class>
- <widget class="QWidget" name="Gui::TaskCSysDragger">
+ <class>Gui::TaskTransformDialog</class>
+ <widget class="QWidget" name="Gui::TaskTransformDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -125,12 +125,10 @@
           <number>0</number>
          </property>
          <item row="4" column="1">
-          <widget class="Gui::QuantitySpinBox" name="zPositionSpinBox">
-          </widget>
+          <widget class="Gui::QuantitySpinBox" name="zPositionSpinBox"/>
          </item>
          <item row="2" column="1">
-          <widget class="Gui::QuantitySpinBox" name="xPositionSpinBox">
-          </widget>
+          <widget class="Gui::QuantitySpinBox" name="xPositionSpinBox"/>
          </item>
          <item row="2" column="0">
           <widget class="QLabel" name="xPositionLabel">
@@ -181,8 +179,7 @@
           </widget>
          </item>
          <item row="3" column="1">
-          <widget class="Gui::QuantitySpinBox" name="yPositionSpinBox">
-          </widget>
+          <widget class="Gui::QuantitySpinBox" name="yPositionSpinBox"/>
          </item>
         </layout>
        </widget>

--- a/src/Gui/ViewProviderDragger.cpp
+++ b/src/Gui/ViewProviderDragger.cpp
@@ -45,7 +45,7 @@
 #include "Inventor/Draggers/SoTransformDragger.h"
 #include "Inventor/SoFCPlacementIndicatorKit.h"
 #include "SoFCUnifiedSelection.h"
-#include "TaskCSysDragger.h"
+#include "TaskTransform.h"
 #include "View3DInventorViewer.h"
 #include "ViewProviderDragger.h"
 #include "Utilities.h"
@@ -109,7 +109,7 @@ void ViewProviderDragger::onChanged(const App::Property* property)
 
 TaskView::TaskDialog* ViewProviderDragger::getTransformDialog()
 {
-    return new TaskCSysDragger(this, transformDragger);
+    return new TaskTransformDialog(this, transformDragger);
 }
 
 bool ViewProviderDragger::doubleClicked()

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -75,7 +75,7 @@
 #include "LinkViewPy.h"
 #include "Selection.h"
 #include "SoFCUnifiedSelection.h"
-#include "TaskCSysDragger.h"
+#include "TaskTransform.h"
 #include "TaskElementColors.h"
 #include "View3DInventor.h"
 #include "ViewParams.h"


### PR DESCRIPTION
This is a follow up PR of https://github.com/FreeCAD/FreeCAD/pull/20667. The SoFCCSysDragger class was renamed to SoTransformDragger so it also makes sense to rename TaskCSysDragger.