### PR TITLE
CAM: Load preferences before activating the workbench

### DIFF
--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -22,9 +22,37 @@
 # *                                                                         *
 # ***************************************************************************
 import FreeCAD
+from PySide.QtCore import QT_TRANSLATE_NOOP
+import Path.Dressup.Gui.Preferences as PathPreferencesPathDressup
+import Path.Tool.assets.ui.preferences as AssetPreferences
+import Path.Main.Gui.PreferencesJob as PathPreferencesPathJob
+import Path.Base.Gui.PreferencesAdvanced as PathPreferencesAdvanced
+import Path.Op.Base
+import Path.Tool
 
 
 FreeCAD.__unit_test__ += ["TestCAMGui"]
+
+
+if FreeCAD.GuiUp:
+    import FreeCADGui
+
+    FreeCADGui.addPreferencePage(
+        PathPreferencesPathJob.JobPreferencesPage,
+        QT_TRANSLATE_NOOP("QObject", "CAM"),
+    )
+    FreeCADGui.addPreferencePage(
+        AssetPreferences.AssetPreferencesPage,
+        QT_TRANSLATE_NOOP("QObject", "CAM"),
+    )
+    FreeCADGui.addPreferencePage(
+        PathPreferencesPathDressup.DressupPreferencesPage,
+        QT_TRANSLATE_NOOP("QObject", "CAM"),
+    )
+    FreeCADGui.addPreferencePage(
+        PathPreferencesAdvanced.AdvancedPreferencesPage,
+        QT_TRANSLATE_NOOP("QObject", "CAM"),
+    )
 
 
 class PathCommandGroup:
@@ -66,13 +94,10 @@ class CAMWorkbench(Workbench):
         import Path.Tool.assets.ui.preferences as AssetPreferences
         import Path.Main.Gui.PreferencesJob as PathPreferencesPathJob
 
-        translate = FreeCAD.Qt.translate
-
         # load the builtin modules
         import Path
         import PathScripts
         import PathGui
-        from PySide import QtCore, QtGui
 
         FreeCADGui.addLanguagePath(":/translations")
         FreeCADGui.addIconPath(":/icons")
@@ -88,19 +113,6 @@ class CAMWorkbench(Workbench):
         import PathCommands
         import subprocess
         from packaging.version import Version, parse
-
-        FreeCADGui.addPreferencePage(
-            PathPreferencesPathJob.JobPreferencesPage,
-            QT_TRANSLATE_NOOP("QObject", "CAM"),
-        )
-        FreeCADGui.addPreferencePage(
-            AssetPreferences.AssetPreferencesPage,
-            QT_TRANSLATE_NOOP("QObject", "CAM"),
-        )
-        FreeCADGui.addPreferencePage(
-            PathPreferencesPathDressup.DressupPreferencesPage,
-            QT_TRANSLATE_NOOP("QObject", "CAM"),
-        )
 
         Path.GuiInit.Startup()
 
@@ -291,14 +303,6 @@ class CAMWorkbench(Workbench):
         if curveAccuracy:
             Path.Area.setDefaultParams(Accuracy=curveAccuracy)
 
-        # keep this one the last entry in the preferences
-        import Path.Base.Gui.PreferencesAdvanced as PathPreferencesAdvanced
-        from Path.Preferences import preferences
-
-        FreeCADGui.addPreferencePage(
-            PathPreferencesAdvanced.AdvancedPreferencesPage,
-            QT_TRANSLATE_NOOP("QObject", "CAM"),
-        )
         Log("Loading CAM workbench... done\n")
 
     def GetClassName(self):
@@ -314,8 +318,6 @@ class CAMWorkbench(Workbench):
         pass
 
     def ContextMenu(self, recipient):
-        import PathScripts
-
         menuAppended = False
         if len(FreeCADGui.Selection.getSelection()) == 1:
             obj = FreeCADGui.Selection.getSelection()[0]


### PR DESCRIPTION
This PR changes InitGui so that CAM preferences are loaded earlier, before the CAM workbench is activated.

Since CAM does not have any preferences that actually require loading the workbench, deferring the load is not necessary. This is in line with how many workbenches load preferences earlier and provides a more consistent UI for the user; the CAM preferences UI can always be used, whether they previously opened the CAM workbench or not.
