### PR TITLE
CAM: sort tool paths for Engrave and Deburr operation

### DIFF
--- a/src/Mod/CAM/Path/Op/EngraveBase.py
+++ b/src/Mod/CAM/Path/Op/EngraveBase.py
@@ -24,6 +24,7 @@ from lazy_loader.lazy_loader import LazyLoader
 import Path
 import Path.Op.Base as PathOp
 import Path.Op.Util as PathOpUtil
+import PathScripts.PathUtils as PathUtils
 import copy
 
 __doc__ = "Base class for all ops in the engrave family."
@@ -60,6 +61,15 @@ class ObjectOp(PathOp.ObjectOp):
     def buildpathocc(self, obj, wires, zValues, relZ=False, forward=True, start_idx=0):
         """buildpathocc(obj, wires, zValues, relZ=False) ... internal helper function to generate engraving commands."""
         Path.Log.track(obj.Label, len(wires), zValues)
+
+        # sort wires, adapted from Area.py
+        if len(wires) > 1:
+            locations = []
+            for w in wires:
+                locations.append({"x": w.BoundBox.Center.x, "y": w.BoundBox.Center.y, "wire": w})
+
+            locations = PathUtils.sort_locations(locations, ["x", "y"])
+            wires = [j["wire"] for j in locations]
 
         decomposewires = []
         for wire in wires:


### PR DESCRIPTION
Sort tool paths for Engrave and Deburr operation. I haven't used the Engrave operation much so it would be nice if someone could give it a try.

The sorting is not very sophisticated. It only uses the center point of the wires, similar to what Area.py is doing. However, for many small wires this should be fine and for larger wires, the time spent travelling will be small compared to the time spent milling anyway.

without sorting:
![before](https://github.com/user-attachments/assets/0cd23c45-0d77-41c5-80b9-94d1fc85d4f6)

with sorting:
![after](https://github.com/user-attachments/assets/164f488b-c696-4ee2-8c03-fa08925234aa)

[sort_engrave_deburr_test.zip](https://github.com/user-attachments/files/20403424/sort_engrave_deburr_test.zip)