### PR TITLE
Sketcher: Implement hints for Point

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -72,12 +72,6 @@ private:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 click to place a point"),
                               {UserInput::MouseLeft}));
-
-                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
-                                          {UserInput::MouseRight}));
-
-                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
-                                          {UserInput::KeyEscape}));
                 break;
             default:
                 break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -72,6 +72,9 @@ private:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 click to place a point"),
                               {UserInput::MouseLeft}));
+
+                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
+                                          {UserInput::KeyEscape}));
                 break;
             default:
                 break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -74,6 +74,9 @@ private:
                               {UserInput::MouseLeft}));
 
                 hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
+                                          {UserInput::MouseRight}));
+
+                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
                                           {UserInput::KeyEscape}));
                 break;
             default:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -27,6 +27,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -59,8 +60,28 @@ public:
     ~DrawSketchHandlerPoint() override = default;
 
 private:
+    void updateHints() const
+    {
+        using Gui::InputHint;
+
+        std::list<InputHint> hints;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 click to place a point"),
+                              {Gui::InputHint::UserInput::MouseLeft}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -63,6 +63,7 @@ private:
     void updateHints() const
     {
         using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
 
         std::list<InputHint> hints;
 
@@ -70,7 +71,7 @@ private:
             case SelectMode::SeekFirst:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 click to place a point"),
-                              {Gui::InputHint::UserInput::MouseLeft}));
+                              {UserInput::MouseLeft}));
                 break;
             default:
                 break;


### PR DESCRIPTION
## Sketcher: Add structured input hint to Point tool

Adds a structured input hint ("🖱 pick point location") to the Point tool using `Gui::InputHint`. Hint appears immediately upon tool activation and uses the new `%1` icon injection pattern with MouseLeft.

<!-- Include a brief summary of the changes. -->
- Implements `updateHints()` in `DrawSketchHandlerPoint` to provide a context-sensitive hint.
- Hint uses the `%1` pattern for icon injection and appears as soon as the Point tool is activated.
- Follows the same pattern as recent Arc tool improvements for consistency.

---

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
**Before:** No structured hint shown when activating the Point tool.  

**After:** "🖱 pick point location" hint appears immediately upon tool activation.
![image](https://github.com/user-attachments/assets/e6d39476-172a-4709-99e2-e9c6e79ec1e4)


---
