### PR TITLE
CAM: Changes in warnings of old Array

### DIFF
--- a/src/Mod/CAM/Path/Op/Gui/Array.py
+++ b/src/Mod/CAM/Path/Op/Gui/Array.py
@@ -24,11 +24,10 @@ import FreeCAD
 import FreeCADGui
 import Path
 import Path.Op.Base as PathOp
-import PathScripts
 import PathScripts.PathUtils as PathUtils
+import Path.Base.Util as PathUtil
 from Path.Dressup.Utils import toolController
 from PySide import QtCore
-from PySide import QtGui
 
 import random
 
@@ -154,8 +153,6 @@ class ObjectArray:
         self.setEditorModes(obj)
         obj.Proxy = self
 
-        self.FirstRun = True
-
     def dumps(self):
         return None
 
@@ -223,41 +220,20 @@ class ObjectArray:
 
         self.setEditorModes(obj)
 
-        self.FirstRun = True
-
     def execute(self, obj):
-        if FreeCAD.GuiUp and self.FirstRun:
-            self.FirstRun = False
-            QtGui.QMessageBox.warning(
-                None,
-                QT_TRANSLATE_NOOP("CAM_ArrayOp", "Operation is deprecated"),
-                QT_TRANSLATE_NOOP(
-                    "CAM_ArrayOp",
-                    (
-                        "CAM -> Path Modification -> Array operation is deprecated "
-                        "and will be removed in future FreeCAD versions.\n\n"
-                        "Please use CAM -> Path Dressup -> Array instead.\n\n"
-                        "DO NOT USE CURRENT ARRAY OPERATION WHEN MACHINING WITH COOLANT!\n"
-                        "Due to a bug - coolant will not be enabled for array paths."
-                    ),
-                ),
-            )
         # backwards compatibility for PathArrays created before support for multiple bases
         if isinstance(obj.Base, list):
             base = obj.Base
         else:
             base = [obj.Base]
 
-        if len(base) == 0:
+        # Do not generate paths and clear current Path data
+        # if operation not Active or no base operations or operations not compatible
+        if not obj.Active or len(base) == 0 or not self.isBaseCompatible(obj):
+            obj.Path = Path.Path()
             return
 
         obj.ToolController = toolController(base[0])
-
-        # Do not generate paths and clear current Path data if operation not
-        if not obj.Active:
-            if obj.Path:
-                obj.Path = Path.Path()
-            return
 
         # use seed if specified, otherwise default to object name for consistency during recomputes
         seed = obj.JitterSeed or obj.Name
@@ -279,6 +255,37 @@ class ObjectArray:
 
         obj.Path = pa.getPath()
         obj.CycleTime = PathOp.getCycleTimeEstimate(obj)
+
+    def isBaseCompatible(self, obj):
+        if not obj.Base:
+            return False
+        tcs = []
+        cms = []
+        for sel in obj.Base:
+            if not sel.isDerivedFrom("Path::Feature"):
+                return False
+            tcs.append(toolController(sel))
+            cms.append(PathUtil.coolantModeForOp(sel))
+
+        if tcs == {None} or len(set(tcs)) > 1:
+            Path.Log.warning(
+                translate(
+                    "PathArray",
+                    "Arrays of toolpaths having different tool controllers or tool controller not selected.",
+                )
+            )
+            return False
+
+        if set(cms) != {"None"}:
+            Path.Log.warning(
+                translate(
+                    "PathArray",
+                    "Arrays not compatible with coolant modes.",
+                )
+            )
+            return False
+
+        return True
 
 
 class PathArray:
@@ -337,10 +344,6 @@ class PathArray:
         """getPath() ... Call this method on an instance of the class to generate and return
         path data for the requested path array."""
 
-        if len(self.baseList) == 0:
-            Path.Log.error(translate("PathArray", "No base objects for PathArray."))
-            return None
-
         base = self.baseList
         for b in base:
             if not b.isDerivedFrom("Path::Feature"):
@@ -351,15 +354,6 @@ class PathArray:
             b_tool_controller = toolController(b)
             if not b_tool_controller:
                 return
-
-            if b_tool_controller != toolController(base[0]):
-                # this may be important if Job output is split by tool controller
-                Path.Log.warning(
-                    translate(
-                        "PathArray",
-                        "Arrays of toolpaths having different tool controllers are handled according to the tool controller of the first path.",
-                    )
-                )
 
         # build copies
         output = ""
@@ -486,14 +480,32 @@ class CommandPathArray:
         return {
             "Pixmap": "CAM_Array",
             "MenuText": QT_TRANSLATE_NOOP("CAM_Array", "Array"),
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_Array", "Creates an array from selected toolpath(s)"),
+            "ToolTip": QT_TRANSLATE_NOOP(
+                "CAM_Array",
+                "Creates an array from selected toolpath(s)\nwith identical tool controllers and without coolant",
+            ),
         }
 
     def IsActive(self):
-        selections = [
-            sel.isDerivedFrom("Path::Feature") for sel in FreeCADGui.Selection.getSelection()
-        ]
-        return selections and all(selections)
+        selection = FreeCADGui.Selection.getSelection()
+        if not selection:
+            return False
+        tcs = []
+        for sel in selection:
+            if not sel.isDerivedFrom("Path::Feature"):
+                return False
+            tc = toolController(sel)
+            if tc:
+                # Active only for operations with identical tool controller
+                tcs.append(tc)
+                if len(set(tcs)) != 1:
+                    return False
+            else:
+                return False
+            if PathUtil.coolantModeForOp(sel) != "None":
+                # Active only for operations without cooling
+                return False
+        return True
 
     def Activated(self):
 


### PR DESCRIPTION
Lets show warning for "old" Array only while create new one
Not every time after open document and recompute


https://github.com/user-attachments/assets/b91aebd9-c817-4fa9-a7a9-134f4e34262a


In this example Array used not like array, but for combine several operations and place each copy in different place