### PR TITLE
Sketcher: Refactor Point tool to direct-return input hint pattern

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -65,7 +65,8 @@ public:
 private:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return lookupPointHints(static_cast<int>(state()));
+        using enum Gui::InputHint::UserInput;
+        return {{QObject::tr("%1 place a point", "Sketcher Point: hint"), {MouseLeft}}};
     }
 
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
@@ -134,17 +135,6 @@ private:
 
 private:
     Base::Vector2d editPoint;
-
-    struct HintEntry
-    {
-        int stateValue;
-        std::list<Gui::InputHint> hints;
-    };
-
-    using HintTable = std::vector<HintEntry>;
-
-    static HintTable getPointHintTable();
-    static std::list<Gui::InputHint> lookupPointHints(int stateValue);
 };
 
 template<>
@@ -283,25 +273,6 @@ void DSHPointController::addConstraints()
                                    handler->sketchgui->getObject());
         }
     }
-}
-
-DrawSketchHandlerPoint::HintTable DrawSketchHandlerPoint::getPointHintTable()
-{
-    return {// Structure: {ConstructionMethod, SelectMode, {hints...}}
-            {0, {{QObject::tr("%1 place a point"), {Gui::InputHint::UserInput::MouseLeft}}}}};
-}
-
-std::list<Gui::InputHint> DrawSketchHandlerPoint::lookupPointHints(int stateValue)
-{
-    const auto pointHintTable = getPointHintTable();
-
-    auto it = std::find_if(pointHintTable.begin(),
-                           pointHintTable.end(),
-                           [stateValue](const HintEntry& entry) {
-                               return entry.stateValue == stateValue;
-                           });
-
-    return (it != pointHintTable.end()) ? it->hints : std::list<Gui::InputHint> {};
 }
 
 }  // namespace SketcherGui


### PR DESCRIPTION


<!-- Include a brief summary of the changes. -->

This PR refactors the `Point` tool's input hint logic in Sketcher to use the direct-return pattern adopted for single-state tools. It removes unnecessary lookup tables and simplifies `getToolHints()` to return a single, localized hint directly.

This matches the declarative style used in tools like `Offset` and `Symmetry` and improves maintainability while preserving behavior.

<!--  
The FreeCAD community thanks you for your contribution!  
By creating a Pull Request you agree to the contributing policy.  
The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md  
-->

---

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A — architectural cleanup

---

## Before and After Images

**Before:**  
The `Point` tool used an internal hint table and lookup function to return a single hint.

**After:**  
The hint is now returned directly in `getToolHints()`, eliminating indirection and reducing code size by 30+ lines.

---

## Design Notes

- The Point tool has only one operational state, making the previous table-driven architecture unnecessary.  
- This direct-return pattern is now preferred for single-state tools for clarity and simplicity.  
- State dispatch remains useful for multi-mode tools (e.g., Rotate, Scale) where input changes dynamically.

---

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  
These items may not require you to take any action.  
This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.  

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).  
-->

