### PR TITLE
Gui: Property editor use a checkbox instead of a combobox for booleans

### DIFF
--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -29,6 +29,7 @@
 #include <limits>
 #include <QApplication>
 #include <QComboBox>
+#include <QCheckBox>
 #include <QFontDatabase>
 #include <QLocale>
 #include <QMessageBox>
@@ -1376,26 +1377,26 @@ void PropertyBoolItem::setValue(const QVariant& value)
 
 QWidget* PropertyBoolItem::createEditor(QWidget* parent,
                                         const std::function<void()>& method,
-                                        FrameOption frameOption) const
+                                        FrameOption /*frameOption*/) const
 {
-    auto cb = new QComboBox(parent);
-    cb->setFrame(static_cast<bool>(frameOption));
-    cb->addItem(QLatin1String("false"));
-    cb->addItem(QLatin1String("true"));
-    QObject::connect(cb, qOverload<int>(&QComboBox::activated), method);
-    return cb;
+    auto checkbox = new QCheckBox(parent);
+    QObject::connect(checkbox, &QCheckBox::toggled, method);
+    return checkbox;
 }
 
 void PropertyBoolItem::setEditorData(QWidget* editor, const QVariant& data) const
 {
-    auto cb = qobject_cast<QComboBox*>(editor);
-    cb->setCurrentIndex(cb->findText(data.toString()));
+    if (auto checkbox = qobject_cast<QCheckBox*>(editor)) {
+        checkbox->setChecked(data.toBool());
+    }
 }
 
 QVariant PropertyBoolItem::editorData(QWidget* editor) const
 {
-    auto cb = qobject_cast<QComboBox*>(editor);
-    return {cb->currentText()};
+    if (auto checkbox = qobject_cast<QCheckBox*>(editor)) {
+        return checkbox->isChecked();
+    }
+    return false;
 }
 
 // ---------------------------------------------------------------

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -1380,7 +1380,6 @@ QWidget* PropertyBoolItem::createEditor(QWidget* parent,
                                         FrameOption /*frameOption*/) const
 {
     auto checkbox = new QCheckBox(parent);
-    QObject::connect(checkbox, &QCheckBox::toggled, method);
     return checkbox;
 }
 

--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -121,6 +121,9 @@ void PropertyItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         checkboxOption.rect = alignedRect;
 
         QApplication::style()->drawPrimitive(QStyle::PE_IndicatorCheckBox, &checkboxOption, painter);
+        QColor borderColor = QApplication::palette().color(QPalette::BrightText);
+        painter->setPen(borderColor);
+        painter->drawRect(checkboxOption.rect.adjusted(0, 0, -1, -1));
         return;
     }
     QItemDelegate::paint(painter, option, index);

--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -22,7 +22,6 @@
 
 
 #include "PreCompiled.h"
-#include <qcheckbox.h>
 
 #ifndef _PreComp_
 # include <QApplication>

--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -251,11 +251,9 @@ void PropertyItemDelegate::valueChanged()
     if (propertyEditor) {
         Base::FlagToggler<> flag(changed);
         Q_EMIT commitData(propertyEditor);
-        if (qobject_cast<QComboBox*>(propertyEditor)) {
-            Q_EMIT closeEditor(propertyEditor);
-            return;
-        }
-        if (qobject_cast<QCheckBox*>(propertyEditor)) {
+        if (qobject_cast<QComboBox*>(propertyEditor)
+            || qobject_cast<QCheckBox*>(propertyEditor))
+        {
             Q_EMIT closeEditor(propertyEditor);
             return;
         }

--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -139,9 +139,10 @@ void PropertyItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         );
         painter->setPen(option.palette.color(QPalette::Text));
         painter->drawText(textRect, Qt::AlignVCenter | Qt::AlignLeft, labelText);
-        return;
     }
-    QItemDelegate::paint(painter, option, index);
+    else {
+        QItemDelegate::paint(painter, option, index);
+    }
 
     QColor color = static_cast<QRgb>(QApplication::style()->styleHint(QStyle::SH_Table_GridLineColor, &opt, qobject_cast<QWidget*>(parent())));
     painter->setPen(QPen(color));


### PR DESCRIPTION
After my lastest commit i added direct click to toggle and a label that should support translations, (the lines should appear after an lupdate)

[checkbox.webm](https://github.com/user-attachments/assets/d750f1df-5e97-443a-8f58-f0a9405ad236)

it has one quirk, clicking anywhere in the cell will toggle the checkbox due to the use of the focusIn event (the one that usually opens the editor)

closes #20763