### PR TITLE
Draft: store 3 ShapeString parameters and remove font from prefs

### DIFF
--- a/src/Mod/Draft/Resources/ui/TaskShapeString.ui
+++ b/src/Mod/Draft/Resources/ui/TaskShapeString.ui
@@ -111,7 +111,7 @@ Uncheck to use working plane coordinate system</string>
            <string/>
           </property>
           <property name="text">
-           <string>Reset Point</string>
+           <string>Reset point</string>
           </property>
          </widget>
         </item>
@@ -143,14 +143,14 @@ Uncheck to use working plane coordinate system</string>
       <item row="1" column="0">
        <layout class="QGridLayout" name="gridLayout_6">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelString">
+         <widget class="QLabel" name="labelText">
           <property name="text">
-           <string>String</string>
+           <string>Text</string>
           </property>
          </widget>
         </item>
        <item row="0" column="1">
-         <widget class="QLineEdit" name="leString">
+         <widget class="QLineEdit" name="leText">
           <property name="toolTip">
            <string>Text to be made into ShapeString</string>
           </property>

--- a/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
@@ -635,38 +635,6 @@ used for linear dimensions.</string>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_6">
-     <property name="title">
-      <string>ShapeStrings</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_1">
-      <item>
-       <widget class="QLabel" name="label_FontFile">
-        <property name="text">
-         <string>Default ShapeString font file</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefFileChooser" name="fileChooser_FontFile">
-        <property name="filter">
-         <string>Font files (*.ttf *.otf *.pfb *.TTF *.OTF *.PFB)</string>
-        </property>
-        <property name="toolTip">
-         <string>Select a font file</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>FontFile</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <spacer name="verticalSpacer_1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -48,7 +48,7 @@ True if Draft_rc.__name__ else False
 class ShapeStringTaskPanel:
     """Base class for Draft_ShapeString task panel."""
 
-    def __init__(self, point=None, size=10, string="", font=""):
+    def __init__(self, point=None, size=None, string="", font=""):
 
         self.form = Gui.PySideUic.loadUi(":/ui/TaskShapeString.ui")
         self.form.setObjectName("ShapeStringTaskPanel")
@@ -75,12 +75,14 @@ class ShapeStringTaskPanel:
         self.display_point(self.point)
         self.pointPicked = False
 
-        self.form.sbHeight.setProperty("rawValue", size)
-        self.string = string if string else translate("draft", "Default")
-        self.form.leString.setText(self.string)
+        self.height = size if size is not None else params.get_param("ShapeStringHeight")
+        self.form.sbHeight.setProperty("rawValue", self.height)
+        self.text = string if string else params.get_param("ShapeStringText")
+        self.form.leText.setText(self.text)
         self.platform_win_dialog("Overwrite")
-        self.font_file = font if font else params.get_param("FontFile")
+        self.font_file = font if font else params.get_param("ShapeStringFontFile")
         self.form.fcFontFile.setFileName(self.font_file)
+
         # Prevent cyclic processing of point values:
         self.display_point_active = False
         # Default for the "DontUseNativeFontDialog" preference:
@@ -92,8 +94,10 @@ class ShapeStringTaskPanel:
         self.form.sbY.valueChanged.connect(self.set_point_y)
         self.form.sbZ.valueChanged.connect(self.set_point_z)
         self.form.cbGlobalMode.stateChanged.connect(self.set_global_mode)
-        self.form.fcFontFile.fileNameSelected.connect(self.set_file)
         self.form.pbReset.clicked.connect(self.reset_point)
+        self.form.sbHeight.valueChanged.connect(self.set_height)
+        self.form.leText.textEdited.connect(self.set_text)
+        self.form.fcFontFile.fileNameSelected.connect(self.set_file)
 
     def action(self, arg):
         """scene event handler"""
@@ -157,12 +161,17 @@ class ShapeStringTaskPanel:
     def set_file(self, val):
         """Assign the selected font file."""
         self.font_file = val
