### PR TITLE
RFC: Docker to build FreeCAD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  freecad:
+    build:
+      context: ./tools/build/Docker
+      dockerfile: Dockerfile
+    image: freecad-test-image
+    container_name: freecad-test
+    ports:
+      - "5000:5000"
+      - "5100:5100"
+    environment:
+      - "DISPLAY"
+      - "QT_X11_NO_MITSHM=1"
+      - "XDG_RUNTIME_DIR=/tmp"
+    volumes:
+      - ".:/mnt/source"
+      - "./build:/mnt/build"
+      - "~/.config/FreeCAD:/root/.local/FreeCAD"
+      - "~/:/mnt/files"
+      - "/tmp/.X11-unix:/tmp/.X11-unix:ro"

--- a/tools/build/Docker/Dockerfile
+++ b/tools/build/Docker/Dockerfile
@@ -1,0 +1,94 @@
+FROM ubuntu:plucky
+
+ENV FREECAD_VERSION="FreeCAD-1-0"
+
+LABEL MAINTAINER="xxxx@example.com"
+LABEL DESCRIPTION="A docker image to build FreeCAD locally"
+LABEL VERSION="$FREECAD_VERSION"
+
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /tmp
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LOCALE="C.UTF-8"
+
+# Build tools, and misc supporting tools
+RUN apt update && \
+    apt install -y build-essential cmake libtool lsb-release git \
+    # Python3
+    python3 swig \
+    # Boost libraries
+    libboost-dev \
+    libboost-date-time-dev \
+    libboost-filesystem-dev \
+    libboost-graph-dev \
+    libboost-iostreams-dev \
+    libboost-program-options-dev \
+    libboost-python-dev \
+    libboost-regex-dev \
+    libboost-serialization-dev \
+    libboost-thread-dev \
+    # Coin libraries
+    libcoin-dev libcoin-doc libcoin-runtime \
+    # Misc libraries
+    libeigen3-dev \
+    libgts-bin \
+    libgts-dev \
+    libkdtree++-dev \
+    libmedc-dev \
+    libopencv-dev \
+    libproj-dev \
+    libvtk9-dev \
+    libx11-dev \
+    libxerces-c-dev \
+    libyaml-cpp-dev \
+    libzipios++-dev \
+    # Python 3 and Qt6
+    libpyside6-py3-6.8 libqt6opengl6-dev \
+    libshiboken2-dev \
+    python3-pyside6.qtcore python3-pyside6.qtgui python3-pyside6.qtnetwork \
+    python3-pyside6.qtsvg python3-pyside6.qtwebchannel \
+    python3-pyside6.qtwebenginequick python3-pyside6.qtwebenginecore \
+    python3-pyside6.qtwebenginewidgets python3-pyside6.qtwidgets \
+    python3-pyside6.qtuitools libpyside6-dev \
+    libqt6opengl6-dev libqt6svg6-dev libshiboken2-dev \
+    qt6-base-dev qt6-tools-dev \
+    python3-dev python3-matplotlib python3-packaging python3-pivy \
+    python3-pybind11 python3-ply \
+    qt6-webengine-dev qt6-l10n-tools qt6-tools-dev-tools \
+    # OpenCascade
+    libocct*-dev occt-draw \
+    # Optional packges
+    checkinstall doxygen graphviz libsimage-dev libspnav-dev \
+    # To fix compilation problems
+    libhdf5-openmpi-dev python3-pip
+
+# Known python dependencies
+# RUN python3 -m pip install --break-system-packages ifcopenshell
+
+# DEBUG C++ with gdb
+RUN apt install -y gdb
+# libcanberra-gtk-module libcanberra-gtk3-module
+# greenlet dependency can not be compiled
+# RUN python3 -m pip install --break-system-packages gdbgui
+ENV FREECAD_GDB_PORT=5000
+EXPOSE 5000
+
+# DEBUG Python with winpdb
+RUN apt install -y wxpython-tools
+RUN python3 -m pip install --break-system-packages winpdb-reborn
+ENV FREECAD_WINPDB_PORT=51000
+ENV FREECAD_WINPDB_PWD=1234
+EXPOSE 51000
+
+# These environment variable are set here to be used
+#   by the different container's scripts
+ENV FREECAD_CONFIG_DIR="/root/.local/FreeCAD"
+ENV FREECAD_BUILD_DIR="/mnt/build"
+ENV FREECAD_SOURCE_DIR="/mnt/source"
+
+# Add the build & debug scripts
+ADD build_FC.sh /root/build_FC.sh
+
+WORKDIR /root

