### PR TITLE
Measure: Remove redundant check for edges > 0

### DIFF
--- a/src/Mod/Measure/App/Measurement.cpp
+++ b/src/Mod/Measure/App/Measurement.cpp
@@ -239,7 +239,7 @@ MeasureType Measurement::findType()
     }
     else if (edges > 0) {
         if (verts > 0) {
-            if (verts > 1 && edges > 0) {
+            if (verts > 1) {
                 mode = MeasureType::Invalid;
             }
             else {


### PR DESCRIPTION
Closes https://github.com/FreeCAD/FreeCAD/security/code-scanning/5313 -- no need for this check, we already know that `edges > 0` from the check two lines above, so the measurement type is indeed invalid if there are both edges and more than one point selected.