### PR TITLE
Gui: Improve orthographic camera rotation stability

### DIFF
--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -700,6 +700,19 @@ void NavigationStyle::reorientCamera(SoCamera* camera, const SbRotation& rotatio
     // Reposition camera so the rotation center stays in the same place
     camera->position = rotationCenter + newRotationCenterDistance;
 
+    if (camera->getTypeId().isDerivedFrom(SoOrthographicCamera::getClassTypeId())) {
+        // Adjust the camera position to keep the focal point in the same place while making sure
+        // the focal distance stays small. This increases rotation stability for small and large
+        // scenes
+
+        SbVec3f direction;
+        camera->orientation.getValue().multVec(SbVec3f(0, 0, -1), direction);
+        
+        constexpr float orthographicFocalDistance = 1;
+        camera->position = getFocalPoint() - orthographicFocalDistance * direction;
+        camera->focalDistance = orthographicFocalDistance;
+    }
+    
 #if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 403)
     // Fix issue with near clipping in orthogonal view
     if (camera->getTypeId().isDerivedFrom(SoOrthographicCamera::getClassTypeId())) {


### PR DESCRIPTION
Fixes #12162.

Problem is that when using the orthographic camera it is possible, mostly in very small or large scenes, that the focal distance becomes very small or large. Resulting in a shaking camera due to floating point precision issues. With this PR I always set the orthographic camera focal distance to 1 and adjust the camera position accordingly. By doing this we reduce the chances of floating point precision issues.

@maxwxyz, can you give this a try?



