### PR TITLE
Sketcher: Make SoDatumLabel constraints more interactable

### DIFF
--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -113,6 +113,25 @@ private:
         float arrowWidth;               // width of the arrow
     };
 
+    struct DiameterGeometry {
+        SbVec3f p1, p2;                 // main points (center and edge for radius, endpoints for diameter)
+        SbVec3f center;                 // center point
+        SbVec3f dir, normal;            // direction and normal vectors
+        SbVec3f pos;                    // text position base
+        SbVec3f pnt1, pnt2;             // line segment points around text
+        SbVec3f ar0, ar1, ar2;          // first arrow head triangle points
+        SbVec3f ar0_1, ar1_1, ar2_1;    // second arrow head triangle points (diameter only)
+        float angle;                    // text angle
+        SbVec3f textOffset;             // text position
+        float radius;                   // radius value
+        float margin;                   // margin for calculations
+        float arrowWidth;               // arrow width
+        bool isDiameter;                // true for diameter, false for radius
+        // Arc helper parameters
+        float startAngle, startRange;   // start parameters
+        float endAngle, endRange;       // start parameters
+    };
+
     float getScaleFactor(SoState*) const;
     void generateDistancePrimitives(SoAction * action, const SbVec3f&, const SbVec3f&);
     void generateDiameterPrimitives(SoAction * action, const SbVec3f&, const SbVec3f&);
@@ -126,6 +145,7 @@ private:
     bool hasDatumText() const;
     void getDimension(float scale, int& srcw, int& srch);
     DistanceGeometry calculateDistanceGeometry(const SbVec3f* points, float scale, int srch) const;
+    DiameterGeometry calculateDiameterGeometry(const SbVec3f* points) const;
     void generateLineSelectionPrimitive(SoAction* action, const SbVec3f& start, const SbVec3f& end, float width);
     void drawDistance(const SbVec3f* points, float scale, int srch, float& angle, SbVec3f& textOffset);
     void drawDistance(const SbVec3f* points);

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -159,6 +159,23 @@ private:
         float margin;                   // margin for calculations
     };
 
+    struct ArcLengthGeometry {
+        SbVec3f ctr, p1, p2;
+        float length;
+        float margin;
+        float startangle, endangle;
+        float range;
+        float radius;
+        SbVec3f vm;                     // middle direction vector
+        SbVec3f pnt1, pnt2, pnt3, pnt4; // line endpoints
+        SbVec3f dirStart, dirEnd;       // arrow directions
+        SbVec3f textOffset;
+        float angle;
+        bool isLargeArc;                // whether range > pi
+        SbVec3f arcCenter;              // center for arc drawing
+        float arcRadius;                // radius for arc drawing
+    };
+
     float getScaleFactor(SoState*) const;
     void generateDistancePrimitives(SoAction * action, const SbVec3f&, const SbVec3f&);
     void generateDiameterPrimitives(SoAction * action, const SbVec3f&, const SbVec3f&);
@@ -168,13 +185,14 @@ private:
     SbVec3f getLabelTextCenterDistance(const SbVec3f&, const SbVec3f&);
     SbVec3f getLabelTextCenterDiameter(const SbVec3f&, const SbVec3f&);
     SbVec3f getLabelTextCenterAngle(const SbVec3f&);
-    SbVec3f getLabelTextCenterArcLength(const SbVec3f&, const SbVec3f&, const SbVec3f&);
+    SbVec3f getLabelTextCenterArcLength(const SbVec3f&, const SbVec3f&, const SbVec3f&) const;
     bool hasDatumText() const;
     void getDimension(float scale, int& srcw, int& srch);
     DistanceGeometry calculateDistanceGeometry(const SbVec3f* points, float scale, int srch) const;
     DiameterGeometry calculateDiameterGeometry(const SbVec3f* points) const;
     AngleGeometry calculateAngleGeometry(const SbVec3f* points) const;
     SymmetricGeometry calculateSymmetricGeometry(const SbVec3f* points) const;
