### PR TITLE
Transform: Advanced options for move to other object

### DIFF
--- a/src/Gui/TaskTransform.ui
+++ b/src/Gui/TaskTransform.ui
@@ -194,10 +194,219 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="QPushButton" name="alignToOtherObjectButton">
-        <property name="text">
-         <string>Move to other object</string>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="topMargin">
+         <number>6</number>
         </property>
+        <item>
+         <widget class="QPushButton" name="alignToOtherObjectButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Move to other object</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="moveOptionsButton">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset theme="preferences-other"/>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+            <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QFrame" name="frameMoveOptions">
+        <property name="visible">
+         <bool>false</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Shadow::Raised</enum>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <property name="topMargin">
+            <number>6</number>
+           </property>
+           <item>
+            <widget class="QCheckBox" name="translateCheckbox">
+             <property name="text">
+              <string>Translate</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="rotateCheckbox">
+             <property name="text">
+              <string>Rotate</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QGridLayout" name="gridLayout_2">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>6</number>
+           </property>
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="matchXcheckbox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Match U/X</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QCheckBox" name="matchYcheckbox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Match V/Y</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QCheckBox" name="matchZcheckbox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Match W/Z</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
+            <widget class="QCheckBox" name="alignXcheckbox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Align U/X</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
+            <widget class="QCheckBox" name="alignYcheckbox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Align V/Y</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="3">
+            <widget class="QCheckBox" name="alignZcheckbox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Align W/Z</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Policy::Fixed</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>18</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="1" column="2">
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Policy::Fixed</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>18</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>

--- a/src/Gui/ViewProviderDragger.h
+++ b/src/Gui/ViewProviderDragger.h
@@ -27,6 +27,7 @@
 #include "ViewProviderDocumentObject.h"
 #include <Base/Placement.h>
 #include <App/PropertyGeo.h>
+#include <Base/Bitmask.h>
 
 class SoDragger;
 class SoTransform;
@@ -82,8 +83,20 @@ public:
     /*! synchronize From FC placement to Coin placement*/
     static void updateTransform(const Base::Placement &from, SoTransform *to);
 
-    /// updates placement of object based on dragger position
-    void updatePlacementFromDragger();
+    enum class DraggerComponent
+    {
+        None = 0,
+        XPos = 1 << 0,
+        YPos = 1 << 1,
+        ZPos = 1 << 2,
+        XRot = 1 << 3,
+        YRot = 1 << 4,
+        ZRot = 1 << 5,
+        All = XPos | YPos | ZPos | XRot | YRot | ZRot
+    };
+    using DraggerComponents = Base::Flags<DraggerComponent>;
+    /// updates placement of object based on dragger position and chosen axes components
+    void updatePlacementFromDragger(DraggerComponents components = DraggerComponent::All);
     /// updates transform of object based on dragger position, can be used to preview movement
     void updateTransformFromDragger();
 
@@ -125,10 +138,17 @@ private:
     void updateDraggerPosition();
 
     Base::Placement draggerPlacement { };
+
+    // Rotation by orthonormalizing depending on given axes components
+    Base::Rotation orthonormalize(Base::Vector3d x,
+                                  Base::Vector3d y,
+                                  Base::Vector3d z,
+                                  ViewProviderDragger::DraggerComponents components = DraggerComponent::All);
 };
 
 } // namespace Gui
 
+ENABLE_BITMASK_OPERATORS(Gui::ViewProviderDragger::DraggerComponent)
 
 #endif // GUI_VIEWPROVIDER_DRAGGER_H
 


### PR DESCRIPTION
Adds per-axis masking to the `Move to other object` command in the transform tool so that users can independently enable or disable X/Y/Z translation and rotation in the dragger's local coordinate system U/V/W.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
fixes https://github.com/FreeCAD/FreeCAD/issues/19272
closes https://github.com/FreeCAD/FreeCAD/pull/19834 (@alfrix I wasn't able to cherry pick as the file was not available anymore, thanks for the help with the initial dialog) 

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
### Before
Move to other object in the transform tool only allowed the both coordinate systems to be perfectly aligned. It was not possible to only rotate or move in defined axes to the selected target:


https://github.com/user-attachments/assets/432ad914-9865-4fd3-b204-5e5bb30d75d7



    
### This PR
Introduce custom options, all checked by default (tool behaves the same as before, aligning selected transform origin with target coordinate system).
It adds options to limit the transform to translation only, rotation only, or specify a combination of all individual components. This allows to align an object to a target, without moving it or without rotating it or lock movement in certain axes:

https://github.com/user-attachments/assets/e227736b-9bd4-48d9-8d83-7f2894f3bcb8






Thanks to @kadet1090 for helping me out in the progress of coding.
Please test as this is my gazillionth attempt of coding this feature.

@FreeCAD/cad-working-group  and @FreeCAD/design-working-group for UI changes.


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
