### PR TITLE
[BIM][Draft][CAM] preparation for deprecation of QCheckBox…

### DIFF
--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -159,9 +159,9 @@ class BIM_Classification:
         self.form.treeClass.itemDoubleClicked.connect(self.apply)
         self.form.search.up.connect(self.onUpArrow)
         self.form.search.down.connect(self.onDownArrow)
-        if hasattr(self.form.onlyVisible, "checkStateChanged"):
+        if hasattr(self.form.onlyVisible, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.onlyVisible.checkStateChanged.connect(self.onVisible)
-        else:
+        else: # Qt version < 6.7.0
             self.form.onlyVisible.stateChanged.connect(self.onVisible)
 
         # center the dialog over FreeCAD window

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -159,7 +159,10 @@ class BIM_Classification:
         self.form.treeClass.itemDoubleClicked.connect(self.apply)
         self.form.search.up.connect(self.onUpArrow)
         self.form.search.down.connect(self.onDownArrow)
-        self.form.onlyVisible.stateChanged.connect(self.onVisible)
+        if hasattr(self.form.onlyVisible, "checkStateChanged"):
+            self.form.onlyVisible.checkStateChanged.connect(self.onVisible)
+        else:
+            self.form.onlyVisible.stateChanged.connect(self.onVisible)
 
         # center the dialog over FreeCAD window
         mw = FreeCADGui.getMainWindow()

--- a/src/Mod/BIM/bimcommands/BimIfcElements.py
+++ b/src/Mod/BIM/bimcommands/BimIfcElements.py
@@ -95,7 +95,10 @@ class BIM_IfcElements:
                 )
         self.form.groupMode.currentIndexChanged.connect(self.update)
         self.form.tree.clicked.connect(self.onClickTree)
-        self.form.onlyVisible.stateChanged.connect(self.update)
+        if hasattr(self.form.onlyVisible, "checkStateChanged"):
+            self.form.onlyVisible.checkStateChanged.connect(self.update)
+        else:
+            self.form.onlyVisible.stateChanged.connect(self.update)
         self.form.buttonBox.accepted.connect(self.accept)
         self.form.globalMode.currentIndexChanged.connect(self.onObjectTypeChanged)
         self.form.globalMaterial.currentIndexChanged.connect(self.onMaterialChanged)

--- a/src/Mod/BIM/bimcommands/BimIfcElements.py
+++ b/src/Mod/BIM/bimcommands/BimIfcElements.py
@@ -95,9 +95,9 @@ class BIM_IfcElements:
                 )
         self.form.groupMode.currentIndexChanged.connect(self.update)
         self.form.tree.clicked.connect(self.onClickTree)
