### PR TITLE
CAM: allow empty lines in Custom operation

### DIFF
--- a/src/Mod/CAM/CAMTests/TestRefactoredTestPost.py
+++ b/src/Mod/CAM/CAMTests/TestRefactoredTestPost.py
@@ -667,6 +667,42 @@ G54
 
     #############################################################################
 
+    def test00191(self):
+        """Make sure postprocessor doesn't crash on blank lines"""
+
+        path = [
+            Path.Command("G0 X1"),
+            Path.Command(""),
+            Path.Command("G0 X2"),
+        ]
+
+        self.post.values["OUTPUT_BLANK_LINES"] = True
+        self.multi_compare(
+            path,
+            """G90
+G21
+G54
+G0 X1.000
+
+G0 X2.000
+""",
+            "",
+        )
+
+        self.post.values["OUTPUT_BLANK_LINES"] = False
+        self.multi_compare(
+            path,
+            """G90
+G21
+G54
+G0 X1.000
+G0 X2.000
+""",
+            "",
+        )
+
+    #############################################################################
+
     def test00200(self):
         """Test Outputting visible arguments.
 

--- a/src/Mod/CAM/Path/Op/Gui/Custom.py
+++ b/src/Mod/CAM/Path/Op/Gui/Custom.py
@@ -61,7 +61,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         return signals
 
     def setGCode(self):
-        self.obj.Gcode = self.form.txtGCode.toPlainText().splitlines()
+        self.obj.Gcode = self.form.txtGCode.toPlainText().split("\n")
 
 
 Command = PathOpGui.SetupOperation(

--- a/src/Mod/CAM/Path/Post/UtilsArguments.py
+++ b/src/Mod/CAM/Path/Post/UtilsArguments.py
@@ -478,6 +478,10 @@ def init_shared_values(values: Values) -> None:
     #
     values["OUTPUT_COMMENTS"] = True
     #
+    # If True output blank lines.  If False blank lines are suppressed.
+    #
+    values["OUTPUT_BLANK_LINES"] = True
+    #
     # if False duplicate axis values or feeds are suppressed
     # if they are the same as the previous line.
     #

--- a/src/Mod/CAM/Path/Post/UtilsParse.py
+++ b/src/Mod/CAM/Path/Post/UtilsParse.py
@@ -720,11 +720,12 @@ def parse_a_path(values: Values, gcode: Gcode, pathobj) -> None:
         command_line = []
 
         # Modify the command name if necessary
-        if command[0] == "(":
+        if command.startswith("("):
             if not values["OUTPUT_COMMENTS"]:
                 continue
             if values["COMMENT_SYMBOL"] != "(" and len(command) > 2:
                 command = create_comment(values, command[1:-1])
+
         cmd = check_for_an_adaptive_op(values, command, command_line, adaptive_op_variables)
         if cmd:
             command = cmd

--- a/src/Mod/CAM/Path/Post/UtilsParse.py
+++ b/src/Mod/CAM/Path/Post/UtilsParse.py
@@ -719,6 +719,11 @@ def parse_a_path(values: Values, gcode: Gcode, pathobj) -> None:
         command = c.Name
         command_line = []
 
+        # Skip blank lines if requested
+        if not command:
+            if not values["OUTPUT_BLANK_LINES"]:
+                continue
+
         # Modify the command name if necessary
         if command.startswith("("):
             if not values["OUTPUT_COMMENTS"]:

--- a/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
@@ -344,7 +344,7 @@ def parse(pathobj):
                 if command == lastcommand:
                     outstring.pop(0)
 
-            if c.Name[0] == "(" and not OUTPUT_COMMENTS:  # command is a comment
+            if c.Name.startswith("(") and not OUTPUT_COMMENTS:  # command is a comment
                 continue
 
             # Now add the remaining parameters in order

--- a/src/Mod/CAM/Path/Post/scripts/centroid_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/centroid_post.py
@@ -282,7 +282,7 @@ def parse(pathobj):
             commandlist = []  # list of elements in the command, code and params.
             command = c.Name  # command M or G code or comment string
 
-            if command[0] == "(":
+            if command.startswith("("):
                 command = PostUtils.fcoms(command, COMMENT)
 
             commandlist.append(command)

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
@@ -401,7 +401,7 @@ def parse(pathobj):
                 if command == lastcommand:
                     outstring.pop(0)
 
-            if c.Name[0] == "(" and not OUTPUT_COMMENTS:  # command is a comment
+            if c.Name.startswith("(") and not OUTPUT_COMMENTS:  # command is a comment
                 continue
 
             # Now add the remaining parameters in order

--- a/src/Mod/CAM/Path/Post/scripts/fablin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fablin_post.py
@@ -251,7 +251,7 @@ def parse(pathobj):
             command = c.Name
 
             # fablin does not support parenthesis syntax, so removing that (pocket) in the agnostic gcode
-            if command[0] == "(":
+            if command.startswith("("):
                 if not OUTPUT_COMMENTS:
                     pass
             else:

--- a/src/Mod/CAM/Path/Post/scripts/fablin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fablin_post.py
@@ -199,9 +199,12 @@ def export(objectslist, filename, argstring):
 
     print("done postprocessing.")
 
-    gfile = pyopen(filename, "w")
-    gfile.write(final)
-    gfile.close()
+    if not filename == "-":
+        gfile = pyopen(filename, "w")
+        gfile.write(final)
+        gfile.close()
+
+    return final
 
 
 def linenumber():

--- a/src/Mod/CAM/Path/Post/scripts/fangling_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fangling_post.py
@@ -411,7 +411,7 @@ def parse(pathobj):
                 if command == lastcommand:
                     outstring.pop(0)
 
-            if c.Name[0] == "(" and not OUTPUT_COMMENTS:  # command is a comment
+            if c.Name.startswith("(") and not OUTPUT_COMMENTS:  # command is a comment
                 continue
 
             # Now add the remaining parameters in order

--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -504,7 +504,7 @@ def parse(pathobj):
             if command == "G80" and lastcommand == nextcommand:
                 continue
 
-            if c.Name[0] == "(" and not OUTPUT_COMMENTS:  # command is a comment
+            if c.Name.startswith("(") and not OUTPUT_COMMENTS:  # command is a comment
                 continue
 
             # Now add the remaining parameters in order

--- a/src/Mod/CAM/Path/Post/scripts/jtech_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/jtech_post.py
@@ -313,7 +313,7 @@ def parse(pathobj):
                 if command == lastcommand:
                     outstring.pop(0)
 
-            if c.Name[0] == "(" and not OUTPUT_COMMENTS:  # command is a comment
+            if c.Name.startswith("(") and not OUTPUT_COMMENTS:  # command is a comment
                 continue
 
             # Now add the remaining parameters in order

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -355,7 +355,7 @@ def parse(pathobj):
                 if command == lastcommand:
                     outstring.pop(0)
 
-            if c.Name[0] == "(" and not OUTPUT_COMMENTS:  # command is a comment
+            if c.Name.startswith("(") and not OUTPUT_COMMENTS:  # command is a comment
                 continue
 
             # Now add the remaining parameters in order

--- a/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/mach3_mach4_post.py
@@ -387,7 +387,7 @@ def parse(pathobj):
                 if command == lastcommand:
                     outstring.pop(0)
 
-            if c.Name[0] == "(" and not OUTPUT_COMMENTS:  # command is a comment
+            if c.Name.startswith("(") and not OUTPUT_COMMENTS:  # command is a comment
                 continue
 
             # Now add the remaining parameters in order

--- a/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
@@ -359,7 +359,7 @@ def parse(pathobj):
                 output += scommands[command](c)
                 if c.Parameters:
                     CurrentState.update(c.Parameters)
-            elif command[0] == "(":
+            elif command.startswith("("):
                 output += "' " + command + "\n"
             else:
                 print("I don't know what the hell the command: ", end="")

--- a/src/Mod/CAM/Path/Post/scripts/philips_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/philips_post.py
@@ -412,7 +412,7 @@ def export(objectslist, filename, argstring):
                 command = command.replace("G0", "G")  # normalize: G01 -> G1
 
             if command != UNITS or UNITS_INCLUDED:
-                if command[0] == "(":
+                if command.startswith("("):
                     command = PostUtils.fcoms(command, COMMENT)
                 # the mapping is done for output only! For internal things we
                 # still use the old value.

--- a/src/Mod/CAM/Path/Post/scripts/philips_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/philips_post.py
@@ -352,6 +352,7 @@ def linenumberify(GCodeString):
 
 
 def export(objectslist, filename, argstring):
+    processArguments(argstring)
     global UNITS
     global linenr
 
@@ -584,8 +585,16 @@ def export(objectslist, filename, argstring):
                 lastcommand = c.Name
     gcode = gcode.replace("_", "-")
     gcode += linenumberify(GCODE_FOOTER)
-    if SHOW_EDITOR:
-        PostUtils.editor(gcode)
-    gfile = pyopen(filename, "w")
-    gfile.write(gcode)
-    gfile.close()
+
+    # show the gCode result dialog
+    if FreeCAD.GuiUp and SHOW_EDITOR:
+        final = PostUtils.editor(gcode)
+    else:
+        final = gcode
+
+    if not filename == "-":
+        gfile = pyopen(filename, "w")
+        gfile.write(final)
+        gfile.close()
+
+    return final

--- a/src/Mod/CAM/Path/Post/scripts/uccnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/uccnc_post.py
@@ -599,7 +599,7 @@ def parse(pathobj):
                 if command == lastcommand:
                     commandlist.pop(0)
 
-            if c.Name[0] == "(" and not OUTPUT_COMMENTS:  # command is a comment
+            if c.Name.startswith("(") and not OUTPUT_COMMENTS:  # command is a comment
                 continue
 
             # Now add the remaining parameters in order

--- a/src/Mod/CAM/Path/Post/scripts/wedm_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/wedm_post.py
@@ -456,7 +456,7 @@ def parse(pathobj):
                 if command == lastcommand:
                     outstring.pop(0)
 
-            if command[0] == "(":  # command is a comment
+            if command.startswith("("):  # command is a comment
                 if OUTPUT_COMMENTS:  # Edit comment  with COMMENT_CHAR
                     outstring.insert(0, COMMENT_CHAR)
                 else:


### PR DESCRIPTION
When having empty lines in the Custom operation, some postprocessors crash. E.g. refactored postprocessors in UtilsParse.py on line 723 (`if command[0] == "(":`) since `command` is empty. Afacit FreeCAD never produces empty lines on its own so I fixed it in Custom.

(Side note: it works if you save and load a file without recomputing since `Toolpath::RestoreDocFile` replaces newlines anyway).