### PR TITLE
CAM: Ensure float constants are single-precision

### DIFF
--- a/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
@@ -511,7 +511,7 @@ void SimDisplay::MoveEye(float x, float z)
     const float arg1 = 124.938F;
     const float arg2 = 578.754F;
     const float arg3 = -20.7993F;
-    float maxValueX = arg1 + arg2 * std::expf(arg3 * mEyeDistFactor);
+    float maxValueX = arg1 + arg2 * exp(arg3 * mEyeDistFactor);
     float maxValueZ = maxValueX * 0.4F;
 
     mEyeX += x;

--- a/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
@@ -508,11 +508,11 @@ void SimDisplay::MoveEye(float x, float z)
 {
     // Exponential calculate maxValue
     // https://forum.freecad.org/viewtopic.php?t=96939
-    const float arg1 = 124.938;
-    const float arg2 = 578.754;
-    const float arg3 = -20.7993;
-    float maxValueX = arg1 + arg2 * exp(arg3 * mEyeDistFactor);
-    float maxValueZ = maxValueX * 0.4;
+    const float arg1 = 124.938F;
+    const float arg2 = 578.754F;
+    const float arg3 = -20.7993F;
+    float maxValueX = arg1 + arg2 * std::expf(arg3 * mEyeDistFactor);
+    float maxValueZ = maxValueX * 0.4F;
 
     mEyeX += x;
     if (mEyeX > maxValueX) {


### PR DESCRIPTION
Add the `F` suffix to ensure that constants are using single-precision rather than double-precision values on initialization (since we are initializing floats). Eliminates compiler warning about truncation.