### PR TITLE
Draft: arrays and ShapeString: specify units of spinboxes in UI file

### DIFF
--- a/src/Mod/Draft/Resources/ui/TaskPanel_CircularArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_CircularArray.ui
@@ -63,7 +63,7 @@
            <string>Distance from one layer of objects to the next layer of objects.</string>
           </property>
           <property name="unit" stdset="0">
-           <string notr="true"/>
+           <string notr="true">mm</string>
           </property>
           <property name="value">
            <double>200.000000000000000</double>
@@ -88,7 +88,7 @@ It cannot be zero.</string>
 It cannot be zero.</string>
           </property>
           <property name="unit" stdset="0">
-           <string notr="true"/>
+           <string notr="true">mm</string>
           </property>
           <property name="value">
            <double>100.000000000000000</double>
@@ -176,7 +176,7 @@ Change the direction of the axis itself in the property editor.</string>
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
             </widget>
            </item>
@@ -196,7 +196,7 @@ Change the direction of the axis itself in the property editor.</string>
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
             </widget>
            </item>
@@ -216,7 +216,7 @@ Change the direction of the axis itself in the property editor.</string>
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
             </widget>
            </item>

--- a/src/Mod/Draft/Resources/ui/TaskPanel_OrthoArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_OrthoArray.ui
@@ -151,7 +151,7 @@ Negative values will result in copies produced in the negative direction.</strin
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
              <property name="quantity" stdset="0">
               <double>100.000000000000000</double>
@@ -174,7 +174,7 @@ Negative values will result in copies produced in the negative direction.</strin
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
             </widget>
            </item>
@@ -194,7 +194,7 @@ Negative values will result in copies produced in the negative direction.</strin
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
             </widget>
            </item>
@@ -242,7 +242,7 @@ Negative values will result in copies produced in the negative direction.</strin
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
             </widget>
            </item>
@@ -262,7 +262,7 @@ Negative values will result in copies produced in the negative direction.</strin
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
              <property name="quantity" stdset="0">
               <double>100.000000000000000</double>
@@ -285,7 +285,7 @@ Negative values will result in copies produced in the negative direction.</strin
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
             </widget>
            </item>
@@ -333,7 +333,7 @@ Negative values will result in copies produced in the negative direction.</strin
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
             </widget>
            </item>
@@ -353,7 +353,7 @@ Negative values will result in copies produced in the negative direction.</strin
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
             </widget>
            </item>
@@ -373,7 +373,7 @@ Negative values will result in copies produced in the negative direction.</strin
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
              <property name="quantity" stdset="0">
               <double>100.000000000000000</double>

--- a/src/Mod/Draft/Resources/ui/TaskPanel_PolarArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_PolarArray.ui
@@ -67,7 +67,7 @@ A negative angle produces a polar pattern in the opposite direction.
 The maximum absolute value is 360 degrees.</string>
           </property>
           <property name="unit" stdset="0">
-           <string notr="true"/>
+           <string notr="true">°</string>
           </property>
           <property name="minimum">
            <double>-360.000000000000000</double>
@@ -138,7 +138,7 @@ Change the direction of the axis itself in the property editor.</string>
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
             </widget>
            </item>
@@ -158,7 +158,7 @@ Change the direction of the axis itself in the property editor.</string>
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
             </widget>
            </item>
@@ -178,7 +178,7 @@ Change the direction of the axis itself in the property editor.</string>
               </sizepolicy>
              </property>
              <property name="unit" stdset="0">
-              <string notr="true"/>
+              <string notr="true">mm</string>
              </property>
             </widget>
            </item>

--- a/src/Mod/Draft/Resources/ui/TaskShapeString.ui
+++ b/src/Mod/Draft/Resources/ui/TaskShapeString.ui
@@ -53,7 +53,7 @@
            <string>Enter coordinates or select point with mouse.</string>
           </property>
           <property name="unit" stdset="0">
-           <string notr="true"/>
+           <string notr="true">mm</string>
           </property>
          </widget>
         </item>
@@ -70,7 +70,7 @@
            <string>Enter coordinates or select point with mouse.</string>
           </property>
           <property name="unit" stdset="0">
-           <string notr="true"/>
+           <string notr="true">mm</string>
           </property>
          </widget>
         </item>
@@ -87,7 +87,7 @@
            <string>Enter coordinates or select point with mouse.</string>
           </property>
           <property name="unit" stdset="0">
