### PR TITLE
BIM: close task panels on doc close

### DIFF
--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -488,6 +488,7 @@ class BIMWorkbench(Workbench):
         import BimStatus
         from nativeifc import ifc_observer
         from draftutils import grid_observer
+        from draftutils import doc_observer
 
         PARAMS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM")
 
@@ -497,6 +498,7 @@ class BIMWorkbench(Workbench):
             FreeCADGui.Snapper.show()
         WorkingPlane._view_observer_start()
         grid_observer._view_observer_setup()
+        doc_observer._doc_observer_start()
 
         if PARAMS.GetBool("FirstTime", True) and (not hasattr(FreeCAD, "TestEnvironment")):
             todo.ToDo.delay(FreeCADGui.runCommand, "BIM_Welcome")
@@ -559,7 +561,6 @@ class BIMWorkbench(Workbench):
 
         Log("BIM workbench activated\n")
 
-
     def Deactivated(self):
 
         from draftutils import todo
@@ -568,6 +569,7 @@ class BIMWorkbench(Workbench):
         import WorkingPlane
         from nativeifc import ifc_observer
         from draftutils import grid_observer
+        from draftutils import doc_observer
 
         PARAMS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM")
 
@@ -581,6 +583,7 @@ class BIMWorkbench(Workbench):
             FreeCADGui.Snapper.hide()
         WorkingPlane._view_observer_stop()
         grid_observer._view_observer_setup()
+        doc_observer._doc_observer_stop()
 
         # print("Deactivating status icon")
         todo.ToDo.delay(BimStatus.setStatusIcons, False)

--- a/src/Mod/BIM/bimcommands/BimBox.py
+++ b/src/Mod/BIM/bimcommands/BimBox.py
@@ -51,6 +51,7 @@ class BIM_Box:
         import draftguitools.gui_trackers as DraftTrackers
 
         FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
+        self.doc = FreeCAD.ActiveDocument
         self.wp = WorkingPlane.get_working_plane()
         # here we will store our points
         self.points = []
@@ -276,15 +277,14 @@ class BIM_Box:
             if self.HeightValue > 0.0:
                 pla = DraftGeomUtils.placement_from_points(p1, p3, p2)
                 self.LengthValue, self.WidthValue = self.WidthValue, self.LengthValue
-        doc = FreeCAD.ActiveDocument
-        doc.openTransaction(translate("Arch","Create Box"))
-        cube = doc.addObject("Part::Box", "Cube")
+        self.doc.openTransaction(translate("Arch","Create Box"))
+        cube = self.doc.addObject("Part::Box", "Box")
         cube.Placement = pla
         cube.Length = self.LengthValue
         cube.Width = self.WidthValue
         cube.Height = abs(self.HeightValue)
-        doc.commitTransaction()
-        doc.recompute()
+        self.doc.commitTransaction()
+        self.doc.recompute()
 
     def _finish(self):
         self.wp._restore()

--- a/src/Mod/BIM/bimcommands/BimCurtainwall.py
+++ b/src/Mod/BIM/bimcommands/BimCurtainwall.py
@@ -52,19 +52,20 @@ class Arch_CurtainWall:
 
     def Activated(self):
 
+        self.doc = FreeCAD.ActiveDocument
         sel = FreeCADGui.Selection.getSelection()
         if len(sel) > 1:
             FreeCAD.Console.PrintError(translate("Arch","Please select only one base object or none")+"\n")
         elif len(sel) == 1:
             # build on selection
             FreeCADGui.Control.closeDialog()
-            FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Curtain Wall"))
+            self.doc.openTransaction(translate("Arch","Create Curtain Wall"))
             FreeCADGui.addModule("Draft")
             FreeCADGui.addModule("Arch")
             FreeCADGui.doCommand("obj = Arch.makeCurtainWall(FreeCAD.ActiveDocument."+FreeCADGui.Selection.getSelection()[0].Name+")")
             FreeCADGui.doCommand("Draft.autogroup(obj)")
