### PR TITLE
FEM: Add thermal contact with CalculiX

### DIFF
--- a/src/Mod/Fem/App/FemConstraintContact.cpp
+++ b/src/Mod/Fem/App/FemConstraintContact.cpp
@@ -58,6 +58,16 @@ ConstraintContact::ConstraintContact()
                       "ConstraintContact",
                       App::PropertyType(App::Prop_None),
                       "Stick slope");
+    ADD_PROPERTY_TYPE(EnableThermalContact,
+                      (false),
+                      "ConstraintContact",
+                      App::PropertyType(App::Prop_None),
+                      "Enable thermal contact");
+    ADD_PROPERTY_TYPE(ThermalContactConductance,
+                      (std::vector<std::string>{}),
+                      "ConstraintContact",
+                      App::PropertyType(App::Prop_None),
+                      "Thermal contact conductance");
 }
 
 App::DocumentObjectExecReturn* ConstraintContact::execute()

--- a/src/Mod/Fem/App/FemConstraintContact.cpp
+++ b/src/Mod/Fem/App/FemConstraintContact.cpp
@@ -64,7 +64,7 @@ ConstraintContact::ConstraintContact()
                       App::PropertyType(App::Prop_None),
                       "Enable thermal contact");
     ADD_PROPERTY_TYPE(ThermalContactConductance,
-                      (std::vector<std::string>{}),
+                      (std::vector<std::string> {}),
                       "ConstraintContact",
                       App::PropertyType(App::Prop_None),
                       "Thermal contact conductance");

--- a/src/Mod/Fem/App/FemConstraintContact.h
+++ b/src/Mod/Fem/App/FemConstraintContact.h
@@ -51,6 +51,8 @@ public:
     App::PropertyBool Friction;
     App::PropertyFloat FrictionCoefficient;
     App::PropertyStiffnessDensity StickSlope;
+    App::PropertyBool EnableThermalContact;
+    App::PropertyStringList ThermalContactConductance;
 
     // etc
     /* */

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_contact.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_contact.py
@@ -89,3 +89,8 @@ def write_constraint(f, femobj, contact_obj, ccxwriter):
         friction = contact_obj.FrictionCoefficient
         stick = contact_obj.StickSlope.getValueAs("MPa/mm").Value
         f.write(f"{friction:.13G}, {stick:.13G}\n")
+    if contact_obj.EnableThermalContact:
+        f.write("*GAP CONDUCTANCE\n")
+        for value in contact_obj.ThermalContactConductance:
+        	f.write(f"{value}\n")
+        f.write("\n")

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_contact.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_contact.py
@@ -92,5 +92,5 @@ def write_constraint(f, femobj, contact_obj, ccxwriter):
     if contact_obj.EnableThermalContact:
         f.write("*GAP CONDUCTANCE\n")
         for value in contact_obj.ThermalContactConductance:
-        	f.write(f"{value}\n")
+            f.write(f"{value}\n")
         f.write("\n")


### PR DESCRIPTION
fixes #22120

Adds two new properties to FEM Constraint contact. One to enable thermal contact and one to define its properties - a list of gap conductance values (optionally) paired with contact pressure and temperature. Due to the tabular nature of this definition, the same approach is used as for plasticity definition in FEM Material nonlinear - a string list property allowing direct definition using CalculiX syntax for this advanced feature.