### PR TITLE
Add support for copy & pasting toolbits in the tool editor dock

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathToolAssetManager.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolAssetManager.py
@@ -3,7 +3,7 @@ import asyncio
 from unittest.mock import Mock
 import pathlib
 import tempfile
-from typing import Any, Mapping, List
+from typing import Any, Mapping, List, Type, cast
 from Path.Tool.assets import (
     AssetManager,
     FileStore,
@@ -24,7 +24,7 @@ class MockAsset(Asset):
         self._id = id
 
     @classmethod
-    def extract_dependencies(cls, data: bytes, serializer: AssetSerializer) -> List[AssetUri]:
+    def extract_dependencies(cls, data: bytes, serializer: Type[AssetSerializer]) -> List[AssetUri]:
         # Mock implementation doesn't use data or format for dependencies
         return []
 
@@ -34,17 +34,78 @@ class MockAsset(Asset):
         data: bytes,
         id: str,
         dependencies: Mapping[AssetUri, Asset] | None,
-        serializer: AssetSerializer,
+        serializer: Type[AssetSerializer],
     ) -> "MockAsset":
         # Create instance with provided id
         return cls(data, id)
 
-    def to_bytes(self, serializer: AssetSerializer) -> bytes:
+    def to_bytes(self, serializer: Type[AssetSerializer]) -> bytes:
         return self._data
 
     def get_id(self) -> str:
         return self._id
 
+    def get_data(self) -> bytes:
+        """Returns the raw data stored in the mock asset."""
+        return self._data
+
+# Mock Asset class with dependencies for testing deepcopy
+class MockAssetWithDeps(Asset):
+    asset_type: str = "mock_asset_with_deps"
+
+    def __init__(
+        self,
+        data: Any = None,
+        id: str = "mock_id",
+        dependencies: Mapping[AssetUri, Asset] | None = None,
+    ):
+        self._data = data
+        self._id = id
+        self._dependencies = dependencies or {}
+
+    @classmethod
+    def extract_dependencies(cls, data: bytes, serializer: Type[AssetSerializer]) -> List[AssetUri]:
+        # Assuming data is a simple JSON string like '{"deps": ["uri1", "uri2"]}'
+        try:
+            import json
+            data_str = data.decode("utf-8")
+            data_dict = json.loads(data_str)
+            dep_uris_str = data_dict.get("deps", [])
+            return [AssetUri(uri_str) for uri_str in dep_uris_str]
+        except Exception:
+            return []
+
+    @classmethod
+    def from_bytes(
+        cls,
+        data: bytes,
+        id: str,
+        dependencies: Mapping[AssetUri, Asset] | None,
+        serializer: Type[AssetSerializer],
+    ) -> "MockAssetWithDeps":
+        # Create instance with provided id and resolved dependencies
+        return cls(data, id, dependencies)
+
+    def to_bytes(self, serializer: Type[AssetSerializer]) -> bytes:
+        # Serialize data and dependency URIs into a simple format
+        try:
+            import json
+            dep_uri_strs = [str(uri) for uri in self._dependencies.keys()]
+            data_dict = {"data": self._data.decode("utf-8"), "deps": dep_uri_strs}
+            return json.dumps(data_dict).encode("utf-8")
+        except Exception:
+            return self._data # Fallback if serialization fails
+
+    def get_id(self) -> str:
+        return self._id
+
+    def get_data(self) -> bytes:
+        """Returns the raw data stored in the mock asset."""
+        return self._data
+
+    def get_dependencies(self) -> Mapping[AssetUri, Asset]:
+        """Returns the resolved dependencies."""
+        return self._dependencies
 
 class TestPathToolAssetManager(unittest.TestCase):
     def test_register_store(self):
@@ -86,11 +147,11 @@ class TestPathToolAssetManager(unittest.TestCase):
                 data: bytes,
                 id: str,
                 dependencies: Mapping[AssetUri, Asset] | None,
-                serializer: AssetSerializer,
+                serializer: Type[AssetSerializer],
             ) -> "AnotherMockAsset":
                 return cls()
 
-            def to_bytes(self, serializer: AssetSerializer) -> bytes:
+            def to_bytes(self, serializer: Type[AssetSerializer]) -> bytes:
                 return b""
 
             def get_id(self) -> str:
@@ -134,12 +195,11 @@ class TestPathToolAssetManager(unittest.TestCase):
             )
 
             # Call AssetManager.get
-            retrieved_object = manager.get(test_uri)
+            retrieved_object = cast(MockAsset, manager.get(test_uri))
 
             # Assert the retrieved object is an instance of MockAsset
             self.assertIsInstance(retrieved_object, MockAsset)
-            # Assert the data was passed to from_bytes
-            self.assertEqual(retrieved_object._data, test_data)
+            self.assertEqual(retrieved_object.get_data(), test_data)
 
             # Test error handling for non-existent URI
             non_existent_uri = AssetUri.build(MockAsset.asset_type, "non_existent", "1")
@@ -210,7 +270,7 @@ class TestPathToolAssetManager(unittest.TestCase):
 
             # Verify the asset was created
             retrieved_data = asyncio.run(local_store.get(created_uri))
-            self.assertEqual(retrieved_data, test_obj.to_bytes(DummyAssetSerializer))
+            self.assertEqual(retrieved_data, test_obj.get_data())
 
             # Test error handling (store not found)
             with self.assertRaises(ValueError) as cm:
@@ -244,9 +304,10 @@ class TestPathToolAssetManager(unittest.TestCase):
             self.assertEqual(updated_uri.version, "2")
 
             # Verify the asset was updated
-            obj = manager.get(updated_uri, store="local")
-            self.assertEqual(updated_data, test_obj.to_bytes(DummyAssetSerializer))
-            self.assertEqual(updated_data, obj.to_bytes(DummyAssetSerializer))
+            obj = cast(MockAsset, manager.get(updated_uri, store="local"))
+            self.assertEqual(updated_data, test_obj.get_data())
+            self.assertIsInstance(obj, MockAsset)
+            self.assertEqual(updated_data, obj.get_data())
 
             # Test error handling (store not found)
             with self.assertRaises(ValueError) as cm:
@@ -382,23 +443,17 @@ class TestPathToolAssetManager(unittest.TestCase):
         uris = [uri1, uri2, uri3]
 
         # Call manager.get_bulk
-        retrieved_assets = manager.get_bulk(uris, store="memory_bulk")
+        retrieved_assets = cast(List[MockAsset], manager.get_bulk(uris, store="memory_bulk"))
 
         # Assert the correct number of assets were returned
         self.assertEqual(len(retrieved_assets), 3)
 
         # Assert the retrieved assets are MockAsset instances with correct data
         self.assertIsInstance(retrieved_assets[0], MockAsset)
-        self.assertEqual(
-            retrieved_assets[0].to_bytes(DummyAssetSerializer),
-            data1,
-        )
+        self.assertEqual(retrieved_assets[0].get_data(), data1)
 
         self.assertIsInstance(retrieved_assets[1], MockAsset)
-        self.assertEqual(
-            retrieved_assets[1].to_bytes(DummyAssetSerializer),
-            data2,
-        )
+        self.assertEqual(retrieved_assets[1].get_data(), data2)
 
         # Assert the non-existent asset is None
         self.assertIsNone(retrieved_assets[2])
@@ -442,9 +497,9 @@ class TestPathToolAssetManager(unittest.TestCase):
         manager_filtered.add_raw(MockAsset.asset_type, "id2", data2, "memory_fetch_filtered")
         manager_filtered.add_raw("another_type", "id3", b"data for id3", "memory_fetch_filtered")
 
-        retrieved_assets_filtered = manager_filtered.fetch(
+        retrieved_assets_filtered = cast(List[MockAsset], manager_filtered.fetch(
             asset_type=MockAsset.asset_type, store="memory_fetch_filtered"
-        )
+        ))
 
         # Assert the correct number of assets were returned
         self.assertEqual(len(retrieved_assets_filtered), 2)
@@ -452,19 +507,329 @@ class TestPathToolAssetManager(unittest.TestCase):
         # Assert the retrieved assets are MockAsset instances with correct data
         self.assertIsInstance(retrieved_assets_filtered[0], MockAsset)
         self.assertEqual(
-            retrieved_assets_filtered[0].to_bytes(DummyAssetSerializer).decode("utf-8"),
+            retrieved_assets_filtered[0].get_data().decode("utf-8"),
             data1.decode("utf-8"),
         )
 
         self.assertIsInstance(retrieved_assets_filtered[1], MockAsset)
         self.assertEqual(
-            retrieved_assets_filtered[1].to_bytes(DummyAssetSerializer).decode("utf-8"),
+            retrieved_assets_filtered[1].get_data().decode("utf-8"),
             data2.decode("utf-8"),
         )
 
         # Test error handling (store not found)
         with self.assertRaises(ValueError) as cm:
             manager.fetch(store="non_existent_store")
