### PR TITLE
[TechDraw] correct extra Tag property back to VertexTag in Document.xml

### DIFF
--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -1335,7 +1335,7 @@ void Vertex::Save(Base::Writer &writer) const
 //    const char r = reference?'1':'0';
 //    writer.Stream() << writer.ind() << "<Reference value=\"" <<  r << "\"/>" << endl;
 
-    Tag::Save(writer);
+    writer.Stream() << writer.ind() << "<VertexTag value=\"" << Tag::getTagAsString() << "\"/>" << endl;
 }
 
 void Vertex::Restore(Base::XMLReader &reader)


### PR DESCRIPTION
On inspection of the output _Document.xml_ of a working file and a failing file it was determined there was an extra `Tag` property which should have been `VertexTag` see https://github.com/FreeCAD/FreeCAD/issues/21069#issuecomment-2844747150, this PR fixes the output and now the file opens error free.

## Issues
fixes #21069 
