### PR TITLE
Gui: Add QGroupBox to all preference pages

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsSelection.ui
+++ b/src/Gui/PreferencePages/DlgSettingsSelection.ui
@@ -7,241 +7,262 @@
     <x>0</x>
     <y>0</y>
     <width>670</width>
-    <height>411</height>
+    <height>641</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Selection</string>
   </property>
-  <layout class="QGridLayout">
-   <property name="leftMargin">
-    <number>9</number>
-   </property>
-   <property name="topMargin">
-    <number>9</number>
-   </property>
-   <property name="rightMargin">
-    <number>9</number>
-   </property>
-   <property name="bottomMargin">
-    <number>9</number>
-   </property>
-   <property name="spacing">
-    <number>6</number>
-   </property>
-   <item row="0" column="0">
-    <widget class="Gui::PrefCheckBox" name="checkBoxPreselection">
-     <property name="minimumSize">
-      <size>
-       <width>240</width>
-       <height>0</height>
-      </size>
+  <layout class="QVBoxLayout" name="verticalLayout_4">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Enable</string>
      </property>
-     <property name="toolTip">
-      <string>Enable preselection, highlighted with specified color</string>
-     </property>
-     <property name="text">
-      <string>Enable preselection</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>EnablePreselection</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>View</cstring>
-     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="4" column="1">
+       <widget class="Gui::PrefColorButton" name="SelectionColor">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>28</red>
+          <green>173</green>
+          <blue>28</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SelectionColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkBoxSelection">
+        <property name="toolTip">
+         <string>Enable selection, highlighted with specified color</string>
+        </property>
+        <property name="text">
+         <string>Enable selection</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>EnableSelection</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefColorButton" name="HighlightColor">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>225</red>
+          <green>225</green>
+          <blue>20</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>HighlightColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkBoxPreselection">
+        <property name="minimumSize">
+         <size>
+          <width>240</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Enable preselection, highlighted with specified color</string>
+        </property>
+        <property name="text">
+         <string>Enable preselection</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>EnablePreselection</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="Gui::PrefColorButton" name="HighlightColor">
-     <property name="text">
-      <string/>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Picking</string>
      </property>
-     <property name="color">
-      <color>
-       <red>225</red>
-       <green>225</green>
-       <blue>20</blue>
-      </color>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>HighlightColor</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>View</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="Gui::PrefCheckBox" name="checkBoxSelection">
-     <property name="toolTip">
-      <string>Enable selection, highlighted with specified color</string>
-     </property>
-     <property name="text">
-      <string>Enable selection</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>EnableSelection</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>View</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="Gui::PrefColorButton" name="SelectionColor">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="color">
-      <color>
-       <red>28</red>
-       <green>173</green>
-       <blue>28</blue>
-      </color>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>SelectionColor</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>View</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_1">
-     <item>
-      <widget class="QLabel" name="spinPickRadiusLabel">
-       <property name="text">
-        <string>Pick radius:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizSpacer_1">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>250</width>
-         <height>10</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="1">
-    <widget class="Gui::PrefDoubleSpinBox" name="spinPickRadius">
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>Area for picking elements in 3D view.
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_1">
+        <item>
+         <widget class="QLabel" name="spinPickRadiusLabel">
+          <property name="text">
+           <string>Radius:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizSpacer_1">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>250</width>
+            <height>10</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefDoubleSpinBox" name="spinPickRadius">
+          <property name="minimumSize">
+           <size>
+            <width>120</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Area for picking elements in 3D view.
 Larger value eases to pick things, but can make small features impossible to select.
       </string>
-     </property>
-     <property name="inputMethodHints">
-      <set>Qt::ImhPreferNumbers</set>
-     </property>
-     <property name="suffix">
-      <string notr="true"> px</string>
-     </property>
-     <property name="decimals">
-      <number>1</number>
-     </property>
-     <property name="minimum">
-      <double>0.500000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>200.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>5.000000000000000</double>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>PickRadius</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>View</cstring>
-     </property>
+          </property>
+          <property name="inputMethodHints">
+           <set>Qt::ImhPreferNumbers</set>
+          </property>
+          <property name="suffix">
+           <string notr="true"> px</string>
+          </property>
+          <property name="decimals">
+           <number>1</number>
+          </property>
+          <property name="minimum">
+           <double>0.500000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>200.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>PickRadius</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>View</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="Gui::PrefCheckBox" name="checkBoxAutoSwitch">
-     <property name="text">
-      <string>Auto switch to the 3D view containing the selected item</string>
+   <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Auto</string>
      </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>SyncView</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>TreeView</cstring>
-     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBoxAutoSwitch">
+        <property name="text">
+         <string>Auto switch to the 3D view containing the selected item</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SyncView</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>TreeView</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBoxAutoExpand">
+        <property name="text">
+         <string>Auto expand tree item when the corresponding object is selected in 3D view</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SyncSelection</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>TreeView</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="Gui::PrefCheckBox" name="checkBoxAutoExpand">
-     <property name="text">
-      <string>Auto expand tree item when the corresponding object is selected in 3D view</string>
+   <item>
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="title">
+      <string>Misc.</string>
      </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>SyncSelection</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>TreeView</cstring>
