### PR TITLE
BIM: ignore FreeCAD groups for IFC export, controlled by a user preference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@
 *.o
 *.orig
 *.output
+# Ignore .db files created by Qt Designer when editing .ui files
+*.db
 qrc_*.cpp
 BuildLog.htm
 cmake_install.cmake

--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -40,6 +40,7 @@ import DraftVecUtils
 
 from FreeCAD import Vector
 from draftutils import params
+from draftutils.groups import is_group
 
 if FreeCAD.GuiUp:
     from PySide import QtGui,QtCore
@@ -819,6 +820,140 @@ def getAllChildren(objectlist):
                     obs.append(c)
     return obs
 
+def get_architectural_contents(
+    initial_objects,
+    recursive=True,
+    discover_hosted_elements=True,
+    include_components_from_additions=False,
+    include_initial_objects_in_result=True
+):
+    """
+    Retrieves a flat list of unique architectural objects that are considered "contents" of or are
+    related to the given initial_objects.
+
+    This includes:
+    - Children from .Group properties (hierarchical traversal if recursive=True).
+    - Architecturally hosted elements (e.g., windows in walls, rebars in structures)
+      if discover_hosted_elements=True.
+    - Optionally, components from .Additions properties.
+
+    The traversal uses a queue and ensures objects are processed only once.
+
+    Parameters:
+    -----------
+    initial_objects : App::DocumentObject or list of App::DocumentObject
+        The starting object(s) from which to discover contents.
+    recursive : bool, optional
+        If True (default), recursively find contents of discovered group-like
+        objects (those with a .Group property and identified by draftutils.groups.is_group()).
+    discover_hosted_elements : bool, optional
+        If True (default), try to find elements like windows, doors, rebars
+        that are architecturally hosted by other elements encountered during traversal.
+        This relies on Draft.getType() and common Arch properties like .Hosts or .Host.
+    include_components_from_additions : bool, optional
+        If False (default), objects found in .Additions lists are not added.
+        Set to True if these components should be part of the discovered contents.
+    include_initial_objects_in_result : bool, optional
+        If True (default), the objects in initial_objects themselves will be
+        included in the output list (if not already discovered as a child of another).
+        If False, only their "descendant" contents are returned.
+
+    Returns:
+    --------
+    list of App::DocumentObject
+        A flat list of unique architectural document objects.
+    """
+
+    final_contents_list = []
+    queue = []
+
+    if not isinstance(initial_objects, list):
+        initial_objects_list = [initial_objects]
+    else:
+        initial_objects_list = list(initial_objects) # Make a copy
+
+    queue.extend(initial_objects_list)
+
+    # Set to keep track of object names already added to the queue or fully processed
+    # This prevents duplicates in the queue and reprocessing.
+    processed_or_queued_names = set()
+    for item in initial_objects_list: # Pre-populate for initial items if they are to be added later
+        processed_or_queued_names.add(item.Name)
+
+
+    idx = 0 # Use an index for iterating the queue, as it can grow
+    while idx < len(queue):
+        obj = queue[idx]
+        idx += 1
+
+        # Add the current object to the final list if it's not already there.
+        # The decision to include initial_objects is handled by how they are first added to queue
+        # and this check.
+        if obj not in final_contents_list:
+            is_initial = obj in initial_objects_list
+            if (is_initial and include_initial_objects_in_result) or not is_initial:
+                final_contents_list.append(obj)
+
+        children_to_add_to_queue_next = []
+
+        # 1. Hierarchical children from .Group (if recursive)
+        if recursive and is_group(obj) and hasattr(obj, "Group") and obj.Group:
+            for child in obj.Group:
+                if child.Name not in processed_or_queued_names:
+                    children_to_add_to_queue_next.append(child)
+                    processed_or_queued_names.add(child.Name) # Mark as queued
+
+        # 2. Architecturally-hosted elements (if discover_hosted_elements)
+        if discover_hosted_elements:
+            host_types = ["Wall", "Structure", "CurtainWall", "Precast", "Panel", "Roof"]
+            if Draft.getType(obj) in host_types:
+                # Hosted elements are typically in the host's InList
+                for item_in_inlist in obj.InList:
+                    element_to_check = item_in_inlist
+                    if hasattr(item_in_inlist, "getLinkedObject"): # Resolve App::Link
+                        linked = item_in_inlist.getLinkedObject()
+                        if linked:
+                            element_to_check = linked
+
+                    if element_to_check.Name in processed_or_queued_names:
+                        continue
+
+                    is_confirmed_hosted = False
+                    element_type = Draft.getType(element_to_check)
+
+                    if element_type == "Window": # This covers Arch Windows and Arch Doors
+                        if hasattr(element_to_check, "Hosts") and obj in element_to_check.Hosts:
+                            is_confirmed_hosted = True
+                    elif element_type == "Rebar":
+                        if hasattr(element_to_check, "Host") and obj == element_to_check.Host:
+                            is_confirmed_hosted = True
+
+                    if is_confirmed_hosted:
+                        children_to_add_to_queue_next.append(element_to_check)
+                        processed_or_queued_names.add(element_to_check.Name) # Mark as queued
+
+        # 3. Components from .Additions list (e.g., walls added to a main wall)
+        if include_components_from_additions and hasattr(obj, "Additions") and obj.Additions:
+            for addition_comp in obj.Additions:
+                actual_addition = addition_comp
+                if hasattr(addition_comp, "getLinkedObject"): # Resolve if Addition is an App::Link
+                    linked_add = addition_comp.getLinkedObject()
+                    if linked_add:
+                        actual_addition = linked_add
+
+                if actual_addition.Name not in processed_or_queued_names:
+                    children_to_add_to_queue_next.append(actual_addition)
+                    processed_or_queued_names.add(actual_addition.Name) # Mark as queued
+
+        if children_to_add_to_queue_next:
+            # Add newly-discovered children to the end of the queue. This function uses an index
+            # (idx) to iterate through the queue, and queue.extend() adds new items to the end. This
+            # results in a breadth-first-like traversal for objects discovered at the same "depth"
+            # from different parent branches. Children of the current 'obj' will be processed after
+            # 'obj's current siblings in the queue.
+            queue.extend(children_to_add_to_queue_next)
+
+    return final_contents_list
 
 def survey(callback=False):
     """survey(): starts survey mode, where you can click edges and faces to get their lengths or area.

--- a/src/Mod/BIM/Resources/ui/preferences-ifc-export.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-ifc-export.ui
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
     <number>9</number>
    </property>
    <item>
@@ -398,22 +407,46 @@ However, at FreeCAD, we believe having a building should not be mandatory, and t
        </widget>
       </item>
       <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_2">
+       <widget class="QGroupBox" name="groupBox_ExportFreeCADGroups">
         <property name="toolTip">
-         <string>In FreeCAD, it is possible to nest groups inside buildings or storeys. If this option is disabled, FreeCAD groups will be saved as IfcGroups and aggregated to the building structure. Aggregating non-building elements such as IfcGroups is however not recommended by the IFC standards. It is therefore also possible to export these groups as IfcElementAssemblies, which produces an IFC-compliant file. However, at FreeCAD, we believe nesting groups inside structures should be possible, and this option is there to have a chance to demonstrate our point of view.</string>
+         <string>If not checked, standard FreeCAD groups (App::DocumentObjectGroup) will not be exported as IfcGroup or IfcElementAssembly.\nTheir children will be re-parented to the container of the skipped group in the IFC structure.</string>
         </property>
-        <property name="text">
-         <string>Export nested groups as assemblies</string>
+        <property name="title">
+         <string>Export FreeCAD groups</string>
         </property>
-        <property name="checked">
+        <property name="checkable">
          <bool>true</bool>
         </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
         <property name="prefEntry" stdset="0">
-         <cstring>IfcGroupsAsAssemblies</cstring>
+         <cstring>IfcExportStdGroups</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Arch</cstring>
         </property>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="Gui::PrefCheckBox" name="checkBox_2">
+           <property name="toolTip">
+            <string>In FreeCAD, it is possible to nest groups inside buildings or storeys. If this option is disabled, FreeCAD groups will be saved as IfcGroups and aggregated to the building structure. Aggregating non-building elements such as IfcGroups is however not recommended by the IFC standards. It is therefore also possible to export these groups as IfcElementAssemblies, which produces an IFC-compliant file. However, at FreeCAD, we believe nesting groups inside structures should be possible, and this option is there to have a chance to demonstrate our point of view.</string>
+           </property>
+           <property name="text">
+            <string>Export nested groups as assemblies</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+           <property name="prefEntry" stdset="0">
+            <cstring>IfcGroupsAsAssemblies</cstring>
+           </property>
+           <property name="prefPath" stdset="0">
+            <cstring>Mod/Arch</cstring>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>

--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -53,7 +53,6 @@ import ArchIFCSchema
 
 from DraftGeomUtils import vec
 from draftutils import params
-from draftutils.groups import is_group
 from draftutils.messages import _msg, _err
 
 from importers import exportIFCHelper
@@ -134,117 +133,33 @@ def _prepare_export_list_skipping_std_groups(initial_export_list, preferences_di
     The net effect is that the children appear directly contained within the IFC representation of
     the skipped group's parent container.
     """
