### PR TITLE
Gui: Make checkbox in the property view QSS aware

### DIFF
--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -107,37 +107,42 @@ void PropertyItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
 
     if (index.column() == 1 && property && dynamic_cast<PropertyBoolItem*>(property)) {
         bool checked = index.data(Qt::EditRole).toBool();
+        bool readonly = property->isReadOnly();
+
+        QStyle* style = option.widget ? option.widget->style() : QApplication::style();
+        QPalette palette = option.widget ? option.widget->palette() : QApplication::palette();
+
         QStyleOptionButton checkboxOption;
-        if (property->isReadOnly()) {
-            checkboxOption.state |= QStyle::State_ReadOnly;
-        } else {
-            checkboxOption.state |= QStyle::State_Enabled;
-        }
+
+        checkboxOption.state |= readonly ? QStyle::State_ReadOnly : QStyle::State_Enabled;
         checkboxOption.state |= checked ? QStyle::State_On : QStyle::State_Off;
+
+        // draw the item (background etc.)
+        style->drawPrimitive(QStyle::PE_PanelItemViewItem, &option, painter, option.widget);
+
         // Draw the checkbox
-        checkboxOption.rect = QApplication::style()->subElementRect(QStyle::SE_CheckBoxIndicator, &checkboxOption);
-        int leftSpacing = QApplication::style()->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr);
+        checkboxOption.rect = style->subElementRect(QStyle::SE_CheckBoxIndicator, &checkboxOption, option.widget);
+        int leftSpacing = style->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, option.widget);
+
         QRect checkboxRect = QStyle::alignedRect(
             option.direction, Qt::AlignVCenter,
             checkboxOption.rect.size(),
             option.rect.adjusted(leftSpacing, 0, -leftSpacing, 0)
         );
         checkboxOption.rect = checkboxRect;
-        QApplication::style()->drawPrimitive(QStyle::PE_IndicatorCheckBox, &checkboxOption, painter);
-        // Draw a bright border on the checkbox to stand out
-        QColor borderColor = QApplication::palette().color(QPalette::BrightText);
-        painter->setPen(borderColor);
-        painter->drawRect(checkboxOption.rect.adjusted(0, 0, -1, -1));
+
+        style->drawPrimitive(QStyle::PE_IndicatorCheckBox, &checkboxOption, painter, option.widget);
+
         // Draw the label of the checkbox
         QString labelText = checked ? tr("Yes") : tr("No");
-        int spacing = QApplication::style()->pixelMetric(QStyle::PM_CheckBoxLabelSpacing, nullptr);
+        int spacing = style->pixelMetric(QStyle::PM_CheckBoxLabelSpacing, nullptr, option.widget);
         QRect textRect(
             checkboxOption.rect.right() + spacing,
             checkboxOption.rect.top(),
             option.rect.right() - (checkboxOption.rect.right() + spacing),
             checkboxOption.rect.height()
         );
-        painter->setPen(option.palette.color(QPalette::Text));
+        painter->setPen(palette.color(QPalette::Text));
         painter->drawText(textRect, Qt::AlignVCenter | Qt::AlignLeft, labelText);
     }
     else {


### PR DESCRIPTION
This is followup for #21555 PR - it makes the checkboxes in the Property View fully styleable with QSS. 

The goal is achieved by ensuring two three:
1. Every style call must be done using style of the widget related to option.
2. Every palette call must do the same.
3. Every style call must pass reference to the widget.

I removed the additional outline outside box - things like this should not be hardcoded in C++ but should come from QSS. 

@alfrix FYI

## Before and After Images

| Theme | Before | After |
|--------|--------|--------|
| **Open Light** | ![image](https://github.com/user-attachments/assets/0eaafaac-b701-494c-80cb-465571d974de) | ![image](https://github.com/user-attachments/assets/6f22a458-5501-4c05-a485-19c71a61fc9b) |
| **FreeCAD Light** | ![image](https://github.com/user-attachments/assets/d32111c4-ae7e-4012-88ea-d60e00bb893c) | ![image](https://github.com/user-attachments/assets/02596cea-d34b-4094-a627-27f397502a5b) |
| **No Stylesheet (Fusion)** | ![image](https://github.com/user-attachments/assets/ae8eb6b2-dbc5-4051-b5a0-1475dd379172) | ![image](https://github.com/user-attachments/assets/64ee5e2f-223e-48d2-a6f1-6e002fd9ce2f) | 

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
