### PR TITLE
DXF: do not ignore the setting that controls importing paper layouts

### DIFF
--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -207,6 +207,10 @@ void ImpExpDxfRead::OnReadLine(const Base::Vector3d& start,
                                const Base::Vector3d& end,
                                bool /*hidden*/)
 {
+    if (shouldSkipEntity()) {
+        return;
+    }
+
     gp_Pnt p0 = makePoint(start);
     gp_Pnt p1 = makePoint(end);
     if (p0.IsEqual(p1, 0.00000001)) {
@@ -219,6 +223,10 @@ void ImpExpDxfRead::OnReadLine(const Base::Vector3d& start,
 
 void ImpExpDxfRead::OnReadPoint(const Base::Vector3d& start)
 {
+    if (shouldSkipEntity()) {
+        return;
+    }
+
     Collector->AddObject(BRepBuilderAPI_MakeVertex(makePoint(start)).Vertex(), "Point");
 }
 
@@ -229,6 +237,10 @@ void ImpExpDxfRead::OnReadArc(const Base::Vector3d& start,
                               bool dir,
                               bool /*hidden*/)
 {
+    if (shouldSkipEntity()) {
+        return;
+    }
+
     gp_Pnt p0 = makePoint(start);
     gp_Pnt p1 = makePoint(end);
     gp_Dir up(0, 0, 1);
@@ -251,6 +263,10 @@ void ImpExpDxfRead::OnReadCircle(const Base::Vector3d& start,
                                  bool dir,
                                  bool /*hidden*/)
 {
+    if (shouldSkipEntity()) {
+        return;
+    }
+
     gp_Pnt p0 = makePoint(start);
     gp_Dir up(0, 0, 1);
     if (!dir) {
@@ -393,6 +409,10 @@ void ImpExpDxfRead::OnReadEllipse(const Base::Vector3d& center,
                                   bool dir)
 // NOLINTEND(bugprone-easily-swappable-parameters)
 {
+    if (shouldSkipEntity()) {
+        return;
+    }
+
     gp_Dir up(0, 0, 1);
     if (!dir) {
         up = -up;
@@ -414,6 +434,10 @@ void ImpExpDxfRead::OnReadText(const Base::Vector3d& point,
                                const std::string& text,
                                const double rotation)
 {
+    if (shouldSkipEntity()) {
+        return;
+    }
+
     // Note that our parameters do not contain all the information needed to properly orient the
     // text. As a result the text will always appear on the XY plane
     if (m_importAnnotations) {
@@ -454,6 +478,10 @@ void ImpExpDxfRead::OnReadInsert(const Base::Vector3d& point,
                                  const std::string& name,
                                  double rotation)
 {
+    if (shouldSkipEntity()) {
+        return;
+    }
+
     Collector->AddInsert(point, scale, name, rotation);
 }
 void ImpExpDxfRead::ExpandInsert(const std::string& name,
@@ -534,6 +562,10 @@ void ImpExpDxfRead::OnReadDimension(const Base::Vector3d& start,
                                     const Base::Vector3d& point,
                                     double /*rotation*/)
 {
+    if (shouldSkipEntity()) {
+        return;
+    }
+
     if (m_importAnnotations) {
         auto makeDimension =
             [this, start, end, point](const Base::Matrix4D& transform) -> App::FeaturePython* {
@@ -576,6 +608,10 @@ void ImpExpDxfRead::OnReadDimension(const Base::Vector3d& start,
 }
 void ImpExpDxfRead::OnReadPolyline(std::list<VertexInfo>& vertices, int flags)
 {
+    if (shouldSkipEntity()) {
+        return;
+    }
+
     std::map<CDxfRead::CommonEntityAttributes, std::list<TopoDS_Shape>> ShapesToCombine;
     {
         // TODO: Currently ExpandPolyline calls OnReadArc etc to generate the pieces, and these

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -108,6 +108,11 @@ public:
     void setOptions();
 
 private:
+    bool shouldSkipEntity() const
+    {
+        // This entity is in paper space, and the user setting says to ignore it.
+        return !m_importPaperSpaceEntities && m_entityAttributes.m_paperSpace;
+    }
     static gp_Pnt makePoint(const Base::Vector3d& point3d)
     {
         return {point3d.x, point3d.y, point3d.z};


### PR DESCRIPTION
The C++ DXF importer was not respecting the user preference to ignore entities from Paper Space layouts. This resulted in geometry from both Model Space and Paper Space being imported together.

This PR introduces a check at the beginning of each entity import function. The check verifies if an entity belongs to Paper Space and, if the user has disabled layout import, skips the creation of the corresponding FreeCAD object.

## Background information

The DXF format separates geometry into two different environments: **Model Space** and **Paper Space**.

- **Model Space** is where the primary 1:1 scale design geometry is drawn. A DXF file can have only one model space.
- **Paper Space** is a layout environment for printing, containing elements like title blocks and scaled viewports that look into Model Space. This is also often called "Layout" space. For most cases, importing it into FreeCAD will not be desirable or needed. A DXF file can have multiple paper spaces.

Entities are designated to one of these spaces via the DXF group code 67. A value of 1 indicates the entity belongs to Paper Space, while its absence or a value of 0 implies Model Space.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
Fixes: https://github.com/FreeCAD/FreeCAD/issues/21520
