### PR TITLE
[TD]Return QT or Conventional coords for geometry in Py routines (fix #21473)

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewPartPy.xml
+++ b/src/Mod/TechDraw/App/DrawViewPartPy.xml
@@ -15,22 +15,26 @@
     </Documentation>
     <Methode Name="getVisibleEdges">
       <Documentation>
-        <UserDocu>getVisibleEdges() - get the visible edges in the View as Part::TopoShapeEdges</UserDocu>
+        <UserDocu>getVisibleEdges([conventionalCoords]) - get the visible edges in the View as Part::TopoShapeEdges. Edges are returned\
+        in conventional coordinates if conventionalCoords is True.  The default is to return Qt inverted Y coordinates.</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="getVisibleVertexes">
       <Documentation>
-        <UserDocu>getVisibleVertexes() - get the visible vertexes as App.Vector in the View's coordinate system.</UserDocu>
+        <UserDocu>getVisibleVertexes() - get the visible vertexes as App.Vector in the View's coordinate system.  App.Vectors are returned\
+        in conventional coordinates if conventionalCoords is True.  The default is to return Qt inverted Y coordinates.</UserDocu>
       </Documentation>
     </Methode>
    <Methode Name="getHiddenEdges">
       <Documentation>
-        <UserDocu>getHiddenEdges() - get the hidden edges in the View as Part::TopoShapeEdges</UserDocu>
+        <UserDocu>getHiddenEdges([conventionalCoords]) - get the hidden edges in the View as Part::TopoShapeEdges.  Edges are returned\
+        in conventional coordinates if conventionalCoords is True.  The default is to return Qt inverted Y coordinates.</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="getHiddenVertexes">
       <Documentation>
-        <UserDocu>getHiddenVertexes() - get the hidden vertexes as App.Vector in the View's coordinate system.</UserDocu>
+        <UserDocu>getHiddenVertexes() - get the hidden vertexes as App.Vector in the View's coordinate system.  App.Vectors are returned\
+        in conventional coordinates if conventionalCoords is True.  The default is to return Qt inverted Y coordinates.</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="makeCosmeticVertex">

--- a/src/Mod/TechDraw/App/DrawViewPartPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPartPyImp.cpp
@@ -62,8 +62,10 @@ std::string DrawViewPartPy::representation() const
 
 PyObject* DrawViewPartPy::getVisibleEdges(PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, "")) {
-        return nullptr;
+    //NOLINTNEXTLINE
+    PyObject* conventionalCoords = Py_False;    // false for gui display (+Y down), true for calculations (+Y up)
+    if (!PyArg_ParseTuple(args, "|O!", &PyBool_Type, &conventionalCoords)) {
+        throw Py::ValueError("Expected '[conventionalCoords=True/False] or None' ");
     }
 
     DrawViewPart* dvp = getDrawViewPartPtr();
@@ -71,7 +73,12 @@ PyObject* DrawViewPartPy::getVisibleEdges(PyObject *args)
     std::vector<TechDraw::BaseGeomPtr> geoms = dvp->getEdgeGeometry();
     for (auto& g: geoms) {
         if (g->getHlrVisible()) {
-            PyObject* pEdge = new Part::TopoShapeEdgePy(new Part::TopoShape(g->getOCCEdge()));
+            TopoDS_Edge occEdge = g->getOCCEdge();
+            if (PyBool_Check(conventionalCoords) && conventionalCoords == Py_True) {
+                TopoDS_Shape occShape = ShapeUtils::invertGeometry(occEdge);
+                occEdge = TopoDS::Edge(occShape);
+            }
+            PyObject* pEdge = new Part::TopoShapeEdgePy(new Part::TopoShape(occEdge));
             pEdgeList.append(Py::asObject(pEdge));
         }
     }
@@ -81,8 +88,10 @@ PyObject* DrawViewPartPy::getVisibleEdges(PyObject *args)
 
 PyObject* DrawViewPartPy::getHiddenEdges(PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, "")) {
-        return nullptr;
+    PyObject* conventionalCoords = Py_False;    // false for gui display (+Y down), true for calculations (+Y up)
+    //NOLINTNEXTLINE
+    if (!PyArg_ParseTuple(args, "|O!", &PyBool_Type, &conventionalCoords)) {
+        throw Py::ValueError("Expected '[conventionalCoords=True/False] or None' ");
     }
 
     DrawViewPart* dvp = getDrawViewPartPtr();
@@ -90,7 +99,12 @@ PyObject* DrawViewPartPy::getHiddenEdges(PyObject *args)
     std::vector<TechDraw::BaseGeomPtr> geoms = dvp->getEdgeGeometry();
     for (auto& g: geoms) {
         if (!g->getHlrVisible()) {
-            PyObject* pEdge = new Part::TopoShapeEdgePy(new Part::TopoShape(g->getOCCEdge()));
+            TopoDS_Edge occEdge = g->getOCCEdge();
+            if (PyBool_Check(conventionalCoords) && conventionalCoords == Py_True) {
+                TopoDS_Shape occShape = ShapeUtils::invertGeometry(occEdge);
+                occEdge = TopoDS::Edge(occShape);
+            }
+            PyObject* pEdge = new Part::TopoShapeEdgePy(new Part::TopoShape(occEdge));
             pEdgeList.append(Py::asObject(pEdge));
         }
     }
@@ -100,8 +114,10 @@ PyObject* DrawViewPartPy::getHiddenEdges(PyObject *args)
 
 PyObject* DrawViewPartPy::getVisibleVertexes(PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, "")) {
-        return nullptr;
+    PyObject* conventionalCoords = Py_False;    // false for gui display (+Y down), true for calculations (+Y up)
+    //NOLINTNEXTLINE
+    if (!PyArg_ParseTuple(args, "|O!", &PyBool_Type, &conventionalCoords)) {
+        throw Py::ValueError("Expected '[conventionalCoords=True/False] or None' ");
     }
 
     DrawViewPart* dvp = getDrawViewPartPtr();
@@ -109,7 +125,11 @@ PyObject* DrawViewPartPy::getVisibleVertexes(PyObject *args)
     auto vertsAll = dvp->getVertexGeometry();
     for (auto& vert: vertsAll) {
         if (vert->getHlrVisible()) {
-            PyObject* pVertex = new Base::VectorPy(new Base::Vector3d(vert->point()));
+            Base::Vector3d vertPoint = vert->point();
+            if (PyBool_Check(conventionalCoords) && conventionalCoords == Py_True) {
+                vertPoint = DU::invertY(vertPoint);
+            }
+            PyObject* pVertex = new Base::VectorPy(new Base::Vector3d(vertPoint));
             pVertexList.append(Py::asObject(pVertex));
         }
     }
@@ -119,8 +139,10 @@ PyObject* DrawViewPartPy::getVisibleVertexes(PyObject *args)
 
 PyObject* DrawViewPartPy::getHiddenVertexes(PyObject *args)
 {
-    if (!PyArg_ParseTuple(args, "")) {
-        return nullptr;
+    PyObject* conventionalCoords = Py_False;    // false for gui display (+Y down), true for calculations (+Y up)
+    //NOLINTNEXTLINE
+    if (!PyArg_ParseTuple(args, "|O!", &PyBool_Type, &conventionalCoords)) {
+        throw Py::ValueError("Expected '[conventionalCoords=True/False] or None' ");
     }
 
     DrawViewPart* dvp = getDrawViewPartPtr();
@@ -128,14 +150,17 @@ PyObject* DrawViewPartPy::getHiddenVertexes(PyObject *args)
     auto vertsAll = dvp->getVertexGeometry();
     for (auto& vert: vertsAll) {
         if (!vert->getHlrVisible()) {
-            PyObject* pVertex = new Base::VectorPy(new Base::Vector3d(vert->point()));
+            Base::Vector3d vertPoint = vert->point();
+            if (PyBool_Check(conventionalCoords) && conventionalCoords == Py_True) {
+                vertPoint = DU::invertY(vertPoint);
+            }
+            PyObject* pVertex = new Base::VectorPy(new Base::Vector3d(vertPoint));
             pVertexList.append(Py::asObject(pVertex));
         }
     }
 
     return Py::new_reference_to(pVertexList);
 }
-
 
 
 PyObject* DrawViewPartPy::requestPaint(PyObject *args)

--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -1347,8 +1347,8 @@ void Vertex::Restore(Base::XMLReader &reader)
 
     reader.readElement("Extract");
     extractType = reader.getAttribute<ExtractionType>("value");
-//    reader.readElement("Visible");
-//    hlrVisible = reader.getAttribute<bool>("value");
+    reader.readElement("Visible");
+    hlrVisible = reader.getAttribute<bool>("value");
     reader.readElement("Ref3D");
     ref3D = reader.getAttribute<long>("value");
     reader.readElement("IsCenter");

--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -512,7 +512,6 @@ void GeometryObject::extractGeometry(EdgeClass category, bool hlrVisible)
 void GeometryObject::addGeomFromCompound(TopoDS_Shape edgeCompound, EdgeClass category,
                                          bool hlrVisible)
 {
-//    Base::Console().message("GO::addGeomFromCompound(%d, %d)\n", category, hlrVisible);
     if (edgeCompound.IsNull()) {
         return;    // There is no OpenCascade Geometry to be calculated
     }
@@ -549,7 +548,6 @@ void GeometryObject::addGeomFromCompound(TopoDS_Shape edgeCompound, EdgeClass ca
         base = BaseGeom::baseFactory(edge);
         if (!base) {
             continue;
-            //            throw Base::ValueError("GeometryObject::addGeomFromCompound - baseFactory failed");
         }
 
         base->source(SourceType::GEOMETRY);
@@ -559,59 +557,60 @@ void GeometryObject::addGeomFromCompound(TopoDS_Shape edgeCompound, EdgeClass ca
         edgeGeom.push_back(base);
 
         //add vertices of new edge if not already in list
-        if (hlrVisible) {
-            BaseGeomPtr lastAdded = edgeGeom.back();
-            bool v1Add = true, v2Add = true;
-            bool c1Add = true;
-            TechDraw::VertexPtr v1 = std::make_shared<TechDraw::Vertex>(lastAdded->getStartPoint());
-            TechDraw::VertexPtr v2 = std::make_shared<TechDraw::Vertex>(lastAdded->getEndPoint());
-            TechDraw::CirclePtr circle = std::dynamic_pointer_cast<TechDraw::Circle>(lastAdded);
-            TechDraw::VertexPtr c1;
-            if (circle) {
-                c1 = std::make_shared<TechDraw::Vertex>(circle->center);
-                c1->isCenter(true);
-                c1->setHlrVisible(true);
-            }
+        // note that if a vertex belongs to both a hidden and a visible edge, it will be treated as
+        // a visible vertex.
+        BaseGeomPtr lastAdded = edgeGeom.back();
+        bool v1Add = true, v2Add = true;
+        bool c1Add = true;
+        TechDraw::VertexPtr v1 = std::make_shared<TechDraw::Vertex>(lastAdded->getStartPoint());
+        TechDraw::VertexPtr v2 = std::make_shared<TechDraw::Vertex>(lastAdded->getEndPoint());
+        TechDraw::CirclePtr circle = std::dynamic_pointer_cast<TechDraw::Circle>(lastAdded);
+        TechDraw::VertexPtr c1;
+        if (circle) {
+            c1 = std::make_shared<TechDraw::Vertex>(circle->center);
+            c1->isCenter(true);
+            c1->setHlrVisible(hlrVisible);
+        }
 
-            std::vector<VertexPtr>::iterator itVertex = vertexGeom.begin();
-            for (; itVertex != vertexGeom.end(); itVertex++) {
-                if ((*itVertex)->isEqual(*v1, Precision::Confusion())) {
-                    v1Add = false;
-                }
-                if ((*itVertex)->isEqual(*v2, Precision::Confusion())) {
-                    v2Add = false;
-                }
-                if (circle) {
-                    if ((*itVertex)->isEqual(*c1, Precision::Confusion())) {
-                        c1Add = false;
-                    }
-                }
+        std::vector<VertexPtr>::iterator itVertex = vertexGeom.begin();
+        for (; itVertex != vertexGeom.end(); itVertex++) {
+            if ((*itVertex)->isEqual(*v1, Precision::Confusion())) {
+                v1Add = false;
             }
-            if (v1Add) {
-                vertexGeom.push_back(v1);
-                v1->setHlrVisible( true);
+            if ((*itVertex)->isEqual(*v2, Precision::Confusion())) {
+                v2Add = false;
             }
-            else {
-                //    delete v1;
-            }
-            if (v2Add) {
-                vertexGeom.push_back(v2);
-                v2->setHlrVisible( true);
-            }
-            else {
-                //    delete v2;
-            }
-
             if (circle) {
-                if (c1Add) {
-                    vertexGeom.push_back(c1);
-                    c1->setHlrVisible( true);
-                }
-                else {
-                    //    delete c1;
+                if ((*itVertex)->isEqual(*c1, Precision::Confusion())) {
+                    c1Add = false;
                 }
             }
         }
+        if (v1Add) {
+            vertexGeom.push_back(v1);
+            v1->setHlrVisible(hlrVisible);
+        }
+        else {
+            //    delete v1;
+        }
+        if (v2Add) {
+            vertexGeom.push_back(v2);
+            v2->setHlrVisible(hlrVisible);
+        }
+        else {
+            //    delete v2;
+        }
+
+        if (circle) {
+            if (c1Add) {
+                vertexGeom.push_back(c1);
+                c1->setHlrVisible(hlrVisible);
+            }
+            else {
+                //    delete c1;
+            }
+        }
+    // }
     }//end TopExp
 }
 


### PR DESCRIPTION
This PR implements a fix for issue #21473.   The python methods for retrieving edges and vertices from a drawing page only returned Qt coordinates (+Y down).  This change adds and optional parameter to allow returning conventional coordinates.

2 other small fixes related to vertex creation and restore are also included.
