### PR TITLE
BIM: avoid display of Arch_Schedule dialog over other applications

### DIFF
--- a/src/Mod/BIM/ArchSchedule.py
+++ b/src/Mod/BIM/ArchSchedule.py
@@ -799,9 +799,6 @@ class ArchScheduleTaskPanel:
         mw = FreeCADGui.getMainWindow()
         self.form.move(mw.frameGeometry().topLeft() + mw.rect().center() - self.form.rect().center())
 
-        # maintain above FreeCAD window
-        self.form.setWindowFlags(self.form.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)
-
         self.form.show()
 
     def add(self):


### PR DESCRIPTION
Fixes: #20639

AFAICT the issue was caused by:
`self.form.setWindowFlags(self.form.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)`

And I have just removed that line.