-            FreeCAD.ActiveDocument.commitTransaction()
-            FreeCAD.ActiveDocument.recompute()
+            self.doc.commitTransaction()
+            self.doc.recompute()
         else:
             # interactive line drawing
             FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
@@ -90,14 +91,14 @@ class Arch_CurtainWall:
             FreeCAD.activeDraftCommand = None
             FreeCADGui.Snapper.off()
             FreeCADGui.Control.closeDialog()
-            FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Curtain Wall"))
+            self.doc.openTransaction(translate("Arch","Create Curtain Wall"))
             FreeCADGui.addModule("Draft")
             FreeCADGui.addModule("Arch")
             FreeCADGui.doCommand("base = Draft.makeLine(FreeCAD."+str(self.points[0])+",FreeCAD."+str(self.points[1])+")")
             FreeCADGui.doCommand("obj = Arch.makeCurtainWall(base)")
             FreeCADGui.doCommand("Draft.autogroup(obj)")
-            FreeCAD.ActiveDocument.commitTransaction()
-            FreeCAD.ActiveDocument.recompute()
+            self.doc.commitTransaction()
+            self.doc.recompute()
 
 
 

--- a/src/Mod/BIM/bimcommands/BimImagePlane.py
+++ b/src/Mod/BIM/bimcommands/BimImagePlane.py
@@ -49,6 +49,7 @@ class BIM_ImagePlane:
         from PySide import QtGui
         import draftguitools.gui_trackers as DraftTrackers
 
+        self.doc = FreeCAD.ActiveDocument
         self.tracker = DraftTrackers.rectangleTracker()
         self.basepoint = None
         self.opposite = None
@@ -115,17 +116,15 @@ class BIM_ImagePlane:
             diagonal = self.opposite.sub(self.basepoint)
             length = DraftVecUtils.project(diagonal, wp.u).Length
             height = DraftVecUtils.project(diagonal, wp.v).Length
-            FreeCAD.ActiveDocument.openTransaction("Create image plane")
-            image = FreeCAD.ActiveDocument.addObject(
-                "Image::ImagePlane", "ImagePlane"
-            )
+            self.doc.openTransaction("Create image plane")
+            image = self.doc.addObject("Image::ImagePlane", "ImagePlane")
             image.Label = os.path.splitext(os.path.basename(self.filename))[0]
             image.ImageFile = self.filename
             image.Placement = FreeCAD.Placement(midpoint, rotation)
             image.XSize = length
             image.YSize = height
-            FreeCAD.ActiveDocument.commitTransaction()
-            FreeCAD.ActiveDocument.recompute()
+            self.doc.commitTransaction()
+            self.doc.recompute()
 
 
 FreeCADGui.addCommand("BIM_ImagePlane", BIM_ImagePlane())

--- a/src/Mod/BIM/bimcommands/BimPanel.py
+++ b/src/Mod/BIM/bimcommands/BimPanel.py
@@ -66,6 +66,8 @@ class Arch_Panel:
         import Draft
         import draftguitools.gui_trackers as DraftTrackers
         from draftutils import params
+
+        self.doc = FreeCAD.ActiveDocument
         self.Length = params.get_param_arch("PanelLength")
         self.Width = params.get_param_arch("PanelWidth")
         self.Thickness = params.get_param_arch("PanelThickness")
@@ -77,14 +79,14 @@ class Arch_Panel:
             if len(sel) == 1:
                 if Draft.getType(sel[0]) == "Panel":
                     return
-            FreeCAD.ActiveDocument.openTransaction(str(translate("Arch","Create Panel")))
+            self.doc.openTransaction(str(translate("Arch","Create Panel")))
             FreeCADGui.addModule("Arch")
             FreeCADGui.addModule("Draft")
             for obj in sel:
                 FreeCADGui.doCommand("obj = Arch.makePanel(FreeCAD.ActiveDocument." + obj.Name + ",thickness=" + str(self.Thickness) + ")")
                 FreeCADGui.doCommand("Draft.autogroup(obj)")
