### PR TITLE
CAM: Simulator Fix thumb right position with speed > 1

### DIFF
--- a/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.cpp
@@ -79,6 +79,9 @@ void MillSimulation::SimNext()
 
     if (mCurStep < mNTotalSteps) {
         mCurStep += mSimSpeed;
+        if (mCurStep > mNTotalSteps) {
+            mCurStep = mNTotalSteps;
+        }
         CalcSegmentPositions();
         simDisplay.updateDisplay = true;
     }


### PR DESCRIPTION
If set speed > 1 than right position of the thumb can be incorrect

Before:
![Screenshot_20250507_111807_lossy](https://github.com/user-attachments/assets/df8e3d5f-c2c8-441f-bc43-bcb11e3c10c5)

https://github.com/user-attachments/assets/e3590f88-96d8-4dd3-ad59-d198ab871c4a

After:

https://github.com/user-attachments/assets/11f1357a-080a-459b-a73d-4d784f922227


