### PR TITLE
Draft: Remove redundant QGroupBoxes from some of the array panels

### DIFF
--- a/src/Mod/Draft/Resources/ui/TaskPanel_CircularArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_CircularArray.ui
@@ -27,251 +27,236 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="main_group">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <layout class="QGridLayout" name="grid_values">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_r_distance">
+       <property name="toolTip">
+        <string>Distance from one layer of objects to the next layer of objects.</string>
+       </property>
+       <property name="text">
+        <string>Radial distance</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="Gui::QuantitySpinBox" name="spinbox_r_distance">
+       <property name="toolTip">
+        <string>Distance from one layer of objects to the next layer of objects.</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="value">
+        <double>200.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_tan_distance">
+       <property name="toolTip">
+        <string>Distance from one element in one ring of the array to the next element in the same ring.
+It cannot be zero.</string>
+       </property>
+       <property name="text">
+        <string>Tangential distance</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="Gui::QuantitySpinBox" name="spinbox_tan_distance">
+       <property name="toolTip">
+        <string>Distance from one element in one ring of the array to the next element in the same ring.
+It cannot be zero.</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="value">
+        <double>100.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_number">
+       <property name="toolTip">
+        <string>Number of circular layers or rings to create, including a copy of the original object.
+It must be at least 2.</string>
+       </property>
+       <property name="text">
+        <string>Number of circular layers</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QSpinBox" name="spinbox_number">
+       <property name="toolTip">
+        <string>Number of circular layers or rings to create, including a copy of the original object.
+It must be at least 2.</string>
+       </property>
+       <property name="minimum">
+        <number>2</number>
+       </property>
+       <property name="maximum">
+        <number>1000000</number>
+       </property>
+       <property name="value">
+        <number>3</number>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_symmetry">
+       <property name="toolTip">
+        <string>The number of symmetry lines in the circular array.</string>
+       </property>
+       <property name="text">
+        <string>Symmetry</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QSpinBox" name="spinbox_symmetry">
+       <property name="toolTip">
+        <string>The number of symmetry lines in the circular array.</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="value">
+        <number>1</number>
+       </property>
+      </widget>
+     </item>
+     </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="group_center">
+     <property name="toolTip">
+      <string>The coordinates of the point through which the axis of rotation passes.
+Change the direction of the axis itself in the property editor.</string>
      </property>
      <property name="title">
-      <string/>
+      <string>Center of rotation</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_4">
+     <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <layout class="QGridLayout" name="grid_values">
+       <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="label_r_distance">
-          <property name="toolTip">
-           <string>Distance from one layer of objects to the next layer of objects.</string>
-          </property>
+         <widget class="QLabel" name="label_c_x">
           <property name="text">
-           <string>Radial distance</string>
+           <string>X</string>
           </property>
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="Gui::QuantitySpinBox" name="spinbox_r_distance">
-          <property name="toolTip">
-           <string>Distance from one layer of objects to the next layer of objects.</string>
+         <widget class="Gui::InputField" name="input_c_x">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
           <property name="unit" stdset="0">
            <string notr="true">mm</string>
-          </property>
-          <property name="value">
-           <double>200.000000000000000</double>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_tan_distance">
-          <property name="toolTip">
-           <string>Distance from one element in one ring of the array to the next element in the same ring.
-It cannot be zero.</string>
-          </property>
+         <widget class="QLabel" name="label_c_y">
           <property name="text">
-           <string>Tangential distance</string>
+           <string>Y</string>
           </property>
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="Gui::QuantitySpinBox" name="spinbox_tan_distance">
-          <property name="toolTip">
-           <string>Distance from one element in one ring of the array to the next element in the same ring.
-It cannot be zero.</string>
+         <widget class="Gui::InputField" name="input_c_y">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
           <property name="unit" stdset="0">
            <string notr="true">mm</string>
           </property>
-          <property name="value">
-           <double>100.000000000000000</double>
-          </property>
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="label_number">
-          <property name="toolTip">
-           <string>Number of circular layers or rings to create, including a copy of the original object.
-It must be at least 2.</string>
-          </property>
+         <widget class="QLabel" name="label_c_z">
           <property name="text">
