### PR TITLE
Gui: Property editor combobox fix not popping up if the user canceled

### DIFF
--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -129,6 +129,12 @@ bool PropertyItemDelegate::eventFilter(QObject *o, QEvent *ev)
 {
     if (ev->type() == QEvent::FocusOut) {
         auto parentEditor = qobject_cast<PropertyEditor*>(this->parent());
+        auto *comboBox = qobject_cast<QComboBox*>(o);
+        if (comboBox) {
+            if (parentEditor && parentEditor->activeEditor == comboBox) {
+                parentEditor->activeEditor = nullptr;
+            }
+        }
         auto widget = qobject_cast<QWidget*>(o);
         if (widget && parentEditor && parentEditor->activeEditor
                    && widget != parentEditor->activeEditor) {

--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -129,8 +129,7 @@ bool PropertyItemDelegate::eventFilter(QObject *o, QEvent *ev)
 {
     if (ev->type() == QEvent::FocusOut) {
         auto parentEditor = qobject_cast<PropertyEditor*>(this->parent());
-        auto *comboBox = qobject_cast<QComboBox*>(o);
-        if (comboBox) {
+        if (auto* comboBox = qobject_cast<QComboBox*>(o)) {
             if (parentEditor && parentEditor->activeEditor == comboBox) {
                 parentEditor->activeEditor = nullptr;
             }


### PR DESCRIPTION
fixes #21675 if the initial popup is canceled and the editor is left active, the combo will popup again-

regarding the regression before you needed a first click to activate the editor, then you can popup the list and hold the click
now the list will popup directly, the amount of clicks i'ts the same so there is no hold needed now, i don't consider this a regression

regarding the scroll on combo, it's incompatible with the approach of clicking an item on the list and directly applying the property directly, if wheel needs to be supported then we need to re-add the click outside to apply.