### PR TITLE
github: Remove description header

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Include a brief summary of the changes. -->
+
 <!--
 The FreeCAD community thanks you for your contribution!
 By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md
@@ -6,9 +8,6 @@ This template provides guidance on creating a PR that can be reviewed and approv
 
 Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
 -->
-
-## Description
-<!-- Include a brief summary of the changes. -->
 
 ## Issues
 <!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->


### PR DESCRIPTION
If PR consists of one commit with long description, github does put it as the first lines of PR so above our header, it can result in inconsistencies. The header is also needlessly duplicated in every PR preview, reducing its usability.

![image](https://github.com/user-attachments/assets/bb891249-d292-48bd-ab67-906fdccb93d2)


<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Before and After Images
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/3d62a186-86e4-42e1-9df2-236c88168ce2) | ![image](https://github.com/user-attachments/assets/b0a018b1-f44d-4013-bc9e-066e3bac1d05) |




<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