-           <string>Number of circular layers</string>
+           <string>Z</string>
           </property>
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="QSpinBox" name="spinbox_number">
-          <property name="toolTip">
-           <string>Number of circular layers or rings to create, including a copy of the original object.
-It must be at least 2.</string>
+         <widget class="Gui::InputField" name="input_c_z">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="minimum">
-           <number>2</number>
-          </property>
-          <property name="maximum">
-           <number>1000000</number>
-          </property>
-          <property name="value">
-           <number>3</number>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_symmetry">
-          <property name="toolTip">
-           <string>The number of symmetry lines in the circular array.</string>
-          </property>
-          <property name="text">
-           <string>Symmetry</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QSpinBox" name="spinbox_symmetry">
-          <property name="toolTip">
-           <string>The number of symmetry lines in the circular array.</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="value">
-           <number>1</number>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
           </property>
          </widget>
         </item>
         </layout>
       </item>
       <item row="1" column="0">
-       <widget class="QGroupBox" name="group_center">
+       <widget class="QPushButton" name="button_reset">
         <property name="toolTip">
-         <string>The coordinates of the point through which the axis of rotation passes.
-Change the direction of the axis itself in the property editor.</string>
+         <string>Reset the coordinates of the center of rotation.</string>
         </property>
-        <property name="title">
-         <string>Center of rotation</string>
+        <property name="text">
+         <string>Reset point</string>
         </property>
-        <layout class="QGridLayout" name="gridLayout_2">
-         <item row="0" column="0">
-          <layout class="QGridLayout" name="gridLayout">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_c_x">
-             <property name="text">
-              <string>X</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="Gui::InputField" name="input_c_x">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_c_y">
-             <property name="text">
-              <string>Y</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="Gui::InputField" name="input_c_y">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_c_z">
-             <property name="text">
-              <string>Z</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="Gui::InputField" name="input_c_z">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-            </widget>
-           </item>
-           </layout>
-         </item>
-         <item row="1" column="0">
-          <widget class="QPushButton" name="button_reset">
-           <property name="toolTip">
-            <string>Reset the coordinates of the center of rotation.</string>
-           </property>
-           <property name="text">
-            <string>Reset point</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </widget>
       </item>
-      <item row="2" column="0">
-       <layout class="QVBoxLayout" name="vertical_layout">
-        <item>
-         <widget class="QCheckBox" name="checkbox_fuse">
-          <property name="toolTip">
-           <string>If checked, the resulting objects in the array will be fused if they touch each other.
-This only works if "Link array" is off.</string>
-          </property>
-          <property name="text">
-           <string>Fuse</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="checkbox_link">
-          <property name="toolTip">
-           <string>If checked, the resulting object will be a "Link array" instead of a regular array.
-A Link array is more efficient when creating multiple copies, but it cannot be fused together.</string>
-          </property>
-          <property name="text">
-           <string>Link array</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="3" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      </layout>
+     </layout>
     </widget>
+   </item>
+   <item row="2" column="0">
+    <layout class="QVBoxLayout" name="vertical_layout">
+     <item>
+      <widget class="QCheckBox" name="checkbox_fuse">
+       <property name="toolTip">
+        <string>If checked, the resulting objects in the array will be fused if they touch each other.
+This only works if "Link array" is off.</string>
+       </property>
+       <property name="text">
+        <string>Fuse</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkbox_link">
+       <property name="toolTip">
+        <string>If checked, the resulting object will be a "Link array" instead of a regular array.
+A Link array is more efficient when creating multiple copies, but it cannot be fused together.</string>
+       </property>
+       <property name="text">
+        <string>Link array</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/Mod/Draft/Resources/ui/TaskPanel_OrthoArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_OrthoArray.ui
@@ -27,479 +27,464 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="main_group">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QGroupBox" name="group_axis_mode">
+     <property name="toolTip">
+      <string>Toggle between Orthogonal mode and Linear mode. In Linear mode, you can select which axis to use.</string>
      </property>
      <property name="title">
-      <string/>
+      <string>Axis mode</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_4">
+     <layout class="QGridLayout" name="gridLayout_axis_mode">
       <item row="0" column="0">