+        self.assertIn("No store registered for name:", str(cm.exception))
+
+    def test_copy(self):
+        # Setup AssetManager with two MemoryStores and MockAsset class
+        memory_store_src = MemoryStore("memory_copy_src")
+        memory_store_dest = MemoryStore("memory_copy_dest")
+        manager = AssetManager()
+        manager.register_store(memory_store_src)
+        manager.register_store(memory_store_dest)
+        manager.register_asset(MockAsset, DummyAssetSerializer)
+
+        # Create a source asset
+        src_data = b"source asset data"
+        src_uri = manager.add_raw(
+            MockAsset.asset_type, "source_id", src_data, "memory_copy_src"
+        )
+
+        # Test copying to a different store with default destination URI
+        copied_uri_default_dest = manager.copy(
+            src_uri, dest_store="memory_copy_dest", store="memory_copy_src"
+        )
+        self.assertEqual(copied_uri_default_dest.asset_type, src_uri.asset_type)
+        self.assertEqual(copied_uri_default_dest.asset_id, src_uri.asset_id)
+        self.assertEqual(copied_uri_default_dest.version, "1")  # First version in dest
+
+        # Verify the copied asset exists in the destination store
+        copied_data_default_dest = manager.get_raw(
+            copied_uri_default_dest, store="memory_copy_dest"
+        )
+        self.assertEqual(copied_data_default_dest, src_data)
+
+        # Test copying to a different store with a specified destination URI
+        dest_uri_specified = AssetUri.build(
+            MockAsset.asset_type, "specified_dest_id", "1"
+        )
+        copied_uri_specified_dest = manager.copy(
+            src_uri,
+            dest_store="memory_copy_dest",
+            store="memory_copy_src",
+            dest=dest_uri_specified,
+        )
+        self.assertEqual(copied_uri_specified_dest, dest_uri_specified)
+
+        # Verify the copied asset exists at the specified destination URI
+        copied_data_specified_dest = manager.get_raw(
+            copied_uri_specified_dest, store="memory_copy_dest"
+        )
+        self.assertEqual(copied_data_specified_dest, src_data)
+
+        # Test copying to the same store with a different destination URI
+        dest_uri_same_store = AssetUri.build(MockAsset.asset_type, "same_store_dest", "1")
+        copied_uri_same_store = manager.copy(
+            src_uri, dest_store="memory_copy_src", store="memory_copy_src", dest=dest_uri_same_store
+        )
+        self.assertEqual(copied_uri_same_store, dest_uri_same_store)
+
+        # Verify the copied asset exists in the same store at the new URI
+        copied_data_same_store = manager.get_raw(
+            copied_uri_same_store, store="memory_copy_src"
+        )
+        self.assertEqual(copied_data_same_store, src_data)
+
+        # Test assertion for source and destination being the same
+        with self.assertRaises(ValueError) as cm:
+            manager.copy(src_uri, dest_store="memory_copy_src", store="memory_copy_src", dest=src_uri)
+        self.assertIn(
+            "Source and destination cannot be the same asset in the same store.",
+            str(cm.exception),
+        )
+
+        # Test overwriting existing destination (add a different asset at specified_dest_id)
+        overwrite_data = b"data to be overwritten"
+        overwrite_uri = manager.add_raw(
+            MockAsset.asset_type, "specified_dest_id", overwrite_data, "memory_copy_dest"
+        )
+        self.assertEqual(overwrite_uri.version, "2") # Should be version 2 now
+
+        # Copy the original src_uri to the existing destination
+        copied_uri_overwrite = manager.copy(
+            src_uri,
+            dest_store="memory_copy_dest",
+            store="memory_copy_src",
+            dest=dest_uri_specified,
+        )
+        # The version should be incremented again due to overwrite
+        self.assertEqual(copied_uri_overwrite.version, "3")
+
+        # Verify the destination now contains the source data
+        retrieved_overwritten_data = manager.get_raw(
+            copied_uri_overwrite, store="memory_copy_dest"
+        )
+        self.assertEqual(retrieved_overwritten_data, src_data)
+
+    def test_deepcopy(self):
+        # Setup AssetManager with two MemoryStores and MockAssetWithDeps class
+        memory_store_src = MemoryStore("memory_deepcopy_src")
+        memory_store_dest = MemoryStore("memory_deepcopy_dest")
+        manager = AssetManager()
+        manager.register_store(memory_store_src)
+        manager.register_store(memory_store_dest)
+        manager.register_asset(MockAssetWithDeps, DummyAssetSerializer)
+
+        # Create dependency assets in the source store
+        dep1_data = b'{"data": "dependency 1 data", "deps": []}'
+        dep2_data = b'{"data": "dependency 2 data", "deps": []}'
+        dep1_uri = manager.add_raw(
+            MockAssetWithDeps.asset_type, "dep1_id", dep1_data, "memory_deepcopy_src"
+        )
+        dep2_uri = manager.add_raw(
+            MockAssetWithDeps.asset_type, "dep2_id", dep2_data, "memory_deepcopy_src"
+        )
+
+        # Create a source asset with dependencies
+        src_data = b'{"data": "source asset data", "deps": ["' + str(dep1_uri).encode('utf-8') + b'", "' + str(dep2_uri).encode('utf-8') + b'"]}'
+        src_uri = manager.add_raw(
+            MockAssetWithDeps.asset_type, "source_id", src_data, "memory_deepcopy_src"
+        )
+
+        # Test deep copying to a different store with default destination URI
+        copied_uri_default_dest = manager.deepcopy(
+            src_uri, dest_store="memory_deepcopy_dest", store="memory_deepcopy_src"
+        )
+        self.assertEqual(copied_uri_default_dest.asset_type, src_uri.asset_type)
+        self.assertEqual(copied_uri_default_dest.asset_id, src_uri.asset_id)
+        self.assertEqual(copied_uri_default_dest.version, "1")  # First version in dest
+
+        # Verify the copied top-level asset exists in the destination store
+        copied_asset_default_dest = cast(MockAssetWithDeps, manager.get(
+            copied_uri_default_dest, store="memory_deepcopy_dest"
+        ))
+        self.assertIsInstance(copied_asset_default_dest, MockAssetWithDeps)
+        # The copied asset's data should be the serialized form including dependencies
+        expected_data = b'{"data": "source asset data", "deps": ["mock_asset_with_deps://dep1_id/1", "mock_asset_with_deps://dep2_id/1"]}'
+        self.assertEqual(copied_asset_default_dest.get_data(), expected_data)
+
+        # Verify dependencies were also copied and resolved correctly
+        copied_deps_default_dest = copied_asset_default_dest.get_dependencies()
+        self.assertEqual(len(copied_deps_default_dest), 2)
+        self.assertIn(dep1_uri, copied_deps_default_dest)
+        self.assertIn(dep2_uri, copied_deps_default_dest)
+
+        copied_dep1 = cast(MockAssetWithDeps, copied_deps_default_dest[dep1_uri])
+        self.assertIsInstance(copied_dep1, MockAssetWithDeps)
+        self.assertEqual(copied_dep1.get_data(), b'{"data": "dependency 1 data", "deps": []}')
+
+        copied_dep2 = cast(MockAssetWithDeps, copied_deps_default_dest[dep2_uri])
+        self.assertIsInstance(copied_dep2, MockAssetWithDeps)
+        self.assertEqual(copied_dep2.get_data(), b'{"data": "dependency 2 data", "deps": []}')
+
+        # Test deep copying with a specified destination URI for the top-level asset
+        dest_uri_specified = AssetUri.build(
+            MockAssetWithDeps.asset_type, "specified_dest_id", "1"
+        )
+        copied_uri_specified_dest = manager.deepcopy(
+            src_uri,
+            dest_store="memory_deepcopy_dest",
+            store="memory_deepcopy_src",
+            dest=dest_uri_specified,
+        )
+        self.assertEqual(copied_uri_specified_dest, dest_uri_specified)
+
+        # Verify the copied asset exists at the specified destination URI
+        copied_asset_specified_dest = cast(MockAssetWithDeps, manager.get(
+            copied_uri_specified_dest, store="memory_deepcopy_dest"
+        ))
+        self.assertIsInstance(copied_asset_specified_dest, MockAssetWithDeps)
+        self.assertEqual(copied_asset_specified_dest.get_data(), b'{"data": "source asset data", "deps": ["mock_asset_with_deps://dep1_id/1", "mock_asset_with_deps://dep2_id/1"]}')
+
+        # Verify dependencies were copied and resolved correctly (their URIs should be
+        # in the destination store, but their asset_type and asset_id should be the same)
+        copied_deps_specified_dest = copied_asset_specified_dest.get_dependencies()
+        self.assertEqual(len(copied_deps_specified_dest), 2)
+
+        # The keys in the dependencies mapping should be the *original* URIs,
+        # but the values should be the *copied* dependency assets.
+        self.assertIn(dep1_uri, copied_deps_specified_dest)
+        self.assertIn(dep2_uri, copied_deps_specified_dest)
+
+        copied_dep1_specified = cast(MockAssetWithDeps, copied_deps_specified_dest[dep1_uri])
+        self.assertIsInstance(copied_dep1_specified, MockAssetWithDeps)
+        self.assertEqual(copied_dep1_specified.get_data(), b'{"data": "dependency 1 data", "deps": []}')
+        # Check the URI of the copied dependency in the destination store
+        self.assertIsNotNone(manager.get_or_none(copied_dep1_specified.get_uri(), store="memory_deepcopy_dest"))
+        self.assertEqual(copied_dep1_specified.get_uri().asset_type, dep1_uri.asset_type)
+        self.assertEqual(copied_dep1_specified.get_uri().asset_id, dep1_uri.asset_id)
+
+
+        copied_dep2_specified = cast(MockAssetWithDeps, copied_deps_specified_dest[dep2_uri])
+        self.assertIsInstance(copied_dep2_specified, MockAssetWithDeps)
+        self.assertEqual(copied_dep2_specified.get_data(), b'{"data": "dependency 2 data", "deps": []}')
+        # Check the URI of the copied dependency in the destination store
+        self.assertIsNotNone(manager.get_or_none(copied_dep2_specified.get_uri(), store="memory_deepcopy_dest"))
+        self.assertEqual(copied_dep2_specified.get_uri().asset_type, dep2_uri.asset_type)
+        self.assertEqual(copied_dep2_specified.get_uri().asset_id, dep2_uri.asset_id)
+
+
+        # Test handling of existing dependencies in the destination store (should be skipped)
+        # Add a dependency with the same URI as dep1_uri to the destination store
+        existing_dep1_data = b'{"data": "existing dependency 1 data", "deps": []}'
+        existing_dep1_uri_in_dest = manager.add_raw(
+             dep1_uri.asset_type, dep1_uri.asset_id, existing_dep1_data, "memory_deepcopy_dest"
+        )
+        self.assertEqual(existing_dep1_uri_in_dest.version, "2") # Should be version 2 now
+
+        # Deep copy the source asset again
+        copied_uri_existing_dep = manager.deepcopy(
+            src_uri, dest_store="memory_deepcopy_dest", store="memory_deepcopy_src"
+        )
+        # The top-level asset should be overwritten, incrementing its version
+        self.assertEqual(copied_uri_existing_dep.version, "2")
+
+        # Verify the top-level asset was overwritten
+        copied_asset_existing_dep = cast(MockAssetWithDeps, manager.get(
+            copied_uri_existing_dep, store="memory_deepcopy_dest"
+        ))
+        self.assertIsInstance(copied_asset_existing_dep, MockAssetWithDeps)
+        self.assertEqual(copied_asset_existing_dep.get_data(), b'{"data": "source asset data", "deps": ["mock_asset_with_deps://dep1_id/1", "mock_asset_with_deps://dep2_id/1"]}')
+
+        # Verify that the existing dependency was *not* overwritten
+        retrieved_existing_dep1 = manager.get_raw(
+            existing_dep1_uri_in_dest, store="memory_deepcopy_dest"
+        )
+        self.assertEqual(retrieved_existing_dep1, existing_dep1_data)
+
+        # Verify the dependencies in the copied asset still point to the correct
+        # (existing) dependency in the destination store.
+        copied_deps_existing_dep = copied_asset_existing_dep.get_dependencies()
+        self.assertEqual(len(copied_deps_existing_dep), 2)
+        self.assertIn(dep1_uri, copied_deps_existing_dep)
+        self.assertIn(dep2_uri, copied_deps_existing_dep)
+
+        copied_dep1_existing = cast(MockAssetWithDeps, copied_deps_existing_dep[dep1_uri])
+        self.assertIsInstance(copied_dep1_existing, MockAssetWithDeps)
+        self.assertEqual(copied_dep1_existing.get_data(), b'{"data": "dependency 1 data", "deps": []}') # Should be the original data from source
+
+        copied_dep2_existing = cast(MockAssetWithDeps, copied_deps_existing_dep[dep2_uri])
+        self.assertIsInstance(copied_dep2_existing, MockAssetWithDeps)
+        self.assertEqual(copied_dep2_existing.get_data(), b'{"data": "dependency 2 data", "deps": []}') # Should be the newly copied raw data
+
+
+        # Test handling of existing top-level asset in the destination store (should be overwritten)
+        # This was implicitly tested in the previous step where the top-level asset's
+        # version was incremented. Let's add a more explicit test.
+        overwrite_src_data = b'{"data": "overwrite source data", "deps": []}'
+        overwrite_src_uri = manager.add_raw(
+             MockAssetWithDeps.asset_type, "overwrite_source_id", overwrite_src_data, "memory_deepcopy_src"
+        )
+
+        # Add an asset to the destination store with the same URI as overwrite_src_uri
+        existing_dest_data = b'{"data": "existing destination data", "deps": []}'
+        existing_dest_uri = manager.add_raw(
+            overwrite_src_uri.asset_type, overwrite_src_uri.asset_id, existing_dest_data, "memory_deepcopy_dest"
+        )
+        self.assertEqual(existing_dest_uri.version, "1")
+
+        # Deep copy overwrite_src_uri to the existing destination URI
+        copied_uri_overwrite_top = manager.deepcopy(
+            overwrite_src_uri, dest_store="memory_deepcopy_dest", store="memory_deepcopy_src", dest=existing_dest_uri
+        )
+        # The version should be incremented
+        self.assertEqual(copied_uri_overwrite_top.version, "2")
+
+        # Verify the destination now contains the source data
+        retrieved_overwritten_top = manager.get_raw(
+            copied_uri_overwrite_top, store="memory_deepcopy_dest"
+        )
+        # Need to parse the data to get the actual content
+        import json
+        retrieved_data_dict = json.loads(retrieved_overwritten_top.decode('utf-8'))
+        self.assertEqual(retrieved_data_dict.get("data"), b'overwrite source data'.decode('utf-8'))
+
+
+        # Test error handling for non-existent source asset
+        non_existent_src_uri = AssetUri.build(MockAssetWithDeps.asset_type, "non_existent_src", "1")
+        with self.assertRaises(FileNotFoundError) as cm:
+            manager.deepcopy(non_existent_src_uri, dest_store="memory_deepcopy_dest", store="memory_deepcopy_src")
+        self.assertIn("Source asset", str(cm.exception))
+        self.assertIn("not found", str(cm.exception))
+
+        # Test error handling for non-existent source store
+        with self.assertRaises(ValueError) as cm:
+            manager.deepcopy(src_uri, dest_store="memory_deepcopy_dest", store="non_existent_store")
+        self.assertIn("Source store", str(cm.exception))
+        self.assertIn("not registered", str(cm.exception))
+
+        # Test error handling for non-existent destination store
+        with self.assertRaises(ValueError) as cm:
+            manager.deepcopy(src_uri, dest_store="non_existent_store", store="memory_deepcopy_src")
+        self.assertIn("Destination store", str(cm.exception))
+        self.assertIn("not registered", str(cm.exception))
+
+    def test_exists(self):
+        # Setup AssetManager with a MemoryStore
+        memory_store = MemoryStore("memory_exists")
+        manager = AssetManager()
+        manager.register_store(memory_store)
+
+        # Create an asset
+        test_uri = manager.add_raw("test_type", "test_id", b"data", "memory_exists")
+
+        # Test exists for an existing asset
+        self.assertTrue(manager.exists(test_uri, store="memory_exists"))
+
+        # Test exists for a non-existent asset
+        non_existent_uri = AssetUri.build("test_type", "non_existent_id", "1")
+        self.assertFalse(manager.exists(non_existent_uri, store="memory_exists"))
+
+        # Test exists for a non-existent store (should raise ValueError)
+        with self.assertRaises(ValueError) as cm:
+            manager.exists(test_uri, store="non_existent_store")
         self.assertIn("No store registered for name:", str(cm.exception))
 
 

