### PR TITLE
App: Introduce async document recompute.

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2294,6 +2294,7 @@ void Application::initTypes()
     App::FeatureTestAbsAddress     ::init();
     App::FeatureTestPlacement      ::init();
     App::FeatureTestAttribute      ::init();
+    App::FeatureTestAsyncBlocker   ::init();
 
     // Feature class
     App::FeaturePython             ::init();

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -206,6 +206,71 @@ using namespace App;
 namespace sp = std::placeholders;
 namespace fs = std::filesystem;
 
+namespace
+{
+
+RecomputeRequest takeNextRecomputeRequest(std::vector<RecomputeRequest>& requests)
+{
+    RecomputeRequest request = std::move(requests.front());
+    requests.erase(requests.begin());
+    return request;
+}
+
+bool requestTargetsDocument(const RecomputeRequest& request, const std::string& documentName)
+{
+    return request.documentName == documentName;
+}
+
+bool documentCanRecomputeOnWorker(const Document& document)
+{
+    const auto& objects = document.getObjects();
+    std::vector<DocumentObject*> recomputeRoots(objects.begin(), objects.end());
+    const auto recomputeObjects = Document::getDependencyList(recomputeRoots, Document::DepSort);
+
+    return std::ranges::all_of(recomputeObjects, [](const DocumentObject* object) {
+        return object && object->canRecomputeOnWorker();
+    });
+}
+
+void reportRecomputeException(const Base::Exception& exception)
+{
+    QMetaObject::invokeMethod(
+        qApp,
+        [exception]() mutable { exception.reportException(); },
+        Qt::QueuedConnection
+    );
+}
+
+RecomputeResult processRecomputeRequest(RecomputeRequest& request)
+{
+    RecomputeResult result;
+
+    try {
+        if (Document* document = request.resolveDocument()) {
+            document->recompute({}, request.force, nullptr, request.options);
+        }
+
+        if (DocumentObject* documentObject = request.resolveDocumentObject()) {
+            documentObject->recomputeFeature(request.recursive);
+        }
+    }
+    catch (Base::BadGraphError& exception) {
+        result.exception = std::make_unique<Base::BadGraphError>(std::move(exception));
+        result.failure = RecomputeFailure::DependencyCycle;
+        result.success = false;
+    }
+    catch (Base::Exception& exception) {
+        reportRecomputeException(exception);
+        result.exception = std::make_unique<Base::Exception>(std::move(exception));
+        result.failure = RecomputeFailure::Exception;
+        result.success = false;
+    }
+
+    return result;
+}
+
+}  // namespace
+
 //==========================================================================
 // Application
 //==========================================================================
@@ -217,6 +282,50 @@ Base::ConsoleObserverFile *Application::_pConsoleObserverFile = nullptr;
 
 AppExport std::map<std::string, std::string> Application::mConfig;
 std::unique_ptr<ApplicationDirectories> Application::_appDirs;
+
+RecomputeRequest RecomputeRequest::fromDocument(const Document& document, bool force, int options)
+{
+    RecomputeRequest request;
+    request.documentName = document.getName();
+    request.force = force;
+    request.options = options;
+    return request;
+}
+
+RecomputeRequest RecomputeRequest::fromDocumentObject(const DocumentObject& documentObject, bool recursive)
+{
+    RecomputeRequest request;
+
+    if (const Document* document = documentObject.getDocument()) {
+        request.documentName = document->getName();
+    }
+
+    request.documentObjectName = documentObject.getNameInDocument();
+    request.recursive = recursive;
+    return request;
+}
+
+Document* RecomputeRequest::resolveDocument() const
+{
+    if (documentName.empty()) {
+        return nullptr;
+    }
+
+    return GetApplication().getDocument(documentName.c_str());
+}
+
+DocumentObject* RecomputeRequest::resolveDocumentObject() const
+{
+    if (documentObjectName.empty()) {
+        return nullptr;
+    }
+
+    if (Document* document = resolveDocument()) {
+        return document->getObject(documentObjectName.c_str());
+    }
+
+    return nullptr;
+}
 
 
 //**************************************************************************
@@ -293,10 +402,22 @@ Application::Application(std::map<std::string,std::string> &mConfig)
     mpcPramManager["System parameter"] = _pcSysParamMngr;
     mpcPramManager["User parameter"] = _pcUserParamMngr;
 
+    _stopRecomputeThread = false;
+    _recomputeThread = std::thread(&Application::recomputeWorker, this);
+
     setupPythonTypes();
 }
 
-Application::~Application() = default;
+Application::~Application()
+{
+    // Signal the recompute worker thread to stop and join it.
+    _stopRecomputeThread = true;
+    _recomputeRequestAvailable.notify_all();
+
+    if (_recomputeThread.joinable()) {
+        _recomputeThread.join();
+    }
+}
 
 void Application::setupPythonTypes()
 {
@@ -546,6 +667,10 @@ bool Application::closeDocument(const Document* doc)
 
 bool Application::closeDocument(const char* name)
 {
+    const std::string documentName(name);
+
+    cancelRecomputeRequestsForDocument(documentName);
+
     const auto pos = DocMap.find( name );
     if (pos == DocMap.end()) // no such document
         return false;
@@ -672,6 +797,76 @@ bool Application::isRestoring() const {
 
 bool Application::isClosingAll() const {
     return _isClosingAll;
+}
+
+bool Application::isAsyncRecomputeEnabled()
+{
+    static const ParameterGrp::handle hGrp = GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Document"
+    );
+    bool enableAsyncRecompute = hGrp->GetBool("EnableAsyncRecompute", false);
+    return enableAsyncRecompute;
+}
+
+bool Application::canRecomputeRequestOnWorker(const RecomputeRequest& req) const
+{
+    if (DocumentObject* documentObject = req.resolveDocumentObject()) {
+        return documentObject->canRecomputeOnWorker();
+    }
+
+    Document* document = req.resolveDocument();
+    return !document || documentCanRecomputeOnWorker(*document);
+}
+
+void Application::queueRecomputeRequest(RecomputeRequest req)
+{
+    if (!canRecomputeRequestOnWorker(req)) {
+        RecomputeResult result;
+
+        // Requests that are not worker-safe stay on the caller thread unless a
+        // GUI main-thread hop is required. In App-only/headless mode there are
+        // no GUI hooks, so processing inline preserves the "stay off the
+        // worker" guarantee without inventing a synthetic main thread.
+        if (App::MainThreadSignalConfig::hasHooks()
+            && !App::MainThreadSignalConfig::isMainThread()) {
+            App::MainThreadSignalConfig::invoke(
+                [&req, &result]() { result = processRecomputeRequest(req); },
+                /*blocking=*/true
+            );
+        }
+        else {
+            result = processRecomputeRequest(req);
+        }
+
+        if (req.callback) {
+            req.callback(req, result);
+        }
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(_recomputeMutex);
+        _recomputeRequests.push_back(std::move(req));
+    }
+    notifyRecomputeWorker();
+}
+
+void Application::cancelRecomputeRequestsForDocument(const std::string& documentName)
+{
+    if (documentName.empty()) {
+        return;
+    }
+
+    std::unique_lock<std::mutex> lock(_recomputeMutex);
+    _recomputeStateChanged.wait(lock, [this, &documentName] {
+        return !_recomputeDocumentsInProgress.contains(documentName);
+    });
+
+    // Cancellation runs on document-close boundaries, so a linear scan keeps
+    // the queue simple without affecting the steady-state worker path.
+    std::erase_if(_recomputeRequests, [&documentName](const RecomputeRequest& request) {
+        return requestTargetsDocument(request, documentName);
+    });
 }
 
 struct DocTiming {
@@ -2826,7 +3021,6 @@ std::list<std::string> Application::processFiles(const std::list<std::string>& f
     std::list<std::string> processed;
     Base::Console().log("Init: Processing command line files\n");
     for (const auto & it : files) {
-
         Base::FileInfo file(it);
         // Can we safely remove the isSymlink check and directly query the canonical
         // path for every string? The reason for avoiding it currently is that
@@ -2963,6 +3157,48 @@ void Application::runApplication()
     }
     else {
         Base::Console().log("Unknown Run mode (%d) in main()?!?\n\n", mConfig["RunMode"].c_str());
+    }
+}
+
+void Application::notifyRecomputeWorker()
+{
+    _recomputeRequestAvailable.notify_one();
+}
+
+void Application::recomputeWorker()
+{
+    while (!_stopRecomputeThread) {
+        std::unique_lock<std::mutex> lock(_recomputeMutex);
+        // Wait until either stop is signaled or there is at least one pending request.
+        _recomputeRequestAvailable.wait(lock, [this] {
+            return _stopRecomputeThread || !_recomputeRequests.empty();
+        });
+        if (_stopRecomputeThread) {
+            break;
+        }
+
+        // Process all pending recompute requests.
+        while (!_recomputeRequests.empty()) {
+            RecomputeRequest request = takeNextRecomputeRequest(_recomputeRequests);
+            if (!request.documentName.empty()) {
+                _recomputeDocumentsInProgress.insert(request.documentName);
+            }
+
+            // Unlock while processing to allow other threads to add new requests.
+            lock.unlock();
+
+            RecomputeResult result = processRecomputeRequest(request);
+
+            if (request.callback) {
+                request.callback(request, result);
+            }
+
+            lock.lock();
+            if (!request.documentName.empty()) {
+                _recomputeDocumentsInProgress.erase(request.documentName);
+                _recomputeStateChanged.notify_all();
+            }
+        }
     }
 }
 

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -209,10 +209,10 @@ namespace fs = std::filesystem;
 namespace
 {
 
-RecomputeRequest takeNextRecomputeRequest(std::vector<RecomputeRequest>& requests)
+RecomputeRequest takeNextRecomputeRequest(std::deque<RecomputeRequest>& requests)
 {
     RecomputeRequest request = std::move(requests.front());
-    requests.erase(requests.begin());
+    requests.pop_front();
     return request;
 }
 
@@ -223,22 +223,34 @@ bool requestTargetsDocument(const RecomputeRequest& request, const std::string& 
 
 bool documentCanRecomputeOnWorker(const Document& document)
 {
-    const auto& objects = document.getObjects();
-    std::vector<DocumentObject*> recomputeRoots(objects.begin(), objects.end());
-    const auto recomputeObjects = Document::getDependencyList(recomputeRoots, Document::DepSort);
+    try {
+        const auto& objects = document.getObjects();
+        std::vector<DocumentObject*> recomputeRoots(objects.begin(), objects.end());
+        const auto recomputeObjects = Document::getDependencyList(recomputeRoots, Document::DepSort);
 
-    return std::ranges::all_of(recomputeObjects, [](const DocumentObject* object) {
-        return object && object->canRecomputeOnWorker();
-    });
+        return std::ranges::all_of(recomputeObjects, [](const DocumentObject* object) {
+            return object && object->canRecomputeOnWorker();
+        });
+    }
+    catch (const Base::BadGraphError&) {
+        return false;
+    }
 }
 
 void reportRecomputeException(const Base::Exception& exception)
 {
-    QMetaObject::invokeMethod(
-        qApp,
-        [exception]() mutable { exception.reportException(); },
-        Qt::QueuedConnection
-    );
+    if (App::MainThreadSignalConfig::hasHooks()) {
+        if (auto* app = QCoreApplication::instance()) {
+            QMetaObject::invokeMethod(
+                app,
+                [exception]() mutable { exception.reportException(); },
+                Qt::QueuedConnection
+            );
+            return;
+        }
+    }
+
+    exception.reportException();
 }
 
 RecomputeResult processRecomputeRequest(RecomputeRequest& request)
@@ -804,7 +816,7 @@ bool Application::isAsyncRecomputeEnabled()
     static const ParameterGrp::handle hGrp = GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Document"
     );
-    bool enableAsyncRecompute = hGrp->GetBool("EnableAsyncRecompute", false);
+    bool enableAsyncRecompute = hGrp->GetBool("EnableAsyncRecompute", true);
     return enableAsyncRecompute;
 }
 

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -34,8 +34,17 @@
 #include <list>
 #include <set>
 #include <map>
+#include <memory>
 #include <string>
 #include <optional>
+
+#include <functional>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <atomic>
+
+#include <Base/Exception.h>
 
 #include <Base/Observer.h>
 #include <Base/Parameter.h>
@@ -86,6 +95,50 @@ enum class MessageOption {
 struct DocumentInitFlags {
     bool createView {true}; ///< Whether to hide the document in the tree view.
     bool temporary {false}; ///< Whether the document should be a temporary one.
+};
+
+/**
+ * @brief Failure category for async recompute processing.
+ */
+enum class RecomputeFailure
+{
+    None,
+    DependencyCycle,
+    Exception
+};
+
+/// Result returned by processing a recompute request.
+struct AppExport RecomputeResult
+{
+    bool success {true};
+    RecomputeFailure failure {RecomputeFailure::None};
+    std::unique_ptr<Base::Exception> exception;
+};
+
+/// Stable, queueable work item for document or object recompute.
+struct AppExport RecomputeRequest
+{
+    static RecomputeRequest fromDocument(const Document& document, bool force = false, int options = 0);
+    static RecomputeRequest fromDocumentObject(
+        const DocumentObject& documentObject,
+        bool recursive = false
+    );
+
+    Document* resolveDocument() const;
+    DocumentObject* resolveDocumentObject() const;
+
+    // Stable identifiers are queued instead of raw pointers so worker-side
+    // resolution cannot dereference destroyed documents or objects. The
+    // internal document name is assigned once at creation time and does not
+    // change afterwards, so queued requests do not need to track
+    // signalRenameDocument.
+    std::string documentName;
+    std::string documentObjectName;
+    bool force {false};
+    int options {0};
+    bool recursive {false};
+    // Callback to be invoked when recompute is complete.
+    std::function<void(RecomputeRequest&, RecomputeResult&)> callback {};
 };
 
 /**
@@ -146,7 +199,6 @@ public:
      * @return Returns true if the document was found and closed, false otherwise.
      */
     bool closeDocument(const char* name);
-
     /**
      * @brief Acquire a unique document name from a proposed name.
      *
@@ -309,12 +361,9 @@ public:
      *
      * @return The new transaction ID.
      */
-
     int setActiveTransaction(TransactionName name);
-
     int openGlobalTransaction(TransactionName name);
     int getGlobalTransaction() const;
-
     bool transactionIsActive(int tid) const;
     std::string getTransactionName(int tid) const;
     bool transactionTmpName(int tid) const;
@@ -341,9 +390,14 @@ public:
     /// Internally call closeActiveTransaction(), but it makes the call site clearer
     bool commitTransaction(int tid);
     bool abortTransaction(int tid);
-
-
     //@}
+
+    // Returns if document and object recomputes should be done async.
+    bool isAsyncRecomputeEnabled();
+    bool canRecomputeRequestOnWorker(const RecomputeRequest& req) const;
+
+    // Adds a recompute request to the processing queue.
+    void queueRecomputeRequest(RecomputeRequest req);
 
     // NOLINTBEGIN
     // clang-format off
@@ -992,6 +1046,26 @@ private:
     // To prevent infinite recursion of reloading a partial document due a truly
     // missing object
     std::map<std::string,std::set<std::string> > _docReloadAttempts;
+
+    // Worker thread for processing pending recompute requests
+    std::thread _recomputeThread;
+    // Protects the queued/in-progress recompute state below
+    std::mutex _recomputeMutex;
+    std::deque<RecomputeRequest> _recomputeRequests;
+    std::set<std::string> _recomputeDocumentsInProgress;
+    std::condition_variable _recomputeRequestAvailable;
+    std::condition_variable _recomputeStateChanged;
+    // Separate from the mutex-protected queue state so shutdown can request a
+    // worker stop and wake waiters without first taking _recomputeMutex.
+    std::atomic<bool> _stopRecomputeThread{false};
+
+    // Worker thread function that processes _recomputeRequests
+    void recomputeWorker();
+    // Helper to notify the worker thread when new requests are available
+    void notifyRecomputeWorker();
+    // Drop queued requests for a document and wait for any active recompute of
+    // that document to finish before closing it
+    void cancelRecomputeRequestsForDocument(const std::string& documentName);
 
     bool _isRestoring{false};
     bool _allowPartial{false};

--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -25,6 +25,8 @@
 
 #include <FCConfig.h>
 
+#include <array>
+
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/FileInfo.h>
@@ -38,6 +40,7 @@
 #include "DocumentPy.h"
 #include "DocumentObserverPython.h"
 #include "DocumentObjectPy.h"
+#include "RecoverySnapshot.h"
 
 
 // using Base::GetConsole;
@@ -179,6 +182,14 @@ PyMethodDef ApplicationPy::Methods[] = {
      METH_VARARGS,
      "closeDocument(string) -> None\n\n"
      "Close the document with a given name."},
+    {"writeRecoverySnapshotToTransientDir",
+     reinterpret_cast<PyCFunction>(
+         reinterpret_cast<void (*)()>(ApplicationPy::sWriteRecoverySnapshotToTransientDir)
+     ),
+     METH_VARARGS | METH_KEYWORDS,
+     "writeRecoverySnapshotToTransientDir(document, *, compressed=True, "
+     "save_binary_brep=True, save_thumbnail=False) -> bool\n\n"
+     "Write a recovery snapshot for the given document into its transient directory."},
     {"activeDocument",
      (PyCFunction)ApplicationPy::sActiveDocument,
      METH_VARARGS,
@@ -502,6 +513,56 @@ PyObject* ApplicationPy::sSaveDocument(PyObject* /*self*/, PyObject* args)
     }
 
     Py_Return;
+}
+
+PyObject* ApplicationPy::sWriteRecoverySnapshotToTransientDir(PyObject* /*self*/,
+                                                              PyObject* args,
+                                                              PyObject* kwd)
+{
+    PyObject* document {};
+    PyObject* compressed = Py_True;
+    PyObject* saveBinaryBrep = Py_True;
+    PyObject* saveThumbnail = Py_False;
+    static constexpr std::array<const char*, 5> kwlist {
+        "document",
+        "compressed",
+        "save_binary_brep",
+        "save_thumbnail",
+        nullptr
+    };
+    if (!Base::Wrapped_ParseTupleAndKeywords(args,
+                                             kwd,
+                                             "O!|O!O!O!",
+                                             kwlist,
+                                             &App::DocumentPy::Type,
+                                             &document,
+                                             &PyBool_Type,
+                                             &compressed,
+                                             &PyBool_Type,
+                                             &saveBinaryBrep,
+                                             &PyBool_Type,
+                                             &saveThumbnail)) {
+        return nullptr;
+    }
+
+    auto* doc = static_cast<App::DocumentPy*>(document)->getDocumentPtr();
+    if (!doc) {
+        PyErr_SetString(PyExc_RuntimeError, "Invalid document");
+        return nullptr;
+    }
+
+    PY_TRY
+    {
+        App::RecoverySnapshotSaveOptions options;
+        options.compressed = Base::asBoolean(compressed);
+        options.saveBinaryBrep = Base::asBoolean(saveBinaryBrep);
+        options.saveThumbnail = Base::asBoolean(saveThumbnail);
+
+        return Py::new_reference_to(
+            Py::Boolean(App::writeRecoverySnapshotToTransientDir(*doc, options))
+        );
+    }
+    PY_CATCH
 }
 
 PyObject* ApplicationPy::sActiveDocument(PyObject* /*self*/, PyObject* args)

--- a/src/App/ApplicationPy.h
+++ b/src/App/ApplicationPy.h
@@ -63,6 +63,8 @@ public:
     static PyObject* sLoadFile               (PyObject *self,PyObject *args);
     static PyObject* sOpenDocument           (PyObject *self,PyObject *args, PyObject *kwd);
     static PyObject* sSaveDocument           (PyObject *self,PyObject *args);
+    static PyObject* sWriteRecoverySnapshotToTransientDir
+                                               (PyObject *self,PyObject *args, PyObject *kwd);
     static PyObject* sNewDocument            (PyObject *self,PyObject *args, PyObject *kwd);
     static PyObject* sCloseDocument          (PyObject *self,PyObject *args);
     static PyObject* sActiveDocument         (PyObject *self,PyObject *args);

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -148,6 +148,7 @@ SET(Document_CPP_SRCS
     Annotation.cpp
     BackupPolicy.cpp
     Document.cpp
+    RecoverySnapshot.cpp
     DocumentObject.cpp
     Extension.cpp
     ExtensionPyImp.cpp
@@ -203,6 +204,7 @@ SET(Document_HPP_SRCS
     Annotation.h
     BackupPolicy.h
     Document.h
+    RecoverySnapshot.h
     DocumentObject.h
     Extension.h
     ExtensionContainer.h

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -341,6 +341,7 @@ SET(FreeCADApp_HPP_SRCS
     ProgramInformation.h
     Services.h
     StringHasher.h
+    MainThreadSignal.h
 )
 
 # auto-generate resource file with all available translations

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2761,17 +2761,20 @@ void Document::renameObjectIdentifiers(
     }
 }
 
-void Document::setPreRecomputeHook(const PreRecomputeHook& hook)
-{
-     d->_preRecomputeHook = hook;
-}
-
 int Document::recompute(const std::vector<DocumentObject*>& objs,
                         bool force,
                         bool* hasError,
                         int options)
 {
     ZoneScoped;
+
+    // Recompute can execute Python-backed features. Keep the GIL for the full
+    // recompute so async recompute still serializes Python execution the same
+    // way the main-thread path does, preserving compatibility with existing
+    // Python-backed objects and addons. Main-thread signal hops such as
+    // signalBeforeRecompute() temporarily release it when they need to run
+    // Python on the GUI thread to avoid deadlocks.
+    Base::PyGILStateLocker locker;
 
     if (d->undoing || d->rollback) {
         if (FC_LOG_INSTANCE.isEnabled(FC_LOGLEVEL_LOG)) {
@@ -2807,12 +2810,7 @@ int Document::recompute(const std::vector<DocumentObject*>& objs,
 
     Base::ObjectStatusLocker<Document::Status, Document> exe(Document::Recomputing, this);
 
-    // This will hop into the main thread, fire signalBeforeRecompute(),
-    // and *block* the worker until the main thread is done, avoiding races
-    // between any running Python code and the rest of the recompute call.
-    if (d->_preRecomputeHook) {
-        d->_preRecomputeHook();
-    }
+    signalBeforeRecompute(*this);
 
     //////////////////////////////////////////////////////////////////////////
     // FIXME Comment by Realthunder:

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2649,7 +2649,7 @@ Document::getDependencyList(const std::vector<DocumentObject*>& objs, int option
                 ss << '\n';
             }
             FC_ERR(ss.str());
-            FC_THROWM(Base::RuntimeError, e.what());
+            FC_THROWM(Base::BadGraphError, e.what());
         }
         FC_ERR(e.what());
         ret = DocumentP::partialTopologicalSort(objs);

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <format>
+#include <optional>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/bimap.hpp>
@@ -63,6 +64,7 @@
 #include <Base/Writer.h>
 #include <Base/Profiler.h>
 #include <Base/Tools.h>
+#include <Base/XMLTools.h>
 #include <Base/Uuid.h>
 #include <Base/Sequencer.h>
 #include <Base/Stream.h>
@@ -104,6 +106,17 @@ using namespace zipios;
 #endif
 
 namespace fs = std::filesystem;
+
+namespace
+{
+
+bool transactionStateBlocksRecoveryWrite(const DocumentP& documentPrivate)
+{
+    return documentPrivate.bookedTransaction != NullTransaction
+        || documentPrivate.activeUndoTransaction != nullptr || documentPrivate.committing;
+}
+
+}  // namespace
 
 namespace App
 {
@@ -207,6 +220,7 @@ bool Document::undo(const int id)
         }
 
         signalUndo(*this);  // now signal the undo
+        signalBecameStable(*this);
 
         return true;
     }
@@ -260,6 +274,7 @@ bool Document::redo(const int id)
         }
 
         signalRedo(*this);
+        signalBecameStable(*this);
         return true;
     }
 
@@ -441,7 +456,7 @@ int Document::setActiveTransaction(TransactionName name, int tid)
             return NullTransaction;
         }
         d->bookedTransaction = tid;
- 
+
         if (GetApplication().transactionTmpName(d->bookedTransaction)) {
             GetApplication().setTransactionName(d->bookedTransaction, name);
         }
@@ -562,7 +577,11 @@ void Document::commitTransaction() // NOLINT
         // commit their transaction if their ID matches
         GetApplication().commitTransaction(d->activeUndoTransaction->getID());
     } else {
+        const bool wasRecoveryWriteBlocked = transactionStateBlocksRecoveryWrite(*d);
         d->bookedTransaction = 0; // Reset booked transaction even if it was not used
+        if (wasRecoveryWriteBlocked) {
+            signalBecameStable(*this);
+        }
     }
 }
 
@@ -580,26 +599,33 @@ bool Document::_commitTransaction(const bool notify)
     }
 
     d->bookedTransaction = 0;
