### PR TITLE
TechDraw: Make 'Add an offset vertex' Title Case

### DIFF
--- a/src/Mod/TechDraw/TechDrawTools/CommandVertexCreations.py
+++ b/src/Mod/TechDraw/TechDrawTools/CommandVertexCreations.py
@@ -74,7 +74,7 @@ class CommandAddOffsetVertex:
         """Return a dictionary with data that will be used by the button or menu item."""
         return {'Pixmap': 'actions/TechDraw_AddOffsetVertex.svg',
                 'Accel': "",
-                'MenuText': QT_TRANSLATE_NOOP("TechDraw_AddOffsetVertex", "Add an offset vertex"),
+                'MenuText': QT_TRANSLATE_NOOP("TechDraw_AddOffsetVertex", "Add An Offset Vertex"),
                 'ToolTip': QT_TRANSLATE_NOOP("TechDraw_AddOffsetVertex", "Create an offset vertex<br>\
                 - select one vertex<br>\
                 - start the tool<br>\


### PR DESCRIPTION
Simple change. The title of "Add an offset vertex" tool has been changed to title case to be consistent with all other tools.

## Issues
No issue filed as it's a small capitalisation change.

## Before and After Images
Before

![20250621_21h18m33s_grim](https://github.com/user-attachments/assets/bcd447a6-e9f0-4aef-8ea7-df7ccbc2551d)

After

![20250621_21h20m46s_grim](https://github.com/user-attachments/assets/c4306381-04e2-4357-a737-f3aa8b4dbaae)