-       <widget class="QGroupBox" name="group_axis_mode">
-        <property name="toolTip">
-         <string>Toggle between Orthogonal mode and Linear mode. In Linear mode, you can select which axis to use.</string>
+       <widget class="QPushButton" name="button_linear_mode">
+        <property name="text">
+         <string>Switch to linear mode</string>
         </property>
-        <property name="title">
-         <string>Axis mode</string>
+        <property name="checkable">
+         <bool>true</bool>
         </property>
-        <layout class="QGridLayout" name="gridLayout_axis_mode">
-         <item row="0" column="0">
-          <widget class="QPushButton" name="button_linear_mode">
-           <property name="text">
-            <string>Switch to linear mode</string>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <layout class="QGridLayout" name="grid_axis_select">
-           <item row="0" column="0">
-            <widget class="QRadioButton" name="radiobutton_x_axis">
-             <property name="text">
-              <string>X axis</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QRadioButton" name="radiobutton_y_axis">
-             <property name="text">
-              <string>Y axis</string>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QRadioButton" name="radiobutton_z_axis">
-             <property name="text">
-              <string>Z axis</string>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QGroupBox" name="group_copies">
-        <property name="toolTip">
-         <string>Number of elements in the array in the specified direction, including a copy of the original object.
-The number must be at least 1 in each direction.</string>
-        </property>
-        <property name="title">
-         <string>Number of elements</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_5">
-         <item row="0" column="0">
-          <layout class="QGridLayout" name="grid_number">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_n_X">
-             <property name="text">
-              <string>X</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QSpinBox" name="spinbox_n_X">
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>1000000</number>
-             </property>
-             <property name="value">
-              <number>2</number>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_n_Y">
-             <property name="text">
-              <string>Y</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QSpinBox" name="spinbox_n_Y">
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>1000000</number>
-             </property>
-             <property name="value">
-              <number>2</number>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_n_Z">
-             <property name="text">
-              <string>Z</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QSpinBox" name="spinbox_n_Z">
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>1000000</number>
-             </property>
-             <property name="value">
-              <number>1</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QGroupBox" name="group_linearmode">
-        <property name="toolTip">
-         <string>Currently selected axis</string>
-        </property>
-        <property name="title">
-         <string></string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_5">
-        </layout>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QGroupBox" name="group_X">
-        <property name="toolTip">
-         <string>Distance between the elements in the X direction.
-Normally, only the X value is necessary; the other two values can give an additional shift in their respective directions.
-Negative values will result in copies produced in the negative direction.</string>
-        </property>
-        <property name="title">
-         <string>X intervals</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_2">
-         <item row="0" column="0">
-          <layout class="QGridLayout" name="grid_X">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_X_x">
-             <property name="text">
-              <string>X</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="Gui::InputField" name="input_X_x">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-             <property name="quantity" stdset="0">
-              <double>100.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_X_y">
-             <property name="text">
-              <string>Y</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="Gui::InputField" name="input_X_y">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_X_z">
-             <property name="text">
-              <string>Z</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="Gui::InputField" name="input_X_z">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-            </widget>
-           </item>
-           </layout>
-         </item>
-         <item row="1" column="0">
-          <widget class="QPushButton" name="button_reset_X">
-           <property name="toolTip">
-            <string>Reset the distances.</string>
-           </property>
-           <property name="text">
-            <string>Reset X</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QGroupBox" name="group_Y">
-        <property name="toolTip">
-         <string>Distance between the elements in the Y direction.
-Normally, only the Y value is necessary; the other two values can give an additional shift in their respective directions.
-Negative values will result in copies produced in the negative direction.</string>
-        </property>
-        <property name="title">
-         <string>Y intervals</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_6">
-         <item row="0" column="0">
-          <layout class="QGridLayout" name="grid_Y">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_Y_x">
-             <property name="text">
-              <string>X</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="Gui::InputField" name="input_Y_x">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_Y_y">
-             <property name="text">
-              <string>Y</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="Gui::InputField" name="input_Y_y">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-             <property name="quantity" stdset="0">
-              <double>100.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_Y_z">
-             <property name="text">
-              <string>Z</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="Gui::InputField" name="input_Y_z">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="1" column="0">
-          <widget class="QPushButton" name="button_reset_Y">
-           <property name="toolTip">
-            <string>Reset the distances.</string>
-           </property>
-           <property name="text">
-            <string>Reset Y</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QGroupBox" name="group_Z">
-        <property name="toolTip">
-         <string>Distance between the elements in the Z direction.
-Normally, only the Z value is necessary; the other two values can give an additional shift in their respective directions.
-Negative values will result in copies produced in the negative direction.</string>
-        </property>
-        <property name="title">
-         <string>Z intervals</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout">
-         <item row="0" column="0">
-          <layout class="QGridLayout" name="grid_Z">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_Z_x">
-             <property name="text">
-              <string>X</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="Gui::InputField" name="input_Z_x">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_Z_y">
-             <property name="text">
-              <string>Y</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="Gui::InputField" name="input_Z_y">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_Z_z">
-             <property name="text">
-              <string>Z</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="Gui::InputField" name="input_Z_z">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-             <property name="quantity" stdset="0">
-              <double>100.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="1" column="0">
-          <widget class="QPushButton" name="button_reset_Z">
-           <property name="toolTip">
-            <string>Reset the distances.</string>
-           </property>
-           <property name="text">
-            <string>Reset Z</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <layout class="QVBoxLayout" name="vertical_layout">
-        <item>
-         <widget class="QCheckBox" name="checkbox_fuse">
-          <property name="toolTip">
-           <string>If checked, the resulting objects in the array will be fused if they touch each other.
-This only works if "Link array" is off.</string>
-          </property>
+       <layout class="QGridLayout" name="grid_axis_select">
+        <item row="0" column="0">
+         <widget class="QRadioButton" name="radiobutton_x_axis">
           <property name="text">
