### PR TITLE
[1.0] Standardize on Py::Long type for Python bindings.

### DIFF
--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -851,7 +851,7 @@ PyObject *Application::sCheckLinkDepth(PyObject * /*self*/, PyObject *args)
         return nullptr;
 
     PY_TRY {
-        return Py::new_reference_to(Py::Int(GetApplication().checkLinkDepth(depth, MessageOption::Throw)));
+        return Py::new_reference_to(Py::Long(GetApplication().checkLinkDepth(depth, MessageOption::Throw)));
     }PY_CATCH;
 }
 
@@ -926,7 +926,7 @@ PyObject *Application::sSetActiveTransaction(PyObject * /*self*/, PyObject *args
         return nullptr;
 
     PY_TRY {
-        Py::Int ret(GetApplication().setActiveTransaction(name, Base::asBoolean(persist)));
+        Py::Long ret(GetApplication().setActiveTransaction(name, Base::asBoolean(persist)));
         return Py::new_reference_to(ret);
     }PY_CATCH;
 }
@@ -943,7 +943,7 @@ PyObject *Application::sGetActiveTransaction(PyObject * /*self*/, PyObject *args
             Py_Return;
         Py::Tuple ret(2);
         ret.setItem(0,Py::String(name));
-        ret.setItem(1,Py::Int(id));
+        ret.setItem(1,Py::Long(id));
         return Py::new_reference_to(ret);
     }PY_CATCH;
 }

--- a/src/App/ComplexGeoDataPy.xml
+++ b/src/App/ComplexGeoDataPy.xml
@@ -117,7 +117,7 @@
       <Documentation>
         <UserDocu>Geometry Tag</UserDocu>
       </Documentation>
-      <Parameter Name="Tag" Type="Int"/>
+      <Parameter Name="Tag" Type="Long"/>
     </Attribute>
     <Attribute Name="Hasher">
       <Documentation>
@@ -129,7 +129,7 @@
       <Documentation>
         <UserDocu>Get the current element map size</UserDocu>
       </Documentation>
-      <Parameter Name="ElementMapSize" Type="Int" />
+      <Parameter Name="ElementMapSize" Type="Long" />
     </Attribute>
     <Attribute Name="ElementMap">
       <Documentation>

--- a/src/App/ComplexGeoDataPyImp.cpp
+++ b/src/App/ComplexGeoDataPyImp.cpp
@@ -106,9 +106,9 @@ PyObject* ComplexGeoDataPy::getFacesFromSubElement(PyObject *args)
     Py::List facet;
     for (const auto & it : facets) {
         Py::Tuple f(3);
-        f.setItem(0,Py::Int(int(it.I1)));
-        f.setItem(1,Py::Int(int(it.I2)));
-        f.setItem(2,Py::Int(int(it.I3)));
+        f.setItem(0,Py::Long(int(it.I1)));
+        f.setItem(1,Py::Long(int(it.I2)));
+        f.setItem(2,Py::Long(int(it.I3)));
         facet.append(f);
     }
     tuple.setItem(1, facet);
@@ -141,8 +141,8 @@ PyObject* ComplexGeoDataPy::getLinesFromSubElement(PyObject *args)
     Py::List line;
     for (const auto & it : lines) {
         Py::Tuple l(2);
-        l.setItem(0,Py::Int((int)it.I1));
-        l.setItem(1,Py::Int((int)it.I2));
+        l.setItem(0,Py::Long((int)it.I1));
+        l.setItem(1,Py::Long((int)it.I2));
         line.append(l);
     }
     tuple.setItem(1, line);
@@ -204,8 +204,8 @@ PyObject* ComplexGeoDataPy::getLines(PyObject *args)
     Py::List line;
     for (const auto & it : lines) {
         Py::Tuple l(2);
-        l.setItem(0,Py::Int((int)it.I1));
-        l.setItem(1,Py::Int((int)it.I2));
+        l.setItem(0,Py::Long((int)it.I1));
+        l.setItem(1,Py::Long((int)it.I2));
         line.append(l);
     }
     tuple.setItem(1, line);
@@ -236,9 +236,9 @@ PyObject* ComplexGeoDataPy::getFaces(PyObject *args)
     Py::List facet;
     for (const auto & it : facets) {
         Py::Tuple f(3);
-        f.setItem(0,Py::Int((int)it.I1));
-        f.setItem(1,Py::Int((int)it.I2));
-        f.setItem(2,Py::Int((int)it.I3));
+        f.setItem(0,Py::Long((int)it.I1));
+        f.setItem(1,Py::Long((int)it.I2));
+        f.setItem(2,Py::Long((int)it.I3));
         facet.append(f);
     }
     tuple.setItem(1, facet);
@@ -494,9 +494,9 @@ Py::Dict ComplexGeoDataPy::getElementReverseMap() const
     return ret;
 }
 
-Py::Int ComplexGeoDataPy::getElementMapSize() const
+Py::Long ComplexGeoDataPy::getElementMapSize() const
 {
-    return Py::Int((long)getComplexGeoDataPtr()->getElementMapSize());
+    return Py::Long((long)getComplexGeoDataPtr()->getElementMapSize());
 }
 
 void ComplexGeoDataPy::setHasher(Py::Object obj)
@@ -559,12 +559,12 @@ Py::String ComplexGeoDataPy::getElementMapVersion() const
 }
 
 
-Py::Int ComplexGeoDataPy::getTag() const
+Py::Long ComplexGeoDataPy::getTag() const
 {
-    return Py::Int(getComplexGeoDataPtr()->Tag);
+    return Py::Long(getComplexGeoDataPtr()->Tag);
 }
 
-void ComplexGeoDataPy::setTag(Py::Int tag)
+void ComplexGeoDataPy::setTag(Py::Long tag)
 {
     getComplexGeoDataPtr()->Tag = tag;
 }

--- a/src/App/DocumentObjectPy.xml
+++ b/src/App/DocumentObjectPy.xml
@@ -305,7 +305,7 @@ or None if the GUI is not up</UserDocu>
             <Documentation>
                 <UserDocu>The unique identifier (among its document) of this object</UserDocu>
             </Documentation>
-            <Parameter Name="ID" Type="Int"/>
+            <Parameter Name="ID" Type="Long"/>
         </Attribute>
         <Attribute Name="Removing" ReadOnly="true">
             <Documentation>

--- a/src/App/DocumentObjectPyImp.cpp
+++ b/src/App/DocumentObjectPyImp.cpp
@@ -776,8 +776,8 @@ int DocumentObjectPy::setCustomAttributes(const char* , PyObject *)
     return 0;
 }
 
