### PR TITLE
Sketcher: Implement hints for Circle

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -28,6 +28,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Part/App/Geometry2d.h>
 
@@ -79,6 +80,8 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -305,6 +308,53 @@ private:
     Base::Vector2d centerPoint, firstPoint, secondPoint;
     double radius;
     bool isDiameter;
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        if (constructionMethod() == ConstructionMethod::Center) {
+            switch (state()) {
+                case SelectMode::SeekFirst:
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick circle center"),
+                                  {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekSecond:
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick rim point"),
+                                  {UserInput::MouseLeft}));
+                    break;
+                default:
+                    break;
+            }
+        }
+        else if (constructionMethod() == ConstructionMethod::ThreeRim) {
+            switch (state()) {
+                case SelectMode::SeekFirst:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick first rim point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekSecond:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick second rim point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekThird:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick third rim point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
 };
 
 template<>


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR updates the Sketcher **Circle** tool to use the new structured input hint system, following the pattern established by @kadet and consistent with recent tools like Arc, Line, and Polygon.

It covers both supported construction methods: **Center + Rim** and **Three Rim Points**. This improves clarity, usability, and consistency with the broader hint modernization effort discussed on Discord.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A — part of the ongoing structured hints rollout tracked via Discord.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

**Before:**
- No Circle tool hints

**After:**
Hints are now context-sensitive and update based on the selected construction method:

---

**Construction Method: Center + Rim**
- **SeekFirst** → `"Pick circle center"` (left-click)
![image](https://github.com/user-attachments/assets/6b672e82-bf4b-46a5-b85c-08e482a9bc76)

- **SeekSecond** → `"Pick rim point"` (left-click)
![image](https://github.com/user-attachments/assets/9fef0e71-0884-4f7a-8e3f-9fbfe467ae67)

**Construction Method: Three Rim Points**
- **SeekFirst** → `"Pick first rim point"` (left-click)
![image](https://github.com/user-attachments/assets/44d3c8db-d7be-4695-94c5-879c9225b473)

- **SeekSecond** → `"Pick second rim point"` (left-click)
![image](https://github.com/user-attachments/assets/af209d0c-ac6e-4c0d-a11c-8f7e80f44653)

- **SeekThird** → `"Pick third rim point"` (left-click)
![image](https://github.com/user-attachments/assets/fde9bdbf-5380-4579-baa6-74acc683896e)

---

This brings Circle in line with other modernized tools and improves user guidance during sketch creation.

