### PR TITLE
Draft: Fix typo in arc input hint ("staring" → "starting")

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -310,7 +310,7 @@ class Arc(gui_base_original.Creator):
             ]
         elif self.step == 2:
             return [
-                Gui.InputHint(translate("draft", "%1 pick staring angle"), Gui.UserInput.MouseLeft),
+                Gui.InputHint(translate("draft", "%1 pick starting angle"), Gui.UserInput.MouseLeft),
                 hint_continue,
             ]
         elif self.step == 3:


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
This PR corrects a minor typo in the Draft workbench input hint for arc creation.

- Replaces "staring angle" with "starting angle" for clarity
- No behavioral or functional changes

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A — this is a minor typo fix with no associated issue.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
This is the input hint text displayed when drawing an arc in the Draft workbench.

N/A — the change affects a text string, not the GUI layout.
Before:
![image](https://github.com/user-attachments/assets/7c4bed29-dbe7-40c9-91e3-323414c7e463)

After:
![image](https://github.com/user-attachments/assets/eb33a418-be68-4491-b5eb-a11680e238cd)

---

Thanks to @hyarion for the related Draft hint logic — and helping me get started with my first contributions.




