### PR TITLE
Sketcher: Fix Constraint Filter Handling

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1101,7 +1101,6 @@ void TaskSketcherConstraints::onListWidgetConstraintsEmitShowSelection3DVisibili
 void TaskSketcherConstraints::changeFilteredVisibility(bool show, ActionTarget target)
 {
     assert(sketchView);
-    const Sketcher::SketchObject* sketch = sketchView->getSketchObject();
 
     auto selecteditems = ui->listWidgetConstraints->selectedItems();
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -731,7 +731,7 @@ ConstraintFilterList::ConstraintFilterList(QWidget* parent)
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-    int filterState = hGrp->GetInt("ConstraintFilterState", defaultFilter);
+    int filterState = hGrp->GetInt("SelectedConstraintFilters", defaultFilter);
 
     for (auto const& filterItem : filterItems) {
         Q_UNUSED(filterItem);
@@ -1750,7 +1750,7 @@ void TaskSketcherConstraints::onFilterListItemChanged(QListWidgetItem* item)
     }
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-    hGrp->SetInt("ConstraintFilterState", filterState);
+    hGrp->SetInt("SelectedConstraintFilters", filterState);
 
     // if tracking, it will call slotConstraintChanged via update mechanism as Multi Filter affects
     // not only visibility, but also filtered list content, if not tracking will still update the

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1489,10 +1489,10 @@ void TaskSketcherConstraints::change3DViewVisibilityToTrackFilter(bool filterEna
             return;
         }
     }
-    
+
     if (!constrIdsToCurrentSpace.empty()) {
         bool ret = doSetVirtualSpace(constrIdsToCurrentSpace, false);
-        
+
         if (!ret) {
             return;
         }
@@ -1515,7 +1515,7 @@ bool TaskSketcherConstraints::doSetVirtualSpace(const std::vector<int>& constrId
         stream << constrIds[i] << ",";
     }
     stream << constrIds[constrIds.size() - 1] << ']';
-    
+
     std::string constrIdList = stream.str();
 
     Gui::Command::openCommand(
@@ -1529,7 +1529,7 @@ bool TaskSketcherConstraints::doSetVirtualSpace(const std::vector<int>& constrId
     }
     catch (const Base::Exception& e) {
         Gui::Command::abortCommand();
-        
+
         Gui::TranslatedUserError(
             sketch, tr("Error"), tr("Impossible to update visibility tracking:") + QLatin1String(" ") + QLatin1String(e.what()));
         return false;

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -724,7 +724,7 @@ ConstraintFilterList::ConstraintFilterList(QWidget* parent)
     associatedFilterIndex = normalFilterCount + 1;
 
     // default filters are all except for special filters
-    int defaultFilter = 0; 
+    int defaultFilter = 0;
     for (int i = 0; i < normalFilterCount; i++) {
         defaultFilter |= 1 << i;
     }

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
@@ -168,6 +168,7 @@ private:
     void slotConstraintsChanged();
     bool isConstraintFiltered(QListWidgetItem* item);
     void change3DViewVisibilityToTrackFilter(bool filterEnabled);
+    bool doSetVirtualSpace(const std::vector<int>& constrIds, bool isvirtualspace);
     void changeFilteredVisibility(bool show, ActionTarget target = ActionTarget::All);
     void updateSelectionFilter();
     void updateAssociatedConstraintsFilter();

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
@@ -167,7 +167,7 @@ public:
 private:
     void slotConstraintsChanged();
     bool isConstraintFiltered(QListWidgetItem* item);
-    void change3DViewVisibilityToTrackFilter();
+    void change3DViewVisibilityToTrackFilter(bool filterEnabled);
     void changeFilteredVisibility(bool show, ActionTarget target = ActionTarget::All);
     void updateSelectionFilter();
     void updateAssociatedConstraintsFilter();


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
Fixes #9476 and #9373

It fixes the problem, that "Special Filters" of constraints are not applied correctly.
To reproduce the bug see https://github.com/FreeCAD/FreeCAD/issues/9476#issuecomment-2017384091

The problem was when initializing the filters all special filters were initialized and the first special filter (selected constraints) disabled the second filter (associated constraints). Then the second filter was initialized (which was disabled) and reset the specialFilterMode variable to none. However the selected constraints checkbox stayed checked but the filtermode for selected constraints was not enabled..

While testing I found another problem. The show only filtered constraints checkbox from the settings button also doesn't work correctly. If there are no filtered constraints and you uncheck the ckeckbox the constraints don't appear in the 3d view again. Fixed with this PR as well

Steps to reproduce:
1. open sketch
2. create geometry with contstraints
3. check filter checkbox to filter only selected constraints (constraint list should now be empty, constraints in sketch are displayed)
4. check settings checkbox to only show filtered constraints (constraints in sketch disappear)
5. uncheck settings checkbox to only show filtered constraints (constraints in sketch should appear again, but they don't)
EDIT: just realized there also exists an issue for that #9373

**Heads up**
I changed the default settings of the constraint filter. So by now the special filters (selected and associated constraints) are disabled for new users. However, since they are saved in the preferences for users who started the sketcher before this fix most likely have the selected constraints setting enabled. And now with this setting working no constraints will be displayed in the constraint list. They have to manually uncheck the checkbox.
I think the most user friendly way would be to update the preferences and uncheck all special filters. Is there a way to achieve this?



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
