### PR TITLE
Remove Command::adjustCameraPosition()

### DIFF
--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -575,11 +575,6 @@ public:
     /// Obtain the current shortcut of this command
     virtual QString getShortcut() const;
 
-    /** @name arbitrary helper methods */
-    //@{
-    void adjustCameraPosition();
-    //@}
-
     /// Helper class to disable python console log
     class LogDisabler {
     public:

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1635,9 +1635,7 @@ void CmdPartOffset::activated(int iMsg)
     updateActive();
 
     doCommand(Gui,"Gui.ActiveDocument.setEdit('%s')",offset.c_str());
-
-    adjustCameraPosition();
-
+    
     copyVisual(offset.c_str(), "ShapeAppearance", shape->getNameInDocument());
     copyVisual(offset.c_str(), "LineColor" , shape->getNameInDocument());
     copyVisual(offset.c_str(), "PointColor", shape->getNameInDocument());
@@ -1692,7 +1690,6 @@ void CmdPartOffset2D::activated(int iMsg)
     doCommand(Doc,"App.ActiveDocument.%s.Value = 1.0",offset.c_str());
     updateActive();
     doCommand(Gui,"Gui.ActiveDocument.setEdit('%s')",offset.c_str());
-    adjustCameraPosition();
 
     copyVisual(offset.c_str(), "ShapeAppearance", shape->getNameInDocument());
     copyVisual(offset.c_str(), "LineColor" , shape->getNameInDocument());
@@ -1876,7 +1873,6 @@ void CmdPartThickness::activated(int iMsg)
                   obj->getDocument()->getName(), obj->getNameInDocument());
     }
     doCommand(Gui,"Gui.ActiveDocument.setEdit('%s')",thick.c_str());
-    adjustCameraPosition();
 
     copyVisual(thick.c_str(), "ShapeAppearance", obj->getNameInDocument());
     copyVisual(thick.c_str(), "LineColor" , obj->getNameInDocument());

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1075,7 +1075,6 @@ void prepareProfileBased(Gui::Command* cmd, const std::string& which, double len
         }
 
         finishProfileBased(cmd, sketch, Feat);
-        cmd->adjustCameraPosition();
     };
 
     prepareProfileBased(pcActiveBody, cmd, which, worker);
@@ -1172,7 +1171,6 @@ void CmdPartDesignHole::activated(int iMsg)
             return;
 
         finishProfileBased(cmd, sketch, Feat);
-        cmd->adjustCameraPosition();
     };
 
     prepareProfileBased(pcActiveBody, this, "Hole", worker);
@@ -1228,7 +1226,6 @@ void CmdPartDesignRevolution::activated(int iMsg)
             FCMD_OBJ_CMD(Feat,"Reversed = 1");
 
         finishProfileBased(cmd, sketch, Feat);
-        cmd->adjustCameraPosition();
     };
 
     prepareProfileBased(pcActiveBody, this, "Revolution", worker);
@@ -1292,7 +1289,6 @@ void CmdPartDesignGroove::activated(int iMsg)
         }
 
         finishProfileBased(cmd, sketch, Feat);
-        cmd->adjustCameraPosition();
     };
 
     prepareProfileBased(pcActiveBody, this, "Groove", worker);
@@ -1339,7 +1335,6 @@ void CmdPartDesignAdditivePipe::activated(int iMsg)
         Gui::Command::updateActive();
 
         finishProfileBased(cmd, sketch, Feat);
-        cmd->adjustCameraPosition();
     };
 
     prepareProfileBased(pcActiveBody, this, "AdditivePipe", worker);
@@ -1387,7 +1382,6 @@ void CmdPartDesignSubtractivePipe::activated(int iMsg)
         Gui::Command::updateActive();
 
         finishProfileBased(cmd, sketch, Feat);
-        cmd->adjustCameraPosition();
     };
 
     prepareProfileBased(pcActiveBody, this, "SubtractivePipe", worker);
@@ -1435,7 +1429,6 @@ void CmdPartDesignAdditiveLoft::activated(int iMsg)
         Gui::Command::updateActive();
 
         finishProfileBased(cmd, sketch, Feat);
-        cmd->adjustCameraPosition();
     };
 
     prepareProfileBased(pcActiveBody, this, "AdditiveLoft", worker);
@@ -1483,7 +1476,6 @@ void CmdPartDesignSubtractiveLoft::activated(int iMsg)
         Gui::Command::updateActive();
 
         finishProfileBased(cmd, sketch, Feat);
-        cmd->adjustCameraPosition();
     };
 
     prepareProfileBased(pcActiveBody, this, "SubtractiveLoft", worker);
@@ -1555,8 +1547,6 @@ void CmdPartDesignAdditiveHelix::activated(int iMsg)
                     view->makeTemporaryVisible(true);
             }
         }
-
-        cmd->adjustCameraPosition();
     };
 
     prepareProfileBased(pcActiveBody, this, "AdditiveHelix", worker);
@@ -1611,7 +1601,6 @@ void CmdPartDesignSubtractiveHelix::activated(int iMsg)
         }
 
         finishProfileBased(cmd, sketch, Feat);
-        cmd->adjustCameraPosition();
     };
 
     prepareProfileBased(pcActiveBody, this, "SubtractiveHelix", worker);


### PR DESCRIPTION
As far as I understand it, the method `Command::adjustCameraPosition()` repositions an orthographic camera if the camera is within the bounding sphere of the scene. It then moves the camera to the edge of the bounding sphere and sets the `nearDistance`, `farDistance` and `focalDistance`. Setting the `nearDistance` and `farDistance` is not needed as this is adjusted by Coin automatically. Setting the `focalDistance` is not needed too because with #21798 this is always set to 1 ( `nearDistance` and `farDistance` adjusted by Coin again). Furthermore, the method `Command::adjustCameraPosition()` does not reposition the camera along the camera Z axis but by the difference between the camera position and the bounding sphere center. This could cause the camera to move in a bit of a random direction and cause issues like #22112.

So I have removed this, in my opinion, unnecessary method and this fixes #22112.

@maxwxyz, could you try this to see if this indeed fixes the issue.