### PR TITLE
Sketcher: Remove not-needed print statements

### DIFF
--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -232,7 +232,7 @@ void EditDatumDialog::accepted()
 
             std::string constraintName = ui_ins_datum->name->text().trimmed().toStdString();
             std::string currConstraintName = sketch->Constraints[ConstrNbr]->Name;
-            printf("datum");
+
             if (constraintName != currConstraintName) {
                 if (!SketcherGui::checkConstraintName(sketch, constraintName)) {
                     constraintName = currConstraintName;

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1223,7 +1223,6 @@ void TaskSketcherConstraints::onListWidgetConstraintsItemChanged(QListWidgetItem
     // b) that the text in the widget item, basename, is not ""
     // otherwise a checkbox change will trigger a rename on the first execution, bloating the
     // constraint icons with the default constraint name "constraint1, constraint2"
-    printf("task");
     if (newName != currConstraintName && !basename.empty()) {
         if (!SketcherGui::checkConstraintName(sketch, newName)) {
             newName = currConstraintName;


### PR DESCRIPTION
As in the title, remove print statements that got through review by mistake.