-        if hasattr(self.form.onlyVisible, "checkStateChanged"):
+        if hasattr(self.form.onlyVisible, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.onlyVisible.checkStateChanged.connect(self.update)
-        else:
+        else: # Qt version < 6.7.0
             self.form.onlyVisible.stateChanged.connect(self.update)
         self.form.buttonBox.accepted.connect(self.accept)
         self.form.globalMode.currentIndexChanged.connect(self.onObjectTypeChanged)

--- a/src/Mod/BIM/bimcommands/BimIfcProperties.py
+++ b/src/Mod/BIM/bimcommands/BimIfcProperties.py
@@ -139,11 +139,11 @@ class BIM_IfcProperties:
         # connect signals
         self.form.tree.selectionModel().selectionChanged.connect(self.updateProperties)
         self.form.groupMode.currentIndexChanged.connect(self.update)
-        if hasattr(self.form.onlyVisible, "checkStateChanged"):
+        if hasattr(self.form.onlyVisible, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.onlyVisible.checkStateChanged.connect(self.update)
             self.form.onlySelected.checkStateChanged.connect(self.onSelected)
             self.form.onlyMatches.checkStateChanged.connect(self.update)
-        else:
+        else: # Qt version < 6.7.0
             self.form.onlyVisible.stateChanged.connect(self.update)
             self.form.onlySelected.stateChanged.connect(self.onSelected)
             self.form.onlyMatches.stateChanged.connect(self.update)

--- a/src/Mod/BIM/bimcommands/BimIfcProperties.py
+++ b/src/Mod/BIM/bimcommands/BimIfcProperties.py
@@ -139,10 +139,15 @@ class BIM_IfcProperties:
         # connect signals
         self.form.tree.selectionModel().selectionChanged.connect(self.updateProperties)
         self.form.groupMode.currentIndexChanged.connect(self.update)
-        self.form.onlyVisible.stateChanged.connect(self.onVisible)
-        self.form.onlySelected.stateChanged.connect(self.onSelected)
+        if hasattr(self.form.onlyVisible, "checkStateChanged"):
+            self.form.onlyVisible.checkStateChanged.connect(self.update)
+            self.form.onlySelected.checkStateChanged.connect(self.onSelected)
+            self.form.onlyMatches.checkStateChanged.connect(self.update)
+        else:
+            self.form.onlyVisible.stateChanged.connect(self.update)
+            self.form.onlySelected.stateChanged.connect(self.onSelected)
+            self.form.onlyMatches.stateChanged.connect(self.update)
         self.form.buttonBox.accepted.connect(self.accept)
-        self.form.onlyMatches.stateChanged.connect(self.update)
         self.form.searchField.currentIndexChanged.connect(self.update)
         self.form.searchField.editTextChanged.connect(self.update)
         self.form.comboProperty.currentIndexChanged.connect(self.addProperty)

--- a/src/Mod/BIM/bimcommands/BimIfcQuantities.py
+++ b/src/Mod/BIM/bimcommands/BimIfcQuantities.py
@@ -122,7 +122,10 @@ class BIM_IfcQuantities:
         self.qmodel.dataChanged.connect(self.setChecked)
         self.form.buttonBox.accepted.connect(self.accept)
         self.form.quantities.clicked.connect(self.onClickTree)
-        self.form.onlyVisible.stateChanged.connect(self.update)
+        if hasattr(self.form.onlyVisible, "checkStateChanged"):
+            self.form.onlyVisible.checkStateChanged.connect(self.update)
+        else:
+            self.form.onlyVisible.stateChanged.connect(self.update)
         self.form.buttonRefresh.clicked.connect(self.update)
         self.form.buttonApply.clicked.connect(self.add_qto)
 

--- a/src/Mod/BIM/bimcommands/BimIfcQuantities.py
+++ b/src/Mod/BIM/bimcommands/BimIfcQuantities.py
@@ -122,9 +122,9 @@ class BIM_IfcQuantities:
         self.qmodel.dataChanged.connect(self.setChecked)
         self.form.buttonBox.accepted.connect(self.accept)
         self.form.quantities.clicked.connect(self.onClickTree)
-        if hasattr(self.form.onlyVisible, "checkStateChanged"):
+        if hasattr(self.form.onlyVisible, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.onlyVisible.checkStateChanged.connect(self.update)
-        else:
+        else: # Qt version < 6.7.0
             self.form.onlyVisible.stateChanged.connect(self.update)
         self.form.buttonRefresh.clicked.connect(self.update)
         self.form.buttonApply.clicked.connect(self.add_qto)

--- a/src/Mod/BIM/bimcommands/BimWall.py
+++ b/src/Mod/BIM/bimcommands/BimWall.py
@@ -358,7 +358,10 @@ class Arch_Wall:
         inputHeight.valueChanged.connect(self.setHeight)
         comboAlignment.currentIndexChanged.connect(self.setAlign)
         inputOffset.valueChanged.connect(self.setOffset)
-        checkboxUseSketches.stateChanged.connect(self.setUseSketch)
+        if hasattr(checkboxUseSketches, "checkStateChanged"):
+            checkboxUseSketches.checkStateChanged.connect(self.setUseSketch)
+        else:
+            checkboxUseSketches.stateChanged.connect(self.setUseSketch)
         comboWallPresets.currentIndexChanged.connect(self.setMat)
 
         # Define the workflow of the input fields:

--- a/src/Mod/BIM/bimcommands/BimWall.py
+++ b/src/Mod/BIM/bimcommands/BimWall.py
@@ -358,9 +358,9 @@ class Arch_Wall:
         inputHeight.valueChanged.connect(self.setHeight)
         comboAlignment.currentIndexChanged.connect(self.setAlign)
         inputOffset.valueChanged.connect(self.setOffset)
-        if hasattr(checkboxUseSketches, "checkStateChanged"):
+        if hasattr(checkboxUseSketches, "checkStateChanged"): # Qt version >= 6.7.0
             checkboxUseSketches.checkStateChanged.connect(self.setUseSketch)
-        else:
+        else: # Qt version < 6.7.0
             checkboxUseSketches.stateChanged.connect(self.setUseSketch)
         comboWallPresets.currentIndexChanged.connect(self.setMat)
 

--- a/src/Mod/BIM/bimcommands/BimWindow.py
+++ b/src/Mod/BIM/bimcommands/BimWindow.py
@@ -315,9 +315,9 @@ class Arch_Window:
         include = QtGui.QCheckBox(translate("Arch","Auto include in host object"))
         include.setChecked(True)
         grid.addWidget(include,0,0,1,2)
-        if hasattr(include, "checkStateChanged"):
+        if hasattr(include, "checkStateChanged"): # Qt version >= 6.7.0
             include.checkStateChanged.connect(self.setInclude)
-        else:
+        else: # Qt version < 6.7.0
             include.stateChanged.connect(self.setInclude)
 
         # sill height

--- a/src/Mod/BIM/bimcommands/BimWindow.py
+++ b/src/Mod/BIM/bimcommands/BimWindow.py
@@ -315,7 +315,10 @@ class Arch_Window:
         include = QtGui.QCheckBox(translate("Arch","Auto include in host object"))
         include.setChecked(True)
         grid.addWidget(include,0,0,1,2)
-        include.stateChanged.connect(self.setInclude)
+        if hasattr(include, "checkStateChanged"):
+            include.checkStateChanged.connect(self.setInclude)
+        else:
+            include.stateChanged.connect(self.setInclude)
 
         # sill height
         labels = QtGui.QLabel(translate("Arch","Sill height"))

--- a/src/Mod/CAM/Path/Base/Gui/PreferencesAdvanced.py
+++ b/src/Mod/CAM/Path/Base/Gui/PreferencesAdvanced.py
@@ -33,10 +33,10 @@ else:
 class AdvancedPreferencesPage:
     def __init__(self, parent=None):
         self.form = FreeCADGui.PySideUic.loadUi(":preferences/Advanced.ui")
-        if hasattr(self.form.WarningSuppressAllSpeeds, "checkStateChanged"):
+        if hasattr(self.form.WarningSuppressAllSpeeds, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.WarningSuppressAllSpeeds.checkStateChanged.connect(self.updateSelection)
             self.form.EnableAdvancedOCLFeatures.checkStateChanged.connect(self.updateSelection)
-        else:
+        else: # Qt version < 6.7.0
             self.form.WarningSuppressAllSpeeds.stateChanged.connect(self.updateSelection)
             self.form.EnableAdvancedOCLFeatures.stateChanged.connect(self.updateSelection)
 

--- a/src/Mod/CAM/Path/Base/Gui/PreferencesAdvanced.py
+++ b/src/Mod/CAM/Path/Base/Gui/PreferencesAdvanced.py
@@ -33,8 +33,12 @@ else:
 class AdvancedPreferencesPage:
     def __init__(self, parent=None):
         self.form = FreeCADGui.PySideUic.loadUi(":preferences/Advanced.ui")
-        self.form.WarningSuppressAllSpeeds.stateChanged.connect(self.updateSelection)
-        self.form.EnableAdvancedOCLFeatures.stateChanged.connect(self.updateSelection)
+        if hasattr(self.form.WarningSuppressAllSpeeds, "checkStateChanged"):
+            self.form.WarningSuppressAllSpeeds.checkStateChanged.connect(self.updateSelection)
+            self.form.EnableAdvancedOCLFeatures.checkStateChanged.connect(self.updateSelection)
+        else:
+            self.form.WarningSuppressAllSpeeds.stateChanged.connect(self.updateSelection)
+            self.form.EnableAdvancedOCLFeatures.stateChanged.connect(self.updateSelection)
 
     def saveSettings(self):
         Path.Preferences.setPreferencesAdvanced(

--- a/src/Mod/CAM/Path/Base/Gui/PreferencesAdvanced.py
+++ b/src/Mod/CAM/Path/Base/Gui/PreferencesAdvanced.py
@@ -33,10 +33,10 @@ else:
 class AdvancedPreferencesPage:
     def __init__(self, parent=None):
         self.form = FreeCADGui.PySideUic.loadUi(":preferences/Advanced.ui")
-        if hasattr(self.form.WarningSuppressAllSpeeds, "checkStateChanged"): # Qt version >= 6.7.0
+        if hasattr(self.form.WarningSuppressAllSpeeds, "checkStateChanged"):  # Qt version >= 6.7.0
             self.form.WarningSuppressAllSpeeds.checkStateChanged.connect(self.updateSelection)
             self.form.EnableAdvancedOCLFeatures.checkStateChanged.connect(self.updateSelection)
-        else: # Qt version < 6.7.0
+        else:  # Qt version < 6.7.0
             self.form.WarningSuppressAllSpeeds.stateChanged.connect(self.updateSelection)
             self.form.EnableAdvancedOCLFeatures.stateChanged.connect(self.updateSelection)
 

--- a/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
@@ -182,7 +182,10 @@ class TaskPanel(object):
         self.form.stockInside.setChecked(self.obj.Inside)
 
         self.form.stock.currentIndexChanged.connect(self.updateStockEditor)
-        self.form.stockInside.stateChanged.connect(self.setDirty)
+        if hasattr(self.form.stockInside, "checkStateChanged"):
+            self.form.stockInside.checkStateChanged.connect(self.setDirty)
+        else:
+            self.form.stockInside.stateChanged.connect(self.setDirty)
         self.form.stockExtXneg.textChanged.connect(self.setDirty)
         self.form.stockExtXpos.textChanged.connect(self.setDirty)
         self.form.stockExtYneg.textChanged.connect(self.setDirty)

--- a/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
@@ -182,9 +182,9 @@ class TaskPanel(object):
         self.form.stockInside.setChecked(self.obj.Inside)
 
         self.form.stock.currentIndexChanged.connect(self.updateStockEditor)
-        if hasattr(self.form.stockInside, "checkStateChanged"):
+        if hasattr(self.form.stockInside, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.stockInside.checkStateChanged.connect(self.setDirty)
-        else:
+        else: # Qt version < 6.7.0
             self.form.stockInside.stateChanged.connect(self.setDirty)
         self.form.stockExtXneg.textChanged.connect(self.setDirty)
         self.form.stockExtXpos.textChanged.connect(self.setDirty)

--- a/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
@@ -182,9 +182,9 @@ class TaskPanel(object):
         self.form.stockInside.setChecked(self.obj.Inside)
 
         self.form.stock.currentIndexChanged.connect(self.updateStockEditor)
-        if hasattr(self.form.stockInside, "checkStateChanged"): # Qt version >= 6.7.0
+        if hasattr(self.form.stockInside, "checkStateChanged"):  # Qt version >= 6.7.0
             self.form.stockInside.checkStateChanged.connect(self.setDirty)
-        else: # Qt version < 6.7.0
+        else:  # Qt version < 6.7.0
             self.form.stockInside.stateChanged.connect(self.setDirty)
         self.form.stockExtXneg.textChanged.connect(self.setDirty)
         self.form.stockExtXpos.textChanged.connect(self.setDirty)

--- a/src/Mod/CAM/Path/Op/Gui/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Gui/Adaptive.py
@@ -68,12 +68,12 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.StockToLeave.valueChanged)
         signals.append(self.form.ZStockToLeave.valueChanged)
         signals.append(self.form.coolantController.currentIndexChanged)
-        if hasattr(self.form.ForceInsideOut, "checkStateChanged"): # Qt version >= 6.7.0
+        if hasattr(self.form.ForceInsideOut, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.ForceInsideOut.checkStateChanged)
             signals.append(self.form.FinishingProfile.checkStateChanged)
             signals.append(self.form.useOutline.checkStateChanged)
             signals.append(self.form.orderCutsByRegion.checkStateChanged)
-        else: # Qt version < 6.7.0
+        else:  # Qt version < 6.7.0
             signals.append(self.form.ForceInsideOut.stateChanged)
             signals.append(self.form.FinishingProfile.stateChanged)
             signals.append(self.form.useOutline.stateChanged)

--- a/src/Mod/CAM/Path/Op/Gui/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Gui/Adaptive.py
@@ -68,12 +68,12 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.StockToLeave.valueChanged)
         signals.append(self.form.ZStockToLeave.valueChanged)
         signals.append(self.form.coolantController.currentIndexChanged)
-        if hasattr(self.form.ForceInsideOut, "checkStateChanged"):
+        if hasattr(self.form.ForceInsideOut, "checkStateChanged"): # Qt version >= 6.7.0
             signals.append(self.form.ForceInsideOut.checkStateChanged)
             signals.append(self.form.FinishingProfile.checkStateChanged)
             signals.append(self.form.useOutline.checkStateChanged)
             signals.append(self.form.orderCutsByRegion.checkStateChanged)
-        else:
+        else: # Qt version < 6.7.0
             signals.append(self.form.ForceInsideOut.stateChanged)
             signals.append(self.form.FinishingProfile.stateChanged)
             signals.append(self.form.useOutline.stateChanged)

--- a/src/Mod/CAM/Path/Op/Gui/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Gui/Adaptive.py
@@ -68,10 +68,16 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.StockToLeave.valueChanged)
         signals.append(self.form.ZStockToLeave.valueChanged)
         signals.append(self.form.coolantController.currentIndexChanged)
-        signals.append(self.form.ForceInsideOut.stateChanged)
-        signals.append(self.form.FinishingProfile.stateChanged)
-        signals.append(self.form.useOutline.stateChanged)
-        signals.append(self.form.orderCutsByRegion.stateChanged)
+        if hasattr(self.form.ForceInsideOut, "checkStateChanged"):
+            signals.append(self.form.ForceInsideOut.checkStateChanged)
+            signals.append(self.form.FinishingProfile.checkStateChanged)
+            signals.append(self.form.useOutline.checkStateChanged)
+            signals.append(self.form.orderCutsByRegion.checkStateChanged)
+        else:
+            signals.append(self.form.ForceInsideOut.stateChanged)
+            signals.append(self.form.FinishingProfile.stateChanged)
+            signals.append(self.form.useOutline.stateChanged)
+            signals.append(self.form.orderCutsByRegion.stateChanged)
         signals.append(self.form.StopButton.toggled)
         return signals
 

--- a/src/Mod/CAM/Path/Op/Gui/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Gui/Drilling.py
@@ -188,15 +188,23 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         signals.append(self.form.peckRetractHeight.editingFinished)
         signals.append(self.form.peckDepth.editingFinished)
         signals.append(self.form.dwellTime.editingFinished)
-        signals.append(self.form.dwellEnabled.stateChanged)
-        signals.append(self.form.peckEnabled.stateChanged)
-        signals.append(self.form.chipBreakEnabled.stateChanged)
+        if hasattr(self.form.dwellEnabled, "checkStateChanged"):
+            signals.append(self.form.dwellEnabled.checkStateChanged)
+            signals.append(self.form.peckEnabled.checkStateChanged)
+            signals.append(self.form.chipBreakEnabled.checkStateChanged)
+        else:
+            signals.append(self.form.dwellEnabled.stateChanged)
+            signals.append(self.form.peckEnabled.stateChanged)
+            signals.append(self.form.chipBreakEnabled.stateChanged)
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.coolantController.currentIndexChanged)
         signals.append(self.form.ExtraOffset.currentIndexChanged)
-        signals.append(self.form.KeepToolDownEnabled.stateChanged)
-        signals.append(self.form.feedRetractEnabled.stateChanged)
-
+        if hasattr(self.form.KeepToolDownEnabled, "checkStateChanged"):
+            signals.append(self.form.KeepToolDownEnabled.checkStateChanged)
+            signals.append(self.form.feedRetractEnabled.checkStateChanged)
+        else:
+            signals.append(self.form.KeepToolDownEnabled.stateChanged)
+            signals.append(self.form.feedRetractEnabled.stateChanged)
         return signals
 
     def updateData(self, obj, prop):

--- a/src/Mod/CAM/Path/Op/Gui/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Gui/Drilling.py
@@ -188,21 +188,21 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         signals.append(self.form.peckRetractHeight.editingFinished)
         signals.append(self.form.peckDepth.editingFinished)
         signals.append(self.form.dwellTime.editingFinished)
-        if hasattr(self.form.dwellEnabled, "checkStateChanged"): # Qt version >= 6.7.0
+        if hasattr(self.form.dwellEnabled, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.dwellEnabled.checkStateChanged)
             signals.append(self.form.peckEnabled.checkStateChanged)
             signals.append(self.form.chipBreakEnabled.checkStateChanged)
-        else: # Qt version < 6.7.0
+        else:  # Qt version < 6.7.0
             signals.append(self.form.dwellEnabled.stateChanged)
             signals.append(self.form.peckEnabled.stateChanged)
             signals.append(self.form.chipBreakEnabled.stateChanged)
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.coolantController.currentIndexChanged)
         signals.append(self.form.ExtraOffset.currentIndexChanged)
-        if hasattr(self.form.KeepToolDownEnabled, "checkStateChanged"): # Qt version >= 6.7.0
+        if hasattr(self.form.KeepToolDownEnabled, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.KeepToolDownEnabled.checkStateChanged)
             signals.append(self.form.feedRetractEnabled.checkStateChanged)
-        else: # Qt version < 6.7.0
+        else:  # Qt version < 6.7.0
             signals.append(self.form.KeepToolDownEnabled.stateChanged)
             signals.append(self.form.feedRetractEnabled.stateChanged)
         return signals

--- a/src/Mod/CAM/Path/Op/Gui/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Gui/Drilling.py
@@ -188,21 +188,21 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         signals.append(self.form.peckRetractHeight.editingFinished)
         signals.append(self.form.peckDepth.editingFinished)
         signals.append(self.form.dwellTime.editingFinished)
-        if hasattr(self.form.dwellEnabled, "checkStateChanged"):
+        if hasattr(self.form.dwellEnabled, "checkStateChanged"): # Qt version >= 6.7.0
             signals.append(self.form.dwellEnabled.checkStateChanged)
             signals.append(self.form.peckEnabled.checkStateChanged)
             signals.append(self.form.chipBreakEnabled.checkStateChanged)
-        else:
+        else: # Qt version < 6.7.0
             signals.append(self.form.dwellEnabled.stateChanged)
             signals.append(self.form.peckEnabled.stateChanged)
             signals.append(self.form.chipBreakEnabled.stateChanged)
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.coolantController.currentIndexChanged)
         signals.append(self.form.ExtraOffset.currentIndexChanged)
