### PR TITLE
CAM: ToolBit editor fixes for high resolution displays

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/ToolBitEditor.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/ToolBitEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1000</width>
-    <height>900</height>
+    <width>750</width>
+    <height>800</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -41,14 +41,14 @@
            </property>
            <property name="sizeIncrement">
             <size>
-             <width>1000</width>
-             <height>1000</height>
+             <width>650</width>
+             <height>850</height>
             </size>
            </property>
            <property name="baseSize">
             <size>
-             <width>1000</width>
-             <height>1000</height>
+             <width>650</width>
+             <height>850</height>
             </size>
            </property>
            <property name="currentIndex">

--- a/src/Mod/CAM/Path/Tool/shape/ui/shapewidget.py
+++ b/src/Mod/CAM/Path/Tool/shape/ui/shapewidget.py
@@ -20,17 +20,17 @@
 # *                                                                         *
 # ***************************************************************************
 from PySide import QtGui, QtCore
+from ..models.base import ToolBitShape
 
 
 class ShapeWidget(QtGui.QWidget):
-    def __init__(self, shape, parent=None):
+    def __init__(self, shape: ToolBitShape, parent=None):
         super(ShapeWidget, self).__init__(parent)
         self.layout = QtGui.QVBoxLayout(self)
         self.layout.setAlignment(QtCore.Qt.AlignHCenter)
 
         self.shape = shape
-        ratio = self.devicePixelRatioF()
-        self.icon_size = QtCore.QSize(200 * ratio, 235 * ratio)
+        self.icon_size = QtCore.QSize(200, 235)
         self.icon_widget = QtGui.QLabel()
         self.layout.addWidget(self.icon_widget)
 
@@ -39,5 +39,7 @@ class ShapeWidget(QtGui.QWidget):
     def _update_icon(self):
         icon = self.shape.get_icon()
         if icon:
-            pixmap = icon.get_qpixmap(self.icon_size)
+            ratio = self.devicePixelRatioF()
+            size = self.icon_size * ratio
+            pixmap = icon.get_qpixmap(size)
             self.icon_widget.setPixmap(pixmap)


### PR DESCRIPTION
This PR attempts to fix three issues with the new toolbit editor on small displays with high resolution:

- Default window size is too large -> this PR reduces the default size
- Shape diagram too large -> Size reduced
- Shape resolution too small -> Resolution of icon increased

This should resolve #21885.
