### PR TITLE
Gui: Implement validator for ExpressionLineEdit

### DIFF
--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -890,6 +890,27 @@ void ExpressionCompleter::slotUpdate(const QString& prefix, int pos)
     }
 }
 
+ExpressionValidator::ExpressionValidator(QObject* parent)
+    : QValidator(parent)
+{}
+
+void ExpressionValidator::fixup(QString &input) const
+{
+    if (input.startsWith(QLatin1String("="))) {
+        input = input.mid(1);
+    }
+}
+
+QValidator::State ExpressionValidator::validate(QString &input, int &pos) const
+{
+    if (input.startsWith(QLatin1String("="))) {
+        pos = 0;
+        return QValidator::Invalid;
+    }
+
+    return QValidator::Acceptable;
+}
+
 ExpressionLineEdit::ExpressionLineEdit(QWidget* parent,
                                        bool noProperty,
                                        char checkPrefix,
@@ -902,6 +923,7 @@ ExpressionLineEdit::ExpressionLineEdit(QWidget* parent,
     , checkInList(checkInList)
     , checkPrefix(checkPrefix)
 {
+    setValidator(new ExpressionValidator(this));
     connect(this, &QLineEdit::textEdited, this, &ExpressionLineEdit::slotTextChanged);
 }
 

--- a/src/Gui/ExpressionCompleter.h
+++ b/src/Gui/ExpressionCompleter.h
@@ -27,6 +27,7 @@
 #include <QLineEdit>
 #include <QObject>
 #include <QPlainTextEdit>
+#include <QValidator>
 #include <App/DocumentObserver.h>
 #include <App/ExpressionTokenizer.h>
 
@@ -40,6 +41,16 @@ class ObjectIdentifier;
 }
 
 namespace Gui {
+
+class GuiExport ExpressionValidator : public QValidator
+{
+    Q_OBJECT
+
+public:
+    explicit ExpressionValidator(QObject* parent = nullptr);
+    void fixup(QString &input) const override;
+    QValidator::State validate(QString &input, int &pos) const override;
+};
 
 /**
  * @brief The ExpressionCompleter class extends the QCompleter class to provide a completer model of documentobject names and properties.


### PR DESCRIPTION
Found this little gem in @wwmayer's repo.

Fixes #21426
Closes #21453

---

As requested in issue 21426 a leading '=' shouldn't be allowed in the edit field. The validator now explicitly disallows a leading '=' in the text. In the future the validator can be extended.

This fixes issue 21426