### PR TITLE
TechDraw: decorateLine fix

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
@@ -1424,15 +1424,14 @@ void CmdTechDrawDecorateLine::activated(int iMsg)
     }
 
     std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
-    TechDraw::DrawViewPart* baseFeat = nullptr;
     if (selection.empty()) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong Selection"),
                                 QObject::tr("You must select a View and/or lines."));
         return;
     }
 
-    baseFeat =  dynamic_cast<TechDraw::DrawViewPart *>(selection[0].getObject());
-    if (!baseFeat) {
+    auto* baseFeat =  static_cast<TechDraw::DrawViewPart *>(selection[0].getObject());
+    if (!baseFeat->isDerivedFrom<TechDraw::DrawViewPart>()) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong Selection"),
                                 QObject::tr("No View in Selection."));
         return;
@@ -1440,13 +1439,6 @@ void CmdTechDrawDecorateLine::activated(int iMsg)
 
     std::vector<std::string> subNames;
 
-    std::vector<Gui::SelectionObject>::iterator itSel = selection.begin();
-    for (; itSel != selection.end(); itSel++)  {
-        if ((*itSel).getObject()->isDerivedFrom<TechDraw::DrawViewPart>()) {
-            baseFeat = static_cast<TechDraw::DrawViewPart*> ((*itSel).getObject());
-            subNames = (*itSel).getSubNames();
-        }
-    }
     std::vector<std::string> edgeNames;
     for (auto& s: subNames) {
         std::string geomType = DrawUtil::getGeomTypeFromName(s);

--- a/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
@@ -1430,14 +1430,25 @@ void CmdTechDrawDecorateLine::activated(int iMsg)
         return;
     }
 
-    auto* baseFeat =  static_cast<TechDraw::DrawViewPart *>(selection[0].getObject());
-    if (!baseFeat->isDerivedFrom<TechDraw::DrawViewPart>()) {
+    TechDraw::DrawViewPart* baseFeat = nullptr;
+    std::vector<std::string> subNames;
+
+    std::vector<Gui::SelectionObject>::iterator itSel = selection.begin();
+    for (; itSel != selection.end(); itSel++)  {
+        if ((*itSel).getObject()->isDerivedFrom<TechDraw::DrawViewPart>()) {
+            subNames = (*itSel).getSubNames();
+            if (!subNames.empty()) {
+                baseFeat = static_cast<TechDraw::DrawViewPart*>((*itSel).getObject());
+                break;
+            }
+        }
+    }
+
+    if (!baseFeat) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong Selection"),
                                 QObject::tr("No View in Selection."));
         return;
     }
-
-    std::vector<std::string> subNames;
 
     std::vector<std::string> edgeNames;
     for (auto& s: subNames) {


### PR DESCRIPTION
Unless I am mistaken, the code of the `TechDraw_DecorateLine` activated was wrong.

First it used `selection[0].getObject()` as base object then browsed the rest of the selection for other drawviewparts. Which makes no sense. Because why making sure the first is a DVP if after that you browse the rest of the selection and select the last one?

I guess the original intent was to browse all the selection to find at least one drawviewpart. Which makes more sense.