### PR TITLE
Part: add "Apply to existing bodies" button to shape appearance settings

### DIFF
--- a/src/Mod/Part/Gui/DlgSettingsObjectColor.h
+++ b/src/Mod/Part/Gui/DlgSettingsObjectColor.h
@@ -49,6 +49,9 @@ public:
 protected:
   void changeEvent(QEvent *e) override;
 
+private Q_SLOTS:
+  void onBtnTVApplyClicked(bool);
+
 private:
   std::unique_ptr<Ui_DlgSettingsObjectColor> ui;
 };

--- a/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
+++ b/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
@@ -481,6 +481,13 @@ will be used or black.</string>
           </property>
          </widget>
         </item>
+        <item row="13" column="0" colspan="3" alignment="Qt::AlignmentFlag::AlignLeft">
+         <widget class="QPushButton" name="btnTVApply">
+          <property name="text">
+           <string>Apply to existing bodies</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>


### PR DESCRIPTION
This PR adds a button "Apply to existing bodies" to the shape appearance settings page. It functions similar to "Apply to existing sketches" in the display sketcher page, i.e. it applies the new settings to all bodies in currently opened documents.

The situation is a little bit more complicated than with the sketcher equivalent since we don't know which objects use the default apperance settings (e.g. Part::Box, PartDesign::Body, ...) and which specify their own settings (e.g. Sketcher::SketchObject, PartDesign::SubShapeBinder, ...). To figure things out this creates instances of every currently used TypeId and checks if the resulting object uses the default appearance.

SubShapeBinder is a special case since it only uses the default appearance if it's name begins with "binder", which is the case when created by the user but not when created via "addObject(...)".

Do you think this is a viable implementation? Any other special cases that come to mind?

Also worth noting: the sketch appearance behaves differently. It uses a ParameterObserver to immediately update it's appearance whenever the settings are changed. This means that you can edit the Line-/PointColor but as soon as you open and close the settings the colors are reset. Closing and opening the file also resets the colors.

I think we should choose one way or the other, the sketches display parameters should either also update immediately without the need for a separate "Apply to all sketches" button or the appearance should get a similar button and only update manually.

What do you think?