### PR TITLE
Fix typing extensions

### DIFF
--- a/package/rattler-build/pixi.lock
+++ b/package/rattler-build/pixi.lock
@@ -9,7 +9,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.11.18-py311h2dc5d0c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.12.6-py311h2dc5d0c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
@@ -28,10 +28,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/calculix-2.22-hae4e037_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cgal-cpp-6.0.1-h6aadc51_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/coin3d-4.0.3-hd74d64a_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.2-py311hd18a35c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.11.12-py311hd8ed1ab_0.conda
@@ -55,12 +55,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-64/fonttools-4.57.0-py311h2dc5d0c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fonttools-4.58.1-py311h2dc5d0c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/freeimage-3.18.0-h3a85593_22.conda
       - conda: https://prefix.dev/conda-forge/linux-64/freetype-2.13.3-ha770c72_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-64/frozenlist-1.5.0-py311h2dc5d0c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/frozenlist-1.6.0-py311h62d540b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/geos-3.13.1-h97f6797_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gl2ps-1.4.2-hae5d5c5_1.conda
@@ -96,7 +96,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20240722.0-cxx17_hbbce691_4.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libasprintf-0.23.1-h8e693c7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libasprintf-0.24.1-h8e693c7_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.9.0-31_h59b9bed_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libboost-1.86.0-h6c02f8c_3.conda
@@ -107,11 +107,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.9.0-31_he106b2a_openblas.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp19.1-19.1.7-default_hb5137d0_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libclang13-20.1.3-default_he06ed0a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp19.1-19.1.7-default_hb5137d0_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libclang13-20.1.6-default_he06ed0a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.13.0-h332b0f4_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.23-h86f0d12_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.14.0-h332b0f4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.124-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
@@ -120,26 +120,26 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.13.3-ha770c72_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.13.3-h48d6fc4_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-14.2.0-h767d61c_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgettextpo-0.23.1-h5888daf_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-14.2.0-hf1ad2bd_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgettextpo-0.24.1-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.84.1-h2ff4ddf_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libglu-9.0.3-h03adeef_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-14.2.0-h767d61c_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.11.2-default_h0d58e46_1001.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.9.0-31_h7ac8fdf_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.9.0-31_he2f377e_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libllvm19-19.1.7-ha7bfdaf_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libllvm20-20.1.3-he9d0ab4_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libllvm20-20.1.6-he9d0ab4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h00e09a9_116.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
@@ -164,17 +164,17 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.5.2-hd0c01bc_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.47-h943b412_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libpq-17.4-h27ae623_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpq-17.5-h27ae623_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libraw-0.21.4-h9969a89_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libspnav-1.1-h4ab18f5_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.49.1-hee588c1_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.50.0-hee588c1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-14.2.0-h8f9b012_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libtheora-1.1.1-h4ab18f5_1006.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.0-hd9ff511_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.0-hf01ce69_5.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libva-2.22.0-h4f16b4b_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
@@ -182,21 +182,21 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.5.0-h851e524_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.9.0-h65c71a3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.13.7-h4bc477f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.10.0-h65c71a3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.13.8-h4bc477f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/loguru-0.7.2-py311h38be061_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/lxml-5.4.0-py311hbd2c71b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/matplotlib-base-3.10.1-py311h2b939e6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/matplotlib-base-3.10.3-py311h2b939e6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.3.1-h24ddda3_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.1-h90cbb55_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/multidict-6.4.3-py311h2dc5d0c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/multidict-6.4.4-py311h2dc5d0c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/mysql-common-9.0.1-h266115a_6.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_6.conda
@@ -204,7 +204,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/nine-1.1.0-py_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/nlohmann_json-3.12.0-h3f2d84a_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/noqt5-1.0-hd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.2.5-py311h5d046bc_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.2.6-py311h5d046bc_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/occt-7.8.1-all_h4c4714a_203.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/olefile-0.47-pyhd8ed1ab_1.conda
@@ -212,18 +212,18 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/opencamlib-2023.01.11-py311h60a5941_7.conda
       - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2024.10.24-h5888daf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/opencv-4.10.0-qt6_py311h6e2ec45_613.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.3.3-hff63da0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.3.3-h2cd1444_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.5.0-hf92e6e3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.9-he970967_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.5.0-h7b32b05_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pango-1.54.0-h3a902e7_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pcl-1.14.1-hd932182_6.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.44-hc749103_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pillow-11.1.0-py311h1322bbf_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pip-25.1-pyh8b19718_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pillow-11.2.1-py311h1322bbf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pivy-0.6.10-py311qt6h4fb66a9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.0-h29eaf8c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
@@ -250,18 +250,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.15.2-py311h8f841c2_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/shapely-2.1.0-py311h3dc67b8_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/shapely-2.1.1-py311h3dc67b8_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/smesh-9.9.0.0-hb7ebc10_14.conda
       - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.1-h8bd8927_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/soqt6-1.6.3-h23d7b0e_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.49.1-h9eae976_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.50.0-h9eae976_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/svgwrite-1.4.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_105.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.1.0-h4ce085d_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.13.2-pyh29332c3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-16.0.0-py311h9ecbd09_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.4.0-pyhd8ed1ab_0.conda
@@ -270,9 +271,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/vtk-base-9.3.1-qt_py311h2a60df7_213.conda
       - conda: https://prefix.dev/conda-forge/linux-64/vtk-io-ffmpeg-9.3.1-qt_py311h3d4e8c9_213.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.43-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.44-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.3.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.3.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
@@ -314,7 +315,7 @@ environments:
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.11.18-py311h58d527c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.12.6-py311h58d527c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.14-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
@@ -333,10 +334,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cairo-1.18.4-h83712da_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/calculix-2.22-h287cb45_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cffi-1.17.1-py311h14e8bb7_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cgal-cpp-6.0.1-hcda14ae_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/coin3d-4.0.3-h411181d_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/contourpy-1.3.2-py311hc07b1fb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.11.12-py311hd8ed1ab_0.conda
@@ -360,12 +361,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/fontconfig-2.15.0-h8dda3cd_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/fonttools-4.57.0-py311h58d527c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/fonttools-4.58.1-py311h58d527c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/freeimage-3.18.0-h6cb32c8_22.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/freetype-2.13.3-h8af1aa0_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/frozenlist-1.5.0-py311h58d527c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/frozenlist-1.6.0-py311ha6a3852_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gdk-pixbuf-2.42.12-ha61d561_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gl2ps-1.4.2-hedfd65a_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/glew-2.1.0-h01db608_2.tar.bz2
@@ -400,7 +401,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lerc-4.0.0-hfdc4d58_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libabseil-20240722.0-cxx17_h18dbdb1_4.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libasprintf-0.23.1-h5e0f5ae_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libasprintf-0.24.1-h5e0f5ae_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libass-0.17.3-hcc173ff_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libblas-3.9.0-31_h1a9f1db_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libboost-1.86.0-h4d13611_3.conda
@@ -411,11 +412,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlidec-1.1.0-h86ecc28_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlienc-1.1.0-h86ecc28_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libcblas-3.9.0-31_hab92f65_openblas.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.7-default_he324ac1_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang13-20.1.3-default_h9e36cb9_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.7-default_he324ac1_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang13-20.1.6-default_h9e36cb9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libcurl-8.13.0-h6702fde_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libdeflate-1.23-he377734_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libcurl-8.14.0-h6702fde_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libdeflate-1.24-he377734_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libdrm-2.4.124-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_2.conda
@@ -424,26 +425,26 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libffi-3.4.6-he21f813_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libfreetype-2.13.3-h8af1aa0_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libfreetype6-2.13.3-he93130f_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-14.2.0-he277a41_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-ng-14.2.0-he9431aa_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-15.1.0-he277a41_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-ng-15.1.0-he9431aa_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgd-2.3.3-hc8d7b1d_11.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgettextpo-0.23.1-h5ad3122_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran-14.2.0-he9431aa_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran5-14.2.0-hb6113d0_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgettextpo-0.24.1-h5ad3122_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran-15.1.0-he9431aa_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran5-15.1.0-hbc25352_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libglib-2.84.1-hc486b8e_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libglu-9.0.3-hc7f7585_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libglu-9.0.3-h5ad3122_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.1.0-he277a41_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libhwloc-2.11.2-default_h2c612a5_1001.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libiconv-1.18-hc99b53d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libjpeg-turbo-3.1.0-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/liblapack-3.9.0-31_h411afd4_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/liblapacke-3.9.0-31_hc659ca5_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm19-19.1.7-h2edbd07_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm20-20.1.4-h07bd352_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm20-20.1.6-h07bd352_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libnetcdf-4.9.2-nompi_h46655bb_116.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libnghttp2-1.64.0-hc8609a4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
@@ -466,38 +467,38 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopus-1.5.2-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpciaccess-0.18-h31becfc_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpng-1.6.47-hec79eb8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libpq-17.4-hf590da8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libpq-17.5-hf590da8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libprotobuf-5.28.2-h029595c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libraw-0.21.4-h74ffddf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/librsvg-2.58.4-h00090f3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libspnav-1.1-h68df207_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libsqlite-3.49.1-h5eb1b54_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libsqlite-3.50.0-h5eb1b54_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-14.2.0-h3f4de04_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-ng-14.2.0-hf1166c9_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-15.1.0-h3f4de04_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-ng-15.1.0-hf1166c9_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libtheora-1.1.1-h68df207_1006.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libtiff-4.7.0-h88f7998_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libtiff-4.7.0-h7c15681_5.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libwebp-base-1.5.0-h0886dbf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libxkbcommon-1.9.0-hbab7b08_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libxml2-2.13.7-he060846_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libxkbcommon-1.10.0-hbab7b08_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libxml2-2.13.8-he060846_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libxslt-1.1.39-h1cc9640_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libzip-1.11.2-h3e8f909_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/loguru-0.7.2-py311hfecb2dc_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lxml-5.4.0-py311h3bfafd0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/markupsafe-3.0.2-py311ha09ea12_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/matplotlib-base-3.10.1-py311h0385ec1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/matplotlib-base-3.10.3-py311h0385ec1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpc-1.3.1-h783934e_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpfr-4.2.1-h2305555_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.1.0-py311hc07b1fb_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/multidict-6.4.3-py311h58d527c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/multidict-6.4.4-py311h58d527c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mysql-common-9.0.1-h3f5c77f_6.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mysql-libs-9.0.1-h11569fd_6.conda
@@ -505,24 +506,24 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/nine-1.1.0-py_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h5ad3122_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/noqt5-1.0-hd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.2.5-py311h6c2b7b4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.2.6-py311h6c2b7b4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/occt-7.8.1-all_h78e3548_203.conda
       - conda: https://prefix.dev/conda-forge/noarch/olefile-0.47-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openblas-0.3.29-pthreads_h3a8cbd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/opencamlib-2023.01.11-py311h4a80dcf_7.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/opencv-4.10.0-headless_py311h66da022_13.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/openexr-3.3.3-h2d73ac1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/openexr-3.3.3-h718fb27_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openh264-2.5.0-h6c5ec6d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openjpeg-2.5.3-h3f56577_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.9-h30c48ee_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.5.0-hd08dc88_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.5.0-hd08dc88_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pandas-2.2.3-py311h848c333_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pango-1.54.0-hf175a2e_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pcl-1.14.1-h777c531_6.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pcre2-10.44-hf4ec17f_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/pillow-11.1.0-py311ha4eaa5e_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pip-25.1-pyh8b19718_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/pillow-11.2.1-py311ha4eaa5e_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pivy-0.6.10-py311qt6hfa6f3c7_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pixman-0.46.0-h86a87f0_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
@@ -549,17 +550,18 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.2-h8382b9d_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.15.2-py311h2973cce_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/smesh-9.9.0.0-h3752d33_14.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/snappy-1.2.1-hd4fb6f5_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/soqt6-1.6.3-h808f404_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/sqlite-3.49.1-h578a6b9_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/sqlite-3.50.0-h578a6b9_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/svgwrite-1.4.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/svt-av1-2.3.0-h5ad3122_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_105.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tbb-2022.1.0-hf6e3e71_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5688188_102.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.13.2-pyh29332c3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/unicodedata2-16.0.0-py311ha879c10_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.4.0-pyhd8ed1ab_0.conda
@@ -569,7 +571,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/vtk-io-ffmpeg-9.3.1-qt_py311h502ffb0_213.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.23.1-h698ed42_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.3.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.3.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-0.4.1-h5c728e9_2.conda
@@ -610,7 +612,7 @@ environments:
         build: h6d4d2f9_0
       osx-64:
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/aiohttp-3.11.18-py311ha3cf9ac_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aiohttp-3.12.6-py311ha3cf9ac_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/arpack-3.9.1-nompi_hdfe9103_102.conda
@@ -628,10 +630,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/cairo-1.18.4-h950ec3b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/calculix-2.22-h1ca30be_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/cgal-cpp-6.0.1-h20ba9b8_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/coin3d-4.0.3-h9b6ce5f_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/contourpy-1.3.2-py311h4e34fa0_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.11.12-py311hd8ed1ab_0.conda
@@ -654,11 +656,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/fontconfig-2.15.0-h37eeddb_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/osx-64/fonttools-4.57.0-py311ha3cf9ac_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/fonttools-4.58.1-py311ha3cf9ac_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/freeimage-3.18.0-h7cd8ba8_22.conda
       - conda: https://prefix.dev/conda-forge/osx-64/freetype-2.13.3-h694c41f_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/osx-64/frozenlist-1.5.0-py311ha3cf9ac_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/frozenlist-1.6.0-py311h029c973_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/gdk-pixbuf-2.42.12-ha587570_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/gl2ps-1.4.2-hd82a5f3_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/glew-2.1.0-h046ec9c_2.tar.bz2
@@ -691,7 +693,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/lerc-4.0.0-hcca01a6_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libabseil-20240722.0-cxx17_h0e468a2_4.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libasprintf-0.23.1-h27064b9_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libasprintf-0.24.1-h27064b9_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libass-0.17.3-h5386a9e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libblas-3.9.0-31_h53a1964_accelerate.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libboost-1.86.0-hf0da243_3.conda
@@ -703,10 +705,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libcblas-3.9.0-31_h6bc05c3_accelerate.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libclang-cpp17-17.0.6-default_h3571c67_8.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libclang13-20.1.3-default_h9644bed_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libcurl-8.13.0-h5dec5d8_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libcxx-20.1.4-hf95d169_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libdeflate-1.23-hcc1b750_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libclang13-20.1.6-default_h9644bed_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libcurl-8.14.0-h5dec5d8_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libcxx-20.1.6-hf95d169_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libdeflate-1.24-hcc1b750_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libexpat-2.7.0-h240833e_0.conda
@@ -714,19 +716,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/libfreetype-2.13.3-h694c41f_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libfreetype6-2.13.3-h40dfd5c_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libgd-2.3.3-h8555400_11.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libgettextpo-0.23.1-h27064b9_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libgettextpo-0.24.1-h27064b9_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libgfortran-14.2.0-hef36b68_105.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libgfortran5-14.2.0-h58528f3_105.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libglib-2.84.0-h5c976ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libhwloc-2.11.2-default_h4cdd727_1001.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libiconv-1.18-h4b5e92a_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libintl-0.23.1-h27064b9_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libintl-0.24.1-h27064b9_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libjpeg-turbo-3.1.0-h6e16a3a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/liblapack-3.9.0-31_hf5f89c0_accelerate.conda
       - conda: https://prefix.dev/conda-forge/osx-64/liblapacke-3.9.0-31_h323ef19_accelerate.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libllvm17-17.0.6-hbedff68_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libllvm20-20.1.4-h29c3a6c_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.1-hd471939_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libllvm20-20.1.6-h29c3a6c_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.1-hd471939_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libnetcdf-4.9.2-nompi_hd7a758f_116.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libntlm-1.8-h6e16a3a_0.conda
@@ -745,33 +747,33 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2024.5.0-hbcac03e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libopus-1.5.2-he3325bb_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libpng-1.6.47-h3c4a55f_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libpq-17.4-h9c5cfc2_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libpq-17.5-h9c5cfc2_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libprotobuf-5.28.2-h8b30cf6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libraw-0.21.4-h0ade9e5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/librsvg-2.58.4-h21a6cfa_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libsqlite-3.49.1-hdb6dae5_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libsqlite-3.50.0-hdb6dae5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libtheora-1.1.1-hfdf4475_1006.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libtiff-4.7.0-hb77a491_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libtiff-4.7.0-h1167cee_5.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libvorbis-1.3.7-h046ec9c_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-64/libvpx-1.14.1-hf036a51_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libwebp-base-1.5.0-h6cf52b4_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libxml2-2.13.7-h93c44a6_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libxml2-2.13.8-h93c44a6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libxslt-1.1.39-h03b04e6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libzip-1.11.2-h31df5bb_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/llvm-openmp-20.1.3-ha54dae1_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/loguru-0.7.2-py311h6eed73b_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/llvm-openmp-20.1.6-ha54dae1_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/lxml-5.4.0-py311h91cdd00_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/lz4-c-1.10.0-h240833e_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/matplotlib-base-3.10.1-py311h19a4563_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/matplotlib-base-3.10.3-py311h19a4563_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/mpc-1.3.1-h9d8efa1_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/mpfr-4.2.1-haed47dc_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/multidict-6.4.3-py311h1cc1194_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/multidict-6.4.4-py311h1cc1194_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-64/mysql-common-9.0.1-hd00b0ec_6.conda
       - conda: https://prefix.dev/conda-forge/osx-64/mysql-libs-9.0.1-h062309a_6.conda
@@ -779,23 +781,23 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/nine-1.1.0-py_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-64/nlohmann_json-3.12.0-h92383a6_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/noqt5-1.0-hd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/numpy-2.2.5-py311h27c81cd_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/numpy-2.2.6-py311h27c81cd_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/occt-7.8.1-all_ha9a7d59_203.conda
       - conda: https://prefix.dev/conda-forge/noarch/olefile-0.47-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/opencamlib-2023.01.11-py311h1bd00d0_7.conda
       - conda: https://prefix.dev/conda-forge/osx-64/opencv-4.10.0-headless_py311h7b38b82_13.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/openexr-3.3.3-h6794a33_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/openexr-3.3.3-h13904a9_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/openh264-2.5.0-hdfcf091_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/openjpeg-2.5.3-h7fd6d84_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/openldap-2.6.9-hd8a590d_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.5.0-hc426f3f_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/openldap-2.6.10-hd8a590d_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.5.0-hc426f3f_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/pandas-2.2.3-py311hcf53e2f_3.conda
       - conda: https://prefix.dev/conda-forge/osx-64/pango-1.54.0-hb83bde0_3.conda
       - conda: https://prefix.dev/conda-forge/osx-64/pcl-1.14.1-hbaf7342_6.conda
       - conda: https://prefix.dev/conda-forge/osx-64/pcre2-10.44-hf733adb_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/pillow-11.1.0-py311h25da234_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pip-25.1-pyh8b19718_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/pillow-11.2.1-py311h25da234_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/pivy-0.6.10-py311qt6h748d45a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/pixman-0.46.0-h1fd1274_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
@@ -822,17 +824,18 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/scipy-1.15.2-py311h0c91ca8_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/smesh-9.9.0.0-h9ba7290_14.conda
       - conda: https://prefix.dev/conda-forge/osx-64/snappy-1.2.1-haf3c120_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/soqt6-1.6.3-h667e493_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/sqlite-3.49.1-h2e4c9dc_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/sqlite-3.50.0-h2e4c9dc_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/svgwrite-1.4.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/svt-av1-2.3.0-h97d8b74_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_105.conda
       - conda: https://prefix.dev/conda-forge/osx-64/tbb-2022.1.0-h479f576_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.13.2-pyh29332c3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/unicodedata2-16.0.0-py311h4d7f069_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.4.0-pyhd8ed1ab_0.conda
@@ -841,7 +844,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/vtk-base-9.3.1-qt_py311h544662b_213.conda
       - conda: https://prefix.dev/conda-forge/osx-64/vtk-io-ffmpeg-9.3.1-qt_py311h6e7d914_213.conda
       - conda: https://prefix.dev/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.3.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.3.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-64/xerces-c-3.3.0-hd0321b6_0.conda
@@ -866,7 +869,7 @@ environments:
         build: he0f4bc8_0
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aiohttp-3.11.18-py311h4921393_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aiohttp-3.12.6-py311h4921393_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/arpack-3.9.1-nompi_h1f29f7c_102.conda
@@ -884,10 +887,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cairo-1.18.4-h6a3b0d2_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/calculix-2.22-hf186d59_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cgal-cpp-6.0.1-h39a0b02_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/coin3d-4.0.3-h705ab75_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/contourpy-1.3.2-py311h210dab8_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.11.12-py311hd8ed1ab_0.conda
@@ -910,11 +913,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/fontconfig-2.15.0-h1383a14_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/osx-arm64/fonttools-4.57.0-py311h4921393_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/fonttools-4.58.1-py311h4921393_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/freeimage-3.18.0-h2e169f6_22.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/freetype-2.13.3-hce30654_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/osx-arm64/frozenlist-1.5.0-py311h4921393_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/frozenlist-1.6.0-py311h87ddb2a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/gdk-pixbuf-2.42.12-h7ddc832_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/gl2ps-1.4.2-hc97c1ff_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/glew-2.1.0-h9f76cd9_2.tar.bz2
@@ -947,7 +950,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/lerc-4.0.0-hd64df32_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_h07bc746_4.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libasprintf-0.23.1-h493aca8_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libasprintf-0.24.1-h493aca8_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libass-0.17.3-hf20b609_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.9.0-31_h504e6c8_accelerate.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libboost-1.86.0-hc9fb7c5_3.conda
@@ -959,10 +962,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libcblas-3.9.0-31_h8d39bcd_accelerate.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libclang-cpp17-17.0.6-default_hf90f093_8.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libclang13-20.1.3-default_hee4fbb3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libcurl-8.13.0-h73640d1_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-20.1.4-ha82da77_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libdeflate-1.23-h5773f1b_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libclang13-20.1.6-default_hee4fbb3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libcurl-8.14.0-h73640d1_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-20.1.6-ha82da77_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libdeflate-1.24-h5773f1b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.7.0-h286801f_0.conda
@@ -970,19 +973,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libfreetype-2.13.3-hce30654_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libfreetype6-2.13.3-h1d14073_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgd-2.3.3-hb2c3a21_11.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgettextpo-0.23.1-h493aca8_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgettextpo-0.24.1-h493aca8_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-14.2.0-heb5dd2a_105.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-14.2.0-h2c44a93_105.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.84.0-hdff4504_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libhwloc-2.11.2-default_hbce5d74_1001.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-hfe07756_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libintl-0.23.1-h493aca8_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libintl-0.24.1-h493aca8_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libjpeg-turbo-3.1.0-h5505292_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/liblapack-3.9.0-31_h3c9cff3_accelerate.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/liblapacke-3.9.0-31_h09be921_accelerate.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm17-17.0.6-hc4b4ae8_3.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm20-20.1.4-h598bca7_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm20-20.1.6-h598bca7_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h6569565_116.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libntlm-1.8-h5505292_0.conda
@@ -1001,33 +1004,33 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2024.5.0-h286801f_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopus-1.5.2-h48c0fde_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libpng-1.6.47-h3783ad8_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libpq-17.4-h6896619_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libpq-17.5-h6896619_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libraw-0.21.4-h62a31ad_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/librsvg-2.58.4-h266df6f_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.49.1-h3f77e49_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.50.0-h3f77e49_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libtheora-1.1.1-h99b78c6_1006.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libtiff-4.7.0-h551f018_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libtiff-4.7.0-h2f21f7c_5.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libvorbis-1.3.7-h9f76cd9_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-arm64/libvpx-1.14.1-h7bae524_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libwebp-base-1.5.0-h2471fea_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-2.13.7-h52572c6_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-2.13.8-h52572c6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libxslt-1.1.39-h223e5b9_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-openmp-20.1.3-hdb05f8b_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/loguru-0.7.2-py311h267d04e_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-openmp-20.1.6-hdb05f8b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/lxml-5.4.0-py311hfcb965d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/matplotlib-base-3.10.1-py311h031da69_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/matplotlib-base-3.10.3-py311h031da69_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/multidict-6.4.3-py311h30e7462_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/multidict-6.4.4-py311h30e7462_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-arm64/mysql-common-9.0.1-hd7719f6_6.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mysql-libs-9.0.1-ha8be5b7_6.conda
@@ -1035,23 +1038,23 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/nine-1.1.0-py_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-arm64/nlohmann_json-3.12.0-ha1acc90_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/noqt5-1.0-hd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.2.5-py311h762c074_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.2.6-py311h762c074_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/occt-7.8.1-all_h869bdd7_203.conda
       - conda: https://prefix.dev/conda-forge/noarch/olefile-0.47-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/opencamlib-2023.01.11-py311h8776c47_7.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/opencv-4.10.0-headless_py311h392f51e_13.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/openexr-3.3.3-h10b4c9a_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openexr-3.3.3-h2542605_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openh264-2.5.0-h774163f_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openjpeg-2.5.3-h8a3d83b_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/openldap-2.6.9-hbe55e7a_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openldap-2.6.10-hbe55e7a_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pandas-2.2.3-py311hca32420_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pango-1.54.0-h3e3e505_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pcl-1.14.1-h4a636e1_6.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pcre2-10.44-ha881caa_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/pillow-11.1.0-py311hb9ba9e9_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pip-25.1-pyh8b19718_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/pillow-11.2.1-py311hb9ba9e9_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pivy-0.6.10-py311qt6h9191212_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pixman-0.46.0-h2f9eb0b_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
