### PR TITLE
Sketcher: Implement hints for for all drawing tools and modes (consolidates previous PRs into a single PR)

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -93,11 +93,14 @@ private:
         if (constructionMethod() == ConstructionMethod::Center) {
             switch (state()) {
                 case SelectMode::SeekFirst:
-                    return {InputHint {QObject::tr("%1 pick arc center"), {MouseLeft}}};
+                    return {InputHint {QObject::tr("%1 pick arc center"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                 case SelectMode::SeekSecond:
-                    return {InputHint {QObject::tr("%1 pick arc start point"), {MouseLeft}}};
+                    return {InputHint {QObject::tr("%1 pick arc start point"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                 case SelectMode::SeekThird:
-                    return {InputHint {QObject::tr("%1 pick arc end point"), {MouseLeft}}};
+                    return {InputHint {QObject::tr("%1 pick arc end point"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                 default:
                     return {};
             }
@@ -105,11 +108,14 @@ private:
         else if (constructionMethod() == ConstructionMethod::ThreeRim) {
             switch (state()) {
                 case SelectMode::SeekFirst:
-                    return {InputHint {QObject::tr("%1 pick first arc point"), {MouseLeft}}};
+                    return {InputHint {QObject::tr("%1 pick first rim point"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                 case SelectMode::SeekSecond:
-                    return {InputHint {QObject::tr("%1 pick second arc point"), {MouseLeft}}};
+                    return {InputHint {QObject::tr("%1 pick second rim point"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                 case SelectMode::SeekThird:
-                    return {InputHint {QObject::tr("%1 pick third arc point"), {MouseLeft}}};
+                    return {InputHint {QObject::tr("%1 pick third rim point"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                 default:
                     return {};
             }
@@ -919,6 +925,12 @@ void DSHArcController::addConstraints()
             }
         }
     }
+}
+
+template<>
+void DSHArcController::doConstructionMethodChanged()
+{
+    handler->updateHint();
 }
 
 }  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -92,24 +92,47 @@ private:
 
         std::list<InputHint> hints;
 
-        switch (state()) {
-            case SelectMode::SeekFirst:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc center"),
-                              {UserInput::MouseLeft}));
-                break;
-            case SelectMode::SeekSecond:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
-                              {UserInput::MouseLeft}));
-                break;
-            case SelectMode::SeekThird:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
-                              {UserInput::MouseLeft}));
-                break;
-            default:
-                break;
+        if (constructionMethod() == ConstructionMethod::Center) {
+            switch (state()) {
+                case SelectMode::SeekFirst:
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc center"),
+                                  {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekSecond:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekThird:
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
+                                  {UserInput::MouseLeft}));
+                    break;
+                default:
+                    break;
+            }
+        }
+        else if (constructionMethod() == ConstructionMethod::ThreeRim) {
+            switch (state()) {
+                case SelectMode::SeekFirst:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick first arc point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekSecond:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick second arc point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekThird:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick third arc point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                default:
+                    break;
+            }
         }
 
         Gui::getMainWindow()->showHints(hints);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -94,17 +94,17 @@ private:
         switch (state()) {
             case SelectMode::SeekFirst:
                 hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 Pick arc center"),
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc center"),
                               {Gui::InputHint::UserInput::MouseLeft}));
                 break;
             case SelectMode::SeekSecond:
                 hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 Pick arc start point"),
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
                               {Gui::InputHint::UserInput::MouseLeft}));
                 break;
             case SelectMode::SeekThird:
                 hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 Pick arc end point"),
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
                               {Gui::InputHint::UserInput::MouseLeft}));
                 break;
             default:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -112,13 +112,6 @@ private:
                 break;
         }
 
-        // Add Mouse Right and Escape key hint for all states
-        hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
-                                  {UserInput::MouseRight}));
-
-        hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
-                                  {UserInput::KeyEscape}));
-
         Gui::getMainWindow()->showHints(hints);
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -28,7 +28,8 @@
 #include <Gui/BitmapFactory.h>
 #include <Gui/Notifications.h>
 #include <Gui/CommandT.h>
-
+#include <Gui/MainWindow.h>
+#include <Gui/InputHint.h>
 #include <Mod/Part/App/Geometry2d.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
@@ -84,8 +85,42 @@ public:
     ~DrawSketchHandlerArc() override = default;
 
 private:
+    void updateHints() const
+    {
+        using Gui::InputHint;
+
+        std::list<InputHint> hints;
+
+        switch (state()) {
+        case SelectMode::SeekFirst:
+            hints.push_back(InputHint(
+                QCoreApplication::translate("Sketcher", "%1 Pick arc center"),
+                { Gui::InputHint::UserInput::MouseLeft }
+            ));
+            break;
+        case SelectMode::SeekSecond:
+            hints.push_back(InputHint(
+                QCoreApplication::translate("Sketcher", "%1 Pick arc start point"),
+                { Gui::InputHint::UserInput::MouseLeft }
+            ));
+            break;
+        case SelectMode::SeekThird:
+            hints.push_back(InputHint(
+                QCoreApplication::translate("Sketcher", "%1 Pick arc end point"),
+                { Gui::InputHint::UserInput::MouseLeft }
+            ));
+            break;
+        default:
+            break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
+    
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -88,54 +88,34 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         if (constructionMethod() == ConstructionMethod::Center) {
             switch (state()) {
                 case SelectMode::SeekFirst:
-                    hints.push_back(
-                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc center"),
-                                  {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick arc center"), {MouseLeft}}};
                 case SelectMode::SeekSecond:
-                    hints.push_back(InputHint(
-                        QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
-                        {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick arc start point"), {MouseLeft}}};
                 case SelectMode::SeekThird:
-                    hints.push_back(
-                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
-                                  {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick arc end point"), {MouseLeft}}};
                 default:
-                    break;
+                    return {};
             }
         }
         else if (constructionMethod() == ConstructionMethod::ThreeRim) {
             switch (state()) {
                 case SelectMode::SeekFirst:
-                    hints.push_back(InputHint(
-                        QCoreApplication::translate("Sketcher", "%1 pick first arc point"),
-                        {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick first arc point"), {MouseLeft}}};
                 case SelectMode::SeekSecond:
-                    hints.push_back(InputHint(
-                        QCoreApplication::translate("Sketcher", "%1 pick second arc point"),
-                        {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick second arc point"), {MouseLeft}}};
                 case SelectMode::SeekThird:
-                    hints.push_back(InputHint(
-                        QCoreApplication::translate("Sketcher", "%1 pick third arc point"),
-                        {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick third arc point"), {MouseLeft}}};
                 default:
-                    break;
+                    return {};
             }
         }
 
-        return hints;
+        return {};
     }
 
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -443,8 +443,8 @@ private:
     using HintTable = std::vector<HintEntry>;
 
     // Static declaration
-    static const Gui::InputHint SWITCH_MODE_HINT;
-    static const HintTable ARC_HINT_TABLE;
+    static Gui::InputHint switchModeHint();
+    static HintTable getArcHintTable();
     static std::list<Gui::InputHint> lookupArcHints(ConstructionMethod method, SelectMode state);
 
 private:
@@ -918,48 +918,57 @@ void DSHArcController::doConstructionMethodChanged()
 }
 
 // Static member definitions
-const Gui::InputHint DrawSketchHandlerArc::SWITCH_MODE_HINT = {QObject::tr("%1 switch mode"),
-                                                               {Gui::InputHint::UserInput::KeyM}};
+Gui::InputHint DrawSketchHandlerArc::switchModeHint()
+{
+    return {QObject::tr("%1 switch mode"), {Gui::InputHint::UserInput::KeyM}};
+}
 
-const DrawSketchHandlerArc::HintTable DrawSketchHandlerArc::ARC_HINT_TABLE = {
-    // Center method
-    {ConstructionMethod::Center,
-     SelectMode::SeekFirst,
-     {{QObject::tr("%1 pick arc center"), {Gui::InputHint::UserInput::MouseLeft}},
-      SWITCH_MODE_HINT}},
-    {ConstructionMethod::Center,
-     SelectMode::SeekSecond,
-     {{QObject::tr("%1 pick arc start point"), {Gui::InputHint::UserInput::MouseLeft}},
-      SWITCH_MODE_HINT}},
-    {ConstructionMethod::Center,
-     SelectMode::SeekThird,
-     {{QObject::tr("%1 pick arc end point"), {Gui::InputHint::UserInput::MouseLeft}},
-      SWITCH_MODE_HINT}},
+DrawSketchHandlerArc::HintTable DrawSketchHandlerArc::getArcHintTable()
+{
+    const auto switchHint = switchModeHint();
+    return {
+        // Structure: {ConstructionMethod, SelectMode, {hints...}}
 
-    // ThreeRim method
-    {ConstructionMethod::ThreeRim,
-     SelectMode::SeekFirst,
-     {{QObject::tr("%1 pick first arc point"), {Gui::InputHint::UserInput::MouseLeft}},
-      SWITCH_MODE_HINT}},
-    {ConstructionMethod::ThreeRim,
-     SelectMode::SeekSecond,
-     {{QObject::tr("%1 pick second arc point"), {Gui::InputHint::UserInput::MouseLeft}},
-      SWITCH_MODE_HINT}},
-    {ConstructionMethod::ThreeRim,
-     SelectMode::SeekThird,
-     {{QObject::tr("%1 pick third arc point"), {Gui::InputHint::UserInput::MouseLeft}},
-      SWITCH_MODE_HINT}}};
+        // Center method
+        {ConstructionMethod::Center,
+         SelectMode::SeekFirst,
+         {{QObject::tr("%1 pick arc center"), {Gui::InputHint::UserInput::MouseLeft}}, switchHint}},
+        {ConstructionMethod::Center,
+         SelectMode::SeekSecond,
+         {{QObject::tr("%1 pick arc start point"), {Gui::InputHint::UserInput::MouseLeft}},
+          switchHint}},
+        {ConstructionMethod::Center,
+         SelectMode::SeekThird,
+         {{QObject::tr("%1 pick arc end point"), {Gui::InputHint::UserInput::MouseLeft}},
+          switchHint}},
+
+        // ThreeRim method
+        {ConstructionMethod::ThreeRim,
+         SelectMode::SeekFirst,
+         {{QObject::tr("%1 pick first arc point"), {Gui::InputHint::UserInput::MouseLeft}},
+          switchHint}},
+        {ConstructionMethod::ThreeRim,
+         SelectMode::SeekSecond,
+         {{QObject::tr("%1 pick second arc point"), {Gui::InputHint::UserInput::MouseLeft}},
+          switchHint}},
+        {ConstructionMethod::ThreeRim,
+         SelectMode::SeekThird,
+         {{QObject::tr("%1 pick third arc point"), {Gui::InputHint::UserInput::MouseLeft}},
+          switchHint}}};
+}
 
 std::list<Gui::InputHint> DrawSketchHandlerArc::lookupArcHints(ConstructionMethod method,
                                                                SelectMode state)
 {
-    auto it = std::find_if(ARC_HINT_TABLE.begin(),
-                           ARC_HINT_TABLE.end(),
+    const auto arcHintTable = getArcHintTable();
+
+    auto it = std::find_if(arcHintTable.begin(),
+                           arcHintTable.end(),
                            [method, state](const HintEntry& entry) {
                                return entry.method == method && entry.state == state;
                            });
 
-    return (it != ARC_HINT_TABLE.end()) ? it->hints : std::list<Gui::InputHint> {};
+    return (it != arcHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
 }
 
 }  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -90,17 +90,20 @@ private:
         using Gui::InputHint;
         using enum Gui::InputHint::UserInput;
 
+        // Define once at function level
+        const InputHint switchModeHint {QObject::tr("%1 switch mode"), {KeyM}};
+
         if (constructionMethod() == ConstructionMethod::Center) {
             switch (state()) {
                 case SelectMode::SeekFirst:
                     return {InputHint {QObject::tr("%1 pick arc center"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                            switchModeHint};
                 case SelectMode::SeekSecond:
                     return {InputHint {QObject::tr("%1 pick arc start point"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                            switchModeHint};
                 case SelectMode::SeekThird:
                     return {InputHint {QObject::tr("%1 pick arc end point"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                            switchModeHint};
                 default:
                     return {};
             }
@@ -108,14 +111,14 @@ private:
         else if (constructionMethod() == ConstructionMethod::ThreeRim) {
             switch (state()) {
                 case SelectMode::SeekFirst:
-                    return {InputHint {QObject::tr("%1 pick first rim point"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                    return {InputHint {QObject::tr("%1 pick first arc point"), {MouseLeft}},
+                            switchModeHint};
                 case SelectMode::SeekSecond:
-                    return {InputHint {QObject::tr("%1 pick second rim point"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                    return {InputHint {QObject::tr("%1 pick second arc point"), {MouseLeft}},
+                            switchModeHint};
                 case SelectMode::SeekThird:
-                    return {InputHint {QObject::tr("%1 pick third rim point"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                    return {InputHint {QObject::tr("%1 pick third arc point"), {MouseLeft}},
+                            switchModeHint};
                 default:
                     return {};
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -85,7 +85,7 @@ public:
     ~DrawSketchHandlerArc() override = default;
 
 private:
-    void updateHints() const
+    std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
         using UserInput = Gui::InputHint::UserInput;
@@ -135,13 +135,11 @@ private:
             }
         }
 
-        Gui::getMainWindow()->showHints(hints);
+        return hints;
     }
 
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
-        updateHints();
-
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -112,6 +112,13 @@ private:
                 break;
         }
 
+        // Add Mouse Right and Escape key hint for all states
+        hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
+                                  {UserInput::MouseRight}));
+
+        hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
+                                  {UserInput::KeyEscape}));
+
         Gui::getMainWindow()->showHints(hints);
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -88,6 +88,7 @@ private:
     void updateHints() const
     {
         using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
 
         std::list<InputHint> hints;
 
@@ -95,17 +96,17 @@ private:
             case SelectMode::SeekFirst:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc center"),
-                              {Gui::InputHint::UserInput::MouseLeft}));
+                              {UserInput::MouseLeft}));
                 break;
             case SelectMode::SeekSecond:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
-                              {Gui::InputHint::UserInput::MouseLeft}));
+                              {UserInput::MouseLeft}));
                 break;
             case SelectMode::SeekThird:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
-                              {Gui::InputHint::UserInput::MouseLeft}));
+                              {UserInput::MouseLeft}));
                 break;
             default:
                 break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -92,31 +92,28 @@ private:
         std::list<InputHint> hints;
 
         switch (state()) {
-        case SelectMode::SeekFirst:
-            hints.push_back(InputHint(
-                QCoreApplication::translate("Sketcher", "%1 Pick arc center"),
-                { Gui::InputHint::UserInput::MouseLeft }
-            ));
-            break;
-        case SelectMode::SeekSecond:
-            hints.push_back(InputHint(
-                QCoreApplication::translate("Sketcher", "%1 Pick arc start point"),
-                { Gui::InputHint::UserInput::MouseLeft }
-            ));
-            break;
-        case SelectMode::SeekThird:
-            hints.push_back(InputHint(
-                QCoreApplication::translate("Sketcher", "%1 Pick arc end point"),
-                { Gui::InputHint::UserInput::MouseLeft }
-            ));
-            break;
-        default:
-            break;
+            case SelectMode::SeekFirst:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 Pick arc center"),
+                              {Gui::InputHint::UserInput::MouseLeft}));
+                break;
+            case SelectMode::SeekSecond:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 Pick arc start point"),
+                              {Gui::InputHint::UserInput::MouseLeft}));
+                break;
+            case SelectMode::SeekThird:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 Pick arc end point"),
+                              {Gui::InputHint::UserInput::MouseLeft}));
+                break;
+            default:
+                break;
         }
 
         Gui::getMainWindow()->showHints(hints);
     }
-    
+
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
         updateHints();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -407,23 +407,47 @@ protected:
 private:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        using Gui::InputHint;
-        using enum Gui::InputHint::UserInput;
-
-        switch (Mode) {
-            case STATUS_SEEK_First:
-                return {InputHint {QObject::tr("%1 pick ellipse center"), {MouseLeft}}};
-            case STATUS_SEEK_Second:
-                return {InputHint {QObject::tr("%1 pick axis point"), {MouseLeft}}};
-            case STATUS_SEEK_Third:
-                return {InputHint {QObject::tr("%1 pick arc start point"), {MouseLeft}}};
-            case STATUS_SEEK_Fourth:
-                return {InputHint {QObject::tr("%1 pick arc end point"), {MouseLeft}}};
-            default:
-                return {};
-        }
+        return lookupArcOfEllipseHints(Mode);
     }
+
+private:
+    struct HintEntry
+    {
+        int mode;
+        std::list<Gui::InputHint> hints;
+    };
+
+    using HintTable = std::vector<HintEntry>;
+
+    static HintTable getArcOfEllipseHintTable();
+    static std::list<Gui::InputHint> lookupArcOfEllipseHints(int mode);
 };
+
+DrawSketchHandlerArcOfEllipse::HintTable DrawSketchHandlerArcOfEllipse::getArcOfEllipseHintTable()
+{
+    return {// Structure: {mode, {hints...}}
+            {STATUS_SEEK_First,
+             {{QObject::tr("%1 pick ellipse center"), {Gui::InputHint::UserInput::MouseLeft}}}},
+            {STATUS_SEEK_Second,
+             {{QObject::tr("%1 pick axis point"), {Gui::InputHint::UserInput::MouseLeft}}}},
+            {STATUS_SEEK_Third,
+             {{QObject::tr("%1 pick arc start point"), {Gui::InputHint::UserInput::MouseLeft}}}},
+            {STATUS_SEEK_Fourth,
+             {{QObject::tr("%1 pick arc end point"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+}
+
+std::list<Gui::InputHint> DrawSketchHandlerArcOfEllipse::lookupArcOfEllipseHints(int mode)
+{
+    const auto arcOfEllipseHintTable = getArcOfEllipseHintTable();
+
+    auto it = std::find_if(arcOfEllipseHintTable.begin(),
+                           arcOfEllipseHintTable.end(),
+                           [mode](const HintEntry& entry) {
+                               return entry.mode == mode;
+                           });
+
+    return (it != arcOfEllipseHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
+}
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -408,35 +408,20 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         switch (Mode) {
             case STATUS_SEEK_First:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick ellipse center"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick ellipse center"), {MouseLeft}}};
             case STATUS_SEEK_Second:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick axis point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick axis point"), {MouseLeft}}};
             case STATUS_SEEK_Third:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick arc start point"), {MouseLeft}}};
             case STATUS_SEEK_Fourth:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick arc end point"), {MouseLeft}}};
             default:
-                break;
+                return {};
         }
-
-        return hints;
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -71,8 +71,6 @@ public:
     {
         using std::numbers::pi;
 
-        updateHints();
-
         if (Mode == STATUS_SEEK_First) {
             setPositionText(onSketchPos);
             seekAndRenderAutoConstraint(sugConstr1,
@@ -221,8 +219,6 @@ public:
             setAngleSnapping(false);
             Mode = STATUS_Close;
         }
-
-        updateHints();
 
         return true;
     }
@@ -405,7 +401,7 @@ protected:
     std::vector<AutoConstraint> sugConstr1, sugConstr2, sugConstr3, sugConstr4;
 
 private:
-    void updateHints() const
+    std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
         using UserInput = Gui::InputHint::UserInput;
@@ -436,7 +432,7 @@ private:
                 break;
         }
 
-        Gui::getMainWindow()->showHints(hints);
+        return hints;
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -220,6 +220,7 @@ public:
             Mode = STATUS_Close;
         }
 
+        updateHint();
         return true;
     }
 
@@ -384,6 +385,9 @@ public:
                                             // ViewProvider
             }
         }
+
+        updateHint();
+
         return true;
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -26,6 +26,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -69,6 +70,8 @@ public:
     void mouseMove(Base::Vector2d onSketchPos) override
     {
         using std::numbers::pi;
+
+        updateHints();
 
         if (Mode == STATUS_SEEK_First) {
             setPositionText(onSketchPos);
@@ -218,6 +221,9 @@ public:
             setAngleSnapping(false);
             Mode = STATUS_Close;
         }
+
+        updateHints();
+
         return true;
     }
 
@@ -397,6 +403,41 @@ protected:
     Base::Vector2d centerPoint, axisPoint, startingPoint, endPoint;
     double rx, ry, startAngle, endAngle, arcAngle, arcAngle_t;
     std::vector<AutoConstraint> sugConstr1, sugConstr2, sugConstr3, sugConstr4;
+
+private:
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (Mode) {
+            case STATUS_SEEK_First:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick ellipse center"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Second:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick axis point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Third:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Fourth:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
+                              {UserInput::MouseLeft}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
 };
 
 }  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -28,6 +28,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -65,6 +66,8 @@ public:
 
     void mouseMove(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         if (Mode == STATUS_SEEK_First) {
             setPositionText(onSketchPos);
             seekAndRenderAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.f, 0.f));
@@ -210,6 +213,8 @@ public:
 
             Mode = STATUS_Close;
         }
+
+        updateHints();
         return true;
     }
 
@@ -407,8 +412,42 @@ protected:
     Base::Vector2d centerPoint, axisPoint, startingPoint, endPoint;
     double arcAngle, arcAngle_t;
     std::vector<AutoConstraint> sugConstr1, sugConstr2, sugConstr3, sugConstr4;
-};
 
+private:
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (Mode) {
+            case STATUS_SEEK_First:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick center point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Second:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick axis point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Third:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Fourth:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
+                              {UserInput::MouseLeft}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
+};
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -415,23 +415,48 @@ protected:
 private:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        using Gui::InputHint;
-        using enum Gui::InputHint::UserInput;
-
-        switch (Mode) {
-            case STATUS_SEEK_First:
-                return {InputHint {QObject::tr("%1 pick center point"), {MouseLeft}}};
-            case STATUS_SEEK_Second:
-                return {InputHint {QObject::tr("%1 pick axis point"), {MouseLeft}}};
-            case STATUS_SEEK_Third:
-                return {InputHint {QObject::tr("%1 pick arc start point"), {MouseLeft}}};
-            case STATUS_SEEK_Fourth:
-                return {InputHint {QObject::tr("%1 pick arc end point"), {MouseLeft}}};
-            default:
-                return {};
-        }
+        return lookupArcOfHyperbolaHints(Mode);
     }
+
+private:
+    struct HintEntry
+    {
+        int mode;
+        std::list<Gui::InputHint> hints;
+    };
+
+    using HintTable = std::vector<HintEntry>;
+
+    static HintTable getArcOfHyperbolaHintTable();
+    static std::list<Gui::InputHint> lookupArcOfHyperbolaHints(int mode);
 };
