### PR TITLE
Sketcher: Implement hints for B-Spline

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -115,7 +115,6 @@ private:
                     InputHint(QCoreApplication::translate("Sketcher", "%1 finish B-spline"),
                               {UserInput::MouseRight}));
                 break;
-            // Add more cases as needed for your state machine
             default:
                 break;
         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -29,7 +29,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
-
+#include <Gui/InputHint.h>
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchDefaultWidgetController.h"
@@ -95,9 +95,37 @@ public:
     }
 
 private:
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case SelectMode::SeekSecond:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
+                              {UserInput::MouseLeft}));
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 finish B-spline"),
+                              {UserInput::MouseRight}));
+                break;
+            // Add more cases as needed for your state machine
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
         prevCursorPosition = onSketchPos;
+        updateHints();
 
         switch (state()) {
             case SelectMode::SeekFirst: {


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR updates the Sketcher **B-spline** tool to use the structured `updateHints()` system. It replaces the legacy hint behavior with dynamic, input-driven guidance that’s consistent with the other modernized Sketcher tools.

This update covers **all four B-spline construction modes**:
- B-spline
- Periodic B-spline
- B-spline by knots
- Periodic B-spline by knots

Each mode now provides contextual hints for point placement and tool completion.
The updated hints guide the user through point placement and clearly indicate how to finish the spline once the desired shape is drawn.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A — final part of the structured hint rollout tracked via Discord and contributor PRs.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

**Before:**
- No dynamic hinting
- No guidance on how to complete a B-spline once point placement begins

**After:**
Hints now display as the user draws the spline:
- `"pick first point"` (left-click)
![image](https://github.com/user-attachments/assets/12dc60cf-f403-485e-aca7-45d6a47e6bc9)

- `"finish B-spline"` (right-click)
![image](https://github.com/user-attachments/assets/74d5c393-0ae3-47cf-89b9-3dfbbf04ffe9)

This closes out the structured input hint integration for core Sketcher tools. The B-spline tool now provides consistent, discoverable guidance aligned with FreeCAD’s evolving UX standards.

