### PR TITLE
FEM: Fix Glyph filter typos

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/TaskPostGlyph.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/TaskPostGlyph.ui
@@ -103,7 +103,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label_4">
         <property name="toolTip">
-         <string>If the scale data is a vector this property decides if the glyph is scaled by vector magnitude or by the individual components</string>
+         <string>Which data field is used to scale the glyphs</string>
         </property>
         <property name="text">
          <string>Data</string>
@@ -121,7 +121,7 @@
            </sizepolicy>
           </property>
           <property name="toolTip">
-           <string>If the scale data is a vector this property decides if the glyph is scaled by vector magnitude or by the individual components</string>
+           <string>Which data field is used to scale the glyphs</string>
           </property>
           <item>
            <property name="text">
@@ -203,7 +203,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string>Which data field is used to scale the glyphs</string>
+         <string>If the scale data is a vector this property decides if the glyph is scaled by vector magnitude or by the individual components</string>
         </property>
         <item>
          <property name="text">

--- a/src/Mod/Fem/femobjects/post_glyphfilter.py
+++ b/src/Mod/Fem/femobjects/post_glyphfilter.py
@@ -106,7 +106,7 @@ class PostGlyphFilter(base_fempythonobject.BaseFemPythonObject):
                 name="MaskMode",
                 group="Masking",
                 doc="Which vertices are used as glyph locations",
-                value=["Use All", "Every Nth", "Uniform Samping"],
+                value=["Use All", "Every Nth", "Uniform Sampling"],
             ),
             _PropHelper(
                 type="App::PropertyIntegerConstraint",
@@ -119,7 +119,7 @@ class PostGlyphFilter(base_fempythonobject.BaseFemPythonObject):
                 type="App::PropertyIntegerConstraint",
                 name="MaxNumber",
                 group="Masking",
-                doc='Defines the maximal number of vertices used for "Uniform Sampling" masking mode',
+                doc='Defines the maximum number of vertices used for "Uniform Sampling" masking mode',
                 value=(1000, 1, 999999999, 1),
             ),
         ]


### PR DESCRIPTION
Fixes some Glyph filter typos, including one task panel option and swapped tooltips.

@ickby FYI
