### PR TITLE
Fix regressions in CI linting generic checks.

### DIFF
--- a/tools/lint/generic_checks.py
+++ b/tools/lint/generic_checks.py
@@ -35,8 +35,12 @@ def check_trailing_whitespace(file_paths):
     for path in file_paths:
         try:
             with open(path, "r", encoding="utf-8") as f:
-                lines = files.read().splitlines()
-                error_lines = [idx if line.endswith(" ") for idx, line in enumerate(lines, start=1)]
+                lines = f.read().splitlines()
+                error_lines = [
+                    idx
+                    for idx, line in enumerate(lines, start=1)
+                    if line != line.rstrip()
+                ]
                 if error_lines:
                     issues[path] = error_lines
         except Exception as e:
@@ -53,8 +57,10 @@ def check_tabs(file_paths):
     for path in file_paths:
         try:
             with open(path, "r", encoding="utf-8") as f:
-                lines = f.readlines()
-                tab_lines = [idx if "\t" in line for idx, line in enumerate(lines, start=1)]
+                lines = f.read().splitlines()
+                tab_lines = [
+                    idx for idx, line in enumerate(lines, start=1) if "\t" in line
+                ]
                 if tab_lines:
                     issues[path] = tab_lines
         except Exception as e:


### PR DESCRIPTION
This got broken due to applying some review suggestions without proper testing.

This reverts commit 5e72c0afe508a698cadb209af190102b12774005.

Closes https://github.com/FreeCAD/FreeCAD/issues/21231.
