### PR TITLE
Sketcher: ShowDimensionalName by default

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -317,7 +317,7 @@ void EditModeCoinManager::ParameterObserver::updateConstraintPresentationParamet
 
     Client.constraintParameters.bHideUnits = hGrpskg->GetBool("HideUnits", false);
     Client.constraintParameters.bShowDimensionalName =
-        hGrpskg->GetBool("ShowDimensionalName", false);
+        hGrpskg->GetBool("ShowDimensionalName", true);
     Client.constraintParameters.sDimensionalStringFormat =
         QString::fromStdString(hGrpskg->GetASCII("DimensionalStringFormat", "%N = %V"));
 }

--- a/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
@@ -100,6 +100,9 @@
         <property name="prefPath" stdset="0">
          <cstring>Mod/Sketcher</cstring>
         </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item row="9" column="1">


### PR DESCRIPTION
From @FreeCAD/design-working-group discussion, set the default in Sketcher to show the dimensional name by default.
This is visible, only if the dimension has a name which can be used in expressions (for normal and reference dimensions)

![Bildschirmfoto 2025-06-09 um 14 10 27](https://github.com/user-attachments/assets/e61d406b-0535-447e-bfa8-d91ae90905d3)