+
+DrawSketchHandlerArcOfHyperbola::HintTable
+DrawSketchHandlerArcOfHyperbola::getArcOfHyperbolaHintTable()
+{
+    return {// Structure: {mode, {hints...}}
+            {STATUS_SEEK_First,
+             {{QObject::tr("%1 pick center point"), {Gui::InputHint::UserInput::MouseLeft}}}},
+            {STATUS_SEEK_Second,
+             {{QObject::tr("%1 pick axis point"), {Gui::InputHint::UserInput::MouseLeft}}}},
+            {STATUS_SEEK_Third,
+             {{QObject::tr("%1 pick arc start point"), {Gui::InputHint::UserInput::MouseLeft}}}},
+            {STATUS_SEEK_Fourth,
+             {{QObject::tr("%1 pick arc end point"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+}
+
+std::list<Gui::InputHint> DrawSketchHandlerArcOfHyperbola::lookupArcOfHyperbolaHints(int mode)
+{
+    const auto arcOfHyperbolaHintTable = getArcOfHyperbolaHintTable();
+
+    auto it = std::find_if(arcOfHyperbolaHintTable.begin(),
+                           arcOfHyperbolaHintTable.end(),
+                           [mode](const HintEntry& entry) {
+                               return entry.mode == mode;
+                           });
+
+    return (it != arcOfHyperbolaHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
+}
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -416,35 +416,20 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         switch (Mode) {
             case STATUS_SEEK_First:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick center point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick center point"), {MouseLeft}}};
             case STATUS_SEEK_Second:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick axis point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick axis point"), {MouseLeft}}};
             case STATUS_SEEK_Third:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick arc start point"), {MouseLeft}}};
             case STATUS_SEEK_Fourth:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick arc end point"), {MouseLeft}}};
             default:
-                break;
+                return {};
         }
-
-        return hints;
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -212,6 +212,7 @@ public:
             Mode = STATUS_Close;
         }
 
+        updateHint();
         return true;
     }
 
@@ -393,6 +394,7 @@ public:
                                             // ViewProvider
             }
         }
+        updateHint();
         return true;
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -66,8 +66,6 @@ public:
 
     void mouseMove(Base::Vector2d onSketchPos) override
     {
-        updateHints();
-
         if (Mode == STATUS_SEEK_First) {
             setPositionText(onSketchPos);
             seekAndRenderAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.f, 0.f));
@@ -214,7 +212,6 @@ public:
             Mode = STATUS_Close;
         }
 
-        updateHints();
         return true;
     }
 
@@ -414,7 +411,7 @@ protected:
     std::vector<AutoConstraint> sugConstr1, sugConstr2, sugConstr3, sugConstr4;
 
 private:
-    void updateHints() const
+    std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
         using UserInput = Gui::InputHint::UserInput;
@@ -445,7 +442,7 @@ private:
                 break;
         }
 
-        Gui::getMainWindow()->showHints(hints);
+        return hints;
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -69,8 +69,6 @@ public:
 
     void mouseMove(Base::Vector2d onSketchPos) override
     {
-        updateHints();
-
         if (Mode == STATUS_SEEK_First) {
             setPositionText(onSketchPos);
             seekAndRenderAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.f, 0.f));
@@ -333,7 +331,7 @@ protected:
     std::vector<AutoConstraint> sugConstr1, sugConstr2, sugConstr3, sugConstr4;
 
 private:
-    void updateHints() const
+    std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
         using UserInput = Gui::InputHint::UserInput;
@@ -364,7 +362,7 @@ private:
                 break;
         }
 
-        Gui::getMainWindow()->showHints(hints);
+        return hints;
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -336,23 +336,47 @@ protected:
 private:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        using Gui::InputHint;
-        using enum Gui::InputHint::UserInput;
-
-        switch (Mode) {
-            case STATUS_SEEK_First:
-                return {InputHint {QObject::tr("%1 pick focus point"), {MouseLeft}}};
-            case STATUS_SEEK_Second:
-                return {InputHint {QObject::tr("%1 pick axis point"), {MouseLeft}}};
-            case STATUS_SEEK_Third:
-                return {InputHint {QObject::tr("%1 pick starting point"), {MouseLeft}}};
-            case STATUS_SEEK_Fourth:
-                return {InputHint {QObject::tr("%1 pick end point"), {MouseLeft}}};
-            default:
-                return {};
-        }
+        return lookupParabolaHints(Mode);
     }
+
+private:
+    struct HintEntry
+    {
+        int mode;
+        std::list<Gui::InputHint> hints;
+    };
+
+    using HintTable = std::vector<HintEntry>;
+
+    static HintTable getParabolaHintTable();
+    static std::list<Gui::InputHint> lookupParabolaHints(int mode);
 };
+
+DrawSketchHandlerArcOfParabola::HintTable DrawSketchHandlerArcOfParabola::getParabolaHintTable()
+{
+    return {// Structure: {mode, {hints...}}
+            {STATUS_SEEK_First,
+             {{QObject::tr("%1 pick focus point"), {Gui::InputHint::UserInput::MouseLeft}}}},
+            {STATUS_SEEK_Second,
+             {{QObject::tr("%1 pick axis point"), {Gui::InputHint::UserInput::MouseLeft}}}},
+            {STATUS_SEEK_Third,
+             {{QObject::tr("%1 pick starting point"), {Gui::InputHint::UserInput::MouseLeft}}}},
+            {STATUS_SEEK_Fourth,
+             {{QObject::tr("%1 pick end point"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+}
+
+std::list<Gui::InputHint> DrawSketchHandlerArcOfParabola::lookupParabolaHints(int mode)
+{
+    const auto parabolaHintTable = getParabolaHintTable();
+
+    auto it = std::find_if(parabolaHintTable.begin(),
+                           parabolaHintTable.end(),
+                           [mode](const HintEntry& entry) {
+                               return entry.mode == mode;
+                           });
+
+    return (it != parabolaHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
+}
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -29,6 +29,7 @@
 
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -68,6 +69,8 @@ public:
 
     void mouseMove(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         if (Mode == STATUS_SEEK_First) {
             setPositionText(onSketchPos);
             seekAndRenderAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.f, 0.f));
@@ -328,9 +331,43 @@ protected:
     Base::Vector2d focusPoint, axisPoint, startingPoint, endPoint;
     double startAngle, endAngle, arcAngle, arcAngle_t;
     std::vector<AutoConstraint> sugConstr1, sugConstr2, sugConstr3, sugConstr4;
+
+private:
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (Mode) {
+            case STATUS_SEEK_First:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick focus point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Second:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick axis point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Third:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick starting point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Fourth:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick end point"),
+                              {UserInput::MouseLeft}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
 };
 
 }  // namespace SketcherGui
-
 
 #endif  // SKETCHERGUI_DrawSketchHandlerArcOfParabola_H

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -337,35 +337,20 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         switch (Mode) {
             case STATUS_SEEK_First:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick focus point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick focus point"), {MouseLeft}}};
             case STATUS_SEEK_Second:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick axis point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick axis point"), {MouseLeft}}};
             case STATUS_SEEK_Third:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick starting point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick starting point"), {MouseLeft}}};
             case STATUS_SEEK_Fourth:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick end point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick end point"), {MouseLeft}}};
             default:
-                break;
+                return {};
         }
-
-        return hints;
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -194,6 +194,8 @@ public:
             endPoint = onSketchPos;
             Mode = STATUS_Close;
         }
+
+        updateHint();
         return true;
     }
 
@@ -314,6 +316,7 @@ public:
                                             // ViewProvider
             }
         }
+        updateHint();
         return true;
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
@@ -94,8 +94,6 @@ public:
     ~DrawSketchHandlerArcSlot() override = default;
 
 private:
-    // ...existing code...
-
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
@@ -94,6 +94,27 @@ public:
     ~DrawSketchHandlerArcSlot() override = default;
 
 private:
+    // ...existing code...
+
+    std::list<Gui::InputHint> getToolHints() const override
+    {
+        using Gui::InputHint;
+        using enum Gui::InputHint::UserInput;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                return {InputHint {QObject::tr("%1 pick arc slot center"), {MouseLeft}}};
+            case SelectMode::SeekSecond:
+                return {InputHint {QObject::tr("%1 pick arc slot radius"), {MouseLeft}}};
+            case SelectMode::SeekThird:
+                return {InputHint {QObject::tr("%1 pick arc slot angle"), {MouseLeft}}};
+            case SelectMode::SeekFourth:
+                return {InputHint {QObject::tr("%1 pick arc slot width"), {MouseLeft}}};
+            default:
+                return {};
+        }
+    }
+
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
         switch (state()) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
@@ -103,13 +103,13 @@ private:
 
         switch (state()) {
             case SelectMode::SeekFirst:
-                return {InputHint {QObject::tr("%1 pick arc slot center"), {MouseLeft}}};
+                return {InputHint {QObject::tr("%1 pick slot center"), {MouseLeft}}};
             case SelectMode::SeekSecond:
-                return {InputHint {QObject::tr("%1 pick arc slot radius"), {MouseLeft}}};
+                return {InputHint {QObject::tr("%1 pick slot radius"), {MouseLeft}}};
             case SelectMode::SeekThird:
-                return {InputHint {QObject::tr("%1 pick arc slot angle"), {MouseLeft}}};
+                return {InputHint {QObject::tr("%1 pick slot angle"), {MouseLeft}}};
             case SelectMode::SeekFourth:
-                return {InputHint {QObject::tr("%1 pick arc slot width"), {MouseLeft}}};
+                return {InputHint {QObject::tr("%1 pick slot width"), {MouseLeft}}};
             default:
                 return {};
         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
@@ -30,6 +30,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -95,6 +96,8 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -510,6 +513,72 @@ private:
             startAngle = startAngle + arcAngle;
             angleReversed = true;
         }
+    }
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (constructionMethod()) {
+            case ConstructionMethod::ArcSlot:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc center"),
+                                      {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 set slot radius"),
+                                      {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case ConstructionMethod::RectangleSlot:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick slot center"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick slot corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick slot orientation"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 set slot width"),
+                                      {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
     }
 
 private:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
@@ -96,8 +96,6 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
-        updateHints();
-
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -513,72 +511,6 @@ private:
             startAngle = startAngle + arcAngle;
             angleReversed = true;
         }
-    }
-
-    void updateHints() const
-    {
-        using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
-
-        switch (constructionMethod()) {
-            case ConstructionMethod::ArcSlot:
-                switch (state()) {
-                    case SelectMode::SeekFirst:
-                        hints.push_back(
-                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick arc center"),
-                                      {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekSecond:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick arc start point"),
-                            {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekThird:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick arc end point"),
-                            {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekFourth:
-                        hints.push_back(
-                            InputHint(QCoreApplication::translate("Sketcher", "%1 set slot radius"),
-                                      {UserInput::MouseMove}));
-                        break;
-                    default:
-                        break;
-                }
-                break;
-            case ConstructionMethod::RectangleSlot:
-                switch (state()) {
-                    case SelectMode::SeekFirst:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick slot center"),
-                            {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekSecond:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick slot corner"),
-                            {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekThird:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick slot orientation"),
-                            {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekFourth:
-                        hints.push_back(
-                            InputHint(QCoreApplication::translate("Sketcher", "%1 set slot width"),
-                                      {UserInput::MouseMove}));
-                        break;
-                    default:
-                        break;
-                }
-                break;
-            default:
-                break;
-        }
-
-        Gui::getMainWindow()->showHints(hints);
     }
 
 private:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -98,28 +98,17 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         switch (state()) {
             case SelectMode::SeekFirst:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick first point"), {MouseLeft}}};
             case SelectMode::SeekSecond:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
-                              {UserInput::MouseLeft}));
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 finish B-spline"),
-                              {UserInput::MouseRight}));
-                break;
+                return {InputHint {QObject::tr("%1 pick next point"), {MouseLeft}},
+                        InputHint {QObject::tr("%1 finish B-spline"), {MouseRight}}};
             default:
-                break;
+                return {};
         }
-
-        return hints;
     }
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -95,7 +95,7 @@ public:
     }
 
 private:
-    void updateHints() const
+    std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
         using UserInput = Gui::InputHint::UserInput;
@@ -115,17 +115,15 @@ private:
                     InputHint(QCoreApplication::translate("Sketcher", "%1 finish B-spline"),
                               {UserInput::MouseRight}));
                 break;
-            // Add more cases as needed for your state machine
             default:
                 break;
         }
 
-        Gui::getMainWindow()->showHints(hints);
+        return hints;
     }
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
         prevCursorPosition = onSketchPos;
