### PR TITLE
[TD]Allow non-shape views to have children (#20768)

### DIFF
--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -442,9 +442,9 @@ DrawView *DrawView::claimParent() const
 //! return *unique* list of DrawView derived items which consider this DVP to be their 'owner'
 //! if a dimension has two references to this dvp, it will appear twice in the inlist, so we need to
 //! pick out duplicates.
-std::vector<TechDraw::DrawView*> DrawView::getUniqueChildren() const
+std::vector<DrawView*> DrawView::getUniqueChildren() const
 {
-    std::vector<TechDraw::DrawView*> result;
+    std::vector<DrawView*> result;
     auto children = getInList();
     std::sort(children.begin(), children.end(), std::less<>());
     auto newEnd = std::unique(children.begin(), children.end());

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -439,6 +439,28 @@ DrawView *DrawView::claimParent() const
     return getCollection();
 }
 
+//! return *unique* list of DrawView derived items which consider this DVP to be their 'owner'
+//! if a dimension has two references to this dvp, it will appear twice in the inlist, so we need to
+//! pick out duplicates.
+std::vector<TechDraw::DrawView*> DrawView::getUniqueChildren() const
+{
+    std::vector<TechDraw::DrawView*> result;
+    auto children = getInList();
+    std::sort(children.begin(), children.end(), std::less<>());
+    auto newEnd = std::unique(children.begin(), children.end());
+    children.erase(newEnd, children.end());
+    for (auto& child : children) {
+        if (child->isDerivedFrom<DrawView>()) {
+            auto* childDV = static_cast<TechDraw::DrawView*>(child);
+            if (childDV->claimParent() == this) {
+                result.push_back(childDV);
+            }
+        }
+    }
+    return result;
+}
+
+
 DrawViewClip* DrawView::getClipGroup()
 {
     for (auto* obj : getInList()) {

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -450,11 +450,9 @@ std::vector<TechDraw::DrawView*> DrawView::getUniqueChildren() const
     auto newEnd = std::unique(children.begin(), children.end());
     children.erase(newEnd, children.end());
     for (auto& child : children) {
-        if (child->isDerivedFrom<DrawView>()) {
-            auto* childDV = static_cast<TechDraw::DrawView*>(child);
-            if (childDV->claimParent() == this) {
-                result.push_back(childDV);
-            }
+        auto* childDV = freecad_cast<DrawView*>(child);
+        if (childDV && childDV->claimParent() == this) {
+            result.push_back(childDV);
         }
     }
     return result;

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -87,6 +87,7 @@ public:
     virtual DrawPage* findParentPage() const;
     virtual std::vector<DrawPage*> findAllParentPages() const;
     virtual DrawView *claimParent() const;
+    std::vector<TechDraw::DrawView*> getUniqueChildren() const;
 
     virtual int countParentPages() const;
     virtual QRectF getRect() const;                      //must be overridden by derived class

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -518,7 +518,7 @@ std::vector<App::DocumentObject*> ViewProviderDrawingView::claimChildren() const
     const std::vector<App::DocumentObject *> &potentialChildren = getViewObject()->getInList();
     try {
       for(auto& child : potentialChildren) {
-          auto view = dynamic_cast<TechDraw::DrawView *>(child);
+          auto* view = freecad_cast<DrawView *>(child);
           if (view && view->claimParent() == getViewObject()) {
               temp.push_back(view);
               continue;

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -498,8 +498,8 @@ void ViewProviderDrawingView::fixSceneDependencies()
     // this is the logic for items other than Dimensions and Balloons
     auto children = getViewObject()->getUniqueChildren();
     for (auto& child : children) {
-        if (child->isDerivedFrom<TechDraw::DrawViewDimension>() ||
-            child->isDerivedFrom<TechDraw::DrawViewBalloon>() ) {
+        if (child->isDerivedFrom<DrawViewDimension>() ||
+            child->isDerivedFrom<DrawViewBalloon>() ) {
             // these are handled by ViewProviderViewPart
             continue;
         }

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
@@ -99,6 +99,10 @@ public:
 
     const char* whoAmI() const;
 
+    virtual void fixSceneDependencies();
+    std::vector<App::DocumentObject*> claimChildren() const override;
+
+
 private:
     void multiParentPaint(std::vector<TechDraw::DrawPage*>& pages);
     void singleParentPaint(const TechDraw::DrawView* dv);


### PR DESCRIPTION
This PR implements a fix for issue #20768.

Views such as Symbols (or DraftView, BIMView,...) that do not display a shape (anything not derived from DrawViewPart) were not envisioned as having children.  This PR allows these views to claim their children.