-           <string>Fuse</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="checkbox_link">
-          <property name="toolTip">
-           <string>If checked, the resulting object will be a "Link array" instead of a regular array.
-A Link array is more efficient when creating multiple copies, but it cannot be fused together.</string>
-          </property>
-          <property name="text">
-           <string>Link array</string>
+           <string>X axis</string>
           </property>
           <property name="checked">
            <bool>true</bool>
           </property>
          </widget>
         </item>
+        <item row="1" column="0">
+         <widget class="QRadioButton" name="radiobutton_y_axis">
+          <property name="text">
+           <string>Y axis</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QRadioButton" name="radiobutton_z_axis">
+          <property name="text">
+           <string>Z axis</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
-      <item row="7" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      </layout>
+     </layout>
     </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="group_copies">
+     <property name="toolTip">
+      <string>Number of elements in the array in the specified direction, including a copy of the original object.
+The number must be at least 1 in each direction.</string>
+     </property>
+     <property name="title">
+      <string>Number of elements</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <layout class="QGridLayout" name="grid_number">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_n_X">
+          <property name="text">
+           <string>X</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QSpinBox" name="spinbox_n_X">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>1000000</number>
+          </property>
+          <property name="value">
+           <number>2</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_n_Y">
+          <property name="text">
+           <string>Y</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="spinbox_n_Y">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>1000000</number>
+          </property>
+          <property name="value">
+           <number>2</number>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_n_Z">
+          <property name="text">
+           <string>Z</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QSpinBox" name="spinbox_n_Z">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>1000000</number>
+          </property>
+          <property name="value">
+           <number>1</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="group_linearmode">
+     <property name="toolTip">
+      <string>Currently selected axis</string>
+     </property>
+     <property name="title">
+      <string></string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="group_X">
+     <property name="toolTip">
+      <string>Distance between the elements in the X direction.
+Normally, only the X value is necessary; the other two values can give an additional shift in their respective directions.
+Negative values will result in copies produced in the negative direction.</string>
+     </property>
+     <property name="title">
+      <string>X intervals</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <layout class="QGridLayout" name="grid_X">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_X_x">
+          <property name="text">
+           <string>X</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="Gui::InputField" name="input_X_x">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
+          </property>
+          <property name="quantity" stdset="0">
+           <double>100.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_X_y">
+          <property name="text">
+           <string>Y</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="Gui::InputField" name="input_X_y">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_X_z">
+          <property name="text">
+           <string>Z</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="Gui::InputField" name="input_X_z">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="button_reset_X">
+        <property name="toolTip">
+         <string>Reset the distances.</string>
+        </property>
+        <property name="text">
+         <string>Reset X</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="group_Y">
+     <property name="toolTip">
+      <string>Distance between the elements in the Y direction.
+Normally, only the Y value is necessary; the other two values can give an additional shift in their respective directions.
+Negative values will result in copies produced in the negative direction.</string>
+     </property>
+     <property name="title">
+      <string>Y intervals</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_1">
+      <item row="0" column="0">
+       <layout class="QGridLayout" name="grid_Y">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_Y_x">
+          <property name="text">
+           <string>X</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="Gui::InputField" name="input_Y_x">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_Y_y">
+          <property name="text">
+           <string>Y</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="Gui::InputField" name="input_Y_y">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
+          </property>
+          <property name="quantity" stdset="0">
+           <double>100.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_Y_z">
+          <property name="text">
+           <string>Z</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="Gui::InputField" name="input_Y_z">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="button_reset_Y">
+        <property name="toolTip">
+         <string>Reset the distances.</string>
+        </property>
+        <property name="text">
+         <string>Reset Y</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QGroupBox" name="group_Z">
+     <property name="toolTip">
+      <string>Distance between the elements in the Z direction.
+Normally, only the Z value is necessary; the other two values can give an additional shift in their respective directions.
+Negative values will result in copies produced in the negative direction.</string>
+     </property>
+     <property name="title">
+      <string>Z intervals</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <layout class="QGridLayout" name="grid_Z">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_Z_x">
+          <property name="text">
+           <string>X</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="Gui::InputField" name="input_Z_x">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_Z_y">
+          <property name="text">
+           <string>Y</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="Gui::InputField" name="input_Z_y">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_Z_z">
+          <property name="text">
+           <string>Z</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="Gui::InputField" name="input_Z_z">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
+          </property>
+          <property name="quantity" stdset="0">
+           <double>100.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="button_reset_Z">
+        <property name="toolTip">
+         <string>Reset the distances.</string>
+        </property>
+        <property name="text">
+         <string>Reset Z</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <layout class="QVBoxLayout" name="vertical_layout">
+     <item>
+      <widget class="QCheckBox" name="checkbox_fuse">
+       <property name="toolTip">
+        <string>If checked, the resulting objects in the array will be fused if they touch each other.
+This only works if "Link array" is off.</string>
+       </property>
+       <property name="text">
+        <string>Fuse</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkbox_link">
+       <property name="toolTip">
+        <string>If checked, the resulting object will be a "Link array" instead of a regular array.
+A Link array is more efficient when creating multiple copies, but it cannot be fused together.</string>
+       </property>
+       <property name="text">
+        <string>Link array</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="7" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/Mod/Draft/Resources/ui/TaskPanel_OrthoArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_OrthoArray.ui
@@ -27,62 +27,53 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="group_axis_mode">
+    <widget class="QPushButton" name="button_linear_mode">
      <property name="toolTip">
       <string>Toggle between Orthogonal mode and Linear mode. In Linear mode, you can select which axis to use.</string>
      </property>
