### PR TITLE
CI: use the weekly build tag in title bar of main window.

### DIFF
--- a/package/rattler-build/scripts/make_version_file.py
+++ b/package/rattler-build/scripts/make_version_file.py
@@ -11,9 +11,12 @@ import SubWCRev
 
 gitInfo = SubWCRev.GitControl()
 gitInfo.extractInfo("","")
+gitDescription = os.environ['BUILD_TAG']
+
 i = open("src/Build/Version.h.cmake")
 content = []
 for line in i.readlines():
+	line = line.replace("-${PACKAGE_VERSION_SUFFIX}",gitDescription)
     line = line.replace("${PACKAGE_WCREF}",gitInfo.rev)
     line = line.replace("${PACKAGE_WCDATE}",gitInfo.date)
     line = line.replace("${PACKAGE_WCURL}",gitInfo.url)
@@ -36,6 +39,6 @@ p = subprocess.Popen(["git", "-c", "user.name='github-actions[bot]'", "-c", "use
 		       "commit", "-a", "-m", "add git information"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 out, err = p.communicate()
-		     		       
+
 print(out.decode())
 print(err.decode())


### PR DESCRIPTION
This PR overrides the version suffix from `dev` to `-${BUILD_TAG}` for the weekly builds.  This will set the title bar to `FreeCAD 1.1.0-weekly-2025.05.12`, for example, which would permit easy distinguishing of the exact version being run.

## Issues

https://github.com/FreeCAD/FreeCAD/issues/20437

## Before and After Images

N/A
