### PR TITLE
Fix Wrong scaled Sketcher Objects

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3971,12 +3971,7 @@ int ViewProviderSketch::defaultFontSizePixels() const
 
 qreal ViewProviderSketch::getDevicePixelRatio() const
 {
-    if (auto activeView = qobject_cast<Gui::View3DInventor*>(this->getActiveView())) {
-        auto glWidget = activeView->getViewer()->getGLWidget();
-        return glWidget->devicePixelRatio();
-    }
-
-    return QApplication::primaryScreen()->devicePixelRatio();
+    return QApplication::primaryScreen()->physicalDotsPerInch() / QApplication::primaryScreen()->logicalDotsPerInch();
 }
 
 int ViewProviderSketch::getApplicationLogicalDPIX() const


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
With #21098 there were fixes for HDPI Screens implemented. Some Elements were rendered too large.
I think this was due to Qt's devicePixelRatio including  OS-Level Scaling additionally to the physical and logical DPI.

I replaced the devicePixelRatio with the calculation of the physicalDPI / logicalDPI which should prevent double scaling effects when the OS Scaling is not 100%.

I can only test on windows with a HDPI Screen, so I'll leave it as draft until someone can test on other systems (see below what to test)

## Issues
should fix #21745 and probably #19887

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
* Before on FreeCAD 1.0.1 (HiDPI Changes were not implemented):
  * <img width="359" alt="freecad 1 0 1" src="https://github.com/user-attachments/assets/564c3c6a-618c-4899-85cb-8a7c458dfb9f" />
* Before on the Development Version (HiDPI Changes were implemented)
  * <img width="365" alt="before fix" src="https://github.com/user-attachments/assets/8ecc48b2-027b-4b69-87cd-12095860bf38" />
* After
  * <img width="440" alt="after fix" src="https://github.com/user-attachments/assets/3e3d2ff5-1dc7-4823-8cf9-8d3fe5a55366" />

## What to test
* Standard- and High-DPI Screens
  * Elements should be sized "normal"
  * On Systems with different screens the sizes of the elements should be comparable
* Different Operating Systems
  * Size of the elements should be comparable (see initial issue #19887)




<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)


  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
