### PR TITLE
[BIM] Fix Attribute Error when user moves and then deletes the BimViewArea dock widget

### DIFF
--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -534,6 +534,8 @@ class BIM_Views:
         """Saves dock widget size and location"""
         if hasattr(area, "value"):
             PARAMS.SetInt("BimViewArea", area.value)
+        else:
+            PARAMS.SetInt("BimViewArea", int(area))
         mw = FreeCADGui.getMainWindow()
         vm = findWidget()
         if vm:

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -532,7 +532,7 @@ class BIM_Views:
 
     def onDockLocationChanged(self, area):
         """Saves dock widget size and location"""
-        if hasattr(area, "value"):
+        if hasattr(area, "value"):  # To support Qt5.15
             PARAMS.SetInt("BimViewArea", area.value)
         else:
             PARAMS.SetInt("BimViewArea", int(area))

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -532,7 +532,8 @@ class BIM_Views:
 
     def onDockLocationChanged(self, area):
         """Saves dock widget size and location"""
-        PARAMS.SetInt("BimViewArea", area.value)
+        if hasattr(area, "value"):
+            PARAMS.SetInt("BimViewArea", area.value)
         mw = FreeCADGui.getMainWindow()
         vm = findWidget()
         if vm:


### PR DESCRIPTION
While carrying out some testing in BIM I moved and deleted the `BIMViewArea` dockwidget and managed to create this attribute error in the Report View:

```
20:46:49  Traceback (most recent call last):
20:46:49    File "/home/john/freecad-daily-build/Mod/BIM/bimcommands/BimViews.py", line 535, in onDockLocationChanged
20:46:49      PARAMS.SetInt("BimViewArea", area.value)
20:46:49                                   ^^^^^^^^^^
20:46:49  AttributeError: 'PySide2.QtCore.Qt.DockWidgetArea' object has no attribute 'value'. Did you mean: 'values'?
```

This PR is to prevent the error being generated in future.