### PR TITLE
Materials: Clean up unused variables

### DIFF
--- a/src/Mod/Material/App/MaterialLoader.cpp
+++ b/src/Mod/Material/App/MaterialLoader.cpp
@@ -250,7 +250,7 @@ void MaterialYamlEntry::addToTree(
                                 finalModel->setPhysicalValue(QString::fromStdString(propertyName),
                                                             propertyValue);
                             }
-                            catch (const Base::ValueError& e) {
+                            catch (const Base::ValueError&) {
                                 // Units mismatch
                                 Base::Console().log("Units mismatch in material '%s':'%s' = '%s', "
                                                     "setting to default property units '%s'\n",

--- a/src/Mod/Material/Gui/MaterialDelegate.cpp
+++ b/src/Mod/Material/Gui/MaterialDelegate.cpp
@@ -148,7 +148,7 @@ void MaterialDelegate::setValue(QAbstractItemModel* model,
         try {
             property->setValue(value);
         }
-        catch (const Base::ValueError& e) {
+        catch (const Base::ValueError&) {
             // Units mismatch
             auto quantity = value.value<Base::Quantity>();
             Base::Console().log("Units mismatch '%s' = '%s', "


### PR DESCRIPTION
Updated error messages no longer refer to the exception object, resulting in compiler warnings.