+    all_potential_objects = Arch.get_architectural_contents(
+        initial_export_list,
+        recursive=True,
+        discover_hosted_elements=True,
+        include_components_from_additions=True,
+        include_initial_objects_in_result=True
+    )
+
     final_objects_for_processing = []
-    # Queue for a depth-first-like traversal of the FreeCAD .Group hierarchy
-    queue = list(initial_export_list)
-    # Set to keep track of objects already added to the queue or processed to prevent duplicates and
-    # cycles
-    queued_or_processed_names = set()
 
-    while queue:
-        obj = queue.pop(0)
-
-        if obj.Name in queued_or_processed_names:
-            continue
-        queued_or_processed_names.add(obj.Name)
-
+    for obj in all_potential_objects:
         is_std_group_to_skip = False
         # Determine if the current object is a standard FreeCAD group that should be skipped
         if obj.isDerivedFrom("App::DocumentObjectGroup"):
             # Check its potential IFC type; only skip if it would become a generic IfcGroup
-            potential_ifc_type = getIfcTypeFromObj(obj) 
+            potential_ifc_type = getIfcTypeFromObj(obj)
             if potential_ifc_type == "IfcGroup":
                 is_std_group_to_skip = True
-        
-        current_obj_children_to_queue = []
 
-        if is_std_group_to_skip:
-            if preferences_dict['DEBUG']: 
-                print(f"DEBUG: IFC Exporter: Skipping StdGroup '{obj.Label}' ({obj.Name}) "
-                      "and processing its children.")
-            # If the group is skipped, process its direct children from the .Group property
-            if hasattr(obj, "Group") and obj.Group:
-                for child in obj.Group:
-                    if child.Name not in queued_or_processed_names:
-                        current_obj_children_to_queue.append(child)
-        else: # Object is NOT a standard group to be skipped
-            # Add the object itself to the list of objects to be exported
-            if obj not in final_objects_for_processing: 
+        if not is_std_group_to_skip:
+            if obj not in final_objects_for_processing: # Ensure uniqueness
                 final_objects_for_processing.append(obj)
