### PR TITLE
CAM: Vcarve - fix zStart

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathVcarve.py
+++ b/src/Mod/CAM/CAMTests/TestPathVcarve.py
@@ -51,16 +51,22 @@ class TestPathVcarve(PathTestWithAssets):
 
     def testFinishingPass(self):
         self.doc = FreeCAD.newDocument()
-        part = FreeCAD.ActiveDocument.addObject("Part::Feature", "TestShape")
-        rect = Part.makePolygon([(0, 0, 0), (5, 0, 0), (5, 10, 0), (0, 10, 0), (0, 0, 0)])
-        part.Shape = Part.makeFace(rect, "Part::FaceMakerSimple")
-        job = PathJob.Create("Job", [part])
+        part1 = FreeCAD.ActiveDocument.addObject("Part::Feature", "TestShape")
+        part2 = FreeCAD.ActiveDocument.addObject("Part::Feature", "TestShape")
+        rect = Part.makePolygon(
+            [(20, 20, 10), (25, 20, 10), (25, 30, 10), (20, 30, 10), (20, 20, 10)]
+        )
+        box = Part.makeBox(100, 100, 10)
+        part1.Shape = box
+        part2.Shape = Part.makeFace(rect, "Part::FaceMakerSimple")
+        job = PathJob.Create("Job", [part1, part2])
+
         toolbit = self.assets.get("toolbit://60degree_Vbit")
         loaded_tool = toolbit.attach_to_doc(doc=job.Document)
         job.Tools.Group[0].Tool = loaded_tool
 
         op = PathVcarve.Create("TestVCarve")
-        op.Base = job.Model.Group[0]
+        op.BaseShapes = job.Model.Group[1]
 
         op.FinishingPass = False
         op.Proxy.execute(op)
@@ -72,7 +78,7 @@ class TestPathVcarve(PathTestWithAssets):
         op.Proxy.execute(op)
         min_z_with_finish = op.Path.BoundBox.ZMin
 
-        self.assertRoughly(min_z_with_finish - min_z_no_finish, finishing_offset)
+        self.assertRoughly(min_z_with_finish - min_z_no_finish, finishing_offset, 1.0)
 
     def test00(self):
         """Verify 90 deg depth calculation"""

--- a/src/Mod/CAM/Path/Op/Vcarve.py
+++ b/src/Mod/CAM/Path/Op/Vcarve.py
@@ -204,8 +204,8 @@ class _Geometry(object):
         return _Geometry(zStart + zOff, max(zStop + zOff, zFinal), zScale, zStepDown)
 
     @classmethod
-    def FromObj(cls, obj, model):
-        zStart = model.Shape.BoundBox.ZMax
+    def FromObj(cls, obj):
+        zStart = obj.BaseShapes[0].Shape.BoundBox.ZMax
         finalDepth = obj.FinalDepth.Value
         stepDown = abs(obj.StepDown.Value)
 
@@ -500,7 +500,7 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
         # iterate over each face separately
         for face, wires in self.buildMedialWires(obj, faces).items():
 
-            geom = _Geometry.FromObj(obj, self.model[0])
+            geom = _Geometry.FromObj(obj)
 
             # If using depth step-down, calculate maximum usable depth for current face.
             # This is done to avoid adding additional step-down engraving passes when it


### PR DESCRIPTION
https://forum.freecad.org/viewtopic.php?t=96919

**Vcarve** operation get `zStart` from the first model in `Model` group of the `Job`,
which no way connected with the **Vcarve** operation and `ShapeString` object
If you change order of the objects in `Model` group for some reason, your `Vcarve` operation will suddenly change

https://github.com/FreeCAD/FreeCAD/blob/41c750be477c70dcbc16972d3a6aca315e465500/src/Mod/CAM/Path/Op/Vcarve.py#L503
https://github.com/FreeCAD/FreeCAD/blob/41c750be477c70dcbc16972d3a6aca315e465500/src/Mod/CAM/Path/Op/Vcarve.py#L208

Probably this is incorrect
For workaround can move clone of `ShapeString` object in `Model` group to the top or change `Placement` of **Vcarve** operation

After this commit `zStart` get form the first `BaseShapes` of the **Vcarve** operation

Before:
![Screenshot_20250525_150426_lossy](https://github.com/user-attachments/assets/f95046e9-0818-448b-80c8-6f8de7033e5c)


After:
![Screenshot_20250525_150318_lossy](https://github.com/user-attachments/assets/0f6e20b8-caf3-4320-9006-68544214ff8c)
![Screenshot_20250525_150311_lossy](https://github.com/user-attachments/assets/5e787a2a-817a-4f16-99a8-96a48c0ca945)

