### PR TITLE
BIM: fix typo in Arch.py

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -1137,7 +1137,7 @@ def makeSectionPlane(objectslist=None, name=None):
         "Part::FeaturePython",
         baseClassName="_SectionPlane",
         internalName="Section",
-        defaultLabel=name if name else translate("Arch", "Secton"),
+        defaultLabel=name if name else translate("Arch", "Section"),
     )
 
     # Initialize all relevant properties


### PR DESCRIPTION
non-trivial typo that would affect translations