### PR TITLE
Gui: PyImp cleanup

### DIFF
--- a/src/Gui/AxisOriginPyImp.cpp
+++ b/src/Gui/AxisOriginPyImp.cpp
@@ -22,14 +22,16 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <Inventor/nodes/SoGroup.h>
-# include <Inventor/details/SoDetail.h>
-# include <Inventor/SoFullPath.h>
+#include <Inventor/nodes/SoGroup.h>
+#include <Inventor/details/SoDetail.h>
+#include <Inventor/SoFullPath.h>
 #endif
 
+#include <Base/Interpreter.h>
+
+// generated out of AxisOrigin.pyi
 #include "AxisOriginPy.h"
 #include "AxisOriginPy.cpp"
-#include <Base/Interpreter.h>
 
 using namespace Gui;
 

--- a/src/Gui/CommandPyImp.cpp
+++ b/src/Gui/CommandPyImp.cpp
@@ -22,9 +22,9 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <sstream>
-# include <QRegularExpression>
-# include <QRegularExpressionMatch>
+#include <sstream>
+#include <QRegularExpression>
+#include <QRegularExpressionMatch>
 #endif
 
 #include <Base/PyWrapParseTupleAndKeywords.h>
@@ -33,15 +33,14 @@
 #include "Action.h"
 #include "Application.h"
 #include "MainWindow.h"
-#include "Selection.h"
-#include "Window.h"
 #include "PythonWrapper.h"
+#include "Selection.h"
+#include "ShortcutManager.h"
+#include "Window.h"
 
-// inclusion of the generated files (generated out of CommandPy.pyi)
+// generated out of Command.pyi
 #include "CommandPy.h"
 #include "CommandPy.cpp"
-#include "ShortcutManager.h"
-
 
 // returns a string which represents the object e.g. when printed in python
 std::string CommandPy::representation() const

--- a/src/Gui/DocumentPyImp.cpp
+++ b/src/Gui/DocumentPyImp.cpp
@@ -21,12 +21,12 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
-# include <sstream>
+#include <sstream>
 #endif
 
 #include <App/Document.h>
+#include <App/DocumentObjectPy.h>
 #include <Base/Matrix.h>
 #include <Base/MatrixPy.h>
 #include <Base/Stream.h>
@@ -34,18 +34,16 @@
 #include "Application.h"
 #include "MergeDocuments.h"
 #include "MDIView.h"
-#include "ViewProviderExtern.h"
-
-// inclusion of the generated files (generated out of DocumentPy.pyi)
-#include "DocumentPy.h"
-#include "DocumentPy.cpp"
-#include <App/DocumentObjectPy.h>
 #include "Tree.h"
 #include "ViewProviderDocumentObject.h"
-#include "ViewProviderDocumentObjectPy.h"
+#include "ViewProviderExtern.h"
+
+// generated out of Document.pyi
+#include "DocumentPy.h"
+#include "DocumentPy.cpp"
+
 #include "ViewProviderPy.h"
 #include "ViewProviderDocumentObjectPy.h"
-
 
 using namespace Gui;
 

--- a/src/Gui/LinkViewPyImp.cpp
+++ b/src/Gui/LinkViewPyImp.cpp
@@ -22,15 +22,16 @@
 
 #include "PreCompiled.h"
 
-#include <Base/BoundBoxPy.h>
-#include <Base/MatrixPy.h>
 #include <App/DocumentObjectPy.h>
 #include <App/MaterialPy.h>
+#include <Base/BoundBoxPy.h>
+#include <Base/MatrixPy.h>
 
+// generated out of LinkView.pyi
 #include "LinkViewPy.h"
 #include "LinkViewPy.cpp"
-#include "ViewProviderDocumentObjectPy.h"
 
+#include "ViewProviderDocumentObjectPy.h"
 
 using namespace Gui;
 

--- a/src/Gui/Navigation/NavigationStylePyImp.cpp
+++ b/src/Gui/Navigation/NavigationStylePyImp.cpp
@@ -21,10 +21,9 @@
 
 #include "PreCompiled.h"
 
-// inclusion of the generated files (generated out of NavigationStylePy.pyi)
+// generated out of NavigationStyle.pyi
 #include "Navigation/NavigationStylePy.h"
 #include "Navigation/NavigationStylePy.cpp"
-
 
 using namespace Gui;
 

--- a/src/Gui/PythonWorkbenchPyImp.cpp
+++ b/src/Gui/PythonWorkbenchPyImp.cpp
@@ -22,10 +22,9 @@
 
 #include "PreCompiled.h"
 
-// inclusion of the generated files (generated out of PythonWorkbenchPy.pyi)
+// generated out of PythonWorkbench.pyi
 #include "PythonWorkbenchPy.h"
 #include "PythonWorkbenchPy.cpp"
-
 
 using namespace Gui;
 

--- a/src/Gui/Selection/SelectionObjectPyImp.cpp
+++ b/src/Gui/Selection/SelectionObjectPyImp.cpp
@@ -29,11 +29,9 @@
 #include "Selection.h"
 #include "SelectionObject.h"
 
-
-// inclusion of the generated files (generated out of SelectionObjectPy.xml)
+// generated out of SelectionObject.pyi
 #include "Selection/SelectionObjectPy.h"
 #include "Selection/SelectionObjectPy.cpp"
