### PR TITLE
[Gui] C++ preparation for deprecation of QCheckBox…

### DIFF
--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -124,8 +124,13 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
 
 DlgExpressionInput::~DlgExpressionInput()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    disconnect(ui->checkBoxVarSets, &QCheckBox::checkStateChanged,
+               this, &DlgExpressionInput::onCheckVarSets);
+#else
     disconnect(ui->checkBoxVarSets, &QCheckBox::stateChanged,
                this, &DlgExpressionInput::onCheckVarSets);
+#endif
     disconnect(ui->comboBoxVarSet, qOverload<int>(&QComboBox::currentIndexChanged),
                this, &DlgExpressionInput::onVarSetSelected);
     disconnect(ui->lineEditGroup, &QLineEdit::textChanged,
@@ -202,8 +207,13 @@ void DlgExpressionInput::initializeVarSets()
     ui->labelInfoActive->setAlignment(Qt::AlignTop | Qt::AlignLeft);
     ui->labelInfoActive->setWordWrap(true);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    connect(ui->checkBoxVarSets, &QCheckBox::checkStateChanged,
+            this, &DlgExpressionInput::onCheckVarSets);
+#else
     connect(ui->checkBoxVarSets, &QCheckBox::stateChanged,
             this, &DlgExpressionInput::onCheckVarSets);
+#endif
     connect(ui->comboBoxVarSet, qOverload<int>(&QComboBox::currentIndexChanged),
             this, &DlgExpressionInput::onVarSetSelected);
     connect(ui->lineEditGroup, &QLineEdit::textChanged,

--- a/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
@@ -77,7 +77,11 @@ DlgSettingsLightSources::DlgSettingsLightSources(QWidget* parent)
                 this,
                 updateLightFunction);
         connect(colorButton, &ColorButton::changed, this, updateLightFunction);
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+        connect(enabledCheckbox, &QCheckBox::checkStateChanged, this, updateLightFunction);
+#else
         connect(enabledCheckbox, &QCheckBox::stateChanged, this, updateLightFunction);
+#endif
     };
 
     const auto updateLight = [&](SoDirectionalLight* light,

--- a/src/Gui/Selection/SelectionView.cpp
+++ b/src/Gui/Selection/SelectionView.cpp
@@ -111,7 +111,11 @@ SelectionView::SelectionView(Gui::Document* pcDocument, QWidget* parent)
     connect(pickList, &QListWidget::itemDoubleClicked, this, &SelectionView::toggleSelect);
     connect(pickList, &QListWidget::itemEntered, this, &SelectionView::preselect);
     connect(selectionView, &QListWidget::customContextMenuRequested, this, &SelectionView::onItemContextMenu);
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    connect(enablePickList, &QCheckBox::checkStateChanged, this, &SelectionView::onEnablePickList);
+#else
     connect(enablePickList, &QCheckBox::stateChanged, this, &SelectionView::onEnablePickList);
+#endif
     // clang-format on
 }
 

--- a/src/Mod/Fem/Gui/TaskTetParameter.cpp
+++ b/src/Mod/Fem/Gui/TaskTetParameter.cpp
@@ -69,7 +69,7 @@ TaskTetParameter::TaskTetParameter(Fem::FemMeshShapeNetgenObject* pcObject, QWid
                      qOverload<int>(&QComboBox::activated),
                      this,
                      &TaskTetParameter::SwitchMethod);
