### PR TITLE
[CAM] Job Type Selection

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/DlgJobCreate.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgJobCreate.ui
@@ -13,52 +13,58 @@
   <property name="windowTitle">
    <string>Create Job</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <item>
-    <widget class="QWidget" name="widget_4">
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="templateGroup">
+     <property name="title">
+      <string>Template</string>
+     </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <widget class="QGroupBox" name="templateGroup">
-        <property name="title">
-         <string>Template</string>
+       <widget class="QComboBox" name="jobTemplate">
+        <property name="enabled">
+         <bool>true</bool>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QComboBox" name="jobTemplate">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="toolTip">
-            <string>Select a template to be used for the job. In case there are no templates you can create one through the popup menu of an existing job. Name the file job_*.json and place it in the macro or the path directory (see preferences) in order to be selectable from this list.</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QGroupBox" name="modelGroup">
-        <property name="title">
-         <string>Model</string>
+        <property name="toolTip">
+         <string>Select a template to be used for the job. In case there are no templates you can create one through the popup menu of an existing job. Name the file job_*.json and place it in the macro or the path directory (see preferences) in order to be selectable from this list.</string>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_6">
-         <item>
-          <widget class="QTreeView" name="modelTree">
-           <property name="editTriggers">
-            <set>QAbstractItemView::NoEditTriggers</set>
-           </property>
-           <property name="tabKeyNavigation">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="typeGroup">
+     <property name="title">
+      <string>Job Type</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QComboBox" name="jobType"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="modelGroup">
+     <property name="title">
+      <string>Model</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <item>
+       <widget class="QTreeView" name="modelTree">
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="tabKeyNavigation">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="autoFillBackground">
       <bool>false</bool>

--- a/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
@@ -14,7 +14,7 @@
    <string>Job Edit</string>
   </property>
   <property name="currentIndex">
-   <number>2</number>
+   <number>0</number>
   </property>
   <widget class="QWidget" name="tabGeneral">
    <attribute name="title">
@@ -31,8 +31,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>707</width>
-         <height>648</height>
+         <width>715</width>
+         <height>692</height>
         </rect>
        </property>
        <attribute name="label">
@@ -47,6 +47,18 @@
           <layout class="QVBoxLayout" name="verticalLayout_16">
            <item>
             <widget class="QLineEdit" name="jobLabel"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox_9">
+          <property name="title">
+           <string>Job Type</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_7">
+           <item row="0" column="0">
+            <widget class="QComboBox" name="jobType"/>
            </item>
           </layout>
          </widget>
@@ -110,8 +122,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>100</width>
-         <height>30</height>
+         <width>715</width>
+         <height>692</height>
         </rect>
        </property>
        <attribute name="label">
@@ -443,8 +455,8 @@ If &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; is se
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>688</width>
-         <height>1368</height>
+         <width>701</width>
+         <height>1029</height>
         </rect>
        </property>
        <attribute name="label">
@@ -1033,8 +1045,8 @@ If &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; is se
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>707</width>
-         <height>648</height>
+         <width>237</width>
+         <height>379</height>
         </rect>
        </property>
        <attribute name="label">
@@ -1141,7 +1153,7 @@ Default: &quot;OpStockZMax+SetupSheet.ClearanceHeightOffset&quot;</string>
             </widget>
            </item>
            <item row="1" column="3">
-            <widget class="Gui::QuantitySpinBox" name="setupClearanceHeightOffs">
+            <widget class="Gui::QuantitySpinBox" name="setupClearanceHeightOffs" native="true">
              <property name="toolTip">
               <string>ClearanceHeightOffset - can be used by expressions to set the default ClearanceHeight for new operations.
 
@@ -1166,7 +1178,7 @@ Default: &quot;OpStockZMax+SetupSheet.SafeHeightOffset&quot;</string>
             </widget>
            </item>
            <item row="3" column="3">
