### PR TITLE
GUI: Refactor - removed soft dependency from freeze toggle

### DIFF
--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -186,14 +186,8 @@ void StdCmdToggleFreeze::activated(int iMsg)
             obj->unfreeze();
             for (auto child : obj->getInListRecursive())
                 child->unfreeze();
-            if (obj->isDerivedFrom(Base::Type::fromName("PartDesign::Body"))) {
-                for (auto child : obj->getOutListRecursive())
-                    child->unfreeze();
-            }
-            else {
-                for (auto child : obj->getOutList())
-                    child->unfreeze();
-            }
+            for (auto child : obj->getOutListRecursive())
+                child->unfreeze();
         } else {
             obj->freeze();
             for (auto parent : obj->getOutListRecursive())


### PR DESCRIPTION
Updates the freeze/unfreeze behavior to remove the soft dependency on `PartDesign::Body`, which was previously used as a workaround due to unclear behavior expectations.

The new approach still improves the original logic by properly dependencies without referencing extension modules like `PartDesign`. 


Related to #20442