### PR TITLE
Base: PyImp cleanup

### DIFF
--- a/src/Base/AxisPyImp.cpp
+++ b/src/Base/AxisPyImp.cpp
@@ -24,12 +24,12 @@
 
 #include "GeometryPyCXX.h"
 
-// inclusion of the generated files (generated out of AxisPy.pyi)
+// generated out of Axis.pyi
 #include "AxisPy.h"
 #include "AxisPy.cpp"
 
-#include "VectorPy.h"
 #include "PlacementPy.h"
+#include "VectorPy.h"
 
 using namespace Base;
 

--- a/src/Base/AxisPyImp.cpp
+++ b/src/Base/AxisPyImp.cpp
@@ -62,18 +62,18 @@ int AxisPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     }
 
     PyErr_Clear();
-    if (PyArg_ParseTuple(args, "O!", &(Base::AxisPy::Type), &o)) {
-        Base::Axis* a = static_cast<Base::AxisPy*>(o)->getAxisPtr();
+    if (PyArg_ParseTuple(args, "O!", &(AxisPy::Type), &o)) {
+        auto a = static_cast<AxisPy*>(o)->getAxisPtr();
         *(getAxisPtr()) = *a;
         return 0;
     }
 
     PyErr_Clear();
     PyObject* d {};
-    if (PyArg_ParseTuple(args, "O!O!", &(Base::VectorPy::Type), &o, &(Base::VectorPy::Type), &d)) {
+    if (PyArg_ParseTuple(args, "O!O!", &(VectorPy::Type), &o, &(VectorPy::Type), &d)) {
         // NOTE: The first parameter defines the base (origin) and the second the direction.
-        *getAxisPtr() = Base::Axis(static_cast<Base::VectorPy*>(o)->value(),
-                                   static_cast<Base::VectorPy*>(d)->value());
+        *getAxisPtr() =
+            Axis(static_cast<VectorPy*>(o)->value(), static_cast<VectorPy*>(d)->value());
         return 0;
     }
 
@@ -114,8 +114,7 @@ PyObject* AxisPy::reversed(PyObject* args)
     if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
     }
-    Base::Axis a = getAxisPtr()->reversed();
-    return new AxisPy(new Axis(a));
+    return new AxisPy(new Axis(getAxisPtr()->reversed()));
 }
 
 Py::Object AxisPy::getBase() const

--- a/src/Base/BaseClassPyImp.cpp
+++ b/src/Base/BaseClassPyImp.cpp
@@ -20,10 +20,11 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
 
-// inclusion of the generated files (generated out of BaseClassPy.pyi)
+#include "Type.h"
+
+// generated out of BaseClass.pyi
 #include "BaseClassPy.h"
 #include "BaseClassPy.cpp"
 
@@ -34,7 +35,6 @@ std::string BaseClassPy::representation() const
 {
     return {"<binding object>"};
 }
-
 
 PyObject* BaseClassPy::isDerivedFrom(PyObject* args) const
 {

--- a/src/Base/BaseClassPyImp.cpp
+++ b/src/Base/BaseClassPyImp.cpp
@@ -43,7 +43,7 @@ PyObject* BaseClassPy::isDerivedFrom(PyObject* args) const
         return nullptr;
     }
 
-    Base::Type type = Base::Type::fromName(name);
+    auto type = Type::fromName(name);
     bool valid = (!type.isBad() && getBaseClassPtr()->isDerivedFrom(type));
     return PyBool_FromLong(valid ? 1 : 0);
 }
@@ -55,7 +55,7 @@ PyObject* BaseClassPy::getAllDerivedFrom(PyObject* args) const
     }
 
     std::vector<Base::Type> ary;
-    Base::Type::getAllDerivedFrom(getBaseClassPtr()->getTypeId(), ary);
+    Type::getAllDerivedFrom(getBaseClassPtr()->getTypeId(), ary);
     Py::List res;
     for (const auto& it : ary) {
         res.append(Py::String(it.getName()));

--- a/src/Base/BoundBoxPyImp.cpp
+++ b/src/Base/BoundBoxPyImp.cpp
@@ -20,15 +20,16 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
 
-// inclusion of the generated files (generated out of BoundBoxPy.pyi)
-#include "MatrixPy.h"
-#include "VectorPy.h"
 #include "GeometryPyCXX.h"
+
+// generated out of BoundBox.pyi
 #include "BoundBoxPy.h"
 #include "BoundBoxPy.cpp"
+
+#include "MatrixPy.h"
+#include "VectorPy.h"
 
 using namespace Base;
 

--- a/src/Base/BoundBoxPyImp.cpp
+++ b/src/Base/BoundBoxPyImp.cpp
@@ -92,19 +92,14 @@ int BoundBoxPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         }
     }
     PyErr_Clear();  // set by PyArg_ParseTuple()
-    if (PyArg_ParseTuple(args,
-                         "O!O!",
-                         &(Base::VectorPy::Type),
-                         &object1,
-                         &(Base::VectorPy::Type),
-                         &object2)) {
-        ptr->Add(*(static_cast<Base::VectorPy*>(object1)->getVectorPtr()));
-        ptr->Add(*(static_cast<Base::VectorPy*>(object2)->getVectorPtr()));
+    if (PyArg_ParseTuple(args, "O!O!", &(VectorPy::Type), &object1, &(VectorPy::Type), &object2)) {
+        ptr->Add(*(static_cast<VectorPy*>(object1)->getVectorPtr()));
+        ptr->Add(*(static_cast<VectorPy*>(object2)->getVectorPtr()));
         return 0;
     }
     PyErr_Clear();  // set by PyArg_ParseTuple()
-    if (PyArg_ParseTuple(args, "O!", &(Base::BoundBoxPy::Type), &object1)) {
-        *ptr = *(static_cast<Base::BoundBoxPy*>(object1)->getBoundBoxPtr());
+    if (PyArg_ParseTuple(args, "O!", &(BoundBoxPy::Type), &object1)) {
+        *ptr = *(static_cast<BoundBoxPy*>(object1)->getBoundBoxPtr());
         return 0;
     }
 
@@ -151,17 +146,17 @@ PyObject* BoundBoxPy::add(PyObject* args)
     }
 
     PyErr_Clear();
-    if (PyArg_ParseTuple(args, "O!", &(Base::VectorPy::Type), &object)) {
-        getBoundBoxPtr()->Add(*(static_cast<Base::VectorPy*>(object)->getVectorPtr()));
+    if (PyArg_ParseTuple(args, "O!", &(VectorPy::Type), &object)) {
+        getBoundBoxPtr()->Add(*(static_cast<VectorPy*>(object)->getVectorPtr()));
         Py_Return;
     }
 
     PyErr_Clear();
     if (PyArg_ParseTuple(args,
                          "O!;Need a Vector, BoundBox or three floats as argument",
-                         &(Base::BoundBoxPy::Type),
+                         &(BoundBoxPy::Type),
                          &object)) {
-        getBoundBoxPtr()->Add(*(static_cast<Base::BoundBoxPy*>(object)->getBoundBoxPtr()));
+        getBoundBoxPtr()->Add(*(static_cast<BoundBoxPy*>(object)->getBoundBoxPtr()));
         Py_Return;
     }
 
@@ -182,8 +177,7 @@ PyObject* BoundBoxPy::getPoint(PyObject* args) const
         return nullptr;
     }
 
-    Base::Vector3d pnt = getBoundBoxPtr()->CalcPoint(index);
-    return new Base::VectorPy(new Base::Vector3d(pnt));
+    return new VectorPy(new Vector3d(getBoundBoxPtr()->CalcPoint(index)));
 }
 
 PyObject* BoundBoxPy::getEdge(PyObject* args) const
@@ -198,8 +192,8 @@ PyObject* BoundBoxPy::getEdge(PyObject* args) const
         return nullptr;
     }
 
-    Base::Vector3d pnt1;
-    Base::Vector3d pnt2;
+    Vector3d pnt1;
+    Vector3d pnt2;
     getBoundBoxPtr()->CalcEdge(index, pnt1, pnt2);
     Py::Tuple tuple(2);
     tuple.setItem(0, Py::Vector(pnt1));
@@ -214,7 +208,7 @@ PyObject* BoundBoxPy::closestPoint(PyObject* args) const
     double z {};
     PyObject* object {};
 
-    Base::Vector3d vec;
+    Vector3d vec;
 
     do {
         if (PyArg_ParseTuple(args, "ddd", &x, &y, &z)) {
@@ -229,8 +223,8 @@ PyObject* BoundBoxPy::closestPoint(PyObject* args) const
         }
 
         PyErr_Clear();
-        if (PyArg_ParseTuple(args, "O!", &(Base::VectorPy::Type), &object)) {
-            vec = *(static_cast<Base::VectorPy*>(object)->getVectorPtr());
+        if (PyArg_ParseTuple(args, "O!", &(VectorPy::Type), &object)) {
+            vec = *(static_cast<VectorPy*>(object)->getVectorPtr());
             break;
         }
 
@@ -238,8 +232,8 @@ PyObject* BoundBoxPy::closestPoint(PyObject* args) const
         return nullptr;
     } while (false);
 
-    Base::Vector3d point = getBoundBoxPtr()->ClosestPoint(vec);
-    return new Base::VectorPy(new Base::Vector3d(point));
+    Vector3d point = getBoundBoxPtr()->ClosestPoint(vec);
+    return new VectorPy(new Vector3d(point));
 }
 
 PyObject* BoundBoxPy::intersect(PyObject* args)
