### PR TITLE
Draft: DraftGui.py correct handling of last point

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -169,8 +169,8 @@ class DraftToolBar:
         self.x = 0  # coord of the point as displayed in the task panel (global/local and relative/absolute)
         self.y = 0  # idem
         self.z = 0  # idem
-        self.new_point = FreeCAD.Vector()   # global point value
-        self.last_point = FreeCAD.Vector()  # idem
+        self.new_point = None   # global point value
+        self.last_point = None  # idem
         self.lvalue = 0
         self.pvalue = 90
         self.avalue = 0
@@ -753,8 +753,8 @@ class DraftToolBar:
         self.x = 0
         self.y = 0
         self.z = 0
-        self.new_point = FreeCAD.Vector()
-        self.last_point = FreeCAD.Vector()
+        self.new_point = None
+        self.last_point = None
         self.pointButton.show()
         if rel: self.isRelative.show()
         todo.delay(self.setFocus, None)
@@ -1259,7 +1259,7 @@ class DraftToolBar:
                 plane = WorkingPlane.get_working_plane(update=False)
             if not last:
                 if self.globalMode:
-                    last = FreeCAD.Vector(0,0,0)
+                    last = FreeCAD.Vector()
                 else:
                     last = plane.position
 
@@ -1607,9 +1607,13 @@ class DraftToolBar:
 
     def get_last_point(self):
         """Get the last point in the GCS."""
-        if hasattr(self.sourceCmd, "node") and self.sourceCmd.node:
+        if getattr(self.sourceCmd, "node", []):
             return self.sourceCmd.node[-1]
-        return self.last_point
+        if self.last_point is not None:
+            return self.last_point
+        if self.globalMode:
+            return FreeCAD.Vector()
+        return WorkingPlane.get_working_plane(update=False).position
 
     def get_new_point(self, delta):
         """Get the new point in the GCS.
@@ -1617,9 +1621,10 @@ class DraftToolBar:
         The delta vector (from the task panel) can be global/local
         and relative/absolute.
         """
-        plane = WorkingPlane.get_working_plane(update=False)
-        base_point = FreeCAD.Vector()
-        if plane and not self.globalMode:
+        if self.globalMode:
+            base_point = FreeCAD.Vector()
+        else:
+            plane = WorkingPlane.get_working_plane(update=False)
             delta = plane.get_global_coords(delta, as_vector=True)
             base_point = plane.position
         if self.relativeMode:
@@ -1678,8 +1683,8 @@ class DraftToolBar:
         self.x = 0
         self.y = 0
         self.z = 0
-        self.new_point = FreeCAD.Vector()
-        self.last_point = FreeCAD.Vector()
+        self.new_point = None
+        self.last_point = None
         self.lvalue = 0
         self.pvalue = 90
         self.avalue = 0


### PR DESCRIPTION
This PR fixes a V1.1 regression.
The default for the last point should be the origin of the working plane if Global mode is off.

Forum topic:
https://forum.freecad.org/viewtopic.php?t=97452