### PR TITLE
CI: attempt to fix random annotations on PRs

### DIFF
--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -26,7 +26,13 @@
 
 name: FreeCAD master CI
 
-on: [workflow_dispatch, push, pull_request, merge_group]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+  workflow_dispatch:
 
 concurrency:
   group: FC-CI-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -31,6 +31,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
### The problem

On every PR, an "Unchanged files with check annotations" appears. This section shows compiler warnings on files that are unrelated and untouched by the PR, creating unnecessary noise.

The primary CI workflow (`CI_master.yml`) is configured to run on every `push` event without restriction. When a pull request is updated, it triggers a `push` event in the background that causes CI to run.

This `push`-triggered workflow builds the entire project, and the problem matchers set up for the project's compilers (GCC, Clang, MSVC) create annotations for warnings found in *any* file. Because these annotations are tied to the commit itself and not the pull request context, GitHub displays them on all files, leading to the noisy "Unchanged files with check annotations" section.

### The solution

The solution is to prevent the CI from running on `push` events related to pull requests, and only run it under the `pull_request` context.

This change restricts the `push` trigger to only the `main` branch. The `pull_request` trigger will continue to correctly run the CI for pull requests and their updates, but the resulting annotations will be properly scoped to only the changed files.

**Update**: applied this to the `pull_request` event as well.