### PR TITLE
macOS: Do not force LANG=UTF-8, which is not valid.

### DIFF
--- a/package/rattler-build/osx/launcher/FreeCAD.cpp
+++ b/package/rattler-build/osx/launcher/FreeCAD.cpp
@@ -28,7 +28,6 @@ int main(int argc, char *argv[], char *const *envp) {
     env["PYTHONHOME"]           = prefix;
     env["FONTCONFIG_FILE"]      = "/etc/fonts/fonts.conf";
     env["FONTCONFIG_PATH"]      = "/etc/fonts";
-    env["LANG"]                 = "UTF-8";                       // https://forum.freecad.org/viewtopic.php?f=22&t=42644
     env["SSL_CERT_FILE"]        = prefix + "/ssl/cacert.pem";    // https://forum.freecad.org/viewtopic.php?f=3&t=42825
     env["GIT_SSL_CAINFO"]       = prefix + "/ssl/cacert.pem";
     env["QT_MAC_WANTS_LAYER"]   = "1";


### PR DESCRIPTION
macOS: Do not force LANG=UTF-8, which is not valid.  Assuming that the user's locale is a valid UTF-8 locale, this will remove warnings that Qt is not able to detect a valid locale and substituting a different one.

## Issues

None.

## Before and After Images

None.