-           <string notr="true"/>
+           <string notr="true">mm</string>
           </property>
          </widget>
         </item>
@@ -128,7 +128,7 @@ Uncheck to use working plane coordinate system</string>
            <string>Height of the result</string>
           </property>
           <property name="unit" stdset="0">
-           <string notr="true"/>
+           <string notr="true">mm</string>
           </property>
           <property name="minimum">
            <double>0.000000000000000</double>

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -78,66 +78,31 @@ class TaskPanelCircularArray:
     """
 
     def __init__(self):
-        self.name = "Circular array"
-        _log(translate("draft","Task panel:") + " {}".format(translate("draft","Circular array")))
 
-        # The .ui file must be loaded into an attribute
-        # called `self.form` so that it is displayed in the task panel.
-        ui_file = ":/ui/TaskPanel_CircularArray.ui"
-        self.form = Gui.PySideUic.loadUi(ui_file)
-
-        icon_name = "Draft_CircularArray"
-        svg = ":/icons/" + icon_name
-        pix = QtGui.QPixmap(svg)
-        icon = QtGui.QIcon.fromTheme(icon_name, QtGui.QIcon(svg))
-        self.form.setWindowIcon(icon)
-        self.form.setWindowTitle(translate("draft","Circular array"))
-
-        self.form.label_icon.setPixmap(pix.scaled(32, 32))
+        self.form = Gui.PySideUic.loadUi(":/ui/TaskPanel_CircularArray.ui")
+        self.form.setWindowTitle(translate("draft", "Circular array"))
+        self.form.setWindowIcon(QtGui.QIcon(":/icons/Draft_CircularArray.svg"))
 
         # -------------------------------------------------------------------
-        # Default values for the internal function,
-        # and for the task panel interface
-        start_distance = U.Quantity(50.0, App.Units.Length)
-        length_unit = start_distance.getUserPreferred()[2]
-
-        self.r_distance = 2 * start_distance.Value
-        self.tan_distance = start_distance.Value
-
-        self.form.spinbox_r_distance.setProperty('rawValue',
-                                                 self.r_distance)
-        self.form.spinbox_r_distance.setProperty('unit', length_unit)
-        self.form.spinbox_tan_distance.setProperty('rawValue',
-                                                   self.tan_distance)
-        self.form.spinbox_tan_distance.setProperty('unit', length_unit)
-
-        self.number = 3
-        self.symmetry = 1
-
-        self.form.spinbox_number.setValue(self.number)
-        self.form.spinbox_symmetry.setValue(self.symmetry)
-
+        # Default values for the internal function, and for the task panel interface
+        self.center = App.Vector()
         # TODO: the axis is currently fixed, it should be editable
         # or selectable from the task panel
         self.axis = App.Vector(0, 0, 1)
-
-        start_point = U.Quantity(0.0, App.Units.Length)
-        length_unit = start_point.getUserPreferred()[2]
-
-        self.center = App.Vector(start_point.Value,
-                                 start_point.Value,
-                                 start_point.Value)
-
-        self.form.input_c_x.setProperty('rawValue', self.center.x)
-        self.form.input_c_x.setProperty('unit', length_unit)
-        self.form.input_c_y.setProperty('rawValue', self.center.y)
-        self.form.input_c_y.setProperty('unit', length_unit)
-        self.form.input_c_z.setProperty('rawValue', self.center.z)
-        self.form.input_c_z.setProperty('unit', length_unit)
-
+        self.r_distance = 100
+        self.tan_distance = 50
+        self.number = 3
+        self.symmetry = 1
         self.fuse = params.get_param("Draft_array_fuse")
         self.use_link = params.get_param("Draft_array_Link")
 
+        self.form.input_c_x.setProperty('rawValue', self.center.x)
+        self.form.input_c_y.setProperty('rawValue', self.center.y)
+        self.form.input_c_z.setProperty('rawValue', self.center.z)
+        self.form.spinbox_r_distance.setProperty('rawValue', self.r_distance)
+        self.form.spinbox_tan_distance.setProperty('rawValue', self.tan_distance)
+        self.form.spinbox_number.setValue(self.number)
+        self.form.spinbox_symmetry.setValue(self.symmetry)
         self.form.checkbox_fuse.setChecked(self.fuse)
         self.form.checkbox_link.setChecked(self.use_link)
         # -------------------------------------------------------------------

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -78,67 +78,35 @@ class TaskPanelOrthoArray:
     """
 
     def __init__(self):
