### PR TITLE
Inform Coin to use EGL when on Wayland

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2295,6 +2295,11 @@ void Application::runApplication()
     int argc = App::Application::GetARGC();
     GUISingleApplication mainApp(argc, App::Application::GetARGV());
 
+    // If QT is running with native Wayland then inform Coin to use EGL
+    if (QGuiApplication::platformName() == QString::fromStdString("wayland")) {
+        setenv("COIN_EGL", "1", 1);
+    }
+    
     // Make sure that we use '.' as decimal point. See also
     // http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=559846
     // and issue #0002891

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2295,10 +2295,12 @@ void Application::runApplication()
     int argc = App::Application::GetARGC();
     GUISingleApplication mainApp(argc, App::Application::GetARGV());
 
+#if defined(FC_OS_LINUX) || defined(FC_OS_BSD)
     // If QT is running with native Wayland then inform Coin to use EGL
     if (QGuiApplication::platformName() == QString::fromStdString("wayland")) {
         setenv("COIN_EGL", "1", 1);
     }
+#endif
     
     // Make sure that we use '.' as decimal point. See also
     // http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=559846


### PR DESCRIPTION
The next version of Coin has some EGL support which can be enabled by setting `COIN_EGL`. This PR sets that environment variable if we are running on Wayland (not XWayland). It is not perfect, it doesn't work when using NVIDIA proprietary drivers (at least for me) so we should default set `QT_QPA_PLATFORM=xcb` for releases. However, non NVIDIA proprietary driver users may benefit from setting `QT_QPA_PLATFORM=wayland` manually.

When the new Coin version is released we also need to add `qt6-wayland` to pixi.