### PR TITLE
Import: add DXF statistics reporter

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -4215,7 +4215,9 @@ class DxfImportReporter:
         self.stats = stats_dict
 
     def to_console_string(self):
-        """Formats the statistics into a human-readable string for console output."""
+        """
+        Formats the statistics into a human-readable string for console output.
+        """
         if not self.stats:
             return "DXF Import: No statistics were returned from the importer.\n"
 
@@ -4224,7 +4226,21 @@ class DxfImportReporter:
         # General Info
         lines.append(f"DXF Version: {self.stats.get('dxfVersion', 'Unknown')}")
         lines.append(f"File Encoding: {self.stats.get('dxfEncoding', 'Unknown')}")
-        # Timing will be 0.0 for now, but the line is ready for when it's fixed.
+
+        # Scaling Info
+        file_units = self.stats.get('fileUnits', 'Not specified')
+        source = self.stats.get('scalingSource', '')
+        if source:
+            lines.append(f"File Units: {file_units} (from {source})")
+        else:
+            lines.append(f"File Units: {file_units}")
+
+        manual_scaling = self.stats.get('importSettings', {}).get('Manual scaling factor', '1.0')
+        lines.append(f"Manual Scaling Factor: {manual_scaling}")
+
+        final_scaling = self.stats.get('finalScalingFactor', 1.0)
+        lines.append(f"Final Scaling: 1 DXF unit = {final_scaling:.4f} mm")
+
         import_time = self.stats.get('importTimeSeconds', 0.0)
         lines.append(f"Import Time: {import_time:.4f} seconds")
         lines.append("")
@@ -4251,9 +4267,16 @@ class DxfImportReporter:
             lines.append(f"  Total entities read: {total_read}")
         else:
             lines.append("  (No entities recorded)")
-
         lines.append(f"FreeCAD objects created: {self.stats.get('totalEntitiesCreated', 0)}")
