### PR TITLE
CAM:  updated opensbp post to work with current Processor.py

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
@@ -181,9 +181,12 @@ def export(objectslist, filename, argstring):
     print("done postprocessing.")
 
     # Write the output
-    gfile = pyopen(filename, "w")
-    gfile.write(final)
-    gfile.close()
+    if not filename == "-":
+        gfile = pyopen(filename, "w")
+        gfile.write(final)
+        gfile.close()
+
+    return final
 
 
 def move(command):


### PR DESCRIPTION
Updates the opensbp post to work with the current version of Processor.py.  In particular it now understands a file name of "-" and "does the right thing".

I manually tested that the opensbp postprocessor now creates reasonable output in a file instead of throwing an exception.

This fixes #20671.
