### PR TITLE
Materials: Set array quantity format

### DIFF
--- a/src/Mod/Material/App/Array2DPyImp.cpp
+++ b/src/Mod/Material/App/Array2DPyImp.cpp
@@ -159,7 +159,9 @@ PyObject* Array2DPy::setValue(PyObject* args)
     if (PyArg_ParseTuple(args, "iiO!", &row, &column, &PyUnicode_Type, &valueObj)) {
         Py::String item(valueObj);
         try {
-            QVariant variant = QVariant::fromValue(Base::Quantity::parse(item.as_string()));
+            auto quantity = Base::Quantity::parse(item.as_string());
+            quantity.setFormat(MaterialValue::getQuantityFormat());
+            QVariant variant = QVariant::fromValue(quantity);
             getArray2DPtr()->setValue(row, column, variant);
         }
         catch (const InvalidIndex&) {

--- a/src/Mod/Material/App/Array3DPyImp.cpp
+++ b/src/Mod/Material/App/Array3DPyImp.cpp
@@ -163,7 +163,9 @@ PyObject* Array3DPy::setDepthValue(PyObject* args)
     if (PyArg_ParseTuple(args, "iO!", &depth, &PyUnicode_Type, &valueObj)) {
         Py::String item(valueObj);
         try {
-            getArray3DPtr()->setDepthValue(depth, Base::Quantity::parse(item.as_string()));
+            auto quantity = Base::Quantity::parse(item.as_string());
+            quantity.setFormat(MaterialValue::getQuantityFormat());
+            getArray3DPtr()->setDepthValue(depth, quantity);
         }
         catch (const Base::ParserError& e) {
             PyErr_SetString(PyExc_ValueError, e.what());
@@ -189,7 +191,9 @@ PyObject* Array3DPy::setValue(PyObject* args)
     if (PyArg_ParseTuple(args, "iiiO!", &depth, &row, &column, &PyUnicode_Type, &valueObj)) {
         Py::String item(valueObj);
         try {
-            getArray3DPtr()->setValue(depth, row, column, Base::Quantity::parse(item.as_string()));
+            auto quantity = Base::Quantity::parse(item.as_string());
+            quantity.setFormat(MaterialValue::getQuantityFormat());
+            getArray3DPtr()->setValue(depth, row, column, quantity);
         }
         catch (const Base::ParserError& e) {
             PyErr_SetString(PyExc_ValueError, e.what());

--- a/src/Mod/Material/App/Array3DPyImp.cpp
+++ b/src/Mod/Material/App/Array3DPyImp.cpp
@@ -165,8 +165,12 @@ PyObject* Array3DPy::setDepthValue(PyObject* args)
         try {
             getArray3DPtr()->setDepthValue(depth, Base::Quantity::parse(item.as_string()));
         }
-        catch (const InvalidIndex&) {
-            PyErr_SetString(PyExc_IndexError, "Invalid array index");
+        catch (const Base::ParserError& e) {
+            PyErr_SetString(PyExc_ValueError, e.what());
+            return nullptr;
+        }
+        catch (const InvalidIndex& e) {
+            PyErr_SetString(PyExc_IndexError, e.what());
             return nullptr;
         }
         Py_Return;
@@ -187,8 +191,12 @@ PyObject* Array3DPy::setValue(PyObject* args)
         try {
             getArray3DPtr()->setValue(depth, row, column, Base::Quantity::parse(item.as_string()));
         }
-        catch (const InvalidIndex&) {
-            PyErr_SetString(PyExc_IndexError, "Invalid array index");
+        catch (const Base::ParserError& e) {
+            PyErr_SetString(PyExc_ValueError, e.what());
+            return nullptr;
+        }
+        catch (const InvalidIndex& e) {
+            PyErr_SetString(PyExc_IndexError, e.what());
             return nullptr;
         }
         Py_Return;


### PR DESCRIPTION
When setting quantity formats, the default format is not actually the default. Instead fixed format is, which causes issues for very small and very large values. This was fixed for C++ but arrays created in Python were not setting the format correctly.
