### PR TITLE
BIM: Change from RGBT to RGBA for IFC

### DIFF
--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -2346,6 +2346,7 @@ def getRepresentation(
                     if hasattr(obj,"Material"):
                         if obj.Material:
                             m = obj.Material.Label
+                            rgbt[i] = (rgbt[i][0], rgbt[i][1], rgbt[i][2], obj.Material.Transparency/100.0)
                     psa = ifcbin.createIfcPresentationStyleAssignment(m,rgbt[i][0],rgbt[i][1],rgbt[i][2],rgbt[i][3])
                     surfstyles[key] = psa
                 isi = ifcfile.createIfcStyledItem(shape,[psa],None)

--- a/src/Mod/BIM/importers/exportIFCHelper.py
+++ b/src/Mod/BIM/importers/exportIFCHelper.py
@@ -381,13 +381,13 @@ class recycler:
                 self.rgbs[key] = c
             return c
 
-    def createIfcSurfaceStyleRendering(self,col,trans=0):
+    def createIfcSurfaceStyleRendering(self,col,trans=1):
         key = (col.Red,col.Green,col.Blue,trans)
         if self.compress and key in self.ssrenderings:
             self.spared += 1
             return self.ssrenderings[key]
         else:
-            if trans == 0:
+            if trans == 1:
                 trans = None
             c = self.ifcfile.createIfcSurfaceStyleRendering(col,trans,None,None,None,None,None,None,"FLAT")
             if self.compress:
@@ -405,7 +405,7 @@ class recycler:
                 self.transformationoperators[key] = c
             return c
 
-    def createIfcSurfaceStyle(self,name,r,g,b,t=0):
+    def createIfcSurfaceStyle(self,name,r,g,b,a=1):
         if name:
             key = name + str((r,g,b))
         else:
@@ -415,22 +415,22 @@ class recycler:
             return self.sstyles[key]
         else:
             col = self.createIfcColourRgb(r,g,b)
-            ssr = self.createIfcSurfaceStyleRendering(col,t)
+            ssr = self.createIfcSurfaceStyleRendering(col,a)
             c = self.ifcfile.createIfcSurfaceStyle(name,"BOTH",[ssr])
             if self.compress:
                 self.sstyles[key] = c
             return c
 
-    def createIfcPresentationStyleAssignment(self,name,r,g,b,t=0,ifc4=False):
+    def createIfcPresentationStyleAssignment(self,name,r,g,b,a=1,ifc4=False):
         if name:
-            key = name+str((r,g,b,t))
+            key = name+str((r,g,b,a))
         else:
-            key = str((r,g,b,t))
+            key = str((r,g,b,a))
         if self.compress and key in self.psas:
             self.spared += 1
             return self.psas[key]
         else:
-            iss = self.createIfcSurfaceStyle(name,r,g,b,t)
+            iss = self.createIfcSurfaceStyle(name,r,g,b,a)
             if ifc4:
                 c = iss
             else:

--- a/src/Mod/BIM/importers/exportIFCHelper.py
+++ b/src/Mod/BIM/importers/exportIFCHelper.py
@@ -381,15 +381,15 @@ class recycler:
                 self.rgbs[key] = c
             return c
 
-    def createIfcSurfaceStyleRendering(self,col,trans=1):
-        key = (col.Red,col.Green,col.Blue,trans)
+    def createIfcSurfaceStyleRendering(self,col,alpha=1):
+        key = (col.Red,col.Green,col.Blue,alpha)
         if self.compress and key in self.ssrenderings:
             self.spared += 1
             return self.ssrenderings[key]
         else:
-            if trans == 1:
-                trans = None
-            c = self.ifcfile.createIfcSurfaceStyleRendering(col,trans,None,None,None,None,None,None,"FLAT")
+            if alpha == 1:
+                alpha = None
+            c = self.ifcfile.createIfcSurfaceStyleRendering(col,alpha,None,None,None,None,None,None,"FLAT")
             if self.compress:
                 self.ssrenderings[key] = c
             return c


### PR DESCRIPTION
Currently users by default have transparent window frames and doors.

Turns out that at some point there was a switch from RGBT to RGBA, which means last transparency element differs in the range of transparency that it specifies (RGBT, where 1 - fully visible, RGBA where 1 - fully transparent). As the changed happened, all of the windows and door became transparent.

This patch changes that, from RGBT to RGBA so we will map transparency properly, as well as adding a possibility to set transparency through material.

A bit lengthy demo but it shows a couple of scenarios:

https://github.com/user-attachments/assets/0df7475d-ee9c-4273-a6d3-3b111343c507

Resolves: https://github.com/FreeCAD/FreeCAD/issues/19138