@@ -1078,18 +1081,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.15.2-py311h0675101_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/smesh-9.9.0.0-h10d9485_14.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/snappy-1.2.1-h98b9ce2_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/soqt6-1.6.3-hd20b56a_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/sqlite-3.49.1-hd7222ec_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/sqlite-3.50.0-hd7222ec_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/svgwrite-1.4.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/svt-av1-2.3.0-hf24288c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_105.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tbb-2022.1.0-h9541205_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tbb-devel-2022.1.0-hf29b1df_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.13.2-pyh29332c3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/unicodedata2-16.0.0-py311h917b07b_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.4.0-pyhd8ed1ab_0.conda
@@ -1098,7 +1102,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/vtk-base-9.3.1-qt_py311h8fa80b4_209.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/vtk-io-ffmpeg-9.3.1-qt_py311hf99a90b_209.conda
       - conda: https://prefix.dev/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.3.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.3.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-arm64/xerces-c-3.3.0-hd62221f_0.conda
@@ -1124,7 +1128,7 @@ environments:
       win-64:
       - conda: https://prefix.dev/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aiohttp-3.11.18-py311h5082efb_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aiohttp-3.12.6-py311h5082efb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/arpack-3.9.1-nompi_h1f7371d_102.conda
@@ -1140,10 +1144,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.4.26-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cairo-1.18.4-h5782bbf_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/calculix-2.22-h9c8f9f9_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cgal-cpp-6.0.1-h31bd75c_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/coin3d-4.0.3-h192c3d0_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/contourpy-1.3.2-py311h3257749_0.conda
@@ -1165,12 +1169,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/win-64/fonttools-4.57.0-py311h5082efb_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/fonttools-4.58.1-py311h5082efb_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/freeglut-3.2.2-he0c23c2_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/freeimage-3.18.0-h8310ca0_22.conda
       - conda: https://prefix.dev/conda-forge/win-64/freetype-2.13.3-h57928b3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/fribidi-1.0.10-h8d14728_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/win-64/frozenlist-1.5.0-py311h5082efb_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/frozenlist-1.6.0-py311hc121033_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/gdk-pixbuf-2.42.12-hed59a49_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/getopt-win32-0.1-hcfcfb64_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/gl2ps-1.4.2-had7236b_1.conda
@@ -1212,27 +1216,27 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libcblas-3.9.0-31_h9bd4c3b_openblas.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libclang13-20.1.3-default_h6e92b77_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libcurl-8.13.0-h88aaa65_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libdeflate-1.23-h76ddb4d_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang13-20.1.6-default_h6e92b77_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libcurl-8.14.0-h88aaa65_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libdeflate-1.24-h76ddb4d_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.0-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libfreetype-2.13.3-h57928b3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libfreetype6-2.13.3-h0b5ce68_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgcc-14.2.0-h1383e82_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgcc-15.1.0-h1383e82_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgd-2.3.3-h7208af6_11.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgfortran-14.2.0-h719f0c7_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgfortran5-14.2.0-hf020157_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgfortran-15.1.0-h719f0c7_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgfortran5-15.1.0-h997fb6f_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libglib-2.84.1-h7025463_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgomp-14.2.0-h1383e82_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgomp-15.1.0-h1383e82_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
       - conda: https://prefix.dev/conda-forge/win-64/libiconv-1.18-h135ad9c_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/libjpeg-turbo-3.1.0-h2466b09_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblapack-3.9.0-31_h2526c6b_openblas.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblapacke-3.9.0-31_h1d0e49f_openblas.conda
-      - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libnetcdf-4.9.2-nompi_h5bdc103_116.conda
       - conda: https://prefix.dev/conda-forge/win-64/libogg-1.3.5-h2466b09_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopenblas-0.3.29-pthreads_head3c61_0.conda
@@ -1254,49 +1258,49 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libraw-0.21.4-h866491b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/librsvg-2.58.4-h5ce5fed_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.49.1-h67fdade_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.50.0-h67fdade_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libssh2-1.11.1-h9aa295b_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libstdcxx-14.2.0-h904f734_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libstdcxx-15.1.0-h904f734_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libtheora-1.1.1-hc70643c_1006.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libtiff-4.7.0-h797046b_4.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libtiff-4.7.0-h05922d8_5.conda
       - conda: https://prefix.dev/conda-forge/win-64/libwebp-base-1.5.0-h3b0e114_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_9.conda
       - conda: https://prefix.dev/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libxml2-2.13.7-h442d1da_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libxml2-2.13.8-h442d1da_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libxslt-1.1.39-h3df6e99_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzip-1.11.2-h3135430_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/loguru-0.7.2-py311h1ea47a8_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/loguru-0.7.3-pyh7428d3b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/lxml-5.4.0-py311h590fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/lz4-c-1.10.0-h2466b09_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/matplotlib-base-3.10.1-py311h8f1b1e4_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/matplotlib-base-3.10.3-py311h8f1b1e4_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpfr-4.2.1-hbc20e70_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/multidict-6.4.3-py311h5082efb_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/multidict-6.4.4-py311h5082efb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/nine-1.1.0-py_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/win-64/nlohmann_json-3.12.0-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/noqt5-1.0-hd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/numpy-2.2.5-py311h5e411d1_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/numpy-2.2.6-py311h5e411d1_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/occt-7.8.1-all_hae6dad1_203.conda
       - conda: https://prefix.dev/conda-forge/noarch/olefile-0.47-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/openblas-0.3.29-pthreads_h4a7f399_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/opencamlib-2023.01.11-py311h2764451_7.conda
       - conda: https://prefix.dev/conda-forge/win-64/opencl-headers-2024.10.24-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/opencv-4.10.0-qt6_py311hdd52cc8_613.conda
-      - conda: https://prefix.dev/conda-forge/win-64/openexr-3.3.3-h1acc403_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/openexr-3.3.3-h9fcfcc6_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/openh264-2.5.0-ha9db3cd_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openjpeg-2.5.3-h4d64b90_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/openssl-3.5.0-ha4e3fda_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/openssl-3.5.0-ha4e3fda_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/pango-1.54.0-h2c73655_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/pcl-1.14.1-h8d4a065_6.conda
       - conda: https://prefix.dev/conda-forge/win-64/pcre2-10.44-h99c9b8b_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/pillow-11.1.0-py311h43e43bb_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pip-25.1-pyh8b19718_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/pillow-11.2.1-py311h43e43bb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pivy-0.6.10-py311qt6hd279cb5_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pixman-0.46.0-had0cd8c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
@@ -1322,17 +1326,18 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/rapidjson-1.1.0.post20240409-he0c23c2_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/scipy-1.15.2-py311h99d06ae_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/smesh-9.9.0.0-h4c8b7ef_14.conda
       - conda: https://prefix.dev/conda-forge/win-64/snappy-1.2.1-h500f7fa_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/soqt6-1.6.3-h796eb14_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/sqlite-3.49.1-h2466b09_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/sqlite-3.50.0-h2466b09_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/svgwrite-1.4.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/svt-av1-2.3.0-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh04b8f61_5.conda
       - conda: https://prefix.dev/conda-forge/win-64/tbb-2022.1.0-ha82c486_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.13.2-pyh29332c3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/unicodedata2-16.0.0-py311he736701_0.conda
@@ -1346,7 +1351,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/win32_setctime-1.2.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
-      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.3.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.3.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
       - conda: https://prefix.dev/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/win-64/xerces-c-3.3.0-he0c23c2_0.conda
@@ -1385,20 +1390,20 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-14.2.0-h767d61c_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-14.2.0-h767d61c_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.49.1-hee588c1_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.50.0-hee588c1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.5.0-h7b32b05_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/python-3.11.12-h9e4cc4f_0_cpython.conda
       - conda: https://prefix.dev/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
@@ -1408,20 +1413,20 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_4.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libexpat-2.7.0-h5ad3122_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libffi-3.4.6-he21f813_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-14.2.0-he277a41_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-ng-14.2.0-he9431aa_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-15.1.0-he277a41_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-ng-15.1.0-he9431aa_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.1.0-he277a41_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libsqlite-3.49.1-h5eb1b54_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libsqlite-3.50.0-h5eb1b54_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.5.0-hd08dc88_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.5.0-hd08dc88_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/python-3.11.12-h1683364_0_cpython.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.2-h8382b9d_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5688188_102.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       osx-64:
       - conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
@@ -1429,74 +1434,58 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/coreutils-9.5-h10d778d_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/dmgbuild-1.6.5-pyh534df25_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ds_store-1.3.1-pyhd8ed1ab_3.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/gettext-0.23.1-hd385c8e_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/gettext-tools-0.23.1-h27064b9_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libasprintf-0.23.1-h27064b9_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libasprintf-devel-0.23.1-h27064b9_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libcxx-20.1.4-hf95d169_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libexpat-2.7.0-h240833e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libgettextpo-0.23.1-h27064b9_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libgettextpo-devel-0.23.1-h27064b9_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libiconv-1.18-h4b5e92a_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libintl-0.23.1-h27064b9_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libintl-devel-0.23.1-h27064b9_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.1-hd471939_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libsqlite-3.49.1-hdb6dae5_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libintl-0.24.1-h27064b9_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.1-hd471939_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libsqlite-3.50.0-hdb6dae5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/mac_alias-2.2.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.5.0-hc426f3f_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.5.0-hc426f3f_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/python-3.11.12-h9ccd52b_0_cpython.conda
       - conda: https://prefix.dev/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/sed-4.7-h3efe00b_1000.tar.bz2
-      - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/sed-4.9-hf9b2955_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.22.0-pyhd8ed1ab_0.conda
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/coreutils-9.5-h93a5062_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/dmgbuild-1.6.5-pyh534df25_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ds_store-1.3.1-pyhd8ed1ab_3.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/gettext-0.23.1-h3dcc1bd_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/gettext-tools-0.23.1-h493aca8_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libasprintf-0.23.1-h493aca8_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libasprintf-devel-0.23.1-h493aca8_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-20.1.4-ha82da77_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.7.0-h286801f_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgettextpo-0.23.1-h493aca8_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgettextpo-devel-0.23.1-h493aca8_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-hfe07756_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libintl-0.23.1-h493aca8_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libintl-devel-0.23.1-h493aca8_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.49.1-h3f77e49_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libintl-0.24.1-h493aca8_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.50.0-h3f77e49_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/mac_alias-2.2.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.11.12-hc22306f_0_cpython.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/sed-4.8-hc6a1b29_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/sed-4.9-h21ae2d7_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.22.0-pyhd8ed1ab_0.conda
       win-64:
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.4.26-h4c7d964_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/git-2.49.0-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/git-2.49.0-h57928b3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.0-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.49.1-h67fdade_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.50.0-h67fdade_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/openssl-3.5.0-ha4e3fda_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/openssl-3.5.0-ha4e3fda_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/python-3.11.12-h3f84c4b_0_cpython.conda
-      - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h2b53caa_26.conda
@@ -1556,12 +1545,12 @@ packages:
   license_family: PSF
   size: 19750
   timestamp: 1741775303303
-- conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.11.18-py311h2dc5d0c_0.conda
-  sha256: cb231084466386d0b2a73f047982775a3c61f28b6e28546f437dd0a22e8230ed
-  md5: 44cda6eb049cf6f07a8d4b6882df91db
+- conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.12.6-py311h2dc5d0c_0.conda
+  sha256: 8a45ef120ac2e49773d89908d374ae908acd838eafc24a12305cc4d3afe3b406
+  md5: f897748c8adef0184376ac9463fc4b94
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aiohappyeyeballs >=2.3.0
+  - aiohappyeyeballs >=2.5.0
   - aiosignal >=1.1.2
   - attrs >=17.3.0
   - frozenlist >=1.1.1
@@ -1573,13 +1562,13 @@ packages:
   - yarl >=1.17.0,<2.0
   license: MIT AND Apache-2.0
   license_family: Apache
-  size: 927134
-  timestamp: 1745257055891
-- conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.11.18-py311h58d527c_0.conda
-  sha256: 49cd13939dcab6e8a73181555f1ff40179c88ffd9179283b7fc1ff2b44eac80a
-  md5: ecf69d1ad5bbbb82b2b9a839c76af7d9
+  size: 979760
+  timestamp: 1748725224774
+- conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.12.6-py311h58d527c_0.conda
+  sha256: c24a2e0b09db86e9c686d452b052b151bba03e24337e48a86cb8f17f17993b13
+  md5: cfe83b799ef7003c810970844ea6bb85
   depends:
-  - aiohappyeyeballs >=2.3.0
+  - aiohappyeyeballs >=2.5.0
   - aiosignal >=1.1.2
   - attrs >=17.3.0
   - frozenlist >=1.1.1
@@ -1592,14 +1581,14 @@ packages:
   - yarl >=1.17.0,<2.0
   license: MIT AND Apache-2.0
   license_family: Apache
-  size: 919574
-  timestamp: 1745255888491
-- conda: https://prefix.dev/conda-forge/osx-64/aiohttp-3.11.18-py311ha3cf9ac_0.conda
-  sha256: fc02e3712cb194211a2a3cba2e57df77fe4b2184b5121e352c32a71328068280
-  md5: 61c06d1d5a667ff660e425b138919988
+  size: 973857
+  timestamp: 1748725361310
+- conda: https://prefix.dev/conda-forge/osx-64/aiohttp-3.12.6-py311ha3cf9ac_0.conda
+  sha256: b0ba67ee75bc8aa6973d57f773b431a43cd87a0ccfa351bc76c863d33555ad51
+  md5: cc412b6f0e8d13ad0f25e4ef2de8e393
   depends:
   - __osx >=10.13
-  - aiohappyeyeballs >=2.3.0
+  - aiohappyeyeballs >=2.5.0
   - aiosignal >=1.1.2
   - attrs >=17.3.0
   - frozenlist >=1.1.1
@@ -1610,14 +1599,14 @@ packages:
   - yarl >=1.17.0,<2.0
   license: MIT AND Apache-2.0
   license_family: Apache
-  size: 891281
-  timestamp: 1745255881110
-- conda: https://prefix.dev/conda-forge/osx-arm64/aiohttp-3.11.18-py311h4921393_0.conda
-  sha256: 31683866abd17b0de3ee68ebdf3c64bb27b1808cd920a9607bc8dc335870dac6
-  md5: 4b7fab539eb10dced90d0ba2e8380b9f
+  size: 949151
+  timestamp: 1748725279040
+- conda: https://prefix.dev/conda-forge/osx-arm64/aiohttp-3.12.6-py311h4921393_0.conda
+  sha256: 8a51e66ed0b9015f6894eb0adce8bdca050fd155f484676da3ce57aed6e6460f
+  md5: 096358f4ef5dcf3360cf4ad27705f48b
   depends:
   - __osx >=11.0
-  - aiohappyeyeballs >=2.3.0
+  - aiohappyeyeballs >=2.5.0
   - aiosignal >=1.1.2
   - attrs >=17.3.0
   - frozenlist >=1.1.1
@@ -1629,13 +1618,13 @@ packages:
   - yarl >=1.17.0,<2.0
   license: MIT AND Apache-2.0
   license_family: Apache
-  size: 895106
-  timestamp: 1745255964250
-- conda: https://prefix.dev/conda-forge/win-64/aiohttp-3.11.18-py311h5082efb_0.conda
-  sha256: 490323f9226d4b7b3f4a7d2426d54c9b16f8d81479fc62c954678eabbaf96564
-  md5: 4e6bf27c23ee7ffe16b965e6450c1558
+  size: 948787
+  timestamp: 1748725479159
+- conda: https://prefix.dev/conda-forge/win-64/aiohttp-3.12.6-py311h5082efb_0.conda
+  sha256: 1445e876e761610ac40505b4162f0fcfeb65f8d197c688bbf28c86001d4341da
+  md5: 52f9d878e426d884aafa42a4869f880f
   depends:
-  - aiohappyeyeballs >=2.3.0
+  - aiohappyeyeballs >=2.5.0
   - aiosignal >=1.1.2
   - attrs >=17.3.0
   - frozenlist >=1.1.1
@@ -1649,8 +1638,8 @@ packages:
   - yarl >=1.17.0,<2.0
   license: MIT AND Apache-2.0
   license_family: Apache
-  size: 872168
-  timestamp: 1745256128393
+  size: 924287
+  timestamp: 1748725436077
 - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
   sha256: 7de8ced1918bbdadecf8e1c1c68237fe5709c097bd9e0d254f4cad118f4345d0
   md5: 1a3981115a398535dbe3f6d5faae3d36
@@ -2541,14 +2530,14 @@ packages:
   license_family: GPL
   size: 2609714
   timestamp: 1736281588040
-- conda: https://prefix.dev/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
-  sha256: 42a78446da06a2568cb13e69be3355169fbd0ea424b00fc80b7d840f5baaacf3
-  md5: c207fa5ac7ea99b149344385a9c0880d
+- conda: https://prefix.dev/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
+  sha256: 52aa837642fd851b3f7ad3b1f66afc5366d133c1d452323f786b0378a391915c
+  md5: c33eeaaa33f45031be34cda513df39b6
   depends:
   - python >=3.9
   license: ISC
-  size: 162721
-  timestamp: 1739515973129
+  size: 157200
+  timestamp: 1746569627830
 - conda: https://prefix.dev/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
   sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
   md5: 55553ecd5328336368db611f350b7039
@@ -2684,15 +2673,15 @@ packages:
   license: GPL3/LGPL3
   size: 5852917
   timestamp: 1729765382648
-- conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
-  sha256: 4e0ee91b97e5de3e74567bdacea27f0139709fceca4db8adffbe24deffccb09b
-  md5: e83a31202d1c0a000fce3e9cf3825875
+- conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.2-pyhd8ed1ab_0.conda
+  sha256: 535ae5dcda8022e31c6dc063eb344c80804c537a5a04afba43a845fa6fa130f5
+  md5: 40fe4284b8b5835a9073a645139f35af
   depends:
   - python >=3.9
   license: MIT
   license_family: MIT
-  size: 47438
-  timestamp: 1735929811779
+  size: 50481
+  timestamp: 1746214981991
 - conda: https://prefix.dev/conda-forge/linux-64/coin3d-4.0.3-hd74d64a_2.conda
   sha256: 953d004ee7a2be78c717cecaf5bb959fea1faefb86106322c19c06dafa3c0e12
   md5: b3addb85bc05327f73bf69a9ed73b890
@@ -3824,9 +3813,9 @@ packages:
   license_family: BSD
   size: 4102
   timestamp: 1566932280397
-- conda: https://prefix.dev/conda-forge/linux-64/fonttools-4.57.0-py311h2dc5d0c_0.conda
-  sha256: 2157fff1f143fc99f9b27d1358b537f08478eb65d917279a3484c9c8989ea5fc
-  md5: 4175f366b41d3d0c80d02661a0a03473
+- conda: https://prefix.dev/conda-forge/linux-64/fonttools-4.58.1-py311h2dc5d0c_0.conda
+  sha256: 8ef83f209dfc3f5b808e583bedd129ca95c9f2cb72645540e01d90f82bde9e0d
+  md5: 9af5d6c8703be9bbe200aeae13a5e6ef
   depends:
   - __glibc >=2.17,<3.0.a0
   - brotli
@@ -3837,11 +3826,11 @@ packages:
   - unicodedata2 >=15.1.0
   license: MIT
   license_family: MIT
-  size: 2927575
-  timestamp: 1743732757561
-- conda: https://prefix.dev/conda-forge/linux-aarch64/fonttools-4.57.0-py311h58d527c_0.conda
-  sha256: bb1d7a6d35502e1f3ff23e23f1bfee08b8a11e2af4af5ff012721d21ef5c9979
-  md5: 9de1b8700aa3ba27c37ce8ad80a42097
+  size: 2884310
+  timestamp: 1748465931685
+- conda: https://prefix.dev/conda-forge/linux-aarch64/fonttools-4.58.1-py311h58d527c_0.conda
+  sha256: dbb339270ffe14dac2aafd90794ed21012abb7552ee243d2fc8ea279d95779f5
+  md5: eeac86a774fdee24dd7cb14190267960
   depends:
   - brotli
   - libgcc >=13
@@ -3852,11 +3841,11 @@ packages:
   - unicodedata2 >=15.1.0
   license: MIT
   license_family: MIT
-  size: 2852649
-  timestamp: 1743732489644
-- conda: https://prefix.dev/conda-forge/osx-64/fonttools-4.57.0-py311ha3cf9ac_0.conda
-  sha256: e246abcec956f1274cb9166bedadd50b589a338cb5d1dcad73faaa8ec5971c58
-  md5: 94528f55777ec709368d3e241a503c25
+  size: 2868866
+  timestamp: 1748465811723
+- conda: https://prefix.dev/conda-forge/osx-64/fonttools-4.58.1-py311ha3cf9ac_0.conda
+  sha256: b206ade2798d5a3d1ea33f4c2e8d51a64dd78975f84af42bc2444bfecc0bafc9
+  md5: 7bb334118fc15d32843547ee1e26ae0d
   depends:
   - __osx >=10.13
   - brotli
@@ -3866,11 +3855,11 @@ packages:
   - unicodedata2 >=15.1.0
   license: MIT
   license_family: MIT
-  size: 2809791
-  timestamp: 1743732470522
-- conda: https://prefix.dev/conda-forge/osx-arm64/fonttools-4.57.0-py311h4921393_0.conda
-  sha256: 8876a5669d5b10a1658344469c00f322c7a05ea395874c1f9df1214f50287cf5
-  md5: c89cabd25f57ac17eb4c3f86e521ad08
+  size: 2832447
+  timestamp: 1748465877409
+- conda: https://prefix.dev/conda-forge/osx-arm64/fonttools-4.58.1-py311h4921393_0.conda
+  sha256: 03c75bcd859414ed52c3f93715ddaaa2137a0277bab7bc4b2fafe20591fc24f8
+  md5: 43283202228c7165b54bb485c2fa9139
   depends:
   - __osx >=11.0
   - brotli
@@ -3881,11 +3870,11 @@ packages:
   - unicodedata2 >=15.1.0
   license: MIT
   license_family: MIT
-  size: 2794769
-  timestamp: 1743732606603
-- conda: https://prefix.dev/conda-forge/win-64/fonttools-4.57.0-py311h5082efb_0.conda
-  sha256: 59938b42ed276e716af76b9795f37f2c2ba9b03ce79e820610b37d036d1b4101
-  md5: 9ecb6a80392fc77239da9cb631e9ab0c
+  size: 2816903
+  timestamp: 1748465892022
+- conda: https://prefix.dev/conda-forge/win-64/fonttools-4.58.1-py311h5082efb_0.conda
+  sha256: c806a73ae3fe27c3ff4fd7a564632d617aa630ec856e5289bb22936fe78355e5
+  md5: 88930bd9938a31990c3b9b0f86930e57
   depends:
   - brotli
   - munkres
@@ -3897,8 +3886,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 2474544
-  timestamp: 1743732768215
+  size: 2484381
+  timestamp: 1748466101704
 - conda: .
   name: freecad
   version: 1.1.0dev
