### PR TITLE
Update CommandPyImp.cpp comment setParameters()

### DIFF
--- a/src/Mod/CAM/App/CommandPyImp.cpp
+++ b/src/Mod/CAM/App/CommandPyImp.cpp
@@ -178,6 +178,10 @@ Py::Dict CommandPy::getParameters() const
     return parameters_copy_dict;
 }
 
+// NB setParameters does NOT set Parameters attribute with the new value, as in typical "setter" fn
+// rather it MERGES the contents of the arg with the existing Parameters dict
+// it should be called addParameters, there is NO setter method. Parameters can never be removed.
+
 void CommandPy::setParameters(Py::Dict arg)
 {
     PyObject* dict_copy = PyDict_Copy(arg.ptr());


### PR DESCRIPTION
setParameters() is NOT a "setter" method. There is not setter method and this attribute does not behave as a python dictionary. 

Since the whole point is to provide python-like behaviour, this is a serious bug which only remains unexplored due to the very limited use context of this attribute.

Until this is fixed a clear note is added to avoid confusion.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