-#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
     QObject::connect(ui->checkBox_SecondOrder,
                      &QCheckBox::checkStateChanged,
                      this,
@@ -92,7 +92,7 @@ TaskTetParameter::TaskTetParameter(Fem::FemMeshShapeNetgenObject* pcObject, QWid
                      qOverload<int>(&QSpinBox::valueChanged),
                      this,
                      &TaskTetParameter::setSegsPerRadius);
-#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
     QObject::connect(ui->checkBox_Optimize,
                      &QCheckBox::checkStateChanged,
                      this,

--- a/src/Mod/Fem/Gui/TaskTetParameter.cpp
+++ b/src/Mod/Fem/Gui/TaskTetParameter.cpp
@@ -69,10 +69,17 @@ TaskTetParameter::TaskTetParameter(Fem::FemMeshShapeNetgenObject* pcObject, QWid
                      qOverload<int>(&QComboBox::activated),
                      this,
                      &TaskTetParameter::SwitchMethod);
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    QObject::connect(ui->checkBox_SecondOrder,
+                     &QCheckBox::checkStateChanged,
+                     this,
+                     &TaskTetParameter::setQuadric);
+#else
     QObject::connect(ui->checkBox_SecondOrder,
                      &QCheckBox::stateChanged,
                      this,
                      &TaskTetParameter::setQuadric);
+#endif
     QObject::connect(ui->doubleSpinBox_GrowthRate,
                      qOverload<double>(&QDoubleSpinBox::valueChanged),
                      this,
@@ -85,11 +92,17 @@ TaskTetParameter::TaskTetParameter(Fem::FemMeshShapeNetgenObject* pcObject, QWid
                      qOverload<int>(&QSpinBox::valueChanged),
                      this,
                      &TaskTetParameter::setSegsPerRadius);
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    QObject::connect(ui->checkBox_Optimize,
+                     &QCheckBox::checkStateChanged,
+                     this,
+                     &TaskTetParameter::setOptimize);
+#else
     QObject::connect(ui->checkBox_Optimize,
                      &QCheckBox::stateChanged,
                      this,
                      &TaskTetParameter::setOptimize);
-
+#endif
     if (pcObject->FemMesh.getValue().getInfo().numNode == 0) {
         touched = true;
     }

--- a/src/Mod/Material/Gui/MaterialSave.cpp
+++ b/src/Mod/Material/Gui/MaterialSave.cpp
@@ -66,8 +66,11 @@ MaterialSave::MaterialSave(const std::shared_ptr<Materials::Material>& material,
     _filename = QString(ui->editFilename->text());  // No filename by default
 
     ui->checkDerived->setChecked(_saveInherited);
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    connect(ui->checkDerived, &QCheckBox::checkStateChanged, this, &MaterialSave::onInherited);
+#else
     connect(ui->checkDerived, &QCheckBox::stateChanged, this, &MaterialSave::onInherited);
-
+#endif
     connect(ui->standardButtons->button(QDialogButtonBox::Ok),
             &QPushButton::clicked,
             this,

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -85,8 +85,11 @@ TaskMeasure::TaskMeasure()
     showDelta = new QCheckBox();
     showDelta->setChecked(delta);
     showDeltaLabel = new QLabel(tr("Show Delta:"));
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    connect(showDelta, &QCheckBox::checkStateChanged, this, &TaskMeasure::showDeltaChanged);
+#else
     connect(showDelta, &QCheckBox::stateChanged, this, &TaskMeasure::showDeltaChanged);
-
+#endif
     autoSaveAction = new QAction(tr("Auto Save"));
     autoSaveAction->setCheckable(true);
     autoSaveAction->setChecked(mAutoSave);

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -85,7 +85,7 @@ TaskMeasure::TaskMeasure()
     showDelta = new QCheckBox();
     showDelta->setChecked(delta);
     showDeltaLabel = new QLabel(tr("Show Delta:"));
-#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
     connect(showDelta, &QCheckBox::checkStateChanged, this, &TaskMeasure::showDeltaChanged);
 #else
     connect(showDelta, &QCheckBox::stateChanged, this, &TaskMeasure::showDeltaChanged);

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -1203,7 +1203,11 @@ protected:
 
         languageChange();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+        QObject::connect(gridAutoSpacing, &QCheckBox::checkStateChanged, [this](int state) {
+#else
         QObject::connect(gridAutoSpacing, &QCheckBox::stateChanged, [this](int state) {
+#endif
             auto* sketchView = getView();
 
             if (sketchView) {
@@ -1459,12 +1463,19 @@ protected:
 
         languageChange();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+        QObject::connect(snapToObjects, &QCheckBox::checkStateChanged, [this](int state) {
+#else
         QObject::connect(snapToObjects, &QCheckBox::stateChanged, [this](int state) {
+#endif
             ParameterGrp::handle hGrp = this->getParameterPath();
             hGrp->SetBool("SnapToObjects", state == Qt::Checked);
         });
-
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+        QObject::connect(snapToGrid, &QCheckBox::checkStateChanged, [this](int state) {
+#else
         QObject::connect(snapToGrid, &QCheckBox::stateChanged, [this](int state) {
+#endif
             ParameterGrp::handle hGrp = this->getParameterPath();
             hGrp->SetBool("SnapToGrid", state == Qt::Checked);
         });

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -910,10 +910,17 @@ TaskSketcherConstraints::TaskSketcherConstraints(ViewProviderSketch* sketchView)
         &ConstraintView::emitShowSelection3DVisibility,
         this,
         &TaskSketcherConstraints::onListWidgetConstraintsEmitShowSelection3DVisibility);
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    QObject::connect(ui->filterBox,
+                     &QCheckBox::checkStateChanged,
+                     this,
+                     &TaskSketcherConstraints::onFilterBoxStateChanged);
+#else
     QObject::connect(ui->filterBox,
                      &QCheckBox::stateChanged,
                      this,
                      &TaskSketcherConstraints::onFilterBoxStateChanged);
+#endif
     QObject::connect(
         ui->filterButton, &QToolButton::clicked, ui->filterButton, &QToolButton::showMenu);
     QObject::connect(ui->showHideButton,

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -1250,10 +1250,17 @@ void TaskSketcherElements::connectSignals()
                      &QListWidget::itemChanged,
                      this,
                      &TaskSketcherElements::onListMultiFilterItemChanged);
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    QObject::connect(ui->filterBox,
+                     &QCheckBox::checkStateChanged,
+                     this,
+                     &TaskSketcherElements::onFilterBoxStateChanged);
+#else
     QObject::connect(ui->filterBox,
                      &QCheckBox::stateChanged,
                      this,
                      &TaskSketcherElements::onFilterBoxStateChanged);
+#endif
     QObject::connect(
         ui->settingsButton, &QToolButton::clicked, ui->settingsButton, &QToolButton::showMenu);
     QObject::connect(std::as_const(ui->settingsButton)->actions()[0],

--- a/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.cpp
@@ -101,7 +101,7 @@ void TaskSketcherSolverAdvanced::setupConnections()
             qOverload<int>(&QSpinBox::valueChanged),
             this,
             &TaskSketcherSolverAdvanced::onSpinBoxMaxIterValueChanged);
-#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
     connect(ui->checkBoxSketchSizeMultiplier,
             &QCheckBox::checkStateChanged,
             this,
@@ -136,7 +136,7 @@ void TaskSketcherSolverAdvanced::setupConnections()
             qOverload<int>(&QSpinBox::valueChanged),
             this,
             &TaskSketcherSolverAdvanced::onSpinBoxRedundantSolverMaxIterationsValueChanged);
-#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
     connect(ui->checkBoxRedundantSketchSizeMultiplier,
             &QCheckBox::checkStateChanged,
             this,

--- a/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.cpp
@@ -101,10 +101,17 @@ void TaskSketcherSolverAdvanced::setupConnections()
             qOverload<int>(&QSpinBox::valueChanged),
             this,
             &TaskSketcherSolverAdvanced::onSpinBoxMaxIterValueChanged);
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    connect(ui->checkBoxSketchSizeMultiplier,
+            &QCheckBox::checkStateChanged,
+            this,
+            &TaskSketcherSolverAdvanced::onCheckBoxSketchSizeMultiplierStateChanged);
+#else
     connect(ui->checkBoxSketchSizeMultiplier,
             &QCheckBox::stateChanged,
             this,
             &TaskSketcherSolverAdvanced::onCheckBoxSketchSizeMultiplierStateChanged);
+#endif
     connect(ui->lineEditConvergence,
             &QLineEdit::editingFinished,
             this,
@@ -129,10 +136,17 @@ void TaskSketcherSolverAdvanced::setupConnections()
             qOverload<int>(&QSpinBox::valueChanged),
             this,
             &TaskSketcherSolverAdvanced::onSpinBoxRedundantSolverMaxIterationsValueChanged);
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    connect(ui->checkBoxRedundantSketchSizeMultiplier,
+            &QCheckBox::checkStateChanged,
+            this,
+            &TaskSketcherSolverAdvanced::onCheckBoxRedundantSketchSizeMultiplierStateChanged);
+#else
     connect(ui->checkBoxRedundantSketchSizeMultiplier,
             &QCheckBox::stateChanged,
             this,
             &TaskSketcherSolverAdvanced::onCheckBoxRedundantSketchSizeMultiplierStateChanged);
+#endif
     connect(ui->comboBoxDebugMode,
             qOverload<int>(&QComboBox::currentIndexChanged),
             this,

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvancedImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvancedImp.cpp
@@ -199,6 +199,28 @@ void DlgPrefsTechDrawAdvancedImp::slotBalloonBoxChecked()
 
 void DlgPrefsTechDrawAdvancedImp::makeBalloonBoxConnections()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    connect(ui->cbBalloonDefault,
+            &QCheckBox::checkStateChanged,
+            this,
+            &DlgPrefsTechDrawAdvancedImp::slotBalloonBoxChecked);
+    connect(ui->cbBalloonShift,
+            &QCheckBox::checkStateChanged,
+            this,
+            &DlgPrefsTechDrawAdvancedImp::slotBalloonBoxChecked);
+    connect(ui->cbBalloonControl,
+            &QCheckBox::checkStateChanged,
+            this,
+            &DlgPrefsTechDrawAdvancedImp::slotBalloonBoxChecked);
+    connect(ui->cbBalloonAlt,
+            &QCheckBox::checkStateChanged,
+            this,
+            &DlgPrefsTechDrawAdvancedImp::slotBalloonBoxChecked);
+    connect(ui->cbBalloonMeta,
+            &QCheckBox::checkStateChanged,
+            this,
+            &DlgPrefsTechDrawAdvancedImp::slotBalloonBoxChecked);
+#else
     connect(ui->cbBalloonDefault,
             qOverload<int>(&QCheckBox::stateChanged),
             this,
@@ -219,6 +241,7 @@ void DlgPrefsTechDrawAdvancedImp::makeBalloonBoxConnections()
             qOverload<int>(&QCheckBox::stateChanged),
             this,
             &DlgPrefsTechDrawAdvancedImp::slotBalloonBoxChecked);
+#endif
 }
 
 

--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -57,7 +57,11 @@ TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *di
 
     // Tolerancing
     ui->cbTheoreticallyExact->setChecked(parent->getDimFeat()->TheoreticalExact.getValue());
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    connect(ui->cbTheoreticallyExact, &QCheckBox::checkStateChanged, this, &TaskDimension::onTheoreticallyExactChanged);
+#else
     connect(ui->cbTheoreticallyExact, &QCheckBox::stateChanged, this, &TaskDimension::onTheoreticallyExactChanged);
+#endif
     // if TheoreticalExact disable tolerances
     if (parent->getDimFeat()->TheoreticalExact.getValue()) {
         ui->cbEqualTolerance->setDisabled(true);
@@ -67,7 +71,11 @@ TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *di
         ui->leFormatSpecifierUnderTolerance->setDisabled(true);
     }
     ui->cbEqualTolerance->setChecked(parent->getDimFeat()->EqualTolerance.getValue());
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    connect(ui->cbEqualTolerance, &QCheckBox::checkStateChanged, this, &TaskDimension::onEqualToleranceChanged);
+#else
     connect(ui->cbEqualTolerance, &QCheckBox::stateChanged, this, &TaskDimension::onEqualToleranceChanged);
+#endif
     // if EqualTolerance overtolernace must not be negative
     if (parent->getDimFeat()->EqualTolerance.getValue())
         ui->qsbOvertolerance->setMinimum(0.0);
@@ -96,7 +104,11 @@ TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *di
     ui->leFormatSpecifier->setText(qs);
     connect(ui->leFormatSpecifier, &QLineEdit::textChanged, this, &TaskDimension::onFormatSpecifierChanged);
     ui->cbArbitrary->setChecked(parent->getDimFeat()->Arbitrary.getValue());
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    connect(ui->cbArbitrary, &QCheckBox::checkStateChanged, this, &TaskDimension::onArbitraryChanged);
+#else
     connect(ui->cbArbitrary, &QCheckBox::stateChanged, this, &TaskDimension::onArbitraryChanged);
+#endif
     StringValue = parent->getDimFeat()->FormatSpecOverTolerance.getValue();
     qs = QString::fromUtf8(StringValue.data(), StringValue.size());
     ui->leFormatSpecifierOverTolerance->setText(qs);
@@ -106,12 +118,20 @@ TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *di
     connect(ui->leFormatSpecifierOverTolerance, &QLineEdit::textChanged, this, &TaskDimension::onFormatSpecifierOverToleranceChanged);
     connect(ui->leFormatSpecifierUnderTolerance, &QLineEdit::textChanged, this, &TaskDimension::onFormatSpecifierUnderToleranceChanged);
     ui->cbArbitraryTolerances->setChecked(parent->getDimFeat()->ArbitraryTolerances.getValue());
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    connect(ui->cbArbitraryTolerances, &QCheckBox::checkStateChanged, this, &TaskDimension::onArbitraryTolerancesChanged);
+#else
     connect(ui->cbArbitraryTolerances, &QCheckBox::stateChanged, this, &TaskDimension::onArbitraryTolerancesChanged);
+#endif
 
     // Display Style
     if (dimensionVP) {
         ui->cbArrowheads->setChecked(dimensionVP->FlipArrowheads.getValue());
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+        connect(ui->cbArrowheads, &QCheckBox::checkStateChanged, this, &TaskDimension::onFlipArrowheadsChanged);
+#else
         connect(ui->cbArrowheads, &QCheckBox::stateChanged, this, &TaskDimension::onFlipArrowheadsChanged);
+#endif
         ui->dimensionColor->setColor(dimensionVP->Color.getValue().asValue<QColor>());
         connect(ui->dimensionColor, &ColorButton::changed, this, &TaskDimension::onColorChanged);
         ui->qsbFontSize->setValue(dimensionVP->Fontsize.getValue());


### PR DESCRIPTION
…stateChanged -> checkStateChanged

Stops compiling warnings from being generated using Qt6.9.0+, example:

```
/home/username/freecad-daily-source/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp:1254:34: warning: ‘void QCheckBox::stateChanged(int)’ is deprecated: Use checkStateChanged() instead [-Wdeprecated-declarations]
 1254 |                      &QCheckBox::stateChanged,
      |                                  ^~~~~~~~~~~~
In file included from /usr/include/qt6/QtWidgets/QCheckBox:1,
                 from /home/username/freecad-daily-build/src/Mod/Sketcher/Gui/SketcherGui_autogen/include/ui_TaskSketcherElements.h:16,
                 from /home/username/freecad-daily-source/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp:56:
/usr/include/qt6/QtWidgets/qcheckbox.h:41:10: note: declared here
   41 |     void stateChanged(int);
      |          ^~~~~~~~~~~~
```