@@ -3920,7 +3909,7 @@ packages:
   - nine
   - noqt5
   - numpy
-  - occt
+  - occt >=7.8,<7.9
   - olefile
   - opencamlib
   - opencv
@@ -3937,30 +3926,32 @@ packages:
   - requests
   - scipy
   - sympy
+  - typing_extensions
   - vtk
   - xlutils
-  - tbb >=2022.1.0
+  - pcl >=1.14.1,<1.14.2.0a0
   - hdf5 >=1.14.4,<1.14.5.0a0
-  - qt6-main >=6.7.3,<6.8.0a0
   - smesh >=9.9.0.0,<9.9.1.0a0
-  - python_abi 3.11.* *_cp311
-  - coin3d >=4.0.3,<4.1.0a0
-  - numpy >=1.21,<3
   - vtk-base >=9.3.1,<9.3.2.0a0
-  - fmt >=11.1.4,<11.2.0a0
-  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
-  - libfreetype >=2.13.3
-  - libfreetype6 >=2.13.3
   - libboost >=1.86.0,<1.87.0a0
   - occt >=7.8.1,<7.8.2.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - fmt >=11.1.4,<11.2.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - qt6-main >=6.7.3,<6.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.21,<3
   - xerces-c >=3.3.0,<3.4.0a0
-  - pcl >=1.14.1,<1.14.2.0a0
+  - coin3d >=4.0.3,<4.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - tbb >=2022.1.0
   input:
-    hash: 963ceb15a6cbf07620d143d4cb02275280e95867508c5091da1a687769822d75
+    hash: 8f769c0a0744436e429d17e4a44a162db45d05a8e4a53766298f940ef5296885
     globs:
     - pixi.toml
+    - recipe.yaml
 - conda: .
   name: freecad
   version: 1.1.0dev
@@ -3982,7 +3973,7 @@ packages:
   - nine
   - noqt5
   - numpy
-  - occt
+  - occt >=7.8,<7.9
   - olefile
   - opencamlib
   - opencv
@@ -3999,29 +3990,31 @@ packages:
   - requests
   - scipy
   - sympy
+  - typing_extensions
   - vtk
   - xlutils
   - libspnav
-  - fmt >=11.1.4,<11.2.0a0
-  - smesh >=9.9.0.0,<9.9.1.0a0
   - pcl >=1.14.1,<1.14.2.0a0
-  - vtk-base >=9.3.1,<9.3.2.0a0
-  - numpy >=1.21,<3
-  - occt >=7.8.1,<7.8.2.0a0
-  - qt6-main >=6.7.3,<6.8.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - python_abi 3.11.* *_cp311
-  - libzlib >=1.3.1,<2.0a0
-  - hdf5 >=1.14.4,<1.14.5.0a0
+  - fmt >=11.1.4,<11.2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - coin3d >=4.0.3,<4.1.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
   - libfreetype >=2.13.3
   - libfreetype6 >=2.13.3
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - python_abi 3.11.* *_cp311
+  - qt6-main >=6.7.3,<6.8.0a0
+  - vtk-base >=9.3.1,<9.3.2.0a0
+  - occt >=7.8.1,<7.8.2.0a0
   - libboost >=1.86.0,<1.87.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.21,<3
+  - smesh >=9.9.0.0,<9.9.1.0a0
   input:
-    hash: 963ceb15a6cbf07620d143d4cb02275280e95867508c5091da1a687769822d75
+    hash: 8f769c0a0744436e429d17e4a44a162db45d05a8e4a53766298f940ef5296885
     globs:
     - pixi.toml
+    - recipe.yaml
 - conda: .
   name: freecad
   version: 1.1.0dev
@@ -4043,7 +4036,7 @@ packages:
   - nine
   - noqt5
   - numpy
-  - occt
+  - occt >=7.8,<7.9
   - olefile
   - opencamlib
   - opencv
@@ -4060,30 +4053,32 @@ packages:
   - requests
   - scipy
   - sympy
+  - typing_extensions
   - vtk
   - xlutils
   - libspnav
   - __glibc >=2.17,<3.0.a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - qt6-main >=6.7.3,<6.8.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - smesh >=9.9.0.0,<9.9.1.0a0
   - libfreetype >=2.13.3
   - libfreetype6 >=2.13.3
-  - numpy >=1.21,<3
-  - pcl >=1.14.1,<1.14.2.0a0
-  - occt >=7.8.1,<7.8.2.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - vtk-base >=9.3.1,<9.3.2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - fmt >=11.1.4,<11.2.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
   - coin3d >=4.0.3,<4.1.0a0
-  - python_abi 3.11.* *_cp311
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - occt >=7.8.1,<7.8.2.0a0
+  - libzlib >=1.3.1,<2.0a0
   - libboost >=1.86.0,<1.87.0a0
+  - python_abi 3.11.* *_cp311
+  - pcl >=1.14.1,<1.14.2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - smesh >=9.9.0.0,<9.9.1.0a0
+  - fmt >=11.1.4,<11.2.0a0
+  - vtk-base >=9.3.1,<9.3.2.0a0
+  - qt6-main >=6.7.3,<6.8.0a0
+  - numpy >=1.21,<3
   input:
-    hash: 963ceb15a6cbf07620d143d4cb02275280e95867508c5091da1a687769822d75
+    hash: 8f769c0a0744436e429d17e4a44a162db45d05a8e4a53766298f940ef5296885
     globs:
     - pixi.toml
+    - recipe.yaml
 - conda: .
   name: freecad
   version: 1.1.0dev
@@ -4105,7 +4100,7 @@ packages:
   - nine
   - noqt5
   - numpy
-  - occt
+  - occt >=7.8,<7.9
   - olefile
   - opencamlib
   - opencv
@@ -4122,28 +4117,30 @@ packages:
   - requests
   - scipy
   - sympy
+  - typing_extensions
   - vtk
   - xlutils
-  - hdf5 >=1.14.4,<1.14.5.0a0
-  - occt >=7.8.1,<7.8.2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - python_abi 3.11.* *_cp311
   - vtk-base >=9.3.1,<9.3.2.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
+  - python_abi 3.11.* *_cp311
   - smesh >=9.9.0.0,<9.9.1.0a0
-  - libboost >=1.86.0,<1.87.0a0
-  - qt6-main >=6.7.3,<6.8.0a0
+  - coin3d >=4.0.3,<4.1.0a0
   - libfreetype >=2.13.3
   - libfreetype6 >=2.13.3
-  - xerces-c >=3.3.0,<3.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libboost >=1.86.0,<1.87.0a0
   - numpy >=1.21,<3
   - fmt >=11.1.4,<11.2.0a0
-  - coin3d >=4.0.3,<4.1.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - occt >=7.8.1,<7.8.2.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - qt6-main >=6.7.3,<6.8.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - pcl >=1.14.1,<1.14.2.0a0
   input:
-    hash: 963ceb15a6cbf07620d143d4cb02275280e95867508c5091da1a687769822d75
+    hash: 8f769c0a0744436e429d17e4a44a162db45d05a8e4a53766298f940ef5296885
     globs:
     - pixi.toml
+    - recipe.yaml
 - conda: .
   name: freecad
   version: 1.1.0dev
@@ -4165,7 +4162,7 @@ packages:
   - nine
   - noqt5
   - numpy
-  - occt
+  - occt >=7.8,<7.9
   - olefile
   - opencamlib
   - opencv
@@ -4182,28 +4179,30 @@ packages:
   - requests
   - scipy
   - sympy
+  - typing_extensions
   - vtk
   - xlutils
-  - vtk-base >=9.3.1,<9.3.2.0a0
-  - occt >=7.8.1,<7.8.2.0a0
-  - coin3d >=4.0.3,<4.1.0a0
-  - hdf5 >=1.14.4,<1.14.5.0a0
-  - python_abi 3.11.* *_cp311
-  - fmt >=11.1.4,<11.2.0a0
-  - libzlib >=1.3.1,<2.0a0
   - qt6-main >=6.7.3,<6.8.0a0
+  - python_abi 3.11.* *_cp311
   - yaml-cpp >=0.8.0,<0.9.0a0
-  - libboost >=1.86.0,<1.87.0a0
   - xerces-c >=3.3.0,<3.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - fmt >=11.1.4,<11.2.0a0
   - numpy >=1.21,<3
+  - occt >=7.8.1,<7.8.2.0a0
   - pcl >=1.14.1,<1.14.2.0a0
+  - coin3d >=4.0.3,<4.1.0a0
+  - vtk-base >=9.3.1,<9.3.2.0a0
+  - smesh >=9.9.0.0,<9.9.1.0a0
   - libfreetype >=2.13.3
   - libfreetype6 >=2.13.3
-  - smesh >=9.9.0.0,<9.9.1.0a0
   input:
-    hash: 963ceb15a6cbf07620d143d4cb02275280e95867508c5091da1a687769822d75
+    hash: 8f769c0a0744436e429d17e4a44a162db45d05a8e4a53766298f940ef5296885
     globs:
     - pixi.toml
+    - recipe.yaml
 - conda: https://prefix.dev/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
   sha256: 676540a8e7f73a894cb1fcb870e7bec623ec1c0a2d277094fd713261a02d8d56
   md5: 84ec3f5b46f3076be49f2cf3f1cfbf02
@@ -4426,56 +4425,60 @@ packages:
   license: LGPL-2.1
   size: 64567
   timestamp: 1604417122064
-- conda: https://prefix.dev/conda-forge/linux-64/frozenlist-1.5.0-py311h2dc5d0c_1.conda
-  sha256: f42d8a79ef19c3ab660bec902c00c3d1c706c499ade10ac08128d757c93a7bfc
-  md5: 3bc993732a46956232503b005a58c051
+- conda: https://prefix.dev/conda-forge/linux-64/frozenlist-1.6.0-py311h62d540b_0.conda
+  sha256: fe83cad8aa17a6dd9c3e5625f2ed44343d057945a6b0fb6aabcb507ca1cf0d5d
+  md5: ad01dcb674e8792b626276999ab1825e
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  - libstdcxx >=13
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: APACHE
-  size: 60911
-  timestamp: 1737645516304
-- conda: https://prefix.dev/conda-forge/linux-aarch64/frozenlist-1.5.0-py311h58d527c_1.conda
-  sha256: 512e68c0053ab9495ccb0207e4d2b29f348dc9d7f7c479a8fd68ef74332226b7
-  md5: 2ed2f19c420343f0fc18277d3dedfe26
+  size: 113590
+  timestamp: 1746635675256
+- conda: https://prefix.dev/conda-forge/linux-aarch64/frozenlist-1.6.0-py311ha6a3852_0.conda
+  sha256: e686f067d039deae1acd53ae635eb9ca59dc289bc33973fd3d2ad71fd5b75b76
+  md5: eee1960fe628f5c365850fb25a2106d3
   depends:
   - libgcc >=13
+  - libstdcxx >=13
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: APACHE
-  size: 61113
-  timestamp: 1737645417807
-- conda: https://prefix.dev/conda-forge/osx-64/frozenlist-1.5.0-py311ha3cf9ac_1.conda
-  sha256: a4948853fc09984850ed7f0ac5a596c87cc62a9016a5fecf3eca6bd74316255a
-  md5: cb01b1d55ae9f23dfd095e68e6771c5b
+  size: 114383
+  timestamp: 1746635649081
+- conda: https://prefix.dev/conda-forge/osx-64/frozenlist-1.6.0-py311h029c973_0.conda
+  sha256: 19e540c11438e07c1b98fa1c6462321447336f56729e5700929d4f2339e9b831
+  md5: 261eb5e67ba98c4cd99e848b609d00f3
   depends:
   - __osx >=10.13
+  - libcxx >=18
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: APACHE
-  size: 55535
-  timestamp: 1737645500147
-- conda: https://prefix.dev/conda-forge/osx-arm64/frozenlist-1.5.0-py311h4921393_1.conda
-  sha256: f23f65686688ba67c5649e3d7ff3f96344d1d5b647ad51f66ee013f8d9bd114c
-  md5: fd7c347b480cd5ff02bc12487806b6f2
+  size: 109680
+  timestamp: 1746635606314
+- conda: https://prefix.dev/conda-forge/osx-arm64/frozenlist-1.6.0-py311h87ddb2a_0.conda
+  sha256: 8b3f8693ba09a2f14f79d7c6677a8b770713633cd8b5f80b90f56408121340a0
+  md5: aa21c15548d24edb6a3e1f3b9d6edea1
   depends:
   - __osx >=11.0
+  - libcxx >=18
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: APACHE
-  size: 56495
-  timestamp: 1737645461874
-- conda: https://prefix.dev/conda-forge/win-64/frozenlist-1.5.0-py311h5082efb_1.conda
-  sha256: 931d0339aaf781fa86295ef261110c4fc94830969136fb157df27e524890ffb8
-  md5: 62542f0d4edd96913c0619c7df90be66
+  size: 110268
+  timestamp: 1746635703732
+- conda: https://prefix.dev/conda-forge/win-64/frozenlist-1.6.0-py311hc121033_0.conda
+  sha256: 82f10c01f2b510977edfa296f35ceee591ed20bbc0427af6578b35d273b59dab
+  md5: c41ad8b2cb368406fd8ca91b5ea48d3f
   depends:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
@@ -4484,8 +4487,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 55040
-  timestamp: 1737645777329
+  size: 108367
+  timestamp: 1746636025535
 - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
   sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
   md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
@@ -4577,68 +4580,12 @@ packages:
   license_family: GPL
   size: 21903
   timestamp: 1694400856979
-- conda: https://prefix.dev/conda-forge/osx-64/gettext-0.23.1-hd385c8e_0.conda
-  sha256: b0a259a09b23892fb93b93badb1b0badee183ba1fb1dbf8c443c3564641800fd
-  md5: 22d89ca70e22979c38bd0146abf21c2a
-  depends:
-  - __osx >=10.13
-  - gettext-tools 0.23.1 h27064b9_0
-  - libasprintf 0.23.1 h27064b9_0
-  - libasprintf-devel 0.23.1 h27064b9_0
-  - libcxx >=18
-  - libgettextpo 0.23.1 h27064b9_0
-  - libgettextpo-devel 0.23.1 h27064b9_0
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.23.1 h27064b9_0
-  - libintl-devel 0.23.1 h27064b9_0
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 484317
-  timestamp: 1739039350883
-- conda: https://prefix.dev/conda-forge/osx-arm64/gettext-0.23.1-h3dcc1bd_0.conda
-  sha256: 9311cd9e64f0ae3bccae58b5b68a4804abd8b3c49f4f327b9573b50b026b317e
-  md5: 123c4d62e1bcba6274511af8c7cf40d5
-  depends:
-  - __osx >=11.0
-  - gettext-tools 0.23.1 h493aca8_0
-  - libasprintf 0.23.1 h493aca8_0
-  - libasprintf-devel 0.23.1 h493aca8_0
-  - libcxx >=18
-  - libgettextpo 0.23.1 h493aca8_0
-  - libgettextpo-devel 0.23.1 h493aca8_0
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.23.1 h493aca8_0
-  - libintl-devel 0.23.1 h493aca8_0
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 484476
-  timestamp: 1739039461682
-- conda: https://prefix.dev/conda-forge/osx-64/gettext-tools-0.23.1-h27064b9_0.conda
-  sha256: e9e9afb674b0ec5af38ca42b5518d8ee52b0aada90151b76199764bb956ebb3a
-  md5: a6bc310a08cf42286627c818da4c0ba1
-  depends:
-  - __osx >=10.13
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.23.1 h27064b9_0
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 2962725
-  timestamp: 1739039298909
-- conda: https://prefix.dev/conda-forge/osx-arm64/gettext-tools-0.23.1-h493aca8_0.conda
-  sha256: c26b38bcff84b3af52f061f55de27a45fb2e9a0544c32b3cbddf8be97c80c296
-  md5: 4086817e75778198f96c9b2ed4bc5a6e
-  depends:
-  - __osx >=11.0
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.23.1 h493aca8_0
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 2890553
-  timestamp: 1739039406578
-- conda: https://prefix.dev/conda-forge/win-64/git-2.49.0-h57928b3_0.conda
-  sha256: 23c313d9a6e7784bdacc71d7fe9d5cd36d6984908e716422ed8ad9b38162d85f
-  md5: 30c89cbda81237c8501ba98adac10ad7
+- conda: https://prefix.dev/conda-forge/win-64/git-2.49.0-h57928b3_1.conda
+  sha256: ec2e366e4dbd350621ce8c73b91dd6ce5cc1b156ab2c6c006eaa7942f3635d0f
+  md5: 4005324dbb3cc47767ab259856b6d687
   license: GPL-2.0-or-later and LGPL-2.1-or-later
-  size: 127194688
-  timestamp: 1742298397813
+  size: 125425138
+  timestamp: 1747243619887
 - conda: https://prefix.dev/conda-forge/linux-64/gl2ps-1.4.2-hae5d5c5_1.conda
   sha256: 68f071ea25e79ee427c0d6c35ccc137d66f093a37660a4e41bafe0c49d64f2d6
   md5: 00e642ec191a19bf806a3915800e9524
@@ -6336,67 +6283,49 @@ packages:
   license_family: BSD
   size: 32567
   timestamp: 1711021603471
-- conda: https://prefix.dev/conda-forge/linux-64/libasprintf-0.23.1-h8e693c7_0.conda
-  sha256: 13b863584fccbb9089de73a2442e540703ce4873e4719c9d98c98e4a8e12f9d1
-  md5: 988f4937281a66ca19d1adb3b5e3f859
+- conda: https://prefix.dev/conda-forge/linux-64/libasprintf-0.24.1-h8e693c7_0.conda
+  sha256: e30733a729eb6efd9cb316db0202897c882d46f6c20a0e647b4de8ec921b7218
+  md5: 57566a81dd1e5aa3d98ac7582e8bfe03
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
   license: LGPL-2.1-or-later
-  size: 43179
-  timestamp: 1739038705987
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libasprintf-0.23.1-h5e0f5ae_0.conda
-  sha256: f80d436462d78c459758176d59b0231c3cce99502408c2e4af03bacee786fc94
-  md5: b34cfd925b96e72b99286e0cff036e82
+  size: 53115
+  timestamp: 1746228856865
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libasprintf-0.24.1-h5e0f5ae_0.conda
+  sha256: 969b002ab70bf2f27fc108c83c07d6e4f4a4fd1a1ad3a8028e625a78a748347b
+  md5: e6dd5b99796423a24ecc42db08ab31da
   depends:
   - libgcc >=13
   - libstdcxx >=13
   license: LGPL-2.1-or-later
-  size: 43700
-  timestamp: 1739038595159
-- conda: https://prefix.dev/conda-forge/osx-64/libasprintf-0.23.1-h27064b9_0.conda
-  sha256: d6a4fbf497040ab4733c5dc65dd273ed6fa827ce6e67fd12abbe08c3cc3e192e
-  md5: 43e1d9e1712208ac61941a513259248d
+  size: 53530
+  timestamp: 1746228742482
+- conda: https://prefix.dev/conda-forge/osx-64/libasprintf-0.24.1-h27064b9_0.conda
+  sha256: 86febbb2cc53b0978cb22057da2e9dc8f07ffe96305148d011c241c3eae668d0
+  md5: 9d7c96ed1ebdf2f180b20d3e09a4c694
   depends:
   - __osx >=10.13
   - libcxx >=18
   license: LGPL-2.1-or-later
-  size: 42365
-  timestamp: 1739039157296
-- conda: https://prefix.dev/conda-forge/osx-arm64/libasprintf-0.23.1-h493aca8_0.conda
-  sha256: 2b27d2ede7867fd362f94644aac1d7fb9af7f7fc3f122cb014647b47ffd402a4
-  md5: baf9e4423f10a15ca7eab26480007639
+  size: 51904
+  timestamp: 1746229317266
+- conda: https://prefix.dev/conda-forge/osx-arm64/libasprintf-0.24.1-h493aca8_0.conda
+  sha256: 54293ab2ce43085ac424dc62804fd4d7ec62cce404a77f0c99a9a48857bca0a9
+  md5: b5a77d2b7c2013b3b1ffce193764302f
   depends:
   - __osx >=11.0
   - libcxx >=18
   license: LGPL-2.1-or-later
-  size: 41679
-  timestamp: 1739039255705
+  size: 52180
+  timestamp: 1746229244376
 - conda: https://prefix.dev/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
   sha256: 8e41136b7e4ec44c1c0bae0ff51cdb0d04e026d0b44eaaf5a9ff8b4e1b6b019b
   md5: 9f661052be1d477dcf61ee3cd77ce5ee
   license: LGPL-2.1-or-later
   size: 49776
   timestamp: 1723629333404
-- conda: https://prefix.dev/conda-forge/osx-64/libasprintf-devel-0.23.1-h27064b9_0.conda
-  sha256: 7962374bc3052db086277fd7e83fd3b05b01a66aa0d7e75c96248b35bee9277e
-  md5: 85b6f23aab6898c44f477f354c675721
-  depends:
-  - __osx >=10.13
-  - libasprintf 0.23.1 h27064b9_0
-  license: LGPL-2.1-or-later
-  size: 34636
-  timestamp: 1739039185415
-- conda: https://prefix.dev/conda-forge/osx-arm64/libasprintf-devel-0.23.1-h493aca8_0.conda
-  sha256: 25999d3c78270440e7e9e06c2e6f4a2e1ac11d2df84ac7b24280c6f530eed06f
-  md5: 13d4d79418eb3137fc94fe61e9e572e7
-  depends:
-  - __osx >=11.0
-  - libasprintf 0.23.1 h493aca8_0
-  license: LGPL-2.1-or-later
-  size: 34641
-  timestamp: 1739039285881
 - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
   sha256: 52afd5e79681185ea33da0e7548aa3721be7e9a153a90f004c5adc33d61f7a14
   md5: 2a66267ba586dadd110cc991063cfff7
@@ -7063,9 +6992,9 @@ packages:
   license_family: Apache
   size: 12785300
   timestamp: 1738083576490
-- conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp19.1-19.1.7-default_hb5137d0_2.conda
-  sha256: 658c8000f3be74ad926b376b48903036611b5beccc07f729417730c49bd73a30
-  md5: 62d6f9353753a12a281ae99e0a3403c4
+- conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp19.1-19.1.7-default_hb5137d0_3.conda
+  sha256: 50a9d8d1b8470fd56fd67c0c6d8eddb9ce831be3504cd0cb825ab92a8072f6b5
+  md5: 31fd8a0902f7baa8e28dab6218fdf317
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -7073,67 +7002,67 @@ packages:
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 20556230
-  timestamp: 1742267376167
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.7-default_he324ac1_2.conda
-  sha256: ee624228956159cb2be407574b8467c67a7bbb538547e2f9299209f08f4a9d7b
-  md5: 0424f44a2b8b81c0da4ade147eacdae2
+  size: 20529698
+  timestamp: 1747714964424
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.7-default_he324ac1_3.conda
+  sha256: ab8860febe3149532526d87d7a942b0fddb9ffbc14181490b68958f4e6521e97
+  md5: 152be843b79b8c59c49726cbeeeea4a2
   depends:
   - libgcc >=13
   - libllvm19 >=19.1.7,<19.2.0a0
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 20098820
-  timestamp: 1742269466891
-- conda: https://prefix.dev/conda-forge/linux-64/libclang13-20.1.3-default_he06ed0a_0.conda
-  sha256: 99c9d0dc741d3675e1ffcaab90a4a1e80090076f9fa1aa71fe8c114d3dcdc61a
-  md5: 1bb2ec3c550f7589b2d16e271aeaeddb
+  size: 20067633
+  timestamp: 1747824828546
+- conda: https://prefix.dev/conda-forge/linux-64/libclang13-20.1.6-default_he06ed0a_0.conda
+  sha256: 5d40dc0cf929532ba4337bf1c7dbe1abb5f7c19ceb76397406006e9946a73fd4
+  md5: cc6c469d9d7fc0ac106cef5f45d973a9
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libllvm20 >=20.1.3,<20.2.0a0
+  - libllvm20 >=20.1.6,<20.2.0a0
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 12098268
-  timestamp: 1744876737219
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libclang13-20.1.3-default_h9e36cb9_0.conda
-  sha256: 9b5e0827d34ebb88aff31efffee89fda36364154026aefca67a4c69147945b75
-  md5: 409dd4c25c875b9b367fe6a203d96ff0
+  size: 12111337
+  timestamp: 1748541871797
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libclang13-20.1.6-default_h9e36cb9_0.conda
+  sha256: bf85078d36157e4fe212d5b3847b5dee3e2121f811ed60201ba4687ed2140fb9
+  md5: ad384e458f9b9c2d5b22a399786b226a
   depends:
   - libgcc >=13
