### PR TITLE
CAM: Feedrate property inside operations parameters

### DIFF
--- a/src/Mod/CAM/Path/Base/FeedRate.py
+++ b/src/Mod/CAM/Path/Base/FeedRate.py
@@ -41,12 +41,17 @@ else:
     Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
 
-def setFeedRate(commandlist, ToolController):
+def setFeedRate(commandlist, ToolController, horizFeed=0, vertFeed=0):
     """Set the appropriate feed rate for a list of Path commands using the information from a Tool Controller
 
     Every motion command in the list will have a feed rate parameter added or overwritten based
     on the information stored in the tool controller. If a motion is a plunge (vertical) motion, the
     VertFeed value will be used, otherwise the HorizFeed value will be used instead."""
+
+    HorizFeed = horizFeed.Value if horizFeed else ToolController.HorizFeed.Value
+    VertFeed = vertFeed.Value if vertFeed else ToolController.VertFeed.Value
+    HorizRapid = ToolController.HorizRapid.Value
+    VertRapid = ToolController.VertRapid.Value
 
     def _isVertical(currentposition, command):
         x = command.Parameters["X"] if "X" in command.Parameters else currentposition.x
@@ -64,17 +69,9 @@ def setFeedRate(commandlist, ToolController):
             continue
 
         if _isVertical(machine.getPosition(), command):
-            rate = (
-                ToolController.VertRapid.Value
-                if command.Name in Path.Geom.CmdMoveRapid
-                else ToolController.VertFeed.Value
-            )
+            rate = VertRapid if command.Name in Path.Geom.CmdMoveRapid else VertFeed
         else:
-            rate = (
-                ToolController.HorizRapid.Value
-                if command.Name in Path.Geom.CmdMoveRapid
-                else ToolController.HorizFeed.Value
-            )
+            rate = HorizRapid if command.Name in Path.Geom.CmdMoveRapid else HorizFeed
 
         params = command.Parameters
         params["F"] = rate

--- a/src/Mod/CAM/Path/Base/SetupSheetOpPrototype.py
+++ b/src/Mod/CAM/Path/Base/SetupSheetOpPrototype.py
@@ -122,6 +122,11 @@ class PropertyLength(PropertyQuantity):
         return "Length"
 
 
+class PropertySpeed(PropertyQuantity):
+    def typeString(self):
+        return "Speed"
+
+
 class PropertyFloat(Property):
     def typeString(self):
         return "Float"
@@ -195,6 +200,7 @@ class OpPrototype(object):
         "App::PropertyLinkSubListGlobal": Property,
         "App::PropertyMap": PropertyMap,
         "App::PropertyPercent": PropertyPercent,
+        "App::PropertySpeed": PropertySpeed,
         "App::PropertyString": PropertyString,
         "App::PropertyStringList": Property,
         "App::PropertyVectorDistance": Property,

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -211,6 +211,24 @@ class ObjectOp(object):
                 ),
             )
             self.addOpValues(obj, ["tooldia"])
+            obj.addProperty(
+                "App::PropertySpeed",
+                "HorizFeed",
+                "Feed",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Feed rate for horizontal moves\nIf not 0, will overwrite value from Tool Controller.",
+                ),
+            )
+            obj.addProperty(
+                "App::PropertySpeed",
+                "VertFeed",
+                "Feed",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Feed rate for vertical moves\nIf not 0, will overwrite value from Tool Controller.",
+                ),
+            )
 
         if FeatureCoolant & features:
             obj.addProperty(
@@ -758,8 +776,16 @@ class ObjectOp(object):
                 )
                 return
             else:
