### PR TITLE
Gui: Add BitmapFactory::empty method

### DIFF
--- a/src/Gui/BitmapFactory.cpp
+++ b/src/Gui/BitmapFactory.cpp
@@ -521,6 +521,17 @@ QPixmap BitmapFactoryInst::disabled(const QPixmap& p) const
     return QApplication::style()->generatedIconPixmap(QIcon::Disabled, p, &opt);
 }
 
+QPixmap BitmapFactoryInst::empty(QSize size) const
+{
+    qreal dpr = getMaximumDPR();
+
+    QPixmap res(size * dpr);
+    res.fill(Qt::transparent);
+    res.setDevicePixelRatio(dpr);
+
+    return res;
+}
+
 void BitmapFactoryInst::convert(const QImage& p, SoSFImage& img) const
 {
     SbVec2s size;

--- a/src/Gui/BitmapFactory.h
+++ b/src/Gui/BitmapFactory.h
@@ -131,6 +131,11 @@ public:
      * of all opaque pixels to a higher value.
      */
     QPixmap disabled(const QPixmap& p) const;
+
+    /** Creates an empty pixmap, takes care of DPI and clearing out the image.
+     */
+    QPixmap empty(QSize size) const;
+
     /** Converts a QImage into a SoSFImage to use it inside a SoImage node.
      */
     void convert(const QImage& img, SoSFImage& out) const;

--- a/src/Gui/InputHintWidget.cpp
+++ b/src/Gui/InputHintWidget.cpp
@@ -136,15 +136,12 @@ QPixmap Gui::InputHintWidget::generateKeyIcon(const InputHint::UserInput key, co
     const QFontMetrics fm(font);
     const QString text = inputRepresentation(key);
     const QRect textBoundingRect = fm.tightBoundingRect(text);
-    const qreal dpr = BitmapFactoryInst::getMaximumDPR();
 
     const int symbolWidth = std::max(textBoundingRect.width() + padding * 2, iconSymbolHeight);
 
     const QRect keyRect(margin, margin, symbolWidth, iconSymbolHeight);
 
-    QPixmap pixmap((symbolWidth + margin * 2) * dpr, height * dpr);
-    pixmap.fill(Qt::transparent);
-    pixmap.setDevicePixelRatio(dpr);
+    QPixmap pixmap = BitmapFactory().empty({ symbolWidth + margin * 2, height });
 
     QPainter painter(&pixmap);
     painter.setRenderHint(QPainter::Antialiasing);


### PR DESCRIPTION
This adds empty(QSize) method to bitmap factory that creates empty pixmap. This may seem useless, but after creating bitmap one needs to remember to clear it and to properly set DPR - BitmapFactory will take care of it.

@maxwxyz FYI