### PR TITLE
Sketcher:  Support symmetry constraint for selection order {Origin, Point, Point}

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -9376,7 +9376,9 @@ CmdSketcherConstrainSymmetric::CmdSketcherConstrainSymmetric()
                            {SelVertex, SelVertex, SelEdgeOrAxis},
                            {SelVertex, SelVertexOrRoot, SelVertex},
                            {SelVertex, SelVertex, SelVertexOrRoot},
-                           {SelVertexOrRoot, SelVertex, SelVertex}};
+                           {SelVertexOrRoot, SelVertex, SelVertex},
+                           {SelRoot, SelVertex, SelVertex}
+                        };
 }
 
 void CmdSketcherConstrainSymmetric::activated(int iMsg)
@@ -9668,6 +9670,22 @@ void CmdSketcherConstrainSymmetric::applyConstraint(std::vector<SelIdPair>& selS
             PosId1 = selSeq.at(0).PosId;
             PosId2 = selSeq.at(1).PosId;
             PosId3 = selSeq.at(2).PosId;
+
+            if (areAllPointsOrSegmentsFixed(Obj, GeoId1, GeoId2, GeoId3)) {
+                showNoConstraintBetweenFixedGeometry(Obj);
+                return;
+            }
+            break;
+        }
+        case 15:// {SelRoot, SelVertex, SelVertex}
+        {
+            // Always make the Origin the "mid" point (GeoId3)
+            GeoId1 = selSeq.at(1).GeoId;
+            PosId1 = selSeq.at(1).PosId;
+            GeoId2 = selSeq.at(2).GeoId;
+            PosId2 = selSeq.at(2).PosId;
+            GeoId3 = selSeq.at(0).GeoId; // Origin is always "mid" point
+            PosId3 = selSeq.at(0).PosId;
 
             if (areAllPointsOrSegmentsFixed(Obj, GeoId1, GeoId2, GeoId3)) {
                 showNoConstraintBetweenFixedGeometry(Obj);


### PR DESCRIPTION
## Summary  
Fixes an inconsistency in the Sketcher symmetry constraint tool related to selection order when using the origin (RootPoint).

The tool now allows the **origin to be selected in any order** when choosing three points.  
If the origin is among the selected points, it is always treated as the **symmetry midpoint**, regardless of whether it’s selected first, second, or third.

No changes were made to other constraint types or general selection logic.

## Behavioral Change (GUI)  
This is a selection logic improvement — no visible UI elements were changed.

Users can now select **any two geometry points plus the origin**, in any order, and the symmetry constraint will be correctly applied with the origin as the midpoint.


## Issues
Fixes #21391
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