-        if hasattr(self.form.KeepToolDownEnabled, "checkStateChanged"):
+        if hasattr(self.form.KeepToolDownEnabled, "checkStateChanged"): # Qt version >= 6.7.0
             signals.append(self.form.KeepToolDownEnabled.checkStateChanged)
             signals.append(self.form.feedRetractEnabled.checkStateChanged)
-        else:
+        else: # Qt version < 6.7.0
             signals.append(self.form.KeepToolDownEnabled.stateChanged)
             signals.append(self.form.feedRetractEnabled.stateChanged)
         return signals

--- a/src/Mod/CAM/Path/Op/Gui/Profile.py
+++ b/src/Mod/CAM/Path/Op/Gui/Profile.py
@@ -125,13 +125,13 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.extraOffset.editingFinished)
         signals.append(self.form.numPasses.editingFinished)
         signals.append(self.form.stepover.editingFinished)
-        if hasattr(self.form.useCompensation, "checkStateChanged"): # Qt version >= 6.7.0
+        if hasattr(self.form.useCompensation, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.useCompensation.checkStateChanged)
             signals.append(self.form.useStartPoint.checkStateChanged)
             signals.append(self.form.processHoles.checkStateChanged)
             signals.append(self.form.processPerimeter.checkStateChanged)
             signals.append(self.form.processCircles.checkStateChanged)