+    ArcLengthGeometry calculateArcLengthGeometry(const SbVec3f* points) const;
     void generateLineSelectionPrimitive(SoAction* action, const SbVec3f& start, const SbVec3f& end, float width);
     void generateArcSelectionPrimitive(SoAction* action, const SbVec3f& center, float radius, float startAngle, float endAngle, float width);
     void generateArrowSelectionPrimitive(SoAction* action, const SbVec3f& base, const SbVec3f& dir, float width, float length);

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -45,6 +45,8 @@ class GuiExport SoDatumLabel : public SoShape {
 
     SO_NODE_HEADER(SoDatumLabel);
 
+    friend class DatumLabelBox;
+
 public:
     enum Type
     {
@@ -96,6 +98,21 @@ protected:
     void notify(SoNotList * l) override;
 
 private:
+    struct DistanceGeometry {
+        SbVec3f p1, p2;                 // main points used for measurement
+        SbVec3f dir, normal;            // dir and normal vecs
+        SbVec3f midpos;                 // mid pt
+        SbVec3f perp1, perp2;           // ext line endpts
+        SbVec3f par1, par2, par3, par4; // dim line pts
+        SbVec3f ar1, ar2;               // 1st arrow head triang pts
+        SbVec3f ar3, ar4;               // 2nd arrow head triang pts
+        float angle;                    // text angle
+        SbVec3f textOffset;             // text pos
+        bool flipTriang;                // check for arrow flipping
+        float margin;                   // margin for arrow calcs
+        float arrowWidth;               // width of the arrow
+    };
+
     float getScaleFactor(SoState*) const;
     void generateDistancePrimitives(SoAction * action, const SbVec3f&, const SbVec3f&);
     void generateDiameterPrimitives(SoAction * action, const SbVec3f&, const SbVec3f&);
@@ -108,6 +125,8 @@ private:
     SbVec3f getLabelTextCenterArcLength(const SbVec3f&, const SbVec3f&, const SbVec3f&);
     bool hasDatumText() const;
     void getDimension(float scale, int& srcw, int& srch);
+    DistanceGeometry calculateDistanceGeometry(const SbVec3f* points, float scale, int srch) const;
+    void generateLineSelectionPrimitive(SoAction* action, const SbVec3f& start, const SbVec3f& end, float width);
     void drawDistance(const SbVec3f* points, float scale, int srch, float& angle, SbVec3f& textOffset);
     void drawDistance(const SbVec3f* points);
     void drawRadiusOrDiameter(const SbVec3f* points, float& angle, SbVec3f& textOffset);

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -151,6 +151,14 @@ private:
         float endLineLength12, endLineLength22; // extension line lengths (other side)
     };
 
+    struct SymmetricGeometry {
+        SbVec3f p1, p2;                 // main points
+        SbVec3f dir, normal;            // direction and normal vectors
+        SbVec3f ar0, ar1, ar2;          // first arrow triangle points (tip, base1, base2)
+        SbVec3f ar3, ar4, ar5;          // second arrow triangle points (tip, base1, base2)
+        float margin;                   // margin for calculations
+    };
+
     float getScaleFactor(SoState*) const;
     void generateDistancePrimitives(SoAction * action, const SbVec3f&, const SbVec3f&);
     void generateDiameterPrimitives(SoAction * action, const SbVec3f&, const SbVec3f&);
@@ -166,6 +174,7 @@ private:
     DistanceGeometry calculateDistanceGeometry(const SbVec3f* points, float scale, int srch) const;
     DiameterGeometry calculateDiameterGeometry(const SbVec3f* points) const;
     AngleGeometry calculateAngleGeometry(const SbVec3f* points) const;
+    SymmetricGeometry calculateSymmetricGeometry(const SbVec3f* points) const;
     void generateLineSelectionPrimitive(SoAction* action, const SbVec3f& start, const SbVec3f& end, float width);
     void generateArcSelectionPrimitive(SoAction* action, const SbVec3f& center, float radius, float startAngle, float endAngle, float width);
     void generateArrowSelectionPrimitive(SoAction* action, const SbVec3f& base, const SbVec3f& dir, float width, float length);

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -132,6 +132,25 @@ private:
         float endAngle, endRange;       // start parameters
     };
 
+    struct AngleGeometry {
+        SbVec3f p0;                             // angle intersection point
+        SbVec3f v0;                             // vector for text position
+        SbVec3f v1, v2;                         // direction vectors for start and end lines
+        SbVec3f pnt1, pnt2, pnt3, pnt4;         // line endpoints
+        SbVec3f startArrowBase, endArrowBase;   // arrow base points
+        SbVec3f dirStart, dirEnd;               // arrow directions
+        float angle;                            // text angle (always 0 for angles)
+        SbVec3f textOffset;                     // text position
+        float length;                           // length parameter
+        float startangle, endangle, range;      // angle parameters
+        float r;                                // arc radius
+        float margin;                           // margin for calculations
+        float arrowLength, arrowWidth;          // arrow dimensions
+        double textMargin;                      // margin around text in arc
+        float endLineLength1, endLineLength2;   // extension line lengths
+        float endLineLength12, endLineLength22; // extension line lengths (other side)
+    };
+
     float getScaleFactor(SoState*) const;
     void generateDistancePrimitives(SoAction * action, const SbVec3f&, const SbVec3f&);
     void generateDiameterPrimitives(SoAction * action, const SbVec3f&, const SbVec3f&);
@@ -146,7 +165,10 @@ private:
     void getDimension(float scale, int& srcw, int& srch);
     DistanceGeometry calculateDistanceGeometry(const SbVec3f* points, float scale, int srch) const;
     DiameterGeometry calculateDiameterGeometry(const SbVec3f* points) const;
+    AngleGeometry calculateAngleGeometry(const SbVec3f* points) const;
     void generateLineSelectionPrimitive(SoAction* action, const SbVec3f& start, const SbVec3f& end, float width);
+    void generateArcSelectionPrimitive(SoAction* action, const SbVec3f& center, float radius, float startAngle, float endAngle, float width);
+    void generateArrowSelectionPrimitive(SoAction* action, const SbVec3f& base, const SbVec3f& dir, float width, float length);
     void drawDistance(const SbVec3f* points, float scale, int srch, float& angle, SbVec3f& textOffset);
     void drawDistance(const SbVec3f* points);
     void drawRadiusOrDiameter(const SbVec3f* points, float& angle, SbVec3f& textOffset);


### PR DESCRIPTION
Fear not reviewers! This is mostly refactor task, as the logic for drawing constraints contained all the necessary stuff to extract it for selection additionally.

As the title says, this patch aligns selectability to what we actually draw, so from now on extension lines and arrowheads will be also selectable.

Basically moved part of the logic that draw<constraint> function had into separate functions and updated bounding boxes that Coin uses and selection geometry to also contain arrowheads and extension lines.

Demo:


https://github.com/user-attachments/assets/8c4bb5ca-6676-4643-98e6-c12ae30906b8


Resolves: https://github.com/FreeCAD/FreeCAD/issues/13132
