### PR TITLE
CAM: Adaptive: Fix bspline processing

### DIFF
--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -854,14 +854,18 @@ def projectFacesToXY(faces, minEdgeLength=1e-10):
         # NOTE: Wires/edges get clipped if we have an "exact fit" bounding box
         projface = Path.Geom.makeBoundBoxFace(f.BoundBox, offset=1, zHeight=0)
 
-        # NOTE: Cylinders, cones, and spheres are messy:
+        # NOTE: Cylinders, cones, B-splines, and spheres are messy:
         # - Internal representation of non-truncted cones and spheres includes
         # the "tip" with a ~0-area closed edge. This is different than the
         # "isNull() note" at the top in magnitude
         # - Projecting edges doesn't naively work due to the way seams are handled
         # - There may be holes at either end that may or may not line up- any
         # overlap is a hole in the projection
-        if type(f.Surface) in [Part.Cone, Part.Cylinder, Part.Sphere]:
+        # FIXME: This needs to check if the surface is a spline, somehow - test sample "type(shp.Faces[0].Surface) is Part.SurfaceOfExtrusion" is True
+        if type(f.Surface) in [Part.Cone, Part.Cylinder, Part.Sphere] or (
+            type(f.Surface) is Part.SurfaceOfExtrusion
+            and sum([e.isSeam(f) for e in f.OuterWire.Edges])
+        ):
             # This gets most of the face outline, but since cylinder/cone faces
             # are hollow, if the ends overlap in the projection there may be a
             # hole we need to remove from the solid projection
@@ -878,8 +882,7 @@ def projectFacesToXY(faces, minEdgeLength=1e-10):
             # a wire from the list, else this could nicely be one line.
             projwires = []
             for w in endfacewires:
-                pp = projface.makeParallelProjection(w, projdir).Wires
-                if pp:
+                if pp := projface.makeParallelProjection(w, projdir).Wires:
                     projwires.append(pp[0])
 
             if len(projwires) > 1:
@@ -1010,7 +1013,22 @@ def _workingEdgeHelperRoughing(op, obj, depths):
             outsideface = stockface.cut(outsideRegions[-1]["region"].Faces)
             # NOTE: See "isNull() note" at top of file
             if outsideface.Wires:
+                """
                 belowFaces = [f.cut(outsideface) for f in modelOutlineFaces]
+                """
+                belowFaces = []
+                for f in modelOutlineFaces:
+                    try:
+                        fc = DraftGeomUtils.concatenate(f).removeSplitter()
+                        ofc = DraftGeomUtils.concatenate(outsideface).removeSplitter()
+                        belowFaces.append(fc.cut(ofc))
+                    except Exception as e:
+                        Part.show(outsideface, "outsideface")
+                        Part.show(f, "f")
+                        Part.show(stockface, "stockface")
+                        for k in outsideRegions[-1]["region"].Faces:
+                            Part.show(k, "outsideRegions")
+                        raise e
             else:
                 # NOTE: Doesn't matter here, but ensure we're making a new list so
                 # we don't clobber modelOutlineFaces
@@ -1319,11 +1337,19 @@ def _getWorkingEdges(op, obj):
                     rcut = stockProjectionDict[depths[0]]
                 else:
                     rcut = stockProjectionDict[depths[0]].cut(r["region"])
-            parentdepths = depths[0:1]
+
+            # If the region is already entirely within in the stock, there's no
+            # way the region can change at a lower depth. That rcut is not
+            # empty is an assumption for the check in the depth loop below
+            if not rcut.Wires:
+                continue
+
             # If the region cut with the stock at a new depth is different than
-            # the original cut, we need to split this region
+            # the original cut, we need to split this region. Only applies if
+            # the region cut with the stock is non-empty
             # The new region gets all of the children, and becomes a child of
             # the existing region.
+            parentdepths = depths[0:1]
             for d in depths[1:]:
                 if (
                     areInsideRegions and r["region"].cut(stockProjectionDict[d]).cut(rcut).Wires
@@ -1345,6 +1371,10 @@ def _getWorkingEdges(op, obj):
                     # recurse and handle splitting that new region if required
                     regions.append(newregion)
                     idnumber += 1
+                    if stockProjectionDict[d].cut(r["region"]).cut(rcut).Wires:
+                        Part.show(stockProjectionDict[d], "spd")
+                        Part.show(r["region"], "region")
+                        Part.show(rcut, "rcut")
                     continue
                 # If we didn't split at this depth, the parent will keep "control"
                 # of this depth


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
This PR nominally fixes the Adaptive toolpath's processing of bspline faces not in the XY plane.

In practice, faces are generated during processing that cause boolean operations to fail- see linked issue and/or https://forum.freecad.org/viewtopic.php?t=96716.

The attached file shows the result as generated by the current PR code. Face f001 is supposed to be cut with outsideface001. This raises a "Null shape" error, despite both faces being valid AFAICT. I could really use some help in diagnosing what's going on there so I can get this bug fixed. The faces appear valid in every way I've checked, aside from the boolean operations failing.

(rename .zip to .FCStd)
[freecad_spline_test_badfaces.zip](https://github.com/user-attachments/files/20113216/freecad_spline_test_badfaces.zip)

Please let me know if there's a better place to ask for help on this- I'd like to get the bug fixed.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #21219




<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
