### PR TITLE
Spreadsheet Fix '=' regression in spreadsheets

### DIFF
--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -921,15 +921,15 @@ ExpressionLineEdit::ExpressionLineEdit(QWidget* parent,
     , noProperty(noProperty)
     , exactMatch(false)
     , checkInList(checkInList)
-    , checkPrefix(checkPrefix)
 {
-    setValidator(new ExpressionValidator(this));
+    setPrefix(checkPrefix);
     connect(this, &QLineEdit::textEdited, this, &ExpressionLineEdit::slotTextChanged);
 }
 
 void ExpressionLineEdit::setPrefix(char prefix)
 {
     checkPrefix = prefix;
+    setValidator(checkPrefix == '=' ? nullptr : new ExpressionValidator(this));
 }
 
 void ExpressionLineEdit::setDocumentObject(const App::DocumentObject* currentDocObj,

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -154,6 +154,8 @@ SheetView::SheetView(Gui::Document* pcDocument, App::DocumentObject* docObj, QWi
     // Set document object to create auto completer
     ui->cellContent->setDocumentObject(sheet);
     ui->cellAlias->setDocumentObject(sheet);
+
+    ui->cellContent->setPrefix('=');
 }
 
 SheetView::~SheetView()

--- a/src/Tools/plugins/widget/customwidgets.h
+++ b/src/Tools/plugins/widget/customwidgets.h
@@ -27,6 +27,7 @@
 #include <QButtonGroup>
 #include <QCheckBox>
 #include <QComboBox>
+#include <QCompleter>
 #include <QDoubleSpinBox>
 #include <QFontComboBox>
 #include <QGridLayout>
@@ -382,6 +383,33 @@ private:
     double Minimum;
     double StepSize;
     int HistorySize;
+};
+
+// ------------------------------------------------------------------------------
+
+class ExpressionLineEdit: public QLineEdit
+{
+    Q_OBJECT
+public:
+    ExpressionLineEdit(QWidget* parent = nullptr);
+
+public Q_SLOTS:
+    void slotTextChanged(const QString& text);
+    void slotCompleteText(const QString& completionPrefix, bool isActivated);
+    void slotCompleteTextHighlighted(const QString& completionPrefix);
+    void slotCompleteTextSelected(const QString& completionPrefix);
+    void setExactMatch(bool enabled = true);
+
+protected:
+    void keyPressEvent(QKeyEvent* event) override;
+    void contextMenuEvent(QContextMenuEvent* event) override;
+
+Q_SIGNALS:
+    void textChanged2(QString text, int pos);
+
+private:
+    QCompleter* completer;
+    bool exactMatch;
 };
 
 // ------------------------------------------------------------------------------

--- a/src/Tools/plugins/widget/plugin.cpp
+++ b/src/Tools/plugins/widget/plugin.cpp
@@ -523,6 +523,56 @@ public:
     }
 };
 
+class ExpressionLineEditPlugin: public QDesignerCustomWidgetInterface
+{
+    Q_INTERFACES(QDesignerCustomWidgetInterface)
+public:
+    ExpressionLineEditPlugin()
+    {}
+    QWidget* createWidget(QWidget* parent)
+    {
+        return new Gui::ExpressionLineEdit(parent);
+    }
+    QString group() const
+    {
+        return QLatin1String("Input Widgets");
+    }
+    QIcon icon() const
+    {
+        return QIcon(QPixmap(inputfield_pixmap));
+    }
+    QString includeFile() const
+    {
+        return QLatin1String("Gui/InputField.h");
+    }
+    QString toolTip() const
+    {
+        return QLatin1String("Expression line edit");
+    }
+    QString whatsThis() const
+    {
+        return QLatin1String("A widget to work with expressions.");
+    }
+    bool isContainer() const
+    {
+        return false;
+    }
+    QString domXml() const
+    {
+        return "<ui language=\"c++\">\n"
+               " <widget class=\"Gui::ExpressionLineEdit\" name=\"exprLineEdit\">\n"
+               "  <property name=\"unit\" stdset=\"0\">\n"
+               "   <string notr=\"true\"></string>\n"
+               "  </property>\n"
+               " </widget>\n"
+               "</ui>";
+    }
+    QString name() const
+    {
+        return QLatin1String("Gui::ExpressionLineEdit");
+    }
+};
+
 /* XPM */
 static const char* quantityspinbox_pixmap[] = {"22 22 6 1",
                                                "a c #000000",
@@ -1653,6 +1703,7 @@ QList<QDesignerCustomWidgetInterface*> CustomWidgetPlugin::customWidgets() const
     cw.append(new FileChooserPlugin);
     cw.append(new AccelLineEditPlugin);
     cw.append(new ActionSelectorPlugin);
+    cw.append(new ExpressionLineEditPlugin);
     cw.append(new InputFieldPlugin);
     cw.append(new QuantitySpinBoxPlugin);
     cw.append(new CommandIconViewPlugin);


### PR DESCRIPTION
Fixes #21914

This also includes a related commit that adds ExpressionLineEdit to QtDesigner plugin by @wwmayer.

After:

https://github.com/user-attachments/assets/8dc6d107-96d8-4a40-9f27-010df509d720

Not obvious from video, but the = is still suppressed in the normal expression editor dialog