-  - libllvm20 >=20.1.3,<20.2.0a0
+  - libllvm20 >=20.1.6,<20.2.0a0
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 11880679
-  timestamp: 1744877892983
-- conda: https://prefix.dev/conda-forge/osx-64/libclang13-20.1.3-default_h9644bed_0.conda
-  sha256: bee47a2e46cb00be0821618742a0c47789ca9041c3ceeeab7ba377798854ed04
-  md5: ffcad513a2e985000689402926e3785a
+  size: 11915302
+  timestamp: 1748540987290
+- conda: https://prefix.dev/conda-forge/osx-64/libclang13-20.1.6-default_h9644bed_0.conda
+  sha256: 0d428dade42bebb6792ca14bd96608e5542457961bc1e0c26f87526d963d1f6b
+  md5: b6a6c8523003d2a5359089bbf1f528bb
   depends:
   - __osx >=10.13
-  - libcxx >=20.1.3
-  - libllvm20 >=20.1.3,<20.2.0a0
+  - libcxx >=20.1.6
+  - libllvm20 >=20.1.6,<20.2.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 8662630
-  timestamp: 1744875319768
-- conda: https://prefix.dev/conda-forge/osx-arm64/libclang13-20.1.3-default_hee4fbb3_0.conda
-  sha256: eb64d7f7f0ad5e3d54971bac0208014e963de10f6166ecaf8fb188e5743323f5
-  md5: 93efb84fbd5e618cd8abc62d276a8a5d
+  size: 8662902
+  timestamp: 1748535988348
+- conda: https://prefix.dev/conda-forge/osx-arm64/libclang13-20.1.6-default_hee4fbb3_0.conda
+  sha256: f45bd3e794b0a1707f3b6a0544f5d0af457770399795cb5e3539d1be36a0b68d
+  md5: 15ea5ee1f9e7a30adc425ebeb3ed8a25
   depends:
   - __osx >=11.0
-  - libcxx >=20.1.3
-  - libllvm20 >=20.1.3,<20.2.0a0
+  - libcxx >=20.1.6
+  - libllvm20 >=20.1.6,<20.2.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 8438601
-  timestamp: 1744875364917
-- conda: https://prefix.dev/conda-forge/win-64/libclang13-20.1.3-default_h6e92b77_0.conda
-  sha256: b4c3d60f0096b8303caf531bf14e51c3e83db6c596fe1b99351f8f3a0a6a9a50
-  md5: e7530cd4a3b5e3d2348be3d836cb196c
+  size: 8435223
+  timestamp: 1748534559012
+- conda: https://prefix.dev/conda-forge/win-64/libclang13-20.1.6-default_h6e92b77_0.conda
+  sha256: 6ac6dc226a2fe5af61730224d89cd32f88123623bf35995a2c42d53a077e0427
+  md5: 3920536319b052a9a49639e02fda2db7
   depends:
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
@@ -7142,8 +7071,8 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 28343558
-  timestamp: 1744881010137
+  size: 28337445
+  timestamp: 1748541917495
 - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
   sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
   md5: d4529f4dff3057982a7617c7ac58fde3
@@ -7168,9 +7097,9 @@ packages:
   license_family: Apache
   size: 4551247
   timestamp: 1689195336749
-- conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.13.0-h332b0f4_0.conda
-  sha256: 38e528acfaa0276b7052f4de44271ff9293fdb84579650601a8c49dac171482a
-  md5: cbdc92ac0d93fe3c796e36ad65c7905c
+- conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.14.0-h332b0f4_0.conda
+  sha256: ddfcb508b723e1ef4234c517da18820cdbb40cc060f3b120aaa8a18eb6ab0564
+  md5: d1738cf06503218acee63669029fd8e8
   depends:
   - __glibc >=2.17,<3.0.a0
   - krb5 >=1.21.3,<1.22.0a0
@@ -7178,60 +7107,60 @@ packages:
   - libnghttp2 >=1.64.0,<2.0a0
   - libssh2 >=1.11.1,<2.0a0
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.4.1,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 438088
-  timestamp: 1743601695669
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libcurl-8.13.0-h6702fde_0.conda
-  sha256: 47d5bdf013ed59429b569fb856d04db5a7071d51fcd237d899a0da646b59c592
-  md5: bc91624cc60090963b8ca9e88d773a65
+  size: 448248
+  timestamp: 1748430884579
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libcurl-8.14.0-h6702fde_0.conda
+  sha256: 4555470faf906eaf0093f4b723ade6c5b9b7b7b967683c816f066ac5770a64f4
+  md5: 8a79af3d23dcc64c2794ce2715d726fc
   depends:
   - krb5 >=1.21.3,<1.22.0a0
   - libgcc >=13
   - libnghttp2 >=1.64.0,<2.0a0
   - libssh2 >=1.11.1,<2.0a0
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.4.1,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 455164
-  timestamp: 1743601846734
-- conda: https://prefix.dev/conda-forge/osx-64/libcurl-8.13.0-h5dec5d8_0.conda
-  sha256: 137d92f1107141d9eb39598fb05837be4f9aad4ead957194d94364834f3cc590
-  md5: a35b1976d746d55cd7380c8842d9a1b5
+  size: 469110
+  timestamp: 1748430879265
+- conda: https://prefix.dev/conda-forge/osx-64/libcurl-8.14.0-h5dec5d8_0.conda
+  sha256: 402abb5baaa473944427a3f9b97610ba476e8ba6918405676f1f121e55286d3d
+  md5: 5e158521376c1b0767fc829adec93dc5
   depends:
   - __osx >=10.13
   - krb5 >=1.21.3,<1.22.0a0
   - libnghttp2 >=1.64.0,<2.0a0
   - libssh2 >=1.11.1,<2.0a0
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.4.1,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 418479
-  timestamp: 1743601943696
-- conda: https://prefix.dev/conda-forge/osx-arm64/libcurl-8.13.0-h73640d1_0.conda
-  sha256: 747f7e8aad390b9b39a300401579ff1b5731537a586869b724dc071a9b315f03
-  md5: 4a5d33f75f9ead15089b04bed8d0eafe
+  size: 423712
+  timestamp: 1748431099255
+- conda: https://prefix.dev/conda-forge/osx-arm64/libcurl-8.14.0-h73640d1_0.conda
+  sha256: 8ecce486f18b2945fd2f4edadc064578d7173c01a581caa8e3f1af271e2846b2
+  md5: 2cdeda15c3cf49965e589107ca316997
   depends:
   - __osx >=11.0
   - krb5 >=1.21.3,<1.22.0a0
   - libnghttp2 >=1.64.0,<2.0a0
   - libssh2 >=1.11.1,<2.0a0
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.4.1,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 397929
-  timestamp: 1743601888428
-- conda: https://prefix.dev/conda-forge/win-64/libcurl-8.13.0-h88aaa65_0.conda
-  sha256: 185553b37c0299b7a15dc66a7a7e2a0d421adaac784ec9298a0b2ad745116ca5
-  md5: c9cf6eb842decbb66c2f34e72c3580d6
+  size: 403452
+  timestamp: 1748431286504
+- conda: https://prefix.dev/conda-forge/win-64/libcurl-8.14.0-h88aaa65_0.conda
+  sha256: 374d36c9e5163e8ac6a2b3e845200db8ecc16702dc85d4c1617c8047f3e2ba3a
+  md5: ae69647c79ac790aae707e6f3977152b
   depends:
   - krb5 >=1.21.3,<1.22.0a0
   - libssh2 >=1.11.1,<2.0a0
@@ -7241,74 +7170,74 @@ packages:
   - vc14_runtime >=14.29.30139
   license: curl
   license_family: MIT
-  size: 357142
-  timestamp: 1743602240803
-- conda: https://prefix.dev/conda-forge/osx-64/libcxx-20.1.4-hf95d169_0.conda
-  sha256: 491ae6c8b5dc678581b52d24de73e303b895fd5f600da2f6f721b385692083d0
-  md5: 9a38a63cfe950dd3e1b3adfcba731d3a
+  size: 368706
+  timestamp: 1748431492245
+- conda: https://prefix.dev/conda-forge/osx-64/libcxx-20.1.6-hf95d169_0.conda
+  sha256: fbc7a8ef613669f3133bb2b0bc5b36f4c51987bb74769b018377fac96610863b
+  md5: 460934df319a215557816480e9ea78cf
   depends:
   - __osx >=10.13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 559984
-  timestamp: 1745991583464
-- conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-20.1.4-ha82da77_0.conda
-  sha256: 1837e2c65f8fc8cfd8b240cfe89406d0ce83112ac63f98c9fb3c9a15b4f2d4e1
-  md5: 10c809af502fcdab799082d338170994
+  size: 561657
+  timestamp: 1748495006359
+- conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-20.1.6-ha82da77_0.conda
+  sha256: b74ec832ec05571f8747c9bd5f96b93d76489909b4f6f37d99d576dc955f21e9
+  md5: 95c1830841844ef54e07efed1654b47f
   depends:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 565811
-  timestamp: 1745991653948
-- conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.23-h86f0d12_0.conda
-  sha256: 4db2f70a1441317d964e84c268e388110ad9cf75ca98994d1336d670e62e6f07
-  md5: 27fe770decaf469a53f3e3a6d593067f
+  size: 567539
+  timestamp: 1748495055530
+- conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
+  sha256: 8420748ea1cc5f18ecc5068b4f24c7a023cc9b20971c99c824ba10641fb95ddf
+  md5: 64f0c503da58ec25ebd359e4d990afa8
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 72783
-  timestamp: 1745260463421
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libdeflate-1.23-he377734_0.conda
-  sha256: 86532decdaed62f4731589af03389684d8469b181fd0ca48309433a229ffcd34
-  md5: 308ad7cbe9fd92add59ef3d547a42c17
+  size: 72573
+  timestamp: 1747040452262
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libdeflate-1.24-he377734_0.conda
+  sha256: dd0e4baa983803227ec50457731d6f41258b90b3530f579b5d3151d5a98af191
+  md5: f0b3d6494663b3385bf87fc206d7451a
   depends:
   - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 70245
-  timestamp: 1745260494767
-- conda: https://prefix.dev/conda-forge/osx-64/libdeflate-1.23-hcc1b750_0.conda
-  sha256: 9105bb8656649f9676008f95b0f058d2b8ef598e058190dcae1678d6ebc1f9b3
-  md5: 5d3507f22dda24f7d9a79325ad313e44
+  size: 70417
+  timestamp: 1747040440762
+- conda: https://prefix.dev/conda-forge/osx-64/libdeflate-1.24-hcc1b750_0.conda
+  sha256: 2733a4adf53daca1aa4f41fe901f0f8ee9e4c509abd23ffcd7660013772d6f45
+  md5: f0a46c359722a3e84deb05cd4072d153
   depends:
   - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 69911
-  timestamp: 1745260530684
-- conda: https://prefix.dev/conda-forge/osx-arm64/libdeflate-1.23-h5773f1b_0.conda
-  sha256: ebc06154e9a2085e8c9edf81f8f5196b73a1698e18ac6386c9b43fb426103327
-  md5: 4dc332b504166d7f89e4b3b18ab5e6ea
+  size: 69751
+  timestamp: 1747040526774
+- conda: https://prefix.dev/conda-forge/osx-arm64/libdeflate-1.24-h5773f1b_0.conda
+  sha256: 417d52b19c679e1881cce3f01cad3a2d542098fa2d6df5485aac40f01aede4d1
+  md5: 3baf58a5a87e7c2f4d243ce2f8f2fe5c
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 54685
-  timestamp: 1745260666631
-- conda: https://prefix.dev/conda-forge/win-64/libdeflate-1.23-h76ddb4d_0.conda
-  sha256: 881244050587dc658078ee45dfc792ecb458bbb1fdc861da67948d747b117dc2
-  md5: 34f03138e46543944d4d7f8538048842
+  size: 54790
+  timestamp: 1747040549847
+- conda: https://prefix.dev/conda-forge/win-64/libdeflate-1.24-h76ddb4d_0.conda
+  sha256: 65347475c0009078887ede77efe60db679ea06f2b56f7853b9310787fe5ad035
+  md5: 08d988e266c6ae77e03d164b83786dc4
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 155548
-  timestamp: 1745260818985
+  size: 156292
+  timestamp: 1747040812624
 - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.124-hb9d3cd8_0.conda
   sha256: f0d5ffbdf3903a7840184d14c14154b503e1a96767c328f61d99ad24b6963e52
   md5: 8bc89311041d7fcb510238cf0848ccae
@@ -7633,63 +7562,63 @@ packages:
   license: GPL-2.0-only OR FTL
   size: 337007
   timestamp: 1745370226578
-- conda: https://prefix.dev/conda-forge/linux-64/libgcc-14.2.0-h767d61c_2.conda
-  sha256: 3a572d031cb86deb541d15c1875aaa097baefc0c580b54dc61f5edab99215792
-  md5: ef504d1acbd74b7cc6849ef8af47dd03
+- conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
+  sha256: 0024f9ab34c09629621aefd8603ef77bf9d708129b0dd79029e502c39ffc2195
+  md5: ea8ac52380885ed41c1baa8f1d6d2b93
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   constrains:
-  - libgomp 14.2.0 h767d61c_2
-  - libgcc-ng ==14.2.0=*_2
+  - libgcc-ng ==15.1.0=*_2
+  - libgomp 15.1.0 h767d61c_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 847885
-  timestamp: 1740240653082
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-14.2.0-he277a41_2.conda
-  sha256: a57f7f9ba2a12f56eafdcd25b6d75f7be10b8fc1a802a58b76a77ca8c66f4503
-  md5: 6b4268a60b10f29257b51b9b67ff8d76
+  size: 829108
+  timestamp: 1746642191935
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-15.1.0-he277a41_2.conda
+  sha256: e5977d63d48507bfa4e86b3052b3d14bae7ea80c3f8b4018868995275b6cc0d8
+  md5: 224e999bbcad260d7bd4c0c27fdb99a4
   depends:
   - _openmp_mutex >=4.5
   constrains:
-  - libgcc-ng ==14.2.0=*_2
-  - libgomp 14.2.0 he277a41_2
+  - libgcc-ng ==15.1.0=*_2
+  - libgomp 15.1.0 he277a41_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 535507
-  timestamp: 1740241069780
-- conda: https://prefix.dev/conda-forge/win-64/libgcc-14.2.0-h1383e82_2.conda
-  sha256: fddf2fc037bc95adb3b369e8866da8a71b6a67ebcfc4d7035ac4208309dc9e72
-  md5: 4a74c1461a0ba47a3346c04bdccbe2ad
+  size: 516718
+  timestamp: 1746656727616
+- conda: https://prefix.dev/conda-forge/win-64/libgcc-15.1.0-h1383e82_2.conda
+  sha256: c0288596ac58366d96a56c57e4088fe1c6dd4194fdcaeacf5862f47fb1e1e5be
+  md5: 9bedb24480136bfeb81ebc81d4285e70
   depends:
   - _openmp_mutex >=4.5
   - libwinpthread >=12.0.0.r4.gg4f2fc60ca
   constrains:
   - msys2-conda-epoch <0.0a0
-  - libgcc-ng ==14.2.0=*_2
-  - libgomp 14.2.0 h1383e82_2
+  - libgcc-ng ==15.1.0=*_2
+  - libgomp 15.1.0 h1383e82_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 666343
-  timestamp: 1740240717807
-- conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_2.conda
-  sha256: fb7558c328b38b2f9d2e412c48da7890e7721ba018d733ebdfea57280df01904
-  md5: a2222a6ada71fb478682efe483ce0f92
+  size: 673459
+  timestamp: 1746656621653
+- conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
+  sha256: 0ab5421a89f090f3aa33841036bb3af4ed85e1f91315b528a9d75fab9aad51ae
+  md5: ddca86c7040dd0e73b2b69bd7833d225
   depends:
-  - libgcc 14.2.0 h767d61c_2
+  - libgcc 15.1.0 h767d61c_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 53758
-  timestamp: 1740240660904
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-ng-14.2.0-he9431aa_2.conda
-  sha256: 9647f75cddc18b07eebe6e1f21500eed50a6af2c43c84e831b4c7a597e10d226
-  md5: 692c2bb75f32cfafb6799cf6d1c5d0e0
+  size: 34586
+  timestamp: 1746642200749
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-ng-15.1.0-he9431aa_2.conda
+  sha256: fe22ddd0f7922edb0b515959ff1180d1143060fc5bfc3739ff4c6a94762c50c6
+  md5: d12a4b26073751bbc3db18de83ccba5f
   depends:
-  - libgcc 14.2.0 he277a41_2
+  - libgcc 15.1.0 he277a41_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 53622
-  timestamp: 1740241074834
+  size: 34773
+  timestamp: 1746656732548
 - conda: https://prefix.dev/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
   sha256: 19e5be91445db119152217e8e8eec4fd0499d854acc7d8062044fb55a70971cd
   md5: 68fc66282364981589ef36868b1a7c78
@@ -7791,47 +7720,47 @@ packages:
   license_family: BSD
   size: 165838
   timestamp: 1737548342665
-- conda: https://prefix.dev/conda-forge/linux-64/libgettextpo-0.23.1-h5888daf_0.conda
-  sha256: 190097140d9c16637aa516757d8087f17e8c22cc844c87288da64404b81ef43c
-  md5: a09ce5decdef385bcce78c32809fa794
+- conda: https://prefix.dev/conda-forge/linux-64/libgettextpo-0.24.1-h5888daf_0.conda
+  sha256: 104f2341546e295d1136ab3010e81391bd3fd5be0f095db59266e8eba2082d37
+  md5: 2ee6d71b72f75d50581f2f68e965efdb
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 166867
-  timestamp: 1739038720211
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libgettextpo-0.23.1-h5ad3122_0.conda
-  sha256: 5fe9ea0f19d4f89c5f5030a5aad853e05d1fe001ee003e102e4a2a01b0e157cc
-  md5: 04aa6b35d4581b59aafb2683345579d7
+  size: 171165
+  timestamp: 1746228870846
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libgettextpo-0.24.1-h5ad3122_0.conda
+  sha256: 3dc0c79b5780d1155ed38a9b4e484d5bd3ea8d5f7e825cff69741cf8dc53313f
+  md5: 54bb1208da39417046f68daa603a37eb
   depends:
   - libgcc >=13
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 207214
-  timestamp: 1739038603075
-- conda: https://prefix.dev/conda-forge/osx-64/libgettextpo-0.23.1-h27064b9_0.conda
-  sha256: 52c2423df75223df4ebee991eb33e3827b9d360957211022246145b99c672dc5
-  md5: 352ffb2b7788775a65a32c018d972a8a
+  size: 217039
+  timestamp: 1746228750642
+- conda: https://prefix.dev/conda-forge/osx-64/libgettextpo-0.24.1-h27064b9_0.conda
+  sha256: e26e5bfe706c37cfbcbfe7598d3ebcdf4c39d89a9497e6c9bfe9069b0a18e3f3
+  md5: facba41133c6e10d9f67b1a12f66bd3a
   depends:
   - __osx >=10.13
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.23.1 h27064b9_0
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.24.1 h27064b9_0
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 183258
-  timestamp: 1739039203159
-- conda: https://prefix.dev/conda-forge/osx-arm64/libgettextpo-0.23.1-h493aca8_0.conda
-  sha256: 4dbd3f698d027330033f06778567eda5b985e2348ca92900083654a114ddd051
-  md5: 18ad77def4cb7326692033eded9c815d
+  size: 192819
+  timestamp: 1746229371415
+- conda: https://prefix.dev/conda-forge/osx-arm64/libgettextpo-0.24.1-h493aca8_0.conda
+  sha256: 0f380fee5d5dc870b6b9d3134cca344965d68bbf454f6ac741907fee4cc3e07a
+  md5: 218a45f477876644cf75c7ed0b5158c7
   depends:
   - __osx >=11.0
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.23.1 h493aca8_0
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.24.1 h493aca8_0
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 166929
-  timestamp: 1739039303132
+  size: 176982
+  timestamp: 1746229282723
 - conda: https://prefix.dev/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
   sha256: 6747bd29a0896b21ee1fe07bd212210475655354a3e8033c25b797e054ddd821
   md5: e46c142e2d2d9ccef31ad3d176b10fab
@@ -7842,52 +7771,28 @@ packages:
   license_family: GPL
   size: 171120
   timestamp: 1723629671164
-- conda: https://prefix.dev/conda-forge/osx-64/libgettextpo-devel-0.23.1-h27064b9_0.conda
-  sha256: b027dcc98ef20813c73e8aba8de7028ee0641cb0f7eec5f3b153fce4271669e0
-  md5: fea8af9c8a5d38b3b1b7f72dc3d7080a
+- conda: https://prefix.dev/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_2.conda
+  sha256: 914daa4f632b786827ea71b5e07cd00d25fc6e67789db2f830dc481eec660342
+  md5: f92e6e0a3c0c0c85561ef61aa59d555d
   depends:
-  - __osx >=10.13
-  - libgettextpo 0.23.1 h27064b9_0
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.23.1 h27064b9_0
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 37271
-  timestamp: 1739039234636
-- conda: https://prefix.dev/conda-forge/osx-arm64/libgettextpo-devel-0.23.1-h493aca8_0.conda
-  sha256: 6031e57ba3c03ca34422b847b98fb70e697a5c10556c8d7b30410a96754c25d8
-  md5: e6f75805f4b533d449a5a6d60cbc9a71
-  depends:
-  - __osx >=11.0
-  - libgettextpo 0.23.1 h493aca8_0
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.23.1 h493aca8_0
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 37264
-  timestamp: 1739039332924
-- conda: https://prefix.dev/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_2.conda
-  sha256: e05263e8960da03c341650f2a3ffa4ccae4e111cb198e8933a2908125459e5a6
-  md5: fb54c4ea68b460c278d26eea89cfbcc3
-  depends:
-  - libgfortran5 14.2.0 hf1ad2bd_2
+  - libgfortran5 15.1.0 hcea5267_2
   constrains:
-  - libgfortran-ng ==14.2.0=*_2
+  - libgfortran-ng ==15.1.0=*_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 53733
-  timestamp: 1740240690977
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran-14.2.0-he9431aa_2.conda
-  sha256: 996d3c0505301901a7ab23b5e7daad21635d1c065240bb0f4faf7e4f75d7f49d
-  md5: d8b9d9dc0c8cd97d375b48e55947ba70
+  size: 34541
+  timestamp: 1746642233221
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran-15.1.0-he9431aa_2.conda
+  sha256: 98175347dba29f9248656dd7626c9826a8f2ed1a3b145a8778a46d991d8e6d53
+  md5: dc8675aa2658bb0d92cefbff83ce2db8
   depends:
-  - libgfortran5 14.2.0 hb6113d0_2
+  - libgfortran5 15.1.0 hbc25352_2
   constrains:
-  - libgfortran-ng ==14.2.0=*_2
+  - libgfortran-ng ==15.1.0=*_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 53611
-  timestamp: 1740241100147
+  size: 34747
+  timestamp: 1746656757321
 - conda: https://prefix.dev/conda-forge/osx-64/libgfortran-14.2.0-hef36b68_105.conda
   sha256: 984040aa98dedcfbe1cf59befd73740e30d368b96cbfa17c002297e67fa5af23
   md5: 6b27baf030f5d6603713c7e72d3f6b9a
@@ -7906,40 +7811,40 @@ packages:
   license_family: GPL
   size: 155474
   timestamp: 1743913530958
-- conda: https://prefix.dev/conda-forge/win-64/libgfortran-14.2.0-h719f0c7_2.conda
-  sha256: 12f83a7bdf786a252809c826356038f3ec956eb722cde70bdc65b79362357a6a
-  md5: 9412c5649152274bf99a6a7533c5fc8e
+- conda: https://prefix.dev/conda-forge/win-64/libgfortran-15.1.0-h719f0c7_2.conda
+  sha256: df4b7670aeb1b733de9410202913b0dd7a41681c35324f42b2ca45b5c4fa4616
+  md5: 6bf5313ee8e16ea85ef2c1bbadb7e726
   depends:
-  - libgfortran5 14.2.0 hf020157_2
+  - libgfortran5 15.1.0 h997fb6f_2
   constrains:
-  - libgfortran-ng ==14.2.0=*_2
+  - libgfortran-ng ==15.1.0=*_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 53876
-  timestamp: 1740240939881
-- conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-14.2.0-hf1ad2bd_2.conda
-  sha256: c17b7cf3073a1f4e1f34d50872934fa326346e104d3c445abc1e62481ad6085c
-  md5: 556a4fdfac7287d349b8f09aba899693
+  size: 57974
+  timestamp: 1746656859536
+- conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_2.conda
+  sha256: be23750f3ca1a5cb3ada858c4f633effe777487d1ea35fddca04c0965c073350
+  md5: 01de444988ed960031dbe84cf4f9b1fc
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14.2.0
+  - libgcc >=15.1.0
   constrains:
-  - libgfortran 14.2.0
+  - libgfortran 15.1.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 1461978
-  timestamp: 1740240671964
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran5-14.2.0-hb6113d0_2.conda
-  sha256: 7b9e1d3666a00e5a52e5d43c003bd1c73ab472804be513c070aaedca9c4c2a9a
-  md5: cd754566661513808ef2408c4ab99a2f
+  size: 1569986
+  timestamp: 1746642212331
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran5-15.1.0-hbc25352_2.conda
+  sha256: 10c0ecff52db325e8b97dcd2c3002c6656359370f23a6ff21c8ebc495a0252be
+  md5: 4b5f4d119f9b28f254f82dbe56b2406f
   depends:
-  - libgcc >=14.2.0
+  - libgcc >=15.1.0
   constrains:
-  - libgfortran 14.2.0
+  - libgfortran 15.1.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 1100765
-  timestamp: 1740241083241
+  size: 1145914
+  timestamp: 1746656740844
 - conda: https://prefix.dev/conda-forge/osx-64/libgfortran5-14.2.0-h58528f3_105.conda
   sha256: 02fc48106e1ca65cf7de15f58ec567f866f6e8e9dcced157d0cff89f0768bb59
   md5: 94560312ff3c78225bed62ab59854c31
@@ -7962,18 +7867,18 @@ packages:
   license_family: GPL
   size: 806283
   timestamp: 1743913488925
-- conda: https://prefix.dev/conda-forge/win-64/libgfortran5-14.2.0-hf020157_2.conda
-  sha256: c3aa58790b0e8be31bfc1ddc5ee1c1300543ae9d2ec8f52cceb804e523413448
-  md5: 62ac6caaf1593e66fa54e843a7d77c70
+- conda: https://prefix.dev/conda-forge/win-64/libgfortran5-15.1.0-h997fb6f_2.conda
+  sha256: 9b9df3ffbd931affe333c9d94f5a83b3226355c671f6ac506f5be04bcca24997
+  md5: 53bfba1b37ec6bb5cbda3a2de872adbb
   depends:
-  - libgcc >=14.2.0
+  - libgcc >=15.1.0
   - libwinpthread >=12.0.0.r4.gg4f2fc60ca
   constrains:
-  - libgfortran 14.2.0
+  - libgfortran 15.1.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 1705968
-  timestamp: 1740240728919
+  size: 1874061
+  timestamp: 1746656632901
 - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
   sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
   md5: 928b8be80851f5d8ffb016f9c81dae7a
@@ -8069,43 +7974,27 @@ packages:
   license: LGPL-2.1-or-later
   size: 3806534
   timestamp: 1743774256525
-- conda: https://prefix.dev/conda-forge/linux-64/libglu-9.0.3-h03adeef_0.conda
-  sha256: cabd78b5ede1f3f161037d3a6cfb6b8a262ec474f9408859c364ef55ba778097
-  md5: b1df5affe904efe82ef890826b68881d
+- conda: https://prefix.dev/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
+  sha256: a0105eb88f76073bbb30169312e797ed5449ebb4e964a756104d6e54633d17ef
+  md5: 8422fcc9e5e172c91e99aef703b3ce65
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libdrm >=2.4.123,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
   - libgcc >=13
-  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
   - libstdcxx >=13
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxxf86vm >=1.1.5,<2.0a0
-  license: SGI-2
-  size: 325361
-  timestamp: 1731470892413
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libglu-9.0.3-hc7f7585_0.conda
-  sha256: fafab7ffb5522d6b788a9c83eab44a76750efa1a71380467599a458c4f7bf849
-  md5: cf9ff275dd030e5e8c9d336f5086da98
+  license: SGI-B-2.0
+  size: 325262
+  timestamp: 1748692137626
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libglu-9.0.3-h5ad3122_1.conda
+  sha256: ddb72f17f6ec029069cddd2e489e63e371e75661cd2408509370508490bb23ad
+  md5: 4d836b60421894bf9a6c77c8ca36782c
   depends:
-  - libdrm >=2.4.123,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
   - libgcc >=13
-  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
   - libstdcxx >=13
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxdmcp >=1.1.5,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxxf86vm >=1.1.5,<2.0a0
-  license: SGI-2
-  size: 317433
-  timestamp: 1731470978326
+  license: SGI-B-2.0
+  size: 310655
+  timestamp: 1748692200349
 - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
   sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
   md5: 434ca7e50e40f4918ab701e3facd59a0
@@ -8139,33 +8028,33 @@ packages:
   license: LicenseRef-libglvnd
   size: 77736
   timestamp: 1731330998960
-- conda: https://prefix.dev/conda-forge/linux-64/libgomp-14.2.0-h767d61c_2.conda
-  sha256: 1a3130e0b9267e781b89399580f3163632d59fe5b0142900d63052ab1a53490e
-  md5: 06d02030237f4d5b3d9a7e7d348fe3c6
+- conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
+  sha256: 05fff3dc7e80579bc28de13b511baec281c4343d703c406aefd54389959154fb
+  md5: fbe7d535ff9d3a168c148e07358cd5b1
   depends:
   - __glibc >=2.17,<3.0.a0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 459862
-  timestamp: 1740240588123
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_2.conda
-  sha256: 4e303711fb7413bf98995beac58e731073099d7a669a3b81e49330ca8da05174
-  md5: b11c09d9463daf4cae492d29806b1889
+  size: 452635
+  timestamp: 1746642113092
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.1.0-he277a41_2.conda
+  sha256: 6362d457591144a4e50247ff60cb2655eb2cf4a7a99dde9e4d7c2d22af20a038
+  md5: a28544b28961994eab37e1132a7dadcf
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 462783
-  timestamp: 1740241005079
-- conda: https://prefix.dev/conda-forge/win-64/libgomp-14.2.0-h1383e82_2.conda
-  sha256: 674ec5f1bf319eac98d0d6ecb9c38e0192f3cf41969a5621d62a7e695e1aa9f3
-  md5: dd6b1ab49e28bcb6154cd131acec985b
+  size: 456053
+  timestamp: 1746656635944
+- conda: https://prefix.dev/conda-forge/win-64/libgomp-15.1.0-h1383e82_2.conda
+  sha256: 4316316097ce5fde2608b6fccd18709cf647dce52e230f5ac66f5c524dfad791
+  md5: 5fbacaa9b41e294a6966602205b99747
   depends:
   - libwinpthread >=12.0.0.r4.gg4f2fc60ca
   constrains:
   - msys2-conda-epoch <0.0a0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 524548
-  timestamp: 1740240660967
+  size: 540903
+  timestamp: 1746656563815
 - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.11.2-default_h0d58e46_1001.conda
   sha256: d14c016482e1409ae1c50109a9ff933460a50940d2682e745ab1c172b5282a69
   md5: 804ca9e91bcaea0824a341d55b1684f2
@@ -8267,24 +8156,24 @@ packages:
   license: LGPL-2.1-only
   size: 638142
   timestamp: 1740128665984
-- conda: https://prefix.dev/conda-forge/osx-64/libintl-0.23.1-h27064b9_0.conda
-  sha256: 1bce54e6c76064032129ba138898a5b188d9415c533eb585f89d48b04e00e576
-  md5: 4182fe11073548596723d9cd2c23b1ac
+- conda: https://prefix.dev/conda-forge/osx-64/libintl-0.24.1-h27064b9_0.conda
+  sha256: f0a759b35784d5a31aeaf519f8f24019415321e62e52579a3ec854a413a1509d
+  md5: b3f498d87404090f731cb6a474045150
   depends:
   - __osx >=10.13
-  - libiconv >=1.17,<2.0a0
+  - libiconv >=1.18,<2.0a0
   license: LGPL-2.1-or-later
-  size: 87157
-  timestamp: 1739039171974
-- conda: https://prefix.dev/conda-forge/osx-arm64/libintl-0.23.1-h493aca8_0.conda
-  sha256: 30d2a8a37070615a61777ce9317968b54c2197d04e9c6c2eea6cdb46e47f94dc
-  md5: 7b8faf3b5fc52744bda99c4cd1d6438d
+  size: 97229
+  timestamp: 1746229336518
+- conda: https://prefix.dev/conda-forge/osx-arm64/libintl-0.24.1-h493aca8_0.conda
+  sha256: fb6d211d9e75e6becfbf339d255ea01f7bd3a61fe6237b3dad740de1b74b3b81
+  md5: 0dca9914f2722b773c863508723dfe6e
   depends:
   - __osx >=11.0
-  - libiconv >=1.17,<2.0a0
+  - libiconv >=1.18,<2.0a0
   license: LGPL-2.1-or-later
-  size: 78921
-  timestamp: 1739039271409
+  size: 90547
+  timestamp: 1746229257769
 - conda: https://prefix.dev/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
   sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
   md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
@@ -8293,26 +8182,6 @@ packages:
   license: LGPL-2.1-or-later
   size: 95568
   timestamp: 1723629479451
-- conda: https://prefix.dev/conda-forge/osx-64/libintl-devel-0.23.1-h27064b9_0.conda
-  sha256: 2a2cfacee2c345f79866487921d222b17e93a826ac9a80b80901a41c0b094633
-  md5: 6d4a30603b01f15bb643e14a9807e46c
-  depends:
-  - __osx >=10.13
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.23.1 h27064b9_0
-  license: LGPL-2.1-or-later
-  size: 40027
-  timestamp: 1739039220643
-- conda: https://prefix.dev/conda-forge/osx-arm64/libintl-devel-0.23.1-h493aca8_0.conda
-  sha256: 5db07fa57b8cb916784353aa035fbf32aa7ee2905e38a8e70b168160372833f0
-  md5: f9c6d5edc5951ef4010be8cbde9f12d4
-  depends:
-  - __osx >=11.0
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.23.1 h493aca8_0
-  license: LGPL-2.1-or-later
-  size: 39774
-  timestamp: 1739039317742
 - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
   sha256: 98b399287e27768bf79d48faba8a99a2289748c65cd342ca21033fab1860d4a4
   md5: 9fa334557db9f63da6c9285fd2a48638
@@ -8572,102 +8441,117 @@ packages:
   license_family: Apache
   size: 39385125
   timestamp: 1737785892355
-- conda: https://prefix.dev/conda-forge/linux-64/libllvm20-20.1.3-he9d0ab4_0.conda
-  sha256: 1d61b4ad305a1b620185b0c7061de1b8128a58f8925e49ccc87e84e0276f1946
-  md5: 74c14fe2ab88e352ab6e4fedf5ecb527
+- conda: https://prefix.dev/conda-forge/linux-64/libllvm20-20.1.6-he9d0ab4_0.conda
+  sha256: 1f446c261c98794c4f4430513065637dfaaacaf00b6d5d41b3f90e9d9f8cb631
+  md5: bf8ccdd2c1c1a54a3fa25bb61f26460e
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
-  - libxml2 >=2.13.7,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - libzlib >=1.3.1,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 43025284
-  timestamp: 1744814708496
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm20-20.1.4-h07bd352_0.conda
-  sha256: e86587e5d2663fc5bcc2ee472ae72a6f44fafae44d699505502718a7268fe14b
-  md5: a83f31777ec098202198145883d86ffb
+  size: 43023023
+  timestamp: 1748507316454
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm20-20.1.6-h07bd352_0.conda
+  sha256: 3b97eeda439f2cbde8119e4b15d682b6b5e985d6f6aec866dc2a66ce6c85f5ec
+  md5: 978603200db5e721247fdb529a6e7321
   depends:
   - libgcc >=13
   - libstdcxx >=13
-  - libxml2 >=2.13.7,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - libzlib >=1.3.1,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 42148423
-  timestamp: 1746010718250
-- conda: https://prefix.dev/conda-forge/osx-64/libllvm20-20.1.4-h29c3a6c_0.conda
-  sha256: a4eed2f705efee1d8ae3bedaa459fdd24607026de0d8c0ef381d4aaa0379281e
-  md5: 23566673d16f39ca62de06ad56ce274d
+  size: 42167195
+  timestamp: 1748502596922
+- conda: https://prefix.dev/conda-forge/osx-64/libllvm20-20.1.6-h29c3a6c_0.conda
+  sha256: 055a09b291676c3b898dda2556257ed72b8c645caabd7cd048610bd85d9aa873
+  md5: 4cef080a544181af0861a71d30548e52
   depends:
   - __osx >=10.13
   - libcxx >=18
-  - libxml2 >=2.13.7,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - libzlib >=1.3.1,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 30786343
-  timestamp: 1746010271379
-- conda: https://prefix.dev/conda-forge/osx-arm64/libllvm20-20.1.4-h598bca7_0.conda
-  sha256: 4e65a33d457ce7f313dbc8f59c94ee64bbb2ac62711a5382256afdfad9a06614
-  md5: c8e530db4952e8c66768f2cf75413cd6
+  size: 30770105
+  timestamp: 1748499606836
+- conda: https://prefix.dev/conda-forge/osx-arm64/libllvm20-20.1.6-h598bca7_0.conda
+  sha256: 8513d01f6e52bca09f95854f0e98d67f4bfd21534523036d6d3a9b6efb9cf431
+  md5: a69ea59e6f3141d46cfaf4bf234544d5
   depends:
   - __osx >=11.0
   - libcxx >=18
-  - libxml2 >=2.13.7,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - libzlib >=1.3.1,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 28902288
-  timestamp: 1746012066614
-- conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_0.conda
-  sha256: f4f21dfc54b08d462f707b771ecce3fa9bc702a2a05b55654f64154f48b141ef
-  md5: 0e87378639676987af32fee53ba32258
+  size: 28900564
+  timestamp: 1748501902946
+- conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda
+  sha256: eeff241bddc8f1b87567dd6507c9f441f7f472c27f0860a07628260c000ef27c
+  md5: a76fd702c93cd2dfd89eff30a5fd45a8
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  constrains:
+  - xz 5.8.1.*
+  - xz ==5.8.1=*_1
   license: 0BSD
-  size: 112709
-  timestamp: 1743771086123
-- conda: https://prefix.dev/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_0.conda
-  sha256: fee534c3fe3911a5164c438b40c7d3458d93086decd359ef72f0d04a7a5d82f4
-  md5: 775d36ea4e469b0c049a6f2cd6253d82
+  size: 112845
+  timestamp: 1746531470399
+- conda: https://prefix.dev/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_1.conda
+  sha256: 245e06d96ac55827a3cf20b09a777e318c3d2a41aa8ff7853bcae0a9c9e28cda
+  md5: 8ced9a547a29f7a71b7f15a4443ad1de
   depends:
   - libgcc >=13
+  constrains:
+  - xz 5.8.1.*
+  - xz ==5.8.1=*_1
   license: 0BSD
-  size: 124919
-  timestamp: 1743773576913
-- conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.1-hd471939_0.conda
-  sha256: 3369b8ef0b544d17aebc530a687c0480051e825e8ffcd001b1a5f594fe276159
-  md5: 8e1197f652c67e87a9ece738d82cef4f
+  size: 124885
+  timestamp: 1746533630888
+- conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.1-hd471939_1.conda
+  sha256: 20a4c5291f3e338548013623bb1dc8ee2fba5dbac8f77acaddd730ed2a7d29b6
+  md5: f87e8821e0e38a4140a7ed4f52530053
   depends:
   - __osx >=10.13
+  constrains:
+  - xz 5.8.1.*
+  - xz ==5.8.1=*_1
   license: 0BSD
-  size: 104689
-  timestamp: 1743771137842
-- conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_0.conda
-  sha256: 4291dde55ebe9868491dc29716b84ac3de21b8084cbd4d05c9eea79d206b8ab7
-  md5: ba24e6f25225fea3d5b6912e2ac562f8
+  size: 104814
+  timestamp: 1746531577001
+- conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_1.conda
+  sha256: 5ab62c179229640c34491a7de806ad4ab7bec47ea2b5fc2136e3b8cf5ef26a57
+  md5: 4e8ef3d79c97c9021b34d682c24c2044
   depends:
   - __osx >=11.0
+  constrains:
+  - xz 5.8.1.*
+  - xz ==5.8.1=*_1
   license: 0BSD
-  size: 92295
-  timestamp: 1743771392206
-- conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_0.conda
-  sha256: 1477e9bff05318f3129d37be0e64c76cce0973c4b8c73d13a467d0b7f03d157c
-  md5: 8d5cb0016b645d6688e2ff57c5d51302
+  size: 92218
+  timestamp: 1746531818330
+- conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_1.conda
+  sha256: adbf6c7bde70536ada734a81b8b5aa23654f2b95445204404622e0cc40e921a0
+  md5: 14a1042c163181e143a7522dfb8ad6ab
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
+  constrains:
+  - xz 5.8.1.*
+  - xz ==5.8.1=*_1
   license: 0BSD
-  size: 104682
-  timestamp: 1743771561515
+  size: 104699
+  timestamp: 1746531718026
 - conda: https://prefix.dev/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h00e09a9_116.conda
   sha256: 8c389b867452b13e7a2e0cf9c8120e0124a4ac1ab419fab23a565e2659084840
   md5: 417864857bdb6c2be2e923e89bffd2e8
@@ -9981,55 +9865,55 @@ packages:
   license: zlib-acknowledgement
   size: 346511
   timestamp: 1745771984515
-- conda: https://prefix.dev/conda-forge/linux-64/libpq-17.4-h27ae623_1.conda
-  sha256: ba2fd74be9d8c38489b9c6c18fa2fa87437dac76dfe285f86425c1b815e59fa2
-  md5: 37fba334855ef3b51549308e61ed7a3d
+- conda: https://prefix.dev/conda-forge/linux-64/libpq-17.5-h27ae623_0.conda
+  sha256: 2dbcef0db82e0e7b6895b6c0dadd3d36c607044c40290c7ca10656f3fca3166f
+  md5: 6458be24f09e1b034902ab44fe9de908
   depends:
   - __glibc >=2.17,<3.0.a0
   - icu >=75.1,<76.0a0
   - krb5 >=1.21.3,<1.22.0a0
   - libgcc >=13
   - openldap >=2.6.9,<2.7.0a0
-  - openssl >=3.4.1,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   license: PostgreSQL
-  size: 2736307
-  timestamp: 1743504522214
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libpq-17.4-hf590da8_1.conda
-  sha256: 6d962dd2e239d552ad01b9de6ae688264f7f2d3aba609199312d129e0b4935af
-  md5: 10fdc78be541c9017e2144f86d092aa2
+  size: 2680582
+  timestamp: 1746743259857
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libpq-17.5-hf590da8_0.conda
+  sha256: 36db4c66ca15337d1077d1490064e04a1a705f393a8d0577aea9b4ffee604129
+  md5: b5a01e5aa04651ccf5865c2d029affa3
   depends:
   - icu >=75.1,<76.0a0
   - krb5 >=1.21.3,<1.22.0a0
   - libgcc >=13
   - openldap >=2.6.9,<2.7.0a0
-  - openssl >=3.4.1,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   license: PostgreSQL
-  size: 2682528
-  timestamp: 1743504484249
-- conda: https://prefix.dev/conda-forge/osx-64/libpq-17.4-h9c5cfc2_1.conda
-  sha256: 3b9f9291c30765bc26cafcfa6cdd93efb3ee91f671fd94cbf44c9a81cf10b4e7
-  md5: 01573599dbdb0a0ac9cf5d50355dc085
+  size: 2677495
+  timestamp: 1746743322764
+- conda: https://prefix.dev/conda-forge/osx-64/libpq-17.5-h9c5cfc2_0.conda
+  sha256: 27e58f71b39c66ede8e29842c0dc160f0a64a028dbc71921017ce99bb66b412f
+  md5: edf4c4f2bee09f941622613b1978c23c
   depends:
   - __osx >=10.13
   - icu >=75.1,<76.0a0
   - krb5 >=1.21.3,<1.22.0a0
   - openldap >=2.6.9,<2.7.0a0
-  - openssl >=3.4.1,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   license: PostgreSQL
-  size: 2466372
-  timestamp: 1743504787138
-- conda: https://prefix.dev/conda-forge/osx-arm64/libpq-17.4-h6896619_1.conda
-  sha256: 7ea6665e3a9e5ab87d4dde16a8ee2bff295b71cd1b8d77d41437c030f1c39d11
-  md5: 7003d9c4232f2fa496505148cd0f93f1
+  size: 2629273
+  timestamp: 1746743709716
+- conda: https://prefix.dev/conda-forge/osx-arm64/libpq-17.5-h6896619_0.conda
+  sha256: afbb8282276224934d1fd13c32253f8b349818f6393c43f5582096f2ebae3b0e
+  md5: 2fac681a36e09ee3c904fb486be1b6b8
   depends:
   - __osx >=11.0
   - icu >=75.1,<76.0a0
   - krb5 >=1.21.3,<1.22.0a0
   - openldap >=2.6.9,<2.7.0a0
-  - openssl >=3.4.1,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   license: PostgreSQL
-  size: 2575311
-  timestamp: 1743504740045
+  size: 2502508
+  timestamp: 1746744054052
 - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
   sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
   md5: ab0bff36363bec94720275a681af8b83
@@ -10272,53 +10156,53 @@ packages:
   license_family: BSD
   size: 76492
   timestamp: 1716963604586
-- conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.49.1-hee588c1_2.conda
-  sha256: a086289bf75c33adc1daed3f1422024504ffb5c3c8b3285c49f025c29708ed16
-  md5: 962d6ac93c30b1dfc54c9cccafd1003e
+- conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.50.0-hee588c1_0.conda
+  sha256: b3dcd409c96121c011387bdf7f4b5758d876feeb9d8e3cfc32285b286931d0a7
+  md5: 71888e92098d0f8c41b09a671ad289bc
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
   license: Unlicense
-  size: 918664
-  timestamp: 1742083674731
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libsqlite-3.49.1-h5eb1b54_2.conda
-  sha256: c0eb05c6db32b52cc80e06a2badfa11fbaa66b49f1e7cff77aa691b74a294dcc
-  md5: 7c45959e187fd3313f9f1734464baecc
+  size: 918995
+  timestamp: 1748549888459
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libsqlite-3.50.0-h5eb1b54_0.conda
+  sha256: b59232c8b4d5236a874b310aba6c396561e3889455d54092e4c793115c535ec7
+  md5: 634a05a598cd4b3b852443f8e3b45003
   depends:
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
   license: Unlicense
-  size: 916419
-  timestamp: 1742083699438
-- conda: https://prefix.dev/conda-forge/osx-64/libsqlite-3.49.1-hdb6dae5_2.conda
-  sha256: 82695c9b16a702de615c8303387384c6ec5cf8b98e16458e5b1935b950e4ec38
-  md5: 1819e770584a7e83a81541d8253cbabe
+  size: 917765
+  timestamp: 1748549857399
+- conda: https://prefix.dev/conda-forge/osx-64/libsqlite-3.50.0-hdb6dae5_0.conda
+  sha256: e88ea982455060b96fdab3d360b947389248bf2139e3b17576e4c72e139526fc
+  md5: caf16742f7e16475603cd9981ef36195
   depends:
   - __osx >=10.13
   - libzlib >=1.3.1,<2.0a0
   license: Unlicense
