### PR TITLE
Compiler warning cleanup

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2686,7 +2686,7 @@ public:
         currentSelectionHandler = nullptr;
     }
 
-    static QCursor makeCursor(QWidget* widget, const QSize& size, const char* svgFile, int hotX, int hotY)
+    static QCursor makeCursor([[maybe_unused]] QWidget* widget, const QSize& size, const char* svgFile, int hotX, int hotY)
     {
         qreal hotXF = hotX;
         qreal hotYF = hotY;

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2698,7 +2698,7 @@ public:
         }
 #endif
         QPixmap px(Gui::BitmapFactory().pixmapFromSvg(svgFile, size));
-        return QCursor(px, hotXF, hotYF);
+        return QCursor(px, static_cast<int>(hotXF), static_cast<int>(hotYF));
     }
 };
 }

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -451,7 +451,7 @@ MainWindow::MainWindow(QWidget * parent, Qt::WindowFlags f)
             this, &MainWindow::onSetActiveSubWindow);
 #else
     connect(d->windowMapper, &QSignalMapper::mappedObject,
-            this, [=](QObject* object) {
+            this, [=, this](QObject* object) {
         onSetActiveSubWindow(qobject_cast<QWidget*>(object));
     });
 #endif

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -1376,9 +1376,11 @@ void PropertyBoolItem::setValue(const QVariant& value)
 }
 
 QWidget* PropertyBoolItem::createEditor(QWidget* parent,
-                                        const std::function<void()>& method,
+                                        const std::function<void()>& /*method*/,
                                         FrameOption /*frameOption*/) const
 {
+    // The checkbox is basically artificial (it is not rendered). Other code handles the callback,
+    // etc.
     auto checkbox = new QCheckBox(parent);
     return checkbox;
 }

--- a/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.cpp
@@ -31,26 +31,28 @@
 
 using namespace MillSim;
 
+// clang-format off
 GuiItem guiItems[] = {
-    {eGuiItemSlider, 0, 0, 28, -80, 0},
-    {eGuiItemThumb, 0, 0, 328, -94, 1},
-    {eGuiItemPause, 0, 0, 28, -50, 'P', true},
-    {eGuiItemPlay, 0, 0, 28, -50, 'S', false},
-    {eGuiItemSingleStep, 0, 0, 68, -50, 'T'},
-    {eGuiItemSlower, 0, 0, 113, -50, ' '},
-    {eGuiItemFaster, 0, 0, 158, -50, 'F'},
-    {eGuiItemX, 0, 0, 208, -45, 0, false, 0},
-    {eGuiItem1, 0, 0, 230, -50, 0, false, 0},
-    {eGuiItem5, 0, 0, 230, -50, 0, true, 0},
-    {eGuiItem10, 0, 0, 230, -50, 0, true, 0},
-    {eGuiItem25, 0, 0, 230, -50, 0, true, 0},
-    {eGuiItem50, 0, 0, 230, -50, 0, true, 0},
-    {eGuiItemRotate, 0, 0, -140, -50, ' ', false, GUIITEM_CHECKABLE},
-    {eGuiItemPath, 0, 0, -100, -50, 'L', false, GUIITEM_CHECKABLE},
-    {eGuiItemAmbientOclusion, 0, 0, -60, -50, 'A', false, GUIITEM_CHECKABLE},
-    {eGuiItemView, 0, 0, -180, -50, 'V', false},
-    {eGuiItemHome, 0, 0, -220, -50, 'H'},
+    {.name=eGuiItemSlider, .vbo=0, .vao=0, .sx=28, .sy=-80, .actionKey=0, .hidden=false, .flags=0},
+    {.name=eGuiItemThumb, .vbo=0, .vao=0, .sx=328, .sy=-94, .actionKey=1, .hidden=false, .flags=0},
+    {.name=eGuiItemPause, .vbo=0, .vao=0, .sx=28, .sy=-50, .actionKey='P', .hidden=true, .flags=0},
+    {.name=eGuiItemPlay, .vbo=0, .vao=0, .sx=28, .sy=-50, .actionKey='S', .hidden=false, .flags=0},
+    {.name=eGuiItemSingleStep, .vbo=0, .vao=0, .sx=68, .sy=-50, .actionKey='T', .hidden=false, .flags=0},
+    {.name=eGuiItemSlower, .vbo=0, .vao=0, .sx=113, .sy=-50, .actionKey=' ', .hidden=false, .flags=0},
+    {.name=eGuiItemFaster, .vbo=0, .vao=0, .sx=158, .sy=-50, .actionKey='F', .hidden=false, .flags=0},
+    {.name=eGuiItemX, .vbo=0, .vao=0, .sx=208, .sy=-45, .actionKey=0, .hidden=false, .flags=0},
+    {.name=eGuiItem1, .vbo=0, .vao=0, .sx=230, .sy=-50, .actionKey=0, .hidden=false, .flags=0},
+    {.name=eGuiItem5, .vbo=0, .vao=0, .sx=230, .sy=-50, .actionKey=0, .hidden=true, .flags=0},
+    {.name=eGuiItem10, .vbo=0, .vao=0, .sx=230, .sy=-50, .actionKey=0, .hidden=true, .flags=0},
+    {.name=eGuiItem25, .vbo=0, .vao=0, .sx=230, .sy=-50, .actionKey=0, .hidden=true, .flags=0},
+    {.name=eGuiItem50, .vbo=0, .vao=0, .sx=230, .sy=-50, .actionKey=0, .hidden=true, .flags=0},
+    {.name=eGuiItemRotate, .vbo=0, .vao=0, .sx=-140, .sy=-50, .actionKey=' ', .hidden=false, .flags=GUIITEM_CHECKABLE},
+    {.name=eGuiItemPath, .vbo=0, .vao=0, .sx=-100, .sy=-50, .actionKey='L', .hidden=false, .flags=GUIITEM_CHECKABLE},
+    {.name=eGuiItemAmbientOclusion, .vbo=0, .vao=0, .sx=-60, .sy=-50, .actionKey='A', .hidden=false, .flags=GUIITEM_CHECKABLE},
+    {.name=eGuiItemView, .vbo=0, .vao=0, .sx=-180, .sy=-50, .actionKey='V', .hidden=false, .flags=0},
+    {.name=eGuiItemHome, .vbo=0, .vao=0, .sx=-220, .sy=-50, .actionKey='H', .hidden=false, .flags=0},
 };