-     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBoxPreselect">
+        <property name="text">
+         <string>Preselect the object in 3D view when hovering the cursor over the tree item</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>PreSelection</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>TreeView</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBoxRecord">
+        <property name="text">
+         <string>Record selection in tree view in order to go back/forward using navigation button</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>RecordSelection</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>TreeView</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBoxSelectionCheckBoxes">
+        <property name="text">
+         <string>Add checkboxes for selection in document tree</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>CheckBoxesSelection</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>TreeView</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="Gui::PrefCheckBox" name="checkBoxPreselect">
-     <property name="text">
-      <string>Preselect the object in 3D view when hovering the cursor over the tree item</string>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>PreSelection</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>TreeView</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="Gui::PrefCheckBox" name="checkBoxRecord">
-     <property name="text">
-      <string>Record selection in tree view in order to go back/forward using navigation button</string>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>RecordSelection</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>TreeView</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="Gui::PrefCheckBox" name="checkBoxSelectionCheckBoxes">
-     <property name="text">
-      <string>Add checkboxes for selection in document tree</string>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>CheckBoxesSelection</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>TreeView</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="2">
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -258,39 +279,59 @@ Larger value eases to pick things, but can make small features impossible to sel
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Gui::PrefDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
    <class>Gui::ColorButton</class>
    <extends>QPushButton</extends>
    <header>Gui/Widgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefColorButton</class>
-   <extends>Gui::ColorButton</extends>
-   <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
+  <customwidget>
+   <class>Gui::PrefDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefColorButton</class>
+   <extends>Gui::ColorButton</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
  </customwidgets>
  <resources/>
-  <connections>
+ <connections>
   <connection>
    <sender>checkBoxPreselection</sender>
    <signal>toggled(bool)</signal>
    <receiver>HighlightColor</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBoxSelection</sender>
    <signal>toggled(bool)</signal>
    <receiver>SelectionColor</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
  </connections>
 </ui>

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenches.ui
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenches.ui
@@ -6,158 +6,185 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>607</width>
+    <width>980</width>
     <height>859</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Available Workbenches</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_3">
-   <item row="4" column="0">
-    <layout class="QHBoxLayout">
-     <property name="spacing">
-      <number>6</number>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Workbenches</string>
      </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="WorkbenchSelectorItemLabel">
-       <property name="text">
-        <string>Workbench selector items style:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="WorkbenchSelectorItem">
-       <property name="toolTip">
-        <string>Customize how the items are displayed.</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="0">
-    <widget class="ListWidgetDragBugFix" name="wbList"/>
-   </item>
-   <item row="3" column="0">
-    <layout class="QHBoxLayout">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="WorkbenchSelectorTypeLabel">
-       <property name="text">
-        <string>Workbench selector type:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="WorkbenchSelectorType">
-       <property name="toolTip">
-        <string>Choose the workbench selector widget type (restart required).</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="noteLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>50</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You can reorder workbenches by drag and drop or sort them by right-clicking on any workbench and select &lt;span style=&quot;  font-weight:600; font-style:italic;&quot;&gt;Sort alphabetically&lt;/span&gt;. Additional workbenches can be installed through the addon manager.&lt;/p&gt;&lt;p&gt;
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <widget class="QLabel" name="noteLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>50</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You can reorder workbenches by drag and drop or sort them by right-clicking on any workbench and select &lt;span style=&quot;  font-weight:600; font-style:italic;&quot;&gt;Sort alphabetically&lt;/span&gt;. Additional workbenches can be installed through the addon manager.&lt;/p&gt;&lt;p&gt;
 Currently, your system has the following workbenches:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ListWidgetDragBugFix" name="wbList"/>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="Gui::PrefCheckBox" name="CheckBox_WbByTab">
-     <property name="toolTip">
-      <string>If checked, application will remember which workbench is active for each tab of the viewport</string>
+   <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Selectors</string>
      </property>
-     <property name="text">
-      <string>Remember active workbench by tab</string>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>SaveWBbyTab</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>View</cstring>
-     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QHBoxLayout">
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="WorkbenchSelectorItemLabel">
+          <property name="text">
+           <string>Workbench selector items style:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="WorkbenchSelectorItem">
+          <property name="toolTip">
+           <string>Customize how the items are displayed.</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout">
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="WorkbenchSelectorTypeLabel">
+          <property name="text">
+           <string>Workbench selector type:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="WorkbenchSelectorType">
+          <property name="toolTip">
+           <string>Choose the workbench selector widget type (restart required).</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <layout class="QHBoxLayout">
-     <property name="spacing">
-      <number>6</number>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Startup</string>
      </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="autoModuleLabel">
-       <property name="text">
-        <string>Start up workbench:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="AutoloadModuleCombo">
-       <property name="toolTip">
-        <string>Choose which workbench will be activated and shown
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout">
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="autoModuleLabel">
+          <property name="text">
+           <string>Start up workbench:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="AutoloadModuleCombo">
+          <property name="toolTip">
+           <string>Choose which workbench will be activated and shown
 after FreeCAD launches</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="CheckBox_WbByTab">
