### PR TITLE
CAM: Pocket and Profile - RetractThreshold

### DIFF
--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -343,8 +343,8 @@ class ObjectOp(PathOp.ObjectOp):
         ):
             pathParams["sort_mode"] = 0
 
-        if not self.areaOpRetractTool(obj):
-            pathParams["threshold"] = 2.001 * self.radius
+        if hasattr(obj, "RetractThreshold"):
+            pathParams["threshold"] = obj.RetractThreshold.Value
 
         if (
             not obj.UseStartPoint
@@ -513,11 +513,7 @@ class ObjectOp(PathOp.ObjectOp):
                 self.commandlist.extend(ppCmds)
                 sims.append(sim)
 
-            if (
-                self.areaOpRetractTool(obj)
-                and self.endVector is not None
-                and len(self.commandlist) > 1
-            ):
+            if self.endVector is not None and len(self.commandlist) > 1:
                 self.endVector[2] = obj.ClearanceHeight.Value
                 self.commandlist.append(
                     Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})
@@ -525,10 +521,6 @@ class ObjectOp(PathOp.ObjectOp):
 
         Path.Log.debug("obj.Name: " + str(obj.Name) + "\n\n")
         return sims
-
-    def areaOpRetractTool(self, obj):
-        """areaOpRetractTool(obj) ... return False to keep the tool at current level between shapes. Default is True."""
-        return True
 
     def areaOpAreaParams(self, obj, isHole):
         """areaOpAreaParams(obj, isHole) ... return operation specific area parameters in a dictionary.

--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -202,6 +202,15 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                     "and disabled UseStartPoint",
                 ),
             ),
+            (
+                "App::PropertyLength",
+                "RetractThreshold",
+                "Profile",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Set distance which will attempts to avoid unnecessary retractions",
+                ),
+            ),
         ]
 
     @classmethod


### PR DESCRIPTION
`RetractThreshold` is a distance which will attempts to avoid unnecessary retractions
In **Profile** and **Pocket_Shape** operations the value of `RetractThreshold` is hard coded now by magic values
- Pocket ->  `RetractThreshold  = 2 * radius`
- other operations -> `RetractThreshold  = 2.001 * radius`

We already have ability to set `RetractThreshold` in **LeadInOut** and **Boundary**

I suggest to replace boolean property `KeepToolDown` by length property `RetractThreshold`
So now user can manually set `RetractThreshold` in `Pocket` and `Profile` operations

`RetractThreshold = 0` - the same behavior `KeepToolDown = False`
`RetractThreshold > 0` - the same behavior `KeepToolDown = True` but with adjusted distance

<img width="1259" height="459" alt="563529082-c79333ae-3b33-44fa-9aab-5a9170878b7d" src="https://github.com/user-attachments/assets/3bcfc313-deef-41ed-958d-a7173a9d1157" />