### PR TITLE
Linux: Force QT_QPA_PLATFORM=xcb for Wayland compat.

### DIFF
--- a/package/rattler-build/linux/AppDir/AppRun
+++ b/package/rattler-build/linux/AppDir/AppRun
@@ -9,6 +9,9 @@ export PATH_TO_FREECAD_LIBDIR=${HERE}/usr/lib
 export FONTCONFIG_FILE=/etc/fonts/fonts.conf
 export FONTCONFIG_PATH=/etc/fonts
 
+# Fix: Use X to run on Wayland
+export QT_QPA_PLATFORM=xcb
+
 # Show packages info if DEBUG env variable is set
 if [ "$DEBUG" = 1 ]; then
     cat ${HERE}/packages.txt


### PR DESCRIPTION
Linux: Force QT_QPA_PLATFORM=xcb for Wayland compatibility.

## Issues

* https://github.com/FreeCAD/FreeCAD/issues/19352
* https://github.com/FreeCAD/FreeCAD/issues/20238
* https://github.com/FreeCAD/FreeCAD/issues/17982
* https://github.com/FreeCAD/FreeCAD/issues/18036
* https://github.com/FreeCAD/FreeCAD/issues/18242
* https://github.com/FreeCAD/FreeCAD/issues/8341

## Before and After Images

N/A