-        updateHints();
 
         switch (state()) {
             case SelectMode::SeekFirst: {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -100,15 +100,17 @@ private:
         using Gui::InputHint;
         using enum Gui::InputHint::UserInput;
 
+        const InputHint switchModeHint {QObject::tr("%1 switch mode"), {KeyM}};
+
         if (constructionMethod() == ConstructionMethod::ControlPoints) {
             switch (state()) {
                 case SelectMode::SeekFirst:
                     return {InputHint {QObject::tr("%1 pick first control point"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                            switchModeHint};
                 case SelectMode::SeekSecond:
                     return {InputHint {QObject::tr("%1 pick next control point"), {MouseLeft}},
                             InputHint {QObject::tr("%1 finish B-spline"), {MouseRight}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                            switchModeHint};
                 default:
                     return {};
             }
@@ -117,11 +119,11 @@ private:
             switch (state()) {
                 case SelectMode::SeekFirst:
                     return {InputHint {QObject::tr("%1 pick first knot"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                            switchModeHint};
                 case SelectMode::SeekSecond:
                     return {InputHint {QObject::tr("%1 pick next knot"), {MouseLeft}},
                             InputHint {QObject::tr("%1 finish B-spline"), {MouseRight}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                            switchModeHint};
                 default:
                     return {};
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -100,15 +100,34 @@ private:
         using Gui::InputHint;
         using enum Gui::InputHint::UserInput;
 
-        switch (state()) {
-            case SelectMode::SeekFirst:
-                return {InputHint {QObject::tr("%1 pick first point"), {MouseLeft}}};
-            case SelectMode::SeekSecond:
-                return {InputHint {QObject::tr("%1 pick next point"), {MouseLeft}},
-                        InputHint {QObject::tr("%1 finish B-spline"), {MouseRight}}};
-            default:
-                return {};
+        if (constructionMethod() == ConstructionMethod::ControlPoints) {
+            switch (state()) {
+                case SelectMode::SeekFirst:
+                    return {InputHint {QObject::tr("%1 pick first control point"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                case SelectMode::SeekSecond:
+                    return {InputHint {QObject::tr("%1 pick next control point"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 finish B-spline"), {MouseRight}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                default:
+                    return {};
+            }
         }
+        else if (constructionMethod() == ConstructionMethod::Knots) {
+            switch (state()) {
+                case SelectMode::SeekFirst:
+                    return {InputHint {QObject::tr("%1 pick first knot"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                case SelectMode::SeekSecond:
+                    return {InputHint {QObject::tr("%1 pick next knot"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 finish B-spline"), {MouseRight}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                default:
+                    return {};
+            }
+        }
+
+        return {};
     }
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
@@ -1101,6 +1120,8 @@ void DSHBSplineController::doConstructionMethodChanged()
     syncConstructionMethodComboboxToHandler();
     bool byCtrlPoints = handler->constructionMethod() == ConstructionMethod::ControlPoints;
     toolWidget->setParameterVisible(WParameter::First, byCtrlPoints);
+
+    handler->updateHint();
 }
 
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -29,7 +29,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
-
+#include <Gui/InputHint.h>
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchDefaultWidgetController.h"
@@ -95,9 +95,37 @@ public:
     }
 
 private:
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case SelectMode::SeekSecond:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
+                              {UserInput::MouseLeft}));
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 finish B-spline"),
+                              {UserInput::MouseRight}));
+                break;
+            // Add more cases as needed for your state machine
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
         prevCursorPosition = onSketchPos;
+        updateHints();
 
         switch (state()) {
             case SelectMode::SeekFirst: {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -80,40 +80,7 @@ public:
 private:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        using Gui::InputHint;
-        using enum Gui::InputHint::UserInput;
-
-        const InputHint switchModeHint {QObject::tr("%1 switch mode"), {KeyM}};
-
-        if (constructionMethod() == ConstructionMethod::Center) {
-            switch (state()) {
-                case SelectMode::SeekFirst:
-                    return {InputHint {QObject::tr("%1 pick circle center"), {MouseLeft}},
-                            switchModeHint};
-                case SelectMode::SeekSecond:
-                    return {InputHint {QObject::tr("%1 pick rim point"), {MouseLeft}},
-                            switchModeHint};
-                default:
-                    return {};
-            }
-        }
-        else if (constructionMethod() == ConstructionMethod::ThreeRim) {
-            switch (state()) {
-                case SelectMode::SeekFirst:
-                    return {InputHint {QObject::tr("%1 pick first rim point"), {MouseLeft}},
-                            switchModeHint};
-                case SelectMode::SeekSecond:
-                    return {InputHint {QObject::tr("%1 pick second rim point"), {MouseLeft}},
-                            switchModeHint};
-                case SelectMode::SeekThird:
-                    return {InputHint {QObject::tr("%1 pick third rim point"), {MouseLeft}},
-                            switchModeHint};
-                default:
-                    return {};
-            }
-        }
-
-        return {};
+        return lookupCircleHints(constructionMethod(), state());
     }
 
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
@@ -341,6 +308,19 @@ private:
     }
 
 private:
+    struct HintEntry
+    {
+        ConstructionMethod method;
+        SelectMode state;
+        std::list<Gui::InputHint> hints;
+    };
+
+    using HintTable = std::vector<HintEntry>;
+
+    static Gui::InputHint switchModeHint();
+    static HintTable getCircleHintTable();
+    static std::list<Gui::InputHint> lookupCircleHints(ConstructionMethod method, SelectMode state);
+
     Base::Vector2d centerPoint, firstPoint, secondPoint;
     double radius;
     bool isDiameter;
@@ -747,6 +727,54 @@ void DSHCircleController::addConstraints()
     // No constraint possible for 3 rim circle.
 }
 
+Gui::InputHint DrawSketchHandlerCircle::switchModeHint()
+{
+    return {QObject::tr("%1 switch mode"), {Gui::InputHint::UserInput::KeyM}};
+}
+
+DrawSketchHandlerCircle::HintTable DrawSketchHandlerCircle::getCircleHintTable()
+{
+    const auto switchHint = switchModeHint();
+    return {
+        // Structure: {ConstructionMethod, SelectMode, {hints...}}
+
+        // Center method
+        {ConstructionMethod::Center,
+         SelectMode::SeekFirst,
+         {{QObject::tr("%1 pick circle center"), {Gui::InputHint::UserInput::MouseLeft}},
+          switchHint}},
+        {ConstructionMethod::Center,
+         SelectMode::SeekSecond,
+         {{QObject::tr("%1 pick rim point"), {Gui::InputHint::UserInput::MouseLeft}}, switchHint}},
+
+        // ThreeRim method
+        {ConstructionMethod::ThreeRim,
+         SelectMode::SeekFirst,
+         {{QObject::tr("%1 pick first rim point"), {Gui::InputHint::UserInput::MouseLeft}},
+          switchHint}},
+        {ConstructionMethod::ThreeRim,
+         SelectMode::SeekSecond,
+         {{QObject::tr("%1 pick second rim point"), {Gui::InputHint::UserInput::MouseLeft}},
+          switchHint}},
+        {ConstructionMethod::ThreeRim,
+         SelectMode::SeekThird,
+         {{QObject::tr("%1 pick third rim point"), {Gui::InputHint::UserInput::MouseLeft}},
+          switchHint}}};
+}
+
+std::list<Gui::InputHint> DrawSketchHandlerCircle::lookupCircleHints(ConstructionMethod method,
+                                                                     SelectMode state)
+{
+    const auto circleHintTable = getCircleHintTable();
+
+    auto it = std::find_if(circleHintTable.begin(),
+                           circleHintTable.end(),
+                           [method, state](const HintEntry& entry) {
+                               return entry.method == method && entry.state == state;
+                           });
+
+    return (it != circleHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
+}
 }  // namespace SketcherGui
 
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -78,7 +78,7 @@ public:
     ~DrawSketchHandlerCircle() override = default;
 
 private:
-    void updateHints() const
+    std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
         using UserInput = Gui::InputHint::UserInput;
@@ -122,13 +122,11 @@ private:
             }
         }
 
-        Gui::getMainWindow()->showHints(hints);
+        return hints;
     }
 
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
-        updateHints();
-
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -86,9 +86,11 @@ private:
         if (constructionMethod() == ConstructionMethod::Center) {
             switch (state()) {
                 case SelectMode::SeekFirst:
-                    return {InputHint {QObject::tr("%1 pick circle center"), {MouseLeft}}};
+                    return {InputHint {QObject::tr("%1 pick circle center"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                 case SelectMode::SeekSecond:
-                    return {InputHint {QObject::tr("%1 pick rim point"), {MouseLeft}}};
+                    return {InputHint {QObject::tr("%1 pick rim point"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                 default:
                     return {};
             }
@@ -96,11 +98,14 @@ private:
         else if (constructionMethod() == ConstructionMethod::ThreeRim) {
             switch (state()) {
                 case SelectMode::SeekFirst:
-                    return {InputHint {QObject::tr("%1 pick first rim point"), {MouseLeft}}};
+                    return {InputHint {QObject::tr("%1 pick first rim point"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                 case SelectMode::SeekSecond:
-                    return {InputHint {QObject::tr("%1 pick second rim point"), {MouseLeft}}};
+                    return {InputHint {QObject::tr("%1 pick second rim point"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                 case SelectMode::SeekThird:
-                    return {InputHint {QObject::tr("%1 pick third rim point"), {MouseLeft}}};
+                    return {InputHint {QObject::tr("%1 pick third rim point"), {MouseLeft}},
+                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                 default:
                     return {};
             }
@@ -635,6 +640,13 @@ void DSHCircleController::doChangeDrawSketchHandlerMode()
         default:
             break;
     }
+}
+
+template<>
+void DSHCircleController::doConstructionMethodChanged()
+{
+    // Just update hints - combobox already handled by framework
+    handler->updateHint();
 }
 
 template<>

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -81,48 +81,32 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         if (constructionMethod() == ConstructionMethod::Center) {
             switch (state()) {
                 case SelectMode::SeekFirst:
-                    hints.push_back(
-                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick circle center"),
-                                  {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick circle center"), {MouseLeft}}};
                 case SelectMode::SeekSecond:
-                    hints.push_back(
-                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick rim point"),
-                                  {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick rim point"), {MouseLeft}}};
                 default:
-                    break;
+                    return {};
             }
         }
         else if (constructionMethod() == ConstructionMethod::ThreeRim) {
             switch (state()) {
                 case SelectMode::SeekFirst:
-                    hints.push_back(InputHint(
-                        QCoreApplication::translate("Sketcher", "%1 pick first rim point"),
-                        {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick first rim point"), {MouseLeft}}};
                 case SelectMode::SeekSecond:
-                    hints.push_back(InputHint(
-                        QCoreApplication::translate("Sketcher", "%1 pick second rim point"),
-                        {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick second rim point"), {MouseLeft}}};
                 case SelectMode::SeekThird:
-                    hints.push_back(InputHint(
-                        QCoreApplication::translate("Sketcher", "%1 pick third rim point"),
-                        {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick third rim point"), {MouseLeft}}};
                 default:
-                    break;
+                    return {};
             }
         }
 
-        return hints;
+        return {};
     }
 
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -28,6 +28,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Part/App/Geometry2d.h>
 
@@ -79,6 +80,8 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -305,6 +308,50 @@ private:
     Base::Vector2d centerPoint, firstPoint, secondPoint;
     double radius;
     bool isDiameter;
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+
+        std::list<InputHint> hints;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                if (constructionMethod() == ConstructionMethod::Center) {
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick center point"),
+                                  {UserInput::MouseLeft}));
+                }
+                else {
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick first rim point"),
+                        {UserInput::MouseLeft}));
+                }
+                break;
+            case SelectMode::SeekSecond:
+                if (constructionMethod() == ConstructionMethod::Center) {
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick rim point"),
+                                  {UserInput::MouseLeft}));
+                }
+                else {
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick second rim point"),
+                        {UserInput::MouseLeft}));
+                }
+                break;
+            case SelectMode::SeekThird:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick third rim point"),
+                              {UserInput::MouseLeft}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
 };
 
 template<>

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -83,14 +83,16 @@ private:
         using Gui::InputHint;
         using enum Gui::InputHint::UserInput;
 
+        const InputHint switchModeHint {QObject::tr("%1 switch mode"), {KeyM}};
+
         if (constructionMethod() == ConstructionMethod::Center) {
             switch (state()) {
                 case SelectMode::SeekFirst:
                     return {InputHint {QObject::tr("%1 pick circle center"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                            switchModeHint};
                 case SelectMode::SeekSecond:
                     return {InputHint {QObject::tr("%1 pick rim point"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                            switchModeHint};
                 default:
                     return {};
             }
@@ -99,13 +101,13 @@ private:
             switch (state()) {
                 case SelectMode::SeekFirst:
                     return {InputHint {QObject::tr("%1 pick first rim point"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                            switchModeHint};
                 case SelectMode::SeekSecond:
                     return {InputHint {QObject::tr("%1 pick second rim point"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                            switchModeHint};
                 case SelectMode::SeekThird:
                     return {InputHint {QObject::tr("%1 pick third rim point"), {MouseLeft}},
-                            InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                            switchModeHint};
                 default:
                     return {};
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -29,7 +29,6 @@
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
 #include <Gui/InputHint.h>
-#include <Gui/InputHint.h>
 
 #include <Mod/Part/App/Geometry2d.h>
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -78,6 +78,53 @@ public:
     ~DrawSketchHandlerCircle() override = default;
 
 private:
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        if (constructionMethod() == ConstructionMethod::Center) {
+            switch (state()) {
+                case SelectMode::SeekFirst:
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick circle center"),
+                                  {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekSecond:
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick rim point"),
+                                  {UserInput::MouseLeft}));
+                    break;
+                default:
+                    break;
+            }
+        }
+        else if (constructionMethod() == ConstructionMethod::ThreeRim) {
+            switch (state()) {
+                case SelectMode::SeekFirst:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick first rim point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekSecond:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick second rim point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekThird:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick third rim point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
+
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
         updateHints();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -28,6 +28,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Part/App/Geometry2d.h>
 
@@ -79,6 +80,8 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -305,6 +308,53 @@ private:
     Base::Vector2d centerPoint, firstPoint, secondPoint;
     double radius;
     bool isDiameter;
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        if (constructionMethod() == ConstructionMethod::Center) {
+            switch (state()) {
+                case SelectMode::SeekFirst:
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick circle center"),
+                                  {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekSecond:
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick rim point"),
+                                  {UserInput::MouseLeft}));
+                    break;
+                default:
+                    break;
+            }
+        }
+        else if (constructionMethod() == ConstructionMethod::ThreeRim) {
+            switch (state()) {
+                case SelectMode::SeekFirst:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick first rim point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekSecond:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick second rim point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekThird:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick third rim point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
 };
 
 template<>

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -84,38 +84,22 @@ public:
     ~DrawSketchHandlerEllipse() override = default;
 
 private:
-private:
+    struct HintEntry
+    {
+        ConstructionMethod method;
+        SelectMode state;
+        std::list<Gui::InputHint> hints;
+    };
+
+    using HintTable = std::vector<HintEntry>;
+
+    static HintTable getEllipseHintTable();
+    static std::list<Gui::InputHint> lookupEllipseHints(ConstructionMethod method,
+                                                        SelectMode state);
+
     std::list<Gui::InputHint> getToolHints() const override
     {
-        using Gui::InputHint;
-        using enum Gui::InputHint::UserInput;
-
-        if (constructionMethod() == ConstructionMethod::Center) {
-            switch (state()) {
-                case SelectMode::SeekFirst:
-                    return {InputHint {QObject::tr("%1 pick ellipse center"), {MouseLeft}}};
-                case SelectMode::SeekSecond:
-                    return {InputHint {QObject::tr("%1 pick axis endpoint"), {MouseLeft}}};
-                case SelectMode::SeekThird:
-                    return {InputHint {QObject::tr("%1 pick minor axis endpoint"), {MouseLeft}}};
-                default:
-                    return {};
-            }
-        }
-        else if (constructionMethod() == ConstructionMethod::ThreeRim) {
-            switch (state()) {
-                case SelectMode::SeekFirst:
-                    return {InputHint {QObject::tr("%1 pick first rim point"), {MouseLeft}}};
-                case SelectMode::SeekSecond:
-                    return {InputHint {QObject::tr("%1 pick second rim point"), {MouseLeft}}};
-                case SelectMode::SeekThird:
-                    return {InputHint {QObject::tr("%1 pick third rim point"), {MouseLeft}}};
-                default:
-                    return {};
-            }
-        }
-
-        return {};
+        return lookupEllipseHints(constructionMethod(), state());
     }
 
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
@@ -986,7 +970,47 @@ void DSHEllipseController::addConstraints()
     // No constraint possible for 3 rim ellipse.
 }
 
+DrawSketchHandlerEllipse::HintTable DrawSketchHandlerEllipse::getEllipseHintTable()
+{
+    return {
+        // Structure: {ConstructionMethod, SelectMode, {hints...}}
 
+        // Center method
+        {ConstructionMethod::Center,
+         SelectMode::SeekFirst,
+         {{QObject::tr("%1 pick ellipse center"), {Gui::InputHint::UserInput::MouseLeft}}}},
+        {ConstructionMethod::Center,
+         SelectMode::SeekSecond,
+         {{QObject::tr("%1 pick axis endpoint"), {Gui::InputHint::UserInput::MouseLeft}}}},
+        {ConstructionMethod::Center,
+         SelectMode::SeekThird,
+         {{QObject::tr("%1 pick minor axis endpoint"), {Gui::InputHint::UserInput::MouseLeft}}}},
+
+        // ThreeRim method
+        {ConstructionMethod::ThreeRim,
+         SelectMode::SeekFirst,
+         {{QObject::tr("%1 pick first rim point"), {Gui::InputHint::UserInput::MouseLeft}}}},
+        {ConstructionMethod::ThreeRim,
+         SelectMode::SeekSecond,
+         {{QObject::tr("%1 pick second rim point"), {Gui::InputHint::UserInput::MouseLeft}}}},
+        {ConstructionMethod::ThreeRim,
+         SelectMode::SeekThird,
+         {{QObject::tr("%1 pick third rim point"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+}
+
+std::list<Gui::InputHint> DrawSketchHandlerEllipse::lookupEllipseHints(ConstructionMethod method,
+                                                                       SelectMode state)
+{
+    const auto ellipseHintTable = getEllipseHintTable();
+
+    auto it = std::find_if(ellipseHintTable.begin(),
+                           ellipseHintTable.end(),
+                           [method, state](const HintEntry& entry) {
+                               return entry.method == method && entry.state == state;
+                           });
+
+    return (it != ellipseHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
+}
 }  // namespace SketcherGui
 
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -84,6 +84,59 @@ public:
     ~DrawSketchHandlerEllipse() override = default;
 
 private:
+private:
+    std::list<Gui::InputHint> getToolHints() const override
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        if (constructionMethod() == ConstructionMethod::Center) {
+            switch (state()) {
+                case SelectMode::SeekFirst:
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick ellipse center"),
+                                  {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekSecond:
+                    hints.push_back(
+                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick axis endpoint"),
+                                  {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekThird:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick minor axis endpoint"),
+                        {UserInput::MouseLeft}));
+                    break;
+                default:
+                    break;
+            }
+        }
+        else if (constructionMethod() == ConstructionMethod::ThreeRim) {
+            switch (state()) {
+                case SelectMode::SeekFirst:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick first rim point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekSecond:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick second rim point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                case SelectMode::SeekThird:
+                    hints.push_back(InputHint(
+                        QCoreApplication::translate("Sketcher", "%1 pick third rim point"),
+                        {UserInput::MouseLeft}));
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return hints;
+    }
+
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
         switch (state()) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -88,53 +88,34 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         if (constructionMethod() == ConstructionMethod::Center) {
             switch (state()) {
                 case SelectMode::SeekFirst:
-                    hints.push_back(
-                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick ellipse center"),
-                                  {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick ellipse center"), {MouseLeft}}};
                 case SelectMode::SeekSecond:
-                    hints.push_back(
-                        InputHint(QCoreApplication::translate("Sketcher", "%1 pick axis endpoint"),
-                                  {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick axis endpoint"), {MouseLeft}}};
                 case SelectMode::SeekThird:
-                    hints.push_back(InputHint(
-                        QCoreApplication::translate("Sketcher", "%1 pick minor axis endpoint"),
-                        {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick minor axis endpoint"), {MouseLeft}}};
                 default:
-                    break;
+                    return {};
             }
         }
         else if (constructionMethod() == ConstructionMethod::ThreeRim) {
             switch (state()) {
                 case SelectMode::SeekFirst:
-                    hints.push_back(InputHint(
-                        QCoreApplication::translate("Sketcher", "%1 pick first rim point"),
-                        {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick first rim point"), {MouseLeft}}};
                 case SelectMode::SeekSecond:
-                    hints.push_back(InputHint(
-                        QCoreApplication::translate("Sketcher", "%1 pick second rim point"),
-                        {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick second rim point"), {MouseLeft}}};
                 case SelectMode::SeekThird:
-                    hints.push_back(InputHint(
-                        QCoreApplication::translate("Sketcher", "%1 pick third rim point"),
-                        {UserInput::MouseLeft}));
-                    break;
+                    return {InputHint {QObject::tr("%1 pick third rim point"), {MouseLeft}}};
                 default:
-                    break;
+                    return {};
             }
         }
 
-        return hints;
+        return {};
     }
 
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -258,13 +258,15 @@ private:
         using Gui::InputHint;
         using enum Gui::InputHint::UserInput;
 
+        const InputHint switchModeHint {QObject::tr("%1 switch mode"), {KeyM}};
+
         switch (state()) {
             case SelectMode::SeekFirst:
                 return {InputHint {QObject::tr("%1 pick first point"), {MouseLeft}},
-                        InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                        switchModeHint};
             case SelectMode::SeekSecond:
                 return {InputHint {QObject::tr("%1 pick second point"), {MouseLeft}},
-                        InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                        switchModeHint};
             default:
                 return {};
         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -270,8 +270,8 @@ private:
 
     using HintTable = std::vector<HintEntry>;
 
-    static const Gui::InputHint SWITCH_MODE_HINT;
-    static const HintTable LINE_HINT_TABLE;
+    static Gui::InputHint switchModeHint();
+    static HintTable getLineHintTable();
     static std::list<Gui::InputHint> lookupLineHints(int method, int state);
 };
 
@@ -818,49 +818,64 @@ void DSHLineController::addConstraints()
     }
 }
 
-const Gui::InputHint DrawSketchHandlerLine::SWITCH_MODE_HINT = {QObject::tr("%1 switch mode"),
-                                                                {Gui::InputHint::UserInput::KeyM}};
+Gui::InputHint DrawSketchHandlerLine::switchModeHint()
+{
+    return {QObject::tr("%1 switch mode"), {Gui::InputHint::UserInput::KeyM}};
+}
 
-const DrawSketchHandlerLine::HintTable DrawSketchHandlerLine::LINE_HINT_TABLE = {
-    // OnePointLengthAngle (0)
-    {0,
-     0,
-     {{QObject::tr("%1 pick first point"), {Gui::InputHint::UserInput::MouseLeft}},
-      SWITCH_MODE_HINT}},
-    {0,
-     1,
-     {{QObject::tr("%1 pick second point"), {Gui::InputHint::UserInput::MouseLeft}},
-      SWITCH_MODE_HINT}},
+DrawSketchHandlerLine::HintTable DrawSketchHandlerLine::getLineHintTable()
+{
+    const auto switchHint = switchModeHint();
+    return {// Structure: {constructionMethod, state, {hints...}}
 
-    // OnePointWidthHeight (1)
-    {1,
-     0,
-     {{QObject::tr("%1 pick first point"), {Gui::InputHint::UserInput::MouseLeft}},
-      SWITCH_MODE_HINT}},
-    {1,
-     1,
-     {{QObject::tr("%1 pick second point"), {Gui::InputHint::UserInput::MouseLeft}},
-      SWITCH_MODE_HINT}},
+            // OnePointLengthAngle (0)
+            {0,
+             0,
+             {// SeekFirst
+              {QObject::tr("%1 pick first point"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}},
+            {0,
+             1,
+             {// SeekSecond
+              {QObject::tr("%1 pick second point"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}},
 
-    // TwoPoints (2)
-    {2,
-     0,
-     {{QObject::tr("%1 pick first point"), {Gui::InputHint::UserInput::MouseLeft}},
-      SWITCH_MODE_HINT}},
-    {2,
-     1,
-     {{QObject::tr("%1 pick second point"), {Gui::InputHint::UserInput::MouseLeft}},
-      SWITCH_MODE_HINT}}};
+            // OnePointWidthHeight (1)
+            {1,
+             0,
+             {// SeekFirst
+              {QObject::tr("%1 pick first point"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}},
+            {1,
+             1,
+             {// SeekSecond
+              {QObject::tr("%1 pick second point"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}},
+
+            // TwoPoints (2)
+            {2,
+             0,
+             {// SeekFirst
+              {QObject::tr("%1 pick first point"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}},
+            {2,
+             1,
+             {// SeekSecond
+              {QObject::tr("%1 pick second point"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}}};
+}
 
 std::list<Gui::InputHint> DrawSketchHandlerLine::lookupLineHints(int method, int state)
 {
-    auto it = std::find_if(LINE_HINT_TABLE.begin(),
-                           LINE_HINT_TABLE.end(),
+    const auto lineHintTable = getLineHintTable();
+
+    auto it = std::find_if(lineHintTable.begin(),
+                           lineHintTable.end(),
                            [method, state](const HintEntry& entry) {
                                return entry.constructionMethod == method && entry.state == state;
                            });
 
-    return (it != LINE_HINT_TABLE.end()) ? it->hints : std::list<Gui::InputHint> {};
+    return (it != lineHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
 }
 
 }  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -28,6 +28,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -88,6 +89,8 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -250,6 +253,31 @@ private:
                                    toVector3d(endPoint),
                                    isConstructionMode());
         }
+    }
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+
+        std::list<InputHint> hints;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case SelectMode::SeekSecond:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick second point"),
+                              {UserInput::MouseLeft}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -260,9 +260,11 @@ private:
 
         switch (state()) {
             case SelectMode::SeekFirst:
-                return {InputHint {QObject::tr("%1 pick first point"), {MouseLeft}}};
+                return {InputHint {QObject::tr("%1 pick first point"), {MouseLeft}},
+                        InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
             case SelectMode::SeekSecond:
-                return {InputHint {QObject::tr("%1 pick second point"), {MouseLeft}}};
+                return {InputHint {QObject::tr("%1 pick second point"), {MouseLeft}},
+                        InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
             default:
                 return {};
         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -89,8 +89,6 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
-        updateHints();
-
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -255,11 +253,10 @@ private:
         }
     }
 
-    void updateHints() const
+    std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
         using UserInput = Gui::InputHint::UserInput;
-
         std::list<InputHint> hints;
 
         switch (state()) {
@@ -277,7 +274,7 @@ private:
                 break;
         }
 
-        Gui::getMainWindow()->showHints(hints);
+        return hints;
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -256,25 +256,16 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         switch (state()) {
             case SelectMode::SeekFirst:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick first point"), {MouseLeft}}};
             case SelectMode::SeekSecond:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick second point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick second point"), {MouseLeft}}};
             default:
-                break;
+                return {};
         }
-
-        return hints;
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -776,7 +776,7 @@ private:
             case STATUS_SEEK_Second:
                 return {InputHint {QObject::tr("%1 pick next point"), {MouseLeft}},
                         InputHint {QObject::tr("%1 finish"), {MouseRight}},
-                        InputHint {QObject::tr("%1 change mode"), {KeyM}}};
+                        InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
             default:
                 return {};
         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -97,34 +97,6 @@ public:
         SNAP_MODE_45Degree
     };
 
-    std::list<Gui::InputHint> getToolHints() const override
-    {
-        using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
-
-        switch (Mode) {
-            case STATUS_SEEK_First:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
-                              {UserInput::MouseLeft}));
-                break;
-            case STATUS_SEEK_Second:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
-                              {UserInput::MouseLeft}));
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 right-click to finish"),
-                              {UserInput::MouseRight}));
-                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 change mode"),
-                                          {UserInput::KeyM}));
-                break;
-            default:
-                break;
-        }
-
-        return hints;
-    }
 
     void registerPressedKey(bool pressed, int key) override
     {
@@ -360,6 +332,7 @@ public:
 
     bool pressButton(Base::Vector2d onSketchPos) override
     {
+
         if (Mode == STATUS_SEEK_First) {
 
             EditCurve[0] = onSketchPos;  // this may be overwritten if previousCurve is found
@@ -466,6 +439,9 @@ public:
                 }
             }
         }
+
+        updateHint();
+
         return true;
     }
 
@@ -738,6 +714,9 @@ public:
                 mouseMove(onSketchPos);  // trigger an update of EditCurve
             }
         }
+
+        updateHint();
+
         return true;
     }
 
@@ -784,6 +763,35 @@ private:
     QString getCrosshairCursorSVGName() const override
     {
         return QStringLiteral("Sketcher_Pointer_Create_Lineset");
+    }
+
+    std::list<Gui::InputHint> getToolHints() const override
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (Mode) {
+            case STATUS_SEEK_First:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Second:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
+                              {UserInput::MouseLeft}));
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 right-click to finish"),
+                              {UserInput::MouseRight}));
+                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 change mode"),
+                                          {UserInput::KeyM}));
+                break;
+            default:
+                break;
+        }
+
+        return hints;
     }
 
 protected:
@@ -845,8 +853,6 @@ protected:
         dirVec.Normalize();
     }
 };
-
-
 }  // namespace SketcherGui
 
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -99,13 +99,31 @@ public:
 
     std::list<Gui::InputHint> getToolHints() const override
     {
+        using Gui::InputHint;
         using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
 
-        return {
-            {QWidget::tr("%1 change mode"), {UserInput::KeyM}},
-            {QWidget::tr("%1 start drawing"), {UserInput::MouseLeft}},
-            {QWidget::tr("%1 stop drawing"), {UserInput::MouseRight}},
-        };
+        switch (Mode) {
+            case STATUS_SEEK_First:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Second:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
+                              {UserInput::MouseLeft}));
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 right-click to finish"),
+                              {UserInput::MouseRight}));
+                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 change mode"),
+                                          {UserInput::KeyM}));
+                break;
+            default:
+                break;
+        }
+
+        return hints;
     }
 
     void registerPressedKey(bool pressed, int key) override
@@ -201,8 +219,6 @@ public:
     void mouseMove(Base::Vector2d onSketchPos) override
     {
         using std::numbers::pi;
-
-        updateHints();
 
         suppressTransition = false;
         if (Mode == STATUS_SEEK_First) {
@@ -344,8 +360,6 @@ public:
 
     bool pressButton(Base::Vector2d onSketchPos) override
     {
-        updateHints();
-
         if (Mode == STATUS_SEEK_First) {
 
             EditCurve[0] = onSketchPos;  // this may be overwritten if previousCurve is found
@@ -457,8 +471,6 @@ public:
 
     bool releaseButton(Base::Vector2d onSketchPos) override
     {
-        updateHints();
-
         if (Mode == STATUS_Do || Mode == STATUS_Close) {
             bool addedGeometry = true;
             if (SegmentMode == SEGMENT_MODE_Line) {
@@ -772,36 +784,6 @@ private:
     QString getCrosshairCursorSVGName() const override
     {
         return QStringLiteral("Sketcher_Pointer_Create_Lineset");
-    }
-
-    void updateHints() const
-    {
-        using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
-
-        switch (Mode) {
-            case STATUS_SEEK_First:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
-                              {UserInput::MouseLeft}));
-                break;
-            case STATUS_SEEK_Second:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
-                              {UserInput::MouseLeft}));
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 right-click to finish"),
-                              {UserInput::MouseRight}));
-
-                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 change mode"),
-                                          {UserInput::KeyM}));
-                break;
-            default:
-                break;
-        }
-
-        Gui::getMainWindow()->showHints(hints);
     }
 
 protected:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -793,6 +793,9 @@ private:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 right-click to finish"),
                               {UserInput::MouseRight}));
+
+                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 change mode"),
+                                          {UserInput::KeyM}));
                 break;
             default:
                 break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -31,6 +31,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -201,6 +202,8 @@ public:
     {
         using std::numbers::pi;
 
+        updateHints();
+
         suppressTransition = false;
         if (Mode == STATUS_SEEK_First) {
             setPositionText(onSketchPos);
@@ -341,6 +344,8 @@ public:
 
     bool pressButton(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         if (Mode == STATUS_SEEK_First) {
 
             EditCurve[0] = onSketchPos;  // this may be overwritten if previousCurve is found
@@ -452,6 +457,8 @@ public:
 
     bool releaseButton(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         if (Mode == STATUS_Do || Mode == STATUS_Close) {
             bool addedGeometry = true;
             if (SegmentMode == SEGMENT_MODE_Line) {
@@ -765,6 +772,32 @@ private:
     QString getCrosshairCursorSVGName() const override
     {
         return QStringLiteral("Sketcher_Pointer_Create_Lineset");
+    }
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        std::list<InputHint> hints;
+
+        switch (Mode) {
+            case STATUS_SEEK_First:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
+                              {Gui::InputHint::UserInput::MouseLeft}));
+                break;
+            case STATUS_SEEK_Second:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
+                              {Gui::InputHint::UserInput::MouseLeft}));
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 right-click to finish"),
+                              {Gui::InputHint::UserInput::MouseRight}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
     }
 
 protected:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -777,21 +777,22 @@ private:
     void updateHints() const
     {
         using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
         std::list<InputHint> hints;
 
         switch (Mode) {
             case STATUS_SEEK_First:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
-                              {Gui::InputHint::UserInput::MouseLeft}));
+                              {UserInput::MouseLeft}));
                 break;
             case STATUS_SEEK_Second:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
-                              {Gui::InputHint::UserInput::MouseLeft}));
+                              {UserInput::MouseLeft}));
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 right-click to finish"),
-                              {Gui::InputHint::UserInput::MouseRight}));
+                              {UserInput::MouseRight}));
                 break;
             default:
                 break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -768,29 +768,18 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         switch (Mode) {
             case STATUS_SEEK_First:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick first point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick first point"), {MouseLeft}}};
             case STATUS_SEEK_Second:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
-                              {UserInput::MouseLeft}));
-                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 finish"),
-                                          {UserInput::MouseRight}));
-                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 change mode"),
-                                          {UserInput::KeyM}));
-                break;
+                return {InputHint {QObject::tr("%1 pick next point"), {MouseLeft}},
+                        InputHint {QObject::tr("%1 finish"), {MouseRight}},
+                        InputHint {QObject::tr("%1 change mode"), {KeyM}}};
             default:
-                break;
+                return {};
         }
-
-        return hints;
     }
 
 protected:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -781,9 +781,8 @@ private:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 pick next point"),
                               {UserInput::MouseLeft}));
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 right-click to finish"),
-                              {UserInput::MouseRight}));
+                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 finish"),
+                                          {UserInput::MouseRight}));
                 hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 change mode"),
                                           {UserInput::KeyM}));
                 break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -143,7 +143,7 @@ private:
 
     using HintTable = std::vector<HintEntry>;
 
-    static const HintTable POINT_HINT_TABLE;
+    static HintTable getPointHintTable();
     static std::list<Gui::InputHint> lookupPointHints(int stateValue);
 };
 
@@ -285,28 +285,23 @@ void DSHPointController::addConstraints()
     }
 }
 
-struct HintEntry
+DrawSketchHandlerPoint::HintTable DrawSketchHandlerPoint::getPointHintTable()
 {
-    int stateValue;
-    std::list<Gui::InputHint> hints;
-};
-
-using HintTable = std::vector<HintEntry>;
-
-const DrawSketchHandlerPoint::HintTable DrawSketchHandlerPoint::POINT_HINT_TABLE = {
-    {0,
-     {// 0 corresponds to the first enum value
-      {QObject::tr("%1 place a point"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+    return {// Structure: {ConstructionMethod, SelectMode, {hints...}}
+            {0, {{QObject::tr("%1 place a point"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+}
 
 std::list<Gui::InputHint> DrawSketchHandlerPoint::lookupPointHints(int stateValue)
 {
-    auto it = std::find_if(POINT_HINT_TABLE.begin(),
-                           POINT_HINT_TABLE.end(),
+    const auto pointHintTable = getPointHintTable();
+
+    auto it = std::find_if(pointHintTable.begin(),
+                           pointHintTable.end(),
                            [stateValue](const HintEntry& entry) {
                                return entry.stateValue == stateValue;
                            });
 
-    return (it != POINT_HINT_TABLE.end()) ? it->hints : std::list<Gui::InputHint> {};
+    return (it != pointHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
 }
 
 }  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -72,12 +72,6 @@ private:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 click to place a point"),
                               {UserInput::MouseLeft}));
-
-                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
-                                          {UserInput::MouseRight}));
-
-                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
-                                          {UserInput::KeyEscape}));
                 break;
             default:
                 break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -72,6 +72,9 @@ private:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 click to place a point"),
                               {UserInput::MouseLeft}));
+
+                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
+                                          {UserInput::KeyEscape}));
                 break;
             default:
                 break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -69,7 +69,7 @@ private:
         switch (state()) {
             case SelectMode::SeekFirst:
                 hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 click to place a point"),
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 place a point"),
                               {UserInput::MouseLeft}));
                 break;
             default:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -74,6 +74,9 @@ private:
                               {UserInput::MouseLeft}));
 
                 hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
+                                          {UserInput::MouseRight}));
+
+                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 cancel"),
                                           {UserInput::KeyEscape}));
                 break;
             default:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -27,6 +27,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -59,8 +60,28 @@ public:
     ~DrawSketchHandlerPoint() override = default;
 
 private:
+    void updateHints() const
+    {
+        using Gui::InputHint;
+
+        std::list<InputHint> hints;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 click to place a point"),
+                              {Gui::InputHint::UserInput::MouseLeft}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -63,6 +63,7 @@ private:
     void updateHints() const
     {
         using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
 
         std::list<InputHint> hints;
 
@@ -70,7 +71,7 @@ private:
             case SelectMode::SeekFirst:
                 hints.push_back(
                     InputHint(QCoreApplication::translate("Sketcher", "%1 click to place a point"),
-                              {Gui::InputHint::UserInput::MouseLeft}));
+                              {UserInput::MouseLeft}));
                 break;
             default:
                 break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -63,20 +63,14 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         switch (state()) {
             case SelectMode::SeekFirst:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 place a point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 place a point"), {MouseLeft}}};
             default:
-                break;
+                return {};
         }
-
-        return hints;
     }
 
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -60,11 +60,10 @@ public:
     ~DrawSketchHandlerPoint() override = default;
 
 private:
-    void updateHints() const
+    std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
         using UserInput = Gui::InputHint::UserInput;
-
         std::list<InputHint> hints;
 
         switch (state()) {
@@ -77,12 +76,11 @@ private:
                 break;
         }
 
-        Gui::getMainWindow()->showHints(hints);
+        return hints;
     }
+
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
-        updateHints();
-
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -30,6 +30,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -74,32 +75,11 @@ public:
     {}
     ~DrawSketchHandlerPolygon() override = default;
 
-    std::list<Gui::InputHint> getToolHints() const override
-    {
-        using UserInput = Gui::InputHint::UserInput;
-
-        switch (state()) {
-            case SelectMode::SeekFirst:
-                return {
-                    {QWidget::tr("%1 pick polygon center"), {UserInput::MouseLeft}},
-                    {QWidget::tr("%1/%2 increase / decrease number of sides"),
-                     {UserInput::KeyU, UserInput::KeyJ}},
-                };
-            case SelectMode::SeekSecond:
-                return {
-                    {QWidget::tr("%1 pick rotation and size"), {UserInput::MouseMove}},
-                    {QWidget::tr("%1 confirm"), {UserInput::MouseLeft}},
-                    {QWidget::tr("%1/%2 increase / decrease number of sides"),
-                     {UserInput::KeyU, UserInput::KeyJ}},
-                };
-            default:
-                return {};
-        }
-    }
-
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -283,6 +263,40 @@ private:
                                    isConstructionMode());
             prevCorner = newCorner;
         }
