### PR TITLE
CI: checkout source prior to installing pixi on weekly builds.

### DIFF
--- a/.github/workflows/sub_weeklyBuild.yml
+++ b/.github/workflows/sub_weeklyBuild.yml
@@ -95,6 +95,11 @@ jobs:
             echo 'RATTLER_CACHE_DIR=D:\rattler' >> "$GITHUB_ENV"
           fi
 
+      - name: Checkout Source
+        shell: bash -l {0}
+        run: |
+          wget -O- https://github.com/FreeCAD/FreeCAD/releases/download/${BUILD_TAG}/freecad_source_${BUILD_TAG}.tar.gz | tar -C ${GITHUB_WORKSPACE} xf -
+
       - uses: prefix-dev/setup-pixi@19eac09b398e3d0c747adc7921926a6d802df4da # v0.8.8
         with:
           pixi-version: v0.42.1
@@ -147,7 +152,6 @@ jobs:
           TARGET_PLATFORM: ${{ matrix.target }}
           UPLOAD_RELEASE: "true"
         run: |
-          wget -O- https://github.com/FreeCAD/FreeCAD/releases/download/${BUILD_TAG}/freecad_source_${BUILD_TAG}.tar.gz | tar xf -
           cd package/rattler-build
           pixi install
           pixi run -e package create_bundle


### PR DESCRIPTION
The source must be checked out prior to installing pixi.  This PR decompresses the release source tarball to be built prior to installing pixi.

## Issues

None

## Before and After Images

N/A