### PR TITLE
Gui: use 'C.UTF-8' for locale as Qt requires UTF-8.

### DIFF
--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -279,7 +279,7 @@ void StartupPostProcess::setLocale()
             hGrp->GetASCII("Language", Translator::instance()->activeLanguage().c_str()));
     }
     else if (localeFormat == 2) {
-        Translator::instance()->setLocale("C");
+        Translator::instance()->setLocale("C.UTF-8");
     }
 }
 


### PR DESCRIPTION
Gui: use 'C.UTF-8' for locale as Qt requires UTF-8.

## Issues

* https://github.com/FreeCAD/FreeCAD/issues/15061

## Before and After Images

N/A