### PR TITLE
[ArchCurtainWall]  Fix Vert-Horiz Mullion Mix-up & Support Swap

### DIFF
--- a/src/Mod/BIM/ArchCurtainWall.py
+++ b/src/Mod/BIM/ArchCurtainWall.py
@@ -284,9 +284,9 @@ class CurtainWall(ArchComponent.Component):
             # Fix issue in 'Curtain wall vertical/horizontal mullion mix-up'
             # https://github.com/FreeCAD/FreeCAD/issues/21845
             #
-            p = face.findPlane()  # Curve face (surface) seems return no Plane
-            if p:
-                if -0.001 < p.Axis[2] < 0.001:  # i.e. face is vertical (normal pointing horizon)
+            face_plane = face.findPlane()  # Curve face (surface) seems return no Plane
+            if face_plane:
+                if -0.001 < face_plane.Axis[2] < 0.001:  # i.e. face is vertical (normal pointing horizon)
                     faceVert = True
                     # Support 'Swap Horizontal Vertical'
                     # See issue 'Swap Horizontal Vertical does not work'
@@ -308,8 +308,8 @@ class CurtainWall(ArchComponent.Component):
                 # Partially improved by checking 'if face is vertical' above
                 #
                 basevector = face.valueAt(fp[1],fp[3]).sub(face.valueAt(fp[0],fp[2]))
-                a = basevector.getAngle(vdir)
-                if (a <= math.pi/2+ANGLETOLERANCE) and (a >= math.pi/2-ANGLETOLERANCE):
+                bv_angle = basevector.getAngle(vdir)
+                if (bv_angle <= math.pi/2+ANGLETOLERANCE) and (bv_angle >= math.pi/2-ANGLETOLERANCE):
                     facedir = True
                     if obj.SwapHorizontalVertical:
                         vertsec = obj.HorizontalSections

--- a/src/Mod/BIM/ArchCurtainWall.py
+++ b/src/Mod/BIM/ArchCurtainWall.py
@@ -279,16 +279,52 @@ class CurtainWall(ArchComponent.Component):
             if not vdir.Length:
                 vdir = FreeCAD.Vector(0,0,1)
             vdir.normalize()
-            basevector = face.valueAt(fp[1],fp[3]).sub(face.valueAt(fp[0],fp[2]))
-            a = basevector.getAngle(vdir)
-            if (a <= math.pi/2+ANGLETOLERANCE) and (a >= math.pi/2-ANGLETOLERANCE):
-                facedir = True
-                vertsec = obj.VerticalSections
-                horizsec = obj.HorizontalSections
-            else:
-                facedir = False
-                vertsec = obj.HorizontalSections
-                horizsec = obj.VerticalSections
+
+            # Check if face if vertical in the first place
+            # Fix issue in 'Curtain wall vertical/horizontal mullion mix-up'
+            # https://github.com/FreeCAD/FreeCAD/issues/21845
+            #
+            p = face.findPlane()  # Curve face (surface) seems return no Plane
+            if p:
+                if -0.001 < p.Axis[2] < 0.001:  # i.e. face is vertical (normal pointing horizon)
+                    faceVert = True
+                    # Support 'Swap Horizontal Vertical'
+                    # See issue 'Swap Horizontal Vertical does not work'
+                    # https://github.com/FreeCAD/FreeCAD/issues/21866
+                    if obj.SwapHorizontalVertical:
+                        vertsec = obj.HorizontalSections
+                        horizsec = obj.VerticalSections
+                    else:
+                        vertsec = obj.VerticalSections
+                        horizsec = obj.HorizontalSections
+                else:
+                    faceVert = False
+
+            # Guess algorithm if face is not vertical
+            if not faceVert:
+                # TODO 2025.6.15 : Need a more robust algorithm below
+                # See issue 'Curtain wall vertical/horizontal mullion mix-up'
+                # https://github.com/FreeCAD/FreeCAD/issues/21845
+                # Partially improved by checking 'if face is vertical' above
+                #
+                basevector = face.valueAt(fp[1],fp[3]).sub(face.valueAt(fp[0],fp[2]))
+                a = basevector.getAngle(vdir)
+                if (a <= math.pi/2+ANGLETOLERANCE) and (a >= math.pi/2-ANGLETOLERANCE):
+                    facedir = True
+                    if obj.SwapHorizontalVertical:
+                        vertsec = obj.HorizontalSections
+                        horizsec = obj.VerticalSections
+                    else:
+                        vertsec = obj.VerticalSections
+                        horizsec = obj.HorizontalSections
+                else:
+                    facedir = False
+                    if obj.SwapHorizontalVertical:
+                        vertsec = obj.VerticalSections
+                        horizsec = obj.HorizontalSections
+                    else:
+                        vertsec = obj.HorizontalSections
+                        horizsec = obj.VerticalSections
 
             hstep = (fp[1]-fp[0])
             if vertsec:


### PR DESCRIPTION
Fix #21845
Curtain wall vertical/horizontal mullion mix-up
- https://github.com/FreeCAD/FreeCAD/issues/21845

Support/Feature #21866
Swap Horizontal Vertical does not work #21866
-  https://github.com/FreeCAD/FreeCAD/issues/21866

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