+    }
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick polygon center"),
+                              {UserInput::MouseLeft}));
+                hints.push_back(InputHint(
+                    QCoreApplication::translate("Sketcher",
+                                                "%1/%2 increase / decrease number of sides"),
+                    {UserInput::KeyU, UserInput::KeyJ}));
+                break;
+            case SelectMode::SeekSecond:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick rotation and size"),
+                              {UserInput::MouseMove}));
+                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 confirm"),
+                                          {UserInput::MouseLeft}));
+                hints.push_back(InputHint(
+                    QCoreApplication::translate("Sketcher",
+                                                "%1/%2 increase / decrease number of sides"),
+                    {UserInput::KeyU, UserInput::KeyJ}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -78,8 +78,6 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
-        updateHints();
-
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -265,7 +263,7 @@ private:
         }
     }
 
-    void updateHints() const
+    std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
         using UserInput = Gui::InputHint::UserInput;
@@ -296,7 +294,7 @@ private:
                 break;
         }
 
-        Gui::getMainWindow()->showHints(hints);
+        return hints;
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -266,35 +266,21 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         switch (state()) {
             case SelectMode::SeekFirst:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick polygon center"),
-                              {UserInput::MouseLeft}));
-                hints.push_back(InputHint(
-                    QCoreApplication::translate("Sketcher",
-                                                "%1/%2 increase / decrease number of sides"),
-                    {UserInput::KeyU, UserInput::KeyJ}));
-                break;
+                return {InputHint {QObject::tr("%1 pick polygon center"), {MouseLeft}},
+                        InputHint {QObject::tr("%1/%2 increase / decrease number of sides"),
+                                   {KeyU, KeyJ}}};
             case SelectMode::SeekSecond:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick rotation and size"),
-                              {UserInput::MouseMove}));
-                hints.push_back(InputHint(QCoreApplication::translate("Sketcher", "%1 confirm"),
-                                          {UserInput::MouseLeft}));
-                hints.push_back(InputHint(
-                    QCoreApplication::translate("Sketcher",
-                                                "%1/%2 increase / decrease number of sides"),
-                    {UserInput::KeyU, UserInput::KeyJ}));
-                break;
+                return {InputHint {QObject::tr("%1 pick rotation and size"), {MouseMove}},
+                        InputHint {QObject::tr("%1 confirm"), {MouseLeft}},
+                        InputHint {QObject::tr("%1/%2 increase / decrease number of sides"),
+                                   {KeyU, KeyJ}}};
             default:
-                break;
+                return {};
         }
-
-        return hints;
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -109,9 +109,6 @@ public:
     ~DrawSketchHandlerRectangle() override = default;
 
 private:
-    // ...existing code...
-
-private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -114,8 +114,6 @@ private:
     {
         using std::numbers::pi;
 
-        updateHints();
-
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -1577,7 +1575,7 @@ private:
         thickness = obliqueThickness * sin(angle412);
     }
 
-    void updateHints() const
+    std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
         using UserInput = Gui::InputHint::UserInput;
@@ -1711,7 +1709,7 @@ private:
                 break;
         }
 
-        Gui::getMainWindow()->showHints(hints);
+        return hints;
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -121,56 +121,72 @@ private:
             case ConstructionMethods::RectangleConstructionMethod::Diagonal:
                 switch (state()) {
                     case SelectMode::SeekFirst:
-                        return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}}};
+                        return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     case SelectMode::SeekSecond:
-                        return {InputHint {QObject::tr("%1 pick opposite corner"), {MouseLeft}}};
+                        return {InputHint {QObject::tr("%1 pick opposite corner"), {MouseLeft}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     case SelectMode::SeekThird:
                         return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
-                                           {MouseMove}}};
+                                           {MouseMove}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     case SelectMode::SeekFourth:
-                        return {InputHint {QObject::tr("%1 set frame thickness"), {MouseMove}}};
+                        return {InputHint {QObject::tr("%1 set frame thickness"), {MouseMove}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     default:
                         return {};
                 }
             case ConstructionMethods::RectangleConstructionMethod::CenterAndCorner:
                 switch (state()) {
                     case SelectMode::SeekFirst:
-                        return {InputHint {QObject::tr("%1 pick center"), {MouseLeft}}};
+                        return {InputHint {QObject::tr("%1 pick center"), {MouseLeft}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     case SelectMode::SeekSecond:
-                        return {InputHint {QObject::tr("%1 pick corner"), {MouseLeft}}};
+                        return {InputHint {QObject::tr("%1 pick corner"), {MouseLeft}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     case SelectMode::SeekThird:
                         return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
-                                           {MouseMove}}};
+                                           {MouseMove}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     case SelectMode::SeekFourth:
-                        return {InputHint {QObject::tr("%1 set frame thickness"), {MouseMove}}};
+                        return {InputHint {QObject::tr("%1 set frame thickness"), {MouseMove}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     default:
                         return {};
                 }
             case ConstructionMethods::RectangleConstructionMethod::ThreePoints:
                 switch (state()) {
                     case SelectMode::SeekFirst:
-                        return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}}};
+                        return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     case SelectMode::SeekSecond:
-                        return {InputHint {QObject::tr("%1 pick second corner"), {MouseLeft}}};
+                        return {InputHint {QObject::tr("%1 pick second corner"), {MouseLeft}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     case SelectMode::SeekThird:
-                        return {InputHint {QObject::tr("%1 pick third corner"), {MouseLeft}}};
+                        return {InputHint {QObject::tr("%1 pick third corner"), {MouseLeft}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     case SelectMode::SeekFourth:
                         return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
-                                           {MouseMove}}};
+                                           {MouseMove}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     default:
                         return {};
                 }
             case ConstructionMethods::RectangleConstructionMethod::CenterAnd3Points:
                 switch (state()) {
                     case SelectMode::SeekFirst:
-                        return {InputHint {QObject::tr("%1 pick center"), {MouseLeft}}};
+                        return {InputHint {QObject::tr("%1 pick center"), {MouseLeft}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     case SelectMode::SeekSecond:
-                        return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}}};
+                        return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     case SelectMode::SeekThird:
-                        return {InputHint {QObject::tr("%1 pick second corner"), {MouseLeft}}};
+                        return {InputHint {QObject::tr("%1 pick second corner"), {MouseLeft}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     case SelectMode::SeekFourth:
                         return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
-                                           {MouseMove}}};
+                                           {MouseMove}},
+                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
                     default:
                         return {};
                 }
@@ -2488,6 +2504,11 @@ void DSHRectangleController::addConstraints()
     }
 }
 
+template<>
+void DSHRectangleController::doConstructionMethodChanged()
+{
+    handler->updateHint();
+}
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -2161,6 +2161,246 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
 }
 
 template<>
+void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
+{
+
+    // If checkboxes need synchronisation (they were changed by the DSH, e.g. by using 'M' to switch
+    // construction method), synchronise them and return.
+    if (syncCheckboxToHandler(WCheckbox::FirstBox, handler->roundCorners)) {
+        return;
+    }
+
+    if (syncCheckboxToHandler(WCheckbox::SecondBox, handler->makeFrame)) {
+        return;
+    }
+
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            if (!onViewParameters[OnViewParameter::First]->isSet) {
+                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
+            }
+
+            if (!onViewParameters[OnViewParameter::Second]->isSet) {
+                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
+            }
+
+            bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
+            onViewParameters[OnViewParameter::First]->setLabelAutoDistanceReverse(!sameSign);
+            onViewParameters[OnViewParameter::Second]->setLabelAutoDistanceReverse(sameSign);
+            onViewParameters[OnViewParameter::First]->setPoints(Base::Vector3d(),
+                                                                toVector3d(onSketchPos));
+            onViewParameters[OnViewParameter::Second]->setPoints(Base::Vector3d(),
+                                                                 toVector3d(onSketchPos));
+        } break;
+        case SelectMode::SeekSecond: {
+            if (handler->constructionMethod() == ConstructionMethod::Diagonal
+                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
+                if (!onViewParameters[OnViewParameter::Third]->isSet) {
+                    double length = handler->cornersReversed ? handler->width : handler->length;
+                    setOnViewParameterValue(OnViewParameter::Third, length);
+                }
+
+                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
+                    double width = handler->cornersReversed ? handler->length : handler->width;
+                    setOnViewParameterValue(OnViewParameter::Fourth, width);
+                }
+
+                Base::Vector3d start = toVector3d(handler->corner1);
+                Base::Vector3d vec = toVector3d(onSketchPos) - start;
+                bool sameSign = vec.x * vec.y > 0.;
+
+                onViewParameters[OnViewParameter::Third]->setLabelAutoDistanceReverse(sameSign);
+                onViewParameters[OnViewParameter::Fourth]->setLabelAutoDistanceReverse(!sameSign);
+
+                onViewParameters[OnViewParameter::Third]->setPoints(
+                    start,
+                    toVector3d(handler->cornersReversed ? handler->corner4 : handler->corner2));
+                onViewParameters[OnViewParameter::Fourth]->setPoints(
+                    start,
+                    toVector3d(handler->cornersReversed ? handler->corner2 : handler->corner4));
+            }
+            else if (handler->constructionMethod() == ConstructionMethod::ThreePoints) {
+                if (!onViewParameters[OnViewParameter::Third]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Third, handler->length);
+                }
+
+                onViewParameters[OnViewParameter::Third]->setPoints(toVector3d(handler->corner4),
+                                                                    toVector3d(handler->corner3));
+
+                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Fourth,
+                                            Base::toDegrees(handler->angle),
+                                            Base::Unit::Angle);
+                }
+
+                onViewParameters[OnViewParameter::Fourth]->setPoints(toVector3d(handler->corner1),
+                                                                     Base::Vector3d());
+                onViewParameters[OnViewParameter::Fourth]->setLabelRange(
+                    (handler->corner2 - handler->corner1).Angle());
+            }
+            else {
+                if (!onViewParameters[OnViewParameter::Third]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Third, onSketchPos.x);
+                }
+
+                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Fourth, onSketchPos.y);
+                }
+
+                bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
+                onViewParameters[OnViewParameter::Third]->setLabelAutoDistanceReverse(!sameSign);
+                onViewParameters[OnViewParameter::Fourth]->setLabelAutoDistanceReverse(sameSign);
+                onViewParameters[OnViewParameter::Third]->setPoints(Base::Vector3d(),
+                                                                    toVector3d(onSketchPos));
+                onViewParameters[OnViewParameter::Fourth]->setPoints(Base::Vector3d(),
+                                                                     toVector3d(onSketchPos));
+            }
+        } break;
+        case SelectMode::SeekThird: {
+            if (handler->constructionMethod() == ConstructionMethod::Diagonal
+                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
+                if (handler->roundCorners) {
+                    if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
+                        setOnViewParameterValue(OnViewParameter::Fifth, handler->radius);
+                    }
+
+                    Base::Vector3d center = handler->center3;
+                    Base::Vector3d end = toVector3d(handler->corner3);
+
+                    if (handler->radius != 0.0) {
+                        Base::Vector3d vec = (end - center).Normalize();
+                        end = center + vec * handler->radius;
+                    }
+
+                    onViewParameters[OnViewParameter::Fifth]->setPoints(center, end);
+                }
+                else {
+                    if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
+                        setOnViewParameterValue(OnViewParameter::Sixth, handler->thickness);
+                    }
+
+                    Base::Vector3d start = toVector3d(handler->corner3);
+                    Base::Vector3d end =
+                        Base::Vector3d(handler->corner3.x, handler->frameCorner3.y, 0.0);
+                    onViewParameters[OnViewParameter::Sixth]->setPoints(start, end);
+                }
+            }
+            else if (handler->constructionMethod() == ConstructionMethod::ThreePoints) {
+                onViewParameters[OnViewParameter::Third]->setPoints(toVector3d(handler->corner4),
+                                                                    toVector3d(handler->corner3));
+
+                bool reversed = handler->cornersReversed;
+
+                if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Fifth,
+                                            reversed ? handler->length : handler->width);
+                }
+
+                Base::Vector3d start = toVector3d(handler->corner1);
+                onViewParameters[OnViewParameter::Fifth]->setLabelAutoDistanceReverse(reversed);
+                onViewParameters[OnViewParameter::Fifth]->setPoints(
+                    start,
+                    toVector3d(reversed ? handler->corner2 : handler->corner4));
+
+
+                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
+                    double val = Base::toDegrees(handler->angle123);
+                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
+                }
+
+                onViewParameters[OnViewParameter::Sixth]->setPoints(
+                    toVector3d(reversed ? handler->corner4 : handler->corner2),
+                    Base::Vector3d());
+                double startAngle = reversed ? (handler->corner1 - handler->corner4).Angle()
+                                             : (handler->corner3 - handler->corner2).Angle();
+                onViewParameters[OnViewParameter::Sixth]->setLabelStartAngle(startAngle);
+                onViewParameters[OnViewParameter::Sixth]->setLabelRange(handler->angle123);
+            }
+            else {
+                bool reversed = handler->cornersReversed;
+
+                if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Fifth,
+                                            reversed ? handler->width : handler->length);
+                }
+
+                Base::Vector3d start = toVector3d(handler->corner1);
+                onViewParameters[OnViewParameter::Fifth]->setLabelAutoDistanceReverse(true);
+                onViewParameters[OnViewParameter::Fifth]->setPoints(
+                    start,
+                    toVector3d(reversed ? handler->corner4 : handler->corner2));
+
+
+                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
+                    double val = Base::toDegrees(handler->angle412);
+                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
+                }
+
+                onViewParameters[OnViewParameter::Sixth]->setPoints(toVector3d(handler->corner1),
+                                                                    Base::Vector3d());
+                double startAngle = (handler->corner2 - handler->corner1).Angle();
+                onViewParameters[OnViewParameter::Sixth]->setLabelStartAngle(startAngle);
+                onViewParameters[OnViewParameter::Sixth]->setLabelRange(handler->angle412);
+            }
+
+        } break;
+        case SelectMode::SeekFourth: {
+            if (handler->constructionMethod() == ConstructionMethod::Diagonal
+                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
+                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Sixth, handler->thickness);
+                }
+
+                Base::Vector3d start = toVector3d(handler->corner3);
+                Base::Vector3d end =
+                    Base::Vector3d(handler->corner3.x, handler->frameCorner3.y, 0.0);
+                onViewParameters[OnViewParameter::Sixth]->setPoints(start, end);
+            }
+            else {
+                if (handler->roundCorners) {
+                    if (!onViewParameters[OnViewParameter::Seventh]->isSet) {
+                        setOnViewParameterValue(OnViewParameter::Seventh, handler->radius);
+                    }
+
+                    Base::Vector3d center = handler->center3;
+                    Base::Vector3d end = toVector3d(handler->corner3);
+
+                    if (handler->radius != 0.0) {
+                        Base::Vector3d vec = (end - center).Normalize();
+                        end = center + vec * handler->radius;
+                    }
+
+                    onViewParameters[OnViewParameter::Seventh]->setPoints(center, end);
+                }
+                else {
+                    if (!onViewParameters[OnViewParameter::Eighth]->isSet) {
+                        setOnViewParameterValue(OnViewParameter::Eighth, handler->thickness);
+                    }
+
+                    Base::Vector3d start = toVector3d(handler->corner3);
+                    Base::Vector3d vec =
+                        toVector3d((handler->corner3 - handler->corner2).Normalize());
+                    Base::Vector3d end = start + handler->thickness * vec;
+                    onViewParameters[OnViewParameter::Eighth]->setPoints(start, end);
+                }
+            }
+        } break;
+        case SelectMode::SeekFifth: {
+            if (!onViewParameters[OnViewParameter::Eighth]->isSet) {
+                setOnViewParameterValue(OnViewParameter::Eighth, handler->thickness);
+            }
+
+            Base::Vector3d start = toVector3d(handler->corner3);
+            Base::Vector3d vec = toVector3d((handler->corner3 - handler->corner2).Normalize());
+            Base::Vector3d end = start + handler->thickness * vec;
+            onViewParameters[OnViewParameter::Eighth]->setPoints(start, end);
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
 void DSHRectangleController::doChangeDrawSketchHandlerMode()
 {
     switch (handler->state()) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -115,123 +115,68 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         switch (constructionMethod()) {
             case ConstructionMethods::RectangleConstructionMethod::Diagonal:
                 switch (state()) {
                     case SelectMode::SeekFirst:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
-                            {UserInput::MouseLeft}));
-                        break;
+                        return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}}};
                     case SelectMode::SeekSecond:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick opposite corner"),
