### PR TITLE
TechDraw: Sheet view: add property to claim sheet as child.

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderSpreadsheet.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderSpreadsheet.h
@@ -43,6 +43,9 @@ public:
     /// destructor
     ~ViewProviderSpreadsheet() override;
 
+    App::PropertyBool ClaimSheetAsChild;
+    std::vector<App::DocumentObject*> claimChildren(void) const override;
+
     bool useNewSelectionModel() const override {return false;}
 
     TechDraw::DrawViewSpreadsheet* getViewObject() const override;


### PR DESCRIPTION
Add a View property to sheet view so that it can claim the sheet object as a child.