### PR TITLE
CAM: Fix array warning 2

### DIFF
--- a/src/Mod/CAM/Path/Op/Gui/Array.py
+++ b/src/Mod/CAM/Path/Op/Gui/Array.py
@@ -206,6 +206,8 @@ class ObjectArray:
 
         self.setEditorModes(obj)
 
+        self.FirstRun = True
+
     def execute(self, obj):
         if FreeCAD.GuiUp and self.FirstRun:
             self.FirstRun = False


### PR DESCRIPTION
Associated with #20765

Added `self.FirstRun` to `onDocumentRestored()`
to resolve error `Array: 'ObjectArray' object has no attribute 'FirstRun'`
after reopen file


PS
It is worth considering the possibility of deleting a warning about the old implementation of **Array**
'Old' **Array** is useful and can not be replaced by **DressupArray**