### PR TITLE
BIM: limit max length of diagonal axis

### DIFF
--- a/src/Mod/BIM/ArchAxis.py
+++ b/src/Mod/BIM/ArchAxis.py
@@ -109,25 +109,20 @@ class _Axis:
         if distances and obj.Length.Value:
             if angles and len(distances) == len(angles):
                 for i in range(len(distances)):
-                    if hasattr(obj.Length,"Value"):
-                        l = obj.Length.Value
-                    else:
-                        l = obj.Length
                     dist += distances[i]
                     ang = math.radians(angles[i])
-                    p1 = Vector(dist,0,0)
-                    p2 = Vector(dist+(l/math.cos(ang))*math.sin(ang),l,0)
+                    ln = obj.Length.Value
+                    ln = 100 * ln if abs(math.cos(ang)) < 0.01 else ln / math.cos(ang)
+                    unitvec = Vector(math.sin(ang), math.cos(ang), 0)
+                    p1 = Vector(dist, 0, 0)
+                    p2 = p1 + unitvec * ln
                     if hasattr(obj,"Limit") and obj.Limit.Value:
-                        p3 = p2.sub(p1)
-                        p3.normalize()
-                        p3.multiply(-obj.Limit.Value)
-                        p4 = p1.sub(p2)
-                        p4.normalize()
-                        p4.multiply(-obj.Limit.Value)
-                        geoms.append(Part.LineSegment(p1,p1.add(p4)).toShape())
-                        geoms.append(Part.LineSegment(p2,p2.add(p3)).toShape())
+                        p3 = unitvec * obj.Limit.Value
+                        p4 = unitvec * -obj.Limit.Value
+                        geoms.append(Part.LineSegment(p1, p1 + p3).toShape())
+                        geoms.append(Part.LineSegment(p2, p2 + p4).toShape())
                     else:
-                        geoms.append(Part.LineSegment(p1,p2).toShape())
+                        geoms.append(Part.LineSegment(p1, p2).toShape())
         if geoms:
             sh = Part.Compound(geoms)
             obj.Shape = sh


### PR DESCRIPTION
Fixes #19578.

Maximize length of axes to `100 * obj.Length` to avoid endless axes if angle is 90 or 270 degrees.