### PR TITLE
Amend Pixi environment bash script so that it also works on macOS

### DIFF
--- a/contrib/clion/pixi/pixi-default.bash
+++ b/contrib/clion/pixi/pixi-default.bash
@@ -1,10 +1,7 @@
 #!/bin/bash
 
 # Change to the directory of this script (any subdirectory in the repository should work)
-cd "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
-
-# If the line above does not work then try uncommenting the line below and insert the absolute path to your FreeCAD repository
-# cd "absolute/path/to/FreeCAD"
+cd "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" &> /dev/null && pwd -P)"
 
 # Activate pixi default environment
 eval "$(pixi shell-hook)"


### PR DESCRIPTION
Previous version works on linux but not Mac. See also #19119