### PR TITLE
BIM: Allow changing Sill parameter in Properties for Window

### DIFF
--- a/src/Mod/BIM/ArchWindowPresets.py
+++ b/src/Mod/BIM/ArchWindowPresets.py
@@ -31,8 +31,7 @@ from draftutils.translate import translate
 WindowPresets =  ["Fixed", "Open 1-pane", "Open 2-pane", "Sash 2-pane", "Sliding 2-pane",
                   "Simple door", "Glass door", "Sliding 4-pane", "Awning", "Opening only"]
 
-def makeWindowPreset(windowtype,width,height,h1,h2,h3,w1,w2,o1,o2,placement=None):
-
+def makeWindowPreset(windowtype,width,height,h1,h2,h3,w1,w2,o1,o2,placement=None,window_sill=None):
     """makeWindowPreset(windowtype,width,height,h1,h2,h3,w1,w2,o1,o2,[placement]): makes a
     window object based on the given data. windowtype must be one of the names
     defined in Arch.WindowPresets"""
@@ -516,6 +515,7 @@ def makeWindowPreset(windowtype,width,height,h1,h2,h3,w1,w2,o1,o2,placement=None
             obj.Frame = w2
             obj.Offset = o1
             obj.Placement = FreeCAD.Placement() # unable to find where this bug comes from...
+            obj.Sill = window_sill if window_sill is not None else 0
             if "door" in windowtype.lower():
                 obj.IfcType = "Door"
                 obj.Label = translate("Arch","Door")

--- a/src/Mod/BIM/bimcommands/BimWindow.py
+++ b/src/Mod/BIM/bimcommands/BimWindow.py
@@ -228,7 +228,7 @@ class Arch_Window:
                 wPl = FreeCAD.SketchArchPl
                 SketchArch = True
             else:
-                FreeCADGui.doCommand("win = Arch.makeWindowPreset('" + WindowPresets[self.Preset] + "' " + wp + ", placement=pl)")
+                FreeCADGui.doCommand("win = Arch.makeWindowPreset('" + WindowPresets[self.Preset] + "' " + wp + ", placement=pl, window_sill=" + str(self.Sill.Value) + ")")
                 SketchArch = False
 
         if self.Include:


### PR DESCRIPTION
User has no possibility to change Sill parameter upon adding Window, it is only possible while creating Window for the first time.

So this patch adds this parameter, and changing it moves the *BASE* coordinate of the object in Z direction.

Demo:

https://github.com/user-attachments/assets/50340633-b829-4230-bb4e-371241b5426f


Resolves: https://github.com/FreeCAD/FreeCAD/issues/20882