+        <property name="toolTip">
+         <string>If checked, application will remember which workbench is active for each tab of the viewport</string>
+        </property>
+        <property name="text">
+         <string>Remember active workbench by tab</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SaveWBbyTab</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -7,73 +7,76 @@
     <x>0</x>
     <y>0</y>
     <width>649</width>
-    <height>773</height>
+    <height>800</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>DXF</string>
   </property>
-  <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
-   <property name="margin">
-    <number>9</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="Gui::PrefCheckBox" name="checkBox_dxfShowDialog">
-     <property name="toolTip">
-      <string>This preferences dialog will be shown when importing/ exporting DXF files</string>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>General options</string>
      </property>
-     <property name="text">
-      <string>Show this dialog when importing and exporting</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>dxfShowDialog</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>Mod/Draft</cstring>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="Gui::PrefCheckBox" name="checkBox_dxfUseLegacyImporter">
-     <property name="toolTip">
-      <string>Python importer is used, otherwise the newer C++ is used.
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_dxfShowDialog">
+        <property name="toolTip">
+         <string>This preferences dialog will be shown when importing/ exporting DXF files</string>
+        </property>
+        <property name="text">
+         <string>Show this dialog when importing and exporting</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>dxfShowDialog</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_dxfUseLegacyImporter">
+        <property name="toolTip">
+         <string>Python importer is used, otherwise the newer C++ is used.
 Note: C++ importer is faster, but is not as featureful yet</string>
-     </property>
-     <property name="text">
-      <string>Use legacy Python importer</string>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>dxfUseLegacyImporter</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>Mod/Draft</cstring>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="Gui::PrefCheckBox" name="checkBox_dxfUseLegacyExporter">
-     <property name="toolTip">
-      <string>Python exporter is used, otherwise the newer C++ is used.
+        </property>
+        <property name="text">
+         <string>Use legacy Python importer</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>dxfUseLegacyImporter</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_dxfUseLegacyExporter">
+        <property name="toolTip">
+         <string>Python exporter is used, otherwise the newer C++ is used.
 Note: C++ exporter is faster, but is not as featureful yet</string>
-     </property>
-     <property name="text">
-      <string>Use legacy Python exporter</string>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>dxfUseLegacyExporter</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>Mod/Draft</cstring>
-     </property>
+        </property>
+        <property name="text">
+         <string>Use legacy Python exporter</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>dxfUseLegacyExporter</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -686,11 +689,6 @@ This might fail for post DXF R12 templates.</string>
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
-   <class>Gui::PrefRadioButton</class>
-   <extends>QRadioButton</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
@@ -700,69 +698,173 @@ This might fail for post DXF R12 templates.</string>
    <extends>QDoubleSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
+  <customwidget>
+   <class>Gui::PrefRadioButton</class>
+   <extends>QRadioButton</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
  </customwidgets>
  <resources/>
  <connections>
-
-   <connection>
+  <connection>
    <sender>checkBox_dxfUseLegacyImporter</sender>
    <signal>toggled(bool)</signal>
    <receiver>label_Create</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBox_dxfUseLegacyImporter</sender>
    <signal>toggled(bool)</signal>
    <receiver>radioButton_dxfCreatePart</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBox_dxfUseLegacyImporter</sender>
    <signal>toggled(bool)</signal>
    <receiver>radioButton_dxfCreateDraft</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBox_dxfUseLegacyImporter</sender>
    <signal>toggled(bool)</signal>
    <receiver>radioButton_dxfCreateSketch</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBox_dxfUseLegacyImporter</sender>
    <signal>toggled(bool)</signal>
    <receiver>checkBox_joingeometry</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBox_dxfUseLegacyImporter</sender>
    <signal>toggled(bool)</signal>
    <receiver>checkBox_dxfStdSize</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBox_dxfUseLegacyImporter</sender>
    <signal>toggled(bool)</signal>
    <receiver>checkBox_importDxfHatches</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBox_dxfUseLegacyImporter</sender>
    <signal>toggled(bool)</signal>
    <receiver>checkBox_renderPolylineWidth</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBox_dxfUseLegacyExporter</sender>
    <signal>toggled(bool)</signal>
    <receiver>checkBox_dxfmesh</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBox_dxfUseLegacyExporter</sender>
    <signal>toggled(bool)</signal>
    <receiver>checkBox_dxfproject</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
  </connections>
 </ui>


### PR DESCRIPTION
NOTE: AddonManager and Telemetry addon ui files are in separate repos

<!-- Include a brief summary of the changes. -->

Adding group boxes for floating checkboxes, etc. per
https://github.com/FreeCAD/FreeCAD/issues/20856

see recent comments about telemetry and addonmanager submodule

## Issues
https://github.com/FreeCAD/FreeCAD/issues/20856

## Before and After Images
See issue above for before images. After:

![image](https://github.com/user-attachments/assets/cea4cb79-250f-4a7e-8e83-32c8218a2469)

![image](https://github.com/user-attachments/assets/cb99535e-afc8-4fcc-8836-64687ae35002)


