### PR TITLE
Sketcher: Prioritize rendering geometry lines rendering over constraints

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -75,7 +75,7 @@ struct DrawingParameters
     const float zMidLines = 0.006f;    // Height used for in-the-middle rendered lines
     const float zHighLines = 0.007f;   // Height used for on top rendered lines
     const float zHighLine = 0.008f;    // Height for highlighted lines (selected/preselected)
-    const float zConstr = 0.009f;      // Height for rendering constraints
+    const float zConstr = 0.004f;      // Height for rendering constraints
     const float zRootPoint = 0.010f;   // Height used for rendering the root point
     const float zLowPoints = 0.011f;   // Height used for bottom rendered points
     const float zMidPoints = 0.012f;   // Height used for mid rendered points

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -1975,11 +1975,6 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 text->size.setValue(drawingParameters.labelFontSize);
                 text->lineWidth = 2 * drawingParameters.pixelScalingFactor;
                 text->useAntialiasing = false;
-                // Remove SoAnnotation wrapper to allow proper depth testing
-                // SoAnnotation* anno = new SoAnnotation();
-                // anno->renderCaching = SoSeparator::OFF;
-                // anno->addChild(text);
-                // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
                 sep->addChild(text);
                 editModeScenegraphNodes.constrGroup->addChild(sep);
                 vConstrType.push_back((*it)->Type);

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -121,7 +121,6 @@ void EditModeConstraintCoinManager::processConstraints(const GeoListFacade& geol
 
     auto zConstrH = ViewProviderSketchCoinAttorney::getViewOrientationFactor(viewProvider)
         * drawingParameters.zConstr;
-
     // After an undo/redo it can happen that we have an empty geometry list but a non-empty
     // constraint list In this case just ignore the constraints. (See bug #0000421)
     if (geolistfacade.geomlist.size() <= 2 && !constrlist.empty()) {
@@ -1976,12 +1975,13 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 text->size.setValue(drawingParameters.labelFontSize);
                 text->lineWidth = 2 * drawingParameters.pixelScalingFactor;
                 text->useAntialiasing = false;
-                SoAnnotation* anno = new SoAnnotation();
-                anno->renderCaching = SoSeparator::OFF;
-                anno->addChild(text);
+                // Remove SoAnnotation wrapper to allow proper depth testing
+                // SoAnnotation* anno = new SoAnnotation();
+                // anno->renderCaching = SoSeparator::OFF;
+                // anno->addChild(text);
                 // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
                 sep->addChild(text);
-                editModeScenegraphNodes.constrGroup->addChild(anno);
+                editModeScenegraphNodes.constrGroup->addChild(sep);
                 vConstrType.push_back((*it)->Type);
                 // nodes not needed
                 sep->unref();


### PR DESCRIPTION
As the title says - since there is pending PR for better SoDatumLabel constraints interactivity, this patch now prioritizes geometry lines over constraints, so constraints will be rendered below lines.

This patch changes rendering order of constraint lines to be below geometry lines, so now selection and rendering will be prioritized for geometry lines instead of constraints.

This is done by changing depth buffer values and removal of SoAnnotation node which was disabling depth buffer checks on constraints at all.

NOTE:
This should be merged before https://github.com/FreeCAD/FreeCAD/pull/21920, there are still some parts to resolve regarding text order and arrowheads, but I will do it in 21920 separately, as it touches `SoDatumLabel.cpp` parts of code, so just to avoid unnecessary conflicts.

Demo:

https://github.com/user-attachments/assets/b47db56b-9625-4bbc-99c3-24e998e7b000

Resolves: https://github.com/FreeCAD/FreeCAD/issues/11603