### PR TITLE
macOS: Remove duplicate RPATHs

### DIFF
--- a/package/rattler-build/osx/create_bundle.sh
+++ b/package/rattler-build/osx/create_bundle.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-set -x 
+set -x
 
 conda_env="FreeCAD.app/Contents/Resources"
 
@@ -41,6 +41,7 @@ find . -name "*.pyc" -type f -delete
 # fix problematic rpaths and reexport_dylibs for signing
 # see https://github.com/FreeCAD/FreeCAD/issues/10144#issuecomment-1836686775
 # and https://github.com/FreeCAD/FreeCAD-Bundle/pull/203
+# and https://github.com/FreeCAD/FreeCAD-Bundle/issues/375
 python ../scripts/fix_macos_lib_paths.py ${conda_env}/lib
 
 # build and install the launcher

--- a/package/rattler-build/scripts/fix_macos_lib_paths.py
+++ b/package/rattler-build/scripts/fix_macos_lib_paths.py
@@ -5,7 +5,7 @@ import sys
 
 if len(sys.argv) < 1 or "-h" in sys.argv:
     print("""Usage: python fix_macos_paths.py <scan_path> [-r] [-s]
-          
+
           Options:
             -r      scan the directory recursively
             -s      scan only without fixing absolute paths in LC_RPATH or LC_REEXPORT_DYLIB
@@ -55,7 +55,7 @@ def scan_directory(directory, recursive=False):
         print(f"Recursively scanning dir: {scan_path}")
     else:
         print(f"Scanning dir: {scan_path}")
-    
+
     for filename in os.listdir(directory):
         full_path = os.path.join(directory, filename)
         if recursive and os.path.isdir(full_path):
@@ -80,7 +80,7 @@ def scan_directory(directory, recursive=False):
         for reexport_dylib in reexport_dylibs:
             if os.path.isabs(reexport_dylib):
                 if scanmode:
-                    print(f'\nFound absolute path inLC_REEXPORT_DYLIB: {reexport_dylib}\nIn: {full_path}')
+                    print(f'\nFound absolute path in LC_REEXPORT_DYLIB: {reexport_dylib}\nIn: {full_path}')
                 else:
                     change_reexport_dylib(full_path, reexport_dylib)
 

--- a/package/rattler-build/scripts/fix_macos_lib_paths.py
+++ b/package/rattler-build/scripts/fix_macos_lib_paths.py
@@ -52,9 +52,9 @@ def change_reexport_dylib(file_path, reexport_dylib):
 
 def scan_directory(directory, recursive=False):
     if recursive:
-        print(f"Recursively scanning dir: {scan_path}")
+        print(f"Recursively scanning dir: {directory}")
     else:
-        print(f"Scanning dir: {scan_path}")
+        print(f"Scanning dir: {directory}")
 
     for filename in os.listdir(directory):
         full_path = os.path.join(directory, filename)

--- a/package/rattler-build/scripts/fix_macos_lib_paths.py
+++ b/package/rattler-build/scripts/fix_macos_lib_paths.py
@@ -71,12 +71,17 @@ def scan_directory(directory, recursive=False):
             continue
 
         file_dir = os.path.dirname(full_path)
+        rpaths_processed = set()
         for rpath in rpaths:
             if os.path.isabs(rpath) and os.path.samefile(file_dir, rpath):
                 if scanmode:
                     print(f'\nFound absolute path in LC_RPATH: {rpath}\nIn: {full_path}')
                 else:
                     remove_rpath(full_path, rpath)
+            if rpath in rpaths_processed:
+                print(f'\nFound duplicate RPATH: {rpath}\nIn: {full_path}')
+                remove_rpath(full_path, rpath)
+            rpaths_processed.add(rpath)
         for reexport_dylib in reexport_dylibs:
             if os.path.isabs(reexport_dylib):
                 if scanmode:


### PR DESCRIPTION
Since macOS 15.4, these duplicate `RPATH`s cause a failure to load libraries, resulting in an inability to import `numpy`, breaking many workbenches and macros.

This PR removes the duplicate `RPATH`s that are sometimes installed by `pixi`.

## Issues

https://github.com/FreeCAD/FreeCAD-Bundle/issues/375#issuecomment-2869174616

## Before and After Images

N/A