-Py::Int DocumentObjectPy::getID() const {
-    return Py::Int(getDocumentObjectPtr()->getID());
+Py::Long DocumentObjectPy::getID() const {
+    return Py::Long(getDocumentObjectPtr()->getID());
 }
 
 Py::Boolean DocumentObjectPy::getRemoving() const {

--- a/src/App/DocumentPy.xml
+++ b/src/App/DocumentPy.xml
@@ -301,25 +301,25 @@ sort: whether to topologically sort the return list
       <Documentation>
         <UserDocu>The Undo mode of the Document (0 = no Undo, 1 = Undo/Redo)</UserDocu>
       </Documentation>
-      <Parameter Name="UndoMode" Type="Int" />
+      <Parameter Name="UndoMode" Type="Long" />
     </Attribute>
     <Attribute Name="UndoRedoMemSize" ReadOnly="true">
       <Documentation>
         <UserDocu>The size of the Undo stack in byte</UserDocu>
       </Documentation>
-      <Parameter Name="UndoRedoMemSize" Type="Int" />
+      <Parameter Name="UndoRedoMemSize" Type="Long" />
     </Attribute>
     <Attribute Name="UndoCount" ReadOnly="true">
       <Documentation>
         <UserDocu>Number of possible Undos</UserDocu>
       </Documentation>
-      <Parameter Name="UndoCount" Type="Int" />
+      <Parameter Name="UndoCount" Type="Long" />
     </Attribute>
     <Attribute Name="RedoCount" ReadOnly="true">
       <Documentation>
         <UserDocu>Number of possible Redos</UserDocu>
       </Documentation>
-      <Parameter Name="RedoCount" Type="Int"/>
+      <Parameter Name="RedoCount" Type="Long"/>
     </Attribute>
     <Attribute Name="UndoNames" ReadOnly="true">
       <Documentation>

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -319,7 +319,7 @@ PyObject*  DocumentPy::addObject(PyObject *args, PyObject *kwd)
             if (view)
                 pyvp = Py::Object(view);
             if (pyvp.isNone())
-                pyvp = Py::Int(1);
+                pyvp = Py::Long(1);
             // 'pyvp' is the python class with the implementation for ViewProvider
             if (pyvp.hasAttr("__vobject__")) {
                 pyvp.setAttr("__vobject__", pyftr.getAttr("ViewObject"));
@@ -583,7 +583,7 @@ PyObject*  DocumentPy::recompute(PyObject * args)
             return nullptr;
         }
 
-        return Py::new_reference_to(Py::Int(objectCount));
+        return Py::new_reference_to(Py::Long(objectCount));
     } PY_CATCH;
 }
 
@@ -758,30 +758,30 @@ Py::List DocumentPy::getRootObjectsIgnoreLinks() const
     return res;
 }
 
-Py::Int DocumentPy::getUndoMode() const
+Py::Long DocumentPy::getUndoMode() const
 {
-    return Py::Int(getDocumentPtr()->getUndoMode());
+    return Py::Long(getDocumentPtr()->getUndoMode());
 }
 
-void  DocumentPy::setUndoMode(Py::Int arg)
+void  DocumentPy::setUndoMode(Py::Long arg)
 {
     getDocumentPtr()->setUndoMode(arg);
 }
 
 
-Py::Int DocumentPy::getUndoRedoMemSize() const
+Py::Long DocumentPy::getUndoRedoMemSize() const
 {
-    return Py::Int((long)getDocumentPtr()->getUndoMemSize());
+    return Py::Long((long)getDocumentPtr()->getUndoMemSize());
 }
 
-Py::Int DocumentPy::getUndoCount() const
+Py::Long DocumentPy::getUndoCount() const
 {
-    return Py::Int((long)getDocumentPtr()->getAvailableUndos());
+    return Py::Long((long)getDocumentPtr()->getAvailableUndos());
 }
 
-Py::Int DocumentPy::getRedoCount() const
+Py::Long DocumentPy::getRedoCount() const
 {
-    return Py::Int((long)getDocumentPtr()->getAvailableRedos());
+    return Py::Long((long)getDocumentPtr()->getAvailableRedos());
 }
 
 Py::List DocumentPy::getUndoNames() const