-            <widget class="Gui::QuantitySpinBox" name="setupSafeHeightOffs">
+            <widget class="Gui::QuantitySpinBox" name="setupSafeHeightOffs" native="true">
              <property name="toolTip">
               <string>SafeHeightOffset can be for expressions to set the SafeHeight for new operations.
 
@@ -1230,8 +1242,8 @@ Default: &quot;5mm&quot;</string>
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>707</width>
-         <height>648</height>
+         <width>715</width>
+         <height>692</height>
         </rect>
        </property>
        <attribute name="label">
@@ -1334,8 +1346,8 @@ Default: &quot;5mm&quot;</string>
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>512</width>
-         <height>183</height>
+         <width>136</width>
+         <height>114</height>
         </rect>
        </property>
        <attribute name="label">
@@ -1359,7 +1371,7 @@ Default: &quot;5mm&quot;</string>
             </widget>
            </item>
            <item row="0" column="1">
-            <widget class="Gui::QuantitySpinBox" name="setupRapidHorizontal">
+            <widget class="Gui::QuantitySpinBox" name="setupRapidHorizontal" native="true">
              <property name="sizePolicy">
               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -1379,7 +1391,7 @@ Default: &quot;5mm&quot;</string>
             </widget>
            </item>
            <item row="1" column="1">
-            <widget class="Gui::QuantitySpinBox" name="setupRapidVertical">
+            <widget class="Gui::QuantitySpinBox" name="setupRapidVertical" native="true">
              <property name="sizePolicy">
               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                <horstretch>0</horstretch>

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -1651,13 +1651,13 @@ class TaskPanel:
         self.updateSelection()
 
 
-def Create(base, template=None, openTaskPanel=True):
+def Create(base, jobType, template=None, openTaskPanel=True):
     """Create(base, template) ... creates a job instance for the given base object
     using template to configure it."""
     FreeCADGui.addModule("Path.Main.Job")
     FreeCAD.ActiveDocument.openTransaction("Create Job")
     try:
-        obj = PathJob.Create("Job", base, template)
+        obj = PathJob.Create("Job", base, jobType, template)
         obj.ViewObject.Proxy = ViewProvider(obj.ViewObject)
         obj.ViewObject.addExtension("Gui::ViewProviderGroupExtensionPython")
         FreeCAD.ActiveDocument.commitTransaction()

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -1521,6 +1521,9 @@ class TaskPanel:
         self.form.postProcessorOutputFile.editingFinished.connect(self.getFields)
         self.form.postProcessorSetOutputFile.clicked.connect(self.setPostProcessorOutputFile)
 
+        # Job Type
+        self.form.jobType.currentIndexChanged.connect(self.getFields)
+
         # Workplan
         self.form.operationsList.itemSelectionChanged.connect(self.operationSelect)
         self.form.operationsList.indexesMoved.connect(self.getFields)

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -721,7 +721,7 @@ class TaskPanel:
         self.postProcessorArgsDefaultTooltip = self.form.postProcessorArguments.toolTip()
 
         # Populate the other comboboxes with enums from the job class
-        comboToPropertyMap = [("orderBy", "OrderOutputBy")]
+        comboToPropertyMap = [("orderBy", "OrderOutputBy"), ("jobType", "JobType")]
         enumTups = PathJob.ObjectJob.propertyEnumerations(dataType="raw")
         self.populateCombobox(self.form, enumTups, comboToPropertyMap)
 

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -839,6 +839,7 @@ class TaskPanel:
             try:
                 self.obj.SplitOutput = self.form.splitOutput.isChecked()
                 self.obj.OrderOutputBy = str(self.form.orderBy.currentData())
+                self.obj.JobType = str(self.form.jobType.currentData())
 
                 flist = []
                 for i in range(self.form.wcslist.count()):

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -958,6 +958,8 @@ class TaskPanel:
             self.form.splitOutput.setChecked(self.obj.SplitOutput)
         if hasattr(self.obj, "OrderOutputBy"):
             self.selectComboBoxText(self.form.orderBy, self.obj.OrderOutputBy)