-
 
 using namespace Gui;
 

--- a/src/Gui/ViewProviderDocumentObjectPyImp.cpp
+++ b/src/Gui/ViewProviderDocumentObjectPyImp.cpp
@@ -21,18 +21,17 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
-# include <sstream>
+#include <sstream>
 #endif
 
 #include <App/DocumentObjectPy.h>
+
 #include "Document.h"
 
-// inclusion of the generated files (generated out of ViewProviderDocumentObjectPy.pyi)
+// generated out of ViewProviderDocumentObject.pyi
 #include "ViewProviderDocumentObjectPy.h"
 #include "ViewProviderDocumentObjectPy.cpp"
-
 
 using namespace Gui;
 

--- a/src/Gui/ViewProviderExtensionPyImp.cpp
+++ b/src/Gui/ViewProviderExtensionPyImp.cpp
@@ -20,17 +20,16 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
-# include <sstream>
+#include <sstream>
 #endif
 
-// inclusion of the generated files (generated out of PropertyContainerPy.pyi)
+#include "ViewProviderDocumentObject.h"
+
+// generated out of ViewProviderExtension.pyi
 #include "ViewProviderExtensionPy.h"
 #include "ViewProviderExtensionPy.cpp"
-#include "ViewProviderDocumentObject.h"
 
 using namespace Gui;
 

--- a/src/Gui/ViewProviderGeometryObjectPyImp.cpp
+++ b/src/Gui/ViewProviderGeometryObjectPyImp.cpp
@@ -22,7 +22,6 @@
  **************************************************************************/
 
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
 #include <sstream>
 #endif
@@ -31,10 +30,9 @@
 #include <App/MaterialPy.h>
 #include <App/PropertyStandard.h>
 
+// generated out of ViewProviderGeometryObject.pyi
 #include "ViewProviderGeometryObjectPy.h"
-
 #include "ViewProviderGeometryObjectPy.cpp"
-
 
 using namespace Gui;
 

--- a/src/Gui/ViewProviderLinkPyImp.cpp
+++ b/src/Gui/ViewProviderLinkPyImp.cpp
@@ -21,17 +21,15 @@
  ****************************************************************************/
 
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
-# include <sstream>
+#include <sstream>
 #endif
 
 #include <Base/PlacementPy.h>
 
-// inclusion of the generated files (generated out of ViewProviderLinkPy.pyi)
+// generated out of ViewProviderLink.pyi
 #include "ViewProviderLinkPy.h"
 #include "ViewProviderLinkPy.cpp"
-
 
 using namespace Gui;
 

--- a/src/Gui/ViewProviderPyImp.cpp
+++ b/src/Gui/ViewProviderPyImp.cpp
@@ -22,35 +22,35 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <Inventor/SbRotation.h>
-# include <Inventor/SoFullPath.h>
-# include <Inventor/details/SoDetail.h>
-# include <Inventor/nodes/SoSeparator.h>
-# include <Inventor/nodes/SoSwitch.h>
-# include <QByteArray>
-# include <QDataStream>
+#include <Inventor/SbRotation.h>
+#include <Inventor/SoFullPath.h>
+#include <Inventor/details/SoDetail.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoSwitch.h>
+#include <QByteArray>
+#include <QDataStream>
 #endif
 
-#include <Base/BoundBoxPy.h>
 #include <Base/PyWrapParseTupleAndKeywords.h>
-
-#include "PythonWrapper.h"
-#include "SoFCDB.h"
-
-// inclusion of the generated files (generated out of ViewProviderPy.pyi)
-#include <Gui/ViewProviderPy.h>
-#include <Gui/ViewProviderPy.cpp>
 #include <Gui/View3DPy.h>
 #include <Gui/View3DInventor.h>
 #include <Base/Interpreter.h>
 #include <Base/Matrix.h>
-#include <Base/MatrixPy.h>
 #include <Base/Placement.h>
-#include <Base/PlacementPy.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
-#include <App/DocumentObjectPy.h>
 
+#include "PythonWrapper.h"
+#include "SoFCDB.h"
+
+// generated out of ViewProvider.pyi
+#include "ViewProviderPy.h"
+#include "ViewProviderPy.cpp"
+
+#include <Base/BoundBoxPy.h>
+#include <Base/MatrixPy.h>
+#include <Base/PlacementPy.h>
+#include <App/DocumentObjectPy.h>
 
 using namespace Gui;
 

--- a/src/Gui/WorkbenchPyImp.cpp
+++ b/src/Gui/WorkbenchPyImp.cpp
@@ -20,13 +20,12 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
 
 #include "Workbench.h"
 #include "WorkbenchManager.h"
 
-// inclusion of the generated files (generated out of WorkbenchPy.xml)
+// generated out of Workbench.pyi
 #include "WorkbenchPy.h"
 #include "WorkbenchPy.cpp"
 


### PR DESCRIPTION
A continuation of #21018
Sort includes and implicitly add missing ones. While there consistently explain where generated files some from.

This is a bit harder here... [cppclean](https://github.com/myint/cppclean) does not deliver good results on *cpp files (even documentation states that) and [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) is yet to be experimented with. Any other suggestions welcome.