-     <property name="title">
-      <string>Axis mode</string>
+     <property name="text">
+      <string>Switch to linear mode</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_axis_mode">
-      <item row="0" column="0">
-       <widget class="QPushButton" name="button_linear_mode">
-        <property name="text">
-         <string>Switch to linear mode</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <layout class="QGridLayout" name="grid_axis_select">
-        <item row="0" column="0">
-         <widget class="QRadioButton" name="radiobutton_x_axis">
-          <property name="text">
-           <string>X axis</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QRadioButton" name="radiobutton_y_axis">
-          <property name="text">
-           <string>Y axis</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QRadioButton" name="radiobutton_z_axis">
-          <property name="text">
-           <string>Z axis</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="1" column="0">
+    <layout class="QGridLayout" name="grid_axis_select">
+     <item row="0" column="0">
+      <widget class="QRadioButton" name="radiobutton_x_axis">
+       <property name="text">
+        <string>X axis</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QRadioButton" name="radiobutton_y_axis">
+       <property name="text">
+        <string>Y axis</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QRadioButton" name="radiobutton_z_axis">
+       <property name="text">
+        <string>Z axis</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
     <widget class="QGroupBox" name="group_copies">
      <property name="toolTip">
       <string>Number of elements in the array in the specified direction, including a copy of the original object.