-  size: 977701
-  timestamp: 1742083869897
-- conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.49.1-h3f77e49_2.conda
-  sha256: 907a95f73623c343fc14785cbfefcb7a6b4f2bcf9294fcb295c121611c3a590d
-  md5: 3b1e330d775170ac46dff9a94c253bd0
+  size: 979930
+  timestamp: 1748549977346
+- conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.50.0-h3f77e49_0.conda
+  sha256: 80bbe9c53d4bf2e842eccdd089653d0659972deba7057cda3ebaebaf43198f79
+  md5: cda0ec640bc4698d0813a8fb459aee58
   depends:
   - __osx >=11.0
   - libzlib >=1.3.1,<2.0a0
   license: Unlicense
-  size: 900188
-  timestamp: 1742083865246
-- conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.49.1-h67fdade_2.conda
-  sha256: c092d42d00fd85cf609cc58574ba2b03c141af5762283f36f5dd445ef7c0f4fe
-  md5: b58b66d4ad1aaf1c2543cbbd6afb1a59
+  size: 901545
+  timestamp: 1748550158812
+- conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.50.0-h67fdade_0.conda
+  sha256: 92546e3ea213ee7b11385b22ea4e7c69bbde1c25586288765b37bc5e96b20dd9
+  md5: 92b11b0b2120d563caa1629928122cee
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Unlicense
-  size: 1081292
-  timestamp: 1742083956001
+  size: 1082124
+  timestamp: 1748550277035
 - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -10376,53 +10260,53 @@ packages:
   license_family: BSD
   size: 292785
   timestamp: 1745608759342
-- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-14.2.0-h8f9b012_2.conda
-  sha256: 8f5bd92e4a24e1d35ba015c5252e8f818898478cb3bc50bd8b12ab54707dc4da
-  md5: a78c856b6dc6bf4ea8daeb9beaaa3fb0
+- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda
+  sha256: 6ae3d153e78f6069d503d9309f2cac6de5b93d067fc6433160a4c05226a5dad4
+  md5: 1cb1c67961f6dd257eae9e9691b341aa
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc 14.2.0 h767d61c_2
+  - libgcc 15.1.0 h767d61c_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 3884556
-  timestamp: 1740240685253
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-14.2.0-h3f4de04_2.conda
-  sha256: c30a74bc996013907f6d9f344da007c26d98ef9a0831151cd50aece3125c45d5
-  md5: eadee2cda99697e29411c1013c187b92
+  size: 3902355
+  timestamp: 1746642227493
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-15.1.0-h3f4de04_2.conda
+  sha256: 15c57c226ecc981714f96d07232c67c27703e42bbe2460dbf9b6122720d0704a
+  md5: 6247ea6d1ecac20a9e98674342984726
   depends:
-  - libgcc 14.2.0 he277a41_2
+  - libgcc 15.1.0 he277a41_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 3810779
-  timestamp: 1740241094774
-- conda: https://prefix.dev/conda-forge/win-64/libstdcxx-14.2.0-h904f734_2.conda
-  sha256: 77364c254c07abf0ddd3216325f52cd98e770cd56a13468148cef613b2318ac3
-  md5: d4ed3b935046595e0876a53623803232
+  size: 3838578
+  timestamp: 1746656751553
+- conda: https://prefix.dev/conda-forge/win-64/libstdcxx-15.1.0-h904f734_2.conda
+  sha256: dde036ce52e4c90e3d2065ad8f410d449207c8b447b64bdcf9e44e4b7b963a68
+  md5: 1f2cbd3537147e276af08877d8be4fd2
   depends:
-  - libgcc 14.2.0 h1383e82_2
+  - libgcc 15.1.0 h1383e82_2
   - libwinpthread >=12.0.0.r4.gg4f2fc60ca
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 4467105
-  timestamp: 1740240742690
-- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_2.conda
-  sha256: e86f38b007cf97cc2c67cd519f2de12a313c4ee3f5ef11652ad08932a5e34189
-  md5: c75da67f045c2627f59e6fcb5f4e3a9b
+  size: 4499057
+  timestamp: 1746656647062
+- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_2.conda
+  sha256: 11bea86e11de7d6bce87589197a383344df3fa0a3552dab7e931785ff1159a5b
+  md5: 9d2072af184b5caa29492bf2344597bb
   depends:
-  - libstdcxx 14.2.0 h8f9b012_2
+  - libstdcxx 15.1.0 h8f9b012_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 53830
-  timestamp: 1740240722530
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-ng-14.2.0-hf1166c9_2.conda
-  sha256: 0107886ead6f255956d8e520f8dff260f9ab3d0d51512f18c52710c406e4b2df
-  md5: c934c1fddad582fcc385b608eb06a70c
+  size: 34647
+  timestamp: 1746642266826
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-ng-15.1.0-hf1166c9_2.conda
+  sha256: f9fa45e88d296ca0a740579c7d74f50aaa3a24bef8cfe7dd359e89cdbd6fe1ea
+  md5: 18e532d1a39ae9f78cc8988a034f1cae
   depends:
-  - libstdcxx 14.2.0 h3f4de04_2
+  - libstdcxx 15.1.0 h3f4de04_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 53715
-  timestamp: 1740241126343
+  size: 34860
+  timestamp: 1746656784407
 - conda: https://prefix.dev/conda-forge/linux-64/libtheora-1.1.1-h4ab18f5_1006.conda
   sha256: 50c8cd416ac8425e415264de167b41ae8442de22a91098dfdd993ddbf9f13067
   md5: 553281a034e9cf8693c9df49f6c78ea1
@@ -10488,13 +10372,13 @@ packages:
   license_family: BSD
   size: 160440
   timestamp: 1719668116346
-- conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.0-hd9ff511_4.conda
-  sha256: 7480613af15795281bd338a4d3d2ca148f9c2ecafc967b9cc233e78ba2fe4a6d
-  md5: 6c1028898cf3a2032d9af46689e1b81a
+- conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.0-hf01ce69_5.conda
+  sha256: 7fa6ddac72e0d803bb08e55090a8f2e71769f1eb7adbd5711bdd7789561601b1
+  md5: e79a094918988bb1807462cd42c83962
   depends:
   - __glibc >=2.17,<3.0.a0
   - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.23,<1.24.0a0
+  - libdeflate >=1.24,<1.25.0a0
   - libgcc >=13
   - libjpeg-turbo >=3.1.0,<4.0a0
   - liblzma >=5.8.1,<6.0a0
@@ -10503,14 +10387,14 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: HPND
-  size: 429381
-  timestamp: 1745372713285
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libtiff-4.7.0-h88f7998_4.conda
-  sha256: a05f1997a3504852ede8717c3c95c00c13af6ea7b27f35a3321732de0d051359
-  md5: 6edd78ac9bee9a972f25cb6e8c6e21ad
+  size: 429575
+  timestamp: 1747067001268
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libtiff-4.7.0-h7c15681_5.conda
+  sha256: 4b2c6f5cd5199d5e345228a0422ecb31a4340ff69579db49faccba14186bb9a2
+  md5: 264a9aac20276b1784dac8c5f8d3704a
   depends:
   - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.23,<1.24.0a0
+  - libdeflate >=1.24,<1.25.0a0
   - libgcc >=13
   - libjpeg-turbo >=3.1.0,<4.0a0
   - liblzma >=5.8.1,<6.0a0
@@ -10519,46 +10403,46 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: HPND
-  size: 464221
-  timestamp: 1745372725621
-- conda: https://prefix.dev/conda-forge/osx-64/libtiff-4.7.0-hb77a491_4.conda
-  sha256: 2bf372fb7da33a25b3c555e2f40ffab5f6b1f2a01a0c14a0a3b2f4eaa372564d
-  md5: b36d793dd65b28e3aeaa3a77abe71678
+  size: 466229
+  timestamp: 1747067015512
+- conda: https://prefix.dev/conda-forge/osx-64/libtiff-4.7.0-h1167cee_5.conda
+  sha256: 517a34be9fc697aaf930218f6727a2eff7c38ee57b3b41fd7d1cc0d72aaac562
+  md5: fc84af14a09e779f1d37ab1d16d5c4e2
   depends:
   - __osx >=10.13
   - lerc >=4.0.0,<5.0a0
   - libcxx >=18
-  - libdeflate >=1.23,<1.24.0a0
+  - libdeflate >=1.24,<1.25.0a0
   - libjpeg-turbo >=3.1.0,<4.0a0
   - liblzma >=5.8.1,<6.0a0
   - libwebp-base >=1.5.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: HPND
-  size: 400931
-  timestamp: 1745372828096
-- conda: https://prefix.dev/conda-forge/osx-arm64/libtiff-4.7.0-h551f018_4.conda
-  sha256: 5d3f7a71b70f0d88470eda8e7b6afe3095d66708a70fb912e79d56fc30b35429
-  md5: 717e02c4cca2a760438384d48b7cd1b9
+  size: 400062
+  timestamp: 1747067122967
+- conda: https://prefix.dev/conda-forge/osx-arm64/libtiff-4.7.0-h2f21f7c_5.conda
+  sha256: cc5ee1cffb8a8afb25a4bfd08fce97c5447f97aa7064a055cb4a617df45bc848
+  md5: 4eb183bbf7f734f69875702fdbe17ea0
   depends:
   - __osx >=11.0
   - lerc >=4.0.0,<5.0a0
   - libcxx >=18
-  - libdeflate >=1.23,<1.24.0a0
+  - libdeflate >=1.24,<1.25.0a0
   - libjpeg-turbo >=3.1.0,<4.0a0
   - liblzma >=5.8.1,<6.0a0
   - libwebp-base >=1.5.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: HPND
-  size: 370898
-  timestamp: 1745372834516
-- conda: https://prefix.dev/conda-forge/win-64/libtiff-4.7.0-h797046b_4.conda
-  sha256: 3456e2a6dfe6c00fd0cda316f0cbb47caddf77f83d3ed4040b6ad17ec1610d2a
-  md5: 7d938ca70c64c5516767b4eae0a56172
+  size: 370943
+  timestamp: 1747067160710
+- conda: https://prefix.dev/conda-forge/win-64/libtiff-4.7.0-h05922d8_5.conda
+  sha256: 1bb0b2e7d076fecc2f8147336bc22e7e6f9a4e0505e0e4ab2be1f56023a4a458
+  md5: 75370aba951b47ec3b5bfe689f1bcf7f
   depends:
   - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.23,<1.24.0a0
+  - libdeflate >=1.24,<1.25.0a0
   - libjpeg-turbo >=3.1.0,<4.0a0
   - liblzma >=5.8.1,<6.0a0
   - libzlib >=1.3.1,<2.0a0
@@ -10567,8 +10451,8 @@ packages:
   - vc14_runtime >=14.29.30139
   - zstd >=1.5.7,<1.6.0a0
   license: HPND
-  size: 980597
-  timestamp: 1745373037447
+  size: 979074
+  timestamp: 1747067408877
 - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
   sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
@@ -10837,38 +10721,38 @@ packages:
   license: LGPL-2.1-or-later
   size: 114269
   timestamp: 1702724369203
-- conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.9.0-h65c71a3_0.conda
-  sha256: e14b284ec7fe85522c81de383dd499bcd41cafb40442b795c3509e7c2c43c587
-  md5: 14fbc598b68d4c6386978f7db09fc5ed
+- conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.10.0-h65c71a3_0.conda
+  sha256: a8043a46157511b3ceb6573a99952b5c0232313283f2d6a066cec7c8dcaed7d0
+  md5: fedf6bfe5d21d21d2b1785ec00a8889a
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
   - libxcb >=1.17.0,<2.0a0
-  - libxml2 >=2.13.7,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - xkeyboard-config
   - xorg-libxau >=1.0.12,<2.0a0
   license: MIT/X11 Derivative
   license_family: MIT
-  size: 673170
-  timestamp: 1745716284939
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libxkbcommon-1.9.0-hbab7b08_0.conda
-  sha256: fcd0cb5b249eb05cb15a3737a4baa7aed950b226e2488caa8534cfd272d3bfe0
-  md5: d8f79e5786c1060e29c209c1c4c67a66
+  size: 707156
+  timestamp: 1747911059945
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libxkbcommon-1.10.0-hbab7b08_0.conda
+  sha256: 620f16864f4f9d7181d89fa4266dba0b18cb9bca72f930500cf9307e549e4247
+  md5: 36cd1db31e923c6068b7e0e6fce2cd7b
   depends:
   - libgcc >=13
   - libstdcxx >=13
   - libxcb >=1.17.0,<2.0a0
-  - libxml2 >=2.13.7,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - xkeyboard-config
   - xorg-libxau >=1.0.12,<2.0a0
   license: MIT/X11 Derivative
   license_family: MIT
-  size: 686069
-  timestamp: 1745716272553
-- conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.13.7-h4bc477f_1.conda
-  sha256: 01c471d9912c482297fd8e83afc193101ff4504c72361b6aec6d07f2fa379263
-  md5: ad1f1f8238834cd3c88ceeaee8da444a
+  size: 719116
+  timestamp: 1747911079432
+- conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.13.8-h4bc477f_0.conda
+  sha256: b0b3a96791fa8bb4ec030295e8c8bf2d3278f33c0f9ad540e73b5e538e6268e7
+  md5: 14dbe05b929e329dbaa6f2d0aa19466d
   depends:
   - __glibc >=2.17,<3.0.a0
   - icu >=75.1,<76.0a0
@@ -10878,11 +10762,11 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: MIT
   license_family: MIT
-  size: 692101
-  timestamp: 1743794568181
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libxml2-2.13.7-he060846_1.conda
-  sha256: 51cda57850353be717f821681cae12f796d56eae806a4c588e26d47f304f9164
-  md5: b461618b5dafbc95c6f9492043cd991a
+  size: 690864
+  timestamp: 1746634244154
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libxml2-2.13.8-he060846_0.conda
+  sha256: b453be503923e213ce5132de0b2e2bc89549d742dcc403acba8dcc4a0ced740c
+  md5: c73dfe6886cc8d39a09c357a36f91fb2
   depends:
   - icu >=75.1,<76.0a0
   - libgcc >=13
@@ -10891,11 +10775,11 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: MIT
   license_family: MIT
-  size: 735238
-  timestamp: 1743794771554
-- conda: https://prefix.dev/conda-forge/osx-64/libxml2-2.13.7-h93c44a6_1.conda
-  sha256: f65c22d825ae7674dd5d1906052a6046cf50eebd1d5f03d6145a6b41c0d305b5
-  md5: ac5c809731d4412fd1ccff49fae27c72
+  size: 733785
+  timestamp: 1746634366734
+- conda: https://prefix.dev/conda-forge/osx-64/libxml2-2.13.8-h93c44a6_0.conda
+  sha256: 4b29663164d7beb9a9066ddcb8578fc67fe0e9b40f7553ea6255cd6619d24205
+  md5: e42a93a31cbc6826620144343d42f472
   depends:
   - __osx >=10.13
   - icu >=75.1,<76.0a0
@@ -10904,11 +10788,11 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: MIT
   license_family: MIT
-  size: 609618
-  timestamp: 1743794752414
-- conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-2.13.7-h52572c6_1.conda
-  sha256: 7afd5879a72e37f44a68b4af3e03f37fc1a310f041bf31fad2461d9a157e823b
-  md5: 522fcdaebf3bac06a7b5a78e0a89195b
+  size: 609197
+  timestamp: 1746634704204
+- conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-2.13.8-h52572c6_0.conda
+  sha256: 13eb825eddce93761d965da3edaf3a42d868c61ece7d9cf21f7e2a13087c2abe
+  md5: d7884c7af8af5a729353374c189aede8
   depends:
   - __osx >=11.0
   - icu >=75.1,<76.0a0
@@ -10917,11 +10801,11 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: MIT
   license_family: MIT
-  size: 583561
-  timestamp: 1743794674233
-- conda: https://prefix.dev/conda-forge/win-64/libxml2-2.13.7-h442d1da_1.conda
-  sha256: 0a013527f784f4702dc18460070d8ec79d1ebb5087dd9e678d6afbeaca68d2ac
-  md5: c14ff7f05e57489df9244917d2b55763
+  size: 583068
+  timestamp: 1746634531197
+- conda: https://prefix.dev/conda-forge/win-64/libxml2-2.13.8-h442d1da_0.conda
+  sha256: 473b8a53c8df714d676ab41711551c8d250f8d799f2db5cb7cb2b177a0ce13f6
+  md5: 833c2dbc1a5020007b520b044c713ed3
   depends:
   - libiconv >=1.18,<2.0a0
   - libzlib >=1.3.1,<2.0a0
@@ -10930,8 +10814,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 1513740
-  timestamp: 1743795035107
+  size: 1513627
+  timestamp: 1746634633560
 - conda: https://prefix.dev/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
   sha256: 684e9b67ef7b9ca0ca993762eeb39705ec58e2e7f958555c758da7ef416db9f3
   md5: e71f31f8cfb0a91439f2086fc8aa0461
@@ -11103,81 +10987,50 @@ packages:
   license_family: Other
   size: 55476
   timestamp: 1727963768015
-- conda: https://prefix.dev/conda-forge/osx-64/llvm-openmp-20.1.3-ha54dae1_0.conda
-  sha256: deaba16df3fd04910255188dfbd2924d07476375a2e75472859b3c6a9fabd60b
-  md5: 16b29a91c8177de8910477ded0f80191
+- conda: https://prefix.dev/conda-forge/osx-64/llvm-openmp-20.1.6-ha54dae1_0.conda
+  sha256: 75aa1b58b86a17aaa3b7882fe994d8f72440aa938d2d3c84e434b4104cfca096
+  md5: c55751d61e1f8be539e0e4beffad3e5a
   depends:
   - __osx >=10.13
   constrains:
-  - openmp 20.1.3|20.1.3.*
+  - openmp 20.1.6|20.1.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 306693
-  timestamp: 1744934078427
-- conda: https://prefix.dev/conda-forge/osx-arm64/llvm-openmp-20.1.3-hdb05f8b_0.conda
-  sha256: daddebd6ebf2960bb3bae945230ed07b254f430642c739c00ebfb4a8c747a033
-  md5: 9f2cc154dd184ff808c2c6afd21cb12c
+  size: 306551
+  timestamp: 1748570208344
+- conda: https://prefix.dev/conda-forge/osx-arm64/llvm-openmp-20.1.6-hdb05f8b_0.conda
+  sha256: 99c8aa89a77870d6ee16d62b858be67e30f2ad4fe13555570c7660cc38f9557b
+  md5: 7a3b28d59940a28e761e0a623241a832
   depends:
   - __osx >=11.0
   constrains:
-  - openmp 20.1.3|20.1.3.*
+  - openmp 20.1.6|20.1.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 282301
-  timestamp: 1744934108744
-- conda: https://prefix.dev/conda-forge/linux-64/loguru-0.7.2-py311h38be061_2.conda
-  sha256: 3c1ea0a9c37fac760c94f167899b4c15ffc967cbeb83f6ed61d49c9974fab46c
-  md5: 733b481d20ff260a34f2b0003ff4fbb3
+  size: 282698
+  timestamp: 1748570308073
+- conda: https://prefix.dev/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
+  sha256: e4a07f357a4cf195a2345dabd98deab80f4d53574abe712a9cc7f22d3f2cc2c3
+  md5: 49647ac1de4d1e4b49124aedf3934e02
   depends:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - __unix
+  - python >=3.9
   license: MIT
   license_family: MIT
-  size: 126239
-  timestamp: 1725349863378
-- conda: https://prefix.dev/conda-forge/linux-aarch64/loguru-0.7.2-py311hfecb2dc_2.conda
-  sha256: d57867b5d16238d8220c0439291cca62e3e7580cd7ec2e4bf2a571fe95abebb2
-  md5: 11e7b2ada75a55bcee6d49c791c9b77d
+  size: 59696
+  timestamp: 1746634858826
+- conda: https://prefix.dev/conda-forge/noarch/loguru-0.7.3-pyh7428d3b_0.conda
+  sha256: 647ce9601c1a63af4710a2d718a74fa521da28262c41bbf86189f6c0906b23f6
+  md5: a6c25c54d8d524735db2e5785aec0a4e
   depends:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  license_family: MIT
-  size: 125181
-  timestamp: 1725351233907
-- conda: https://prefix.dev/conda-forge/osx-64/loguru-0.7.2-py311h6eed73b_2.conda
-  sha256: dcd47a089a6d096ee221126efce9f4b67663e522c05e84e37d3e8e7312e31bdd
-  md5: 7f1619b30b39af5c0a7386577ff77d1f
-  depends:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  license_family: MIT
-  size: 126346
-  timestamp: 1725349845053
-- conda: https://prefix.dev/conda-forge/osx-arm64/loguru-0.7.2-py311h267d04e_2.conda
-  sha256: dd218c3908ae4eb16c5acb977570baf0c56f74af02daca6a151c33ea182b18df
-  md5: 85ca4ac94b7c12fc61fa4b7cbb5f5b14
-  depends:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  license_family: MIT
-  size: 126364
-  timestamp: 1725350146667
-- conda: https://prefix.dev/conda-forge/win-64/loguru-0.7.2-py311h1ea47a8_2.conda
-  sha256: a4f72b9dac72db4025a31ffd939766e16471a13992cbe48ad6941e827d0c5736
-  md5: e27a1628e277942c45b87c6ab4bcdcf4
-  depends:
+  - __win
   - colorama >=0.3.4
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.9
   - win32_setctime >=1.0.0
   license: MIT
   license_family: MIT
-  size: 126182
-  timestamp: 1725349956128
+  size: 60119
+  timestamp: 1746634872414
 - conda: https://prefix.dev/conda-forge/linux-64/lxml-5.4.0-py311hbd2c71b_0.conda
   sha256: 87fb5cc03e97a21b353fea5400a9f2eeea239a68c83f1e674fcd365bbbb699b0
   md5: 8f918de217abd92a1197cd0ef3b5ce16
@@ -11377,16 +11230,18 @@ packages:
   license_family: BSD
   size: 28238
   timestamp: 1733220208800
-- conda: https://prefix.dev/conda-forge/linux-64/matplotlib-base-3.10.1-py311h2b939e6_0.conda
-  sha256: e64e7b9e7fe80051b0a99f79a93fefb2266fd107182853567e7fdec6abf05d74
-  md5: eed17bae389043337f33b95a0fd8c172
+- conda: https://prefix.dev/conda-forge/linux-64/matplotlib-base-3.10.3-py311h2b939e6_0.conda
+  sha256: 39e54c0b54c374c9b27e4ba5dcf78220ce346007c39be9c83441f1eb4a4e33f1
+  md5: 0d1b7dfe2bbf983cb7907f6cbd6613e6
   depends:
   - __glibc >=2.17,<3.0.a0
   - contourpy >=1.0.1
   - cycler >=0.10
   - fonttools >=4.22.0
-  - freetype >=2.12.1,<3.0a0
+  - freetype
   - kiwisolver >=1.3.1
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
   - libgcc >=13
   - libstdcxx >=13
   - numpy >=1.19,<3
@@ -11401,17 +11256,19 @@ packages:
   - tk >=8.6.13,<8.7.0a0
   license: PSF-2.0
   license_family: PSF
-  size: 8433966
-  timestamp: 1740781071748
-- conda: https://prefix.dev/conda-forge/linux-aarch64/matplotlib-base-3.10.1-py311h0385ec1_0.conda
-  sha256: 3baf692048805419828d4818d0ee6d80e9698cf6d461977930641fdfaf348dd5
-  md5: 517cd4d43e69d6a740cd74b0eb8f2cea
+  size: 8302117
+  timestamp: 1746820694094
+- conda: https://prefix.dev/conda-forge/linux-aarch64/matplotlib-base-3.10.3-py311h0385ec1_0.conda
+  sha256: b1a2cf03aeac3b5d0fd6adc6425ae89382e9b3191e56bb74269c713725a245bb
+  md5: 12e13b027ccad56f7af4ece1e557a6e9
   depends:
   - contourpy >=1.0.1
   - cycler >=0.10
   - fonttools >=4.22.0
-  - freetype >=2.12.1,<3.0a0
+  - freetype
   - kiwisolver >=1.3.1
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
   - libgcc >=13
   - libstdcxx >=13
   - numpy >=1.19,<3
@@ -11427,19 +11284,21 @@ packages:
   - tk >=8.6.13,<8.7.0a0
   license: PSF-2.0
   license_family: PSF
