### PR TITLE
Sketcher: fix Esc can leave setting synchronization

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -292,7 +292,7 @@ void ViewProviderSketch::ParameterObserver::initParameters()
               updateBoolProperty(string, property, true);
           },
           &Client.AvoidRedundant}},
-        {"updateEscapeKeyBehaviour",
+        {"LeaveSketchWithEscape",
          {[this](const std::string& string, App::Property* property) {
               updateEscapeKeyBehaviour(string, property);
           },


### PR DESCRIPTION
The "Esc can leave sketch edit mode" setting was working, but it's state wasn't properly refreshed after changes (requiring a restart for it to take effect).

All the required code was already there just a small mistake in property name. Seems like the wrong name was there from the time it was introduced in 92e6094 . I am guessing it was a placeholder/copy paste error which wasn't properly tested due to being part of giant refactoring commit.

Test plan:
* enable "esc can leave sketch edit mode" sketcher option
* restart FreeCad (just to be sure, technically not needed after the fix)
* create sketch
* press esc -> should exit sketch
* create second sketch (keep opened)
* open preferences and disable "esc can leave"
* press esc -> should not exit sketch
* exit sketch using mouse
* open first sketch
* press esc -> should not exit  (before fix state got saved per sketch, that's why testing with multiple sketches)
* enable "esc can leave"
* press esc -> should exit
* disable "esc can leave" while no sketch is opened
* open first sketch and press esc -> should not exit

## Issues

Closes #18944

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
