### PR TITLE
Sketcher: Implement hints for Slot

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
@@ -31,6 +31,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -82,6 +83,8 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -336,6 +339,35 @@ private:
         else if (fmod(fabs(angle + pi / 2), pi) < Precision::Confusion()) {
             isVertical = true;
         }
+    }
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick slot start point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case SelectMode::SeekSecond:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick slot end point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case SelectMode::SeekThird:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 set slot radius"),
+                              {UserInput::MouseMove}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
     }
 
 private:


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR refactors the Sketcher **Slot** tool to use the structured input hints system (`updateHints()`), replacing the legacy approach.

The implementation adds context-sensitive hints for all supported slot construction modes and input steps, ensuring consistent, step-by-step guidance. This brings the Slot tool in line with the rest of the updated Sketcher tools (Arc, Circle, Polygon, Rectangle, etc.).

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A — part of the ongoing Sketcher input hint modernization effort tracked via Discord and community discussion.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

**Before:**
- Slot tool used static hinting logic
- Input guidance was minimal and not tied to construction mode or step

**After:**
Hints are now shown dynamically based on the slot type and step:

- `"pick slot start point"` (left-click)
![image](https://github.com/user-attachments/assets/aac1222b-d8ee-46b7-934d-d08a9af3129d)

- `"pick slot end point"` (left-click)
![image](https://github.com/user-attachments/assets/70751d0f-f1c4-4dfb-9aea-9bdea32ca1aa)

- `"set slot radius"` or similar (mouse move or confirm)
![image](https://github.com/user-attachments/assets/c918a36e-9f8e-4308-a805-5f1061998c8c)

Each construction mode is supported, and the hints are delivered using `Gui::InputHint` for consistent formatting and input mapping.

