### PR TITLE
Gui: Manually specify correct QVariant conversion

### DIFF
--- a/src/Gui/Dialogs/DlgCustomizeSpaceball.cpp
+++ b/src/Gui/Dialogs/DlgCustomizeSpaceball.cpp
@@ -210,7 +210,7 @@ QVariant ButtonModel::data (const QModelIndex &index, int role) const
     {
         static QPixmap icon(BitmapFactory().pixmap("spaceball_button").scaled
                             (32, 32, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-        return {icon};
+        return QVariant(QIcon(icon));  // Cannot make a QPixmap into a QVariant, so convert to a QIcon first
     }
     if (role == Qt::UserRole)
         return {QString::fromStdString(groupVector.at(index.row())->GetASCII("Command"))};


### PR DESCRIPTION
There are multiple possible conversion paths for a QPixmap to QVariant, which results in a compiler warning. Explicitly specify the path we intend to silence the warning.
