### PR TITLE
Doc: Improve the documentation of transactions (trivial out-of-place)

### DIFF
--- a/src/App/AutoTransaction.h
+++ b/src/App/AutoTransaction.h
@@ -31,31 +31,38 @@ namespace App
 
 class Application;
 
-/// Helper class to manager transaction (i.e. undo/redo)
+/**
+ * @brief A helper class to manage transactions (i.e. undo/redo).
+ *
+ * An AutoTransaction object is meant to be allocated on the stack and governs
+ * the transactions in that scope.
+ */
 class AppExport AutoTransaction
 {
 public:
-    /// Private new operator to prevent heap allocation
+    /// Delete the new operator to prevent heap allocation.
     void* operator new(std::size_t) = delete;
 
 public:
-    /** Constructor
+    /**
+     * @brief Construct an auto transaction.
      *
-     * @param name: optional new transaction name on construction
-     * @param tmpName: if true and a new transaction is setup, the name given is
+     * @param[in] name: optional new transaction name on construction
+     * @param[in] tmpName: if true and a new transaction is setup, the name given is
      * considered as temporary, and subsequent construction of this class (or
      * calling Application::setActiveTransaction()) can override the transaction
      * name.
      *
      * The constructor increments an internal counter
      * (Application::_activeTransactionGuard). The counter prevents any new
-     * active transaction being setup. It also prevents close (i.e. commits) the
-     * current active transaction until it reaches zero. It does not have any
-     * effect on aborting transaction, though.
+     * active transactions being setup. It also prevents to close
+     * (i.e. commits) the current active transaction until it reaches zero. It
+     * does not have any effect on aborting transactions though.
      */
     AutoTransaction(const char* name = nullptr, bool tmpName = false);
 
-    /** Destructor
+    /**
+     * @brief Destruct an auto transaction.
      *
      * This destructor decrease an internal counter
      * (Application::_activeTransactionGuard), and will commit any current
@@ -63,15 +70,19 @@ public:
      */
     ~AutoTransaction();
 
-    /** Close or abort the transaction
+    /**
+     * @brief Close or abort the transaction.
      *
      * This function can be used to explicitly close (i.e. commit) the
      * transaction, if the current transaction ID matches the one created inside
-     * the constructor. For aborting, it will abort any current transaction
+     * the constructor. For aborting, it will abort any current transaction.
+     *
+     * @param[in] abort: if true, abort the transaction; otherwise, commit it.
      */
     void close(bool abort = false);
 
-    /** Enable/Disable any AutoTransaction instance in the current stack
+    /**
+     * @brief Enable/Disable any AutoTransaction instance on the current stack.
      *
      * Once disabled, any empty temporary named transaction is closed. If there
      * are non-empty or non-temporary named active transaction, it will not be
@@ -79,6 +90,8 @@ public:
      *
      * This function may be used in, for example, Gui::Document::setEdit() to
      * allow a transaction live past any command scope.
+     *
+     * @param[in] enable: if true, enable the AutoTransaction; otherwise, disable it.
      */
     static void setEnable(bool enable);
 
@@ -87,47 +100,53 @@ private:
 };
 
 
