### PR TITLE
CI: Add weekly build notes.

### DIFF
--- a/.github/workflows/sub_weeklyBuild.yml
+++ b/.github/workflows/sub_weeklyBuild.yml
@@ -46,7 +46,7 @@ jobs:
              rm \$sha1.tar"
           gzip freecad_source_${BUILD_TAG}.tar
           sha256sum freecad_source_${BUILD_TAG}.tar.gz > freecad_source_${BUILD_TAG}.tar.gz-SHA256.txt
-          gh release create ${BUILD_TAG} --title "Development Build ${BUILD_TAG}" --notes "Development Build ${BUILD_TAG}" --prerelease || true
+          gh release create ${BUILD_TAG} --title "Development Build ${BUILD_TAG}" -F .github/workflows/weekly-build-notes.md --prerelease || true
           gh release upload --clobber ${BUILD_TAG} "freecad_source_${BUILD_TAG}.tar.gz" "freecad_source_${BUILD_TAG}.tar.gz-SHA256.txt"
 
   build:

--- a/.github/workflows/weekly-build-notes.md
+++ b/.github/workflows/weekly-build-notes.md
@@ -1,0 +1,21 @@
+# Weekly Development Build
+
+## How-to use
+
+Download the appropriate asset for your OS below
+
+Unpack the bundle to any folder on your system
+
+Launch the application
+
+* **Windows**
+
+    Run `\bin\FreeCAD.exe` in the extracted directory
+
+* **macOS**
+
+    Launch `/FreeCAD.app` in the extracted directory
+
+* **Linux**
+
+    Open the *.AppImage


### PR DESCRIPTION
Adds notes to the weekly releases with usage instructions.

The file `.github/workflows/weekly-build-notes.md` contains the build notes to be used for the weekly release.  We could add templating if we want to provide customization to each release.

## Issues

Addresses request in https://github.com/FreeCAD/FreeCAD/pull/21053

## Before and After Images

N/A