### PR TITLE
TD: Fix hatch size constraint

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderHatch.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderHatch.cpp
@@ -46,7 +46,7 @@ using namespace TechDrawGui;
 //App::PropertyFloatConstraint::Constraints ViewProviderHatch::scaleRange = {Precision::Confusion(),
 //                                                                  std::numeric_limits<double>::max(),
 //                                                                  pow(10, - Base::UnitsApi::getDecimals())};
-App::PropertyFloatConstraint::Constraints ViewProviderHatch::scaleRange = {pow(10, - Base::UnitsApi::getDecimals()),
+App::PropertyFloatConstraint::Constraints ViewProviderHatch::scaleRange = {pow(10, - static_cast<int>(Base::UnitsApi::getDecimals())),
                                                                   1000.0,
                                                                   0.1};
 


### PR DESCRIPTION
Commit 1155f0d7 changed `UnitsApi::getDecimals()` from `int` to `size_t`, which changes the meaning of the negation since it is now unsigned. Cast it to an integer before the negation to restore the old behavior.