### PR TITLE
CAM: fix loading Array dressup with unused properties

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Array.py
+++ b/src/Mod/CAM/Path/Dressup/Array.py
@@ -166,8 +166,35 @@ class DressupArray:
         if prop == "Type":
             self.setEditorModes(obj)
 
-    def dresupOnDocumentRestored(self, obj):
+    def onDocumentRestored(self, obj):
         """onDocumentRestored(obj) ... Called automatically when document is restored."""
+
+        # Before commit 24c32c9 array dressups did have their own CoolantMode
+        # and ToolController which they copied from the base operation. We need
+        # to remove those properties when loading a file that was created before
+        # that commit. Otherwise the wrong or no CoolantMode/ToolController will
+        # be used.
+
+        if hasattr(obj, "CoolantMode"):
+            obj.removeProperty("CoolantMode")
+            FreeCAD.Console.PrintWarning(
+                translate(
+                    "DressupArray",
+                    "Removing CoolantMode property from {} as base operation's CoolantMode is now used.",
+                ).format(obj.Name)
+                + "\n"
+            )
+
+        if hasattr(obj, "ToolController"):
+            obj.removeProperty("ToolController")
+            FreeCAD.Console.PrintWarning(
+                translate(
+                    "DressupArray",
+                    "Removing ToolController property from {} as base operation's ToolController is now used.",
+                ).format(obj.Name)
+                + "\n"
+            )
+
         self.obj = obj
         self.setEditorModes(obj)
 


### PR DESCRIPTION
Array dressups before commit 24c32c9 did have their own CoolantMode and ToolControler property. When loading a file that contains such an Array dressup we need to remove those properties. Otherwise if the user changes the CoolantMode or ToolController of the base operation, the one that is still specified in the Array dressup might be used. Even worse, if the Array dressup was applied to another dressup, those two properties might be empty resulting in no tool change being emitted. Even if those files might be rare since the Array dressup didn't exist for long before the mentioned commit, we should still check for it because it can crash peoples machines and ruin their parts... ask me how I know... 🤦