### PR TITLE
Sketcher: Implement hints for Hyperbola tool

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -28,6 +28,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -65,6 +66,8 @@ public:
 
     void mouseMove(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         if (Mode == STATUS_SEEK_First) {
             setPositionText(onSketchPos);
             seekAndRenderAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.f, 0.f));
@@ -210,6 +213,8 @@ public:
 
             Mode = STATUS_Close;
         }
+
+        updateHints();
         return true;
     }
 
@@ -407,8 +412,42 @@ protected:
     Base::Vector2d centerPoint, axisPoint, startingPoint, endPoint;
     double arcAngle, arcAngle_t;
     std::vector<AutoConstraint> sugConstr1, sugConstr2, sugConstr3, sugConstr4;
-};
 
+private:
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (Mode) {
+            case STATUS_SEEK_First:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick center point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Second:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick axis point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Third:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Fourth:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
+                              {UserInput::MouseLeft}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
+};
 
 }  // namespace SketcherGui
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR adds structured input hints to the Sketcher **Arc of Hyperbola** tool using the `updateHints()` system. It provides dynamic, context-aware guidance throughout the arc creation sequence, bringing this tool in line with the rest of the updated Sketcher toolset.

Note: This update adds hints to the existing tool logic only. It does **not** refactor the tool to use the controller/state machine pattern adopted by other recently updated tools.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A — final addition in the structured input hint rollout tracked via Discord.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

**Before:**
- Arc of Hyperbola tool had no dynamic input hints
- The multi-step workflow lacked user guidance

**After:**
Hints now guide the user step-by-step:

- `"pick center point"` (left-click)
![image](https://github.com/user-attachments/assets/c0a8e4de-e148-4819-a2ab-6e636c0338ce)

- `"pick axis point"` (left-click)
![image](https://github.com/user-attachments/assets/853f2b81-ec8c-4626-a6c6-e6910c93f0c9)

- `"pick arc start point"` (left-click)
![image](https://github.com/user-attachments/assets/7c7424b8-d204-47c9-99e3-126e677639a6)

- `"pick arc end point"` (left-click)
![image](https://github.com/user-attachments/assets/84bff538-5820-4729-975c-af5b08180da2)

This brings hint support to the last remaining conic tool and finalizes the input hint effort across Sketcher.
