### PR TITLE
PartDesign: Add a tear drop option to the hole feature

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -75,6 +75,9 @@ public:
     App::PropertyBool           UseCustomThreadClearance;
     App::PropertyLength         CustomThreadClearance;
     App::PropertyInteger        BaseProfileType;
+    App::PropertyBool           RainDrop;       // Make a raindrop shape to make it easier to 3d print upright
+    // App::PropertyAngle          RainDropAngle;
+    // App::PropertyDirection      RainDropDirection;
 
     enum BaseProfileTypeOptions {
         OnPoints    = 1 << 0,
@@ -255,6 +258,13 @@ private:
     void rotateToNormal(const gp_Dir& helixAxis, const gp_Dir& normalAxis, TopoDS_Shape& helixShape) const;
     gp_Vec computePerpendicular(const gp_Vec&) const;
     TopoDS_Shape makeThread(const gp_Vec&, const gp_Vec&, double);
+
+    // Make a little hat for the hole to make it easier to print
+    // @xDir the normal vector from the center of the hole to the tip of the hat
+    // @zDir the normal vector in the drilling direction
+    // @depth the depth of the hole
+    // @angle the angle between the hat sides and xDir
+    static TopoDS_Shape makeRainDropHat(const gp_Vec& xDir, const gp_Vec& zDir, double radius, double depth, double angle);
     TopoShape findHoles(std::vector<TopoShape> &holes, const TopoShape& profileshape, const TopoDS_Shape& protohole) const;
 
     // helpers for nlohmann json

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -75,11 +75,11 @@ public:
     App::PropertyBool           UseCustomThreadClearance;
     App::PropertyLength         CustomThreadClearance;
     App::PropertyInteger        BaseProfileType;
-    App::PropertyBool           RainDrop;       // Make a raindrop shape to make it easier to 3d print upright
-    App::PropertyAngle          RainDropAngle;
-    App::PropertyDirection      RainDropDirection;
-    App::PropertyBool           RainDropReversed;
-    App::PropertyLinkSub        RainDropReferenceAxis;
+    App::PropertyBool           TearDrop;       // Make a tear drop shape to make it easier to 3d print upright
+    App::PropertyAngle          TearDropAngle;
+    App::PropertyDirection      TearDropDirection;
+    App::PropertyBool           TearDropReversed;
+    App::PropertyLinkSub        TearDropReferenceAxis;
 
     enum BaseProfileTypeOptions {
         OnPoints    = 1 << 0,
@@ -134,7 +134,7 @@ protected:
     void setupObject() override;
 
     static const App::PropertyAngle::Constraints floatAngle;
-    static const App::PropertyAngle::Constraints rainDropAngleRange;
+    static const App::PropertyAngle::Constraints tearDropAngleRange;
 
 private:
     static const char* DepthTypeEnums[];
@@ -267,8 +267,8 @@ private:
     // @zDir the normal vector in the drilling direction
     // @depth the depth of the hole
     // @angle the angle between the hat sides and xDir
-    static TopoDS_Shape makeRainDropHat(const gp_Vec& xDir, const gp_Vec& zDir, double radius, double depth, double angle);
-    void updateRainDropAxis();
+    static TopoDS_Shape makeTearDropHat(const gp_Vec& xDir, const gp_Vec& zDir, double radius, double depth, double angle);
+    void updateTearDropAxis();
     TopoShape findHoles(std::vector<TopoShape> &holes, const TopoShape& profileshape, const TopoDS_Shape& protohole) const;
 
     // helpers for nlohmann json

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -76,8 +76,8 @@ public:
     App::PropertyLength         CustomThreadClearance;
     App::PropertyInteger        BaseProfileType;
     App::PropertyBool           RainDrop;       // Make a raindrop shape to make it easier to 3d print upright
-    // App::PropertyAngle          RainDropAngle;
-    // App::PropertyDirection      RainDropDirection;
+    App::PropertyAngle          RainDropAngle;
+    App::PropertyDirection      RainDropDirection;
 
     enum BaseProfileTypeOptions {
         OnPoints    = 1 << 0,
@@ -132,6 +132,7 @@ protected:
     void setupObject() override;
 
     static const App::PropertyAngle::Constraints floatAngle;
+    static const App::PropertyAngle::Constraints rainDropAngleRange;
 
 private:
     static const char* DepthTypeEnums[];

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -78,6 +78,8 @@ public:
     App::PropertyBool           RainDrop;       // Make a raindrop shape to make it easier to 3d print upright
     App::PropertyAngle          RainDropAngle;
     App::PropertyDirection      RainDropDirection;
+    App::PropertyBool           RainDropReversed;
+    App::PropertyLinkSub        RainDropReferenceAxis;
 
     enum BaseProfileTypeOptions {
         OnPoints    = 1 << 0,
@@ -266,6 +268,7 @@ private:
     // @depth the depth of the hole
     // @angle the angle between the hat sides and xDir
     static TopoDS_Shape makeRainDropHat(const gp_Vec& xDir, const gp_Vec& zDir, double radius, double depth, double angle);
+    void updateRainDropAxis();
     TopoShape findHoles(std::vector<TopoShape> &holes, const TopoShape& profileshape, const TopoDS_Shape& protohole) const;
 
     // helpers for nlohmann json

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -187,14 +187,14 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
 
     ui->BaseProfileType->setCurrentIndex(PartDesign::Hole::baseProfileOption_bitmaskToIdx(pcHole->BaseProfileType.getValue()));
 
-    ui->RainDrop->setChecked(pcHole->RainDrop.getValue());
-    ui->RainDropReversed->setChecked(pcHole->RainDropReversed.getValue());
-    ui->RainDropAngle->setMinimum(pcHole->RainDropAngle.getMinimum());
-    ui->RainDropAngle->setMaximum(pcHole->RainDropAngle.getMaximum());
-    ui->RainDropAngle->setValue(pcHole->RainDropAngle.getValue());
-    ui->RainDropParams->setVisible(ui->RainDrop->isChecked());
-    propRainDropReferenceAxis = &(pcHole->RainDropReferenceAxis);
-    fillRainDropAxisCombo();
+    ui->TearDrop->setChecked(pcHole->TearDrop.getValue());
+    ui->TearDropReversed->setChecked(pcHole->TearDropReversed.getValue());
+    ui->TearDropAngle->setMinimum(pcHole->TearDropAngle.getMinimum());
+    ui->TearDropAngle->setMaximum(pcHole->TearDropAngle.getMaximum());
+    ui->TearDropAngle->setValue(pcHole->TearDropAngle.getValue());
+    ui->TearDropParams->setVisible(ui->TearDrop->isChecked());
+    propTearDropReferenceAxis = &(pcHole->TearDropReferenceAxis);
+    fillTearDropAxisCombo();
 
     setCutDiagram();
 
@@ -253,14 +253,14 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
             this, &TaskHoleParameters::threadDepthChanged);
     connect(ui->BaseProfileType, qOverload<int>(&QComboBox::currentIndexChanged),
             this, &TaskHoleParameters::baseProfileTypeChanged);
-    connect(ui->RainDrop, &QCheckBox::toggled, 
-            this, &TaskHoleParameters::rainDropChanged);
-    connect(ui->RainDropAngle, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
-            this, &TaskHoleParameters::rainDropAngleValueChanged);
-    connect(ui->RainDropAxis, qOverload<int>(&QComboBox::activated),
-            this, &TaskHoleParameters::onRainDropAxisChanged);
-    connect(ui->RainDropReversed, &QCheckBox::toggled, 
-            this, &TaskHoleParameters::rainDropReversedChanged);
+    connect(ui->TearDrop, &QCheckBox::toggled, 
+            this, &TaskHoleParameters::tearDropChanged);
+    connect(ui->TearDropAngle, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+            this, &TaskHoleParameters::tearDropAngleValueChanged);
+    connect(ui->TearDropAxis, qOverload<int>(&QComboBox::activated),
+            this, &TaskHoleParameters::onTearDropAxisChanged);
+    connect(ui->TearDropReversed, &QCheckBox::toggled, 
+            this, &TaskHoleParameters::tearDropReversedChanged);
     // clang-format on
 
     getViewObject()->show();
@@ -274,7 +274,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
     ui->TaperedAngle->bind(pcHole->TaperedAngle);
     ui->ThreadDepth->bind(pcHole->ThreadDepth);
     ui->CustomThreadClearance->bind(pcHole->CustomThreadClearance);
-    ui->RainDropAngle->bind(pcHole->RainDropAngle);
+    ui->TearDropAngle->bind(pcHole->TearDropAngle);
 
     // NOLINTBEGIN
     connectPropChanged = App::GetApplication().signalChangePropertyEditor.connect(
@@ -423,28 +423,28 @@ void TaskHoleParameters::baseProfileTypeChanged(int index)
         recomputeFeature();
     }
 }
-void TaskHoleParameters::rainDropChanged()
+void TaskHoleParameters::tearDropChanged()
 {
-    bool isChecked = ui->RainDrop->isChecked();
-    ui->RainDropParams->setVisible(isChecked);
+    bool isChecked = ui->TearDrop->isChecked();
+    ui->TearDropParams->setVisible(isChecked);
     if (auto hole = getObject<PartDesign::Hole>()) {
-        hole->RainDrop.setValue(isChecked);
+        hole->TearDrop.setValue(isChecked);
 
         if (isChecked) {
-            onRainDropAxisChanged(ui->RainDropAxis->currentIndex());
+            onTearDropAxisChanged(ui->TearDropAxis->currentIndex());
         }
 
         recomputeFeature();
     }
 }
-void TaskHoleParameters::rainDropAngleValueChanged(double value)
+void TaskHoleParameters::tearDropAngleValueChanged(double value)
 {
     if (auto hole = getObject<PartDesign::Hole>()) {
-        hole->RainDropAngle.setValue(value);
+        hole->TearDropAngle.setValue(value);
         recomputeFeature();
     }
 }
-void TaskHoleParameters::onRainDropAxisChanged(int num)
+void TaskHoleParameters::onTearDropAxisChanged(int num)
 {
     if (isUpdateBlocked()) {
         return;
@@ -455,7 +455,7 @@ void TaskHoleParameters::onRainDropAxisChanged(int num)
         return;
     }
 
-    std::vector<std::string> oldSubRefAxis = propRainDropReferenceAxis->getSubValues();
+    std::vector<std::string> oldSubRefAxis = propTearDropReferenceAxis->getSubValues();
     std::string oldRefName;
     if (!oldSubRefAxis.empty()) {
         oldRefName = oldSubRefAxis.front();
@@ -473,16 +473,16 @@ void TaskHoleParameters::onRainDropAxisChanged(int num)
             Base::Console().error("Object was deleted\n");
             return;
         }
-        propRainDropReferenceAxis->Paste(lnk);
+        propTearDropReferenceAxis->Paste(lnk);
         exitSelectionMode();
     }
 
     recomputeFeature();
 }
-void TaskHoleParameters::rainDropReversedChanged()
+void TaskHoleParameters::tearDropReversedChanged()
 {
     if (auto hole = getObject<PartDesign::Hole>()) {
-        hole->RainDropReversed.setValue(ui->RainDropReversed->isChecked());
+        hole->TearDropReversed.setValue(ui->TearDropReversed->isChecked());
         recomputeFeature();
     }
 }
@@ -984,17 +984,17 @@ void TaskHoleParameters::changedObject(const App::Document&, const App::Property
         ui->BaseProfileType->setEnabled(true);
         updateComboBox(ui->BaseProfileType, PartDesign::Hole::baseProfileOption_bitmaskToIdx(hole->BaseProfileType.getValue()));
     }
-    else if (&Prop == &hole->RainDrop) {
-        ui->RainDrop->setEnabled(true);
-        updateCheckable(ui->RainDrop, hole->RainDrop.getValue());
+    else if (&Prop == &hole->TearDrop) {
+        ui->TearDrop->setEnabled(true);
+        updateCheckable(ui->TearDrop, hole->TearDrop.getValue());
     }
-    else if (&Prop == &hole->RainDropAngle) {
-        ui->RainDropAngle->setEnabled(true);
-        updateSpinBox(ui->RainDropAngle, hole->RainDropAngle.getValue());
+    else if (&Prop == &hole->TearDropAngle) {
+        ui->TearDropAngle->setEnabled(true);
+        updateSpinBox(ui->TearDropAngle, hole->TearDropAngle.getValue());
     }
-    else if (&Prop == &hole->RainDropReversed) {
-        ui->RainDropAngle->setEnabled(true);
-        updateCheckable(ui->RainDropReversed, hole->RainDropReversed.getValue());
+    else if (&Prop == &hole->TearDropReversed) {
+        ui->TearDropAngle->setEnabled(true);
+        updateCheckable(ui->TearDropReversed, hole->TearDropReversed.getValue());
     }
 }
 
@@ -1015,7 +1015,7 @@ void TaskHoleParameters::updateHoleTypeCombo()
         ui->HoleType->setCurrentIndex(Clearance);
     }
 }
-void TaskHoleParameters::fillRainDropAxisCombo(bool forceRefill)
+void TaskHoleParameters::fillTearDropAxisCombo(bool forceRefill)
 {
     Base::StateLocker lock(getUpdateBlockRef(), true);
 
@@ -1025,7 +1025,7 @@ void TaskHoleParameters::fillRainDropAxisCombo(bool forceRefill)
     }
 
     if (forceRefill) {
-        ui->RainDropAxis->clear();
+        ui->TearDropAxis->clear();
         axesInList.clear();
 
         auto *pcFeat = getObject<PartDesign::ProfileBased>();
@@ -1064,8 +1064,8 @@ void TaskHoleParameters::fillRainDropAxisCombo(bool forceRefill)
     //add current link, if not in list
     //first, figure out the item number for current axis
     int indexOfCurrent = -1;
-    App::DocumentObject* ax = propRainDropReferenceAxis->getValue();
-    const std::vector<std::string> &subList = propRainDropReferenceAxis->getSubValues();
+    App::DocumentObject* ax = propTearDropReferenceAxis->getValue();
+    const std::vector<std::string> &subList = propTearDropReferenceAxis->getSubValues();
     for (size_t i = 0; i < axesInList.size(); i++) {
         if (ax == axesInList[i]->getValue() && subList == axesInList[i]->getSubValues()) {
             indexOfCurrent = int(i);
@@ -1083,14 +1083,14 @@ void TaskHoleParameters::fillRainDropAxisCombo(bool forceRefill)
 
     //highlight current.
     if (indexOfCurrent != -1) {
-        ui->RainDropAxis->setCurrentIndex(indexOfCurrent);
+        ui->TearDropAxis->setCurrentIndex(indexOfCurrent);
     }
 }
 void TaskHoleParameters::addAxisToCombo(App::DocumentObject* linkObj,
                                         const std::string& linkSubname,
                                         const QString& itemText)
 {
-    this->ui->RainDropAxis->addItem(itemText);
+    this->ui->TearDropAxis->addItem(itemText);
     this->axesInList.emplace_back(new App::PropertyLinkSub());
     App::PropertyLinkSub &lnk = *(axesInList[axesInList.size()-1]);
     lnk.setValue(linkObj, std::vector<std::string>(1, linkSubname));
@@ -1102,10 +1102,10 @@ void TaskHoleParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
         std::vector<std::string> axis;
         App::DocumentObject* selObj {};
         if (getReferencedSelection(getObject(), msg, selObj, axis) && selObj) {
-            propRainDropReferenceAxis->setValue(selObj, axis);
+            propTearDropReferenceAxis->setValue(selObj, axis);
 
             recomputeFeature();
-            fillRainDropAxisCombo();
+            fillTearDropAxisCombo();
         }
     }
 }
@@ -1255,15 +1255,15 @@ int TaskHoleParameters::getBaseProfileType() const
 {
     return PartDesign::Hole::baseProfileOption_idxToBitmask(ui->BaseProfileType->currentIndex());
 }
-bool TaskHoleParameters::getRainDrop() const
+bool TaskHoleParameters::getTearDrop() const
 {
-    return ui->RainDrop->isChecked();
+    return ui->TearDrop->isChecked();
 }
-double TaskHoleParameters::getRainDropAngle() const
+double TaskHoleParameters::getTearDropAngle() const
 {
-    return ui->RainDropAngle->value().getValue();
+    return ui->TearDropAngle->value().getValue();
 }
-std::string TaskHoleParameters::getRainDropAxis()
+std::string TaskHoleParameters::getTearDropAxis()
 {
     std::vector<std::string> sub;
     App::DocumentObject* obj {};
@@ -1271,9 +1271,9 @@ std::string TaskHoleParameters::getRainDropAxis()
     std::string axis = buildLinkSingleSubPythonStr(obj, sub);
     return axis;
 }
-bool TaskHoleParameters::getRainDropReversed() const
+bool TaskHoleParameters::getTearDropReversed() const
 {
-    return ui->RainDropReversed->isChecked();
+    return ui->TearDropReversed->isChecked();
 }
 void TaskHoleParameters::getReferenceAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const
 {
@@ -1281,7 +1281,7 @@ void TaskHoleParameters::getReferenceAxis(App::DocumentObject*& obj, std::vector
         throw Base::RuntimeError("Not initialized!");
     }
 
-    int num = ui->RainDropAxis->currentIndex();
+    int num = ui->TearDropAxis->currentIndex();
     const App::PropertyLinkSub &lnk = *(axesInList[num]);
     if (!lnk.getValue()) {
         throw Base::RuntimeError("Still in reference selection mode; reference wasn't selected yet");
@@ -1308,7 +1308,7 @@ void TaskHoleParameters::apply()
     ui->Depth->apply();
     ui->DrillPointAngle->apply();
     ui->TaperedAngle->apply();
-    ui->RainDropAngle->apply();
+    ui->TearDropAngle->apply();
 
     if (!hole->Threaded.isReadOnly()) {
         FCMD_OBJ_CMD(hole, "Threaded = " << (getThreaded() ? 1 : 0));
@@ -1365,17 +1365,17 @@ void TaskHoleParameters::apply()
     if (!hole->BaseProfileType.isReadOnly()) {
         FCMD_OBJ_CMD(hole, "BaseProfileType = " << getBaseProfileType());
     }
-    if (!hole->RainDrop.isReadOnly()) {
-        FCMD_OBJ_CMD(hole, "RainDrop = " << getRainDrop());
+    if (!hole->TearDrop.isReadOnly()) {
+        FCMD_OBJ_CMD(hole, "TearDrop = " << getTearDrop());
     }
-    if (!hole->RainDropAngle.isReadOnly()) {
-        FCMD_OBJ_CMD(hole, "RainDropAngle = " << getRainDropAngle());
+    if (!hole->TearDropAngle.isReadOnly()) {
+        FCMD_OBJ_CMD(hole, "TearDropAngle = " << getTearDropAngle());
     }
-    if (!hole->RainDropReferenceAxis.isReadOnly()) {
-        FCMD_OBJ_CMD(hole, "RainDropReferenceAxis = " << getRainDropAxis());
+    if (!hole->TearDropReferenceAxis.isReadOnly()) {
+        FCMD_OBJ_CMD(hole, "TearDropReferenceAxis = " << getTearDropAxis());
     }
-    if (!hole->RainDropReversed.isReadOnly()) {
-        FCMD_OBJ_CMD(hole, "RainDropReversed = " << getRainDropReversed());
+    if (!hole->TearDropReversed.isReadOnly()) {
+        FCMD_OBJ_CMD(hole, "TearDropReversed = " << getTearDropReversed());
     }
 
     isApplying = false;

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -182,6 +182,9 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
 
     ui->BaseProfileType->setCurrentIndex(PartDesign::Hole::baseProfileOption_bitmaskToIdx(pcHole->BaseProfileType.getValue()));
 
+    ui->makeRaindropHat->setChecked(false);
+    ui->raindropParams->setVisible(ui->makeRaindropHat->isChecked());
+
     setCutDiagram();
 
     // clang-format off
@@ -239,7 +242,10 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
             this, &TaskHoleParameters::threadDepthChanged);
     connect(ui->BaseProfileType, qOverload<int>(&QComboBox::currentIndexChanged),
             this, &TaskHoleParameters::baseProfileTypeChanged);
-    // clang-format on
+    connect(ui->makeRaindropHat, &QCheckBox::toggled, 
+            this, &TaskHoleParameters::makeRaindropHatChanged);
+    
+            // clang-format on
 
     getViewObject()->show();
 
@@ -332,7 +338,6 @@ void TaskHoleParameters::useCustomThreadClearanceChanged()
         recomputeFeature();
     }
 }
-
 void TaskHoleParameters::customThreadClearanceChanged(double value)
 {
     if (auto hole = getObject<PartDesign::Hole>()) {
@@ -398,6 +403,15 @@ void TaskHoleParameters::baseProfileTypeChanged(int index)
 {
     if (auto hole = getObject<PartDesign::Hole>()) {
         hole->BaseProfileType.setValue(PartDesign::Hole::baseProfileOption_idxToBitmask(index));
+        recomputeFeature();
+    }
+}
+void TaskHoleParameters::makeRaindropHatChanged()
+{
+    bool isChecked = ui->makeRaindropHat->isChecked();
+    ui->raindropParams->setEnabled(isChecked);
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->RainDrop.setValue(isChecked);
         recomputeFeature();
     }
 }

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -109,6 +109,7 @@ private Q_SLOTS:
     void threadDepthTypeChanged(int index);
     void threadDepthChanged(double value);
     void baseProfileTypeChanged(int index);
+    void makeRaindropHatChanged();
     void setCutDiagram();
 
 private:

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -82,6 +82,9 @@ public:
     int getBaseProfileType() const;
     bool getRainDrop() const;
     double getRainDropAngle() const;
+    std::string getRainDropAxis();
+    bool getRainDropReversed() const;
+    void getReferenceAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
 
 private Q_SLOTS:
     void holeTypeChanged(int index);
@@ -113,6 +116,8 @@ private Q_SLOTS:
     void baseProfileTypeChanged(int index);
     void rainDropChanged();
     void rainDropAngleValueChanged(double value);
+    void onRainDropAxisChanged(int num);
+    void rainDropReversedChanged();
     void setCutDiagram();
 
 private:
@@ -139,6 +144,11 @@ private:
     void updateHoleCutLimits(PartDesign::Hole* hole);
     void updateHoleTypeCombo();
 
+    void fillRainDropAxisCombo(bool forceRefill = false);
+    void addAxisToCombo(App::DocumentObject* linkObj,
+                        const std::string& linkSubname,
+                        const QString& itemText);
+
 private:
 
     using Connection = boost::signals2::scoped_connection;
@@ -148,6 +158,17 @@ private:
     bool isApplying;
     QWidget* proxy;
     std::unique_ptr<Ui_TaskHoleParameters> ui;
+
+    App::PropertyLinkSub* propRainDropReferenceAxis;
+    /**
+     * @brief axesInList is the list of links corresponding to axis combo; must
+     * be kept in sync with the combo. A special value of zero-pointer link is
+     * for "Select axis" item.
+     *
+     * It is a list of pointers, because properties prohibit assignment. Use new
+     * when adding stuff, and delete when removing stuff.
+     */
+    std::vector<std::unique_ptr<App::PropertyLinkSub>> axesInList;
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -80,10 +80,10 @@ public:
     long getThreadDepthType() const;
     double getThreadDepth() const;
     int getBaseProfileType() const;
-    bool getRainDrop() const;
-    double getRainDropAngle() const;
-    std::string getRainDropAxis();
-    bool getRainDropReversed() const;
+    bool getTearDrop() const;
+    double getTearDropAngle() const;
+    std::string getTearDropAxis();
+    bool getTearDropReversed() const;
     void getReferenceAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
 
 private Q_SLOTS:
@@ -114,10 +114,10 @@ private Q_SLOTS:
     void threadDepthTypeChanged(int index);
     void threadDepthChanged(double value);
     void baseProfileTypeChanged(int index);
-    void rainDropChanged();
-    void rainDropAngleValueChanged(double value);
-    void onRainDropAxisChanged(int num);
-    void rainDropReversedChanged();
+    void tearDropChanged();
+    void tearDropAngleValueChanged(double value);
+    void onTearDropAxisChanged(int num);
+    void tearDropReversedChanged();
     void setCutDiagram();
 
 private:
@@ -144,7 +144,7 @@ private:
     void updateHoleCutLimits(PartDesign::Hole* hole);
     void updateHoleTypeCombo();
 
-    void fillRainDropAxisCombo(bool forceRefill = false);
+    void fillTearDropAxisCombo(bool forceRefill = false);
     void addAxisToCombo(App::DocumentObject* linkObj,
                         const std::string& linkSubname,
                         const QString& itemText);
@@ -159,7 +159,7 @@ private:
     QWidget* proxy;
     std::unique_ptr<Ui_TaskHoleParameters> ui;
 
-    App::PropertyLinkSub* propRainDropReferenceAxis;
+    App::PropertyLinkSub* propTearDropReferenceAxis;
     /**
      * @brief axesInList is the list of links corresponding to axis combo; must
      * be kept in sync with the combo. A special value of zero-pointer link is

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -80,6 +80,8 @@ public:
     long getThreadDepthType() const;
     double getThreadDepth() const;
     int getBaseProfileType() const;
+    bool getRainDrop() const;
+    double getRainDropAngle() const;
 
 private Q_SLOTS:
     void holeTypeChanged(int index);
@@ -109,7 +111,8 @@ private Q_SLOTS:
     void threadDepthTypeChanged(int index);
     void threadDepthChanged(double value);
     void baseProfileTypeChanged(int index);
-    void makeRaindropHatChanged();
+    void rainDropChanged();
+    void rainDropAngleValueChanged(double value);
     void setCutDiagram();
 
 private:

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>366</width>
-    <height>924</height>
+    <width>362</width>
+    <height>1127</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -72,7 +72,7 @@
         </sizepolicy>
        </property>
        <property name="layoutDirection">
-        <enum>Qt::LayoutDirection::RightToLeft</enum>
+        <enum>Qt::LeftToRight</enum>
        </property>
        <property name="text">
         <string>Head Type</string>
@@ -88,7 +88,7 @@
         </sizepolicy>
        </property>
        <property name="layoutDirection">
-        <enum>Qt::LayoutDirection::LeftToRight</enum>
+        <enum>Qt::LeftToRight</enum>
        </property>
        <item>
         <property name="text">
@@ -111,7 +111,7 @@
         </sizepolicy>
        </property>
        <property name="layoutDirection">
-        <enum>Qt::LayoutDirection::LeftToRight</enum>
+        <enum>Qt::LeftToRight</enum>
        </property>
        <property name="text">
         <string>Depth Type</string>
@@ -145,7 +145,7 @@
       <string>Check to override the values predefined by the 'Type'</string>
      </property>
      <property name="layoutDirection">
-      <enum>Qt::LayoutDirection::LeftToRight</enum>
+      <enum>Qt::LeftToRight</enum>
      </property>
      <property name="text">
       <string>Custom head values</string>
@@ -209,7 +209,7 @@
               </sizepolicy>
              </property>
              <property name="contextMenuPolicy">
-              <enum>Qt::ContextMenuPolicy::NoContextMenu</enum>
+              <enum>Qt::NoContextMenu</enum>
              </property>
              <property name="keyboardTracking">
               <bool>false</bool>
@@ -415,9 +415,6 @@ account for the depth of blind holes</string>
              <property name="text">
               <string>Countersink angle</string>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-             </property>
             </widget>
            </item>
            <item>
@@ -460,9 +457,6 @@ account for the depth of blind holes</string>
              <property name="text">
               <string>Depth</string>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-             </property>
             </widget>
            </item>
            <item>
@@ -504,9 +498,6 @@ account for the depth of blind holes</string>
              </property>
              <property name="text">
               <string>Diameter</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
              </property>
             </widget>
            </item>
@@ -574,7 +565,7 @@ account for the depth of blind holes</string>
           </sizepolicy>
          </property>
          <property name="layoutDirection">
-          <enum>Qt::LayoutDirection::LeftToRight</enum>
+          <enum>Qt::LeftToRight</enum>
          </property>
          <property name="text">
           <string>Tapered</string>
@@ -857,9 +848,6 @@ Note that the calculation can take some time</string>
           <property name="text">
            <string>Direction</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
-          </property>
          </widget>
         </item>
         <item>
@@ -1049,7 +1037,7 @@ Note that the calculation can take some time</string>
             <string>Customize thread clearance</string>
            </property>
            <property name="layoutDirection">
-            <enum>Qt::LayoutDirection::LeftToRight</enum>
+            <enum>Qt::LeftToRight</enum>
            </property>
            <property name="text">
             <string>Custom Clearance</string>
@@ -1082,6 +1070,60 @@ Note that the calculation can take some time</string>
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="makeRaindropHat">
+     <property name="text">
+      <string>Raindrop</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="raindropParams">
+     <property name="title">
+      <string/>
+     </property>
+     <widget class="QWidget" name="verticalLayoutWidget_3">
+      <property name="geometry">
+       <rect>
+        <x>-1</x>
+        <y>10</y>
+        <width>351</width>
+        <height>161</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_17">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_20">
+         <item>
+          <widget class="QToolButton" name="buttonSelectRaindropHatUpVector">
+           <property name="text">
+            <string>Select up vector</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QListWidget" name="listWidget"/>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_14">
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Angle to vertical</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Gui::QuantitySpinBox" name="raindropHatAngle"/>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -1086,18 +1086,56 @@ Note that the calculation can take some time</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_16">
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_20">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QToolButton" name="buttonSelectRaindropHatUpVector">
+         <widget class="QLabel" name="label_2">
           <property name="text">
-           <string>Select up vector</string>
+           <string>Axis</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QListWidget" name="listWidget"/>
+         <widget class="QComboBox" name="RainDropAxis">
+          <item>
+           <property name="text">
+            <string>Base X axis</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Base Y axis</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Base Z axis</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Horizontal sketch axis</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Vertical sketch axis</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Select reference...</string>
+           </property>
+          </item>
+         </widget>
         </item>
        </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="RainDropReversed">
+        <property name="text">
+         <string>Reversed</string>
+        </property>
+       </widget>
       </item>
       <item>
        <layout class="QVBoxLayout" name="verticalLayout_14">

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -1073,14 +1073,17 @@ Note that the calculation can take some time</string>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="RainDrop">
+    <widget class="QCheckBox" name="TearDrop">
+     <property name="toolTip">
+      <string>Make a tear drop shape for easier printing on FDM machines without support</string>
+     </property>
      <property name="text">
-      <string>Raindrop</string>
+      <string>Tear Drop</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="RainDropParams">
+    <widget class="QGroupBox" name="TearDropParams">
      <property name="title">
       <string/>
      </property>
@@ -1090,12 +1093,15 @@ Note that the calculation can take some time</string>
         <item>
          <widget class="QLabel" name="label_2">
           <property name="text">
-           <string>Axis</string>
+           <string>Direction</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="RainDropAxis">
+         <widget class="QComboBox" name="TearDropAxis">
+          <property name="toolTip">
+           <string>Direction of the tip, it should point up from the print bed</string>
+          </property>
           <item>
            <property name="text">
             <string>Base X axis</string>
@@ -1131,7 +1137,7 @@ Note that the calculation can take some time</string>
        </layout>
       </item>
       <item>
-       <widget class="QCheckBox" name="RainDropReversed">
+       <widget class="QCheckBox" name="TearDropReversed">
         <property name="text">
          <string>Reversed</string>
         </property>
@@ -1142,12 +1148,15 @@ Note that the calculation can take some time</string>
         <item>
          <widget class="QLabel" name="label">
           <property name="text">
-           <string>Angle to vertical</string>
+           <string>Angle to direction</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="Gui::PrefQuantitySpinBox" name="RainDropAngle">
+         <widget class="Gui::PrefQuantitySpinBox" name="TearDropAngle">
+          <property name="toolTip">
+           <string>Angle of the tear drop, smaller is pointier</string>
+          </property>
           <property name="unit" stdset="0">
            <string notr="true">deg</string>
           </property>

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>362</width>
-    <height>1127</height>
+    <width>351</width>
+    <height>1107</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -1073,57 +1073,51 @@ Note that the calculation can take some time</string>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="makeRaindropHat">
+    <widget class="QCheckBox" name="RainDrop">
      <property name="text">
       <string>Raindrop</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="raindropParams">
+    <widget class="QGroupBox" name="RainDropParams">
      <property name="title">
       <string/>
      </property>
-     <widget class="QWidget" name="verticalLayoutWidget_3">
-      <property name="geometry">
-       <rect>
-        <x>-1</x>
-        <y>10</y>
-        <width>351</width>
-        <height>161</height>
-       </rect>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_17">
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_20">
-         <item>
-          <widget class="QToolButton" name="buttonSelectRaindropHatUpVector">
-           <property name="text">
-            <string>Select up vector</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QListWidget" name="listWidget"/>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_14">
-           <item>
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string>Angle to vertical</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="Gui::QuantitySpinBox" name="raindropHatAngle"/>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
+     <layout class="QVBoxLayout" name="verticalLayout_16">
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_20">
+        <item>
+         <widget class="QToolButton" name="buttonSelectRaindropHatUpVector">
+          <property name="text">
+           <string>Select up vector</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QListWidget" name="listWidget"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_14">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Angle to vertical</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefQuantitySpinBox" name="RainDropAngle">
+          <property name="unit" stdset="0">
+           <string notr="true">deg</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Adds an option to create a teardrop shape in a given direction instead of a cylinder shape for holes. This makes it quicker to prepare files for FDM 3d printing when printing holes which axis is perpendicular to the z axis of the printer.

It handles counterbores and counterdrills by making 2 tear drops, one for the body of the hole and one for the head.

Some noted that it might be better to put this functionality in a 3d printing workbench or a post-processing macro, but I found it useful to my workflow so I suggest it here.

Relevant discussion on the forum: https://forum.freecad.org/viewtopic.php?t=82955

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

without tear drop
![Screenshot from 2025-06-08 16-09-41](https://github.com/user-attachments/assets/26ee5406-2789-4cef-be6f-fff94b3d9505)

with tear drop
![Screenshot from 2025-06-08 16-09-30](https://github.com/user-attachments/assets/469c4561-fc14-4d76-ad32-a55a01e45d41)

dialog changes (the bottom part is only visible when [Tear drop] is checked):
![Screenshot from 2025-06-08 16-08-51](https://github.com/user-attachments/assets/e5e01916-3383-4cec-9c02-5f6cd189cd71)

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
