### PR TITLE
Gui: Make variable more local

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2688,11 +2688,11 @@ public:
 
     static QCursor makeCursor(QWidget* widget, const QSize& size, const char* svgFile, int hotX, int hotY)
     {
-        qreal pRatio = widget->devicePixelRatioF();
         qreal hotXF = hotX;
         qreal hotYF = hotY;
 #if !defined(Q_OS_WIN32) && !defined(Q_OS_MACOS)
         if (qApp->platformName() == QLatin1String("xcb")) {
+            qreal pRatio = widget->devicePixelRatioF();
             hotXF *= pRatio;
             hotYF *= pRatio;
         }


### PR DESCRIPTION
Eliminate a compiler warning about an unused variable by making the variable more local to the point-of-use.