### PR TITLE
Sketcher: Remove dead code

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -614,13 +614,6 @@ int SketchObject::solve(bool updateGeoAfterSolving /*=true*/)
             }
         }
     }
-    else if (err < 0) {
-        // if solver failed, invalid constraints were likely added before solving
-        // (see solve in addConstraint), so solver information is definitely invalid.
-        //
-        // Update: ViewProviderSketch shall now rely on the signalSolverUpdate below for update
-        // this->Constraints.touch();
-    }
 
     signalSolverUpdate();
 


### PR DESCRIPTION
Closes https://github.com/FreeCAD/FreeCAD/security/code-scanning/5306 by completely removing the code block, which was no longer needed.