### PR TITLE
BIM/Help: Access DockWidgetArea QFlag enum correctly

### DIFF
--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -475,8 +475,7 @@ class BIM_Views:
 
     def onDockLocationChanged(self, area):
         """Saves dock widget size and location"""
-
-        PARAMS.SetInt("BimViewArea", int(area))
+        PARAMS.SetInt("BimViewArea", area.value)
         mw = FreeCADGui.getMainWindow()
         vm = findWidget()
         if vm:

--- a/src/Mod/Help/Help.py
+++ b/src/Mod/Help/Help.py
@@ -460,7 +460,7 @@ def openBrowserHTML(html, baseurl, title, icon, dialog=False):
 
     # save dock widget size and location
     def onDockLocationChanged(area):
-        PREFS.SetInt("dockWidgetArea", int(area))
+        PREFS.SetInt("dockWidgetArea", int(area.value))
         mw = FreeCADGui.getMainWindow()
         dock = mw.findChild(QtWidgets.QDockWidget, "HelpWidget")
         if dock:


### PR DESCRIPTION
Currently, for both Help and BIM Views panels we can get a traceback about incorrect casting if we move the panel.

This is because the QFlag of DockWidgetArea that is being passed, as it is not able to be parsed down to an int. Most probably some historical change either in Qt or FC.

This error also caused to not write current BIM Views/Help panel setup to config, resulting in the position being resetted every run.

Resolves: https://github.com/FreeCAD/FreeCAD/issues/21368