+    bool committed = false;
     if (d->activeUndoTransaction) {
-        Base::FlagToggler<> flag(d->committing);
-        Application::TransactionSignaller signaller(false, true);
-        const int id = d->activeUndoTransaction->getID();
+        {
+            Base::FlagToggler<> flag(d->committing);
+            Application::TransactionSignaller signaller(false, true);
+            const int id = d->activeUndoTransaction->getID();
 
-        mUndoTransactions.push_back(d->activeUndoTransaction);
-        d->activeUndoTransaction = nullptr;
+            mUndoTransactions.push_back(d->activeUndoTransaction);
+            d->activeUndoTransaction = nullptr;
 
-        // check the stack for the limits
-        if (mUndoTransactions.size() > d->UndoMaxStackSize) {
-            mUndoMap.erase(mUndoTransactions.front()->getID());
-            delete mUndoTransactions.front();
-            mUndoTransactions.pop_front();
+            // check the stack for the limits
+            if (mUndoTransactions.size() > d->UndoMaxStackSize) {
+                mUndoMap.erase(mUndoTransactions.front()->getID());
+                delete mUndoTransactions.front();
+                mUndoTransactions.pop_front();
+            }
+            signalCommitTransaction(*this);
+
+            // commitTransaction() may call again _commitTransaction()
+            if (notify) {
+                GetApplication().commitTransaction(id);
+            }
         }
-        signalCommitTransaction(*this);
-
-        // commitTransaction() may call again _commitTransaction()
-        if (notify) {
-            GetApplication().commitTransaction(id);
-        }
+        committed = true;
+    }
+    if (committed) {
+        signalBecameStable(*this);
     }
     return true;
 }
@@ -615,7 +641,11 @@ void Document::abortTransaction() const
     if (d->activeUndoTransaction) {
         GetApplication().abortTransaction(d->activeUndoTransaction->getID());
     } else {
+        const bool wasRecoveryWriteBlocked = transactionStateBlocksRecoveryWrite(*d);
         d->bookedTransaction = 0; // Reset booked transaction even if it was not used
+        if (wasRecoveryWriteBlocked) {
+            signalBecameStable(*this);
+        }
     }
 }
 
@@ -628,18 +658,25 @@ void Document::_abortTransaction()
     }
 
     d->bookedTransaction = 0;
+    bool aborted = false;
     if (d->activeUndoTransaction) {
-        Base::FlagToggler<bool> flag(d->rollback);
-        Application::TransactionSignaller signaller(true, true);
+        {
+            Base::FlagToggler<bool> flag(d->rollback);
+            Application::TransactionSignaller signaller(true, true);
 
-        // applying the so far made changes
-        d->activeUndoTransaction->apply(*this, false);
+            // applying the so far made changes
+            d->activeUndoTransaction->apply(*this, false);
 
-        // destroy the undo
-        mUndoMap.erase(d->activeUndoTransaction->getID());
-        delete d->activeUndoTransaction;
-        d->activeUndoTransaction = nullptr;
-        signalAbortTransaction(*this);
+            // destroy the undo
+            mUndoMap.erase(d->activeUndoTransaction->getID());
+            delete d->activeUndoTransaction;
+            d->activeUndoTransaction = nullptr;
+            signalAbortTransaction(*this);
+        }
+        aborted = true;
+    }
+    if (aborted) {
+        signalBecameStable(*this);
     }
 }
 
@@ -1872,6 +1909,13 @@ bool Document::saveCopy(const char* file) const
     return this->FileName.getStrValue() != checked ? saveToFile(checked.c_str()) : false;
 }
 
