### PR TITLE
Point OndselSolver to FreeCAD's organization's repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/3rdParty/OndselSolver"]
 	path = src/3rdParty/OndselSolver
-	url = https://github.com/Ondsel-Development/OndselSolver.git
+	url = https://github.com/FreeCAD/OndselSolver.git
 [submodule "tests/lib"]
 	path = tests/lib
 	url = https://github.com/google/googletest


### PR DESCRIPTION
This will point our existing submodule to the newly forked OndselSolver into FreeCAD/OndselSolver.

Syncing and update submodule should work, but if it doesn't then the following will reset it (+ remove all local changes):
```sh
git submodule deinit -f src/3rdParty/OndselSolver
git submodule update --init --recursive src/3rdParty/OndselSolver
```