### PR TITLE
Sketcher: remove "SecondIcon" logs on constraint icon hover

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2254,8 +2254,6 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(const SoPi
                         if (tail
                             != sep->getChild(
                                 static_cast<int>(ConstraintNodePosition::FirstIconIndex))) {
-                            Base::Console().log("SecondIcon\n");
-
                             auto translation2 = static_cast<SoZoomTranslation*>(
                                 static_cast<SoSeparator*>(tailFather)
                                     ->getChild(static_cast<int>(


### PR DESCRIPTION
Hovering the cursor over constraint icons sometimes logs "SecondIcon" messages to the report view, doing so for every cursor move event. This message isn't useful outside of a development context and in fact is a leftover from 11c76c998e80428c6931c3b678940124a9518dfe.

Removes this message.

## Issues

Fixes #21417