### PR TITLE
fix #21330: prevent hover tooltip from covering menu items

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -606,9 +606,35 @@ void ActionGroup::onActivated (QAction* act)
     }
 }
 
-void ActionGroup::onHovered (QAction *act)
+/**
+ * Shows tooltip at the right side when hovered.
+ */
+void ActionGroup::onHovered(QAction *act)
 {
-    QToolTip::showText(QCursor::pos(), act->toolTip());
+    const auto topLevelWidgets = QApplication::topLevelWidgets();
+    QMenu* foundMenu = nullptr;
+
+    for (QWidget* widget : topLevelWidgets) {
+        QList<QMenu*> menus = widget->findChildren<QMenu*>();
+
+        for (QMenu* menu : menus) {
+            if (menu->isVisible() && menu->actions().contains(act)) {
+                foundMenu = menu;
+                break;
+            }
+        }
+
+        if (foundMenu)
+            break;
+    }
+
+    if (foundMenu) {
+        QRect actionRect = foundMenu->actionGeometry(act);
+        QPoint globalPos = foundMenu->mapToGlobal(actionRect.topRight());
+        QToolTip::showText(globalPos, act->toolTip(), foundMenu, actionRect);
+    } else {
+        QToolTip::showText(QCursor::pos(), act->toolTip());
+    }
 }
 
 


### PR DESCRIPTION
Instead of showing the tooltip at the mouse cursor, it is now displayed to the right of the corresponding menu option, avoiding overlap with the menu itself.