### PR TITLE
CAM(libarea): Fix encoding of clipper.cpp

### DIFF
--- a/src/Mod/CAM/libarea/clipper.cpp
+++ b/src/Mod/CAM/libarea/clipper.cpp
@@ -4832,10 +4832,10 @@ inline double DistanceSqrd(const IntPoint& pt1, const IntPoint& pt2)
 double DistanceFromLineSqrd(const IntPoint& pt, const IntPoint& ln1, const IntPoint& ln2)
 {
     // The equation of a line in general form (Ax + By + C = 0)
-    // given 2 points (x¹,y¹) & (x²,y²) is ...
-    //(y¹ - y²)x + (x² - x¹)y + (y² - y¹)x¹ - (x² - x¹)y¹ = 0
-    // A = (y¹ - y²); B = (x² - x¹); C = (y² - y¹)x¹ - (x² - x¹)y¹
-    // perpendicular distance of point (x³,y³) = (Ax³ + By³ + C)/Sqrt(A² + B²)
+    // given 2 points (xÂ¹,yÂ¹) & (xÂ²,yÂ²) is ...
+    //(yÂ¹ - yÂ²)x + (xÂ² - xÂ¹)y + (yÂ² - yÂ¹)xÂ¹ - (xÂ² - xÂ¹)yÂ¹ = 0
+    // A = (yÂ¹ - yÂ²); B = (xÂ² - xÂ¹); C = (yÂ² - yÂ¹)xÂ¹ - (xÂ² - xÂ¹)yÂ¹
+    // perpendicular distance of point (xÂ³,yÂ³) = (AxÂ³ + ByÂ³ + C)/Sqrt(AÂ² + BÂ²)
     // see http://en.wikipedia.org/wiki/Perpendicular_distance
     double A = double(ln1.Y - ln2.Y);
     double B = double(ln2.X - ln1.X);


### PR DESCRIPTION
This file was encoded in ISO-8859-1, but contained characters that were illegal in that encoding (superscripts). Convert to UTF-8.

