### PR TITLE
Sketcher: remove surplus push_back to shapes (fixes #21499)

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -387,7 +387,6 @@ void SketchObject::buildShape()
                       convertSubName(indexedName, false));
         }
         else {
-            shapes.push_back(getEdge(geo, convertSubName(indexedName, false).c_str()));
             addEdge(geo, indexedName);
         }
     }


### PR DESCRIPTION
fixes #21499