### PR TITLE
[1.0] [App] add MeterDecimal to Unit Scheme Enum

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -916,7 +916,7 @@ class Scheme(IntEnum):
     MmMin = 6
     ImperialCivil = 7
     FemMilliMeterNewton = 8
-    MeterDeciaml = 9
+    MeterDecimal = 9
 
 App.Units.Scheme = Scheme
 

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -916,6 +916,7 @@ class Scheme(IntEnum):
     MmMin = 6
     ImperialCivil = 7
     FemMilliMeterNewton = 8
+    MeterDeciaml = 9
 
 App.Units.Scheme = Scheme
 


### PR DESCRIPTION
As part of the investigation into issues with the new Unit System in 1.1dev, I noticed that `MeterDecimal` was missing from the Scheme Enum in FreeCADInit.py - 1.0 branch.
