### PR TITLE
Import: improve DXF C++ importer support for BLOCK and INSERT entities

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -4296,6 +4296,18 @@ class DxfImportReporter:
         else:
             lines.append("  (No entities recorded)")
         lines.append(f"FreeCAD objects created: {self.stats.get('totalEntitiesCreated', 0)}")
+
+        lines.append("")
+
+        # System Blocks
+        lines.append("System Blocks:")
+        system_blocks = self.stats.get('systemBlockCounts', {})
+        if system_blocks:
+            for key, value in sorted(system_blocks.items()):
+                lines.append(f"  - {key}: {value}")
+        else:
+            lines.append("  (None found or imported)")
+
         lines.append("")
         if has_unsupported_indicator:
             lines.append("(*) Entity type not supported by importer.")

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -229,6 +229,7 @@ void ImpExpDxfRead::setOptions()
 
 bool ImpExpDxfRead::OnReadBlock(const std::string& name, int flags)
 {
+    ImportObservation("DEBUG: OnReadBlock entered for block: '%s'\n", name.c_str());
     if ((flags & 0x04) != 0) {  // Block is an Xref
         UnsupportedFeature("External (xref) BLOCK");
         return SkipBlockContents();
@@ -581,6 +582,7 @@ void ImpExpDxfRead::OnReadInsert(const Base::Vector3d& point,
 
     // Create the App::Link object directly in C++
     App::Link* link = document->addObject<App::Link>(linkName.c_str());
+    ImportObservation("DEBUG: Creating App::Link for block '%s'\n", name.c_str());
     if (!link) {
         ImportError("Failed to create App::Link for block '%s'", name.c_str());
         return;

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -414,8 +414,6 @@ void ImpExpDxfRead::FinishImport()
 
 bool ImpExpDxfRead::OnReadBlock(const std::string& name, int flags)
 {
-    ImportObservation("DEBUG: OnReadBlock parsing block: '%s'\n", name.c_str());
-
     // Step 1: Check for external references first. This is a critical check.
     if ((flags & 0x04) != 0) {  // Block is an Xref
         UnsupportedFeature("External (xref) BLOCK");
@@ -772,7 +770,6 @@ void ImpExpDxfRead::OnReadInsert(const Base::Vector3d& point,
 
     // Create the App::Link object directly in C++
     App::Link* link = document->addObject<App::Link>(linkName.c_str());
-    ImportObservation("DEBUG: Creating App::Link for block '%s'\n", name.c_str());
     if (!link) {
         ImportError("Failed to create App::Link for block '%s'", name.c_str());
         return;

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -431,6 +431,7 @@ void ImpExpDxfRead::ComposeParametricBlock(const std::string& blockName,
                 auto geomFeature = document->addObject<Part::Feature>(
                     document->getStandardObjectLabel(primitive_base_label.c_str(), 3).c_str());
 
+                IncrementCreatedObjectCount();
                 geomFeature->Shape.setValue(shape);
                 geomFeature->Visibility.setValue(false);
 

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -523,6 +523,17 @@ void ImpExpDxfRead::FinishImport()
         m_unreferencedBlocksGroup->Visibility.setValue(false);
     }
 
+    // If no blocks were defined in the file at all, remove the main definitions
+    // group as well to keep the document clean.
+    if (m_blockDefinitionGroup && m_blockDefinitionGroup->Group.getValues().empty()) {
+        try {
+            document->removeObject(m_blockDefinitionGroup->getNameInDocument());
+        }
+        catch (const Base::Exception& e) {
+            e.reportException();
+        }
+    }
+
     // call the base class implementation if it has one
     CDxfRead::FinishImport();
 }

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -797,7 +797,7 @@ void ImpExpDxfRead::OnReadText(const Base::Vector3d& point,
             PyObject* draftModule = getDraftModule();
             if (draftModule != nullptr) {
                 Base::Matrix4D localTransform;
-                localTransform.rotZ(rotation);
+                localTransform.rotZ(Base::toRadians(rotation));
                 localTransform.move(point);
                 PyObject* placement =
                     new Base::PlacementPy(Base::Placement(transform * localTransform));

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -292,11 +292,16 @@ void ImpExpDxfRead::ComposeSingleBlock(const std::string& blockName,
         // Then, iterate through each shape in that group and create a separate feature for it.
         for (const auto& shape : shapeList) {
             if (!shape.IsNull()) {
-                std::string cleanPrefix = blockName;
-                if (!cleanPrefix.empty() && std::isdigit(cleanPrefix[0])) {
+                std::string cleanBlockLabel = blockName;
+                if (!cleanBlockLabel.empty() && std::isdigit(cleanBlockLabel[0])) {
                     // Workaround for FreeCAD's unique name generator, which prepends an underscore
                     // to names that start with a digit. We add our own prefix.
-                    cleanPrefix.insert(0, "B_");
+                    cleanBlockLabel.insert(0, "_");
+                }
+                else if (!cleanBlockLabel.empty() && std::isdigit(cleanBlockLabel.back())) {
+                    // Add a trailing underscore to prevent the unique name generator
+                    // from incrementing the number in the block's name.
+                    cleanBlockLabel += "_";
                 }
                 // Determine a more descriptive name for the primitive feature.
                 std::string type_suffix = "Shape";
@@ -342,7 +347,7 @@ void ImpExpDxfRead::ComposeSingleBlock(const std::string& blockName,
                     type_suffix = "Compound";
                 }
 
-                std::string primitive_base_label = cleanPrefix + "_" + type_suffix;
+                std::string primitive_base_label = cleanBlockLabel + "_" + type_suffix;
                 // Use getStandardObjectLabel to get a unique user-facing label (e.g.,
                 // "block01_Line001") while keeping the internal object name clean.
                 auto geomFeature = document->addObject<Part::Feature>(

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -730,6 +730,10 @@ void ImpExpDxfRead::OnReadSpline(struct SplineData& sd)
     // Flags:
     // 1: Closed, 2: Periodic, 4: Rational, 8: Planar, 16: Linear
 
+    if (shouldSkipEntity()) {
+        return;
+    }
+
     try {
         Handle(Geom_BSplineCurve) geom;
         if (sd.control_points > 0) {

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -208,6 +208,7 @@ private:
     std::map<std::string, TopoDS_Shape> m_flattenedBlockShapes;
     std::map<std::string, App::DocumentObject*> m_blockDefinitions;
     App::DocumentObjectGroup* m_blockDefinitionGroup = nullptr;
+    App::DocumentObjectGroup* m_unreferencedBlocksGroup = nullptr;
     App::Document* document;
     std::string m_optionSource;
 

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -294,7 +294,13 @@ protected:
 
             // Create a unique name for the link
             std::string linkName = "Link_";
-            linkName += name;
+            std::string cleanName = name;
+            if (!cleanName.empty() && std::isdigit(cleanName.back())) {
+                // Add a trailing underscore to prevent the unique name generator
+                // from incrementing the number in the block's name.
+                cleanName += "_";
+            }
+            linkName += cleanName;
             linkName = Reader.document->getUniqueObjectName(linkName.c_str());
 
             // Create the App::Link object directly in C++

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -125,7 +125,8 @@ private:
     PyObject* DraftModule = nullptr;
     std::set<std::string> m_referencedBlocks;
     void ComposeBlocks();
-    void ComposeSingleBlock(const std::string& blockName, std::set<std::string>& composed);
+    void ComposeParametricBlock(const std::string& blockName, std::set<std::string>& composed);
+    void ComposeFlattenedBlock(const std::string& blockName, std::set<std::string>& composed);
 
 protected:
     PyObject* getDraftModule()
@@ -204,6 +205,7 @@ protected:
 
 private:
     std::map<std::string, Block> Blocks;
+    std::map<std::string, TopoDS_Shape> m_flattenedBlockShapes;
     std::map<std::string, App::DocumentObject*> m_blockDefinitions;
     App::DocumentObjectGroup* m_blockDefinitionGroup = nullptr;
     App::Document* document;

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -23,12 +23,14 @@
 #ifndef IMPEXPDXF_H
 #define IMPEXPDXF_H
 
+#include <set>
 #include <gp_Pnt.hxx>
 
 #include <App/Document.h>
 #include <TopoDS_Shape.hxx>
 #include <Mod/Part/App/TopoShape.h>
 #include <Mod/Part/App/PartFeature.h>
+#include <Mod/Part/App/FeatureCompound.h>
 
 #include "dxf.h"
 
@@ -107,6 +109,7 @@ public:
         m_optionSource = sourceName;
     }
     void setOptions();
+    void FinishImport() override;
 
 private:
     bool shouldSkipEntity() const
@@ -124,6 +127,9 @@ private:
     void CombineShapes(std::list<TopoDS_Shape>& shapes, const char* nameBase) const;
     TopoDS_Shape CombineShapesToCompound(const std::list<TopoDS_Shape>& shapes) const;
     PyObject* DraftModule = nullptr;
+    std::set<std::string> m_referencedBlocks;
+    void ComposeBlocks();
+    void ComposeSingleBlock(const std::string& blockName, std::set<std::string>& composed);
 
 protected:
     PyObject* getDraftModule()

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2990,6 +2990,7 @@ bool CDxfRead::ReadBlocksSection()
         if (!IsObjectName("BLOCK")) {
             continue;  // quietly ignore non-BLOCK records
         }
+        ImportObservation("DEBUG: ReadBlocksSection found a BLOCK entity.\n");
         if (!ReadBlockInfo()) {
             ImportError("CDxfRead::DoRead() Failed to read block\n");
         }

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2990,7 +2990,6 @@ bool CDxfRead::ReadBlocksSection()
         if (!IsObjectName("BLOCK")) {
             continue;  // quietly ignore non-BLOCK records
         }
-        ImportObservation("DEBUG: ReadBlocksSection found a BLOCK entity.\n");
         if (!ReadBlockInfo()) {
             ImportError("CDxfRead::DoRead() Failed to read block\n");
         }

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2352,7 +2352,6 @@ bool CDxfRead::ReadBlockInfo()
     int blockType = 0;
     std::string blockName;
     InitializeAttributes();
-    m_stats.entityCounts["BLOCK"]++;
     // Both 2 and 3 are the block name.
     SetupStringAttribute(eName, blockName);
     SetupStringAttribute(eExtraText, blockName);

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -3161,7 +3161,10 @@ Base::Color CDxfRead::ObjectColor(ColorIndex_t index)
         result = wheel((index - 1) * 4, 0x00);
     }
     else if (index == 7) {
-        result = Base::Color(1, 1, 1);
+        // DXF color 7 is "black/white" and should adapt to the background.
+        // Since we cannot easily query the background theme from here, we will use a
+        // neutral mid-gray, which is visible on both light and dark themes.
+        result = Base::Color(0.5f, 0.5f, 0.5f);
     }
     else if (index == 8) {
         result = Base::Color(0.5, 0.5, 0.5);

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -188,6 +188,8 @@ struct DxfImportStats
     std::map<std::string, int> entityCounts;
     std::map<std::string, std::string> importSettings;
     std::map<std::string, std::vector<std::pair<int, std::string>>> unsupportedFeatures;
+    std::map<std::string, int> systemBlockCounts;
+
     int totalEntitiesCreated = 0;
 };
 

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -359,6 +359,7 @@ private:
     // both places could include a declaration.
     Py::Object readDXF(const Py::Tuple& args)
     {
+        Base::Console().message("DEBUG: C++ readDXF function in AppImportGuiPy.cpp entered.\n");
         char* Name = nullptr;
         const char* DocName = nullptr;
         const char* optionSource = nullptr;

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -359,7 +359,6 @@ private:
     // both places could include a declaration.
     Py::Object readDXF(const Py::Tuple& args)
     {
-        Base::Console().message("DEBUG: C++ readDXF function in AppImportGuiPy.cpp entered.\n");
         char* Name = nullptr;
         const char* DocName = nullptr;
         const char* optionSource = nullptr;

--- a/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
+++ b/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
@@ -90,14 +90,6 @@ void ImpExpDxfReadGui::ApplyGuiStyles(App::Link* object) const
         return;
     }
 
-    // --- TEMPORARY DEBUGGING ---
-    const auto& attrs = m_entityAttributes;
-    Base::Console().log("Applying style for Link '%s'. Layer: '%s', DXF Color Index: %d\n",
-                        object->getNameInDocument(),
-                        attrs.m_Layer ? attrs.m_Layer->Name.c_str() : "None",
-                        attrs.m_Color);
-    // ---------------------------
-
     if (m_preserveColors) {
         // The user wants to see colors from the DXF file.
         // We style the link by setting its ViewProvider's properties directly,

--- a/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
+++ b/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
@@ -52,6 +52,8 @@
 #endif
 #include <regex>
 
+#include <App/Link.h>
+
 #include <Gui/Application.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/ViewProviderDocumentObject.h>
@@ -75,6 +77,30 @@ void ImpExpDxfReadGui::ApplyGuiStyles(Part::Feature* object) const
     view->ShapeAppearance.setDiffuseColor(color);
     view->DrawStyle.setValue(GetDrawStyle());
     view->Transparency.setValue(0);
+}
+
+void ImpExpDxfReadGui::ApplyGuiStyles(App::Link* object) const
+{
+    // For App::Link, we get its ViewProvider directly.
+    // It's a generic ViewProvider, not a specific PartGui one.
+    auto view = GuiDocument->getViewProvider(object);
+    if (!view) {
+        return;
+    }
+    Base::Color color = ObjectColor(m_entityAttributes.m_Color);
+
+    // Links have LineColor and PointColor properties that affect their appearance
+    // when not in "UseOriginalColor" mode.
+    if (auto prop = view->getPropertyByName("LineColor")) {
+        if (prop->getTypeId().isDerivedFrom(App::PropertyColor::getClassTypeId())) {
+            static_cast<App::PropertyColor*>(prop)->setValue(color);
+        }
+    }
+    if (auto prop = view->getPropertyByName("PointColor")) {
+        if (prop->getTypeId().isDerivedFrom(App::PropertyColor::getClassTypeId())) {
+            static_cast<App::PropertyColor*>(prop)->setValue(color);
+        }
+    }
 }
 
 void ImpExpDxfReadGui::ApplyGuiStyles(App::FeaturePython* object) const

--- a/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
+++ b/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
@@ -81,26 +81,24 @@ void ImpExpDxfReadGui::ApplyGuiStyles(Part::Feature* object) const
 
 void ImpExpDxfReadGui::ApplyGuiStyles(App::Link* object) const
 {
-    // For App::Link, we get its ViewProvider directly.
-    // It's a generic ViewProvider, not a specific PartGui one.
     auto view = GuiDocument->getViewProvider(object);
     if (!view) {
         return;
     }
-    Base::Color color = ObjectColor(m_entityAttributes.m_Color);
 
-    // Links have LineColor and PointColor properties that affect their appearance
-    // when not in "UseOriginalColor" mode.
-    if (auto prop = view->getPropertyByName("LineColor")) {
-        if (prop->getTypeId().isDerivedFrom(App::PropertyColor::getClassTypeId())) {
-            static_cast<App::PropertyColor*>(prop)->setValue(color);
+    // Setting DrawStyle to "Original" tells the link's ViewProvider to
+    // use the appearance of the linked object. This is the correct
+    // way to handle visual instancing.
+    if (auto* prop = view->getPropertyByName("DrawStyle")) {
+        if (auto* penum = dynamic_cast<App::PropertyEnumeration*>(prop)) {
+            penum->setValue("Original");
         }
     }
-    if (auto prop = view->getPropertyByName("PointColor")) {
-        if (prop->getTypeId().isDerivedFrom(App::PropertyColor::getClassTypeId())) {
-            static_cast<App::PropertyColor*>(prop)->setValue(color);
-        }
-    }
+
+    // TODO: The link's view provider may still have color properties set,
+    // which can override the "Original" draw style. The C++ API does not appear
+    // to expose a way to reset these properties to their default state. This is
+    // a known limitation and can be addressed in the future if a method is found.
 }
 
 void ImpExpDxfReadGui::ApplyGuiStyles(App::FeaturePython* object) const

--- a/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
+++ b/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
@@ -90,6 +90,14 @@ void ImpExpDxfReadGui::ApplyGuiStyles(App::Link* object) const
         return;
     }
 
+    // --- TEMPORARY DEBUGGING ---
+    const auto& attrs = m_entityAttributes;
+    Base::Console().log("Applying style for Link '%s'. Layer: '%s', DXF Color Index: %d\n",
+                        object->getNameInDocument(),
+                        attrs.m_Layer ? attrs.m_Layer->Name.c_str() : "None",
+                        attrs.m_Color);
+    // ---------------------------
+
     if (m_preserveColors) {
         // The user wants to see colors from the DXF file.
         // We style the link by setting its ViewProvider's properties directly,

--- a/src/Mod/Import/Gui/dxf/ImpExpDxfGui.h
+++ b/src/Mod/Import/Gui/dxf/ImpExpDxfGui.h
@@ -41,6 +41,7 @@ public:
 
 protected:
     void ApplyGuiStyles(Part::Feature* object) const override;
+    void ApplyGuiStyles(App::Link* object) const override;
     void ApplyGuiStyles(App::FeaturePython* object) const override;
 
 private:


### PR DESCRIPTION
This pull request introduces an enhancement to the C++ DXF importer, adding structured support for `BLOCK` and `INSERT` entities. 

### Features

*   **Nested block support:** the importer now handles nested block definitions (blocks that contain `INSERT`s of other blocks). It preserves the parametric hierarchy by creating `Part::Compound` objects for block definitions which, in turn, contain `App::Link`s to their nested components. [Learn more about BLOCKs and INSERTs](https://wiki.freecad.org/DXF#BLOCKs_and_INSERTs).

*   **Parametric/flattened import selection:** the existing **"Group layers into blocks"** import preference controls how blocks and assemblies are imported:
    1.  **Parametric block assembly (unchecked):** creates reusable, hidden block definitions (`Part::Compound`) and represents `INSERT`s as `App::Link`s. This mode prioritizes editability over speed and size.
    2.  **Flattened block assembly (checked):**  geometrically merges all entities within a block definition into a single, static `Part::Feature`. This mode prioritizes import speed and smaller document sizes and loading time.

*   **Unreferenced blocks classification:**
    *   Block definitions that are defined in the DXF but never used ("unreferenced" or "library" blocks) are now sorted into a separate, hidden `_UnreferencedBlocks` group.
    *   Users can then easily inspect, use, or purge unused definitions without cluttering the main `_BlockDefinitions` group or the document tree.

### Implementation principles

1. Separation of definition and instances: `BLOCK` definitions are treated as master templates, imported as hidden `Part::Compound`s. `INSERT` entities become visible `App::Link` instances pointing to these masters.
2. Instance primacy: the `App::Link` (representing the `INSERT`) controls the top-level properties of an instance, such as its layer and final appearance.
3. Hierarchy preservation: the full nested structure of blocks is preserved parametrically via `App::Link`s within `Part::Compound` definitions.
4.  Clean document: used and unused block definitions are segregated and hidden in their own groups for a clean document tree.
5. All blocks imported: to prevent data loss, all blocks, including those unused, are imported. It is the responsibility of the user to purge unused blocks before or after the import if desired. Purging before can dramatically decrease import and document loading times.

### Known issues and limitations

- All blocks, also unused, are imported unconditionally. DXF files with a large number of unused blocks might take longer times to import, and the final `.FCStd` file size will increase as well. **It is advised to purge unused blocks with the relevant CAD software (usually they provide a command to do so) before importing the files into FreeCAD**. A further iteration may provide the ability to not import unused blocks, controlled by a new or existing setting.
- When manually deleting compounds, or the groups they're in, be aware of https://github.com/FreeCAD/FreeCAD/issues/22070. One might end up in this situation if advice from the previous point has not been followed.
- FreeCAD's unique name generator, when it encounters a name that starts with a digit, it replaces that digit in the label with an underscore (`_`). This is known behaviour, but rather unexpected: one would expect that the underscore is added as a prefix instead of overwriting the label. This can make the objects created on this PR (blocks and inserts) be difficult to visually associate with each other. To work around this, this PR adds an underscore to those imported objects with a digit in the first character of their label, before they are passed to the unique name generator.
- FreeCAD's unique name generator, when it encounters a name that ends with a digit, replaces that digit and previous ones it encounters with an automatically increased figure. Again unexpected but known behaviour. It affects this feature as well. The workaround here is to add an underscore after the label's last digit before passing it to the unique name generator. This is not yet consistently applied to all block-related object the importer creates, though.
- To work around https://github.com/FreeCAD/FreeCAD/issues/19281 (which also affects the importer), **DXF color index 7 is imported unconditionally as mid-gray**, which is well visible both with FreeCAD's Light and Dark themes. A fix for that issue is still required, but it is beyond the scope of this PR.

### Testing

- [test_files.zip](https://github.com/user-attachments/files/20825146/test_files.zip) contains:
  - A set of original `.dxf` files kindly provided by @semhustej 
  - The resulting `.FCStd` files produced by the importer changes in this branch. The purpose is examination of the objects hierarchy for review. These files names have been prefixed with `AFTER_`.
  - The files have been produced with the settings in the screenshot below. There are two versions of the files, one with `_PARAMETRIC` suffix in the name (produced with "Group layers into blocks" unchecked), and one with the `_FLATTENED` suffix in the name (produced with "Group layers into blocks" checked).
  - In some cases, files produced with a FreeCAD version before this change have been provided for comparison. These are prefixed with `BEFORE_`

![image](https://github.com/user-attachments/assets/4a7dd23e-4dce-454b-b6b2-ecbbd18f5d24)
 
## Issues
Fixes: https://github.com/FreeCAD/FreeCAD/issues/21962
Fixes: #21548  (*)

(*) Unrelated. It's a trivial one-liner commit and I had a testing build, so I added it too to reduce the overhead of another PR + review cycle.