### PR TITLE
Sketcher: Implement hints for Rectangle

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -30,6 +30,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -112,6 +113,8 @@ private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
         using std::numbers::pi;
+
+        updateHints();
 
         switch (state()) {
             case SelectMode::SeekFirst: {
@@ -1573,6 +1576,143 @@ private:
 
         thickness = obliqueThickness * sin(angle412);
     }
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (constructionMethod()) {
+            case ConstructionMethod::Diagonal:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick opposite corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher",
+                                                        "%1 set corner radius or frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    case SelectMode::SeekFifth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case ConstructionMethod::CenterAndCorner:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick center"),
+                                      {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick corner"),
+                                      {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher",
+                                                        "%1 set corner radius or frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case ConstructionMethod::ThreePoints:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick second corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick third corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher",
+                                                        "%1 set corner radius or frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    case SelectMode::SeekFifth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case ConstructionMethod::CenterAnd3Points:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick center"),
+                                      {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick second corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher",
+                                                        "%1 set corner radius or frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    case SelectMode::SeekFifth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
 };
 
 template<>
@@ -2069,246 +2209,6 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
 
                 onSketchPos = handler->corner1 - dir * tr;
             }
-        } break;
-        default:
-            break;
-    }
-}
-
-template<>
-void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
-{
-
-    // If checkboxes need synchronisation (they were changed by the DSH, e.g. by using 'M' to switch
-    // construction method), synchronise them and return.
-    if (syncCheckboxToHandler(WCheckbox::FirstBox, handler->roundCorners)) {
-        return;
-    }
-
-    if (syncCheckboxToHandler(WCheckbox::SecondBox, handler->makeFrame)) {
-        return;
-    }
-
-    switch (handler->state()) {
-        case SelectMode::SeekFirst: {
-            if (!onViewParameters[OnViewParameter::First]->isSet) {
-                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
-            }
-
-            if (!onViewParameters[OnViewParameter::Second]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
-            }
-
-            bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
-            onViewParameters[OnViewParameter::First]->setLabelAutoDistanceReverse(!sameSign);
-            onViewParameters[OnViewParameter::Second]->setLabelAutoDistanceReverse(sameSign);
-            onViewParameters[OnViewParameter::First]->setPoints(Base::Vector3d(),
-                                                                toVector3d(onSketchPos));
-            onViewParameters[OnViewParameter::Second]->setPoints(Base::Vector3d(),
-                                                                 toVector3d(onSketchPos));
-        } break;
-        case SelectMode::SeekSecond: {
-            if (handler->constructionMethod() == ConstructionMethod::Diagonal
-                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
-                if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    double length = handler->cornersReversed ? handler->width : handler->length;
-                    setOnViewParameterValue(OnViewParameter::Third, length);
-                }
-
-                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    double width = handler->cornersReversed ? handler->length : handler->width;
-                    setOnViewParameterValue(OnViewParameter::Fourth, width);
-                }
-
-                Base::Vector3d start = toVector3d(handler->corner1);
-                Base::Vector3d vec = toVector3d(onSketchPos) - start;
-                bool sameSign = vec.x * vec.y > 0.;
-
-                onViewParameters[OnViewParameter::Third]->setLabelAutoDistanceReverse(sameSign);
-                onViewParameters[OnViewParameter::Fourth]->setLabelAutoDistanceReverse(!sameSign);
-
-                onViewParameters[OnViewParameter::Third]->setPoints(
-                    start,
-                    toVector3d(handler->cornersReversed ? handler->corner4 : handler->corner2));
-                onViewParameters[OnViewParameter::Fourth]->setPoints(
-                    start,
-                    toVector3d(handler->cornersReversed ? handler->corner2 : handler->corner4));
-            }
-            else if (handler->constructionMethod() == ConstructionMethod::ThreePoints) {
-                if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Third, handler->length);
-                }
-
-                onViewParameters[OnViewParameter::Third]->setPoints(toVector3d(handler->corner4),
-                                                                    toVector3d(handler->corner3));
-
-                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fourth,
-                                            Base::toDegrees(handler->angle),
-                                            Base::Unit::Angle);
-                }
-
-                onViewParameters[OnViewParameter::Fourth]->setPoints(toVector3d(handler->corner1),
-                                                                     Base::Vector3d());
-                onViewParameters[OnViewParameter::Fourth]->setLabelRange(
-                    (handler->corner2 - handler->corner1).Angle());
-            }
-            else {
-                if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Third, onSketchPos.x);
-                }
-
-                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fourth, onSketchPos.y);
-                }
-
-                bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
-                onViewParameters[OnViewParameter::Third]->setLabelAutoDistanceReverse(!sameSign);
-                onViewParameters[OnViewParameter::Fourth]->setLabelAutoDistanceReverse(sameSign);
-                onViewParameters[OnViewParameter::Third]->setPoints(Base::Vector3d(),
-                                                                    toVector3d(onSketchPos));
-                onViewParameters[OnViewParameter::Fourth]->setPoints(Base::Vector3d(),
-                                                                     toVector3d(onSketchPos));
-            }
-        } break;
-        case SelectMode::SeekThird: {
-            if (handler->constructionMethod() == ConstructionMethod::Diagonal
-                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
-                if (handler->roundCorners) {
-                    if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                        setOnViewParameterValue(OnViewParameter::Fifth, handler->radius);
-                    }
-
-                    Base::Vector3d center = handler->center3;
-                    Base::Vector3d end = toVector3d(handler->corner3);
-
-                    if (handler->radius != 0.0) {
-                        Base::Vector3d vec = (end - center).Normalize();
-                        end = center + vec * handler->radius;
-                    }
-
-                    onViewParameters[OnViewParameter::Fifth]->setPoints(center, end);
-                }
-                else {
-                    if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                        setOnViewParameterValue(OnViewParameter::Sixth, handler->thickness);
-                    }
-
-                    Base::Vector3d start = toVector3d(handler->corner3);
-                    Base::Vector3d end =
-                        Base::Vector3d(handler->corner3.x, handler->frameCorner3.y, 0.0);
-                    onViewParameters[OnViewParameter::Sixth]->setPoints(start, end);
-                }
-            }
-            else if (handler->constructionMethod() == ConstructionMethod::ThreePoints) {
-                onViewParameters[OnViewParameter::Third]->setPoints(toVector3d(handler->corner4),
-                                                                    toVector3d(handler->corner3));
-
-                bool reversed = handler->cornersReversed;
-
-                if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fifth,
-                                            reversed ? handler->length : handler->width);
-                }
-
-                Base::Vector3d start = toVector3d(handler->corner1);
-                onViewParameters[OnViewParameter::Fifth]->setLabelAutoDistanceReverse(reversed);
-                onViewParameters[OnViewParameter::Fifth]->setPoints(
-                    start,
-                    toVector3d(reversed ? handler->corner2 : handler->corner4));
-
-
-                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                    double val = Base::toDegrees(handler->angle123);
-                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
-                }
-
-                onViewParameters[OnViewParameter::Sixth]->setPoints(
-                    toVector3d(reversed ? handler->corner4 : handler->corner2),
-                    Base::Vector3d());
-                double startAngle = reversed ? (handler->corner1 - handler->corner4).Angle()
-                                             : (handler->corner3 - handler->corner2).Angle();
-                onViewParameters[OnViewParameter::Sixth]->setLabelStartAngle(startAngle);
-                onViewParameters[OnViewParameter::Sixth]->setLabelRange(handler->angle123);
-            }
-            else {
-                bool reversed = handler->cornersReversed;
-
-                if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fifth,
-                                            reversed ? handler->width : handler->length);
-                }
-
-                Base::Vector3d start = toVector3d(handler->corner1);
-                onViewParameters[OnViewParameter::Fifth]->setLabelAutoDistanceReverse(true);
-                onViewParameters[OnViewParameter::Fifth]->setPoints(
-                    start,
-                    toVector3d(reversed ? handler->corner4 : handler->corner2));
-
-
-                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                    double val = Base::toDegrees(handler->angle412);
-                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
-                }
-
-                onViewParameters[OnViewParameter::Sixth]->setPoints(toVector3d(handler->corner1),
-                                                                    Base::Vector3d());
-                double startAngle = (handler->corner2 - handler->corner1).Angle();
-                onViewParameters[OnViewParameter::Sixth]->setLabelStartAngle(startAngle);
-                onViewParameters[OnViewParameter::Sixth]->setLabelRange(handler->angle412);
-            }
-
-        } break;
-        case SelectMode::SeekFourth: {
-            if (handler->constructionMethod() == ConstructionMethod::Diagonal
-                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
-                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Sixth, handler->thickness);
-                }
-
-                Base::Vector3d start = toVector3d(handler->corner3);
-                Base::Vector3d end =
-                    Base::Vector3d(handler->corner3.x, handler->frameCorner3.y, 0.0);
-                onViewParameters[OnViewParameter::Sixth]->setPoints(start, end);
-            }
-            else {
-                if (handler->roundCorners) {
-                    if (!onViewParameters[OnViewParameter::Seventh]->isSet) {
-                        setOnViewParameterValue(OnViewParameter::Seventh, handler->radius);
-                    }
-
-                    Base::Vector3d center = handler->center3;
-                    Base::Vector3d end = toVector3d(handler->corner3);
-
-                    if (handler->radius != 0.0) {
-                        Base::Vector3d vec = (end - center).Normalize();
-                        end = center + vec * handler->radius;
-                    }
-
-                    onViewParameters[OnViewParameter::Seventh]->setPoints(center, end);
-                }
-                else {
-                    if (!onViewParameters[OnViewParameter::Eighth]->isSet) {
-                        setOnViewParameterValue(OnViewParameter::Eighth, handler->thickness);
-                    }
-
-                    Base::Vector3d start = toVector3d(handler->corner3);
-                    Base::Vector3d vec =
-                        toVector3d((handler->corner3 - handler->corner2).Normalize());
-                    Base::Vector3d end = start + handler->thickness * vec;
-                    onViewParameters[OnViewParameter::Eighth]->setPoints(start, end);
-                }
-            }
-        } break;
-        case SelectMode::SeekFifth: {
-            if (!onViewParameters[OnViewParameter::Eighth]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Eighth, handler->thickness);
-            }
-
-            Base::Vector3d start = toVector3d(handler->corner3);
-            Base::Vector3d vec = toVector3d((handler->corner3 - handler->corner2).Normalize());
-            Base::Vector3d end = start + handler->thickness * vec;
-            onViewParameters[OnViewParameter::Eighth]->setPoints(start, end);
         } break;
         default:
             break;


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR refactors the Sketcher **Rectangle** tool to use the new structured input hints system (`updateHints()`), replacing the legacy hint logic.

