### PR TITLE
Gui: Center notification label and disable show report view by default

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -418,7 +418,7 @@ MainWindow::MainWindow(QWidget * parent, Qt::WindowFlags f)
         notificationArea->setObjectName(QStringLiteral("notificationArea"));
         //: A context menu action used to show or hide the 'notificationArea' toolbar widget
         notificationArea->setWindowTitle(tr("Notification area"));
-        notificationArea->setStyleSheet(QStringLiteral("text-align:left;"));
+        notificationArea->setStyleSheet(QStringLiteral("text-align:center;"));
         statusBar()->addPermanentWidget(notificationArea);
     }
 

--- a/src/Gui/PreferencePages/DlgSettingsReportView.ui
+++ b/src/Gui/PreferencePages/DlgSettingsReportView.ui
@@ -115,7 +115,7 @@ on-screen while displaying the error</string>
          <string>Show report view on error</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>checkShowReportViewOnError</cstring>

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -241,7 +241,7 @@ public:
     }
     static bool showOnError()
     {
-        return getGroup()->GetBool("checkShowReportViewOnError", true);
+        return getGroup()->GetBool("checkShowReportViewOnError", false);
     }
     static void toggleShowOnError()
     {

--- a/src/Gui/Stylesheets/FreeCAD Dark.qss
+++ b/src/Gui/Stylesheets/FreeCAD Dark.qss
@@ -236,6 +236,12 @@ QStatusBar QLabel {
   background-color: transparent;
 }
 
+QStatusBar QPushButton {
+    min-width: 0;
+    padding-left: 8px;
+    padding-right: 8px;
+}
+
 /* QCheckBox --------------------------------------------------------------
 
 https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qcheckbox

--- a/src/Gui/Stylesheets/FreeCAD Light.qss
+++ b/src/Gui/Stylesheets/FreeCAD Light.qss
@@ -237,6 +237,12 @@ QStatusBar QLabel {
   background-color: transparent;
 }
 
+QStatusBar QPushButton {
+    min-width: 0;
+    padding-left: 8px;
+    padding-right: 8px;
+}
+
 /* QCheckBox --------------------------------------------------------------
 
 https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qcheckbox


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
In discussion with @FreeCAD/design-working-group 
Currently two obtrusive notification systems are shown to the user in parallel.
This PR sets the default so that the report view panel does not pop up if the user has not enabled it and centers the notification label which was touching the border in the status bar button.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
Before:
![Bildschirmfoto 2025-06-08 um 19 01 52](https://github.com/user-attachments/assets/1f364d48-feb1-4910-8331-036900e8208c)

![Bildschirmfoto 2025-06-08 um 19 01 12](https://github.com/user-attachments/assets/bae8181e-10a0-4afd-9dd5-8b9082486bf5)



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
