### PR TITLE
CI: set MACOS_DEPLOYMENT_TARGET=10.13 for Intel macOS.

### DIFF
--- a/package/rattler-build/conda_build_config.yaml
+++ b/package/rattler-build/conda_build_config.yaml
@@ -1,7 +1,7 @@
-c_compiler:           # [win]
-  - vs2022            # [win]
-cxx_compiler:         # [win]
-  - vs2022            # [win]
+c_compiler:               # [win]
+  - vs2022                # [win]
+cxx_compiler:             # [win]
+  - vs2022                # [win]
 
-MACOSX_SDK_VERSION:   # [osx]
-  - '11.0'            # [osx]
+MACOSX_DEPLOYMENT_TARGET: # [osx]
+  - '10.13'               # [osx]


### PR DESCRIPTION
The MACOS_DEPLOYMENT_TARGET was not explicitly set, resulting in a default of 10.9, which does not support C++ features needed by some components in FreeCAD. This PR sets the MACOS_DEPLOYMENT_TARGET to 10.13 to build for platforms running macOS High Sierra (2017) or newer.

## Issues

No GH issues filed, but it has been brought to my attention on Discord.

## Before and After Images

None.