### PR TITLE
Base: Disable XML external entity expansion

### DIFF
--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -1872,6 +1872,7 @@ int ParameterManager::LoadDocument(const XERCES_CPP_NAMESPACE_QUALIFIER InputSou
     parser->setDoSchema(gDoSchema);
     parser->setValidationSchemaFullChecking(gSchemaFullChecking);
     parser->setCreateEntityReferenceNodes(gDoCreate);
+    parser->setDisableDefaultEntityResolution(true);
 
     auto errReporter = new DOMTreeErrorReporter();
     parser->setErrorHandler(errReporter);


### PR DESCRIPTION
Addresses https://github.com/FreeCAD/FreeCAD/security/code-scanning/29

From CodeQL: "Parsing untrusted XML files with a weakly configured XML parser may lead to an XML external entity (XXE) attack. This type of attack uses external entity references to access arbitrary files on a system, carry out denial-of-service (DoS) attacks, or server-side request forgery. Even when the result of parsing is not returned to the user, DoS attacks are still possible and out-of-band data retrieval techniques may allow attackers to steal sensitive data."