### PR TITLE
TD: Remove unused variable

### DIFF
--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -1570,7 +1570,7 @@ bool GeometryUtils::getCircleParms(const TopoDS_Edge& occEdge, double& radius, B
         center = Base::convertTo<Base::Vector3d>(circleFromParms->Circ().Location());
         return true;
     }
-    catch (Standard_Failure& err) {
+    catch (Standard_Failure&) {
         Base::Console().message("Geo::getCircleParms - failed to make a circle\n");
     }
 


### PR DESCRIPTION
This exception clause does not ever refer to the exception object, resulting in a compiler warning since the object was given a name. Remove the name to silence the warning. An alternative would be to print the text of the exception message as part of the error. It's also not clear to me why this error message is a `message` and not an `error`, @WandererFan.