### PR TITLE
[BIM} remove incorrect check which was stopping the default Pipe…

### DIFF
--- a/src/Mod/BIM/ArchPipe.py
+++ b/src/Mod/BIM/ArchPipe.py
@@ -122,8 +122,6 @@ class _ArchPipe(ArchComponent.Component):
         import DraftGeomUtils
         if self.clone(obj):
             return
-        if not self.ensureBase(obj):
-            return
         pl = obj.Placement
         w = self.getWire(obj)
         if not w:


### PR DESCRIPTION
…being created

Forum report, see No 1 in https://forum.freecad.org/viewtopic.php?t=96794

In version 1.0 the default Pipe of 50mm diameter x 1000mm long is created as expected, a regression introduced in main stopped this functionality, this PR corrects that.