### PR TITLE
Implement Sketcher note geometry for inline textual annotation

### DIFF
--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -104,6 +104,7 @@
 #include "LineSegmentPy.h"
 #include "OffsetCurvePy.h"
 #include "OffsetSurfacePy.h"
+#include "NotePy.h"
 #include "ParabolaPy.h"
 #include "Part2DObject.h"
 #include "Part2DObjectPy.h"
@@ -298,6 +299,7 @@ PyMOD_INIT_FUNC(Part)
     Base::Interpreter().addType(&Part::LinePy               ::Type,partModule,"Line");
     Base::Interpreter().addType(&Part::LineSegmentPy        ::Type,partModule,"LineSegment");
     Base::Interpreter().addType(&Part::PointPy              ::Type,partModule,"Point");
+    Base::Interpreter().addType(&Part::NotePy               ::Type,partModule,"Note");
     Base::Interpreter().addType(&Part::ConicPy              ::Type,partModule,"Conic");
     Base::Interpreter().addType(&Part::ArcOfConicPy         ::Type,partModule,"ArcOfConic");
     Base::Interpreter().addType(&Part::CirclePy             ::Type,partModule,"Circle");
@@ -507,6 +509,7 @@ PyMOD_INIT_FUNC(Part)
     Part::GeometryMigrationExtension	::init();
     Part::GeometryMigrationPersistenceExtension	::init();
     Part::Geometry                	::init();
+    Part::GeomNote               	::init();
     Part::GeomPoint               	::init();
     Part::GeomCurve               	::init();
     Part::GeomBoundedCurve        	::init();

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -62,6 +62,7 @@ generate_from_py(GeometrySurface)
 generate_from_py(Line)
 generate_from_py(LineSegment)
 generate_from_py(Point)
+generate_from_py(Note)
 generate_from_py(BezierCurve)
 generate_from_py(BSplineCurve)
 generate_from_py(Plane)
@@ -309,6 +310,8 @@ SET(Python_SRCS
     LineSegmentPyImp.cpp
     Point.pyi
     PointPyImp.cpp
+    Note.pyi
+    NotePyImp.cpp
     BezierCurve.pyi
     BezierCurvePyImp.cpp
     BSplineCurve.pyi

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -184,6 +184,51 @@ private:
     Handle(Geom_CartesianPoint) myPoint;
 };
 
+class PartExport GeomNote : public Geometry
+{
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
+public:
+    GeomNote();
+    GeomNote(const GeomNote& other);
+    explicit GeomNote(const Base::Vector3d&);
+    GeomNote(const Base::Vector3d& p, const std::string& txt);
+    ~GeomNote() override;
+    Geometry* copy() const override;
+    TopoDS_Shape toShape() const override;
+    void copyFrom(const GeomNote& other);
+
+    // Persistence implementer ---------------------
+    void Save(Base::Writer &writer) const override;
+    void Restore(Base::XMLReader &reader) override;
+
+    // Base implementer ----------------------------
+    PyObject* getPyObject() override;
+
+    bool isSame(const Geometry& other, double tol, double atol) const override;
+    const Handle(Geom_Geometry)& handle() const override;
+
+    // Getters/Setters
+    Base::Vector3d getPosition() const;
+    void setPosition(const Base::Vector3d& p);
+
+    std::string getText() const;
+    void setText(const std::string& t);
+
+    double getFontSize() const;
+    void setFontSize(double fs);
+
+    const float* getColor() const;
+    void setColor(const float rgba[4]);
+
+private:
+    Base::Vector3d position;
+    std::string text;
+    double fontSize;
+    float color[4];
+private:
+    Handle(Geom_Geometry) myNote;
+};
+
 class GeomBSplineCurve;
 class GeomLine;
 class GeomLineSegment;

--- a/src/Mod/Part/App/Note.pyi
+++ b/src/Mod/Part/App/Note.pyi
@@ -1,0 +1,55 @@
+from Base.Metadata import export, constmethod
+from Base.Vector import Vector
+from Geometry import Geometry
+from typing import overload
+
+
+@export(
+    PythonName="Part.Note",
+    Twin="GeomNote",
+    TwinPointer="GeomNote",
+    Include="Mod/Part/App/Geometry.h",
+    FatherInclude="Mod/Part/App/GeometryPy.h",
+    Constructor=True,
+)
+class Note(Geometry):
+    """
+    Describes a note
+    To create a note there are several ways:
+    Part.Note()
+        Creates a default note
+    
+    Part.Note(Vector)
+        Creates a note for the given coordinates
+    
+    Part.Note(Vector, str)
+        Creates a note with the text (str) for the given coordinates
+
+    """
+
+    @overload
+    def __init__(self) -> None: ...
+
+    @overload
+    def __init__(self, coordinates: Vector) -> None: ...
+
+    @overload
+    def __init__(self, coordinates: Vector, text: str) -> None: ...
+
+    X: float = ...
+    """X component of this note."""
+
+    Y: float = ...
+    """Y component of this note."""
+
+    Z: float = ...
+    """Z component of this note."""
+
+    Text: str = ...
+    """Text content of the note."""
+
+    FontSize: float = ...
+    """Font size used in the note."""
+
+    Color: tuple = ...
+    """Color of the note as an RGBA tuple."""

