### PR TITLE
Gui: Use proper placement property for Link

### DIFF
--- a/src/Gui/ViewProviderDragger.cpp
+++ b/src/Gui/ViewProviderDragger.cpp
@@ -170,6 +170,20 @@ bool ViewProviderDragger::forwardToLink()
 
     return forwardedViewProvider != nullptr;
 }
+App::PropertyPlacement* ViewProviderDragger::getPlacementProperty() const
+{
+    auto object = getObject();
+
+    if (auto linkExtension = object->getExtensionByType<App::LinkBaseExtension>()) {
+        if (auto linkPlacementProp = linkExtension->getLinkPlacementProperty()) {
+            return linkPlacementProp;
+        }
+
+        return linkExtension->getPlacementProperty();
+    }
+
+    return getObject()->getPropertyByName<App::PropertyPlacement>("Placement");
+}
 
 bool ViewProviderDragger::setEdit(int ModNum)
 {
@@ -254,7 +268,7 @@ void ViewProviderDragger::dragMotionCallback(void* data, [[maybe_unused]] SoDrag
 
 void ViewProviderDragger::updatePlacementFromDragger(DraggerComponents components)
 {
-    const auto placement = getObject()->getPropertyByName<App::PropertyPlacement>("Placement");
+    const auto placement = getPlacementProperty();
 
     if (!placement) {
         return;
@@ -379,7 +393,7 @@ void ViewProviderDragger::updateTransformFromDragger()
 
 Base::Placement ViewProviderDragger::getObjectPlacement() const
 {
-    if (auto placement = getObject()->getPropertyByName<App::PropertyPlacement>("Placement")) {
+    if (auto placement = getPlacementProperty()) {
         return placement->getValue();
     }
 

--- a/src/Gui/ViewProviderDragger.h
+++ b/src/Gui/ViewProviderDragger.h
@@ -120,6 +120,9 @@ protected:
 
     bool forwardToLink();
 
+    /// Gets placement property of the object
+    App::PropertyPlacement* getPlacementProperty() const;
+
     /**
      * Returns a newly create dialog for the part to be placed in the task view
      * Must be reimplemented in subclasses.


### PR DESCRIPTION
Links require different placement property (`LinkPlacement`) to be used, otherwise it breaks the transform.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
Fixes: #20776

<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->