### PR TITLE
Sketcher: Implement hints for Ellipse

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -26,6 +26,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -69,6 +70,8 @@ public:
     void mouseMove(Base::Vector2d onSketchPos) override
     {
         using std::numbers::pi;
+
+        updateHints();
 
         if (Mode == STATUS_SEEK_First) {
             setPositionText(onSketchPos);
@@ -218,6 +221,9 @@ public:
             setAngleSnapping(false);
             Mode = STATUS_Close;
         }
+
+        updateHints();
+
         return true;
     }
 
@@ -397,6 +403,41 @@ protected:
     Base::Vector2d centerPoint, axisPoint, startingPoint, endPoint;
     double rx, ry, startAngle, endAngle, arcAngle, arcAngle_t;
     std::vector<AutoConstraint> sugConstr1, sugConstr2, sugConstr3, sugConstr4;
+
+private:
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (Mode) {
+            case STATUS_SEEK_First:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick ellipse center"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Second:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick axis point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Third:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Fourth:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
+                              {UserInput::MouseLeft}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
 };
 
 }  // namespace SketcherGui


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR refactors the Sketcher **Arc of Ellipse** tool to use the new structured `updateHints()` system, replacing older static hints with dynamic, context-sensitive guidance.

The update covers all four interaction steps of the arc of ellipse creation workflow and ensures consistent formatting and input mapping with other Sketcher tools (e.g., Circle, Arc, Parabola).

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A — part of the structured hint rollout tracked via Discord and contributor PRs.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

**Before:**
- Arc of Ellipse tool had static or unclear hint messages
- Multi-step process lacked real-time guidance

**After:**
Hints now guide the user step-by-step:

- `"pick ellipse center"` (left-click)
![image](https://github.com/user-attachments/assets/67a83ee0-5c67-442d-a068-617eeb1f43db)

- `"Pick axis point"` (left-click)
![image](https://github.com/user-attachments/assets/4264e17a-c7e1-4ae3-b80c-8cc00e5174c0)

- `"Pick arc start point"` (left-click)
![image](https://github.com/user-attachments/assets/199be6fe-eadd-4f7c-990f-a9b48098df7e)

- `"Pick arc end point"` (left-click)
![image](https://github.com/user-attachments/assets/794dc813-61d5-47bd-b736-8b5e1dc5fb5f)

Hints are implemented via `Gui::InputHint` for consistent UX across all Sketcher tools.
