### PR TITLE
Draft: avoid redundant constraints in make_sketch.py

### DIFF
--- a/src/Mod/Draft/draftmake/make_sketch.py
+++ b/src/Mod/Draft/draftmake/make_sketch.py
@@ -238,9 +238,9 @@ def make_sketch(objects_list, autoconstraints=False, addTo=None,
     nobj.addConstraint(constraints)
     if autoconstraints:
         nobj.detectMissingPointOnPointConstraints(utils.tolerance())
-        nobj.makeMissingPointOnPointCoincident(False)
+        nobj.makeMissingPointOnPointCoincident(True)
         nobj.detectMissingVerticalHorizontalConstraints(utils.tolerance())
-        nobj.makeMissingVerticalHorizontal(False)
+        nobj.makeMissingVerticalHorizontal(True)
 
     return nobj
 


### PR DESCRIPTION
Forum topic:
https://forum.freecad.org/viewtopic.php?t=97072

The MissingVerticalHorizontal functions from the Sketcher WB do not behave as expected. See #21396.

A check for redundant contraints is required if   `makeMissingVerticalHorizontal()` is used. The argument for the function should be `True`. For consistency the same was done for makeMissingPointOnPointCoincident().
