### PR TITLE
BIM: Allow CurtainWall to have Window being assigned upon Remove/Add ops

### DIFF
--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -102,7 +102,7 @@ def addComponents(objectsList,host):
     if hostType in ["Floor","Building","Site","Project","BuildingPart"]:
         for o in objectsList:
             host.addObject(o)
-    elif hostType in ["Wall","Structure","Precast","Window","Roof","Stairs","StructuralSystem","Panel","Component","Pipe"]:
+    elif hostType in ["Wall","CurtainWall","Structure","Precast","Window","Roof","Stairs","StructuralSystem","Panel","Component","Pipe"]:
         import DraftGeomUtils
         a = host.Additions
         if hasattr(host,"Axes"):
@@ -146,7 +146,7 @@ def removeComponents(objectsList,host=None):
     if not isinstance(objectsList,list):
         objectsList = [objectsList]
     if host:
-        if Draft.getType(host) in ["Wall","Structure","Precast","Window","Roof","Stairs","StructuralSystem","Panel","Component","Pipe"]:
+        if Draft.getType(host) in ["Wall","CurtainWall","Structure","Precast","Window","Roof","Stairs","StructuralSystem","Panel","Component","Pipe"]:
             if hasattr(host,"Tool"):
                 if objectsList[0] == host.Tool:
                     host.Tool = None


### PR DESCRIPTION
Currently user has no possibility to insert Window to the host, if the host is a Curtain Wall.

Solution is simple - just populate the array of acceptable hosts that haven't been extended.

NOTE: Although this feels wrong, I've noted to change it as having some kind of an internal flag allowing for add/remove for the host, since extending this array looks like a really bad approach.

Demo:

https://github.com/user-attachments/assets/f87e07d5-b268-4567-8da7-df2a7ac49592

Resolves: https://github.com/FreeCAD/FreeCAD/issues/20920