-                            {UserInput::MouseLeft}));
-                        break;
+                        return {InputHint {QObject::tr("%1 pick opposite corner"), {MouseLeft}}};
                     case SelectMode::SeekThird:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher",
-                                                        "%1 set corner radius or frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
+                        return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
+                                           {MouseMove}}};
                     case SelectMode::SeekFourth:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
+                        return {InputHint {QObject::tr("%1 set frame thickness"), {MouseMove}}};
                     default:
-                        break;
+                        return {};
                 }
-                break;
             case ConstructionMethods::RectangleConstructionMethod::CenterAndCorner:
                 switch (state()) {
                     case SelectMode::SeekFirst:
-                        hints.push_back(
-                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick center"),
-                                      {UserInput::MouseLeft}));
-                        break;
+                        return {InputHint {QObject::tr("%1 pick center"), {MouseLeft}}};
                     case SelectMode::SeekSecond:
-                        hints.push_back(
-                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick corner"),
-                                      {UserInput::MouseLeft}));
-                        break;
+                        return {InputHint {QObject::tr("%1 pick corner"), {MouseLeft}}};
                     case SelectMode::SeekThird:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher",
-                                                        "%1 set corner radius or frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
+                        return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
+                                           {MouseMove}}};
                     case SelectMode::SeekFourth:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
+                        return {InputHint {QObject::tr("%1 set frame thickness"), {MouseMove}}};
                     default:
-                        break;
+                        return {};
                 }
-                break;
             case ConstructionMethods::RectangleConstructionMethod::ThreePoints:
                 switch (state()) {
                     case SelectMode::SeekFirst:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
-                            {UserInput::MouseLeft}));
-                        break;
+                        return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}}};
                     case SelectMode::SeekSecond:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick second corner"),
-                            {UserInput::MouseLeft}));
-                        break;
+                        return {InputHint {QObject::tr("%1 pick second corner"), {MouseLeft}}};
                     case SelectMode::SeekThird:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick third corner"),
-                            {UserInput::MouseLeft}));
-                        break;
+                        return {InputHint {QObject::tr("%1 pick third corner"), {MouseLeft}}};
                     case SelectMode::SeekFourth:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher",
-                                                        "%1 set corner radius or frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
+                        return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
+                                           {MouseMove}}};
                     default:
-                        break;
+                        return {};
                 }
-                break;
             case ConstructionMethods::RectangleConstructionMethod::CenterAnd3Points:
                 switch (state()) {
                     case SelectMode::SeekFirst:
-                        hints.push_back(
-                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick center"),
-                                      {UserInput::MouseLeft}));
-                        break;
+                        return {InputHint {QObject::tr("%1 pick center"), {MouseLeft}}};
                     case SelectMode::SeekSecond:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
-                            {UserInput::MouseLeft}));
-                        break;
+                        return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}}};
                     case SelectMode::SeekThird:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick second corner"),
-                            {UserInput::MouseLeft}));
-                        break;
+                        return {InputHint {QObject::tr("%1 pick second corner"), {MouseLeft}}};
                     case SelectMode::SeekFourth:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher",
-                                                        "%1 set corner radius or frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
+                        return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
+                                           {MouseMove}}};
                     default:
-                        break;
+                        return {};
                 }
-                break;
             default:
-                break;
+                return {};
         }
-
-        return hints;
     }
 
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
@@ -2194,246 +2139,6 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
 
                 onSketchPos = handler->corner1 - dir * tr;
             }
-        } break;
-        default:
-            break;
-    }
-}
-
-template<>
-void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
-{
-
-    // If checkboxes need synchronisation (they were changed by the DSH, e.g. by using 'M' to switch
-    // construction method), synchronise them and return.
-    if (syncCheckboxToHandler(WCheckbox::FirstBox, handler->roundCorners)) {
-        return;
-    }
-
-    if (syncCheckboxToHandler(WCheckbox::SecondBox, handler->makeFrame)) {
-        return;
-    }
-
-    switch (handler->state()) {
-        case SelectMode::SeekFirst: {
-            if (!onViewParameters[OnViewParameter::First]->isSet) {
-                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
-            }
-
-            if (!onViewParameters[OnViewParameter::Second]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
-            }
-
-            bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
-            onViewParameters[OnViewParameter::First]->setLabelAutoDistanceReverse(!sameSign);
-            onViewParameters[OnViewParameter::Second]->setLabelAutoDistanceReverse(sameSign);
-            onViewParameters[OnViewParameter::First]->setPoints(Base::Vector3d(),
-                                                                toVector3d(onSketchPos));
-            onViewParameters[OnViewParameter::Second]->setPoints(Base::Vector3d(),
-                                                                 toVector3d(onSketchPos));
-        } break;
-        case SelectMode::SeekSecond: {
-            if (handler->constructionMethod() == ConstructionMethod::Diagonal
-                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
-                if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    double length = handler->cornersReversed ? handler->width : handler->length;
-                    setOnViewParameterValue(OnViewParameter::Third, length);
-                }
-
-                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    double width = handler->cornersReversed ? handler->length : handler->width;
-                    setOnViewParameterValue(OnViewParameter::Fourth, width);
-                }
-
-                Base::Vector3d start = toVector3d(handler->corner1);
-                Base::Vector3d vec = toVector3d(onSketchPos) - start;
-                bool sameSign = vec.x * vec.y > 0.;
-
-                onViewParameters[OnViewParameter::Third]->setLabelAutoDistanceReverse(sameSign);
-                onViewParameters[OnViewParameter::Fourth]->setLabelAutoDistanceReverse(!sameSign);
-
-                onViewParameters[OnViewParameter::Third]->setPoints(
-                    start,
-                    toVector3d(handler->cornersReversed ? handler->corner4 : handler->corner2));
-                onViewParameters[OnViewParameter::Fourth]->setPoints(
-                    start,
-                    toVector3d(handler->cornersReversed ? handler->corner2 : handler->corner4));
-            }
-            else if (handler->constructionMethod() == ConstructionMethod::ThreePoints) {
-                if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Third, handler->length);
-                }
-
-                onViewParameters[OnViewParameter::Third]->setPoints(toVector3d(handler->corner4),
-                                                                    toVector3d(handler->corner3));
-
-                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fourth,
-                                            Base::toDegrees(handler->angle),
-                                            Base::Unit::Angle);
-                }
-
-                onViewParameters[OnViewParameter::Fourth]->setPoints(toVector3d(handler->corner1),
-                                                                     Base::Vector3d());
-                onViewParameters[OnViewParameter::Fourth]->setLabelRange(
-                    (handler->corner2 - handler->corner1).Angle());
-            }
-            else {
-                if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Third, onSketchPos.x);
-                }
-
-                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fourth, onSketchPos.y);
-                }
-
-                bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
-                onViewParameters[OnViewParameter::Third]->setLabelAutoDistanceReverse(!sameSign);
-                onViewParameters[OnViewParameter::Fourth]->setLabelAutoDistanceReverse(sameSign);
-                onViewParameters[OnViewParameter::Third]->setPoints(Base::Vector3d(),
-                                                                    toVector3d(onSketchPos));
-                onViewParameters[OnViewParameter::Fourth]->setPoints(Base::Vector3d(),
-                                                                     toVector3d(onSketchPos));
-            }
-        } break;
-        case SelectMode::SeekThird: {
-            if (handler->constructionMethod() == ConstructionMethod::Diagonal
-                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
-                if (handler->roundCorners) {
-                    if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                        setOnViewParameterValue(OnViewParameter::Fifth, handler->radius);
-                    }
-
-                    Base::Vector3d center = handler->center3;
-                    Base::Vector3d end = toVector3d(handler->corner3);
-
-                    if (handler->radius != 0.0) {
-                        Base::Vector3d vec = (end - center).Normalize();
-                        end = center + vec * handler->radius;
-                    }
-
-                    onViewParameters[OnViewParameter::Fifth]->setPoints(center, end);
-                }
-                else {
-                    if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                        setOnViewParameterValue(OnViewParameter::Sixth, handler->thickness);
-                    }
-
-                    Base::Vector3d start = toVector3d(handler->corner3);
-                    Base::Vector3d end =
-                        Base::Vector3d(handler->corner3.x, handler->frameCorner3.y, 0.0);
-                    onViewParameters[OnViewParameter::Sixth]->setPoints(start, end);
-                }
-            }
-            else if (handler->constructionMethod() == ConstructionMethod::ThreePoints) {
-                onViewParameters[OnViewParameter::Third]->setPoints(toVector3d(handler->corner4),
-                                                                    toVector3d(handler->corner3));
-
-                bool reversed = handler->cornersReversed;
-
-                if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fifth,
-                                            reversed ? handler->length : handler->width);
-                }
-
-                Base::Vector3d start = toVector3d(handler->corner1);
-                onViewParameters[OnViewParameter::Fifth]->setLabelAutoDistanceReverse(reversed);
-                onViewParameters[OnViewParameter::Fifth]->setPoints(
-                    start,
-                    toVector3d(reversed ? handler->corner2 : handler->corner4));
-
-
-                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                    double val = Base::toDegrees(handler->angle123);
-                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
-                }
-
-                onViewParameters[OnViewParameter::Sixth]->setPoints(
-                    toVector3d(reversed ? handler->corner4 : handler->corner2),
-                    Base::Vector3d());
-                double startAngle = reversed ? (handler->corner1 - handler->corner4).Angle()
-                                             : (handler->corner3 - handler->corner2).Angle();
-                onViewParameters[OnViewParameter::Sixth]->setLabelStartAngle(startAngle);
-                onViewParameters[OnViewParameter::Sixth]->setLabelRange(handler->angle123);
-            }
-            else {
-                bool reversed = handler->cornersReversed;
-
-                if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fifth,
-                                            reversed ? handler->width : handler->length);
-                }
-
-                Base::Vector3d start = toVector3d(handler->corner1);
-                onViewParameters[OnViewParameter::Fifth]->setLabelAutoDistanceReverse(true);
-                onViewParameters[OnViewParameter::Fifth]->setPoints(
-                    start,
-                    toVector3d(reversed ? handler->corner4 : handler->corner2));
-
-
-                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                    double val = Base::toDegrees(handler->angle412);
-                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
-                }
-
-                onViewParameters[OnViewParameter::Sixth]->setPoints(toVector3d(handler->corner1),
-                                                                    Base::Vector3d());
-                double startAngle = (handler->corner2 - handler->corner1).Angle();
-                onViewParameters[OnViewParameter::Sixth]->setLabelStartAngle(startAngle);
-                onViewParameters[OnViewParameter::Sixth]->setLabelRange(handler->angle412);
-            }
-
-        } break;
-        case SelectMode::SeekFourth: {
-            if (handler->constructionMethod() == ConstructionMethod::Diagonal
-                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
-                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Sixth, handler->thickness);
-                }
-
-                Base::Vector3d start = toVector3d(handler->corner3);
-                Base::Vector3d end =
-                    Base::Vector3d(handler->corner3.x, handler->frameCorner3.y, 0.0);
-                onViewParameters[OnViewParameter::Sixth]->setPoints(start, end);
-            }
-            else {
-                if (handler->roundCorners) {
-                    if (!onViewParameters[OnViewParameter::Seventh]->isSet) {
-                        setOnViewParameterValue(OnViewParameter::Seventh, handler->radius);
-                    }
-
-                    Base::Vector3d center = handler->center3;
-                    Base::Vector3d end = toVector3d(handler->corner3);
-
-                    if (handler->radius != 0.0) {
-                        Base::Vector3d vec = (end - center).Normalize();
-                        end = center + vec * handler->radius;
-                    }
-
-                    onViewParameters[OnViewParameter::Seventh]->setPoints(center, end);
-                }
-                else {
-                    if (!onViewParameters[OnViewParameter::Eighth]->isSet) {
-                        setOnViewParameterValue(OnViewParameter::Eighth, handler->thickness);
-                    }
-
-                    Base::Vector3d start = toVector3d(handler->corner3);
-                    Base::Vector3d vec =
-                        toVector3d((handler->corner3 - handler->corner2).Normalize());
-                    Base::Vector3d end = start + handler->thickness * vec;
-                    onViewParameters[OnViewParameter::Eighth]->setPoints(start, end);
-                }
-            }
-        } break;
-        case SelectMode::SeekFifth: {
-            if (!onViewParameters[OnViewParameter::Eighth]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Eighth, handler->thickness);
-            }
-
-            Base::Vector3d start = toVector3d(handler->corner3);
-            Base::Vector3d vec = toVector3d((handler->corner3 - handler->corner2).Normalize());
-            Base::Vector3d end = start + handler->thickness * vec;
-            onViewParameters[OnViewParameter::Eighth]->setPoints(start, end);
         } break;
         default:
             break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -111,89 +111,23 @@ public:
 private:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        using Gui::InputHint;
-        using enum Gui::InputHint::UserInput;
-
-        const InputHint switchModeHint {QObject::tr("%1 switch mode"), {KeyM}};
-
-        switch (constructionMethod()) {
-            case ConstructionMethods::RectangleConstructionMethod::Diagonal:
-                switch (state()) {
-                    case SelectMode::SeekFirst:
-                        return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}},
-                                switchModeHint};
-                    case SelectMode::SeekSecond:
-                        return {InputHint {QObject::tr("%1 pick opposite corner"), {MouseLeft}},
-                                switchModeHint};
-                    case SelectMode::SeekThird:
-                        return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
-                                           {MouseMove}},
-                                switchModeHint};
-                    case SelectMode::SeekFourth:
-                        return {InputHint {QObject::tr("%1 set frame thickness"), {MouseMove}},
-                                switchModeHint};
-                    default:
-                        return {};
-                }
-            case ConstructionMethods::RectangleConstructionMethod::CenterAndCorner:
-                switch (state()) {
-                    case SelectMode::SeekFirst:
-                        return {InputHint {QObject::tr("%1 pick center"), {MouseLeft}},
-                                switchModeHint};
-                    case SelectMode::SeekSecond:
-                        return {InputHint {QObject::tr("%1 pick corner"), {MouseLeft}},
-                                switchModeHint};
-                    case SelectMode::SeekThird:
-                        return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
-                                           {MouseMove}},
-                                switchModeHint};
-                    case SelectMode::SeekFourth:
-                        return {InputHint {QObject::tr("%1 set frame thickness"), {MouseMove}},
-                                switchModeHint};
-                    default:
-                        return {};
-                }
-            case ConstructionMethods::RectangleConstructionMethod::ThreePoints:
-                switch (state()) {
-                    case SelectMode::SeekFirst:
-                        return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}},
-                                switchModeHint};
-                    case SelectMode::SeekSecond:
-                        return {InputHint {QObject::tr("%1 pick second corner"), {MouseLeft}},
-                                switchModeHint};
-                    case SelectMode::SeekThird:
-                        return {InputHint {QObject::tr("%1 pick third corner"), {MouseLeft}},
-                                switchModeHint};
-                    case SelectMode::SeekFourth:
-                        return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
-                                           {MouseMove}},
-                                switchModeHint};
-                    default:
-                        return {};
-                }
-            case ConstructionMethods::RectangleConstructionMethod::CenterAnd3Points:
-                switch (state()) {
-                    case SelectMode::SeekFirst:
-                        return {InputHint {QObject::tr("%1 pick center"), {MouseLeft}},
-                                switchModeHint};
-                    case SelectMode::SeekSecond:
-                        return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}},
-                                switchModeHint};
-                    case SelectMode::SeekThird:
-                        return {InputHint {QObject::tr("%1 pick second corner"), {MouseLeft}},
-                                switchModeHint};
-                    case SelectMode::SeekFourth:
-                        return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
-                                           {MouseMove}},
-                                switchModeHint};
-                    default:
-                        return {};
-                }
-            default:
-                return {};
-        }
+        return lookupRectangleHints(constructionMethod(), state());
     }
 
+private:
+    struct HintEntry
+    {
+        ConstructionMethods::RectangleConstructionMethod method;
+        SelectMode state;
+        std::list<Gui::InputHint> hints;
+    };
+
+    using HintTable = std::vector<HintEntry>;
+
+    static Gui::InputHint switchModeHint();
+    static HintTable getRectangleHintTable();
+    static std::list<Gui::InputHint>
+    lookupRectangleHints(ConstructionMethods::RectangleConstructionMethod method, SelectMode state);
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
         using std::numbers::pi;
@@ -2749,6 +2683,104 @@ void DSHRectangleController::doConstructionMethodChanged()
     handler->updateHint();
 }
 
