### PR TITLE
CAM: prevent dogbones between two travel moves

### DIFF
--- a/src/Mod/CAM/Path/Dressup/DogboneII.py
+++ b/src/Mod/CAM/Path/Dressup/DogboneII.py
@@ -271,6 +271,8 @@ class Proxy(object):
         return PathDressup.toolController(obj.Base).Tool.Diameter.Value / 2
 
     def createBone(self, obj, move0, move1):
+        if move0.isRapid() and move1.isRapid():
+            return None
         kink = dogboneII.Kink(move0, move1)
         Path.Log.debug(f"{obj.Label}.createBone({kink})")
         if insertBone(obj, kink):


### PR DESCRIPTION
In certain cases the Dogbone dressup created dogbones between two travel moves. Depending on the geometry of the travel those could also get extremely long.

![Bildschirmfoto_20250523_033203](https://github.com/user-attachments/assets/c914efbc-c321-406a-8667-1a39c4d792c6)

[dogbone_on_travel_moves.zip](https://github.com/user-attachments/files/20402663/dogbone_on_travel_moves.zip)
