### PR TITLE
[TechDraw]Detail highlight drag (fix #21828)

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -400,6 +400,13 @@ void DrawViewDetail::postHlrTasks(void)
         Scale.purgeTouched();
         detailExec(m_saveShape, m_saveDvp, m_saveDvs);
     }
+
+    auto* baseView = freecad_cast<DrawViewPart*>(BaseView.getValue());
+    if (!baseView) {
+        throw Base::RuntimeError("Detail has no base view!");
+    }
+    baseView->requestPaint();   // repaint the highlight on the base view.
+
     overrideKeepUpdated(false);
 }
 

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -718,6 +718,38 @@ void DrawViewPart::onFacesFinished()
     requestPaint();
 }
 
+
+//! returns the position of the first visible vertex within snap radius of newAnchorPoint.  newAnchorPoint
+//! should be unscaled in conventional coordinates.  if no suitable vertex is found, newAnchorPoint
+//! is returned. the result is unscaled and inverted?
+Base::Vector3d DrawViewPart::snapHighlightToVertex(Base::Vector3d newAnchorPoint,
+                                                   double radius) const
+{
+    if (!Preferences::snapDetailHighlights()) {
+        return newAnchorPoint;
+    }
+
+    double snapRadius = radius * Preferences::detailSnapRadius();
+    double dvpScale = getScale();
+    std::vector<Base::Vector3d> vertexPoints;
+    auto vertsAll = getVertexGeometry();
+    double nearDistance{std::numeric_limits<double>::max()};
+    Base::Vector3d nearPoint{newAnchorPoint};
+    for (auto& vert: vertsAll) {
+        if (vert->getHlrVisible()) {
+            Base::Vector3d vertPointUnscaled = DU::invertY(vert->point()) / dvpScale;
+            double distanceToVertex = (vertPointUnscaled - newAnchorPoint).Length();
+            if (distanceToVertex < snapRadius &&
+                distanceToVertex < nearDistance) {
+                nearDistance = distanceToVertex;
+                nearPoint = vertPointUnscaled;
+            }
+        }
+    }
+    return nearPoint;
+}
+
+
 //retrieve all the face hatches associated with this dvp
 std::vector<TechDraw::DrawHatch*> DrawViewPart::getHatches() const
 {

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -243,6 +243,9 @@ public:
     bool isCosmeticEdge(const std::string& element);
     bool isCenterLine(const std::string& element);
 
+    Base::Vector3d snapHighlightToVertex(Base::Vector3d newAnchorPoint, double radius) const;
+
+
 public Q_SLOTS:
     void onHlrFinished(void);
     void onFacesFinished(void);

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -693,3 +693,15 @@ bool Preferences::showUnits()
 }
 
 
+bool Preferences::snapDetailHighlights()
+{
+    return Preferences::getPreferenceGroup("General")->GetBool("SnapHighlights", true);
+}
+
+
+//! distance within which we should snap a highlight to a vertex
+double Preferences::detailSnapRadius()
+{
+    return getPreferenceGroup("General")->GetFloat("DetailSnapRadius", 0.6);
+}
+

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -163,6 +163,9 @@ public:
 
     static bool showUnits();
 
+    static bool snapDetailHighlights();
+    static double detailSnapRadius();
+
 };
 
 

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>578</width>
-    <height>1073</height>
+    <width>676</width>
+    <height>1200</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -254,7 +254,7 @@ for ProjectionGroups</string>
          </spacer>
         </item>
         <item row="1" column="2">
-         <widget class="Gui::PrefUnitSpinBox" name="plsb_LabelSize">
+         <widget class="Gui::PrefUnitSpinBox" name="plsb_LabelSize" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -264,10 +264,7 @@ for ProjectionGroups</string>
           <property name="toolTip">
            <string>Label size</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
+          <property name="value" stdset="0">
            <double>8.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
@@ -449,7 +446,7 @@ for ProjectionGroups</string>
          </widget>
         </item>
         <item row="2" column="2">
