### PR TITLE
[Start] add Tooltip to show full path when the ShortCustomFolder is true

### DIFF
--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -448,6 +448,7 @@ void StartView::retranslateUi()
     bool shortCustomFolder = hGrp->GetBool("ShortCustomFolder", true);  // false shows full path
     if (!customFolder.empty()) {
         if (shortCustomFolder) {
+            _customFolderLabel->setToolTip(QString::fromUtf8(customFolder.c_str()));
             customFolder = customFolder.substr(customFolder.find_last_of("/\\") + 1);
         }
         _customFolderLabel->setText(h1Start + QString::fromUtf8(customFolder.c_str()) + h1End);


### PR DESCRIPTION
As requested in https://github.com/FreeCAD/FreeCAD/pull/21847#issuecomment-2953939037 when just the folder name is shown i.e. `ShortCustomFolder` is `true` then the full path is shown as a tooltip.
