### PR TITLE
Part: Enable SwitchToTask as a preference

### DIFF
--- a/src/Mod/Part/Gui/DlgSettingsGeneral.cpp
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.cpp
@@ -63,6 +63,7 @@ void DlgSettingsGeneral::saveSettings()
     ui->checkObjectNaming->onSave();
     ui->checkAllowCompoundBody->onSave();
     ui->comboDefaultProfileTypeForHole->onSave();
+    ui->checkSwitchToTask->onSave();
 }
 
 void DlgSettingsGeneral::loadSettings()
@@ -73,6 +74,7 @@ void DlgSettingsGeneral::loadSettings()
     ui->checkObjectNaming->onRestore();
     ui->checkAllowCompoundBody->onRestore();
     ui->comboDefaultProfileTypeForHole->onRestore();
+    ui->checkSwitchToTask->onRestore();
 }
 
 /**

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -110,40 +110,63 @@
      <property name="title">
       <string>Features settings</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Default profile type for holes</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Default profile type for holes</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefComboBox" name="comboDefaultProfileTypeForHole">
+          <property name="currentIndex">
+           <number>1</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>defaultBaseTypeHole</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/PartDesign</cstring>
+          </property>
+          <item>
+           <property name="text">
+            <string>Circles and arcs</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Points, circles and arcs</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Points</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
-       <widget class="Gui::PrefComboBox" name="comboDefaultProfileTypeForHole">
-        <property name="currentIndex">
-         <number>1</number>
+       <widget class="Gui::PrefCheckBox" name="checkSwitchToTask" native="true">
+        <property name="text" stdset="0">
+         <string>Switch to task panel when entering PartDesign workbench</string>
+        </property>
+        <property name="toolTip" stdset="0">
+         <string>Automatically switch to the task panel when the PartDesign workbench is activated</string>
+        </property>
+        <property name="checked" stdset="0">
+         <bool>true</bool>
         </property>
         <property name="prefEntry" stdset="0">
-         <cstring>defaultBaseTypeHole</cstring>
+         <cstring>SwitchToTask</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/PartDesign</cstring>
         </property>
-        <item>
-         <property name="text">
-          <string>Circles and arcs</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Points, circles and arcs</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Points</string>
-         </property>
-        </item>
        </widget>
       </item>
      </layout>

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -153,7 +153,7 @@
       <item>
        <widget class="Gui::PrefCheckBox" name="checkSwitchToTask" native="true">
         <property name="text" stdset="0">
-         <string>Switch to task panel when entering PartDesign workbench</string>
+         <string>Switch to task panel when entering Part Design workbench</string>
         </property>
         <property name="toolTip" stdset="0">
          <string>Automatically switch to the task panel when the Part Design workbench is activated</string>

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -156,7 +156,7 @@
          <string>Switch to task panel when entering PartDesign workbench</string>
         </property>
         <property name="toolTip" stdset="0">
-         <string>Automatically switch to the task panel when the PartDesign workbench is activated</string>
+         <string>Automatically switch to the task panel when the Part Design workbench is activated</string>
         </property>
         <property name="checked" stdset="0">
          <bool>true</bool>


### PR DESCRIPTION
As the title says. No clue why this variable was not available in preferences, but giving it to users allow them to stop Part Design workbench to switch to Tasks tab by default, everytime they switch workbench, which users claim to be annoying.

So this patch adds this preference under Part/Part Design.

Demo:

https://github.com/user-attachments/assets/5f14e0f5-0b82-4b33-b39d-9a6fe1050b16

Resolves: https://github.com/FreeCAD/FreeCAD/issues/13322
