### PR TITLE
Gui: property-editor open the combo directly and apply after selection

### DIFF
--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -25,6 +25,7 @@
 
 #ifndef _PreComp_
 # include <QApplication>
+# include <QComboBox>
 # include <QModelIndex>
 # include <QPainter>
 #endif
@@ -124,7 +125,16 @@ bool PropertyItemDelegate::editorEvent (QEvent * event, QAbstractItemModel* mode
 
 bool PropertyItemDelegate::eventFilter(QObject *o, QEvent *ev)
 {
-    if (ev->type() == QEvent::FocusOut) {
+    if (ev->type() == QEvent::FocusIn) {
+        auto *comboBox = qobject_cast<QComboBox*>(o);
+        if (comboBox) {
+            auto parentEditor = qobject_cast<PropertyEditor*>(this->parent());
+            if (parentEditor && parentEditor->activeEditor == comboBox) {
+                comboBox->showPopup();
+            }
+        }
+    }
+    else if (ev->type() == QEvent::FocusOut) {
         auto parentEditor = qobject_cast<PropertyEditor*>(this->parent());
         auto widget = qobject_cast<QWidget*>(o);
         if (widget && parentEditor && parentEditor->activeEditor
@@ -218,6 +228,10 @@ void PropertyItemDelegate::valueChanged()
     if (propertyEditor) {
         Base::FlagToggler<> flag(changed);
         Q_EMIT commitData(propertyEditor);
+        auto *comboBox = qobject_cast<QComboBox*>(propertyEditor);
+        if (comboBox) {
+            Q_EMIT closeEditor(propertyEditor);
+        }
     }
 }
 


### PR DESCRIPTION
while working in #21555 i discovered that i can improve ux significantly for the combobox/dropdown

Currently you have to make 4 clicks to apply a combo:
 1 to enter edit, 1 to open the combo, 1 to select, and 1 to defocus and apply

with this commit only 2 clicks:
1 to open the combo and 1 to select

Master:

[master.webm](https://github.com/user-attachments/assets/a9b16398-4ef4-4314-84c8-f045c003f43a)


This PR:

[pr.webm](https://github.com/user-attachments/assets/f0603eb7-c78b-474d-a9e1-224a9b12819a)