-            
-            # If this non-skipped object is itself a group-like entity (e.g., ArchSite,
-            # ArchBuildingPart), add its direct .Group children to the queue for further processing.
-            if is_group(obj) and hasattr(obj, "Group") and obj.Group: 
-                for child in obj.Group:
-                    if child.Name not in queued_or_processed_names:
-                         current_obj_children_to_queue.append(child)
+        elif preferences_dict['DEBUG']:
+            print(f"DEBUG: IFC Exporter: StdGroup '{obj.Label}' ({obj.Name}) "
+                  "was identified by get_architectural_contents but is now being filtered out.")
 
-            # Discover and queue architecturally hosted elements (e.g., Windows in a Wall).
-            # This is needed if a Wall (child of a skipped group) hosts windows,
-            # ensuring those windows are also processed for export.
-            hosted_elements = _get_hosted_elements_for_queue(
-                obj, queued_or_processed_names, preferences_dict)
-            current_obj_children_to_queue.extend(hosted_elements)
-        
-        if current_obj_children_to_queue:
-            # Add all newly found children (hierarchical and hosted) to the front of the main queue.
-            # Reversing them first means children from .Group (or .InList) will be processed
-            # effectively in reverse of their original list order when popped from the queue.
-            queue = current_obj_children_to_queue[::-1] + queue
-    
     return final_objects_for_processing
-
-def _get_hosted_elements_for_queue(host_obj, queued_or_processed_names, preferences_dict):
-    """
-    Identifies elements architecturally hosted by host_obj (e.g., Windows in a Wall)
-    and returns a list of those elements that are not yet queued or processed.
-    This is used to ensure hosted elements are included in the export list when their
-    host is processed, especially if an intermediate group was skipped.
-    """
-    hosted_elements_to_queue = []
-    # Define common FreeCAD types that can act as hosts for architectural elements
-    host_types = ["Wall", "Structure", "CurtainWall", "Precast", "Panel", "Roof"]
-    if Draft.getType(host_obj) not in host_types:
-        return hosted_elements_to_queue # Not a known host type
-
-    # Iterate through objects that depend on the host_obj (found in its InList).
-    # Hosted elements like Windows often cause the host Wall's shape to depend on them (for
-    # openings), placing the Window in the Wall's InList.
-    # The .Hosts property of the Window then confirms the architectural hosting relationship.
-    for potential_hosted_element in host_obj.InList:
-        element_to_check = potential_hosted_element
-        # Resolve App::Link objects to get the actual element, as InList might contain the Link
-        if hasattr(potential_hosted_element, "getLinkedObject"):
-            linked = potential_hosted_element.getLinkedObject()
-            if linked: # Ensure the link is not broken and points to a valid object
-                element_to_check = linked
-        
-        if element_to_check.Name in queued_or_processed_names:
-            continue # Already queued or processed
-
-        # Determine the IFC type the element would be exported as
-        element_ifc_target_type = getIfcTypeFromObj(element_to_check)
-
-        is_confirmed_hosted = False
-        # Check for Window or Door types and verify the .Hosts property
-        if element_ifc_target_type in ["IfcWindow", "IfcDoor"]:
-            if hasattr(element_to_check, "Hosts") and host_obj in element_to_check.Hosts:
-                is_confirmed_hosted = True
-        # Check for ReinforcingBar type and verify the .Host property
-        elif element_ifc_target_type == "IfcReinforcingBar": 
-            if hasattr(element_to_check, "Host") and host_obj == element_to_check.Host:
-                is_confirmed_hosted = True
-        # TODO: Add checks for other hosted types if necessary (e.g., IfcSanitaryTerminal,
-        # IfcDistributionElement) based on how their hosting relationship is defined in FreeCAD
-        # (e.g., specific properties).
-
-        if is_confirmed_hosted:
-            hosted_elements_to_queue.append(element_to_check)
-            if preferences_dict['DEBUG']:
-                print(f"DEBUG _get_hosted_elements: Found hosted {element_to_check.Label} "
-                      f"(IFC Type: {element_ifc_target_type}) in {host_obj.Label}")
-            
-    return hosted_elements_to_queue
 
 def getPreferences():
     """Retrieve the IFC preferences available in import and export."""