-  size: 8291924
-  timestamp: 1740781166798
-- conda: https://prefix.dev/conda-forge/osx-64/matplotlib-base-3.10.1-py311h19a4563_0.conda
-  sha256: 1dce571830349dd53f6bcd1957104f55be4006065c4858fe1fdbb50f8a16c246
-  md5: ac02f0859f38337a267a50fd2489bbe2
+  size: 8354290
+  timestamp: 1746820865481
+- conda: https://prefix.dev/conda-forge/osx-64/matplotlib-base-3.10.3-py311h19a4563_0.conda
+  sha256: c24699a7f44dde0a7efadd81891d67d2b2ff923f0c487c76b4eb698e09809288
+  md5: bd5e832b3bde5e5045fa5b195da43a1b
   depends:
   - __osx >=10.13
   - contourpy >=1.0.1
   - cycler >=0.10
   - fonttools >=4.22.0
-  - freetype >=2.12.1,<3.0a0
+  - freetype
   - kiwisolver >=1.3.1
   - libcxx >=18
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
   - numpy >=1.19,<3
   - numpy >=1.23
   - packaging >=20.0
@@ -11451,19 +11310,21 @@ packages:
   - qhull >=2020.2,<2020.3.0a0
   license: PSF-2.0
   license_family: PSF
-  size: 8316783
-  timestamp: 1740781377284
-- conda: https://prefix.dev/conda-forge/osx-arm64/matplotlib-base-3.10.1-py311h031da69_0.conda
-  sha256: 54288dbcab3717e18a343ec5bd08406ffcf15c498c8e33d9e1800aa2a459970e
-  md5: fcdba4a9595e3807fdd7df6d9095aeed
+  size: 8274783
+  timestamp: 1746820771309
+- conda: https://prefix.dev/conda-forge/osx-arm64/matplotlib-base-3.10.3-py311h031da69_0.conda
+  sha256: b7e1d35fbd54f65fd75334b2d4c5361249948124db6cb8f604c1f9fbe85ecc22
+  md5: 6e40d3975da9017a6850ea8fbad9e3c9
   depends:
   - __osx >=11.0
   - contourpy >=1.0.1
   - cycler >=0.10
   - fonttools >=4.22.0
-  - freetype >=2.12.1,<3.0a0
+  - freetype
   - kiwisolver >=1.3.1
   - libcxx >=18
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
   - numpy >=1.19,<3
   - numpy >=1.23
   - packaging >=20.0
@@ -11476,17 +11337,19 @@ packages:
   - qhull >=2020.2,<2020.3.0a0
   license: PSF-2.0
   license_family: PSF
-  size: 8172936
-  timestamp: 1740781470917
-- conda: https://prefix.dev/conda-forge/win-64/matplotlib-base-3.10.1-py311h8f1b1e4_0.conda
-  sha256: e1aa6dfd3398ced671982d201c7bb324c971c956310d6076a5c5af18766b3891
-  md5: aa2ed7c80539b874cfa847e6e831a60c
+  size: 8048426
+  timestamp: 1746820924090
+- conda: https://prefix.dev/conda-forge/win-64/matplotlib-base-3.10.3-py311h8f1b1e4_0.conda
+  sha256: 582d80c942961d8949912621084f222b138d688a066bb6200783b5b69a432e94
+  md5: 15a163d8d830085a19b97ce92f9a9fa3
   depends:
   - contourpy >=1.0.1
   - cycler >=0.10
   - fonttools >=4.22.0
-  - freetype >=2.12.1,<3.0a0
+  - freetype
   - kiwisolver >=1.3.1
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
   - numpy >=1.19,<3
   - numpy >=1.23
   - packaging >=20.0
@@ -11501,8 +11364,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: PSF-2.0
   license_family: PSF
-  size: 8024811
-  timestamp: 1740782228655
+  size: 8120800
+  timestamp: 1746821100074
 - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.3.1-h24ddda3_1.conda
   sha256: 1bf794ddf2c8b3a3e14ae182577c624fa92dea975537accff4bc7e5fea085212
   md5: aa14b9a5196a6d8dd364164b7ce56acf
@@ -11674,9 +11537,9 @@ packages:
   license_family: Apache
   size: 89472
   timestamp: 1725975909671
-- conda: https://prefix.dev/conda-forge/linux-64/multidict-6.4.3-py311h2dc5d0c_0.conda
-  sha256: 841e1368f34a8b968e9e33e26c4287be0f55f1681954fc937067c269d40dd531
-  md5: 75ce8e460c19ba5040f39d11284b70a6
+- conda: https://prefix.dev/conda-forge/linux-64/multidict-6.4.4-py311h2dc5d0c_0.conda
+  sha256: ea7af4ad113255613cd5b058dc36dab44484240b0105751f5c7dcd3bd7fb3a08
+  md5: cf1ae2989d73b0e6d86f2ee7c08d7a9b
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -11684,11 +11547,11 @@ packages:
   - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: APACHE
-  size: 86901
-  timestamp: 1744972594981
-- conda: https://prefix.dev/conda-forge/linux-aarch64/multidict-6.4.3-py311h58d527c_0.conda
-  sha256: f32a52346258497fdbc95bf8fd4db25512e3ae4f7890fe8a8625c1c7141cfd19
-  md5: 9b44ca35c2030cbf6b8a7c0446e7ad7d
+  size: 87715
+  timestamp: 1747722625336
+- conda: https://prefix.dev/conda-forge/linux-aarch64/multidict-6.4.4-py311h58d527c_0.conda
+  sha256: 8cb657b1aff17689c568c152bf58901a5bc306058078d5cb7d67ad45e52cf280
+  md5: 9712a67063153e137db9e64c9186f9eb
   depends:
   - libgcc >=13
   - python >=3.11,<3.12.0a0
@@ -11696,22 +11559,22 @@ packages:
   - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: APACHE
-  size: 89020
-  timestamp: 1744972728569
-- conda: https://prefix.dev/conda-forge/osx-64/multidict-6.4.3-py311h1cc1194_0.conda
-  sha256: c3e4df22eb7604d4d79239160c5e3ff250dd100bd2b2f8e650f8e947333adbfb
-  md5: 4b3b9d9b0ef0d47b1e91d3d3b73f896d
+  size: 89952
+  timestamp: 1747722640518
+- conda: https://prefix.dev/conda-forge/osx-64/multidict-6.4.4-py311h1cc1194_0.conda
+  sha256: 1f4d276a820d7058854b65a260a43ac073db9803ef9908ee68532009b4f7c23a
+  md5: e4e420d4cedb7539e218b000894b399b
   depends:
   - __osx >=10.13
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: APACHE
-  size: 75072
-  timestamp: 1744972613895
-- conda: https://prefix.dev/conda-forge/osx-arm64/multidict-6.4.3-py311h30e7462_0.conda
-  sha256: e086eb01c8e695c8d962e043536b9a99a427d4b7c3d1c6a261c750f824dd8de3
-  md5: 6e2ed27dbe81d39bdb131ef0c8f10754
+  size: 76171
+  timestamp: 1747722564754
+- conda: https://prefix.dev/conda-forge/osx-arm64/multidict-6.4.4-py311h30e7462_0.conda
+  sha256: c269699d35d8de676ea898ab19bc25d767e5425674a752e698d48175e409cb55
+  md5: 5f0793f1d48be073204d0787644f8047
   depends:
   - __osx >=11.0
   - python >=3.11,<3.12.0a0
@@ -11719,11 +11582,11 @@ packages:
   - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: APACHE
-  size: 74486
-  timestamp: 1744972692393
-- conda: https://prefix.dev/conda-forge/win-64/multidict-6.4.3-py311h5082efb_0.conda
-  sha256: cbb1a322a003ea43777561d202fb6fa4ec55b1340d7ae3f50ce879445e868fd6
-  md5: 015064f83961f02dcb2f19e4adc23d0c
+  size: 75637
+  timestamp: 1747722590511
+- conda: https://prefix.dev/conda-forge/win-64/multidict-6.4.4-py311h5082efb_0.conda
+  sha256: 3b90f79bd1db9df617a488269b1ed8660ce8200ba348b766bb2c539933fe87e2
+  md5: fa8f9e7e2b4fa11e9d22c598cddeb1cf
   depends:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
@@ -11732,8 +11595,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 76111
-  timestamp: 1744973322827
+  size: 77361
+  timestamp: 1747722680662
 - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
   sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
   md5: 2ba8498c1018c1e9c61eb99b973dfe19
@@ -11932,9 +11795,9 @@ packages:
   license_family: BSD
   size: 6347
   timestamp: 1732243385797
-- conda: https://prefix.dev/conda-forge/linux-64/numpy-2.2.5-py311h5d046bc_0.conda
-  sha256: 66988aa1a624f7fab4f8c5ccb1b848ee52d9d36dd8eb8b3d0149657316ee53f9
-  md5: df82417acd53257028de5425047ebc22
+- conda: https://prefix.dev/conda-forge/linux-64/numpy-2.2.6-py311h5d046bc_0.conda
+  sha256: f28273a72d25f4d7d62a9ba031d5271082afc498121bd0f6783d72b4103dbbc7
+  md5: babce4d9841ebfcee64249d98eb4e0d4
   depends:
   - __glibc >=2.17,<3.0.a0
   - libblas >=3.9.0,<4.0a0
@@ -11948,11 +11811,11 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 9054544
-  timestamp: 1745119332553
-- conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.2.5-py311h6c2b7b4_0.conda
-  sha256: 9caa59fc5a76df70d06697144035b3e6e4fa183c22ed7b7541925a6eb50179c4
-  md5: 05ac3dbf27ad31730c0713c1b03130ce
+  size: 9068997
+  timestamp: 1747545091884
+- conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.2.6-py311h6c2b7b4_0.conda
+  sha256: 72c45b0303078f96f90130e81ecf65fc763f759f87b72744d6382c5f0c549c56
+  md5: 4a70fd8be7dbeb9a9c6f163d111cbb48
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
@@ -11966,11 +11829,11 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 7755534
-  timestamp: 1745119339554
-- conda: https://prefix.dev/conda-forge/osx-64/numpy-2.2.5-py311h27c81cd_0.conda
-  sha256: 3700f5b01d236dd86b770c7ff54d3c587f5d117ca60f7d17b8b82067fcc6b4f6
-  md5: 5164212554b8d50a535db11621a08d54
+  size: 7784386
+  timestamp: 1747545056518
+- conda: https://prefix.dev/conda-forge/osx-64/numpy-2.2.6-py311h27c81cd_0.conda
+  sha256: bcb2c6fd701f3591fd4cd04580ec62ad88622c09671139a98d82ca80e2ae365f
+  md5: 8e850d1284fd8a90aeb4b5195a0116f3
   depends:
   - __osx >=10.13
   - libblas >=3.9.0,<4.0a0
@@ -11983,11 +11846,11 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 8207720
-  timestamp: 1745119282736
-- conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.2.5-py311h762c074_0.conda
-  sha256: 9e5c2e6b603bd4e165760bc354e33bd7b3551096bf0e93499637fc7229081cd3
-  md5: fae31abeb9224e4a29b5e09bd3a9246d
+  size: 8182747
+  timestamp: 1747545065417
+- conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.2.6-py311h762c074_0.conda
+  sha256: c6cd42960418a2bd60cfbc293f08d85076f7d8aacf7a94f516195381241d4d93
+  md5: 9446d2629b529e92769dfb34c7c194bb
   depends:
   - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
@@ -12001,11 +11864,11 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 7152823
-  timestamp: 1745119359025
-- conda: https://prefix.dev/conda-forge/win-64/numpy-2.2.5-py311h5e411d1_0.conda
-  sha256: 4e2efa4ebd9de0b17d6ed4286af26bfebdf093d78b5c71c67b00614a5d7cd239
-  md5: 5344f61c044719da0e95abb7d0a23c7b
+  size: 7018728
+  timestamp: 1747545122995
+- conda: https://prefix.dev/conda-forge/win-64/numpy-2.2.6-py311h5e411d1_0.conda
+  sha256: f4ea606273089836e4b2b2355209142c1514d8bf103346ed435e85008df0804d
+  md5: 6612dfa4e68dd90c539f2e9f40a42514
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
@@ -12019,8 +11882,8 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 7723082
-  timestamp: 1745119890450
+  size: 7800740
+  timestamp: 1747545419079
 - conda: https://prefix.dev/conda-forge/linux-64/occt-7.8.1-all_h4c4714a_203.conda
   sha256: 581ac3387afaf349f44d4b03469d7849093ad868509ef109e6e149d48211f990
   md5: 43aed13aae8e2d25f232e98cb636e139
@@ -12319,62 +12182,62 @@ packages:
   license_family: Apache
   size: 26792
   timestamp: 1734366273945
-- conda: https://prefix.dev/conda-forge/linux-64/openexr-3.3.3-hff63da0_0.conda
-  sha256: 3178113a42c2442c3d4e6aa6af4fa89a73ad1c472e2a6eda5dfd23c0e0d160ee
-  md5: d03a2c3b23ee7675a6e66e050033b110
+- conda: https://prefix.dev/conda-forge/linux-64/openexr-3.3.3-h2cd1444_1.conda
+  sha256: 0e3cfffd3292ad880bd3c4f3119b78b3462ccf31f990aa1f92f6a3dd8117c117
+  md5: 9448844749a0ddbdecf61dc1ac4a7dd9
   depends:
-  - libstdcxx >=13
-  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libzlib >=1.3.1,<2.0a0
-  - libdeflate >=1.23,<1.24.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - imath >=3.1.12,<3.1.13.0a0
+  - libdeflate >=1.24,<1.25.0a0
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1319461
-  timestamp: 1742803755009
-- conda: https://prefix.dev/conda-forge/linux-aarch64/openexr-3.3.3-h2d73ac1_0.conda
-  sha256: 87ac0157cbac2d0a504d130d0816b291c5f79e80bf53257c22b275694849b354
-  md5: 1c46390713ec05fa8c658ab41daf1f6b
+  size: 1319524
+  timestamp: 1747073128491
+- conda: https://prefix.dev/conda-forge/linux-aarch64/openexr-3.3.3-h718fb27_1.conda
+  sha256: 52f7ffd4eb99fb5a89356795b272ebe879670dde41925cbdb6dc20404410ce6c
+  md5: f20bbeb358bfcc412bc7bea3f58df614
   depends:
   - libstdcxx >=13
   - libgcc >=13
-  - libdeflate >=1.23,<1.24.0a0
-  - libzlib >=1.3.1,<2.0a0
   - imath >=3.1.12,<3.1.13.0a0
+  - libdeflate >=1.24,<1.25.0a0
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1275768
-  timestamp: 1742803770993
-- conda: https://prefix.dev/conda-forge/osx-64/openexr-3.3.3-h6794a33_0.conda
-  sha256: 42252ae54a0e6092d525596b115377a05ee5565686d4e965a11b9a4605236546
-  md5: e6753e95d3ac824f14b1f893e69a4e7e
+  size: 1275893
+  timestamp: 1747073135627
+- conda: https://prefix.dev/conda-forge/osx-64/openexr-3.3.3-h13904a9_1.conda
+  sha256: 540414e7fdbb1ee90e7d44e9250c87c3c92c1c659b2aba96790b4ea4bdf16115
+  md5: a61826af514546e1c27ca018369d8595
   depends:
   - libcxx >=18
   - __osx >=10.13
-  - libdeflate >=1.23,<1.24.0a0
-  - libzlib >=1.3.1,<2.0a0
   - imath >=3.1.12,<3.1.13.0a0
+  - libdeflate >=1.24,<1.25.0a0
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1128784
-  timestamp: 1742803785075
-- conda: https://prefix.dev/conda-forge/osx-arm64/openexr-3.3.3-h10b4c9a_0.conda
-  sha256: 88f3468b3fd6f154f97fdb1259b63e4a479b39b42cbae9fea7d125aa2ec5787f
-  md5: 9a9fc4b01632f63c3389f26185803769
+  size: 1128981
+  timestamp: 1747073230804
+- conda: https://prefix.dev/conda-forge/osx-arm64/openexr-3.3.3-h2542605_1.conda
+  sha256: 4626122558b282c7a3141b804a510db886023b0695d74b769159e37c3bb895f7
+  md5: 8464bab8454afa1152b176732dbb8371
   depends:
-  - libcxx >=18
   - __osx >=11.0
-  - libdeflate >=1.23,<1.24.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libcxx >=18
+  - libdeflate >=1.24,<1.25.0a0
   - imath >=3.1.12,<3.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1099706
-  timestamp: 1742803793657
-- conda: https://prefix.dev/conda-forge/win-64/openexr-3.3.3-h1acc403_0.conda
-  sha256: 89e04298afacdc43b3a6de03067486f529eeebbfc249c99417ec2de6d20ba4a0
-  md5: 1fd0778c8850a74fedfb401ba013cce9
+  size: 1099832
+  timestamp: 1747073193860
+- conda: https://prefix.dev/conda-forge/win-64/openexr-3.3.3-h9fcfcc6_1.conda
+  sha256: 7f6ae0b5c10b2c30b78fe64b3338b9bd37b9126b2d665eead46e2e87452a8338
+  md5: a27df1241cdc6988ff9e18bea3dc7fbc
   depends:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -12382,13 +12245,13 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - ucrt >=10.0.20348.0
-  - imath >=3.1.12,<3.1.13.0a0
   - libzlib >=1.3.1,<2.0a0
-  - libdeflate >=1.23,<1.24.0a0
+  - imath >=3.1.12,<3.1.13.0a0
+  - libdeflate >=1.24,<1.25.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1045157
-  timestamp: 1742803785709
+  size: 1045250
+  timestamp: 1747073148781
 - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.5.0-hf92e6e3_0.conda
   sha256: dedda20c58aec3d8f9c12e3660225608b93a257a21e0da703fdd814789291519
   md5: d1b18a73fc3cfd0de9c7e786d2febb8f
@@ -12508,103 +12371,103 @@ packages:
   license_family: BSD
   size: 240148
   timestamp: 1733817010335
-- conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.9-he970967_0.conda
-  sha256: 224f458848f792fe9e3587ee6b626d4eaad63aead0e5e6c25cbe29aba7b05c53
-  md5: ca2de8bbdc871bce41dbf59e51324165
+- conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
+  sha256: cb0b07db15e303e6f0a19646807715d28f1264c6350309a559702f4f34f37892
+  md5: 2e5bf4f1da39c0b32778561c3c4e5878
   depends:
   - __glibc >=2.17,<3.0.a0
   - cyrus-sasl >=2.1.27,<3.0a0
   - krb5 >=1.21.3,<1.22.0a0
   - libgcc >=13
   - libstdcxx >=13
-  - openssl >=3.4.0,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   license: OLDAP-2.8
   license_family: BSD
-  size: 784483
-  timestamp: 1732674189726
-- conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.9-h30c48ee_0.conda
-  sha256: ee09612f256dd3532b1309c8ff70489d21db3bde2a0849da08393e5ffd84400d
-  md5: c07822a5de65ce9797b9afa257faa917
+  size: 780253
+  timestamp: 1748010165522
+- conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
+  sha256: 13c7ba058b6e151468111235218158083b9e867738e66a5afb96096c5c123348
+  md5: 48f31a61be512ec1929f4b4a9cedf4bd
   depends:
   - cyrus-sasl >=2.1.27,<3.0a0
   - krb5 >=1.21.3,<1.22.0a0
   - libgcc >=13
   - libstdcxx >=13
-  - openssl >=3.4.0,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   license: OLDAP-2.8
   license_family: BSD
-  size: 904889
-  timestamp: 1732674273894
-- conda: https://prefix.dev/conda-forge/osx-64/openldap-2.6.9-hd8a590d_0.conda
-  sha256: b0c541939d905a1a23c41f0f22ad34401da50470e779a6e618c37fdba6c057aa
-  md5: 10dff9d8c67ae8b807b9fe8cfe9ca1d0
+  size: 902902
+  timestamp: 1748010210718
+- conda: https://prefix.dev/conda-forge/osx-64/openldap-2.6.10-hd8a590d_0.conda
+  sha256: 70b8c1ffc06629c3ef824d337ab75df28c50a05293a4c544b03ff41d82c37c73
+  md5: 60bd9b6c1e5208ff2f4a39ab3eabdee8
   depends:
   - __osx >=10.13
   - cyrus-sasl >=2.1.27,<3.0a0
   - krb5 >=1.21.3,<1.22.0a0
   - libcxx >=18
-  - openssl >=3.4.0,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   license: OLDAP-2.8
   license_family: BSD
-  size: 777835
-  timestamp: 1732674429367
-- conda: https://prefix.dev/conda-forge/osx-arm64/openldap-2.6.9-hbe55e7a_0.conda
-  sha256: 5ae85f00a9dcf438e375d4fb5c45c510c7116e32c4b7af608ffd88e9e9dc6969
-  md5: 8291e59e1dd136bceecdefbc7207ecd6
+  size: 777643
+  timestamp: 1748010635431
+- conda: https://prefix.dev/conda-forge/osx-arm64/openldap-2.6.10-hbe55e7a_0.conda
+  sha256: 08d859836b81296c16f74336c3a9a455b23d57ce1d7c2b0b3e1b7a07f984c677
+  md5: 6fd5d73c63b5d37d9196efb4f044af76
   depends:
   - __osx >=11.0
   - cyrus-sasl >=2.1.27,<3.0a0
   - krb5 >=1.21.3,<1.22.0a0
   - libcxx >=18
-  - openssl >=3.4.0,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   license: OLDAP-2.8
   license_family: BSD
-  size: 842504
-  timestamp: 1732674565486
-- conda: https://prefix.dev/conda-forge/linux-64/openssl-3.5.0-h7b32b05_0.conda
-  sha256: 38285d280f84f1755b7c54baf17eccf2e3e696287954ce0adca16546b85ee62c
-  md5: bb539841f2a3fde210f387d00ed4bb9d
+  size: 843597
+  timestamp: 1748010484231
+- conda: https://prefix.dev/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
+  sha256: b4491077c494dbf0b5eaa6d87738c22f2154e9277e5293175ec187634bd808a0
+  md5: de356753cfdbffcde5bb1e86e3aa6cd0
   depends:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=13
   license: Apache-2.0
   license_family: Apache
-  size: 3121673
-  timestamp: 1744132167438
-- conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.5.0-hd08dc88_0.conda
-  sha256: 07854dcfcddc13b5614202c47c825f57e93e826ffee194ee435b3cf75cfe5853
-  md5: 26af4dcecaf373c31ae91f403ae98259
+  size: 3117410
+  timestamp: 1746223723843
+- conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.5.0-hd08dc88_1.conda
+  sha256: 58120daf06a52ba203f94eccb43900213a9f2b3cc310bbaa868505ccd7afbdaa
+  md5: ee68fdc3a8723e9c58bdd2f10544658f
   depends:
   - ca-certificates
   - libgcc >=13
   license: Apache-2.0
   license_family: Apache
-  size: 3641486
-  timestamp: 1744134183977
-- conda: https://prefix.dev/conda-forge/osx-64/openssl-3.5.0-hc426f3f_0.conda
-  sha256: 7ee137b67f2de89d203e5ac2ebffd6d42252700005bf6af2bbf3dc11a9dfedbd
-  md5: e06e13c34056b6334a7a1188b0f4c83c
+  size: 3642633
+  timestamp: 1746225726804
+- conda: https://prefix.dev/conda-forge/osx-64/openssl-3.5.0-hc426f3f_1.conda
+  sha256: bcac94cb82a458b4e3164da8d9bced08cc8c3da2bc3bd7330711a3689c1464a5
+  md5: 919faa07b9647beb99a0e7404596a465
   depends:
   - __osx >=10.13
   - ca-certificates
   license: Apache-2.0
   license_family: Apache
-  size: 2737547
-  timestamp: 1744140967264
-- conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_0.conda
-  sha256: 53f825acb8d3e13bdad5c869f6dc7df931941450eea7f6473b955b0aaea1a399
-  md5: 3d2936da7e240d24c656138e07fa2502
+  size: 2739181
+  timestamp: 1746224401118
+- conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_1.conda
+  sha256: 73d366c1597a10bcd5f3604b5f0734b31c23225536e03782c6a13f9be9d01bff
+  md5: 5c7aef00ef60738a14e0e612cfc5bcde
   depends:
   - __osx >=11.0
   - ca-certificates
   license: Apache-2.0
   license_family: Apache
