### PR TITLE
BIM: Add support for deactivation active object to BIM Views Tree

### DIFF
--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -814,6 +814,7 @@ class ViewProviderBuildingPart:
             menuTxt = translate("Arch", "Activate")
             actionActivate = QtGui.QAction(menuTxt, menu)
             actionActivate.setCheckable(True)
+            print("FreeCADGui.ActiveDocument.ActiveView.getActiveObject", FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch"))
             if FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch") == self.Object:
                 actionActivate.setChecked(True)
             else:
@@ -885,8 +886,19 @@ class ViewProviderBuildingPart:
             autoclip = vobj.AutoCutView
         if restore:
             if wp.label.rstrip("*") == self.Object.Label:
-                prev = wp._previous()
-                print("prev: ", prev)
+                prev_data = wp._previous()
+                if prev_data:
+                    prev_label = prev_data.get("label", "").rstrip("*")
+                    prev_obj = None
+                    for obj in FreeCAD.ActiveDocument.Objects:
+                        if hasattr(obj, "Label") and obj.Label == prev_label:
+                            prev_obj = obj
+                            break
+
+                    if prev_obj:
+                        import FreeCADGui
+                        FreeCADGui.ActiveDocument.ActiveView.setActiveObject("Arch", prev_obj)
+                        print("Set active object to:", prev_obj.Label)
 
             if autoclip:
                 vobj.CutView = False

--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -814,7 +814,6 @@ class ViewProviderBuildingPart:
             menuTxt = translate("Arch", "Activate")
             actionActivate = QtGui.QAction(menuTxt, menu)
             actionActivate.setCheckable(True)
-            print("FreeCADGui.ActiveDocument.ActiveView.getActiveObject", FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch"))
             if FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch") == self.Object:
                 actionActivate.setChecked(True)
             else:
@@ -860,19 +859,14 @@ class ViewProviderBuildingPart:
         menu.addAction(actionCloneUp)
 
     def activate(self, action=None):
+        from draftutils.utils import toggle_working_plane
         vobj = self.Object.ViewObject
-        if FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch") == self.Object:
-            FreeCADGui.ActiveDocument.ActiveView.setActiveObject("Arch", None)
-            if vobj.SetWorkingPlane:
-                self.setWorkingPlane(restore=True)
-                if action:
-                    action.setChecked(False)
-        elif (not hasattr(vobj,"DoubleClickActivates")) or vobj.DoubleClickActivates:
-            FreeCADGui.ActiveDocument.ActiveView.setActiveObject("Arch", self.Object)
-            if vobj.SetWorkingPlane:
-                self.setWorkingPlane()
-                if action:
-                    action.setChecked(True)
+        
+        if (not hasattr(vobj,"DoubleClickActivates")) or vobj.DoubleClickActivates:
+            if toggle_working_plane(self.Object, action, restore=True):
+                print("Setting active working plane to: ", self.Object.Label)
+            else:
+                print("Deactivating working plane from: ", self.Object.Label)
 
         FreeCADGui.Selection.clearSelection()
 

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -1623,6 +1623,7 @@ class PlaneGui(PlaneBase):
         self.set_parameters(self._history["data_list"][idx])
         self._history["idx"] = idx
         self._update_all(_hist_add=False)
+        return self._history["data_list"][idx]
 
     def _next(self):
         idx = self._history["idx"]

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -1068,4 +1068,57 @@ def pyopen(file, mode='r', buffering=-1, encoding=None, errors=None, newline=Non
         encoding = 'utf-8'
     return open(file, mode, buffering, encoding, errors, newline, closefd, opener)
 
+def toggle_working_plane(obj, action=None, restore=False, dialog=None):
+    """Toggle the active state of a working plane object.
+
+    This function handles the common logic for activating and deactivating
+    working plane objects like BuildingParts and WorkingPlaneProxies.
+    It can be used by different modules that need to implement similar
+    working plane activation behavior.
+
+    Parameters
+    ----------
+    obj : App::DocumentObject
+        The object to activate or deactivate as a working plane.
+    action : QAction, optional
+        The action button that triggered this function, to update its checked state.
+    restore : bool, optional
+        If True, will restore the previous working plane when deactivating.
+        Defaults to False.
+    dialog : QDialog, optional
+        If provided, will update the checked state of the activate button in the dialog.
+
+    Returns
+    -------
+    bool
+        True if the object was activated, False if it was deactivated.
+    """
+    import FreeCADGui
+    
+    # Check if the object is already active
+    is_active = (FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch") == obj)
+    
+    if is_active:
+        # Deactivate the object
+        FreeCADGui.ActiveDocument.ActiveView.setActiveObject("Arch", None)
+        if hasattr(obj, "ViewObject") and hasattr(obj.ViewObject, "Proxy") and \
+           hasattr(obj.ViewObject.Proxy, "setWorkingPlane"):
+            obj.ViewObject.Proxy.setWorkingPlane(restore=True)
+        if action:
+            action.setChecked(False)
+        if dialog and hasattr(dialog, "buttonActivate"):
+            dialog.buttonActivate.setChecked(False)
+        return False
+    else:
+        # Activate the object
+        FreeCADGui.ActiveDocument.ActiveView.setActiveObject("Arch", obj)
+        if hasattr(obj, "ViewObject") and hasattr(obj.ViewObject, "Proxy") and \
+           hasattr(obj.ViewObject.Proxy, "setWorkingPlane"):
+            obj.ViewObject.Proxy.setWorkingPlane()
+        if action:
+            action.setChecked(True)
+        if dialog and hasattr(dialog, "buttonActivate"):
+            dialog.buttonActivate.setChecked(True)
+        return True
+
 ## @}


### PR DESCRIPTION
As the title says - it adds the checkbox that's similarly done in Part workbench, so user can select/deselect the item and if they had previous active object, it will also fall back to the previous object.

Also:
- moved out part of the common logic from ArchBuildingPart and BimViews to utils,
- fixed a problem where we could activate two objects in a row, but we didn't set back the previous one as activate after deactivating current one (we were only setting working plane)
- changed to checkbox for default Model tree
- 
Demo:

https://github.com/user-attachments/assets/dbc8d6d0-60c2-4d1e-a9de-5634cee142ad

Resolves: https://github.com/FreeCAD/FreeCAD/issues/21405