--- a/src/Mod/CAM/CAMTests/TestPathToolBitBrowserWidget.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolBitBrowserWidget.py
@@ -62,8 +62,8 @@ class TestToolBitBrowserWidget(PathTestWithAssets):
         search_term = "Endmill"
         self.widget._search_edit.setText(search_term)
 
-        # Directly trigger the fetch and filtering logic
-        self.widget._trigger_fetch()
+        # Directly trigger the filtering logic
+        self.widget._update_list()
 
         # Verify that the filter was applied to the list widget
         # We can check if items are hidden/shown based on the filter term
@@ -99,28 +99,6 @@ class TestToolBitBrowserWidget(PathTestWithAssets):
                 actual_visible_uris.add(item_uri)
 
         self.assertEqual(actual_visible_uris, expected_visible_uris)
-
-    def test_lazy_loading_on_scroll(self):
-        # This test requires more than self._batch_size toolbits to be effective.
-        # The default test assets might not have enough.
-        # We'll assume there are enough for the test structure.
-
-        initial_count = self.widget._tool_list_widget.count()
-        if initial_count < self.widget._batch_size:
-            self.skipTest("Not enough toolbits for lazy loading test.")
-
-        # Simulate scrolling to the bottom by emitting the signal
-        scrollbar = self.widget._tool_list_widget.verticalScrollBar()
-        # Set the scrollbar value to its maximum to simulate reaching the end
-        scrollbar.valueChanged.emit(scrollbar.maximum())
-
-        # Verify that more items were loaded
-        new_count = self.widget._tool_list_widget.count()
-        self.assertGreater(new_count, initial_count)
-        # Verify that the number of new items is approximately the batch size
-        self.assertAlmostEqual(
-            new_count - initial_count, self.widget._batch_size, delta=5
-        )  # Allow small delta
 
     def test_tool_selected_signal(self):
         mock_slot = MagicMock()

--- a/src/Mod/CAM/CAMTests/TestPathToolBitSerializer.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolBitSerializer.py
@@ -1,3 +1,4 @@
+import yaml
 import json
 from typing import Type, cast
 import FreeCAD
@@ -6,6 +7,7 @@ from Path.Tool.toolbit import ToolBit, ToolBitEndmill
 from Path.Tool.toolbit.serializers import (
     FCTBSerializer,
     CamoticsToolBitSerializer,
+    YamlToolBitSerializer,
 )
 from Path.Tool.assets.asset import Asset
 from Path.Tool.assets.serializer import AssetSerializer
@@ -132,3 +134,72 @@ class TestFCTBSerializer(_BaseToolBitSerializerTestCase):
         self.assertEqual(deserialized_bit.get_shape_name(), "Endmill")
         self.assertEqual(str(deserialized_bit.get_diameter()), "4.12 mm")
         self.assertEqual(str(deserialized_bit.get_length()), "15.0 mm")
