### PR TITLE
CAM: ZigZagOffset - offset between ZigZag and Offset (do not merge)

### DIFF
--- a/src/Mod/CAM/App/Area.cpp
+++ b/src/Mod/CAM/App/Area.cpp
@@ -2671,7 +2671,8 @@ TopoDS_Shape Area::makePocket(int index, PARAM_ARGS(PARAM_FARG, AREA_PARAMS_POCK
     }
 
     if (!done) {
-        CAreaPocketParams params(tool_radius, extra_offset, stepover, from_center, pm, angle);
+        CAreaPocketParams
+            params(tool_radius, extra_offset, extra_offsetzz, stepover, from_center, pm, angle);
         CArea in(*myArea);
         // MakePocketToolPath internally uses libarea Offset which somehow demands
         // reorder before input, otherwise nothing is shown.

--- a/src/Mod/CAM/App/AreaParams.h
+++ b/src/Mod/CAM/App/AreaParams.h
@@ -144,7 +144,12 @@
          PocketExtraOffset,                                                                        \
          0.0,                                                                                      \
          "Extra offset for pocketing",                                                             \
-         App::PropertyDistance))(                                                                  \
+         App::PropertyDistance))((double,                                                          \
+                                  extra_offsetzz,                                                  \
+                                  PocketExtraOffsetzz,                                             \
+                                  0.0,                                                             \
+                                  "Extra offset for ZigZag path in pocketing",                     \
+                                  App::PropertyDistance))(                                         \
         (double,                                                                                   \
          stepover,                                                                                 \
          PocketStepover,                                                                           \

--- a/src/Mod/CAM/App/AreaPyImp.cpp
+++ b/src/Mod/CAM/App/AreaPyImp.cpp
@@ -49,7 +49,7 @@ static PyObject* areaAbort(PyObject*, PyObject* args, PyObject* kwd)
 static PyObject* areaSetParams(PyObject*, PyObject* args, PyObject* kwd)
 {
 
-    static const std::array<const char*, 43> kwlist {
+    static const std::array<const char*, 44> kwlist {
         PARAM_FIELD_STRINGS(NAME, AREA_PARAMS_STATIC_CONF),
         nullptr
     };
@@ -435,7 +435,7 @@ PyObject* AreaPy::makeOffset(PyObject* args, PyObject* keywds)
 
 PyObject* AreaPy::makePocket(PyObject* args, PyObject* keywds)
 {
-    static const std::array<const char*, 11> kwlist {
+    static const std::array<const char*, 12> kwlist {
         "index",
         PARAM_FIELD_STRINGS(ARG, AREA_PARAMS_POCKET),
         nullptr
@@ -602,7 +602,7 @@ PyObject* AreaPy::setDefaultParams(PyObject*, PyObject*)
 
 PyObject* AreaPy::setParams(PyObject* args, PyObject* keywds)
 {
-    static const std::array<const char*, 43> kwlist {
+    static const std::array<const char*, 44> kwlist {
         PARAM_FIELD_STRINGS(NAME, AREA_PARAMS_CONF),
         nullptr
     };

--- a/src/Mod/CAM/App/FeatureAreaPyImp.cpp
+++ b/src/Mod/CAM/App/FeatureAreaPyImp.cpp
@@ -52,7 +52,7 @@ PyObject* FeatureAreaPy::getArea(PyObject* args)
 
 PyObject* FeatureAreaPy::setParams(PyObject* args, PyObject* keywds)
 {
-    static const std::array<const char*, 43> kwlist {
+    static const std::array<const char*, 44> kwlist {
         PARAM_FIELD_STRINGS(NAME, AREA_PARAMS_CONF),
         nullptr
     };

--- a/src/Mod/CAM/Path/Op/PocketBase.py
+++ b/src/Mod/CAM/Path/Op/PocketBase.py
@@ -103,6 +103,8 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         pass
 
     def opExecute(self, obj):
+        extraOffsetZigZagMode = 0 if obj.ClearingPattern == "ZigZagOffset" else 2
+        obj.setEditorMode("ExtraOffsetZigZag", extraOffsetZigZagMode)
         if len(obj.Base) == 0:
             return
         super().opExecute(obj)
@@ -137,6 +139,15 @@ class ObjectPocket(PathAreaOp.ObjectOp):
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "Extra offset to apply to the operation. Direction is operation dependent.",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyDistance",
+            "ExtraOffsetZigZag",
+            "Pocket",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Extra offset to apply to the ZigZag path with pattern ZigZagOffset.",
             ),
         )
         obj.addProperty(
@@ -222,8 +233,9 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         params["PocketStepover"] = (self.radius * 2) * (float(obj.StepOver) / 100)
         extraOffset = obj.ExtraOffset.Value
         if self.pocketInvertExtraOffset():
-            extraOffset = 0 - extraOffset
+            extraOffset = -extraOffset
         params["PocketExtraOffset"] = extraOffset
+        params["PocketExtraOffsetzz"] = obj.ExtraOffsetZigZag.Value
         params["ToolRadius"] = self.radius
         params["PocketLastStepover"] = obj.PocketLastStepOver
 
@@ -265,6 +277,16 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                 QT_TRANSLATE_NOOP(
                     "App::Property",
                     "Skips machining regions that have already been cleared by previous operations.",
+                ),
+            )
+        if not hasattr(obj, "ExtraOffsetZigZag"):
+            obj.addProperty(
+                "App::PropertyDistance",
+                "ExtraOffsetZigZag",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Extra offset to apply to the ZigZag path with pattern ZigZagOffset.",
                 ),
             )
 

--- a/src/Mod/CAM/libarea/Area.cpp
+++ b/src/Mod/CAM/libarea/Area.cpp
@@ -629,7 +629,14 @@ void CArea::MakePocketToolpath(std::list<CCurve>& curve_list, const CAreaPocketP
 
     if (params.mode == ZigZagPocketMode || params.mode == ZigZagThenSingleOffsetPocketMode) {
         curve_list_for_zigs = &curve_list;
-        zigzag(a_offset);
+        if (params.mode == ZigZagThenSingleOffsetPocketMode && params.extra_offsetzz != 0) {
+            CArea a_offset_zz = a_offset;
+            a_offset_zz.Offset(params.extra_offsetzz);
+            zigzag(a_offset_zz);
+        }
+        else {
+            zigzag(a_offset);
+        }
     }
     else if (params.mode == SpiralPocketMode) {
         std::list<CArea> m_areas;
@@ -660,7 +667,7 @@ void CArea::MakePocketToolpath(std::list<CCurve>& curve_list, const CAreaPocketP
             double dmin = Point::tolerance;
             for (auto it = a_offset.m_curves.begin(); it != a_offset.m_curves.end(); it++) {
                 const double dist = it->NearestPoint(start).dist(start);
-                if (dist < dmin) {
+                if (dist < dmin + params.extra_offsetzz) {
                     dmin = dist;
                     curve_itmin = it;
                 }
@@ -668,7 +675,7 @@ void CArea::MakePocketToolpath(std::list<CCurve>& curve_list, const CAreaPocketP
 
             // if the start point is on that curve (within Point::tolerance), do the profile
             // starting on that curve
-            if (dmin < Point::tolerance) {
+            if (dmin < Point::tolerance + params.extra_offsetzz) {
                 // split the curve into two parts -- starting with this point, and ending with this
                 // point
                 CCurve startCurve;

--- a/src/Mod/CAM/libarea/Area.h
+++ b/src/Mod/CAM/libarea/Area.h
@@ -23,6 +23,7 @@ struct CAreaPocketParams
 {
     double tool_radius;
     double extra_offset;
+    double extra_offsetzz;
     double stepover;
     bool from_center;
     PocketMode mode;
@@ -31,6 +32,7 @@ struct CAreaPocketParams
     CAreaPocketParams(
         double Tool_radius,
         double Extra_offset,
+        double Extra_offsetzz,
         double Stepover,
         bool From_center,
         PocketMode Mode,
@@ -39,6 +41,7 @@ struct CAreaPocketParams
     {
         tool_radius = Tool_radius;
         extra_offset = Extra_offset;
+        extra_offsetzz = Extra_offsetzz;
         stepover = Stepover;
         from_center = From_center;
         mode = Mode;

--- a/src/Mod/CAM/libarea/pyarea.cpp
+++ b/src/Mod/CAM/libarea/pyarea.cpp
@@ -140,6 +140,7 @@ std::list<CCurve> MakePocketToolpath(
     const CArea& a,
     double tool_radius,
     double extra_offset,
+    double extra_offsetzz,
     double stepover,
     bool from_center,
     bool use_zig_zag,
@@ -151,6 +152,7 @@ std::list<CCurve> MakePocketToolpath(
     CAreaPocketParams params(
         tool_radius,
         extra_offset,
+        extra_offsetzz,
         stepover,
         from_center,
         use_zig_zag ? ZigZagPocketMode : SpiralPocketMode,


### PR DESCRIPTION
https://forum.freecad.org/viewtopic.php?t=97248

`ZigZagOffset` pattern use one offset value (`ExtraOffset`) for _ZigZag_ and _Offset_ Path in **Pocket** and **MillFace**

**Before**
![Screenshot_20250527_100657_hor](https://github.com/user-attachments/assets/3be7fe88-2ce6-48bf-b29c-cbd16dd614ad)


**After**
Added offset between `ZigZag` and `Offset` in clearing pattern `ZigZagOffset`
![1_hor](https://github.com/user-attachments/assets/0016447c-5c86-49ad-b36b-135bcd12ac76)

> [!Caution]
> Another way to solve this task looks much more promising
> - #25313