-            FreeCAD.ActiveDocument.commitTransaction()
-            FreeCAD.ActiveDocument.recompute()
+            self.doc.commitTransaction()
+            self.doc.recompute()
             return
 
         # interactive mode
@@ -111,7 +113,7 @@ class Arch_Panel:
         self.tracker.finalize()
         if point is None:
             return
-        FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Panel"))
+        self.doc.openTransaction(translate("Arch","Create Panel"))
         FreeCADGui.addModule("Arch")
         if self.Profile:
             pr = Presets[self.Profile]
@@ -123,8 +125,8 @@ class Arch_Panel:
         FreeCADGui.doCommand('s.Placement.Base = '+DraftVecUtils.toString(point))
         if self.rotated:
             FreeCADGui.doCommand('s.Placement.Rotation = FreeCAD.Rotation(FreeCAD.Vector(1.00,0.00,0.00),90.00)')
-        FreeCAD.ActiveDocument.commitTransaction()
-        FreeCAD.ActiveDocument.recompute()
+        self.doc.commitTransaction()
+        self.doc.recompute()
         if FreeCADGui.draftToolBar.continueCmd.isChecked():
             self.Activated()
 

--- a/src/Mod/BIM/bimcommands/BimProfile.py
+++ b/src/Mod/BIM/bimcommands/BimProfile.py
@@ -54,6 +54,7 @@ class Arch_Profile:
         import ArchProfile
 
         FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
+        self.doc = FreeCAD.ActiveDocument
         self.Profile = None
         self.Categories = []
         self.Presets = ArchProfile.readPresets()
@@ -118,7 +119,7 @@ class Arch_Profile:
         if not self.Profile:
             return
         pt = "FreeCAD.Vector("+str(point.x)+","+str(point.y)+","+str(point.z)+")"
-        FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Profile"))
+        self.doc.openTransaction(translate("Arch","Create Profile"))
         FreeCADGui.addModule("Arch")
         FreeCADGui.doCommand('p = Arch.makeProfile('+str(self.Profile)+')')
         FreeCADGui.addModule('WorkingPlane')
@@ -126,8 +127,8 @@ class Arch_Profile:
         FreeCADGui.doCommand('p.Placement.Base = ' + pt)
         FreeCADGui.addModule("Draft")
         FreeCADGui.doCommand("Draft.autogroup(p)")
-        FreeCAD.ActiveDocument.commitTransaction()
-        FreeCAD.ActiveDocument.recompute()
+        self.doc.commitTransaction()
+        self.doc.recompute()
 
     def setCategory(self,i):
 

--- a/src/Mod/BIM/bimcommands/BimTruss.py
+++ b/src/Mod/BIM/bimcommands/BimTruss.py
@@ -51,6 +51,7 @@ class Arch_Truss:
 
     def Activated(self):
 
+        self.doc = FreeCAD.ActiveDocument
         sel = FreeCADGui.Selection.getSelection()
         if len(sel) > 1:
             FreeCAD.Console.PrintError(translate("Arch","Please select only one base object or none")+"\n")
@@ -90,7 +91,7 @@ class Arch_Truss:
         """Creates the truss"""
 
         FreeCADGui.Control.closeDialog()
-        FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Truss"))
+        self.doc.openTransaction(translate("Arch","Create Truss"))
         FreeCADGui.addModule("Draft")
         FreeCADGui.addModule("Arch")
         if not basename:
@@ -101,8 +102,8 @@ class Arch_Truss:
                 basename = "base"
         FreeCADGui.doCommand("obj = Arch.makeTruss("+basename+")")
         FreeCADGui.doCommand("Draft.autogroup(obj)")
-        FreeCAD.ActiveDocument.commitTransaction()
-        FreeCAD.ActiveDocument.recompute()
+        self.doc.commitTransaction()
+        self.doc.recompute()
 
 
 FreeCADGui.addCommand('Arch_Truss', Arch_Truss())

