### PR TITLE
CI: pin occt==7.8.1 on weekly builds.

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -102,7 +102,7 @@ requirements:
     - matplotlib-base
     - noqt5
     - numpy
-    - occt
+    - occt>=7.8,<7.9
     - pcl
     - pivy
     - ply
@@ -151,7 +151,7 @@ requirements:
     - nine
     - noqt5
     - numpy
-    - occt
+    - occt>=7.8,<7.9
     - olefile
     - opencamlib
     - opencv


### PR DESCRIPTION
Due to lack of ability to use the `pixi.lock` files, the `rattler-build` system that builds the weekly build will incorporate `occt==7.9.0` when building, which is incompatible with run-time dependencies.

This PR pins `occt==7.8.1` to ensure that the weekly build may run.

## Issues

None.

## Before and After Images

N/A.