### PR TITLE
BIM: group 2D view creation commands

### DIFF
--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -103,11 +103,14 @@ class BIMWorkbench(Workbench):
             "Arch_AxisSystem",
             "Arch_Grid",
             "Arch_SectionPlane",
-            "BIM_DrawingView",
-            "BIM_Shape2DView",
-            "BIM_Shape2DCut",
             "BIM_TDPage",
             "BIM_TDView",
+        ]
+
+        self.create_2dviews = [
+             "BIM_DrawingView",
+             "BIM_Shape2DView",
+             "BIM_Shape2DCut",
         ]
 
         self.bimtools = [
@@ -255,7 +258,6 @@ class BIMWorkbench(Workbench):
         ]
 
         # create generic tools command
-
         class BIM_GenericTools:
             def __init__(self, tools):
                 self.tools = tools
@@ -270,6 +272,22 @@ class BIMWorkbench(Workbench):
         FreeCADGui.addCommand("BIM_GenericTools", BIM_GenericTools(self.generictools))
         self.bimtools.append("BIM_GenericTools")
 
+        # create create 2D views command
+        class BIM_Create2DViews:
+            def __init__(self, tools):
+                self.tools = tools
+            def GetCommands(self):
+                return self.tools
+            def GetResources(self):
+                t = QT_TRANSLATE_NOOP("BIM_Create2DViews", "Create 2D views")
+                return { "MenuText": t, "ToolTip": t, "Icon": "BIM_DrawingView"}
+            def IsActive(self):
+                v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+                return v
+        FreeCADGui.addCommand("BIM_Create2DViews", BIM_Create2DViews(self.create_2dviews))
+        insert_at_index = self.annotationtools.index("BIM_TDPage")
+        self.annotationtools.insert(insert_at_index, "BIM_Create2DViews")
+        
         # load rebar tools (Reinforcement addon)
 
         try:


### PR DESCRIPTION
The BIM workbench is one of the most extensive workbenches in terms of the number of commands (buttons) on the toolbar area. This PR attempts to reduce the cognitive load and toolbar area real state usage by logically grouping commands with similar functionality (and icons) from one area: the annotation toolbar.

The additional benefit is that the user can also be better guided through the [typical document production workflow](https://yorik.uncreated.net/?blog%2F2024-011-freecad-news-25).

The <kbd>2D Drawing</kbd> (`BIM_DrawingView`) command is the default one on the group, so that in the typical workflow the dropdown does not need to be expanded.

Before:

![image](https://github.com/user-attachments/assets/acf64c5f-1ed5-4b00-8adc-64aaa57bf94b)

After:

![Captura de pantalla de 2025-04-23 14-25-19](https://github.com/user-attachments/assets/8cd06299-403c-4da4-8cd5-eaf6dee67d4e)

Typical document production workflow:

![image12](https://github.com/user-attachments/assets/28293a8d-cf44-4d32-8723-6dd589d9464f)

1. Section plane
2. 2D Drawing container with views from section plane. No need to expand drop-down in the typical use case.
3. New TechDraw page
4. Add views in 2D Drawing container to page

