### PR TITLE
TechDraw: Remove redundant apply button. (Fix #21792)

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -777,12 +777,10 @@ QString TaskProjGroup::formatVector(Base::Vector3d vec)
 }
 
 void TaskProjGroup::saveButtons(QPushButton* btnOK,
-                             QPushButton* btnCancel,
-                             QPushButton* btnApply)
+                             QPushButton* btnCancel)
 {
     m_btnOK = btnOK;
     m_btnCancel = btnCancel;
-    m_btnApply = btnApply;
 }
 
 
@@ -887,8 +885,7 @@ void TaskDlgProjGroup::modifyStandardButtons(QDialogButtonBox* box)
 {
     QPushButton* btnOK = box->button(QDialogButtonBox::Ok);
     QPushButton* btnCancel = box->button(QDialogButtonBox::Cancel);
-    QPushButton* btnApply = box->button(QDialogButtonBox::Apply);
-    widget->saveButtons(btnOK, btnCancel, btnApply);
+    widget->saveButtons(btnOK, btnCancel);
 }
 
 //==== calls from the TaskView ===============================================================

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.h
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.h
@@ -61,8 +61,7 @@ public:
     virtual bool apply();
     void modifyStandardButtons(QDialogButtonBox* box);
     void saveButtons(QPushButton* btnOK,
-                     QPushButton* btnCancel,
-                     QPushButton* btnApply);
+                     QPushButton* btnCancel);
 
     void updateTask();
     // Sets the numerator and denominator widgets to match newScale
@@ -126,7 +125,6 @@ private:
 
     QPushButton* m_btnOK{nullptr};
     QPushButton* m_btnCancel{nullptr};
-    QPushButton* m_btnApply{nullptr};
 
     std::vector<App::DocumentObject*> m_saveSource;
     std::string    m_saveProjType;
@@ -151,7 +149,7 @@ public:
     TechDraw::DrawView* getView() const { return view; }
 
     QDialogButtonBox::StandardButtons getStandardButtons() const override
-    { return QDialogButtonBox::Ok | QDialogButtonBox::Apply | QDialogButtonBox::Cancel; }
+    { return QDialogButtonBox::Ok | QDialogButtonBox::Cancel; }
     void modifyStandardButtons(QDialogButtonBox* box) override;
 
     /// is called the TaskView when the dialog is opened


### PR DESCRIPTION
## Summary
PR https://github.com/FreeCAD/FreeCAD/pull/21783 makes the "Apply" button redundant. This PR removes the "Apply" button.

## Issues
Closes #21792.

## Before and After Images
Before: 
![old](https://github.com/user-attachments/assets/380789d7-80da-48d0-904e-3b26c41c0230)



After:


![new](https://github.com/user-attachments/assets/59c712b1-1230-4e4a-8ea1-426a2ced5d28)

## Notes For Reviewers
There are more instances where code that references an "apply" exists in TaskProjGroup.cpp and TaskProjGroup.h, but I believe each one of them is neccessary for other processes. 

I have tested my code changes locally and try everything I could to see if something would break, and everything seems to work as intended.