-        else: # Qt version < 6.7.0
+        else:  # Qt version < 6.7.0
             signals.append(self.form.useCompensation.stateChanged)
             signals.append(self.form.useStartPoint.stateChanged)
             signals.append(self.form.processHoles.stateChanged)
@@ -166,9 +166,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.stepover.setEnabled(self.obj.NumPasses > 1)
 
     def registerSignalHandlers(self, obj):
-        if hasattr(self.form.useCompensation, "checkStateChanged"): # Qt version >= 6.7.0
+        if hasattr(self.form.useCompensation, "checkStateChanged"):  # Qt version >= 6.7.0
             self.form.useCompensation.checkStateChanged.connect(self.updateVisibility)
-        else: # Qt version < 6.7.0
+        else:  # Qt version < 6.7.0
             self.form.useCompensation.stateChanged.connect(self.updateVisibility)
         self.form.numPasses.editingFinished.connect(self.updateVisibility)
 

--- a/src/Mod/CAM/Path/Op/Gui/Profile.py
+++ b/src/Mod/CAM/Path/Op/Gui/Profile.py
@@ -125,13 +125,13 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.extraOffset.editingFinished)
         signals.append(self.form.numPasses.editingFinished)
         signals.append(self.form.stepover.editingFinished)
-        if hasattr(self.form.useCompensation, "checkStateChanged"):
+        if hasattr(self.form.useCompensation, "checkStateChanged"): # Qt version >= 6.7.0
             signals.append(self.form.useCompensation.checkStateChanged)
             signals.append(self.form.useStartPoint.checkStateChanged)
             signals.append(self.form.processHoles.checkStateChanged)
             signals.append(self.form.processPerimeter.checkStateChanged)
             signals.append(self.form.processCircles.checkStateChanged)
-        else:
+        else: # Qt version < 6.7.0
             signals.append(self.form.useCompensation.stateChanged)
             signals.append(self.form.useStartPoint.stateChanged)
             signals.append(self.form.processHoles.stateChanged)
@@ -166,9 +166,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.stepover.setEnabled(self.obj.NumPasses > 1)
 
     def registerSignalHandlers(self, obj):
-        if hasattr(self.form.useCompensation, "checkStateChanged"):
+        if hasattr(self.form.useCompensation, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.useCompensation.checkStateChanged.connect(self.updateVisibility)
-        else:
+        else: # Qt version < 6.7.0
             self.form.useCompensation.stateChanged.connect(self.updateVisibility)
         self.form.numPasses.editingFinished.connect(self.updateVisibility)
 

--- a/src/Mod/CAM/Path/Op/Gui/Profile.py
+++ b/src/Mod/CAM/Path/Op/Gui/Profile.py
@@ -125,11 +125,18 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.extraOffset.editingFinished)
         signals.append(self.form.numPasses.editingFinished)
         signals.append(self.form.stepover.editingFinished)
-        signals.append(self.form.useCompensation.stateChanged)
-        signals.append(self.form.useStartPoint.stateChanged)
-        signals.append(self.form.processHoles.stateChanged)
-        signals.append(self.form.processPerimeter.stateChanged)
-        signals.append(self.form.processCircles.stateChanged)
+        if hasattr(self.form.useCompensation, "checkStateChanged"):
+            signals.append(self.form.useCompensation.checkStateChanged)
+            signals.append(self.form.useStartPoint.checkStateChanged)
+            signals.append(self.form.processHoles.checkStateChanged)
+            signals.append(self.form.processPerimeter.checkStateChanged)
+            signals.append(self.form.processCircles.checkStateChanged)
+        else:
+            signals.append(self.form.useCompensation.stateChanged)
+            signals.append(self.form.useStartPoint.stateChanged)
+            signals.append(self.form.processHoles.stateChanged)
+            signals.append(self.form.processPerimeter.stateChanged)
+            signals.append(self.form.processCircles.stateChanged)
 
         return signals
 
@@ -159,7 +166,10 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.stepover.setEnabled(self.obj.NumPasses > 1)
 
     def registerSignalHandlers(self, obj):
-        self.form.useCompensation.stateChanged.connect(self.updateVisibility)
+        if hasattr(self.form.useCompensation, "checkStateChanged"):
+            self.form.useCompensation.checkStateChanged.connect(self.updateVisibility)
+        else:
+            self.form.useCompensation.stateChanged.connect(self.updateVisibility)
         self.form.numPasses.editingFinished.connect(self.updateVisibility)
 
 

--- a/src/Mod/CAM/Path/Op/Gui/Slot.py
+++ b/src/Mod/CAM/Path/Op/Gui/Slot.py
@@ -142,9 +142,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.geo2Reference.currentIndexChanged)
         signals.append(self.form.layerMode.currentIndexChanged)
         signals.append(self.form.pathOrientation.currentIndexChanged)
-        if hasattr(self.form.reverseDirection, "checkStateChanged"): # Qt version >= 6.7.0
+        if hasattr(self.form.reverseDirection, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.reverseDirection.checkStateChanged)
-        else: # Qt version < 6.7.0
+        else:  # Qt version < 6.7.0
             signals.append(self.form.reverseDirection.stateChanged)
         return signals
 

--- a/src/Mod/CAM/Path/Op/Gui/Slot.py
+++ b/src/Mod/CAM/Path/Op/Gui/Slot.py
@@ -142,9 +142,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.geo2Reference.currentIndexChanged)
         signals.append(self.form.layerMode.currentIndexChanged)
         signals.append(self.form.pathOrientation.currentIndexChanged)
-        if hasattr(self.form.reverseDirection, "checkStateChanged"):
+        if hasattr(self.form.reverseDirection, "checkStateChanged"): # Qt version >= 6.7.0
             signals.append(self.form.reverseDirection.checkStateChanged)
-        else:
+        else: # Qt version < 6.7.0
             signals.append(self.form.reverseDirection.stateChanged)
         return signals
 