--- a/src/Mod/Part/App/NotePyImp.cpp
+++ b/src/Mod/Part/App/NotePyImp.cpp
@@ -1,0 +1,170 @@
+/***************************************************************************
+ *   Copyright (c) 2025 [Teu Nome]                                         *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+#endif
+
+#include <Base/VectorPy.h>
+
+#include "NotePy.h"
+#include "NotePy.cpp"
+#include "OCCError.h"
+
+using namespace Part;
+
+std::string NotePy::representation() const
+{
+    std::stringstream str;
+    Base::Vector3d pos = getGeomNotePtr()->getPosition();
+    str << "<Note position=(" << pos.x << ", " << pos.y << ", " << pos.z << "), text=\"" 
+        << getGeomNotePtr()->getText() << "\" >";
+    return str.str();
+}
+
+PyObject* NotePy::PyMake(struct _typeobject *, PyObject *, PyObject *)
+{
+    return new NotePy(new GeomNote);
+}
+
+int NotePy::PyInit(PyObject* args, PyObject* /*kwd*/)
+{
+    if (PyArg_ParseTuple(args, "")) {
+        return 0;
+    }
+
+    PyErr_Clear();
+
+    PyObject* pVecOnly = nullptr;
+    if (PyArg_ParseTuple(args, "O!", &(Base::VectorPy::Type), &pVecOnly)) {
+        Base::Vector3d vec = static_cast<Base::VectorPy*>(pVecOnly)->value();
+        getGeomNotePtr()->setPosition(vec);
+        return 0;
+    }
+
+    PyErr_Clear();
+
+    PyObject* pVec = nullptr;
+    const char* txt = nullptr;
+    if (PyArg_ParseTuple(args, "O!s", &(Base::VectorPy::Type), &pVec, &txt)) {
+        Base::Vector3d vec = static_cast<Base::VectorPy*>(pVec)->value();
+        getGeomNotePtr()->setPosition(vec);
+        getGeomNotePtr()->setText(txt);
+        return 0;
+    }
+
+    PyErr_SetString(PyExc_TypeError, "Note constructor accepts:\n"
+        "-- empty parameter list\n"
+        "-- Coordinates vector\n"
+        "-- Coordinates vector and a string (position, text)");
+    return -1;
+}
+
+Py::Float NotePy::getX() const
+{
+    return Py::Float(getGeomNotePtr()->getPosition().x);
+}
+
+void NotePy::setX(Py::Float x)
+{
+    auto pos = getGeomNotePtr()->getPosition();
+    pos.x = double(x);
+    getGeomNotePtr()->setPosition(pos);
+}
+
+Py::Float NotePy::getY() const
+{
+    return Py::Float(getGeomNotePtr()->getPosition().y);
+}
+
+void NotePy::setY(Py::Float y)
+{
+    auto pos = getGeomNotePtr()->getPosition();
+    pos.y = double(y);
+    getGeomNotePtr()->setPosition(pos);
+}
+
+Py::Float NotePy::getZ() const
+{
+    return Py::Float(getGeomNotePtr()->getPosition().z);
+}
+
+void NotePy::setZ(Py::Float z)
+{
+    auto pos = getGeomNotePtr()->getPosition();
+    pos.z = double(z);
+    getGeomNotePtr()->setPosition(pos);
+}
+
+Py::String NotePy::getText() const
+{
+    return Py::String(getGeomNotePtr()->getText());
+}
+
+void NotePy::setText(Py::String arg)
+{
+    std::string s = arg;
+    getGeomNotePtr()->setText(s);
+}
+
+Py::Float NotePy::getFontSize() const
+{
+    return Py::Float(getGeomNotePtr()->getFontSize());
+}
+
+void NotePy::setFontSize(Py::Float fs)
+{
+    getGeomNotePtr()->setFontSize(double(fs));
+}
+
+Py::Tuple NotePy::getColor() const
+{
+    const float* c = getGeomNotePtr()->getColor();
+    Py::Tuple tuple(4);
+    for (int i=0; i<4; ++i) {
+        tuple[i] = Py::Float(c[i]);
+    }
+    return tuple;
+}
+
+void NotePy::setColor(Py::Tuple arg)
+{
+    if (arg.length() != 4) {
+        throw Py::TypeError("Color must be a tuple of 4 floats");
+    }
+    float rgba[4];
+    for (int i = 0; i < 4; ++i) {
+        Py::Object item = arg[i];
+        rgba[i] = static_cast<float>(Py::Float(item));
+    }
+    getGeomNotePtr()->setColor(rgba);
+}
+
+PyObject* NotePy::getCustomAttributes(const char* attr) const
+{
+    return 0; 
+}
+
+int NotePy::setCustomAttributes(const char* attr, PyObject* obj)
+{
+    return 0; 
+}

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -227,6 +227,8 @@ public:
     int addArcOfParabola(const Part::GeomArcOfParabola& parabolaSegment, bool fixed = false);
     /// add a BSpline
     int addBSpline(const Part::GeomBSplineCurve& spline, bool fixed = false);
