### PR TITLE
Fix position measurement causing a crash

### DIFF
--- a/src/Mod/Measure/App/MeasurePosition.cpp
+++ b/src/Mod/Measure/App/MeasurePosition.cpp
@@ -96,6 +96,14 @@ App::DocumentObjectExecReturn* MeasurePosition::execute()
     const App::DocumentObject* object = Element.getValue();
     const std::vector<std::string>& subElements = Element.getSubValues();
 
+    if (!object || !object->isValid()) {
+        return new App::DocumentObjectExecReturn("Submitted object is not valid");
+    }
+
+    if (subElements.empty()) {
+        return new App::DocumentObjectExecReturn("No geometry element picked");
+    }
+
     App::SubObjectT subject {object, subElements.front().c_str()};
     auto info = getMeasureInfo(subject);
 


### PR DESCRIPTION
The measurement tool causes a crash after measuring a point location and then pressing the reset button or clicking anywhere that causes the selection to clear.

I took a look at the other measurement tools and noticed that they also validate if `subElements` is empty and used them as an example to implement a fix.

Related: #20329 

I cannot reproduce any crashes noted in the comments. Something might've changed since then that fixed those issues.