### PR TITLE
Update Pixi bash file for mac os

### DIFF
--- a/contrib/clion/pixi/pix-default.bash
+++ b/contrib/clion/pixi/pix-default.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Change to the directory of this script (any subdirectory in the repository should work)
+cd "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" &> /dev/null && pwd -P)"
+# Activate pixi default environment
+eval "$(pixi shell-hook)"


### PR DESCRIPTION
Changes the bash script so that it works on macOS.

See also discussion at #19119

