### PR TITLE
CAM: Dragknife dressup adds unnecessary maneuvers

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/Dragknife.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Dragknife.py
@@ -149,16 +149,17 @@ class ObjectDressup:
         return myAngle
 
     def getIncidentAngle(self, queue):
-        # '''returns in the incident angle in radians between the current and previous moves'''
+        # '''returns in the incident angle in degrees between the current and previous moves'''
 
         angleatend = float(math.degrees(self.segmentAngleXY(queue[2], queue[1], True)))
-        if angleatend < 0:
-            angleatend = 360 + angleatend
         angleatstart = float(math.degrees(self.segmentAngleXY(queue[1], queue[0])))
-        if angleatstart < 0:
-            angleatstart = 360 + angleatstart
 
-        incident_angle = angleatend - angleatstart
+        incident_angle = (angleatstart - angleatend + 360) % 360
+
+        # The incident can never be greater than 180 degrees.  If it is
+        # then we need to measure the other way around the circle.
+        if incident_angle > 180:
+            incident_angle = 360 - incident_angle
 
         return incident_angle
 


### PR DESCRIPTION
The CAM dragknife dressup calculates the angles between subsequent paths and determines if it needs to maneuver the cutter around in order to make sharp corners.

The code calculates the vectors between any 2 movements (line vectors or arc tangent vectors) and subtracts them to determine how "sharp" the angle is.  Consider a vector at 350 degrees and the subsequent vector at 10 degrees.  The angle between them is 20 degrees however the existing code calculates it as 350 - 10 = 340 which is incorrect.  When the resulting calculation is greater than 180, it means it calculated in the wrong direction around the circle.

## Issues
Fixes #21533
