### PR TITLE
Core: Track saved state of the document with transactions

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -722,7 +722,7 @@ void Application::importFrom(const char* FileName, const char* DocName, const ch
                 checkRestoreError(doc);
                 checkForRecomputes();
                 if (activeDocument()) {
-                    activeDocument()->setAwayFromSaved(0);
+                    activeDocument()->setModified(Document::ModificationType::Reset);
                 }
             }
             else {
@@ -754,7 +754,7 @@ void Application::importFrom(const char* FileName, const char* DocName, const ch
                 }
 
                 if (doc) {
-                    doc->setModified(true);
+                    doc->setModified(Document::ModificationType::OutOfTransaction);
 
                     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
                         "User parameter:BaseApp/Preferences/View");
@@ -2630,7 +2630,7 @@ App::Document* Application::reopen(App::Document* doc)
             }
             if (reset) {
                 v.second->getDocument()->purgeTouched();
-                v.second->setAwayFromSaved(0);
+                v.second->setModified(Document::ModificationType::Reset);
             }
         }
     }

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -722,7 +722,7 @@ void Application::importFrom(const char* FileName, const char* DocName, const ch
                 checkRestoreError(doc);
                 checkForRecomputes();
                 if (activeDocument()) {
-                    activeDocument()->setModified(false);
+                    activeDocument()->setAwayFromSaved(0);
                 }
             }
             else {
@@ -2630,7 +2630,7 @@ App::Document* Application::reopen(App::Document* doc)
             }
             if (reset) {
                 v.second->getDocument()->purgeTouched();
-                v.second->setModified(false);
+                v.second->setAwayFromSaved(0);
             }
         }
     }

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -997,7 +997,6 @@ void Document::slotNewObject(const App::DocumentObject& Obj)
 void Document::slotDeletedObject(const App::DocumentObject& Obj)
 {
     std::list<Gui::BaseView*>::iterator vIt;
-    setModified(true);
 
     // cycling to all views of the document
     ViewProvider* viewProvider = getViewProvider(&Obj);

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -87,6 +87,7 @@ protected:
     void slotFinishRestoreDocument(const App::Document&);
     void slotUndoDocument(const App::Document&);
     void slotRedoDocument(const App::Document&);
+    void slotCommitTransaction(const App::Document&);
     void slotShowHidden(const App::Document&);
     void slotFinishImportObjects(const std::vector<App::DocumentObject*> &);
     void slotFinishRestoreObject(const App::DocumentObject &obj);
@@ -290,6 +291,12 @@ public:
     void undo(int iSteps);
     /// Will REDO one or more steps
     void redo(int iSteps) ;
+
+    /// Set the number of transactions away
+    /// we currently are from the saved state
+    /// if it is 0, it will call setIsModified(false);
+    void setAwayFromSaved(int away);
+
     /** Check if the document is performing undo/redo transaction
      *
      * Unlike App::Document::isPerformingTransaction(), Gui::Document will

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -169,7 +169,13 @@ public:
     //@}
 
     /// Observer message from the App doc
-    void setModified(bool);
+    enum class ModificationType {
+        Reset,
+        TransactionDone,
+        TransactionUndone,
+        OutOfTransaction // Modification done 
+    };
+    void setModified(ModificationType type);
     bool isModified() const;
 
     /// Returns true if the document is about to be closed, false otherwise
@@ -291,11 +297,6 @@ public:
     void undo(int iSteps);
     /// Will REDO one or more steps
     void redo(int iSteps) ;
-
-    /// Set the number of transactions away
-    /// we currently are from the saved state
-    /// if it is 0, it will call setIsModified(false);
-    void setAwayFromSaved(int away);
 
     /** Check if the document is performing undo/redo transaction
      *

--- a/src/Gui/DocumentPyImp.cpp
+++ b/src/Gui/DocumentPyImp.cpp
@@ -529,7 +529,9 @@ Py::Boolean DocumentPy::getModified() const
 
 void DocumentPy::setModified(Py::Boolean arg)
 {
-    getDocumentPtr()->setModified(arg);
+    // If the setModified call came from some python script, mark as out of transaction / reset
+    // so that it is honored even if there is no transaction
+    getDocumentPtr()->setModified(arg ? Gui::Document::ModificationType::OutOfTransaction : Gui::Document::ModificationType::Reset);
 }
 
 Py::List DocumentPy::getTreeRootObjects() const

--- a/src/Gui/DocumentRecovery.cpp
+++ b/src/Gui/DocumentRecovery.cpp
@@ -299,8 +299,9 @@ void DocumentRecovery::accept()
             }
             else {
                 auto gdoc = Application::Instance->getDocument(docs[i]);
-                if (gdoc)
-                    gdoc->setModified(true);
+                if (gdoc) {
+                    gdoc->setModified(Document::ModificationType::OutOfTransaction);
+                }
 
                 info.status = DocumentRecoveryPrivate::Success;
                 if (item) {

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -165,6 +165,7 @@ void ViewProviderDocumentObject::onBeforeChange(const App::Property* prop)
 
 void ViewProviderDocumentObject::onChanged(const App::Property* prop)
 {
+    bool changedVisibility = false;
     if (prop == &DisplayMode) {
         setActiveMode();
     }
@@ -179,6 +180,7 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
                 && getObject()
                 && getObject()->Visibility.getValue()!=Visibility.getValue())
         {
+            changedVisibility = true;
             // Changing the visibility of a document object will automatically set
             // the document modified but if the 'TouchDocument' flag is not set then
             // this is undesired behaviour. So, if this change marks the document as
@@ -208,6 +210,16 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
             static_cast<SoFCSelectionRoot*>(getRoot())->selectionStyle = SelectionStyle.getValue()
                 ? SoFCSelectionRoot::Box : SoFCSelectionRoot::Full;
         }
+    }
+
+    if (prop && !prop->testStatus(App::Property::NoModify)
+             && pcDocument
+            //  && !pcDocument->isModified()
+             && testStatus(Gui::ViewStatus::TouchDocument)
+            && !(prop == &Visibility && !changedVisibility)) {
+        if (prop)
+            FC_LOG(prop->getFullName() << " changed");
+        pcDocument->setModified(Document::ModificationType::OutOfTransaction);
     }
 
     ViewProvider::onChanged(prop);

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -210,15 +210,6 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
         }
     }
 
-    if (prop && !prop->testStatus(App::Property::NoModify)
-             && pcDocument
-             && !pcDocument->isModified()
-             && testStatus(Gui::ViewStatus::TouchDocument)) {
-        if (prop)
-            FC_LOG(prop->getFullName() << " changed");
-        pcDocument->setModified(true);
-    }
-
     ViewProvider::onChanged(prop);
 }
 

--- a/src/Mod/TechDraw/Gui/PagePrinter.cpp
+++ b/src/Mod/TechDraw/Gui/PagePrinter.cpp
@@ -143,7 +143,6 @@ void PagePrinter::printAll(QPrinter* printer, App::Document* doc)
     QPainter painter(printer);
 
     auto ourDoc = Gui::Application::Instance->getDocument(doc);
-    auto docModifiedState = ourDoc->isModified();
 
     bool firstTime = true;
     for (auto& obj : docObjs) {
@@ -171,8 +170,6 @@ void PagePrinter::printAll(QPrinter* printer, App::Document* doc)
         renderPage(vpp, painter, sourceRect, targetRect);
         dPage->redrawCommand();
     }
-
-    ourDoc->setModified(docModifiedState);
 }
 
 //! print all pages in a document to pdf
@@ -211,7 +208,6 @@ void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
     QPainter painter(&pdfWriter);
 
     auto ourDoc = Gui::Application::Instance->getDocument(doc);
-    auto docModifiedState = ourDoc->isModified();
 
     bool firstTime = true;
     for (auto& obj : docObjs) {
@@ -244,8 +240,6 @@ void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
 
         ourScene->setExportingPdf(true);
     }
-
-    ourDoc->setModified(docModifiedState);
 }
 
 
@@ -327,14 +321,12 @@ void PagePrinter::print(ViewProviderPage* vpPage, QPrinter* printer)
         ourScene->setExportingPdf(true);
     }
     auto ourDoc = Gui::Application::Instance->getDocument(dPage->getDocument());
-    auto docModifiedState = ourDoc->isModified();
 
     QRect targetRect = printer->pageLayout().fullRectPixels(printer->resolution());
     QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
     renderPage(vpPage, painter, sourceRect, targetRect);
 
     ourScene->setExportingPdf(false);  // doesn't hurt if not pdf
-    ourDoc->setModified(docModifiedState);
     dPage->redrawCommand();
 }
 
@@ -378,7 +370,6 @@ void PagePrinter::printPdf(ViewProviderPage* vpPage, const std::string& file)
     auto ourScene = vpPage->getQGSPage();
     ourScene->setExportingPdf(true);
     auto ourDoc = Gui::Application::Instance->getDocument(dPage->getDocument());
-    auto docModifiedState = ourDoc->isModified();
 
     // render the page
     QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
@@ -389,7 +380,6 @@ void PagePrinter::printPdf(ViewProviderPage* vpPage, const std::string& file)
     renderPage(vpPage, painter, sourceRect, targetRect);
 
     ourScene->setExportingPdf(false);
-    ourDoc->setModified(docModifiedState);
     dPage->redrawCommand();
 }
 
@@ -408,12 +398,10 @@ void PagePrinter::saveSVG(ViewProviderPage* vpPage, const std::string& file)
     auto ourScene = vpPage->getQGSPage();
     ourScene->setExportingSvg(true);
     auto ourDoc = vpPage->getDocument();
-    auto docModifiedState = ourDoc->isModified();
 
     ourScene->saveSvg(filename);
 
     ourScene->setExportingSvg(false);
-    ourDoc->setModified(docModifiedState);
 }
 
 


### PR DESCRIPTION
Use transaction commit, undo and redo signals to change the saved state of the document rather than using property changes, new and deleted objects signals.

Note: this changes the way the "*" symbol appears. Instead of appearing right as a command is launched, it appears when it is confirmed. As a user I think this behavior makes more sense, but let me know if I should work on an hybrid solution which would set the modified flag sooner.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues

Implements a fix for #6220
Implements a fix for #13735

<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
