### PR TITLE
BIM: close BIM_Library task panel on doc close

### DIFF
--- a/src/Mod/BIM/bimcommands/BimLibrary.py
+++ b/src/Mod/BIM/bimcommands/BimLibrary.py
@@ -104,7 +104,9 @@ class BIM_Library:
                 # save file paths with forward slashes even on windows
                 pr.SetString("destination", addondir.replace("\\", "/"))
                 libok = True
-        FreeCADGui.Control.showDialog(BIM_Library_TaskPanel(offlinemode=libok))
+        task = FreeCADGui.Control.showDialog(BIM_Library_TaskPanel(offlinemode=libok))
+        task.setDocumentName(FreeCAD.ActiveDocument.Name)
+        task.setAutoCloseOnDeletedDocument(True)
 
 
 class BIM_Library_TaskPanel:


### PR DESCRIPTION
Fixes #21179.

This PR uses the built-in solution to close the task panel.

I was not aware of this feature before. My 2 previous PRs related to the closing of task panels, #20719 and #21073, will (largely) have to be reverted/redone in favor of this solution.