The implementation provides context-sensitive hints for all supported rectangle construction methods. This ensures consistency with recent updates to the Arc, Line, Circle, and Polygon tools.

Note: All rectangle construction modes are supported and can be cycled after tool activation using `M`, even if they are not all directly exposed via the toolbar UI.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A — part of the structured input hint migration tracked via Discord.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

**Before:**
- Static hints via legacy mechanisms
- No distinction between rectangle construction modes
- Hints were generic and not aligned with newer tools

**After:**
Hints now reflect the selected rectangle construction method:

- **Corner-Corner:**  
  - `"Pick first corner"` (left-click)  
 ![image](https://github.com/user-attachments/assets/678090ed-7d36-45b8-99f0-72e29807b207)
  - `"Pick opposite corner"` (left-click)
![image](https://github.com/user-attachments/assets/9a399ad3-5485-4efb-a4b9-cb37bfd87577)

- **Center-Corner:**  
  - `"Pick center point"` (left-click)   
![image](https://github.com/user-attachments/assets/51ab9dac-9b2a-4915-b74b-e2b1d80ef88a)
  - `"Pick corner point"` (left-click)
![image](https://github.com/user-attachments/assets/e0deba8b-cc6f-4a9a-aee7-ab3188a78a88)

- **3-Point Rectangle / Parallelogram:**  
  - `"Pick first point"` (left-click)  
![image](https://github.com/user-attachments/assets/20618564-3f66-494a-850c-d9509f81b504)
  - `"Pick second point"` (left-click)  
![image](https://github.com/user-attachments/assets/d7e10d65-0b81-45e6-bc18-04355bf15e6e)
  - `"Pick third point"` (left-click)
![image](https://github.com/user-attachments/assets/c3f15322-24ba-47aa-bf1a-6f8fb2759ce9)

- **Rounded / Framed Rectangle:**
  - Same 2-point flow as above (first two steps match base mode)
  - Then: `"Set corner radius or frame thickness"` (mouse move or scroll) 
![image](https://github.com/user-attachments/assets/e65de211-1073-4aeb-834b-9dfbd4019c13)

The hints are delivered using `Gui::InputHint`, with consistent formatting and actionable input guidance.


