### PR TITLE
PD: hole change the task panel threaded and model thread checkboxes into a combo/dropdown 

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -80,15 +80,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
     ui->ThreadSize->setHidden(isNone);
     ui->labelSize->setHidden(isNone);
 
-    if (pcHole->Threaded.getValue()) {
-        if (pcHole->ModelThread.getValue()) {
-            ui->HoleType->setCurrentIndex(static_cast<int>(HoleTypeIndex::ModeledThread));
-        } else {
-            ui->HoleType->setCurrentIndex(static_cast<int>(HoleTypeIndex::TapDrill));
-        }
-    } else {
-        ui->HoleType->setCurrentIndex(static_cast<int>(HoleTypeIndex::Clearance));
-    }
+    updateHoleTypeCombo();
     ui->ThreadType->setCurrentIndex(pcHole->ThreadType.getValue());
 
     ui->ThreadSize->clear();
@@ -797,16 +789,7 @@ void TaskHoleParameters::changedObject(const App::Document&, const App::Property
     };
 
     if (&Prop == &hole->Threaded || &Prop == &hole->ModelThread) {
-        if (hole->Threaded.getValue()) {
-            if (hole->ModelThread.getValue()) {
-                updateComboBox(ui->HoleType, static_cast<int>(HoleTypeIndex::ModeledThread));
-            } else {
-                updateComboBox(ui->HoleType, static_cast<int>(HoleTypeIndex::TapDrill));
-            }
-        } else {
-            updateComboBox(ui->HoleType, static_cast<int>(HoleTypeIndex::Clearance));
-        }
-        ui->HoleType->setDisabled(false);
+        updateHoleTypeCombo();
     }
     else if (&Prop == &hole->ThreadType) {
         ui->ThreadType->setEnabled(true);
@@ -916,6 +899,24 @@ void TaskHoleParameters::changedObject(const App::Document&, const App::Property
     }
 }
 
+void TaskHoleParameters::updateHoleTypeCombo()
+{
+    auto hole = getObject<PartDesign::Hole>();
+    if (!hole) {
+        return;
+    }
+    [[maybe_unused]] QSignalBlocker blocker(ui->HoleType);
+    if (hole->Threaded.getValue()) {
+        if (hole->ModelThread.getValue()) {
+            ui->HoleType->setCurrentIndex(ModeledThread);
+        } else {
+            ui->HoleType->setCurrentIndex(TapDrill);
+        }
+    } else {
+        ui->HoleType->setCurrentIndex(Clearance);
+    }
+}
+
 void TaskHoleParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
     Q_UNUSED(msg)
@@ -923,12 +924,12 @@ void TaskHoleParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 
 bool TaskHoleParameters::getThreaded() const
 {
-    return ui->HoleType->currentIndex() != static_cast<int>(HoleTypeIndex::Clearance);
+    return ui->HoleType->currentIndex() != Clearance;
 }
 
 bool TaskHoleParameters::getModelThread() const
 {
-    return ui->HoleType->currentIndex() == static_cast<int>(HoleTypeIndex::ModeledThread);
+    return ui->HoleType->currentIndex() == ModeledThread;
 }
 
 long TaskHoleParameters::getThreadType() const

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -82,7 +82,7 @@ public:
     int getBaseProfileType() const;
 
 private Q_SLOTS:
-    void threadedChanged();
+    void holeTypeChanged(int index);
     void threadTypeChanged(int index);
     void threadSizeChanged(int index);
     void threadClassChanged(int index);
@@ -103,7 +103,6 @@ private Q_SLOTS:
     void taperedChanged();
     void taperedAngleChanged(double value);
     void reversedChanged();
-    void modelThreadChanged();
     void useCustomThreadClearanceChanged();
     void customThreadClearanceChanged(double value);
     void updateViewChanged(bool isChecked);
@@ -120,6 +119,11 @@ private:
         void slotChangedObject(const App::DocumentObject& Obj, const App::Property& Prop) override;
         TaskHoleParameters * owner;
         PartDesign::Hole * hole;
+    };
+    enum class HoleTypeIndex : int {
+        Clearance = 0,
+        TapDrill = 1,
+        ModeledThread = 2
     };
 
 protected:

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -120,7 +120,7 @@ private:
         TaskHoleParameters * owner;
         PartDesign::Hole * hole;
     };
