### PR TITLE
CMake: Do not optimize debug builds.

### DIFF
--- a/cMake/FreeCAD_Helpers/SetGlobalCompilerAndLinkerSettings.cmake
+++ b/cMake/FreeCAD_Helpers/SetGlobalCompilerAndLinkerSettings.cmake
@@ -20,12 +20,12 @@ macro(SetGlobalCompilerAndLinkerSettings)
     endif()
 
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-        # Only add -Og if no -O* optimization flag exists
+        # Only add -O0 if no -O* optimization flag exists
         if (NOT "${CMAKE_C_FLAGS_DEBUG}" MATCHES "-O[a-z0-9]+")
-            set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Og")
+            set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")
         endif()
         if (NOT "${CMAKE_CXX_FLAGS_DEBUG}" MATCHES "-O[a-z0-9]+")
-            set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og")
+            set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
         endif()
     endif()
     if(MSVC)


### PR DESCRIPTION
Optimization of any level eliminates macros from the resulting binary.  As the FreeCAD typing system relies heavily on macros, this eliminates a vital source of debugging information.

This PR sets the optimization to `-O0` on debug builds to ensure that the macros are not optimized away.

## Issues

https://github.com/FreeCAD/FreeCAD/pull/20780#issuecomment-2821239890

## Before and After Images

N/A