-/** Helper class to lock a transaction from being closed or aborted.
+/**
+ * @brief Helper class to lock a transaction from being closed or aborted.
  *
- * The helper class is used to protect some critical transaction from being
+ * The helper class is used to protect some critical transactions from being
  * closed prematurely, e.g. when deleting some object.
  */
 class AppExport TransactionLocker
 {
 public:
-    /** Constructor
-     * @param lock: whether to activate the lock
+
+    /**
+     * @brief Construct a transaction locker.
+     *
+     * @param[in] lock: whether to activate the lock.
      */
     TransactionLocker(bool lock = true);
 
-    /** Destructor
-     * Unlock the transaction is this locker is active
+    /**
+     * @brief Destruct a transaction locker.
+     *
+     * Unlock the transaction if this locker is active.
      */
     ~TransactionLocker();
 
-    /** Activate or deactivate this locker
-     * @param enable: whether to activate the locker
+    /**
+     * @brief Activate or deactivate this locker.
      *
      * An internal counter is used to support recursive locker. When activated,
      * the current active transaction cannot be closed or aborted.  But the
      * closing call (Application::closeActiveTransaction()) will be remembered,
      * and performed when the internal lock counter reaches zero.
+     *
+     * @param enable: whether to activate the locker
      */
     void activate(bool enable);
 
-    /// Check if the locker is active
     bool isActive() const
     {
         return active;
     }
 
-    /// Check if transaction is being locked
     static bool isLocked();
 
     friend class Application;
 
 public:
-    /// Private new operator to prevent heap allocation
+    /// Delete the new operator to prevent heap allocation.
     void* operator new(std::size_t) = delete;
 
 private:

--- a/src/App/TransactionalObject.h
+++ b/src/App/TransactionalObject.h
@@ -32,20 +32,47 @@ namespace App
 class Document;
 class TransactionObject;
 
-/** Base class of transactional objects
+/**
+ * @brief Base class of transactional objects.
+ *
+ * A transactional object provides functionality that is inherited by its
+ * children to ensure that these children objects can be targeted by a
+ * transaction.
  */
 class AppExport TransactionalObject: public App::ExtensionContainer
 {
     PROPERTY_HEADER_WITH_OVERRIDE(App::TransactionalObject);
 
 public:
-    /// Constructor
+    /// Construct a transactional object.
     TransactionalObject();
+
+    /// Destruct a transactional object.
     ~TransactionalObject() override;
+
+    /**
+     * @brief Check if this object is attached to a document.
+     *
+     * @return true if this object is attached to a document; otherwise false.
+     */
     virtual bool isAttachedToDocument() const;
+
+    /**
+     * @brief Deteach this object from the document.
+     *
+     * @return the name of the document this object was attached to.
+     */
     virtual const char* detachFromDocument();
 
 protected:
+    /**
+     * @brief Notify the document that a property is about to be changed.
+     *
+     * This function is called before the property is changed.
+     *
+     * @param[in,out] doc the document this object is attached to.
+     * @param[in] prop the property that is about to be changed.
+     */
     void onBeforeChangeProperty(Document* doc, const Property* prop);
 };
 

--- a/src/App/Transactions.cpp
+++ b/src/App/Transactions.cpp
@@ -57,10 +57,6 @@ Transaction::Transaction(int id)
     transID = id;
 }
 
-/**
- * A destructor.
- * A more elaborate description of the destructor.
- */
 Transaction::~Transaction()
 {
     auto& index = _Objects.get<0>();
@@ -281,16 +277,8 @@ TYPESYSTEM_SOURCE_ABSTRACT(App::TransactionObject, Base::Persistence)
 //**************************************************************************
 // Construction/Destruction
 
-/**
- * A constructor.
- * A more elaborate description of the constructor.
- */
 TransactionObject::TransactionObject() = default;
 
-/**
- * A destructor.
- * A more elaborate description of the destructor.
- */
 TransactionObject::~TransactionObject()
 {
     for (auto& v : _PropChangeMap) {
@@ -319,7 +307,7 @@ void TransactionObject::applyChn(Document& /*Doc*/, TransactionalObject* pcObj, 
             }
 
             // getPropertyName() is specially coded to be safe even if prop has
-            // been destroies. We must prepare for the case where user removed
+            // been destroyed. We must prepare for the case where user removed
             // a dynamic property but does not recordered as transaction.
             auto name = pcObj->getPropertyName(prop);
             if (!name || (!data.name.empty() && data.name != name)

--- a/src/App/core-app.dox
+++ b/src/App/core-app.dox
@@ -443,3 +443,20 @@
  * For a more high-level discussion see the topic @ref APP "App".
  */
 
+
+// Documentation for trivial functions
+
+/**
+ * @fn App::TransactionLocker::isActive() const
+ * @brief Check if the locker is active.
+ *
+ * @return true if the locker is active; otherwise false.
+ */
+
+/**
+ * @fn App::TransactionLocker::isLocked() const
+ * @brief Check if transaction is being locked.
+ *
+ * @return true if the transaction is locked; otherwise false.
+ */
+


### PR DESCRIPTION
This PR is an alternative to https://github.com/FreeCAD/FreeCAD/pull/21494 in which doc comments that are trivial are moved out of place.

In both PRs, there are a couple of functions in TransactionLocker that have trivial doc comments, trivial because they don't really add any new information to what the function name says. In #21494, these are added to the header file. In this PR, these are added to the main `.dox` file of package App. A third option is to refrain from documenting them at all.

I prefer to comment these function because with these comments, the output is consistent, looks well-organized and thoughtfully maintained.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Part of https://github.com/FreeCAD/FreeCAD/issues/20503

## Before and After Images

The output of this PR is:

![screenshot](https://github.com/user-attachments/assets/41e532a3-3ef5-4db9-90a0-095b6a5169cb)

In comparison to the [image in this comment](https://github.com/FreeCAD/FreeCAD/pull/21494#discussion_r2106843440), the documentation for `friend` is not there anymore because you cannot refer to it from a different file. By the way, we could also choose to remove the friend relations from the output of doxygen altogether I believe.



<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
