### PR TITLE
BIM: Parse Classification in IFC correctly for conversion/type assign

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_types.py
+++ b/src/Mod/BIM/nativeifc/ifc_types.py
@@ -27,6 +27,7 @@
 import FreeCAD
 
 from . import ifc_tools
+from . import ifc_objects
 
 translate = FreeCAD.Qt.translate
 
@@ -95,6 +96,10 @@ def convert_to_type(obj, keep_object=False):
     if keep_object:
         obj.Type = type_obj
     else:
+        # *SHORTLY* before deletion we hold a reference to the type we are replacing the
+        # original object with, to correctly assign Classification
+        obj.Proxy.generated_type = type_obj
+
         ifc_tools.remove_ifc_element(obj, delete_obj=True)
     ifc_tools.get_group(project, "IfcTypesGroup").addObject(type_obj)
 


### PR DESCRIPTION
Currently, during IFC object conversion to IFC Type conversion, we are getting a traceback about missing `Classification` method. This is because it is simply not existing.

So, this patch implements it. What new `Classification` method does is - whenever `Type` property changes, which can occur in two scenarios, first - user has assigned linked IFC type to IFC object. In this case, `Classification` assigns existing `Classification` property (if it exists) to this type. Second scenario - if the object is being converted from IFC object to IFC type - then we basically copy whatever `Classification` was assigned under it, and move it to the newly created IFC Type.

Demo:

https://github.com/user-attachments/assets/53c63e79-ce12-4b06-b54d-3f496ebe8bae

Resolves: https://github.com/FreeCAD/FreeCAD/issues/20677