### PR TITLE
[1.0] [Gui] Fix warning in Qt6.9.0 due to invalid index

### DIFF
--- a/src/Gui/propertyeditor/PropertyModel.cpp
+++ b/src/Gui/propertyeditor/PropertyModel.cpp
@@ -535,7 +535,7 @@ void PropertyModel::updateChildren(PropertyItem* item, int column, const QModelI
     int numChild = item->childCount();
     if (numChild > 0) {
         QModelIndex topLeft = this->index(0, column, parent);
-        QModelIndex bottomRight = this->index(numChild, column, parent);
+        QModelIndex bottomRight = this->index(numChild - 1, column, parent);
         Q_EMIT dataChanged(topLeft, bottomRight);
     }
 }


### PR DESCRIPTION
This is a backport PR for #20990 as Arch based distros are already shipping 1.0 with Qt6.9.0