### PR TITLE
Draft: aux.fake_function should not overwrite functions

### DIFF
--- a/src/Mod/Draft/drafttests/test_airfoildat.py
+++ b/src/Mod/Draft/drafttests/test_airfoildat.py
@@ -55,8 +55,7 @@ class DraftAirfoilDAT(test_base.DraftTestCaseDoc):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_airfoildat = aux.fake_function
-        obj = Draft.import_airfoildat(in_file)
+        obj = aux.fake_function(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_export_airfoildat(self):
@@ -69,8 +68,7 @@ class DraftAirfoilDAT(test_base.DraftTestCaseDoc):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_airfoildat = aux.fake_function
-        obj = Draft.export_airfoildat(out_file)
+        obj = aux.fake_function(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
 ## @}

--- a/src/Mod/Draft/drafttests/test_dwg.py
+++ b/src/Mod/Draft/drafttests/test_dwg.py
@@ -54,8 +54,7 @@ class DraftDWG(test_base.DraftTestCaseDoc):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_dwg = aux.fake_function
-        obj = Draft.import_dwg(in_file)
+        obj = aux.fake_function(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_export_dwg(self):
@@ -68,8 +67,7 @@ class DraftDWG(test_base.DraftTestCaseDoc):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_dwg = aux.fake_function
-        obj = Draft.export_dwg(out_file)
+        obj = aux.fake_function(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
 ## @}

--- a/src/Mod/Draft/drafttests/test_dxf.py
+++ b/src/Mod/Draft/drafttests/test_dxf.py
@@ -55,8 +55,7 @@ class DraftDXF(test_base.DraftTestCaseDoc):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_dxf = aux.fake_function
-        obj = Draft.import_dxf(in_file)
+        obj = aux.fake_function(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_export_dxf(self):
@@ -69,8 +68,7 @@ class DraftDXF(test_base.DraftTestCaseDoc):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_dxf = aux.fake_function
-        obj = Draft.export_dxf(out_file)
+        obj = aux.fake_function(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
 ## @}

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -183,8 +183,7 @@ class DraftModification(test_base.DraftTestCaseDoc):
         line2 = Draft.make_line(c, d)
         self.doc.recompute()
 
-        Draft.trim_objects = aux.fake_function
-        obj = Draft.trim_objects(line, line2)
+        obj = aux.fake_function(line, line2)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_extend(self):
@@ -204,8 +203,7 @@ class DraftModification(test_base.DraftTestCaseDoc):
         line2 = Draft.make_line(c, d)
         self.doc.recompute()
 
-        Draft.extrude = aux.fake_function
-        obj = Draft.extrude(line, line2)
+        obj = aux.fake_function(line, line2)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_join(self):
@@ -651,8 +649,7 @@ class DraftModification(test_base.DraftTestCaseDoc):
         line = Draft.make_line(a, b)
         direction = Vector(4, 1, 0)
 
-        Draft.stretch = aux.fake_function
-        obj = Draft.stretch(line, direction)
+        obj = aux.fake_function(line, direction)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_scale_part_feature_arcs(self):

--- a/src/Mod/Draft/drafttests/test_oca.py
+++ b/src/Mod/Draft/drafttests/test_oca.py
@@ -55,8 +55,7 @@ class DraftOCA(test_base.DraftTestCaseDoc):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_oca = aux.fake_function
-        obj = Draft.import_oca(in_file)
+        obj = aux.fake_function(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_export_oca(self):
@@ -69,8 +68,7 @@ class DraftOCA(test_base.DraftTestCaseDoc):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_oca = aux.fake_function
-        obj = Draft.export_oca(out_file)
+        obj = aux.fake_function(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
 ## @}

--- a/src/Mod/Draft/drafttests/test_svg.py
+++ b/src/Mod/Draft/drafttests/test_svg.py
@@ -62,8 +62,7 @@ class DraftSVG(test_base.DraftTestCaseDoc):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_svg = aux.fake_function
-        obj = Draft.import_svg(in_file)
+        obj = aux.fake_function(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_export_svg(self):
@@ -76,8 +75,7 @@ class DraftSVG(test_base.DraftTestCaseDoc):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_svg = aux.fake_function
-        obj = Draft.export_svg(out_file)
+        obj = aux.fake_function(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     @unittest.skipIf(not have_arch, "BIM module is not installed")


### PR DESCRIPTION
The `aux.fake_function` is used in the Draft unit tests as a substitute for functions that, in most cases, do not yet exist. But in test_modification.py it would overwrite Draft.extrude leading to issues with BIM unit tests.

See:
https://github.com/FreeCAD/FreeCAD/pull/21134#issuecomment-2869178563
