### PR TITLE
CI: add ifcopenshell to Ubuntu native builds

### DIFF
--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -80,6 +80,14 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
+
+      - name: Install FreeCAD Python build/test dependencies
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq python3-pip
+          python3 -m pip install --upgrade pip
+          python3 -m pip install ifcopenshell==0.8.0
+
       - name: Install FreeCAD dependencies
         run: ./package/ubuntu/install-apt-packages.sh
 

--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -81,15 +81,15 @@ jobs:
         with:
           submodules: true
 
-      - name: Install FreeCAD Python build/test dependencies
+      - name: Install FreeCAD dependencies
+        run: ./package/ubuntu/install-apt-packages.sh
+
+      - name: Install FreeCAD Python test dependencies
         run: |
           sudo apt-get update -y -qq
           sudo apt-get install -y -qq python3-pip
           python3 -m pip install --upgrade pip
           python3 -m pip install ifcopenshell==0.8.0
-
-      - name: Install FreeCAD dependencies
-        run: ./package/ubuntu/install-apt-packages.sh
 
       - name: Make needed directories, files and initializations
         id: Init

--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -89,7 +89,7 @@ jobs:
           sudo apt-get update -y -qq
           sudo apt-get install -y -qq python3-pip
           python3 -m pip install --upgrade pip
-          python3 -m pip install ifcopenshell==0.8.0
+          python3 -m pip install ifcopenshell==0.8.2
 
       - name: Make needed directories, files and initializations
         id: Init


### PR DESCRIPTION
Currently parts of the BIM workbench and the IFC importer/exporter code cannot be tested during the CI builds as they depend on `ifcopenshell` being installed.

This PR installs `ifcopenshell` in the Ubuntu native build as it's probably the easiest platform to install it on. Once installed, then we'll be able to execute unit tests that exercise IFC operations for the BIM workbench. The tests can be written so that they can be skipped when run on a CI workflow that doesn't have `ifcopenshell` installed.

With recent fixes in the pixi builds (https://github.com/FreeCAD/FreeCAD/pull/21641, https://github.com/FreeCAD/FreeCAD/pull/21714), I believe `ifcopenshell` should already be installed there. This means, tests could eventually be executed for the pixi builds, and Ubuntu native builds. Then skipped for the Windows builds.

I added a dedicated job to keep separation between the build/runtime dependencies in `install-apt-packages.sh`. It is run after the build/runtime dependencies job, since that installs `python3-numpy`. Without `numpy` previously installed, `ifcopenshell` would pull a newer version that causes FEM tests to fail.

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
