### PR TITLE
CAM: fix default asset directory

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathPreferences.py
+++ b/src/Mod/CAM/CAMTests/TestPathPreferences.py
@@ -52,8 +52,8 @@ class TestPathPreferences(PathTestUtils.PathTestBase):
         """Default paths for tools are resolved correctly"""
 
         self.assertEqual(
-            Path.Preferences.getDefaultAssetPath().parts[-2:],
-            ("CAM", "Tools"),
+            Path.Preferences.getDefaultAssetPath().parts[-1],
+            "CamAssets",
             str(Path.Preferences.getDefaultAssetPath()),
         )
         self.assertEqual(

--- a/src/Mod/CAM/Path/Preferences.py
+++ b/src/Mod/CAM/Path/Preferences.py
@@ -116,7 +116,7 @@ def getBuiltinToolBitPath() -> pathlib.Path:
 
 def getDefaultAssetPath():
     config = pathlib.Path(FreeCAD.ConfigGet("UserConfigPath"))
-    return config / "Mod" / "CAM" / "Tools"
+    return config / "CamAssets"
 
 
 def getAssetPath() -> pathlib.Path:


### PR DESCRIPTION
## Issues

This fixes the issue found in #21735

The default directory used to store CAM assets was incorrect. This PR fixes the issue.


## Change

Old:
`<config-base-dir>/Mod/CAM/Tools`

New:
`<config-base-dir>/CamAssets`