-        self.name = "Orthogonal array"
-        _log(translate("draft","Task panel:") + " {}".format(translate("draft","Orthogonal array")))
 
-        # The .ui file must be loaded into an attribute
-        # called `self.form` so that it is displayed in the task panel.
-        ui_file = ":/ui/TaskPanel_OrthoArray.ui"
-        self.form = Gui.PySideUic.loadUi(ui_file)
-
-        icon_name = "Draft_Array"
-        svg = ":/icons/" + icon_name
-        pix = QtGui.QPixmap(svg)
-        icon = QtGui.QIcon.fromTheme(icon_name, QtGui.QIcon(svg))
-        self.form.setWindowIcon(icon)
-        self.form.setWindowTitle(translate("draft","Orthogonal array"))
-
-        self.form.label_icon.setPixmap(pix.scaled(32, 32))
+        self.form = Gui.PySideUic.loadUi(":/ui/TaskPanel_OrthoArray.ui")
+        self.form.setWindowTitle(translate("draft", "Orthogonal array"))
+        self.form.setWindowIcon(QtGui.QIcon(":/icons/Draft_Array.svg"))
 
         # -------------------------------------------------------------------
-        # Default values for the internal function,
-        # and for the task panel interface
-        start_x = U.Quantity(100.0, App.Units.Length)
-        start_y = start_x
-        start_z = start_x
-        length_unit = start_x.getUserPreferred()[2]
-
-        self.v_x = App.Vector(start_x.Value, 0, 0)
-        self.v_y = App.Vector(0, start_y.Value, 0)
-        self.v_z = App.Vector(0, 0, start_z.Value)
-
-        self.form.input_X_x.setProperty('rawValue', self.v_x.x)
-        self.form.input_X_x.setProperty('unit', length_unit)
-        self.form.input_X_y.setProperty('rawValue', self.v_x.y)
-        self.form.input_X_y.setProperty('unit', length_unit)
-        self.form.input_X_z.setProperty('rawValue', self.v_x.z)
-        self.form.input_X_z.setProperty('unit', length_unit)
-
-        self.form.input_Y_x.setProperty('rawValue', self.v_y.x)
-        self.form.input_Y_x.setProperty('unit', length_unit)
-        self.form.input_Y_y.setProperty('rawValue', self.v_y.y)
-        self.form.input_Y_y.setProperty('unit', length_unit)
-        self.form.input_Y_z.setProperty('rawValue', self.v_y.z)
-        self.form.input_Y_z.setProperty('unit', length_unit)
-
-        self.form.input_Z_x.setProperty('rawValue', self.v_z.x)
-        self.form.input_Z_x.setProperty('unit', length_unit)
-        self.form.input_Z_y.setProperty('rawValue', self.v_z.y)
-        self.form.input_Z_y.setProperty('unit', length_unit)
-        self.form.input_Z_z.setProperty('rawValue', self.v_z.z)
-        self.form.input_Z_z.setProperty('unit', length_unit)
-
+        # Default values for the internal function, and for the task panel interface
+        start = 100
+        self.v_x = App.Vector(start, 0, 0)
+        self.v_y = App.Vector(0, start, 0)
+        self.v_z = App.Vector(0, 0, start)
         self.n_x = 2
         self.n_y = 2
         self.n_z = 1
-
-        self.form.spinbox_n_X.setValue(self.n_x)
-        self.form.spinbox_n_Y.setValue(self.n_y)
-        self.form.spinbox_n_Z.setValue(self.n_z)
-
         self.fuse = params.get_param("Draft_array_fuse")
         self.use_link = params.get_param("Draft_array_Link")
 