+        if hasattr(self.obj, "JobType"):
+            self.selectComboBoxText(self.form.jobType, self.obj.JobType)
 
         if hasattr(self.obj, "Fixtures"):
             for f in self.obj.Fixtures:

--- a/src/Mod/CAM/Path/Main/Gui/JobCmd.py
+++ b/src/Mod/CAM/Path/Main/Gui/JobCmd.py
@@ -74,14 +74,24 @@ class CommandJobCreate:
                 FreeCAD.ActiveDocument.recompute()
 
     @classmethod
-    def Execute(cls, base, template):
+    def Execute(cls, base, jobType, template):
         FreeCADGui.addModule("Path.Main.Gui.Job")
         if template:
             template = "'%s'" % template
         else:
             template = "None"
+
+        if jobType:
+            jobType = "'%s'" % jobType
+        else:
+            jobTypes = PathJob.ObjectJob.propertyEnumerations(dataType="raw")['JobType']
+            # jobTypes returns a list of tuples, e.g. [('Milling', 'Milling'), ('Turning', 'Turning')]
+            # where the first element is the translated type and the second element is the actual value.
+            # use primary index selecting the untranslated value
+            jobType = jobTypes[0][1]
+
         FreeCADGui.doCommand(
-            "Path.Main.Gui.Job.Create(%s, %s)" % ([o.Name for o in base], template)
+            "Path.Main.Gui.Job.Create(%s, %s, %s)" % ([o.Name for o in base], jobType, template)
         )
 
 

--- a/src/Mod/CAM/Path/Main/Gui/JobCmd.py
+++ b/src/Mod/CAM/Path/Main/Gui/JobCmd.py
@@ -69,7 +69,7 @@ class CommandJobCreate:
         if dialog.exec_() == 1:
             models = dialog.getModels()
             if models:
-                self.Execute(models, dialog.getTemplate())
+                self.Execute(models, dialog.getType(), dialog.getTemplate())
                 FreeCAD.ActiveDocument.recompute()
 
     @classmethod

--- a/src/Mod/CAM/Path/Main/Gui/JobCmd.py
+++ b/src/Mod/CAM/Path/Main/Gui/JobCmd.py
@@ -65,6 +65,7 @@ class CommandJobCreate:
     def Activated(self):
         dialog = PathJobDlg.JobCreate()
         dialog.setupTemplate()
+        dialog.setUpType()
         dialog.setupModel()
         if dialog.exec_() == 1:
             models = dialog.getModels()

--- a/src/Mod/CAM/Path/Main/Gui/JobDlg.py
+++ b/src/Mod/CAM/Path/Main/Gui/JobDlg.py
@@ -308,6 +308,12 @@ class JobCreate:
         Path.Log.track(path)
         return glob.glob(path + "/job_*.json")
 
+    def setUpType(self):
+        """setUpType() ... answer the type of the setup, either 'job' or 'resource'"""
+        jobTypes = PathJob.ObjectJob.propertyEnumerations(dataType="raw")['JobType']
+        for text, data in jobTypes:
+            self.dialog.jobType.addItem(text, data)
+
     def getModels(self):
         models = []
 

--- a/src/Mod/CAM/Path/Main/Gui/JobDlg.py
+++ b/src/Mod/CAM/Path/Main/Gui/JobDlg.py
@@ -338,6 +338,10 @@ class JobCreate:
         """answer the file name of the template to be assigned"""
         return self.dialog.jobTemplate.itemData(self.dialog.jobTemplate.currentIndex())
 
+    def getType(self):
+        """answer the type of the job to be created"""
+        return self.dialog.jobType.itemData(self.dialog.jobType.currentIndex())
+
     def exec_(self):
         # ml: For some reason the callback has to be unregistered, otherwise there is a
         # segfault when python is shutdown. To keep it symmetric I also put the callback

