### PR TITLE
App: Trim “Gui::” and “NavigationStyle” more securely

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -3774,7 +3774,12 @@ void Application::getVerboseCommonInfo(QTextStream& str, const std::map<std::str
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
 
-    const QString navStyle = QString::fromStdString(hGrp->GetASCII("NavigationStyle", "Gui::CADNavigationStyle")).remove(0, 5).chopped(15);
+    QString navStyle = QString::fromStdString(hGrp->GetASCII("NavigationStyle", "Gui::CADNavigationStyle"));
+    // All navigation styles are named on the format "Gui::<Name>NavigationStyle"
+    // so we remove the "Gui::" prefix and the "NavigationStyle" suffix before printing.
+    navStyle.replace(QRegularExpression(QLatin1String("^Gui::")), {});
+    navStyle.replace(QRegularExpression(QLatin1String("NavigationStyle$")), {});
+
     const QString orbitStyle = QStringLiteral("Turntable,Trackball,Free Turntable,Trackball Classic,Rounded Arcball")
                                .split(QLatin1Char(','))
                                .at(hGrp->GetInt("OrbitStyle", 4));


### PR DESCRIPTION
By using regex we can remove prefix and suffix more securely as we can’t assume all navigation styles are formatted the same (mistakes can happen)

Code speaks for itself.