### PR TITLE
CI: add typing_extensions to runtime dependency for weekly build.

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -168,6 +168,7 @@ requirements:
     - requests
     - scipy
     - sympy
+    - typing_extension
     - vtk
     - xlutils
 


### PR DESCRIPTION
The `openifc` package in `conda-forge` does not declare a runtime requirement of `typing_extensions`.  This PR brings in `typing_extensions` for the weekly builds to ensure it is present.

## Issues

https://github.com/FreeCAD/FreeCAD/issues/19051

## Before and After Images

None.