### PR TITLE
macOS: Remove QT_MAC_WANTS_LAYER=1, which is no longer valid.

### DIFF
--- a/package/rattler-build/osx/launcher/FreeCAD.cpp
+++ b/package/rattler-build/osx/launcher/FreeCAD.cpp
@@ -31,7 +31,6 @@ int main(int argc, char *argv[], char *const *envp) {
     env["LANG"]                 = "UTF-8";                       // https://forum.freecad.org/viewtopic.php?f=22&t=42644
     env["SSL_CERT_FILE"]        = prefix + "/ssl/cacert.pem";    // https://forum.freecad.org/viewtopic.php?f=3&t=42825
     env["GIT_SSL_CAINFO"]       = prefix + "/ssl/cacert.pem";
-    env["QT_MAC_WANTS_LAYER"]   = "1";
 
     char **new_env = new char*[env.size() + 1];
     int i = 0;


### PR DESCRIPTION
macOS: Remove QT_MAC_WANTS_LAYER=1, which is no longer valid.

This removes annoying terminal messages that this setting is no longer supported.

## Issues

None.

## Before and After Images

N/A