### PR TITLE
App: Invoke `signalBeforeRecompute()` on the GUI thread

### DIFF
--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -193,6 +193,8 @@ public:
     //@}
     // NOLINTEND
 
+    using PreRecomputeHook = std::function<void()>;
+    void setPreRecomputeHook(const PreRecomputeHook& hook);
 
     void clearDocument();
 

--- a/src/App/private/DocumentP.h
+++ b/src/App/private/DocumentP.h
@@ -98,6 +98,8 @@ struct DocumentP
 
     StringHasherRef Hasher {new StringHasher};
 
+    Document::PreRecomputeHook _preRecomputeHook;
+
     DocumentP();
 
     void addRecomputeLog(const char* why, App::DocumentObject* obj)

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -39,6 +39,7 @@
 # include <QOpenGLWidget>
 # include <QTextStream>
 # include <QTimer>
+# include <QThread>
 # include <QStatusBar>
 # include <Inventor/actions/SoSearchAction.h>
 # include <Inventor/nodes/SoSeparator.h>
@@ -504,6 +505,8 @@ Document::Document(App::Document* pcDocument,Application * app)
     d->connectTransactionRemove = pcDocument->signalTransactionRemove.connect
         (std::bind(&Gui::Document::slotTransactionRemove, this, sp::_1, sp::_2));
     //NOLINTEND
+
+    pcDocument->setPreRecomputeHook([this] { callSignalBeforeRecompute(); });
 
     // pointer to the python class
     // NOTE: As this Python object doesn't get returned to the interpreter we
@@ -1190,6 +1193,25 @@ void Document::slotTouchedObject(const App::DocumentObject &Obj)
     if(!isModified()) {
         FC_LOG(Obj.getFullName() << " touched");
         setModified(true);
+    }
+}
+
+// helper that guarantees signalBeforeRecompute call is executed in the GUI thread and
+// that the worker waits until it finishes
+void Document::callSignalBeforeRecompute()
+{
+    auto invokeSignalBeforeRecompute = [this]{
+        // this runs in the GUI thread
+        this->getDocument()->signalBeforeRecompute(*this->getDocument());
+    };
+
+    if (QThread::currentThread() == qApp->thread()) {
+        // already on GUI thread – no hop, just call it
+        invokeSignalBeforeRecompute();
+    } else {
+        // hop to GUI and *block* until it returns
+        QMetaObject::invokeMethod(qApp, std::move(invokeSignalBeforeRecompute),
+                                  Qt::BlockingQueuedConnection);
     }
 }
 

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -94,6 +94,7 @@ protected:
     void slotSkipRecompute(const App::Document &doc, const std::vector<App::DocumentObject*> &objs);
     void slotTouchedObject(const App::DocumentObject &);
     void slotChangePropertyEditor(const App::Document&, const App::Property &);
+    void callSignalBeforeRecompute();
     //@}
 
 public:


### PR DESCRIPTION
Historically, `App::Document::recompute()` ran entirely on the main (GUI) thread and directly emitted `signalBeforeRecompute()`.

* Add-ons like Assembly3 depend on that signal for setup/teardown hooks before any recompute work begins.

* After offloading `recompute()` into a background worker thread to keep the UI responsive, calling `signalBeforeRecompute()` directly from the worker would break thread-affinity rules and silently break compatibility with those add-ons.

**Solution**

1. Introduce a precompute hook (`PreRecomputeHook`) in `App::Document`:

* It is `std::function<void()>` that, if set, is invoked at the very start of `recompute()`.

2. Wire up the hook in `Gui::Document`:

* In the GUI wrapper’s constructor, install a hook that calls `callSignalBeforeRecompute()`.

* `callSignalBeforeRecompute()` uses `QMetaObject::invokeMethod(..., Qt::BlockingQueuedConnection)` to enqueue `signalBeforeRecompute()` on the GUI thread and **block** the worker until it completes.

    * If already on the GUI thread, it simply calls the signal directly.

3. Maintain add-on compatibility:

* From the add-on’s perspective nothing changes, they still receive `signalBeforeRecompute()` on the main thread before any recompute work.

This work is done as part of an FPA grant: https://github.com/FreeCAD/FPA-grant-proposals/issues/36

@ickby Interested in taking a look at this one?

