### PR TITLE
CAM: Dressup Boundary - CmdMoveDrill

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Boundary.py
@@ -210,7 +210,12 @@ class PathBoundary:
                 if bogusY:
                     bogusY = "Y" not in cmd.Parameters
                 edge = Path.Geom.edgeForCmd(cmd, pos)
-                if edge:
+                if edge and cmd.Name in Path.Geom.CmdMoveDrill:
+                    inside = edge.common(self.boundary).Edges
+                    outside = edge.cut(self.boundary).Edges
+                    if 1 == len(inside) and 0 == len(outside):
+                        commands.append(cmd)
+                if edge and not cmd.Name in Path.Geom.CmdMoveDrill:
                     inside = edge.common(self.boundary).Edges
                     outside = edge.cut(self.boundary).Edges
                     if not self.inside:  # UI "inside boundary" param

--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -391,7 +391,7 @@ def edgeForCmd(cmd, startPoint):
     Path.Log.debug("startpoint {}".format(startPoint))
 
     endPoint = commandEndPoint(cmd, startPoint)
-    if (cmd.Name in CmdMoveStraight) or (cmd.Name in CmdMoveRapid):
+    if (cmd.Name in CmdMoveStraight) or (cmd.Name in CmdMoveRapid) or (cmd.Name in CmdMoveDrill):
         if pointsCoincide(startPoint, endPoint):
             return None
         return Part.Edge(Part.LineSegment(startPoint, endPoint))


### PR DESCRIPTION
Before this changes Dressup Boundary ignore (do not append) drill commands

**Before:**
![Screenshot_20250529_222149_lossy](https://github.com/user-attachments/assets/a159ae4d-73a4-4de0-ac2e-1ce1ef30540b)

**After:**
![Screenshot_20250529_222232_lossy](https://github.com/user-attachments/assets/d086689c-813c-438f-8b71-95188a570390)