+    /// add a note
+    int addNote(const Part::GeomNote& note, bool fixed = false);
     //@}
 
 
@@ -522,7 +524,8 @@ public:
         ArcOfEllipse = 6,
         ArcOfHyperbola = 7,
         ArcOfParabola = 8,
-        BSpline = 9
+        BSpline = 9,
+        Note = 10
     };
 
 private:
@@ -724,6 +727,7 @@ private:
     void tryUpdateGeometry();
     void updateGeometry(const GeoDef&);
     void updatePoint(const GeoDef&);
+    void updateNote(const GeoDef&);
     void updateLineSegment(const GeoDef&);
     void updateArcOfCircle(const GeoDef&);
     void updateArcOfEllipse(const GeoDef&);

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1641,7 +1641,8 @@ bool SketchObject::isSupportedGeometry(const Part::Geometry* geo) const
         || geo->is<Part::GeomArcOfHyperbola>()
         || geo->is<Part::GeomArcOfParabola>()
         || geo->is<Part::GeomBSplineCurve>()
-        || geo->is<Part::GeomLineSegment>()) {
+        || geo->is<Part::GeomLineSegment>()
+        || geo->is<Part::GeomNote>()) {
         return true;
     }
     if (geo->is<Part::GeomTrimmedCurve>()) {

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -115,7 +115,7 @@ PyObject* SketchObjectPy::addGeometry(PyObject* args)
                  || geo->is<Part::GeomEllipse>() || geo->is<Part::GeomArcOfCircle>()
                  || geo->is<Part::GeomArcOfEllipse>() || geo->is<Part::GeomArcOfHyperbola>()
                  || geo->is<Part::GeomArcOfParabola>() || geo->is<Part::GeomBSplineCurve>()
-                 || geo->is<Part::GeomLineSegment>()) {
+                 || geo->is<Part::GeomLineSegment>() || geo->is<Part::GeomNote>()) {
             ret = this->getSketchObjectPtr()->addGeometry(geo, isConstruction);
         }
         else {
@@ -167,7 +167,7 @@ PyObject* SketchObjectPy::addGeometry(PyObject* args)
                          || geo->is<Part::GeomEllipse>() || geo->is<Part::GeomArcOfCircle>()
                          || geo->is<Part::GeomArcOfEllipse>() || geo->is<Part::GeomArcOfHyperbola>()
                          || geo->is<Part::GeomArcOfParabola>() || geo->is<Part::GeomBSplineCurve>()
-                         || geo->is<Part::GeomLineSegment>()) {
+                         || geo->is<Part::GeomLineSegment>() || geo->is<Part::GeomNote>()) {
                     geoList.push_back(geo);
                 }
                 else {

--- a/src/Mod/Sketcher/App/SolverGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/SolverGeometryExtension.cpp
@@ -89,7 +89,8 @@ void SolverGeometryExtension::notifyAttachment(Part::Geometry* geo)
         {Part::GeomEllipse::getClassTypeId(), 3},
         {Part::GeomArcOfHyperbola::getClassTypeId(), 5},
         {Part::GeomArcOfParabola::getClassTypeId(), 4},
-        {Part::GeomBSplineCurve::getClassTypeId(), 0}  // is dynamic
+        {Part::GeomBSplineCurve::getClassTypeId(), 0},  // is dynamic
+        {Part::GeomNote::getClassTypeId(), 0}
     };
 
     GeometryType = geo->getTypeId();

--- a/src/Mod/Sketcher/App/SolverGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/SolverGeometryExtension.cpp
@@ -90,8 +90,7 @@ void SolverGeometryExtension::notifyAttachment(Part::Geometry* geo)
         {Part::GeomArcOfHyperbola::getClassTypeId(), 5},
         {Part::GeomArcOfParabola::getClassTypeId(), 4},
         {Part::GeomBSplineCurve::getClassTypeId(), 0},  // is dynamic
-        {Part::GeomNote::getClassTypeId(), 0}
-    };
+        {Part::GeomNote::getClassTypeId(), 0}};
 
     GeometryType = geo->getTypeId();
 