@@ -159,7 +150,7 @@ The number must be at least 1 in each direction.</string>
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QGroupBox" name="group_linearmode">
      <property name="toolTip">
       <string>Currently selected axis</string>
@@ -171,7 +162,7 @@ The number must be at least 1 in each direction.</string>
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QGroupBox" name="group_X">
      <property name="toolTip">
       <string>Distance between the elements in the X direction.
@@ -262,7 +253,7 @@ Negative values will result in copies produced in the negative direction.</strin
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QGroupBox" name="group_Y">
      <property name="toolTip">
       <string>Distance between the elements in the Y direction.
@@ -353,7 +344,7 @@ Negative values will result in copies produced in the negative direction.</strin
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QGroupBox" name="group_Z">
      <property name="toolTip">
       <string>Distance between the elements in the Z direction.
@@ -444,7 +435,7 @@ Negative values will result in copies produced in the negative direction.</strin
      </layout>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <layout class="QVBoxLayout" name="vertical_layout">
      <item>
       <widget class="QCheckBox" name="checkbox_fuse">
@@ -473,7 +464,7 @@ A Link array is more efficient when creating multiple copies, but it cannot be f
      </item>
     </layout>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/Mod/Draft/Resources/ui/TaskPanel_PolarArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_PolarArray.ui
@@ -27,213 +27,198 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="main_group">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string/>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <layout class="QGridLayout" name="grid_values">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_angle">
-          <property name="toolTip">
-           <string>Sweeping angle of the polar distribution.
+    <layout class="QGridLayout" name="grid_values">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_angle">
+       <property name="toolTip">
+        <string>Sweeping angle of the polar distribution.
 A negative angle produces a polar pattern in the opposite direction.
 The maximum absolute value is 360 degrees.</string>
-          </property>
+       </property>
+       <property name="text">
+        <string>Polar angle</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="Gui::QuantitySpinBox" name="spinbox_angle">
+       <property name="toolTip">
+        <string>Sweeping angle of the polar distribution.
+A negative angle produces a polar pattern in the opposite direction.
+The maximum absolute value is 360 degrees.</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">°</string>
+       </property>
+       <property name="minimum">
+        <double>-360.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>360.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>360.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_number">
+       <property name="toolTip">
+        <string>Number of elements in the array, including a copy of the original object.
+It must be at least 2.</string>
+       </property>
+       <property name="text">
+        <string>Number of elements</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="spinbox_number">
+       <property name="toolTip">
+        <string>Number of elements in the array, including a copy of the original object.
+It must be at least 2.</string>
+       </property>
+       <property name="minimum">
+        <number>2</number>
+       </property>
+       <property name="maximum">
+        <number>1000000</number>
+       </property>
+       <property name="value">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="group_center">
+     <property name="toolTip">
+      <string>The coordinates of the point through which the axis of rotation passes.
+Change the direction of the axis itself in the property editor.</string>
+     </property>
+     <property name="title">
+      <string>Center of rotation</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <layout class="QGridLayout" name="grid_center">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_c_x">
           <property name="text">
-           <string>Polar angle</string>
+           <string>X</string>
           </property>
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="Gui::QuantitySpinBox" name="spinbox_angle">
-          <property name="toolTip">
-           <string>Sweeping angle of the polar distribution.
-A negative angle produces a polar pattern in the opposite direction.
-The maximum absolute value is 360 degrees.</string>
+         <widget class="Gui::InputField" name="input_c_x">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
           <property name="unit" stdset="0">
-           <string notr="true">°</string>
-          </property>
-          <property name="minimum">
-           <double>-360.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>360.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>360.000000000000000</double>
+           <string notr="true">mm</string>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_number">
-          <property name="toolTip">
-           <string>Number of elements in the array, including a copy of the original object.
-It must be at least 2.</string>
-          </property>
+         <widget class="QLabel" name="label_c_y">
           <property name="text">
-           <string>Number of elements</string>
+           <string>Y</string>
           </property>
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QSpinBox" name="spinbox_number">
-          <property name="toolTip">
-           <string>Number of elements in the array, including a copy of the original object.
-It must be at least 2.</string>
+         <widget class="Gui::InputField" name="input_c_y">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="minimum">
-           <number>2</number>
-          </property>
-          <property name="maximum">
-           <number>1000000</number>
-          </property>
-          <property name="value">
-           <number>5</number>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
           </property>
          </widget>
         </item>
