### PR TITLE
BIM: Hide all objects that aren't selected during Isolate

### DIFF
--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -311,9 +311,10 @@ class BIM_Views:
 
                 # We reuse the variable later on in "Isolate", to not traverse the tree once
                 # again
-                self.allItemsInTree = getAllItemsInTree(vm.tree) + getAllItemsInTree(vm.viewtree)
+                self.allItemsInTree = getAllItemsInTree(vm.tree)
+                allItemsInTrees = self.allItemsInTree + getAllItemsInTree(vm.viewtree)
 
-                for item in self.allItemsInTree:
+                for item in allItemsInTrees:
                     if item.text(0) in objNameSelected:
                         item.setSelected(True)
                     if objActive and item.toolTip(0) == objActive.Name:
@@ -455,7 +456,8 @@ class BIM_Views:
         for item in self.allItemsInTree:
             toolTip = item.toolTip(0)
             obj = FreeCAD.ActiveDocument.getObject(toolTip)
-            obj.ViewObject.Visibility = True
+            if obj:
+                obj.ViewObject.Visibility = True
 
         vm = findWidget()
         if vm:
@@ -463,10 +465,11 @@ class BIM_Views:
             for item in self.allItemsInTree:
                 toolTip = item.toolTip(0)
                 obj = FreeCAD.ActiveDocument.getObject(toolTip)
-                if item not in selectedItems:
-                    obj.ViewObject.Visibility = False
-                else:
-                    obj.ViewObject.Visibility = True
+                if obj:
+                    if item not in selectedItems:
+                        obj.ViewObject.Visibility = False
+                    else:
+                        obj.ViewObject.Visibility = True
 
             FreeCAD.ActiveDocument.recompute()
 

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -52,6 +52,7 @@ class BIM_Views:
         from PySide import QtCore, QtGui
 
         vm = findWidget()
+        self.allItemsInTree = []
         bimviewsbutton = None
         mw = FreeCADGui.getMainWindow()
         st = mw.statusBar()
@@ -189,6 +190,7 @@ class BIM_Views:
         if vm and FreeCAD.ActiveDocument:
             if vm.isVisible() and (vm.tree.state() != vm.tree.State.EditingState):
                 vm.tree.clear()
+                self.allItemsInTree.clear()
                 treeViewItems = []  # QTreeWidgetItem to Display in tree
                 lvHold = []
                 soloProxyHold = []
@@ -306,8 +308,12 @@ class BIM_Views:
                     objActive = FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch")
                 tparam = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/TreeView")
                 activeColor = tparam.GetUnsigned("TreeActiveColor",0)
-                allItemsInTree = getAllItemsInTree(vm.tree) + getAllItemsInTree(vm.viewtree)
-                for item in allItemsInTree:
+
+                # We reuse the variable later on in "Isolate", to not traverse the tree once
+                # again
+                self.allItemsInTree = getAllItemsInTree(vm.tree) + getAllItemsInTree(vm.viewtree)
+
+                for item in self.allItemsInTree:
                     if item.text(0) in objNameSelected:
                         item.setSelected(True)
                     if objActive and item.toolTip(0) == objActive.Name:
@@ -435,44 +441,32 @@ class BIM_Views:
 
     def isolate(self):
         """
-        Traverse the tree and hide all items (and their ancestors) that are not the currently
-        selected item or a descendant of the currently selected item.
+        Isolate the currently selected items in the tree view.
 
-        This ensures that only the selected item and its ancestors remain visible, while
-        all other items are hidden.
+        This function first makes all items in the tree visible to ensure a clean slate.
+        Then, it hides all items that are not currently selected by the user in the GUI tree view.
+        As a result, only the selected items remain visible in the 3D view, effectively isolating them.
+
+        Assumes that `self.allItemsInTree` is a list of all QTreeWidgetItems in the tree.
         """
+
+        # Iterate through all of the items and show them beforehand if they were hidden
+        # so we can "reset" the tree state before the real processing
+        for item in self.allItemsInTree:
+            toolTip = item.toolTip(0)
+            obj = FreeCAD.ActiveDocument.getObject(toolTip)
+            obj.ViewObject.Visibility = True
 
         vm = findWidget()
         if vm:
-            onnames = vm.tree.selectedItems()
-            selectedItsTooltips = [item.toolTip(0) for item in vm.tree.selectedItems()]
-            def is_ancestor_of_any(potential_parent, selected_items):
-                """Check if potential_parent is an ancestor of ANY selected item."""
-                for item in selected_items:
-                    current = item.parent()
-                    while current:
-                        if current.toolTip(0) == potential_parent:
-                            return True
-                        current = current.parent()
-                return False
-
-            def traverse_and_hide(item):
-                """Recursively traverse the tree and hide/show parents accordingly."""
+            selectedItems = vm.tree.selectedItems()
+            for item in self.allItemsInTree:
                 toolTip = item.toolTip(0)
                 obj = FreeCAD.ActiveDocument.getObject(toolTip)
-                if toolTip not in selectedItsTooltips and not is_ancestor_of_any(toolTip, onnames):
-                    if obj:
-                        obj.ViewObject.Visibility = False
-                
-                # Traverse on lower levels of this tree only if we didn't hide current level
-                if obj and obj.ViewObject.Visibility != False:
-                    for i in range(item.childCount()):
-                        traverse_and_hide(item.child(i))
-        
-            # Start from top-level items
-            for i in range(vm.tree.topLevelItemCount()):
-                top_item = vm.tree.topLevelItem(i)
-                traverse_and_hide(top_item)
+                if item not in selectedItems:
+                    obj.ViewObject.Visibility = False
+                else:
+                    obj.ViewObject.Visibility = True
 
             FreeCAD.ActiveDocument.recompute()
 

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -466,6 +466,9 @@ class BIM_Views:
             toolTip = item.toolTip(0)
             obj = FreeCAD.ActiveDocument.getObject(toolTip)
             if obj:
+                # We switch visibility to be sure we will show childs of other childs
+                # beforehand, as the Visibility may not be propagated.
+                obj.ViewObject.Visibility = False
                 obj.ViewObject.Visibility = True
 
         vm = findWidget()

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -471,7 +471,6 @@ class BIM_Views:
                     else:
                         obj.ViewObject.Visibility = True
 
-            FreeCAD.ActiveDocument.recompute()
 
     def saveView(self):
         "save the current camera angle to the selected item"


### PR DESCRIPTION
Currently if user selects an item and does `Isolate` operation on it in BIM, everything is being hidden if the item was inside another container (like Building).

This is because we are prioritizing on hiding parents of current object if they are not the selected ones, which is causing the child of the parent to be hidden as well (duh).

So, this patch fixes isolate method to hide all other parents and their childs. If they are not a parent of our child under selection -> hide them and proceed further. If we are processing parent of our selection, just hide anything on current level that is not our selection while leaving parent intact.

Demo:

https://github.com/user-attachments/assets/2154df5b-b386-4b2d-86fe-e65c599abfb3


FYI: @semhustej @furgo16 

Resolves: https://github.com/FreeCAD/FreeCAD/issues/20886


