### PR TITLE
Sketcher: Add contextual input hints to edit tools (InputHints Phase 3)

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
@@ -191,6 +191,7 @@ public:
                 return true;
             }
         }
+        updateHint();
         return false;
     }
 
@@ -218,7 +219,42 @@ private:
         Q_UNUSED(sketchgui);
         setAxisPickStyle(true);
     }
+
+    // Add hint structures here
+    struct HintEntry
+    {
+        int stateValue;
+        std::list<Gui::InputHint> hints;
+    };
+
+    using HintTable = std::vector<HintEntry>;
+
+    static HintTable getCarbonCopyHintTable();
+    static std::list<Gui::InputHint> lookupCarbonCopyHints(int stateValue);
+
+public:
+    std::list<Gui::InputHint> getToolHints() const override
+    {
+        return lookupCarbonCopyHints(0);
+    }
 };
+
+DrawSketchHandlerCarbonCopy::HintTable DrawSketchHandlerCarbonCopy::getCarbonCopyHintTable()
+{
+    return {
+        {0, {{QObject::tr("%1 select sketch to copy"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+}
+
+std::list<Gui::InputHint> DrawSketchHandlerCarbonCopy::lookupCarbonCopyHints(int stateValue)
+{
+    const auto carbonCopyHintTable = getCarbonCopyHintTable();
+
+    auto it = std::ranges::find_if(carbonCopyHintTable, [stateValue](const HintEntry& entry) {
+        return entry.stateValue == stateValue;
+    });
+
+    return (it != carbonCopyHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
+}
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
@@ -241,8 +241,7 @@ public:
 
 DrawSketchHandlerCarbonCopy::HintTable DrawSketchHandlerCarbonCopy::getCarbonCopyHintTable()
 {
-    return {
-        {0, {{QObject::tr("%1 select sketch to copy"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+    return {{0, {{QObject::tr("%1 pick sketch to copy"), {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
 std::list<Gui::InputHint> DrawSketchHandlerCarbonCopy::lookupCarbonCopyHints(int stateValue)

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
@@ -220,47 +220,13 @@ private:
         setAxisPickStyle(true);
     }
 
-    enum State
-    {
-        WaitingForSketch
-    };
-
-    struct HintEntry
-    {
-        State state;
-        std::list<Gui::InputHint> hints;
-    };
-
-    using HintTable = std::vector<HintEntry>;
-
-    static HintTable getCarbonCopyHintTable();
-    static std::list<Gui::InputHint> lookupCarbonCopyHints(State state);
-
 public:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return lookupCarbonCopyHints(WaitingForSketch);
+        return {{QObject::tr("%1 pick sketch to copy", "Sketcher CarbonCopy: hint"),
+                 {Gui::InputHint::UserInput::MouseLeft}}};
     }
 };
-
-DrawSketchHandlerCarbonCopy::HintTable DrawSketchHandlerCarbonCopy::getCarbonCopyHintTable()
-{
-    return {{WaitingForSketch,
-             {{QObject::tr("%1 pick sketch to copy", "Sketcher CarbonCopy: hint"),
-               {Gui::InputHint::UserInput::MouseLeft}}}}};
-}
-
-std::list<Gui::InputHint>
-DrawSketchHandlerCarbonCopy::lookupCarbonCopyHints(DrawSketchHandlerCarbonCopy::State state)
-{
-    const auto carbonCopyHintTable = getCarbonCopyHintTable();
-
-    auto it = std::ranges::find_if(carbonCopyHintTable, [state](const HintEntry& entry) {
-        return entry.state == state;
-    });
-
-    return (it != carbonCopyHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
-}
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
@@ -220,36 +220,43 @@ private:
         setAxisPickStyle(true);
     }
 
-    // Add hint structures here
+    enum State
+    {
+        WaitingForSketch
+    };
+
     struct HintEntry
     {
-        int stateValue;
+        State state;
         std::list<Gui::InputHint> hints;
     };
 
     using HintTable = std::vector<HintEntry>;
 
     static HintTable getCarbonCopyHintTable();
-    static std::list<Gui::InputHint> lookupCarbonCopyHints(int stateValue);
+    static std::list<Gui::InputHint> lookupCarbonCopyHints(State state);
 
 public:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return lookupCarbonCopyHints(0);
+        return lookupCarbonCopyHints(WaitingForSketch);
     }
 };
 
 DrawSketchHandlerCarbonCopy::HintTable DrawSketchHandlerCarbonCopy::getCarbonCopyHintTable()
 {
-    return {{0, {{QObject::tr("%1 pick sketch to copy"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+    return {{WaitingForSketch,
+             {{QObject::tr("%1 pick sketch to copy", "Sketcher CarbonCopy: hint"),
+               {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
-std::list<Gui::InputHint> DrawSketchHandlerCarbonCopy::lookupCarbonCopyHints(int stateValue)
+std::list<Gui::InputHint>
+DrawSketchHandlerCarbonCopy::lookupCarbonCopyHints(DrawSketchHandlerCarbonCopy::State state)
 {
     const auto carbonCopyHintTable = getCarbonCopyHintTable();
 
-    auto it = std::ranges::find_if(carbonCopyHintTable, [stateValue](const HintEntry& entry) {
-        return entry.stateValue == stateValue;
+    auto it = std::ranges::find_if(carbonCopyHintTable, [state](const HintEntry& entry) {
+        return entry.state == state;
     });
 
     return (it != carbonCopyHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
@@ -400,11 +400,10 @@ private:
 
 DrawSketchHandlerExtend::HintTable DrawSketchHandlerExtend::getExtendHintTable()
 {
-    return {
-        {0, {{QObject::tr("%1 select edge to extend"), {Gui::InputHint::UserInput::MouseLeft}}}},
-        {1,
-         {{QObject::tr("%1 click to set extension length"),
-           {Gui::InputHint::UserInput::MouseLeft}}}}};
+    return {{0, {{QObject::tr("%1 pick edge to extend"), {Gui::InputHint::UserInput::MouseLeft}}}},
+            {1,
+             {{QObject::tr("%1 click to set extension length"),
+               {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
 std::list<Gui::InputHint> DrawSketchHandlerExtend::lookupExtendHints(int stateValue)

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
@@ -376,19 +376,19 @@ protected:
     // Add hint structures here
     struct HintEntry
     {
-        int stateValue;
+        SelectMode state;
         std::list<Gui::InputHint> hints;
     };
 
     using HintTable = std::vector<HintEntry>;
 
     static HintTable getExtendHintTable();
-    static std::list<Gui::InputHint> lookupExtendHints(int stateValue);
+    static std::list<Gui::InputHint> lookupExtendHints(SelectMode state);
 
 public:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return lookupExtendHints(static_cast<int>(Mode));
+        return lookupExtendHints(Mode);
     }
 
 private:
@@ -400,17 +400,20 @@ private:
 
 DrawSketchHandlerExtend::HintTable DrawSketchHandlerExtend::getExtendHintTable()
 {
-    return {
-        {0, {{QObject::tr("%1 pick edge to extend"), {Gui::InputHint::UserInput::MouseLeft}}}},
-        {1, {{QObject::tr("%1 set extension length"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+    return {{STATUS_SEEK_First,
+             {{QObject::tr("%1 pick edge to extend", "Sketcher Extend: hint"),
+               {Gui::InputHint::UserInput::MouseLeft}}}},
+            {STATUS_SEEK_Second,
+             {{QObject::tr("%1 set extension length", "Sketcher Extend: hint"),
+               {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
-std::list<Gui::InputHint> DrawSketchHandlerExtend::lookupExtendHints(int stateValue)
+std::list<Gui::InputHint> DrawSketchHandlerExtend::lookupExtendHints(SelectMode state)
 {
     const auto extendHintTable = getExtendHintTable();
 
-    auto it = std::ranges::find_if(extendHintTable, [stateValue](const HintEntry& entry) {
-        return entry.stateValue == stateValue;
+    auto it = std::ranges::find_if(extendHintTable, [state](const HintEntry& entry) {
+        return entry.state == state;
     });
 
     return (it != extendHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
@@ -344,6 +344,8 @@ public:
             sketchgui
                 ->purgeHandler();  // no code after this line, Handler get deleted in ViewProvider
         }
+
+        updateHint();
         return true;
     }
 
@@ -371,6 +373,24 @@ protected:
     double Increment;
     std::vector<AutoConstraint> SugConstr;
 
+    // Add hint structures here
+    struct HintEntry
+    {
+        int stateValue;
+        std::list<Gui::InputHint> hints;
+    };
+
+    using HintTable = std::vector<HintEntry>;
+
+    static HintTable getExtendHintTable();
+    static std::list<Gui::InputHint> lookupExtendHints(int stateValue);
+
+public:
+    std::list<Gui::InputHint> getToolHints() const override
+    {
+        return lookupExtendHints(static_cast<int>(Mode));
+    }
+
 private:
     int crossProduct(Base::Vector2d& vec1, Base::Vector2d& vec2)
     {
@@ -378,8 +398,26 @@ private:
     }
 };
 
+DrawSketchHandlerExtend::HintTable DrawSketchHandlerExtend::getExtendHintTable()
+{
+    return {
+        {0, {{QObject::tr("%1 select edge to extend"), {Gui::InputHint::UserInput::MouseLeft}}}},
+        {1,
+         {{QObject::tr("%1 click to set extension length"),
+           {Gui::InputHint::UserInput::MouseLeft}}}}};
+}
+
+std::list<Gui::InputHint> DrawSketchHandlerExtend::lookupExtendHints(int stateValue)
+{
+    const auto extendHintTable = getExtendHintTable();
+
+    auto it = std::ranges::find_if(extendHintTable, [stateValue](const HintEntry& entry) {
+        return entry.stateValue == stateValue;
+    });
+
+    return (it != extendHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
+}
 
 }  // namespace SketcherGui
-
 
 #endif  // SKETCHERGUI_DrawSketchHandlerExtend_H

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
@@ -400,12 +400,14 @@ private:
 
 DrawSketchHandlerExtend::HintTable DrawSketchHandlerExtend::getExtendHintTable()
 {
-    return {{STATUS_SEEK_First,
-             {{QObject::tr("%1 pick edge to extend", "Sketcher Extend: hint"),
-               {Gui::InputHint::UserInput::MouseLeft}}}},
-            {STATUS_SEEK_Second,
-             {{QObject::tr("%1 set extension length", "Sketcher Extend: hint"),
-               {Gui::InputHint::UserInput::MouseLeft}}}}};
+    using enum Gui::InputHint::UserInput;
+
+    return {
+        {.state = STATUS_SEEK_First,
+         .hints = {{QObject::tr("%1 pick edge to extend", "Sketcher Extend: hint"), {MouseLeft}}}},
+        {.state = STATUS_SEEK_Second,
+         .hints = {
+             {QObject::tr("%1 set extension length", "Sketcher Extend: hint"), {MouseLeft}}}}};
 }
 
 std::list<Gui::InputHint> DrawSketchHandlerExtend::lookupExtendHints(SelectMode state)

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
@@ -400,10 +400,9 @@ private:
 
 DrawSketchHandlerExtend::HintTable DrawSketchHandlerExtend::getExtendHintTable()
 {
-    return {{0, {{QObject::tr("%1 pick edge to extend"), {Gui::InputHint::UserInput::MouseLeft}}}},
-            {1,
-             {{QObject::tr("%1 click to set extension length"),
-               {Gui::InputHint::UserInput::MouseLeft}}}}};
+    return {
+        {0, {{QObject::tr("%1 pick edge to extend"), {Gui::InputHint::UserInput::MouseLeft}}}},
+        {1, {{QObject::tr("%1 set extension length"), {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
 std::list<Gui::InputHint> DrawSketchHandlerExtend::lookupExtendHints(int stateValue)

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
@@ -266,8 +266,7 @@ public:
 DrawSketchHandlerExternal::HintTable DrawSketchHandlerExternal::getExternalHintTable()
 {
     return {
-        {0,
-         {{QObject::tr("%1 select external geometry"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+        {0, {{QObject::tr("%1 pick external geometry"), {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
 std::list<Gui::InputHint> DrawSketchHandlerExternal::lookupExternalHints(int stateValue)

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
@@ -245,47 +245,13 @@ private:
     bool alwaysReference;
     bool intersection;
 
-    enum State
-    {
-        WaitingForSelection
-    };
-
-    struct HintEntry
-    {
-        State state;
-        std::list<Gui::InputHint> hints;
-    };
-
-    using HintTable = std::vector<HintEntry>;
-
-    static HintTable getExternalHintTable();
-    static std::list<Gui::InputHint> lookupExternalHints(State state);
-
 public:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return lookupExternalHints(WaitingForSelection);
+        return {{QObject::tr("%1 pick external geometry", "Sketcher External: hint"),
+                 {Gui::InputHint::UserInput::MouseLeft}}};
     }
 };
-
-DrawSketchHandlerExternal::HintTable DrawSketchHandlerExternal::getExternalHintTable()
-{
-    return {{WaitingForSelection,
-             {{QObject::tr("%1 pick external geometry", "Sketcher External: hint"),
-               {Gui::InputHint::UserInput::MouseLeft}}}}};
-}
-
-std::list<Gui::InputHint>
-DrawSketchHandlerExternal::lookupExternalHints(DrawSketchHandlerExternal::State state)
-{
-    const auto externalHintTable = getExternalHintTable();
-
-    auto it = std::ranges::find_if(externalHintTable, [state](const HintEntry& entry) {
-        return entry.state == state;
-    });
-
-    return (it != externalHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
-}
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
@@ -245,36 +245,43 @@ private:
     bool alwaysReference;
     bool intersection;
 
+    enum State
+    {
+        WaitingForSelection
+    };
+
     struct HintEntry
     {
-        int stateValue;
+        State state;
         std::list<Gui::InputHint> hints;
     };
 
     using HintTable = std::vector<HintEntry>;
 
     static HintTable getExternalHintTable();
-    static std::list<Gui::InputHint> lookupExternalHints(int stateValue);
+    static std::list<Gui::InputHint> lookupExternalHints(State state);
 
 public:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return lookupExternalHints(0);
+        return lookupExternalHints(WaitingForSelection);
     }
 };
 
 DrawSketchHandlerExternal::HintTable DrawSketchHandlerExternal::getExternalHintTable()
 {
-    return {
-        {0, {{QObject::tr("%1 pick external geometry"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+    return {{WaitingForSelection,
+             {{QObject::tr("%1 pick external geometry", "Sketcher External: hint"),
+               {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
-std::list<Gui::InputHint> DrawSketchHandlerExternal::lookupExternalHints(int stateValue)
+std::list<Gui::InputHint>
+DrawSketchHandlerExternal::lookupExternalHints(DrawSketchHandlerExternal::State state)
 {
     const auto externalHintTable = getExternalHintTable();
 
-    auto it = std::ranges::find_if(externalHintTable, [stateValue](const HintEntry& entry) {
-        return entry.stateValue == stateValue;
+    auto it = std::ranges::find_if(externalHintTable, [state](const HintEntry& entry) {
+        return entry.state == state;
     });
 
     return (it != externalHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
@@ -208,6 +208,8 @@ public:
                 return true;
             }
         }
+        updateHint();
+
         return false;
     }
 
@@ -242,8 +244,42 @@ private:
 
     bool alwaysReference;
     bool intersection;
+
+    struct HintEntry
+    {
+        int stateValue;
+        std::list<Gui::InputHint> hints;
+    };
+
+    using HintTable = std::vector<HintEntry>;
+
+    static HintTable getExternalHintTable();
+    static std::list<Gui::InputHint> lookupExternalHints(int stateValue);
+
+public:
+    std::list<Gui::InputHint> getToolHints() const override
+    {
+        return lookupExternalHints(0);
+    }
 };
 
+DrawSketchHandlerExternal::HintTable DrawSketchHandlerExternal::getExternalHintTable()
+{
+    return {
+        {0,
+         {{QObject::tr("%1 select external geometry"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+}
+
+std::list<Gui::InputHint> DrawSketchHandlerExternal::lookupExternalHints(int stateValue)
+{
+    const auto externalHintTable = getExternalHintTable();
+
+    auto it = std::ranges::find_if(externalHintTable, [stateValue](const HintEntry& entry) {
+        return entry.stateValue == stateValue;
+    });
+
+    return (it != externalHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
+}
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
@@ -411,22 +411,21 @@ private:
     int vtId, geoId1, geoId2;
     Base::Vector2d firstPos, secondPos;
 
-    // Add hint structures here
     struct HintEntry
     {
-        int stateValue;
+        SelectMode state;
         std::list<Gui::InputHint> hints;
     };
 
     using HintTable = std::vector<HintEntry>;
 
     static HintTable getFilletHintTable();
-    static std::list<Gui::InputHint> lookupFilletHints(int stateValue);
+    static std::list<Gui::InputHint> lookupFilletHints(SelectMode state);
 
 public:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return lookupFilletHints(static_cast<int>(state()));
+        return lookupFilletHints(state());
     }
 };
 
@@ -478,19 +477,23 @@ void DSHFilletController::adaptDrawingToCheckboxChange(int checkboxindex, bool v
 
 DrawSketchHandlerFillet::HintTable DrawSketchHandlerFillet::getFilletHintTable()
 {
-    return {
-        {0,
-         {{QObject::tr("%1 pick first edge or vertex"), {Gui::InputHint::UserInput::MouseLeft}}}},
-        {1, {{QObject::tr("%1 pick second edge"), {Gui::InputHint::UserInput::MouseLeft}}}},
-        {2, {{QObject::tr("%1 create fillet"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+    return {{SelectMode::SeekFirst,
+             {{QObject::tr("%1 pick first edge or vertex", "Sketcher Fillet/Chamfer: hint"),
+               {Gui::InputHint::UserInput::MouseLeft}}}},
+            {SelectMode::SeekSecond,
+             {{QObject::tr("%1 pick second edge", "Sketcher Fillet/Chamfer: hint"),
+               {Gui::InputHint::UserInput::MouseLeft}}}},
+            {SelectMode::End,
+             {{QObject::tr("%1 create fillet", "Sketcher Fillet/Chamfer: hint"),
+               {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
-std::list<Gui::InputHint> DrawSketchHandlerFillet::lookupFilletHints(int stateValue)
+std::list<Gui::InputHint> DrawSketchHandlerFillet::lookupFilletHints(SelectMode state)
 {
     const auto filletHintTable = getFilletHintTable();
 
-    auto it = std::ranges::find_if(filletHintTable, [stateValue](const HintEntry& entry) {
-        return entry.stateValue == stateValue;
+    auto it = std::ranges::find_if(filletHintTable, [state](const HintEntry& entry) {
+        return entry.state == state;
     });
 
     return (it != filletHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
@@ -477,15 +477,18 @@ void DSHFilletController::adaptDrawingToCheckboxChange(int checkboxindex, bool v
 
 DrawSketchHandlerFillet::HintTable DrawSketchHandlerFillet::getFilletHintTable()
 {
-    return {{SelectMode::SeekFirst,
-             {{QObject::tr("%1 pick first edge or vertex", "Sketcher Fillet/Chamfer: hint"),
-               {Gui::InputHint::UserInput::MouseLeft}}}},
-            {SelectMode::SeekSecond,
-             {{QObject::tr("%1 pick second edge", "Sketcher Fillet/Chamfer: hint"),
-               {Gui::InputHint::UserInput::MouseLeft}}}},
-            {SelectMode::End,
-             {{QObject::tr("%1 create fillet", "Sketcher Fillet/Chamfer: hint"),
-               {Gui::InputHint::UserInput::MouseLeft}}}}};
+    using enum Gui::InputHint::UserInput;
+
+    return {
+        {.state = SelectMode::SeekFirst,
+         .hints = {{QObject::tr("%1 pick first edge or vertex", "Sketcher Fillet/Chamfer: hint"),
+                    {MouseLeft}}}},
+        {.state = SelectMode::SeekSecond,
+         .hints = {{QObject::tr("%1 pick second edge", "Sketcher Fillet/Chamfer: hint"),
+                    {MouseLeft}}}},
+        {.state = SelectMode::End,
+         .hints = {
+             {QObject::tr("%1 create fillet", "Sketcher Fillet/Chamfer: hint"), {MouseLeft}}}}};
 }
 
 std::list<Gui::InputHint> DrawSketchHandlerFillet::lookupFilletHints(SelectMode state)

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
@@ -480,9 +480,9 @@ DrawSketchHandlerFillet::HintTable DrawSketchHandlerFillet::getFilletHintTable()
 {
     return {
         {0,
-         {{QObject::tr("%1 pick first line or vertex"), {Gui::InputHint::UserInput::MouseLeft}}}},
-        {1, {{QObject::tr("%1 pick second line"), {Gui::InputHint::UserInput::MouseLeft}}}},
-        {2, {{QObject::tr("%1 click to create fillet"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+         {{QObject::tr("%1 pick first edge or vertex"), {Gui::InputHint::UserInput::MouseLeft}}}},
+        {1, {{QObject::tr("%1 pick second edge"), {Gui::InputHint::UserInput::MouseLeft}}}},
+        {2, {{QObject::tr("%1 create fillet"), {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
 std::list<Gui::InputHint> DrawSketchHandlerFillet::lookupFilletHints(int stateValue)

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
@@ -479,16 +479,15 @@ DrawSketchHandlerFillet::HintTable DrawSketchHandlerFillet::getFilletHintTable()
 {
     using enum Gui::InputHint::UserInput;
 
-    return {
-        {.state = SelectMode::SeekFirst,
-         .hints = {{QObject::tr("%1 pick first edge or vertex", "Sketcher Fillet/Chamfer: hint"),
-                    {MouseLeft}}}},
-        {.state = SelectMode::SeekSecond,
-         .hints = {{QObject::tr("%1 pick second edge", "Sketcher Fillet/Chamfer: hint"),
-                    {MouseLeft}}}},
-        {.state = SelectMode::End,
-         .hints = {
-             {QObject::tr("%1 create fillet", "Sketcher Fillet/Chamfer: hint"), {MouseLeft}}}}};
+    return {{.state = SelectMode::SeekFirst,
+             .hints = {{QObject::tr("%1 pick first edge or point", "Sketcher Fillet/Chamfer: hint"),
+                        {MouseLeft}}}},
+            {.state = SelectMode::SeekSecond,
+             .hints = {{QObject::tr("%1 pick second edge", "Sketcher Fillet/Chamfer: hint"),
+                        {MouseLeft}}}},
+            {.state = SelectMode::End,
+             .hints = {
+                 {QObject::tr("%1 create fillet", "Sketcher Fillet/Chamfer: hint"), {MouseLeft}}}}};
 }
 
 std::list<Gui::InputHint> DrawSketchHandlerFillet::lookupFilletHints(SelectMode state)

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -200,7 +200,7 @@ private:
 public:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return {{QObject::tr("%1 pick edge to split", "Sketcher Splitting: hint"),
+        return {{QObject::tr("%1 pick location on edge to split", "Sketcher Splitting: hint"),
                  {Gui::InputHint::UserInput::MouseLeft}}};
     }
 };

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -204,10 +204,15 @@ private:
     static HintTable getSplittingHintTable();
     static std::list<Gui::InputHint> lookupSplittingHints(State state);
 
+private:
+    std::vector<Base::Vector2d> EditMarkers;
+    bool mousePressed = false;
+
 public:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return lookupSplittingHints(WaitingForEdge);
+        return {{QObject::tr("%1 pick edge to split", "Sketcher Splitting: hint"),
+                 {Gui::InputHint::UserInput::MouseLeft}}};
     }
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -188,36 +188,43 @@ private:
         return QStringLiteral("Sketcher_Pointer_Splitting");
     }
 
-    // Add hint structures here
+    enum State
+    {
+        WaitingForEdge
+    };
+
     struct HintEntry
     {
-        int stateValue;
+        State state;
         std::list<Gui::InputHint> hints;
     };
 
     using HintTable = std::vector<HintEntry>;
 
     static HintTable getSplittingHintTable();
-    static std::list<Gui::InputHint> lookupSplittingHints(int stateValue);
+    static std::list<Gui::InputHint> lookupSplittingHints(State state);
 
 public:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return lookupSplittingHints(0);
+        return lookupSplittingHints(WaitingForEdge);
     }
 };
 
 DrawSketchHandlerSplitting::HintTable DrawSketchHandlerSplitting::getSplittingHintTable()
 {
-    return {{0, {{QObject::tr("%1 pick edge to split"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+    return {{WaitingForEdge,
+             {{QObject::tr("%1 pick edge to split", "Sketcher Splitting: hint"),
+               {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
-std::list<Gui::InputHint> DrawSketchHandlerSplitting::lookupSplittingHints(int stateValue)
+std::list<Gui::InputHint>
+DrawSketchHandlerSplitting::lookupSplittingHints(DrawSketchHandlerSplitting::State state)
 {
     const auto splittingHintTable = getSplittingHintTable();
 
-    auto it = std::ranges::find_if(splittingHintTable, [stateValue](const HintEntry& entry) {
-        return entry.stateValue == stateValue;
+    auto it = std::ranges::find_if(splittingHintTable, [state](const HintEntry& entry) {
+        return entry.state == state;
     });
 
     return (it != splittingHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -209,7 +209,7 @@ public:
 
 DrawSketchHandlerSplitting::HintTable DrawSketchHandlerSplitting::getSplittingHintTable()
 {
-    return {{0, {{QObject::tr("%1 click edge to split"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+    return {{0, {{QObject::tr("%1 pick edge to split"), {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
 std::list<Gui::InputHint> DrawSketchHandlerSplitting::lookupSplittingHints(int stateValue)

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -187,7 +187,41 @@ private:
     {
         return QStringLiteral("Sketcher_Pointer_Splitting");
     }
+
+    // Add hint structures here
+    struct HintEntry
+    {
+        int stateValue;
+        std::list<Gui::InputHint> hints;
+    };
+
+    using HintTable = std::vector<HintEntry>;
+
+    static HintTable getSplittingHintTable();
+    static std::list<Gui::InputHint> lookupSplittingHints(int stateValue);
+
+public:
+    std::list<Gui::InputHint> getToolHints() const override
+    {
+        return lookupSplittingHints(0);
+    }
 };
+
+DrawSketchHandlerSplitting::HintTable DrawSketchHandlerSplitting::getSplittingHintTable()
+{
+    return {{0, {{QObject::tr("%1 click edge to split"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+}
+
+std::list<Gui::InputHint> DrawSketchHandlerSplitting::lookupSplittingHints(int stateValue)
+{
+    const auto splittingHintTable = getSplittingHintTable();
+
+    auto it = std::ranges::find_if(splittingHintTable, [stateValue](const HintEntry& entry) {
+        return entry.stateValue == stateValue;
+    });
+
+    return (it != splittingHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
+}
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -193,17 +193,6 @@ private:
         WaitingForEdge
     };
 
-    struct HintEntry
-    {
-        State state;
-        std::list<Gui::InputHint> hints;
-    };
-
-    using HintTable = std::vector<HintEntry>;
-
-    static HintTable getSplittingHintTable();
-    static std::list<Gui::InputHint> lookupSplittingHints(State state);
-
 private:
     std::vector<Base::Vector2d> EditMarkers;
     bool mousePressed = false;
@@ -215,25 +204,6 @@ public:
                  {Gui::InputHint::UserInput::MouseLeft}}};
     }
 };
-
-DrawSketchHandlerSplitting::HintTable DrawSketchHandlerSplitting::getSplittingHintTable()
-{
-    return {{WaitingForEdge,
-             {{QObject::tr("%1 pick edge to split", "Sketcher Splitting: hint"),
-               {Gui::InputHint::UserInput::MouseLeft}}}}};
-}
-
-std::list<Gui::InputHint>
-DrawSketchHandlerSplitting::lookupSplittingHints(DrawSketchHandlerSplitting::State state)
-{
-    const auto splittingHintTable = getSplittingHintTable();
-
-    auto it = std::ranges::find_if(splittingHintTable, [state](const HintEntry& entry) {
-        return entry.state == state;
-    });
-
-    return (it != splittingHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
-}
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -209,47 +209,13 @@ private:
     std::vector<Base::Vector2d> EditMarkers;
     bool mousePressed = false;
 
-    enum State
-    {
-        WaitingForEdge
-    };
-
-    struct HintEntry
-    {
-        State state;
-        std::list<Gui::InputHint> hints;
-    };
-
-    using HintTable = std::vector<HintEntry>;
-
-    static HintTable getTrimmingHintTable();
-    static std::list<Gui::InputHint> lookupTrimmingHints(State state);
-
 public:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return lookupTrimmingHints(WaitingForEdge);
+        return {{QObject::tr("%1 pick edge to trim", "Sketcher Trimming: hint"),
+                 {Gui::InputHint::UserInput::MouseLeft}}};
     }
 };
-
-DrawSketchHandlerTrimming::HintTable DrawSketchHandlerTrimming::getTrimmingHintTable()
-{
-    return {{WaitingForEdge,
-             {{QObject::tr("%1 pick edge to trim", "Sketcher Trimming: hint"),
-               {Gui::InputHint::UserInput::MouseLeft}}}}};
-}
-
-std::list<Gui::InputHint>
-DrawSketchHandlerTrimming::lookupTrimmingHints(DrawSketchHandlerTrimming::State state)
-{
-    const auto trimmingHintTable = getTrimmingHintTable();
-
-    auto it = std::ranges::find_if(trimmingHintTable, [state](const HintEntry& entry) {
-        return entry.state == state;
-    });
-
-    return (it != trimmingHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
-}
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -208,10 +208,42 @@ private:
 private:
     std::vector<Base::Vector2d> EditMarkers;
     bool mousePressed = false;
+
+    // Add hint structures here
+    struct HintEntry
+    {
+        int stateValue;
+        std::list<Gui::InputHint> hints;
+    };
+
+    using HintTable = std::vector<HintEntry>;
+
+    static HintTable getTrimmingHintTable();
+    static std::list<Gui::InputHint> lookupTrimmingHints(int stateValue);
+
+public:
+    std::list<Gui::InputHint> getToolHints() const override
+    {
+        return lookupTrimmingHints(0);
+    }
 };
 
+DrawSketchHandlerTrimming::HintTable DrawSketchHandlerTrimming::getTrimmingHintTable()
+{
+    return {{0, {{QObject::tr("%1 click edge to trim"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+}
+
+std::list<Gui::InputHint> DrawSketchHandlerTrimming::lookupTrimmingHints(int stateValue)
+{
+    const auto trimmingHintTable = getTrimmingHintTable();
+
+    auto it = std::ranges::find_if(trimmingHintTable, [stateValue](const HintEntry& entry) {
+        return entry.stateValue == stateValue;
+    });
+
+    return (it != trimmingHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
+}
 
 }  // namespace SketcherGui
-
 
 #endif  // SKETCHERGUI_DrawSketchHandlerTrimming_H

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -230,7 +230,7 @@ public:
 
 DrawSketchHandlerTrimming::HintTable DrawSketchHandlerTrimming::getTrimmingHintTable()
 {
-    return {{0, {{QObject::tr("%1 click edge to trim"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+    return {{0, {{QObject::tr("%1 pick edge to trim"), {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
 std::list<Gui::InputHint> DrawSketchHandlerTrimming::lookupTrimmingHints(int stateValue)

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -209,36 +209,43 @@ private:
     std::vector<Base::Vector2d> EditMarkers;
     bool mousePressed = false;
 
-    // Add hint structures here
+    enum State
+    {
+        WaitingForEdge
+    };
+
     struct HintEntry
     {
-        int stateValue;
+        State state;
         std::list<Gui::InputHint> hints;
     };
 
     using HintTable = std::vector<HintEntry>;
 
     static HintTable getTrimmingHintTable();
-    static std::list<Gui::InputHint> lookupTrimmingHints(int stateValue);
+    static std::list<Gui::InputHint> lookupTrimmingHints(State state);
 
 public:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return lookupTrimmingHints(0);
+        return lookupTrimmingHints(WaitingForEdge);
     }
 };
 
 DrawSketchHandlerTrimming::HintTable DrawSketchHandlerTrimming::getTrimmingHintTable()
 {
-    return {{0, {{QObject::tr("%1 pick edge to trim"), {Gui::InputHint::UserInput::MouseLeft}}}}};
+    return {{WaitingForEdge,
+             {{QObject::tr("%1 pick edge to trim", "Sketcher Trimming: hint"),
+               {Gui::InputHint::UserInput::MouseLeft}}}}};
 }
 
-std::list<Gui::InputHint> DrawSketchHandlerTrimming::lookupTrimmingHints(int stateValue)
+std::list<Gui::InputHint>
+DrawSketchHandlerTrimming::lookupTrimmingHints(DrawSketchHandlerTrimming::State state)
 {
     const auto trimmingHintTable = getTrimmingHintTable();
 
-    auto it = std::ranges::find_if(trimmingHintTable, [stateValue](const HintEntry& entry) {
-        return entry.stateValue == stateValue;
+    auto it = std::ranges::find_if(trimmingHintTable, [state](const HintEntry& entry) {
+        return entry.state == state;
     });
 
     return (it != trimmingHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR extends the `InputHints` system to Sketcher's **edit tools**, continuing the integration pattern introduced in [PR #21632](https://github.com/FreeCAD/FreeCAD/pull/21632) and expanded in Phase 2 for constraint tools. It provides in-canvas, contextual prompts for all major editing operations based on internal tool state.

Tools now covered include:
- **Fillet**
- **Chamfer**
- **Trim**
- **Split**
- **Extend**
- **External Geometry**
- **Carbon Copy**

Each handler uses a localized hint table keyed by tool state or mode, delivering real-time guidance to users as they interact.

---

## Issues

N/A — this is part of the ongoing integration of the InputHints framework into Sketcher

---

## Before and After

**Before:**  
Sketcher edit tools provided no contextual feedback. Users had to rely on trial-and-error to understand what to select or do next.

**After:**  
Each edit tool now displays helpful, state-aware prompts. For example:

- **Trim**: 
![image](https://github.com/user-attachments/assets/ab205eed-edd0-4087-bc17-01e8b35c8047)

- **Extend**:  
![image](https://github.com/user-attachments/assets/8888d913-bc8b-4125-8bb1-8337c321d833)
![image](https://github.com/user-attachments/assets/c30e671d-60c5-4431-a54f-48267ca8be3e)

- **Fillet**:  
![image](https://github.com/user-attachments/assets/cb91f360-16c4-4224-84d0-159c471f5f34)
 ![image](https://github.com/user-attachments/assets/bf97ebe2-bf6c-447f-a4f5-f40731fa1c94)

- **Carbon Copy**: 
![image](https://github.com/user-attachments/assets/bc63b1f6-31fb-4056-a175-563bba773988)

> These are **representative examples** — all covered tools follow the same hint structure using localized, context-sensitive prompts that update based on internal state.

---

## What’s Included

- Contextual `InputHint` support for all core edit tools
- Modern C++20 hint implementation using designated initializers and using enum for clarity
- Type-safe enum-based state management replacing int with proper enums
- Declarative hint tables with runtime localization (`QObject::tr`)
- State-based lookups that match internal handler logic
- Seamless integration with Sketcher's existing `updateHint()` mechanism
- Simplified single-state tools with direct hint return (CarbonCopy, External, Splitting, Trimming)
- Declarative hint tables for multi-state tools (Extend, Fillet) with runtime localization

All changes follow the pattern established in Phases 1 and 2, with isolated, low-risk additions scoped to each tool handler.

---

## Design Considerations
**Why two approaches?**
Multi-state tools (Extend, Fillet) benefit from declarative tables for state management, while single-state tools (CarbonCopy, External, etc.) are simplified with direct hint return to eliminate unnecessary boilerplate.

**Why localized hint tables?**  
Keeps each tool’s logic self-contained and avoids central complexity. This pattern has proven reliable across drawing and constraint tools.

**Why runtime evaluation?**  
`QObject::tr()` must resolve at runtime to support localization, so hint tables are built dynamically.

**Does this affect performance?**  
No. InputHints are lightweight and only active during interactive sessions.

---

## Testing Performed

Manual testing in Sketcher with:

**Edit Tool Coverage**
- [x] Fillet / Chamfer: multiple states and geometries
- [x] Trim, Split, Extend: real-time feedback during editing
- [x] External Geometry & Carbon Copy: selection hints on entry

**Integration Checks**
- [x] No regressions to existing editing behavior
- [x] Hints appear/disappear as expected
- [x] Smooth transitions between tools

**Compliance**
- [x] All hint strings follow the official InputHint guidelines introduced in [PR #21759](https://github.com/FreeCAD/FreeCAD/pull/21759)
- [x] Prompts begin with input symbol (`%1`) and lowercase verb
- [x] Phrasing is concise and unambiguous
- [x] All strings are localized via `QObject::tr()`
- [x] Hint lists are short (≤6) and update cleanly by state

---

## What’s Next
This PR completes **Phase 3** of the InputHints rollout for Sketcher.  

**Phase 4** will focus on bringing contextual hinting to the **transform tools** — including Move, Rotate, Scale, and Mirror — further improving guidance across the full Sketcher workflow.

