### PR TITLE
Help: Change URL sanitization to be safer

### DIFF
--- a/src/Mod/Help/Help.py
+++ b/src/Mod/Help/Help.py
@@ -169,7 +169,7 @@ def location_url(url_localized: str, url_english: str) -> tuple:
         req = urllib.request.Request(url_localized)
         with urllib.request.urlopen(req) as response:
             html = response.read().decode("utf-8")
-            if re.search(MD_RAW_URL, url_localized):
+            if url_localized.startswith(MD_RAW_URL):
                 pagename_match = re.search(r"Name/.*?:\s*(.+)", html)
             else:
                 # Pages from FreeCAD Wiki fall here


### PR DESCRIPTION
This doesn't need to be a regex at all, as far as I can tell, so take a safer (and faster) route and just use `startswith()`. Solves https://github.com/FreeCAD/FreeCAD/security/code-scanning/2