### PR TITLE
Start: Fix crash

### DIFF
--- a/src/App/ProjectFile.cpp
+++ b/src/App/ProjectFile.cpp
@@ -66,6 +66,26 @@ using namespace App;
 
 namespace
 {
+
+class ZipTools
+{
+public:
+    static std::unique_ptr<zipios::ZipFile> open(const std::string& file)
+    {
+        std::unique_ptr<zipios::ZipFile> project;
+        try {
+            project = std::make_unique<zipios::ZipFile>(file);
+            if (!project->isValid()) {
+                project.reset();
+            }
+        }
+        catch (const std::exception&) {
+        }
+
+        return project;
+    }
+};
+
 class DocumentMetadata
 {
 public:
@@ -212,11 +232,12 @@ bool ProjectFile::loadDocument()
         return true;  // already loaded
     }
 
-    zipios::ZipFile project(stdFile);
-    if (!project.isValid()) {
+    auto project = ZipTools::open(stdFile);
+    if (!project) {
         return false;
     }
-    std::unique_ptr<std::istream> str(project.getInputStream("Document.xml"));
+
+    std::unique_ptr<std::istream> str(project->getInputStream("Document.xml"));
     if (str) {
         std::unique_ptr<XercesDOMParser> parser(new XercesDOMParser);
         parser->setValidationScheme(XercesDOMParser::Val_Auto);

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -417,8 +417,7 @@ void StartView::changeEvent(QEvent* event)
     _openFirstStart->setEnabled(true);
     Gui::Document* doc = Gui::Application::Instance->activeDocument();
     if (doc) {
-        Gui::View3DInventor* view = static_cast<Gui::View3DInventor*>(doc->getActiveView());
-        if (view) {
+        if (auto view = dynamic_cast<Gui::View3DInventor*>(doc->getActiveView())) {
             Gui::View3DInventorViewer* viewer = view->getViewer();
             if (viewer->isEditing()) {
                 _openFirstStart->setEnabled(false);


### PR DESCRIPTION
As soon as a FCStd file that is in the Recent Files list gets corrupted loading the Start page makes the application almost unusable. Steps to reproduce:
1. Create a simple FCStd file and load it
2. Close FreeCAD
3. Replace the FCStd file with random e.g. a text file
4. Start FreeCAD and try to open the Start page

Exception is repeatedly thrown and not much can be done:
```
[ ] C++ exception thrown (Unable to find zip structure: End-of-central-directory)
[ ] C++ exception thrown (Unable to find zip structure: End-of-central-directory)
...
[ ] C++ exception thrown (Unable to find zip structure: End-of-central-directory)
```
Although FreeCAD can be still closed, sometimes it crashes various ways, for example:
```
Program received signal SIGSEGV, Segmentation fault.
#0  /lib/x86_64-linux-gnu/libc.so.6(+0x3c050) [0x7facc2a5b050]
#1  /lib/x86_64-linux-gnu/libQt5Core.so.5(+0xca110) [0x7facc2cca110]
#2  0x7facc2ede8c1 in QObjectPrivate::connectImpl(QObject const*, int, QObject const*, void**, QtPrivate::QSlotObjectBase*, Qt::ConnectionType, int const*, QMetaObject const*) from /lib/x86_64-linux-gnu/libQt5Core.so.5+0x181
#3  0x7facc2eded85 in QObject::connectImpl(QObject const*, void**, QObject const*, void**, QtPrivate::QSlotObjectBase*, Qt::ConnectionType, int const*, QMetaObject const*) from /lib/x86_64-linux-gnu/libQt5Core.so.5+0xf5
#4  0x7fac6b5d88f7 in QMetaObject::Connection QObject::connect<void (QAbstractItemView::*)(QModelIndex const&), void (StartGui::StartView::*)(QModelIndex const&)>(QtPrivate::FunctionPointer<void (QAbstractItemView::*)(QModelIndex const&)>::Object const*, void (QAbstractItemView::*)(QModelIndex const&), QtPrivate::FunctionPointer<void (StartGui::StartView::*)(QModelIndex const&)>::Object const*, void (StartGui::StartView::*)(QModelIndex const&), Qt::ConnectionType) from <FC>/Mod/Start/StartGui.so+0x9d
#5  0x7fac6b5d4412 in StartGui::StartView::StartView(QWidget*) from <FC>/Mod/Start/StartGui.so+0x942
#6  0x7fac6b5d294a in CmdStart::activated(int) from <FC>/Mod/Start/StartGui.so+0xa8
#7  0x7facc7ac1a56 in Gui::Command::_invoke(int, bool) from <FC>/lib/libFreeCADGui.so+0x272
#8  0x7facc7ac17b6 in Gui::Command::invoke(int, Gui::Command::TriggerSource) from <FC>/lib/libFreeCADGui.so+0x12a
#9  0x7facc7acb64e in Gui::CommandManager::runCommandByName(char const*) const from <FC>/lib/libFreeCADGui.so+0x44
#10  0x7fac6b57fe39 in StartGui::StartLauncher::Launch() from <FC>/Mod/Start/StartGui.so+0x81
#11  0x7fac6b57ff03 in StartGui::StartLauncher::EnsureLaunched() from <FC>/Mod/Start/StartGui.so+0x8b
#12  0x7fac6b57fdb5 in StartGui::StartLauncher::Launch()::{lambda()#1}::operator()() const from <FC>/Mod/Start/StartGui.so+0x1b
#13  0x7fac6b5850d7 in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, StartGui::StartLauncher::Launch()::{lambda()#1}>::call(StartGui::StartLauncher::Launch()::{lambda()#1}&, void**) from <FC>/Mod/Start/StartGui.so+0x1c
#14  0x7fac6b584d19 in void QtPrivate::Functor<StartGui::StartLauncher::Launch()::{lambda()#1}, 0>::call<QtPrivate::List<>, void>(StartGui::StartLauncher::Launch()::{lambda()#1}&, void*, void**) from <FC>/Mod/Start/StartGui.so+0x27
#15  0x7fac6b5849fe in QtPrivate::QFunctorSlotObject<StartGui::StartLauncher::Launch()::{lambda()#1}, 0, QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) from <FC>/Mod/Start/StartGui.so+0x65
#16  /lib/x86_64-linux-gnu/libQt5Core.so.5(+0x2ece42) [0x7facc2eece42]
#17  0x7facc2edd54d in QObject::event(QEvent*) from /lib/x86_64-linux-gnu/libQt5Core.so.5+0x9d
#18  0x7facc3b62fae in QApplicationPrivate::notify_helper(QObject*, QEvent*) from /lib/x86_64-linux-gnu/libQt5Widgets.so.5+0x7e
#19  0x7facc7a52582 in Gui::GUIApplication::notify(QObject*, QEvent*) from <FC>/lib/libFreeCADGui.so+0x134
#20  0x7facc2eb1738 in QCoreApplication::notifyInternal2(QObject*, QEvent*) from /lib/x86_64-linux-gnu/libQt5Core.so.5+0x118
#21  0x7facc2f08c71 in QTimerInfoList::activateTimers() from /lib/x86_64-linux-gnu/libQt5Core.so.5+0x391
#22  /lib/x86_64-linux-gnu/libQt5Core.so.5(+0x30953c) [0x7facc2f0953c]
#23  /lib/x86_64-linux-gnu/libglib-2.0.so.0(g_main_context_dispatch+0x299) [0x7facc111e7a9]
#24  /lib/x86_64-linux-gnu/libglib-2.0.so.0(+0x54a38) [0x7facc111ea38]
#25  /lib/x86_64-linux-gnu/libglib-2.0.so.0(g_main_context_iteration+0x2c) [0x7facc111eacc]
#26  0x7facc2f09876 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) from /lib/x86_64-linux-gnu/libQt5Core.so.5+0x66
#27  0x7facc2eb01bb in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) from /lib/x86_64-linux-gnu/libQt5Core.so.5+0x12b
#28  0x7facc2eb8316 in QCoreApplication::exec() from /lib/x86_64-linux-gnu/libQt5Core.so.5+0x96
#29  <FC>/lib/libFreeCADGui.so(+0x12db6bc) [0x7facc78db6bc]
#30  <FC>/lib/libFreeCADGui.so(+0x12db980) [0x7facc78db980]
#31  0x7facc78dbc5e in Gui::Application::runApplication() from <FC>/lib/libFreeCADGui.so+0x1e2
#32  ./bin/FreeCAD(+0x2acab) [0x56093b764cab]
#33  /lib/x86_64-linux-gnu/libc.so.6(+0x2724a) [0x7facc2a4624a]
#34  /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x85) [0x7facc2a46305]
#35  ./bin/FreeCAD(+0x296c1) [0x56093b7636c1]
```