-         <widget class="Gui::PrefFileChooser" name="pfc_HatchFile">
+         <widget class="Gui::PrefFileChooser" name="pfc_HatchFile" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>1</horstretch>
@@ -468,7 +465,7 @@ for ProjectionGroups</string>
          </widget>
         </item>
         <item row="3" column="2">
-         <widget class="Gui::PrefFileChooser" name="pfc_LineGroup">
+         <widget class="Gui::PrefFileChooser" name="pfc_LineGroup" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>1</horstretch>
@@ -487,7 +484,7 @@ for ProjectionGroups</string>
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="Gui::PrefFileChooser" name="pfc_DefTemp">
+         <widget class="Gui::PrefFileChooser" name="pfc_DefTemp" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>1</horstretch>
@@ -518,7 +515,7 @@ for ProjectionGroups</string>
          </widget>
         </item>
         <item row="5" column="2">
-         <widget class="Gui::PrefFileChooser" name="pfc_FilePattern">
+         <widget class="Gui::PrefFileChooser" name="pfc_FilePattern" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>1</horstretch>
@@ -537,7 +534,7 @@ for ProjectionGroups</string>
          </widget>
         </item>
         <item row="4" column="2">
-         <widget class="Gui::PrefFileChooser" name="pfc_Welding">
+         <widget class="Gui::PrefFileChooser" name="pfc_Welding" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>1</horstretch>
@@ -546,9 +543,6 @@ for ProjectionGroups</string>
           </property>
           <property name="toolTip">
            <string>Default directory for welding symbols</string>
-          </property>
-          <property name="mode">
-           <enum>Gui::FileChooser::Directory</enum>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>WeldingDir</cstring>
@@ -559,7 +553,7 @@ for ProjectionGroups</string>
          </widget>
         </item>
         <item row="1" column="2">
-         <widget class="Gui::PrefFileChooser" name="pfc_DefDir">
+         <widget class="Gui::PrefFileChooser" name="pfc_DefDir" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>1</horstretch>
@@ -568,9 +562,6 @@ for ProjectionGroups</string>
           </property>
           <property name="toolTip">
            <string>Starting directory for menu 'Insert Page using Template'</string>
-          </property>
-          <property name="mode">
-           <enum>Gui::FileChooser::Directory</enum>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>TemplateDir</cstring>
@@ -588,7 +579,7 @@ for ProjectionGroups</string>
          </widget>
         </item>
         <item row="7" column="2">
-         <widget class="Gui::PrefFileChooser" name="fcSymbolDir">
+         <widget class="Gui::PrefFileChooser" name="fcSymbolDir" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>1</horstretch>
@@ -597,9 +588,6 @@ for ProjectionGroups</string>
           </property>
           <property name="toolTip">
            <string>Alternate directory to search for SVG symbol files.</string>
-          </property>
-          <property name="mode">
-           <enum>Gui::FileChooser::Directory</enum>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>DirSymbol</cstring>
@@ -752,14 +740,11 @@ for ProjectionGroups</string>
          </widget>
         </item>
         <item row="1" column="2">
-         <widget class="Gui::PrefUnitSpinBox" name="psb_GridSpacing">
+         <widget class="Gui::PrefUnitSpinBox" name="psb_GridSpacing" native="true">
           <property name="toolTip">
            <string>Distance between Page grid lines.</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
+          <property name="value" stdset="0">
            <double>10.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
@@ -899,7 +884,7 @@ for ProjectionGroups</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_9">
       <item>
-       <layout class="QGridLayout" name="gridLayout_8" columnstretch="1,0,2">
+       <layout class="QGridLayout" name="gridLayout_8" columnstretch="1,0,2,0">
         <item row="0" column="0">
          <widget class="Gui::PrefCheckBox" name="cb_SnapViews">
           <property name="toolTip">
