### PR TITLE
CAM: Pocket KeepToolDown fix

### DIFF
--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -287,7 +287,7 @@ class ObjectOp(PathOp.ObjectOp):
             pathParams["sort_mode"] = 0
 
         if not self.areaOpRetractTool(obj):
-            pathParams["threshold"] = 2.001 * self.radius
+            pathParams["threshold"] = 2.010 * self.radius
 
         if self.endVector is not None:
             pathParams["start"] = self.endVector


### PR DESCRIPTION
In  **Pocket** operation `KeepToolDown` property does not work if `StepOver` == 100 %
So automatically decrease `StepOver` from 100 to 99, if user set `KeepToolDown` = true

![Screenshot_20250516_083156_hor](https://github.com/user-attachments/assets/1f5d6375-b183-49b2-b184-93ab2a4013f0)
