### PR TITLE
BIM: BIM_TDView, add tooltip info on how to insert the view on a particular page

### DIFF
--- a/src/Mod/BIM/bimcommands/BimTDView.py
+++ b/src/Mod/BIM/bimcommands/BimTDView.py
@@ -38,7 +38,7 @@ class BIM_TDView:
             "MenuText": QT_TRANSLATE_NOOP("BIM_TDView", "Insert view"),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "BIM_TDView",
-                "Inserts a drawing view on a page",
+                "Inserts a drawing view on a page.\nTo chose where to insert the view when multiple pages are available, \nselect both the view and the page before you execute the command.",
             ),
             'Accel': "V, I",
         }


### PR DESCRIPTION
Currently, there is no info on how to add a section view to a particular page. This PR adds this info to the command's tooltip, so that users don't need to resort to the forum (often down) or the wiki (also currently down).

Mitigates, but does not fix https://github.com/FreeCAD/FreeCAD/issues/19469
