### PR TITLE
CI: add missing token to fix weekly build.

### DIFF
--- a/.github/workflows/sub_weeklyBuild.yml
+++ b/.github/workflows/sub_weeklyBuild.yml
@@ -2,6 +2,7 @@ name: Weekly Build
 on:
   schedule:
    - cron: "42 18 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -25,6 +26,8 @@ jobs:
       - name: Tag Build
         id: tag_build
         shell: bash -l {0}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           export BUILD_TAG=weekly-$(date "+%Y.%m.%d")
           echo "BUILD_TAG=${BUILD_TAG}" >> "$GITHUB_ENV"
@@ -32,6 +35,7 @@ jobs:
           gh release create ${BUILD_TAG} --title "Development Build ${BUILD_TAG}" -F .github/workflows/weekly-build-notes.md --prerelease || true
 
       - name: Upload Source
+        shell: bash -l {0}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
CI: add missing token to fix weekly build.

Also adds the `on:workflow_dispatch` so that a weekly build may be manually triggered, as needed.

## Issues

None, yet!

## Before and After Images

N/A