### PR TITLE
Sketcher: Implement hints for Parabola

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -29,6 +29,7 @@
 
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -68,6 +69,8 @@ public:
 
     void mouseMove(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         if (Mode == STATUS_SEEK_First) {
             setPositionText(onSketchPos);
             seekAndRenderAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.f, 0.f));
@@ -328,9 +331,43 @@ protected:
     Base::Vector2d focusPoint, axisPoint, startingPoint, endPoint;
     double startAngle, endAngle, arcAngle, arcAngle_t;
     std::vector<AutoConstraint> sugConstr1, sugConstr2, sugConstr3, sugConstr4;
+
+private:
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (Mode) {
+            case STATUS_SEEK_First:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick focus point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Second:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick axis point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Third:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick starting point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Fourth:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick end point"),
+                              {UserInput::MouseLeft}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
 };
 
 }  // namespace SketcherGui
-
 
 #endif  // SKETCHERGUI_DrawSketchHandlerArcOfParabola_H


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR adds structured input hints to the Sketcher **Parabola** tool using the `updateHints()` system, replacing static hint logic with contextual, step-based guidance.

Hints now reflect the full interaction sequence: from defining the parabola's focus and axis, through to start and end points. This improves discoverability and aligns the Parabola tool with the broader structured hint system used across Arc, Circle, B-spline, etc.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A — part of the structured hint rollout tracked via Discord and community review.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

**Before:**
- Parabola tool had static or no hint feedback
- Multi-step flow lacked guidance

**After:**
Hints now guide the user through each input step:

- `"Pick focus point"` (left-click)
![image](https://github.com/user-attachments/assets/32ac5904-acda-4990-9e32-4651da126307)

- `"Pick axis point"` (left-click)
![image](https://github.com/user-attachments/assets/a4755453-f0fc-466a-b472-30507c3a56fe)

- `"Pick starting point"` (left-click)
![image](https://github.com/user-attachments/assets/dee44eec-3a4c-4720-a129-97d9e975e315)

- `"Pick end point"` (left-click)
![image](https://github.com/user-attachments/assets/ffbe14a4-ff51-4549-b565-7e938b13737c)

All hints use `Gui::InputHint` for consistent formatting and input mapping across the Sketcher UI.

