### PR TITLE
BIM: Make a correct mapping to weight during IFC Quantities assignment

### DIFF
--- a/src/Mod/BIM/bimcommands/BimIfcQuantities.py
+++ b/src/Mod/BIM/bimcommands/BimIfcQuantities.py
@@ -60,7 +60,7 @@ QTO_TYPES = {
     "IfcQuantityNumber": "App::PropertyInteger",
     "IfcQuantityTime": "App::PropertyTime",
     "IfcQuantityVolume": "App::PropertyVolume",
-    "IfcQuantityWeight": "App::PropertyWeight",
+    "IfcQuantityWeight": "App::PropertyMass",
 }
 
 


### PR DESCRIPTION
Currently we can assign quantities to a BIM object, but upon exporting quantities are not visible in the IFC file.

This was because we didn't have a correct mapping to weight property. `App::PropertyWeight" basically doesn't exist, so this patch changes it to `App::PropertyMass`, as it is the same. The incorrect mapping resulted in a traceback, which in turn resulted in missing a big part of additional processing for the properties, which resulted in `writeQuantities` checking for non-existent IfcData in the object.

Another small patch -_-

Demo:

https://github.com/user-attachments/assets/cbd263c2-2c00-4fc5-ae5e-e95eb56d03e7

Resolves: https://github.com/FreeCAD/FreeCAD/issues/21363