-       </layout>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_c_z">
+          <property name="text">
+           <string>Z</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="Gui::InputField" name="input_c_z">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
+          </property>
+         </widget>
+        </item>
+        </layout>
       </item>
       <item row="1" column="0">
-       <widget class="QGroupBox" name="group_center">
+       <widget class="QPushButton" name="button_reset">
         <property name="toolTip">
-         <string>The coordinates of the point through which the axis of rotation passes.
-Change the direction of the axis itself in the property editor.</string>
+         <string>Reset the coordinates of the center of rotation.</string>
         </property>
-        <property name="title">
-         <string>Center of rotation</string>
+        <property name="text">
+         <string>Reset point</string>
         </property>
-        <layout class="QGridLayout" name="gridLayout_2">
-         <item row="0" column="0">
-          <layout class="QGridLayout" name="grid_center">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_c_x">
-             <property name="text">
-              <string>X</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="Gui::InputField" name="input_c_x">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_c_y">
-             <property name="text">
-              <string>Y</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="Gui::InputField" name="input_c_y">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_c_z">
-             <property name="text">
-              <string>Z</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="Gui::InputField" name="input_c_z">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="unit" stdset="0">
-              <string notr="true">mm</string>
-             </property>
-            </widget>
-           </item>
-           </layout>
-         </item>
-         <item row="1" column="0">
-          <widget class="QPushButton" name="button_reset">
-           <property name="toolTip">
-            <string>Reset the coordinates of the center of rotation.</string>
-           </property>
-           <property name="text">
-            <string>Reset point</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </widget>
       </item>
-      <item row="2" column="0">
-       <layout class="QVBoxLayout" name="vertical_layout">
-        <item>
-         <widget class="QCheckBox" name="checkbox_fuse">
-          <property name="toolTip">
-           <string>If checked, the resulting objects in the array will be fused if they touch each other.
-This only works if "Link array" is off.</string>
-          </property>
-          <property name="text">
-           <string>Fuse</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="checkbox_link">
-          <property name="toolTip">
-           <string>If checked, the resulting object will be a "Link array" instead of a regular array.
-A Link array is more efficient when creating multiple copies, but it cannot be fused together.</string>
-          </property>
-          <property name="text">
-           <string>Link array</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="3" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      </layout>
+     </layout>
     </widget>
+   </item>
+   <item row="2" column="0">
+    <layout class="QVBoxLayout" name="vertical_layout">
+     <item>
+      <widget class="QCheckBox" name="checkbox_fuse">
+       <property name="toolTip">
+        <string>If checked, the resulting objects in the array will be fused if they touch each other.
+This only works if "Link array" is off.</string>
+       </property>
+       <property name="text">
+        <string>Fuse</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkbox_link">
+       <property name="toolTip">
+        <string>If checked, the resulting object will be a "Link array" instead of a regular array.
+A Link array is more efficient when creating multiple copies, but it cannot be fused together.</string>
+       </property>
+       <property name="text">
+        <string>Link array</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/Mod/Draft/Resources/ui/TaskShapeString.ui
+++ b/src/Mod/Draft/Resources/ui/TaskShapeString.ui
@@ -27,160 +27,145 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string/>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout_7">
-        <item row="0" column="0">
-         <widget class="QLabel" name="labelX">
-          <property name="text">
-           <string>X</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="Gui::QuantitySpinBox" name="sbX">
-          <property name="toolTip">
-           <string>Enter coordinates or select point with mouse.</string>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true">mm</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="labelY">
-          <property name="text">
-           <string>Y</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="Gui::QuantitySpinBox" name="sbY">
-          <property name="toolTip">
-           <string>Enter coordinates or select point with mouse.</string>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true">mm</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="labelZ">
-          <property name="text">
-           <string>Z</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="Gui::QuantitySpinBox" name="sbZ">
-          <property name="toolTip">
-           <string>Enter coordinates or select point with mouse.</string>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true">mm</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QCheckBox" name="cbGlobalMode">
-          <property name="toolTip">
-           <string>Coordinates relative to global coordinate system.
+    <layout class="QGridLayout" name="gridLayout_7">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelX">
+       <property name="text">
+        <string>X</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="Gui::QuantitySpinBox" name="sbX">
+       <property name="toolTip">
+        <string>Enter coordinates or select point with mouse.</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelY">
+       <property name="text">
+        <string>Y</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="Gui::QuantitySpinBox" name="sbY">
+       <property name="toolTip">
+        <string>Enter coordinates or select point with mouse.</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelZ">
+       <property name="text">
+        <string>Z</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="Gui::QuantitySpinBox" name="sbZ">
+       <property name="toolTip">
+        <string>Enter coordinates or select point with mouse.</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="cbGlobalMode">
+       <property name="toolTip">
+        <string>Coordinates relative to global coordinate system.
 Uncheck to use working plane coordinate system</string>
