### PR TITLE
[CAM] Fix ramp dressup performance

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -28,7 +28,6 @@ import Path
 import Path.Base.Language as PathLanguage
 import Path.Dressup.Utils as PathDressup
 import PathScripts.PathUtils as PathUtils
-from Path.Geom import wireForPath
 import math
 
 __doc__ = """LeadInOut Dressup USE ROLL-ON ROLL-OFF to profile"""
@@ -130,9 +129,6 @@ class ObjectDressup:
         )
         obj.Proxy = self
 
-        self.wire = None
-        self.rapids = None
-
     def dumps(self):
         return None
 
@@ -172,7 +168,6 @@ class ObjectDressup:
             )
             obj.LengthOut = 0.1
 
-        self.wire, self.rapids = wireForPath(PathUtils.getPathWithPlacement(obj.Base))
         obj.Path = self.generateLeadInOutCurve(obj)
 
     def onDocumentRestored(self, obj):

--- a/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
@@ -255,11 +255,11 @@ class ObjectDressup:
                     projectionlen = plungelen * math.tan(
                         math.radians(rampangle)
                     )  # length of the forthcoming ramp projected to XY plane
-                    Path.Log.debug(
-                        "Found plunge move at X:{} Y:{} From Z:{} to Z{}, length of ramp: {}".format(
-                            p0.x, p0.y, p0.z, p1.z, projectionlen
-                        )
-                    )
+                    # Path.Log.debug(
+                    #    "Found plunge move at X:{} Y:{} From Z:{} to Z{}, length of ramp: {}".format(
+                    #        p0.x, p0.y, p0.z, p1.z, projectionlen
+                    #    )
+                    # )
                     if self.method == "RampMethod3":
                         projectionlen = projectionlen / 2
 
@@ -509,12 +509,12 @@ class ObjectDressup:
                     # will reach end of ramp within this edge, needs to be split
                     p1 = self.getSplitPoint(redge, rampremaining)
                     splitEdge = Path.Geom.splitEdgeAt(redge, p1)
-                    Path.Log.debug("Ramp remaining: {}".format(rampremaining))
-                    Path.Log.debug(
-                        "Got split edge (index: {}) (total len: {}) with lengths: {}, {}".format(
-                            i, redge.Length, splitEdge[0].Length, splitEdge[1].Length
-                        )
-                    )
+                    # Path.Log.debug("Ramp remaining: {}".format(rampremaining))
+                    # Path.Log.debug(
+                    #    "Got split edge (index: {}) (total len: {}) with lengths: {}, {}".format(
+                    #        i, redge.Length, splitEdge[0].Length, splitEdge[1].Length
+                    #    )
+                    # )
                     # ramp ends to the last point of first edge
                     p1 = splitEdge[0].valueAt(splitEdge[0].LastParameter)
                     outedges.append(self.createRampEdge(splitEdge[0], curPoint, p1))
@@ -549,7 +549,7 @@ class ObjectDressup:
             if not done:
                 # we did not reach the end of the ramp going this direction, lets reverse.
                 rampedges = self.getreversed(rampedges)
-                Path.Log.debug("Reversing")
+                # Path.Log.debug("Reversing")
                 if goingForward:
                     goingForward = False
                 else:

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -646,7 +646,7 @@ class PathData:
         Path.Log.track(obj.Base.Name)
         self.obj = obj
         path = PathUtils.getPathWithPlacement(obj.Base)
-        self.wire, rapid = Path.Geom.wireForPath(path)
+        self.wire, rapid, rapid_indexes = Path.Geom.wireForPath(path)
         self.rapid = _RapidEdges(rapid)
         if self.wire:
             self.edges = self.wire.Edges

