### PR TITLE
Gui: Fix wildcard call disconnects warnings Qt6.9

### DIFF
--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -392,7 +392,7 @@ public:
      */
     void addQObject(QObject* obj, PyObject* pyobj)
     {
-        // static array to contain created connetions so they can be safely disconnected later
+        // static array to contain created connections so they can be safely disconnected later
         static std::map<QObject*, QMetaObject::Connection> connections = {};
 
         const auto PyW_uniqueName = QString::number(reinterpret_cast<quintptr>(pyobj));

--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -392,34 +392,39 @@ public:
      */
     void addQObject(QObject* obj, PyObject* pyobj)
     {
-        const auto PyW_unique_name = QString::number(reinterpret_cast <quintptr> (pyobj));
-        auto PyW_invalidator = findChild <QObject *> (PyW_unique_name, Qt::FindDirectChildrenOnly);
+        // static array to contain created connetions so they can be safely disconnected later
+        static std::map<QObject*, QMetaObject::Connection> connections = {};
+
+        const auto PyW_uniqueName = QString::number(reinterpret_cast<quintptr>(pyobj));
+        auto PyW_invalidator = findChild<QObject*>(PyW_uniqueName, Qt::FindDirectChildrenOnly);
 
         if (PyW_invalidator == nullptr) {
             PyW_invalidator = new QObject(this);
-            PyW_invalidator->setObjectName(PyW_unique_name);
+            PyW_invalidator->setObjectName(PyW_uniqueName);
 
             Py_INCREF (pyobj);
         }
-        else {
-            PyW_invalidator->disconnect();
+        else if (connections.contains(PyW_invalidator)) {
+            disconnect(connections[PyW_invalidator]);
+            connections.erase(PyW_invalidator);
         }
 
-        auto destroyedFun = [pyobj](){
+        auto destroyedFun = [pyobj]() {
             Base::PyGILStateLocker lock;
-            auto sbk_ptr = reinterpret_cast <SbkObject *> (pyobj);
-            if (sbk_ptr != nullptr) {
-                Shiboken::Object::setValidCpp(sbk_ptr, false);
+
+            if (auto sbkPtr = reinterpret_cast<SbkObject*>(pyobj); sbkPtr != nullptr) {
+                Shiboken::Object::setValidCpp(sbkPtr, false);
             }
             else {
                 Base::Console().developerError("WrapperManager", "A QObject has just been destroyed after its Pythonic wrapper.\n");
             }
+
             Py_DECREF (pyobj);
         };
 
-        QObject::connect(PyW_invalidator, &QObject::destroyed, this, destroyedFun);
-        QObject::connect(obj, &QObject::destroyed, PyW_invalidator, &QObject::deleteLater);
-}
+        connections[PyW_invalidator] = connect(PyW_invalidator, &QObject::destroyed, this, destroyedFun);
+        connect(obj, &QObject::destroyed, PyW_invalidator, &QObject::deleteLater);
+    }
 
 private:
     void wrapQApplication()


### PR DESCRIPTION
Qt 6.9 deprecated wildcard disconnects it seems, and for main window we did a lot of disconnects like this. 

@xtemp09 FYI

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
Fixes https://github.com/FreeCAD/FreeCAD/issues/21903 - this does not get rid of _all_ warnings mentioned in comments, only the one that is most obnoxious i.e. the one from the description.

<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
