### PR TITLE
Gui: Change ordering of names in Link property

### DIFF
--- a/src/Gui/Dialogs/DlgPropertyLink.cpp
+++ b/src/Gui/Dialogs/DlgPropertyLink.cpp
@@ -173,8 +173,8 @@ DlgPropertyLink::formatObject(App::Document* ownerDoc, App::DocumentObject* obj,
         if (obj->Label.getStrValue() == obj->getNameInDocument()) {
             return QLatin1String(objName);
         }
-        return QStringLiteral("%1 (%2)").arg(QLatin1String(objName),
-                                                  QString::fromUtf8(obj->Label.getValue()));
+        return QStringLiteral("%1 (%2)").arg(QString::fromUtf8(obj->Label.getValue()),
+                                                  QLatin1String(objName));
     }
 
     auto sobj = obj->getSubObject(sub);
@@ -182,10 +182,10 @@ DlgPropertyLink::formatObject(App::Document* ownerDoc, App::DocumentObject* obj,
         return QStringLiteral("%1.%2").arg(QLatin1String(objName), QString::fromUtf8(sub));
     }
 
-    return QStringLiteral("%1.%2 (%3)")
-        .arg(QLatin1String(objName),
-             QString::fromUtf8(sub),
-             QString::fromUtf8(sobj->Label.getValue()));
+    return QStringLiteral("%1 (%2.%3)")
+        .arg(QString::fromUtf8(sobj->Label.getValue()),
+             QLatin1String(objName),
+             QString::fromUtf8(sub));
 }
 
 static inline bool isLinkSub(const QList<App::SubObjectT>& links)


### PR DESCRIPTION
As the title says, currently it is:
ObjName (Label), this patch changes it to Label (ObjName) to be more user friendly.

@semhustej pls check, tia

Demo:

https://github.com/user-attachments/assets/e1a102fb-7a4c-4164-93fb-f4c301780db1

Resolves: https://github.com/FreeCAD/FreeCAD/issues/21930