--- a/src/Mod/CAM/Path/Op/Gui/Slot.py
+++ b/src/Mod/CAM/Path/Op/Gui/Slot.py
@@ -142,7 +142,10 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.geo2Reference.currentIndexChanged)
         signals.append(self.form.layerMode.currentIndexChanged)
         signals.append(self.form.pathOrientation.currentIndexChanged)
-        signals.append(self.form.reverseDirection.stateChanged)
+        if hasattr(self.form.reverseDirection, "checkStateChanged"):
+            signals.append(self.form.reverseDirection.checkStateChanged)
+        else:
+            signals.append(self.form.reverseDirection.stateChanged)
         return signals
 
     def updateVisibility(self, sentObj=None):

--- a/src/Mod/CAM/Path/Op/Gui/Surface.py
+++ b/src/Mod/CAM/Path/Op/Gui/Surface.py
@@ -217,12 +217,12 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.depthOffset.editingFinished)
         signals.append(self.form.stepOver.editingFinished)
         signals.append(self.form.sampleInterval.editingFinished)
-        if hasattr(self.form.useStartPoint, "checkStateChanged"): # Qt version >= 6.7.0
+        if hasattr(self.form.useStartPoint, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.useStartPoint.checkStateChanged)
             signals.append(self.form.boundaryEnforcement.checkStateChanged)
             signals.append(self.form.optimizeEnabled.checkStateChanged)
             signals.append(self.form.optimizeStepOverTransitions.checkStateChanged)
-        else: # Qt version < 6.7.0
+        else:  # Qt version < 6.7.0
             signals.append(self.form.useStartPoint.stateChanged)
             signals.append(self.form.boundaryEnforcement.stateChanged)
             signals.append(self.form.optimizeEnabled.stateChanged)

--- a/src/Mod/CAM/Path/Op/Gui/Surface.py
+++ b/src/Mod/CAM/Path/Op/Gui/Surface.py
@@ -217,10 +217,16 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.depthOffset.editingFinished)
         signals.append(self.form.stepOver.editingFinished)
         signals.append(self.form.sampleInterval.editingFinished)
-        signals.append(self.form.useStartPoint.stateChanged)
-        signals.append(self.form.boundaryEnforcement.stateChanged)
-        signals.append(self.form.optimizeEnabled.stateChanged)
-        signals.append(self.form.optimizeStepOverTransitions.stateChanged)
+        if hasattr(self.form.useStartPoint, "checkStateChanged"):
+            signals.append(self.form.useStartPoint.checkStateChanged)
+            signals.append(self.form.boundaryEnforcement.checkStateChanged)
+            signals.append(self.form.optimizeEnabled.checkStateChanged)
+            signals.append(self.form.optimizeStepOverTransitions.checkStateChanged)
+        else:
+            signals.append(self.form.useStartPoint.stateChanged)
+            signals.append(self.form.boundaryEnforcement.stateChanged)
+            signals.append(self.form.optimizeEnabled.stateChanged)
+            signals.append(self.form.optimizeStepOverTransitions.stateChanged)
 
         return signals
 

--- a/src/Mod/CAM/Path/Op/Gui/Surface.py
+++ b/src/Mod/CAM/Path/Op/Gui/Surface.py
@@ -217,12 +217,12 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.depthOffset.editingFinished)
         signals.append(self.form.stepOver.editingFinished)
         signals.append(self.form.sampleInterval.editingFinished)
-        if hasattr(self.form.useStartPoint, "checkStateChanged"):
+        if hasattr(self.form.useStartPoint, "checkStateChanged"): # Qt version >= 6.7.0
             signals.append(self.form.useStartPoint.checkStateChanged)
             signals.append(self.form.boundaryEnforcement.checkStateChanged)
             signals.append(self.form.optimizeEnabled.checkStateChanged)
             signals.append(self.form.optimizeStepOverTransitions.checkStateChanged)
-        else:
+        else: # Qt version < 6.7.0
             signals.append(self.form.useStartPoint.stateChanged)
             signals.append(self.form.boundaryEnforcement.stateChanged)
             signals.append(self.form.optimizeEnabled.stateChanged)

--- a/src/Mod/CAM/Path/Op/Gui/ThreadMilling.py
+++ b/src/Mod/CAM/Path/Op/Gui/ThreadMilling.py
@@ -229,7 +229,10 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         signals.append(self.form.threadTPI.editingFinished)
         signals.append(self.form.opDirection.currentIndexChanged)
         signals.append(self.form.opPasses.editingFinished)
-        signals.append(self.form.leadInOut.stateChanged)
+        if hasattr(self.form.leadInOut, "checkStateChanged"):
+            signals.append(self.form.leadInOut.checkStateChanged)
+        else:
+            signals.append(self.form.leadInOut.stateChanged)
 
         signals.append(self.form.toolController.currentIndexChanged)
 

--- a/src/Mod/CAM/Path/Op/Gui/ThreadMilling.py
+++ b/src/Mod/CAM/Path/Op/Gui/ThreadMilling.py
@@ -229,9 +229,9 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         signals.append(self.form.threadTPI.editingFinished)
         signals.append(self.form.opDirection.currentIndexChanged)
         signals.append(self.form.opPasses.editingFinished)
-        if hasattr(self.form.leadInOut, "checkStateChanged"):
+        if hasattr(self.form.leadInOut, "checkStateChanged"): # Qt version >= 6.7.0
             signals.append(self.form.leadInOut.checkStateChanged)
-        else:
+        else: # Qt version < 6.7.0
             signals.append(self.form.leadInOut.stateChanged)
 
         signals.append(self.form.toolController.currentIndexChanged)

--- a/src/Mod/CAM/Path/Op/Gui/ThreadMilling.py
+++ b/src/Mod/CAM/Path/Op/Gui/ThreadMilling.py
@@ -229,9 +229,9 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         signals.append(self.form.threadTPI.editingFinished)
         signals.append(self.form.opDirection.currentIndexChanged)
         signals.append(self.form.opPasses.editingFinished)
-        if hasattr(self.form.leadInOut, "checkStateChanged"): # Qt version >= 6.7.0
+        if hasattr(self.form.leadInOut, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.leadInOut.checkStateChanged)
-        else: # Qt version < 6.7.0
+        else:  # Qt version < 6.7.0
             signals.append(self.form.leadInOut.stateChanged)
 
         signals.append(self.form.toolController.currentIndexChanged)

--- a/src/Mod/CAM/Path/Op/Gui/Waterline.py
+++ b/src/Mod/CAM/Path/Op/Gui/Waterline.py
@@ -126,7 +126,10 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.boundaryAdjustment.editingFinished)
         signals.append(self.form.stepOver.editingFinished)
         signals.append(self.form.sampleInterval.editingFinished)
-        signals.append(self.form.optimizeEnabled.stateChanged)
+        if hasattr(self.form.optimizeEnabled, "checkStateChanged"):
+            signals.append(self.form.optimizeEnabled.checkStateChanged)
+        else:
+            signals.append(self.form.optimizeEnabled.stateChanged)
 
         return signals
 

--- a/src/Mod/CAM/Path/Op/Gui/Waterline.py
+++ b/src/Mod/CAM/Path/Op/Gui/Waterline.py
@@ -126,9 +126,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.boundaryAdjustment.editingFinished)
         signals.append(self.form.stepOver.editingFinished)
         signals.append(self.form.sampleInterval.editingFinished)
-        if hasattr(self.form.optimizeEnabled, "checkStateChanged"): # Qt version >= 6.7.0
+        if hasattr(self.form.optimizeEnabled, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.optimizeEnabled.checkStateChanged)
-        else: # Qt version < 6.7.0
+        else:  # Qt version < 6.7.0
             signals.append(self.form.optimizeEnabled.stateChanged)
 
         return signals

