### PR TITLE
BIM: Avoid traceback if there is no Classification selected

### DIFF
--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -624,6 +624,12 @@ class BIM_Classification:
                 FreeCAD.ActiveDocument.commitTransaction()
                 FreeCAD.ActiveDocument.recompute()
         else:
+            # Close the form if user has pressed Enter and did not
+            # select anything
+            if len(self.form.treeClass.selectedItems()) < 1:
+                self.form.close()
+                return
+
             code = self.form.treeClass.selectedItems()[0].text(0)
             pl = self.isEditing.PropertiesList
             if ("StandardCode" in pl) or ("IfcClass" in pl):


### PR DESCRIPTION
As the title says, if user selects `OK` button and has no Classification selected (which can happen only if the list is empty I think), then they get a traceback since we're trying to access list of selections directly.

So this patch adds a small QMessageBox that will remind the user to populate `Classification` directory and exits safely instead of throwing a traceback.

Demo: 

https://github.com/user-attachments/assets/382ba09f-9bd4-44ce-a192-4be8d2a3869d

@semhustej Maybe a message box is a bad choice here, let me know what you think. I've found about this traceback accidentally when playing with IFC features.