### PR TITLE
CI: install black for python format checker.

### DIFF
--- a/tools/lint/black.py
+++ b/tools/lint/black.py
@@ -71,7 +71,7 @@ def main():
     init_environment(args)
 
     logging.info("Installing black (if needed)...")
-    run_command(["pip", "install", "-q", "black"], check=True)
+    run_command(["pipx", "install", "-q", "black"], check=True)
 
     cmd = [
         "black",


### PR DESCRIPTION
Installs black for Python format checker during CI lint stage.

## Issues

https://github.com/FreeCAD/FreeCAD/issues/21821

## Before and After Images

N/A