### PR TITLE
BIM: Fix Python syntax error

### DIFF
--- a/src/Mod/BIM/ArchPanel.py
+++ b/src/Mod/BIM/ArchPanel.py
@@ -312,7 +312,7 @@ class _Panel(ArchComponent.Component):
                             downsegment = Part.Wire([e3,e4])
                         else:
                             r = e2.Curve.Radius+obj.Thickness.Value
-                            z = math.sqrt(r^2 - obj.WaveLength.Value^2)
+                            z = math.sqrt(r**2 - obj.WaveLength.Value**2)
                             p6 = e2.Curve.Center.add(Vector(-obj.WaveLength,0,-z))
                             p7 = e2.Curve.Center.add(Vector(0,0,-r))
                             p8 = e2.Curve.Center.add(Vector(obj.WaveLength,0,-z))


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Due to the use of an incorrect exponentiation operator the following exception was triggered when changing attributes of a wave profile:

TypeError: Unsupported operand type(s) for ^: 'float' and 'float'

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fixes #21048

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
Before: Changing the attribute “wavelength” has no effect, but leads to the exception mentioned.
 ![grafik](https://github.com/user-attachments/assets/1abfbeba-bf94-4c40-ab41-9a34424a0170)
After: The change to the “Wavelength” attribute is displayed accordingly.
![grafik](https://github.com/user-attachments/assets/8828148b-4823-4ff3-8097-05d821707d2a)

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
