### PR TITLE
Core: Allow users to add groups to active objects

### DIFF
--- a/src/App/GroupExtension.pyi
+++ b/src/App/GroupExtension.pyi
@@ -70,3 +70,9 @@ class GroupExtension(DocumentObjectExtension):
         @param recursive  if true check also if the obj is child of some sub group (default is false).
         """
         ...
+
+    def allowObject(self, obj: Any) -> bool:
+        """
+        Returns true if obj is allowed in the group extension.
+        """
+        ...

--- a/src/App/GroupExtensionPyImp.cpp
+++ b/src/App/GroupExtensionPyImp.cpp
@@ -318,3 +318,30 @@ int GroupExtensionPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*
 {
     return 0;
 }
+
+// def allowObject(self, obj: Any) -> bool:
+PyObject* GroupExtensionPy::allowObject(PyObject* args)
+{
+    PyObject* object;
+    if (!PyArg_ParseTuple(args, "O!", &(DocumentObjectPy::Type), &object)) {
+        return nullptr;
+    }
+
+    auto* docObj = static_cast<DocumentObjectPy*>(object);
+    if (!docObj->getDocumentObjectPtr()
+        || !docObj->getDocumentObjectPtr()->isAttachedToDocument()) {
+        PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot check an invalid object");
+        return nullptr;
+    }
+    if (docObj->getDocumentObjectPtr()->getDocument()
+        != getGroupExtensionPtr()->getExtendedObject()->getDocument()) {
+        PyErr_SetString(Base::PyExc_FC_GeneralError,
+                        "Cannot check an object from another document from this group");
+        return nullptr;
+    }
+
+    GroupExtension* grp = getGroupExtensionPtr();
+
+    bool allowed = grp->allowObject(docObj->getDocumentObjectPtr());
+    return PyBool_FromLong(allowed ? 1 : 0);
+}

--- a/src/Gui/ActiveObjectList.cpp
+++ b/src/Gui/ActiveObjectList.cpp
@@ -197,3 +197,15 @@ void ActiveObjectList::objectDeleted(const ViewProviderDocumentObject &vp)
         }
     }
 }
+
+App::DocumentObject* ActiveObjectList::getObjectWithExtension(const Base::Type extensionTypeId) const
+{
+    for (const auto& pair : _ObjectMap) {
+        App::DocumentObject* obj = getObject(pair.second, true);
+        if (obj && obj->hasExtension(extensionTypeId)) {
+            return obj;
+        }
+    }
+
+    return nullptr;
+}

--- a/src/Gui/ActiveObjectList.h
+++ b/src/Gui/ActiveObjectList.h
@@ -27,6 +27,7 @@
 
 #include <map>
 #include <string>
+#include <Base/Type.h>
 #include <Gui/TreeItemMode.h>
 #include <FCGlobal.h>
 
@@ -66,6 +67,8 @@ namespace Gui
         bool hasObject(const char*)const;
         void objectDeleted(const ViewProviderDocumentObject& viewProviderIn);
         bool hasObject(App::DocumentObject *obj, const char *, const char *subname=nullptr) const;
+
+        App::DocumentObject* getObjectWithExtension(Base::Type extensionTypeId) const;
 
     private:
         struct ObjectInfo;

--- a/src/Gui/MDIView.h
+++ b/src/Gui/MDIView.h
@@ -147,6 +147,11 @@ public:
         return ActiveObjects.hasObject(o,n,subname);
     }
 
+    App::DocumentObject* getActiveObjectWithExtension(const Base::Type extensionTypeId) const
+    {
+        return ActiveObjects.getObjectWithExtension(extensionTypeId);
+    }
+
     /*!
      * \brief containsViewProvider
      * Checks if the given view provider is part of this view. The default implementation


### PR DESCRIPTION
As the title says, if right now there is Arch type active (like Level, Building, etc. etc.), then it's not possible to assign Group to it automatically (it's being created on root level of the document).

So this patch adds autogroup functionality, if no object is no active -> no harm, the function will check that and insert Group in the root document object, if there is active object -> it will insert the Group under it.


Demo:

https://github.com/user-attachments/assets/6f3dccf6-b021-488f-80aa-6434b0b36aaf

Resolves: https://github.com/FreeCAD/FreeCAD/issues/21380