--- a/tools/build/Docker/build_FC.sh
+++ b/tools/build/Docker/build_FC.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# This script will launch the build of FreeCAD.
+#
+
+p_build_type="Debug"
+
+#------------------------------------------------------------------------------
+# FUNCTION: usage
+#------------------------------------------------------------------------------
+usage()
+{
+    cat >&2 <<EOF
+
+Usage: $(basename $0)
+
+Build FreeCAD either in Debug (default) or Release mode
+
+General options:
+    -d|--debug: Launch a debug build. This is the default.
+    -r|--release: Launch a release build.
+    -h|--help: This message
+
+SYNOPSIS:
+
+Build FreeCAD in Debug mode
+?> $0
+?> $0 --debug
+
+Build FreeCAD in Rebug mode
+?> $0 --release
+
+EOF
+}
+
+
+#==============================================================================
+#
+# MAIN PROGRAM SECTION.
+#
+#==============================================================================
+options=$(getopt --alternative --name $(basename $0) --options "hdr" --longoptions help,debug,release -- $0 "$@")
+if [ $? -ne 0 ]; then
+    usage
+    exit 1
+fi
+eval set -- "$options"
+while true; do
+    case "$1" in
+    -d|--debug)   p_build_type="Debug" ;;
+    -r|--release) p_build_type="Release" ;;
+    -h|--help)    usage; exit 0 ;;
+    --) shift; break ;;
+    esac
+    shift
+done
+
+git config --global --add safe.directory ${FREECAD_SOURCE_DIR}
+
+set -e
+
+# NOTE: The PYTHON_LIBRARY is dependant on the base image used
+#   in the docker file.
+cmake \
+    -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.13.so.1.0 \
+    -D PYTHON_INCLUDE_DIR=/usr/include/python3.13/ \
+    -D PYTHON_EXECUTABLE=/usr/bin/python3 \
+    -D FREECAD_USE_OCC_VARIANT="Official Version" \
+    -D BUILD_QT6=ON \
+    -D BUILD_FEM=ON \
+    -D BUILD_SANDBOX=OFF \
+    -D BUILD_DESIGNER_PLUGIN=ON \
+    -D FREECAD_QT_MAJOR_VERSION=6 \
+    -D FREECAD_QT_VERSION=6 \
+    -D ENABLE_DEVELOPER_TESTS=Off \
+    -D Boost_USE_DEBUG_RUNTIME=FALSE \
+    -D FREECAD_USE_PCL=Off \
+    -D CMAKE_BUILD_TYPE=$p_build_type \
+    -S ${FREECAD_SOURCE_DIR} \
+    -B ${FREECAD_BUILD_DIR}
+
+pushd ${FREECAD_BUILD_DIR}
+make -j $(nproc --ignore=1)


### PR DESCRIPTION


There are several bugs related to not having a repeatable documented solution to build FreeCAD:

* #13460
* #13983
* #17788
* #20246
* #20505
* #20245
* #16960

The wiki, the Dockerfiles and scripts on tools/build/Docker and https://github.com/FreeCAD/Docker are outdated

This proposal is based on https://github.com/rostskadat/FreeCAD-Docker but was updated to compile with Qt6 and integrated with the FreeCAD sources

The Dockerfile use dependencies already packaged on ubuntu instead of try to compile every dependency

Instructions:

Clone the repository:
```
git clone --recurse-submodules https://github.com/FreeCAD/FreeCAD.git ./freecad_source
```

Start a docker container with the dependencies
```
cd freecad_sorce
docker compose run freecad bash
```

Build:
```
./build_FC.sh
```

Run:
```
/mnt/build/bin/FreeCAD
```

I have tested this on Fedora 42, more testing is needed

Limitations:

* Probably only useful on linux
* The FreeCAD-Docker repository enabled debugging with winpdb, bud I could not find a version compatible with the other newer dependencies.
* ifcopenshell is not installed

Comments? Is this useful to others? 