--- a/src/Mod/BIM/bimcommands/BimWall.py
+++ b/src/Mod/BIM/bimcommands/BimWall.py
@@ -71,6 +71,8 @@ class Arch_Wall:
         import WorkingPlane
         from draftutils import params
         import draftguitools.gui_trackers as DraftTrackers
+
+        self.doc = FreeCAD.ActiveDocument
         self.Align = ["Center","Left","Right"][params.get_param_arch("WallAlignment")]
         self.MultiMat = None
         self.Length = None
@@ -81,44 +83,38 @@ class Arch_Wall:
         self.JOIN_WALLS_SKETCHES = params.get_param_arch("joinWallSketches")
         self.AUTOJOIN = params.get_param_arch("autoJoinWalls")
         sel = FreeCADGui.Selection.getSelectionEx()
-        done = False
         self.existing = []
         self.wp = None
 
         if sel:
             # automatic mode
             if Draft.getType(sel[0].Object) != "Wall":
-                FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Wall"))
+                self.doc.openTransaction(translate("Arch","Create Wall"))
                 FreeCADGui.addModule("Arch")
                 for selobj in sel:
-                    if Draft.getType(selobj.Object) == "Space":
-                        spacedone = False
-                        if selobj.HasSubObjects:
-                            if "Face" in selobj.SubElementNames[0]:
-                                idx = int(selobj.SubElementNames[0][4:])
-                                FreeCADGui.doCommand("obj = Arch.makeWall(FreeCAD.ActiveDocument."+selobj.Object.Name+",face="+str(idx)+")")
-                                spacedone = True
-                        if not spacedone:
-                            FreeCADGui.doCommand('obj = Arch.makeWall(FreeCAD.ActiveDocument.'+selobj.Object.Name+')')
+                    if Draft.getType(selobj.Object) == "Space" \
+                            and selobj.HasSubObjects \
+                            and "Face" in selobj.SubElementNames[0]:
+                        idx = int(selobj.SubElementNames[0][4:])
+                        FreeCADGui.doCommand("obj = Arch.makeWall(FreeCAD.ActiveDocument."+selobj.Object.Name+",face="+str(idx)+")")
                     else:
-                        FreeCADGui.doCommand('obj = Arch.makeWall(FreeCAD.ActiveDocument.'+selobj.Object.Name+')')
+                        FreeCADGui.doCommand("obj = Arch.makeWall(FreeCAD.ActiveDocument."+selobj.Object.Name+")")
                 FreeCADGui.addModule("Draft")
                 FreeCADGui.doCommand("Draft.autogroup(obj)")
-                FreeCAD.ActiveDocument.commitTransaction()
-                FreeCAD.ActiveDocument.recompute()
-                done = True
+                self.doc.commitTransaction()
+                self.doc.recompute()
+                return
 
-        if not done:
-            # interactive mode
+        # interactive mode
 
