### PR TITLE
Base: add missing Coin3D include dirs

### DIFF
--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -23,6 +23,7 @@ target_include_directories(
     SYSTEM
     PUBLIC
     ${Boost_INCLUDE_DIRS}
+    ${COIN3D_INCLUDE_DIRS}
     ${PYCXX_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}
     ${XercesC_INCLUDE_DIRS}


### PR DESCRIPTION
Without this change my build ended on 50% failing to find Inventor/C/Basic.h header.

With this change FreeCAD built fine on Fedora 42 system.