### PR TITLE
BIM: Fix Arch_SectionPlane having incorrect display style upon init

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -1200,7 +1200,7 @@ def makeSectionPlane(objectslist=None, name=None):
     from WorkingPlane import get_working_plane
 
     sectionPlane = _initializeArchObject(
-        "Part::FeaturePython",
+        "App::FeaturePython",
         baseClassName="_SectionPlane",
         internalName="Section",
         defaultLabel=name if name else translate("Arch", "Section"),


### PR DESCRIPTION
Regressed from previous behavior - there was Arch's refactor and the base element that `SectionPlane` was inheriting from was `App::FeaturePython`, not `Part::FeaturePython`. This changes a lot, since `Part::FeaturePython` has predefined color (black in this case), which later on - during property set of `SectionPlane` in properties caused skipping of preferred setup of color.

Caused-by: https://github.com/FreeCAD/FreeCAD/pull/21342

FYI @furgo16 

Demo:

https://github.com/user-attachments/assets/cfab79f2-d78e-4a75-bd2e-28d38538ce63

Resolves: https://github.com/FreeCAD/FreeCAD/issues/21875