+Gui::InputHint DrawSketchHandlerRectangle::switchModeHint()
+{
+    return {QObject::tr("%1 switch mode"), {Gui::InputHint::UserInput::KeyM}};
+}
+
+DrawSketchHandlerRectangle::HintTable DrawSketchHandlerRectangle::getRectangleHintTable()
+{
+    const auto switchHint = switchModeHint();
+    return {// Structure: {ConstructionMethod, SelectMode, {hints...}}
+
+            // Diagonal method
+            {ConstructionMethods::RectangleConstructionMethod::Diagonal,
+             SelectMode::SeekFirst,
+             {{QObject::tr("%1 pick first corner"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}},
+            {ConstructionMethods::RectangleConstructionMethod::Diagonal,
+             SelectMode::SeekSecond,
+             {{QObject::tr("%1 pick opposite corner"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}},
+            {ConstructionMethods::RectangleConstructionMethod::Diagonal,
+             SelectMode::SeekThird,
+             {{QObject::tr("%1 set corner radius or frame thickness"),
+               {Gui::InputHint::UserInput::MouseMove}},
+              switchHint}},
+            {ConstructionMethods::RectangleConstructionMethod::Diagonal,
+             SelectMode::SeekFourth,
+             {{QObject::tr("%1 set frame thickness"), {Gui::InputHint::UserInput::MouseMove}},
+              switchHint}},
+
+            // CenterAndCorner method
+            {ConstructionMethods::RectangleConstructionMethod::CenterAndCorner,
+             SelectMode::SeekFirst,
+             {{QObject::tr("%1 pick center"), {Gui::InputHint::UserInput::MouseLeft}}, switchHint}},
+            {ConstructionMethods::RectangleConstructionMethod::CenterAndCorner,
+             SelectMode::SeekSecond,
+             {{QObject::tr("%1 pick corner"), {Gui::InputHint::UserInput::MouseLeft}}, switchHint}},
+            {ConstructionMethods::RectangleConstructionMethod::CenterAndCorner,
+             SelectMode::SeekThird,
+             {{QObject::tr("%1 set corner radius or frame thickness"),
+               {Gui::InputHint::UserInput::MouseMove}},
+              switchHint}},
+            {ConstructionMethods::RectangleConstructionMethod::CenterAndCorner,
+             SelectMode::SeekFourth,
+             {{QObject::tr("%1 set frame thickness"), {Gui::InputHint::UserInput::MouseMove}},
+              switchHint}},
+
+            // ThreePoints method
+            {ConstructionMethods::RectangleConstructionMethod::ThreePoints,
+             SelectMode::SeekFirst,
+             {{QObject::tr("%1 pick first corner"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}},
+            {ConstructionMethods::RectangleConstructionMethod::ThreePoints,
+             SelectMode::SeekSecond,
+             {{QObject::tr("%1 pick second corner"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}},
+            {ConstructionMethods::RectangleConstructionMethod::ThreePoints,
+             SelectMode::SeekThird,
+             {{QObject::tr("%1 pick third corner"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}},
+            {ConstructionMethods::RectangleConstructionMethod::ThreePoints,
+             SelectMode::SeekFourth,
+             {{QObject::tr("%1 set corner radius or frame thickness"),
+               {Gui::InputHint::UserInput::MouseMove}},
+              switchHint}},
+
+            // CenterAnd3Points method
+            {ConstructionMethods::RectangleConstructionMethod::CenterAnd3Points,
+             SelectMode::SeekFirst,
+             {{QObject::tr("%1 pick center"), {Gui::InputHint::UserInput::MouseLeft}}, switchHint}},
+            {ConstructionMethods::RectangleConstructionMethod::CenterAnd3Points,
+             SelectMode::SeekSecond,
+             {{QObject::tr("%1 pick first corner"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}},
+            {ConstructionMethods::RectangleConstructionMethod::CenterAnd3Points,
+             SelectMode::SeekThird,
+             {{QObject::tr("%1 pick second corner"), {Gui::InputHint::UserInput::MouseLeft}},
+              switchHint}},
+            {ConstructionMethods::RectangleConstructionMethod::CenterAnd3Points,
+             SelectMode::SeekFourth,
+             {{QObject::tr("%1 set corner radius or frame thickness"),
+               {Gui::InputHint::UserInput::MouseMove}},
+              switchHint}}};
+}
+
+std::list<Gui::InputHint> DrawSketchHandlerRectangle::lookupRectangleHints(
+    ConstructionMethods::RectangleConstructionMethod method,
+    SelectMode state)
+{
+    const auto rectangleHintTable = getRectangleHintTable();
+
+    auto it = std::find_if(rectangleHintTable.begin(),
+                           rectangleHintTable.end(),
+                           [method, state](const HintEntry& entry) {
+                               return entry.method == method && entry.state == state;
+                           });
+
+    return (it != rectangleHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
+}
 }  // namespace SketcherGui
 
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -117,22 +117,24 @@ private:
         using Gui::InputHint;
         using enum Gui::InputHint::UserInput;
 
+        const InputHint switchModeHint {QObject::tr("%1 switch mode"), {KeyM}};
+
         switch (constructionMethod()) {
             case ConstructionMethods::RectangleConstructionMethod::Diagonal:
                 switch (state()) {
                     case SelectMode::SeekFirst:
                         return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     case SelectMode::SeekSecond:
                         return {InputHint {QObject::tr("%1 pick opposite corner"), {MouseLeft}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     case SelectMode::SeekThird:
                         return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
                                            {MouseMove}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     case SelectMode::SeekFourth:
                         return {InputHint {QObject::tr("%1 set frame thickness"), {MouseMove}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     default:
                         return {};
                 }
@@ -140,17 +142,17 @@ private:
                 switch (state()) {
                     case SelectMode::SeekFirst:
                         return {InputHint {QObject::tr("%1 pick center"), {MouseLeft}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     case SelectMode::SeekSecond:
                         return {InputHint {QObject::tr("%1 pick corner"), {MouseLeft}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     case SelectMode::SeekThird:
                         return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
                                            {MouseMove}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     case SelectMode::SeekFourth:
                         return {InputHint {QObject::tr("%1 set frame thickness"), {MouseMove}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     default:
                         return {};
                 }
@@ -158,17 +160,17 @@ private:
                 switch (state()) {
                     case SelectMode::SeekFirst:
                         return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     case SelectMode::SeekSecond:
                         return {InputHint {QObject::tr("%1 pick second corner"), {MouseLeft}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     case SelectMode::SeekThird:
                         return {InputHint {QObject::tr("%1 pick third corner"), {MouseLeft}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     case SelectMode::SeekFourth:
                         return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
                                            {MouseMove}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     default:
                         return {};
                 }
@@ -176,17 +178,17 @@ private:
                 switch (state()) {
                     case SelectMode::SeekFirst:
                         return {InputHint {QObject::tr("%1 pick center"), {MouseLeft}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     case SelectMode::SeekSecond:
                         return {InputHint {QObject::tr("%1 pick first corner"), {MouseLeft}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     case SelectMode::SeekThird:
                         return {InputHint {QObject::tr("%1 pick second corner"), {MouseLeft}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     case SelectMode::SeekFourth:
                         return {InputHint {QObject::tr("%1 set corner radius or frame thickness"),
                                            {MouseMove}},
-                                InputHint {QObject::tr("%1 switch mode"), {KeyM}}};
+                                switchModeHint};
                     default:
                         return {};
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -30,6 +30,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -112,6 +113,8 @@ private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
         using std::numbers::pi;
+
+        updateHints();
 
         switch (state()) {
             case SelectMode::SeekFirst: {
@@ -1573,6 +1576,143 @@ private:
 
         thickness = obliqueThickness * sin(angle412);
     }
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (constructionMethod()) {
+            case ConstructionMethod::Diagonal:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick opposite corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher",
+                                                        "%1 set corner radius or frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    case SelectMode::SeekFifth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case ConstructionMethod::CenterAndCorner:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick center"),
+                                      {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick corner"),
+                                      {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher",
+                                                        "%1 set corner radius or frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case ConstructionMethod::ThreePoints:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick second corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick third corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher",
+                                                        "%1 set corner radius or frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    case SelectMode::SeekFifth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case ConstructionMethod::CenterAnd3Points:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick center"),
+                                      {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick second corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher",
+                                                        "%1 set corner radius or frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    case SelectMode::SeekFifth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
+    }
 };
 
 template<>
@@ -2069,246 +2209,6 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
 
                 onSketchPos = handler->corner1 - dir * tr;
             }
-        } break;
-        default:
-            break;
-    }
-}
-
-template<>
-void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
-{
-
-    // If checkboxes need synchronisation (they were changed by the DSH, e.g. by using 'M' to switch
-    // construction method), synchronise them and return.
-    if (syncCheckboxToHandler(WCheckbox::FirstBox, handler->roundCorners)) {
-        return;
-    }
-
-    if (syncCheckboxToHandler(WCheckbox::SecondBox, handler->makeFrame)) {
-        return;
-    }
-
-    switch (handler->state()) {
-        case SelectMode::SeekFirst: {
-            if (!onViewParameters[OnViewParameter::First]->isSet) {
-                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
-            }
-
-            if (!onViewParameters[OnViewParameter::Second]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
-            }
-
-            bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
-            onViewParameters[OnViewParameter::First]->setLabelAutoDistanceReverse(!sameSign);
-            onViewParameters[OnViewParameter::Second]->setLabelAutoDistanceReverse(sameSign);
-            onViewParameters[OnViewParameter::First]->setPoints(Base::Vector3d(),
-                                                                toVector3d(onSketchPos));
-            onViewParameters[OnViewParameter::Second]->setPoints(Base::Vector3d(),
-                                                                 toVector3d(onSketchPos));
-        } break;
-        case SelectMode::SeekSecond: {
-            if (handler->constructionMethod() == ConstructionMethod::Diagonal
-                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
-                if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    double length = handler->cornersReversed ? handler->width : handler->length;
-                    setOnViewParameterValue(OnViewParameter::Third, length);
-                }
-
-                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    double width = handler->cornersReversed ? handler->length : handler->width;
-                    setOnViewParameterValue(OnViewParameter::Fourth, width);
-                }
-
-                Base::Vector3d start = toVector3d(handler->corner1);
-                Base::Vector3d vec = toVector3d(onSketchPos) - start;
-                bool sameSign = vec.x * vec.y > 0.;
-
-                onViewParameters[OnViewParameter::Third]->setLabelAutoDistanceReverse(sameSign);
-                onViewParameters[OnViewParameter::Fourth]->setLabelAutoDistanceReverse(!sameSign);
-
-                onViewParameters[OnViewParameter::Third]->setPoints(
-                    start,
-                    toVector3d(handler->cornersReversed ? handler->corner4 : handler->corner2));
-                onViewParameters[OnViewParameter::Fourth]->setPoints(
-                    start,
-                    toVector3d(handler->cornersReversed ? handler->corner2 : handler->corner4));
-            }
-            else if (handler->constructionMethod() == ConstructionMethod::ThreePoints) {
-                if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Third, handler->length);
-                }
-
-                onViewParameters[OnViewParameter::Third]->setPoints(toVector3d(handler->corner4),
-                                                                    toVector3d(handler->corner3));
-
-                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fourth,
-                                            Base::toDegrees(handler->angle),
-                                            Base::Unit::Angle);
-                }
-
-                onViewParameters[OnViewParameter::Fourth]->setPoints(toVector3d(handler->corner1),
-                                                                     Base::Vector3d());
-                onViewParameters[OnViewParameter::Fourth]->setLabelRange(
-                    (handler->corner2 - handler->corner1).Angle());
-            }
-            else {
-                if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Third, onSketchPos.x);
-                }
-
-                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fourth, onSketchPos.y);
-                }
-
-                bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
-                onViewParameters[OnViewParameter::Third]->setLabelAutoDistanceReverse(!sameSign);
-                onViewParameters[OnViewParameter::Fourth]->setLabelAutoDistanceReverse(sameSign);
-                onViewParameters[OnViewParameter::Third]->setPoints(Base::Vector3d(),
-                                                                    toVector3d(onSketchPos));
-                onViewParameters[OnViewParameter::Fourth]->setPoints(Base::Vector3d(),
-                                                                     toVector3d(onSketchPos));
-            }
-        } break;
-        case SelectMode::SeekThird: {
-            if (handler->constructionMethod() == ConstructionMethod::Diagonal
-                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
-                if (handler->roundCorners) {
-                    if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                        setOnViewParameterValue(OnViewParameter::Fifth, handler->radius);
-                    }
-
-                    Base::Vector3d center = handler->center3;
-                    Base::Vector3d end = toVector3d(handler->corner3);
-
-                    if (handler->radius != 0.0) {
-                        Base::Vector3d vec = (end - center).Normalize();
-                        end = center + vec * handler->radius;
-                    }
-
-                    onViewParameters[OnViewParameter::Fifth]->setPoints(center, end);
-                }
-                else {
-                    if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                        setOnViewParameterValue(OnViewParameter::Sixth, handler->thickness);
-                    }
-
-                    Base::Vector3d start = toVector3d(handler->corner3);
-                    Base::Vector3d end =
-                        Base::Vector3d(handler->corner3.x, handler->frameCorner3.y, 0.0);
-                    onViewParameters[OnViewParameter::Sixth]->setPoints(start, end);
-                }
-            }
-            else if (handler->constructionMethod() == ConstructionMethod::ThreePoints) {
-                onViewParameters[OnViewParameter::Third]->setPoints(toVector3d(handler->corner4),
-                                                                    toVector3d(handler->corner3));
-
-                bool reversed = handler->cornersReversed;
-
-                if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fifth,
-                                            reversed ? handler->length : handler->width);
-                }
-
-                Base::Vector3d start = toVector3d(handler->corner1);
-                onViewParameters[OnViewParameter::Fifth]->setLabelAutoDistanceReverse(reversed);
-                onViewParameters[OnViewParameter::Fifth]->setPoints(
-                    start,
-                    toVector3d(reversed ? handler->corner2 : handler->corner4));
-
-
-                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                    double val = Base::toDegrees(handler->angle123);
-                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
-                }
-
-                onViewParameters[OnViewParameter::Sixth]->setPoints(
-                    toVector3d(reversed ? handler->corner4 : handler->corner2),
-                    Base::Vector3d());
-                double startAngle = reversed ? (handler->corner1 - handler->corner4).Angle()
-                                             : (handler->corner3 - handler->corner2).Angle();
-                onViewParameters[OnViewParameter::Sixth]->setLabelStartAngle(startAngle);
-                onViewParameters[OnViewParameter::Sixth]->setLabelRange(handler->angle123);
-            }
-            else {
-                bool reversed = handler->cornersReversed;
-
-                if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Fifth,
-                                            reversed ? handler->width : handler->length);
-                }
-
-                Base::Vector3d start = toVector3d(handler->corner1);
-                onViewParameters[OnViewParameter::Fifth]->setLabelAutoDistanceReverse(true);
-                onViewParameters[OnViewParameter::Fifth]->setPoints(
-                    start,
-                    toVector3d(reversed ? handler->corner4 : handler->corner2));
-
-
-                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                    double val = Base::toDegrees(handler->angle412);
-                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
-                }
-
-                onViewParameters[OnViewParameter::Sixth]->setPoints(toVector3d(handler->corner1),
-                                                                    Base::Vector3d());
-                double startAngle = (handler->corner2 - handler->corner1).Angle();
-                onViewParameters[OnViewParameter::Sixth]->setLabelStartAngle(startAngle);
-                onViewParameters[OnViewParameter::Sixth]->setLabelRange(handler->angle412);
-            }
-
-        } break;
-        case SelectMode::SeekFourth: {
-            if (handler->constructionMethod() == ConstructionMethod::Diagonal
-                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
-                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                    setOnViewParameterValue(OnViewParameter::Sixth, handler->thickness);
-                }
-
-                Base::Vector3d start = toVector3d(handler->corner3);
-                Base::Vector3d end =
-                    Base::Vector3d(handler->corner3.x, handler->frameCorner3.y, 0.0);
-                onViewParameters[OnViewParameter::Sixth]->setPoints(start, end);
-            }
-            else {
-                if (handler->roundCorners) {
-                    if (!onViewParameters[OnViewParameter::Seventh]->isSet) {
-                        setOnViewParameterValue(OnViewParameter::Seventh, handler->radius);
-                    }
-
-                    Base::Vector3d center = handler->center3;
-                    Base::Vector3d end = toVector3d(handler->corner3);
-
-                    if (handler->radius != 0.0) {
-                        Base::Vector3d vec = (end - center).Normalize();
-                        end = center + vec * handler->radius;
-                    }
-
-                    onViewParameters[OnViewParameter::Seventh]->setPoints(center, end);
-                }
-                else {
-                    if (!onViewParameters[OnViewParameter::Eighth]->isSet) {
-                        setOnViewParameterValue(OnViewParameter::Eighth, handler->thickness);
-                    }
-
-                    Base::Vector3d start = toVector3d(handler->corner3);
-                    Base::Vector3d vec =
-                        toVector3d((handler->corner3 - handler->corner2).Normalize());
-                    Base::Vector3d end = start + handler->thickness * vec;
-                    onViewParameters[OnViewParameter::Eighth]->setPoints(start, end);
-                }
-            }
-        } break;
-        case SelectMode::SeekFifth: {
-            if (!onViewParameters[OnViewParameter::Eighth]->isSet) {
-                setOnViewParameterValue(OnViewParameter::Eighth, handler->thickness);
-            }
-
-            Base::Vector3d start = toVector3d(handler->corner3);
-            Base::Vector3d vec = toVector3d((handler->corner3 - handler->corner2).Normalize());
-            Base::Vector3d end = start + handler->thickness * vec;
-            onViewParameters[OnViewParameter::Eighth]->setPoints(start, end);
         } break;
         default:
             break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -31,7 +31,6 @@
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
 #include <Gui/InputHint.h>
-
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchDefaultWidgetController.h"
@@ -110,6 +109,131 @@ public:
     ~DrawSketchHandlerRectangle() override = default;
 
 private:
+    // ...existing code...
+
+private:
+    std::list<Gui::InputHint> getToolHints() const override
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (constructionMethod()) {
+            case ConstructionMethods::RectangleConstructionMethod::Diagonal:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick opposite corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher",
+                                                        "%1 set corner radius or frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case ConstructionMethods::RectangleConstructionMethod::CenterAndCorner:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick center"),
+                                      {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick corner"),
+                                      {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher",
+                                                        "%1 set corner radius or frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case ConstructionMethods::RectangleConstructionMethod::ThreePoints:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick second corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick third corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher",
+                                                        "%1 set corner radius or frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case ConstructionMethods::RectangleConstructionMethod::CenterAnd3Points:
+                switch (state()) {
+                    case SelectMode::SeekFirst:
+                        hints.push_back(
+                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick center"),
+                                      {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekSecond:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekThird:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher", "%1 pick second corner"),
+                            {UserInput::MouseLeft}));
+                        break;
+                    case SelectMode::SeekFourth:
+                        hints.push_back(InputHint(
+                            QCoreApplication::translate("Sketcher",
+                                                        "%1 set corner radius or frame thickness"),
+                            {UserInput::MouseMove}));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            default:
+                break;
+        }
+
+        return hints;
+    }
+
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
         using std::numbers::pi;
@@ -1574,143 +1698,6 @@ private:
 
         thickness = obliqueThickness * sin(angle412);
     }
-
-    std::list<Gui::InputHint> getToolHints() const override
-    {
-        using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
-
-        switch (constructionMethod()) {
-            case ConstructionMethod::Diagonal:
-                switch (state()) {
-                    case SelectMode::SeekFirst:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
-                            {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekSecond:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick opposite corner"),
-                            {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekThird:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher",
-                                                        "%1 set corner radius or frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
-                    case SelectMode::SeekFourth:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
-                    case SelectMode::SeekFifth:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
-                    default:
-                        break;
-                }
-                break;
-            case ConstructionMethod::CenterAndCorner:
-                switch (state()) {
-                    case SelectMode::SeekFirst:
-                        hints.push_back(
-                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick center"),
-                                      {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekSecond:
-                        hints.push_back(
-                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick corner"),
-                                      {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekThird:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher",
-                                                        "%1 set corner radius or frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
-                    case SelectMode::SeekFourth:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
-                    default:
-                        break;
-                }
-                break;
-            case ConstructionMethod::ThreePoints:
-                switch (state()) {
-                    case SelectMode::SeekFirst:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
-                            {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekSecond:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick second corner"),
-                            {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekThird:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick third corner"),
-                            {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekFourth:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher",
-                                                        "%1 set corner radius or frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
-                    case SelectMode::SeekFifth:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
-                    default:
-                        break;
-                }
-                break;
-            case ConstructionMethod::CenterAnd3Points:
-                switch (state()) {
-                    case SelectMode::SeekFirst:
-                        hints.push_back(
-                            InputHint(QCoreApplication::translate("Sketcher", "%1 pick center"),
-                                      {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekSecond:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick first corner"),
-                            {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekThird:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 pick second corner"),
-                            {UserInput::MouseLeft}));
-                        break;
-                    case SelectMode::SeekFourth:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher",
-                                                        "%1 set corner radius or frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
-                    case SelectMode::SeekFifth:
-                        hints.push_back(InputHint(
-                            QCoreApplication::translate("Sketcher", "%1 set frame thickness"),
-                            {UserInput::MouseMove}));
-                        break;
-                    default:
-                        break;
-                }
-                break;
-            default:
-                break;
-        }
-
-        return hints;
-    }
 };
 
 template<>
@@ -2207,6 +2194,246 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
 
                 onSketchPos = handler->corner1 - dir * tr;
             }
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
+{
+
+    // If checkboxes need synchronisation (they were changed by the DSH, e.g. by using 'M' to switch
+    // construction method), synchronise them and return.
+    if (syncCheckboxToHandler(WCheckbox::FirstBox, handler->roundCorners)) {
+        return;
+    }
+
+    if (syncCheckboxToHandler(WCheckbox::SecondBox, handler->makeFrame)) {
+        return;
+    }
+
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            if (!onViewParameters[OnViewParameter::First]->isSet) {
+                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
+            }
+
+            if (!onViewParameters[OnViewParameter::Second]->isSet) {
+                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
+            }
+
+            bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
+            onViewParameters[OnViewParameter::First]->setLabelAutoDistanceReverse(!sameSign);
+            onViewParameters[OnViewParameter::Second]->setLabelAutoDistanceReverse(sameSign);
+            onViewParameters[OnViewParameter::First]->setPoints(Base::Vector3d(),
+                                                                toVector3d(onSketchPos));
+            onViewParameters[OnViewParameter::Second]->setPoints(Base::Vector3d(),
+                                                                 toVector3d(onSketchPos));
+        } break;
+        case SelectMode::SeekSecond: {
+            if (handler->constructionMethod() == ConstructionMethod::Diagonal
+                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
+                if (!onViewParameters[OnViewParameter::Third]->isSet) {
+                    double length = handler->cornersReversed ? handler->width : handler->length;
+                    setOnViewParameterValue(OnViewParameter::Third, length);
+                }
+
+                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
+                    double width = handler->cornersReversed ? handler->length : handler->width;
+                    setOnViewParameterValue(OnViewParameter::Fourth, width);
+                }
+
+                Base::Vector3d start = toVector3d(handler->corner1);
+                Base::Vector3d vec = toVector3d(onSketchPos) - start;
+                bool sameSign = vec.x * vec.y > 0.;
+
+                onViewParameters[OnViewParameter::Third]->setLabelAutoDistanceReverse(sameSign);
+                onViewParameters[OnViewParameter::Fourth]->setLabelAutoDistanceReverse(!sameSign);
+
+                onViewParameters[OnViewParameter::Third]->setPoints(
+                    start,
+                    toVector3d(handler->cornersReversed ? handler->corner4 : handler->corner2));
+                onViewParameters[OnViewParameter::Fourth]->setPoints(
+                    start,
+                    toVector3d(handler->cornersReversed ? handler->corner2 : handler->corner4));
+            }
+            else if (handler->constructionMethod() == ConstructionMethod::ThreePoints) {
+                if (!onViewParameters[OnViewParameter::Third]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Third, handler->length);
+                }
+
+                onViewParameters[OnViewParameter::Third]->setPoints(toVector3d(handler->corner4),
+                                                                    toVector3d(handler->corner3));
+
+                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Fourth,
+                                            Base::toDegrees(handler->angle),
+                                            Base::Unit::Angle);
+                }
+
+                onViewParameters[OnViewParameter::Fourth]->setPoints(toVector3d(handler->corner1),
+                                                                     Base::Vector3d());
+                onViewParameters[OnViewParameter::Fourth]->setLabelRange(
+                    (handler->corner2 - handler->corner1).Angle());
+            }
+            else {
+                if (!onViewParameters[OnViewParameter::Third]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Third, onSketchPos.x);
+                }
+
+                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Fourth, onSketchPos.y);
+                }
+
+                bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
+                onViewParameters[OnViewParameter::Third]->setLabelAutoDistanceReverse(!sameSign);
+                onViewParameters[OnViewParameter::Fourth]->setLabelAutoDistanceReverse(sameSign);
+                onViewParameters[OnViewParameter::Third]->setPoints(Base::Vector3d(),
+                                                                    toVector3d(onSketchPos));
+                onViewParameters[OnViewParameter::Fourth]->setPoints(Base::Vector3d(),
+                                                                     toVector3d(onSketchPos));
+            }
+        } break;
+        case SelectMode::SeekThird: {
+            if (handler->constructionMethod() == ConstructionMethod::Diagonal
+                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
+                if (handler->roundCorners) {
+                    if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
+                        setOnViewParameterValue(OnViewParameter::Fifth, handler->radius);
+                    }
+
+                    Base::Vector3d center = handler->center3;
+                    Base::Vector3d end = toVector3d(handler->corner3);
+
+                    if (handler->radius != 0.0) {
+                        Base::Vector3d vec = (end - center).Normalize();
+                        end = center + vec * handler->radius;
+                    }
+
+                    onViewParameters[OnViewParameter::Fifth]->setPoints(center, end);
+                }
+                else {
+                    if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
+                        setOnViewParameterValue(OnViewParameter::Sixth, handler->thickness);
+                    }
+
+                    Base::Vector3d start = toVector3d(handler->corner3);
+                    Base::Vector3d end =
+                        Base::Vector3d(handler->corner3.x, handler->frameCorner3.y, 0.0);
+                    onViewParameters[OnViewParameter::Sixth]->setPoints(start, end);
+                }
+            }
+            else if (handler->constructionMethod() == ConstructionMethod::ThreePoints) {
+                onViewParameters[OnViewParameter::Third]->setPoints(toVector3d(handler->corner4),
+                                                                    toVector3d(handler->corner3));
+
+                bool reversed = handler->cornersReversed;
+
+                if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Fifth,
+                                            reversed ? handler->length : handler->width);
+                }
+
+                Base::Vector3d start = toVector3d(handler->corner1);
+                onViewParameters[OnViewParameter::Fifth]->setLabelAutoDistanceReverse(reversed);
+                onViewParameters[OnViewParameter::Fifth]->setPoints(
+                    start,
+                    toVector3d(reversed ? handler->corner2 : handler->corner4));
+
+
+                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
+                    double val = Base::toDegrees(handler->angle123);
+                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
+                }
+
+                onViewParameters[OnViewParameter::Sixth]->setPoints(
+                    toVector3d(reversed ? handler->corner4 : handler->corner2),
+                    Base::Vector3d());
+                double startAngle = reversed ? (handler->corner1 - handler->corner4).Angle()
+                                             : (handler->corner3 - handler->corner2).Angle();
+                onViewParameters[OnViewParameter::Sixth]->setLabelStartAngle(startAngle);
+                onViewParameters[OnViewParameter::Sixth]->setLabelRange(handler->angle123);
+            }
+            else {
+                bool reversed = handler->cornersReversed;
+
+                if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Fifth,
+                                            reversed ? handler->width : handler->length);
+                }
+
+                Base::Vector3d start = toVector3d(handler->corner1);
+                onViewParameters[OnViewParameter::Fifth]->setLabelAutoDistanceReverse(true);
+                onViewParameters[OnViewParameter::Fifth]->setPoints(
+                    start,
+                    toVector3d(reversed ? handler->corner4 : handler->corner2));
+
+
+                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
+                    double val = Base::toDegrees(handler->angle412);
+                    setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
+                }
+
+                onViewParameters[OnViewParameter::Sixth]->setPoints(toVector3d(handler->corner1),
+                                                                    Base::Vector3d());
+                double startAngle = (handler->corner2 - handler->corner1).Angle();
+                onViewParameters[OnViewParameter::Sixth]->setLabelStartAngle(startAngle);
+                onViewParameters[OnViewParameter::Sixth]->setLabelRange(handler->angle412);
+            }
+
+        } break;
+        case SelectMode::SeekFourth: {
+            if (handler->constructionMethod() == ConstructionMethod::Diagonal
+                || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
+                if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Sixth, handler->thickness);
+                }
+
+                Base::Vector3d start = toVector3d(handler->corner3);
+                Base::Vector3d end =
+                    Base::Vector3d(handler->corner3.x, handler->frameCorner3.y, 0.0);
+                onViewParameters[OnViewParameter::Sixth]->setPoints(start, end);
+            }
+            else {
+                if (handler->roundCorners) {
+                    if (!onViewParameters[OnViewParameter::Seventh]->isSet) {
+                        setOnViewParameterValue(OnViewParameter::Seventh, handler->radius);
+                    }
+
+                    Base::Vector3d center = handler->center3;
+                    Base::Vector3d end = toVector3d(handler->corner3);
+
+                    if (handler->radius != 0.0) {
+                        Base::Vector3d vec = (end - center).Normalize();
+                        end = center + vec * handler->radius;
+                    }
+
+                    onViewParameters[OnViewParameter::Seventh]->setPoints(center, end);
+                }
+                else {
+                    if (!onViewParameters[OnViewParameter::Eighth]->isSet) {
+                        setOnViewParameterValue(OnViewParameter::Eighth, handler->thickness);
+                    }
+
+                    Base::Vector3d start = toVector3d(handler->corner3);
+                    Base::Vector3d vec =
+                        toVector3d((handler->corner3 - handler->corner2).Normalize());
+                    Base::Vector3d end = start + handler->thickness * vec;
+                    onViewParameters[OnViewParameter::Eighth]->setPoints(start, end);
+                }
+            }
+        } break;
+        case SelectMode::SeekFifth: {
+            if (!onViewParameters[OnViewParameter::Eighth]->isSet) {
+                setOnViewParameterValue(OnViewParameter::Eighth, handler->thickness);
+            }
+
+            Base::Vector3d start = toVector3d(handler->corner3);
+            Base::Vector3d vec = toVector3d((handler->corner3 - handler->corner2).Normalize());
+            Base::Vector3d end = start + handler->thickness * vec;
+            onViewParameters[OnViewParameter::Eighth]->setPoints(start, end);
         } break;
         default:
             break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
@@ -84,30 +84,18 @@ private:
     std::list<Gui::InputHint> getToolHints() const override
     {
         using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
+        using enum Gui::InputHint::UserInput;
 
         switch (state()) {
             case SelectMode::SeekFirst:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick slot start point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick slot start point"), {MouseLeft}}};
             case SelectMode::SeekSecond:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick slot end point"),
-                              {UserInput::MouseLeft}));
-                break;
+                return {InputHint {QObject::tr("%1 pick slot end point"), {MouseLeft}}};
             case SelectMode::SeekThird:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 set slot radius"),
-                              {UserInput::MouseMove}));
-                break;
+                return {InputHint {QObject::tr("%1 set slot radius"), {MouseMove}}};
             default:
-                break;
+                return {};
         }
-
-        return hints;
     }
 
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
@@ -81,10 +81,37 @@ public:
     ~DrawSketchHandlerSlot() override = default;
 
 private:
+    std::list<Gui::InputHint> getToolHints() const override
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick slot start point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case SelectMode::SeekSecond:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick slot end point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case SelectMode::SeekThird:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 set slot radius"),
+                              {UserInput::MouseMove}));
+                break;
+            default:
+                break;
+        }
+
+        return hints;
+    }
+
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
-        updateHints();
-
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -339,35 +366,6 @@ private:
         else if (fmod(fabs(angle + pi / 2), pi) < Precision::Confusion()) {
             isVertical = true;
         }