+bool Document::canWriteRecoverySnapshot() const
+{
+    return !testStatus(Document::PartialDoc) && !testStatus(Document::TempDoc)
+        && !testStatus(Document::Recomputing) && !transactionStateBlocksRecoveryWrite(*d)
+        && !isPerformingTransaction();
+}
+
 // Save the document under the name it has been opened
 bool Document::save()
 {
@@ -2807,8 +2851,8 @@ int Document::recompute(const std::vector<DocumentObject*>& objs,
     d->clearRecomputeLog();
 
     Base::TimeTracker tracker("Document::recompute");
-
-    Base::ObjectStatusLocker<Document::Status, Document> exe(Document::Recomputing, this);
+    std::optional<Base::ObjectStatusLocker<Document::Status, Document>> recomputingStatus;
+    recomputingStatus.emplace(Document::Recomputing, this);
 
     signalBeforeRecompute(*this);
 
@@ -2928,7 +2972,15 @@ int Document::recompute(const std::vector<DocumentObject*>& objs,
         obj->setStatus(ObjectStatus::Recompute2, false);
     }
 
+    // Keep the document marked as Recomputing while signalRecomputed() runs.
+    // Those observers may execute Python or GUI code; clearing the status
+    // first would let re-entrant code see the document as stable before
+    // recompute teardown has finished. signalBecameStable() is the first
+    // point where observers may treat the document as stable again.
+
     signalRecomputed(*this, topoSortedObjects);
+    recomputingStatus.reset();
+    signalBecameStable(*this);
 
     tracker.checkpoint("Recompute total");
 

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -255,7 +255,9 @@ public:
     App::MainThreadSignal<void(const Document&, const std::string&)> signalFinishSave;
     /// Signal before recomputing the document.
     App::MainThreadSignal<void(const Document&)> signalBeforeRecompute;
-    /// Signal after recomputing the document.
+    /// Signal after recomputing the document but before the document is fully
+    /// stable again. Observers that require a fully stable post-recompute
+    /// state should wait for signalBecameStable().
     App::MainThreadSignal<void(const Document&, const std::vector<DocumentObject*>&)> signalRecomputed;
     /// Signal after recomputing an object.
     App::MainThreadSignal<void(const DocumentObject&)> signalRecomputedObject;
@@ -265,6 +267,9 @@ public:
     App::MainThreadSignal<void(const Document&)> signalCommitTransaction;
     /// Signal on an aborted transaction.
     App::MainThreadSignal<void(const Document&)> signalAbortTransaction;
+    /// Signal after document recompute/transaction state has fully unwound and
+    /// observers may treat the document as stable again.
+    App::MainThreadSignal<void(const Document&)> signalBecameStable;
     /// Signal on a skipping a recompute.
     App::MainThreadSignal<void(const Document&, const std::vector<DocumentObject*>&)> signalSkipRecompute;
     /// Signal on finishing restoring an object.
@@ -301,6 +306,16 @@ public:
      * @param[in] file: The file name to save the copy to.
      */
     bool saveCopy(const char* file) const;
+
+    /**
+     * @brief Return whether App-side document state allows a recovery write.
+     *
+     * This intentionally does not account for GUI-only concerns such as an
+     * active Gui transaction. Callers in Gui can combine this with their own
+     * additional checks. App-side transaction scopes are tracked explicitly so
+     * this does not depend on undo state being enabled.
+     */
+    bool canWriteRecoverySnapshot() const;
 
     /**
      * @brief Restore the document from the file in Property Path.

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -30,6 +30,7 @@
 #include <Base/Type.h>
 #include <Base/Handle.h>
 #include <Base/Bitmask.h>
+#include <App/MainThreadSignal.h>
 
 #include "PropertyContainer.h"
 #include "PropertyLinks.h"
@@ -198,31 +199,31 @@ public:
     // clang-format off
 
     /// Signal before changing a document property.
-    fastsignals::signal<void(const Document&, const Property&)> signalBeforeChange;
+    App::MainThreadSignal<void(const Document&, const Property&)> signalBeforeChange;
     /// Signal on a changed document property.
-    fastsignals::signal<void(const Document&, const Property&)> signalChanged;
+    App::MainThreadSignal<void(const Document&, const Property&)> signalChanged;
     /// Signal on new object.
-    fastsignals::signal<void(const DocumentObject&)> signalNewObject;
+    App::MainThreadSignal<void(const DocumentObject&)> signalNewObject;
     /// Signal on a deleted object.
-    fastsignals::signal<void(const DocumentObject&)> signalDeletedObject;
+    App::MainThreadSignal<void(const DocumentObject&)> signalDeletedObject;
     /// Signal before changing an object.
-    fastsignals::signal<void(const DocumentObject&, const Property&)> signalBeforeChangeObject;
+    App::MainThreadSignal<void(const DocumentObject&, const Property&)> signalBeforeChangeObject;
     /// Signal on a changed object.
-    fastsignals::signal<void(const DocumentObject&, const Property&)> signalChangedObject;
+    App::MainThreadSignal<void(const DocumentObject&, const Property&)> signalChangedObject;
     /// Signal on a manually called DocumentObject::touch().
-    fastsignals::signal<void(const DocumentObject&)> signalTouchedObject;
+    App::MainThreadSignal<void(const DocumentObject&)> signalTouchedObject;
     /// Signal on relabeled object.
-    fastsignals::signal<void(const DocumentObject&)> signalRelabelObject;
+    App::MainThreadSignal<void(const DocumentObject&)> signalRelabelObject;
     /// Signal on an activated object.
-    fastsignals::signal<void(const DocumentObject&)> signalActivatedObject;
+    App::MainThreadSignal<void(const DocumentObject&)> signalActivatedObject;
     /// Signal on a created object.
-    fastsignals::signal<void(const DocumentObject&, Transaction*)> signalTransactionAppend;
+    App::MainThreadSignal<void(const DocumentObject&, Transaction*)> signalTransactionAppend;
     /// Signal on a removed object.
-    fastsignals::signal<void(const DocumentObject&, Transaction*)> signalTransactionRemove;
+    App::MainThreadSignal<void(const DocumentObject&, Transaction*)> signalTransactionRemove;
     /// Signal on undo.
-    fastsignals::signal<void(const Document&)> signalUndo;
+    App::MainThreadSignal<void(const Document&)> signalUndo;
     /// Signal on redo.
-    fastsignals::signal<void(const Document&)> signalRedo;
+    App::MainThreadSignal<void(const Document&)> signalRedo;
 
     /**
      * @brief Signal on load/save document.
@@ -231,56 +232,48 @@ public:
      * hook to write additional information in the file (like Gui::Document
      * does).
      */
-    fastsignals::signal<void(Base::Writer&)> signalSaveDocument;
+    App::MainThreadSignal<void(Base::Writer&)> signalSaveDocument;
     /// Signal on restoring a document.
-    fastsignals::signal<void(Base::XMLReader&)> signalRestoreDocument;
+    App::MainThreadSignal<void(Base::XMLReader&)> signalRestoreDocument;
     /// Signal on exporting objects.
-    fastsignals::signal<void(const std::vector<DocumentObject*>&, Base::Writer&)> signalExportObjects;
+    App::MainThreadSignal<void(const std::vector<DocumentObject*>&, Base::Writer&)> signalExportObjects;
     /// Signal on exporting view objects.
-    fastsignals::signal<void(const std::vector<DocumentObject*>&, Base::Writer&)> signalExportViewObjects;
+    App::MainThreadSignal<void(const std::vector<DocumentObject*>&, Base::Writer&)> signalExportViewObjects;
     /// Signal on importing objects.
-    fastsignals::signal<void(const std::vector<DocumentObject*>&, Base::XMLReader&)> signalImportObjects;
+    App::MainThreadSignal<void(const std::vector<DocumentObject*>&, Base::XMLReader&)> signalImportObjects;
     /// Signal on importing view objects.
-    fastsignals::signal<void(const std::vector<DocumentObject*>&, Base::Reader&,
+    App::MainThreadSignal<void(const std::vector<DocumentObject*>&, Base::Reader&,
                                  const std::map<std::string, std::string>&)> signalImportViewObjects;
     /// Signal after finishing importing objects.
-    fastsignals::signal<void(const std::vector<DocumentObject*>&)> signalFinishImportObjects;
+    App::MainThreadSignal<void(const std::vector<DocumentObject*>&)> signalFinishImportObjects;
     /// Signal starting a save action to a file.
-    fastsignals::signal<void(const Document&, const std::string&)> signalStartSave;
+    App::MainThreadSignal<void(const Document&, const std::string&)> signalStartSave;
     /// Signal finishing a save action to a file.
-    fastsignals::signal<void(const Document&, const std::string&)> signalFinishSave;
+    App::MainThreadSignal<void(const Document&, const std::string&)> signalFinishSave;
     /// Signal before recomputing the document.
-    fastsignals::signal<void(const Document&)> signalBeforeRecompute;
+    App::MainThreadSignal<void(const Document&)> signalBeforeRecompute;
     /// Signal after recomputing the document.
-    fastsignals::signal<void(const Document&, const std::vector<DocumentObject*>&)> signalRecomputed;
+    App::MainThreadSignal<void(const Document&, const std::vector<DocumentObject*>&)> signalRecomputed;
     /// Signal after recomputing an object.
-    fastsignals::signal<void(const DocumentObject&)> signalRecomputedObject;
+    App::MainThreadSignal<void(const DocumentObject&)> signalRecomputedObject;
     /// Signal on a new opened transaction.
-    fastsignals::signal<void(const Document&, std::string)> signalOpenTransaction;
+    App::MainThreadSignal<void(const Document&, std::string)> signalOpenTransaction;
     /// Signal on a committed transaction.
-    fastsignals::signal<void(const Document&)> signalCommitTransaction;
+    App::MainThreadSignal<void(const Document&)> signalCommitTransaction;
     /// Signal on an aborted transaction.
-    fastsignals::signal<void(const Document&)> signalAbortTransaction;
+    App::MainThreadSignal<void(const Document&)> signalAbortTransaction;
     /// Signal on a skipping a recompute.
-    fastsignals::signal<void(const Document&, const std::vector<DocumentObject*>&)> signalSkipRecompute;
+    App::MainThreadSignal<void(const Document&, const std::vector<DocumentObject*>&)> signalSkipRecompute;
     /// Signal on finishing restoring an object.
-    fastsignals::signal<void(const DocumentObject&)> signalFinishRestoreObject;
+    App::MainThreadSignal<void(const DocumentObject&)> signalFinishRestoreObject;
     /// Signal on a changed property in the property editor.
-    fastsignals::signal<void(const Document&, const Property&)> signalChangePropertyEditor;
+    App::MainThreadSignal<void(const Document&, const Property&)> signalChangePropertyEditor;
     /// Signal on setting a value in an external link.
-    fastsignals::signal<void(std::string)> signalLinkXsetValue;
+    App::MainThreadSignal<void(std::string)> signalLinkXsetValue;
 
     // clang-format on
     /// @}
     // NOLINTEND
-
-    using PreRecomputeHook = std::function<void()>;
-
-    /** @brief Set a hook for before a recompute.
-     *
-     * @param[in] hook: The function to be called before a recompute.
-     */
-    void setPreRecomputeHook(const PreRecomputeHook& hook);
 
     /// Clear the document of all its administration.
     void clearDocument();

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -197,6 +197,9 @@ public:
      * @{
      */
     // clang-format off
+    // Document-scoped signals use MainThreadSignal so GUI observers can rely on
+    // main-thread delivery even when recompute runs on a worker. Raw
+    // DocumentObject signals intentionally keep their same-thread semantics.
 
     /// Signal before changing a document property.
     App::MainThreadSignal<void(const Document&, const Property&)> signalBeforeChange;

--- a/src/App/Document.pyi
+++ b/src/App/Document.pyi
@@ -102,6 +102,16 @@ class Document(PropertyContainer):
         """
         ...
 
+    def canWriteRecoverySnapshot(self) -> bool:
+        """
+        Return whether the document is in an App-side state that allows writing
+        a recovery snapshot.
+
+        This does not account for GUI-only constraints such as an active Gui
+        transaction.
+        """
+        ...
+
     def load(self, path: str, /) -> None:
         """
         Load the document from the given path.

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -183,6 +183,9 @@ public:
      * @brief Signal that the property of this object has changed.
      *
      * Subscribers will get the current object and the property that has changed.
+     * This is a raw same-thread signal. It is not marshaled back to the GUI
+     * thread; GUI code should generally subscribe to App::Document's
+     * document-scoped MainThreadSignal notifications instead.
      *
      * @param[in] obj  The document object whose property just changed.
      * @param[in] prop The property that was changed.
@@ -193,6 +196,8 @@ public:
      * @brief Emitted immediately after any property of this object has changed.
      *
      * This is fired before the outer "document-scoped" change notification.
+     * It intentionally keeps same-thread semantics and is not suitable for GUI
+     * observers that require main-thread delivery.
      *
      * @param[in] obj  The document object whose property just changed.
      * @param[in] prop The property that was changed.
@@ -1189,7 +1194,10 @@ public:
      * @brief Whether this object's recompute path is safe to run on the worker thread.
      *
      * This is used by async recompute scheduling. Objects that can touch GUI or
-     * other thread-affine state during recompute must return false.
+     * other thread-affine state during recompute must return false. Returning
+     * true means the recompute path is limited to worker-safe App/model work
+     * and does not depend on GUI, Qt event-loop state, or other thread-affine
+     * APIs.
      */
     virtual bool canRecomputeOnWorker() const
     {

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -1186,6 +1186,17 @@ public:
     }
 
     /**
+     * @brief Whether this object's recompute path is safe to run on the worker thread.
+     *
+     * This is used by async recompute scheduling. Objects that can touch GUI or
+     * other thread-affine state during recompute must return false.
+     */
+    virtual bool canRecomputeOnWorker() const
+    {
+        return true;
+    }
+
+    /**
      * @brief Called when an element reference is updated.
      *
      * @param[in] prop The property that was updated.

--- a/src/App/DocumentObjectPyImp.cpp
+++ b/src/App/DocumentObjectPyImp.cpp
@@ -26,6 +26,7 @@
 #include <Base/GeometryPyCXX.h>
 #include <Base/MatrixPy.h>
 #include <Base/PlacementPy.h>
+#include <Base/Console.h>
 #include <Base/PyWrapParseTupleAndKeywords.h>
 #include <Base/ServiceProvider.h>
 
@@ -35,6 +36,7 @@
 #include "GeoFeature.h"
 #include "GeoFeatureGroupExtension.h"
 #include "GroupExtension.h"
+#include "MainThreadSignal.h"
 #include "Services.h"
 
 
@@ -276,6 +278,16 @@ Py::Object DocumentObjectPy::getViewObject() const
             // in v0.14+, the GUI module can be loaded in console mode (but doesn't have all its
             // document methods)
             return Py::None();
+        }
+        if (!App::MainThreadSignalConfig::isMainThread()) {
+            Base::Console().error(
+                "GUI API 'App::DocumentObjectPy::getViewObject' may only be used from the main "
+                "thread.\n"
+            );
+            throw Py::RuntimeError(
+                "GUI API 'App::DocumentObjectPy::getViewObject' may only be used from the main "
+                "thread"
+            );
         }
         if (!getDocumentObjectPtr()->getDocument()) {
             throw Py::RuntimeError("Object has no document");

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -181,6 +181,15 @@ PyObject* DocumentPy::saveCopy(PyObject* args)
     PY_CATCH
 }
 
+PyObject* DocumentPy::canWriteRecoverySnapshot(PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
+    return Py::new_reference_to(Py::Boolean(getDocumentPtr()->canWriteRecoverySnapshot()));
+}
+
 PyObject* DocumentPy::load(PyObject* args)
 {
     char* filename = nullptr;

--- a/src/App/FeaturePython.cpp
+++ b/src/App/FeaturePython.cpp
@@ -581,6 +581,27 @@ int FeaturePythonImp::canLoadPartial() const
     }
 }
 
+FeaturePythonImp::ValueT FeaturePythonImp::supportsAsyncRecompute() const
+{
+    _FC_PY_CALL_CHECK(supportsAsyncRecompute, return (NotImplemented));
+    Base::PyGILStateLocker lock;
+    try {
+        Py::Tuple args(1);
+        args.setItem(0, Py::Object(object->getPyObject(), true));
+        Py::Boolean ok(Base::pyCall(py_supportsAsyncRecompute.ptr(), args.ptr()));
+        return ok ? Accepted : Rejected;
+    }
+    catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
+        Base::PyException e;  // extract the Python error text
+        e.reportException();
+        return Rejected;
+    }
+}
+
 FeaturePythonImp::ValueT FeaturePythonImp::redirectSubName(std::ostringstream& ss,
                                                            App::DocumentObject* topParent,
                                                            App::DocumentObject* child) const

--- a/src/App/FeaturePython.h
+++ b/src/App/FeaturePython.h
@@ -83,6 +83,8 @@ public:
 
     int canLoadPartial() const;
 
+    ValueT supportsAsyncRecompute() const;
+
     /// return true to activate tree view group object handling
     ValueT hasChildElement() const;
     /// Get sub-element visibility
@@ -117,6 +119,7 @@ private:
     FC_PY_ELEMENT(allowDuplicateLabel)                                                             \
     FC_PY_ELEMENT(redirectSubName)                                                                 \
     FC_PY_ELEMENT(canLoadPartial)                                                                  \
+    FC_PY_ELEMENT(supportsAsyncRecompute)                                                          \
     FC_PY_ELEMENT(hasChildElement)                                                                 \
     FC_PY_ELEMENT(isElementVisible)                                                                \
     FC_PY_ELEMENT(setElementVisible)                                                               \
@@ -341,6 +344,15 @@ public:
             return ret;
         }
         return FeatureT::canLoadPartial();
+    }
+
+    bool canRecomputeOnWorker() const override
+    {
+        if (!FeatureT::canRecomputeOnWorker()) {
+            return false;
+        }
+
+        return imp->supportsAsyncRecompute() == FeaturePythonImp::Accepted;
     }
 
     /**

--- a/src/App/FeatureTest.cpp
+++ b/src/App/FeatureTest.cpp
@@ -24,6 +24,8 @@
 
 
 #include <boost/core/ignore_unused.hpp>
+#include <condition_variable>
+#include <mutex>
 #include <sstream>
 
 #include <Base/Console.h>
@@ -42,6 +44,25 @@
 #endif
 
 using namespace App;
+
+namespace
+{
+
+struct AsyncBlockerState
+{
+    std::mutex mutex;
+    std::condition_variable changed;
+    bool started = false;
+    bool proceed = false;
+};
+
+AsyncBlockerState& getAsyncBlockerState()
+{
+    static AsyncBlockerState state;
+    return state;
+}
+
+}  // namespace
 
 
 PROPERTY_SOURCE(App::FeatureTest, App::DocumentObject)
@@ -368,5 +389,49 @@ DocumentObjectExecReturn* FeatureTestAttribute::execute()
         str << "No such attribute '" << Attribute.getValue() << "'";
         throw Base::AttributeError(str.str());
     }
+    return StdReturn;
+}
+
+// ----------------------------------------------------------------------------
+
+PROPERTY_SOURCE(App::FeatureTestAsyncBlocker, App::DocumentObject)
+
+
+FeatureTestAsyncBlocker::FeatureTestAsyncBlocker() = default;
+
+FeatureTestAsyncBlocker::~FeatureTestAsyncBlocker() = default;
+
+void FeatureTestAsyncBlocker::resetBlocker()
+{
+    auto& state = getAsyncBlockerState();
+    std::lock_guard<std::mutex> lock(state.mutex);
+    state.started = false;
+    state.proceed = false;
+}
+
+bool FeatureTestAsyncBlocker::waitUntilStarted(std::chrono::milliseconds timeout)
+{
+    auto& state = getAsyncBlockerState();
+    std::unique_lock<std::mutex> lock(state.mutex);
+    return state.changed.wait_for(lock, timeout, [&state] { return state.started; });
+}
+
+void FeatureTestAsyncBlocker::releaseBlocker()
+{
+    auto& state = getAsyncBlockerState();
+    {
+        std::lock_guard<std::mutex> lock(state.mutex);
+        state.proceed = true;
+    }
+    state.changed.notify_all();
+}
+
+DocumentObjectExecReturn* FeatureTestAsyncBlocker::execute()
+{
+    auto& state = getAsyncBlockerState();
+    std::unique_lock<std::mutex> lock(state.mutex);
+    state.started = true;
+    state.changed.notify_all();
+    state.changed.wait(lock, [&state] { return state.proceed; });
     return StdReturn;
 }

--- a/src/App/FeatureTest.h
+++ b/src/App/FeatureTest.h
@@ -214,6 +214,7 @@ public:
     FeatureTestAttribute();
     ~FeatureTestAttribute() override;
     DocumentObjectExecReturn* execute() override;
+    bool canRecomputeOnWorker() const override { return false; }
 
     App::PropertyPythonObject Object;
     App::PropertyString Attribute;

--- a/src/App/FeatureTest.h
+++ b/src/App/FeatureTest.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <chrono>
+
 #include "DocumentObject.h"
 #include "PropertyGeo.h"
 #include "PropertyLinks.h"
@@ -218,6 +220,21 @@ public:
 
     App::PropertyPythonObject Object;
     App::PropertyString Attribute;
+};
+
+class AppExport FeatureTestAsyncBlocker: public DocumentObject
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(App::FeatureTestAsyncBlocker);
+
+public:
+    FeatureTestAsyncBlocker();
+    ~FeatureTestAsyncBlocker() override;
+    DocumentObjectExecReturn* execute() override;
+    bool canRecomputeOnWorker() const override { return true; }
+
+    static void resetBlocker();
+    static bool waitUntilStarted(std::chrono::milliseconds timeout);
+    static void releaseBlocker();
 };
 
 

--- a/src/App/MainThreadSignal.h
+++ b/src/App/MainThreadSignal.h
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2025 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#ifndef APP_MAINTHREADSIGNAL_H
+#define APP_MAINTHREADSIGNAL_H
+
+#include <Base/Interpreter.h>
+#include <fastsignals/signal.h>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace App
+{
+
+// App owns these signal types because App::Document declares them. Gui installs
+// the actual main-thread hooks when a GUI application is available.
+class MainThreadSignalConfig
+{
+public:
+    using IsMainThreadFn = bool (*)();  // true iff currently on GUI/main thread
+    using InvokeFn = void (*)(std::function<void()>&& fn, bool blocking);
+
+    static void setHooks(IsMainThreadFn isMainThread, InvokeFn invoke)
+    {
+        isMainThreadSlot() = isMainThread;
+        invokeSlot() = invoke;
+    }
+
+    static inline bool isMainThread()
+    {
+        auto* f = isMainThreadSlot();
+        return f ? f() : true;  // no hooks, treat current thread as "main"
+    }
+
+    static inline bool hasHooks()
+    {
+        return isMainThreadSlot() && invokeSlot();
+    }
+
+    static inline void invoke(std::function<void()>&& fn, bool blocking)
+    {
+        auto* f = invokeSlot();
+        if (f) {
+            f(std::move(fn), blocking);
+        }
+        else {
+            fn();  // no hooks, run inline
+        }
+    }
+
+private:
+    static IsMainThreadFn& isMainThreadSlot()
+    {
+        static IsMainThreadFn fn = nullptr;
+        return fn;
+    }
+    static InvokeFn& invokeSlot()
+    {
+        static InvokeFn fn = nullptr;
+        return fn;
+    }
+};
+
+namespace detail
+{
+// Holds a value (for by-value params)
+template<class T>
+struct SignalArgValue
+{
+    T v;
+    constexpr decltype(auto) get() noexcept
+    {
+        return (v);
+    }
+    constexpr decltype(auto) get() const noexcept
+    {
+        return (v);
+    }
+};
+
+// Holds a pointer (for by-reference params, preserves cv-qualifiers)
+template<class T>
+struct SignalArgRef
+{
+    using Raw = std::remove_reference_t<T>;  // keeps const if present
+    Raw* p {};                               // pointer preserves cv-ness
+    constexpr decltype(auto) get() const noexcept
+    {
+        return *p;
+    }  // Raw& or const Raw&
+};
+
+// Explicitly choose storage kind from the declared parameter type PDecl
+template<class PDecl>
+auto captureSignalArg(PDecl&& x)
+{
+    if constexpr (std::is_lvalue_reference_v<PDecl>) {
+        using Raw = std::remove_reference_t<PDecl>;
+        return SignalArgRef<Raw> {std::addressof(x)};  // &param → pointer
+    }
+    else {
+        using V = std::decay_t<PDecl>;
+        return SignalArgValue<V> {std::forward<PDecl>(x)};  // value param → by value
+    }
+}
+
+template<class T>
+using non_void_t = std::conditional_t<std::is_void_v<T>, std::monostate, T>;
+}  // namespace detail
+
+// Wrapper that mirrors fastsignals::signal but executes slots on GUI thread.
+template<class Signature, template<class T> class Combiner = ::fastsignals::optional_last_value>
+class MainThreadSignal;
+
+template<class Return, class... Arguments, template<class T> class Combiner>
+class MainThreadSignal<Return(Arguments...), Combiner>
+{
+    using base_sig = ::fastsignals::signal<Return(Arguments...), Combiner>;
+
+public:
+    using signature_type = typename base_sig::signature_type;
+    using slot_type = typename base_sig::slot_type;
+    using combiner_type = typename base_sig::combiner_type;
+    using result_type = typename base_sig::result_type;
+
+    MainThreadSignal() = default;
+    MainThreadSignal(const MainThreadSignal&) = delete;
+    MainThreadSignal& operator=(const MainThreadSignal&) = delete;
+    MainThreadSignal(MainThreadSignal&&) = default;
+    MainThreadSignal& operator=(MainThreadSignal&&) = default;
+
+    // connections
+    ::fastsignals::connection connect(slot_type slot)
+    {
+        return sig_.connect(std::move(slot));
+    }
+    ::fastsignals::advanced_connection connect(slot_type slot, ::fastsignals::advanced_tag tag)
+    {
+        return sig_.connect(std::move(slot), tag);
+    }
+
+    void disconnect_all_slots() noexcept
+    {
+        sig_.disconnect_all_slots();
+    }
+    std::size_t num_slots() const noexcept
+    {
+        return sig_.num_slots();
+    }
+    bool empty() const noexcept
+    {
+        return sig_.empty();
+    }
+
+    // ---- emission APIs ------------------------------------------------------
+
+    result_type emit(typename ::fastsignals::signal_arg_t<Arguments>... args)
+    {
+        return emitImpl(this, std::forward<typename ::fastsignals::signal_arg_t<Arguments>>(args)...);
+    }
+
+    result_type emit(typename ::fastsignals::signal_arg_t<Arguments>... args) const
+    {
+        return emitImpl(this, std::forward<typename ::fastsignals::signal_arg_t<Arguments>>(args)...);
+    }
+
+    result_type operator()(typename ::fastsignals::signal_arg_t<Arguments>... args)
+    {
+        return emit(std::forward<typename ::fastsignals::signal_arg_t<Arguments>>(args)...);
+    }
+
+    result_type operator()(typename ::fastsignals::signal_arg_t<Arguments>... args) const
+    {
+        return emit(std::forward<typename ::fastsignals::signal_arg_t<Arguments>>(args)...);
+    }
+
+    // Plug a MainThreadSignal into a plain fastsignal as a slot:
+    operator slot_type() const noexcept
+    {
+        return [this](typename ::fastsignals::signal_arg_t<Arguments>... args) {
+            emit(std::forward<typename ::fastsignals::signal_arg_t<Arguments>>(args)...);
+            if constexpr (!std::is_void_v<Return>) {
+                return Return();
+            }
+        };
+    }
+
+    // escape hatch
+    base_sig& underlying()
+    {
+        return sig_;
+    }
+    const base_sig& underlying() const
+    {
+        return sig_;
+    }
+
+private:
+    template<class Self>
+    static result_type emitImpl(
+        Self* self,
+        typename ::fastsignals::signal_arg_t<Arguments>... args
+    )
+    {
+        if (MainThreadSignalConfig::isMainThread()) {
+            return self->sig_(std::forward<typename ::fastsignals::signal_arg_t<Arguments>>(args)...);
+        }
+
+        Base::PyGILStateRelease release;
+
+        auto caps = std::make_tuple(
+            detail::captureSignalArg<typename ::fastsignals::signal_arg_t<Arguments>>(args)...
+        );
+
+        if constexpr (std::is_void_v<result_type>) {
+            MainThreadSignalConfig::invoke(
+                [self, caps = std::move(caps)]() mutable {
+                    std::apply([self](auto&... c) { self->sig_(c.get()...); }, caps);
+                },
+                /*blocking=*/true
+            );
+        }
+        else {
+            std::optional<detail::non_void_t<result_type>> result;
+            MainThreadSignalConfig::invoke(
+                [self, caps = std::move(caps), &result]() mutable {
+                    result.emplace(
+                        std::apply([self](auto&... c) { return self->sig_(c.get()...); }, caps)
+                    );
+                },
+                /*blocking=*/true
+            );
+            return std::move(*result);
+        }
+    }
+
+    mutable base_sig sig_;
+};
+
+}  // namespace App
+
+#endif  // APP_MAINTHREADSIGNAL_H

