### PR TITLE
CAM: Add 3.175mm endmill to default tool library as it's extremely common size

### DIFF
--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -412,6 +412,7 @@ SET(Tools_SRCS
 
 SET(Tools_Bit_SRCS
     Tools/Bit/30degree_Vbit.fctb
+    Tools/Bit/3.175mm_Endmill.fctb
     Tools/Bit/375-16_Tap.fctb
     Tools/Bit/45degree_chamfer.fctb
     Tools/Bit/45degree_Vbit.fctb

--- a/src/Mod/CAM/Tools/Bit/3.175mm_Endmill.fctb
+++ b/src/Mod/CAM/Tools/Bit/3.175mm_Endmill.fctb
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "name": "3.175mm Endmill",
+  "shape": "endmill.fcstd",
+  "shape-type": "Endmill",
+  "parameter": {
+    "CuttingEdgeHeight": "25.0000 mm",
+    "Diameter": "3.1750 mm",
+    "Length": "45.0000 mm",
+    "ShankDiameter": "3.1750 mm"
+  },
+  "attribute": {}
+}

--- a/src/Mod/CAM/Tools/Library/Default.fctl
+++ b/src/Mod/CAM/Tools/Library/Default.fctl
@@ -2,50 +2,54 @@
   "tools": [
     {
       "nr": 1,
-      "path": "5mm_Endmill.fctb"
+      "path": "3.175mm_Endmill.fctb"
     },
     {
       "nr": 2,
-      "path": "5mm_Drill.fctb"
+      "path": "5mm_Endmill.fctb"
     },
     {
       "nr": 3,
-      "path": "6mm_Ball_End.fctb"
+      "path": "5mm_Drill.fctb"
     },
     {
       "nr": 4,
-      "path": "6mm_Bullnose.fctb"
+      "path": "6mm_Ball_End.fctb"
     },
     {
       "nr": 5,
-      "path": "30degree_Vbit.fctb"
+      "path": "6mm_Bullnose.fctb"
     },
     {
       "nr": 6,
-      "path": "45degree_Vbit.fctb"
+      "path": "30degree_Vbit.fctb"
     },
     {
       "nr": 7,
-      "path": "60degree_Vbit.fctb"
+      "path": "45degree_Vbit.fctb"
     },
     {
       "nr": 8,
-      "path": "90degree_Vbit.fctb"
+      "path": "60degree_Vbit.fctb"
     },
     {
       "nr": 9,
-      "path": "45degree_chamfer.fctb"
+      "path": "90degree_Vbit.fctb"
     },
     {
       "nr": 10,
-      "path": "slittingsaw.fctb"
+      "path": "45degree_chamfer.fctb"
     },
     {
       "nr": 11,
-      "path": "probe.fctb"
+      "path": "slittingsaw.fctb"
     },
     {
       "nr": 12,
+      "path": "probe.fctb"
+    },
+    {
+      "nr": 13,
       "path": "5mm-thread-cutter.fctb"
     }
   ],


### PR DESCRIPTION
While being a metric guy, i still have to admit, that 3.175mm (or 1/8 inch as someone might say) is one of the most common endmill diameters due to wide availability/compatibility even outside of the imperial world. It's very popular among hobby CNC users and PCB manufacturers. It's also often a default diameter in many kinds of CAM related software.

Therefore i took the liberty of including it in default FreeCAD CAM tool library to welcome new users with familiar toolbit.
