### PR TITLE
App: fix exported object dynamic property type identifier

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1184,7 +1184,7 @@ void Document::exportObjects(const std::vector<DocumentObject*>& obj, std::ostre
                 FC_LOG("exporting " << o->getFullName());
                 if (!o->getPropertyByName("_ObjectUUID")) {
                     auto prop = static_cast<PropertyUUID*>(
-                        o->addDynamicProperty("PropertyUUID",
+                        o->addDynamicProperty("App::PropertyUUID",
                                               "_ObjectUUID",
                                               nullptr,
                                               nullptr,


### PR DESCRIPTION
Revert change from 9d6f1ad37c1d ("App: Align Document to best practices")

Fixes #21414