### PR TITLE
CAM: Simulator - Drilling - RetractMode G98/G99

### DIFF
--- a/src/Mod/CAM/PathSimulator/AppGL/GCodeParser.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/GCodeParser.h
@@ -45,8 +45,8 @@ public:
 
 public:
     std::vector<MillMotion> Operations;
-    MillMotion lastState = {eNop, 0, 0, 0, 0, 0, 0, 0, 0};
-    MillMotion lastLastState = {eNop, 0, 0, 0, 0, 0, 0, 0, 0};
+    MillMotion lastState = {eNop, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    MillMotion lastLastState = {eNop, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 protected:
     const char* GetNextToken(const char* ptr, GCToken* token);

--- a/src/Mod/CAM/PathSimulator/AppGL/MillMotion.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillMotion.h
@@ -53,6 +53,8 @@ struct MillMotion
     float x, y, z;
     float i, j, k;
     float r;
+    char retract_mode;
+    float retract_z;
 };
 
 static inline void MotionPosToVec(vec3 vec, const MillMotion* motion)


### PR DESCRIPTION
At this moment new **Simulator** not take in to account Retract mode (G98/G99) while drilling
- RetractMode = G99 - retract to the position specified by the R word of the canned cycle 
- RetractMode = G98 - retract to the position that axis was in just before this series of one or more contiguous canned cycles was started (`ClearanceHeight`)

In any case **Simulator** draw path for mode G99 (use retract from R of drill operation)

![Screenshot_20250530_160246_lossy](https://github.com/user-attachments/assets/e2f2fd84-4a1c-4193-9950-096633a27791)

[drill.zip](https://github.com/user-attachments/files/20521081/drill.zip)


https://forum.freecad.org/viewtopic.php?p=829657#p829657

After this commit **Simulator** draw correct Path for drilling operation with G98 or G99 Retract mode
Added extra property `mode` to structure `MillMotion`
Probably this property can be used for some other cases

![Screenshot_20250530_083702_hor](https://github.com/user-attachments/assets/74aa6e90-b8a5-40ef-bfc8-5d27c5a76d2e)

**Note**:
I am not C++ designer
So probably this solution is very dirty and can not be merged like this
Also not removed many `qDebug` calls while this is a Draft 