### PR TITLE
Gui: Eliminate double->float truncations

### DIFF
--- a/src/Gui/Inventor/SoFCPlacementIndicatorKit.h
+++ b/src/Gui/Inventor/SoFCPlacementIndicatorKit.h
@@ -33,21 +33,21 @@ namespace Gui {
 class GuiExport SoFCPlacementIndicatorKit : public SoBaseKit {
     using inherited = SoBaseKit;
 
-    static constexpr double planeIndicatorRadius = 0.4f;
-    static constexpr double planeIndicatorMargin = 0.2f;
-    static constexpr double planeIndicatorTransparency = 0.3f;
+    static constexpr float planeIndicatorRadius = 0.4F;
+    static constexpr double planeIndicatorMargin = 0.2;
+    static constexpr float planeIndicatorTransparency = 0.3F;
 
-    static constexpr double axisMargin = 0.0f;
-    static constexpr double axisLengthDefault = 0.6f;
-    static constexpr double axisThickness = 0.065f;
+    static constexpr double axisMargin = 0.0;
+    static constexpr float axisLengthDefault = 0.6F;
+    static constexpr float axisThickness = 0.065F;
 
-    static constexpr double arrowHeadRadius = axisThickness * 1.25f;
-    static constexpr double arrowHeadHeight = arrowHeadRadius * 3.f;
+    static constexpr float arrowHeadRadius = axisThickness * 1.25F;
+    static constexpr float arrowHeadHeight = arrowHeadRadius * 3.F;
 
-    static constexpr double labelOffset = 0.4f;
+    static constexpr double labelOffset = 0.4;
     static constexpr int labelFontSize = 9;
 
-    static constexpr double scaleFactorDefault = 40.f;
+    static constexpr float scaleFactorDefault = 40.F;
 
     SO_KIT_HEADER(SoFCPlacementIndicatorKit);
 

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -552,7 +552,7 @@ private:
         float startangle = atan2f(vc1[1], vc1[0]);
         float endangle = atan2f(vc2[1], vc2[0]);
         if (endangle < startangle) {
-            endangle += 2. * std::numbers::pi;
+            endangle += 2.F * std::numbers::pi_v<float>;
         }
 
         SbVec3f textCenter;
@@ -697,7 +697,7 @@ SbVec3f SoDatumLabel::getLabelTextCenterArcLength(const SbVec3f& ctr, const SbVe
     float endangle = atan2f(vc2[1], vc2[0]);
 
     if (endangle < startangle) {
-        endangle += 2. * std::numbers::pi;
+        endangle += 2.F * std::numbers::pi_v<float>;
     }
 
     // Text location

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3606,7 +3606,7 @@ void View3DInventorViewer::alignToSelection()
             angle *= -1;
         }
 
-        using std::numbers::pi;
+        constexpr auto pi = std::numbers::pi_v<float>;
 
         // Make angle positive
         if (angle < 0) {


### PR DESCRIPTION
Our GUI code uses a mix of floats and doubles to represent floating point numbers, and in a few places interchanges them in a way that causes an invisible loss of precision, and a compiler warning about that loss. Change the double precision "default" values to float defaults, and use the appropriate value for pi.

This PR makes no attempt to "correct" any usage of float or double for the base values, but only updates the calculations of those values to use consistent precision. In particular, when the final value uses a double precision number, the values used in its calculation are retained in double precision. Only when the final value is a float are the values changed to floats.

In none of these cases is the use of double versus float expected to have any perceivable consequence.