### PR TITLE
[Measure] Fix seg fault in MeasurePosition::execute if subElements is empty

### DIFF
--- a/src/Mod/Measure/App/MeasurePosition.cpp
+++ b/src/Mod/Measure/App/MeasurePosition.cpp
@@ -98,16 +98,16 @@ App::DocumentObjectExecReturn* MeasurePosition::execute()
     if (subElements.empty()) {
         return {};
     }
-    else {
-        App::SubObjectT subject {object, subElements.front().c_str()};
-        auto info = getMeasureInfo(subject);
-        if (!info || !info->valid) {
-            return new App::DocumentObjectExecReturn("Cannot calculate position");
-        }
-        auto positionInfo = std::dynamic_pointer_cast<Part::MeasurePositionInfo>(info);
-        Position.setValue(positionInfo->position);
-        return DocumentObject::StdReturn;
+    App::SubObjectT subject {object, subElements.front().c_str()};
+    auto info = getMeasureInfo(subject);
+
+    if (!info || !info->valid) {
+        return new App::DocumentObjectExecReturn("Cannot calculate position");
     }
+
+    auto positionInfo = std::dynamic_pointer_cast<Part::MeasurePositionInfo>(info);
+    Position.setValue(positionInfo->position);
+    return DocumentObject::StdReturn;
 }
 
 

--- a/src/Mod/Measure/App/MeasurePosition.cpp
+++ b/src/Mod/Measure/App/MeasurePosition.cpp
@@ -95,17 +95,19 @@ App::DocumentObjectExecReturn* MeasurePosition::execute()
 {
     const App::DocumentObject* object = Element.getValue();
     const std::vector<std::string>& subElements = Element.getSubValues();
-
-    App::SubObjectT subject {object, subElements.front().c_str()};
-    auto info = getMeasureInfo(subject);
-
-    if (!info || !info->valid) {
-        return new App::DocumentObjectExecReturn("Cannot calculate position");
+    if (subElements.empty()) {
+        return {};
     }
-
-    auto positionInfo = std::dynamic_pointer_cast<Part::MeasurePositionInfo>(info);
-    Position.setValue(positionInfo->position);
-    return DocumentObject::StdReturn;
+    else {
+        App::SubObjectT subject {object, subElements.front().c_str()};
+        auto info = getMeasureInfo(subject);
+        if (!info || !info->valid) {
+            return new App::DocumentObjectExecReturn("Cannot calculate position");
+        }
+        auto positionInfo = std::dynamic_pointer_cast<Part::MeasurePositionInfo>(info);
+        Position.setValue(positionInfo->position);
+        return DocumentObject::StdReturn;
+    }
 }
 
 


### PR DESCRIPTION
This PR is to fix the seg fault reported on the [forum](https://forum.freecad.org/viewtopic.php?t=97756) only when Measurement is started before selection of vertices.
Regression tested pre-selection of vertices with PR successfully.

Fixes #20329 
Fixes #20194 

@hlorus FYI