### PR TITLE
fix #10514

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsEditor.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsEditor.cpp
@@ -273,7 +273,11 @@ void DlgSettingsEditor::loadSettings()
     QStringList fixedFamilyNames;
     for (const auto& name : familyNames) {
         if (QFontDatabase().isFixedPitch(name)) {
-            if (name.compare(QLatin1String("8514oem"), Qt::CaseInsensitive) != 0) {
+            // cursor.pcf was removed to cope with a problem with the Qt Font Manager
+            // See https://github.com/FreeCAD/FreeCAD/issues/10514 for details
+            if (name.compare(QLatin1String("8514oem"), Qt::CaseInsensitive) != 0
+                && name.compare(QLatin1String("cursor.pcf"), Qt::CaseInsensitive) != 0)
+              {
                 fixedFamilyNames.append(name);
             }
         }
@@ -283,7 +287,11 @@ void DlgSettingsEditor::loadSettings()
     QStringList fixedFamilyNames;
     for (const auto& name : familyNames) {
         if (QFontDatabase::isFixedPitch(name)) {
-            if (name.compare(QLatin1String("8514oem"), Qt::CaseInsensitive) != 0) {
+            // cursor.pcf was removed to cope with a problem with the Qt Font Manager
+            // See https://github.com/FreeCAD/FreeCAD/issues/10514 for details
+            if (name.compare(QLatin1String("8514oem"), Qt::CaseInsensitive) != 0
+                && name.compare(QLatin1String("cursor.pcf"), Qt::CaseInsensitive) != 0)
+              {
                 fixedFamilyNames.append(name);
             }
         }


### PR DESCRIPTION


Fix https://github.com/FreeCAD/FreeCAD/issues/10514


This change blacklists the cursor.pcf font from being background saved into the preferences serialization file.
When this font is loaded, extents cannot be computed, and Freecad freezes at 100% cpu, with errors streamed to stderr.

A proposed workaround, that involves manually editing ~/.config/FreeCAD/user.cfg, to clear the cursor.pcf field when modified, only goes so far.

Since some actions that trigger the behavior - such as DXF import and export - don't provide any opportunity to save work, before one has to perform the pkil, and re-edit the user.cfg, so it is not possible to progress the design.

I believe this change is low risk, since it follows https://github.com/FreeCAD/FreeCAD/pull/10555

tested on nixos with freecad v1.0.1.

Direct nixos patch, https://github.com/NixOS/nixpkgs/pull/412903

 

 
 