### PR TITLE
Part: Enable solid creation by default

### DIFF
--- a/src/Mod/Part/App/PartFeatures.cpp
+++ b/src/Mod/Part/App/PartFeatures.cpp
@@ -177,7 +177,7 @@ Loft::Loft()
 {
     ADD_PROPERTY_TYPE(Sections, (nullptr), "Loft", App::Prop_None, "List of sections");
     Sections.setSize(0);
-    ADD_PROPERTY_TYPE(Solid, (false), "Loft", App::Prop_None, "Create solid");
+    ADD_PROPERTY_TYPE(Solid, (true), "Loft", App::Prop_None, "Create solid");
     ADD_PROPERTY_TYPE(Ruled, (false), "Loft", App::Prop_None, "Ruled surface");
     ADD_PROPERTY_TYPE(Closed, (false), "Loft", App::Prop_None, "Close Last to First Profile");
     ADD_PROPERTY_TYPE(MaxDegree, (5), "Loft", App::Prop_None, "Maximum Degree");
@@ -263,7 +263,7 @@ Sweep::Sweep()
     ADD_PROPERTY_TYPE(Sections, (nullptr), "Sweep", App::Prop_None, "List of sections");
     Sections.setSize(0);
     ADD_PROPERTY_TYPE(Spine, (nullptr), "Sweep", App::Prop_None, "Path to sweep along");
-    ADD_PROPERTY_TYPE(Solid, (false), "Sweep", App::Prop_None, "Create solid");
+    ADD_PROPERTY_TYPE(Solid, (true), "Sweep", App::Prop_None, "Create solid");
     ADD_PROPERTY_TYPE(Frenet, (true), "Sweep", App::Prop_None, "Frenet");
     ADD_PROPERTY_TYPE(Transition, (long(1)), "Sweep", App::Prop_None, "Transition mode");
     ADD_PROPERTY_TYPE(Linearize,(false), "Sweep", App::Prop_None,

--- a/src/Mod/Part/Gui/DlgExtrusion.ui
+++ b/src/Mod/Part/Gui/DlgExtrusion.ui
@@ -339,6 +339,9 @@ If both lengths are zero, magnitude of direction is used.</string>
      <property name="text">
       <string>Create solid</string>
      </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>

--- a/src/Mod/Part/Gui/DlgRevolution.ui
+++ b/src/Mod/Part/Gui/DlgRevolution.ui
@@ -325,7 +325,10 @@
       <string>If checked, revolving wires will produce solids. If not, revolving a wire yields a shell.</string>
      </property>
      <property name="text">
-      <string>Create Solid</string>
+      <string>Create solid</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/src/Mod/Part/Gui/TaskLoft.ui
+++ b/src/Mod/Part/Gui/TaskLoft.ui
@@ -22,6 +22,9 @@
      <property name="text">
       <string>Create solid</string>
      </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="1" column="1">

--- a/src/Mod/Part/Gui/TaskSweep.ui
+++ b/src/Mod/Part/Gui/TaskSweep.ui
@@ -52,6 +52,9 @@
      <property name="text">
       <string>Create solid</string>
      </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="3" column="1">


### PR DESCRIPTION
This PR simply sets the "Create solid" checkbox to true by default for Part Extrude, Revolve, Sweep and Loft since that's the desired result in most cases. It also changes "Create Solid" to "Create solid" in the Part Revolve task panel (for consistency).