### PR TITLE
Fem: Fix grammer in VTK module warning: 'then' -> 'than'

### DIFF
--- a/src/Mod/Fem/femguiutils/vtk_module_handling.py
+++ b/src/Mod/Fem/femguiutils/vtk_module_handling.py
@@ -178,7 +178,7 @@ def vtk_module_handling():
         message = translate(
             "FEM",
             (
-                "FreeCAD is linked to a different VTK library then the imported "
+                "FreeCAD is linked to a different VTK library than the imported "
                 "VTK python module. This is incompatible and will lead to errors."
                 "\n\nWrong python module is imported from: \n{}"
             ),


### PR DESCRIPTION
Fixes a minor grammatical error in a warning message shown when VTK Python modules are mismatched.

Changed "then" → "than" in `src/Mod/Fem/femguiutils/vtk_module_handling.py` to improve grammar.

## Issues
N/A – This is a minor typo fix and not linked to a specific issue.

## Before and After Images
N/A

## Notes on PR
This is my first ever pull request. This small grammatical change was suggested by the FreeCAD dev team to learn how to do a PR. Please let me know if I have made any mistakes!