-    }
-
-    void updateHints() const
-    {
-        using Gui::InputHint;
-        using UserInput = Gui::InputHint::UserInput;
-        std::list<InputHint> hints;
-
-        switch (state()) {
-            case SelectMode::SeekFirst:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick slot start point"),
-                              {UserInput::MouseLeft}));
-                break;
-            case SelectMode::SeekSecond:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick slot end point"),
-                              {UserInput::MouseLeft}));
-                break;
-            case SelectMode::SeekThird:
-                hints.push_back(
-                    InputHint(QCoreApplication::translate("Sketcher", "%1 set slot radius"),
-                              {UserInput::MouseMove}));
-                break;
-            default:
-                break;
-        }
-
-        Gui::getMainWindow()->showHints(hints);
     }
 
 private:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
@@ -31,6 +31,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/InputHint.h>
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -82,6 +83,8 @@ public:
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
+        updateHints();
+
         switch (state()) {
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
@@ -336,6 +339,35 @@ private:
         else if (fmod(fabs(angle + pi / 2), pi) < Precision::Confusion()) {
             isVertical = true;
         }
+    }
+
+    void updateHints() const
+    {
+        using Gui::InputHint;
+        using UserInput = Gui::InputHint::UserInput;
+        std::list<InputHint> hints;
+
+        switch (state()) {
+            case SelectMode::SeekFirst:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick slot start point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case SelectMode::SeekSecond:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 pick slot end point"),
+                              {UserInput::MouseLeft}));
+                break;
+            case SelectMode::SeekThird:
+                hints.push_back(
+                    InputHint(QCoreApplication::translate("Sketcher", "%1 set slot radius"),
+                              {UserInput::MouseMove}));
+                break;
+            default:
+                break;
+        }
+
+        Gui::getMainWindow()->showHints(hints);
     }
 
 private:


### PR DESCRIPTION
<!-- Summary of changes -->

This PR adds structured, context-sensitive input hints for **all Sketcher geometry creation tools** by overriding the existing `getToolHints()` method in each relevant tool handler. These hints improve guidance during tool use by showing clear instructions for each step of the sketching process.

Each tool now returns a list of `Gui::InputHint` objects describing required input (mouse/keyboard) actions, improving user experience, especially for newer users. These hints are fully integrated with the Sketcher UI and respect the tool state.

Following maintainer feedback, this version replaces earlier `updateHints()` implementations with `getToolHints()` overrides for full alignment with Sketcher tool architecture.

---

## Tools updated

This PR introduces structured hints for the following geometry tools:

- ✅ Point  
- ✅ Line  
- ✅ Polyline  
- ✅ Arc  
- ✅ Circle  
- ✅ Polygon  
- ✅ Rectangle (all construction modes)  
- ✅ Slot  
- ✅ Arc Slot  
- ✅ B-spline (all 4 construction modes)  
- ✅ Parabola  
- ✅ Arc of Ellipse  
- ✅ Arc of Hyperbola  

---

## Behavior summary

Each tool's `getToolHints()` method dynamically generates context-specific hints such as:

- `"pick first point"` (left-click)
- `"pick center point"` (left-click)
- `"right-click to finish"` (right-click)
- `"U / J to increase / decrease sides"` (keyboard)

These hints are displayed using the existing `Gui::getMainWindow()->showHints(...)` mechanism and update automatically as the tool progresses.

---

## Supersedes

This PR replaces the following individual PRs, consolidating the work into a single branch:

- #21601 — Hyperbola  
- #21600 — Ellipse  
- #21598 — Parabola  
- #21597 — B-Spline  
- #21594 — Arc Slot  
- #21593 — Slot  
- #21592 — Rectangle  
- #21589 — Circle  
- #21586 — Line  
- #21585 — Polyline (LineSet)  
- #21565 — Point  
- #21560 — Arc  

These are retained for historical discussion.

---

## Before and After

**Before:**
- No structured input hints
- Inconsistent or missing tool guidance
- Users relied on guesswork for multi-step tools

**After:**
- Dynamic hint display based on tool state
- Standardized input terminology across all tools
- Improved discoverability and usability

---

## Notes

- This work only affects input hints. Tool logic, geometry creation, and constraints are unchanged.
- No cancel hints are included, per prior maintainer guidance.
- This sets the stage for potential follow-up UX polish (e.g., mode-switch hints or constraint hinting, state machinery to handle hints, etc).
