### PR TITLE
Core: Introduce searching in Preferences

### DIFF
--- a/src/Gui/Dialogs/DlgPreferences.ui
+++ b/src/Gui/Dialogs/DlgPreferences.ui
@@ -210,6 +210,35 @@
             </property>
            </spacer>
           </item>
+          <item>
+           <layout class="QHBoxLayout" name="searchInputLayout">
+            <property name="spacing">
+             <number>4</number>
+            </property>
+            <item>
+             <widget class="QLineEdit" name="searchBox">
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>200</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="placeholderText">
+               <string>Search preferences...</string>
+              </property>
+              <property name="clearButtonEnabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
          </layout>
         </item>
         <item>

--- a/src/Gui/Dialogs/DlgPreferencesImp.cpp
+++ b/src/Gui/Dialogs/DlgPreferencesImp.cpp
@@ -176,9 +176,9 @@ private:
     {
         boldFont = baseFont;
         boldFont.setBold(true);
+        boldFont.setPointSize(boldFont.pointSize() - 1); // make header smaller like a subtitle
         
-        normalFont = baseFont;
-        normalFont.setPointSize(normalFont.pointSize() + 2); // make lower text 2 pixels bigger
+        normalFont = baseFont; // keep widget text at normal size
     }
 
     LayoutInfo calculateLayout(const QString& pathText, const QString& widgetText,
@@ -1812,7 +1812,9 @@ QString PreferencesSearchController::getHighlightStyleForWidget(QWidget* widget)
 
 void PreferencesSearchController::applyHighlightToWidget(QWidget* widget)
 {
-    if (!widget) return;
+    if (!widget) {
+        return;
+    }
     
     m_originalStyles[widget] = widget->styleSheet();
     widget->setStyleSheet(getHighlightStyleForWidget(widget));

--- a/src/Gui/Dialogs/DlgPreferencesImp.cpp
+++ b/src/Gui/Dialogs/DlgPreferencesImp.cpp
@@ -1254,7 +1254,7 @@ PreferencesSearchController::PreferencesSearchController(DlgPreferencesImp* pare
     
     // Create the search results popup list
     m_searchResultsList = new QListWidget(m_parentDialog);
-    m_searchResultsList->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
+    m_searchResultsList->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
     m_searchResultsList->setVisible(false);
     m_searchResultsList->setMinimumWidth(300);
     m_searchResultsList->setMaximumHeight(400); // Increased max height

--- a/src/Gui/Dialogs/DlgPreferencesImp.cpp
+++ b/src/Gui/Dialogs/DlgPreferencesImp.cpp
@@ -1258,11 +1258,6 @@ PreferencesSearchController::PreferencesSearchController(DlgPreferencesImp* pare
     m_searchResultsList->installEventFilter(m_parentDialog);
 }
 
-PreferencesSearchController::~PreferencesSearchController()
-{
-    // Destructor - cleanup handled by Qt's object system
-}
-
 void PreferencesSearchController::setPreferencesModel(QStandardItemModel* model)
 {
     m_preferencesModel = model;
@@ -1381,7 +1376,9 @@ void PreferencesSearchController::clearHighlights()
 
 void PreferencesSearchController::collectSearchResults(QWidget* widget, const QString& searchText, const QString& groupName, const QString& pageName, const QString& pageDisplayName, const QString& tabName)
 {
-    if (!widget) return;
+    if (!widget) {
+        return;
+    }
     
     const QString lowerSearchText = searchText.toLower();
     
@@ -1415,7 +1412,7 @@ void PreferencesSearchController::onSearchResultSelected()
     // This method is called when a search result is selected (arrow keys or single click)
     // Navigate immediately but keep popup open
     if (m_searchResultsList && m_searchResultsList->currentItem()) {
-        navigateToCurrentSearchResult(false); // false = don't close popup
+        navigateToCurrentSearchResult(PopupAction::KeepOpen);
     }
     
     ensureSearchBoxFocus();
@@ -1425,7 +1422,7 @@ void PreferencesSearchController::onSearchResultClicked()
 {
     // Handle single click - navigate immediately but keep popup open
     if (m_searchResultsList && m_searchResultsList->currentItem()) {
-        navigateToCurrentSearchResult(false); // false = don't close popup
+        navigateToCurrentSearchResult(PopupAction::KeepOpen);
     }
     
     ensureSearchBoxFocus();
@@ -1435,11 +1432,11 @@ void PreferencesSearchController::onSearchResultDoubleClicked()
 {
     // Handle double click - navigate and close popup
     if (m_searchResultsList && m_searchResultsList->currentItem()) {
-        navigateToCurrentSearchResult(true); // true = close popup
+        navigateToCurrentSearchResult(PopupAction::CloseAfter);
     }
 }
 
-void PreferencesSearchController::navigateToCurrentSearchResult(bool closePopup)
+void PreferencesSearchController::navigateToCurrentSearchResult(PopupAction action)
 {
     QListWidgetItem* currentItem = m_searchResultsList->currentItem();
     
@@ -1468,7 +1465,7 @@ void PreferencesSearchController::navigateToCurrentSearchResult(bool closePopup)
         // For page-level matches, we just navigate without highlighting anything
         
         // Close popup only if requested (double-click or Enter)
-        if (closePopup) {
+        if (action == PopupAction::CloseAfter) {
             hideSearchResultsList();
         }
     }
@@ -1831,7 +1828,7 @@ bool PreferencesSearchController::handleSearchBoxKeyPress(QKeyEvent* keyEvent)
         }
         case Qt::Key_Return:
         case Qt::Key_Enter:
-            navigateToCurrentSearchResult(true); // true = close popup
+            navigateToCurrentSearchResult(PopupAction::CloseAfter);
             return true;
         case Qt::Key_Escape:
             hideSearchResultsList();
@@ -1846,7 +1843,7 @@ bool PreferencesSearchController::handlePopupKeyPress(QKeyEvent* keyEvent)
     switch (keyEvent->key()) {
         case Qt::Key_Return:
         case Qt::Key_Enter:
-            navigateToCurrentSearchResult(true); // true = close popup
+            navigateToCurrentSearchResult(PopupAction::CloseAfter);
             return true;
         case Qt::Key_Escape:
             hideSearchResultsList();

--- a/src/Gui/Dialogs/DlgPreferencesImp.cpp
+++ b/src/Gui/Dialogs/DlgPreferencesImp.cpp
@@ -1385,17 +1385,19 @@ void PreferencesSearchController::collectSearchResults(QWidget* widget, const QS
     // First, check if the page display name itself matches (highest priority)
     int pageScore = 0;
     if (fuzzyMatch(searchText, pageDisplayName, pageScore)) {
-        SearchResult result;
-        result.groupName = groupName;
-        result.pageName = pageName;
-        result.widget = widget; // Use the page widget itself
-        result.matchText = pageDisplayName; // Use display name, not internal name
-        result.groupBoxName = QString(); // No groupbox for page-level match
-        result.tabName = tabName;
-        result.pageDisplayName = pageDisplayName;
-        result.isPageLevelMatch = true; // Mark as page-level match
-        result.score = pageScore + 2000; // Boost page-level matches
-        result.displayText = formatSearchResultText(result);
+        SearchResult result
+        {
+            .groupName = groupName,
+            .pageName = pageName,
+            .widget = widget,              // Use the page widget itself
+            .matchText = pageDisplayName,  // Use display name, not internal name
+            .groupBoxName = QString(),     // No groupbox for page-level match
+            .tabName = tabName,
+            .pageDisplayName = pageDisplayName,
+            .displayText = formatSearchResultText(result),
+            .isPageLevelMatch = true,   // Mark as page-level match
+            .score = pageScore + 2000  // Boost page-level matches
+        };
         m_searchResults.append(result);
         // Continue searching for individual items even if page matches
     }
@@ -1543,23 +1545,6 @@ QString PreferencesSearchController::formatSearchResultText(const SearchResult& 
     return text;
 }
 
-void PreferencesSearchController::createSearchResult(QWidget* widget, const QString& matchText, const QString& groupName,
-                                          const QString& pageName, const QString& pageDisplayName, const QString& tabName)
-{
-    SearchResult result;
-    result.groupName = groupName;
-    result.pageName = pageName;
-    result.widget = widget;
-    result.matchText = matchText;
-    result.groupBoxName = findGroupBoxForWidget(widget);
-    result.tabName = tabName;
-    result.pageDisplayName = pageDisplayName;
-    result.isPageLevelMatch = false;
-    result.score = 0; // Will be set by the caller
-    result.displayText = formatSearchResultText(result);
-    m_searchResults.append(result);
-}
-
 template<typename WidgetType>
 void PreferencesSearchController::searchWidgetType(QWidget* parentWidget, const QString& searchText, const QString& groupName,
                                         const QString& pageName, const QString& pageDisplayName, const QString& tabName)
@@ -1583,11 +1568,20 @@ void PreferencesSearchController::searchWidgetType(QWidget* parentWidget, const 
         // Use fuzzy matching instead of simple contains
         int score = 0;
         if (fuzzyMatch(searchText, widgetText, score)) {
-            createSearchResult(widget, widgetText, groupName, pageName, pageDisplayName, tabName);
-            // Update the score of the last added result
-            if (!m_searchResults.isEmpty()) {
-                m_searchResults.last().score = score;
-            }
+            SearchResult result
+            {
+                .groupName = groupName,
+                .pageName = pageName,
+                .widget = widget,
+                .matchText = widgetText,
+                .groupBoxName = findGroupBoxForWidget(widget),
+                .tabName = tabName,
+                .pageDisplayName = pageDisplayName,
+                .displayText = formatSearchResultText(result),
+                .isPageLevelMatch = false,
+                .score = score
+            };
+            m_searchResults.append(result);
         }
     }
 }

--- a/src/Gui/Dialogs/DlgPreferencesImp.cpp
+++ b/src/Gui/Dialogs/DlgPreferencesImp.cpp
@@ -1886,11 +1886,15 @@ bool PreferencesSearchController::handlePopupKeyPress(QKeyEvent* keyEvent)
 
 bool PreferencesSearchController::isClickOutsidePopup(QMouseEvent* mouseEvent)
 {
-    QPointF globalPos = mouseEvent->globalPosition();
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+    QPoint globalPos = mouseEvent->globalPos();
+#else
+    QPoint globalPos = mouseEvent->globalPosition().toPoint();
+#endif
     QRect searchBoxRect = QRect(m_searchBox->mapToGlobal(QPoint(0, 0)), m_searchBox->size());
     QRect popupRect = QRect(m_searchResultsList->mapToGlobal(QPoint(0, 0)), m_searchResultsList->size());
     
-    return !searchBoxRect.contains(globalPos.x(), globalPos.y()) && !popupRect.contains(globalPos.x(), globalPos.y());
+    return !searchBoxRect.contains(globalPos) && !popupRect.contains(globalPos);
 }
 
 bool DlgPreferencesImp::eventFilter(QObject* obj, QEvent* event)

--- a/src/Gui/Dialogs/DlgPreferencesImp.cpp
+++ b/src/Gui/Dialogs/DlgPreferencesImp.cpp
@@ -369,8 +369,6 @@ void DlgPreferencesImp::setupConnections()
     
     // Install event filter for keyboard navigation in search results
     searchResultsList->installEventFilter(this);
-    
-
 }
 
 void DlgPreferencesImp::setupPages()
@@ -1257,8 +1255,6 @@ void DlgPreferencesImp::performSearch(const QString& searchText)
     }
 }
 
-
-
 void DlgPreferencesImp::clearSearchHighlights()
 {
     // Restore original styles for all highlighted widgets
@@ -1271,8 +1267,6 @@ void DlgPreferencesImp::clearSearchHighlights()
     highlightedWidgets.clear();
     originalStyles.clear();
 }
-
-
 
 void DlgPreferencesImp::collectSearchResults(QWidget* widget, const QString& searchText, const QString& groupName, const QString& pageName, const QString& pageDisplayName, const QString& tabName)
 {
@@ -1501,7 +1495,9 @@ void DlgPreferencesImp::showSearchResultsList()
 
 QString DlgPreferencesImp::findGroupBoxForWidget(QWidget* widget)
 {
-    if (!widget) return QString();
+    if (!widget) {
+        return QString();
+    }
     
     // Walk up the parent hierarchy to find a QGroupBox
     QWidget* parent = widget->parentWidget();
@@ -1844,11 +1840,11 @@ bool DlgPreferencesImp::handlePopupKeyPress(QKeyEvent* keyEvent)
 
 bool DlgPreferencesImp::isClickOutsidePopup(QMouseEvent* mouseEvent)
 {
-    QPoint globalPos = mouseEvent->globalPos();
+    QPointF globalPos = mouseEvent->globalPosition();
     QRect searchBoxRect = QRect(ui->searchBox->mapToGlobal(QPoint(0, 0)), ui->searchBox->size());
     QRect popupRect = QRect(searchResultsList->mapToGlobal(QPoint(0, 0)), searchResultsList->size());
     
-    return !searchBoxRect.contains(globalPos) && !popupRect.contains(globalPos);
+    return !searchBoxRect.contains(globalPos.x(), globalPos.y()) && !popupRect.contains(globalPos.x(), globalPos.y());
 }
 
 #include "moc_DlgPreferencesImp.cpp"

--- a/src/Gui/Dialogs/DlgPreferencesImp.h
+++ b/src/Gui/Dialogs/DlgPreferencesImp.h
@@ -49,6 +49,13 @@ class DlgPreferencesImp;
 class GuiExport PreferencesSearchController : public QObject
 {
     Q_OBJECT
+
+private:
+    enum class PopupAction {
+        KeepOpen,    // don't close popup (used for keyboard navigation)
+        CloseAfter   // close popup (used for mouse clicks and Enter/Return)
+    };
+
 public:
     // Search results structure
     struct SearchResult {
@@ -65,7 +72,7 @@ public:
     };
 
     explicit PreferencesSearchController(DlgPreferencesImp* parentDialog, QObject* parent = nullptr);
-    ~PreferencesSearchController();
+    ~PreferencesSearchController() = default;
 
     // Setup methods
     void setPreferencesModel(QStandardItemModel* model);
@@ -93,7 +100,7 @@ public:
     void showSearchResultsList();
 
     // Navigation
-    void navigateToCurrentSearchResult(bool closePopup);
+    void navigateToCurrentSearchResult(PopupAction action);
 
 Q_SIGNALS:
     void navigationRequested(const QString& groupName, const QString& pageName);

--- a/src/Gui/Dialogs/DlgPreferencesImp.h
+++ b/src/Gui/Dialogs/DlgPreferencesImp.h
@@ -57,6 +57,12 @@ private:
     };
 
 public:
+    // Custom data roles for separating path and widget text
+    enum SearchDataRole {
+        PathRole = Qt::UserRole + 10,        // Path to page (e.g., "Display/3D View")
+        WidgetTextRole = Qt::UserRole + 11   // Text from the widget (e.g., "Enable anti-aliasing")
+    };
+
     // Search results structure
     struct SearchResult {
         QString groupName;

--- a/src/Gui/Dialogs/DlgPreferencesImp.h
+++ b/src/Gui/Dialogs/DlgPreferencesImp.h
@@ -116,8 +116,6 @@ private:
     void collectSearchResults(QWidget* widget, const QString& searchText, const QString& groupName, 
                              const QString& pageName, const QString& pageDisplayName, const QString& tabName);
     void populateSearchResultsList();
-    void createSearchResult(QWidget* widget, const QString& matchText, const QString& groupName, 
-                           const QString& pageName, const QString& pageDisplayName, const QString& tabName);
     
     template<typename WidgetType>
     void searchWidgetType(QWidget* parentWidget, const QString& searchText, const QString& groupName,

--- a/src/Gui/Dialogs/DlgPreferencesImp.h
+++ b/src/Gui/Dialogs/DlgPreferencesImp.h
@@ -72,7 +72,6 @@ public:
         QString groupBoxName;
         QString tabName; // The tab name (like "Display")
         QString pageDisplayName; // The page display name (like "3D View")
-        QString displayText;
         bool isPageLevelMatch = false; // True if this is a page title match
         int score = 0; // Fuzzy search score for sorting
     };
@@ -139,7 +138,6 @@ private:
     
     // Utility methods
     QString findGroupBoxForWidget(QWidget* widget);
-    QString formatSearchResultText(const SearchResult& result);
     bool fuzzyMatch(const QString& searchText, const QString& targetText, int& score);
     bool isExactMatch(const QString& searchText, const QString& targetText);
 


### PR DESCRIPTION
This PR introduces search box in preferences.
Features:
* supports left click on the result, taking user to the result
* clicking anywhere cancels searching and closes popup box, same with ESC key
* double click on the result closes the popup too (same behavior as enter)
* supports enter (although if you are on the position you are already on it so enter just closes the popup basically)
* you can navigate through the list with mouse
* support fuzzy search so stuff like "OVP" is being matched to "On-View-Parameters"
* there is hierarchical display (tab/page/setting)
* some of the results are prioritized but fuzzy search prioritizing is the most important
* highlights found item
* goes into found item
* if the pop-up box won't fit next to the right side of the screen, it is added underneath the search box

Thank you for anyone participating to make this a better experience for users, especially guys from @FreeCAD/design-working-group 

Demo:

https://github.com/user-attachments/assets/b54da758-1b2d-4119-9de3-731b4eed7c7b

Resolves: https://github.com/FreeCAD/FreeCAD/issues/13538 