### PR TITLE
Base: use nullptr instead of 0 in Base.

### DIFF
--- a/src/Base/BaseClass.h
+++ b/src/Base/BaseClass.h
@@ -102,7 +102,7 @@ private:                                                                        
     Base::Type _class_::classTypeId = Base::Type::BadType;                                         \
     void* _class_::create(void)                                                                    \
     {                                                                                              \
-        return 0;                                                                                  \
+        return nullptr;                                                                            \
     }
 
 


### PR DESCRIPTION
Returns `nullptr` instead of `0` in Base.

## Issues

None

## Before and After Images

N/A