### PR TITLE
BIM: Terrain should not also be in Group of Site

### DIFF
--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -659,8 +659,15 @@ class _Site(ArchIFC.IfcProduct):
 
     def onChanged(self, obj, prop):
         ArchComponent.Component.onChanged(self, obj, prop)
-        if prop == "Terrain" and obj.Terrain and FreeCAD.GuiUp:
-            obj.Terrain.ViewObject.hide()
+        if prop == "Terrain" and obj.Terrain:
+            if obj.Terrain in getattr(obj,"Group",[]):
+                grp = obj.Group
+                grp.remove(obj.Terrain)
+                obj.Group = grp
+            if FreeCAD.GuiUp:
+                obj.Terrain.ViewObject.hide()
+        if prop == "Group" and getattr(obj,"Terrain",None) in obj.Group:
+            obj.Terrain = None
 
     def getMovableChildren(self, obj):
         return obj.Additions + obj.Subtractions


### PR DESCRIPTION
Addresses one of the issues mentioned in #21667.

* If the Terrain is dropped on the Site it is added to the Group (as before) but the Terrain property is then also set to None.
* If one of the objects in Group is selected as the Terrain it is removed from the Group.