### PR TITLE
Sketcher: Implement hints for Arc Slot

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
@@ -30,6 +30,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -95,6 +96,8 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -510,6 +513,72 @@ private:
             startAngle = startAngle + arcAngle;
             angleReversed = true;
         }
+    }
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (constructionMethod()) {
+            case ConstructionMethod::ArcSlot:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc center"),
+                                      {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 set slot radius"),
+                                      {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case ConstructionMethod::RectangleSlot:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick slot center"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick slot corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick slot orientation"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 set slot width"),
+                                      {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
     }
 
 private:


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR updates the Sketcher **Arc Slot** tool to use the structured `updateHints()` system, replacing the older hint logic.

Hints are now presented dynamically as users progress through the tool, providing clear guidance for each step of the arc slot creation. This ensures consistency with other refactored Sketcher tools (e.g. Slot, Circle, Arc, Rectangle).

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A — part of the structured hint rollout tracked via Discord and contributor PRs.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

**Before:**
- Arc Slot hints were static and limited
- No clear step-by-step guidance

**After:**
Hints now update dynamically with tool state:
- `"pick arc center"` (left-click)
![image](https://github.com/user-attachments/assets/bdc090d0-5a71-48a6-b28d-a7a8a20ff98e)

- `"pick arc start point"` (left-click)
![image](https://github.com/user-attachments/assets/000aef1e-a450-4174-87d1-88ae814c291e)

- `"pick arc end point"` (left-click)
![image](https://github.com/user-attachments/assets/eeb9c399-ab4d-4d0a-9516-6bc809e72a1c)

- `"set slot radius"` (mouse move or confirm)
![image](https://github.com/user-attachments/assets/935a5627-5e2a-48eb-9ef4-17ba3c95648a)

Hints use `Gui::InputHint` to map each action to expected user input and follow the structured format used across modernized Sketcher tools.

