### PR TITLE
Gui, Draft, BIM: Add PrefCheckableGroupBox, use it in IFC exporter preferences page

### DIFF
--- a/src/Gui/PrefWidgets.cpp
+++ b/src/Gui/PrefWidgets.cpp
@@ -864,4 +864,37 @@ void PrefFontBox::savePreferences()
   getWindowParameter()->SetASCII(entryName(), currName.toUtf8());
 }
 
+// --------------------------------------------------------------------
+
+PrefCheckableGroupBox::PrefCheckableGroupBox(QWidget* parent)
+    : QGroupBox(parent), PrefWidget()
+{
+}
+
+PrefCheckableGroupBox::~PrefCheckableGroupBox() = default;
+
+void PrefCheckableGroupBox::restorePreferences()
+{
+    if (getWindowParameter().isNull() || entryName().isEmpty()) {
+        failedToRestore(objectName());
+        return;
+    }
+
+    // Default value is the current state of the checkbox (usually from .ui on first load)
+    bool defaultValueInUi = isChecked();
+    bool actualValue = getWindowParameter()->GetBool(entryName(), defaultValueInUi);
+    setChecked(actualValue);
+}
+
+void PrefCheckableGroupBox::savePreferences()
+{
+    if (getWindowParameter().isNull() || entryName().isEmpty())
+    {
+        failedToSave(objectName());
+        return;
+    }
+
+    getWindowParameter()->SetBool(entryName(), isChecked());
+}
+
 #include "moc_PrefWidgets.cpp"

--- a/src/Gui/PrefWidgets.h
+++ b/src/Gui/PrefWidgets.h
@@ -26,6 +26,7 @@
 #include <QCheckBox>
 #include <QComboBox>
 #include <QFontComboBox>
+#include <QGroupBox>
 #include <QRadioButton>
 #include <QTextEdit>
 
@@ -424,6 +425,31 @@ protected:
   // restore from/save to parameters
   void restorePreferences() override;
   void savePreferences() override;
+};
+
+/**
+ * The PrefCheckableGroupBox class allows a QGroupBox to act as a boolean preference.
+ * Its 'checked' state is saved to and restored from the FreeCAD parameter system
+ * using the 'prefEntry' and 'prefPath' dynamic properties set in the .ui file.
+ * When the GroupBox is checked, its children are enabled; when unchecked, disabled (standard
+ * QGroupBox behavior).
+ */
+class GuiExport PrefCheckableGroupBox : public QGroupBox, public PrefWidget
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QByteArray prefEntry READ entryName    WRITE setEntryName)    // clazy:exclude=qproperty-without-notify
+    Q_PROPERTY(QByteArray prefPath  READ paramGrpPath WRITE setParamGrpPath) // clazy:exclude=qproperty-without-notify
+
+public:
+    explicit PrefCheckableGroupBox(QWidget* parent = nullptr);
+    ~PrefCheckableGroupBox() override;
+
+protected:
+  // restore from/save to parameters
+    void restorePreferences() override;
+    void savePreferences() override;
+
 };
 
 } // namespace Gui

--- a/src/Gui/PropertyPage.cpp
+++ b/src/Gui/PropertyPage.cpp
@@ -187,6 +187,7 @@ void PreferenceUiForm::loadSettings()
     loadPrefWidgets<Gui::PrefColorButton    *>();
     loadPrefWidgets<Gui::PrefUnitSpinBox    *>();
     loadPrefWidgets<Gui::PrefQuantitySpinBox*>();
+    loadPrefWidgets<Gui::PrefCheckableGroupBox*>();
 }
 
 void PreferenceUiForm::saveSettings()
@@ -208,6 +209,7 @@ void PreferenceUiForm::saveSettings()
     savePrefWidgets<Gui::PrefColorButton    *>();
     savePrefWidgets<Gui::PrefUnitSpinBox    *>();
     savePrefWidgets<Gui::PrefQuantitySpinBox*>();
+    savePrefWidgets<Gui::PrefCheckableGroupBox*>();
 }
 
 QWidget* Gui::Dialog::PreferenceUiForm::form()

--- a/src/Gui/resource.cpp
+++ b/src/Gui/resource.cpp
@@ -115,6 +115,7 @@ WidgetFactorySupplier::WidgetFactorySupplier()
     new WidgetProducer<Gui::PrefComboBox>;
     new WidgetProducer<Gui::PrefFontBox>;
     new WidgetProducer<Gui::PrefCheckBox>;
+    new WidgetProducer<Gui::PrefCheckableGroupBox>;
     new WidgetProducer<Gui::PrefRadioButton>;
     new WidgetProducer<Gui::PrefSlider>;
     new WidgetProducer<Gui::PrefFileChooser>;

--- a/src/Mod/BIM/Resources/ui/preferences-ifc-export.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-ifc-export.ui
@@ -407,7 +407,7 @@ However, at FreeCAD, we believe having a building should not be mandatory, and t
        </widget>
       </item>
       <item>
-       <widget class="QGroupBox" name="groupBox_ExportFreeCADGroups">
+       <widget class="Gui::PrefCheckableGroupBox" name="groupBox_ExportFreeCADGroups">
         <property name="toolTip">
          <string>If not checked, standard FreeCAD groups (App::DocumentObjectGroup) will not be exported as IfcGroup or IfcElementAssembly.\nTheir children will be re-parented to the container of the skipped group in the IFC structure.</string>
         </property>

--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -696,6 +696,11 @@ def _get_param_dictionary():
                 elif att_class == "Gui::PrefFontBox":
                     path, entry, value = _param_from_PrefFontBox(widget)
                     typ = "string"
+                elif att_class == "Gui::PrefCheckableGroupBox":
+                    # It's a boolean preference, so we can reuse the parsing logic
+                    # from _param_from_PrefCheckBox, which looks for <property name="checked">.
+                    path, entry, value = _param_from_PrefCheckBox(widget)
+                    typ = "bool"
 
                 if path is not None:
                     if path in param_dict:


### PR DESCRIPTION
Create a custom widget (`Gui::PrefCheckableGroupBox`), in the style of `Gui::PrefCheckBox` for checkable QGroupBoxes. This new widget enables developers to use QGroupBoxes to both save/restore parameters as all other custom FreeCAD preference widgets, and to conditionally enable/disable the widgets they contain.

It's a general approach and a prerequisite to fix the linked issue. There, the IFC Exporter preference page uses this new widget to conditionally control the status of group export preferences, depending on whether groups are ignored or not at export time.

Before, the parameter associated with the groups setting was not saved to disk, and functioned out of sheer luck. This was because of the fact that the default setting worked through masking an error by negating the parameter's value, and returning a bool. If the negation hadn't been there, a string containing an error description would have been returned, unexpectedly.

## Issues
Fixes: https://github.com/FreeCAD/FreeCAD/issues/21919

## Additional notes

With the new widget, the `loadSettings` and `saveSettings` in places such as added in https://github.com/FreeCAD/FreeCAD/pull/15207 could probably be removed.


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
