### PR TITLE
Sketcher: Implement hints for Line

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -28,6 +28,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Part/App/Geometry2d.h>
 
@@ -79,6 +80,8 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -305,6 +308,50 @@ private:
     Base::Vector2d centerPoint, firstPoint, secondPoint;
     double radius;
     bool isDiameter;
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+
+        std::list<InputHint> hints;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                if (constructionMethod() == ConstructionMethod::Center) {
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick center point"),
+                                  {UserInput::MouseLeft}));
+                }
+                else {
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick first rim point"),
+                        {UserInput::MouseLeft}));
+                }
+                break;
+            case SelectMode::SeekSecond:
+                if (constructionMethod() == ConstructionMethod::Center) {
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick rim point"),
+                                  {UserInput::MouseLeft}));
+                }
+                else {
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick second rim point"),
+                        {UserInput::MouseLeft}));
+                }
+                break;
+            case SelectMode::SeekThird:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick third rim point"),
+                              {UserInput::MouseLeft}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
 };
 
 template<>

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -28,6 +28,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -88,6 +89,8 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -250,6 +253,31 @@ private:
                                    toVector3d(endPoint),
                                    isConstructionMode());
         }
+    }
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+
+        std::list<InputHint> hints;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case SelectMode::SeekSecond:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick second point"),
+                              {UserInput::MouseLeft}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
     }
 };
 


### PR DESCRIPTION
Adds structured input hints for the Sketcher **Line** tool, continuing the rollout of contextual guidance across Sketcher tools.

### Behavior:
Hints update dynamically based on current selection state:
- **SeekFirst** → `"Pick first point"` (left-click):
![image](https://github.com/user-attachments/assets/979e694d-1b8e-4183-8fa9-2489725cff6a)

- **SeekSecond** → `"Pick second point"` (left-click)
![image](https://github.com/user-attachments/assets/f4045798-614b-4346-9cc0-7f03be7afaa8)


### Notes:
- Follows the same structured approach used in previous tools (e.g. Point, Arc, Polyline).
- Message phrasing and input mapping is consistent across the hint system.
- Uses `Gui::InputHint` to display actionable instructions during tool use, improving clarity for both new and experienced users.

Part of the ongoing effort to provide full input hint coverage across Sketcher.
