### PR TITLE
CAM: Fix adaptive repeating cuts excessively at various depths

### DIFF
--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -1319,11 +1319,18 @@ def _getWorkingEdges(op, obj):
                     rcut = stockProjectionDict[depths[0]]
                 else:
                     rcut = stockProjectionDict[depths[0]].cut(r["region"])
-            parentdepths = depths[0:1]
+
+            # If the region is already entirely within in the stock, there's no
+            # way the region can change at a lower depth. That rcut is not
+            # empty is an assumption for the check in the depth loop below
+            if not rcut.Wires:
+                continue
+
             # If the region cut with the stock at a new depth is different than
             # the original cut, we need to split this region
             # The new region gets all of the children, and becomes a child of
             # the existing region.
+            parentdepths = depths[0:1]
             for d in depths[1:]:
                 if (
                     areInsideRegions and r["region"].cut(stockProjectionDict[d]).cut(rcut).Wires


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Correctly handle regions contained entirely within the stock to avoid recutting them multiple times. Root cause was regions fully contained within the stock not being correctly computed as "the same", resulting in them being re-computed, along with the region at every lower depth, resulting in a factorial(ish) number of duplicate cuts.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #21086.
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
N/A


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
