### PR TITLE
Gui: Remove default init of shared_ptr

### DIFF
--- a/src/Gui/Selection/SelectionFilter.cpp
+++ b/src/Gui/Selection/SelectionFilter.cpp
@@ -132,15 +132,13 @@ bool SelectionFilterGatePython::allow(App::Document*, App::DocumentObject* obj, 
 // ----------------------------------------------------------------------------
 
 SelectionFilter::SelectionFilter(const char* filter, App::DocumentObject* container)
-    : Ast(nullptr)
-    , container(container)
+    : container(container)
 {
     setFilter(filter);
 }
 
 SelectionFilter::SelectionFilter(const std::string& filter, App::DocumentObject* container)
-    : Ast(nullptr)
-    , container(container)
+    : container(container)
 {
     setFilter(filter.c_str());
 }


### PR DESCRIPTION
`std::shared_ptr` default-initializes to `nullptr`, so there is no need to do it manually, and in the current code the initialization is in the wrong order (so generates a compiler warning).