### PR TITLE
BIM: Pass correct object for Compass while updating Visibility property

### DIFF
--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -1069,7 +1069,7 @@ class _ViewProviderSite:
                     self.windroseswitch.whichChild = -1
         elif prop == 'Visibility':
             if vobj.Visibility:
-                self.updateCompassVisibility(self.Object)
+                self.updateCompassVisibility(vobj)
             else:
                 self.compass.hide()
         elif prop == 'Orientation':


### PR DESCRIPTION
Currently, if user selects `Site` object in the Model tree, and hides it while having `Compass` property selected to `true` and then unhides it, the Compass is not appearing even though the property still remains to be true.

This is because for the `Compass` property itself and `Visibility` property we're using two different object types. For `Compass` property we're using View provider geometry object, whereas for the `Visibility` property we're using `Part::Feature` object. Since `Part::Feature` object doesn't have compass attribute and Compass directly under it, we're never hitting the logic to show the compass.

So, this patch just changes the object type that is being passed to `updateCompassVisibility` during change of `Visibility` property, to match the same object type passed during change of `Compass` property.

Demo:

https://github.com/user-attachments/assets/000404db-1c6b-47a9-b72a-a3fa35ca0563


Resolves: https://github.com/FreeCAD/FreeCAD/issues/20999