### PR TITLE
Fix Sketcher multi-mode drawing tool parameter exceptions

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -310,35 +310,34 @@ private:
 template<>
 auto DSHCircleControllerBase::getState(int labelindex) const
 {
-
     if (handler->constructionMethod() == DrawSketchHandlerCircle::ConstructionMethod::Center) {
         switch (labelindex) {
             case OnViewParameter::First:
             case OnViewParameter::Second:
                 return SelectMode::SeekFirst;
-                break;
             case OnViewParameter::Third:
                 return SelectMode::SeekSecond;
-                break;
+            // Handle ThreeRim parameters when in Center mode
+            case OnViewParameter::Fourth:
+            case OnViewParameter::Fifth:
+            case OnViewParameter::Sixth:
+                return SelectMode::SeekFirst;  // Safe fallback state
             default:
                 THROWM(Base::ValueError,
                        "OnViewParameter index without an associated machine state")
         }
     }
-    else {  // ConstructionMethod::ThreeRim
+    else {  // ThreeRim mode - unchanged
         switch (labelindex) {
             case OnViewParameter::First:
             case OnViewParameter::Second:
                 return SelectMode::SeekFirst;
-                break;
             case OnViewParameter::Third:
             case OnViewParameter::Fourth:
                 return SelectMode::SeekSecond;
-                break;
             case OnViewParameter::Fifth:
             case OnViewParameter::Sixth:
                 return SelectMode::SeekThird;
-                break;
             default:
                 THROWM(Base::ValueError, "Label index without an associated machine state")
         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -1584,11 +1584,9 @@ auto DSHRectangleControllerBase::getState(int labelindex) const
             case OnViewParameter::First:
             case OnViewParameter::Second:
                 return SelectMode::SeekFirst;
-                break;
             case OnViewParameter::Third:
             case OnViewParameter::Fourth:
                 return SelectMode::SeekSecond;
-                break;
             case OnViewParameter::Fifth:
                 if (handler->roundCorners) {
                     return SelectMode::SeekThird;
@@ -1596,7 +1594,6 @@ auto DSHRectangleControllerBase::getState(int labelindex) const
                 else {
                     return SelectMode::End;
                 }
-                break;
             case OnViewParameter::Sixth:
                 if (handler->makeFrame) {
                     if (!handler->roundCorners) {
@@ -1609,7 +1606,9 @@ auto DSHRectangleControllerBase::getState(int labelindex) const
                 else {
                     return SelectMode::End;
                 }
-                break;
+            case OnViewParameter::Seventh:
+            case OnViewParameter::Eighth:
+                return SelectMode::SeekFirst;  // Handle ThreePoints parameters gracefully
             default:
                 THROWM(Base::ValueError, "Parameter index without an associated machine state")
         }
@@ -1619,15 +1618,12 @@ auto DSHRectangleControllerBase::getState(int labelindex) const
             case OnViewParameter::First:
             case OnViewParameter::Second:
                 return SelectMode::SeekFirst;
-                break;
             case OnViewParameter::Third:
             case OnViewParameter::Fourth:
                 return SelectMode::SeekSecond;
-                break;
             case OnViewParameter::Fifth:
             case OnViewParameter::Sixth:
                 return SelectMode::SeekThird;
-                break;
             case OnViewParameter::Seventh:
                 if (handler->roundCorners) {
                     return SelectMode::SeekFourth;
@@ -1635,7 +1631,6 @@ auto DSHRectangleControllerBase::getState(int labelindex) const
                 else {
                     return SelectMode::End;
                 }
-                break;
             case OnViewParameter::Eighth:
                 if (handler->makeFrame) {
                     if (!handler->roundCorners) {
@@ -1648,7 +1643,6 @@ auto DSHRectangleControllerBase::getState(int labelindex) const
                 else {
                     return SelectMode::End;
                 }
-                break;
             default:
                 THROWM(Base::ValueError, "Parameter index without an associated machine state")
         }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

Fix parameter exceptions in Circle and Rectangle tools during construction method switching. These tools would throw "Parameter index without an associated machine state" exceptions when pressing M to switch between construction methods that use different parameter counts.

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

Fixes #21646

## Summary

This PR resolves parameter exceptions that occur when switching construction methods in Circle and Rectangle drawing tools using the M key.

**Problem:**
- Circle and Rectangle tools have multiple construction methods with different parameter counts
- Circle: 2-point vs 3-point construction methods
- Rectangle: 4 construction methods using either 6 or 8 parameters
- When switching between methods, the framework attempts to access all possible parameter indices
- Methods with fewer parameters would throw exceptions when asked about parameter indices they don't handle

**Solution:**
- Modified `getState()` template specializations in both tools to handle all possible parameter indices
- Added graceful fallback states for parameters not used by the current construction method
- Removed unreachable `break` statements after `return` statements

**Testing:**
- Verified Circle tool M key switching works without exceptions (all 2 construction methods)
- Verified Rectangle tool M key switching works without exceptions (all 4 construction methods)  
- Tested Arc, Line, and B-Spline tools - confirmed they do not seem to have similar issues
- All construction method functionality remains intact

**Files Modified:**
- `src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h` - Fixed Circle getState() method
- `src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h` - Fixed Rectangle getState() method

This fix ensures smooth construction method switching for users while maintaining all existing tool functionality.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

**Before:**
Console shows "Unhandled exception in ViewProvider::eventCallback: Parameter index without an associated machine state" when pressing M key in Circle/Rectangle tools

**After:** 
M key switches construction methods smoothly without exceptions, user experience is seamless
