### PR TITLE
Techdraw: Add spacing preview

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -575,10 +575,13 @@ void TaskProjGroup::spacingChanged()
     if (blockUpdate || !multiView) {
         return;
     }
+
     multiView->spacingX.setValue(ui->sbXSpacing->value().getValue());
     multiView->spacingY.setValue(ui->sbYSpacing->value().getValue());
-    multiView->recomputeFeature();
+
+    multiView->autoPositionChildren();
 }
+
 
 void TaskProjGroup::updateTask()
 {
@@ -846,6 +849,10 @@ bool TaskProjGroup::reject()
         //set the DPG and its views back to entry state.
         if (Gui::Command::hasPendingCommand()) {
             Gui::Command::abortCommand();
+        }
+        // Restore views to initial spacing
+        if (multiView) {
+            multiView->autoPositionChildren();
         }
     }
     Gui::Command::runCommand(Gui::Command::Gui, "Gui.ActiveDocument.resetEdit()");


### PR DESCRIPTION
Old functionality: 
Adjusting spacing between views had no preview and required clicking "Apply" to view changes each time a value was changed

New functionality:
Each time a value is adjusted, the view is updated on the page instantly. When clicking "Cancel", views are restored to their old positions. 


## Issues
Fixes #21779

## Video of Before and After

**Note: if clips don't automagically load, right-click on the clip and 'Open in new tab'** *--luzpaz edit*

Before: 

https://github.com/user-attachments/assets/c8d66a4d-3ab3-4abd-b6cc-4660357d4f45

After:

https://github.com/user-attachments/assets/5f801e3a-2d35-449d-87c8-c821de1bd2d2



## Notes on the PR Review Process
Relevant discussion in Discord -> ux-topics -> TechDraw: Add support for updating preview when adjusting spacing between drawing views

This is my first time making a functional code change to any project on GitHub, so please review carefully. I've tested it myself locally and it seems to all be working.
