### PR TITLE
Draft: Finish command if user deselected Chained Mode

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -941,6 +941,10 @@ class DraftToolBar:
         params.set_param("ChainedMode", bool(val))
         self.chainedMode = bool(val)
         self.continueCmd.setEnabled(not val)
+        if val == False:
+            # If user has deselected the checkbox, reactive the command
+            # which will result in closing it
+            FreeCAD.activeDraftCommand.Activated()
 
     # val=-1 is used to temporarily switch to relativeMode and disable the checkbox.
     # val=-2 is used to switch back.

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -74,7 +74,7 @@ class Dimension(gui_base_original.Creator):
     def __init__(self):
         super().__init__()
         self.max = 2
-        self.chain = None
+        self.chain = None # Last chain's leg in ChainMode
         self.contMode = None
         self.dir = None
         self.featureName = "Dimension"


### PR DESCRIPTION
As the title says - currently, if user deselects Chained Mode, they can't exit it without using ESC key for example, as the old behavior of ContinueMode is kept under it.

So, this patch finishes the command if user has deselected it, at the same time finishing previous chain.

FYI @semhustej. Is that what you meant?

Demo:

https://github.com/user-attachments/assets/54b30923-edfe-413d-b45e-e32002649d46