@@ -256,24 +250,24 @@ PyObject* BoundBoxPy::intersect(PyObject* args)
     do {
         if (PyArg_ParseTuple(args,
                              "O!O!",
-                             &(Base::VectorPy::Type),
+                             &(VectorPy::Type),
                              &object1,
-                             &(Base::VectorPy::Type),
+                             &(VectorPy::Type),
                              &object2)) {
-            retVal = getBoundBoxPtr()->IsCutLine(
-                *(static_cast<Base::VectorPy*>(object1)->getVectorPtr()),
-                *(static_cast<Base::VectorPy*>(object2)->getVectorPtr()));
+            retVal =
+                getBoundBoxPtr()->IsCutLine(*(static_cast<VectorPy*>(object1)->getVectorPtr()),
+                                            *(static_cast<VectorPy*>(object2)->getVectorPtr()));
             break;
         }
 
         PyErr_Clear();
-        if (PyArg_ParseTuple(args, "O!", &(Base::BoundBoxPy::Type), &object1)) {
-            if (!static_cast<Base::BoundBoxPy*>(object1)->getBoundBoxPtr()->IsValid()) {
+        if (PyArg_ParseTuple(args, "O!", &(BoundBoxPy::Type), &object1)) {
+            if (!static_cast<BoundBoxPy*>(object1)->getBoundBoxPtr()->IsValid()) {
                 PyErr_SetString(PyExc_FloatingPointError, "Invalid bounding box argument");
                 return nullptr;
             }
-            retVal = getBoundBoxPtr()->Intersect(
-                *(static_cast<Base::BoundBoxPy*>(object1)->getBoundBoxPtr()));
+            retVal =
+                getBoundBoxPtr()->Intersect(*(static_cast<BoundBoxPy*>(object1)->getBoundBoxPtr()));
             break;
         }
 
@@ -292,17 +286,17 @@ PyObject* BoundBoxPy::intersected(PyObject* args)
     }
 
     PyObject* object {};
-    if (!PyArg_ParseTuple(args, "O!", &(Base::BoundBoxPy::Type), &object)) {
+    if (!PyArg_ParseTuple(args, "O!", &(BoundBoxPy::Type), &object)) {
         return nullptr;
     }
-    if (!static_cast<Base::BoundBoxPy*>(object)->getBoundBoxPtr()->IsValid()) {
+    if (!static_cast<BoundBoxPy*>(object)->getBoundBoxPtr()->IsValid()) {
         PyErr_SetString(PyExc_FloatingPointError, "Invalid bounding box argument");
         return nullptr;
     }
 
-    Base::BoundBox3d bbox =
-        getBoundBoxPtr()->Intersected(*static_cast<Base::BoundBoxPy*>(object)->getBoundBoxPtr());
-    return new Base::BoundBoxPy(new Base::BoundBox3d(bbox));
+    BoundBox3d bbox =
+        getBoundBoxPtr()->Intersected(*static_cast<BoundBoxPy*>(object)->getBoundBoxPtr());
+    return new BoundBoxPy(new BoundBox3d(bbox));
 }
 
 PyObject* BoundBoxPy::united(PyObject* args)
@@ -313,17 +307,16 @@ PyObject* BoundBoxPy::united(PyObject* args)
     }
 
     PyObject* object {};
-    if (!PyArg_ParseTuple(args, "O!", &(Base::BoundBoxPy::Type), &object)) {
+    if (!PyArg_ParseTuple(args, "O!", &(BoundBoxPy::Type), &object)) {
         return nullptr;
     }
-    if (!static_cast<Base::BoundBoxPy*>(object)->getBoundBoxPtr()->IsValid()) {
+    if (!static_cast<BoundBoxPy*>(object)->getBoundBoxPtr()->IsValid()) {
         PyErr_SetString(PyExc_FloatingPointError, "Invalid bounding box argument");
         return nullptr;
     }
 
-    Base::BoundBox3d bbox =
-        getBoundBoxPtr()->United(*static_cast<Base::BoundBoxPy*>(object)->getBoundBoxPtr());
-    return new Base::BoundBoxPy(new Base::BoundBox3d(bbox));
+    BoundBox3d bbox = getBoundBoxPtr()->United(*static_cast<BoundBoxPy*>(object)->getBoundBoxPtr());
+    return new BoundBoxPy(new BoundBox3d(bbox));
 }
 
 PyObject* BoundBoxPy::enlarge(PyObject* args)
@@ -343,25 +336,25 @@ PyObject* BoundBoxPy::getIntersectionPoint(PyObject* args)
     double epsilon = 0.0001;
     if (!PyArg_ParseTuple(args,
                           "O!O!|d;Need base and direction vector",
-                          &(Base::VectorPy::Type),
+                          &(VectorPy::Type),
                           &object1,
-                          &(Base::VectorPy::Type),
+                          &(VectorPy::Type),
                           &object2,
                           &epsilon)) {
         return nullptr;
     }
 
-    Base::Vector3d point;
-    bool ok = getBoundBoxPtr()->IntersectionPoint(
-        *(static_cast<Base::VectorPy*>(object1)->getVectorPtr()),
-        *(static_cast<Base::VectorPy*>(object2)->getVectorPtr()),
-        point,
-        epsilon);
+    Vector3d point;
+    bool ok =
+        getBoundBoxPtr()->IntersectionPoint(*(static_cast<VectorPy*>(object1)->getVectorPtr()),
+                                            *(static_cast<VectorPy*>(object2)->getVectorPtr()),
+                                            point,
+                                            epsilon);
     if (ok) {
         return new VectorPy(point);
     }
 
-    PyErr_SetString(Base::PyExc_FC_GeneralError, "No intersection");
+    PyErr_SetString(PyExc_FC_GeneralError, "No intersection");
     return nullptr;
 }
 
@@ -372,7 +365,7 @@ PyObject* BoundBoxPy::move(PyObject* args)
     double z {};
     PyObject* object {};
 
-    Base::Vector3d vec;
+    Vector3d vec;
 
     do {
         if (PyArg_ParseTuple(args, "ddd", &x, &y, &z)) {
@@ -387,8 +380,8 @@ PyObject* BoundBoxPy::move(PyObject* args)
         }
 
         PyErr_Clear();
-        if (PyArg_ParseTuple(args, "O!", &(Base::VectorPy::Type), &object)) {
-            vec = *(static_cast<Base::VectorPy*>(object)->getVectorPtr());
+        if (PyArg_ParseTuple(args, "O!", &(VectorPy::Type), &object)) {
+            vec = *(static_cast<VectorPy*>(object)->getVectorPtr());
             break;
         }
 
@@ -410,7 +403,7 @@ PyObject* BoundBoxPy::scale(PyObject* args)
     double z {};
     PyObject* object {};
 
-    Base::Vector3d vec;
+    Vector3d vec;
 
     do {
         if (PyArg_ParseTuple(args, "ddd", &x, &y, &z)) {
@@ -425,8 +418,8 @@ PyObject* BoundBoxPy::scale(PyObject* args)
         }
 
         PyErr_Clear();
-        if (PyArg_ParseTuple(args, "O!", &(Base::VectorPy::Type), &object)) {
-            vec = *(static_cast<Base::VectorPy*>(object)->getVectorPtr());
+        if (PyArg_ParseTuple(args, "O!", &(VectorPy::Type), &object)) {
+            vec = *(static_cast<VectorPy*>(object)->getVectorPtr());
             break;
         }
 
@@ -445,16 +438,15 @@ PyObject* BoundBoxPy::transformed(PyObject* args)
 {
     PyObject* mat {};
 
-    if (!PyArg_ParseTuple(args, "O!", &(Base::MatrixPy::Type), &mat)) {
+    if (!PyArg_ParseTuple(args, "O!", &(MatrixPy::Type), &mat)) {
         return nullptr;
     }
 
     if (!getBoundBoxPtr()->IsValid()) {
         throw Py::FloatingPointError("Cannot transform invalid bounding box");
     }
-    Base::BoundBox3d bbox =
-        getBoundBoxPtr()->Transformed(*static_cast<Base::MatrixPy*>(mat)->getMatrixPtr());
-    return new Base::BoundBoxPy(new Base::BoundBox3d(bbox));
+    BoundBox3d bbox = getBoundBoxPtr()->Transformed(*static_cast<MatrixPy*>(mat)->getMatrixPtr());
+    return new BoundBoxPy(new BoundBox3d(bbox));
 }
 
 PyObject* BoundBoxPy::isCutPlane(PyObject* args)
@@ -470,15 +462,15 @@ PyObject* BoundBoxPy::isCutPlane(PyObject* args)
 
     if (!PyArg_ParseTuple(args,
                           "O!O!;Need base and normal vector of a plane",
-                          &(Base::VectorPy::Type),
+                          &(VectorPy::Type),
                           &object,
-                          &(Base::VectorPy::Type),
+                          &(VectorPy::Type),
                           &object2)) {
         return nullptr;
     }
 
-    retVal = getBoundBoxPtr()->IsCutPlane(*(static_cast<Base::VectorPy*>(object)->getVectorPtr()),
-                                          *(static_cast<Base::VectorPy*>(object2)->getVectorPtr()));
+    retVal = getBoundBoxPtr()->IsCutPlane(*(static_cast<VectorPy*>(object)->getVectorPtr()),
+                                          *(static_cast<VectorPy*>(object2)->getVectorPtr()));
 
     return Py::new_reference_to(retVal);
 }
@@ -509,20 +501,19 @@ PyObject* BoundBoxPy::isInside(PyObject* args)
         }
 
         PyErr_Clear();
-        if (PyArg_ParseTuple(args, "O!", &(Base::VectorPy::Type), &object)) {
-            retVal =
-                getBoundBoxPtr()->IsInBox(*(static_cast<Base::VectorPy*>(object)->getVectorPtr()));
+        if (PyArg_ParseTuple(args, "O!", &(VectorPy::Type), &object)) {
+            retVal = getBoundBoxPtr()->IsInBox(*(static_cast<VectorPy*>(object)->getVectorPtr()));
             break;
         }
 
         PyErr_Clear();
-        if (PyArg_ParseTuple(args, "O!", &(Base::BoundBoxPy::Type), &object)) {
-            if (!static_cast<Base::BoundBoxPy*>(object)->getBoundBoxPtr()->IsValid()) {
+        if (PyArg_ParseTuple(args, "O!", &(BoundBoxPy::Type), &object)) {
+            if (!static_cast<BoundBoxPy*>(object)->getBoundBoxPtr()->IsValid()) {
                 PyErr_SetString(PyExc_FloatingPointError, "Invalid bounding box argument");
                 return nullptr;
             }
-            retVal = getBoundBoxPtr()->IsInBox(
-                *(static_cast<Base::BoundBoxPy*>(object)->getBoundBoxPtr()));
+            retVal =
+                getBoundBoxPtr()->IsInBox(*(static_cast<BoundBoxPy*>(object)->getBoundBoxPtr()));
             break;
         }
 

--- a/src/Base/CoordinateSystemPyImp.cpp
+++ b/src/Base/CoordinateSystemPyImp.cpp
@@ -22,13 +22,15 @@
 
 #include "PreCompiled.h"
 
-#include "AxisPy.h"
+#include "GeometryPyCXX.h"
+
+// generated out of CoordinateSystem.pyi
 #include "CoordinateSystemPy.h"
 #include "CoordinateSystemPy.cpp"
-#include "GeometryPyCXX.h"
+
+#include "AxisPy.h"
 #include "PlacementPy.h"
 #include "VectorPy.h"
-
 
 using namespace Base;
 

--- a/src/Base/CoordinateSystemPyImp.cpp
+++ b/src/Base/CoordinateSystemPyImp.cpp
@@ -132,7 +132,7 @@ Py::Object CoordinateSystemPy::getAxis() const
 
 void CoordinateSystemPy::setAxis(Py::Object arg)
 {
-    if (PyObject_TypeCheck(arg.ptr(), &(Base::AxisPy::Type))) {
+    if (PyObject_TypeCheck(arg.ptr(), &(AxisPy::Type))) {
         AxisPy* axis = static_cast<AxisPy*>(arg.ptr());
         getCoordinateSystemPtr()->setAxis(*axis->getAxisPtr());
         return;

--- a/src/Base/MatrixPyImp.cpp
+++ b/src/Base/MatrixPyImp.cpp
@@ -40,7 +40,7 @@ using namespace Base;
 // returns a string which represents the object e.g. when printed in python
 std::string MatrixPy::representation() const
 {
-    const Base::Matrix4D& m = *(this->getMatrixPtr());
+    const Matrix4D& m = *(this->getMatrixPtr());
     std::stringstream str;
     str << "Matrix (";
     str << "(" << m[0][0] << "," << m[0][1] << "," << m[0][2] << "," << m[0][3] << ")"
@@ -88,7 +88,7 @@ int MatrixPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
     PyErr_Clear();
     PyObject* o {};
-    if (PyArg_ParseTuple(args, "O!", &(Base::MatrixPy::Type), &o)) {
+    if (PyArg_ParseTuple(args, "O!", &(MatrixPy::Type), &o)) {
         MatrixPy::PointerType ptr = getMatrixPtr();
         (*ptr) = static_cast<MatrixPy*>(o)->value();
         return 0;
@@ -100,14 +100,14 @@ int MatrixPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyObject* o3 {};
     PyObject* o4 {};
     if (PyArg_ParseTuple(args, "O!O!O!|O!",
-                         &(Base::VectorPy::Type), &o1,
-                         &(Base::VectorPy::Type), &o2,
-                         &(Base::VectorPy::Type), &o3,
-                         &(Base::VectorPy::Type), &o4)) {
-        Base::Vector3d v1 = Py::Vector(o1, false).toVector();
-        Base::Vector3d v2 = Py::Vector(o2, false).toVector();
-        Base::Vector3d v3 = Py::Vector(o3, false).toVector();
-        Base::Vector3d v4;
+                         &(VectorPy::Type), &o1,
+                         &(VectorPy::Type), &o2,
+                         &(VectorPy::Type), &o3,
+                         &(VectorPy::Type), &o4)) {
+        Vector3d v1 = Py::Vector(o1, false).toVector();
+        Vector3d v2 = Py::Vector(o2, false).toVector();
+        Vector3d v3 = Py::Vector(o3, false).toVector();
+        Vector3d v4;
         if (o4) {
             v4 = Py::Vector(o4, false).toVector();
         }
@@ -147,8 +147,8 @@ PyObject* MatrixPy::number_add_handler(PyObject* self, PyObject* other)
         PyErr_SetString(PyExc_TypeError, "Second arg must be Matrix");
         return nullptr;
     }
-    Base::Matrix4D a = static_cast<MatrixPy*>(self)->value();
-    Base::Matrix4D b = static_cast<MatrixPy*>(other)->value();
+    Matrix4D a = static_cast<MatrixPy*>(self)->value();
+    Matrix4D b = static_cast<MatrixPy*>(other)->value();
     return new MatrixPy(a + b);
 }
 
@@ -162,15 +162,15 @@ PyObject* MatrixPy::number_subtract_handler(PyObject* self, PyObject* other)
         PyErr_SetString(PyExc_TypeError, "Second arg must be Matrix");
         return nullptr;
     }
-    Base::Matrix4D a = static_cast<MatrixPy*>(self)->value();
-    Base::Matrix4D b = static_cast<MatrixPy*>(other)->value();
+    Matrix4D a = static_cast<MatrixPy*>(self)->value();
+    Matrix4D b = static_cast<MatrixPy*>(other)->value();
     return new MatrixPy(a - b);
 }
 
 PyObject* MatrixPy::number_multiply_handler(PyObject* self, PyObject* other)
 {
     if (PyObject_TypeCheck(self, &(MatrixPy::Type))) {
-        Base::Matrix4D a = static_cast<MatrixPy*>(self)->value();
+        Matrix4D a = static_cast<MatrixPy*>(self)->value();
 
         if (PyObject_TypeCheck(other, &(VectorPy::Type))) {
             auto b = static_cast<VectorPy*>(other)->value();
@@ -190,7 +190,7 @@ PyObject* MatrixPy::number_multiply_handler(PyObject* self, PyObject* other)
         }
 
         if (PyObject_TypeCheck(other, &(MatrixPy::Type))) {
-            Base::Matrix4D b = static_cast<MatrixPy*>(other)->value();
+            Matrix4D b = static_cast<MatrixPy*>(other)->value();
             return new MatrixPy(a * b);
         }
 
@@ -213,7 +213,7 @@ PyObject* MatrixPy::number_power_handler(PyObject* self, PyObject* other, PyObje
         return nullptr;
     }
 
-    Base::Matrix4D a = static_cast<MatrixPy*>(self)->value();
+    Matrix4D a = static_cast<MatrixPy*>(self)->value();
 
     long b = Py::Long(other);
     if (b == 0) {
@@ -269,7 +269,7 @@ PyObject* MatrixPy::move(PyObject* args)
     double x {};
     double y {};
     double z {};
-    Base::Vector3d vec;
+    Vector3d vec;
     PyObject* pcVecObj {};
 
     do {  // dummy do..while for cascaded if
@@ -289,10 +289,10 @@ PyObject* MatrixPy::move(PyObject* args)
         PyErr_Clear();
         if (PyArg_ParseTuple(args,
                              "O!;three floats, or a tuple, or a vector is needed",
-                             &(Base::VectorPy::Type),
+                             &(VectorPy::Type),
                              &pcVecObj)) {
-            Base::VectorPy* pcObject = static_cast<Base::VectorPy*>(pcVecObj);
-            Base::Vector3d* val = pcObject->getVectorPtr();
+            VectorPy* pcObject = static_cast<VectorPy*>(pcVecObj);
+            Vector3d* val = pcObject->getVectorPtr();
             vec.Set(val->x, val->y, val->z);
             break;
         }
@@ -312,7 +312,7 @@ PyObject* MatrixPy::scale(PyObject* args)
     double x {};
     double y {};
     double z {};
-    Base::Vector3d vec;
+    Vector3d vec;
     PyObject* pcVecObj {};
 
     do {  // dummy do..while for cascaded if
@@ -338,10 +338,10 @@ PyObject* MatrixPy::scale(PyObject* args)
         PyErr_Clear();
         if (PyArg_ParseTuple(args,
                              "O!;one or three floats, or a tuple, or a vector is needed",
-                             &(Base::VectorPy::Type),
+                             &(VectorPy::Type),
                              &pcVecObj)) {
-            Base::VectorPy* pcObject = static_cast<Base::VectorPy*>(pcVecObj);
-            Base::Vector3d* val = pcObject->getVectorPtr();
+            VectorPy* pcObject = static_cast<VectorPy*>(pcVecObj);
+            Vector3d* val = pcObject->getVectorPtr();
             vec.Set(val->x, val->y, val->z);
             break;
         }
@@ -430,7 +430,7 @@ PyObject* MatrixPy::isUnity(PyObject* args) const
 
 PyObject* MatrixPy::transform(PyObject* args)
 {
-    Base::Vector3d vec;
+    Vector3d vec;
     Matrix4D mat;
     PyObject* pcVecObj {};
     PyObject* pcMatObj {};
@@ -438,15 +438,15 @@ PyObject* MatrixPy::transform(PyObject* args)
     if (!PyArg_ParseTuple(
             args,
             "O!O!: a transform point (Vector) and a transform matrix (Matrix) is needed",
-            &(Base::VectorPy::Type),
+            &(VectorPy::Type),
             &pcVecObj,
             &(MatrixPy::Type),
             &pcMatObj)) {
         return nullptr;
     }
 
-    Base::VectorPy* pcObject = static_cast<Base::VectorPy*>(pcVecObj);
-    Base::Vector3d* val = pcObject->getVectorPtr();
+    VectorPy* pcObject = static_cast<VectorPy*>(pcVecObj);
+    Vector3d* val = pcObject->getVectorPtr();
     vec.Set(val->x, val->y, val->z);
     mat = *(static_cast<MatrixPy*>(pcMatObj)->getMatrixPtr());
 
@@ -467,7 +467,7 @@ PyObject* MatrixPy::col(PyObject* args) const
     }
 
     Matrix4D* mat = getMatrixPtr();
-    Base::Vector3d v = mat->getCol(index);
+    Vector3d v = mat->getCol(index);
     return Py::new_reference_to(Py::Vector(v));
 }
 
@@ -484,7 +484,7 @@ PyObject* MatrixPy::setCol(PyObject* args)
         return nullptr;
     }
 
-    Base::Vector3d v = Py::Vector(o, false).toVector();
+    Vector3d v = Py::Vector(o, false).toVector();
     Matrix4D* mat = getMatrixPtr();
     mat->setCol(index, v);
     Py_Return;
@@ -503,7 +503,7 @@ PyObject* MatrixPy::row(PyObject* args) const
     }
 
     Matrix4D* mat = getMatrixPtr();
-    Base::Vector3d v = mat->getRow(index);
+    Vector3d v = mat->getRow(index);
     return Py::new_reference_to(Py::Vector(v));
 }
 
@@ -520,7 +520,7 @@ PyObject* MatrixPy::setRow(PyObject* args)
         return nullptr;
     }
 
-    Base::Vector3d v = Py::Vector(o, false).toVector();
+    Vector3d v = Py::Vector(o, false).toVector();
     Matrix4D* mat = getMatrixPtr();
     mat->setRow(index, v);
     Py_Return;
@@ -529,7 +529,7 @@ PyObject* MatrixPy::setRow(PyObject* args)
 PyObject* MatrixPy::diagonal() const
 {
     Matrix4D* mat = getMatrixPtr();
-    Base::Vector3d v = mat->diagonal();
+    Vector3d v = mat->diagonal();
     return Py::new_reference_to(Py::Vector(v));
 }
 
@@ -540,7 +540,7 @@ PyObject* MatrixPy::setDiagonal(PyObject* args)
         return nullptr;
     }
 
-    Base::Vector3d v = Py::Vector(o, false).toVector();
+    Vector3d v = Py::Vector(o, false).toVector();
     Matrix4D* mat = getMatrixPtr();
     mat->setDiagonal(v);
     Py_Return;
@@ -551,10 +551,10 @@ PyObject* MatrixPy::rotateX(PyObject* args)
     double angle = 0;
     do {
         PyObject* object {};
-        if (PyArg_ParseTuple(args, "O!", &(Base::QuantityPy::Type), &object)) {
-            Quantity* q = static_cast<Base::QuantityPy*>(object)->getQuantityPtr();
-            if (q->getUnit() == Base::Unit::Angle) {
-                angle = q->getValueAs(Base::Quantity::Radian);
+        if (PyArg_ParseTuple(args, "O!", &(QuantityPy::Type), &object)) {
+            Quantity* q = static_cast<QuantityPy*>(object)->getQuantityPtr();
+            if (q->getUnit() == Unit::Angle) {
+                angle = q->getValueAs(Quantity::Radian);
                 break;
             }
         }
@@ -581,10 +581,10 @@ PyObject* MatrixPy::rotateY(PyObject* args)
     double angle = 0;
     do {
         PyObject* object {};
-        if (PyArg_ParseTuple(args, "O!", &(Base::QuantityPy::Type), &object)) {
-            Quantity* q = static_cast<Base::QuantityPy*>(object)->getQuantityPtr();
-            if (q->getUnit() == Base::Unit::Angle) {
-                angle = q->getValueAs(Base::Quantity::Radian);
+        if (PyArg_ParseTuple(args, "O!", &(QuantityPy::Type), &object)) {
+            Quantity* q = static_cast<QuantityPy*>(object)->getQuantityPtr();
+            if (q->getUnit() == Unit::Angle) {
+                angle = q->getValueAs(Quantity::Radian);
                 break;
             }
         }
@@ -611,10 +611,10 @@ PyObject* MatrixPy::rotateZ(PyObject* args)
     double angle = 0;
     do {
         PyObject* object {};
-        if (PyArg_ParseTuple(args, "O!", &(Base::QuantityPy::Type), &object)) {
-            Quantity* q = static_cast<Base::QuantityPy*>(object)->getQuantityPtr();
-            if (q->getUnit() == Base::Unit::Angle) {
-                angle = q->getValueAs(Base::Quantity::Radian);
+        if (PyArg_ParseTuple(args, "O!", &(QuantityPy::Type), &object)) {
+            Quantity* q = static_cast<QuantityPy*>(object)->getQuantityPtr();
+            if (q->getUnit() == Unit::Angle) {
+                angle = q->getValueAs(Quantity::Radian);
                 break;
             }
         }
@@ -640,13 +640,13 @@ PyObject* MatrixPy::multiply(PyObject* args) const
 {
     PyObject* o {};
     if (PyArg_ParseTuple(args, "O!", &(MatrixPy::Type), &o)) {
-        Matrix4D mat = (*getMatrixPtr()) * static_cast<Base::MatrixPy*>(o)->value();
+        Matrix4D mat = (*getMatrixPtr()) * static_cast<MatrixPy*>(o)->value();
         return new MatrixPy(new Matrix4D(mat));
     }
 
     PyErr_Clear();
     if (PyArg_ParseTuple(args, "O!", &(VectorPy::Type), &o)) {
-        Vector3d vec = (*getMatrixPtr()) * static_cast<Base::VectorPy*>(o)->value();
+        Vector3d vec = (*getMatrixPtr()) * static_cast<VectorPy*>(o)->value();
         return new VectorPy(new Vector3d(vec));
     }
 
@@ -661,7 +661,7 @@ PyObject* MatrixPy::multVec(PyObject* args) const
         return nullptr;
     }
 
-    Base::Vector3d vec(static_cast<VectorPy*>(obj)->value());
+    Vector3d vec(static_cast<VectorPy*>(obj)->value());
     getMatrixPtr()->multVec(vec, vec);
     return new VectorPy(new Vector3d(vec));
 }
@@ -675,7 +675,7 @@ PyObject* MatrixPy::invert()
             Py_Return;
         }
 
-        PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot invert singular matrix");
+        PyErr_SetString(PyExc_FC_GeneralError, "Cannot invert singular matrix");
         return nullptr;
     }
     PY_CATCH;
@@ -686,12 +686,12 @@ PyObject* MatrixPy::inverse() const
     PY_TRY
     {
         if (fabs(getMatrixPtr()->determinant()) > std::numeric_limits<double>::epsilon()) {
-            Base::Matrix4D m = *getMatrixPtr();
+            Matrix4D m = *getMatrixPtr();
             m.inverseGauss();
             return new MatrixPy(m);
         }
 
-        PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot invert singular matrix");
+        PyErr_SetString(PyExc_FC_GeneralError, "Cannot invert singular matrix");
         return nullptr;
     }
     PY_CATCH;
@@ -714,8 +714,8 @@ PyObject* MatrixPy::submatrix(PyObject* args) const
         return nullptr;
     }
 
-    const Base::Matrix4D& mat = *getMatrixPtr();
-    Base::Matrix4D sub;
+    const Matrix4D& mat = *getMatrixPtr();
+    Matrix4D sub;
     switch (dim) {
         case 1:
             sub[0][0] = mat[0][0];
@@ -752,8 +752,8 @@ PyObject* MatrixPy::isOrthogonal(PyObject* args) const
         return nullptr;
     }
 
-    const Base::Matrix4D& mat = *getMatrixPtr();
-    Base::Matrix4D trp = mat;
+    const Matrix4D& mat = *getMatrixPtr();
+    Matrix4D trp = mat;
     trp.transpose();
     trp = trp * mat;
 
@@ -783,7 +783,7 @@ PyObject* MatrixPy::transposed() const
 {
     PY_TRY
     {
-        Base::Matrix4D m = *getMatrixPtr();
+        Matrix4D m = *getMatrixPtr();
         m.transpose();
         return new MatrixPy(m);
     }
@@ -1045,7 +1045,7 @@ PyObject* MatrixPy::number_negative_handler(PyObject* self)
         return nullptr;
     }
 
-    Base::Matrix4D a = static_cast<MatrixPy*>(self)->value();
+    Matrix4D a = static_cast<MatrixPy*>(self)->value();
     return new MatrixPy(a * -1);
 }
 
@@ -1056,7 +1056,7 @@ PyObject* MatrixPy::number_positive_handler(PyObject* self)
         return nullptr;
     }
 
-    Base::Matrix4D a = static_cast<MatrixPy*>(self)->value();
+    Matrix4D a = static_cast<MatrixPy*>(self)->value();
     return new MatrixPy(a);
 }
 

--- a/src/Base/MatrixPyImp.cpp
+++ b/src/Base/MatrixPyImp.cpp
@@ -20,21 +20,20 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
 #include <limits>
 #endif
 
-// inclusion of the generated files (generated out of MatrixPy.pyi)
-#include "RotationPy.h"
-#include "VectorPy.h"
 #include "GeometryPyCXX.h"
-#include "QuantityPy.h"
+
+// generated out of Matrix.pyi
 #include "MatrixPy.h"
 #include "MatrixPy.cpp"
 
+#include "RotationPy.h"
+#include "QuantityPy.h"
+#include "VectorPy.h"
 
 using namespace Base;
 

--- a/src/Base/PersistencePyImp.cpp
+++ b/src/Base/PersistencePyImp.cpp
@@ -43,7 +43,7 @@ std::string PersistencePy::representation() const
 
 Py::String PersistencePy::getContent() const
 {
-    Base::StringWriter writer;
+    StringWriter writer;
     // force all objects to write pure XML without files
     writer.setForceXML(true);
     getPersistencePtr()->Save(writer);
@@ -61,7 +61,7 @@ PyObject* PersistencePy::dumpContent(PyObject* args, PyObject* kwds) const
     int compression = 3;
     static const std::array<const char*, 2> kwds_def {"Compression", nullptr};
     PyErr_Clear();
-    if (!Base::Wrapped_ParseTupleAndKeywords(args, kwds, "|i", kwds_def, &compression)) {
+    if (!Wrapped_ParseTupleAndKeywords(args, kwds, "|i", kwds_def, &compression)) {
         return nullptr;
     }
 
@@ -71,7 +71,7 @@ PyObject* PersistencePy::dumpContent(PyObject* args, PyObject* kwds) const
     try {
         getPersistencePtr()->dumpToStream(stream, compression);
     }
-    catch (Base::NotImplementedError&) {
+    catch (NotImplementedError&) {
         PyErr_SetString(PyExc_NotImplementedError,
                         "Dumping content of this object type is not implemented");
         return nullptr;

--- a/src/Base/PersistencePyImp.cpp
+++ b/src/Base/PersistencePyImp.cpp
@@ -20,16 +20,15 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
 
 #include <boost/iostreams/stream.hpp>
 
 #include "Persistence.h"
+#include "PyWrapParseTupleAndKeywords.h"
 #include "Writer.h"
-#include <Base/PyWrapParseTupleAndKeywords.h>
 
-// inclusion of the generated files (generated out of PersistencePy.pyi)
+// generated out of Persistence.pyi
 #include "PersistencePy.h"
 #include "PersistencePy.cpp"
 

--- a/src/Base/PlacementPyImp.cpp
+++ b/src/Base/PlacementPyImp.cpp
@@ -20,20 +20,20 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
 
 #include "GeometryPyCXX.h"
-#include <Base/PyWrapParseTupleAndKeywords.h>
+#include "Matrix.h"
+#include "PyWrapParseTupleAndKeywords.h"
+#include "Tools.h"
 
-// inclusion of the generated files (generated out of PlacementPy.pyi)
+// generated out of Placement.pyi
 #include "PlacementPy.h"
 #include "PlacementPy.cpp"
-#include "Matrix.h"
+
 #include "MatrixPy.h"
 #include "RotationPy.h"
 #include "VectorPy.h"
-#include "Tools.h"
 
 using namespace Base;
 

--- a/src/Base/PlacementPyImp.cpp
+++ b/src/Base/PlacementPyImp.cpp
@@ -70,21 +70,21 @@ int PlacementPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     }
 
     PyErr_Clear();
-    if (PyArg_ParseTuple(args, "O!", &(Base::MatrixPy::Type), &o)) {
+    if (PyArg_ParseTuple(args, "O!", &(MatrixPy::Type), &o)) {
         try {
-            Base::Matrix4D mat = static_cast<Base::MatrixPy*>(o)->value();
+            Matrix4D mat = static_cast<MatrixPy*>(o)->value();
             getPlacementPtr()->fromMatrix(mat);
             return 0;
         }
-        catch (const Base::Exception& e) {
+        catch (const Exception& e) {
             PyErr_SetString(e.getPyExceptionType(), e.what());
             return -1;
         }
     }
 
     PyErr_Clear();
-    if (PyArg_ParseTuple(args, "O!", &(Base::PlacementPy::Type), &o)) {
-        Base::Placement* plm = static_cast<Base::PlacementPy*>(o)->getPlacementPtr();
+    if (PyArg_ParseTuple(args, "O!", &(PlacementPy::Type), &o)) {
+        Placement* plm = static_cast<PlacementPy*>(o)->getPlacementPtr();
         *(getPlacementPtr()) = *plm;
         return 0;
     }
@@ -94,25 +94,25 @@ int PlacementPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     double angle {};
     if (PyArg_ParseTuple(args,
                          "O!O!d",
-                         &(Base::VectorPy::Type), &o,
-                         &(Base::VectorPy::Type), &d,
+                         &(VectorPy::Type), &o,
+                         &(VectorPy::Type), &d,
                          &angle)) {
         // NOTE: The first parameter defines the translation, the second the rotation axis
         // and the last parameter defines the rotation angle in degree.
-        Base::Rotation rot(static_cast<Base::VectorPy*>(d)->value(),
-                           Base::toRadians(angle));
-        *getPlacementPtr() = Base::Placement(static_cast<Base::VectorPy*>(o)->value(), rot);
+        Rotation rot(static_cast<VectorPy*>(d)->value(),
+                           toRadians(angle));
+        *getPlacementPtr() = Placement(static_cast<VectorPy*>(o)->value(), rot);
         return 0;
     }
 
     PyErr_Clear();
     if (PyArg_ParseTuple(args,
                          "O!O!",
-                         &(Base::VectorPy::Type), &o,
-                         &(Base::RotationPy::Type), &d)) {
-        Base::Vector3d* pos = static_cast<Base::VectorPy*>(o)->getVectorPtr();
+                         &(VectorPy::Type), &o,
+                         &(RotationPy::Type), &d)) {
+        Vector3d* pos = static_cast<VectorPy*>(o)->getVectorPtr();
         getPlacementPtr()->setPosition(*pos);
-        Base::Rotation* rot = static_cast<Base::RotationPy*>(d)->getRotationPtr();
+        Rotation* rot = static_cast<RotationPy*>(d)->getRotationPtr();
         getPlacementPtr()->setRotation(*rot);
         return 0;
     }
@@ -121,13 +121,13 @@ int PlacementPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyObject* c {};
     if (PyArg_ParseTuple(args,
                          "O!O!O!",
-                         &(Base::VectorPy::Type), &o,
-                         &(Base::RotationPy::Type), &d,
-                         &(Base::VectorPy::Type), &c)) {
-        Base::Vector3d* pos = static_cast<Base::VectorPy*>(o)->getVectorPtr();
-        Base::Rotation* rot = static_cast<Base::RotationPy*>(d)->getRotationPtr();
-        Base::Vector3d* cnt = static_cast<Base::VectorPy*>(c)->getVectorPtr();
-        Base::Placement p(*pos, *rot, *cnt);
+                         &(VectorPy::Type), &o,
+                         &(RotationPy::Type), &d,
+                         &(VectorPy::Type), &c)) {
+        Vector3d* pos = static_cast<VectorPy*>(o)->getVectorPtr();
+        Rotation* rot = static_cast<RotationPy*>(d)->getRotationPtr();
+        Vector3d* cnt = static_cast<VectorPy*>(c)->getVectorPtr();
+        Placement p(*pos, *rot, *cnt);
         getPlacementPtr()->operator=(p);
         return 0;
     }
@@ -141,8 +141,8 @@ PyObject* PlacementPy::richCompare(PyObject* v, PyObject* w, int op)
 {
     if (PyObject_TypeCheck(v, &(PlacementPy::Type))
         && PyObject_TypeCheck(w, &(PlacementPy::Type))) {
-        Base::Placement p1 = *static_cast<PlacementPy*>(v)->getPlacementPtr();
-        Base::Placement p2 = *static_cast<PlacementPy*>(w)->getPlacementPtr();
+        Placement p1 = *static_cast<PlacementPy*>(v)->getPlacementPtr();
+        Placement p2 = *static_cast<PlacementPy*>(w)->getPlacementPtr();
 
         PyObject* res = nullptr;
         if (op != Py_EQ && op != Py_NE) {
@@ -187,7 +187,7 @@ PyObject* PlacementPy::rotate(PyObject* args, PyObject* kwds)
     Vector3d axis;
     PyObject* pyComp = Py_False;  // NOLINT
 
-    if (!Base::Wrapped_ParseTupleAndKeywords(args,
+    if (!Wrapped_ParseTupleAndKeywords(args,
                                              kwds,
                                              "(ddd)(ddd)d|O!",
                                              kwlist,
@@ -203,7 +203,7 @@ PyObject* PlacementPy::rotate(PyObject* args, PyObject* kwds)
          * documentation - generates Placements different from TopoShape.rotate() to ensure
          * compatibility for existing code
          */
-        bool comp = Base::asBoolean(pyComp);
+        bool comp = asBoolean(pyComp);
 
         if (!comp) {
             getPlacementPtr()->multRight(
@@ -239,7 +239,7 @@ PyObject* PlacementPy::multVec(PyObject* args) const
     if (!PyArg_ParseTuple(args, "O!", &(VectorPy::Type), &vec)) {
         return nullptr;
     }
-    Base::Vector3d pnt(static_cast<VectorPy*>(vec)->value());
+    Vector3d pnt(static_cast<VectorPy*>(vec)->value());
     getPlacementPtr()->multVec(pnt, pnt);
     return new VectorPy(new Vector3d(pnt));
 }
@@ -257,7 +257,7 @@ PyObject* PlacementPy::toMatrix(PyObject* args) const
     if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
     }
-    Base::Matrix4D mat = getPlacementPtr()->toMatrix();
+    Matrix4D mat = getPlacementPtr()->toMatrix();
     return new MatrixPy(new Matrix4D(mat));
 }
 
@@ -266,7 +266,7 @@ PyObject* PlacementPy::inverse(PyObject* args) const
     if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
     }
-    Base::Placement p = getPlacementPtr()->inverse();
+    Placement p = getPlacementPtr()->inverse();
     return new PlacementPy(new Placement(p));
 }
 
@@ -277,7 +277,7 @@ PyObject* PlacementPy::pow(PyObject* args) const
     if (!PyArg_ParseTuple(args, "d|O!", &t, &(PyBool_Type), &shorten)) {
         return nullptr;
     }
-    Base::Placement ret = getPlacementPtr()->pow(t, Base::asBoolean(shorten));
+    Placement ret = getPlacementPtr()->pow(t, asBoolean(shorten));
     return new PlacementPy(new Placement(ret));
 }
 
@@ -296,9 +296,8 @@ PyObject* PlacementPy::sclerp(PyObject* args) const
                           &shorten)) {
         return nullptr;
     }
-    Base::Placement plm2 = static_cast<Base::PlacementPy*>(pyplm2)->value();
-    Base::Placement ret =
-        Base::Placement::sclerp(*getPlacementPtr(), plm2, t, Base::asBoolean(shorten));
+    Placement plm2 = static_cast<PlacementPy*>(pyplm2)->value();
+    Placement ret = Placement::sclerp(*getPlacementPtr(), plm2, t, asBoolean(shorten));
     return new PlacementPy(new Placement(ret));
 }
 
@@ -309,8 +308,8 @@ PyObject* PlacementPy::slerp(PyObject* args) const
     if (!PyArg_ParseTuple(args, "O!d", &(PlacementPy::Type), &pyplm2, &t)) {
         return nullptr;
     }
-    Base::Placement plm2 = static_cast<Base::PlacementPy*>(pyplm2)->value();
-    Base::Placement ret = Base::Placement::slerp(*getPlacementPtr(), plm2, t);
+    Placement plm2 = static_cast<PlacementPy*>(pyplm2)->value();
+    Placement ret = Placement::slerp(*getPlacementPtr(), plm2, t);
     return new PlacementPy(new Placement(ret));
 }
 
@@ -332,8 +331,8 @@ PyObject* PlacementPy::isSame(PyObject* args) const
         return nullptr;
     }
 
-    Base::Placement plm1 = *getPlacementPtr();
-    Base::Placement plm2 = *static_cast<PlacementPy*>(plm)->getPlacementPtr();
+    Placement plm1 = *getPlacementPtr();
+    Placement plm2 = *static_cast<PlacementPy*>(plm)->getPlacementPtr();
     bool same = tol > 0.0 ? plm1.isSame(plm2, tol) : plm1.isSame(plm2);
     return Py_BuildValue("O", (same ? Py_True : Py_False));
 }
@@ -357,16 +356,16 @@ void PlacementPy::setRotation(Py::Object arg)
 {
     Py::Rotation rot;
     if (rot.accepts(arg.ptr())) {
-        getPlacementPtr()->setRotation(static_cast<Base::Rotation>(Py::Rotation(arg)));
+        getPlacementPtr()->setRotation(static_cast<Rotation>(Py::Rotation(arg)));
         return;
     }
     Py::Tuple tuple;
     if (tuple.accepts(arg.ptr())) {
         tuple = arg;
-        getPlacementPtr()->setRotation(Base::Rotation(static_cast<double>(Py::Float(tuple[0])),
-                                                      static_cast<double>(Py::Float(tuple[1])),
-                                                      static_cast<double>(Py::Float(tuple[2])),
-                                                      static_cast<double>(Py::Float(tuple[3]))));
+        getPlacementPtr()->setRotation(Rotation(static_cast<double>(Py::Float(tuple[0])),
+                                                static_cast<double>(Py::Float(tuple[1])),
+                                                static_cast<double>(Py::Float(tuple[2])),
+                                                static_cast<double>(Py::Float(tuple[3]))));
         return;
     }
 
@@ -388,7 +387,7 @@ void PlacementPy::setMatrix(Py::Object arg)
         mat = arg;
         getPlacementPtr()->fromMatrix(mat);
     }
-    catch (const Base::ValueError& e) {
+    catch (const ValueError& e) {
         throw Py::ValueError(e.what());
     }
 }
@@ -416,7 +415,7 @@ int PlacementPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
 PyObject* PlacementPy::number_multiply_handler(PyObject* self, PyObject* other)
 {
     if (PyObject_TypeCheck(self, &(PlacementPy::Type))) {
-        Base::Placement a = static_cast<PlacementPy*>(self)->value();
+        Placement a = static_cast<PlacementPy*>(self)->value();
 
         if (PyObject_TypeCheck(other, &(VectorPy::Type))) {
             Vector3d res;

--- a/src/Base/PrecisionPyImp.cpp
+++ b/src/Base/PrecisionPyImp.cpp
@@ -22,13 +22,12 @@
 
 #include "PreCompiled.h"
 
+// generated out of Precision.pyi
 #include "PrecisionPy.h"
 #include "PrecisionPy.cpp"
 
-
 using Base::Precision;
 using Base::PrecisionPy;
-
 
 // returns a string which represents the object e.g. when printed in python
 std::string PrecisionPy::representation() const

--- a/src/Base/QuantityPyImp.cpp
+++ b/src/Base/QuantityPyImp.cpp
@@ -21,16 +21,17 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
 #include <limits>
 #endif
 
-// inclusion of the generated files (generated out of QuantityPy.pyi)
+#include "Unit.h"
+
+// generated out of Quantity.pyi
 #include "QuantityPy.h"
-#include "UnitPy.h"
 #include "QuantityPy.cpp"
 
+#include "UnitPy.h"
 
 using namespace Base;
 

--- a/src/Base/QuantityPyImp.cpp
+++ b/src/Base/QuantityPyImp.cpp
@@ -87,20 +87,20 @@ int QuantityPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
     PyErr_Clear();  // set by PyArg_ParseTuple()
     PyObject* object {};
-    if (PyArg_ParseTuple(args, "O!", &(Base::QuantityPy::Type), &object)) {
-        *self = *(static_cast<Base::QuantityPy*>(object)->getQuantityPtr());
+    if (PyArg_ParseTuple(args, "O!", &(QuantityPy::Type), &object)) {
+        *self = *(static_cast<QuantityPy*>(object)->getQuantityPtr());
         return 0;
     }
 
     PyErr_Clear();  // set by PyArg_ParseTuple()
     double f = std::numeric_limits<double>::max();
-    if (PyArg_ParseTuple(args, "dO!", &f, &(Base::UnitPy::Type), &object)) {
-        *self = Quantity(f, *(static_cast<Base::UnitPy*>(object)->getUnitPtr()));
+    if (PyArg_ParseTuple(args, "dO!", &f, &(UnitPy::Type), &object)) {
+        *self = Quantity(f, *(static_cast<UnitPy*>(object)->getUnitPtr()));
         return 0;
     }
 
     PyErr_Clear();  // set by PyArg_ParseTuple()
-    if (PyArg_ParseTuple(args, "dO!", &f, &(Base::QuantityPy::Type), &object)) {
+    if (PyArg_ParseTuple(args, "dO!", &f, &(QuantityPy::Type), &object)) {
         PyErr_SetString(PyExc_TypeError, "Second argument must be a Unit not a Quantity");
         return -1;
     }
@@ -137,7 +137,7 @@ int QuantityPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         try {
             *self = Quantity::parse(str);
         }
-        catch (const Base::ParserError& e) {
+        catch (const ParserError& e) {
             PyErr_SetString(PyExc_ValueError, e.what());
             return -1;
         }
@@ -152,7 +152,7 @@ int QuantityPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         try {
             *self = Quantity(f, unit);
         }
-        catch (const Base::ParserError& e) {
+        catch (const ParserError& e) {
             PyErr_SetString(PyExc_ValueError, e.what());
             return -1;
         }
@@ -187,16 +187,16 @@ PyObject* QuantityPy::getValueAs(PyObject* args) const
     // first try Quantity
     if (!quant.isValid()) {
         PyObject* object {};
-        if (PyArg_ParseTuple(args, "O!", &(Base::QuantityPy::Type), &object)) {
-            quant = *static_cast<Base::QuantityPy*>(object)->getQuantityPtr();
+        if (PyArg_ParseTuple(args, "O!", &(QuantityPy::Type), &object)) {
+            quant = *static_cast<QuantityPy*>(object)->getQuantityPtr();
         }
     }
 
     if (!quant.isValid()) {
         PyObject* object {};
         PyErr_Clear();
-        if (PyArg_ParseTuple(args, "O!", &(Base::UnitPy::Type), &object)) {
-            quant.setUnit(*static_cast<Base::UnitPy*>(object)->getUnitPtr());
+        if (PyArg_ParseTuple(args, "O!", &(UnitPy::Type), &object)) {
+            quant.setUnit(*static_cast<UnitPy*>(object)->getUnitPtr());
             quant.setValue(1.0);
         }
     }
@@ -205,8 +205,8 @@ PyObject* QuantityPy::getValueAs(PyObject* args) const
         PyObject* object {};
         double value {};
         PyErr_Clear();
-        if (PyArg_ParseTuple(args, "dO!", &value, &(Base::UnitPy::Type), &object)) {
-            quant.setUnit(*static_cast<Base::UnitPy*>(object)->getUnitPtr());
+        if (PyArg_ParseTuple(args, "dO!", &value, &(UnitPy::Type), &object)) {
+            quant.setUnit(*static_cast<UnitPy*>(object)->getUnitPtr());
             quant.setValue(value);
         }
     }
@@ -301,7 +301,7 @@ PyObject* QuantityPy::number_negative_handler(PyObject* self)
         return nullptr;
     }
 
-    Base::Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
+    Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
     double b = -1;
     return new QuantityPy(new Quantity(*a * b));
 }
@@ -313,7 +313,7 @@ PyObject* QuantityPy::number_positive_handler(PyObject* self)
         return nullptr;
     }
 
-    Base::Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
+    Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
     return new QuantityPy(new Quantity(*a));
 }
 
@@ -324,14 +324,14 @@ PyObject* QuantityPy::number_absolute_handler(PyObject* self)
         return nullptr;
     }
 
-    Base::Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
+    Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
     return new QuantityPy(new Quantity(fabs(a->getValue()), a->getUnit()));
 }
 
 static Quantity& pyToQuantity(Quantity& q, PyObject* pyobj)
 {
-    if (PyObject_TypeCheck(pyobj, &Base::QuantityPy::Type)) {
-        q = *static_cast<Base::QuantityPy*>(pyobj)->getQuantityPtr();
+    if (PyObject_TypeCheck(pyobj, &QuantityPy::Type)) {
+        q = *static_cast<QuantityPy*>(pyobj)->getQuantityPtr();
     }
     else if (PyFloat_Check(pyobj)) {
         q = Quantity(PyFloat_AsDouble(pyobj));
@@ -459,11 +459,11 @@ PyObject* QuantityPy::number_remainder_handler(PyObject* self, PyObject* other)
 
     double d1 {};
     double d2 {};
-    Base::Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
+    Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
     d1 = a->getValue();
 
     if (PyObject_TypeCheck(other, &(QuantityPy::Type))) {
-        Base::Quantity* b = static_cast<QuantityPy*>(other)->getQuantityPtr();
+        Quantity* b = static_cast<QuantityPy*>(other)->getQuantityPtr();
         d2 = b->getValue();
     }
     else if (PyFloat_Check(other)) {
@@ -507,19 +507,19 @@ PyObject* QuantityPy::number_power_handler(PyObject* self, PyObject* other, PyOb
     PY_TRY
     {
         if (PyObject_TypeCheck(other, &(QuantityPy::Type))) {
-            Base::Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
-            Base::Quantity* b = static_cast<QuantityPy*>(other)->getQuantityPtr();
-            Base::Quantity q(a->pow(*b));  // to prevent memory leak in case of exception
+            Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
+            Quantity* b = static_cast<QuantityPy*>(other)->getQuantityPtr();
+            Quantity q(a->pow(*b));  // to prevent memory leak in case of exception
 
             return new QuantityPy(new Quantity(q));
         }
         if (PyFloat_Check(other)) {
-            Base::Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
+            Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
             double b = PyFloat_AsDouble(other);
             return new QuantityPy(new Quantity(a->pow(b)));
         }
         if (PyLong_Check(other)) {
-            Base::Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
+            Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
             double b = (double)PyLong_AsLong(other);
             return new QuantityPy(new Quantity(a->pow(b)));
         }
@@ -535,7 +535,7 @@ int QuantityPy::number_nonzero_handler(PyObject* self)
         return 1;
     }
 
-    Base::Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
+    Quantity* a = static_cast<QuantityPy*>(self)->getQuantityPtr();
     return a->getValue() != 0.0;
 }
 
@@ -628,12 +628,12 @@ Py::Object QuantityPy::getUnit() const
 
 void QuantityPy::setUnit(Py::Object arg)
 {
-    Py::Type UnitType(Base::getTypeAsObject(&Base::UnitPy::Type));
+    Py::Type UnitType(getTypeAsObject(&UnitPy::Type));
     if (!arg.isType(UnitType)) {
         throw Py::AttributeError("Not yet implemented");
     }
 
-    getQuantityPtr()->setUnit(*static_cast<Base::UnitPy*>((*arg))->getUnitPtr());
+    getQuantityPtr()->setUnit(*static_cast<UnitPy*>((*arg))->getUnitPtr());
 }
 
 Py::String QuantityPy::getUserString() const
@@ -678,7 +678,7 @@ void QuantityPy::setFormat(Py::Dict arg)
             }
 
             bool ok = false;
-            fmt.format = Base::QuantityFormat::toFormat(fmtstr[0], &ok);
+            fmt.format = QuantityFormat::toFormat(fmtstr[0], &ok);
             if (!ok) {
                 throw Py::ValueError("Invalid format character");
             }

--- a/src/Base/RotationPyImp.cpp
+++ b/src/Base/RotationPyImp.cpp
@@ -68,8 +68,8 @@ int RotationPy::PyInit(PyObject* args, PyObject* kwds)
     }
 
     PyErr_Clear();
-    if (PyArg_ParseTuple(args, "O!", &(Base::RotationPy::Type), &o)) {
-        Base::Rotation* rot = static_cast<Base::RotationPy*>(o)->getRotationPtr();
+    if (PyArg_ParseTuple(args, "O!", &(RotationPy::Type), &o)) {
+        Rotation* rot = static_cast<RotationPy*>(o)->getRotationPtr();
         getRotationPtr()->setValue(rot->getValue());
         return 0;
     }
@@ -77,39 +77,39 @@ int RotationPy::PyInit(PyObject* args, PyObject* kwds)
     PyErr_Clear();
     double angle {};
     static const std::array<const char*, 3> kw_deg {"Axis", "Degree", nullptr};
-    if (Base::Wrapped_ParseTupleAndKeywords(args,
+    if (Wrapped_ParseTupleAndKeywords(args,
                                             kwds,
                                             "O!d",
                                             kw_deg,
-                                            &(Base::VectorPy::Type),
+                                            &(VectorPy::Type),
                                             &o,
                                             &angle)) {
         // NOTE: The last parameter defines the rotation angle in degree.
-        getRotationPtr()->setValue(static_cast<Base::VectorPy*>(o)->value(),
-                                   Base::toRadians<double>(angle));
+        getRotationPtr()->setValue(static_cast<VectorPy*>(o)->value(),
+                                   toRadians<double>(angle));
         return 0;
     }
 
     PyErr_Clear();
     static const std::array<const char*, 3> kw_rad {"Axis", "Radian", nullptr};
-    if (Base::Wrapped_ParseTupleAndKeywords(args,
+    if (Wrapped_ParseTupleAndKeywords(args,
                                             kwds,
                                             "O!d",
                                             kw_rad,
-                                            &(Base::VectorPy::Type),
+                                            &(VectorPy::Type),
                                             &o,
                                             &angle)) {
-        getRotationPtr()->setValue(static_cast<Base::VectorPy*>(o)->value(), angle);
+        getRotationPtr()->setValue(static_cast<VectorPy*>(o)->value(), angle);
         return 0;
     }
 
     PyErr_Clear();
-    if (PyArg_ParseTuple(args, "O!", &(Base::MatrixPy::Type), &o)) {
+    if (PyArg_ParseTuple(args, "O!", &(MatrixPy::Type), &o)) {
         try {
-            getRotationPtr()->setValue(static_cast<Base::MatrixPy*>(o)->value());
+            getRotationPtr()->setValue(static_cast<MatrixPy*>(o)->value());
             return 0;
         }
-        catch (const Base::Exception& e) {
+        catch (const Exception& e) {
             PyErr_SetString(e.getPyExceptionType(), e.what());
             return -1;
         }
@@ -171,7 +171,7 @@ int RotationPy::PyInit(PyObject* args, PyObject* kwds)
             getRotationPtr()->setValue(mtx);
             return 0;
         }
-        catch (const Base::Exception& e) {
+        catch (const Exception& e) {
             PyErr_SetString(e.getPyExceptionType(), e.what());
             return -1;
         }
@@ -191,7 +191,7 @@ int RotationPy::PyInit(PyObject* args, PyObject* kwds)
             getRotationPtr()->setValue(mtx);
             return 0;
         }
-        catch (const Base::Exception& e) {
+        catch (const Exception& e) {
             PyErr_SetString(e.getPyExceptionType(), e.what());
             return -1;
         }
@@ -202,8 +202,8 @@ int RotationPy::PyInit(PyObject* args, PyObject* kwds)
     PyObject* v2 {};
     if (PyArg_ParseTuple(args,
                          "O!O!",
-                         &(Base::VectorPy::Type), &v1,
-                         &(Base::VectorPy::Type), &v2)) {
+                         &(VectorPy::Type), &v1,
+                         &(VectorPy::Type), &v2)) {
         Py::Vector from(v1, false);
         Py::Vector to(v2, false);
         getRotationPtr()->setValue(from.toVector(), to.toVector());
@@ -215,9 +215,9 @@ int RotationPy::PyInit(PyObject* args, PyObject* kwds)
     const char* priority = nullptr;
     if (PyArg_ParseTuple(args,
                          "O!O!O!|s",
-                         &(Base::VectorPy::Type), &v1,
-                         &(Base::VectorPy::Type), &v2,
-                         &(Base::VectorPy::Type), &v3,
+                         &(VectorPy::Type), &v1,
+                         &(VectorPy::Type), &v2,
+                         &(VectorPy::Type), &v3,
                          &priority)) {
         Py::Vector xdir(v1, false);
         Py::Vector ydir(v2, false);
@@ -231,12 +231,12 @@ int RotationPy::PyInit(PyObject* args, PyObject* kwds)
                                                               zdir.toVector(),
                                                               priority));
         }
-        catch (Base::Exception& e) {
+        catch (Exception& e) {
             std::string str;
             str += "FreeCAD exception thrown (";
             str += e.what();
             str += ")";
-            PyErr_SetString(Base::PyExc_FC_GeneralError, str.c_str());
+            PyErr_SetString(PyExc_FC_GeneralError, str.c_str());
             return -1;
         }
 
@@ -262,8 +262,8 @@ int RotationPy::PyInit(PyObject* args, PyObject* kwds)
 PyObject* RotationPy::richCompare(PyObject* v, PyObject* w, int op)
 {
     if (PyObject_TypeCheck(v, &(RotationPy::Type)) && PyObject_TypeCheck(w, &(RotationPy::Type))) {
-        Base::Rotation r1 = *static_cast<RotationPy*>(v)->getRotationPtr();
-        Base::Rotation r2 = *static_cast<RotationPy*>(w)->getRotationPtr();
+        Rotation r1 = *static_cast<RotationPy*>(v)->getRotationPtr();
+        Rotation r2 = *static_cast<RotationPy*>(w)->getRotationPtr();
 
         PyObject* res = nullptr;
         if (op != Py_EQ && op != Py_NE) {
@@ -318,7 +318,7 @@ PyObject* RotationPy::multVec(PyObject* args) const
     if (!PyArg_ParseTuple(args, "O!", &(VectorPy::Type), &obj)) {
         return nullptr;
     }
-    Base::Vector3d vec(static_cast<VectorPy*>(obj)->value());
+    Vector3d vec(static_cast<VectorPy*>(obj)->value());
     getRotationPtr()->multVec(vec, vec);
     return new VectorPy(new Vector3d(vec));
 }
@@ -379,7 +379,7 @@ PyObject* RotationPy::setEulerAngles(PyObject* args)
         getRotationPtr()->setEulerAngles(Rotation::eulerSequenceFromName(seq), A, B, C);
         Py_Return;
     }
-    catch (const Base::Exception& e) {
+    catch (const Exception& e) {
         e.setPyException();
         return nullptr;
     }
@@ -420,7 +420,7 @@ PyObject* RotationPy::toMatrix(PyObject* args) const
     if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
     }
-    Base::Matrix4D mat;
+    Matrix4D mat;
     getRotationPtr()->getValue(mat);
     return new MatrixPy(new Matrix4D(mat));
 }
@@ -432,8 +432,8 @@ PyObject* RotationPy::isSame(PyObject* args)
     if (!PyArg_ParseTuple(args, "O!|d", &(RotationPy::Type), &rot, &tol)) {
         return nullptr;
     }
-    Base::Rotation rot1 = *getRotationPtr();
-    Base::Rotation rot2 = *static_cast<RotationPy*>(rot)->getRotationPtr();
+    Rotation rot1 = *getRotationPtr();
+    Rotation rot2 = *static_cast<RotationPy*>(rot)->getRotationPtr();
     bool same = tol > 0.0 ? rot1.isSame(rot2, tol) : rot1.isSame(rot2);
     return Py_BuildValue("O", (same ? Py_True : Py_False));
 }
@@ -484,7 +484,7 @@ void RotationPy::setQ(Py::Tuple arg)
 
 Py::Object RotationPy::getRawAxis() const
 {
-    Base::Vector3d axis;
+    Vector3d axis;
     double angle {};
     this->getRotationPtr()->getRawValue(axis, angle);
     return Py::Vector(axis);  // NOLINT
@@ -492,7 +492,7 @@ Py::Object RotationPy::getRawAxis() const
 
 Py::Object RotationPy::getAxis() const
 {
-    Base::Vector3d axis;
+    Vector3d axis;
     double angle {};
     this->getRotationPtr()->getValue(axis, angle);
     return Py::Vector(axis);  // NOLINT
@@ -500,7 +500,7 @@ Py::Object RotationPy::getAxis() const
 
 void RotationPy::setAxis(Py::Object arg)
 {
-    Base::Vector3d axis;
+    Vector3d axis;
     double angle {};
     this->getRotationPtr()->getValue(axis, angle);
     axis = Py::Vector(arg).toVector();
@@ -509,7 +509,7 @@ void RotationPy::setAxis(Py::Object arg)
 
 Py::Float RotationPy::getAngle() const
 {
-    Base::Vector3d axis;
+    Vector3d axis;
     double angle {};
     this->getRotationPtr()->getValue(axis, angle);
     return Py::Float(angle);
@@ -517,7 +517,7 @@ Py::Float RotationPy::getAngle() const
 
 void RotationPy::setAngle(Py::Float arg)
 {
-    Base::Vector3d axis;
+    Vector3d axis;
     double angle {};
     this->getRotationPtr()->getRawValue(axis, angle);
     angle = static_cast<double>(arg);
@@ -568,7 +568,7 @@ int RotationPy::setCustomAttributes(const char* attr, PyObject* obj)
                 this->getRotationPtr()->setValue(*static_cast<MatrixPy*>(obj)->getMatrixPtr());
                 return 1;
             }
-            catch (const Base::Exception& e) {
+            catch (const Exception& e) {
                 PyErr_SetString(e.getPyExceptionType(), e.what());
                 return -1;
             }
@@ -582,8 +582,8 @@ int RotationPy::setCustomAttributes(const char* attr, PyObject* obj)
                 Py::Object vec2 = sequence.getItem(1);
                 if (PyObject_TypeCheck(vec1.ptr(), &(VectorPy::Type))
                     && PyObject_TypeCheck(vec2.ptr(), &(VectorPy::Type))) {
-                    Base::Vector3d* pt1 = static_cast<VectorPy*>(vec1.ptr())->getVectorPtr();
-                    Base::Vector3d* pt2 = static_cast<VectorPy*>(vec2.ptr())->getVectorPtr();
+                    Vector3d* pt1 = static_cast<VectorPy*>(vec1.ptr())->getVectorPtr();
+                    Vector3d* pt2 = static_cast<VectorPy*>(vec2.ptr())->getVectorPtr();
                     this->getRotationPtr()->setValue(*pt1, *pt2);
                     return 1;
                 }

--- a/src/Base/RotationPyImp.cpp
+++ b/src/Base/RotationPyImp.cpp
@@ -20,18 +20,17 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
 
-#include <Base/GeometryPyCXX.h>
-#include <Base/Tools.h>
-#include <Base/PyWrapParseTupleAndKeywords.h>
+#include "GeometryPyCXX.h"
+#include "PyWrapParseTupleAndKeywords.h"
+#include "Tools.h"
 
-// inclusion of the generated files (generated out of RotationPy.pyi)
+// generated out of Rotation.pyi
 #include "RotationPy.h"
 #include "RotationPy.cpp"
-#include "VectorPy.h"
 
+#include "VectorPy.h"
 
 using namespace Base;
 

--- a/src/Base/TypePyImp.cpp
+++ b/src/Base/TypePyImp.cpp
@@ -46,8 +46,7 @@ PyObject* TypePy::fromName(PyObject* args)
         return nullptr;
     }
 
-    Base::Type type = Base::Type::fromName(name);
-    return new TypePy(new Base::Type(type));
+    return new TypePy(new Base::Type(Type::fromName(name)));
 }
 
 PyObject* TypePy::fromKey(PyObject* args)
@@ -57,8 +56,7 @@ PyObject* TypePy::fromKey(PyObject* args)
         return nullptr;
     }
 
-    Base::Type type = Base::Type::fromKey(index);
-    return new TypePy(new Base::Type(type));
+    return new TypePy(new Base::Type(Type::fromKey(index)));
 }
 
 PyObject* TypePy::getNumTypes(PyObject* args)
@@ -67,7 +65,7 @@ PyObject* TypePy::getNumTypes(PyObject* args)
         return nullptr;
     }
 
-    int num = Base::Type::getNumTypes();
+    int num = Type::getNumTypes();
     return PyLong_FromLong(num);
 }
 
@@ -77,7 +75,7 @@ PyObject* TypePy::getBadType(PyObject* args)
         return nullptr;
     }
 
-    return new TypePy(new Base::Type(Base::Type::BadType));
+    return new TypePy(new Base::Type(Type::BadType));
 }
 
 PyObject* TypePy::getParent(PyObject* args) const
@@ -86,8 +84,7 @@ PyObject* TypePy::getParent(PyObject* args) const
         return nullptr;
     }
 
-    Base::Type type = getBaseTypePtr()->getParent();
-    return new TypePy(new Base::Type(type));
+    return new TypePy(new Base::Type(getBaseTypePtr()->getParent()));
 }
 
 PyObject* TypePy::isBad(PyObject* args) const
@@ -107,7 +104,7 @@ PyObject* TypePy::isDerivedFrom(PyObject* args) const
     do {
         const char* name {};
         if (PyArg_ParseTuple(args, "s", &name)) {
-            type = Base::Type::fromName(name);
+            type = Type::fromName(name);
             break;
         }
 
@@ -133,7 +130,7 @@ PyObject* TypePy::getAllDerivedFrom(PyObject* args)
     do {
         const char* name {};
         if (PyArg_ParseTuple(args, "s", &name)) {
-            type = Base::Type::fromName(name);
+            type = Type::fromName(name);
             break;
         }
 
@@ -149,7 +146,7 @@ PyObject* TypePy::getAllDerivedFrom(PyObject* args)
     } while (false);
 
     std::vector<Base::Type> ary;
-    Base::Type::getAllDerivedFrom(type, ary);
+    Type::getAllDerivedFrom(type, ary);
     Py::List res;
     for (const auto& it : ary) {
         res.append(Py::asObject(new TypePy(new Base::Type(it))));
@@ -163,9 +160,9 @@ PyObject* TypePy::getAllDerived(PyObject* args) const
         return nullptr;
     }
 
-    Base::Type type = Base::Type::fromName(getBaseTypePtr()->getName());
+    Base::Type type = Type::fromName(getBaseTypePtr()->getName());
     std::vector<Base::Type> ary;
-    Base::Type::getAllDerivedFrom(type, ary);
+    Type::getAllDerivedFrom(type, ary);
     Py::List res;
     for (const auto& it : ary) {
         res.append(Py::asObject(new TypePy(new Base::Type(it))));
@@ -177,29 +174,29 @@ namespace
 {
 void deallocPyObject(PyObject* py)
 {
-    Base::PyObjectBase* pybase = static_cast<Base::PyObjectBase*>(py);
-    Base::BaseClass* base = static_cast<Base::BaseClass*>(pybase->getTwinPointer());
-    if (Base::BindingManager::instance().retrieveWrapper(base) == py) {
-        Base::BindingManager::instance().releaseWrapper(base, py);
+    PyObjectBase* pybase = static_cast<PyObjectBase*>(py);
+    BaseClass* base = static_cast<BaseClass*>(pybase->getTwinPointer());
+    if (BindingManager::instance().retrieveWrapper(base) == py) {
+        BindingManager::instance().releaseWrapper(base, py);
         delete base;
     }
 
-    Base::PyObjectBase::PyDestructor(py);
+    PyObjectBase::PyDestructor(py);
 }
 
-PyObject* createPyObject(Base::BaseClass* base)
+PyObject* createPyObject(BaseClass* base)
 {
     PyObject* py = base->getPyObject();
 
-    if (PyObject_TypeCheck(py, &Base::PyObjectBase::Type)) {
+    if (PyObject_TypeCheck(py, &PyObjectBase::Type)) {
         // if the Python wrapper is a sub-class of PyObjectBase then
         // check if the C++ object must be added to the list of tracked objects
-        Base::PyObjectBase* pybase = static_cast<Base::PyObjectBase*>(py);
+        PyObjectBase* pybase = static_cast<PyObjectBase*>(py);
         if (base == pybase->getTwinPointer()) {
             // steal a reference because at this point the counter is at 2
             Py_DECREF(py);
             Py_TYPE(py)->tp_dealloc = deallocPyObject;
-            Base::BindingManager::instance().registerWrapper(base, py);
+            BindingManager::instance().registerWrapper(base, py);
         }
         else {
             // The Python wrapper creates its own copy of the C++ object
@@ -236,9 +233,8 @@ PyObject* TypePy::createInstanceByName(PyObject* args)
         return nullptr;
     }
 
-    bool loadModule = Base::asBoolean(load);
-    Base::Type type =
-        Base::Type::getTypeIfDerivedFrom(name, Base::BaseClass::getClassTypeId(), loadModule);
+    bool loadModule = asBoolean(load);
+    Base::Type type = Type::getTypeIfDerivedFrom(name, BaseClass::getClassTypeId(), loadModule);
     if (type.isBad()) {
         Py_Return;
     }
@@ -248,7 +244,7 @@ PyObject* TypePy::createInstanceByName(PyObject* args)
         Py_Return;
     }
 
-    Base::BaseClass* base = static_cast<Base::BaseClass*>(typeInstance);
+    BaseClass* base = static_cast<BaseClass*>(typeInstance);
 
     return createPyObject(base);
 }

--- a/src/Base/TypePyImp.cpp
+++ b/src/Base/TypePyImp.cpp
@@ -20,11 +20,12 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
 
 #include "Type.h"
 #include "BindingManager.h"
+
+// generated out of Type.pyi
 #include "TypePy.h"
 #include "TypePy.cpp"
 

--- a/src/Base/UnitPyImp.cpp
+++ b/src/Base/UnitPyImp.cpp
@@ -69,15 +69,15 @@ int UnitPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     Unit* self = getUnitPtr();
 
     // get quantity
-    if (PyArg_ParseTuple(args, "O!", &(Base::QuantityPy::Type), &object)) {
-        *self = static_cast<Base::QuantityPy*>(object)->getQuantityPtr()->getUnit();
+    if (PyArg_ParseTuple(args, "O!", &(QuantityPy::Type), &object)) {
+        *self = static_cast<QuantityPy*>(object)->getQuantityPtr()->getUnit();
         return 0;
     }
     PyErr_Clear();  // set by PyArg_ParseTuple()
 
     // get unit
-    if (PyArg_ParseTuple(args, "O!", &(Base::UnitPy::Type), &object)) {
-        *self = *(static_cast<Base::UnitPy*>(object)->getUnitPtr());
+    if (PyArg_ParseTuple(args, "O!", &(UnitPy::Type), &object)) {
+        *self = *(static_cast<UnitPy*>(object)->getUnitPtr());
         return 0;
     }
     PyErr_Clear();  // set by PyArg_ParseTuple()
@@ -91,7 +91,7 @@ int UnitPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             *self = Quantity::parse(str).getUnit();
             return 0;
         }
-        catch (const Base::ParserError& e) {
+        catch (const ParserError& e) {
             PyErr_SetString(PyExc_ValueError, e.what());
             return -1;
         }
@@ -111,7 +111,7 @@ int UnitPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             *self = Unit(i1, i2, i3, i4, i5, i6, i7, i8);
             return 0;
         }
-        catch (const Base::OverflowError& e) {
+        catch (const OverflowError& e) {
             PyErr_SetString(PyExc_OverflowError, e.what());
             return -1;
         }
@@ -132,8 +132,8 @@ PyObject* UnitPy::number_add_handler(PyObject* self, PyObject* other)
         PyErr_SetString(PyExc_TypeError, "Second arg must be Unit");
         return nullptr;
     }
-    Base::Unit* a = static_cast<UnitPy*>(self)->getUnitPtr();
-    Base::Unit* b = static_cast<UnitPy*>(other)->getUnitPtr();
+    Unit* a = static_cast<UnitPy*>(self)->getUnitPtr();
+    Unit* b = static_cast<UnitPy*>(other)->getUnitPtr();
 
     if (*a != *b) {
         PyErr_SetString(PyExc_TypeError, "Units not matching!");
@@ -153,8 +153,8 @@ PyObject* UnitPy::number_subtract_handler(PyObject* self, PyObject* other)
         PyErr_SetString(PyExc_TypeError, "Second arg must be Unit");
         return nullptr;
     }
-    Base::Unit* a = static_cast<UnitPy*>(self)->getUnitPtr();
-    Base::Unit* b = static_cast<UnitPy*>(other)->getUnitPtr();
+    Unit* a = static_cast<UnitPy*>(self)->getUnitPtr();
+    Unit* b = static_cast<UnitPy*>(other)->getUnitPtr();
 
     if (*a != *b) {
         PyErr_SetString(PyExc_TypeError, "Units not matching!");
@@ -172,8 +172,8 @@ PyObject* UnitPy::number_multiply_handler(PyObject* self, PyObject* other)
     }
 
     if (PyObject_TypeCheck(other, &(UnitPy::Type))) {
-        Base::Unit* a = static_cast<UnitPy*>(self)->getUnitPtr();
-        Base::Unit* b = static_cast<UnitPy*>(other)->getUnitPtr();
+        Unit* a = static_cast<UnitPy*>(self)->getUnitPtr();
+        Unit* b = static_cast<UnitPy*>(other)->getUnitPtr();
 
         return new UnitPy(new Unit((*a) * (*b)));
     }

--- a/src/Base/UnitPyImp.cpp
+++ b/src/Base/UnitPyImp.cpp
@@ -22,12 +22,13 @@
 
 #include "PreCompiled.h"
 
-#include <Base/Unit.h>
+#include "Unit.h"
 
-// inclusion of the generated files (generated out of UnitPy.pyi)
-#include <Base/UnitPy.h>
-#include <Base/QuantityPy.h>
-#include <Base/UnitPy.cpp>
+// generated out of Unit.pyi
+#include "UnitPy.h"
+#include "UnitPy.cpp"
+
+#include "QuantityPy.h"
 
 using namespace Base;
 

--- a/src/Base/VectorPyImp.cpp
+++ b/src/Base/VectorPyImp.cpp
@@ -69,8 +69,8 @@ int VectorPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         return 0;
     }
     PyErr_Clear();  // set by PyArg_ParseTuple()
-    if (PyArg_ParseTuple(args, "O!", &(Base::VectorPy::Type), &object)) {
-        *ptr = *(static_cast<Base::VectorPy*>(object)->getVectorPtr());
+    if (PyArg_ParseTuple(args, "O!", &(VectorPy::Type), &object)) {
+        *ptr = *(static_cast<VectorPy*>(object)->getVectorPtr());
         return 0;
     }
     PyErr_Clear();  // set by PyArg_ParseTuple()
@@ -96,10 +96,10 @@ PyObject* VectorPy::__reduce__(PyObject* args) const
 
     Py::Tuple tuple(2);
 
-    Py::Object type(Base::getTypeAsObject(&Base::VectorPy::Type));
+    Py::Object type(getTypeAsObject(&VectorPy::Type));
     tuple.setItem(0, type);
 
-    Base::Vector3d v = this->value();
+    Vector3d v = this->value();
     Py::Tuple xyz(3);
     xyz.setItem(0, Py::Float(v.x));
     xyz.setItem(1, Py::Float(v.y));
@@ -118,8 +118,8 @@ PyObject* VectorPy::number_add_handler(PyObject* self, PyObject* other)
         PyErr_SetString(PyExc_TypeError, "Second arg must be Vector");
         return nullptr;
     }
-    Base::Vector3d a = static_cast<VectorPy*>(self)->value();
-    Base::Vector3d b = static_cast<VectorPy*>(other)->value();
+    Vector3d a = static_cast<VectorPy*>(self)->value();
+    Vector3d b = static_cast<VectorPy*>(other)->value();
     return new VectorPy(a + b);
 }
 
@@ -133,18 +133,18 @@ PyObject* VectorPy::number_subtract_handler(PyObject* self, PyObject* other)
         PyErr_SetString(PyExc_TypeError, "Second arg must be Vector");
         return nullptr;
     }
-    Base::Vector3d a = static_cast<VectorPy*>(self)->value();
-    Base::Vector3d b = static_cast<VectorPy*>(other)->value();
+    Vector3d a = static_cast<VectorPy*>(self)->value();
+    Vector3d b = static_cast<VectorPy*>(other)->value();
     return new VectorPy(a - b);
 }
 
 PyObject* VectorPy::number_multiply_handler(PyObject* self, PyObject* other)
 {
     if (PyObject_TypeCheck(self, &(VectorPy::Type))) {
-        Base::Vector3d a = static_cast<VectorPy*>(self)->value();
+        Vector3d a = static_cast<VectorPy*>(self)->value();
 
         if (PyObject_TypeCheck(other, &(VectorPy::Type))) {
-            Base::Vector3d b = static_cast<VectorPy*>(other)->value();
+            Vector3d b = static_cast<VectorPy*>(other)->value();
             Py::Float mult(a * b);
             return Py::new_reference_to(mult);
         }
@@ -156,7 +156,7 @@ PyObject* VectorPy::number_multiply_handler(PyObject* self, PyObject* other)
         return nullptr;
     }
     if (PyObject_TypeCheck(other, &(VectorPy::Type))) {
-        Base::Vector3d a = static_cast<VectorPy*>(other)->value();
+        Vector3d a = static_cast<VectorPy*>(other)->value();
         if (PyNumber_Check(self)) {
             double b = PyFloat_AsDouble(self);
             return new VectorPy(a * b);
@@ -190,7 +190,7 @@ PyObject* VectorPy::sequence_item(PyObject* self, Py_ssize_t index)
     }
 
     unsigned short pos = index % 3;
-    Base::Vector3d vec = self_->value();
+    Vector3d vec = self_->value();
     Py::Float item {vec[pos]};
     self_->sequence.setItem(pos, item);
 
@@ -249,7 +249,7 @@ PyObject* VectorPy::mapping_subscript(PyObject* self, PyObject* item)
         }
         if (start == 0 && step == 1 && slicelength == sequence_length(self)
             && PyObject_TypeCheck(self, &(VectorPy::Type))) {
-            Base::Vector3d v = static_cast<VectorPy*>(self)->value();
+            Vector3d v = static_cast<VectorPy*>(self)->value();
             Py::Tuple xyz(3);
             xyz.setItem(0, Py::Float(v.x));
             xyz.setItem(1, Py::Float(v.y));
@@ -257,7 +257,7 @@ PyObject* VectorPy::mapping_subscript(PyObject* self, PyObject* item)
             return Py::new_reference_to(xyz);
         }
         if (PyObject_TypeCheck(self, &(VectorPy::Type))) {
-            Base::Vector3d v = static_cast<VectorPy*>(self)->value();
+            Vector3d v = static_cast<VectorPy*>(self)->value();
             Py::Tuple xyz(static_cast<size_t>(slicelength));
 
             for (cur = start, i = 0; i < slicelength; cur += step, i++) {
@@ -287,7 +287,7 @@ PyObject* VectorPy::add(PyObject* args) const
     VectorPy::PointerType this_ptr = getVectorPtr();
     VectorPy::PointerType vect_ptr = vec->getVectorPtr();
 
-    Base::Vector3d v = (*this_ptr) + (*vect_ptr);
+    Vector3d v = (*this_ptr) + (*vect_ptr);
     return new VectorPy(v);
 }
 
@@ -303,7 +303,7 @@ PyObject* VectorPy::sub(PyObject* args) const
     VectorPy::PointerType this_ptr = getVectorPtr();
     VectorPy::PointerType vect_ptr = vec->getVectorPtr();
 
-    Base::Vector3d v = (*this_ptr) - (*vect_ptr);
+    Vector3d v = (*this_ptr) - (*vect_ptr);
     return new VectorPy(v);
 }
 
@@ -314,7 +314,7 @@ PyObject* VectorPy::negative(PyObject* args) const
     }
 
     VectorPy::PointerType this_ptr = getVectorPtr();
-    Base::Vector3d v = -(*this_ptr);
+    Vector3d v = -(*this_ptr);
     return new VectorPy(v);
 }
 
@@ -448,7 +448,7 @@ PyObject* VectorPy::cross(PyObject* args) const
     VectorPy::PointerType this_ptr = getVectorPtr();
     VectorPy::PointerType vect_ptr = vec->getVectorPtr();
 
-    Base::Vector3d v = (*this_ptr) % (*vect_ptr);
+    Vector3d v = (*this_ptr) % (*vect_ptr);
     return new VectorPy(v);
 }
 
@@ -503,7 +503,7 @@ PyObject* VectorPy::normalize(PyObject* args)
     }
     VectorPy::PointerType ptr = getVectorPtr();
     if (ptr->Length() < Vector3d::epsilon()) {
-        PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot normalize null vector");
+        PyErr_SetString(PyExc_FC_GeneralError, "Cannot normalize null vector");
         return nullptr;
     }
 
@@ -579,7 +579,7 @@ PyObject* VectorPy::distanceToPoint(PyObject* args) const
     VectorPy::PointerType this_ptr = getVectorPtr();
     VectorPy::PointerType base_ptr = base_vec->getVectorPtr();
 
-    Py::Float dist(Base::Distance(*this_ptr, *base_ptr));
+    Py::Float dist(Distance(*this_ptr, *base_ptr));
     return Py::new_reference_to(dist);
 }
 
@@ -748,7 +748,7 @@ PyObject* VectorPy::number_divide_handler(PyObject* self, PyObject* other)
             return nullptr;
         }
 
-        Base::Vector3d vec = static_cast<VectorPy*>(self)->value();
+        Vector3d vec = static_cast<VectorPy*>(self)->value();
         double div = PyFloat_AsDouble(other);
         if (div == 0.0) {
             PyErr_Format(PyExc_ZeroDivisionError, "'%s' division by zero", Py_TYPE(self)->tp_name);
@@ -770,8 +770,8 @@ PyObject* VectorPy::number_remainder_handler(PyObject* self, PyObject* other)
 {
     if (PyObject_TypeCheck(self, &(VectorPy::Type))
         && PyObject_TypeCheck(other, &(VectorPy::Type))) {
-        Base::Vector3d a = static_cast<VectorPy*>(self)->value();
-        Base::Vector3d b = static_cast<VectorPy*>(other)->value();
+        Vector3d a = static_cast<VectorPy*>(self)->value();
+        Vector3d b = static_cast<VectorPy*>(other)->value();
         return new VectorPy(a % b);
     }
 
@@ -803,7 +803,7 @@ PyObject* VectorPy::number_power_handler(PyObject* self, PyObject* other, PyObje
 PyObject* VectorPy::number_negative_handler(PyObject* self)
 {
     if (PyObject_TypeCheck(self, &(VectorPy::Type))) {
-        Base::Vector3d vec = static_cast<VectorPy*>(self)->value();
+        Vector3d vec = static_cast<VectorPy*>(self)->value();
         return new VectorPy(-vec);
     }
 
@@ -814,7 +814,7 @@ PyObject* VectorPy::number_negative_handler(PyObject* self)
 PyObject* VectorPy::number_positive_handler(PyObject* self)
 {
     if (PyObject_TypeCheck(self, &(VectorPy::Type))) {
-        Base::Vector3d vec = static_cast<VectorPy*>(self)->value();
+        Vector3d vec = static_cast<VectorPy*>(self)->value();
         return new VectorPy(vec);
     }
 
@@ -825,7 +825,7 @@ PyObject* VectorPy::number_positive_handler(PyObject* self)
 PyObject* VectorPy::number_absolute_handler(PyObject* self)
 {
     if (PyObject_TypeCheck(self, &(VectorPy::Type))) {
-        Base::Vector3d vec = static_cast<VectorPy*>(self)->value();
+        Vector3d vec = static_cast<VectorPy*>(self)->value();
         vec.x = fabs(vec.x);
         vec.y = fabs(vec.y);
         vec.z = fabs(vec.z);

--- a/src/Base/VectorPyImp.cpp
+++ b/src/Base/VectorPyImp.cpp
@@ -20,17 +20,15 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
 #include <sstream>
 #endif
 
+#include "GeometryPyCXX.h"
 #include "Vector3D.h"
 
-// inclusion of the generated files (generated out of VectorPy.pyi)
-#include "GeometryPyCXX.h"
+// generated out of Vector.pyi
 #include "VectorPy.h"
 #include "VectorPy.cpp"
 


### PR DESCRIPTION
This PR comes to repair embarrassing flaw found after #20983 was merged.

- sort includes and consistently explain where the generated ones come from
- implicitly include needed ones
- explicit `Base` namespace-name is used randomly across PyImp sources and as they are `using namespace Base` remove it.