### PR TITLE
CAM: find job in parent chain when adding a new operation

### DIFF
--- a/src/Mod/CAM/PathScripts/PathUtilsGui.py
+++ b/src/Mod/CAM/PathScripts/PathUtilsGui.py
@@ -63,36 +63,38 @@ class PathUtilsUserInput(object):
     def chooseJob(self, jobs):
         job = None
         selected = FreeCADGui.Selection.getSelection()
-        if 1 == len(selected) and selected[0] in jobs:
-            job = selected[0]
+        if 1 == len(selected):
+            found = PathUtils.findParentJob(selected[0])
+            if found:
+                return found
+
+        modelSelected = []
+        for job in jobs:
+            if all([o in job.Model.Group for o in selected]):
+                modelSelected.append(job)
+        if 1 == len(modelSelected):
+            job = modelSelected[0]
         else:
-            modelSelected = []
+            modelObjectSelected = []
             for job in jobs:
-                if all([o in job.Model.Group for o in selected]):
-                    modelSelected.append(job)
-            if 1 == len(modelSelected):
-                job = modelSelected[0]
+                if all([o in job.Proxy.baseObjects(job) for o in selected]):
+                    modelObjectSelected.append(job)
+            if 1 == len(modelObjectSelected):
+                job = modelObjectSelected[0]
             else:
-                modelObjectSelected = []
-                for job in jobs:
-                    if all([o in job.Proxy.baseObjects(job) for o in selected]):
-                        modelObjectSelected.append(job)
-                if 1 == len(modelObjectSelected):
-                    job = modelObjectSelected[0]
+                if modelObjectSelected:
+                    mylist = [j.Label for j in modelObjectSelected]
                 else:
-                    if modelObjectSelected:
-                        mylist = [j.Label for j in modelObjectSelected]
-                    else:
-                        mylist = [j.Label for j in jobs]
+                    mylist = [j.Label for j in jobs]
 
-                    jobname, result = QtGui.QInputDialog.getItem(
-                        None, translate("Path", "Choose a CAM Job"), None, mylist
-                    )
+                jobname, result = QtGui.QInputDialog.getItem(
+                    None, translate("Path", "Choose a CAM Job"), None, mylist
+                )
 
-                    if result is False:
-                        return None
-                    else:
-                        job = [j for j in jobs if j.Label == jobname][0]
+                if result is False:
+                    return None
+                else:
+                    job = [j for j in jobs if j.Label == jobname][0]
         return job
 
     def createJob(self):


### PR DESCRIPTION
This change helps choosing the right CAM Job when the document has multiple jobs, and something is already selected inside a job. The original behavior is to select the current job only if that is the only one selected. However, it would be more intuitive to go up in the model chain to detect the appropriate job.

Also, there was a minor case of indentitis in the same method.

## Issues

I couldn't find any relevant issues to this problem.

## Before and After Images

There is no GUI changes, apart from the fact the "Choose a CAM Job" dialog pops up less often.