### PR TITLE
[Start] show the actual custom folder name...

### DIFF
--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -441,7 +441,17 @@ void StartView::retranslateUi()
     _newFileLabel->setText(h1Start + tr("New File") + h1End);
     _examplesLabel->setText(h1Start + tr("Examples") + h1End);
     _recentFilesLabel->setText(h1Start + tr("Recent Files") + h1End);
-    _customFolderLabel->setText(h1Start + tr("Custom Folder") + h1End);
+
+    auto hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Start");
+    std::string customFolder(hGrp->GetASCII("CustomFolder", ""));
+    bool shortCustomFolder = hGrp->GetBool("ShortCustomFolder", true);  // false shows full path
+    if (!customFolder.empty()) {
+        if (shortCustomFolder) {
+            customFolder = customFolder.substr(customFolder.find_last_of("/\\") + 1);
+        }
+        _customFolderLabel->setText(h1Start + QString::fromUtf8(customFolder.c_str()) + h1End);
+    }
 
     QString application = QString::fromUtf8(App::Application::Config()["ExeName"].c_str());
     _openFirstStart->setText(tr("Open first start setup"));


### PR DESCRIPTION
...instead of 'Custom Folder'

## Before and After Images

Before:

![Current](https://github.com/user-attachments/assets/f57cbc05-e7d1-417f-8a74-c2a88424d32a)

After, default short folder name:

![WithPR](https://github.com/user-attachments/assets/25b6a3a5-82ba-40d7-9d30-2346ea95002d)

After, full path folder name (user name redacted):

![LongFolder](https://github.com/user-attachments/assets/087449a4-529f-4fe2-88dc-346e227942c9)



The user has the ability to set the full path by the use of the boolean `ShortCustomFolder` parameter, will be documented in https://wiki.freecad.org/Fine-tuning

FYI @furgo16 not sure whether you're doing much with the Start module

@FreeCAD/design-working-group for approval
