### PR TITLE
CI: Update to LibPack 3.1.1.3

### DIFF
--- a/.github/workflows/actions/windows/getLibpack/action.yml
+++ b/.github/workflows/actions/windows/getLibpack/action.yml
@@ -41,11 +41,11 @@ inputs:
   libpackdownloadurl:
     description: "URL where to download libpack"
     required: false
-    default: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.1.1.2/LibPack-1.1.0-v3.1.1.2-Release.7z
+    default: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.1.1.3/LibPack-1.1.0-v3.1.1.3-Release.7z
   libpackname:
     description: "Libpack name (once downloaded)"
     required: false
-    default: LibPack-1.1.0-v3.1.1.2-Release
+    default: LibPack-1.1.0-v3.1.1.3-Release
 
 runs:
   using: "composite"


### PR DESCRIPTION
Adds the `cxxstd=20` compiler option to `boost`, enabling compilation of #20449 when using the LibPack.