-            self.points = []
-            self.wp = WorkingPlane.get_working_plane()
-            self.tracker = DraftTrackers.boxTracker()
-            FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
-            FreeCADGui.Snapper.getPoint(callback=self.getPoint,
-                                        extradlg=self.taskbox(),
-                                        title=translate("Arch","First point of wall")+":")
-            FreeCADGui.draftToolBar.continueCmd.show()
+        FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
+        self.points = []
+        self.wp = WorkingPlane.get_working_plane()
+        self.tracker = DraftTrackers.boxTracker()
+        FreeCADGui.Snapper.getPoint(callback=self.getPoint,
+                                    extradlg=self.taskbox(),
+                                    title=translate("Arch","First point of wall")+":")
+        FreeCADGui.draftToolBar.continueCmd.show()
 
     def getPoint(self,point=None,obj=None):
         """Callback for clicks during interactive mode.
@@ -144,9 +140,9 @@ class Arch_Wall:
                 if not obj in self.existing:
                     self.existing.append(obj)
         if point is None:
-            self.tracker.finalize()
             FreeCAD.activeDraftCommand = None
             FreeCADGui.Snapper.off()
+            self.tracker.finalize()
             return
         self.points.append(point)
         if len(self.points) == 1:
@@ -160,12 +156,12 @@ class Arch_Wall:
                                         title=translate("Arch","Next point")+":",mode="line")
 
         elif len(self.points) == 2:
-            l = Part.LineSegment(self.wp.get_local_coords(self.points[0]),
-                                 self.wp.get_local_coords(self.points[1]))
-            self.tracker.off()
             FreeCAD.activeDraftCommand = None
             FreeCADGui.Snapper.off()
-            FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Wall"))
+            self.tracker.off()
+            l = Part.LineSegment(self.wp.get_local_coords(self.points[0]),
+                                 self.wp.get_local_coords(self.points[1]))
+            self.doc.openTransaction(translate("Arch","Create Wall"))
             FreeCADGui.addModule("Arch")
             FreeCADGui.doCommand('import Part')
             FreeCADGui.doCommand('trace=Part.LineSegment(FreeCAD.'+str(l.StartPoint)+',FreeCAD.'+str(l.EndPoint)+')')
@@ -183,16 +179,16 @@ class Arch_Wall:
                             # if not possible, add new wall as addition to the existing one
                             self.addDefault()
                             if self.AUTOJOIN:
-                                FreeCADGui.doCommand('Arch.addComponents(FreeCAD.ActiveDocument.'+FreeCAD.ActiveDocument.Objects[-1].Name+',FreeCAD.ActiveDocument.'+w.Name+')')
+                                FreeCADGui.doCommand('Arch.addComponents(FreeCAD.ActiveDocument.'+self.doc.Objects[-1].Name+',FreeCAD.ActiveDocument.'+w.Name+')')
                     else:
                         self.addDefault()
                 else:
                     # add new wall as addition to the first existing one
                     self.addDefault()
                     if self.AUTOJOIN:
-                        FreeCADGui.doCommand('Arch.addComponents(FreeCAD.ActiveDocument.'+FreeCAD.ActiveDocument.Objects[-1].Name+',FreeCAD.ActiveDocument.'+self.existing[0].Name+')')
-            FreeCAD.ActiveDocument.commitTransaction()
-            FreeCAD.ActiveDocument.recompute()
+                        FreeCADGui.doCommand('Arch.addComponents(FreeCAD.ActiveDocument.'+self.doc.Objects[-1].Name+',FreeCAD.ActiveDocument.'+self.existing[0].Name+')')
+            self.doc.commitTransaction()
+            self.doc.recompute()
             # gui_utils.end_all_events()  # Causes a crash on Linux.
             self.tracker.finalize()
             if FreeCADGui.draftToolBar.continueCmd.isChecked():
@@ -283,7 +279,7 @@ class Arch_Wall:
         matCombo.setToolTip(translate("Arch","This list shows all the MultiMaterials objects of this document. Create some to define wall types."))
         self.multimats = []
         self.MultiMat = None
-        for o in FreeCAD.ActiveDocument.Objects:
+        for o in self.doc.Objects:
             if Draft.getType(o) == "MultiMaterial":
                 self.multimats.append(o)
                 matCombo.addItem(o.Label)
@@ -396,13 +392,13 @@ class Arch_Wall:
     def createFromGUI(self):
         """Callback to create wall by using the _CommandWall.taskbox()"""
 
-        FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Wall"))
+        self.doc.openTransaction(translate("Arch","Create Wall"))
         FreeCADGui.addModule("Arch")
         FreeCADGui.doCommand('wall = Arch.makeWall(length='+str(self.lengthValue)+',width='+str(self.Width)+',height='+str(self.Height)+',align="'+str(self.Align)+'")')
         if self.MultiMat:
             FreeCADGui.doCommand("wall.Material = FreeCAD.ActiveDocument."+self.MultiMat.Name)
-        FreeCAD.ActiveDocument.commitTransaction()
-        FreeCAD.ActiveDocument.recompute()
+        self.doc.commitTransaction()
+        self.doc.recompute()
         if hasattr(FreeCADGui,"draftToolBar"):
             FreeCADGui.draftToolBar.escape()
 

--- a/src/Mod/BIM/bimcommands/BimWindow.py
+++ b/src/Mod/BIM/bimcommands/BimWindow.py
@@ -62,6 +62,8 @@ class Arch_Window:
         import Draft
         import WorkingPlane
         import draftguitools.gui_trackers as DraftTrackers
+
+        self.doc = FreeCAD.ActiveDocument
         self.sel = FreeCADGui.Selection.getSelection()
         self.W1 = params.get_param_arch("WindowW1")  # thickness of the fixed frame
         if self.doormode:
@@ -100,7 +102,7 @@ class Arch_Window:
                         if obj.Objects[0].Inlist:
                             host = obj.Objects[0].Inlist[0]
 
-                    FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Window"))
+                    self.doc.openTransaction(translate("Arch","Create Window"))
                     FreeCADGui.addModule("Arch")
                     FreeCADGui.doCommand("win = Arch.makeWindow(FreeCAD.ActiveDocument."+obj.Name+")")
                     if host and self.Include:
@@ -111,19 +113,19 @@ class Arch_Window:
                             if not sibling in sibs:
                                 sibs.append(sibling)
                                 FreeCADGui.doCommand("win.Hosts = win.Hosts+[FreeCAD.ActiveDocument."+sibling.Name+"]")
-                    FreeCAD.ActiveDocument.commitTransaction()
-                    FreeCAD.ActiveDocument.recompute()
+                    self.doc.commitTransaction()
+                    self.doc.recompute()
                     return
 
                 # Try to detect an object to use as a window type - TODO we must make this safer
 
                 elif obj.Shape.Solids and (Draft.getType(obj) not in ["Wall","Structure","Roof"]):
                     # we consider the selected object as a type
-                    FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Window"))
+                    self.doc.openTransaction(translate("Arch","Create Window"))
                     FreeCADGui.addModule("Arch")
                     FreeCADGui.doCommand("Arch.makeWindow(FreeCAD.ActiveDocument."+obj.Name+")")
-                    FreeCAD.ActiveDocument.commitTransaction()
-                    FreeCAD.ActiveDocument.recompute()
+                    self.doc.commitTransaction()
+                    self.doc.recompute()
                     return
 
         # interactive mode
@@ -171,7 +173,7 @@ class Arch_Window:
         if self.sel:
             obj = self.sel[0]
         point = point.add(FreeCAD.Vector(0,0,self.Sill))
-        FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Window"))
+        self.doc.openTransaction(translate("Arch","Create Window"))
 
         FreeCADGui.doCommand("import FreeCAD, Arch, DraftGeomUtils, WorkingPlane")
         FreeCADGui.doCommand("wp = WorkingPlane.get_working_plane()")
@@ -188,11 +190,11 @@ class Arch_Window:
         if self.Preset >= len(WindowPresets):
             preset = False
             # library object
-            col = FreeCAD.ActiveDocument.Objects
+            col = self.doc.Objects
             path = self.librarypresets[self.Preset - len(WindowPresets)][1]
             FreeCADGui.doCommand("FreeCADGui.ActiveDocument.mergeProject('" + path + "')")
             # find the latest added window
-            nol = FreeCAD.ActiveDocument.Objects
+            nol = self.doc.Objects
             for o in nol[len(col):]:
                 if Draft.getType(o) == "Window":
                     if Draft.getType(o.Base) != "Sketcher::SketchObject":
@@ -246,8 +248,8 @@ class Arch_Window:
                     if SketchArch:
                         ArchSketchObject.attachToHost(w, target=host, pl=wPl)
 
-        FreeCAD.ActiveDocument.commitTransaction()
-        FreeCAD.ActiveDocument.recompute()
+        self.doc.commitTransaction()
+        self.doc.recompute()
         # gui_utils.end_all_events()  # Causes a crash on Linux.
         self.tracker.finalize()
         return
@@ -265,7 +267,7 @@ class Arch_Window:
         if info:
             if "Face" in info['Component']:
                 import DraftGeomUtils
-                o = FreeCAD.ActiveDocument.getObject(info['Object'])
+                o = self.doc.getObject(info['Object'])
                 self.baseFace = [o,int(info['Component'][4:])-1]
                 #print("switching to ",o.Label," face ",self.baseFace[1])
                 f = o.Shape.Faces[self.baseFace[1]]

--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -498,11 +498,10 @@ class Arc_3Points(gui_base.GuiCommandBase):
 
         Gui.Snapper.getPoint(callback=self.getPoint,
                              movecallback=self.drawArc)
-        self.ui = Gui.Snapper.ui  ## self must have a ui for _finish_command_on_doc_close in doc_observer.py.
-        self.ui.sourceCmd = self
-        self.ui.setTitle(title=translate("draft", "Arc by 3 points"),
-                         icon="Draft_Arc_3Points")
-        self.ui.continueCmd.show()
+        Gui.Snapper.ui.sourceCmd = self
+        Gui.Snapper.ui.setTitle(title=translate("draft", "Arc by 3 points"),
+                                icon="Draft_Arc_3Points")
+        Gui.Snapper.ui.continueCmd.show()
 
     def getPoint(self, point, info):
         """Get the point by clicking on the 3D view.
