### PR TITLE
[GUI] Remove dark fringe around letters

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -134,6 +134,7 @@ SoDatumLabel::SoDatumLabel()
     SO_NODE_ADD_FIELD(name, ("Helvetica"));
     SO_NODE_ADD_FIELD(size, (10.F));
     SO_NODE_ADD_FIELD(lineWidth, (2.F));
+    SO_NODE_ADD_FIELD(sampling, (2.F));
 
     SO_NODE_ADD_FIELD(datumtype, (SoDatumLabel::DISTANCE));
 
@@ -187,7 +188,8 @@ void SoDatumLabel::drawImage()
     QColor front;
     front.setRgbF(t[0],t[1], t[2]);
 
-    QImage image(w, h,QImage::Format_ARGB32_Premultiplied);
+    QImage image(w * sampling.getValue(), h * sampling.getValue(), QImage::Format_ARGB32_Premultiplied);
+    image.setDevicePixelRatio(sampling.getValue());
     image.fill(0x00000000);
 
     QPainter painter(&image);
@@ -1165,7 +1167,7 @@ void SoDatumLabel::getDimension(float scale, int& srcw, int& srch)
     srch = imgsize[1];
 
     float aspectRatio =  (float) srcw / (float) srch;
-    this->imgHeight = scale * (float) (srch);
+    this->imgHeight = scale * (float) (srch) / sampling.getValue();
     this->imgWidth  = aspectRatio * (float) this->imgHeight;
 }
 

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -85,6 +85,7 @@ public:
     SoSFVec3f  norm;
     SoSFImage  image;
     SoSFFloat  lineWidth;
+    SoSFFloat  sampling;
     bool       useAntialiasing;
 
 protected:


### PR DESCRIPTION


Closes #12394. I have read too much of literature, tried many things, but so far, I cannot say why exactly this works.


`glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);` is the right way to blend colors with alpha channel, however, it gives blur with single-colored background, so conversion just ARGB32 without pre-multiplication gives good-looking result.


Just ARGB32 without pre-multiplication with unchanged blending parameters gives dark fringe anyway.


It would be good if somebody tests it on _Windows_ with Line Smoothing/Antialiasing on.