@@ -913,6 +898,44 @@ for ProjectionGroups</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>SnapViews</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="Gui::PrefCheckBox" name="cb_SnapHighlights">
+          <property name="toolTip">
+           <string>Check this box if you want detail view highlights to snap to the nearest vertex when dragging in TaskDetail.</string>
+          </property>
+          <property name="text">
+           <string>Snap Detail Highlights</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SnapHighlights</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="psb_SnapFactor">
+          <property name="toolTip">
+           <string>When dragging a view, if it is within this fraction of view size of the correct alignment, it will snap into alignment.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <double>0.050000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SnapLimitFactor</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/General</cstring>
@@ -939,23 +962,31 @@ for ProjectionGroups</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="psb_SnapFactor">
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_14">
+          <property name="text">
+           <string>Highlight SnappingFactor</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="psb_HighlightSnapFactor">
           <property name="toolTip">
-           <string>When dragging a view, if it is within this fraction of view size of the correct alignment, it will snap into alignment.</string>
+           <string>Controls the snap radius for highlights. Vertex must be within this factor times the highlight size to be a snap target.</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
           <property name="value">
-           <double>0.050000000000000</double>
+           <double>0.600000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>SnapLimitFactor</cstring>
+           <cstring>DetailSnapRadius</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/General</cstring>
           </property>
+
          </widget>
         </item>
        </layout>
@@ -1046,8 +1077,6 @@ for ProjectionGroups</string>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="Resources/TechDraw.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
@@ -81,6 +81,8 @@ void DlgPrefsTechDrawGeneralImp::saveSettings()
     ui->cb_alwaysShowLabel->onSave();
     ui->cb_SnapViews->onSave();
     ui->psb_SnapFactor->onSave();
+    ui->cb_SnapHighlights->onSave();
+    ui->psb_HighlightSnapFactor->onSave();
 }
 
 void DlgPrefsTechDrawGeneralImp::loadSettings()
@@ -129,6 +131,9 @@ void DlgPrefsTechDrawGeneralImp::loadSettings()
 
     ui->cb_SnapViews->onRestore();
     ui->psb_SnapFactor->onRestore();