@@ -543,11 +542,10 @@ class Arc_3Points(gui_base.GuiCommandBase):
             Gui.Snapper.getPoint(last=self.points[-1],
                                  callback=self.getPoint,
                                  movecallback=self.drawArc)
-            self.ui = Gui.Snapper.ui
-            self.ui.sourceCmd = self
-            self.ui.setTitle(title=translate("draft", "Arc by 3 points"),
-                             icon="Draft_Arc_3Points")
-            self.ui.continueCmd.show()
+            Gui.Snapper.ui.sourceCmd = self
+            Gui.Snapper.ui.setTitle(title=translate("draft", "Arc by 3 points"),
+                                    icon="Draft_Arc_3Points")
+            Gui.Snapper.ui.continueCmd.show()
 
         else:
             # If three points were already picked in the 3D view

--- a/src/Mod/Draft/draftutils/doc_observer.py
+++ b/src/Mod/Draft/draftutils/doc_observer.py
@@ -1,3 +1,27 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2025 FreeCAD Project Association                        *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
 import FreeCAD as App
 
 if App.GuiUp:
@@ -34,9 +58,13 @@ if App.GuiUp:
         and use a task panel.
         """
         if getattr(App, "activeDraftCommand", None) \
-                and getattr(App.activeDraftCommand, "doc", None) == gui_doc.Document \
-                and getattr(App.activeDraftCommand, "ui", None):
-            if hasattr(App.activeDraftCommand.ui, "reject"):
-                ToDo.delay(App.activeDraftCommand.ui.reject, None)
-            elif hasattr(App.activeDraftCommand.ui, "escape"):
-                ToDo.delay(App.activeDraftCommand.ui.escape, None)
+                and getattr(App.activeDraftCommand, "doc", None) == gui_doc.Document:
+            if hasattr(App.activeDraftCommand, "ui"):
+                if hasattr(App.activeDraftCommand.ui, "reject"):
+                    ToDo.delay(App.activeDraftCommand.ui.reject, None)
+                elif hasattr(App.activeDraftCommand.ui, "escape"):
+                    ToDo.delay(App.activeDraftCommand.ui.escape, None)
+            elif hasattr(Gui, "Snapper") \
+                    and hasattr(Gui.Snapper, "ui") \
+                    and hasattr(Gui.Snapper.ui, "escape"):
+                ToDo.delay(Gui.Snapper.ui.escape, None)


### PR DESCRIPTION
Fixes #17952.

This PR is a continuation of #20719.

It mainly involves adding `self.doc`. This new attribute is then also used in the rest of the modified classes. In some cases code was slightly reordered for consistency.

The `_finish_command_on_doc_close` function has been modifief to also handle `Gui.Snapper.ui.escape` and the code in gui_arcs.py has been updated accordingly.

Additionally:
Removed the `done` and `spacedone` variables in BimWall.py by tweaking the code.
