### PR TITLE
Gui: Fix TreeWidget::addDependentToSelection

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1305,9 +1305,11 @@ void TreeWidget::addDependentToSelection(App::Document* doc, App::DocumentObject
     Selection().addSelection(doc->getName(), docObject->getNameInDocument());
     // get the dependent
     auto subObjectList = docObject->getOutList();
-    // the dependent can in turn have dependents, thus add them recursively
-    for (auto itDepend = subObjectList.begin(); itDepend != subObjectList.end(); ++itDepend)
-        addDependentToSelection(doc, (*itDepend));
+    for (auto itDepend : subObjectList) {
+        if (!Selection().isSelected(itDepend)) {
+            addDependentToSelection(doc, itDepend);
+        }
+    }
 }
 
 // add dependents of the selected tree object to selection

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1303,11 +1303,11 @@ void TreeWidget::addDependentToSelection(App::Document* doc, App::DocumentObject
 {
     // add the docObject to the selection
     Selection().addSelection(doc->getName(), docObject->getNameInDocument());
-    // get the dependent objects recursively
-    auto subObjectList = docObject->getOutListRecursive();
-    for (auto itDepend = subObjectList.begin(); itDepend != subObjectList.end(); ++itDepend) {
-        Selection().addSelection(doc->getName(), (*itDepend)->getNameInDocument());
-    }
+    // get the dependent
+    auto subObjectList = docObject->getOutList();
+    // the dependent can in turn have dependents, thus add them recursively
+    for (auto itDepend = subObjectList.begin(); itDepend != subObjectList.end(); ++itDepend)
+        addDependentToSelection(doc, (*itDepend));
 }
 
 // add dependents of the selected tree object to selection


### PR DESCRIPTION
Fixes: #20859

Although #20915 claims to fix #20859, it does not select anything. Instead it throws:
```
Unhandled Base::Exception caught in GUIApplication::notify.
The error message is: DocumentObject::getOutListRecursive(): cyclic dependency detected!
```