### PR TITLE
Part: Remove remnants of code from TNP merge

### DIFF
--- a/src/Mod/Part/App/PartFeatures.cpp
+++ b/src/Mod/Part/App/PartFeatures.cpp
@@ -243,12 +243,6 @@ App::DocumentObjectExecReturn* Loft::execute()
     }
 }
 
-void Part::Loft::setupObject()
-{
-    Feature::setupObject();
-//    Linearize.setValue(PartParams::getLinearizeExtrusionDraft()); // TODO: Resolve after PartParams
-}
-
 // ----------------------------------------------------------------------------
 
 const char* Part::Sweep::TransitionEnums[] = {"Transformed",
@@ -347,12 +341,6 @@ App::DocumentObjectExecReturn* Sweep::execute()
     catch (...) {
         return new App::DocumentObjectExecReturn("A fatal error occurred when making the sweep");
     }
-}
-
-void Part::Sweep::setupObject()
-{
-    Feature::setupObject();
-//    Linearize.setValue(PartParams::getLinearizeExtrusionDraft()); // TODO: Resolve after PartParams
 }
 
 // ----------------------------------------------------------------------------

--- a/src/Mod/Part/App/PartFeatures.h
+++ b/src/Mod/Part/App/PartFeatures.h
@@ -50,7 +50,6 @@ public:
     short mustExecute() const override;
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderRuledSurface";
-    void setupObject();
     }
     //@}
 
@@ -86,7 +85,6 @@ public:
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderLoft";
     }
-    void setupObject() override;
     //@}
 
 protected:
@@ -118,7 +116,6 @@ public:
     const char* getViewProviderName() const override {
         return "PartGui::ViewProviderSweep";
     }
-    void setupObject() override;
     //@}
 
 protected:


### PR DESCRIPTION
There is a malformed method in PartFeatures.h that was leftover from the TNP merge: it didn't matter that it was malformed because in the end we didn't need any of these methods. See https://github.com/FreeCAD/FreeCAD/pull/12511 for context.