### PR TITLE
PD: Correct update of baseidx in onChanged

### DIFF
--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -180,7 +180,7 @@ void Feature::onChanged(const App::Property *prop)
                     int idx = -1;
                     body->Group.find(this->getNameInDocument(), &idx);
                     int baseidx = -1;
-                    body->Group.find(BaseFeature.getValue()->getNameInDocument(), &idx);
+                    body->Group.find(BaseFeature.getValue()->getNameInDocument(), &baseidx);
                     if (idx >= 0 && baseidx >= 0 && baseidx+1 != idx)
                         body->insertObject(BaseFeature.getValue(), this);
                 }


### PR DESCRIPTION
Found via static analysis (https://github.com/FreeCAD/FreeCAD/security/code-scanning/5309), the update here should almost certainly be to `baseidx`, not to `idx`. I don't know what tests to conduct to verify this, however, or if this will close some other open issue(s).