-    enum class HoleTypeIndex : int {
+    enum HoleTypeIndex : int {
         Clearance = 0,
         TapDrill = 1,
         ModeledThread = 2
@@ -133,6 +133,7 @@ protected:
 private:
     void onSelectionChanged(const Gui::SelectionChanges &msg) override;
     void updateHoleCutLimits(PartDesign::Hole* hole);
+    void updateHoleTypeCombo();
 
 private:
 

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -615,17 +615,7 @@ over 90: larger hole radius at the bottom</string>
      <property name="topMargin">
       <number>0</number>
      </property>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="ThreadType">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
+     <item row="0" column="0">
       <widget class="Gui::ElideLabel" name="labelThreadType">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
@@ -638,8 +628,8 @@ over 90: larger hole radius at the bottom</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="ThreadSize">
+     <item row="0" column="1">
+      <widget class="QComboBox" name="ThreadType">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -648,7 +638,7 @@ over 90: larger hole radius at the bottom</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="1" column="0">
       <widget class="Gui::ElideLabel" name="labelSize">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
@@ -661,23 +651,43 @@ over 90: larger hole radius at the bottom</string>
        </property>
       </widget>
      </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="ThreadSize">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="HoleType">
+       <item>
+        <property name="text">
+         <string>Clearance / Passthrough</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Tap Drill (To Be Threaded)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Modeled Thread</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="Gui::ElideLabel" name="labelHoleType">
+       <property name="text">
+        <string>Hole Type</string>
+       </property>
+      </widget>
+     </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="Threaded">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>Whether the hole gets a thread</string>
-     </property>
-     <property name="text">
-      <string>Threaded</string>
-     </property>
-    </widget>
    </item>
    <item>
     <widget class="QWidget" name="ClearanceWidget" native="true">
@@ -779,6 +789,26 @@ Only available for holes without thread</string>
        <number>6</number>
       </property>
       <item>
+       <widget class="Gui::ElideCheckBox" name="UpdateView">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Live update of changes to the thread
+Note that the calculation can take some time</string>
+        </property>
+        <property name="text">
+         <string>Update thread view</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <layout class="QGridLayout" name="classLayout" columnstretch="2,5">
         <property name="topMargin">
          <number>0</number>
@@ -877,52 +907,6 @@ Only available for holes without thread</string>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="Gui::ElideCheckBox" name="ModelThread">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Whether the hole gets a modelled thread</string>
-          </property>
-          <property name="text">
-           <string>Model Thread</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::ElideCheckBox" name="UpdateView">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Live update of changes to the thread
-Note that the calculation can take some time</string>
-          </property>
-          <property name="text">
-           <string>Update thread view</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
        <widget class="QWidget" name="ThreadDepthWidget" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -944,7 +928,7 @@ Note that the calculation can take some time</string>
           <number>0</number>
          </property>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="2,5">
+          <layout class="QHBoxLayout" name="depthTypeLayout">
            <property name="spacing">
             <number>6</number>
            </property>
@@ -993,7 +977,7 @@ Note that the calculation can take some time</string>
          </item>
          <item>
           <widget class="QWidget" name="ThreadDepthDimensionWidget" native="true">
-           <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="2,5">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -1037,7 +1021,7 @@ Note that the calculation can take some time</string>
       </item>
       <item>
        <widget class="QWidget" name="CustomClearanceWidget" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="2,5">
+        <layout class="QHBoxLayout" name="horizontalLayout_13">
          <property name="spacing">
           <number>6</number>
          </property>


### PR DESCRIPTION
Motivation 
I had to explain more than once how the hole feature works in regards to threads, it's clearly a problem and even after I've rewritten the wiki, we talked with @benj5378  on Discord that this is not enough

The idea revolves around the fact that this solution is more self-explanatory

* Clearance / passthrough
Previously Not threaded and Not modeled, the bolt threads will not have contact, or at least it's threads will not engage.

* Tap Drill (To Be Threaded)
Previously Threaded but Not modeled; the hole is intended to be tapped, in woodworking it would be called pilot hole 
^ This one should get the cosmetic thread

* Modeled thread
Previously Threaded and Modeled; fully modeled thread probably for 3D printing.

this proposal is visual and the internal booleans and properties are maintained so it doesn't loose compatibility against older versions

[hole_type_combo.webm](https://github.com/user-attachments/assets/744ca8b1-6895-4587-8041-9a900be6c0d5)

i've also tweaked the split between the last 2 items since the label was too small and nor the combo or the input needed more space.
Also moved the update thread view checkbox closer since it should be next or very to modeled (shown only if modeled)

![output](https://github.com/user-attachments/assets/328dbbf9-d2da-4c4c-b1ce-5391897864f4)