### PR TITLE
NETGENPlugin - NETGENPlugin_Mesher: fix /tmp file path concatenation

### DIFF
--- a/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_Mesher.cpp
+++ b/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_Mesher.cpp
@@ -4187,7 +4187,7 @@ void NETGENPlugin_NetgenLibWrapper::setMesh( Ng_Mesh* mesh )
 std::string NETGENPlugin_NetgenLibWrapper::getOutputFileName()
 {
 //  std::string aTmpDir = SALOMEDS_Tool::GetTmpDir();
-  std::string aTmpDir = "/tmp";
+  std::string aTmpDir = "/tmp/";
 
   TCollection_AsciiString aGenericName = (char*)aTmpDir.c_str();
   aGenericName += "NETGEN_";


### PR DESCRIPTION
Previously, FreeCAD attempted to write at apths in `/`, such as `/tmpNETGEN_3825524_190303824.out`.
This was discovered while packaging netgen support for FreeCAD in nixpkgs [1].

The fix is trivial: Just add to `/tmp/` to actually be in the tmp directory.

[1] https://github.com/NixOS/nixpkgs/pull/408577#issuecomment-2904013103

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

```
Program received signal SIGSEGV, Segmentation fault.
#0  /nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib/libc.so.6(+0x41470) [0x7f4a57071470]
#1  0x7f4923b28323 in netgen::OCCGeometry::GetEdge(TopoDS_Shape const&) const from /nix/store/wldkbf7csbf8sdxq61slfpx17y65l8ih-netgen-6.2.2501/lib/libnglib.so+0x23
#2  0x7f4923b1e496 in netgen::OCCSetLocalMeshSize(netgen::OCCGeometry const&, netgen::Mesh&, netgen::MeshingParameters const&, netgen::OCCParameters const&) from /nix/store/wldkbf7csbf8sdxq61slfpx17y65l8ih-netgen-6.2.2501/lib/libnglib.so+0xc26
#3  0x7f49239f784d in netgen::NetgenGeometry::GenerateMesh(std::shared_ptr<netgen::Mesh>&, netgen::MeshingParameters&) from /nix/store/wldkbf7csbf8sdxq61slfpx17y65l8ih-netgen-6.2.2501/lib/libnglib.so+0x63d
#4  0x7f4980e65e87 in netgen::OCCGenerateMesh(netgen::OCCGeometry&, std::shared_ptr<netgen::Mesh>&, netgen::MeshingParameters&) from /nix/store/7p308w4c1pasdwv95ql0rwam48mcd0hr-freecad-1.0.1/lib/libNETGENPlugin.so+0x27
#5  0x7f4980e5acb1 in NETGENPlugin_Mesher::Compute() from /nix/store/7p308w4c1pasdwv95ql0rwam48mcd0hr-freecad-1.0.1/lib/libNETGENPlugin.so+0x391
#6  0x7f4980f7efac in Fem::FemMeshShapeNetgenObject::execute() from /nix/store/7p308w4c1pasdwv95ql0rwam48mcd0hr-freecad-1.0.1/lib/Fem.so+0x17c
#7  0x7f491dfbf9d0 in FemGui::TaskDlgMeshShapeNetgen::clicked(int) from /nix/store/7p308w4c1pasdwv95ql0rwam48mcd0hr-freecad-1.0.1/lib/FemGui.so+0x70
#8  /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Core.so.5(+0x334cde) [0x7f4a57a30cde]
#9  0x7f4a586c227f in QDialogButtonBox::clicked(QAbstractButton*) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5+0x3f
#10  /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5(+0x31b971) [0x7f4a586c2971]
#11  /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Core.so.5(+0x334cb2) [0x7f4a57a30cb2]
#12  0x7f4a58611ce2 in QAbstractButton::clicked(bool) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5+0x42
#13  /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5(+0x26afda) [0x7f4a58611fda]
#14  /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5(+0x26c925) [0x7f4a58613925]
#15  0x7f4a58613b74 in QAbstractButton::mouseReleaseEvent(QMouseEvent*) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5+0x134
#16  0x7f4a5855bb98 in QWidget::event(QEvent*) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5+0x298
#17  0x7f4a585184ce in QApplicationPrivate::notify_helper(QObject*, QEvent*) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5+0x7e
#18  0x7f4a58520899 in QApplication::notify(QObject*, QEvent*) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5+0x13b9
#19  0x7f4a5b4f18f8 in Gui::GUIApplication::notify(QObject*, QEvent*) from /nix/store/7p308w4c1pasdwv95ql0rwam48mcd0hr-freecad-1.0.1/lib/libFreeCADGui.so+0xd8
#20  0x7f4a579f57d8 in QCoreApplication::notifyInternal2(QObject*, QEvent*) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Core.so.5+0x128
#21  0x7f4a5851e91e in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5+0x1be
#22  /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5(+0x1cf0f6) [0x7f4a585760f6]
#23  /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5(+0x1d266f) [0x7f4a5857966f]
#24  0x7f4a585184ce in QApplicationPrivate::notify_helper(QObject*, QEvent*) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Widgets.so.5+0x7e
#25  0x7f4a5b4f18f8 in Gui::GUIApplication::notify(QObject*, QEvent*) from /nix/store/7p308w4c1pasdwv95ql0rwam48mcd0hr-freecad-1.0.1/lib/libFreeCADGui.so+0xd8
#26  0x7f4a579f57d8 in QCoreApplication::notifyInternal2(QObject*, QEvent*) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Core.so.5+0x128
#27  0x7f4a57e21383 in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Gui.so.5+0x923
#28  0x7f4a57df1574 in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Gui.so.5+0xb4
#29  /nix/store/m0mk8wjmpa08zz8zsm5cri0aqyvjj6fj-qtbase-5.15.16-bin/lib/qt-5.15.16/plugins/platforms/../../../../../x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5XcbQpa.so.5(+0x6de2a) [0x7f4a514b3e2a]
#30  /nix/store/bkpj51fz88rbyjd60i6lrp0xdax1b24g-glib-2.84.1/lib/libglib-2.0.so.0(+0x6181e) [0x7f4a531b881e]
#31  /nix/store/bkpj51fz88rbyjd60i6lrp0xdax1b24g-glib-2.84.1/lib/libglib-2.0.so.0(+0x63a90) [0x7f4a531baa90]
#32  /nix/store/bkpj51fz88rbyjd60i6lrp0xdax1b24g-glib-2.84.1/lib/libglib-2.0.so.0(g_main_context_iteration+0x2c) [0x7f4a531bb2bc]
#33  0x7f4a57a53469 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Core.so.5+0x69
#34  0x7f4a579f3ff2 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Core.so.5+0x132
#35  0x7f4a579fcee2 in QCoreApplication::exec() from /nix/store/x39ids55l0q41haifyqgjkcalnah21b3-qtbase-5.15.16/lib/libQt5Core.so.5+0x92
#36  0x7f4a5b40af1f in Gui::Application::runApplication() from /nix/store/7p308w4c1pasdwv95ql0rwam48mcd0hr-freecad-1.0.1/lib/libFreeCADGui.so+0xbbf
#37  /nix/store/7p308w4c1pasdwv95ql0rwam48mcd0hr-freecad-1.0.1/bin/freecad() [0x407ce6]
#38  /nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib/libc.so.6(+0x2a47e) [0x7f4a5705a47e]
#39  /nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib/libc.so.6(__libc_start_main+0x89) [0x7f4a5705a539]
#40  /nix/store/7p308w4c1pasdwv95ql0rwam48mcd0hr-freecad-1.0.1/bin/freecad() [0x408055]
```

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
