### PR TITLE
Sketcher: Remove redundant checks

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1789,8 +1789,9 @@ int SketchObject::delGeometry(int GeoId, bool deleteinternalgeo)
     Base::StateLocker lock(managedoperation, true);
 
     const std::vector<Part::Geometry*>& vals = getInternalGeometry();
-    if (GeoId < 0 || GeoId >= int(vals.size()))
+    if (GeoId >= int(vals.size())) {
         return -1;
+    }
 
     if (deleteinternalgeo && hasInternalGeometry(getGeometry(GeoId))) {
         // Only for supported types
@@ -7573,8 +7574,9 @@ const Part::Geometry* SketchObject::_getGeometry(int GeoId) const
         if (GeoId < int(geomlist.size()))
             return geomlist[GeoId];
     }
-    else if (GeoId < 0 && -GeoId-1 < ExternalGeo.getSize())
+    else if (-GeoId-1 < ExternalGeo.getSize()) {
         return ExternalGeo[-GeoId-1];
+    }
 
     return nullptr;
 }


### PR DESCRIPTION
Two `GeoId` checks are redundant (one was always true and the other always false). Remove the extra checks. Also cleanup missing curly braces in the two clauses affected. Closes https://github.com/FreeCAD/FreeCAD/security/code-scanning/5307 and https://github.com/FreeCAD/FreeCAD/security/code-scanning/5308.