### PR TITLE
Gui: remove taskheader opacity changing animation on hover

### DIFF
--- a/src/Gui/QSint/actionpanel/actionpanelscheme.cpp
+++ b/src/Gui/QSint/actionpanel/actionpanelscheme.cpp
@@ -63,7 +63,6 @@ ActionPanelScheme::ActionPanelScheme()
 {
     QFontMetrics fm(QApplication::font());
     headerSize = fm.height() + 10;
-    headerAnimation = true;
 
     QPalette p = QApplication::palette();
 

--- a/src/Gui/QSint/actionpanel/actionpanelscheme.h
+++ b/src/Gui/QSint/actionpanel/actionpanelscheme.h
@@ -59,11 +59,6 @@ public:
     int headerSize;
 
     /**
-     * @brief Whether mouseover on the header triggers a slow opacity change.
-     */
-    bool headerAnimation;
-
-    /**
      * @brief Image of the folding button when the group is expanded.
      */
     QPixmap headerButtonFold;

--- a/src/Gui/QSint/actionpanel/taskheader_p.cpp
+++ b/src/Gui/QSint/actionpanel/taskheader_p.cpp
@@ -25,7 +25,6 @@ TaskHeader::TaskHeader(const QIcon &icon, const QString &title, bool expandable,
   m_over(false),
   m_buttonOver(false),
   m_fold(true),
-  m_opacity(0.1),
   myButton(nullptr)
 {
     setProperty("class", "header");
@@ -118,71 +117,6 @@ void TaskHeader::setScheme(ActionPanelScheme *scheme)
     setFixedHeight(scheme->headerSize);
     update();
   }
-}
-
-void TaskHeader::paintEvent ( QPaintEvent * event )
-{
-  QPainter p(this);
-
-  if (myScheme->headerAnimation) {
-    p.setOpacity(m_opacity+0.7);
-  }
-
-  BaseClass::paintEvent(event);
-}
-
-void TaskHeader::animate()
-{
-  if (!myScheme->headerAnimation) {
-    return;
-  }
-
-  if (!isEnabled()) {
-    m_opacity = 0.1;
-    update();
-    return;
-  }
-
-  if (m_over) {
-    if (m_opacity >= 0.3) {
-      m_opacity = 0.3;
-      return;
-    }
-    m_opacity += 0.05;
-  } else {
-    if (m_opacity <= 0.1) {
-      m_opacity = 0.1;
-      return;
-    }
-    m_opacity = qMax(0.1, m_opacity-0.05);
-  }
-
-  QTimer::singleShot(100, this, &TaskHeader::animate);
-  update();
-}
-
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-void TaskHeader::enterEvent ( QEvent * /*event*/ )
-#else
-void TaskHeader::enterEvent ( QEnterEvent * /*event*/ )
-#endif
-{
-  m_over = true;
-
-  if (isEnabled()) {
-    QTimer::singleShot(100, this, &TaskHeader::animate);
-  }
-  update();
-}
-
-void TaskHeader::leaveEvent ( QEvent * /*event*/ )
-{
-  m_over = false;
-
-  if (isEnabled()) {
-    QTimer::singleShot(100, this, &TaskHeader::animate);
-  }
-  update();
 }
 
 void TaskHeader::fold()

--- a/src/Gui/QSint/actionpanel/taskheader_p.h
+++ b/src/Gui/QSint/actionpanel/taskheader_p.h
@@ -43,17 +43,7 @@ public:
 public Q_SLOTS:
   void fold();
 
-protected Q_SLOTS:
-  void animate();
-
 protected:
-  void paintEvent ( QPaintEvent * event ) override;
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-  void enterEvent ( QEvent * event ) override;
-#else
-  void enterEvent ( QEnterEvent * event ) override;
-#endif
-  void leaveEvent ( QEvent * event ) override;
   void mouseReleaseEvent ( QMouseEvent * event ) override;
   void keyPressEvent ( QKeyEvent * event ) override;
   void keyReleaseEvent ( QKeyEvent * event ) override;
@@ -66,7 +56,6 @@ protected:
 
   bool myExpandable;
   bool m_over, m_buttonOver, m_fold;
-  double m_opacity;
 
   ActionLabel *myTitle;
   QLabel *myButton;


### PR DESCRIPTION
this proposal removes the taskheader opcity animation, supposedly the header of the task groups changes opacity on hover, something that doesn't seem to work, or I'm failing to even notice, this just removes this unnecesary animation