### PR TITLE
Gui: Selectively disable MSVC 4251 warning

### DIFF
--- a/src/Gui/DocumentObserver.h
+++ b/src/Gui/DocumentObserver.h
@@ -306,6 +306,11 @@ private:
     ViewProviderWeakPtrT ptr;
 };
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4251)  // MSVC emits warning C4251 too conservatively for our use-case
+#endif
+
 /**
  * The DocumentObserver class simplifies the step to write classes that listen
  * to what happens inside a document.
@@ -367,6 +372,10 @@ private:
     Connection connectDocumentRedo;
     Connection connectDocumentDelete;
 };
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 } //namespace Gui
 


### PR DESCRIPTION
MSVC warning 4251 is emitted when a class that is exported from a DLL has a member that doesn't itself have a proper DLL interface -- Boost specifically (and intentionally) does not export `scoped_connection`. But for our use this doesn't matter because when compiling FreeCAD, all DLLs are built at the same time, with the same compiler, with the same Boost headers and settings, and we're not exposing `scoped_connection` in any exported symbols (it's a private data member). So the theoretical ABI-compatibility problems this code might present cannot manifest themselves. Disable this warning (but only for this particular piece of code, since the warning itself might apply elsewhere).