+// clang-format on
 
 #define NUM_GUI_ITEMS (sizeof(guiItems) / sizeof(GuiItem))
 #define TEX_SIZE 256

--- a/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.cpp
@@ -32,6 +32,7 @@
 using namespace MillSim;
 
 // clang-format off
+// NOLINTBEGIN(*-magic-numbers)
 GuiItem guiItems[] = {
     {.name=eGuiItemSlider, .vbo=0, .vao=0, .sx=28, .sy=-80, .actionKey=0, .hidden=false, .flags=0},
     {.name=eGuiItemThumb, .vbo=0, .vao=0, .sx=328, .sy=-94, .actionKey=1, .hidden=false, .flags=0},
@@ -52,6 +53,7 @@ GuiItem guiItems[] = {
     {.name=eGuiItemView, .vbo=0, .vao=0, .sx=-180, .sy=-50, .actionKey='V', .hidden=false, .flags=0},
     {.name=eGuiItemHome, .vbo=0, .vao=0, .sx=-220, .sy=-50, .actionKey='H', .hidden=false, .flags=0},
 };
+// NOLINTEND(*-magic-numbers)
 // clang-format on
 
 #define NUM_GUI_ITEMS (sizeof(guiItems) / sizeof(GuiItem))

--- a/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.h
@@ -107,9 +107,11 @@ protected:
     std::vector<MillPathSegment*> MillPathSegments;
     std::ostringstream mFpsStream;
 
-    MillMotion mZeroPos = {eNop, -1, 0, 0, 100, 0, 0, 0, 0};
-    MillMotion mCurMotion = {eNop, -1, 0, 0, 0, 0, 0, 0, 0};
-    MillMotion mDestMotion = {eNop, -1, 0, 0, 0, 0, 0, 0, 0};
+    // clang-format off
+    MillMotion mZeroPos = {.cmd=eNop, .tool=-1, .x=0, .y=0, .z=100, .i=0, .j=0, .k=0, .r=0, .retract_mode='\0', .retract_z=0.0};
+    MillMotion mCurMotion = {.cmd=eNop, .tool=-1, .x=0, .y=0, .z=0, .i=0, .j=0, .k=0, .r=0, .retract_mode='\0', .retract_z=0.0};
+    MillMotion mDestMotion = {.cmd=eNop, .tool=-1, .x=0, .y=0, .z=0, .i=0, .j=0, .k=0, .r=0, .retract_mode='\0', .retract_z=0.0};
+    // clang-format on
 
     StockObject mStockObject;
     SolidObject mBaseShape;

--- a/src/Mod/Fem/Gui/TaskPostBoxes.h
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.h
@@ -577,7 +577,6 @@ private:
     void onOperatorsActivated(int index);
 
 private:
-    QWidget* proxy;
     std::unique_ptr<Ui_TaskPostCalculator> ui;
 };
 

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -287,7 +287,6 @@ void QGIViewPart::drawAllFaces(void)
             std::vector<LineSet> lineSets = fGeom->getTrimmedLines(iFace);
             if (!lineSets.empty()) {
                 // this face has geometric hatch lines
-                newFace->clearLineSets();
                 for (auto& ls : lineSets) {
                     newFace->addLineSet(ls);
                 }

--- a/src/Mod/TechDraw/Gui/QGIViewSection.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSection.cpp
@@ -112,7 +112,6 @@ void QGIViewSection::drawSectionFace()
             newFace->setLineWeight(sectionVp->WeightPattern.getValue());
             std::vector<TechDraw::LineSet> lineSets = section->getDrawableLines(i);
             if (!lineSets.empty()) {
-                newFace->clearLineSets();
                 for (auto& ls: lineSets) {
                     newFace->addLineSet(ls);
                 }

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
@@ -79,7 +79,7 @@ public:
     int prefHighlightStyle(void);
 
     std::vector<App::DocumentObject*> claimChildren(void) const override;
-    void fixSceneDependencies();
+    void fixSceneDependencies() override;
 
     TechDraw::DrawViewPart* getViewObject() const override;
     TechDraw::DrawViewPart* getViewPart() const;


### PR DESCRIPTION
Each commit in this PR addresses one particular compiler warning, kept separate for easy rollback if one turns out to be faulty.

@marioalexis84 could you please check https://github.com/FreeCAD/FreeCAD/commit/0faeed100da8f9e580377d1db50e5426957bf71c ?

@WandererFan could you please check https://github.com/FreeCAD/FreeCAD/commit/c864b29cd408152b4b86048aaa2bb9bd00a1f747 ?

The rest of them are basically rote fixes (though I decided to add designated initializers to the structs based on a discussion with @kadet1090, which might be a more controversial change, and isn't required to fix the compiler warnings about omitted initializers).