### PR TITLE
Contributing: Add requirement to clearly mark ownership for cherry-picked PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,11 @@ The FreeCAD Contribution Process is expressed here with the following specific g
 10. Changes that break python API used by extensions SHALL be avoided. If it is not possible to avoid breaking changes, the amount of them MUST be minimized and PR MUST clearly describe all breaking changes with clear description on how to replace no longer working solution with newer one. Contributor SHOULD search for addons that will be broken and list them in the PR.
 11. Each commit message in a PR MUST succinctly explain what the commit achieves. The commit message SHALL follow the suggestions in the `git commit --help` documentation, section DISCUSSION.
 12. The PR message MUST consist of a single short line, the PR Title, summarizing the problem being solved, followed by a blank line and then the proposed solution in the Body. If a PR consists of more than one commit, the PR Title MUST succinctly explain what the PR achieves. The Body MAY be as detailed as needed. If a PR changes the user interface (UI), the body of the text MUST include a presentation of these UI changes, preferably with screenshots of the previous and revised state.
-13. If PR contains work of another author, for example is cherry-picked from some fork by non-author, the message MUST contain proper attribution as first line of the message, for example: "This is work of XYZ cherry-picked from <link>". In such case commits must have proper attribution original author.
-14. A “Valid PR” is one which satisfies the above requirements.
+13. If PR contains work of another author, for example is cherry-picked from some fork by non-author:
+    1. the description MUST contain proper attribution as the first line, for example: "This is work of XYZ cherry-picked from <link>";
+    2. all commits MUST have proper authorship, i.e. be authored by the original author and commited by the author of the PR;
+    3. if changes to cherry-picked commits are necessary they should be done either as follow-up commits, or if not possible they should contain `Co-Authored-By` trailer.
+15. A “Valid PR” is one which satisfies the above requirements.
 
 ## 6. Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,8 @@ The FreeCAD Contribution Process is expressed here with the following specific g
 10. Changes that break python API used by extensions SHALL be avoided. If it is not possible to avoid breaking changes, the amount of them MUST be minimized and PR MUST clearly describe all breaking changes with clear description on how to replace no longer working solution with newer one. Contributor SHOULD search for addons that will be broken and list them in the PR.
 11. Each commit message in a PR MUST succinctly explain what the commit achieves. The commit message SHALL follow the suggestions in the `git commit --help` documentation, section DISCUSSION.
 12. The PR message MUST consist of a single short line, the PR Title, summarizing the problem being solved, followed by a blank line and then the proposed solution in the Body. If a PR consists of more than one commit, the PR Title MUST succinctly explain what the PR achieves. The Body MAY be as detailed as needed. If a PR changes the user interface (UI), the body of the text MUST include a presentation of these UI changes, preferably with screenshots of the previous and revised state.
-13. A “Valid PR” is one which satisfies the above requirements.
+13. If PR contains work of another author, for example is cherry-picked from some fork by non-author, the message MUST contain proper attribution as first line of the message, for example: "This is work of XYZ cherry-picked from <link>".
+14. A “Valid PR” is one which satisfies the above requirements.
 
 ## 6. Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ The FreeCAD Contribution Process is expressed here with the following specific g
     1. the description MUST contain proper attribution as the first line, for example: "This is work of XYZ cherry-picked from <link>";
     2. all commits MUST have proper authorship, i.e. be authored by the original author and commited by the author of the PR;
     3. if changes to cherry-picked commits are necessary they should be done either as follow-up commits, or if not possible they should contain `Co-Authored-By` trailer.
-15. A “Valid PR” is one which satisfies the above requirements.
+14. A “Valid PR” is one which satisfies the above requirements.
 
 ## 6. Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,9 +59,9 @@ The FreeCAD Contribution Process is expressed here with the following specific g
 11. Each commit message in a PR MUST succinctly explain what the commit achieves. The commit message SHALL follow the suggestions in the `git commit --help` documentation, section DISCUSSION.
 12. The PR message MUST consist of a single short line, the PR Title, summarizing the problem being solved, followed by a blank line and then the proposed solution in the Body. If a PR consists of more than one commit, the PR Title MUST succinctly explain what the PR achieves. The Body MAY be as detailed as needed. If a PR changes the user interface (UI), the body of the text MUST include a presentation of these UI changes, preferably with screenshots of the previous and revised state.
 13. If PR contains work of another author, for example is cherry-picked from some fork by non-author:
