### PR TITLE
BIM: Fix IFC type assignment not being saved to file

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_objects.py
+++ b/src/Mod/BIM/nativeifc/ifc_objects.py
@@ -65,6 +65,7 @@ class ifc_object:
         elif prop == "Schema":
             self.edit_schema(obj, obj.Schema)
         elif prop == "Type":
+            self.edit_type(obj)
             self.assign_classification(obj)
         elif prop == "Classification":
             self.edit_classification(obj)


### PR DESCRIPTION
As the title says, this is simple fix - basically right now anytime user changed Link property to point to proper IFC type, we weren't writing to the IFC file buffer to finally write it to the file if user would save it.

So this patch makes sure we write to this buffer by calling appropriate function, and making ifc object have proper pointer to IFC type.

@semhustej fyi pls check, tia

Demo:

https://github.com/user-attachments/assets/f038dca3-50de-4d82-980c-04e5d1912daa

Resolves: https://github.com/FreeCAD/FreeCAD/issues/21928