--- a/src/Mod/CAM/Path/Op/Gui/Waterline.py
+++ b/src/Mod/CAM/Path/Op/Gui/Waterline.py
@@ -126,9 +126,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.boundaryAdjustment.editingFinished)
         signals.append(self.form.stepOver.editingFinished)
         signals.append(self.form.sampleInterval.editingFinished)
-        if hasattr(self.form.optimizeEnabled, "checkStateChanged"):
+        if hasattr(self.form.optimizeEnabled, "checkStateChanged"): # Qt version >= 6.7.0
             signals.append(self.form.optimizeEnabled.checkStateChanged)
-        else:
+        else: # Qt version < 6.7.0
             signals.append(self.form.optimizeEnabled.stateChanged)
 
         return signals

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -972,7 +972,7 @@ class DraftToolBar:
     #     gui_stretch.py
     def setRelative(self, val=-1):
         if val < 0:
-	    if hasattr(self.isRelative, "checkStateChanged"):
+            if hasattr(self.isRelative, "checkStateChanged"):
                 QtCore.QObject.disconnect(self.isRelative,
                                       QtCore.SIGNAL("checkStateChanged(int)"),
                                       self.setRelative)

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -987,7 +987,7 @@ class DraftToolBar:
                 val = params.get_param("RelativeMode")
                 self.isRelative.setChecked(val)
                 self.relativeMode = val
-	    if hasattr(self.isRelative, "checkStateChanged"):
+            if hasattr(self.isRelative, "checkStateChanged"):
                 QtCore.QObject.disconnect(self.isRelative,
                                       QtCore.SIGNAL("checkStateChanged(int)"),
                                       self.setRelative)

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -432,7 +432,10 @@ class DraftToolBar:
         QtCore.QObject.connect(self.zValue,QtCore.SIGNAL("valueChanged(double)"),self.changeZValue)
         QtCore.QObject.connect(self.lengthValue,QtCore.SIGNAL("valueChanged(double)"),self.changeLengthValue)
         QtCore.QObject.connect(self.angleValue,QtCore.SIGNAL("valueChanged(double)"),self.changeAngleValue)
-        QtCore.QObject.connect(self.angleLock,QtCore.SIGNAL("stateChanged(int)"),self.toggleAngle)
+        if hasattr(self.angleLock, "checkStateChanged"):
+            QtCore.QObject.connect(self.angleLock,QtCore.SIGNAL("checkStateChanged(int)"),self.toggleAngle)
+        else:
+            QtCore.QObject.connect(self.angleLock,QtCore.SIGNAL("stateChanged(int)"),self.toggleAngle)
         QtCore.QObject.connect(self.radiusValue,QtCore.SIGNAL("valueChanged(double)"),self.changeRadiusValue)
         QtCore.QObject.connect(self.xValue,QtCore.SIGNAL("returnPressed()"),self.checkx)
         QtCore.QObject.connect(self.yValue,QtCore.SIGNAL("returnPressed()"),self.checky)
@@ -457,15 +460,22 @@ class DraftToolBar:
         QtCore.QObject.connect(self.orientWPButton,QtCore.SIGNAL("pressed()"),self.orientWP)
         QtCore.QObject.connect(self.undoButton,QtCore.SIGNAL("pressed()"),self.undoSegment)
         QtCore.QObject.connect(self.selectButton,QtCore.SIGNAL("pressed()"),self.selectEdge)
-        QtCore.QObject.connect(self.continueCmd,QtCore.SIGNAL("stateChanged(int)"),self.setContinue)
-        QtCore.QObject.connect(self.chainedModeCmd,QtCore.SIGNAL("stateChanged(int)"),self.setChainedMode)
-
-        QtCore.QObject.connect(self.isCopy,QtCore.SIGNAL("stateChanged(int)"),self.setCopymode)
-        QtCore.QObject.connect(self.isSubelementMode, QtCore.SIGNAL("stateChanged(int)"), self.setSubelementMode)
-
-        QtCore.QObject.connect(self.isRelative,QtCore.SIGNAL("stateChanged(int)"),self.setRelative)
-        QtCore.QObject.connect(self.isGlobal,QtCore.SIGNAL("stateChanged(int)"),self.setGlobal)
-        QtCore.QObject.connect(self.makeFace,QtCore.SIGNAL("stateChanged(int)"),self.setMakeFace)
+        if hasattr(self.continueCmd, "checkStateChanged"):
+            QtCore.QObject.connect(self.continueCmd,QtCore.SIGNAL("checkStateChanged(int)"),self.setContinue)
+            QtCore.QObject.connect(self.chainedModeCmd,QtCore.SIGNAL("checkStateChanged(int)"),self.setChainedMode)
+            QtCore.QObject.connect(self.isCopy,QtCore.SIGNAL("checkStateChanged(int)"),self.setCopymode)
+            QtCore.QObject.connect(self.isSubelementMode, QtCore.SIGNAL("checkStateChanged(int)"), self.setSubelementMode)
+            QtCore.QObject.connect(self.isRelative,QtCore.SIGNAL("checkStateChanged(int)"),self.setRelative)
+            QtCore.QObject.connect(self.isGlobal,QtCore.SIGNAL("checkStateChanged(int)"),self.setGlobal)
+            QtCore.QObject.connect(self.makeFace,QtCore.SIGNAL("checkStateChanged(int)"),self.setMakeFace)
+        else:
+            QtCore.QObject.connect(self.continueCmd,QtCore.SIGNAL("stateChanged(int)"),self.setContinue)
+            QtCore.QObject.connect(self.chainedModeCmd,QtCore.SIGNAL("stateChanged(int)"),self.setChainedMode)
+            QtCore.QObject.connect(self.isCopy,QtCore.SIGNAL("stateChanged(int)"),self.setCopymode)
+            QtCore.QObject.connect(self.isSubelementMode, QtCore.SIGNAL("stateChanged(int)"), self.setSubelementMode)
+            QtCore.QObject.connect(self.isRelative,QtCore.SIGNAL("stateChanged(int)"),self.setRelative)
+            QtCore.QObject.connect(self.isGlobal,QtCore.SIGNAL("stateChanged(int)"),self.setGlobal)
+            QtCore.QObject.connect(self.makeFace,QtCore.SIGNAL("stateChanged(int)"),self.setMakeFace)
         QtCore.QObject.connect(self.baseWidget,QtCore.SIGNAL("resized()"),self.relocate)
         QtCore.QObject.connect(self.baseWidget,QtCore.SIGNAL("retranslate()"),self.retranslateUi)
 
@@ -962,7 +972,12 @@ class DraftToolBar:
     #     gui_stretch.py
     def setRelative(self, val=-1):
         if val < 0:
-            QtCore.QObject.disconnect(self.isRelative,
+	    if hasattr(self.isRelative, "checkStateChanged"):
+                QtCore.QObject.disconnect(self.isRelative,
+                                      QtCore.SIGNAL("checkStateChanged(int)"),
+                                      self.setRelative)
+            else:
+                QtCore.QObject.disconnect(self.isRelative,
                                       QtCore.SIGNAL("stateChanged(int)"),
                                       self.setRelative)
             if val == -1:
@@ -972,9 +987,14 @@ class DraftToolBar:
                 val = params.get_param("RelativeMode")
                 self.isRelative.setChecked(val)
                 self.relativeMode = val
-            QtCore.QObject.connect(self.isRelative,
-                                   QtCore.SIGNAL("stateChanged(int)"),
-                                   self.setRelative)
+	    if hasattr(self.isRelative, "checkStateChanged"):
+                QtCore.QObject.disconnect(self.isRelative,
+                                      QtCore.SIGNAL("checkStateChanged(int)"),
+                                      self.setRelative)
+            else:
+                QtCore.QObject.disconnect(self.isRelative,
+                                      QtCore.SIGNAL("stateChanged(int)"),
+                                      self.setRelative)
         else:
             params.set_param("RelativeMode", bool(val))
             self.relativeMode = bool(val)

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -432,9 +432,9 @@ class DraftToolBar:
         QtCore.QObject.connect(self.zValue,QtCore.SIGNAL("valueChanged(double)"),self.changeZValue)
         QtCore.QObject.connect(self.lengthValue,QtCore.SIGNAL("valueChanged(double)"),self.changeLengthValue)
         QtCore.QObject.connect(self.angleValue,QtCore.SIGNAL("valueChanged(double)"),self.changeAngleValue)
-        if hasattr(self.angleLock, "checkStateChanged"):
+        if hasattr(self.angleLock, "checkStateChanged"): # Qt version >= 6.7.0
             QtCore.QObject.connect(self.angleLock,QtCore.SIGNAL("checkStateChanged(int)"),self.toggleAngle)
-        else:
+        else: # Qt version < 6.7.0
             QtCore.QObject.connect(self.angleLock,QtCore.SIGNAL("stateChanged(int)"),self.toggleAngle)
         QtCore.QObject.connect(self.radiusValue,QtCore.SIGNAL("valueChanged(double)"),self.changeRadiusValue)
         QtCore.QObject.connect(self.xValue,QtCore.SIGNAL("returnPressed()"),self.checkx)
@@ -460,7 +460,7 @@ class DraftToolBar:
         QtCore.QObject.connect(self.orientWPButton,QtCore.SIGNAL("pressed()"),self.orientWP)
         QtCore.QObject.connect(self.undoButton,QtCore.SIGNAL("pressed()"),self.undoSegment)
         QtCore.QObject.connect(self.selectButton,QtCore.SIGNAL("pressed()"),self.selectEdge)
-        if hasattr(self.continueCmd, "checkStateChanged"):
+        if hasattr(self.continueCmd, "checkStateChanged"): # Qt version >= 6.7.0
             QtCore.QObject.connect(self.continueCmd,QtCore.SIGNAL("checkStateChanged(int)"),self.setContinue)
             QtCore.QObject.connect(self.chainedModeCmd,QtCore.SIGNAL("checkStateChanged(int)"),self.setChainedMode)
             QtCore.QObject.connect(self.isCopy,QtCore.SIGNAL("checkStateChanged(int)"),self.setCopymode)
@@ -468,7 +468,7 @@ class DraftToolBar:
             QtCore.QObject.connect(self.isRelative,QtCore.SIGNAL("checkStateChanged(int)"),self.setRelative)
             QtCore.QObject.connect(self.isGlobal,QtCore.SIGNAL("checkStateChanged(int)"),self.setGlobal)
             QtCore.QObject.connect(self.makeFace,QtCore.SIGNAL("checkStateChanged(int)"),self.setMakeFace)
-        else:
+        else: # Qt version < 6.7.0
             QtCore.QObject.connect(self.continueCmd,QtCore.SIGNAL("stateChanged(int)"),self.setContinue)
             QtCore.QObject.connect(self.chainedModeCmd,QtCore.SIGNAL("stateChanged(int)"),self.setChainedMode)
             QtCore.QObject.connect(self.isCopy,QtCore.SIGNAL("stateChanged(int)"),self.setCopymode)
@@ -972,11 +972,11 @@ class DraftToolBar:
     #     gui_stretch.py
     def setRelative(self, val=-1):
         if val < 0:
-            if hasattr(self.isRelative, "checkStateChanged"):
+            if hasattr(self.isRelative, "checkStateChanged"): # Qt version >= 6.7.0
                 QtCore.QObject.disconnect(self.isRelative,
                                       QtCore.SIGNAL("checkStateChanged(int)"),
                                       self.setRelative)
-            else:
+            else: # Qt version < 6.7.0
                 QtCore.QObject.disconnect(self.isRelative,
                                       QtCore.SIGNAL("stateChanged(int)"),
                                       self.setRelative)
@@ -987,11 +987,11 @@ class DraftToolBar:
                 val = params.get_param("RelativeMode")
                 self.isRelative.setChecked(val)
                 self.relativeMode = val
-            if hasattr(self.isRelative, "checkStateChanged"):
+            if hasattr(self.isRelative, "checkStateChanged"): # Qt version >= 6.7.0
                 QtCore.QObject.disconnect(self.isRelative,
                                       QtCore.SIGNAL("checkStateChanged(int)"),
                                       self.setRelative)
-            else:
+            else: # Qt version < 6.7.0
                 QtCore.QObject.disconnect(self.isRelative,
                                       QtCore.SIGNAL("stateChanged(int)"),
                                       self.setRelative)

--- a/src/Mod/Draft/draftguitools/gui_fillets.py
+++ b/src/Mod/Draft/draftguitools/gui_fillets.py
@@ -100,10 +100,10 @@ class Fillet(gui_base_original.Creator):
                                                     "Create chamfer"))
             self.ui.check_chamfer.show()
 
-            if hasattr(self.ui.check_delete, "checkStateChanged"):
+            if hasattr(self.ui.check_delete, "checkStateChanged"): # Qt version >= 6.7.0
                 self.ui.check_delete.checkStateChanged.connect(self.set_delete)
                 self.ui.check_chamfer.checkStateChanged.connect(self.set_chamfer)
-            else:
+            else: # Qt version < 6.7.0
                 self.ui.check_delete.stateChanged.connect(self.set_delete)
                 self.ui.check_chamfer.stateChanged.connect(self.set_chamfer)
 

--- a/src/Mod/Draft/draftguitools/gui_fillets.py
+++ b/src/Mod/Draft/draftguitools/gui_fillets.py
@@ -100,8 +100,12 @@ class Fillet(gui_base_original.Creator):
                                                     "Create chamfer"))
             self.ui.check_chamfer.show()
 
-            self.ui.check_delete.stateChanged.connect(self.set_delete)
-            self.ui.check_chamfer.stateChanged.connect(self.set_chamfer)
+            if hasattr(self.ui.check_delete, "checkStateChanged"):
+                self.ui.check_delete.checkStateChanged.connect(self.set_delete)
+                self.ui.check_chamfer.checkStateChanged.connect(self.set_chamfer)
+            else:
+                self.ui.check_delete.stateChanged.connect(self.set_delete)
+                self.ui.check_chamfer.stateChanged.connect(self.set_chamfer)
 
             # TODO: somehow we need to set up the trackers
             # to show a preview of the fillet.

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -126,9 +126,9 @@ class Draft_SelectPlane:
         form.buttonPrevious.clicked.connect(self.on_click_previous)
         form.buttonNext.clicked.connect(self.on_click_next)
         form.fieldOffset.textEdited.connect(self.on_set_offset)
-        if hasattr(form.checkCenter, "checkStateChanged"):
+        if hasattr(form.checkCenter, "checkStateChanged"): # Qt version >= 6.7.0
             form.checkCenter.checkStateChanged.connect(self.on_set_center)
-        else:
+        else: # Qt version < 6.7.0
             form.checkCenter.stateChanged.connect(self.on_set_center)
         form.fieldGridSpacing.textEdited.connect(self.on_set_grid_size)
         form.fieldGridMainLine.valueChanged.connect(self.on_set_main_line)

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -126,7 +126,10 @@ class Draft_SelectPlane:
         form.buttonPrevious.clicked.connect(self.on_click_previous)
         form.buttonNext.clicked.connect(self.on_click_next)
         form.fieldOffset.textEdited.connect(self.on_set_offset)