+        self.form.input_X_x.setProperty('rawValue', self.v_x.x)
+        self.form.input_X_y.setProperty('rawValue', self.v_x.y)
+        self.form.input_X_z.setProperty('rawValue', self.v_x.z)
+        self.form.input_Y_x.setProperty('rawValue', self.v_y.x)
+        self.form.input_Y_y.setProperty('rawValue', self.v_y.y)
+        self.form.input_Y_z.setProperty('rawValue', self.v_y.z)
+        self.form.input_Z_x.setProperty('rawValue', self.v_z.x)
+        self.form.input_Z_y.setProperty('rawValue', self.v_z.y)
+        self.form.input_Z_z.setProperty('rawValue', self.v_z.z)
+        self.form.spinbox_n_X.setValue(self.n_x)
+        self.form.spinbox_n_Y.setValue(self.n_y)
+        self.form.spinbox_n_Z.setValue(self.n_z)
         self.form.checkbox_fuse.setChecked(self.fuse)
         self.form.checkbox_link.setChecked(self.use_link)
         # -------------------------------------------------------------------

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -78,54 +78,24 @@ class TaskPanelPolarArray:
     """
 
     def __init__(self):
-        self.name = "Polar array"
-        _log(translate("draft","Task panel:") + " {}".format(self.name))
 
-        # The .ui file must be loaded into an attribute
-        # called `self.form` so that it is displayed in the task panel.
-        ui_file = ":/ui/TaskPanel_PolarArray.ui"
-        self.form = Gui.PySideUic.loadUi(ui_file)
-
-        icon_name = "Draft_PolarArray"
-        svg = ":/icons/" + icon_name
-        pix = QtGui.QPixmap(svg)
-        icon = QtGui.QIcon.fromTheme(icon_name, QtGui.QIcon(svg))
-        self.form.setWindowIcon(icon)
-        self.form.setWindowTitle(translate("draft","Polar array"))
-
-        self.form.label_icon.setPixmap(pix.scaled(32, 32))
+        self.form = Gui.PySideUic.loadUi(":/ui/TaskPanel_PolarArray.ui")
+        self.form.setWindowTitle(translate("draft", "Polar array"))
+        self.form.setWindowIcon(QtGui.QIcon(":/icons/Draft_PolarArray.svg"))
 
         # -------------------------------------------------------------------
-        # Default values for the internal function,
-        # and for the task panel interface
-        start_angle = U.Quantity(360.0, App.Units.Angle)
-        angle_unit = start_angle.getUserPreferred()[2]
-
-        self.angle = start_angle.Value
+        # Default values for the internal function, and for the task panel interface
+        self.center = App.Vector()
+        self.angle = 360
         self.number = 5
-
-        self.form.spinbox_angle.setProperty('rawValue', self.angle)
-        self.form.spinbox_angle.setProperty('unit', angle_unit)
-
-        self.form.spinbox_number.setValue(self.number)
-
-        start_point = U.Quantity(0.0, App.Units.Length)
-        length_unit = start_point.getUserPreferred()[2]
-
-        self.center = App.Vector(start_point.Value,
-                                 start_point.Value,
-                                 start_point.Value)
-
-        self.form.input_c_x.setProperty('rawValue', self.center.x)
-        self.form.input_c_x.setProperty('unit', length_unit)
-        self.form.input_c_y.setProperty('rawValue', self.center.y)
-        self.form.input_c_y.setProperty('unit', length_unit)
-        self.form.input_c_z.setProperty('rawValue', self.center.z)
-        self.form.input_c_z.setProperty('unit', length_unit)
-
         self.fuse = params.get_param("Draft_array_fuse")
         self.use_link = params.get_param("Draft_array_Link")
 
+        self.form.input_c_x.setProperty('rawValue', self.center.x)
+        self.form.input_c_y.setProperty('rawValue', self.center.y)
+        self.form.input_c_z.setProperty('rawValue', self.center.z)
+        self.form.spinbox_angle.setProperty('rawValue', self.angle)
+        self.form.spinbox_number.setValue(self.number)
         self.form.checkbox_fuse.setChecked(self.fuse)
         self.form.checkbox_link.setChecked(self.use_link)
         # -------------------------------------------------------------------

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -51,15 +51,8 @@ class ShapeStringTaskPanel:
     def __init__(self, point=None, size=None, string="", font=""):
 
         self.form = Gui.PySideUic.loadUi(":/ui/TaskShapeString.ui")
-        self.form.setObjectName("ShapeStringTaskPanel")
         self.form.setWindowTitle(translate("draft", "ShapeString"))
         self.form.setWindowIcon(QtGui.QIcon(":/icons/Draft_ShapeString.svg"))
-
-        unit_length = App.Units.Quantity(0.0, App.Units.Length).getUserPreferred()[2]
-        self.form.sbX.setProperty("unit", unit_length)
-        self.form.sbY.setProperty("unit", unit_length)
-        self.form.sbZ.setProperty("unit", unit_length)
-        self.form.sbHeight.setProperty("unit", unit_length)
 
         self.global_mode = params.get_param("GlobalMode")
         self.form.cbGlobalMode.setChecked(self.global_mode)


### PR DESCRIPTION
* Specify the units for quantity spinboxes in the array and ShapeString UI files.
* Additionally: somewhat simplify the __init__ functions in the task_*array.py files.
