### PR TITLE
Sketcher tests: Silence compiler warning with cast

### DIFF
--- a/tests/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -92,7 +92,7 @@ TEST_F(ConstraintsTest, tangentBSplineAndArc)  // NOLINT
         weightsAsPtr.push_back(&weights[i]);
     }
     for (size_t i = 0; i < knots.size(); ++i) {
-        knots[i] = i;
+        knots[i] = static_cast<double>(i);
         knotsAsPtr.push_back(&knots[i]);
     }
     GCS::Arc arc;


### PR DESCRIPTION
This test uses the index as a spline knot: cast that index to a double to match the expected type, silencing a compiler warning about the lossy conversion.