--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -472,17 +472,19 @@ def wireForPath(path, startPoint=Vector(0, 0, 0)):
     Returns a wire representing all move commands found in the given path."""
     edges = []
     rapid = []
+    rapid_indexes = set()
     if hasattr(path, "Commands"):
         for cmd in path.Commands:
             edge = edgeForCmd(cmd, startPoint)
             if edge:
                 if cmd.Name in CmdMoveRapid:
                     rapid.append(edge)
+                    rapid_indexes.add(len(edges))
                 edges.append(edge)
                 startPoint = commandEndPoint(cmd, startPoint)
     if not edges:
-        return (None, rapid)
-    return (Part.Wire(edges), rapid)
+        return (None, rapid, rapid_indexes)
+    return (Part.Wire(edges), rapid, rapid_indexes)
 
 
 def wiresForPath(path, startPoint=Vector(0, 0, 0)):

--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -320,24 +320,24 @@ def cmdsForEdge(edge, flip=False, useHelixForBSpline=True, segm=50, hSpeed=0, vS
                 offset = edge.Curve.Center - pt
             else:
                 pd = Part.Circle(xy(p1), xy(p2), xy(p3)).Center
-                Path.Log.debug(
-                    "**** %s.%d: (%.2f, %.2f, %.2f) - (%.2f, %.2f, %.2f) - (%.2f, %.2f, %.2f) -> center=(%.2f, %.2f)"
-                    % (
-                        cmd,
-                        flip,
-                        p1.x,
-                        p1.y,
-                        p1.z,
-                        p2.x,
-                        p2.y,
-                        p2.z,
-                        p3.x,
-                        p3.y,
-                        p3.z,
-                        pd.x,
-                        pd.y,
-                    )
-                )
+                # Path.Log.debug(
+                #    "**** %s.%d: (%.2f, %.2f, %.2f) - (%.2f, %.2f, %.2f) - (%.2f, %.2f, %.2f) -> center=(%.2f, %.2f)"
+                #    % (
+                #        cmd,
+                #        flip,
+                #        p1.x,
+                #        p1.y,
+                #        p1.z,
+                #        p2.x,
+                #        p2.y,
+                #        p2.z,
+                #        p3.x,
+                #        p3.y,
+                #        p3.z,
+                #        pd.x,
+                #        pd.y,
+                #    )
+                # )
 
                 # Have to calculate the center in the XY plane, using pd leads to an error if this is a helix
                 pa = xy(p1)
@@ -345,15 +345,15 @@ def cmdsForEdge(edge, flip=False, useHelixForBSpline=True, segm=50, hSpeed=0, vS
                 pc = xy(p3)
                 offset = Part.Circle(pa, pb, pc).Center - pa
 
-                Path.Log.debug(
-                    "**** (%.2f, %.2f, %.2f) - (%.2f, %.2f, %.2f)"
-                    % (pa.x, pa.y, pa.z, pc.x, pc.y, pc.z)
-                )
-                Path.Log.debug(
-                    "**** (%.2f, %.2f, %.2f) - (%.2f, %.2f, %.2f)"
-                    % (pb.x, pb.y, pb.z, pd.x, pd.y, pd.z)
-                )
-            Path.Log.debug("**** (%.2f, %.2f, %.2f)" % (offset.x, offset.y, offset.z))
+                # Path.Log.debug(
+                #    "**** (%.2f, %.2f, %.2f) - (%.2f, %.2f, %.2f)"
+                #    % (pa.x, pa.y, pa.z, pc.x, pc.y, pc.z)
+                # )
+                # Path.Log.debug(
+                #    "**** (%.2f, %.2f, %.2f) - (%.2f, %.2f, %.2f)"
+                #    % (pb.x, pb.y, pb.z, pd.x, pd.y, pd.z)
+                # )
+            # Path.Log.debug("**** (%.2f, %.2f, %.2f)" % (offset.x, offset.y, offset.z))
 
             params.update({"I": offset.x, "J": offset.y, "K": (p3.z - p1.z) / 2})
             # G2/G3 commands are always performed at hSpeed
@@ -387,8 +387,8 @@ def edgeForCmd(cmd, startPoint):
     """edgeForCmd(cmd, startPoint).
     Returns an Edge representing the given command, assuming a given startPoint."""
 
-    Path.Log.debug("cmd: {}".format(cmd))
-    Path.Log.debug("startpoint {}".format(startPoint))
+    # Path.Log.debug("cmd: {}".format(cmd))
+    # Path.Log.debug("startpoint {}".format(startPoint))
 
     endPoint = commandEndPoint(cmd, startPoint)
     if (cmd.Name in CmdMoveStraight) or (cmd.Name in CmdMoveRapid) or (cmd.Name in CmdMoveDrill):
@@ -403,9 +403,9 @@ def edgeForCmd(cmd, startPoint):
         d = -B.x * A.y + B.y * A.x
 
         if isRoughly(d, 0, 0.005):
-            Path.Log.debug(
-                "Half circle arc at: (%.2f, %.2f, %.2f)" % (center.x, center.y, center.z)
-            )
+            # Path.Log.debug(
+            #    "Half circle arc at: (%.2f, %.2f, %.2f)" % (center.x, center.y, center.z)
+            # )
             # we're dealing with half a circle here
             angle = getAngle(A) + math.pi / 2
             if cmd.Name in CmdMoveCW:
@@ -413,34 +413,34 @@ def edgeForCmd(cmd, startPoint):
         else:
             C = A + B
             angle = getAngle(C)
-            Path.Log.debug(
-                "Arc (%8f) at: (%.2f, %.2f, %.2f) -> angle=%f"
-                % (d, center.x, center.y, center.z, angle / math.pi)
-            )
+            # Path.Log.debug(
+            #    "Arc (%8f) at: (%.2f, %.2f, %.2f) -> angle=%f"
+            #    % (d, center.x, center.y, center.z, angle / math.pi)
+            # )
 
         R = A.Length
-        Path.Log.debug(
-            "arc: p1=(%.2f, %.2f) p2=(%.2f, %.2f) -> center=(%.2f, %.2f)"
-            % (startPoint.x, startPoint.y, endPoint.x, endPoint.y, center.x, center.y)
-        )
-        Path.Log.debug("arc: A=(%.2f, %.2f) B=(%.2f, %.2f) -> d=%.2f" % (A.x, A.y, B.x, B.y, d))
-        Path.Log.debug("arc: R=%.2f angle=%.2f" % (R, angle / math.pi))
+        # Path.Log.debug(
+        #    "arc: p1=(%.2f, %.2f) p2=(%.2f, %.2f) -> center=(%.2f, %.2f)"
+        #    % (startPoint.x, startPoint.y, endPoint.x, endPoint.y, center.x, center.y)
+        # )
+        # Path.Log.debug("arc: A=(%.2f, %.2f) B=(%.2f, %.2f) -> d=%.2f" % (A.x, A.y, B.x, B.y, d))
+        # Path.Log.debug("arc: R=%.2f angle=%.2f" % (R, angle / math.pi))
         if isRoughly(startPoint.z, endPoint.z):
             midPoint = center + Vector(math.cos(angle), math.sin(angle), 0) * R
-            Path.Log.debug(
-                "arc: (%.2f, %.2f) -> (%.2f, %.2f) -> (%.2f, %.2f)"
-                % (
-                    startPoint.x,
-                    startPoint.y,
-                    midPoint.x,
-                    midPoint.y,
-                    endPoint.x,
-                    endPoint.y,
-                )
-            )
-            Path.Log.debug("StartPoint:{}".format(startPoint))
-            Path.Log.debug("MidPoint:{}".format(midPoint))
-            Path.Log.debug("EndPoint:{}".format(endPoint))
+            # Path.Log.debug(
+            #    "arc: (%.2f, %.2f) -> (%.2f, %.2f) -> (%.2f, %.2f)"
+            #    % (
+            #        startPoint.x,
+            #        startPoint.y,
+            #        midPoint.x,
+            #        midPoint.y,
+            #        endPoint.x,
+            #        endPoint.y,
+            #    )
+            # )
+            # Path.Log.debug("StartPoint:{}".format(startPoint))
+            # Path.Log.debug("MidPoint:{}".format(midPoint))
+            # Path.Log.debug("EndPoint:{}".format(endPoint))
 
             if pointsCoincide(startPoint, endPoint, 0.001):
                 return Part.makeCircle(R, center, FreeCAD.Vector(0, 0, 1))


### PR DESCRIPTION
Sub-project 3 of [grant proposal](https://github.com/FreeCAD/FPA-grant-proposals/issues/46)

TODO create issue

Sometimes, when ramping long paths, FreeCAD freezes during ramp path computation, and can remain frozen for minutes. The problem can be seen on this sample file: [sample_model.zip](https://github.com/user-attachments/files/20699787/sample_model.zip). The generated gcode for this model does not change with this PR, but computation speeds up (on my machine) from ~2 minutes to 1.5 seconds.

The two biggest problems were:

- a call to edges.index(edge) to find the index in an array. I replaced this with tracking the index during iteration
- looping over an array of rapid edges to check if the current edge is a rapid move. When this is done on input edges I replaced this with index tracking as well, and when it is done on output edges I replaced it with tagging output edges as rapid/normal at generation time

The other problem I fixed was time wasted in unused Path.Log.debug calls. Even if the log line is not kept, these lines take time to invoke traceback.extract_stack and determine the current file (and thus the log level of the current file), and if this is done in a sufficiently hot loop, that time matters. I commented out a few notably influential log calls, and some others that were less notably problematic as well.

After these changes, profiling ([python line profiler](https://github.com/pyutils/line_profiler)) shows that the remaining wasted time is largely spent doing small property lookups and method calls from python into C inside busy loops. This could be further improved by operating on a path representation that stays closer to gcode/python, but I decided that the current state is good enough and it's not worth rewriting that much code for further improvements at the moment.

Here is some sample profiler output after performance improvements. Note that the most expensive remaining lines are high level function calls (the real work is inside somewhere) and python property access:

```
$ cat profile_output.txt | sort -n -k 3
# ...(all entries remaining over 50ms:)
# line   call count    time(ns)   per call (ns)
   282      1578   58881149.0  37313.8      7.2                          cp1 = candidate.Vertexes[1].Point
   292      5989   63172715.0  10548.1     13.5      pt = edge.valueAt(edge.LastParameter) if not flip else edge.valueAt(edge.FirstParameter)
   246      1848   68927189.0  37298.3      8.4                  p1 = edge.Vertexes[1].Point
   294      5989   71505047.0  11939.4     15.3      if type(edge.Curve) == Part.Line or type(edge.Curve) == Part.LineSegment:
   499      2315   72107705.0  31148.0     38.8              edge = edgeForCmd(cmd, startPoint)
   245      1848   74985932.0  40576.8      9.1                  p0 = edge.Vertexes[0].Point
   281      1578   80796801.0  51202.0      9.8                          cp0 = candidate.Vertexes[0].Point
   508         1  101011844.0    1e+08     54.3      return (Part.Wire(edges), rapid, rapid_indexes)
   562       221  112466102.0 508896.4     27.0                  rampedges = self.getreversed(rampedges)
   556      3178  138311942.0  43521.7     33.1                      outedges.append(self.createRampEdge(redge, curPoint, newPoint))
   228         2  194172169.0    1e+08     10.1          self.wire, self.rapids, self.rapid_indexes = Path.Geom.wireForPath(
   316       154  432265112.0    3e+06     52.6                                  self.createRampMethod1(rampedges, p0, projectionlen, rampangle)
   767      5989  551057905.0  92011.7     76.5                  commands.extend(Path.Geom.cmdsForEdge(edge))
   232         1  833127784.0    8e+08     43.4              self.outedges = self.generateRamps()
   235         1  868352735.0    9e+08     45.2          obj.Path = self.createCommands(obj, self.outedges)
```

