### PR TITLE
App: Fix inheritance information for PropertyEnumeration

### DIFF
--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -277,7 +277,7 @@ unsigned int PropertyPath::getMemSize() const
 // PropertyEnumeration
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-TYPESYSTEM_SOURCE(App::PropertyEnumeration, App::PropertyInteger)
+TYPESYSTEM_SOURCE(App::PropertyEnumeration, App::Property)
 
 //**************************************************************************
 // Construction/Destruction


### PR DESCRIPTION
For some reason `PropertyEnumeration` in our type information system was said to be inherited from `App::PropertyInteger`, which is not the case. This commit fixes that mistake.