### PR TITLE
CAM: Adaptive: Fix helix entry start height (fix #21058)

### DIFF
--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -734,13 +734,39 @@ def Execute(op, obj):
             adaptiveResults = list()
             for depths, region in cutlist:
                 for result in region["toolpaths"]:
+                    # Top depth is the height where the helix starts for a
+                    # region.
+                    # We want the lowest of 3 possibilities:
+                    # - the top of the stock OR
+                    # - the region's first cut depth + stepdown OR
+                    # - the operation's starting depth
+                    # The starting depth option covers the case where the user
+                    # has a previous operations that cleared some stock and
+                    # wants the adaptive toolpath to pick up where the previous
+                    # operation left off.
+                    # Regions are only generated where stock needs to be
+                    # removed, so we can't start at the cut level- we know
+                    # there's material there.
+                    # TODO: Due to the adaptive algorithm currently not
+                    # processing holes in the stock when finding entry points,
+                    # this may result in a helix up to stepdown in height where
+                    # one isn't required. This should be fixed in FindEntryPoint
+                    # or FindEntryPointOutside in Adaptive.cpp, not bandaged
+                    # here.
+
+                    TopDepth = min(
+                        topZ,
+                        depths[0] + stepdown,
+                        obj.StartDepth.Value,
+                    )
+
                     adaptiveResults.append(
                         {
                             "HelixCenterPoint": result.HelixCenterPoint,
                             "StartPoint": result.StartPoint,
                             "AdaptivePaths": result.AdaptivePaths,
                             "ReturnMotionType": result.ReturnMotionType,
-                            "TopDepth": depths[0] + stepdown,
+                            "TopDepth": TopDepth,
                             "BottomDepth": depths[-1],
                         }
                     )


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Fixes the Adaptive toolpath helix entry start height calculation to correctly account for the operation start height and the stock boundaries. Previously naive math was done that could result in an entry from excessive height if a large stepdown was used.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #21058

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
Before, with large stepdown (helix starts at end depth + large stepdown, far above stock):
![before](https://github.com/user-attachments/assets/47b55090-0388-4a5c-8a4a-a9c4870348d5)

After (helix start is clamped to top of stock):
![after](https://github.com/user-attachments/assets/41c8b263-e1d0-4aee-9fed-174cba8241b7)

![after_side](https://github.com/user-attachments/assets/8e27520a-c56c-4500-bb78-082dfef99fb9)


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
