### PR TITLE
Gui: Set QStyle to Fusion if not set

### DIFF
--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -295,6 +295,10 @@ void StartupPostProcess::setQtStyle()
 {
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("MainWindow");
     auto qtStyle = hGrp->GetASCII("QtStyle");
+    if (qtStyle.empty()) {
+        qtStyle = "Fusion";
+        hGrp->SetASCII("QtStyle", qtStyle);
+    }
     QApplication::setStyle(QString::fromStdString(qtStyle));
 }
 

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -298,8 +298,12 @@ void StartupPostProcess::setQtStyle()
     if (qtStyle.empty()) {
         qtStyle = "Fusion";
         hGrp->SetASCII("QtStyle", qtStyle);
+    } else if (qtStyle == "System") {
+        // Special value to not set a QtStyle explicitly
+        return;
     }
     QApplication::setStyle(QString::fromStdString(qtStyle));
+
 }
 
 void StartupPostProcess::checkOpenGL()


### PR DESCRIPTION
setting the qstyle to fusion fixes various margins and issues across OSs, it seems that the Basic Style of Qt6 is not good enough

here is a comparison under Debian Trixie using Qt6
| Basic | Fusion |
|-|-|
| ![Basic_style](https://github.com/user-attachments/assets/39ff837c-eeb8-4e4c-81a9-e013bc7296a8) | ![Fusion_style](https://github.com/user-attachments/assets/0fda6e11-1a1b-4d29-b34c-9bfa6bf280b1) |

this should fix #21262