### PR TITLE
CAM: Add BetterToolLibrary to Menu and Toolbar, if addon BTL installed

### DIFF
--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -138,8 +138,8 @@ class CAMWorkbench(Workbench):
         toolcmdlist.extend(PathToolBitLibraryCmd.BarList)
         toolbitcmdlist = PathToolBitLibraryCmd.MenuList
 
-        if FreeCADGui.Command.get('CAM_ToolBitLibraryOpenBTL'):
-            toolcmdlist.append('CAM_ToolBitLibraryOpenBTL')
+        if FreeCADGui.Command.get("CAM_ToolBitLibraryOpenBTL"):
+            toolcmdlist.append("CAM_ToolBitLibraryOpenBTL")
 
         engravecmdgroup = ["CAM_EngraveTools"]
         FreeCADGui.addCommand(

--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -138,6 +138,9 @@ class CAMWorkbench(Workbench):
         toolcmdlist.extend(PathToolBitLibraryCmd.BarList)
         toolbitcmdlist = PathToolBitLibraryCmd.MenuList
 
+        if FreeCADGui.Command.get('CAM_ToolBitLibraryOpenBTL'):
+            toolcmdlist.append('CAM_ToolBitLibraryOpenBTL')
+
         engravecmdgroup = ["CAM_EngraveTools"]
         FreeCADGui.addCommand(
             "CAM_EngraveTools",


### PR DESCRIPTION
Added _CAM_ToolBitLibraryOpenBTL_ to _Tool_Commands_ toolbar and TopMenu,
if addon [BetterToolLibrary](https://github.com/knipknap/better-tool-library) installed

https://forum.freecad.org/viewtopic.php?t=96425

https://github.com/knipknap/better-tool-library/pull/56

![Screenshot_20250418_153850_lossy](https://github.com/user-attachments/assets/0cd7fe3f-52a3-4b7d-8042-ce06a191e722)