+
+
+class TestYamlToolBitSerializer(_BaseToolBitSerializerTestCase):
+    serializer_class = YamlToolBitSerializer
+
+    def test_serialize(self):
+        super().test_serialize()
+        serialized_data = self.serializer_class.serialize(self.test_tool_bit)
+        # YAML specific assertions
+        data = yaml.safe_load(serialized_data.decode("utf-8"))
+        self.assertEqual(data.get("id"), "5mm_Endmill")
+        self.assertEqual(data.get("name"), "Test Tool")
+        self.assertEqual(data.get("shape"), "Endmill")
+        self.assertEqual(data.get("shape-type"), "Endmill")
+        self.assertEqual(data.get("parameter", {}).get("Diameter"), "4.12 mm")
+        self.assertEqual(data.get("parameter", {}).get("Length"), "15.00 mm")
+
+    def test_extract_dependencies(self):
+        """Test dependency extraction for YAML."""
+        yaml_data = (
+            b"name: Test Tool\n"
+            b"shape: endmill\n"
+            b"shape-type: Endmill\n"
+            b"parameter:\n"
+            b"  Diameter: 4.12 mm\n"
+            b"  Length: 15.0 mm\n"
+            b"attribute: {}\n"
+        )
+        dependencies = self.serializer_class.extract_dependencies(yaml_data)
+        self.assertIsInstance(dependencies, list)
+        self.assertEqual(len(dependencies), 1)
+        self.assertEqual(dependencies[0], AssetUri.build("toolbitshape", "endmill"))
+
+    def test_deserialize(self):
+        # Create a known serialized data string based on the YAML format
+        yaml_data = (
+            b"id: TestID\n"
+            b"name: Test Tool\n"
+            b"shape: endmill\n"
+            b"shape-type: Endmill\n"
+            b"parameter:\n"
+            b"  Diameter: 4.12 mm\n"
+            b"  Length: 15.0 mm\n"
+            b"attribute: {}\n"
+        )
+        # Create a ToolBitShapeEndmill instance for 'endmill'
+        shape = ToolBitShapeEndmill("endmill")
+
+        # Create the dependencies dictionary with the shape instance
+        dependencies: Mapping[AssetUri, Asset] = {AssetUri.build("toolbitshape", "endmill"): shape}
+
+        # Provide dummy id and dependencies for deserialization test
+        deserialized_bit = cast(
+            ToolBitEndmill,
+            self.serializer_class.deserialize(yaml_data, "TestID", dependencies=dependencies),
+        )
+        self.assertIsInstance(deserialized_bit, ToolBit)
+        self.assertEqual(deserialized_bit.id, "TestID")
+        self.assertEqual(deserialized_bit.label, "Test Tool")
+        self.assertEqual(deserialized_bit.get_shape_name(), "Endmill")
+        self.assertEqual(str(deserialized_bit.get_diameter()), "4.12 mm")
+        self.assertEqual(str(deserialized_bit.get_length()), "15.0 mm")
+
+        # Test with ID argument.
+        deserialized_bit = cast(
+            ToolBitEndmill,
+            self.serializer_class.deserialize(yaml_data, id="test_id", dependencies=dependencies),
+        )
+        self.assertEqual(deserialized_bit.id, "test_id")

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -188,6 +188,7 @@ SET(PathPythonToolsToolBitSerializers_SRCS
     Path/Tool/toolbit/serializers/__init__.py
     Path/Tool/toolbit/serializers/camotics.py
     Path/Tool/toolbit/serializers/fctb.py
+    Path/Tool/toolbit/serializers/yaml.py
 )
 
 SET(PathPythonToolsToolBitUi_SRCS

--- a/src/Mod/CAM/Path/Tool/assets/manager.py
+++ b/src/Mod/CAM/Path/Tool/assets/manager.py
@@ -979,7 +979,7 @@ class AssetManager:
                 # If it doesn't exist, or if it's a dependency that doesn't exist, create it
                 logger.debug(f"Creating asset '{asset_uri}' in '{dest_store}'")
                 logger.debug(f"Raw data before writing: {asset_data.raw_data}")  # Added log
-                new_uri = await dest_store.create(
+                await dest_store.create(
                     asset_uri.asset_type,
                     asset_uri.asset_id,
                     asset_data.raw_data,

--- a/src/Mod/CAM/Path/Tool/assets/serializer.py
+++ b/src/Mod/CAM/Path/Tool/assets/serializer.py
@@ -28,7 +28,7 @@ from .asset import Asset
 
 class AssetSerializer(ABC):
     for_class: Type[Asset]
-    extensions: Tuple[str] = tuple()
+    extensions: Tuple[str, ...] = tuple()
     mime_type: str
     can_import: bool = True
     can_export: bool = True

--- a/src/Mod/CAM/Path/Tool/library/models/library.py
+++ b/src/Mod/CAM/Path/Tool/library/models/library.py
@@ -172,6 +172,12 @@ class Library(Asset):
         self._bits = [t for t in self._bits if t.id != bit.id]
         self._bit_nos = {k: v for (k, v) in self._bit_nos.items() if v.id != bit.id}
 
+    def remove_bit_by_uri(self, uri: AssetUri|str):
+        if isinstance(uri, str):
+            uri = AssetUri(uri)
+        self._bits = [t for t in self._bits if t.get_uri() != uri]
+        self._bit_nos = {k: v for (k, v) in self._bit_nos.items() if v.get_uri() != uri}
+
     def dump(self, summarize: bool = False):
         title = 'Library "{}" ({}) (instance {})'.format(self.label, self.id, id(self))
         print("-" * len(title))

--- a/src/Mod/CAM/Path/Tool/library/models/library.py
+++ b/src/Mod/CAM/Path/Tool/library/models/library.py
@@ -172,7 +172,7 @@ class Library(Asset):
         self._bits = [t for t in self._bits if t.id != bit.id]
         self._bit_nos = {k: v for (k, v) in self._bit_nos.items() if v.id != bit.id}
 
-    def remove_bit_by_uri(self, uri: AssetUri|str):
+    def remove_bit_by_uri(self, uri: AssetUri | str):
         if isinstance(uri, str):
             uri = AssetUri(uri)
         self._bits = [t for t in self._bits if t.get_uri() != uri]

--- a/src/Mod/CAM/Path/Tool/library/ui/browser.py
+++ b/src/Mod/CAM/Path/Tool/library/ui/browser.py
@@ -136,7 +136,6 @@ class LibraryBrowserWidget(ToolBitBrowserWidget):
                     # Scroll to the first selected item
                     is_first = False
                     self._tool_list_widget.scrollToItem(item)
-                break
 
     def refresh(self):
         """Reads available libraries and toolbits from disk."""
@@ -269,7 +268,6 @@ class LibraryBrowserWidget(ToolBitBrowserWidget):
 
     def _on_cut_requested(self):
         """Handles cut request by copying and marking for removal from library."""
-        mime_type = "application/x-freecad-toolbit-list-yaml"
         uris = self.get_selected_bit_uris()
         library = self._get_current_library()
         if not library or not uris:
@@ -402,7 +400,7 @@ class LibraryBrowserWidget(ToolBitBrowserWidget):
 
             toolbit_data_bytes = toolbit_yaml_str.encode("utf-8")
             toolbit = YamlToolBitSerializer.deserialize(toolbit_data_bytes, dependencies=None)
-            success = source_library.remove_bit(toolbit)
+            source_library.remove_bit(toolbit)
 
             # Remove it from the old library, add it to the new library
             source_library.remove_bit(toolbit)

--- a/src/Mod/CAM/Path/Tool/library/ui/browser.py
+++ b/src/Mod/CAM/Path/Tool/library/ui/browser.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa E731
 # ***************************************************************************
 # *   Copyright (c) 2025 Samuel Abels <knipknap@gmail.com>                  *
 # *                                                                         *
@@ -22,12 +23,20 @@
 
 """Widget for browsing Tool Library assets with filtering and sorting."""
 
-from typing import cast
-from PySide import QtGui
+import FreeCAD
+from typing import cast, List
+from PySide import QtGui, QtCore
+from PySide.QtGui import QMenu, QAction, QKeySequence
 import Path
-from ...toolbit.ui.browser import ToolBitBrowserWidget
-from ...assets import AssetManager
-from ...library import Library
+import yaml
+from ...assets import AssetManager, AssetUri
+from ...toolbit.ui.browser import ToolBitBrowserWidget, ToolBitUriRole
+from ...toolbit.serializers import YamlToolBitSerializer
+from ..models.library import Library
+
+
+Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+Path.Log.trackModule(Path.Log.thisModule())
 
 
 class LibraryBrowserWidget(ToolBitBrowserWidget):
@@ -57,23 +66,89 @@ class LibraryBrowserWidget(ToolBitBrowserWidget):
         self._top_layout.insertWidget(0, self._library_combo)
         self._library_combo.currentIndexChanged.connect(self._on_library_changed)
 
-    def refresh(self):
-        """Refreshes the library dropdown and fetches all assets."""
-        self._library_combo.clear()
-        self._fetch_all_assets()
+    def _get_state(self):
+        """Gets the current library URI, selected toolbit URI, and scroll
+        position."""
+        current_library = self._get_current_library()
+        current_library_uri_str = (
+            str(current_library.get_uri()) if current_library else None
+        )
 
-    def _fetch_all_assets(self):
-        """Populates the library dropdown with available libraries."""
-        # Use list_assets("toolbitlibrary") to get URIs
+        selected_toolbit_uris = []
+        selected_items = self._tool_list_widget.selectedItems()
+        if selected_items:
+            selected_toolbit_uris = [
+                item.data(ToolBitUriRole) for item in selected_items
+            ]
+
+        scroll_pos = self._tool_list_widget.verticalScrollBar().value()
+
+        return {
+            "library_uri": current_library_uri_str,
+            "toolbit_uris": selected_toolbit_uris,
+            "scroll_pos": scroll_pos,
+        }
+
+    def _set_state(self, selection_data):
+        """Restores the library selection, toolbit selection, and scroll
+        position."""
+        library_uri_str = selection_data.get("library_uri")
+        toolbit_uris = selection_data.get("toolbit_uris", [])
+        scroll_pos = selection_data.get("scroll_pos", 0)
+
+        # Restore library selection
+        if library_uri_str:
+            for i in range(self._library_combo.count()):
+                item_data = self._library_combo.itemData(i)
+                if isinstance(item_data, Library):
+                    if str(item_data.get_uri()) == library_uri_str:
+                        self._library_combo.setCurrentIndex(i)
+                        # The _on_library_changed signal will be emitted automatically
+                        # and will repopulate the tool list.
+                        break
+
+        # Restore toolbit selection after the tool list has been repopulated
+        # by _on_library_changed.
+        if toolbit_uris:
+            for uri in toolbit_uris:
+                for i in range(self._tool_list_widget.count()):
+                    item = self._tool_list_widget.item(i)
+                    if item.data(ToolBitUriRole) == uri:
+                        item.setSelected(True) # Use setSelected(True)
+
+        # Always restore scroll position
+        self._tool_list_widget.verticalScrollBar().setValue(scroll_pos)
+
+    def _select_by_uri(self, uris: List[str]):
+        if not uris:
+            return
+
+        # Select and scroll to the first toolbit
+        is_first = True
+        for i in range(self._tool_list_widget.count()):
+            item = self._tool_list_widget.item(i)
+            if item.data(ToolBitUriRole) in uris:
+                self._tool_list_widget.setCurrentItem(item)
+                if is_first:
+                    # Scroll to the first selected item
+                    is_first = False
+                    self._tool_list_widget.scrollToItem(item)
+                break
+
+    def refresh(self):
+        """Reads available libraries and toolbits from disk."""
+        Path.Log.debug("refresh(): Fetching and populating libraries and toolbits.")
+        selection_data = self._get_state()
+        self._library_combo.clear()
+
+        # Fetch the library (shallow load). Updating the combo box also
+        # triggers the _on_library_changed method, which populates the
+        # tool list widget with the toolbits from the selected library.
         libraries = self._asset_manager.fetch("toolbitlibrary", store=self._store_name, depth=0)
         for library in sorted(libraries, key=lambda x: x.label):
             self._library_combo.addItem(library.label, userData=library)
 
-        if not self._library_combo.count():
-            return
-
-        # Trigger initial load after populating libraries
-        self._on_library_changed(0)
+        self._set_state(selection_data)
 
     def get_tool_no_from_current_library(self, toolbit):
         """
@@ -112,5 +187,271 @@ class LibraryBrowserWidget(ToolBitBrowserWidget):
         self._all_assets = [t for t in library]
         self._sort_assets()
         self._tool_list_widget.clear_list()
-        self._scroll_position = 0
-        self._trigger_fetch()  # Display data for the selected library
+        self._update_list()  # Display data for the selected library
+
+    def _add_shortcuts(self):
+        """Adds keyboard shortcuts for common actions."""
+        Path.Log.debug("LibraryBrowserWidget._add_shortcuts: Called.")
+        super()._add_shortcuts()
+
+        cut_action = QAction(self)
+        cut_action.setShortcuts(QKeySequence.Cut)
+        cut_action.triggered.connect(self._on_cut_requested)
+        self.addAction(cut_action)
+
+        duplicate_action = QAction(self)
+        duplicate_action.setShortcut(QKeySequence("Ctrl+D"))
+        duplicate_action.triggered.connect(self._on_duplicate_requested)
+        self.addAction(duplicate_action)
+
+        remove_action = QAction(self)
+        remove_action.setShortcut(QKeySequence.Delete)
+        remove_action.triggered.connect(self._on_remove_from_library_requested)
+        self.addAction(remove_action)
+
+        paste_action = QAction(self)
+        paste_action.setShortcuts(QKeySequence.Paste)
+        paste_action.triggered.connect(self._on_paste_requested)
+        self.addAction(paste_action)
+
+    def _show_context_menu(self, position):
+        """Shows the context menu at the given position."""
+        context_menu = QMenu(self)
+
+        selected_items = self._tool_list_widget.selectedItems()
+        has_selection = bool(selected_items)
+
+        # Add actions in the desired order
+        edit_action = context_menu.addAction("Edit", self._on_edit_requested)
+        edit_action.setEnabled(has_selection)
+
+        context_menu.addSeparator()
+
+        action = context_menu.addAction("Copy", self._on_copy_requested)
+        action.setShortcut(QtGui.QKeySequence("Ctrl+C"))
+
+        action = context_menu.addAction("Cut", self._on_cut_requested)
+        action.setShortcut(QtGui.QKeySequence("Ctrl+X"))
+
+        action = context_menu.addAction("Paste", self._on_paste_requested)
+        action.setShortcut(QtGui.QKeySequence("Ctrl+V"))
+
+        # Paste is enabled if there is data in the clipboard
+        clipboard = QtGui.QApplication.clipboard()
+        mime_type = "application/x-freecad-toolbit-list-yaml"
+        action.setEnabled(clipboard.mimeData().hasFormat(mime_type))
+
+        action = context_menu.addAction("Duplicate", self._on_duplicate_requested)
+        action.setShortcut(QtGui.QKeySequence("Ctrl+D"))
+
+        context_menu.addSeparator()
+
+        action = context_menu.addAction("Remove from Library",
+                                       self._on_remove_from_library_requested)
+        action.setShortcut(QtGui.QKeySequence.Delete)
+
+        action = context_menu.addAction("Delete from disk",
+                                       self._on_delete_requested)
+        action.setShortcut(QtGui.QKeySequence("Shift+Delete"))
+
+        # Execute the menu
+        context_menu.exec_(self._tool_list_widget.mapToGlobal(position))
+
+    def _get_current_library(self) -> Library | None:
+        """Helper to get the currently selected library."""
+        selected_library = self._library_combo.currentData()
+        if isinstance(selected_library, Library):
+            return selected_library
+        return None
+
+    def _on_cut_requested(self):
+        """Handles cut request by copying and marking for removal from library."""
+        mime_type = "application/x-freecad-toolbit-list-yaml"
+        uris = self.get_selected_bit_uris()
+        library = self._get_current_library()
+        if not library or not uris:
+            return
+
+        # Copy to clipboard (handled by base class _to_clipboard)
+        extra_data = {"source_library_uri": str(library.get_uri())}
+        self._to_clipboard(uris, mode="cut", extra_data=extra_data)
+
+    def _on_duplicate_requested(self):
+        """Handles duplicate request by duplicating and adding to library."""
+        Path.Log.debug("LibraryBrowserWidget._on_duplicate_requested: Called.\n")
+        uris = self.get_selected_bit_uris()
+        library = self._get_current_library()
+        if not library or not uris:
+            Path.Log.debug("LibraryBrowserWidget._on_duplicate_requested: No library or URIs selected. Returning.\n")
+            return
+
+        new_uris = set()
+        for uri_string in uris:
+            toolbit = self._asset_manager.get(AssetUri(uri_string), depth=0)
+            if not toolbit:
+                Path.Log.warning(f"Toolbit {uri_string} not found.\n")
+                continue
+
+            # Change the ID of the toolbit and save it to disk
+            toolbit.set_id()  # Generate a new ID
+            toolbit.label = toolbit.label + " (copy)"
+            added_uri = self._asset_manager.add(toolbit)
+            if added_uri:
+                new_uris.add(str(toolbit.get_uri()))
+
+            # Add the bit to the current library
+            library.add_bit(toolbit)
+
+        self._asset_manager.add(library) # Save the modified library
+        self.refresh()
+
+        # Select and scroll to the first duplicated toolbit
+        self._select_by_uri(new_uris)
+
+    def _on_paste_requested(self):
+        """Handles paste request by adding toolbits to the current library."""
+        current_library = self._get_current_library()
+        if not current_library:
+            return
+
+        clipboard = QtGui.QApplication.clipboard()
+        mime_type = "application/x-freecad-toolbit-list-yaml"
+        mime_data = clipboard.mimeData()
+
+        if not mime_data.hasFormat(mime_type):
+            return
+
+        try:
+            clipboard_content_yaml = mime_data.data(mime_type).data().decode('utf-8')
+            clipboard_data_dict = yaml.safe_load(clipboard_content_yaml)
+
+            if not isinstance(clipboard_data_dict, dict) \
+               or "toolbits" not in clipboard_data_dict \
+               or not isinstance(clipboard_data_dict["toolbits"], list):
+                return
+
+            serialized_toolbits_data = clipboard_data_dict["toolbits"]
+            mode = clipboard_data_dict.get("operation", "copy")
+            source_library_uri_str = clipboard_data_dict.get("source_library_uri")
+
+            if mode == "copy":
+                self._on_copy_paste(current_library, serialized_toolbits_data)
+            elif mode == "cut" and source_library_uri_str:
+                self._on_cut_paste(
+                    current_library, serialized_toolbits_data, source_library_uri_str
+                )
+
+        except Exception as e:
+            Path.Log.warning(
+                f"An unexpected error occurred during paste: {e}"
+            )
+
+    def _on_copy_paste(self, current_library: Library, serialized_toolbits_data: list):
+        """Handles pasting toolbits that were copied."""
+        new_uris = set()
+        for toolbit_yaml_str in serialized_toolbits_data:
+            if not isinstance(toolbit_yaml_str, str) or not toolbit_yaml_str.strip():
+                continue
+
+            toolbit_data_bytes = toolbit_yaml_str.encode('utf-8')
+            toolbit = YamlToolBitSerializer.deserialize(
+                toolbit_data_bytes, dependencies=None
+            )
+            # Assign a new tool id and a label
+            toolbit.set_id()
+            self._asset_manager.add(toolbit) # Save the new toolbit to disk
+
+            # Save the bit to disk (handled by asset manager add)
+            # Add the bit to the current library
+            added_toolbit = current_library.add_bit(toolbit)
+            if added_toolbit:
+                new_uris.add(str(toolbit.get_uri()))
+
+        if new_uris:
+            self._asset_manager.add(current_library) # Save the modified library
+            self.refresh()
+            self._select_by_uri(new_uris)
+
+    def _on_cut_paste(
+        self,
+        current_library: Library,
+        serialized_toolbits_data: list,
+        source_library_uri_str: str,
+    ):
+        """Handles pasting toolbits that were cut."""
+        source_library_uri = AssetUri(source_library_uri_str)
+        if source_library_uri == current_library.get_uri():
+            # Cut from the same library, do nothing
+            return
+
+        try:
+            source_library = cast(Library, self._asset_manager.get(
+                source_library_uri, store=self._store_name, depth=1
+            ))
+        except FileNotFoundError:
+            Path.Log.warning(
+                f"Source library {source_library_uri_str} not found.\n"
+            )
+            return
+
+        new_uris = set()
+        for toolbit_yaml_str in serialized_toolbits_data:
+            if not isinstance(toolbit_yaml_str, str) or not toolbit_yaml_str.strip():
+                continue
+
+            toolbit_data_bytes = toolbit_yaml_str.encode('utf-8')
+            toolbit = YamlToolBitSerializer.deserialize(
+                toolbit_data_bytes, dependencies=None
+            )
+            success = source_library.remove_bit(toolbit)
+
+            # Remove it from the old library, add it to the new library
+            source_library.remove_bit(toolbit)
+            added_toolbit = current_library.add_bit(toolbit)
+            if added_toolbit:
+                new_uris.add(str(toolbit.get_uri()))
+
+            # The toolbit itself does not change, so we don't need to save it.
+            # It is only the reference in the library that changes.
+
+        if new_uris:
+            # Save the modified libraries
+            self._asset_manager.add(current_library)
+            self._asset_manager.add(source_library)
+            self.refresh()
+            self._select_by_uri(new_uris)
+
+    def _on_remove_from_library_requested(self):
+        """Handles request to remove selected toolbits from the current library."""
+        Path.Log.debug("_on_remove_from_library_requested: Called.")
+        uris = self.get_selected_bit_uris()
+        library = self._get_current_library()
+        if not library or not uris:
+            return
+
+        # Ask for confirmation
+        reply = QtGui.QMessageBox.question(
+            self,
+            FreeCAD.Qt.translate("CAM", "Confirm Removal"),
+            FreeCAD.Qt.translate("CAM", "Are you sure you want to remove the selected toolbit(s) from the library?"),
+            QtGui.QMessageBox.Yes | QtGui.QMessageBox.No,
+            QtGui.QMessageBox.No,
+        )
+
+        if reply == QtGui.QMessageBox.Yes:
+            self._remove_toolbits_from_library(library, uris)
+
+    def _remove_toolbits_from_library(self, library: Library, uris: List[str]):
+        """Removes toolbits with the given URIs from the specified library."""
+        removed_count = 0
+        for uri_string in uris:
+            try:
+                # Remove the toolbit from the library
+                library.remove_bit_by_uri(uri_string)
+                removed_count += 1
+            except Exception as e:
+                Path.Log.error(f"Failed to remove toolbit {uri_string} from library: {e}\n")
+
+        if removed_count > 0:
+            self._asset_manager.add(library) # Save the modified library
+            self.refresh()

--- a/src/Mod/CAM/Path/Tool/library/ui/dock.py
+++ b/src/Mod/CAM/Path/Tool/library/ui/dock.py
@@ -92,7 +92,7 @@ class ToolBitLibraryDock(object):
 
         # Connect signals from the browser widget and buttons
         self.browser_widget.toolSelected.connect(self._update_state)
-        self.browser_widget.itemDoubleClicked.connect(partial(self._add_tool_controller_to_doc))
+        self.browser_widget.itemDoubleClicked.connect(partial(self._on_doubleclick))
         self.libraryEditorOpenButton.clicked.connect(self._open_editor)
         self.addToolControllerButton.clicked.connect(partial(self._add_tool_controller_to_doc))
 
@@ -108,6 +108,10 @@ class ToolBitLibraryDock(object):
         if selected and FreeCAD.ActiveDocument:
             jobs = len([1 for j in FreeCAD.ActiveDocument.Objects if j.Name[:3] == "Job"]) >= 1
             self.addToolControllerButton.setEnabled(len(selected) >= 1 and jobs)
+
+    def _on_doubleclick(self, toolbit: ToolBit):
+        """Opens the ToolBitEditor for the selected toolbit."""
+        self.browser_widget._on_edit_requested()
 
     def _open_editor(self):
         library = LibraryEditor()

--- a/src/Mod/CAM/Path/Tool/toolbit/models/base.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/models/base.py
@@ -288,6 +288,9 @@ class ToolBit(Asset, ABC):
         """Returns the unique ID of the tool bit."""
         return self.id
 
+    def set_id(self, id: str = None):
+        self.id = id if id is not None else str(uuid.uuid4())
+
     def _promote_toolbit(self):
         """
         Updates the toolbit properties for backward compatibility.

--- a/src/Mod/CAM/Path/Tool/toolbit/serializers/__init__.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/serializers/__init__.py
@@ -1,12 +1,18 @@
 from .camotics import CamoticsToolBitSerializer
 from .fctb import FCTBSerializer
+from .yaml import YamlToolBitSerializer
 
 
-all_serializers = CamoticsToolBitSerializer, FCTBSerializer
+all_serializers = (
+    CamoticsToolBitSerializer,
+    FCTBSerializer,
+    YamlToolBitSerializer,
+)
 
 
 __all__ = [
     "CamoticsToolBitSerializer",
     "FCTBSerializer",
+    "YamlToolBitSerializer",
     "all_serializers",
 ]

--- a/src/Mod/CAM/Path/Tool/toolbit/serializers/yaml.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/serializers/yaml.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+# ***************************************************************************
+# *   Copyright (c) 2025 Samuel Abels <knipknap@gmail.com>                  *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+import yaml
+from typing import List, Optional, Mapping, Type
+from ...assets.serializer import AssetSerializer
+from ...assets.uri import AssetUri
+from ...shape import ToolBitShape
+from ..models.base import ToolBit
+from ..util import format_value
+
+
+class YamlToolBitSerializer(AssetSerializer):
+    """
+    Serializes and deserializes ToolBit instances to and from YAML.
+    """
+
+    for_class: Type[ToolBit] = ToolBit
+    extensions: tuple[str, ...] = (".yaml", ".yml")
+    mime_type: str = "application/x-yaml"
+    can_import: bool = True
+    can_export: bool = True
+
+    @classmethod
+    def get_label(cls) -> str:
+        return "YAML ToolBit"
+
+    @classmethod
+    def extract_dependencies(cls, data: bytes) -> List[AssetUri]:
+        """Extracts URIs of dependencies from serialized data."""
+        try:
+            data_dict = yaml.safe_load(data)
+            if isinstance(data_dict, dict):
+                shape_id = data_dict.get("shape")
+                if shape_id:
+                    # Assuming shape is identified by its ID/name
+                    return [ToolBitShape.resolve_name(str(shape_id))]
+        except yaml.YAMLError:
+            pass
+        return []
+
+    @classmethod
+    def serialize(cls, asset: ToolBit) -> bytes:
+        """Serializes a ToolBit instance to bytes (shallow)."""
+        # Shallow serialization: only serialize direct attributes and shape ID
+        data = {
+            "id": asset.id,
+            "name": asset.label,
+            "shape": asset.get_shape_name(),  # Serialize shape ID/name
+            "shape-type": asset.obj.ShapeType,  # Include shape type for deserialization
+            "parameter": {},
+            "attribute": {},
+        }
+
+        # Include parameters and attributes from the FreeCAD object
+        for prop_name in asset.obj.PropertiesList:
+            group = asset.obj.getGroupOfProperty(prop_name)
+            if group == "Shape":
+                # Parameters are part of the shape schema
+                data["parameter"][prop_name] = format_value(asset.get_property(prop_name))
+            elif group == "Attributes":
+                # Attributes are general toolbit properties
+                data["attribute"][prop_name] = format_value(asset.get_property(prop_name))
+
+        return yaml.dump(data, default_flow_style=False).encode("utf-8")
+
+    @classmethod
+    def deserialize(
+        cls,
+        data: bytes,
+        id: str | None = None,
+        dependencies: Optional[Mapping[AssetUri, ToolBitShape]] = None,
+    ) -> ToolBit:
+        """
+        Creates a ToolBit instance from serialized data and resolved
+        dependencies (shallow).
+        """
+        data_dict = yaml.safe_load(data)
+        if not isinstance(data_dict, dict):
+            raise ValueError("Invalid YAML data for ToolBit")
+
+        # Ensure required keys are present
+        if "shape" not in data_dict:
+            raise ValueError("YAML data is missing attribute 'shape'")
+        if "shape-type" not in data_dict:
+            raise ValueError("YAML data is missing attribute 'shape-type'")
+
+        # Deserialize shallowly: use the provided dependencies or create a dummy
+        tool_bit_shape = None
+        shape_id = str(data_dict["shape"])
+        shape_uri = ToolBitShape.resolve_name(shape_id)
+
+        if dependencies and shape_uri in dependencies:
+            tool_bit_shape = dependencies[shape_uri]
+        else:
+            # If dependency not provided, create a dummy shape instance
+            shape_type = data_dict["shape-type"]
+            shape_class = ToolBitShape.get_subclass_by_name(shape_type or shape_id)
+            if not shape_class:
+                raise ValueError(f"Unknown tool shape type: {shape_type or shape_id}")
+            tool_bit_shape = shape_class(shape_id)
+
+        # Create the ToolBit instance using from_shape
+        # Pass the full data_dict to from_shape to handle parameters/attributes
+        id = id or data_dict.get("id")
+        return ToolBit.from_shape(tool_bit_shape, data_dict, id=id)
+
+    @classmethod
+    def deep_deserialize(cls, data: bytes) -> ToolBit:
+        """
+        Like deserialize(), but builds dependencies itself if they are
+        sufficiently defined in the data.
+        """
+        raise NotImplementedError

--- a/src/Mod/CAM/Path/Tool/toolbit/serializers/yaml.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/serializers/yaml.py
@@ -46,15 +46,12 @@ class YamlToolBitSerializer(AssetSerializer):
     @classmethod
     def extract_dependencies(cls, data: bytes) -> List[AssetUri]:
         """Extracts URIs of dependencies from serialized data."""
-        try:
-            data_dict = yaml.safe_load(data)
-            if isinstance(data_dict, dict):
-                shape_id = data_dict.get("shape")
-                if shape_id:
-                    # Assuming shape is identified by its ID/name
-                    return [ToolBitShape.resolve_name(str(shape_id))]
-        except yaml.YAMLError:
-            pass
+        data_dict = yaml.safe_load(data)
+        if isinstance(data_dict, dict):
+            shape_id = data_dict.get("shape")
+            if shape_id:
+                # Assuming shape is identified by its ID/name
+                return [ToolBitShape.resolve_name(str(shape_id))]
         return []
 
     @classmethod

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/browser.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/browser.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa E731
 # ***************************************************************************
 # *   Copyright (c) 2025 Samuel Abels <knipknap@gmail.com>                  *
 # *                                                                         *
@@ -22,13 +23,23 @@
 
 """Widget for browsing ToolBit assets with filtering and sorting."""
 
+import yaml
 from typing import List, cast
+import PySide
 from PySide import QtGui, QtCore
-from typing import List, cast
-from PySide import QtGui, QtCore
+from PySide.QtGui import QApplication, QMessageBox, QMenu, QAction, QKeySequence
+from PySide.QtCore import QMimeData
+import FreeCAD
+import Path
 from ...assets import AssetManager, AssetUri
-from ...toolbit import ToolBit
+from ..models.base import ToolBit
+from ..serializers.yaml import YamlToolBitSerializer
 from .toollist import ToolBitListWidget, CompactToolBitListWidget, ToolBitUriRole
+from .editor import ToolBitEditor
+
+
+Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+Path.Log.trackModule(Path.Log.thisModule())
 
 
 class ToolBitBrowserWidget(QtGui.QWidget):
@@ -40,11 +51,10 @@ class ToolBitBrowserWidget(QtGui.QWidget):
     # Signal emitted when a tool is selected in the list
     toolSelected = QtCore.Signal(str)  # Emits ToolBit URI string
     # Signal emitted when a tool is requested for editing (e.g., double-click)
-    itemDoubleClicked = QtCore.Signal(str)  # Emits ToolBit URI string
+    itemDoubleClicked = QtCore.Signal(ToolBit)  # Emits ToolBit URI string
 
     # Debounce timer for search input
     _search_timer_interval = 300  # milliseconds
-    _batch_size = 20  # Number of items to insert per batch
 
     def __init__(
         self,
@@ -63,8 +73,8 @@ class ToolBitBrowserWidget(QtGui.QWidget):
         self._store_name = store
         self._all_assets: List[ToolBit] = []  # Store all fetched assets
         self._current_search = ""  # Track current search term
-        self._scroll_position = 0  # Track scroll position
         self._sort_key = "tool_no" if tool_no_factory else "label"
+        self._selected_uris: List[str] = [] # Track selected toolbit URIs
 
         # UI Elements
         self._search_edit = QtGui.QLineEdit()
@@ -97,15 +107,20 @@ class ToolBitBrowserWidget(QtGui.QWidget):
         self._search_timer = QtCore.QTimer(self)
         self._search_timer.setSingleShot(True)
         self._search_timer.setInterval(self._search_timer_interval)
-        self._search_timer.timeout.connect(self._trigger_fetch)
+        self._search_timer.timeout.connect(self._update_list)
         self._search_edit.textChanged.connect(self._search_timer.start)
         self._sort_combo.currentIndexChanged.connect(self._on_sort_changed)
 
-        scrollbar = self._tool_list_widget.verticalScrollBar()
-        scrollbar.valueChanged.connect(self._on_scroll)
-
+        # Connect signals from the list widget
         self._tool_list_widget.itemDoubleClicked.connect(self._on_item_double_clicked)
         self._tool_list_widget.currentItemChanged.connect(self._on_item_selection_changed)
+
+        # Connect list widget context menu request to browser handler
+        self._tool_list_widget.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self._tool_list_widget.customContextMenuRequested.connect(self._show_context_menu)
+
+        # Add keyboard shortcuts
+        self._add_shortcuts()
 
         # Note that fetching of assets is done at showEvent(),
         # because we need to know the widget size to calculate the number
@@ -116,10 +131,10 @@ class ToolBitBrowserWidget(QtGui.QWidget):
         super().showEvent(event)
         # Fetch all assets the first time the widget is shown
         if not self._all_assets and not self._is_fetching:
-            self._fetch_all_assets()
+            self.refresh()
 
-    def _fetch_all_assets(self):
-        """Fetches all ToolBit assets and stores them in memory."""
+    def refresh(self):
+        """Fetches all ToolBit assets and stores them in memory, then updates the UI."""
         if self._is_fetching:
             return
         self._is_fetching = True
@@ -135,7 +150,8 @@ class ToolBitBrowserWidget(QtGui.QWidget):
             self._sort_assets()
         finally:
             self._is_fetching = False
-        self._trigger_fetch()
+
+        self._update_list()
 
     def _sort_assets(self):
         """Sorts the in-memory assets based on the current sort key."""
@@ -146,101 +162,230 @@ class ToolBitBrowserWidget(QtGui.QWidget):
                 key=lambda x: (int(self._tool_no_factory(x)) or 0) if self._tool_no_factory else 0
             )
 
-    def _trigger_fetch(self):
-        """Initiates a data fetch, clearing the list only if search term changes."""
-        new_search = self._search_edit.text()
-        if new_search != self._current_search:
-            self._current_search = new_search
-            self._tool_list_widget.clear_list()
-            self._scroll_position = 0
-        self._fetch_data()
-
-    def _fetch_batch(self, offset):
-        """Inserts a batch of filtered assets into the list widget."""
-        filtered_assets = [
-            asset
-            for asset in self._all_assets
-            if not self._current_search or self._matches_search(asset, self._current_search)
-        ]
-        end_idx = min(offset + self._batch_size, len(filtered_assets))
-        for i in range(offset, end_idx):
-            self._tool_list_widget.add_toolbit(filtered_assets[i])
-        return end_idx < len(filtered_assets)  # Return True if more items remain
-
     def _matches_search(self, toolbit, search_term):
         """Checks if a ToolBit matches the search term."""
         search_term = search_term.lower()
         return search_term in toolbit.label.lower() or search_term in toolbit.summary.lower()
 
-    def _fetch_data(self):
-        """Inserts filtered and sorted ToolBit assets into the list widget."""
+    def _update_list(self):
+        """Updates the list widget based on current search and sort."""
         if self._is_fetching:
             return
-        self._is_fetching = True
-        try:
-            # Save current scroll position and selected item
-            scrollbar = self._tool_list_widget.verticalScrollBar()
-            self._scroll_position = scrollbar.value()
-            selected_uri = self._tool_list_widget.get_selected_toolbit_uri()
 
-            # Insert initial batches to fill the viewport
-            offset = self._tool_list_widget.count()
-            more_items = True
-            while more_items:
-                more_items = self._fetch_batch(offset)
-                offset += self._batch_size
-                if scrollbar.maximum() != 0:
-                    break
-
-            # Apply filter to ensure UI consistency
-            self._tool_list_widget.apply_filter(self._current_search)
-
-            # Restore scroll position and selection
-            scrollbar.setValue(self._scroll_position)
-            if selected_uri:
-                for i in range(self._tool_list_widget.count()):
-                    item = self._tool_list_widget.item(i)
-                    if item.data(ToolBitUriRole) == selected_uri and not item.isHidden():
-                        self._tool_list_widget.setCurrentItem(item)
-                        break
-
-        finally:
-            self._is_fetching = False
-
-    def _on_scroll(self, value):
-        """Handles scroll events for lazy batch insertion."""
-        scrollbar = self._tool_list_widget.verticalScrollBar()
-        is_near_bottom = value >= scrollbar.maximum() - scrollbar.singleStep()
-        filtered_count = sum(
-            1
+        self._current_search = self._search_edit.text()
+        filtered_assets = [
+            asset
             for asset in self._all_assets
             if not self._current_search or self._matches_search(asset, self._current_search)
-        )
-        more_might_exist = self._tool_list_widget.count() < filtered_count
+        ]
 
-        if is_near_bottom and more_might_exist and not self._is_fetching:
-            self._fetch_data()
+        # Collect current items in the list widget
+        current_items = {}
+        for i in range(self._tool_list_widget.count()):
+            item = self._tool_list_widget.item(i)
+            uri = item.data(ToolBitUriRole)
+            if uri:
+                current_items[uri] = item
+
+        filtered_assets_map = {str(asset.get_uri()): asset for asset in filtered_assets}
+
+        # Iterate through filtered assets and update the list widget
+        for i, asset in enumerate(filtered_assets):
+            uri = str(asset.get_uri())
+            if uri in current_items:
+                # Item exists, remove the old one and insert the new one
+                item = current_items[uri]
+                row = self._tool_list_widget.row(item)
+                self._tool_list_widget.takeItem(row)
+                self._tool_list_widget.insert_toolbit(i, asset)
+                del current_items[uri]
+            else:
+                # Insert new item
+                self._tool_list_widget.insert_toolbit(i, asset)
+
+        # Remove items that are no longer in filtered_assets
+        for uri, item in current_items.items():
+            row = self._tool_list_widget.row(item)
+            self._tool_list_widget.takeItem(row)
+
+        # Restore selection and scroll to the selected item
+        if self._selected_uris:
+            first_selected_item = None
+            for i in range(self._tool_list_widget.count()):
+                item = self._tool_list_widget.item(i)
+                uri = item.data(ToolBitUriRole)
+                if uri in self._selected_uris:
+                    item.setSelected(True)
+                    if first_selected_item is None:
+                        first_selected_item = item
+            if first_selected_item:
+                self._tool_list_widget.scrollToItem(first_selected_item)
+
+        # Apply the filter to trigger highlighting in the list widget
+        self._tool_list_widget.apply_filter(self._current_search)
 
     def _on_sort_changed(self):
         """Handles sort order change from the dropdown."""
         self._sort_key = self._sort_combo.itemData(self._sort_combo.currentIndex())
         self._sort_assets()
-        self._tool_list_widget.clear_list()
-        self._scroll_position = 0
-        self._fetch_data()
+        self._update_list()
 
     def _on_item_double_clicked(self, item):
-        """Emits itemDoubleClicked signal when an item is double-clicked."""
-        uri = item.data(ToolBitUriRole)
-        if uri:
-            self.itemDoubleClicked.emit(uri)
+        """Handles double-click on a list item to request editing."""
+        uri_string = item.data(ToolBitUriRole)
+        if not uri_string:
+            return
+        toolbit = self._asset_manager.get(AssetUri(uri_string))
+        if toolbit:
+            self.itemDoubleClicked.emit(toolbit)
 
     def _on_item_selection_changed(self, current_item, previous_item):
-        """Emits toolSelected signal when the selection changes."""
-        uri = None
-        if current_item:
-            uri = current_item.data(ToolBitUriRole)
-        self.toolSelected.emit(uri if current_item else None)
+        """Emits toolSelected signal and tracks selected URIs."""
+        selected_uris = self._tool_list_widget.get_selected_toolbit_uris()
+        self._selected_uris = selected_uris
+        # Emit signal for the first selected item or None if no selection
+        self.toolSelected.emit(selected_uris[0] if selected_uris else None)
+
+    def _on_edit_requested(self):
+        """Opens the ToolBitEditor for the selected toolbit."""
+        uris = self.get_selected_bit_uris()
+        if not uris:
+            return
+
+        # For now, only handle editing the first selected toolbit
+        uri_string = uris[0]
+        toolbit = self._asset_manager.get(AssetUri(uri_string))
+        if not toolbit:
+            return
+
+        # Open the editor for the selected toolbit
+        editor = ToolBitEditor(toolbit)
+        result = editor.show()
+        if result != PySide.QtGui.QDialog.Accepted:
+            return
+
+        # If the editor was closed with "OK", save the changes
+        self._asset_manager.add(toolbit)
+        Path.Log.info(f"Toolbit {toolbit.get_id()} saved.")
+        self.refresh()
+        self._update_list()
+
+    def _add_shortcuts(self):
+        """Adds keyboard shortcuts for common actions."""
+        copy_action = QAction(self)
+        copy_action.setShortcut(QKeySequence.Copy)
+        copy_action.triggered.connect(self._on_copy_requested)
+        self.addAction(copy_action)
+
+        delete_action = QAction(self)
+        delete_action.setShortcut(QKeySequence("Shift+Delete"))
+        delete_action.triggered.connect(self._on_delete_requested)
+        self.addAction(delete_action)
+
+    def _create_base_context_menu(self):
+        """Creates the base context menu with Edit, Copy, and Delete actions."""
+        selected_items = self._tool_list_widget.selectedItems()
+        has_selection = bool(selected_items)
+
+        context_menu = QMenu(self)
+
+        edit_action = context_menu.addAction("Edit", self._on_edit_requested)
+        edit_action.setEnabled(has_selection)
+        context_menu.addSeparator()
+        action = context_menu.addAction("Copy", self._on_copy_requested)
+        action.setShortcut(QKeySequence.Copy)
+        action = context_menu.addAction("Delete from disk", self._on_delete_requested)
+        action.setShortcut(QKeySequence("Shift+Delete"))
+
+        return context_menu
+
+    def _show_context_menu(self, position):
+        """Shows the context menu at the given position."""
+        context_menu = self._create_base_context_menu()
+        context_menu.exec_(self._tool_list_widget.mapToGlobal(position))
+
+    def _to_clipboard(self, uris: List[str], mode: str = "copy", extra_data: dict = None):
+        """Copies selected toolbits to the clipboard as YAML."""
+        if not uris:
+            return
+
+        selected_bits = [self._asset_manager.get(AssetUri(uri)) for uri in uris]
+        selected_bits = [bit for bit in selected_bits if bit] # Filter out None
+
+        if not selected_bits:
+            return
+
+        # Serialize selected toolbits individually
+        serialized_toolbits_data = []
+        for toolbit in selected_bits:
+            yaml_data = YamlToolBitSerializer.serialize(toolbit)
+            serialized_toolbits_data.append(yaml_data.decode('utf-8'))
+
+        # Create a dictionary to hold the operation type and serialized data
+        clipboard_data_dict = {
+            "operation": mode,
+            "toolbits": serialized_toolbits_data,
+        }
+
+        # Include extra data if provided
+        if extra_data:
+            clipboard_data_dict.update(extra_data)
+
+        # Serialize the dictionary to YAML
+        clipboard_content_yaml = yaml.dump(
+            clipboard_data_dict, default_flow_style=False
+        )
+
+        # Put the YAML data on the clipboard with a custom MIME type
+        mime_data = QMimeData()
+        mime_type = "application/x-freecad-toolbit-list-yaml"
+        mime_data.setData(mime_type, clipboard_content_yaml.encode('utf-8'))
+
+        # Put it in text format for pasting to text editors
+        toolbit_list = [yaml.safe_load(d) for d in serialized_toolbits_data]
+        mime_data.setText(yaml.dump(toolbit_list, default_flow_style=False))
+
+        clipboard = QApplication.clipboard()
+        clipboard.setMimeData(mime_data)
+
+    def _on_copy_requested(self):
+        """Copies selected toolbits to the clipboard as YAML."""
+        uris = self.get_selected_bit_uris()
+        self._to_clipboard(uris, mode="copy")
+
+    def _on_delete_requested(self):
+        """Deletes selected toolbits."""
+        Path.Log.debug("ToolBitBrowserWidget._on_delete_requested: Function entered.")
+        uris = self.get_selected_bit_uris()
+        if not uris:
+            Path.Log.debug("_on_delete_requested: No URIs selected. Returning.")
+            return
+
+        # Ask for confirmation
+        reply = QMessageBox.question(
+            self,
+            FreeCAD.Qt.translate("CAM", "Confirm Deletion"),
+            FreeCAD.Qt.translate("CAM", "Are you sure you want to delete the selected toolbit(s)?"),
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+
+        if reply != QMessageBox.Yes:
+            return
+
+        deleted_count = 0
+        for uri_string in uris:
+            try:
+                # Delete the toolbit using the asset manager
+                self._asset_manager.delete(AssetUri(uri_string))
+                deleted_count += 1
+            except Exception as e:
+                Path.Log.error(f"Failed to delete toolbit {uri_string}: {e}")
+                # Optionally show a message box to the user
+
+        if deleted_count > 0:
+            Path.Log.info(f"Deleted {deleted_count} toolbit(s).")
+            self.refresh()
 
     def get_selected_bit_uris(self) -> List[str]:
         """

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/browser.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/browser.py
@@ -25,9 +25,8 @@
 
 import yaml
 from typing import List, cast
-import PySide
 from PySide import QtGui, QtCore
-from PySide.QtGui import QApplication, QMessageBox, QMenu, QAction, QKeySequence
+from PySide.QtGui import QApplication, QMessageBox, QMenu, QAction, QKeySequence, QDialog
 from PySide.QtCore import QMimeData
 import FreeCAD
 import Path
@@ -187,8 +186,6 @@ class ToolBitBrowserWidget(QtGui.QWidget):
             if uri:
                 current_items[uri] = item
 
-        filtered_assets_map = {str(asset.get_uri()): asset for asset in filtered_assets}
-
         # Iterate through filtered assets and update the list widget
         for i, asset in enumerate(filtered_assets):
             uri = str(asset.get_uri())
@@ -261,7 +258,7 @@ class ToolBitBrowserWidget(QtGui.QWidget):
         # Open the editor for the selected toolbit
         editor = ToolBitEditor(toolbit)
         result = editor.show()
-        if result != PySide.QtGui.QDialog.Accepted:
+        if result != QDialog.Accepted:
             return
 
         # If the editor was closed with "OK", save the changes

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/browser.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/browser.py
@@ -74,7 +74,7 @@ class ToolBitBrowserWidget(QtGui.QWidget):
         self._all_assets: List[ToolBit] = []  # Store all fetched assets
         self._current_search = ""  # Track current search term
         self._sort_key = "tool_no" if tool_no_factory else "label"
-        self._selected_uris: List[str] = [] # Track selected toolbit URIs
+        self._selected_uris: List[str] = []  # Track selected toolbit URIs
 
         # UI Elements
         self._search_edit = QtGui.QLineEdit()
@@ -310,7 +310,7 @@ class ToolBitBrowserWidget(QtGui.QWidget):
             return
 
         selected_bits = [self._asset_manager.get(AssetUri(uri)) for uri in uris]
-        selected_bits = [bit for bit in selected_bits if bit] # Filter out None
+        selected_bits = [bit for bit in selected_bits if bit]  # Filter out None
 
         if not selected_bits:
             return
@@ -319,7 +319,7 @@ class ToolBitBrowserWidget(QtGui.QWidget):
         serialized_toolbits_data = []
         for toolbit in selected_bits:
             yaml_data = YamlToolBitSerializer.serialize(toolbit)
-            serialized_toolbits_data.append(yaml_data.decode('utf-8'))
+            serialized_toolbits_data.append(yaml_data.decode("utf-8"))
 
         # Create a dictionary to hold the operation type and serialized data
         clipboard_data_dict = {
@@ -332,14 +332,12 @@ class ToolBitBrowserWidget(QtGui.QWidget):
             clipboard_data_dict.update(extra_data)
 
         # Serialize the dictionary to YAML
-        clipboard_content_yaml = yaml.dump(
-            clipboard_data_dict, default_flow_style=False
-        )
+        clipboard_content_yaml = yaml.dump(clipboard_data_dict, default_flow_style=False)
 
         # Put the YAML data on the clipboard with a custom MIME type
         mime_data = QMimeData()
         mime_type = "application/x-freecad-toolbit-list-yaml"
-        mime_data.setData(mime_type, clipboard_content_yaml.encode('utf-8'))
+        mime_data.setData(mime_type, clipboard_content_yaml.encode("utf-8"))
 
         # Put it in text format for pasting to text editors
         toolbit_list = [yaml.safe_load(d) for d in serialized_toolbits_data]

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/toollist.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/toollist.py
@@ -25,7 +25,8 @@
 from typing import Callable, List
 from PySide import QtGui, QtCore
 from .tablecell import TwoLineTableCell, CompactTwoLineTableCell
-from ..models.base import ToolBit  # For type hinting
+from ..models.base import ToolBit
+
 
 # Role for storing the ToolBit URI string
 ToolBitUriRole = QtCore.Qt.UserRole + 1
@@ -40,22 +41,12 @@ class ToolBitListWidget(QtGui.QListWidget):
     def __init__(self, parent=None, tool_no_factory: Callable | None = None):
         super().__init__(parent)
         self._tool_no_factory = tool_no_factory
-        # Optimize view for custom widgets
-        self.setUniformItemSizes(False)  # Allow different heights if needed
         self.setAutoScroll(True)
         self.setSelectionMode(QtGui.QAbstractItemView.ExtendedSelection)
-        # Consider setting view mode if needed, default is ListMode
-        # self.setViewMode(QtGui.QListView.ListMode)
-        # self.setResizeMode(QtGui.QListView.Adjust) # Adjust items on resize
 
-    def add_toolbit(self, toolbit: ToolBit, tool_no: int | None = None):
+    def _create_toolbit_item(self, toolbit: ToolBit, tool_no: int | None = None):
         """
-        Adds a ToolBit to the list.
-
-        Args:
-            toolbit (ToolBit): The ToolBit object to add.
-            tool_no (int | None): The tool number associated with the ToolBit,
-                                  or None if not applicable.
+        Creates a QListWidgetItem and populates it with ToolBit data.
         """
         # Use the factory function if provided, otherwise use the passed tool_no
         final_tool_no = None
@@ -79,6 +70,33 @@ class ToolBitListWidget(QtGui.QListWidget):
 
         # Store the ToolBit URI for later retrieval
         item.setData(ToolBitUriRole, str(toolbit.get_uri()))
+
+        return item
+
+    def add_toolbit(self, toolbit: ToolBit, tool_no: int | None = None):
+        """
+        Adds a ToolBit to the list.
+
+        Args:
+            toolbit (ToolBit): The ToolBit object to add.
+            tool_no (int | None): The tool number associated with the ToolBit,
+                                  or None if not applicable.
+        """
+        item = self._create_toolbit_item(toolbit, tool_no)
+        self.addItem(item)
+
+    def insert_toolbit(self, row: int, toolbit: ToolBit, tool_no: int | None = None):
+        """
+        Inserts a ToolBit to the list at the specified row.
+
+        Args:
+            row (int): The row index where the item should be inserted.
+            toolbit (ToolBit): The ToolBit object to add.
+            tool_no (int | None): The tool number associated with the ToolBit,
+                                  or None if not applicable.
+        """
+        item = self._create_toolbit_item(toolbit, tool_no)
+        self.insertItem(row, item)
 
     def clear_list(self):
         """Removes all items from the list."""
@@ -147,14 +165,10 @@ class CompactToolBitListWidget(ToolBitListWidget):
     CompactTwoLineTableCell widgets.
     """
 
-    def add_toolbit(self, toolbit: ToolBit, tool_no: int | None = None):
+    def _create_toolbit_item(self, toolbit: ToolBit, tool_no: int | None = None):
         """
-        Adds a ToolBit to the list using CompactTwoLineTableCell.
-
-        Args:
-            toolbit (ToolBit): The ToolBit object to add.
-            tool_no (int | None): The tool number associated with the ToolBit,
-                                  or None if not applicable.
+        Creates a QListWidgetItem and populates it with ToolBit data
+        using CompactTwoLineTableCell.
         """
         # Use the factory function if provided, otherwise use the passed tool_no
         final_tool_no = None
@@ -163,15 +177,14 @@ class CompactToolBitListWidget(ToolBitListWidget):
         elif tool_no is not None:
             final_tool_no = tool_no
 
-        item = QtGui.QListWidgetItem(self)  # Add item to this widget
-        cell = CompactTwoLineTableCell(self)  # Parent the cell to this widget
+        item = QtGui.QListWidgetItem(self)
+        cell = CompactTwoLineTableCell(self)
 
         # Populate the cell widget
         cell.set_tool_no(final_tool_no)
         cell.set_upper_text(toolbit.label)
-        lower_text = toolbit.summary
+        cell.set_lower_text(toolbit.summary)
         cell.set_icon_from_shape(toolbit._tool_bit_shape)
-        cell.set_lower_text(lower_text)
 
         # Set the custom widget for the list item
         item.setSizeHint(cell.sizeHint())
@@ -179,3 +192,5 @@ class CompactToolBitListWidget(ToolBitListWidget):
 
         # Store the ToolBit URI for later retrieval
         item.setData(ToolBitUriRole, str(toolbit.get_uri()))
+
+        return item

--- a/src/Mod/CAM/TestCAMApp.py
+++ b/src/Mod/CAM/TestCAMApp.py
@@ -81,6 +81,7 @@ from CAMTests.TestPathToolShapeIcon import (
 from CAMTests.TestPathToolBitSerializer import (
     TestCamoticsToolBitSerializer,
     TestFCTBSerializer,
+    TestYamlToolBitSerializer,
 )
 from CAMTests.TestPathToolLibrary import TestPathToolLibrary
 from CAMTests.TestPathToolLibrarySerializer import (


### PR DESCRIPTION
This PR adds copy & paste support for toolbits.

### Backend changes

- Extends the AssetManager with support for copying and deep copying.
- Adds a serializer for YAML. The purpose being: Depending on where a tool is pasted, YAML serialization is nicer for users to see. For example, if you copy in FreeCAD, then paste it in an external text editor, you will get the "human friendly" YAML representation.
- Adds tests for the YAML serializer.

### Frontend changes

- Support for copy, cut, paste, and duplicate using the usual keyboard shortcuts.
- Support for remove from library + physical deletion of toolbits
- Adds a right click context menu

![image](https://github.com/user-attachments/assets/88f3ee0d-5de8-4796-a882-e0ca1040b77d)
