### PR TITLE
Revert: Enable pcl by default on non windows systems #20372

### DIFF
--- a/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
+++ b/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
@@ -180,7 +180,7 @@ macro(InitializeFreeCADBuildOptions)
     endif(MSVC)
     if(NOT MSVC)
         option(BUILD_FEM_NETGEN "Build the FreeCAD FEM module with the NETGEN mesher" OFF)
-        option(FREECAD_USE_PCL "Build the features that use PCL libs" ON)
+        option(FREECAD_USE_PCL "Build the features that use PCL libs" OFF)
     endif(NOT MSVC)
 
     # if this is set override some options


### PR DESCRIPTION
With https://github.com/FreeCAD/FreeCAD/pull/20372 enabling the Point Cloud Library by default on non-Windows systems, several build methods broke, e.g. daily PPA, traditionnal Linux builds (not using pixi) as instructed on the [Dev Handbook](https://freecad.github.io/DevelopersHandbook/gettingstarted/dependencies.html#linux) or the [Wiki](https://wiki.freecad.org/Compile_on_Linux). PCL also had to be disabled specifically on Snap because of dependencies conflicts (VTK). That was more than one month ago.

This PR revert is meant to be temporary, so people relying on the above build methods can as least build and use the latest FreeCAD (and test and report bugs, main purpose of daily builds I guess). Proper fix would be to update build systems and documentation so it works everywhere with PCL enabled.

Some organization (GitHub group, tags, packagers, bot) was proposed, but none put in place to prevent such issues in the future. Please advice how to move forward =D 

## Issues
Fixes https://github.com/FreeCAD/FreeCAD-Bundle/issues/397
Fixes https://github.com/FreeCAD/FreeCAD-Bundle/issues/401
