### PR TITLE
Fix .ui files modifications not detected

### DIFF
--- a/src/Mod/Assembly/Gui/CMakeLists.txt
+++ b/src/Mod/Assembly/Gui/CMakeLists.txt
@@ -65,7 +65,7 @@ SOURCE_GROUP("Module" FILES ${AssemblyGui_SRCS_Module})
 
 SET(AssemblyGui_SRCS
     ${AssemblyResource_SRCS}
-    ${AssemblyGui_UIC_HDRS}
+    ${AssemblyGui_UIC_SRCS}
     ${AssemblyGui_SRCS_Module}
     ${Python_SRCS}
 )

--- a/src/Mod/PartDesign/Gui/CMakeLists.txt
+++ b/src/Mod/PartDesign/Gui/CMakeLists.txt
@@ -226,7 +226,7 @@ SOURCE_GROUP("Python" FILES ${Python_SRCS})
 
 SET(PartDesignGui_SRCS
     ${PartDesignGui_SRCS}
-    ${PartDesignGui_UIC_HDRS}
+    ${PartDesignGui_UIC_SRCS}
     ${PartDesignGuiModule_SRCS}
     ${PartDesignGuiTaskDlgs_SRCS}
     ${PartDesignGuiViewProvider_SRCS}


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/21766

My understanding of cmake is very limited. This fix was suggested by Gemini 2.5 so perhaps someone could confirm it is correct. It does fix the issue.

For reference here is what it advised:

> The key issue is ${PartDesignGui_UIC_HDRS}.
> This variable is intended to hold the paths to the generated ui_*.h files.
> However, there is no command shown (like qt5_wrap_ui or qt6_wrap_ui) that populates PartDesignGui_UIC_HDRS from PartDesignGui_UIC_SRCS.
> If CMAKE_AUTOUIC is active, it handles generation automatically, and you don't typically need to manually collect generated headers into a variable like PartDesignGui_UIC_HDRS to add to sources. The autogenerated headers are placed in a build directory that's automatically added to include paths.
> The .ui files listed in PartDesignGuiTaskDlgs_SRCS are added to the target sources, so AUTOUIC should process them correctly.
> However, if there are .ui files in PartDesignGui_UIC_SRCS that are not also listed in PartDesignGuiTaskDlgs_SRCS (or another list that gets merged into PartDesignGui_SRCS), AUTOUIC might not "see" them unless they are explicitly added to the target's sources or found via search paths. The DlgReference.ui file is an example.

> Solution:
> To make PartDesign behave like TechDraw and leverage CMAKE_AUTOUIC:
> Ensure CMAKE_AUTOUIC (and CMAKE_AUTOMOC) is enabled for the PartDesignGui target. This is often done by default when you link against Qt libraries, but being explicit is safer.
> Instead of adding the unpopulated ${PartDesignGui_UIC_HDRS} to your target's sources, add the actual list of UI files (${PartDesignGui_UIC_SRCS}) to the target's sources. This ensures all .ui files are known to CMake for AUTOUIC processing.

> SET(PartDesignGui_SRCS ...):
> Changed ${PartDesignGui_UIC_HDRS} to ${PartDesignGui_UIC_SRCS}.
> This directly adds all .ui files (from the PartDesignGui_UIC_SRCS list) to the list of source files for the PartDesignGui library.
> 
> With these changes, when you modify a .ui file listed in PartDesignGui_UIC_SRCS (or any other .ui file that becomes part of PartDesignGui_SRCS), CMake's AUTOUIC mechanism should detect the change, regenerate the corresponding ui_*.h file, and consequently trigger the recompilation of any C++ files that depend on it. This should resolve the build errors and eliminate the need for a full rebuild.