### PR TITLE
DXF: rename "Group layers into blocks" setting

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -394,7 +394,7 @@ Note that this can take a while!</string>
         <item>
          <widget class="Gui::PrefCheckBox" name="checkBox_groupLayers">
           <property name="toolTip">
-           <string>Objects from the same layers will be joined into Draft Blocks,
+           <string>Objects from the same layers will be joined into Part Compounds,
 turning the display faster, but making them less easily editable.</string>
           </property>
           <property name="text">


### PR DESCRIPTION
Clarify the label of the DXF importer setting under Preferences > Import/Export > DXF: it does not affect layers, but their children

- Before:
  > Group layers into blocks
- After:
  > **Merge layer contents** into blocks

Tooltip (https://github.com/FreeCAD/FreeCAD/pull/21896#issuecomment-2958611607):
- Before:
  > Objects from the same layers will be joined into Draft Blocks, turning the display faster, but making them less easily editable.
- After:
  > Objects from the same layers will be joined into **Part Compounds**, turning the display faster, but making them less easily editable.

Given the number of interdependent options and different behaviour of Python vs C++ importer, I've struggled with understanding this setting in the past. I've had to import a few DXF documents recently, and I've struggled again. 

Proposing this change to make it unequivocally clear that it refers to the objects contained in the layers, not the layers themselves. Also avoided the verb "Group" to avoid any possible confusion with Group objects. I've considered "compound" instead of "merge" as well. Suggestions welcome.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