-    1. the description MUST contain proper attribution as the first line, for example: "This is work of XYZ cherry-picked from <link>";
+    1. the PR description MUST contain proper attribution as the first line, for example: "This is work of XYZ cherry-picked from <link>";
     2. all commits MUST have proper authorship, i.e. be authored by the original author and commited by the author of the PR;
-    3. if changes to cherry-picked commits are necessary they should be done either as follow-up commits, or if not possible they should contain `Co-Authored-By` trailer.
+    3. if changes to cherry-picked commits are necessary they should be done either as follow-up commits, or if not possible their messages should contain `Co-Authored-By` trailer.
 14. A “Valid PR” is one which satisfies the above requirements.
 
 ## 6. Process

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ The FreeCAD Contribution Process is expressed here with the following specific g
 10. Changes that break python API used by extensions SHALL be avoided. If it is not possible to avoid breaking changes, the amount of them MUST be minimized and PR MUST clearly describe all breaking changes with clear description on how to replace no longer working solution with newer one. Contributor SHOULD search for addons that will be broken and list them in the PR.
 11. Each commit message in a PR MUST succinctly explain what the commit achieves. The commit message SHALL follow the suggestions in the `git commit --help` documentation, section DISCUSSION.
 12. The PR message MUST consist of a single short line, the PR Title, summarizing the problem being solved, followed by a blank line and then the proposed solution in the Body. If a PR consists of more than one commit, the PR Title MUST succinctly explain what the PR achieves. The Body MAY be as detailed as needed. If a PR changes the user interface (UI), the body of the text MUST include a presentation of these UI changes, preferably with screenshots of the previous and revised state.
-13. If PR contains work of another author, for example is cherry-picked from some fork by non-author, the message MUST contain proper attribution as first line of the message, for example: "This is work of XYZ cherry-picked from <link>".
+13. If PR contains work of another author, for example is cherry-picked from some fork by non-author, the message MUST contain proper attribution as first line of the message, for example: "This is work of XYZ cherry-picked from <link>". In such case commits must have proper attribution original author.
 14. A “Valid PR” is one which satisfies the above requirements.
 
 ## 6. Process

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,10 +58,10 @@ The FreeCAD Contribution Process is expressed here with the following specific g
 10. Changes that break python API used by extensions SHALL be avoided. If it is not possible to avoid breaking changes, the amount of them MUST be minimized and PR MUST clearly describe all breaking changes with clear description on how to replace no longer working solution with newer one. Contributor SHOULD search for addons that will be broken and list them in the PR.
 11. Each commit message in a PR MUST succinctly explain what the commit achieves. The commit message SHALL follow the suggestions in the `git commit --help` documentation, section DISCUSSION.
 12. The PR message MUST consist of a single short line, the PR Title, summarizing the problem being solved, followed by a blank line and then the proposed solution in the Body. If a PR consists of more than one commit, the PR Title MUST succinctly explain what the PR achieves. The Body MAY be as detailed as needed. If a PR changes the user interface (UI), the body of the text MUST include a presentation of these UI changes, preferably with screenshots of the previous and revised state.
-13. If PR contains work of another author, for example is cherry-picked from some fork by non-author:
+13. If a PR contains the work of another author (for example, if it is cherry-picked from a fork by someone other than the PR-submitter):
     1. the PR description MUST contain proper attribution as the first line, for example: "This is work of XYZ cherry-picked from <link>";
-    2. all commits MUST have proper authorship, i.e. be authored by the original author and commited by the author of the PR;
-    3. if changes to cherry-picked commits are necessary they should be done either as follow-up commits, or if not possible their messages should contain `Co-Authored-By` trailer.
+    2. all commits MUST have proper authorship, i.e. be authored by the original author and committed by the author of the PR;
+    3. if changes to cherry-picked commits are necessary they SHOULD be done as follow-up commits. If it is not possible to do so, then the modified commits MUST contain a `Co-Authored-By` trailer in their commit message.
 14. A “Valid PR” is one which satisfies the above requirements.
 
 ## 6. Process


### PR DESCRIPTION
This adds requirement for new PRs to contain proper attribution in description and commits if PR is made by non-author.