### PR TITLE
[BimWindow] Normal Default Auto _&_ SketchArch Support Sill Property

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -1672,7 +1672,12 @@ def makeWindow(baseobj=None, width=None, height=None, parts=None, name=None):
     if height:
         obj.Height = height
     if baseobj:
-        obj.Normal = baseobj.Placement.Rotation.multVec(FreeCAD.Vector(0, 0, -1))
+        # 2025.5.25
+        # Historically, this normal was deduced by the orientation of the Base Sketch and hardcoded in the Normal property.
+        # Now with the new AutoNormalReversed property/flag, set True as default, the auto Normal previously in opposite direction to is now consistent with that previously hardcoded.
+        # With the normal set to 'auto', window object would not suffer weird shape if the Base Sketch is rotated by some reason.
+        # Keep the property be 'auto' (0,0,0) here.  
+        #obj.Normal = baseobj.Placement.Rotation.multVec(FreeCAD.Vector(0, 0, -1))
         obj.Base = baseobj
     if parts is not None:
         obj.WindowParts = parts

--- a/src/Mod/BIM/bimcommands/BimWindow.py
+++ b/src/Mod/BIM/bimcommands/BimWindow.py
@@ -210,7 +210,12 @@ class Arch_Window:
                         break
                     FreeCADGui.doCommand("win = FreeCAD.ActiveDocument.getObject('" + o.Name + "')")
                     FreeCADGui.doCommand("win.Base.Placement = pl")
-                    FreeCADGui.doCommand("win.Normal = pl.Rotation.multVec(FreeCAD.Vector(0, 0, -1))")
+                    # 2025.5.25
+                    # Historically, this normal was deduced by the orientation of the Base Sketch and hardcoded in the Normal property.
+                    # Now with the new AutoNormalReversed property/flag, set True as default, the auto Normal previously in opposite direction to is now consistent with that previously hardcoded.
+                    # With the normal set to 'auto', window object would not suffer weird shape if the Base Sketch is rotated by some reason.
+                    # Keep the property be 'auto' (0,0,0) here.  
+                    #FreeCADGui.doCommand("win.Normal = pl.Rotation.multVec(FreeCAD.Vector(0, 0, -1))")
                     FreeCADGui.doCommand("win.Width = " + str(self.Width))
                     FreeCADGui.doCommand("win.Height = " + str(self.Height))
                     FreeCADGui.doCommand("win.Base.recompute()")
@@ -233,8 +238,13 @@ class Arch_Window:
                 hasattr(ArchSketchObject, 'attachToHost') and 
                 hasattr(FreeCAD, 'ArchSketchLock') and 
                 FreeCAD.ArchSketchLock):
-                # Window sketch's stay at orgin is good if addon exists
-                FreeCADGui.doCommand("win = Arch.makeWindowPreset('" + WindowPresets[self.Preset] + "' " + wp + ")")
+                if self.Include:
+                    # Window base sketch's placement stay at orgin is good if addon exists and self.Include
+                    FreeCADGui.doCommand("win = Arch.makeWindowPreset('" + WindowPresets[self.Preset] + "' " + wp + ", window_sill=" + str(self.Sill.Value) + ")")
+                else:
+                    # Window base sketch's placement follow getPoint placement if addon exists but NOT self.Include
+                    FreeCADGui.doCommand("win = Arch.makeWindowPreset('" + WindowPresets[self.Preset] + "' " + wp + ", placement=pl, window_sill=" + str(self.Sill.Value) + ")")
+                    FreeCADGui.doCommand("win.AttachToAxisOrSketch = 'None'")
                 FreeCADGui.doCommand("FreeCADGui.Selection.addSelection(win)")
                 w = FreeCADGui.Selection.getSelection()[0]
                 FreeCADGui.doCommand("FreeCAD.SketchArchPl = pl")


### PR DESCRIPTION
ArchWindow/makeWindow() Normal Default Auto _&_ SketchArch Support Sill Property Groundwork


https://github.com/FreeCAD/FreeCAD/pull/21261 - [ArchWindow] Add AutoNormalReversed property 

Historically, the normal of a Window object was deduced by the orientation of the Base Sketch and hardcoded in the Normal property. Now with the new AutoNormalReversed property/flag (above PR), set True as default, the auto Normal previously in opposite direction to is now consistent with that previously hardcoded. With the normal set to 'auto', window object would not suffer weird shape if the Base Sketch is rotated by some reason. The Normal property is set to  'auto' (0,0,0) default following the above PR.

https://github.com/FreeCAD/FreeCAD/pull/21005 - BIM: Allow changing Sill parameter in Properties for Window

Groundwork added to support Window augmented by SketchArch Parametric Placement feature (PR to ArchWindow.py to be submitted separately)

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