+
+    ui->cb_SnapHighlights->onRestore();
+    ui->psb_HighlightSnapFactor->onRestore();
 }
 
 /**

--- a/src/Mod/TechDraw/Gui/QGIHighlight.cpp
+++ b/src/Mod/TechDraw/Gui/QGIHighlight.cpp
@@ -64,6 +64,8 @@ QGIHighlight::~QGIHighlight()
 
 }
 
+
+// QGIHighlight is no longer dragged except through TaskDetail.
 void QGIHighlight::onDragFinished()
 {
 //    Base::Console().message("QGIH::onDragFinished - pos: %s\n",

--- a/src/Mod/TechDraw/Gui/TaskDetail.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDetail.cpp
@@ -266,7 +266,8 @@ void TaskDetail::setUiFromFeat()
     ui->cbScaleType->setCurrentIndex(ScaleType);
     if (ui->cbScaleType->currentIndex() == 2) { // only if custom scale
         ui->qsbScale->setEnabled(true);
-    } else {
+    }
+    else {
         ui->qsbScale->setEnabled(false);
     }
     ui->qsbScale->setValue(scale);

--- a/src/Mod/TechDraw/Gui/TaskDetail.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDetail.cpp
@@ -36,6 +36,7 @@
 #include <Mod/TechDraw/App/DrawProjGroupItem.h>
 #include <Mod/TechDraw/App/DrawViewDetail.h>
 #include <Mod/TechDraw/App/DrawViewPart.h>
+#include <Mod/TechDraw/App/DrawUtil.h>
 
 #include "ui_TaskDetail.h"
 #include "TaskDetail.h"
@@ -59,7 +60,7 @@ TaskDetail::TaskDetail(TechDraw::DrawViewPart* baseFeat):
     m_ghost(nullptr),
     m_detailFeat(nullptr),
     m_baseFeat(baseFeat),
-    m_basePage(nullptr),
+    m_basePage(m_baseFeat->findParentPage()),
     m_qgParent(nullptr),
     m_inProgressLock(false),
     m_btnOK(nullptr),
@@ -67,9 +68,6 @@ TaskDetail::TaskDetail(TechDraw::DrawViewPart* baseFeat):
     m_saveAnchor(Base::Vector3d(0.0, 0.0, 0.0)),
     m_saveRadius(0.0),
     m_saved(false),
-    m_baseName(std::string()),
-    m_pageName(std::string()),
-    m_detailName(std::string()),
     m_doc(nullptr),
     m_mode(CREATEMODE),
     m_created(false)
@@ -137,9 +135,6 @@ TaskDetail::TaskDetail(TechDraw::DrawViewDetail* detailFeat):
     m_saveAnchor(Base::Vector3d(0.0, 0.0, 0.0)),
     m_saveRadius(0.0),
     m_saved(false),
-    m_baseName(std::string()),
-    m_pageName(std::string()),
-    m_detailName(std::string()),
     m_doc(nullptr),
     m_mode(EDITMODE),
     m_created(false)
@@ -160,12 +155,13 @@ TaskDetail::TaskDetail(TechDraw::DrawViewDetail* detailFeat):
 
     App::DocumentObject* baseObj = m_detailFeat->BaseView.getValue();
     m_baseFeat = dynamic_cast<TechDraw::DrawViewPart*>(baseObj);
-    if (m_baseFeat) {
-        m_baseName = m_baseFeat->getNameInDocument();
-    } else {
+    if (!m_baseFeat) {
         Base::Console().error("TaskDetail - no BaseView.  Can not proceed.\n");
         return;
     }
+    m_baseName = m_baseFeat->getNameInDocument();
+    // repaint baseObj here to make highlight inactive.
+    m_baseFeat->requestPaint();
 
     ui->setupUi(this);
 
@@ -219,7 +215,6 @@ void TaskDetail::changeEvent(QEvent *e)
 //save the start conditions
 void TaskDetail::saveDetailState()
 {
-//    Base::Console().message("TD::saveDetailState()\n");
     TechDraw::DrawViewDetail* dvd = getDetailFeat();
     m_saveAnchor = dvd->AnchorPoint.getValue();
     m_saveRadius  = dvd->Radius.getValue();
@@ -228,7 +223,6 @@ void TaskDetail::saveDetailState()
 
 void TaskDetail::restoreDetailState()
 {
-//    Base::Console().message("TD::restoreDetailState()\n");
     TechDraw::DrawViewDetail* dvd = getDetailFeat();
     dvd->AnchorPoint.setValue(m_saveAnchor);
     dvd->Radius.setValue(m_saveRadius);
@@ -238,7 +232,6 @@ void TaskDetail::restoreDetailState()
 
 void TaskDetail::setUiFromFeat()
 {
-//    Base::Console().message("TD::setUIFromFeat()\n");
     if (m_baseFeat) {
         std::string baseName = getBaseFeat()->getNameInDocument();
         ui->leBaseView->setText(QString::fromStdString(baseName));
@@ -271,10 +264,11 @@ void TaskDetail::setUiFromFeat()
     ui->qsbRadius->setValue(radius);
     ui->qsbScale->setDecimals(decimals);
     ui->cbScaleType->setCurrentIndex(ScaleType);
-    if (ui->cbScaleType->currentIndex() == 2) // only if custom scale
+    if (ui->cbScaleType->currentIndex() == 2) { // only if custom scale
         ui->qsbScale->setEnabled(true);
-    else
+    } else {
         ui->qsbScale->setEnabled(false);
+    }
     ui->qsbScale->setValue(scale);
     ui->leReference->setText(ref);
 }
@@ -282,16 +276,23 @@ void TaskDetail::setUiFromFeat()
 //update ui point fields after tracker finishes
 void TaskDetail::updateUi(QPointF pos)
 {
+    ui->qsbX->blockSignals(true);
+    ui->qsbY->blockSignals(true);
+
     ui->qsbX->setValue(pos.x());
-    ui->qsbY->setValue(- pos.y());
+    ui->qsbY->setValue(pos.y());
+
+    ui->qsbX->blockSignals(false);
+    ui->qsbY->blockSignals(false);
 }
 
 void TaskDetail::enableInputFields(bool isEnabled)
 {
     ui->qsbX->setEnabled(isEnabled);
     ui->qsbY->setEnabled(isEnabled);
-    if (ui->cbScaleType->currentIndex() == 2) // only if custom scale
+    if (ui->cbScaleType->currentIndex() == 2) {    // only if custom scale
         ui->qsbScale->setEnabled(isEnabled);
+    }
     ui->qsbRadius->setEnabled(isEnabled);
     ui->leReference->setEnabled(isEnabled);
 }
@@ -315,10 +316,10 @@ void TaskDetail::onScaleTypeEdit()
 {
     TechDraw::DrawViewDetail* detailFeat = getDetailFeat();
 
-     if (ui->cbScaleType->currentIndex() == 0) {
+    detailFeat->ScaleType.setValue(ui->cbScaleType->currentIndex());
+    if (ui->cbScaleType->currentIndex() == 0) {
          // page scale
          ui->qsbScale->setEnabled(false);
-         detailFeat->ScaleType.setValue(0.0);
          // set the page scale if there is a valid page
          if (m_basePage) {
              // set the page scale
@@ -331,15 +332,12 @@ void TaskDetail::onScaleTypeEdit()
     else if (ui->cbScaleType->currentIndex() == 1) {
         // automatic scale (if view is too large to fit into page, it will be scaled down)
         ui->qsbScale->setEnabled(false);
-        detailFeat->ScaleType.setValue(1.0);
         // updating the feature will trigger the rescaling
         updateDetail();
     }
     else if (ui->cbScaleType->currentIndex() == 2) {
         // custom scale
         ui->qsbScale->setEnabled(true);
-        detailFeat->ScaleType.setValue(2.0);
-        // no updateDetail() necessary since nothing visibly was changed
     }
 }
 
@@ -359,12 +357,10 @@ void TaskDetail::onDraggerClicked(bool clicked)
     ui->pbDragger->setEnabled(false);
     enableInputFields(false);
     editByHighlight();
-    return;
 }
 
 void TaskDetail::editByHighlight()
 {
-//    Base::Console().message("TD::editByHighlight()\n");
     if (!m_ghost) {
         Base::Console().error("TaskDetail::editByHighlight - no ghost object\n");
         return;
@@ -382,34 +378,38 @@ void TaskDetail::editByHighlight()
 //dragEnd is in scene coords.
 void TaskDetail::onHighlightMoved(QPointF dragEnd)
 {
-//    Base::Console().message("TD::onHighlightMoved(%s) - highlight: %X\n",
-//                            DrawUtil::formatVector(dragEnd).c_str(), m_ghost);
     ui->pbDragger->setEnabled(true);
 
+    double radius = m_detailFeat->Radius.getValue();
     double scale = getBaseFeat()->getScale();
     double x = Rez::guiX(getBaseFeat()->X.getValue());
     double y = Rez::guiX(getBaseFeat()->Y.getValue());
 
     DrawViewPart* dvp = getBaseFeat();
-    DrawProjGroupItem* dpgi = freecad_cast<DrawProjGroupItem*>(dvp);
-    if (dpgi) {
-        DrawProjGroup* dpg = dpgi->getPGroup();
-        if (!dpg) {
-            Base::Console().message("TD::getAnchorScene - projection group is confused\n");
-            //TODO::throw something.
-            return;
-        }
+    auto* dpgi = freecad_cast<DrawProjGroupItem*>(dvp);
+    DrawProjGroup* dpg{nullptr};
+    if (dpgi && DrawView::isProjGroupItem(dpgi)) {
+        dpg = dpgi->getPGroup();
+    }
+
+    if (dpg) {
         x += Rez::guiX(dpg->X.getValue());
         y += Rez::guiX(dpg->Y.getValue());
     }
 
     QPointF basePosScene(x, -y);                 //base position in scene coords
     QPointF anchorDisplace = dragEnd - basePosScene;
-    QPointF newAnchorPos = Rez::appX(anchorDisplace / scale);
+    QPointF newAnchorPosScene = Rez::appX(anchorDisplace / scale);
 
-    updateUi(newAnchorPos);
+
+    Base::Vector3d newAnchorPosPage = DrawUtil::toVector3d(newAnchorPosScene);
+    newAnchorPosPage = DrawUtil::invertY(newAnchorPosPage);
+    Base::Vector3d snappedPos = dvp->snapHighlightToVertex(newAnchorPosPage, radius);
+
+    updateUi(DrawUtil::toQPointF(snappedPos));
     updateDetail();
     enableInputFields(true);
+
     m_ghost->setSelected(false);
     m_ghost->hide();
 }
@@ -430,7 +430,6 @@ void TaskDetail::enableTaskButtons(bool button)
 //***** Feature create & edit stuff *******************************************
 void TaskDetail::createDetail()
 {
-//    Base::Console().message("TD::createDetail()\n");
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Detail View"));
 
     const std::string objectName{"Detail"};
@@ -471,14 +470,15 @@ void TaskDetail::createDetail()
 
 void TaskDetail::updateDetail()
 {
-//    Base::Console().message("TD::updateDetail()\n");
+    TechDraw::DrawViewDetail* detailFeat = getDetailFeat();
     try {
         Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Update Detail"));
         double x = ui->qsbX->rawValue();
         double y = ui->qsbY->rawValue();
         Base::Vector3d temp(x, y, 0.0);
-        TechDraw::DrawViewDetail* detailFeat = getDetailFeat();
-        detailFeat->AnchorPoint.setValue(temp);
+
+        detailFeat->AnchorPoint.setValue(temp);     // point2d
+
         double scale = ui->qsbScale->rawValue();
         detailFeat->Scale.setValue(scale);
         double radius = ui->qsbRadius->rawValue();
@@ -487,8 +487,6 @@ void TaskDetail::updateDetail()
         std::string ref = qRef.toStdString();
         detailFeat->Reference.setValue(ref);
 
-        detailFeat->recomputeFeature();
-        getBaseFeat()->requestPaint();
         Gui::Command::updateActive();
         Gui::Command::commitCommand();
     }
@@ -496,6 +494,8 @@ void TaskDetail::updateDetail()
         //this is probably due to appl closing while dialog is still open
         Base::Console().error("Task Detail - detail feature update failed.\n");
     }
+
+    detailFeat->recomputeFeature();
 }
 
 //***** Getters ****************************************************************
@@ -504,45 +504,42 @@ void TaskDetail::updateDetail()
 QPointF TaskDetail::getAnchorScene()
 {
     DrawViewPart* dvp = getBaseFeat();
-    DrawProjGroupItem* dpgi = freecad_cast<DrawProjGroupItem*>(dvp);
+    auto* dpgi = freecad_cast<DrawProjGroupItem*>(dvp);
     DrawViewDetail* dvd = getDetailFeat();
     Base::Vector3d anchorPos = dvd->AnchorPoint.getValue();
     anchorPos.y = -anchorPos.y;
     Base::Vector3d basePos;
     double scale = 1;
 
-    if (!dpgi) {          //base is normal view
-        double x = dvp->X.getValue();
-        double y = dvp->Y.getValue();
-        basePos = Base::Vector3d (x, -y, 0.0);
-        scale = dvp->getScale();
-    } else {                       //part of projection group
+    double x = dvp->X.getValue();
+    double y = dvp->Y.getValue();
+    scale = dvp->getScale();
 
-        DrawProjGroup* dpg = dpgi->getPGroup();
-        if (!dpg) {
-            Base::Console().message("TD::getAnchorScene - projection group is confused\n");
-            //TODO::throw something.
-            return QPointF(0.0, 0.0);
-        }
-        double x = dpg->X.getValue();
+    DrawProjGroup* dpg{nullptr};
+    if (dpgi && DrawProjGroup::isProjGroupItem(dpgi)) {
+        dpg = dpgi->getPGroup();
+    }
+
+    if (dpg) {
+        // part of a projection group
+        x = dpg->X.getValue();
         x += dpgi->X.getValue();
-        double y = dpg->Y.getValue();
+        y = dpg->Y.getValue();
         y += dpgi->Y.getValue();
-        basePos = Base::Vector3d(x, -y, 0.0);
         scale = dpgi->getScale();
     }
+
+    basePos = Base::Vector3d (x, -y, 0.0);
 
     Base::Vector3d xyScene = Rez::guiX(basePos);
     Base::Vector3d anchorOffsetScene = Rez::guiX(anchorPos) * scale;
     Base::Vector3d netPos = xyScene + anchorOffsetScene;
-    return QPointF(netPos.x, netPos.y);
+    return {netPos.x, netPos.y};
 }
 
 // protects against stale pointers
 DrawViewPart* TaskDetail::getBaseFeat()
 {
-//    Base::Console().message("TD::getBaseFeat()\n");
-
     if (m_doc) {
         App::DocumentObject* baseObj = m_doc->getObject(m_baseName.c_str());
         if (baseObj) {
@@ -560,8 +557,6 @@ DrawViewPart* TaskDetail::getBaseFeat()
 // protects against stale pointers
 DrawViewDetail* TaskDetail::getDetailFeat()
 {
-//    Base::Console().message("TD::getDetailFeat()\n");
-
     if (m_baseFeat) {
         App::DocumentObject* detailObj = m_baseFeat->getDocument()->getObject(m_detailName.c_str());
         if (detailObj) {
@@ -572,7 +567,6 @@ DrawViewDetail* TaskDetail::getDetailFeat()
     std::string msg = "TaskDetail - detail feature " +
                         m_detailName +
                         " not found \n";
-//        throw Base::TypeError("TaskDetail - detail feature not found\n");
     throw Base::TypeError(msg);
     return nullptr;
 }
@@ -581,15 +575,14 @@ DrawViewDetail* TaskDetail::getDetailFeat()
 
 bool TaskDetail::accept()
 {
-//    Base::Console().message("TD::accept()\n");
-
     Gui::Document* doc = Gui::Application::Instance->getDocument(m_basePage->getDocument());
-    if (!doc)
+    if (!doc) {
         return false;
+    }
 
     m_ghost->hide();
-    getDetailFeat()->requestPaint();
-    getBaseFeat()->requestPaint();
+    getDetailFeat()->recomputeFeature();
+
     Gui::Command::doCommand(Gui::Command::Gui, "Gui.ActiveDocument.resetEdit()");
 
     return true;
@@ -597,10 +590,10 @@ bool TaskDetail::accept()
 
 bool TaskDetail::reject()
 {
-//    Base::Console().message("TD::reject()\n");
     Gui::Document* doc = Gui::Application::Instance->getDocument(m_basePage->getDocument());
-    if (!doc)
+    if (!doc) {
         return false;
+    }
 
     m_ghost->hide();
     if (m_mode == CREATEMODE) {

--- a/src/Mod/TechDraw/Gui/TaskDetail.h
+++ b/src/Mod/TechDraw/Gui/TaskDetail.h
@@ -28,6 +28,7 @@
 #include <Gui/TaskView/TaskView.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
+#include "QGIGhostHighlight.h"
 
 namespace TechDraw
 {

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -60,6 +60,7 @@
 #include "TaskProjGroup.h"
 #include "ViewProviderViewPart.h"
 #include "ViewProviderPage.h"
+#include "QGIViewPart.h"
 #include "QGIViewDimension.h"
 #include "QGIViewBalloon.h"
 #include "QGSPage.h"
@@ -213,8 +214,8 @@ void ViewProviderViewPart::onChanged(const App::Property* prop)
 void ViewProviderViewPart::attach(App::DocumentObject *pcFeat)
 {
 //    Base::Console().message("VPVP::attach(%s)\n", pcFeat->getNameInDocument());
-    TechDraw::DrawViewMulti* dvm = dynamic_cast<TechDraw::DrawViewMulti*>(pcFeat);
-    TechDraw::DrawViewDetail* dvd = dynamic_cast<TechDraw::DrawViewDetail*>(pcFeat);
+    auto* dvm = dynamic_cast<TechDraw::DrawViewMulti*>(pcFeat);
+    auto* dvd = dynamic_cast<TechDraw::DrawViewDetail*>(pcFeat);
     if (dvm) {
         sPixmap = "TechDraw_TreeMulti";
     } else if (dvd) {
@@ -269,7 +270,7 @@ std::vector<App::DocumentObject*> ViewProviderViewPart::claimChildren() const
       }
       return temp;
     } catch (...) {
-        return std::vector<App::DocumentObject*>();
+        return {};
     }
 }
 
@@ -287,24 +288,31 @@ bool ViewProviderViewPart::setEdit(int ModNum)
     Gui::Selection().clearSelection();
 
     TechDraw::DrawViewPart* dvp = getViewObject();
-    TechDraw::DrawViewDetail* dvd = dynamic_cast<TechDraw::DrawViewDetail*>(dvp);
+    auto* dvd = dynamic_cast<TechDraw::DrawViewDetail*>(dvp);
     if (dvd) {
         if (!dvd->BaseView.getValue()) {
             Base::Console().error("DrawViewDetail - %s - has no BaseView!\n", dvd->getNameInDocument());
             return false;
         }
-        Gui::Control().showDialog(new TaskDlgDetail(dvd));
-        Gui::Selection().clearSelection();
-        Gui::Selection().addSelection(dvd->getDocument()->getName(),
-                                        dvd->getNameInDocument());
+        return setDetailEdit(ModNum, dvd);
     }
-    else {
-        auto* view = getObject<TechDraw::DrawView>();
-        Gui::Control().showDialog(new TaskDlgProjGroup(view, false));
-    }
+    auto* view = getObject<TechDraw::DrawView>();
+    Gui::Control().showDialog(new TaskDlgProjGroup(view, false));
 
     return true;
 }
+
+bool ViewProviderViewPart::setDetailEdit(int ModNum, DrawViewDetail* dvd)
+{
+    Q_UNUSED(ModNum);
+
+    Gui::Control().showDialog(new TaskDlgDetail(dvd));
+    Gui::Selection().clearSelection();
+    Gui::Selection().addSelection(dvd->getDocument()->getName(),
+                                  dvd->getNameInDocument());
+    return true;
+}
+
 
 bool ViewProviderViewPart::doubleClicked()
 {

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
@@ -71,6 +71,7 @@ public:
     bool onDelete(const std::vector<std::string> &) override;
     bool canDelete(App::DocumentObject* obj) const override;
     bool setEdit(int ModNum) override;
+    bool setDetailEdit(int ModNum, TechDraw::DrawViewDetail* dvd);
     bool doubleClicked(void) override;
     void onChanged(const App::Property *prop) override;
     void handleChangedPropertyType(Base::XMLReader &reader, const char *TypeName, App::Property * prop) override;


### PR DESCRIPTION
This PR implements a fix for issue #21828.  Specifically, it:

- eliminates the conflict between the dragable highlight on base views and the update process in TaskDetail
- uses DrawView::isProjGroupItem() instead of dynamic_cast or isDerivedFrom<>() to determine if a views belongs to a projection group.  This eliminates the spurious "ProjectionGroup is confused" message.
- implements snapping of highlights to the closest vertex in the TaskDialog drag highlight process.