### PR TITLE
CAM(PathSimulator): Use single-precision pi

### DIFF
--- a/src/Mod/CAM/PathSimulator/AppGL/MillPathSegment.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillPathSegment.cpp
@@ -27,7 +27,7 @@
 #include "GlUtils.h"
 #include <iostream>
 
-using std::numbers::pi;
+constexpr auto pi = std::numbers::pi_v<float>;
 
 #define N_MILL_SLICES 8
 #define MAX_SEG_DEG (pi / 2.0f)   // 90 deg

--- a/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
@@ -36,8 +36,6 @@
 namespace MillSim
 {
 
-using std::numbers::pi;
-
 void SimDisplay::InitShaders()
 {
     // use shaders

--- a/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.h
@@ -34,7 +34,7 @@
 namespace MillSim
 {
 
-using std::numbers::pi;
+constexpr auto pi = std::numbers::pi_v<float>;
 
 struct Point3D
 {


### PR DESCRIPTION
All of `PathSimulator` uses floats, rather than doubles: to prevent compiler warnings about truncation, explicitly use the single-precision version of the standard `pi` constant.