--- a/src/App/FeaturePython.cpp
+++ b/src/App/FeaturePython.cpp
@@ -264,12 +264,12 @@ bool FeaturePythonImp::getSubObject(DocumentObject *&ret, const char *subname,
         args.setItem(0, Py::Object(object->getPyObject(), true));
         if(!subname) subname = "";
         args.setItem(1,Py::String(subname));
-        args.setItem(2,Py::Int(pyObj?2:1));
+        args.setItem(2,Py::Long(pyObj?2:1));
         Base::MatrixPy *pyMat = new Base::MatrixPy(new Base::Matrix4D);
         if(_mat) *pyMat->getMatrixPtr() = *_mat;
         args.setItem(3,Py::asObject(pyMat));
         args.setItem(4,Py::Boolean(transform));
-        args.setItem(5,Py::Int(depth));
+        args.setItem(5,Py::Long(depth));
 
         Py::Object res(Base::pyCall(py_getSubObject.ptr(),args.ptr()));
         if(res.isNone()) {
@@ -320,7 +320,7 @@ bool FeaturePythonImp::getSubObjects(std::vector<std::string> &ret, int reason) 
     try {
         Py::Tuple args(2);
         args.setItem(0, Py::Object(object->getPyObject(), true));
-        args.setItem(1, Py::Int(reason));
+        args.setItem(1, Py::Long(reason));
         Py::Object res(Base::pyCall(py_getSubObjects.ptr(),args.ptr()));
         if(!res.isTrue())
             return true;
@@ -359,7 +359,7 @@ bool FeaturePythonImp::getLinkedObject(DocumentObject *&ret, bool recurse,
         if(_mat) *pyMat->getMatrixPtr() = *_mat;
         args.setItem(2,Py::asObject(pyMat));
         args.setItem(3,Py::Boolean(transform));
-        args.setItem(4,Py::Int(depth));
+        args.setItem(4,Py::Long(depth));
 
         Py::Object res(Base::pyCall(py_getLinkedObject.ptr(),args.ptr()));
         if(!res.isTrue()) {
@@ -432,7 +432,7 @@ int FeaturePythonImp::isElementVisible(const char *element) const {
         Py::Tuple args(2);
         args.setItem(0, Py::Object(object->getPyObject(), true));
         args.setItem(1,Py::String(element?element:""));
-        return Py::Int(Base::pyCall(py_isElementVisible.ptr(),args.ptr()));
+        return Py::Long(Base::pyCall(py_isElementVisible.ptr(),args.ptr()));
     }
     catch (Py::Exception&) {
         if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
@@ -453,7 +453,7 @@ int FeaturePythonImp::setElementVisible(const char *element, bool visible) {
         args.setItem(0, Py::Object(object->getPyObject(), true));
         args.setItem(1,Py::String(element?element:""));
         args.setItem(2,Py::Boolean(visible));
-        return Py::Int(Base::pyCall(py_setElementVisible.ptr(),args.ptr()));
+        return Py::Long(Base::pyCall(py_setElementVisible.ptr(),args.ptr()));
     }
     catch (Py::Exception&) {
         if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
@@ -534,7 +534,7 @@ int FeaturePythonImp::canLoadPartial() const {
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Object(object->getPyObject(), true));
-        Py::Int ret(Base::pyCall(py_canLoadPartial.ptr(),args.ptr()));
+        Py::Long ret(Base::pyCall(py_canLoadPartial.ptr(),args.ptr()));
         return ret;
     }
     catch (Py::Exception&) {

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -364,7 +364,7 @@ App::DocumentObjectExecReturn *LinkBaseExtension::extensionExecute() {
                         } else {
                             const auto &elements = _getElementListValue();
                             for(int i=0; i<_getElementCountValue(); ++i) {
-                                args.setItem(2, Py::Int(i));
+                                args.setItem(2, Py::Long(i));
                                 if(i < (int)elements.size())
                                     args.setItem(3, Py::asObject(elements[i]->getPyObject()));
                                 else

--- a/src/App/LinkBaseExtensionPyImp.cpp
+++ b/src/App/LinkBaseExtensionPyImp.cpp
@@ -238,7 +238,7 @@ PyObject* LinkBaseExtensionPy::setLink(PyObject *_args)
             PyObject *key, *value;
             Py_ssize_t pos = 0;
             while(PyDict_Next(pcObj, &pos, &key, &value))
-                parseLink(ext,Py::Int(key),value);
+                parseLink(ext,Py::Long(key),value);
         }else if(PySequence_Check(pcObj)) {
             ext->setLink(-1,nullptr);
             Py::Sequence seq(pcObj);

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -626,16 +626,16 @@ Py::Object ObjectIdentifier::Component::get(const Py::Object &pyobj) const {
         res = pyobj.getAttr(getName());
     } else if(isArray()) {
         if(pyobj.isMapping())
-            res = Py::Mapping(pyobj).getItem(Py::Int(begin));
+            res = Py::Mapping(pyobj).getItem(Py::Long(begin));
         else
             res = Py::Sequence(pyobj).getItem(begin);
     }else if(isMap())
         res = Py::Mapping(pyobj).getItem(getName());
     else {
         assert(isRange());
-        Py::Object slice(PySlice_New(Py::Int(begin).ptr(),
-                                    end!=INT_MAX?Py::Int(end).ptr():nullptr,
-                                    step!=1?Py::Int(step).ptr():nullptr),true);
+        Py::Object slice(PySlice_New(Py::Long(begin).ptr(),
+                                    end!=INT_MAX?Py::Long(end).ptr():nullptr,
+                                    step!=1?Py::Long(step).ptr():nullptr),true);
         PyObject *r = PyObject_GetItem(pyobj.ptr(),slice.ptr());
         if(!r)
             Base::PyException::ThrowException();
@@ -654,16 +654,16 @@ void ObjectIdentifier::Component::set(Py::Object &pyobj, const Py::Object &value
             Base::PyException::ThrowException();
     } else if(isArray()) {
         if(pyobj.isMapping())
-            Py::Mapping(pyobj).setItem(Py::Int(begin),value);
+            Py::Mapping(pyobj).setItem(Py::Long(begin),value);
         else
             Py::Sequence(pyobj).setItem(begin,value);
     }else if(isMap())
         Py::Mapping(pyobj).setItem(getName(),value);
     else {
         assert(isRange());
-        Py::Object slice(PySlice_New(Py::Int(begin).ptr(),
-                                    end!=INT_MAX?Py::Int(end).ptr():nullptr,
-                                    step!=1?Py::Int(step).ptr():nullptr),true);
+        Py::Object slice(PySlice_New(Py::Long(begin).ptr(),
+                                    end!=INT_MAX?Py::Long(end).ptr():nullptr,
+                                    step!=1?Py::Long(step).ptr():nullptr),true);
         if(PyObject_SetItem(pyobj.ptr(),slice.ptr(),value.ptr())<0)
             Base::PyException::ThrowException();
     }
@@ -674,16 +674,16 @@ void ObjectIdentifier::Component::del(Py::Object &pyobj) const {
         pyobj.delAttr(getName());
     else if(isArray()) {
         if(pyobj.isMapping())
-            Py::Mapping(pyobj).delItem(Py::Int(begin));
+            Py::Mapping(pyobj).delItem(Py::Long(begin));
         else
             PySequence_DelItem(pyobj.ptr(),begin);
     } else if(isMap())
         Py::Mapping(pyobj).delItem(getName());
     else {
         assert(isRange());
-        Py::Object slice(PySlice_New(Py::Int(begin).ptr(),
-                                    end!=INT_MAX?Py::Int(end).ptr():nullptr,
-                                    step!=1?Py::Int(step).ptr():nullptr),true);
+        Py::Object slice(PySlice_New(Py::Long(begin).ptr(),
+                                    end!=INT_MAX?Py::Long(end).ptr():nullptr,
+                                    step!=1?Py::Long(step).ptr():nullptr),true);
         if(PyObject_DelItem(pyobj.ptr(),slice.ptr())<0)
             Base::PyException::ThrowException();
     }

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -267,7 +267,7 @@ PyObject* PropertyContainerPy::setPropertyStatus(PyObject *args)
             status.set(it->second, value);
         }
         else if (item.isNumeric()) {
-            int v = Py::Int(item);
+            int v = Py::Long(item);
             if (v < 0) {
                 value = false;
                 v = -v;
@@ -323,7 +323,7 @@ PyObject*  PropertyContainerPy::getPropertyStatus(PyObject *args)
                 }
             }
             if (!found)
-                ret.append(Py::Int(static_cast<long>(i)));
+                ret.append(Py::Long(static_cast<long>(i)));
         }
     }
     return Py::new_reference_to(ret);

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -478,7 +478,7 @@ void PropertyEnumeration::setPyObject(PyObject *value)
             if(seq.size() == 2) {
                 Py::Object v(seq[0].ptr());
                 if(!v.isString() && v.isSequence()) {
-                    idx = Py::Int(seq[1].ptr());
+                    idx = Py::Long(seq[1].ptr());
                     seq = v;
                 }
             }
@@ -579,14 +579,14 @@ bool PropertyEnumeration::getPyPathValue(const ObjectIdentifier &path, Py::Objec
         else {
             Py::Tuple tuple(2);
             tuple.setItem(0, res);
-            tuple.setItem(1, Py::Int(getValue()));
+            tuple.setItem(1, Py::Long(getValue()));
             r = tuple;
         }
     } else if (p == ".String") {
         auto v = getValueAsString();
         r = Py::String(v?v:"");
     } else
-        r = Py::Int(getValue());
+        r = Py::Long(getValue());
     return true;
 }
 

--- a/src/App/StringHasherPy.xml
+++ b/src/App/StringHasherPy.xml
@@ -40,13 +40,13 @@ base64: indicate if the input 'txt' is base64 encoded binary data
             <Documentation>
                 <UserDocu>Return count of used hashes</UserDocu>
             </Documentation>
-            <Parameter Name="Count" Type="Int" />
+            <Parameter Name="Count" Type="Long" />
         </Attribute>
         <Attribute Name="Size" ReadOnly="true">
             <Documentation>
                 <UserDocu>Return the size of the hashes</UserDocu>
             </Documentation>
-            <Parameter Name="Size" Type="Int"/>
+            <Parameter Name="Size" Type="Long"/>
         </Attribute>
         <Attribute Name="SaveAll">
             <Documentation>
@@ -58,7 +58,7 @@ base64: indicate if the input 'txt' is base64 encoded binary data
             <Documentation>
                 <UserDocu>Data length exceed this threshold will be hashed before storing</UserDocu>
             </Documentation>
-            <Parameter Name="Threshold" Type="Int"/>
+            <Parameter Name="Threshold" Type="Long"/>
         </Attribute>
         <Attribute Name="Table" ReadOnly="true">
             <Documentation>

--- a/src/App/StringIDPy.xml
+++ b/src/App/StringIDPy.xml
@@ -24,7 +24,7 @@
             <Documentation>
                 <UserDocu>Return the integer value of this ID</UserDocu>
             </Documentation>
-            <Parameter Name="Value" Type="Int"/>
+            <Parameter Name="Value" Type="Long"/>
         </Attribute>
         <Attribute Name="Related" ReadOnly="true">
             <Documentation>
@@ -54,7 +54,7 @@
             <Documentation>
                 <UserDocu>Geometry index. Only meaningful for geometry element name</UserDocu>
             </Documentation>
-            <Parameter Name="Index" Type="Int"/>
+            <Parameter Name="Index" Type="Long"/>
         </Attribute>
 		<ClassDeclarations>private:
     friend class StringID;

--- a/src/Base/MatrixPyImp.cpp
+++ b/src/Base/MatrixPyImp.cpp
@@ -212,7 +212,7 @@ PyObject* MatrixPy::number_power_handler(PyObject* self, PyObject* other, PyObje
 
     Base::Matrix4D a = static_cast<MatrixPy*>(self)->value();
 
-    long b = Py::Int(other);
+    long b = Py::Long(other);
     if (b == 0) {
         return new MatrixPy(Matrix4D());
     }
@@ -363,7 +363,7 @@ PyObject* MatrixPy::hasScale(PyObject* args)
     ScaleType type = getMatrixPtr()->hasScale(tol);
     Py::Module mod("FreeCAD");
     return Py::new_reference_to(
-        mod.callMemberFunction("ScaleType", Py::TupleN(Py::Int(static_cast<int>(type)))));
+        mod.callMemberFunction("ScaleType", Py::TupleN(Py::Long(static_cast<int>(type)))));
 }
 
 PyObject* MatrixPy::decompose(PyObject* args)

--- a/src/Base/PersistencePy.xml
+++ b/src/Base/PersistencePy.xml
@@ -26,7 +26,7 @@ Class to dump and restore the content of an object.</UserDocu>
       <Documentation>
         <UserDocu>Memory size of the object in bytes.</UserDocu>
       </Documentation>
-      <Parameter Name="MemSize" Type="Int"/>
+      <Parameter Name="MemSize" Type="Long"/>
     </Attribute>
     <Methode Name="dumpContent" Keyword="true" Const="true">
             <Documentation>

--- a/src/Base/PersistencePyImp.cpp
+++ b/src/Base/PersistencePyImp.cpp
@@ -52,9 +52,9 @@ Py::String PersistencePy::getContent() const
     return {writer.getString()};
 }
 
-Py::Int PersistencePy::getMemSize() const
+Py::Long PersistencePy::getMemSize() const
 {
-    return Py::Int((long)getPersistencePtr()->getMemSize());
+    return Py::Long((long)getPersistencePtr()->getMemSize());
 }
 
 PyObject* PersistencePy::dumpContent(PyObject* args, PyObject* kwds)

--- a/src/Base/QuantityPyImp.cpp
+++ b/src/Base/QuantityPyImp.cpp
@@ -641,9 +641,9 @@ Py::Dict QuantityPy::getFormat() const
     QuantityFormat fmt = getQuantityPtr()->getFormat();
 
     Py::Dict dict;
-    dict.setItem("Precision", Py::Int(fmt.precision));
+    dict.setItem("Precision", Py::Long(fmt.precision));
     dict.setItem("NumberFormat", Py::Char(fmt.toFormat()));
-    dict.setItem("Denominator", Py::Int(fmt.denominator));
+    dict.setItem("Denominator", Py::Long(fmt.denominator));
     return dict;
 }
 
@@ -652,14 +652,14 @@ void QuantityPy::setFormat(Py::Dict arg)
     QuantityFormat fmt = getQuantityPtr()->getFormat();
 
     if (arg.hasKey("Precision")) {
-        Py::Int prec(arg.getItem("Precision"));
+        Py::Long prec(arg.getItem("Precision"));
         fmt.precision = static_cast<int>(prec);
     }
 
     if (arg.hasKey("NumberFormat")) {
         Py::Object item = arg.getItem("NumberFormat");
         if (item.isNumeric()) {
-            int format = static_cast<int>(Py::Int(item));
+            int format = static_cast<int>(Py::Long(item));
             if (format < 0 || format > QuantityFormat::Scientific) {
                 throw Py::ValueError("Invalid format value");
             }
@@ -681,7 +681,7 @@ void QuantityPy::setFormat(Py::Dict arg)
     }
 
     if (arg.hasKey("Denominator")) {
-        Py::Int denom(arg.getItem("Denominator"));
+        Py::Long denom(arg.getItem("Denominator"));
         int fracInch = static_cast<int>(denom);
         // check that the value is positive and a power of 2
         if (fracInch <= 0) {

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1560,7 +1560,7 @@ void PythonGroupCommand::activated(int iMsg)
         if (cmd.hasAttr("Activated")) {
             Py::Callable call(cmd.getAttr("Activated"));
             Py::Tuple args(1);
-            args.setItem(0, Py::Int(iMsg));
+            args.setItem(0, Py::Long(iMsg));
             Py::Object ret = call.apply(args);
         }
         // If the command group doesn't implement the 'Activated' method then invoke the command directly
@@ -1640,7 +1640,7 @@ Action * PythonGroupCommand::createAction()
 
         if (cmd.hasAttr("GetDefaultCommand")) {
             Py::Callable call2(cmd.getAttr("GetDefaultCommand"));
-            Py::Int def(call2.apply(args));
+            Py::Long def(call2.apply(args));
             defaultId = static_cast<int>(def);
         }
 

--- a/src/Gui/DocumentPy.xml
+++ b/src/Gui/DocumentPy.xml
@@ -223,7 +223,7 @@ obj : Gui.ViewProvider</UserDocu>
       <Documentation>
         <UserDocu>Current edit mode. Only meaningful when there is a current object in edit.</UserDocu>
       </Documentation>
-    <Parameter Name="EditMode" Type="Int" />
+    <Parameter Name="EditMode" Type="Long" />
     </Attribute>
     <Attribute Name="Document" ReadOnly="true">
       <Documentation>

--- a/src/Gui/DocumentPyImp.cpp
+++ b/src/Gui/DocumentPyImp.cpp
@@ -471,7 +471,7 @@ Py::Object DocumentPy::getInEditInfo() const {
         return Py::None();
 
     return Py::TupleN(Py::Object(vp->getObject()->getPyObject(),true),
-            Py::String(subname),Py::String(subelement),Py::Int(mode));
+            Py::String(subname),Py::String(subelement),Py::Long(mode));
 }
 
 void DocumentPy::setInEditInfo(Py::Object arg)
@@ -486,12 +486,12 @@ void DocumentPy::setInEditInfo(Py::Object arg)
                 pyobj)->getViewProviderDocumentObjectPtr(),subname);
 }
 
-Py::Int DocumentPy::getEditMode() const
+Py::Long DocumentPy::getEditMode() const
 {
     int mode = -1;
     getDocumentPtr()->getInEdit(nullptr,nullptr,&mode);
 
-    return Py::Int(mode);
+    return Py::Long(mode);
 }
 
 Py::Boolean DocumentPy::getTransacting() const

--- a/src/Gui/LinkViewPy.xml
+++ b/src/Gui/LinkViewPy.xml
@@ -154,7 +154,7 @@ Return a tuple(path,detail) for the coin3D SoPath and SoDetail of the element
             <Documentation>
                 <UserDocu>Set the element size to create an array of linked object</UserDocu>
             </Documentation>
-            <Parameter Name="Count" Type="Int" />
+            <Parameter Name="Count" Type="Long" />
         </Attribute>
         <Methode Name="getChildren" Const="true">
             <Documentation>

--- a/src/Gui/LinkViewPyImp.cpp
+++ b/src/Gui/LinkViewPyImp.cpp
@@ -83,7 +83,7 @@ PyObject* LinkViewPy::setMaterial(PyObject *args) {
             Py_ssize_t pos = 0;
             std::map<int,App::Material*> materials;
             while(PyDict_Next(pyObj, &pos, &key, &value)) {
-                Py::Int idx(key);
+                Py::Long idx(key);
                 if(value == Py_None)
                     materials[(int)idx] = nullptr;
                 else if(!PyObject_TypeCheck(value,&App::MaterialPy::Type)) {
@@ -135,7 +135,7 @@ PyObject* LinkViewPy::setTransform(PyObject *args) {
             Py_ssize_t pos = 0;
             std::map<int,Base::Matrix4D*> mat;
             while(PyDict_Next(pyObj, &pos, &key, &value)) {
-                Py::Int idx(key);
+                Py::Long idx(key);
                 if(!PyObject_TypeCheck(value,&Base::MatrixPy::Type)) {
                     PyErr_SetString(PyExc_TypeError, "exepcting a type of Matrix");
                     return nullptr;
@@ -384,11 +384,11 @@ PyObject* LinkViewPy::getChildren(PyObject *args) {
     return Py::new_reference_to(ret);
 }
 
-Py::Int LinkViewPy::getCount() const {
-    return Py::Int(getLinkViewPtr()->getSize());
+Py::Long LinkViewPy::getCount() const {
+    return Py::Long(getLinkViewPtr()->getSize());
 }
 
-void LinkViewPy::setCount(Py::Int count) {
+void LinkViewPy::setCount(Py::Long count) {
     try {
         getLinkViewPtr()->setSize((int)count);
     } catch (const Base::Exception& e) {

--- a/src/Gui/PythonConsolePy.cpp
+++ b/src/Gui/PythonConsolePy.cpp
@@ -50,7 +50,7 @@ Py::Object PythonStdout::getattr(const char *name)
 {
     if (strcmp(name, "softspace") == 0) {
         int i=0;
-        return Py::Int(i);
+        return Py::Long(i);
     }
     return getattr_methods(name);
 }
@@ -114,7 +114,7 @@ Py::Object PythonStderr::getattr(const char *name)
 {
     if (strcmp(name, "softspace") == 0) {
         int i=0;
-        return Py::Int(i);
+        return Py::Long(i);
     }
     return getattr_methods(name);
 }
@@ -175,7 +175,7 @@ Py::Object OutputStdout::getattr(const char *name)
 {
     if (strcmp(name, "softspace") == 0) {
         int i=0;
-        return Py::Int(i);
+        return Py::Long(i);
     }
     return getattr_methods(name);
 }
@@ -236,7 +236,7 @@ Py::Object OutputStderr::getattr(const char *name)
 {
     if (strcmp(name, "softspace") == 0) {
         int i=0;
-        return Py::Int(i);
+        return Py::Long(i);
     }
     return getattr_methods(name);
 }

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -1274,8 +1274,8 @@ Py::Object View3DInventorPy::getCursorPos()
         auto viewer = getView3DIventorPtr()->getViewer();
         SbVec2s vec = viewer->fromQPoint(pos);
         Py::Tuple tuple(2);
-        tuple.setItem(0, Py::Int(vec[0]));
-        tuple.setItem(1, Py::Int(vec[1]));
+        tuple.setItem(0, Py::Long(vec[0]));
+        tuple.setItem(1, Py::Long(vec[1]));
         return tuple;
     }
     catch (const Py::Exception&) {
@@ -1292,13 +1292,13 @@ Py::Object View3DInventorPy::getObjectInfo(const Py::Tuple& args)
 
     try {
         //Note: For gcc (4.2) we need the 'const' keyword to avoid the compiler error:
-        //conversion from 'Py::seqref<Py::Object>' to non-scalar type 'Py::Int' requested
+        //conversion from 'Py::seqref<Py::Object>' to non-scalar type 'Py::Long' requested
         //We should report this problem to the PyCXX project as in the documentation an
         //example without the 'const' keyword is used.
-        //Or we can also write Py::Int x(tuple[0]);
+        //Or we can also write Py::Long x(tuple[0]);
         const Py::Tuple tuple(object);
-        Py::Int x(tuple[0]);
-        Py::Int y(tuple[1]);
+        Py::Long x(tuple[0]);
+        Py::Long y(tuple[1]);
 
         // As this method could be called during a SoHandleEventAction scene
         // graph traversal we must not use a second SoHandleEventAction as
@@ -1398,13 +1398,13 @@ Py::Object View3DInventorPy::getObjectsInfo(const Py::Tuple& args)
 
     try {
         //Note: For gcc (4.2) we need the 'const' keyword to avoid the compiler error:
-        //conversion from 'Py::seqref<Py::Object>' to non-scalar type 'Py::Int' requested
+        //conversion from 'Py::seqref<Py::Object>' to non-scalar type 'Py::Long' requested
         //We should report this problem to the PyCXX project as in the documentation an
         //example without the 'const' keyword is used.
-        //Or we can also write Py::Int x(tuple[0]);
+        //Or we can also write Py::Long x(tuple[0]);
         const Py::Tuple tuple(object);
-        Py::Int x(tuple[0]);
-        Py::Int y(tuple[1]);
+        Py::Long x(tuple[0]);
+        Py::Long y(tuple[1]);
 
         // As this method could be called during a SoHandleEventAction scene
         // graph traversal we must not use a second SoHandleEventAction as
@@ -1506,8 +1506,8 @@ Py::Object View3DInventorPy::getSize()
     try {
         SbVec2s size = getView3DIventorPtr()->getViewer()->getSoRenderManager()->getSize();
         Py::Tuple tuple(2);
-        tuple.setItem(0, Py::Int(size[0]));
-        tuple.setItem(1, Py::Int(size[1]));
+        tuple.setItem(0, Py::Long(size[0]));
+        tuple.setItem(1, Py::Long(size[1]));
         return tuple;
     }
     catch (const Py::Exception&) {
@@ -1521,8 +1521,8 @@ Py::Object View3DInventorPy::getPointOnFocalPlane(const Py::Tuple& args)
     if (!PyArg_ParseTuple(args.ptr(), "hh", &x, &y)) {
         PyErr_Clear();
         Py::Tuple t(args[0]);
-        x = (int)Py::Int(t[0]);
-        y = (int)Py::Int(t[1]);
+        x = (int)Py::Long(t[0]);
+        y = (int)Py::Long(t[1]);
     }
     try {
         SbVec3f pt = getView3DIventorPtr()->getViewer()->getPointOnFocalPlane(SbVec2s(x,y));
@@ -1556,8 +1556,8 @@ Py::Object View3DInventorPy::getPointOnViewport(const Py::Tuple& args)
     try {
         SbVec2s pt = getView3DIventorPtr()->getViewer()->getPointOnViewport(SbVec3f(vx,vy,vz));
         Py::Tuple tuple(2);
-        tuple.setItem(0, Py::Int(pt[0]));
-        tuple.setItem(1, Py::Int(pt[1]));
+        tuple.setItem(0, Py::Long(pt[0]));
+        tuple.setItem(1, Py::Long(pt[1]));
 
         return tuple;
     }
@@ -1575,8 +1575,8 @@ Py::Object View3DInventorPy::projectPointToLine(const Py::Tuple& args)
     if (!PyArg_ParseTuple(args.ptr(), "hh", &x, &y)) {
         PyErr_Clear();
         Py::Tuple t(args[0]);
-        x = (int)Py::Int(t[0]);
-        y = (int)Py::Int(t[1]);
+        x = (int)Py::Long(t[0]);
+        y = (int)Py::Long(t[1]);
     }
     try {
         SbVec3f pt1, pt2;
@@ -1635,8 +1635,8 @@ void View3DInventorPy::eventCallback(void * ud, SoEventCallback * n)
         dict.setItem("Time", Py::String(std::string(e->getTime().formatDate("%Y-%m-%d %H:%M:%S").getString())));
         SbVec2s p = n->getEvent()->getPosition();
         Py::Tuple pos(2);
-        pos.setItem(0, Py::Int(p[0]));
-        pos.setItem(1, Py::Int(p[1]));
+        pos.setItem(0, Py::Long(p[0]));
+        pos.setItem(1, Py::Long(p[1]));
         // Position
         dict.setItem("Position", pos);
         // Shift, Ctrl, Alt down
@@ -2509,7 +2509,7 @@ Py::Object View3DInventorPy::setCornerCrossSize(const Py::Tuple& args)
 Py::Object View3DInventorPy::getCornerCrossSize()
 {
     int size = getView3DIventorPtr()->getViewer()->getFeedbackSize();
-    return Py::Int(size);
+    return Py::Long(size);
 }
 
 Py::Object View3DInventorPy::cast_to_base()

--- a/src/Gui/View3DViewerPy.cpp
+++ b/src/Gui/View3DViewerPy.cpp
@@ -267,8 +267,8 @@ Py::Object View3DInventorViewerPy::seekToPoint(const Py::Tuple& args)
             _viewer->seekToPoint(hitpoint);
         }
         else {
-            Py::Int x(tuple[0]);
-            Py::Int y(tuple[1]);
+            Py::Long x(tuple[0]);
+            Py::Long y(tuple[1]);
 
             SbVec2s hitpoint ((long)x,(long)y);
             _viewer->seekToPoint(hitpoint);
@@ -334,8 +334,8 @@ Py::Object View3DInventorViewerPy::getPointOnFocalPlane(const Py::Tuple& args)
     if (!PyArg_ParseTuple(args.ptr(), "hh", &x, &y)) {
         PyErr_Clear();
         Py::Tuple t(args[0]);
-        x = (int)Py::Int(t[0]);
-        y = (int)Py::Int(t[1]);
+        x = (int)Py::Long(t[0]);
+        y = (int)Py::Long(t[1]);
     }
     try {
         SbVec3f pt = _viewer->getPointOnFocalPlane(SbVec2s(x,y));

--- a/src/Gui/ViewProviderFeaturePython.cpp
+++ b/src/Gui/ViewProviderFeaturePython.cpp
@@ -356,7 +356,7 @@ ViewProviderFeaturePythonImp::setEdit(int ModNum)
     try {
         if (has__object__) {
             Py::Tuple args(1);
-            args.setItem(0, Py::Int(ModNum));
+            args.setItem(0, Py::Long(ModNum));
             Py::Object ret(Base::pyCall(py_setEdit.ptr(),args.ptr()));
             if (ret.isNone())
                 return NotImplemented;
@@ -367,7 +367,7 @@ ViewProviderFeaturePythonImp::setEdit(int ModNum)
         else {
             Py::Tuple args(2);
             args.setItem(0, Py::Object(object->getPyObject(), true));
-            args.setItem(1, Py::Int(ModNum));
+            args.setItem(1, Py::Long(ModNum));
             Py::Object ret(Base::pyCall(py_setEdit.ptr(),args.ptr()));
             if (ret.isNone())
                 return NotImplemented;
@@ -397,7 +397,7 @@ ViewProviderFeaturePythonImp::unsetEdit(int ModNum)
     try {
         if (has__object__) {
             Py::Tuple args(1);
-            args.setItem(0, Py::Int(ModNum));
+            args.setItem(0, Py::Long(ModNum));
             Py::Object ret(Base::pyCall(py_unsetEdit.ptr(),args.ptr()));
             if (ret.isNone())
                 return NotImplemented;
@@ -408,7 +408,7 @@ ViewProviderFeaturePythonImp::unsetEdit(int ModNum)
         else {
             Py::Tuple args(2);
             args.setItem(0, Py::Object(object->getPyObject(), true));
-            args.setItem(1, Py::Int(ModNum));
+            args.setItem(1, Py::Long(ModNum));
             Py::Object ret(Base::pyCall(py_unsetEdit.ptr(),args.ptr()));
             if (ret.isNone())
                 return NotImplemented;
@@ -439,7 +439,7 @@ ViewProviderFeaturePythonImp::setEditViewer(View3DInventorViewer *viewer, int Mo
         Py::Tuple args(3);
         args.setItem(0, Py::Object(object->getPyObject(),true));
         args.setItem(1, Py::Object(viewer->getPyObject(),true));
-        args.setItem(2, Py::Int(ModNum));
+        args.setItem(2, Py::Long(ModNum));
         Py::Object ret(Base::pyCall(py_setEditViewer.ptr(),args.ptr()));
         return ret.isTrue()?Accepted:Rejected;
     }
@@ -649,7 +649,7 @@ void ViewProviderFeaturePythonImp::finishRestoring()
         Py::Object vp = Proxy.getValue();
         if (vp.isNone()) {
             object->show();
-            Proxy.setValue(Py::Int(1));
+            Proxy.setValue(Py::Long(1));
         } else {
             _FC_PY_CALL_CHECK(finishRestoring,return);
             Base::pyCall(py_finishRestoring.ptr());

--- a/src/Gui/ViewProviderPy.xml
+++ b/src/Gui/ViewProviderPy.xml
@@ -314,7 +314,7 @@ view: View3DInventorPy
       <Documentation>
         <UserDocu>Get/Set the default display mode in turns of coin node index.</UserDocu>
       </Documentation>
-      <Parameter Name="DefaultNode" Type="Int" />
+      <Parameter Name="DefaultNode" Type="Long" />
     </Attribute>
     <Attribute Name="IV" ReadOnly="true">
       <Documentation>

--- a/src/Gui/ViewProviderPyImp.cpp
+++ b/src/Gui/ViewProviderPyImp.cpp
@@ -304,7 +304,7 @@ PyObject* ViewProviderPy::replaceObject(PyObject *args)
         int ret = getViewProviderPtr()->replaceObject(
                 static_cast<App::DocumentObjectPy*>(oldObj)->getDocumentObjectPtr(),
                 static_cast<App::DocumentObjectPy*>(newObj)->getDocumentObjectPtr());
-        return Py::new_reference_to(Py::Int(ret));
+        return Py::new_reference_to(Py::Long(ret));
     }
     PY_CATCH;
 }
@@ -456,7 +456,7 @@ PyObject* ViewProviderPy::partialRender(PyObject* args)
         }
     }
 
-    Py::Int ret(getViewProviderPtr()->partialRender(values, Base::asBoolean(clear)));
+    Py::Long ret(getViewProviderPtr()->partialRender(values, Base::asBoolean(clear)));
     return Py::new_reference_to(ret);
 }
 
@@ -677,12 +677,12 @@ Py::Object ViewProviderPy::getIcon() const
     return wrap.fromQIcon(new QIcon(icon));
 }
 
-Py::Int ViewProviderPy::getDefaultMode() const
+Py::Long ViewProviderPy::getDefaultMode() const
 {
-    return Py::Int((long)getViewProviderPtr()->getDefaultMode());
+    return Py::Long((long)getViewProviderPtr()->getDefaultMode());
 }
 
-void ViewProviderPy::setDefaultMode(Py::Int arg)
+void ViewProviderPy::setDefaultMode(Py::Long arg)
 {
     return getViewProviderPtr()->setDefaultMode(arg);
 }

--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -584,7 +584,7 @@ Py::Object PyResource::value(const Py::Tuple& args)
         item = Py::Long(static_cast<unsigned long>(v.toUInt()));
         break;
     case QMetaType::Int:
-        item = Py::Int(v.toInt());
+        item = Py::Long(v.toInt());
         break;
     default:
         item = Py::String("");

--- a/src/Mod/CAM/App/AreaPyImp.cpp
+++ b/src/Mod/CAM/App/AreaPyImp.cpp
@@ -666,7 +666,7 @@ Py::List AreaPy::getShapes() const
     Area* area = getAreaPtr();
     const std::list<Area::Shape>& shapes = area->getChildren();
     for (auto& s : shapes) {
-        ret.append(Py::TupleN(Part::shape2pyshape(s.shape), Py::Int(s.op)));
+        ret.append(Py::TupleN(Part::shape2pyshape(s.shape), Py::Long(s.op)));
     }
     return ret;
 }

--- a/src/Mod/CAM/App/VoronoiCellPy.xml
+++ b/src/Mod/CAM/App/VoronoiCellPy.xml
@@ -39,7 +39,7 @@
             <Documentation>
                 <UserDocu>Returns the cell's category as an integer</UserDocu>
             </Documentation>
-            <Parameter Name="SourceCategory" Type="Int"/>
+            <Parameter Name="SourceCategory" Type="Long"/>
         </Attribute>
         <Attribute Name="SourceCategoryName" ReadOnly="true">
             <Documentation>

--- a/src/Mod/CAM/App/VoronoiCellPyImp.cpp
+++ b/src/Mod/CAM/App/VoronoiCellPyImp.cpp
@@ -134,10 +134,10 @@ Py::Long VoronoiCellPy::getSourceIndex() const
     return Py::Long(index);
 }
 
-Py::Int VoronoiCellPy::getSourceCategory() const
+Py::Long VoronoiCellPy::getSourceCategory() const
 {
     VoronoiCell* c = getVoronoiCellFromPy(this);
-    return Py::Int(c->ptr->source_category());
+    return Py::Long(c->ptr->source_category());
 }
 
 Py::String VoronoiCellPy::getSourceCategoryName() const

--- a/src/Mod/Material/App/Array2DPy.xml
+++ b/src/Mod/Material/App/Array2DPy.xml
@@ -25,13 +25,13 @@
       <Documentation>
         <UserDocu>The number of rows in the array.</UserDocu>
       </Documentation>
-      <Parameter Name="Rows" Type="Int"/>
+      <Parameter Name="Rows" Type="Long"/>
     </Attribute>
     <Attribute Name="Columns" ReadOnly="true">
       <Documentation>
         <UserDocu>The number of columns in the array.</UserDocu>
       </Documentation>
-      <Parameter Name="Columns" Type="Int"/>
+      <Parameter Name="Columns" Type="Long"/>
     </Attribute>
     <Methode Name="getRow" ReadOnly="true">
       <Documentation>

--- a/src/Mod/Material/App/Array2DPyImp.cpp
+++ b/src/Mod/Material/App/Array2DPyImp.cpp
@@ -81,14 +81,14 @@ Py::List Array2DPy::getArray() const
     return list;
 }
 
-Py::Int Array2DPy::getRows() const
+Py::Long Array2DPy::getRows() const
 {
-    return Py::Int(getMaterial2DArrayPtr()->rows());
+    return Py::Long(getMaterial2DArrayPtr()->rows());
 }
 
-Py::Int Array2DPy::getColumns() const
+Py::Long Array2DPy::getColumns() const
 {
-    return Py::Int(getMaterial2DArrayPtr()->columns());
+    return Py::Long(getMaterial2DArrayPtr()->columns());
 }
 
 PyObject* Array2DPy::getRow(PyObject* args)

--- a/src/Mod/Material/App/Array3DPy.xml
+++ b/src/Mod/Material/App/Array3DPy.xml
@@ -25,13 +25,13 @@
       <Documentation>
         <UserDocu>The number of columns in the array.</UserDocu>
       </Documentation>
-      <Parameter Name="Columns" Type="Int"/>
+      <Parameter Name="Columns" Type="Long"/>
     </Attribute>
     <Attribute Name="Depth" ReadOnly="true">
       <Documentation>
         <UserDocu>The depth of the array (3rd dimension).</UserDocu>
       </Documentation>
-      <Parameter Name="Columns" Type="Int"/>
+      <Parameter Name="Columns" Type="Long"/>
     </Attribute>
     <Methode Name="getRows" ReadOnly="true">
       <Documentation>

--- a/src/Mod/Material/App/Array3DPyImp.cpp
+++ b/src/Mod/Material/App/Array3DPyImp.cpp
@@ -83,14 +83,14 @@ Py::List Array3DPy::getArray() const
     return list;
 }
 
-Py::Int Array3DPy::getColumns() const
+Py::Long Array3DPy::getColumns() const
 {
-    return Py::Int(getMaterial3DArrayPtr()->columns());
+    return Py::Long(getMaterial3DArrayPtr()->columns());
 }
 
-Py::Int Array3DPy::getDepth() const
+Py::Long Array3DPy::getDepth() const
 {
-    return Py::Int(getMaterial3DArrayPtr()->depth());
+    return Py::Long(getMaterial3DArrayPtr()->depth());
 }
 
 PyObject* Array3DPy::getRows(PyObject* args)

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -1048,7 +1048,7 @@ private:
                           if (!PyLong_Check(value)) {
                               throw Py::ValueError(err);
                           }
-                          int order = Py::Int(value);
+                          int order = Py::Long(value);
                           params.orders[s] = static_cast<TopoShape::Continuity>(order);
                           return;
                       });
@@ -1125,7 +1125,7 @@ private:
                           if (!PyLong_Check(value)) {
                               throw Py::ValueError(err);
                           }
-                          int order = Py::Int(value);
+                          int order = Py::Long(value);
                           params.orders[s] = static_cast<TopoShape::Continuity>(order);
                           return;
                       });

--- a/src/Mod/Part/App/PartFeaturePyImp.cpp
+++ b/src/Mod/Part/App/PartFeaturePyImp.cpp
@@ -65,7 +65,7 @@ PyObject *PartFeaturePy::getElementHistory(PyObject *args, PyObject *kwds) {
                 } else
                     ret.setItem(0, Py::Object(history.obj->getPyObject(), true));
             } else
-                ret.setItem(0, Py::Int(history.tag));
+                ret.setItem(0, Py::Long(history.tag));
             tmp.clear();
             ret.setItem(1, Py::String(history.element.appendToBuffer(tmp)));
             Py::List intermedates;

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -1889,7 +1889,7 @@ PyObject* TopoShapePy::countElement(PyObject *args)
         return nullptr;
 
     PY_TRY {
-        return Py::new_reference_to(Py::Int((long)getTopoShapePtr()->countSubShapes(input)));
+        return Py::new_reference_to(Py::Long((long)getTopoShapePtr()->countSubShapes(input)));
     }
     PY_CATCH_OCC
 }
@@ -2362,10 +2362,10 @@ PyObject* TopoShapePy::findSubShape(PyObject* args)
         for (auto& s : getPyShapes(pyobj)) {
             int index = getTopoShapePtr()->findShape(s.getShape());
             if (index > 0) {
-                res.append(Py::TupleN(Py::String(s.shapeName()), Py::Int(index)));
+                res.append(Py::TupleN(Py::String(s.shapeName()), Py::Long(index)));
             }
             else {
-                res.append(Py::TupleN(Py::Object(), Py::Int(0)));
+                res.append(Py::TupleN(Py::Object(), Py::Long(0)));
             }
         }
         if (PySequence_Check(pyobj)) {
@@ -2652,7 +2652,7 @@ PyObject* TopoShapePy::getElementHistory(PyObject* args)
             Py_Return;
         }
         Py::Tuple ret(3);
-        ret.setItem(0, Py::Int(tag));
+        ret.setItem(0, Py::Long(tag));
         std::string tmp;
         ret.setItem(1, Py::String(original.appendToBuffer(tmp)));
         Py::List pyHistory;

--- a/src/Mod/Sandbox/Gui/AppSandboxGui.cpp
+++ b/src/Mod/Sandbox/Gui/AppSandboxGui.cpp
@@ -114,7 +114,7 @@ private:
                 args.setItem(3,vector.apply(xyz));
 
                 args.setItem(4,Py::Float(radius));
-                args.setItem(5,Py::Int((int)0));
+                args.setItem(5,Py::Long((int)0));
                 Py::Tuple ret(method.apply(args));
                 Py::Object S1(ret.getItem(0));
                 Py::Object S2(ret.getItem(1));
@@ -154,7 +154,7 @@ private:
                 args.setItem(2,Py::Vector(l2));
                 args.setItem(3,Py::Vector(Base::Vector3d(0,0,1)));
                 args.setItem(4,Py::Float(radius));
-              //args.setItem(5,Py::Int((int)0));
+              //args.setItem(5,Py::Long((int)0));
                 args.setItem(5,Py::Long((long)1));
                 Py::Tuple ret(method.apply(args));
                 Py::Vector S1(ret.getItem(0));

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -2399,7 +2399,7 @@ Py::List SketchObjectPy::getConflictingConstraints() const
     Py::List conflicting;
 
     for (auto cid : conflictinglist) {
-        conflicting.append(Py::Int(cid));
+        conflicting.append(Py::Long(cid));
     }
 
     return conflicting;
@@ -2412,7 +2412,7 @@ Py::List SketchObjectPy::getRedundantConstraints() const
     Py::List redundant;
 
     for (auto cid : redundantlist) {
-        redundant.append(Py::Int(cid));
+        redundant.append(Py::Long(cid));
     }
 
     return redundant;
@@ -2425,7 +2425,7 @@ Py::List SketchObjectPy::getPartiallyRedundantConstraints() const
     Py::List redundant;
 
     for (auto cid : redundantlist) {
-        redundant.append(Py::Int(cid));
+        redundant.append(Py::Long(cid));
     }
 
     return redundant;
@@ -2438,7 +2438,7 @@ Py::List SketchObjectPy::getMalformedConstraints() const
     Py::List malformed;
 
     for (auto cid : malformedlist) {
-        malformed.append(Py::Int(cid));
+        malformed.append(Py::Long(cid));
     }
 
     return malformed;

--- a/src/Mod/Sketcher/App/SketchPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchPyImp.cpp
@@ -178,7 +178,7 @@ PyObject* SketchPy::movePoint(PyObject* args)
 
 Py::Long SketchPy::getConstraint() const
 {
-    // return Py::Int();
+    // return Py::Long();
     throw Py::AttributeError("Not yet implemented");
 }
 


### PR DESCRIPTION
backport of 10513144d96d43776fd127eafe82a3c715c0cf75 which was part of part of #19479 , without this freecad doesn't build on fedora 42 with the system version of pycxx

```
/tmp/rpkg/freecad-14-ynoebqzc/freecad-1.0.1-build/FreeCAD/build/src/Base/PersistencePy.h:68:9: error: ‘Int’ in namespace ‘Py’ does not name a type
   68 |     Py::Int getMemSize() const;
      |         ^~~
/tmp/rpkg/freecad-14-ynoebqzc/freecad-1.0.1-build/FreeCAD/build/src/App/DocumentObjectPy.h:235:9: error: ‘Int’ in namespace ‘Py’ does not name a type
  235 |     Py::Int getID() const;
      |         ^~~
```
@tritao @chennes is this safe to put on 1.0 branch? please also check that I backported correctly