### PR TITLE
Avoid error importing spreadsheet with deleted sheet (#19757)

### DIFF
--- a/src/Mod/Spreadsheet/importXLSX.py
+++ b/src/Mod/Spreadsheet/importXLSX.py
@@ -372,8 +372,8 @@ def handleWorkBook(theBook, sheetDict, Doc):
         nameRef = sheetAtts.getNamedItem("name")
         sheetName = getText(nameRef.childNodes)
         # print("table name: ", sheetName)
-        idRef = sheetAtts.getNamedItem("sheetId")
-        sheetFile = "sheet" + getText(idRef.childNodes) + ".xml"
+        idRef = sheetAtts.getNamedItem("r:id")
+        sheetFile = "sheet" + getText(idRef.childNodes)[3:] + ".xml"
         # print("sheetFile: ", sheetFile)
         # add FreeCAD-spreadsheet
         sheetDict[sheetName] = (Doc.addObject("Spreadsheet::Sheet", sheetName), sheetFile)


### PR DESCRIPTION
This fix was proposed by pageeddie on https://github.com/FreeCAD/FreeCAD/issues/19757

The solution to the bug was proposed in the ticket, but there are not a PR provided

I give credit to pageeddie (the author) in the commit message

## Issues

https://github.com/FreeCAD/FreeCAD/issues/19757


## Before and After Images

Before:

![image](https://github.com/user-attachments/assets/85ea714e-6b1f-4fd7-8925-6ce3b6430191)


The image show FreeCad opening the spreadsheet

![image](https://github.com/user-attachments/assets/96177d16-55a1-4586-8089-6df305f30d35)
