### PR TITLE
Assembly: Fix conflicting shortcuts

### DIFF
--- a/src/Mod/Assembly/CommandCreateJoint.py
+++ b/src/Mod/Assembly/CommandCreateJoint.py
@@ -392,7 +392,7 @@ class CommandCreateJointGears:
         return {
             "Pixmap": "Assembly_CreateJointGears",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_CreateJointGears", "Create Gears Joint"),
-            "Accel": "X",
+            "Accel": "T",
             "ToolTip": "<p>"
             + QT_TRANSLATE_NOOP(
                 "Assembly_CreateJointGears",
@@ -423,7 +423,7 @@ class CommandCreateJointBelt:
         return {
             "Pixmap": "Assembly_CreateJointPulleys",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_CreateJointBelt", "Create Belt Joint"),
-            "Accel": "P",
+            "Accel": "L",
             "ToolTip": "<p>"
             + QT_TRANSLATE_NOOP(
                 "Assembly_CreateJointBelt",

--- a/src/Mod/Assembly/CommandCreateSimulation.py
+++ b/src/Mod/Assembly/CommandCreateSimulation.py
@@ -65,7 +65,7 @@ class CommandCreateSimulation:
         return {
             "Pixmap": "Assembly_CreateSimulation",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_CreateSimulation", "Create Simulation"),
-            "Accel": "S",
+            "Accel": "V",
             "ToolTip": "<p>"
             + QT_TRANSLATE_NOOP(
                 "Assembly_CreateSimulation",


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Currently there are three conflicting shortcuts in the Assembly WB
- S for Slider joint and Simulate
- P for Part and Belt Joint
- X for Angle and Gear Joint

This PR adds shortcuts:
- V for Simulation
- L for Belt
- T for Gear

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

fixes https://github.com/FreeCAD/FreeCAD/issues/20971
fixes https://github.com/FreeCAD/FreeCAD/issues/20972

<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
