### PR TITLE
FEM: Fix test if VTK or VTK python is not available

### DIFF
--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -1653,7 +1653,9 @@ void FemMesh::read(const char* FileName)
 
 void FemMesh::writeVTK(const std::string& fileName, bool highest) const
 {
+#ifdef FC_USE_VTK
     FemVTKTools::writeVTKMesh(fileName.c_str(), this, highest);
+#endif
 }
 
 void FemMesh::writeABAQUS(const std::string& Filename,

--- a/src/Mod/Fem/Gui/CMakeLists.txt
+++ b/src/Mod/Fem/Gui/CMakeLists.txt
@@ -43,11 +43,17 @@ SET(Python_SRCS
     ViewProviderFemConstraintPyImp.cpp
     ViewProviderFemMeshPy.xml
     ViewProviderFemMeshPyImp.cpp
-    ViewProviderFemPostPipelinePy.xml
-    ViewProviderFemPostPipelinePyImp.cpp
-    ViewProviderFemPostFilterPy.xml
-    ViewProviderFemPostFilterPyImp.cpp
 )
+if(BUILD_FEM_VTK)
+    set(Python_SRCS
+        ${Python_SRCS}
+        ViewProviderFemPostPipelinePy.xml
+        ViewProviderFemPostPipelinePyImp.cpp
+        ViewProviderFemPostFilterPy.xml
+        ViewProviderFemPostFilterPyImp.cpp
+    )
+endif(BUILD_FEM_VTK)
+
 SOURCE_GROUP("Python" FILES ${Python_SRCS})
 
 

--- a/src/Mod/Fem/feminout/importCcxFrdResults.py
+++ b/src/Mod/Fem/feminout/importCcxFrdResults.py
@@ -63,6 +63,9 @@ def setupPipeline(doc, analysis, results_name, result_data):
     import ObjectsFem
     from . import importToolsFem
 
+    if not "BUILD_FEM_VTK" in FreeCAD.__cmake__:
+        return
+
     # create a results pipeline if not already existing
     pipeline_name = "Pipeline_" + results_name
     pipeline_obj = doc.getObject(pipeline_name)

--- a/src/Mod/Fem/femtest/app/test_common.py
+++ b/src/Mod/Fem/femtest/app/test_common.py
@@ -122,8 +122,13 @@ class TestFemCommon(unittest.TestCase):
             fcc_print(f"Try importing {mod} ...")
             try:
                 im = __import__(f"{mod}")
-            except ImportError:
-                im = False
+            except ImportError as e:
+                # check if it is a VTK module that is missing, because maybe we should not need it
+                if "vtkmodules" in e.name and \
+                   not "BUILD_FEM_VTK_PYTHON" in FreeCAD.__cmake__:
+                       im = True
+                else:
+                    im = False
             if not im:
                 # to get an error message what was going wrong
                 __import__(f"{mod}")

--- a/src/Mod/Fem/femtest/app/test_common.py
+++ b/src/Mod/Fem/femtest/app/test_common.py
@@ -124,9 +124,8 @@ class TestFemCommon(unittest.TestCase):
                 im = __import__(f"{mod}")
             except ImportError as e:
                 # check if it is a VTK module that is missing, because maybe we should not need it
-                if "vtkmodules" in e.name and \
-                   not "BUILD_FEM_VTK_PYTHON" in FreeCAD.__cmake__:
-                       im = True
+                if "vtkmodules" in e.name and not "BUILD_FEM_VTK_PYTHON" in FreeCAD.__cmake__:
+                    im = True
                 else:
                     im = False
             if not im:

--- a/src/Mod/Fem/femtest/app/test_object.py
+++ b/src/Mod/Fem/femtest/app/test_object.py
@@ -68,10 +68,9 @@ class TestObjectCreate(unittest.TestCase):
 
         # count the def make in ObjectsFem module
         # if FEM VTK post processing is disabled, we are not able to create VTK post objects
-        if "BUILD_FEM_VTK" in FreeCAD.__cmake__:
-            count_defmake = testtools.get_defmake_count()
-        else:
-            count_defmake = testtools.get_defmake_count(False)
+        vtk_objects_used = "BUILD_FEM_VTK" in FreeCAD.__cmake__
+        count_defmake = testtools.get_defmake_count(vtk_objects_used)
+
         # TODO if the children are added to the analysis, they show up twice on Tree
         # thus they are not added to the analysis group ATM
         # https://forum.freecad.org/viewtopic.php?t=25283
@@ -79,16 +78,23 @@ class TestObjectCreate(unittest.TestCase):
         # solver children: equations --> 10
         # gmsh mesh children: group, region, boundary layer --> 3
         # result children: mesh result --> 1
-        # post pipeline children: region, scalar, cut, wrap --> 5
         # analysis itself is not in analysis group --> 1
+        # vtk post pipeline children: region, scalar, cut, wrap, glyph --> 5
         # vtk python post objects: glyph --> 1
 
-        subtraction = 20
-        if "BUILD_FEM_VTK_PYTHON" in FreeCAD.__cmake__:
-            subtraction += 1
+        subtraction = 15
+        if vtk_objects_used:
+            subtraction += 6
 
         self.assertEqual(len(doc.Analysis.Group), count_defmake - subtraction)
-        self.assertEqual(len(doc.Objects), count_defmake)
+
+        # if vtk used, but python API is not available, the vtk python based objects "def make" functions
+        # have been counted, but will not be executed to create objects
+        failed = 0
+        if vtk_objects_used and not ("BUILD_FEM_VTK_PYTHON" in FreeCAD.__cmake__):
+            failed += 1
+
+        self.assertEqual(len(doc.Objects), count_defmake - failed)
 
         fcc_print(
             "doc objects count: {}, method: {}".format(


### PR DESCRIPTION
It seems I introduced a failing FEM test for the case  BUILD_FEM_VTK_PYTHON=OFF with my latest commits. This pull request fixes this.

Additionally:
- Fixes FEM build with BUILD_FEM_VTK=OFF
- Fixes FEM tests with BUILD_FEM_VTK=OFF

I tested all locally and should work fine now.

Thanks HighwayStar for reporting and helping with fixing it.