### PR TITLE
Gui: Fix crash when creating a LCS

### DIFF
--- a/src/Gui/ViewProviderCoordinateSystem.cpp
+++ b/src/Gui/ViewProviderCoordinateSystem.cpp
@@ -227,7 +227,7 @@ bool ViewProviderCoordinateSystem::onDelete(const std::vector<std::string> &)
         return false;
     }
 
-    if (lcs && !lcs->getInList().empty()) {
+    if (lcs->is<App::Origin>() && !lcs->getInList().empty()) {
         // Do not allow deletion of origin objects that are not lost.
         return false;
     }

--- a/src/Gui/ViewProviderCoordinateSystem.h
+++ b/src/Gui/ViewProviderCoordinateSystem.h
@@ -100,7 +100,6 @@ public:
     static const uint32_t defaultColor = 0x3296faff;
 
 protected:
-    void updateData(const App::Property*) override;
     bool onDelete(const std::vector<std::string> &) override;
 
 private:


### PR DESCRIPTION
Cherry pick (with cleanup) of @wwmayer's fix in 3e578cb

From commit:
> This is a left-over of the regressions introduced with PR 18126.
> Thanks to some moderinization of the code base and replacing static with dynamic casts undefined behaviour
> has changed to well-defined behaviour but now unchecked null pointers.
> 
> This change does some extra null pointer checks and uses the now correct types for down casting.
> 
> Hint: Upstream still uses many static casts here that already cause undefined behaviour when creating a LCS.
> This could be the reason for the possible crashes when deleting a LCS as described in #20261