### PR TITLE
Base: Rebuild .cpp/.h files from .pyi on build

### DIFF
--- a/cMake/FreeCadMacros.cmake
+++ b/cMake/FreeCadMacros.cmake
@@ -134,7 +134,7 @@ macro(generate_from_xml BASE_NAME)
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${BASE_NAME}.h" "${CMAKE_CURRENT_BINARY_DIR}/${BASE_NAME}.cpp"
         COMMAND ${Python3_EXECUTABLE} "${TOOL_NATIVE_PATH}" --outputPath "${OUTPUT_NATIVE_PATH}" ${BASE_NAME}.xml
-        MAIN_DEPENDENCY "${BASE_NAME}.xml"
+        MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/${BASE_NAME}.xml"
         DEPENDS
         "${CMAKE_SOURCE_DIR}/src/Tools/bindings/templates/templateClassPyExport.py"
         "${TOOL_PATH}"
@@ -167,7 +167,7 @@ macro(generate_from_py_impl BASE_NAME SUFFIX)
     add_custom_command(
         OUTPUT "${SOURCE_H_PATH}" "${SOURCE_CPP_PATH}"
         COMMAND ${Python3_EXECUTABLE} "${TOOL_NATIVE_PATH}" --outputPath "${OUTPUT_NATIVE_PATH}" ${BASE_NAME}.pyi
-        MAIN_DEPENDENCY "${BASE_NAME}.pyi"
+        MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/${BASE_NAME}.pyi"
         DEPENDS
             "${CMAKE_SOURCE_DIR}/src/Tools/bindings/templates/templateClassPyExport.py"
             "${TOOL_PATH}"

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -315,6 +315,7 @@ SET(FreeCADBase_SRCS
     ${FreeCADBase_CPP_SRCS}
     ${FreeCADBase_HPP_SRCS}
     ${FreeCADBase_XML_SRCS}
+    ${FreeCADBase_Pyi_SRCS}
     ${FreeCADBase_UNITAPI_SRCS}
     PyTools.c
     PyTools.h

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1362,6 +1362,7 @@ SET(FreeCADGui_SRCS
     ${FreeCADGui_connexion_HDRS}
     ${FreeCADGui_CPP_SRCS}
     ${FreeCADGui_XML_SRCS}
+    ${FreeCADGui_Pyi_SRCS}
     ${qsint_MOC_SRCS}
     ${Gui_QRC_SRCS}
     ${Gui_UIC_HDRS}


### PR DESCRIPTION
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Description
It fixes an issue with source files generated from .pyi files not being regenerated which required cleaning build directory and in consequence full rebuild. One line with .pyi sources was missing for the Base module.