+        params.set_param("ShapeStringFontFile", self.font_file)
 
     def set_global_mode(self, val):
         self.global_mode = bool(val)
         params.set_param("GlobalMode", self.global_mode)
         self.change_coord_labels()
         self.display_point(self.point)
+
+    def set_height(self, val):
+        self.height = App.Units.Quantity(val).Value
+        params.set_param("ShapeStringHeight", self.height)
 
     def set_point_coord(self, coord, val):
         """Change self.point based on  X, Y or Z value entered in the task panel.
@@ -190,6 +199,11 @@ class ShapeStringTaskPanel:
     def set_point_z(self, val):
         self.set_point_coord("z", val)
 
+    def set_text(self, val):
+        """Assign the selected font file."""
+        self.text = val
+        params.set_param("ShapeStringText", self.text)
+
 
 class ShapeStringTaskPanelCmd(ShapeStringTaskPanel):
     """Task panel for Draft_ShapeString."""
@@ -206,15 +220,12 @@ class ShapeStringTaskPanelCmd(ShapeStringTaskPanel):
 
     def create_object(self):
         """Create object in the current document."""
-        string = self.escape_string(self.form.leString.text())
-        size = App.Units.Quantity(self.form.sbHeight.text()).Value
-
         Gui.addModule("Draft")
         Gui.addModule("WorkingPlane")
         cmd = "Draft.make_shapestring("
-        cmd += "String=\"" + string + "\", "
-        cmd += "FontFile=\"" + self.font_file + "\", "
-        cmd += "Size=" + str(size) + ", "
+        cmd += "String=\"" + self.escape_string(self.text) + "\", "
+        cmd += "FontFile=\"" + self.escape_string(self.font_file) + "\", "
+        cmd += "Size=" + str(self.height) + ", "
         cmd += "Tracking=0.0"
         cmd += ")"
         self.sourceCmd.commit(
@@ -249,13 +260,10 @@ class ShapeStringTaskPanelEdit(ShapeStringTaskPanel):
 
     def accept(self):
 
-        string = self.escape_string(self.form.leString.text())
-        size = App.Units.Quantity(self.form.sbHeight.text()).Value
-
         Gui.doCommand("ss = FreeCAD.ActiveDocument.getObject(\"" + self.obj.Name + "\")")
-        Gui.doCommand("ss.String=\"" + string + "\"")
-        Gui.doCommand("ss.FontFile=\"" + self.font_file + "\"")
-        Gui.doCommand("ss.Size=" + str(size))
+        Gui.doCommand("ss.String=\"" + self.escape_string(self.text) + "\"")
+        Gui.doCommand("ss.FontFile=\"" + self.escape_string(self.font_file) + "\"")
+        Gui.doCommand("ss.Size=" + str(self.height))
         Gui.doCommand("ss.Placement.Base=" + toString(self.point))
         Gui.doCommand("FreeCAD.ActiveDocument.recompute()")
 

--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -357,6 +357,7 @@ def _param_from_PrefLineEdit(widget):
 
 
 def _param_from_PrefFileChooser(widget):
+    # Does not occur in Draft preferences anymore.
     for elem in list(widget):
         if "name" in elem.keys():
             att_name = elem.attrib["name"]
@@ -436,6 +437,9 @@ def _get_param_dictionary():
         "ScaleCopy":                   ("bool",      False),
         "ScaleRelative":               ("bool",      False),
         "ScaleUniform":                ("bool",      False),
+        "ShapeStringFontFile":         ("string",    ""),
+        "ShapeStringHeight":           ("float",     10.0),
+        "ShapeStringText":             ("string",    translate("draft", "Default")),
         "snapModes":                   ("string",    "100000000000000"),
         "snapRange":                   ("int",       8),
         "SubelementMode":              ("bool",      False),


### PR DESCRIPTION
With this PR 3 ShapeString parameters are stored:
* ShapeStringFontFile: this replaces the old FontFile parameter.
* ShapeStringHeight
* ShapeStringText

The ShapeStringFontFile is just the last selected font file and not exposed in the Preferences editor.

Additionally:
* Changed the label of the text input box from "String" to "Text".
* Changed the label of the point reset button to sentence case.
