### PR TITLE
CAM: Show abbreviation on each label to match input value to shape image on the UI

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathToolShapeIcon.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolShapeIcon.py
@@ -183,8 +183,8 @@ class TestToolBitShapeSvgIcon(TestToolBitShapeIconBase):
         svg_content = self.test_svg.data
         abbr = ToolBitShapeSvgIcon.get_abbreviations_from_svg(svg_content)
         # Assuming the test_svg data has 'diameter' and 'length' ids
-        self.assertIn("diameter", abbr)
-        self.assertIn("length", abbr)
+        self.assertIn("Diameter", abbr)
+        self.assertIn("Length", abbr)
 
         # Test with invalid SVG
         invalid_svg = b"<svg><text id='param1'>A1</text>"  # Missing closing tag

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/editor.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/editor.py
@@ -49,7 +49,9 @@ class ToolBitPropertiesWidget(QtGui.QWidget):
         self._id_label = QtGui.QLabel()  # Read-only ID
         self._id_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
 
-        self._property_editor = DocumentObjectEditorWidget()
+        theicon = toolbit.get_icon() if toolbit else None
+        abbr = theicon.abbreviations if theicon else {}
+        self._property_editor = DocumentObjectEditorWidget(property_suffixes=abbr)
         self._property_editor.setSizePolicy(
             QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding
         )


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a6501dc9-6740-42c3-a703-d99f980a5226)

Note the abbreviations behind the labels.

Old label: Length
New label: Length (L)