-        lines.append(f"Unsupported features: {self.stats.get('unsupportedFeaturesCount', 0)}")
+        lines.append("")
+
+        lines.append("Unsupported Features:")
+        unsupported = self.stats.get('unsupportedFeatures', {})
+        if unsupported:
+            for key, value in sorted(unsupported.items()):
+                lines.append(f"  - {key}: {value} time(s)")
+        else:
+            lines.append("  (None)")
 
         lines.append("--- End of Summary ---\n")
         return "\n".join(lines)

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -4228,38 +4228,38 @@ class DxfImportReporter:
         Formats the statistics into a human-readable string for console output.
         """
         if not self.stats:
-            return "DXF Import: No statistics were returned from the importer.\n"
+            return "DXF Import: no statistics were returned from the importer.\n"
 
-        lines = ["\n--- DXF Import Summary ---"]
+        lines = ["\n--- DXF import summary ---"]
 
         # General info
-        lines.append(f"DXF Version: {self.stats.get('dxfVersion', 'Unknown')}")
-        lines.append(f"File Encoding: {self.stats.get('dxfEncoding', 'Unknown')}")
+        lines.append(f"DXF version: {self.stats.get('dxfVersion', 'Unknown')}")
+        lines.append(f"File encoding: {self.stats.get('dxfEncoding', 'Unknown')}")
 
         # Scaling info
         file_units = self.stats.get('fileUnits', 'Not specified')
         source = self.stats.get('scalingSource', '')
         if source:
-            lines.append(f"File Units: {file_units} (from {source})")
+            lines.append(f"File units: {file_units} (from {source})")
         else:
-            lines.append(f"File Units: {file_units}")
+            lines.append(f"File units: {file_units}")
 
         manual_scaling = self.stats.get('importSettings', {}).get('Manual scaling factor', '1.0')
-        lines.append(f"Manual Scaling Factor: {manual_scaling}")
+        lines.append(f"Manual scaling factor: {manual_scaling}")
 
         final_scaling = self.stats.get('finalScalingFactor', 1.0)
-        lines.append(f"Final Scaling: 1 DXF unit = {final_scaling:.4f} mm")
+        lines.append(f"Final scaling: 1 DXF unit = {final_scaling:.4f} mm")
         lines.append("")
 
         # Timing
         lines.append("Performance:")
         cpp_time = self.stats.get('importTimeSeconds', 0.0)
-        lines.append(f"  - C++ Import Time: {cpp_time:.4f} seconds")
-        lines.append(f"  - Total Import Time: {self.total_time:.4f} seconds")
+        lines.append(f"  - C++ import time: {cpp_time:.4f} seconds")
+        lines.append(f"  - Total import time: {self.total_time:.4f} seconds")
         lines.append("")
 
         # Settings
-        lines.append("Import Settings:")
+        lines.append("Import settings:")
         settings = self.stats.get('importSettings', {})
         if settings:
             for key, value in sorted(settings.items()):
@@ -4269,7 +4269,7 @@ class DxfImportReporter:
         lines.append("")
 
         # Counts
-        lines.append("Entity Counts:")
+        lines.append("Entity counts:")
         total_read = 0
         entities = self.stats.get('entityCounts', {})
         if entities:
@@ -4283,15 +4283,31 @@ class DxfImportReporter:
         lines.append(f"FreeCAD objects created: {self.stats.get('totalEntitiesCreated', 0)}")
         lines.append("")
 
-        lines.append("Unsupported Features:")
+        lines.append("Import issues and unsupported features:")
         unsupported = self.stats.get('unsupportedFeatures', {})
         if unsupported:
-            for key, value in sorted(unsupported.items()):
-                lines.append(f"  - {key}: {value} time(s)")
-        else:
-            lines.append("  (None)")
+            for key, occurrences in sorted(unsupported.items()):
+                count = len(occurrences)
+                max_details_to_show = 5
 
-        lines.append("--- End of Summary ---\n")
+                details_list = []
+                for i, (line, handle) in enumerate(occurrences):
+                    if i >= max_details_to_show:
+                        break
+                    if handle:
+                        details_list.append(f"line {line} (handle {handle})")
+                    else:
+                        details_list.append(f"line {line} (no handle available)")
+
+                details_str = ", ".join(details_list)
+                if count > max_details_to_show:
+                    lines.append(f"  - {key}: {count} time(s). Examples: {details_str}, ...")
+                else:
+                    lines.append(f"  - {key}: {count} time(s) at {details_str}")
+        else:
+            lines.append("  (none)")
+
+        lines.append("--- End of summary ---\n")
         return "\n".join(lines)
 
     def report_to_console(self):

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -2838,7 +2838,7 @@ def open(filename):
 
         total_end_time = time.perf_counter()
         if stats:
-            reporter = DxfImportReporter(stats, total_end_time - total_start_time)
+            reporter = DxfImportReporter(filename, stats, total_end_time - total_start_time)
             reporter.report_to_console()
 
         Draft.convert_draft_texts() # convert annotations to Draft texts
@@ -2888,7 +2888,7 @@ def insert(filename, docname):
 
         total_end_time = time.perf_counter()
         if stats:
-            reporter = DxfImportReporter(stats, total_end_time - total_start_time)
+            reporter = DxfImportReporter(filename, stats, total_end_time - total_start_time)
             reporter.report_to_console()
 
         Draft.convert_draft_texts() # convert annotations to Draft texts
@@ -4219,7 +4219,8 @@ def readPreferences():
 
 class DxfImportReporter:
     """Formats and reports statistics from a DXF import process."""
-    def __init__(self, stats_dict, total_time=0.0):
+    def __init__(self, filename, stats_dict, total_time=0.0):
+        self.filename = filename
         self.stats = stats_dict
         self.total_time = total_time
 
@@ -4231,6 +4232,7 @@ class DxfImportReporter:
             return "DXF Import: no statistics were returned from the importer.\n"
 
         lines = ["\n--- DXF import summary ---"]
+        lines.append(f"Import of file: '{self.filename}'\n")
 
         # General info
         lines.append(f"DXF version: {self.stats.get('dxfVersion', 'Unknown')}")
@@ -4283,7 +4285,7 @@ class DxfImportReporter:
         lines.append(f"FreeCAD objects created: {self.stats.get('totalEntitiesCreated', 0)}")
         lines.append("")
 
-        lines.append("Import issues and unsupported features:")
+        lines.append("Unsupported features:")
         unsupported = self.stats.get('unsupportedFeatures', {})
         if unsupported:
             for key, occurrences in sorted(unsupported.items()):

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -4273,10 +4273,23 @@ class DxfImportReporter:
         # Counts
         lines.append("Entity counts:")
         total_read = 0
+        unsupported_keys = self.stats.get('unsupportedFeatures', {}).keys()
+        unsupported_entity_names = set()
+        for key in unsupported_keys:
+            # Extract the entity name from the key string, e.g., 'HATCH' from "Entity type 'HATCH'"
+            entity_name_match = re.search(r"\'(.*?)\'", key)
+            if entity_name_match:
+                unsupported_entity_names.add(entity_name_match.group(1))
+
+        has_unsupported_indicator = False
         entities = self.stats.get('entityCounts', {})
         if entities:
             for key, value in sorted(entities.items()):
-                lines.append(f"  - {key}: {value}")
+                indicator = ""
+                if key in unsupported_entity_names:
+                    indicator = " (*)"
+                    has_unsupported_indicator = True
+                lines.append(f"  - {key}: {value}{indicator}")
                 total_read += value
             lines.append("----------------------------")
             lines.append(f"  Total entities read: {total_read}")
@@ -4284,6 +4297,9 @@ class DxfImportReporter:
             lines.append("  (No entities recorded)")
         lines.append(f"FreeCAD objects created: {self.stats.get('totalEntitiesCreated', 0)}")
         lines.append("")
+        if has_unsupported_indicator:
+            lines.append("(*) Entity type not supported by importer.")
+            lines.append("")
 
         lines.append("Unsupported features:")
         unsupported = self.stats.get('unsupportedFeatures', {})

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -48,6 +48,7 @@
 #endif
 #endif
 
+#include <chrono>
 #include "dxf/ImpExpDxf.h"
 #include "SketchExportHelper.h"
 #include <App/Application.h>
@@ -413,7 +414,13 @@ private:
             ImpExpDxfRead dxf_file(EncodedName, pcDoc);
             dxf_file.setOptionSource(defaultOptions);
             dxf_file.setOptions();
+
+            auto startTime = std::chrono::high_resolution_clock::now();
             dxf_file.DoRead(IgnoreErrors);
+            auto endTime = std::chrono::high_resolution_clock::now();
+            std::chrono::duration<double> elapsed = endTime - startTime;
+            dxf_file.setImportTime(elapsed.count());
+
             pcDoc->recompute();
             return dxf_file.getStatsAsPyObject();
         }
@@ -423,7 +430,6 @@ private:
         catch (const Base::Exception& e) {
             throw Py::RuntimeError(e.what());
         }
-        return Py::None();
     }
 
 

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -415,6 +415,7 @@ private:
             dxf_file.setOptions();
             dxf_file.DoRead(IgnoreErrors);
             pcDoc->recompute();
+            return dxf_file.getStatsAsPyObject();
         }
         catch (const Standard_Failure& e) {
             throw Py::RuntimeError(e.GetMessageString());

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -1375,8 +1375,10 @@ void ImpExpDxfWrite::exportDiametricDim(Base::Vector3d textLocn,
 
 Py::Object ImpExpDxfRead::getStatsAsPyObject()
 {
+    // Create a Python dictionary to hold all import statistics.
     Py::Dict statsDict;
 
+    // Populate the dictionary with general information about the import.
     statsDict.setItem("dxfVersion", Py::String(m_stats.dxfVersion));
     statsDict.setItem("dxfEncoding", Py::String(m_stats.dxfEncoding));
     statsDict.setItem("scalingSource", Py::String(m_stats.scalingSource));
@@ -1385,23 +1387,27 @@ Py::Object ImpExpDxfRead::getStatsAsPyObject()
     statsDict.setItem("importTimeSeconds", Py::Float(m_stats.importTimeSeconds));
     statsDict.setItem("totalEntitiesCreated", Py::Long(m_stats.totalEntitiesCreated));
 
+    // Create a nested dictionary for the counts of each DXF entity type read.
     Py::Dict entityCountsDict;
     for (const auto& pair : m_stats.entityCounts) {
         entityCountsDict.setItem(pair.first.c_str(), Py::Long(pair.second));
     }
     statsDict.setItem("entityCounts", entityCountsDict);
 
+    // Create a nested dictionary for the import settings used for this session.
     Py::Dict importSettingsDict;
     for (const auto& pair : m_stats.importSettings) {
         importSettingsDict.setItem(pair.first.c_str(), Py::String(pair.second));
     }
     statsDict.setItem("importSettings", importSettingsDict);
 
+    // Create a nested dictionary for any unsupported DXF features encountered.
     Py::Dict unsupportedFeaturesDict;
     for (const auto& pair : m_stats.unsupportedFeatures) {
         unsupportedFeaturesDict.setItem(pair.first.c_str(), Py::Long(pair.second));
     }
     statsDict.setItem("unsupportedFeatures", unsupportedFeaturesDict);
 
+    // Return the fully populated statistics dictionary to the Python caller.
     return statsDict;
 }

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -1404,7 +1404,14 @@ Py::Object ImpExpDxfRead::getStatsAsPyObject()
     // Create a nested dictionary for any unsupported DXF features encountered.
     Py::Dict unsupportedFeaturesDict;
     for (const auto& pair : m_stats.unsupportedFeatures) {
-        unsupportedFeaturesDict.setItem(pair.first.c_str(), Py::Long(pair.second));
+        Py::List occurrencesList;
+        for (const auto& occurrence : pair.second) {
+            Py::Tuple infoTuple(2);
+            infoTuple.setItem(0, Py::Long(occurrence.first));
+            infoTuple.setItem(1, Py::String(occurrence.second));
+            occurrencesList.append(infoTuple);
+        }
+        unsupportedFeaturesDict.setItem(pair.first.c_str(), occurrencesList);
     }
     statsDict.setItem("unsupportedFeatures", unsupportedFeaturesDict);
 

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -1372,3 +1372,27 @@ void ImpExpDxfWrite::exportDiametricDim(Base::Vector3d textLocn,
     arc2[2] = arcPoint2.z;
     writeDiametricDim(text, arc1, arc2, dimText);
 }
+
+Py::Object ImpExpDxfRead::getStatsAsPyObject()
+{
+    Py::Dict statsDict;
+
+    statsDict.setItem("dxfVersion", Py::String(m_stats.dxfVersion));
+    statsDict.setItem("dxfEncoding", Py::String(m_stats.dxfEncoding));
+    statsDict.setItem("totalEntitiesCreated", Py::Long(m_stats.totalEntitiesCreated));
+    statsDict.setItem("unsupportedFeaturesCount", Py::Long(m_stats.unsupportedFeaturesCount));
+
+    Py::Dict entityCountsDict;
+    for (const auto& pair : m_stats.entityCounts) {
+        entityCountsDict.setItem(pair.first.c_str(), Py::Long(pair.second));
+    }
+    statsDict.setItem("entityCounts", entityCountsDict);
+
+    Py::Dict importSettingsDict;
+    for (const auto& pair : m_stats.importSettings) {
+        importSettingsDict.setItem(pair.first.c_str(), Py::String(pair.second));
+    }
+    statsDict.setItem("importSettings", importSettingsDict);
+
+    return statsDict;
+}

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -1384,7 +1384,6 @@ Py::Object ImpExpDxfRead::getStatsAsPyObject()
     statsDict.setItem("finalScalingFactor", Py::Float(m_stats.finalScalingFactor));
     statsDict.setItem("importTimeSeconds", Py::Float(m_stats.importTimeSeconds));
     statsDict.setItem("totalEntitiesCreated", Py::Long(m_stats.totalEntitiesCreated));
-    statsDict.setItem("unsupportedFeaturesCount", Py::Long(m_stats.unsupportedFeaturesCount));
 
     Py::Dict entityCountsDict;
     for (const auto& pair : m_stats.entityCounts) {
@@ -1397,6 +1396,12 @@ Py::Object ImpExpDxfRead::getStatsAsPyObject()
         importSettingsDict.setItem(pair.first.c_str(), Py::String(pair.second));
     }
     statsDict.setItem("importSettings", importSettingsDict);
+
+    Py::Dict unsupportedFeaturesDict;
+    for (const auto& pair : m_stats.unsupportedFeatures) {
+        unsupportedFeaturesDict.setItem(pair.first.c_str(), Py::Long(pair.second));
+    }
+    statsDict.setItem("unsupportedFeatures", unsupportedFeaturesDict);
 
     return statsDict;
 }

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -1379,6 +1379,10 @@ Py::Object ImpExpDxfRead::getStatsAsPyObject()
 
     statsDict.setItem("dxfVersion", Py::String(m_stats.dxfVersion));
     statsDict.setItem("dxfEncoding", Py::String(m_stats.dxfEncoding));
+    statsDict.setItem("scalingSource", Py::String(m_stats.scalingSource));
+    statsDict.setItem("fileUnits", Py::String(m_stats.fileUnits));
+    statsDict.setItem("finalScalingFactor", Py::Float(m_stats.finalScalingFactor));
+    statsDict.setItem("importTimeSeconds", Py::Float(m_stats.importTimeSeconds));
     statsDict.setItem("totalEntitiesCreated", Py::Long(m_stats.totalEntitiesCreated));
     statsDict.setItem("unsupportedFeaturesCount", Py::Long(m_stats.unsupportedFeaturesCount));
 

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -204,6 +204,11 @@ private:
     std::string m_optionSource;
 
 protected:
+    friend class DrawingEntityCollector;
+    void IncrementCreatedObjectCount()
+    {
+        m_stats.totalEntitiesCreated++;
+    }
     virtual void ApplyGuiStyles(Part::Feature* /*object*/) const
     {}
     virtual void ApplyGuiStyles(App::FeaturePython* /*object*/) const

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -50,6 +50,8 @@ public:
         Py_XDECREF(DraftModule);
     }
 
+    Py::Object getStatsAsPyObject();
+
     bool ReadEntitiesSection() override;
 
     // CDxfRead's virtual functions

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2342,8 +2342,8 @@ bool CDxfRead::ReadDimension()
 
 bool CDxfRead::ReadUnknownEntity()
 {
-    UnsupportedFeature("Entity type '%s'", m_record_data);
     ProcessAllEntityAttributes();
+    UnsupportedFeature("Entity type '%s'", m_record_data);
     return true;
 }
 
@@ -2403,7 +2403,7 @@ void CDxfRead::UnsupportedFeature(const char* format, args&&... argValuess)
 {
     // NOLINTNEXTLINE(runtime/printf)
     std::string formattedMessage = fmt::sprintf(format, std::forward<args>(argValuess)...);
-    m_stats.unsupportedFeatures[formattedMessage]++;
+    m_stats.unsupportedFeatures[formattedMessage].emplace_back(m_line, m_current_entity_handle);
 }
 
 bool CDxfRead::get_next_record()
@@ -2798,6 +2798,8 @@ bool CDxfRead::ReadEntity()
 {
     InitializeAttributes();
     m_entityAttributes.SetDefaults();
+    m_current_entity_handle.clear();
+    SetupStringAttribute(eHandle, m_current_entity_handle);
     EntityNormalVector.Set(0, 0, 1);
     Setup3DVectorAttribute(eExtrusionDirection, EntityNormalVector);
     SetupStringAttribute(eLinetypeName, m_entityAttributes.m_LineType);

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2349,6 +2349,7 @@ bool CDxfRead::ReadBlockInfo()
     int blockType = 0;
     std::string blockName;
     InitializeAttributes();
+    m_stats.entityCounts["BLOCK"]++;
     // Both 2 and 3 are the block name.
     SetupStringAttribute(eName, blockName);
     SetupStringAttribute(eExtraText, blockName);

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -3179,3 +3179,5 @@ Base::Color CDxfRead::ObjectColor(ColorIndex_t index)
     return result;
 }
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+
+template void CDxfRead::UnsupportedFeature<>(const char*);

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2400,11 +2400,12 @@ void CDxfRead::UnsupportedFeature(const char* format, args&&... argValuess)
     // NOLINTNEXTLINE(runtime/printf)
     std::string formattedMessage = fmt::sprintf(format, std::forward<args>(argValuess)...);
     m_stats.unsupportedFeatures[formattedMessage]++;
+    // *** This message is now disabled here because we use the stats reporter instead ***
     // We place these formatted messages in a map, count their occurrences and not their first
     // occurrence.
-    if (m_unsupportedFeaturesNoted[formattedMessage].first++ == 0) {
-        m_unsupportedFeaturesNoted[formattedMessage].second = m_line;
-    }
+    // if (m_unsupportedFeaturesNoted[formattedMessage].first++ == 0) {
+    //    m_unsupportedFeaturesNoted[formattedMessage].second = m_line;
+    // }
 }
 
 bool CDxfRead::get_next_record()

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2397,9 +2397,9 @@ bool CDxfRead::SkipBlockContents()
 template<typename... args>
 void CDxfRead::UnsupportedFeature(const char* format, args&&... argValuess)
 {
-    m_stats.unsupportedFeaturesCount++;
     // NOLINTNEXTLINE(runtime/printf)
     std::string formattedMessage = fmt::sprintf(format, std::forward<args>(argValuess)...);
+    m_stats.unsupportedFeatures[formattedMessage]++;
     // We place these formatted messages in a map, count their occurrences and not their first
     // occurrence.
     if (m_unsupportedFeaturesNoted[formattedMessage].first++ == 0) {

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2002,6 +2002,9 @@ void CDxfRead::ProcessAllEntityAttributes()
 void CDxfRead::ResolveEntityAttributes()
 {
     m_entityAttributes.ResolveBylayerAttributes(*this);
+    if (m_entityAttributes.m_paperSpace) {
+        m_stats.entityCounts["ENTITIES_IN_PAPERSPACE"]++;
+    }
     // TODO: Look at the space and layer (hidden/frozen?) and options and return false if the entity
     // is not needed.
     // TODO: INSERT must not call this because an INSERT on a hidden layer should always be

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2404,12 +2404,6 @@ void CDxfRead::UnsupportedFeature(const char* format, args&&... argValuess)
     // NOLINTNEXTLINE(runtime/printf)
     std::string formattedMessage = fmt::sprintf(format, std::forward<args>(argValuess)...);
     m_stats.unsupportedFeatures[formattedMessage]++;
-    // *** This message is now disabled here because we use the stats reporter instead ***
-    // We place these formatted messages in a map, count their occurrences and not their first
-    // occurrence.
-    // if (m_unsupportedFeaturesNoted[formattedMessage].first++ == 0) {
-    //    m_unsupportedFeaturesNoted[formattedMessage].second = m_line;
-    // }
 }
 
 bool CDxfRead::get_next_record()
@@ -2730,17 +2724,6 @@ void CDxfRead::DoRead(const bool ignore_errors /* = false */)
             }
         }
         FinishImport();
-
-        // Flush out any unsupported features messages
-        if (!m_unsupportedFeaturesNoted.empty()) {
-            ImportError("Unsupported DXF features:\n");
-            for (auto& featureInfo : m_unsupportedFeaturesNoted) {
-                ImportError("%s: %d time(s) first at line %d\n",
-                            featureInfo.first,
-                            featureInfo.second.first,
-                            featureInfo.second.second);
-            }
-        }
     }
     catch (const Base::Exception& e) {
         // This catches specific FreeCAD exceptions and re-throws them.

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2343,7 +2343,7 @@ bool CDxfRead::ReadDimension()
 bool CDxfRead::ReadUnknownEntity()
 {
     ProcessAllEntityAttributes();
-    UnsupportedFeature("Entity type '%s'", m_record_data);
+    UnsupportedFeature("Entity type '%s'", m_current_entity_name.c_str());
     return true;
 }
 
@@ -2403,7 +2403,8 @@ void CDxfRead::UnsupportedFeature(const char* format, args&&... argValuess)
 {
     // NOLINTNEXTLINE(runtime/printf)
     std::string formattedMessage = fmt::sprintf(format, std::forward<args>(argValuess)...);
-    m_stats.unsupportedFeatures[formattedMessage].emplace_back(m_line, m_current_entity_handle);
+    m_stats.unsupportedFeatures[formattedMessage].emplace_back(m_current_entity_line_number,
+                                                               m_current_entity_handle);
 }
 
 bool CDxfRead::get_next_record()
@@ -2796,6 +2797,8 @@ void CDxfRead::ProcessLayerReference(CDxfRead* object, void* target)
 }
 bool CDxfRead::ReadEntity()
 {
+    m_current_entity_line_number = m_line;
+    m_current_entity_name = m_record_data;
     InitializeAttributes();
     m_entityAttributes.SetDefaults();
     m_current_entity_handle.clear();

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2342,6 +2342,7 @@ bool CDxfRead::SkipBlockContents()
 template<typename... args>
 void CDxfRead::UnsupportedFeature(const char* format, args&&... argValuess)
 {
+    m_stats.unsupportedFeaturesCount++;
     // NOLINTNEXTLINE(runtime/printf)
     std::string formattedMessage = fmt::sprintf(format, std::forward<args>(argValuess)...);
     // We place these formatted messages in a map, count their occurrences and not their first
@@ -2538,6 +2539,8 @@ bool CDxfRead::ReadVersion()
         m_version = RUnknown;
     }
 
+    m_stats.dxfVersion = m_record_data;
+
     return ResolveEncoding();
 }
 
@@ -2606,6 +2609,9 @@ bool CDxfRead::ResolveEncoding()
         Py_DECREF(pyDecoder);
         Py_DECREF(pyUTF8Decoder);
     }
+
+    m_stats.dxfEncoding = m_encoding;
+
     return !m_encoding.empty();
 }
 
@@ -2759,6 +2765,9 @@ bool CDxfRead::ReadEntity()
         m_entityAttributes.m_paperSpace);  // TODO: Ensure the stream is noboolalpha (for that
                                            // matter ensure the stream has the "C" locale
     SetupValueAttribute(eColor, m_entityAttributes.m_Color);
+
+    m_stats.entityCounts[m_record_data]++;
+
     // The entity record is already the current record and is already checked as a type 0 record
     if (IsObjectName("LINE")) {
         return ReadLine();

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -182,6 +182,9 @@ struct DxfImportStats
     double importTimeSeconds = 0.0;
     std::string dxfVersion;
     std::string dxfEncoding;
+    std::string scalingSource;
+    std::string fileUnits;
+    double finalScalingFactor = 1.0;
     std::map<std::string, int> entityCounts;
     std::map<std::string, std::string> importSettings;
     int totalEntitiesCreated = 0;

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -862,6 +862,10 @@ public:
     {
         return m_fail;
     }
+    void setImportTime(double seconds)
+    {
+        m_stats.importTimeSeconds = seconds;
+    }
     void
     DoRead(bool ignore_errors = false);  // this reads the file and calls the following functions
     virtual void StartImport()

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -187,8 +187,8 @@ struct DxfImportStats
     double finalScalingFactor = 1.0;
     std::map<std::string, int> entityCounts;
     std::map<std::string, std::string> importSettings;
+    std::map<std::string, int> unsupportedFeatures;
     int totalEntitiesCreated = 0;
-    int unsupportedFeaturesCount = 0;
 };
 
 

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -176,6 +176,18 @@ struct LWPolyDataOut
     point3D Extr;
 };
 
+// Statistics reporting structure
+struct DxfImportStats
+{
+    double importTimeSeconds = 0.0;
+    std::string dxfVersion;
+    std::string dxfEncoding;
+    std::map<std::string, int> entityCounts;
+    std::map<std::string, std::string> importSettings;
+    int totalEntitiesCreated = 0;
+    int unsupportedFeaturesCount = 0;
+};
+
 
 // "using" for enums is not supported by all platforms
 // https://stackoverflow.com/questions/41167119/how-to-fix-a-wsubobject-linkage-warning
@@ -455,6 +467,7 @@ private:
     double m_unitScalingFactor = 0.0;
 
 protected:
+    DxfImportStats m_stats;
     // An additional scaling factor which can be modified before readDXF is called, and will be
     // incorporated into m_unitScalingFactor.
     void SetAdditionalScaling(double scaling)

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -716,7 +716,6 @@ protected:
     void UnsupportedFeature(const char* format, args&&... argValues);
 
 private:
-    std::map<std::string, std::pair<int, int>> m_unsupportedFeaturesNoted;
     std::string m_CodePage;  // Code Page name from $DWGCODEPAGE or null if none/not read yet
     // The following was going to be python's canonical name for the encoding, but this is (a) not
     // easily found and (b) does not speed up finding the encoding object.

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -463,6 +463,8 @@ private:
     bool m_not_eof = true;
     int m_line = 0;
     bool m_repeat_last_record = false;
+    int m_current_entity_line_number = 0;
+    std::string m_current_entity_name;
     std::string m_current_entity_handle;
 
     // The scaling from DXF units to millimetres.

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -187,7 +187,7 @@ struct DxfImportStats
     double finalScalingFactor = 1.0;
     std::map<std::string, int> entityCounts;
     std::map<std::string, std::string> importSettings;
-    std::map<std::string, int> unsupportedFeatures;
+    std::map<std::string, std::vector<std::pair<int, std::string>>> unsupportedFeatures;
     int totalEntitiesCreated = 0;
 };
 
@@ -200,6 +200,7 @@ enum eDXFGroupCode_t
     ePrimaryText = 1,
     eName = 2,
     eExtraText = 3,
+    eHandle = 5,
     eLinetypeName = 6,
     eTextStyleName = 7,
     eLayerName = 8,
@@ -462,6 +463,7 @@ private:
     bool m_not_eof = true;
     int m_line = 0;
     bool m_repeat_last_record = false;
+    std::string m_current_entity_handle;
 
     // The scaling from DXF units to millimetres.
     // This does not include the dxfScaling option

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -403,6 +403,7 @@ private:
             dxf_file.setOptions();
             dxf_file.DoRead(IgnoreErrors);
             pcDoc->recompute();
+            return dxf_file.getStatsAsPyObject();
         }
         catch (const Standard_Failure& e) {
             throw Py::RuntimeError(e.GetMessageString());
@@ -410,7 +411,6 @@ private:
         catch (const Base::Exception& e) {
             throw Py::RuntimeError(e.what());
         }
-        return Py::None();
     }
 
     Py::Object exportOptions(const Py::Tuple& args)

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -46,6 +46,7 @@
 #endif
 #endif
 
+#include <chrono>
 #include "ExportOCAFGui.h"
 #include "ImportOCAFGui.h"
 #include "OCAFBrowser.h"
@@ -401,7 +402,13 @@ private:
             ImpExpDxfReadGui dxf_file(EncodedName, pcDoc);
             dxf_file.setOptionSource(defaultOptions);
             dxf_file.setOptions();
+
+            auto startTime = std::chrono::high_resolution_clock::now();
             dxf_file.DoRead(IgnoreErrors);
+            auto endTime = std::chrono::high_resolution_clock::now();
+            std::chrono::duration<double> elapsed = endTime - startTime;
+            dxf_file.setImportTime(elapsed.count());
+
             pcDoc->recompute();
             return dxf_file.getStatsAsPyObject();
         }


### PR DESCRIPTION
Add a console DXF statistics reporter for the FreeCAD C++ importer. Help both users and developers understand the content of DXF files and the importer's behaviour.

> [!NOTE]
> This PR does not change the functionality of the DXF importer. It simply adds reporting capabilities to it.

Goals:
- Provide more feedback to the user. DXF import is a complex process: there are two importers currently and each supports a set of features. More information removes uncertainty from the process.
- Provide more context for reporting bugs. In particular, the import settings have been included in the report, so that they can be pasted on issue reports.
- Provide the user more context on what the optimal import settings are. There are currently multiple settings and setting combinations that lead to different importer results. Comparing the report output with different settings can guide the user to find the most optimal combination for their goals. 

Reports on:
- DXF file metadata (file name, DXF version, file encoding, scale)
- Effective scaling applied to the document depending on import settings
- Time to import
- Import settings
- Individual read entity counts, with an indicator of whether they are supported or not.
- Total entities read and total FreeCAD objects created
- Unsupported features/entities count (*), with details on line no. and DXF handle for each. These are generally skipped by the importer.

(*) Note: the original code did report on this, but as a warning that always popped up on import. To have a less disruptive import operation, these original warnings have been removed. Instead, the counts are included in the report.

<details><summary>Expand for a typical listing from the reporter:</summary>

```
--- DXF import summary ---
Import of file: '/home/me/sample-arch-dxf.dxf'

DXF version: AC1027
File encoding: utf_8
File units: Millimeters (from $INSUNITS)
Manual scaling factor: 1.000000
Final scaling: 1 DXF unit = 1.0000 mm

Performance:
  - C++ import time: 2.3620 seconds
  - Total import time: 2.8031 seconds

Import settings:
  - Import hidden blocks: No
  - Import layout objects: No
  - Import points: No
  - Import texts and dimensions: No
  - Join geometry: No
  - Manual scaling factor: 1.000000
  - Merge option: Create Part shapes
  - Use colors from the DXF file: Yes
  - Use layers: Yes

Entity counts:
  - ARC: 578
  - ATTDEF: 4 (*)
  - BLOCK: 159
  - CIRCLE: 37
  - DIMENSION: 31
  - ELLIPSE: 21
  - ENTITIES_IN_PAPERSPACE: 105
  - HATCH: 8 (*)
  - INSERT: 24
  - LINE: 2921
  - LWPOLYLINE: 187
  - MLINE: 5 (*)
  - REGION: 1 (*)
  - SPLINE: 90
  - TEXT: 9
  - VIEWPORT: 2 (*)
----------------------------
  Total entities read: 4182
FreeCAD objects created: 684

(*) Entity type not supported by importer.

Unsupported features:
  - Entity type 'ATTDEF': 4 time(s) at line 9488 (handle D3), line 9530 (handle D4), line 9572 (handle D5), line 9614 (handle D6)
  - Entity type 'HATCH': 8 time(s). Examples: line 42498 (handle 2843), line 50930 (handle 349A), line 148756 (handle 111B1), line 148922 (handle 111B2), line 149082 (handle 111B3), ...
  - Entity type 'MLINE': 5 time(s) at line 147470 (handle 10D3D), line 147576 (handle 10D3E), line 148438 (handle 10DD0), line 148544 (handle 10DD1), line 148650 (handle 10DD2)
  - Entity type 'REGION': 1 time(s) at line 14880 (handle 654)
  - Entity type 'VIEWPORT': 2 time(s) at line 155372 (handle FB23), line 155492 (handle FB25)
--- End of summary ---

```

</details>

Potential future improvements and features:

1. Report on a dialog if the GUI is up (will probably be added in a subsequent PR)
2.  Report on skipped entities and the reason for skipping them
3. Better reporting on anonymous vs user blocks (added in a separate PR: https://github.com/FreeCAD/FreeCAD/pull/22045)
4. Review output formatting

Known limitations:
- There is no distinction between user and system (anonymous) BLOCK entities when reporting. This is fixed in https://github.com/FreeCAD/FreeCAD/pull/22045
- FreeCAD object count is not correct for Compound objects (only the compound is called and not their children). This is fixed in https://github.com/FreeCAD/FreeCAD/pull/22045

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
