### PR TITLE
CAM: OperationCopy - Expressions for properties

### DIFF
--- a/src/Mod/CAM/PathCommands.py
+++ b/src/Mod/CAM/PathCommands.py
@@ -22,7 +22,8 @@
 
 import FreeCAD
 import Path
-import PathScripts
+
+# import PathScripts
 import traceback
 
 from PathScripts.PathUtils import loopdetect
@@ -35,7 +36,8 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from PySide import QtCore
+
+    # from PySide import QtCore
     from PySide import QtGui
 
 # translate = FreeCAD.Qt.translate
@@ -202,9 +204,22 @@ class _CopyOperation:
             return False
 
     def Activated(self):
-        for sel in FreeCADGui.Selection.getSelectionEx():
-            jobname = findParentJob(sel.Object).Name
-            addToJob(FreeCAD.ActiveDocument.copyObject(sel.Object, False), jobname)
+        for sel in FreeCADGui.Selection.getSelection():
+            jobname = findParentJob(sel).Name
+            newObj = FreeCAD.ActiveDocument.copyObject(sel, False)
+            addToJob(newObj, jobname)
+            for property in newObj.PropertiesList:
+                if property == "Label":
+                    newObj.Label = f"{sel.Name}_expCopy"
+                elif property not in [
+                    "_ElementMapVersion",
+                    "ExpressionEngine",
+                    "removalshape",
+                    "CycleTime",
+                    "Visibility",
+                ]:
+                    expression = f"{sel.Name}.{property}"
+                    newObj.setExpression(property, expression)
 
 
 if FreeCAD.GuiUp:


### PR DESCRIPTION
Instead just create a copy, also set expressions to get parametric copy of operation
So any change of original operation will change also a `..._expCopy`

I want try to use it to get reverse Path for `Mirror` dressup

Probably better create new feature for this instead of change `CAM_OperationCopy`

![Screenshot_20250607_234652_lossy](https://github.com/user-attachments/assets/9f683211-e95d-4706-9627-1c7e871f7f6b)