-                self.vertFeed = tc.VertFeed.Value
-                self.horizFeed = tc.HorizFeed.Value
+                self.vertFeed = (
+                    obj.VertFeed.Value
+                    if hasattr(obj, "VertFeed") and obj.VertFeed.Value
+                    else tc.VertFeed.Value
+                )
+                self.horizFeed = (
+                    obj.HorizFeed.Value
+                    if hasattr(obj, "HorizFeed") and obj.HorizFeed.Value
+                    else tc.HorizFeed.Value
+                )
                 self.vertRapid = tc.VertRapid.Value
                 self.horizRapid = tc.HorizRapid.Value
                 tool = tc.Proxy.getTool(tc)

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -314,7 +314,12 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
         machine.addCommand(command)
 
         # Apply feedrates to commands
-        PathFeedRate.setFeedRate(self.commandlist, obj.ToolController)
+        if hasattr(obj, "HorizFeed") and hasattr(obj, "VertFeed"):
+            PathFeedRate.setFeedRate(
+                self.commandlist, obj.ToolController, obj.HorizFeed, obj.VertFeed
+            )
+        else:
+            PathFeedRate.setFeedRate(self.commandlist, obj.ToolController)
 
     def opSetDefaultValues(self, obj, job):
         """opSetDefaultValues(obj, job) ... set default value for RetractHeight"""

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -285,7 +285,12 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             for command in results:
                 self.commandlist.append(command)
 
-        PathFeedRate.setFeedRate(self.commandlist, obj.ToolController)
+        if hasattr(obj, "HorizFeed") and hasattr(obj, "VertFeed"):
+            PathFeedRate.setFeedRate(
+                self.commandlist, obj.ToolController, obj.HorizFeed, obj.VertFeed
+            )
+        else:
+            PathFeedRate.setFeedRate(self.commandlist, obj.ToolController)
 
 
 def SetupProperties():

--- a/src/Mod/CAM/Path/Op/Tapping.py
+++ b/src/Mod/CAM/Path/Op/Tapping.py
@@ -246,7 +246,12 @@ class ObjectTapping(PathCircularHoleBase.ObjectOp):
         # machine.addCommand(command)       DLH - Not needed.
 
         # Apply feed rates to commands
-        PathFeedRate.setFeedRate(self.commandlist, obj.ToolController)
+        if hasattr(obj, "HorizFeed") and hasattr(obj, "VertFeed"):
+            PathFeedRate.setFeedRate(
+                self.commandlist, obj.ToolController, obj.HorizFeed, obj.VertFeed
+            )
+        else:
+            PathFeedRate.setFeedRate(self.commandlist, obj.ToolController)
 
     def opSetDefaultValues(self, obj, job):
         """opSetDefaultValues(obj, job) ... set default value for RetractHeight"""

--- a/src/Mod/CAM/Path/Op/Vcarve.py
+++ b/src/Mod/CAM/Path/Op/Vcarve.py
@@ -482,8 +482,16 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
                     )
                 )
 
-            hSpeed = obj.ToolController.HorizFeed.Value
-            vSpeed = obj.ToolController.VertFeed.Value
+            hSpeed = (
+                obj.HorizFeed.Value
+                if hasattr(obj, "HorizFeed") and obj.HorizFeed.Value
+                else obj.ToolController.HorizFeed.Value
+            )
+            vSpeed = (
+                obj.VertFeed.Value
+                if hasattr(obj, "VertFeed") and obj.VertFeed.Value
+                else obj.ToolController.VertFeed.Value
+            )
             path.append(
                 Path.Command(
                     "G1 X{} Y{} Z{} F{}".format(newPosition.x, newPosition.y, newPosition.z, vSpeed)


### PR DESCRIPTION
At this moment feedrate value get only from ToolController
If we need to set different feedrate in different operations for one tool we should create different ToolController with the same tool
This create useless tool change gcode
 
Added property `HorizFeed` and `VertFeed` to all operations
By default path generate with values from ToolController
But if set property not 0 in operation, this value will overwrite value from ToolController

![Screenshot_20250521_104553_vert](https://github.com/user-attachments/assets/6b275458-a2ef-4254-96b0-5b7c478e6a88)

PS
New property will create only for new operations
Old program must working without changes