### PR TITLE
Make Label property on Document read only (#10010)

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -824,7 +824,7 @@ Document::Document(const char* documentName)
         GetApplication()
             .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
             ->GetASCII("prefCompany", "");
-    ADD_PROPERTY_TYPE(Label, ("Unnamed"), 0, Prop_None, "The name of the document");
+    ADD_PROPERTY_TYPE(Label, ("Unnamed"), 0, Prop_ReadOnly, "The name of the document");
     ADD_PROPERTY_TYPE(FileName,
                       (""),
                       0,


### PR DESCRIPTION
Make the Label property on the Document read only to avoid confusing the user. Changing the label will not have effect, the Label property reflect the file name. Soultion suggested on issue https://github.com/FreeCAD/FreeCAD/issues/10010

## Issues
Fixes https://github.com/FreeCAD/FreeCAD/issues/10010

## Before and After Images


![Captura desde 2025-05-24 18-52-11](https://github.com/user-attachments/assets/dc720b85-fb4b-43d2-8dac-902a2e9d3daa)

The Label property can no be modified anymore

![Captura desde 2025-05-24 18-52-21](https://github.com/user-attachments/assets/6b6f3684-6942-4136-8423-1066ac4a1bbc)

This is my first contribution (thanks for the "Good First Issue" label), let me know if I should do any change to this submition
