### PR TITLE
Import: DXF, handle non-standard 8859_1 encoding

### DIFF
--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2811,11 +2811,18 @@ bool CDxfRead::ReadHeaderSection()
         if (m_record_type != eVariableName) {
             continue;  // Quietly ignore unknown record types
         }
+
+        // Store the variable name before we try to read its value.
+        std::string currentVarName = m_record_data;
         if (!ReadVariable()) {
-            return false;
+            // If ReadVariable returns false, throw an exception with the variable name.
+            throw Base::Exception("Failed while reading value for HEADER variable: "
+                                  + currentVarName);
         }
     }
-    return false;
+
+    // If the loop finishes without finding ENDSEC, it's an error.
+    throw Base::Exception("Unexpected end of file inside HEADER section.");
 }
 
 bool CDxfRead::ReadVariable()


### PR DESCRIPTION
## The issue

When importing the attached file ([test_codepage.zip](https://github.com/user-attachments/files/20669977/test_codepage.zip), uncompress first), the C++ DXF importer fails with this error:

```
Error reading DXF file: <built-in method readDXF of tuple object at 0x7efdc35bd240> returned a result with an exception set
```

The file is a simplified header-only version for testing purposes. The real file I initially had troubles with is much larger.

## The proposed fix

This PR fixes that error in two stages:
1. Improve exception handling to pinpoint the exact cause (9de117846d33b92d9f0d24ea9ee0cf1082ba9fc5 and 42c78729c31713c56d32e1f1c2d2701f475fea40). Then the error becomes much clearer:
   ```python
   Traceback (most recent call last):
     File "<string>", line 2, in <module>
     File "/home/me/dev/FreeCAD/build/Ext/freecad/module_io.py", line 16, in OpenInsertObject
       getattr(importerModule, importMethod)(objectPath, *importArgs, **importKwargs)
     File "/home/me/dev/FreeCAD/build/Mod/Draft/importDXF.py", line 2872, in insert
       ImportGui.readDXF(filename)
   <class 'RuntimeError'>: Failed while reading value for HEADER variable: $DWGCODEPAGE
   ```
2. Fix the error: an unexpected, non-standard codepage (`8859_1`) read correctly from the DXF file, but that Python cannot map to any encoding known to it (55dc3a0be982b0ff4ce0a213366720a95be3d298).

## Additional notes

Regarding the code page, I refer to this reference to infer that `8859_1` is not standard, but there might be alternative DXF references that list other code pages as well:

https://ezdxf.readthedocs.io/en/stable/dxfinternals/fileencoding.html

There's also https://help.autodesk.com/view/OARX/2025/ENU/?guid=GUID-A85E8E67-27CD-4C59-BE61-4DC9FADBE74A, but it describes the variable, not its accepted values.

The DXF file was created with QGis (which is an ubiquitous multiplatform app), so I think it might be worth handling this error. QCAD did load the file without errors, and so did FreeCAD's legacy (Python) DXF importer, although I suspect because the variable might have been ignored in the later. It is ultimately addressing a quirk, but so are many DXF files created by different vendors. The code in question is easily mappable to the one Python understands, and other ones can be mapped in the future should the need arise.

Regarding pinpointing the exact header variable that causes an error, this PR only changes `ReadHeaderSection`, which is the one I was having troubles with. It might be worth doing the same with `ReadTablesSection`, `ReadBlocksSection`, `ReadEntitiesSection` in a subsequent PR.