### PR TITLE
CI: add missing command line args to codespell.py.

### DIFF
--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -305,7 +305,7 @@ jobs:
         continue-on-error: ${{ inputs.codespellFailSilent }}
         run: |
           python3 tools/lint/codespell.py \
-            --files "${{ inputs.changedFiles }}" \
+            --files ${{ inputs.changedFiles }} \
             --ignore-words "${{ inputs.listIgnoredMisspelling }}" \
             --skip "${{ inputs.spellingIgnore }}" \
             --log-dir "${{ env.logdir }}" \

--- a/tools/lint/codespell.py
+++ b/tools/lint/codespell.py
@@ -81,7 +81,7 @@ def main():
     )
     parser.add_argument(
         "--verbose",
-        default=False,
+        action='store_true',
         help="Use verbose output."
     )
     args = parser.parse_args()

--- a/tools/lint/codespell.py
+++ b/tools/lint/codespell.py
@@ -107,7 +107,7 @@ def main():
         args.skip,
         "-D",
         dictionary_file,
-    ] + args.files.split()
+    ] + args.files
     stdout, stderr, _ = run_command(cmd)
     output = stdout + "\n" + stderr + "\n"
 

--- a/tools/lint/codespell.py
+++ b/tools/lint/codespell.py
@@ -55,12 +55,34 @@ def main():
         description="Run codespell on files and append a Markdown report."
     )
     parser.add_argument(
+        "--files",
+        action="extend",
+        nargs="+",
+        required=True,
+        help="List of files to spell check."
+    )
+    parser.add_argument(
         "--ignore-words",
         required=True,
         help="Comma-separated list of words to ignore (from codespellignore).",
     )
     parser.add_argument(
+        "--log-dir",
+        required=True,
+        help="Directory to store the log file."
+    )
+    parser.add_argument(
+        "--report-file",
+        required=True,
+        help="Name of the report file."
+    )
+    parser.add_argument(
         "--skip", required=True, help="Comma-separated list of file patterns to skip."
+    )
+    parser.add_argument(
+        "--verbose",
+        default=False,
+        help="Use verbose output."
     )
     args = parser.parse_args()
     init_environment(args)


### PR DESCRIPTION
Adds missing command line arguments to `tools/lint/codespell.py` that were breaking the CI linting process.

## Issues

https://github.com/FreeCAD/FreeCAD/issues/21121

## Before and After Images

N/A