--- a/src/App/MainThreadSignal.h
+++ b/src/App/MainThreadSignal.h
@@ -37,6 +37,11 @@ namespace App
 
 // App owns these signal types because App::Document declares them. Gui installs
 // the actual main-thread hooks when a GUI application is available.
+//
+// These signals are intended for document-scoped notifications that GUI code
+// may observe while recompute can run on a worker thread. Raw
+// App::DocumentObject signals intentionally remain plain fastsignals with
+// same-thread semantics.
 class MainThreadSignalConfig
 {
 public:

--- a/src/App/RecoverySnapshot.cpp
+++ b/src/App/RecoverySnapshot.cpp
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <sstream>
+#include <utility>
+
+#include <Base/Exception.h>
+#include <Base/FileInfo.h>
+#include <Base/Stream.h>
+#include <Base/Writer.h>
+#include <Base/XMLTools.h>
+
+#include "Application.h"
+#include "Document.h"
+#include "RecoverySnapshot.h"
+
+namespace
+{
+
+class ScopedSaveThumbnailPreference
+{
+public:
+    ScopedSaveThumbnailPreference(ParameterGrp::handle params, bool enabled)
+        : params(std::move(params))
+        , originalValue(this->params->GetBool("SaveThumbnail", true))
+    {
+        this->params->SetBool("SaveThumbnail", enabled);
+    }
+
+    ScopedSaveThumbnailPreference(const ScopedSaveThumbnailPreference&) = delete;
+    ScopedSaveThumbnailPreference& operator=(const ScopedSaveThumbnailPreference&) = delete;
+
+    ~ScopedSaveThumbnailPreference()
+    {
+        params->SetBool("SaveThumbnail", originalValue);
+    }
+
+private:
+    ParameterGrp::handle params;
+    bool originalValue;
+};
+
+std::string recoveryDirectoryFor(const App::Document& doc)
+{
+    std::string dirName = doc.TransientDir.getValue();
+    dirName += "/fc_recovery_files";
+    return dirName;
+}
+
+void writeRecoveryMetadataFile(const App::Document& doc)
+{
+    std::string fileName = doc.TransientDir.getValue();
+    fileName += "/fc_recovery_file.xml";
+    const auto escapedLabel = XMLTools::escapeXml(doc.Label.getValue());
+    const auto escapedFileName = XMLTools::escapeXml(doc.FileName.getValue());
+
+    Base::FileInfo fileInfo(fileName);
+    Base::ofstream file(fileInfo, std::ios::out | std::ios::binary);
+    if (!file.is_open()) {
+        throw Base::FileException("Failed to open auto-recovery metadata file", fileInfo);
+    }
+
+    file << "<?xml version='1.0' encoding='utf-8'?>\n"
+         << "<AutoRecovery SchemaVersion=\"1\">\n"
+         << "  <Status>Created</Status>\n"
+         << "  <Label>" << escapedLabel << "</Label>\n"
+         << "  <FileName>" << escapedFileName << "</FileName>\n"
+         << "</AutoRecovery>\n";
+}
+
+template<typename WriterT>
+void writeRecoverySnapshotContents(const App::Document& doc, WriterT& writer)
+{
+    writer.putNextEntry("Document.xml");
+    doc.Save(writer);
+
+    // Special handling for Gui document state.
+    doc.signalSaveDocument(writer);
+    writer.writeFiles();
+
+    if (writer.hasErrors()) {
+        std::stringstream message;
+        message << "Failed to write all data to auto-recovery output ";
+        message << writer.getErrors().front();
+        throw Base::FileException(message.str().c_str());
+    }
+}
+
+void writeUncompressedRecoverySnapshot(const App::Document& doc, bool saveBinaryBrep)
+{
+    std::string dirName = recoveryDirectoryFor(doc);
+    Base::FileInfo dir(dirName);
+    if (!dir.exists() && !dir.createDirectory()) {
+        throw Base::FileException("Failed to create auto-recovery directory", dir);
+    }
+
+    Base::FileWriter writer(dirName.c_str());
+    if (saveBinaryBrep) {
+        writer.setMode("BinaryBrep");
+    }
+
+    writeRecoverySnapshotContents(doc, writer);
+}
+
+void writeCompressedRecoverySnapshot(const App::Document& doc, bool saveBinaryBrep)
+{
+    std::string fileName = doc.TransientDir.getValue();
+    fileName += "/fc_recovery_file.fcstd";
+
+    Base::FileInfo fileInfo(fileName);
+    Base::ofstream file(fileInfo, std::ios::out | std::ios::binary);
+    if (!file.is_open()) {
+        throw Base::FileException("Failed to open auto-recovery archive", fileInfo);
+    }
+
+    Base::ZipWriter writer(file);
+    if (saveBinaryBrep) {
+        writer.setMode("BinaryBrep");
+    }
+
+    writer.setComment("AutoRecovery file");
+    writer.setLevel(1);  // Prefer lower latency over compression ratio for autosave.
+    writeRecoverySnapshotContents(doc, writer);
+}
+
+}  // namespace
+
+namespace App
+{
+
+bool writeRecoverySnapshotToTransientDir(const Document& doc,
+                                         const RecoverySnapshotSaveOptions& options)
+{
+    if (!doc.canWriteRecoverySnapshot()) {
+        std::stringstream message;
+        message << "Document '" << doc.Label.getValue()
+                << "' is not in a stable App state for recovery write";
+        throw Base::RuntimeError(message.str().c_str());
+    }
+
+    auto params = GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Document"
+    );
+    ScopedSaveThumbnailPreference saveThumbnailPreference(params, options.saveThumbnail);
+
+    writeRecoveryMetadataFile(doc);
+
+    if (!options.compressed) {
+        writeUncompressedRecoverySnapshot(doc, options.saveBinaryBrep);
+        return true;
+    }
+
+    writeCompressedRecoverySnapshot(doc, options.saveBinaryBrep);
+    return true;
+}
+
+}  // namespace App

--- a/src/App/RecoverySnapshot.h
+++ b/src/App/RecoverySnapshot.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include "ExportInfo.h"
+
+namespace App
+{
+class Document;
+
+struct AppExport RecoverySnapshotSaveOptions
+{
+    bool compressed {true};
+    bool saveBinaryBrep {true};
+    bool saveThumbnail {false};
+};
+
+AppExport bool writeRecoverySnapshotToTransientDir(
+    const Document& doc,
+    const RecoverySnapshotSaveOptions& options
+);
+}  // namespace App

--- a/src/App/private/DocumentP.h
+++ b/src/App/private/DocumentP.h
@@ -107,8 +107,6 @@ struct DocumentP
 
     StringHasherRef Hasher {new StringHasher};
 
-    Document::PreRecomputeHook _preRecomputeHook;
-
     DocumentP();
 
     void addRecomputeLog(const char* why, App::DocumentObject* obj)

--- a/src/Base/Exception.h
+++ b/src/Base/Exception.h
@@ -164,6 +164,9 @@ class BaseExport Exception: public BaseClass
 
 public:
     explicit Exception(std::string message = "FreeCAD Exception");
+    Exception(const Exception& inst);
+    Exception(Exception&& inst) noexcept;
+
     ~Exception() noexcept override = default;
 
     Exception& operator=(const Exception& inst);
@@ -196,10 +199,6 @@ public:
 
     virtual PyObject* getPyExceptionType() const;
     virtual void setPyException() const;
-
-protected:
-    Exception(const Exception& inst);
-    Exception(Exception&& inst) noexcept;
 
 private:
     std::string errorMessage;

--- a/src/Doc/AsyncRecompute.dox
+++ b/src/Doc/AsyncRecompute.dox
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-FileCopyrightText: 2026 Joao Matos */
+/* SPDX-FileNotice: Part of the FreeCAD project. */
+
+/** \page asyncrecompute Async recompute threading rules
+
+Async recompute allows some document recomputes to run on a worker thread.
+That changes the threading contract for code that can run during recompute or
+observe recompute-side state.
+
+\section asyncrecompute_scope Scope
+
+The current async recompute implementation is request-based. A recompute
+request may run on a worker thread when the request target is explicitly marked
+as worker-safe. Worker-safety is determined through
+App::DocumentObject::canRecomputeOnWorker().
+
+Objects that are not known to be worker-safe are expected to return false. In
+that case the recompute request falls back to the main thread instead of being
+queued to the worker.
+
+\section asyncrecompute_cpp Rules for C++ code
+
+- Code that runs from DocumentObject::execute(), document recompute hooks, or
+  any other recompute-side callback must be safe to execute concurrently with
+  the GUI thread and with other unrelated asynchronous activity.
+- Code that touches Qt widgets, view providers, FreeCADGui APIs, event loops,
+  timers, network callbacks, or any other thread-affine state must stay on the
+  main thread.
+- If an object's recompute path is not worker-safe, override
+  App::DocumentObject::canRecomputeOnWorker() to return false.
+- Document-scoped signals in App::Document use App::MainThreadSignal and are
+  intended for observers that need main-thread delivery, especially GUI code.
+- Raw App::DocumentObject signals remain plain fastsignals with same-thread
+  semantics. GUI code should not subscribe to them directly.
+
+\section asyncrecompute_python Rules for Python-backed objects
+
+Python-backed features may execute from the recompute worker. The GIL is kept
+for the duration of document recompute so Python execution stays serialized, but
+that does not make GUI access worker-safe.
+
+- App::FeaturePython objects default to worker-unsafe and therefore stay on the
+  main thread unless they explicitly opt in.
+- Python execute() implementations must not access Qt UI or FreeCADGui objects
+  from a worker thread.
+- Worker-thread GUI access should fail fast through the guarded FreeCADGui and
+  ViewObject entry points instead of proceeding silently.
+
+\section asyncrecompute_review Review checklist
+
+When changing recompute-related code, check at least the following:
+
+- Does this code run during recompute, or observe state that recompute mutates?
+- Does it touch GUI, Qt event-loop state, or any other thread-affine API?
+- Should this object override canRecomputeOnWorker()?
+- Is GUI-facing code subscribed to document-scoped main-thread signals instead
+  of raw DocumentObject signals?
+- Does the change introduce a new background callback path such as QTimer,
+  QThread, QNetwork, QtConcurrent, or a custom worker that can now overlap with
+  recompute?
+
+*/

--- a/src/Doc/mainpage.dox.in
+++ b/src/Doc/mainpage.dox.in
@@ -27,6 +27,7 @@
     @section toc Table of Contents
     - @ref intro_main "Introduction"
     - @ref organization "Organization of the API Documentation"
+    - @ref asyncrecompute "Async recompute threading rules"
     - @ref other_doc "Other Documentation"
 
     @section intro_main Introduction

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -386,18 +386,22 @@ struct PyMethodDef FreeCADGui_methods[] = {
     {nullptr, nullptr, 0, nullptr} /* sentinel */
 };
 
