### PR TITLE
Tools: Use a safer hostname detection

### DIFF
--- a/src/Tools/SubWCRev.py
+++ b/src/Tools/SubWCRev.py
@@ -10,6 +10,7 @@
 # 2011/02/05: The script was extended to support also Bazaar
 
 import os, sys, re, time, getopt
+from urllib.parse import urlparse
 import xml.sax
 import xml.sax.handler
 import xml.sax.xmlreader
@@ -275,9 +276,10 @@ class GitControl(VersionControl):
                     match = re.match(r"ssh://\S+?@(\S+)", url)
                     if match is not None:
                         url = "git://%s" % match.group(1)
+                    parsed_url = urlparse(url)
                     entryscore = (
                         url == "git://github.com/FreeCAD/FreeCAD.git",
-                        "github.com" in url,
+                        parsed_url.netloc == "github.com",
                         branch == self.branch,
                         branch == "main",
                         "@" not in url,


### PR DESCRIPTION
In the original, the string "github.com" could have been at any location in the URL. While not really important for our particular use-case here, it's flagged as a high-importance bug by analyzers, so eliminate that problem anyway. Closes https://github.com/FreeCAD/FreeCAD/security/code-scanning/1