### PR TITLE
CI: only lint on PRs.

### DIFF
--- a/.github/workflows/sub_prepare.yml
+++ b/.github/workflows/sub_prepare.yml
@@ -146,7 +146,7 @@ jobs:
           commitCnt=$(jq -re '.ahead_by' ${{ env.logdir }}compare.json)
           echo "Changeset is composed of $commitCnt commit(s)" | tee -a ${{env.reportdir}}${{ env.reportfilename }}
       - name: Get files modified in changeset #TODO check what happens with deleted file in the subsequent process
-        if: env.isPR == 'true' || env.isPush == 'true'
+        if: env.isPR == 'true'
         env:
           API_URL: ${{ github.api_url }}
           TOKEN: ${{ github.token }}


### PR DESCRIPTION
Attempting to identify the changed files of a PR was being triggered on push events, which would fail as there is no PR associated on merges to `main`.

## Issues

## Before and After Images
