### PR TITLE
[Backport][CAM] write the post file with UTF-8 encoding

### DIFF
--- a/src/Mod/CAM/Path/Post/Command.py
+++ b/src/Mod/CAM/Path/Post/Command.py
@@ -131,7 +131,7 @@ class CommandPathPost:
             if dlg.exec_():
                 filename = dlg.selectedFiles()[0]
                 Path.Log.debug(filename)
-                with open(filename, "w") as f:
+                with open(filename, "w", encoding="utf-8") as f:
                     f.write(gcode)
             else:
                 return
@@ -140,7 +140,7 @@ class CommandPathPost:
             while os.path.isfile(filename):
                 base, ext = os.path.splitext(filename)
                 filename = f"{base}-1{ext}"
-            with open(filename, "w") as f:
+            with open(filename, "w", encoding="utf-8") as f:
                 f.write(gcode)
 
         elif policy == "Open File Dialog on conflict":
@@ -153,16 +153,16 @@ class CommandPathPost:
                 if dlg.exec_():
                     filename = dlg.selectedFiles()[0]
                     Path.Log.debug(filename)
-                    with open(filename, "w") as f:
+                    with open(filename, "w", encoding="utf-8") as f:
                         f.write(gcode)
                 else:
                     return
             else:
-                with open(filename, "w") as f:
+                with open(filename, "w", encoding="utf-8") as f:
                     f.write(gcode)
 
         else:  # Overwrite
-            with open(filename, "w") as f:
+            with open(filename, "w", encoding="utf-8") as f:
                 f.write(gcode)
 
         FreeCAD.Console.PrintMessage(f"File written to {filename}\n")


### PR DESCRIPTION
Based on #20421, Fixes #18698

@Syres916 I kept you as author in the commit but I did not use `codecs` given the PR comments, let me know if you prefer me to remove you as author