### PR TITLE
Fix compiling ProgressIndicator with precompiled headers

### DIFF
--- a/src/Base/ProgressIndicator.cpp
+++ b/src/Base/ProgressIndicator.cpp
@@ -20,6 +20,8 @@
  *                                                                         *
  **************************************************************************/
 
+#include "PreCompiled.h"
+
 #include "ProgressIndicator.h"
 
 namespace Base


### PR DESCRIPTION
The new ProgressIndicator feature that was merged broke building with precompiled headers enabled on Windows.

Reference: #21427