### PR TITLE
CAM: Improve conditions to add tool change commands

### DIFF
--- a/src/Mod/CAM/Path/Base/Generator/toolchange.py
+++ b/src/Mod/CAM/Path/Base/Generator/toolchange.py
@@ -100,3 +100,34 @@ def generateSubstitute(newTC, oldTC=None):
         return [Path.Command(sd.value, {"S": newTC.SpindleSpeed})]
 
     return []
+
+
+def needToolChange(newTC, oldTC):
+    """
+    Check two toolcontrollers object for conditions to add commands for tool change
+    """
+    if newTC is None:
+        # No need to change tool if no New Tool Controller, in any case
+        return False
+
+    if oldTC is None:
+        # Need to change tool if New Tool controller is set
+        # and no Old Tool Controller
+        return True
+
+    if newTC.Tool != oldTC.Tool:
+        # Need to change tool if New Tool controller is set
+        # and toolbit is different from Old Tool Controller
+        return True
+
+    if newTC.SpindleSpeed != oldTC.SpindleSpeed:
+        # Need to change tool if New Tool controller is set
+        # and SpindleSpeed is different from Old Tool Controller
+        return True
+
+    if newTC.SpindleDir != oldTC.SpindleDir:
+        # Need to change tool if New Tool controller is set
+        # and SpindleDir is different from Old Tool Controller
+        return True
+
+    return False


### PR DESCRIPTION
#21657

At this moment condition for append tool change operation is change `ToolNumber`
But tool change operation will cancel if we duplicate tool controller and set e.g. different `SpindleSpeed`

This commit add function to check necessity to add tool change operation by this conditions:
- change `ToolBit`
- change `SpindleSpeed`
- change `SpindleDir`

At this moment tried only with `Fixture` order