-  size: 3067649
-  timestamp: 1744132084304
-- conda: https://prefix.dev/conda-forge/win-64/openssl-3.5.0-ha4e3fda_0.conda
-  sha256: 43dd7f56da142ca83c614c8b0085589650ae9032b351a901c190e48eefc73675
-  md5: 4ea7db75035eb8c13fa680bb90171e08
+  size: 3064197
+  timestamp: 1746223530698
+- conda: https://prefix.dev/conda-forge/win-64/openssl-3.5.0-ha4e3fda_1.conda
+  sha256: 02846553d2a4c9bde850c60824d0f02803eb9c9b674d5c1a8cce25bc387e748f
+  md5: 72c07e46b6766bb057018a9a74861b89
   depends:
   - ca-certificates
   - ucrt >=10.0.20348.0
@@ -12612,8 +12475,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: Apache
-  size: 8999138
-  timestamp: 1744135594688
+  size: 9025176
+  timestamp: 1746227349882
 - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
   sha256: 289861ed0c13a15d7bbb408796af4de72c2fe67e2bcb0de98f4c3fce259d7991
   md5: 58335b26c38bf4a20f399384c33cbcf9
@@ -13111,15 +12974,16 @@ packages:
   license_family: BSD
   size: 816653
   timestamp: 1745931851696
-- conda: https://prefix.dev/conda-forge/linux-64/pillow-11.1.0-py311h1322bbf_0.conda
-  sha256: 71e0ce18201695adec3bbbfbab74e82b0ab05fe8929ad046d2c507a71c8a3c63
-  md5: 9f4f5593335f76c1dbf7381c11fe7155
+- conda: https://prefix.dev/conda-forge/linux-64/pillow-11.2.1-py311h1322bbf_0.conda
+  sha256: 35ad7e1a9fe8152d0bad51046490c3903d7c56e06a1ba2a0af5be4fd3bdc18c7
+  md5: 4c49bdabd1d4e09386dabc676fb6bd65
   depends:
   - __glibc >=2.17,<3.0.a0
-  - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.16,<3.0a0
+  - lcms2 >=2.17,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
   - libgcc >=13
-  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
   - libtiff >=4.7.0,<4.8.0a0
   - libwebp-base >=1.5.0,<2.0a0
   - libxcb >=1.17.0,<2.0a0
@@ -13129,16 +12993,17 @@ packages:
   - python_abi 3.11.* *_cp311
   - tk >=8.6.13,<8.7.0a0
   license: HPND
-  size: 42021920
-  timestamp: 1735929841160
-- conda: https://prefix.dev/conda-forge/linux-aarch64/pillow-11.1.0-py311ha4eaa5e_0.conda
-  sha256: d31c5eed4a5b0a5f7aee0da620c255d217ac154b59022dca1970395e744f3ba9
-  md5: 588cc6d9e6adc21508221b3655cb5949
+  size: 43489672
+  timestamp: 1746646364323
+- conda: https://prefix.dev/conda-forge/linux-aarch64/pillow-11.2.1-py311ha4eaa5e_0.conda
+  sha256: b01558b6c06db0754da0ed1dfa9d069cd99fa3849aa10c0ba179abccc2eb7102
+  md5: 580e0d3c80c27c4f3997ad094dc9f127
   depends:
-  - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.16,<3.0a0
+  - lcms2 >=2.17,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
   - libgcc >=13
-  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
   - libtiff >=4.7.0,<4.8.0a0
   - libwebp-base >=1.5.0,<2.0a0
   - libxcb >=1.17.0,<2.0a0
@@ -13148,16 +13013,17 @@ packages:
   - python_abi 3.11.* *_cp311
   - tk >=8.6.13,<8.7.0a0
   license: HPND
-  size: 42077620
-  timestamp: 1735931287216
-- conda: https://prefix.dev/conda-forge/osx-64/pillow-11.1.0-py311h25da234_0.conda
-  sha256: a04db4036102af89cc1c64963a90fae596d650338909380b92984703a3ec5e31
-  md5: bd7476bdaad356e51ad68ed077cda405
+  size: 42601207
+  timestamp: 1746648100320
+- conda: https://prefix.dev/conda-forge/osx-64/pillow-11.2.1-py311h25da234_0.conda
+  sha256: 458f64344dedcc191ead84f38c8a999ef6979fcc6318bbc9c324258259774011
+  md5: 29787dad70a341b2f02af34d7a1162f3
   depends:
   - __osx >=10.13
-  - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.16,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
+  - lcms2 >=2.17,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libjpeg-turbo >=3.1.0,<4.0a0
   - libtiff >=4.7.0,<4.8.0a0
   - libwebp-base >=1.5.0,<2.0a0
   - libxcb >=1.17.0,<2.0a0
@@ -13167,16 +13033,17 @@ packages:
   - python_abi 3.11.* *_cp311
   - tk >=8.6.13,<8.7.0a0
   license: HPND
-  size: 42402940
-  timestamp: 1735929955131
-- conda: https://prefix.dev/conda-forge/osx-arm64/pillow-11.1.0-py311hb9ba9e9_0.conda
-  sha256: 9d9274b1456e463401169a8b7bfc35378c09686cfac56d2b96a1393085f3fd8f
-  md5: d8bb4736b33791e270c998dd68a76621
+  size: 42137799
+  timestamp: 1746646519853
+- conda: https://prefix.dev/conda-forge/osx-arm64/pillow-11.2.1-py311hb9ba9e9_0.conda
+  sha256: f2652d15d6a3c6f5e40d0e87fbc459e67778abe2319e7715196d45215805b0cb
+  md5: 5cdc7320584eedc6080df391668eaf41
   depends:
   - __osx >=11.0
-  - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.16,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
+  - lcms2 >=2.17,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libjpeg-turbo >=3.1.0,<4.0a0
   - libtiff >=4.7.0,<4.8.0a0
   - libwebp-base >=1.5.0,<2.0a0
   - libxcb >=1.17.0,<2.0a0
@@ -13187,15 +13054,16 @@ packages:
   - python_abi 3.11.* *_cp311
   - tk >=8.6.13,<8.7.0a0
   license: HPND
-  size: 42451890
-  timestamp: 1735929996422
-- conda: https://prefix.dev/conda-forge/win-64/pillow-11.1.0-py311h43e43bb_0.conda
-  sha256: 0eea0c0ce4bf15d9b6dfba7e0e8a8f292a25765ba578dd84dbea0f8bf0fb450b
-  md5: bb2c647a5a1452c4271557d00c0d344b
+  size: 42632596
+  timestamp: 1746646647318
+- conda: https://prefix.dev/conda-forge/win-64/pillow-11.2.1-py311h43e43bb_0.conda
+  sha256: 16cf0466ce3666ecb867bf5cd33fb5bb50ba766151dd698d6bfff6f6e5a334cf
+  md5: cfb76166a1a96819fadef74097ef9d87
   depends:
-  - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.16,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
+  - lcms2 >=2.17,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libjpeg-turbo >=3.1.0,<4.0a0
   - libtiff >=4.7.0,<4.8.0a0
   - libwebp-base >=1.5.0,<2.0a0
   - libxcb >=1.17.0,<2.0a0
@@ -13208,19 +13076,19 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: HPND
-  size: 42176152
-  timestamp: 1735930533925
-- conda: https://prefix.dev/conda-forge/noarch/pip-25.1-pyh8b19718_0.conda
-  sha256: 81a7ffe7b7ca8718bc09476a258cd48754e1d4e1bd3b80a6fef41ffb71e3bfc8
-  md5: 2247aa245832ea47e8b971bef73d7094
+  size: 42624917
+  timestamp: 1746646855016
+- conda: https://prefix.dev/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+  sha256: ebfa591d39092b111b9ebb3210eb42251be6da89e26c823ee03e5e838655a43e
+  md5: 32d0781ace05105cc99af55d36cbec7c
   depends:
   - python >=3.9,<3.13.0a0
   - setuptools
   - wheel
   license: MIT
   license_family: MIT
-  size: 1247085
-  timestamp: 1745671930895
+  size: 1242995
+  timestamp: 1746249983238
 - conda: https://prefix.dev/conda-forge/linux-64/pivy-0.6.10-py311qt6h4fb66a9_0.conda
   sha256: 577da5879c08517982e5f78231a161206f6e122eba257c2e68e930caad45c333
   md5: 0005ba5bcdfc553fe0545bfb504aec9c
@@ -13304,6 +13172,7 @@ packages:
   - libgcc >=13
   - libstdcxx >=13
   license: MIT
+  license_family: MIT
   size: 398664
   timestamp: 1746011575217
 - conda: https://prefix.dev/conda-forge/linux-aarch64/pixman-0.46.0-h86a87f0_0.conda
@@ -13313,6 +13182,7 @@ packages:
   - libgcc >=13
   - libstdcxx >=13
   license: MIT
+  license_family: MIT
   size: 304461
   timestamp: 1746012923693
 - conda: https://prefix.dev/conda-forge/osx-64/pixman-0.46.0-h1fd1274_0.conda
@@ -13322,6 +13192,7 @@ packages:
   - __osx >=10.13
   - libcxx >=18
   license: MIT
+  license_family: MIT
   size: 341650
   timestamp: 1746011664546
 - conda: https://prefix.dev/conda-forge/osx-arm64/pixman-0.46.0-h2f9eb0b_0.conda
@@ -13331,6 +13202,7 @@ packages:
   - __osx >=11.0
   - libcxx >=18
   license: MIT
+  license_family: MIT
   size: 213341
   timestamp: 1746011718977
 - conda: https://prefix.dev/conda-forge/win-64/pixman-0.46.0-had0cd8c_0.conda
@@ -13341,6 +13213,7 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
+  license_family: MIT
   size: 472718
   timestamp: 1746016414502
 - conda: https://prefix.dev/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
@@ -14586,36 +14459,38 @@ packages:
   license_family: BSD
   size: 15487645
   timestamp: 1739793313482
-- conda: https://prefix.dev/conda-forge/osx-64/sed-4.7-h3efe00b_1000.tar.bz2
-  sha256: c7dc65d2d43561aa20f2ee3ddcb9b8d19fd52d18802b5ca87e508f6041c0b225
-  md5: 12e92b1d4ac4f839fcdd66289caea89f
+- conda: https://prefix.dev/conda-forge/osx-64/sed-4.9-hf9b2955_0.conda
+  sha256: d4a0aaaed132d2af39861f53293f5103c8ae46e202dbec74b7cf681d1f545de2
+  md5: baaba507123980047f12299fc674bfc2
   depends:
-  - gettext >=0.19.2
-  - gettext >=0.19.8.1,<1.0a0
-  license: GPL-3
-  size: 263631
-  timestamp: 1550735515743
-- conda: https://prefix.dev/conda-forge/osx-arm64/sed-4.8-hc6a1b29_0.tar.bz2
-  sha256: a9c4193ccfa633aa7ab37aa95c7d28101a1df45b27efcaf28828d7266c2d43c1
-  md5: 1b410382feb5302344180b25df05b591
+  - __osx >=10.13
+  - libintl >=0.24.1,<1.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 272555
+  timestamp: 1746562301530
+- conda: https://prefix.dev/conda-forge/osx-arm64/sed-4.9-h21ae2d7_0.conda
+  sha256: 8c95129762d26d5e0c1513d5ff0c79cd436357da96aa2a23b1d21a4da847beed
+  md5: d3c7f3721d56985890cb6b9aadb084f0
   depends:
-  - gettext >=0.19.2
-  - gettext >=0.19.8.1,<1.0a0
-  license: GPL-3
-  size: 279194
-  timestamp: 1605307517437
-- conda: https://prefix.dev/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
-  sha256: 5ebc4bb71fbdc8048b08848519150c8d44b8eb18445711d3258c9d402ba87a2c
-  md5: fa6669cc21abd4b7b6c5393b7bc71914
+  - __osx >=11.0
+  - libintl >=0.24.1,<1.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 260859
+  timestamp: 1746562327489
+- conda: https://prefix.dev/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+  sha256: 972560fcf9657058e3e1f97186cc94389144b46dbdf58c807ce62e83f977e863
+  md5: 4de79c071274a53dcaf2a8c749d1499e
   depends:
   - python >=3.9
   license: MIT
   license_family: MIT
-  size: 787541
-  timestamp: 1745484086827
-- conda: https://prefix.dev/conda-forge/linux-64/shapely-2.1.0-py311h3dc67b8_0.conda
-  sha256: 4ad0dbd446d4e64c09e30866da9caff2bae5d1d58a69c48356600faa3364b22c
-  md5: 697054700855c7699805f41ad7f204a3
+  size: 748788
+  timestamp: 1748804951958
+- conda: https://prefix.dev/conda-forge/linux-64/shapely-2.1.1-py311h3dc67b8_0.conda
+  sha256: 067fe9836e91fd46065371ad80579e0b1f646ff9c2e3fd95abf12fe07c0e594c
+  md5: ea7501cf4d40188cc662b29bcc07f13b
   depends:
   - __glibc >=2.17,<3.0.a0
   - geos >=3.13.1,<3.13.2.0a0
@@ -14625,8 +14500,8 @@ packages:
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
-  size: 651397
-  timestamp: 1743678453768
+  size: 652197
+  timestamp: 1747664453189
 - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
   sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
   md5: a451d576819089b0d672f18768be0f65
@@ -14834,66 +14709,66 @@ packages:
   license_family: BSD
   size: 250216
   timestamp: 1728083269744
-- conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.49.1-h9eae976_2.conda
-  sha256: 85c5b96686a900411ad8bdd424dcc2efb2044f15488bb89e57dff3bfcb74cc65
-  md5: 1894a9d3a8c3ffa53f8ca09fcd2fac25
+- conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.50.0-h9eae976_0.conda
+  sha256: 732632884dbc9001871ca20f84133ce1989032109de27286aa353a05e52befa9
+  md5: 641d2950ff5031073b5c447457a63be6
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libsqlite 3.49.1 hee588c1_2
+  - libsqlite 3.50.0 hee588c1_0
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
   license: Unlicense
-  size: 859553
-  timestamp: 1742083683966
-- conda: https://prefix.dev/conda-forge/linux-aarch64/sqlite-3.49.1-h578a6b9_2.conda
-  sha256: 7d6f064b29cf9abf61a70aba2f796f950a973759c48f6aeb9bddf723c573b422
-  md5: 2e9105f342b94fd9c70e9668325512fc
+  size: 899186
+  timestamp: 1748549899745
+- conda: https://prefix.dev/conda-forge/linux-aarch64/sqlite-3.50.0-h578a6b9_0.conda
+  sha256: bfe9ebbb7d8b58a7bbffca8f37625696d965557b94080dbd2c4747cb789c9e32
+  md5: e06f6d0a1f2bd5b86c092ac4cffdbd95
   depends:
   - libgcc >=13
-  - libsqlite 3.49.1 h5eb1b54_2
+  - libsqlite 3.50.0 h5eb1b54_0
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
   license: Unlicense
-  size: 913469
-  timestamp: 1742083706776
-- conda: https://prefix.dev/conda-forge/osx-64/sqlite-3.49.1-h2e4c9dc_2.conda
-  sha256: 38fff9dddfa80f01a9f0cba3d5f00ff2ca29a8a246cb9cf41177b7cead78005c
-  md5: 775febaf021c23b27b8b04b2fa428388
+  size: 917840
+  timestamp: 1748549864366
+- conda: https://prefix.dev/conda-forge/osx-64/sqlite-3.50.0-h2e4c9dc_0.conda
+  sha256: d860f7eeb50617ab1f4c050e51d8047513226dca7add6512942fa6dabeadc5a6
+  md5: 75061777459103ce843d7d0c72b0388f
   depends:
   - __osx >=10.13
-  - libsqlite 3.49.1 hdb6dae5_2
+  - libsqlite 3.50.0 hdb6dae5_0
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
   license: Unlicense
-  size: 941074
-  timestamp: 1742083889419
-- conda: https://prefix.dev/conda-forge/osx-arm64/sqlite-3.49.1-hd7222ec_2.conda
-  sha256: d359322cb4404df74d938a11a22b932e49d5f8c931a03e63d34127c9fecac200
-  md5: 69dd1428d6a7d068bfc1d2ad70ab6701
+  size: 974281
+  timestamp: 1748549994681
+- conda: https://prefix.dev/conda-forge/osx-arm64/sqlite-3.50.0-hd7222ec_0.conda
+  sha256: c94e55de40bbcabf834b5b2870d4121efa45158df3e5a6d4ee75b15e8ed9719f
+  md5: bbbbdf7c9a0344190b6199568ef2601b
   depends:
   - __osx >=11.0
-  - libsqlite 3.49.1 h3f77e49_2
+  - libsqlite 3.50.0 h3f77e49_0
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
   license: Unlicense
-  size: 883664
-  timestamp: 1742083897015
-- conda: https://prefix.dev/conda-forge/win-64/sqlite-3.49.1-h2466b09_2.conda
-  sha256: 0b072d1fd075fdf5d41ff2689c6db2c6246ca58979c0f13dc15fb89d26ee83ed
-  md5: e30b7cd408f01cc06073d9e68bfc1710
+  size: 885840
+  timestamp: 1748550185297
+- conda: https://prefix.dev/conda-forge/win-64/sqlite-3.50.0-h2466b09_0.conda
+  sha256: 216be8d0beef8c2b75a977e18b73ea25cbde4eee51e33f6094ff62c76bf5f0d1
+  md5: 62ac646eb576e0883d746ade587ac5e6
   depends:
-  - libsqlite 3.49.1 h67fdade_2
+  - libsqlite 3.50.0 h67fdade_0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Unlicense
-  size: 1105027
-  timestamp: 1742083977188
+  size: 1105359
+  timestamp: 1748550307463
 - conda: https://prefix.dev/conda-forge/noarch/svgwrite-1.4.3-pyhd8ed1ab_1.conda
   sha256: 0571b8426cd6fab05cd0639d4a5203e0f01ba8da75b48ed7b7b1103445e6a3b2
   md5: 9a13b437c86284d668ba1ad03647f6c7
@@ -15045,55 +14920,68 @@ packages:
   - tbb 2022.1.0 h9541205_0
   size: 1085639
   timestamp: 1743578953834
-- conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
-  md5: d453b98d9c83e71da0741bb0ff4d76bc
+- conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+  sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
+  md5: a0116df4f4ed05c303811a837d5b39d8
   depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
   license: TCL
   license_family: BSD
-  size: 3318875
-  timestamp: 1699202167581
-- conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
-  sha256: 7fa27cc512d3a783f38bd16bbbffc008807372499d5b65d089a8e43bde9db267
-  md5: f75105e0585851f818e0009dd1dde4dc
+  size: 3285204
+  timestamp: 1748387766691
+- conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5688188_102.conda
+  sha256: 46e10488e9254092c655257c18fcec0a9864043bdfbe935a9fbf4fb2028b8514
+  md5: 2562c9bfd1de3f9c590f0fe53858d85c
   depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
   license: TCL
   license_family: BSD
-  size: 3351802
-  timestamp: 1695506242997
-- conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
-  sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
-  md5: bf830ba5afc507c6232d4ef0fb1a882d
+  size: 3342845
+  timestamp: 1748393219221
+- conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
+  sha256: b24468006a96b71a5f4372205ea7ec4b399b0f2a543541e86f883de54cd623fc
+  md5: 9864891a6946c2fe037c02fca7392ab4
   depends:
-  - libzlib >=1.2.13,<2.0.0a0
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
   license: TCL
   license_family: BSD
-  size: 3270220
-  timestamp: 1699202389792
-- conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
-  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
-  md5: b50a57ba89c32b62428b71a875291c9b
+  size: 3259809
+  timestamp: 1748387843735
+- conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+  sha256: cb86c522576fa95c6db4c878849af0bccfd3264daf0cc40dd18e7f4a7bfced0e
+  md5: 7362396c170252e7b7b0c8fb37fe9c78
   depends:
-  - libzlib >=1.2.13,<2.0.0a0
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
   license: TCL
   license_family: BSD
-  size: 3145523
-  timestamp: 1699202432999
-- conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
-  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
-  md5: fc048363eb8f03cd1737600a5d08aafe
+  size: 3125538
+  timestamp: 1748388189063
+- conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
+  sha256: e3614b0eb4abcc70d98eae159db59d9b4059ed743ef402081151a948dce95896
+  md5: ebd0e761de9aa879a51d22cc721bd095
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: TCL
   license_family: BSD
-  size: 3503410
-  timestamp: 1699202577803
+  size: 3466348
+  timestamp: 1748388121356
+- conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.13.2-pyh29332c3_0.conda
+  sha256: a8aaf351e6461de0d5d47e4911257e25eec2fa409d71f3b643bb2f748bde1c08
+  md5: 83fc6ae00127671e301c9f44254c31b8
+  depends:
+  - python >=3.9
+  - python
+  license: PSF-2.0
+  license_family: PSF
+  size: 52189
+  timestamp: 1744302253997
 - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
   sha256: 5aaa366385d716557e365f0a4e9c3fca43ba196872abbbe3d56bb610d131e192
   md5: 4222072737ccff51314b5ece9c7d6f5a
@@ -15605,13 +15493,13 @@ packages:
   license_family: MIT
   size: 324694
   timestamp: 1745806658759
-- conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.43-hd8ed1ab_0.conda
-  sha256: 7a2c4c7d8b3754332fa12dc206f228d079925e4d6df22db68f1f658e4d122ea8
-  md5: 15be7b62f44e0b7f18db7af4eded345d
+- conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.44-hd8ed1ab_0.conda
+  sha256: 95ceed109aeab664e4f43ff1de3edba9ec8671bd9ffe216383d0f14f422f538a
+  md5: 4c33d6dd91f49a0efcc0748fd4d7348b
   license: MIT
   license_family: MIT
-  size: 132240
-  timestamp: 1744133409242
+  size: 135536
+  timestamp: 1747922526864
 - conda: https://prefix.dev/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
   sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
   md5: 75cb7132eb58d97896e173ef12ac9986
@@ -15639,17 +15527,17 @@ packages:
   license: LicenseRef-Public-Domain
   size: 9555
   timestamp: 1733130678956
-- conda: https://prefix.dev/conda-forge/noarch/wslink-2.3.3-pyhd8ed1ab_0.conda
-  sha256: b3cb4702e8bf92a5a437de3cab5f6fef11a56bada56bc891bd46dc91d9228104
-  md5: 56a61f85bb39bb89e9dd332f09be0763
+- conda: https://prefix.dev/conda-forge/noarch/wslink-2.3.4-pyhd8ed1ab_0.conda
+  sha256: a3d344dbca9b8c94b84f7428d031e4376397f495bfe8a169adacb8ae87440777
+  md5: 9748c4ed9bb4784914bedf2efcc0ac1f
   depends:
   - aiohttp <4
   - msgpack-python >=1,<2
   - python >=3.9
   license: BSD-3-Clause
   license_family: BSD
-  size: 35694
-  timestamp: 1742768550826
+  size: 35753
+  timestamp: 1747717971323
 - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
   sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
   md5: 6c99772d483f566d59e25037fea2c4b1
@@ -16811,15 +16699,15 @@ packages:
   license_family: Apache
   size: 148113
   timestamp: 1744973285417
-- conda: https://prefix.dev/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
-  sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
-  md5: 0c3cc595284c5e8f0f9900a9b228a332
+- conda: https://prefix.dev/conda-forge/noarch/zipp-3.22.0-pyhd8ed1ab_0.conda
+  sha256: 3f7a58ff4ff1d337d56af0641a7eba34e7eea0bf32e49934c96ee171640f620b
+  md5: 234be740b00b8e41567e5b0ed95aaba9
   depends:
   - python >=3.9
   license: MIT
   license_family: MIT
-  size: 21809
-  timestamp: 1732827613585
+  size: 22691
+  timestamp: 1748277499928
 - conda: https://prefix.dev/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
   sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
   md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -168,7 +168,7 @@ requirements:
     - requests
     - scipy
     - sympy
-    - typing_extension
+    - typing_extensions
     - vtk
     - xlutils
 


### PR DESCRIPTION
This is a followup to
- #21641

Includes fixed typo in package name and an updated lock file.

I am waiting for my local build verifying the fix to finish at which point I turn off the Draft option here.