### PR TITLE
UI: Remove qPixmapFromMimeSource pixmap function

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsPDF.ui
+++ b/src/Gui/PreferencePages/DlgSettingsPDF.ui
@@ -96,7 +96,6 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefComboBox</class>

--- a/src/Gui/TaskView/TaskAppearance.ui
+++ b/src/Gui/TaskView/TaskAppearance.ui
@@ -209,7 +209,6 @@
    </item>
   </layout>
  </widget>
- <pixmapfunction/>
  <resources/>
  <connections>
   <connection>

--- a/src/Mod/BIM/Resources/ui/preferences-arch.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-arch.ui
@@ -603,7 +603,6 @@ instead of the FreeCAD web workbench</string>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefSpinBox</class>

--- a/src/Mod/BIM/Resources/ui/preferences-archdefaults.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-archdefaults.ui
@@ -554,7 +554,6 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::QuantitySpinBox</class>

--- a/src/Mod/BIM/Resources/ui/preferences-dae.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-dae.ui
@@ -321,7 +321,6 @@ The gradient of the local mesh size h(x) is bound by |Δh(x)| ≤ 1/value.</stri
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefSpinBox</class>

--- a/src/Mod/BIM/Resources/ui/preferences-ifc-export.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-ifc-export.ui
@@ -435,7 +435,6 @@ However, at FreeCAD, we believe having a building should not be mandatory, and t
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefCheckBox</class>

--- a/src/Mod/BIM/Resources/ui/preferences-ifc.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-ifc.ui
@@ -493,7 +493,6 @@ are placed in a 'Group' instead.
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefSpinBox</class>

--- a/src/Mod/BIM/Resources/ui/preferences-sh3d-import.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-sh3d-import.ui
@@ -493,7 +493,6 @@
     </layout>
   </widget>
   <layoutdefault spacing="6" margin="11" />
-  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
   <customwidgets>
     <customwidget>
       <class>Gui::PrefSpinBox</class>

--- a/src/Mod/CAM/Gui/Resources/preferences/PathJob.ui
+++ b/src/Mod/CAM/Gui/Resources/preferences/PathJob.ui
@@ -692,7 +692,6 @@ Should multiple tools or tool shapes with the same name exist in different direc
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::InputField</class>

--- a/src/Mod/Draft/Resources/ui/preferences-draft.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draft.ui
@@ -449,7 +449,6 @@ accidentally and modifying the entered value.</string>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefCheckBox</class>

--- a/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
@@ -819,7 +819,6 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefCheckBox</class>

--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -529,7 +529,6 @@ Major grid lines are thicker than minor grid lines.</string>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::QuantitySpinBox</class>

--- a/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
@@ -644,7 +644,6 @@ used for linear dimensions.</string>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="30"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefCheckBox</class>

--- a/src/Mod/Draft/Resources/ui/preferences-draftvisual.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftvisual.ui
@@ -199,7 +199,6 @@ pattern definitions to be added to the standard patterns</string>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefLineEdit</class>

--- a/src/Mod/Draft/Resources/ui/preferences-dwg.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dwg.ui
@@ -123,7 +123,6 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::FileChooser</class>

--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -683,7 +683,6 @@ This might fail for post DXF R12 templates.</string>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefRadioButton</class>

--- a/src/Mod/Draft/Resources/ui/preferences-oca.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-oca.ui
@@ -77,7 +77,6 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefCheckBox</class>

--- a/src/Mod/Draft/Resources/ui/preferences-svg.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-svg.ui
@@ -324,7 +324,6 @@ This value is the maximum segment length.</string>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefCheckBox</class>

--- a/src/Mod/Import/Resources/ui/preferences-import.ui
+++ b/src/Mod/Import/Resources/ui/preferences-import.ui
@@ -118,7 +118,6 @@
  </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefRadioButton</class>

--- a/src/Mod/OpenSCAD/Resources/ui/openscadprefs-base.ui
+++ b/src/Mod/OpenSCAD/Resources/ui/openscadprefs-base.ui
@@ -499,7 +499,6 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Gui::FileChooser</class>

--- a/src/Mod/Part/Gui/DlgBlock.ui
+++ b/src/Mod/Part/Gui/DlgBlock.ui
@@ -331,7 +331,6 @@
    </item>
   </layout>
  </widget>
- <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <tabstops>
   <tabstop>FirstLimitType</tabstop>
   <tabstop>FirstLimitLength</tabstop>


### PR DESCRIPTION
This function dates back to Qt3, and was removed in Qt4. Modern Qt no longer uses this ui file entry, and in some circumstances the uic complains about its presence.