--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -251,10 +251,9 @@ class ObjectJob:
                 (translate("CAM_Job", "Operation"), "Operation"),
             ],
             "JobType": [
-                (translate("CAM_Job", "2D"), "2D"),
-                (translate("CAM_Job", "2.5D"), "2.5D"),
-                (translate("CAM_Job", "Lathe"), "Lathe"),
-                (translate("CAM_Job", "Multiaxis"), "Multiaxis"),
+                (translate("CAM_Job", "Milling"), "Milling"),
+                (translate("CAM_Job", "Turning"), "Turning"),
+                (translate("CAM_Job", "Cutting"), "Cutting"),
             ],
         }
 

--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -60,6 +60,7 @@ class JobTemplate:
     Fixtures = "Fixtures"
     OrderOutputBy = "OrderOutputBy"
     SplitOutput = "SplitOutput"
+    JobType = "JobType"
     SetupSheet = "SetupSheet"
     Stock = "Stock"
     # TCs are grouped under Tools in a job, the template refers to them directly though
@@ -215,6 +216,7 @@ class ObjectJob:
         for n in self.propertyEnumerations():
             setattr(obj, n[0], n[1])
 
+        obj.JobType = jobType
         obj.PostProcessorOutputFile = Path.Preferences.defaultOutputFile()
         obj.PostProcessor = postProcessors = Path.Preferences.allEnabledPostProcessors()
         defaultPostProcessor = Path.Preferences.defaultPostProcessor()
@@ -588,6 +590,9 @@ class ObjectJob:
                 if attrs.get(JobTemplate.SplitOutput):
                     obj.SplitOutput = attrs.get(JobTemplate.SplitOutput)
 
+                if attrs.get(JobTemplate.JobType):
+                    obj.JobType = attrs.get(JobTemplate.JobType)
+
                 Path.Log.debug("setting tool controllers (%d)" % len(tcs))
                 if tcs:
                     obj.Tools.Group = tcs
@@ -614,6 +619,8 @@ class ObjectJob:
         attrs[JobTemplate.GeometryTolerance] = str(obj.GeometryTolerance.Value)
         if obj.Description:
             attrs[JobTemplate.Description] = obj.Description
+        if obj.JobType:
+            attrs[JobTemplate.JobType] = obj.JobType
         return attrs
 
     def dumps(self):

--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -102,7 +102,7 @@ Notification = NotificationClass()
 
 
 class ObjectJob:
-    def __init__(self, obj, models, templateFile=None):
+    def __init__(self, obj, models, jobType, templateFile=None):
         self.obj = obj
         self.tooltip = None
         self.tooltipArgs = None
@@ -804,7 +804,7 @@ def Instances():
     return []
 
 
-def Create(name, base, templateFile=None):
+def Create(name, base, jobType, templateFile=None):
     """Create(name, base, templateFile=None) ... creates a new job and all it's resources.
     If a template file is specified the new job is initialized with the values from the template."""
     if isinstance(base[0], str):
@@ -815,5 +815,5 @@ def Create(name, base, templateFile=None):
         models = base
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
     obj.addExtension("App::GroupExtensionPython")
-    obj.Proxy = ObjectJob(obj, models, templateFile)
+    obj.Proxy = ObjectJob(obj, models, jobType, templateFile)
     return obj


### PR DESCRIPTION
Forum Discussion: https://forum.freecad.org/viewtopic.php?t=80115

Enable job types for CAM jobs. 

Job Types:
- Milling
- Turning
- Cutting (Laser, Waterjet, Plasma)

Job types are required to enable the CAM workbench to handle specific attributes for machining types. For example:

- Filter operation types for the selected job type
- Filter toolbits suitable for the job type
- Postprocess with parameters for the job type
- Simulate the correct operation i.e. milling / turning

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

Job Creation Dialog:

![image](https://github.com/user-attachments/assets/b16bedb6-bf6c-4200-9c45-93e006ddb470)

![image](https://github.com/user-attachments/assets/ac4a469c-a557-4cda-9ded-f4a971fc0d5f)

Job Edit Dialog:

![image](https://github.com/user-attachments/assets/1f817042-6418-4ebb-a4ab-328b0005e2a4)
