### PR TITLE
[Gui] Fix warning in Qt6.9.0 due to invalid index

### DIFF
--- a/src/Gui/propertyeditor/PropertyModel.cpp
+++ b/src/Gui/propertyeditor/PropertyModel.cpp
@@ -577,7 +577,7 @@ void PropertyModel::updateChildren(PropertyItem* item, int column, const QModelI
     int numChild = item->childCount();
     if (numChild > 0) {
         QModelIndex topLeft = this->index(0, column, parent);
-        QModelIndex bottomRight = this->index(numChild, column, parent);
+        QModelIndex bottomRight = this->index(numChild - 1, column, parent);
         Q_EMIT dataChanged(topLeft, bottomRight);
     }
 }


### PR DESCRIPTION
The index for `bottomRight` appears to have been incorrect for a long time, if the number of children was five then the index would be _0 to 4_ not _0 to 5_ as it is currently.

fixes #20940

_Has the PR been considered for backporting to the latest release branch?_ A backport PR will follow this PR immediately