### PR DESCRIPTION
## Summary

This PR adds a new feature to control whether a BIM model's standard groups are present or skipped when exporting that model to the IFC format.

The feature is controlled by a new IFC exporter user preference: `Export FreeCAD groups`. **Exporting groups is disabled by default**, meaning that groups (but not their children) will effectively be skipped from the resulting IFC exported file:

![Image](https://github.com/user-attachments/assets/fa7263b6-3276-49b1-b1cf-b9de185ce796)

> [!NOTE]  
> - This PR changes the IFC exporter's current default behaviour, whereby now groups will NOT be present in the exported IFC file.
> - The <kbd>Export nested groups as assemblies</kbd> preference is only enabled (and thus taken into account) if groups ARE present in the exported IFC file.

## Issues
Fixes: #21476
Works around: https://github.com/FreeCAD/FreeCAD/issues/18107

## Testing

- The test file from https://github.com/FreeCAD/FreeCAD/issues/18107 now generates correct IFC output, including correct substractions
- I've tested this also with a file that has walls added to another wall and substractions on top. That generates the expected IFC output as well
- Regardless, it would be good to test this PR with more models
- I'd like to write a unit test for this, but there's the issue that ifcopenshell is not installed on CI

## Design decisions

### Default setting: do not export groups

The decision to not export groups by default is grounded on the fact that it provides a sensible workaround for https://github.com/FreeCAD/FreeCAD/issues/18107.

In addition, [there doesn't seem to be consensus on the OS Arch community](https://community.osarch.org/discussion/comment/20488/#Comment_20488) on the way the translation of generic groups created by modeling software into IFC entities should work. This can potentially lead to non-IFC-compliant files, or different entities interpretation from BIM modelers or viewers. By removing groups entirely from the export, this no longer becomes an issue. 

Since defaults can be easily reversed, this decision can be revised at a later date if necessary (e.g. if/when there is a fiy for #18107)

### Workaround or substractions/additions fix

The main question before creating this PR was whether it was worth the effort adding the new feature if a fix for #18107 could be provided instead.

I first spent some time researching and [attempting to provide a fix](https://github.com/FreeCAD/FreeCAD/pull/21441). However, the domain knowledge packed into the IFC exporter's `export()` function, its size and monolithic nature, and all the edge cases to consider provided too much of a challenge for my skills and time. A refactor was considered, but that would have been a considerable effort and risk. Also likely beyond my skill set and FreeCAD BIM/IFC domain knowledge.

Based on this, the decision was made to provide the workaround as described. The main idea was to leave the exporter's processing loop unchanged, and do the group removal and children reparenting in a self-contained function that effectively filters and rearranges those objects 

That self-contained function (plus another function helper) quickly became more complex than I anticipated, given the multiple ways of establishing ancestry or dependency relationships between objects in FreeCAD BIM. I do not claim I've covered all possible cases, but I feel this provides a more than acceptable benefit to users vs. not being able to produce valid IFC models.

The helper functions have been profusely documented with comments to ease review and maintenance.  

## Before and After Images

See groupbox at the bottom of the page.

Before:
![image](https://github.com/user-attachments/assets/2dae4124-87bd-42d6-b801-abbd96f0f1a9)

After:
![image-after-1](https://github.com/user-attachments/assets/081223a2-947b-497b-a842-244410a5f9e8)

## Additional info

1. To include the modified preferences `.ui` file in the build, I had to manually run `touch src/Mod/BIM/Resources/Arch.qrc`. It was quite disconcerting, as generally CMake takes care of this.
