### PR TITLE
[TD]fix bad element name in Vertex::Restore

### DIFF
--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -1338,7 +1338,7 @@ void Vertex::Restore(Base::XMLReader &reader)
 
     reader.readElement("Extract");
     extractType = reader.getAttribute<ExtractionType>("value");
-    reader.readElement("Visible");
+    reader.readElement("HLRVisible");
     hlrVisible = reader.getAttribute<bool>("value");
     reader.readElement("Ref3D");
     ref3D = reader.getAttribute<int>("value");


### PR DESCRIPTION
In PR ##21374, an element name in Vertex::Restore is misnamed.  This causes document loads to fail if they contain a CosmeticVertex.

This PR corrects the element name.