-        form.checkCenter.stateChanged.connect(self.on_set_center)
+        if hasattr(form.checkCenter, "checkStateChanged"):
+            form.checkCenter.checkStateChanged.connect(self.on_set_center)
+        else:
+            form.checkCenter.stateChanged.connect(self.on_set_center)
         form.fieldGridSpacing.textEdited.connect(self.on_set_grid_size)
         form.fieldGridMainLine.valueChanged.connect(self.on_set_main_line)
         form.fieldGridExtension.valueChanged.connect(self.on_set_extension)

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -164,10 +164,10 @@ class TaskPanelCircularArray:
         self.form.button_reset.clicked.connect(self.reset_point)
 
         # When the checkbox changes, change the internal value
-        if hasattr(self.form.checkbox_fuse, "checkStateChanged"):
+        if hasattr(self.form.checkbox_fuse, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.checkbox_fuse.checkStateChanged.connect(self.set_fuse)
             self.form.checkbox_link.checkStateChanged.connect(self.set_link)
-        else:
+        else: # Qt version < 6.7.0
             self.form.checkbox_fuse.stateChanged.connect(self.set_fuse)
             self.form.checkbox_link.stateChanged.connect(self.set_link)
 

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -164,8 +164,12 @@ class TaskPanelCircularArray:
         self.form.button_reset.clicked.connect(self.reset_point)
 
         # When the checkbox changes, change the internal value
-        self.form.checkbox_fuse.stateChanged.connect(self.set_fuse)
-        self.form.checkbox_link.stateChanged.connect(self.set_link)
+        if hasattr(self.form.checkbox_fuse, "checkStateChanged"):
+            self.form.checkbox_fuse.checkStateChanged.connect(self.set_fuse)
+            self.form.checkbox_link.checkStateChanged.connect(self.set_link)
+        else:
+            self.form.checkbox_fuse.stateChanged.connect(self.set_fuse)
+            self.form.checkbox_link.stateChanged.connect(self.set_link)
 
 
     def accept(self):

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -175,10 +175,10 @@ class TaskPanelOrthoArray:
         self.form.button_reset_Z.clicked.connect(lambda: self.reset_v("Z"))
 
         # When the checkbox changes, change the internal value
-        if hasattr(self.form.checkbox_fuse, "checkStateChanged"):
+        if hasattr(self.form.checkbox_fuse, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.checkbox_fuse.checkStateChanged.connect(self.set_fuse)
             self.form.checkbox_link.checkStateChanged.connect(self.set_link)
-        else:
+        else: # Qt version < 6.7.0
             self.form.checkbox_fuse.stateChanged.connect(self.set_fuse)
             self.form.checkbox_link.stateChanged.connect(self.set_link)
 

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -175,8 +175,12 @@ class TaskPanelOrthoArray:
         self.form.button_reset_Z.clicked.connect(lambda: self.reset_v("Z"))
 
         # When the checkbox changes, change the internal value
-        self.form.checkbox_fuse.stateChanged.connect(self.set_fuse)
-        self.form.checkbox_link.stateChanged.connect(self.set_link)
+        if hasattr(self.form.checkbox_fuse, "checkStateChanged"):
+            self.form.checkbox_fuse.checkStateChanged.connect(self.set_fuse)
+            self.form.checkbox_link.checkStateChanged.connect(self.set_link)
+        else:
+            self.form.checkbox_fuse.stateChanged.connect(self.set_fuse)
+            self.form.checkbox_link.stateChanged.connect(self.set_link)
 
         # Linear mode callbacks - only set up if the UI elements exist
         self.form.button_linear_mode.clicked.connect(self.toggle_linear_mode)

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -152,8 +152,12 @@ class TaskPanelPolarArray:
         self.form.button_reset.clicked.connect(self.reset_point)
 
         # When the checkbox changes, change the internal value
-        self.form.checkbox_fuse.stateChanged.connect(self.set_fuse)
-        self.form.checkbox_link.stateChanged.connect(self.set_link)
+        if hasattr(self.form.checkbox_fuse, "checkStateChanged"):
+            self.form.checkbox_fuse.checkStateChanged.connect(self.set_fuse)
+            self.form.checkbox_link.checkStateChanged.connect(self.set_link)
+        else:
+            self.form.checkbox_fuse.stateChanged.connect(self.set_fuse)
+            self.form.checkbox_link.stateChanged.connect(self.set_link)
 
 
     def accept(self):

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -152,10 +152,10 @@ class TaskPanelPolarArray:
         self.form.button_reset.clicked.connect(self.reset_point)
 
         # When the checkbox changes, change the internal value
-        if hasattr(self.form.checkbox_fuse, "checkStateChanged"):
+        if hasattr(self.form.checkbox_fuse, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.checkbox_fuse.checkStateChanged.connect(self.set_fuse)
             self.form.checkbox_link.checkStateChanged.connect(self.set_link)
-        else:
+        else: # Qt version < 6.7.0
             self.form.checkbox_fuse.stateChanged.connect(self.set_fuse)
             self.form.checkbox_link.stateChanged.connect(self.set_link)
 

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -93,7 +93,7 @@ class ShapeStringTaskPanel:
         self.form.sbX.valueChanged.connect(self.set_point_x)
         self.form.sbY.valueChanged.connect(self.set_point_y)
         self.form.sbZ.valueChanged.connect(self.set_point_z)
-	    if hasattr(self.form.cbGlobalMode.checkbox_fuse, "checkStateChanged"):
+        if hasattr(self.form.cbGlobalMode.checkbox_fuse, "checkStateChanged"):
             self.form.cbGlobalMode.checkStateChanged.connect(self.set_global_mode)
         else:
             self.form.cbGlobalMode.stateChanged.connect(self.set_global_mode)

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -93,7 +93,10 @@ class ShapeStringTaskPanel:
         self.form.sbX.valueChanged.connect(self.set_point_x)
         self.form.sbY.valueChanged.connect(self.set_point_y)
         self.form.sbZ.valueChanged.connect(self.set_point_z)
-        self.form.cbGlobalMode.stateChanged.connect(self.set_global_mode)
+	    if hasattr(self.form.cbGlobalMode.checkbox_fuse, "checkStateChanged"):
+            self.form.cbGlobalMode.checkStateChanged.connect(self.set_global_mode)
+        else:
+            self.form.cbGlobalMode.stateChanged.connect(self.set_global_mode)
         self.form.pbReset.clicked.connect(self.reset_point)
         self.form.sbHeight.valueChanged.connect(self.set_height)
         self.form.leText.textEdited.connect(self.set_text)

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -93,9 +93,9 @@ class ShapeStringTaskPanel:
         self.form.sbX.valueChanged.connect(self.set_point_x)
         self.form.sbY.valueChanged.connect(self.set_point_y)
         self.form.sbZ.valueChanged.connect(self.set_point_z)
-        if hasattr(self.form.cbGlobalMode.checkbox_fuse, "checkStateChanged"):
+        if hasattr(self.form.cbGlobalMode.checkbox_fuse, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.cbGlobalMode.checkStateChanged.connect(self.set_global_mode)
-        else:
+        else: # Qt version < 6.7.0
             self.form.cbGlobalMode.stateChanged.connect(self.set_global_mode)
         self.form.pbReset.clicked.connect(self.reset_point)
         self.form.sbHeight.valueChanged.connect(self.set_height)


### PR DESCRIPTION
…stateChanged -> checkStateChanged

Due to Deprecation warnings already being raised in Qt6.9.0 and to maintain backwards compatibility to Qt5.x and early Qt6.x this PR allows all current supported builds to still function as expected.

Note: this is just the first Python changes, C++ will follow.