### PR TITLE
CAM: Offer correct side for Profile

### DIFF
--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -131,14 +131,25 @@ class ObjectOp(PathOp.ObjectOp):
         if prop in ["AreaParams", "PathParams", "removalshape"]:
             obj.setEditorMode(prop, 2)
 
-        if prop == "Base" and len(obj.Base) == 1:
-            (base, sub) = obj.Base[0]
+        if hasattr(obj, "Side") and prop == "Base" and len(obj.Base) == 1:
+            (base, subNames) = obj.Base[0]
             bb = base.Shape.BoundBox  # parent boundbox
-            subobj = base.Shape.getElement(sub[0])
-            fbb = subobj.BoundBox  # feature boundbox
 
-            if hasattr(obj, "Side"):
+            if "Face" in subNames[0]:
+                face = base.Shape.getElement(subNames[0])
+                fbb = face.BoundBox  # face boundbox
                 if bb.XLength == fbb.XLength and bb.YLength == fbb.YLength:
+                    obj.Side = "Outside"
+                else:
+                    obj.Side = "Inside"
+
+            elif "Edge" in subNames[0]:
+                edges = [
+                    base.Shape.getElement(sub).copy() for sub in subNames if sub.startswith("Edge")
+                ]
+                wire = Part.Wire(Part.__sortEdges__(edges))
+                wbb = wire.BoundBox  # wire boundbox
+                if not wire.isClosed() or (bb.XLength == wbb.XLength and bb.YLength == wbb.YLength):
                     obj.Side = "Outside"
                 else:
                     obj.Side = "Inside"


### PR DESCRIPTION
At this moment determination of side for profile performed only for selected `Face`
For selected `Edges` every time by default offer Side = `Inside`
Also for open Edges must be Side = `Outside` every time, but offer `Inside` 
Which is not correct if after apply **Dressup LeadInOut**

**Before**
![Screenshot_20250528_092126_hor](https://github.com/user-attachments/assets/8a654885-dd3f-4a28-926d-6889768022af)

![Screenshot_20250528_100140_lossy](https://github.com/user-attachments/assets/e8714c6d-4cca-4eca-9c3c-58771dd27a57)



**After**
![Screenshot_20250528_092630_hor](https://github.com/user-attachments/assets/91e26e73-fcf4-4aed-84c2-f3dc7c940cfd)

![Screenshot_20250528_095956_lossy](https://github.com/user-attachments/assets/f27307c0-2f9d-4d50-98d1-ffe528f3ec07)

