### PR TITLE
Core: Fix to sanity checking of ElementMap::restore()

### DIFF
--- a/src/App/ElementMap.cpp
+++ b/src/App/ElementMap.cpp
@@ -258,7 +258,7 @@ ElementMapPtr ElementMap::restore(::App::StringHasherRef hasherRef, std::istream
 
     std::vector<ElementMapPtr> childMaps;
     count = 0;
-    constexpr int practicalMaximum {1 << 30 / sizeof(ElementMapPtr)};  // a 1GB child map vector: almost certainly a bug
+    constexpr int practicalMaximum {(1 << 30) / sizeof(ElementMapPtr)};  // a 1GB child map vector: almost certainly a bug
     if (!(stream >> tmp >> count) || tmp != "MapCount" || count == 0 || count > practicalMaximum) {
         FC_THROWM(Base::RuntimeError, msg);  // NOLINT
     }


### PR DESCRIPTION
An operator precedence error in new sanity checking code within ElementMap::restore() causes <X>.Shape.Map.txt files with more than 2 element maps to be rejected as invalid.  This silently corrupts projects upon loading, potentially unrecoverably.

The preexisting code comment is still appropriate if ironic.