### PR TITLE
Gui: Emit signal to EditableDatumLabel only if there's no digits

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -575,8 +575,9 @@ void QuantitySpinBox::userInput(const QString & text)
         // only emit signal to reset EditableDatumLabel if the input is truly empty or has
         // no meaningful number don't emit for partially typed numbers like "71." which are
         // temporarily invalid
-        QString trimmedText = text.trimmed();
-        if (trimmedText.isEmpty() || !trimmedText.contains(QRegularExpression(QStringLiteral("[0-9]")))) {
+        const QString trimmedText = text.trimmed();
+        static const QRegularExpression partialNumberRegex(QStringLiteral(R"([+-]?(\d+)?(\.,\d*)?)"));
+        if (trimmedText.isEmpty() || !trimmedText.contains(partialNumberRegex)) {
             // we have to emit here signal explicitly as validator will not pass
             // this value further but we want to check it to disable isSet flag if
             // it has been set previously


### PR DESCRIPTION
Small regression of mine, basically this signal to remove set/locked state of EditableDatumLabel should be only sent out if current text in the label is empty or it doesn't contain digits.

Previously it was emitted every intermediate wrong state, so stuff like "71." was also being matched, and it resulted in resetting the locked state of the label, which in turn resulted in keeping user from entering float values.

Demo showcasing that it works now:

https://github.com/user-attachments/assets/4383f603-2fa5-4a88-9b25-ff40d6c33803