--- a/src/Mod/Sketcher/App/planegcs/Geo.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Geo.cpp
@@ -128,6 +128,25 @@ DeriVector2 Curve::Value(double /*u*/, double /*du*/, const double* /*derivparam
     return DeriVector2();
 }
 
+//----------------Note
+int Note::PushOwnParams(VEC_pD& pvec)
+{
+    int cnt = 0;
+    pvec.push_back(x);
+    cnt++;
+    pvec.push_back(y);
+    cnt++;
+    return cnt;
+}
+
+void Note::ReconstructOnNewPvec(VEC_pD& pvec, int& cnt)
+{
+    x = pvec[cnt];
+    cnt++;
+    y = pvec[cnt];
+    cnt++;
+}
+
 //----------------Line
 
 DeriVector2 Line::CalculateNormal(const Point& p, const double* derivparam) const

--- a/src/Mod/Sketcher/App/planegcs/Geo.h
+++ b/src/Mod/Sketcher/App/planegcs/Geo.h
@@ -148,6 +148,27 @@ public:
 // Geometries
 ///////////////////////////////////////
 
+
+class SketcherExport Note
+{
+public:
+    Note()
+    {
+        x = nullptr;
+        y = nullptr;
+    }
+    Note(double* px, double* py)
+    {
+        x = px;
+        y = py;
+    }
+    double* x;
+    double* y;
+    int PushOwnParams(VEC_pD& pvec);
+    void ReconstructOnNewPvec(VEC_pD& pvec, int& cnt);
+};
+
+
 /// A base class for all curve-based objects (line, circle/arc, ellipse/arc).
 class SketcherExport Curve
 {

--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -17,6 +17,7 @@ set(Sketcher_TestScripts
     SketcherTests/TestSketcherSolver.py
     SketcherTests/TestSketchExpression.py
     SketcherTests/TestSketchValidateCoincidents.py
+    SketcherTests/TestSketchNote.py
 )
 
 if(BUILD_GUI)

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -1894,7 +1894,6 @@ void CmdSketcherCreateNote::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     ActivateHandler(getActiveGuiDocument(), std::make_unique<DrawSketchHandlerNote>());
-    
 }
 
 bool CmdSketcherCreateNote::isActive()

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -72,6 +72,7 @@
 #include "DrawSketchHandlerSlot.h"
 #include "DrawSketchHandlerSplitting.h"
 #include "DrawSketchHandlerTrimming.h"
+#include "DrawSketchHandlerNote.h"
 
 
 using namespace std;
@@ -1868,6 +1869,40 @@ bool CmdSketcherCarbonCopy::isActive()
     return isCommandActive(getActiveGuiDocument());
 }
 
+
+// Notes ================================================================
+
+DEF_STD_CMD_AU(CmdSketcherCreateNote)
+
+CmdSketcherCreateNote::CmdSketcherCreateNote()
+    : Command("Sketcher_CreateNote")
+{
+    sAppModule = "Sketcher";
+    sGroup = "Sketcher";
+    sMenuText = QT_TR_NOOP("Create note");
+    sToolTipText = QT_TR_NOOP("Create a note in the sketch");
+    sWhatsThis = "Sketcher_CreateNote";
+    sStatusTip = sToolTipText;
+    sPixmap = "Sketcher_CreateText";
+    sAccel = "N, P";
+    eType = ForEdit;
+}
+
+CONSTRUCTION_UPDATE_ACTION(CmdSketcherCreateNote, "Sketcher_CreateNote")
+
+void CmdSketcherCreateNote::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    ActivateHandler(getActiveGuiDocument(), std::make_unique<DrawSketchHandlerNote>());
+    
+}
+
+bool CmdSketcherCreateNote::isActive()
+{
+    return isCommandActive(getActiveGuiDocument());
+}
+
+
 void CreateSketcherCommandsCreateGeo()
 {
     Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
@@ -1922,4 +1957,5 @@ void CreateSketcherCommandsCreateGeo()
     rcCmdMgr.addCommand(new CmdSketcherCompCreateFillets());
     rcCmdMgr.addCommand(new CmdSketcherCompCurveEdition());
     rcCmdMgr.addCommand(new CmdSketcherCompExternal());
+    rcCmdMgr.addCommand(new CmdSketcherCreateNote());
 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerNote.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerNote.h
@@ -1,0 +1,286 @@
+/***************************************************************************
+ *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef SKETCHERGUI_DrawSketchHandlerNote_H
+#define SKETCHERGUI_DrawSketchHandlerNote_H
+
+#include <Gui/BitmapFactory.h>
+#include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
+#include <QInputDialog>
+#include <QLineEdit>
+
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "GeometryCreationMode.h"
+
+#include "DrawSketchDefaultWidgetController.h"
+#include "DrawSketchControllableHandler.h"
+
+namespace SketcherGui
+{
+
+extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
+
+class DrawSketchHandlerNote;
+
+using DSHNoteController = DrawSketchController<DrawSketchHandlerNote,
+                                                StateMachines::OneSeekEnd,
+                                                /*PAutoConstraintSize =*/1,
+                                                /*OnViewParametersT =*/OnViewParameters<2>>;
+
+using DrawSketchHandlerNoteBase = DrawSketchControllableHandler<DSHNoteController>;
+
+class DrawSketchHandlerNote: public DrawSketchHandlerNoteBase
+{
+    // Allow specialisations of controllers access to private members
+    friend DSHNoteController;
+
+public:
+    DrawSketchHandlerNote() = default;
+    ~DrawSketchHandlerNote() override = default;
+
+private:
+    void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
+    {
+        switch (state()) {
+            case SelectMode::SeekFirst: {
+                toolWidgetManager.drawPositionAtCursor(onSketchPos);
+
+                editNote = onSketchPos;
+
+                seekAndRenderAutoConstraint(sugConstraints[0],
+                                            onSketchPos,
+                                            Base::Vector2d(0.f, 0.f));
+            } break;
+            default:
+                break;
+        }    
+    }
+
+    void executeCommands() override
+    {
+        try {
+            bool ok;
+            QString text = QInputDialog::getText(
+                nullptr,  
+                QObject::tr("Create Note"),
+                QObject::tr("Note text:"),
+                QLineEdit::Normal,
+                QString(),       
+                &ok);
+            if (!ok || text.isEmpty()) {
+                Gui::Command::abortCommand();
+                return;
+            }
+            Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch note"));
+            Gui::cmdAppObjectArgs(sketchgui->getObject(),
+                                  "addGeometry(Part.Note(App.Vector(%f,%f,0), '%s'), %s)",
+                                  editNote.x,
+                                  editNote.y,
+                                  text.toStdString().c_str(),
+                                  isConstructionMode() ? "True" : "False");
+            Gui::Command::commitCommand();
+        }
+        catch (const Base::Exception&) {
+            Gui::NotifyError(sketchgui,
+                             QT_TRANSLATE_NOOP("Notifications", "Error"),
+                             QT_TRANSLATE_NOOP("Notifications", "Failed to add note"));
+
+            Gui::Command::abortCommand();
+        }
+    }
+
+    void createAutoConstraints() override
+    {
+        
+        if (!sugConstraints[0].empty()) {
+            DrawSketchHandler::createAutoConstraints(sugConstraints[0],
+                                                     getHighestCurveIndex(),
+                                                     Sketcher::PointPos::start);
+            sugConstraints[0].clear();
+        }
+    }
+
+    std::string getToolName() const override
+    {
+        return "DSH_Note";
+    }
+
+    QString getCrosshairCursorSVGName() const override
+    {
+        return QStringLiteral("Sketcher_Pointer_Text");
+    }
+
+    std::unique_ptr<QWidget> createWidget() const override
+    {
+        return std::make_unique<SketcherToolDefaultWidget>();
+    }
+
+private:
+    Base::Vector2d editNote;
+    
+};
+
+template<>
+auto DSHNoteController::getState(int labelindex) const
+{
+    switch (labelindex) {
+        case OnViewParameter::First:
+        case OnViewParameter::Second:
+            return SelectMode::SeekFirst;
+            break;
+        default:
+            THROWM(Base::ValueError, "Parameter index without an associated machine state")
+    }
+}
+
+template<>
+void DSHNoteController::configureOnViewParameters()
+{
+    onViewParameters[OnViewParameter::First]->setLabelType(Gui::SoDatumLabel::DISTANCEX);
+    onViewParameters[OnViewParameter::Second]->setLabelType(Gui::SoDatumLabel::DISTANCEY);
+}
+
+template<>
+void DSHNoteController::adaptDrawingToOnViewParameterChange(int labelindex, double value)
+{
+    switch (labelindex) {
+        case OnViewParameter::First:
+            handler->editNote.x = value;
+            break;
+        case OnViewParameter::Second:
+            handler->editNote.y = value;
+            break;
+    }
+    onViewParameters[OnViewParameter::First]->setPoints(
+        Base::Vector3d(0., 0., 0.),
+        Base::Vector3d(handler->editNote.x, handler->editNote.y, 0.));
+    onViewParameters[OnViewParameter::Second]->setPoints(
+        Base::Vector3d(0., 0., 0.),
+        Base::Vector3d(handler->editNote.x, handler->editNote.y, 0.));
+}
+
+template<>
+void DSHNoteController::doEnforceControlParameters(Base::Vector2d& onSketchPos)
+{
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            if (onViewParameters[OnViewParameter::First]->isSet) {
+                onSketchPos.x = onViewParameters[OnViewParameter::First]->getValue();
+            }
+
+            if (onViewParameters[OnViewParameter::Second]->isSet) {
+                onSketchPos.y = onViewParameters[OnViewParameter::Second]->getValue();
+            }
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHNoteController::adaptParameters(Base::Vector2d onSketchPos)
+{
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            if (!onViewParameters[OnViewParameter::First]->isSet) {
+                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
+            }
+
+            if (!onViewParameters[OnViewParameter::Second]->isSet) {
+                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
+            }
+
+            bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
+            onViewParameters[OnViewParameter::First]->setLabelAutoDistanceReverse(!sameSign);
+            onViewParameters[OnViewParameter::Second]->setLabelAutoDistanceReverse(sameSign);
+            onViewParameters[OnViewParameter::First]->setPoints(
+                Base::Vector3d(0., 0., 0.),
+                Base::Vector3d(onSketchPos.x, onSketchPos.y, 0.));
+            onViewParameters[OnViewParameter::Second]->setPoints(
+                Base::Vector3d(0., 0., 0.),
+                Base::Vector3d(onSketchPos.x, onSketchPos.y, 0.));
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHNoteController::doChangeDrawSketchHandlerMode()
+{
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            if (onViewParameters[OnViewParameter::First]->isSet
+                && onViewParameters[OnViewParameter::Second]->isSet) {
+
+                handler->setState(SelectMode::End);
+                // handler->finish(); // Called by the change of mode
+            }
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHNoteController::addConstraints()
+{
+    int firstCurve = handler->getHighestCurveIndex();
+
+    auto x0 = onViewParameters[OnViewParameter::First]->getValue();
+    auto y0 = onViewParameters[OnViewParameter::Second]->getValue();
+
+    auto x0set = onViewParameters[OnViewParameter::First]->isSet;
+    auto y0set = onViewParameters[OnViewParameter::Second]->isSet;
+
+    using namespace Sketcher;
+
+    if (x0set && y0set && x0 == 0. && y0 == 0.) {
+        ConstraintToAttachment(GeoElementId(firstCurve, PointPos::start),
+                               GeoElementId::RtPnt,
+                               x0,
+                               handler->sketchgui->getObject());
+    }
+    else {
+        if (x0set) {
+            ConstraintToAttachment(GeoElementId(firstCurve, PointPos::start),
+                                   GeoElementId::VAxis,
+                                   x0,
+                                   handler->sketchgui->getObject());
+        }
+
+        if (y0set) {
+            ConstraintToAttachment(GeoElementId(firstCurve, PointPos::start),
+                                   GeoElementId::HAxis,
+                                   y0,
+                                   handler->sketchgui->getObject());
+        }
+    }
+}
+
+}  // namespace SketcherGui
+
+
+#endif  // SKETCHERGUI_DrawSketchHandlerNote_H

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerNote.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerNote.h
@@ -45,9 +45,9 @@ extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGe
 class DrawSketchHandlerNote;
 
 using DSHNoteController = DrawSketchController<DrawSketchHandlerNote,
-                                                StateMachines::OneSeekEnd,
-                                                /*PAutoConstraintSize =*/1,
-                                                /*OnViewParametersT =*/OnViewParameters<2>>;
+                                               StateMachines::OneSeekEnd,
+                                               /*PAutoConstraintSize =*/1,
+                                               /*OnViewParametersT =*/OnViewParameters<2>>;
 
 using DrawSketchHandlerNoteBase = DrawSketchControllableHandler<DSHNoteController>;
 
@@ -75,20 +75,19 @@ private:
             } break;
             default:
                 break;
-        }    
+        }
     }
 
     void executeCommands() override
     {
         try {
             bool ok;
-            QString text = QInputDialog::getText(
-                nullptr,  
-                QObject::tr("Create Note"),
-                QObject::tr("Note text:"),
-                QLineEdit::Normal,
-                QString(),       
-                &ok);
+            QString text = QInputDialog::getText(nullptr,
+                                                 QObject::tr("Create Note"),
+                                                 QObject::tr("Note text:"),
+                                                 QLineEdit::Normal,
+                                                 QString(),
+                                                 &ok);
             if (!ok || text.isEmpty()) {
                 Gui::Command::abortCommand();
                 return;
@@ -113,7 +112,7 @@ private:
 
     void createAutoConstraints() override
     {
-        
+
         if (!sugConstraints[0].empty()) {
             DrawSketchHandler::createAutoConstraints(sugConstraints[0],
                                                      getHighestCurveIndex(),
@@ -139,7 +138,6 @@ private:
 
 private:
     Base::Vector2d editNote;
-    
 };
 
 template<>

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -185,6 +185,14 @@ struct GeometryLayerNodes
     std::vector<std::vector<SoCoordinate3*>>& CurvesCoordinate;
     std::vector<std::vector<SoLineSet*>>& CurveSet;
     //@}
+
+    /** @name Note nodes*/
+    //@{
+    std::vector<SoMaterial*>& NotesMaterials;
+    std::vector<SoTranslation*>& NotesCoordinates;
+    std::vector<SoFont*>& NotesFonts;
+    std::vector<SoText2*>& NotesTexts;
+    //@}
 };
 
 /** @brief
@@ -423,6 +431,15 @@ struct EditModeScenegraphNodes
     SoDrawStyle* CurvesExternalDrawStyle;
     SoDrawStyle* CurvesExternalDefiningDrawStyle;
     SoDrawStyle* HiddenCurvesDrawStyle;
+    //@}
+
+    /** @name Note nodes*/
+    //@{
+    SmSwitchboard* NotesGroup;
+    std::vector<SoMaterial*> NotesMaterials;
+    std::vector<SoText2*> NotesTexts;
+    std::vector<SoTranslation*> NotesCoordinates;
+    std::vector<SoFont*> NotesFonts;
     //@}
 
     /** @name Axes nodes*/

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.cpp
@@ -331,7 +331,7 @@ void EditModeGeometryCoinConverter::convert(const Sketcher::GeoListFacade& geoli
         text->justification = SoText2::CENTER;
         text->spacing = 1.0f;
         text->string.setNum(Notes[l].size());
-        SbString *text_strings = text->string.startEditing();
+        SbString* text_strings = text->string.startEditing();
 
         i = 0;  // setting up the note set
         for (auto& note : Notes[l]) {

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.h
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.h
@@ -168,7 +168,7 @@ private:
     std::vector<std::vector<std::vector<unsigned int>>> Index;
     std::vector<std::vector<Base::Vector3d>> Notes;
     std::vector<std::vector<std::string>> Texts;
-    
+
     // temporal counters, one per layer
     std::vector<int> pointCounter;
 

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.h
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.h
@@ -81,7 +81,8 @@ private:
         InsertSingle,
         InsertStartEnd,
         InsertStartEndMid,
-        InsertMidOnly
+        InsertMidOnly,
+        InsertNote
     };
 
     enum class CurveMode
@@ -165,7 +166,9 @@ private:
     std::vector<std::vector<Base::Vector3d>> Points;
     std::vector<std::vector<std::vector<Base::Vector3d>>> Coords;
     std::vector<std::vector<std::vector<unsigned int>>> Index;
-
+    std::vector<std::vector<Base::Vector3d>> Notes;
+    std::vector<std::vector<std::string>> Texts;
+    
     // temporal counters, one per layer
     std::vector<int> pointCounter;
 

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -102,16 +102,17 @@ void EditModeGeometryCoinManager::processGeometry(const GeoListFacade& geolistfa
     editModeScenegraphNodes.NotesGroup->enable.finishEditing();
 
     // Define the coin nodes that will be filled in with the geometry layers
-    GeometryLayerNodes geometrylayernodes {editModeScenegraphNodes.PointsMaterials,
-                                           editModeScenegraphNodes.PointsCoordinate,
-                                           editModeScenegraphNodes.CurvesMaterials,
-                                           editModeScenegraphNodes.CurvesCoordinate,
-                                           editModeScenegraphNodes.CurveSet,
-                                           editModeScenegraphNodes.NotesMaterials,
-                                           editModeScenegraphNodes.NotesCoordinates,
-                                           editModeScenegraphNodes.NotesFonts,
-                                           editModeScenegraphNodes.NotesTexts,
-                                           };
+    GeometryLayerNodes geometrylayernodes {
+        editModeScenegraphNodes.PointsMaterials,
+        editModeScenegraphNodes.PointsCoordinate,
+        editModeScenegraphNodes.CurvesMaterials,
+        editModeScenegraphNodes.CurvesCoordinate,
+        editModeScenegraphNodes.CurveSet,
+        editModeScenegraphNodes.NotesMaterials,
+        editModeScenegraphNodes.NotesCoordinates,
+        editModeScenegraphNodes.NotesFonts,
+        editModeScenegraphNodes.NotesTexts,
+    };
 
     // process geometry layers
     EditModeGeometryCoinConverter gcconv(viewProvider,
@@ -748,7 +749,7 @@ void EditModeGeometryCoinManager::createEditModeNoteInventorNodes()
 
         SoMaterialBinding* MtlBind = new SoMaterialBinding;
         MtlBind->setName(concat("NotesMaterialBinding", i).c_str());
-        MtlBind->value = SoMaterialBinding::PER_VERTEX; //OVERALL?
+        MtlBind->value = SoMaterialBinding::PER_VERTEX;  // OVERALL?
         sep->addChild(MtlBind);
 
         auto coords = new SoTranslation;

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.h
@@ -111,6 +111,7 @@ private:
     void emptyGeometryRootNodes();
     void createEditModePointInventorNodes();
     void createEditModeCurveInventorNodes();
+    void createEditModeNoteInventorNodes();
 
 private:
     ViewProviderSketch& viewProvider;

--- a/src/Mod/Sketcher/Gui/Resources/translations/Sketcher.ts
+++ b/src/Mod/Sketcher/Gui/Resources/translations/Sketcher.ts
@@ -893,6 +893,19 @@ with respect to a line or a third point</source>
     </message>
 </context>
 <context>
+    <name>CmdSketcherCreateNote</name>
+    <message>
+        <location filename="../../CommandCreateNote.cpp" line="1727"/>
+        <source>Create note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CommandCreateGeo.cpp" line="1728"/>
+        <source>Create a note in the sketch</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CmdSketcherDecreaseDegree</name>
     <message>
         <location filename="../../CommandSketcherBSpline.cpp" line="268"/>

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -428,6 +428,21 @@ inline void SketcherAddWorkspaceCurveEdition<Gui::ToolBarItem>(Gui::ToolBarItem&
 }
 
 template<typename T>
+void SketcherAddWorkspaceNotes(T& geom);
+
+template<>
+inline void SketcherAddWorkspaceNotes<Gui::MenuItem>(Gui::MenuItem& geom)
+{
+    geom << "Sketcher_CreateNote";
+}
+
+template<>
+inline void SketcherAddWorkspaceNotes<Gui::ToolBarItem>(Gui::ToolBarItem& geom)
+{
+    geom << "Sketcher_CreateNote";
+}
+
+template<typename T>
 inline void SketcherAddWorkbenchGeometries(T& geom)
 {
     geom << "Sketcher_CreatePoint";
@@ -436,6 +451,7 @@ inline void SketcherAddWorkbenchGeometries(T& geom)
     SketcherAddWorkspaceRectangles(geom);
     SketcherAddWorkspaceRegularPolygon(geom);
     SketcherAddWorkspaceslots(geom);
+    SketcherAddWorkspaceNotes(geom);
     geom << "Separator"
          << "Sketcher_ToggleConstruction";
     /*<< "Sketcher_CreateText"*/

--- a/src/Mod/Sketcher/SketcherTests/TestSketchNote.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchNote.py
@@ -1,5 +1,4 @@
-# **************************************************************************
-#   Copyright (c) 2011 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+# *************************************************************************
 #   Copyright (c) 2021 Emmanuel O'Brien                                   *
 #                                                                         *
 #   This file is part of the FreeCAD CAx development system.              *
@@ -21,15 +20,29 @@
 #   USA                                                                   *
 # **************************************************************************
 
-# Broken-out test modules
-from SketcherTests.TestSketcherSolver import TestSketcherSolver
-from SketcherTests.TestSketchFillet import TestSketchFillet
-from SketcherTests.TestSketchExpression import TestSketchExpression
-from SketcherTests.TestSketchValidateCoincidents import TestSketchValidateCoincidents
-from SketcherTests.TestSketchNote import TestSketchNote
+import unittest
+import FreeCAD
+import Part
+import Sketcher
+from FreeCAD import Vector
 
-# Path and PartDesign tests use these functions that used to live here
-# but moved to SketcherTests/TestSketcherSolver.py
-from SketcherTests.TestSketcherSolver import CreateCircleSketch
-from SketcherTests.TestSketcherSolver import CreateRectangleSketch
-from SketcherTests.TestSketcherSolver import CreateSlotPlateSet
+App = FreeCAD
+
+class TestSketchNote(unittest.TestCase):
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("SketchNoteTest")
+
+    def test_note_creation(self):
+        sketch = self.doc.addObject("Sketcher::SketchObject", "Sketcher")
+        pos = FreeCAD.Vector(10, 20, 30)
+        text = "Note test"
+
+        note_geom = Part.Note(pos, text)
+        idx = sketch.addGeometry(note_geom, False)
+
+        note = sketch.Geometry[idx]
+
+        self.assertEqual(str(note_geom).strip(), str(note).strip())
+    
+    def tearDown(self):
+        FreeCAD.closeDocument(self.doc.Name)

--- a/src/Mod/Sketcher/SketcherTests/TestSketchNote.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchNote.py
@@ -28,6 +28,7 @@ from FreeCAD import Vector
 
 App = FreeCAD
 
+
 class TestSketchNote(unittest.TestCase):
     def setUp(self):
         self.doc = FreeCAD.newDocument("SketchNoteTest")
@@ -43,6 +44,6 @@ class TestSketchNote(unittest.TestCase):
         note = sketch.Geometry[idx]
 
         self.assertEqual(str(note_geom).strip(), str(note).strip())
-    
+
     def tearDown(self):
         FreeCAD.closeDocument(self.doc.Name)


### PR DESCRIPTION
This feature introduces a new geometry type, Part::GeomNote, to the Sketcher workbench, enabling users to add text notes directly inside sketchers. Notes can be positioned precisely and support customizable text content, making it easier to visually document sketches.

<!-- Include a brief summary of the changes. -->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fixes #20571
## Before and After Images

Before:
![imagem](https://github.com/user-attachments/assets/9a44b956-cdcc-4187-8fd2-b603ba9636f0)
After:
![imagem](https://github.com/user-attachments/assets/928d4032-c3bd-4f6f-8535-4b07503fef6a)
![imagem](https://github.com/user-attachments/assets/f15a9b55-569d-4202-8139-dea619071bb0)
![imagem](https://github.com/user-attachments/assets/620e8106-f6eb-482b-8e2b-6005d9ab520c)
