### PR TITLE
Sketcher: Implement hints for Polyline (aka LineSet)

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -793,6 +793,9 @@ private:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 right-click to finish"),
                               {UserInput::MouseRight}));
+
+                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 change mode"),
+                                          {UserInput::KeyM}));
                 break;
             default:
                 break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -31,6 +31,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -201,6 +202,8 @@ public:
     {
         using std::numbers::pi;
 
+        updateHints();
+
         suppressTransition = false;
         if (Mode == STATUS_SEEK_First) {
             setPositionText(onSketchPos);
@@ -341,6 +344,8 @@ public:
 
     bool pressButton(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         if (Mode == STATUS_SEEK_First) {
 
             EditCurve[0] = onSketchPos;  // this may be overwritten if previousCurve is found
@@ -452,6 +457,8 @@ public:
 
     bool releaseButton(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         if (Mode == STATUS_Do || Mode == STATUS_Close) {
             bool addedGeometry = true;
             if (SegmentMode == SEGMENT_MODE_Line) {
@@ -765,6 +772,32 @@ private:
     QString getCrosshairCursorSVGName() const override
     {
         return QStringLiteral("Sketcher_Pointer_Create_Lineset");
+    }
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        std::list<InputHint> hints;
+
+        switch (Mode) {
+            case STATUS_SEEK_First:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
+                              {Gui::InputHint::UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Second:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
+                              {Gui::InputHint::UserInput::MouseLeft}));
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 right-click to finish"),
+                              {Gui::InputHint::UserInput::MouseRight}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
     }
 
 protected:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -777,21 +777,22 @@ private:
     void updateHints() const
     {
         using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
         std::list<InputHint> hints;
 
         switch (Mode) {
             case STATUS_SEEK_First:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
-                              {Gui::InputHint::UserInput::MouseLeft}));
+                              {UserInput::MouseLeft}));
                 break;
             case STATUS_SEEK_Second:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
-                              {Gui::InputHint::UserInput::MouseLeft}));
+                              {UserInput::MouseLeft}));
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 right-click to finish"),
-                              {Gui::InputHint::UserInput::MouseRight}));
+                              {UserInput::MouseRight}));
                 break;
             default:
                 break;


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR adds structured input hints to the Sketcher Polyline (`LineSet`) tool, improving step-by-step guidance during polyline creation. These hints help users understand the current tool state and available actions without needing external documentation.

This update follows the pattern established in the `Point` and `Arc` tool hint integrations, and was discussed on Discord as part of the ongoing Sketcher UX refinement initiative.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A — this is part of an ongoing structured hints rollout tracked via Discord and community discussions.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

**Before:**  
The Polyline tool did not show any input hints during use, leaving users with no contextual guidance on what to do next.

**After:**  
Hints now appear in the status area as the user works:
- When starting the tool:
![image](https://github.com/user-attachments/assets/1df956bc-b48d-42e7-9494-652d333d5e36)

- As additional segments are created:
![image](https://github.com/user-attachments/assets/a0e1fe9e-978b-404a-aa70-8d34bbb5b8da)

These dynamic hints improve usability for both new and experienced users.

<!-- Optional: include a screenshot or screencast if desired -->


