### PR TITLE
PD: Move hole base profiles types to the top

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>366</width>
-    <height>844</height>
+    <height>924</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -33,12 +33,38 @@
     <number>6</number>
    </property>
    <item>
-    <layout class="QGridLayout" name="headLayout" columnstretch="2,5">
+    <layout class="QGridLayout" name="TopLayout" columnstretch="2,5">
      <property name="topMargin">
       <number>10</number>
      </property>
-     <item row="2" column="0">
-      <widget class="Gui::ElideLabel" name="labelDepthType">
+     <item row="0" column="0">
+      <widget class="Gui::ElideLabel" name="labelProfileType">
+       <property name="text">
+        <string>Base profile types</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="BaseProfileType">
+       <item>
+        <property name="text">
+         <string>Circles and arcs</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Points, circles and arcs</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Points</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="Gui::ElideLabel" name="labelHeadType">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -46,14 +72,14 @@
         </sizepolicy>
        </property>
        <property name="layoutDirection">
-        <enum>Qt::LayoutDirection::LeftToRight</enum>
+        <enum>Qt::LayoutDirection::RightToLeft</enum>
        </property>
        <property name="text">
-        <string>Depth Type</string>
+        <string>Head Type</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QComboBox" name="DepthType">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
@@ -76,8 +102,8 @@
        </item>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="Gui::ElideLabel" name="labelHeadType">
+     <item row="3" column="0">
+      <widget class="Gui::ElideLabel" name="labelDepthType">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -85,14 +111,14 @@
         </sizepolicy>
        </property>
        <property name="layoutDirection">
-        <enum>Qt::LayoutDirection::RightToLeft</enum>
+        <enum>Qt::LayoutDirection::LeftToRight</enum>
        </property>
        <property name="text">
-        <string>Head Type</string>
+        <string>Depth Type</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
+     <item row="1" column="1">
       <widget class="QComboBox" name="HoleCutType">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
@@ -589,29 +615,6 @@ over 90: larger hole radius at the bottom</string>
      <property name="topMargin">
       <number>0</number>
      </property>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="ThreadSize">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="Gui::ElideLabel" name="labelSize">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Size</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="1">
       <widget class="QComboBox" name="ThreadType">
        <property name="sizePolicy">
@@ -632,6 +635,29 @@ over 90: larger hole radius at the bottom</string>
        </property>
        <property name="text">
         <string>Standard</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="ThreadSize">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="Gui::ElideLabel" name="labelSize">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Size</string>
        </property>
       </widget>
      </item>
@@ -1073,36 +1099,6 @@ Note that the calculation can take some time</string>
       </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="BaseProfileLayout" stretch="2,5">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Base profile types</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="BaseProfileType">
-       <item>
-        <property name="text">
-         <string>Circles and arcs</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Points, circles and arcs</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Points</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION

move the profile types to the top and keep it aligned

the bottom of the group is intended for thread options, so profile types was out of place

changed the label to be able to ellipsize since it can be long in translations


![taskpanel](https://github.com/user-attachments/assets/39b53ea1-7ef5-44f2-b5d2-e21e0990d5b9)
