### PR TITLE
TechDraw: Defer UI updates via Qt queued connections

### DIFF
--- a/src/Mod/Measure/App/MeasureBase.h
+++ b/src/Mod/Measure/App/MeasureBase.h
@@ -56,8 +56,6 @@ public:
 
     App::PropertyPlacement Placement;
 
-    // boost::signals2::signal<void (const MeasureBase*)> signalGuiInit;
-
     // return PyObject as MeasureBasePy
     PyObject* getPyObject() override;
 

--- a/src/Mod/TechDraw/App/DrawViewDraft.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDraft.cpp
@@ -84,6 +84,13 @@ App::DocumentObjectExecReturn *DrawViewDraft::execute()
         return App::DocumentObject::StdReturn;
     }
 
+    QMetaObject::invokeMethod(qApp, [this]() { updateVisual(); }, Qt::QueuedConnection);
+
+    overrideKeepUpdated(false);
+    return DrawView::execute();
+}
+
+void DrawViewDraft::updateVisual() {
     App::DocumentObject* sourceObj = Source.getValue();
     if (sourceObj) {
         std::string svgFrag;
@@ -107,19 +114,16 @@ App::DocumentObjectExecReturn *DrawViewDraft::execute()
                  << ", techdraw=True"
                  << ", override=" << (OverrideStyle.getValue() ? "True" : "False");
 
-// this is ok for a starting point, but should eventually make dedicated Draft functions that build the svg for all the special cases
-// (Arch section, etc)
-// like Draft.makeDrawingView, but we don't need to create the actual document objects in Draft, just the svg.
+        // this is ok for a starting point, but should eventually make dedicated Draft functions that build the svg for all the special cases
+        // (Arch section, etc)
+        // like Draft.makeDrawingView, but we don't need to create the actual document objects in Draft, just the svg.
         Base::Interpreter().runString("import Draft");
         Base::Interpreter().runStringArg("svgBody = Draft.get_svg(App.activeDocument().%s %s)",
-                                         SourceName.c_str(), paramStr.str().c_str());
-//        Base::Interpreter().runString("print svgBody");
+                                        SourceName.c_str(), paramStr.str().c_str());
+        // Base::Interpreter().runString("print svgBody");
         Base::Interpreter().runStringArg("App.activeDocument().%s.Symbol = '%s' + svgBody + '%s'",
-                                          FeatName.c_str(), svgHead.c_str(), svgTail.c_str());
-        }
-
-    overrideKeepUpdated(false);
-    return DrawView::execute();
+                                        FeatName.c_str(), svgHead.c_str(), svgTail.c_str());
+    }
 }
 
 std::string DrawViewDraft::getSVGHead()

--- a/src/Mod/TechDraw/App/DrawViewDraft.h
+++ b/src/Mod/TechDraw/App/DrawViewDraft.h
@@ -67,6 +67,8 @@ public:
     short mustExecute() const override;
 
 protected:
+    void updateVisual();
+
 /*    virtual void onChanged(const App::Property* prop) override;*/
     Base::BoundBox3d bbox;
     std::string getSVGHead();

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -295,17 +295,22 @@ Gui::MDIView *ViewProviderDrawingView::getMDIView() const
 
 void ViewProviderDrawingView::onGuiRepaint(const TechDraw::DrawView* dv)
 {
-//    Base::Console().message("VPDV::onGuiRepaint(%s) - this: %x\n", dv->getNameInDocument(), this);
-    Gui::Document* guiDoc = Gui::Application::Instance->getDocument(getViewObject()->getDocument());
-    if (!guiDoc)
-        return;
+    auto document = dv->getDocument();
+    QMetaObject::invokeMethod(qApp, [this, dv, document]() {
+        //Base::Console().message("VPDV::onGuiRepaint(%s) - this: %x\n", dv->getNameInDocument(), this);
 
-    std::vector<TechDraw::DrawPage*> pages = getViewObject()->findAllParentPages();
-    if (pages.size() > 1) {
-        multiParentPaint(pages);
-    } else if (dv == getViewObject()) {
-        singleParentPaint(dv);
-    }
+        Gui::Document* guiDoc = Gui::Application::Instance->getDocument(document);
+        if (!guiDoc) {
+            return;
+        }
+
+        std::vector<TechDraw::DrawPage*> pages = getViewObject()->findAllParentPages();
+        if (pages.size() > 1) {
+            multiParentPaint(pages);
+        } else if (dv == getViewObject()) {
+            singleParentPaint(dv);
+        }
+    }, Qt::QueuedConnection);
 }
 
 void ViewProviderDrawingView::multiParentPaint(std::vector<TechDraw::DrawPage*>& pages)

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -505,12 +505,14 @@ void ViewProviderPage::dropObject(App::DocumentObject* docObj)
 //! Redo the whole visual page
 void ViewProviderPage::onGuiRepaint(const TechDraw::DrawPage* dp)
 {
-    if (dp == getDrawPage()) {
-        //this signal is for us
-        if (!getDrawPage()->isUnsetting()) {
-            m_graphicsScene->fixOrphans();
+    QMetaObject::invokeMethod(qApp, [this, dp]() {
+        if (dp == getDrawPage()) {
+            //this signal is for us
+            if (!getDrawPage()->isUnsetting()) {
+                m_graphicsScene->fixOrphans();
+            }
         }
-    }
+    }, Qt::QueuedConnection);
 }
 
 TechDraw::DrawPage* ViewProviderPage::getDrawPage() const


### PR DESCRIPTION
With the future async document recompute model, the `execute` loop can be running under a worker thread, which is incompatible with invoking GUI code directly. These changes improve thread safety by deferring visual‐update calls to the Qt event loop, avoid direct GUI updates from worker threads.

`DrawViewDraft`:
 - Introduce `updateVisual()` helper
 - Invoke `updateVisual()` via `QMetaObject::invokeMethod` to defer SVG regeneration on the GUI thread

`ViewProviderDrawingView` and `ViewProviderPage`:
- Wrap repaint logic in lambdas invoked with `Qt::QueuedConnection` to ensure painting occurs on the GUI thread

This work is done as part of an FPA grant: https://github.com/FreeCAD/FPA-grant-proposals/issues/36