-          </property>
-          <property name="text">
-           <string>Global</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QPushButton" name="pbReset">
-          <property name="toolTip">
-           <string>Reset 3D point selection</string>
-          </property>
-          <property name="statusTip">
-           <string/>
-          </property>
-          <property name="text">
-           <string>Reset point</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="labelHeight">
-          <property name="text">
-           <string>Height</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="Gui::QuantitySpinBox" name="sbHeight">
-          <property name="toolTip">
-           <string>Height of the result</string>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true">mm</string>
-          </property>
-          <property name="minimum">
-           <double>0.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>10.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0">
-       <layout class="QGridLayout" name="gridLayout_6">
-        <item row="0" column="0">
-         <widget class="QLabel" name="labelText">
-          <property name="text">
-           <string>Text</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="leText">
-          <property name="toolTip">
-           <string>Text to be made into ShapeString</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="labelFontFile">
-          <property name="text">
-           <string>Font file</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="Gui::FileChooser" name="fcFontFile">
-          <property name="filter">
-           <string>Font files (*.ttc *.ttf *.otf *.pfb *.TTC *.TTF *.OTF *.PFB)</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="2" column="0">
-       <spacer name="verticalSpacer_1">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
+       </property>
+       <property name="text">
+        <string>Global</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QPushButton" name="pbReset">
+       <property name="toolTip">
+        <string>Reset 3D point selection</string>
+       </property>
+       <property name="statusTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Reset point</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelHeight">
+       <property name="text">
+        <string>Height</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="Gui::QuantitySpinBox" name="sbHeight">
+       <property name="toolTip">
+        <string>Height of the result</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <layout class="QGridLayout" name="gridLayout_6">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelText">
+       <property name="text">
+        <string>Text</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="leText">
+       <property name="toolTip">
+        <string>Text to be made into ShapeString</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelFontFile">
+       <property name="text">
+        <string>Font file</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="Gui::FileChooser" name="fcFontFile">
+       <property name="filter">
+        <string>Font files (*.ttc *.ttf *.otf *.pfb *.TTC *.TTF *.OTF *.PFB)</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <spacer name="verticalSpacer_1">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
As the title says. We had a discussion that those QGroupBoxes (global one and additional one around the button and radio buttons for Ortho Array) are completely redundant, and the panel would look better if we'd remove them.

So they got removed + removed icons from the panels as they are already visible in the panel's tab.
FYI @kaiwas @PaddleStroke 
Showcase:

BEFORE:
![image](https://github.com/user-attachments/assets/6ff0a996-0866-4a31-a6a0-85c5c385e4c4)
![image](https://github.com/user-attachments/assets/4a44495b-c9df-45da-8f24-95384270cff7)
![image](https://github.com/user-attachments/assets/591c7a52-2107-43a0-b326-dc565d9ae7bf)
![image](https://github.com/user-attachments/assets/f17c5f0e-ac8f-413d-8290-fd782dfd51d4)
===========================

AFTER:
![image](https://github.com/user-attachments/assets/81e88fce-6856-4c23-b646-cc14af545051)
![image](https://github.com/user-attachments/assets/8cd90687-362c-4dc3-a8ca-31c0957becc9)
![image](https://github.com/user-attachments/assets/dc3b31b2-dcef-4e9a-8f11-e94c00d8d5c6)
![image](https://github.com/user-attachments/assets/d92c71ed-2fdb-4674-8895-630a71cb4c3c)
============================