-class MainThreadInvoker final : public QObject {
+class MainThreadInvoker final: public QObject
+{
 public:
-    static MainThreadInvoker* instance() {
-        static MainThreadInvoker* inst = []{
+    static MainThreadInvoker* instance()
+    {
+        static MainThreadInvoker* inst = [] {
             auto* obj = new MainThreadInvoker();
             // Ensure the object lives on the GUI thread
-            if (qApp && qApp->thread() && QThread::currentThread() != qApp->thread())
+            if (qApp && qApp->thread() && QThread::currentThread() != qApp->thread()) {
                 obj->moveToThread(qApp->thread());
+            }
             return obj;
         }();
         return inst;
     }
+
 private:
     MainThreadInvoker() = default;
     ~MainThreadInvoker() override = default;
@@ -419,9 +423,7 @@ void qtInvokeOnMain(std::function<void()>&& fn, bool blocking)
 
     QMetaObject::invokeMethod(
         MainThreadInvoker::instance(),
-        [f = std::move(fn)]() mutable {
-            f();
-        },
+        [f = std::move(fn)]() mutable { f(); },
         blocking ? Qt::BlockingQueuedConnection : Qt::QueuedConnection
     );
 }

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -40,6 +40,7 @@
 #include <QSurfaceFormat>
 #include <QTextStream>
 #include <QTimer>
+#include <QThread>
 #include <QWindow>
 #include <QStyleFactory>
 
@@ -385,6 +386,46 @@ struct PyMethodDef FreeCADGui_methods[] = {
     {nullptr, nullptr, 0, nullptr} /* sentinel */
 };
 
+class MainThreadInvoker final : public QObject {
+public:
+    static MainThreadInvoker* instance() {
+        static MainThreadInvoker* inst = []{
+            auto* obj = new MainThreadInvoker();
+            // Ensure the object lives on the GUI thread
+            if (qApp && qApp->thread() && QThread::currentThread() != qApp->thread())
+                obj->moveToThread(qApp->thread());
+            return obj;
+        }();
+        return inst;
+    }
+private:
+    MainThreadInvoker() = default;
+    ~MainThreadInvoker() override = default;
+};
+
+// Hook: are we currently on the GUI (main) thread?
+bool qtIsMainThread()
+{
+    return !qApp || (QThread::currentThread() == qApp->thread());
+}
+
+// Hook: invoke a functor on the GUI thread, either blocking or queued.
+void qtInvokeOnMain(std::function<void()>&& fn, bool blocking)
+{
+    if (!qApp) {
+        fn();
+        return;
+    }
+
+    QMetaObject::invokeMethod(
+        MainThreadInvoker::instance(),
+        [f = std::move(fn)]() mutable {
+            f();
+        },
+        blocking ? Qt::BlockingQueuedConnection : Qt::QueuedConnection
+    );
+}
+
 }  // namespace Gui
 
 void Application::initStyleParameterManager()
@@ -464,11 +505,14 @@ void Application::initStyleParameterManager()
 
     Base::registerServiceImplementation(d->styleParameterManager);
 }
+
 // clang-format off
 Application::Application(bool GUIenabled)
 {
     // App::GetApplication().Attach(this);
     if (GUIenabled) {
+        App::MainThreadSignalConfig::setHooks(&qtIsMainThread, &qtInvokeOnMain);
+
         // NOLINTBEGIN
         App::GetApplication().signalNewDocument.connect(
             std::bind(&Gui::Application::slotNewDocument, this, sp::_1, sp::_2));

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -51,6 +51,7 @@
 
 #include <App/Document.h>
 #include <App/DocumentObjectPy.h>
+#include <App/MainThreadSignal.h>
 #include <Base/Console.h>
 #include <Base/Interpreter.h>
 #include <Base/Exception.h>
@@ -170,6 +171,18 @@ extern const long NlErrorCode;  // initialized before main() by navlib_load.cpp
 
 namespace Gui
 {
+
+void requireMainThread(const char* api)
+{
+    if (App::MainThreadSignalConfig::isMainThread()) {
+        return;
+    }
+
+    Base::Console().error("GUI API '%s' may only be used from the main thread.\n", api);
+    throw Base::RuntimeError(
+        std::string("GUI API '") + api + "' may only be used from the main thread"
+    );
+}
 
 class ViewProviderMap
 {
@@ -1699,6 +1712,7 @@ Gui::Document* Application::getDocument(const App::Document* pDoc) const
 
 void Application::showViewProvider(const App::DocumentObject* obj)
 {
+    requireMainThread("Gui::Application::showViewProvider");
     ViewProvider* vp = getViewProvider(obj);
     if (vp) {
         vp->show();
@@ -1707,6 +1721,7 @@ void Application::showViewProvider(const App::DocumentObject* obj)
 
 void Application::hideViewProvider(const App::DocumentObject* obj)
 {
+    requireMainThread("Gui::Application::hideViewProvider");
     ViewProvider* vp = getViewProvider(obj);
     if (vp) {
         vp->hide();
@@ -1715,6 +1730,7 @@ void Application::hideViewProvider(const App::DocumentObject* obj)
 
 Gui::ViewProvider* Application::getViewProvider(const App::DocumentObject* obj) const
 {
+    requireMainThread("Gui::Application::getViewProvider");
     return d->viewproviderMap.getViewProvider(obj);
 }
 

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -37,6 +37,8 @@ class NavlibInterface;
 
 namespace Gui
 {
+GuiExport void requireMainThread(const char* api);
+
 class ApplicationPy;
 class BaseView;
 class CommandManager;

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -1136,6 +1136,8 @@ PyObject* ApplicationPy::sActivateWorkbenchHandler(PyObject* /*self*/, PyObject*
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.activateWorkbench");
+
     // search for workbench handler from the dictionary
     PyObject* pcWorkbench = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary, psKey);
     if (!pcWorkbench) {
@@ -1446,6 +1448,8 @@ PyObject* ApplicationPy::sAddCommand(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.addCommand");
+
     // get the call stack to find the Python module name
     //
     std::string module;
@@ -1543,6 +1547,8 @@ PyObject* ApplicationPy::sRunCommand(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.runCommand");
+
     Gui::Command::LogDisabler d1;
     Gui::SelectionLogDisabler d2;
 
@@ -1562,6 +1568,8 @@ PyObject* ApplicationPy::sDoCommand(PyObject* /*self*/, PyObject* args)
     if (!PyArg_ParseTuple(args, "s", &sCmd)) {
         return nullptr;
     }
+
+    requirePythonMainThread("FreeCADGui.doCommand");
 
     Gui::Command::LogDisabler d1;
     Gui::SelectionLogDisabler d2;
@@ -1593,6 +1601,8 @@ PyObject* ApplicationPy::sDoCommandGui(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.doCommandGui");
+
     Gui::Command::LogDisabler d1;
     Gui::SelectionLogDisabler d2;
 
@@ -1623,6 +1633,8 @@ PyObject* ApplicationPy::sDoCommandEval(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.doCommandEval");
+
     Gui::Command::LogDisabler d1;
     Gui::SelectionLogDisabler d2;
 
@@ -1649,6 +1661,8 @@ PyObject* ApplicationPy::sDoCommandSkip(PyObject* /*self*/, PyObject* args)
     if (!PyArg_ParseTuple(args, "s", &sCmd)) {
         return nullptr;
     }
+
+    requirePythonMainThread("FreeCADGui.doCommandSkip");
 
     Gui::Command::LogDisabler d1;
     Gui::SelectionLogDisabler d2;

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -35,6 +35,7 @@
 #include <App/DocumentObjectPy.h>
 #include <App/DocumentPy.h>
 #include <App/PropertyFile.h>
+#include <Base/Exception.h>
 #include <Base/Interpreter.h>
 #include <Base/Console.h>
 #include <Base/PyWrapParseTupleAndKeywords.h>
@@ -71,6 +72,19 @@
 
 
 using namespace Gui;
+
+namespace
+{
+void requirePythonMainThread(const char* api)
+{
+    try {
+        Gui::requireMainThread(api);
+    }
+    catch (const Base::Exception& exception) {
+        throw Py::RuntimeError(exception.what());
+    }
+}
+}  // namespace
 
 // Application methods structure
 PyMethodDef ApplicationPy::Methods[] = {
@@ -559,6 +573,8 @@ PyObject* Gui::ApplicationPy::sEditDocument(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.editDocument");
+
     Document* pcDoc = Application::Instance->editDocument();
     if (pcDoc) {
         return pcDoc->getPyObject();
@@ -572,6 +588,8 @@ PyObject* Gui::ApplicationPy::sActiveDocument(PyObject* /*self*/, PyObject* args
     if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
     }
+
+    requirePythonMainThread("FreeCADGui.activeDocument");
 
     Document* pcDoc = Application::Instance->activeDocument();
     if (pcDoc) {
@@ -587,6 +605,8 @@ PyObject* Gui::ApplicationPy::sActiveView(PyObject* /*self*/, PyObject* args)
     if (!PyArg_ParseTuple(args, "|s", &typeName)) {
         return nullptr;
     }
+
+    requirePythonMainThread("FreeCADGui.activeView");
 
     PY_TRY
     {
@@ -630,6 +650,8 @@ PyObject* Gui::ApplicationPy::sActivateView(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.activateView");
+
     Base::Type type = Base::Type::fromName(typeStr);
     Application::Instance->activateView(type, Base::asBoolean(create));
 
@@ -671,6 +693,8 @@ PyObject* Gui::ApplicationPy::sSetActiveDocument(PyObject* /*self*/, PyObject* a
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.setActiveDocument");
+
     if (Application::Instance->activeDocument() != pcDoc) {
         Gui::MDIView* view = pcDoc->getActiveView();
         getMainWindow()->setActiveWindow(view);
@@ -681,6 +705,8 @@ PyObject* Gui::ApplicationPy::sSetActiveDocument(PyObject* /*self*/, PyObject* a
 
 PyObject* ApplicationPy::sGetDocument(PyObject* /*self*/, PyObject* args)
 {
+    requirePythonMainThread("FreeCADGui.getDocument");
+
     char* pstr = nullptr;
     if (PyArg_ParseTuple(args, "s", &pstr)) {
         Document* pcDoc = Application::Instance->getDocument(pstr);
@@ -716,6 +742,8 @@ PyObject* ApplicationPy::sHide(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.hide");
+
     Document* pcDoc = Application::Instance->activeDocument();
 
     if (pcDoc) {
@@ -731,6 +759,8 @@ PyObject* ApplicationPy::sShow(PyObject* /*self*/, PyObject* args)
     if (!PyArg_ParseTuple(args, "s;Name of the object to show has to be given!", &psFeatStr)) {
         return nullptr;
     }
+
+    requirePythonMainThread("FreeCADGui.show");
 
     Document* pcDoc = Application::Instance->activeDocument();
 
@@ -748,6 +778,8 @@ PyObject* ApplicationPy::sHideObject(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.hideObject");
+
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(object)->getDocumentObjectPtr();
     Application::Instance->hideViewProvider(obj);
@@ -761,6 +793,8 @@ PyObject* ApplicationPy::sShowObject(PyObject* /*self*/, PyObject* args)
     if (!PyArg_ParseTuple(args, "O!", &(App::DocumentObjectPy::Type), &object)) {
         return nullptr;
     }
+
+    requirePythonMainThread("FreeCADGui.showObject");
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(object)->getDocumentObjectPtr();
@@ -928,6 +962,8 @@ PyObject* ApplicationPy::sSendActiveView(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.SendMsgToActiveView");
+
     if (!Application::Instance->sendMsgToActiveView(psCommandStr)) {
         if (!Base::asBoolean(suppress)) {
             Base::Console().warning("Unknown view command: %s\n", psCommandStr);
@@ -946,6 +982,8 @@ PyObject* ApplicationPy::sSendFocusView(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.SendMsgToFocusView");
+
     if (!Application::Instance->sendMsgToFocusView(psCommandStr)) {
         if (!Base::asBoolean(suppress)) {
             Base::Console().warning("Unknown view command: %s\n", psCommandStr);
@@ -961,6 +999,8 @@ PyObject* ApplicationPy::sGetMainWindow(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.getMainWindow");
+
     try {
         return Py::new_reference_to(MainWindowPy::createWrapper(Gui::getMainWindow()));
     }
@@ -974,6 +1014,8 @@ PyObject* ApplicationPy::sUpdateGui(PyObject* /*self*/, PyObject* args)
     if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
     }
+
+    requirePythonMainThread("FreeCADGui.updateGui");
 
     qApp->processEvents();
 
@@ -1639,6 +1681,8 @@ PyObject* ApplicationPy::sShowDownloads(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    requirePythonMainThread("FreeCADGui.showDownloads");
+
     Gui::Dialog::DownloadManager::getInstance();
 
     Py_Return;
@@ -1651,6 +1695,8 @@ PyObject* ApplicationPy::sShowPreferences(PyObject* /*self*/, PyObject* args)
     if (!PyArg_ParseTuple(args, "|si", &pstr, &idx)) {
         return nullptr;
     }
+
+    requirePythonMainThread("FreeCADGui.showPreferences");
 
     Gui::Dialog::DlgPreferencesImp cDlg(getMainWindow());
     if (pstr) {
@@ -1672,6 +1718,8 @@ PyObject* ApplicationPy::sShowPreferencesByName(PyObject* /*self*/, PyObject* ar
     if (!PyArg_ParseTuple(args, "s|s", &pstr, &prefType)) {
         return nullptr;
     }
+
+    requirePythonMainThread("FreeCADGui.showPreferences");
 
     Gui::Dialog::DlgPreferencesImp cDlg(getMainWindow());
     if (pstr && prefType) {
@@ -1699,6 +1747,7 @@ PyObject* ApplicationPy::sCreateViewer(PyObject* /*self*/, PyObject* args)
         PyErr_Format(PyExc_ValueError, "views must be > 0");
         return nullptr;
     }
+    requirePythonMainThread("FreeCADGui.createViewer");
     if (num_of_views == 1) {
         auto viewer = new View3DInventor(nullptr, nullptr);
         if (title) {

--- a/src/Gui/AutoSaver.cpp
+++ b/src/Gui/AutoSaver.cpp
@@ -21,32 +21,47 @@
  ***************************************************************************/
 
 #include <QApplication>
-#include <QFile>
-#include <QDir>
-#include <QRunnable>
-#include <QTextStream>
-#include <QThreadPool>
+#include <QTimer>
+#include <QThread>
 
 #include <App/Application.h>
 #include <App/Document.h>
-#include <App/DocumentObject.h>
+#include <App/RecoverySnapshot.h>
 #include <Base/Console.h>
-#include <Base/FileInfo.h>
-#include <Base/Stream.h>
 #include <Base/TimeInfo.h>
 #include <Base/Tools.h>
-#include <Base/Writer.h>
 
 #include "AutoSaver.h"
+#include "Application.h"
 #include "Document.h"
 #include "MainWindow.h"
-#include "ViewProvider.h"
 #include "WaitCursor.h"
 
 FC_LOG_LEVEL_INIT("App", true, true)
 
 using namespace Gui;
-namespace sp = std::placeholders;
+
+namespace
+{
+
+bool isGuiDocumentStableForAutoSave(const App::Document* doc)
+{
+    if (!doc) {
+        return false;
+    }
+
+    if (auto* app = Gui::Application::Instance) {
+        if (auto* guiDoc = app->getDocument(doc)) {
+            if (guiDoc->isPerformingTransaction()) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+}  // namespace
 
 AutoSaver* AutoSaver::self = nullptr;
 const int AutoSaveTimeout = 900000;
@@ -56,14 +71,12 @@ AutoSaver::AutoSaver(QObject* parent)
     , timeout(AutoSaveTimeout)
     , compressed(true)
 {
-    // NOLINTBEGIN
-    App::GetApplication().signalNewDocument.connect(
-        std::bind(&AutoSaver::slotCreateDocument, this, sp::_1)
-    );
-    App::GetApplication().signalDeleteDocument.connect(
-        std::bind(&AutoSaver::slotDeleteDocument, this, sp::_1)
-    );
-    // NOLINTEND
+    App::GetApplication().signalNewDocument.connect([this](const App::Document& doc, bool) {
+        slotCreateDocument(doc);
+    });
+    App::GetApplication().signalDeleteDocument.connect([this](const App::Document& doc) {
+        slotDeleteDocument(doc);
+    });
 }
 
 AutoSaver::~AutoSaver() = default;
@@ -76,16 +89,22 @@ AutoSaver* AutoSaver::instance()
     return self;
 }
 
-void AutoSaver::renameFile(QString dirName, QString file, QString tmpFile)
+void AutoSaver::flushPendingSave(const QString& documentName)
 {
-    FC_LOG("auto saver rename " << tmpFile.toUtf8().constData() << " -> " << file.toUtf8().constData());
-    QDir dir(dirName);
-    dir.remove(file);
-    if (!dir.rename(tmpFile, file)) {
-        FC_ERR(
-            "Failed to rename autosave file " << tmpFile.toStdString() << " to "
-                                              << file.toStdString() << "\n"
-        );
+    // This runs from a queued singleShot after signalBecameStable(). Re-check
+    // that the document still exists and let saveDocument() consume any
+    // outstanding pending/scheduled state for this pass.
+    const auto name = documentName.toStdString();
+    auto it = saverMap.find(name);
+    if (it == saverMap.end()) {
+        return;
+    }
+
+    try {
+        saveDocument(it->first, *it->second);
+    }
+    catch (...) {
+        Base::Console().error("Failed to auto-save document '%s'\n", it->first.c_str());
     }
 }
 
@@ -114,14 +133,6 @@ void AutoSaver::slotCreateDocument(const App::Document& Doc)
     int id = timeout > 0 ? startTimer(timeout) : 0;
     AutoSaveProperty* as = new AutoSaveProperty(&Doc);
     as->timerId = id;
-
-    if (!this->compressed) {
-        std::string dirName = Doc.TransientDir.getValue();
-        dirName += "/fc_recovery_files";
-        Base::FileInfo fi(dirName);
-        fi.createDirectory();
-        as->dirName = dirName;
-    }
     saverMap.insert(std::make_pair(name, as));
 }
 
@@ -140,98 +151,58 @@ void AutoSaver::slotDeleteDocument(const App::Document& Doc)
 
 void AutoSaver::saveDocument(const std::string& name, AutoSaveProperty& saver)
 {
-    Gui::WaitCursor wc;
+    Q_ASSERT(QThread::currentThread() == thread());
+
     App::Document* doc = App::GetApplication().getDocument(name.c_str());
-    if (doc && !doc->testStatus(App::Document::PartialDoc)
-        && !doc->testStatus(App::Document::TempDoc)) {
-        // Set the document's current transient directory
-        std::string dirName = doc->TransientDir.getValue();
-        dirName += "/fc_recovery_files";
-        saver.dirName = dirName;
+    if (!doc) {
+        return;
+    }
 
-        // Write recovery meta file
-        QFile file(QStringLiteral("%1/fc_recovery_file.xml")
-                       .arg(QString::fromUtf8(doc->TransientDir.getValue())));
-        if (file.open(QFile::WriteOnly)) {
-            QTextStream str(&file);
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-            str.setCodec("UTF-8");
-#endif
-            str << "<?xml version='1.0' encoding='utf-8'?>\n"
-                << "<AutoRecovery SchemaVersion=\"1\">\n";
-            str << "  <Status>Created</Status>\n";
-            str << "  <Label>" << QString::fromUtf8(doc->Label.getValue())
-                << "</Label>\n";  // store the document's current label
-            str << "  <FileName>" << QString::fromUtf8(doc->FileName.getValue())
-                << "</FileName>\n";  // store the document's current filename
-            str << "</AutoRecovery>\n";
-            file.close();
-        }
+    // Claim the currently pending work for this save attempt. If new document
+    // changes arrive while the snapshot is being written they will call
+    // markPendingAutosave() again, and the post-save check below will schedule
+    // another pass.
+    if (!saver.consumePendingAutosave()) {
+        return;
+    }
 
-        // make sure to tmp. disable saving thumbnails because this causes trouble if the
-        // associated 3d view is not active
-        Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetParameterGroupByPath(
-            "User parameter:BaseApp/Preferences/Document"
-        );
-        bool save = hGrp->GetBool("SaveThumbnail", true);
-        hGrp->SetBool("SaveThumbnail", false);
+    if (!doc->canWriteRecoverySnapshot() || !isGuiDocumentStableForAutoSave(doc)) {
+        // Keep timer-triggered saves out of unstable document states. Instead
+        // of trying to save during recompute or an open transaction, just keep
+        // the save pending. signalBecameStable() will queue a retry once the
+        // document returns to a state where a consistent full snapshot can be
+        // written.
+        saver.markPendingAutosave();
+        return;
+    }
 
-        getMainWindow()->showMessage(tr("Wait until the auto-recovery file has been saved…"), 5000);
-        // qApp->processEvents();
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Document"
+    );
+    App::RecoverySnapshotSaveOptions options;
+    options.compressed = this->compressed;
+    options.saveBinaryBrep = !this->compressed || hGrp->GetBool("SaveBinaryBrep", true);
+    options.saveThumbnail = false;
 
-        Base::TimeElapsed startTime;
-        // open extra scope to close ZipWriter properly
-        {
-            if (!this->compressed) {
-                RecoveryWriter writer(saver);
+    Gui::WaitCursor wc;
+    getMainWindow()->showMessage(tr("Wait until the auto-recovery file has been saved…"), 5000);
+    // qApp->processEvents();
 
-                // We will be using thread pool if not compressed.
-                // So, always force binary format because ASCII
-                // is not reentrant. See PropertyPartShape::SaveDocFile
-                writer.setMode("BinaryBrep");
+    Base::TimeElapsed startTime;
+    try {
+        App::writeRecoverySnapshotToTransientDir(*doc, options);
+    }
+    catch (...) {
+        saver.restorePendingAutosave();
+        throw;
+    }
 
-                writer.putNextEntry("Document.xml");
-
-                doc->Save(writer);
-
-                // Special handling for Gui document.
-                doc->signalSaveDocument(writer);
-
-                // write additional files
-                writer.writeFiles();
-            }
-            // only create the file if something has changed
-            else if (!saver.touched.empty()) {
-                std::string fn = doc->TransientDir.getValue();
-                fn += "/fc_recovery_file.fcstd";
-                Base::FileInfo tmp(fn);
-                Base::ofstream file(tmp, std::ios::out | std::ios::binary);
-                if (file.is_open()) {
-                    Base::ZipWriter writer(file);
-                    if (hGrp->GetBool("SaveBinaryBrep", true)) {
-                        writer.setMode("BinaryBrep");
-                    }
-
-                    writer.setComment("AutoRecovery file");
-                    writer.setLevel(1);  // apparently the fastest compression
-                    writer.putNextEntry("Document.xml");
-
-                    doc->Save(writer);
-
-                    // Special handling for Gui document.
-                    doc->signalSaveDocument(writer);
-
-                    // write additional files
-                    writer.writeFiles();
-                }
-            }
-        }
-
-        Base::Console().log(
-            "Save auto-recovery file in %fs\n",
-            Base::TimeElapsed::diffTimeF(startTime, Base::TimeElapsed())
-        );
-        hGrp->SetBool("SaveThumbnail", save);
+    Base::Console().log(
+        "Save auto-recovery file in %fs\n",
+        Base::TimeElapsed::diffTimeF(startTime, Base::TimeElapsed())
+    );
+    if (saver.hasPendingAutosave()) {
+        saver.schedulePendingAutosaveRetry();
     }
 }
 
@@ -242,7 +213,6 @@ void AutoSaver::timerEvent(QTimerEvent* event)
         if (it.second->timerId == id) {
             try {
                 saveDocument(it.first, *it.second);
-                it.second->touched.clear();
                 break;
             }
             catch (...) {
@@ -257,186 +227,96 @@ void AutoSaver::timerEvent(QTimerEvent* event)
 AutoSaveProperty::AutoSaveProperty(const App::Document* doc)
     : timerId(-1)
 {
-    // NOLINTBEGIN
-    documentNew = const_cast<App::Document*>(doc)->signalNewObject.connect(
-        std::bind(&AutoSaveProperty::slotNewObject, this, sp::_1)
+    auto* mutableDoc = const_cast<App::Document*>(doc);
+    documentChanged = mutableDoc->signalChanged.connect(
+        [this](const App::Document&, const App::Property&) { markPendingAutosave(); }
     );
-    documentMod = const_cast<App::Document*>(doc)->signalChangedObject.connect(
-        std::bind(&AutoSaveProperty::slotChangePropertyData, this, sp::_2)
+    documentNew = mutableDoc->signalNewObject.connect([this](const App::DocumentObject&) {
+        markPendingAutosave();
+    });
+    documentDeleted = mutableDoc->signalDeletedObject.connect([this](const App::DocumentObject&) {
+        markPendingAutosave();
+    });
+    documentMod = mutableDoc->signalChangedObject.connect(
+        [this](const App::DocumentObject&, const App::Property&) { markPendingAutosave(); }
     );
-    // NOLINTEND
+    documentUndo = mutableDoc->signalUndo.connect([this](const App::Document&) {
+        markPendingAutosave();
+    });
+    documentRedo = mutableDoc->signalRedo.connect([this](const App::Document&) {
+        markPendingAutosave();
+    });
+    documentStable = mutableDoc->signalBecameStable.connect([this](const App::Document& changedDoc) {
+        slotDocumentBecameStable(changedDoc);
+    });
+
+    documentName = doc->getName();
 }
 
 AutoSaveProperty::~AutoSaveProperty()
 {
+    documentChanged.disconnect();
     documentNew.disconnect();
+    documentDeleted.disconnect();
     documentMod.disconnect();
+    documentUndo.disconnect();
+    documentRedo.disconnect();
+    documentStable.disconnect();
 }
 
-void AutoSaveProperty::slotNewObject(const App::DocumentObject& obj)
+void AutoSaveProperty::markPendingAutosave()
 {
-    std::vector<App::Property*> props;
-    obj.getPropertyList(props);
-
-    // if an object was deleted and then restored by an undo then add all properties
-    // because this might be the data files which we may want to re-write
-    for (const auto& prop : props) {
-        slotChangePropertyData(*prop);
-    }
+    // The save itself is deferred until the document becomes stable again or
+    // until the next timer pass notices the pending flag.
+    pendingAutosave = true;
 }
 
-void AutoSaveProperty::slotChangePropertyData(const App::Property& prop)
+bool AutoSaveProperty::consumePendingAutosave()
 {
-    std::stringstream str;
-    str << static_cast<const void*>(&prop) << std::ends;
-    std::string address = str.str();
-    this->touched.insert(address);
+    if (!pendingAutosave) {
+        retryScheduled = false;
+        return false;
+    }
+
+    pendingAutosave = false;
+    retryScheduled = false;
+    return true;
 }
 
-// ----------------------------------------------------------------------------
-
-RecoveryWriter::RecoveryWriter(AutoSaveProperty& saver)
-    : Base::FileWriter(saver.dirName.c_str())
-    , saver(saver)
-{}
-
-RecoveryWriter::~RecoveryWriter() = default;
-
-bool RecoveryWriter::shouldWrite(const std::string& name, const Base::Persistence* object) const
+void AutoSaveProperty::restorePendingAutosave()
 {
-    // Property files of a view provider can always be written because
-    // these are rather small files.
-    if (object->isDerivedFrom<App::Property>()) {
-        const auto* prop = static_cast<const App::Property*>(object);
-        const App::PropertyContainer* parent = prop->getContainer();
-        if (parent && parent->isDerivedFrom<Gui::ViewProvider>()) {
-            return true;
-        }
-    }
-    else if (object->isDerivedFrom<Gui::Document>()) {
-        return true;
-    }
-
-    // These are the addresses of touched properties of a document object.
-    std::stringstream str;
-    str << static_cast<const void*>(object) << std::ends;
-    std::string address = str.str();
-
-    // Check if the property will be exported to the same file. If the file has changed or if the
-    // property hasn't been yet exported then (re-)write the file.
-    std::map<std::string, std::string>::iterator it = saver.fileMap.find(address);
-    if (it == saver.fileMap.end() || it->second != name) {
-        saver.fileMap[address] = name;
-        return true;
-    }
-
-    std::set<std::string>::const_iterator jt = saver.touched.find(address);
-    return (jt != saver.touched.end());
+    pendingAutosave = true;
+    retryScheduled = false;
 }
 
-namespace Gui
+bool AutoSaveProperty::hasPendingAutosave() const
 {
+    return pendingAutosave;
+}
 
-class RecoveryRunnable: public QRunnable
+void AutoSaveProperty::schedulePendingAutosaveRetry()
 {
-public:
-    RecoveryRunnable(
-        const std::set<std::string>& modes,
-        const char* dir,
-        const char* file,
-        const App::Property* p
-    )
-        : prop(p->Copy())
-        , writer(dir)
-    {
-        writer.setModes(modes);
-
-        dirName = QString::fromUtf8(dir);
-        fileName = QString::fromUtf8(file);
-        tmpName = QStringLiteral("%1.tmp%2").arg(fileName).arg(rand());
-        writer.putNextEntry(tmpName.toUtf8().constData());
-    }
-    ~RecoveryRunnable() override
-    {
-        delete prop;
-    }
-    void run() override
-    {
-        try {
-            prop->SaveDocFile(writer);
-            writer.close();
-
-            // We could have renamed the file in this thread. However, there is
-            // still chance of crash when we deleted the original and before rename
-            // the new file. So we ask the main thread to do it. There is still
-            // possibility of crash caused by thread other than the main, but
-            // that's the best we can do for now.
-            QMetaObject::invokeMethod(
-                AutoSaver::instance(),
-                "renameFile",
-                Qt::QueuedConnection,
-                Q_ARG(QString, dirName),
-                Q_ARG(QString, fileName),
-                Q_ARG(QString, tmpName)
-            );
-        }
-        catch (const Base::Exception& e) {
-            Base::Console().warning("Exception in auto-saving: %s\n", e.what());
-        }
-        catch (const std::exception& e) {
-            Base::Console().warning("C++ exception in auto-saving: %s\n", e.what());
-        }
-        catch (...) {
-            Base::Console().warning("Unknown exception in auto-saving\n");
-        }
+    if (!pendingAutosave || retryScheduled) {
+        return;
     }
 
-private:
-    App::Property* prop;
-    Base::FileWriter writer;
-    QString dirName;
-    QString fileName;
-    QString tmpName;
-};
+    retryScheduled = true;
+    const QString qDocumentName = QString::fromStdString(documentName);
 
-}  // namespace Gui
+    // Queue a later GUI-thread pass instead of flushing inline from
+    // signalBecameStable(). retryScheduled coalesces repeated stability
+    // notifications, so there is at most one queued retry outstanding at a
+    // time.
+    QTimer::singleShot(0, AutoSaver::instance(), [qDocumentName]() {
+        AutoSaver::instance()->flushPendingSave(qDocumentName);
+    });
+}
 
-void RecoveryWriter::writeFiles()
+void AutoSaveProperty::slotDocumentBecameStable(const App::Document&)
 {
-    // use a while loop because it is possible that while
-    // processing the files new ones can be added
-    size_t index = 0;
-    this->FileStream.close();
-    while (index < FileList.size()) {
-        FileEntry entry = FileList.begin()[index];
-
-        if (shouldWrite(entry.FileName, entry.Object)) {
-            std::string filePath = entry.FileName;
-            std::string::size_type pos = 0;
-            while ((pos = filePath.find('/', pos)) != std::string::npos) {
-                std::string dirName = DirName + "/" + filePath.substr(0, pos);
-                pos++;
-                Base::FileInfo fi(dirName);
-                fi.createDirectory();
-            }
-
-            // For properties a copy can be created and then this can be written to disk in a thread
-            if (entry.Object->isDerivedFrom<App::Property>()) {
-                const auto* prop = static_cast<const App::Property*>(entry.Object);
-                QThreadPool::globalInstance()->start(
-                    new RecoveryRunnable(getModes(), DirName.c_str(), entry.FileName.c_str(), prop)
-                );
-            }
-            else {
-                std::string fileName = DirName + "/" + entry.FileName;
-                this->FileStream.open(fileName.c_str(), std::ios::out | std::ios::binary);
-                entry.Object->SaveDocFile(*this);
-                this->FileStream.close();
-            }
-        }
-
-        index++;
-    }
+    // Stability only means "it is now legal to try again". The pending and
+    // scheduled flags decide whether there is actually anything left to flush.
+    schedulePendingAutosaveRetry();
 }
 
 

--- a/src/Gui/AutoSaver.h
+++ b/src/Gui/AutoSaver.h
@@ -26,38 +26,67 @@
 #include <QObject>
 
 #include <map>
-#include <set>
 #include <string>
 #include <fastsignals/signal.h>
-#include <Base/Writer.h>
 
 namespace App
 {
 class Document;
-class DocumentObject;
-class Property;
 }  // namespace App
 
 namespace Gui
 {
-class ViewProvider;
-
+/**
+ * Per-document autosave scheduling state shared between document change
+ * notifications, timer callbacks, and queued stable-state retries.
+ *
+ * State model:
+ * - pendingAutosave: the document changed since the last successful autosave,
+ *   or a save attempt was deferred/failed and still needs a retry.
+ * - retryScheduled: a queued retry already exists, so repeated
+ *   signalBecameStable() notifications should not queue another one.
+ *
+ * Save flow:
+ * 1. Document/object changes call markPendingAutosave().
+ * 2. A timer pass or queued stable-state retry calls consumePendingAutosave()
+ *    to claim the current pending work for one save attempt.
+ * 3. saveDocument() writes a full recovery snapshot through App::Document.
+ * 4. If the document is unstable or the save fails, pendingAutosave stays set
+ *    and schedulePendingAutosaveRetry() retries once the document becomes
+ *    stable.
+ *
+ * All callbacks arrive on the GUI thread: document change signals are delivered
+ * via MainThreadSignal, and timer/retry callbacks run on AutoSaver's thread.
+ * No additional locking is required.
+ */
 class AutoSaveProperty
 {
 public:
+    friend class AutoSaver;
     AutoSaveProperty(const App::Document* doc);
     ~AutoSaveProperty();
     int timerId;
-    std::set<std::string> touched;
-    std::string dirName;
-    std::map<std::string, std::string> fileMap;
+    void markPendingAutosave();
+    bool consumePendingAutosave();
+    void restorePendingAutosave();
+    bool hasPendingAutosave() const;
 
 private:
-    void slotNewObject(const App::DocumentObject&);
-    void slotChangePropertyData(const App::Property&);
+    void schedulePendingAutosaveRetry();
+    void slotDocumentBecameStable(const App::Document&);
     using Connection = fastsignals::connection;
+    Connection documentChanged;
     Connection documentNew;
+    Connection documentDeleted;
     Connection documentMod;
+    Connection documentUndo;
+    Connection documentRedo;
+    Connection documentStable;
+    std::string documentName;
+    // True when newer unsaved document state still needs a save pass.
+    bool pendingAutosave {false};
+    // True when schedulePendingAutosaveRetry() has already queued a retry.
+    bool retryScheduled {false};
 };
 
 /*!
@@ -91,30 +120,12 @@ protected:
     void saveDocument(const std::string&, AutoSaveProperty&);
 
 public Q_SLOTS:
-    void renameFile(QString dirName, QString file, QString tmpFile);
+    void flushPendingSave(const QString& documentName);
 
 private:
     int timeout; /*!< Timeout in milliseconds */
     bool compressed;
     std::map<std::string, AutoSaveProperty*> saverMap;
-};
-
-class RecoveryWriter: public Base::FileWriter
-{
-public:
-    RecoveryWriter(AutoSaveProperty&);
-    ~RecoveryWriter() override;
-
-    /*!
-     This method can be re-implemented in sub-classes to avoid
-     to write out certain objects. The default implementation
-     always returns true.
-     */
-    bool shouldWrite(const std::string&, const Base::Persistence*) const override;
-    void writeFiles() override;
-
-private:
-    AutoSaveProperty& saver;
 };
 
 }  // namespace Gui

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -21,6 +21,8 @@
  ***************************************************************************/
 
 #include <Inventor/nodes/SoCamera.h>
+#include <algorithm>
+
 #include <QApplication>
 #include <QCheckBox>
 #include <QClipboard>
@@ -1686,6 +1688,68 @@ StdCmdRefresh::StdCmdRefresh()
     }
 }
 
+namespace
+{
+
+bool shouldProceedAfterDependencyCycle()
+{
+    return QMessageBox::warning(
+               getMainWindow(),
+               QObject::tr("Dependency error"),
+               qApp->translate(
+                   "Std_Refresh",
+                   "The document contains dependency cycles.\n"
+                   "Check the report view for more details.\n\n"
+                   "Proceed?"
+               ),
+               QMessageBox::Yes,
+               QMessageBox::No
+           )
+        == QMessageBox::Yes;
+}
+
+void handleDocumentRecomputeResult(const std::string& documentName, App::RecomputeFailure failure)
+{
+    if (failure == App::RecomputeFailure::None) {
+        return;
+    }
+
+    if (failure != App::RecomputeFailure::DependencyCycle) {
+        return;
+    }
+
+    App::Document* document = App::GetApplication().getDocument(documentName.c_str());
+    if (!document) {
+        return;
+    }
+
+    if (!shouldProceedAfterDependencyCycle()) {
+        return;
+    }
+
+    // If the user wants to proceed, enqueue another recompute request without
+    // the cycle-check option so the document recomputes like the legacy path.
+    App::RecomputeRequest newRequest = App::RecomputeRequest::fromDocument(*document, /*force=*/true);
+    App::GetApplication().queueRecomputeRequest(newRequest);
+}
+
+void refreshDocumentSynchronously(App::Document& document)
+{
+    try {
+        document.recompute({}, true, nullptr, App::Document::DepNoCycle);
+    }
+    catch (Base::BadGraphError&) {
+        if (shouldProceedAfterDependencyCycle()) {
+            document.recompute({}, true);
+        }
+    }
+    catch (Base::Exception& exception) {
+        exception.reportException();
+    }
+}
+
+}  // namespace
+
 void StdCmdRefresh::activated([[maybe_unused]] int iMsg)
 {
     if (!getActiveGuiDocument()) {
@@ -1693,28 +1757,29 @@ void StdCmdRefresh::activated([[maybe_unused]] int iMsg)
     }
 
     App::AutoTransaction trans((eType & NoTransaction) ? 0 : openActiveDocumentCommand("Recompute"));
+    auto doc = getActiveGuiDocument()->getDocument();
 
-    try {
-        doCommand(Doc, "App.activeDocument().recompute(None,True,True)");
+    App::RecomputeRequest request
+        = App::RecomputeRequest::fromDocument(*doc, true, App::Document::DepNoCycle);
+
+    if (!App::GetApplication().isAsyncRecomputeEnabled()
+        || !App::GetApplication().canRecomputeRequestOnWorker(request)) {
+        refreshDocumentSynchronously(*doc);
+        return;
     }
-    catch (Base::Exception& /*e*/) {
-        auto ret = QMessageBox::warning(
-            getMainWindow(),
-            QObject::tr("Dependency Error"),
-            qApp->translate(
-                "Std_Refresh",
-                "The document contains dependency cycles.\n"
-                "Check the report view for more details.\n\n"
-                "Proceed?"
-            ),
-            QMessageBox::Yes,
-            QMessageBox::No
+
+    request.callback = [](App::RecomputeRequest& request, App::RecomputeResult& result) {
+        // Handle the result in the UI thread.
+        QMetaObject::invokeMethod(
+            qApp,
+            [documentName = request.documentName, failure = result.failure]() {
+                handleDocumentRecomputeResult(documentName, failure);
+            },
+            Qt::QueuedConnection
         );
-        if (ret == QMessageBox::No) {
-            return;
-        }
-        doCommand(Doc, "App.activeDocument().recompute(None,True)");
-    }
+    };
+
+    App::GetApplication().queueRecomputeRequest(request);
 }
 
 bool StdCmdRefresh::isActive()

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -35,8 +35,6 @@
 #include <QMessageBox>
 #include <QOpenGLWidget>
 #include <QTextStream>
-#include <QTimer>
-#include <QThread>
 #include <QStatusBar>
 #include <Inventor/actions/SoSearchAction.h>
 #include <Inventor/nodes/SoSeparator.h>

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -530,8 +530,6 @@ Document::Document(App::Document* pcDocument, Application* app)
     );
     // NOLINTEND
 
-    pcDocument->setPreRecomputeHook([this] { callSignalBeforeRecompute(); });
-
     // pointer to the python class
     // NOTE: As this Python object doesn't get returned to the interpreter we
     // mustn't increment it (Werner Jan-12-2006)
@@ -1288,29 +1286,6 @@ void Document::slotTouchedObject(const App::DocumentObject& Obj)
     if (!isModified()) {
         FC_LOG(Obj.getFullName() << " touched");
         setModified(true);
-    }
-}
-
-// helper that guarantees signalBeforeRecompute call is executed in the GUI thread and
-// that the worker waits until it finishes
-void Document::callSignalBeforeRecompute()
-{
-    auto invokeSignalBeforeRecompute = [this] {
-        // this runs in the GUI thread
-        this->getDocument()->signalBeforeRecompute(*this->getDocument());
-    };
-
-    if (QThread::currentThread() == qApp->thread()) {
-        // already on GUI thread – no hop, just call it
-        invokeSignalBeforeRecompute();
-    }
-    else {
-        // hop to GUI and *block* until it returns
-        QMetaObject::invokeMethod(
-            qApp,
-            std::move(invokeSignalBeforeRecompute),
-            Qt::BlockingQueuedConnection
-        );
     }
 }
 

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -102,7 +102,6 @@ protected:
     void slotSkipRecompute(const App::Document& doc, const std::vector<App::DocumentObject*>& objs);
     void slotTouchedObject(const App::DocumentObject&);
     void slotChangePropertyEditor(const App::Document&, const App::Property&);
-    void callSignalBeforeRecompute();
     //@}
 
 public:

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -523,6 +523,12 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
 
 MainWindow::~MainWindow()
 {
+    // QWidget teardown may still emit subWindowActivated while child MDI
+    // windows are being destroyed. Disconnect first so shutdown cannot re-enter
+    // MainWindow slots after derived destruction has started.
+    if (d->mdiArea) {
+        disconnect(d->mdiArea, &QMdiArea::subWindowActivated, this, &MainWindow::onWindowActivated);
+    }
     delete d->status;
     delete d;
     instance = nullptr;

--- a/src/Gui/PreferencePages/DlgSettingsDocument.ui
+++ b/src/Gui/PreferencePages/DlgSettingsDocument.ui
@@ -208,6 +208,22 @@ This feature may slightly increase recomputation time.</string>
         </property>
        </widget>
       </item>
+      <item row="8" column="0">
+       <widget class="Gui::PrefCheckBox" name="prefEnableAsyncRecompute">
+        <property name="toolTip">
+         <string>This experimental feature allows more responsive GUI while recomputing features.</string>
+        </property>
+        <property name="text">
+         <string>Enables async document recomputation</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>EnableAsyncRecompute</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Document</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Gui/PreferencePages/DlgSettingsDocument.ui
+++ b/src/Gui/PreferencePages/DlgSettingsDocument.ui
@@ -213,6 +213,9 @@ This feature may slightly increase recomputation time.</string>
         <property name="toolTip">
          <string>This experimental feature allows more responsive GUI while recomputing features.</string>
         </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
         <property name="text">
          <string>Enables async document recomputation</string>
         </property>

--- a/src/Gui/PreferencePages/DlgSettingsDocumentImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsDocumentImp.cpp
@@ -157,6 +157,7 @@ void DlgSettingsDocumentImp::saveSettings()
     ui->prefAutoSaveEnabled->onSave();
     ui->prefAutoSaveTimeout->onSave();
     ui->prefCanAbortRecompute->onSave();
+    ui->prefEnableAsyncRecompute->onSave();
 
     int timeout = ui->prefAutoSaveTimeout->value();
     if (!ui->prefAutoSaveEnabled->isChecked()) {
@@ -192,6 +193,7 @@ void DlgSettingsDocumentImp::loadSettings()
     ui->prefAutoSaveEnabled->onRestore();
     ui->prefAutoSaveTimeout->onRestore();
     ui->prefCanAbortRecompute->onRestore();
+    ui->prefEnableAsyncRecompute->onRestore();
 }
 
 /**

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -35,8 +35,6 @@
 #include <QOpenGLFunctions>
 #include <QProcess>
 #include <QStatusBar>
-#include <QThread>
-#include <QTimer>
 #include <QWindow>
 
 #include <Inventor/SoDB.h>

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -568,6 +568,7 @@ bool ViewProviderDocumentObject::canDelete(App::DocumentObject* obj) const
 
 PyObject* ViewProviderDocumentObject::getPyObject()
 {
+    requireMainThread("Gui::ViewProviderDocumentObject::getPyObject");
     if (!pyViewObject) {
         pyViewObject = new ViewProviderDocumentObjectPy(this);
     }

--- a/src/Mod/Fem/Gui/TaskPostBoxes.cpp
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.cpp
@@ -219,13 +219,22 @@ TaskPostWidget::TaskPostWidget(
     setWindowIcon(icon);
     m_icon = icon;
 
-    m_connection = m_object->signalChanged.connect(
-        boost::bind(
-            &TaskPostWidget::handlePropertyChange,
-            this,
-            boost::placeholders::_1,
-            boost::placeholders::_2
-        )
+    auto object = getObject();
+    if (!object) {
+        return;
+    }
+
+    auto document = object->getDocument();
+    if (!document) {
+        return;
+    }
+
+    m_connection = document->signalChangedObject.connect(
+        [this, object](const App::DocumentObject& changedObject, const App::Property& prop) {
+            if (&changedObject == object) {
+                handlePropertyChange(changedObject, prop);
+            }
+        }
     );
 }
 

--- a/src/Mod/Inspection/App/InspectionFeature.h
+++ b/src/Mod/Inspection/App/InspectionFeature.h
@@ -263,6 +263,10 @@ public:
     short mustExecute() const override;
     /// recalculate the Feature
     App::DocumentObjectExecReturn* execute() override;
+    bool canRecomputeOnWorker() const override
+    {
+        return false;
+    }
     //@}
 
     /// returns the type name of the ViewProvider

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -24,6 +24,8 @@
 #include "Gui/Application.h"
 #include "Gui/MDIView.h"
 
+#include <functional>
+
 #include <Inventor/actions/SoGetMatrixAction.h>
 #include <Inventor/nodes/SoAnnotation.h>
 #include <Inventor/nodes/SoBaseColor.h>
@@ -39,7 +41,7 @@
 #include <Inventor/engines/SoConcatenate.h>
 #include <Inventor/SbViewportRegion.h>
 
-
+#include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <Base/Console.h>
 #include <Base/UnitsApi.h>
@@ -432,15 +434,18 @@ void ViewProviderMeasureBase::connectToSubject(App::DocumentObject* subject)
         _mVisibilityChangedConnection.disconnect();
     }
 
-    // NOLINTBEGIN
-    auto bndVisibility = std::bind(
-        &ViewProviderMeasureBase::onSubjectVisibilityChanged,
-        this,
-        std::placeholders::_1,
-        std::placeholders::_2
+    App::Document* document = subject->getDocument();
+    if (!document) {
+        return;
+    }
+
+    _mVisibilityChangedConnection = document->signalChangedObject.connect(
+        [this, subject](const App::DocumentObject& obj, const App::Property& prop) {
+            if (&obj == subject) {
+                onSubjectVisibilityChanged(obj, prop);
+            }
+        }
     );
-    // NOLINTEND
-    _mVisibilityChangedConnection = subject->signalChanged.connect(bndVisibility);
 }
 
 //! connect to the subject to receive visibility updates

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -67,6 +67,7 @@ public:
     App::DocumentObjectExecReturn* recompute() override;
     /// recalculate the Feature
     App::DocumentObjectExecReturn *execute() override;
+    bool canRecomputeOnWorker() const override { return false; }
     void onDocumentRestored() override;
     short mustExecute() const override;
     //@}

--- a/src/Mod/Test/AutoSaverStress.py
+++ b/src/Mod/Test/AutoSaverStress.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Joao Matos
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+Opt-in GUI autosave soak test.
+
+This module is intentionally not registered in FreeCAD.__unit_test__, so it is
+only run when requested explicitly.
+
+Examples:
+    FreeCAD src/Mod/Test/RunAutoSaverStress.py
+    FreeCAD src/Mod/Test/RunAutoSaverStress.py documents=3 objects=150
+    FreeCAD src/Mod/Test/RunAutoSaverStress.py iterations=25 burst=10 timeout=5.0
+"""
+
+import os
+import statistics
+import sys
+import time
+import traceback
+import unittest
+import zipfile
+
+import FreeCAD
+import FreeCADGui
+from PySide6 import QtCore, QtWidgets
+
+
+def _get_key_value_arg(names):
+    for arg in sys.argv[2:]:
+        for name in names:
+            prefix = f"{name}="
+            if arg.startswith(prefix):
+                return arg[len(prefix) :]
+    return None
+
+
+def _get_int_arg(names, default):
+    value = _get_key_value_arg(names)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"Expected integer value for one of {names}") from exc
+
+
+def _get_float_arg(names, default):
+    value = _get_key_value_arg(names)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise ValueError(f"Expected float value for one of {names}") from exc
+
+
+def _format_seconds(values):
+    if not values:
+        return "n/a"
+    return f"min={min(values):.3f}s avg={statistics.mean(values):.3f}s " f"max={max(values):.3f}s"
+
+
+def _format_bytes(values):
+    if not values:
+        return "n/a"
+    return f"min={min(values)} avg={statistics.mean(values):.0f} " f"max={max(values)}"
+
+
+class TestAutoSaverStress(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.document_count = _get_int_arg(("documents", "docs"), 2)
+        cls.object_count = _get_int_arg(("objects",), 75)
+        cls.iteration_count = _get_int_arg(("iterations",), 12)
+        cls.burst_count = _get_int_arg(("burst",), 6)
+        cls.wait_timeout = _get_float_arg(("timeout",), 5.0)
+
+        for option_name, option_value in (
+            ("documents", cls.document_count),
+            ("objects", cls.object_count),
+            ("iterations", cls.iteration_count),
+            ("burst", cls.burst_count),
+        ):
+            if option_value < 1:
+                raise ValueError(f"{option_name} must be greater than zero")
+        if cls.wait_timeout <= 0:
+            raise ValueError("timeout must be greater than zero")
+
+    def setUp(self):
+        self.autosaver = self._findAutoSaver()
+        self.direct_flush_durations = []
+        self.queued_flush_durations = []
+        self.archive_sizes = []
+        self.documents = []
+
+        for index in range(self.document_count):
+            document = FreeCAD.newDocument(f"AutoSaverStressDoc{index}")
+            self.assertIsNotNone(FreeCADGui.getDocument(document.Name))
+            objects = [
+                document.addObject("App::FeaturePython", f"StressObject{obj_index}")
+                for obj_index in range(self.object_count)
+            ]
+            self.documents.append((document, objects))
+
+    def tearDown(self):
+        for document, _objects in reversed(self.documents):
+            if FreeCAD.getDocument(document.Name):
+                FreeCAD.closeDocument(document.Name)
+
+    def _findAutoSaver(self):
+        app = QtWidgets.QApplication.instance()
+        self.assertIsNotNone(app)
+
+        for child in app.children():
+            meta_object = child.metaObject() if hasattr(child, "metaObject") else None
+            if meta_object and meta_object.className() == "Gui::AutoSaver":
+                return child
+
+        raise self.failureException("Gui::AutoSaver was not found in the QApplication object tree")
+
+    def _recoveryArchive(self, document):
+        return os.path.join(document.TransientDir, "fc_recovery_file.fcstd")
+
+    def _removeRecoveryArchive(self, document):
+        archive = self._recoveryArchive(document)
+        if os.path.exists(archive):
+            os.remove(archive)
+
+    def _invokeAutoSaverFlush(self, document):
+        invoked = QtCore.QMetaObject.invokeMethod(
+            self.autosaver,
+            "flushPendingSave",
+            QtCore.Qt.ConnectionType.DirectConnection,
+            QtCore.Q_ARG(str, document.Name),
+        )
+        self.assertTrue(invoked)
+
+    def _processEventsUntil(self, predicate):
+        deadline = time.monotonic() + self.wait_timeout
+        while time.monotonic() < deadline:
+            QtWidgets.QApplication.processEvents(QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 50)
+            if predicate():
+                return True
+            time.sleep(0.01)
+
+        return predicate()
+
+    def _assertRecoveryArchiveContains(self, document, expected_label):
+        archive = self._recoveryArchive(document)
+        self.assertTrue(os.path.isfile(archive), archive)
+
+        with zipfile.ZipFile(archive) as recovery:
+            self.assertIn("Document.xml", recovery.namelist())
+            self.assertIn("GuiDocument.xml", recovery.namelist())
+            document_xml = recovery.read("Document.xml").decode("utf-8", errors="replace")
+            self.assertIn(expected_label, document_xml)
+
+        self.archive_sizes.append(os.path.getsize(archive))
+
+    def _mutateAllObjects(self, objects, label_prefix):
+        for obj_index, obj in enumerate(objects):
+            obj.Label = f"{label_prefix}-{obj_index}"
+
+    def testSoak(self):
+        for document_index, (document, objects) in enumerate(self.documents):
+            for iteration in range(self.iteration_count):
+                direct_label = f"direct-{document_index}-{iteration}"
+                self._mutateAllObjects(objects, direct_label)
+                self._removeRecoveryArchive(document)
+
+                start = time.monotonic()
+                self._invokeAutoSaverFlush(document)
+                self.direct_flush_durations.append(time.monotonic() - start)
+                self._assertRecoveryArchiveContains(
+                    document,
+                    f"{direct_label}-{self.object_count - 1}",
+                )
+
+                blocked_label = None
+                self._removeRecoveryArchive(document)
+                document.openTransaction(f"AutoSaverStress-{document_index}-{iteration}")
+                rotating_object = objects[iteration % len(objects)]
+                for burst in range(self.burst_count):
+                    blocked_label = f"blocked-{document_index}-{iteration}-{burst}"
+                    rotating_object.Label = blocked_label
+                    self._invokeAutoSaverFlush(document)
+                    self.assertFalse(os.path.exists(self._recoveryArchive(document)))
+
+                start = time.monotonic()
+                document.commitTransaction()
+                self.assertTrue(
+                    self._processEventsUntil(
+                        lambda: os.path.exists(self._recoveryArchive(document))
+                    )
+                )
+                self.queued_flush_durations.append(time.monotonic() - start)
+                self._assertRecoveryArchiveContains(document, blocked_label)
+
+        print(
+            (
+                "AutoSaver soak summary: "
+                f"documents={self.document_count} "
+                f"objects_per_document={self.object_count} "
+                f"iterations={self.iteration_count} "
+                f"burst={self.burst_count} "
+                f"direct_flush={_format_seconds(self.direct_flush_durations)} "
+                f"queued_flush={_format_seconds(self.queued_flush_durations)} "
+                f"archive_bytes={_format_bytes(self.archive_sizes)}"
+            ),
+            flush=True,
+        )
+
+
+def _is_direct_script_run():
+    if __name__ == "__main__":
+        return True
+    return len(sys.argv) > 1 and os.path.abspath(sys.argv[1]) == os.path.abspath(__file__)
+
+
+def runDirect():
+    case = TestAutoSaverStress("testSoak")
+    try:
+        TestAutoSaverStress.setUpClass()
+        case.setUp()
+        try:
+            case.testSoak()
+        finally:
+            case.tearDown()
+    except Exception:
+        traceback.print_exc()
+        return 1
+    return 0
+
+
+if _is_direct_script_run():
+    sys.exit(runDirect())

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -3,6 +3,8 @@ SET(Test_SRCS
     __init__.py
     Init.py
     BaseTests.py
+    AutoSaverStress.py
+    RunAutoSaverStress.py
     Document.py
     GuiDocument.py
     Metadata.py

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -21,7 +21,7 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import FreeCAD, os, unittest, tempfile
+import FreeCAD, os, unittest, tempfile, zipfile
 from FreeCAD import Base
 import math
 import xml.etree.ElementTree as ET
@@ -838,6 +838,66 @@ class DocumentSaveRestoreCases(unittest.TestCase):
     def tearDown(self):
         # closing doc
         FreeCAD.closeDocument("SaveRestoreTests")
+
+
+class DocumentRecoveryCases(unittest.TestCase):
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("RecoveryTests")
+        self.Obj = self.Doc.addObject("App::FeatureTest", "RecoveryObject")
+        self.savedFileName = None
+
+    def tearDown(self):
+        if FreeCAD.getDocument("RecoveryTests") is not None:
+            FreeCAD.closeDocument("RecoveryTests")
+        if self.savedFileName and os.path.exists(self.savedFileName):
+            os.remove(self.savedFileName)
+
+    def testWriteCompressedRecoverySnapshot(self):
+        self.assertTrue(self.Doc.canWriteRecoverySnapshot())
+        self.assertTrue(FreeCAD.writeRecoverySnapshotToTransientDir(self.Doc))
+
+        metadata = os.path.join(self.Doc.TransientDir, "fc_recovery_file.xml")
+        archive = os.path.join(self.Doc.TransientDir, "fc_recovery_file.fcstd")
+
+        self.assertTrue(os.path.isfile(metadata))
+        self.assertTrue(os.path.isfile(archive))
+
+        root = ET.parse(metadata).getroot()
+        self.assertEqual(root.tag, "AutoRecovery")
+
+        with zipfile.ZipFile(archive) as recovery:
+            self.assertIn("Document.xml", recovery.namelist())
+
+    def testWriteUncompressedRecoverySnapshot(self):
+        self.assertTrue(FreeCAD.writeRecoverySnapshotToTransientDir(self.Doc, compressed=False))
+
+        metadata = os.path.join(self.Doc.TransientDir, "fc_recovery_file.xml")
+        document_xml = os.path.join(self.Doc.TransientDir, "fc_recovery_files", "Document.xml")
+
+        self.assertTrue(os.path.isfile(metadata))
+        self.assertTrue(os.path.isfile(document_xml))
+
+    def testRecoveryMetadataEscapesXml(self):
+        self.Doc.Label = 'Recovery <Label> & "Name"'
+        self.savedFileName = os.path.join(tempfile.gettempdir(), "Recovery&Name.FCStd")
+        self.Doc.saveAs(self.savedFileName)
+
+        self.assertTrue(FreeCAD.writeRecoverySnapshotToTransientDir(self.Doc))
+
+        metadata = os.path.join(self.Doc.TransientDir, "fc_recovery_file.xml")
+        root = ET.parse(metadata).getroot()
+
+        self.assertEqual(root.findtext("Label"), self.Doc.Label)
+        self.assertEqual(root.findtext("FileName"), self.savedFileName)
+
+    def testRejectRecoverySnapshotDuringTransaction(self):
+        self.Doc.openTransaction("RecoveryWrite")
+        try:
+            self.assertFalse(self.Doc.canWriteRecoverySnapshot())
+            with self.assertRaises(RuntimeError):
+                FreeCAD.writeRecoverySnapshotToTransientDir(self.Doc)
+        finally:
+            self.Doc.abortTransaction()
 
 
 class DocumentRecomputeCases(unittest.TestCase):

--- a/src/Mod/Test/GuiDocument.py
+++ b/src/Mod/Test/GuiDocument.py
@@ -21,7 +21,12 @@
 *                                                                          *
 ***************************************************************************/"""
 
-import FreeCAD, FreeCADGui, unittest
+import threading
+import time
+import unittest
+
+import FreeCAD
+import FreeCADGui
 
 # ---------------------------------------------------------------------------
 # define the functions to test the FreeCAD Gui Document code
@@ -55,3 +60,51 @@ class TestGuiDocument(unittest.TestCase):
         # Check if the new function returns the correct root objects
         expected_root_objects = [group1, group2, obj1, part1]
         self.assertEqual(set(root_objects), set(expected_root_objects))
+
+    def testViewObjectRequiresMainThread(self):
+        obj = self.doc.addObject("App::FeaturePython", "ThreadGuard")
+
+        result = {}
+
+        def access_view_object():
+            try:
+                _ = obj.ViewObject
+            except Exception as exc:  # pragma: no cover - exercised through assertion below
+                result["exception"] = exc
+
+        worker = threading.Thread(target=access_view_object)
+        worker.start()
+        worker.join()
+
+        self.assertIn("exception", result)
+        self.assertIsInstance(result["exception"], RuntimeError)
+        self.assertIn("main thread", str(result["exception"]).lower())
+
+    def testRefreshFallsBackToSyncForFeaturePython(self):
+        params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Document")
+        old_async = params.GetBool("EnableAsyncRecompute", False)
+
+        class RefreshProxy:
+            def __init__(self):
+                self.executed_thread_id = None
+
+            def execute(self, obj):
+                self.executed_thread_id = threading.get_ident()
+                time.sleep(0.05)
+
+        proxy = RefreshProxy()
+        obj = self.doc.addObject("App::FeaturePython", "PythonFeature")
+        obj.Proxy = proxy
+        obj.touch()
+
+        try:
+            params.SetBool("EnableAsyncRecompute", True)
+
+            start = time.monotonic()
+            FreeCADGui.runCommand("Std_Refresh", 0)
+            elapsed = time.monotonic() - start
+        finally:
+            params.SetBool("EnableAsyncRecompute", old_async)
+
+        self.assertEqual(proxy.executed_thread_id, threading.get_ident())
+        self.assertGreaterEqual(elapsed, 0.04)

--- a/src/Mod/Test/GuiDocument.py
+++ b/src/Mod/Test/GuiDocument.py
@@ -82,7 +82,7 @@ class TestGuiDocument(unittest.TestCase):
 
     def testRefreshFallsBackToSyncForFeaturePython(self):
         params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Document")
-        old_async = params.GetBool("EnableAsyncRecompute", False)
+        old_async = params.GetBool("EnableAsyncRecompute", True)
 
         class RefreshProxy:
             def __init__(self):

--- a/src/Mod/Test/GuiDocument.py
+++ b/src/Mod/Test/GuiDocument.py
@@ -21,12 +21,15 @@
 *                                                                          *
 ***************************************************************************/"""
 
+import os
 import threading
 import time
 import unittest
+import zipfile
 
 import FreeCAD
 import FreeCADGui
+from PySide6 import QtCore, QtWidgets
 
 # ---------------------------------------------------------------------------
 # define the functions to test the FreeCAD Gui Document code
@@ -41,6 +44,56 @@ class TestGuiDocument(unittest.TestCase):
     def tearDown(self):
         # Close the document
         FreeCAD.closeDocument("TestDoc")
+
+    def _findAutoSaver(self):
+        app = QtWidgets.QApplication.instance()
+        self.assertIsNotNone(app)
+
+        for child in app.children():
+            meta_object = child.metaObject() if hasattr(child, "metaObject") else None
+            if meta_object and meta_object.className() == "Gui::AutoSaver":
+                return child
+
+        raise self.failureException("Gui::AutoSaver was not found in the QApplication object tree")
+
+    def _recoveryArchive(self):
+        return os.path.join(self.doc.TransientDir, "fc_recovery_file.fcstd")
+
+    def _removeRecoveryArchive(self):
+        archive = self._recoveryArchive()
+        if os.path.exists(archive):
+            os.remove(archive)
+
+    def _invokeAutoSaverFlush(self):
+        invoked = QtCore.QMetaObject.invokeMethod(
+            self._findAutoSaver(),
+            "flushPendingSave",
+            QtCore.Qt.ConnectionType.DirectConnection,
+            QtCore.Q_ARG(str, self.doc.Name),
+        )
+        self.assertTrue(invoked)
+
+    def _processEventsUntil(self, predicate, timeout=3.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            QtWidgets.QApplication.processEvents(QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 50)
+            if predicate():
+                return True
+            time.sleep(0.01)
+
+        return predicate()
+
+    def _assertRecoveryArchiveContains(self, expected_label=None):
+        archive = self._recoveryArchive()
+        self.assertTrue(os.path.isfile(archive))
+
+        with zipfile.ZipFile(archive) as recovery:
+            self.assertIn("Document.xml", recovery.namelist())
+            self.assertIn("GuiDocument.xml", recovery.namelist())
+
+            if expected_label is not None:
+                document_xml = recovery.read("Document.xml").decode("utf-8", errors="replace")
+                self.assertIn(expected_label, document_xml)
 
     def testGetTreeRootObject(self):
         # Create objects at the root level
@@ -108,3 +161,50 @@ class TestGuiDocument(unittest.TestCase):
 
         self.assertEqual(proxy.executed_thread_id, threading.get_ident())
         self.assertGreaterEqual(elapsed, 0.04)
+
+    def testRecoverySnapshotIncludesGuiDocument(self):
+        self.doc.addObject("App::FeaturePython", "RecoveryGuiObject")
+
+        self.assertTrue(FreeCAD.writeRecoverySnapshotToTransientDir(self.doc))
+
+        self._assertRecoveryArchiveContains()
+
+    def testAutoSaverFlushWritesRecoverySnapshot(self):
+        obj = self.doc.addObject("App::FeaturePython", "AutoSaveGuiObject")
+        obj.Label = "AutoSaveImmediate"
+        self._removeRecoveryArchive()
+
+        self._invokeAutoSaverFlush()
+
+        self._assertRecoveryArchiveContains(expected_label="AutoSaveImmediate")
+
+    def testAutoSaverRetriesWhenDocumentBecomesStable(self):
+        obj = self.doc.addObject("App::FeaturePython", "AutoSaveBlockedObject")
+        self._removeRecoveryArchive()
+
+        self.doc.openTransaction("AutoSaveBlocked")
+        obj.Label = "AutoSaveRetried"
+        self._invokeAutoSaverFlush()
+
+        self.assertFalse(os.path.exists(self._recoveryArchive()))
+
+        self.doc.abortTransaction()
+
+        self.assertTrue(self._processEventsUntil(lambda: os.path.exists(self._recoveryArchive())))
+        self._assertRecoveryArchiveContains()
+
+    def testAutoSaverCoalescesBlockedFlushesToLatestCommittedState(self):
+        obj = self.doc.addObject("App::FeaturePython", "AutoSaveChurnObject")
+        self._removeRecoveryArchive()
+
+        self.doc.openTransaction("AutoSaveChurn")
+        for index in range(8):
+            obj.Label = f"AutoSaveBurst{index}"
+            self._invokeAutoSaverFlush()
+
+        self.assertFalse(os.path.exists(self._recoveryArchive()))
+
+        self.doc.commitTransaction()
+
+        self.assertTrue(self._processEventsUntil(lambda: os.path.exists(self._recoveryArchive())))
+        self._assertRecoveryArchiveContains(expected_label="AutoSaveBurst7")

--- a/src/Mod/Test/RunAutoSaverStress.py
+++ b/src/Mod/Test/RunAutoSaverStress.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Joao Matos
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+Driver for the opt-in GUI autosave soak test.
+
+Examples from the repository root:
+    FreeCAD src/Mod/Test/RunAutoSaverStress.py
+    FreeCAD src/Mod/Test/RunAutoSaverStress.py documents=3
+    FreeCAD src/Mod/Test/RunAutoSaverStress.py iterations=25 burst=10
+"""
+
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
+import AutoSaverStress
+
+sys.exit(AutoSaverStress.runDirect())

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+#include <boost/scope_exit.hpp>
+#include <gtest/gtest.h>
+
+#include "App/Application.h"
+#include "App/Document.h"
+#include "App/FeatureTest.h"
+#include <src/App/InitApplication.h>
+
+using namespace std::chrono_literals;
+
+class AsyncRecomputeTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        _docName = App::GetApplication().getUniqueDocumentName("async_recompute");
+        _doc = App::GetApplication().newDocument(_docName.c_str(), "testUser");
+    }
+
+    void TearDown() override
+    {
+        if (!_docName.empty() && App::GetApplication().getDocument(_docName.c_str())) {
+            App::GetApplication().closeDocument(_docName.c_str());
+        }
+    }
+
+    std::string _docName;
+    App::Document* _doc {};
+};
+
+TEST_F(AsyncRecomputeTest, CloseDocumentWaitsForInFlightAsyncRecompute)
+{
+    auto* object = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "BlockingFeature")
+    );
+    ASSERT_NE(object, nullptr);
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    BOOST_SCOPE_EXIT_ALL(&)
+    {
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+    };
+
+    object->touch();
+
+    App::GetApplication().queueRecomputeRequest(App::RecomputeRequest::fromDocumentObject(*object));
+
+    ASSERT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2s));
+
+    auto closeFuture = std::async(std::launch::async, [this] {
+        return App::GetApplication().closeDocument(_docName.c_str());
+    });
+
+    EXPECT_EQ(closeFuture.wait_for(50ms), std::future_status::timeout);
+
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+
+    ASSERT_EQ(closeFuture.wait_for(2s), std::future_status::ready);
+    EXPECT_TRUE(closeFuture.get());
+
+    _doc = nullptr;
+}
+
+TEST_F(AsyncRecomputeTest, WorkerSafetyIsCheckedFromRequest)
+{
+    auto* safeObject = dynamic_cast<App::FeatureTest*>(
+        _doc->addObject("App::FeatureTest", "SafeFeature")
+    );
+    auto* unsafeObject = dynamic_cast<App::FeatureTestAttribute*>(
+        _doc->addObject("App::FeatureTestAttribute", "UnsafeFeature")
+    );
+
+    ASSERT_NE(safeObject, nullptr);
+    ASSERT_NE(unsafeObject, nullptr);
+
+    EXPECT_TRUE(
+        App::GetApplication().canRecomputeRequestOnWorker(
+            App::RecomputeRequest::fromDocumentObject(*safeObject)
+        )
+    );
+    EXPECT_FALSE(
+        App::GetApplication().canRecomputeRequestOnWorker(
+            App::RecomputeRequest::fromDocumentObject(*unsafeObject)
+        )
+    );
+    EXPECT_FALSE(
+        App::GetApplication().canRecomputeRequestOnWorker(App::RecomputeRequest::fromDocument(*_doc))
+    );
+}

--- a/tests/src/App/CMakeLists.txt
+++ b/tests/src/App/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 add_executable(App_tests_run
+        AsyncRecompute.cpp
         Application.cpp
         ApplicationDirectories.cpp
         BackupPolicy.cpp


### PR DESCRIPTION
Introduce optional asynchronous recomputation of documents and features to keep the UI responsive during heavy operations. When enabled, recompute requests are processed by background worker thread, allowing the main GUI thread to continue rendering and handling user input.

Errors such as dependency cycles are reported back on the UI thread via callbacks, and the classic synchronous recompute path remains available when the feature is turned off.

This adds the base infrastructure, which will be used by following PRs to enable aborting long running operations.

**Background worker:**

On startup, `Application` spawns a `_recomputeThread` that waits on a `std::condition_variable`.

Requests are enqueued via `queueRecomputeRequest()`, protected by a mutex, and the thread cleanly shuts down in the destructor by signaling `_stopRecomputeThread`.

**Request/Result types:**

`RecomputeRequest` holds pointers to a `Document` or `DocumentObject`, a recursion flag, and a callback.

`RecomputeResult` captures success or exception state.

`isAsyncRecomputeEnabled()` reads this flag to choose async vs. sync.

This enhancement will ensure long recompute operations no longer block the interface, improving user experience while retaining full backwards compatibility, though some more work is needed to fully achieve this.

This work is done as part of an FPA grant: https://github.com/FreeCAD/FPA-grant-proposals/issues/36