### PR TITLE
PD: Fix regression about single-solid check

### DIFF
--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -159,7 +159,6 @@ App::DocumentObjectExecReturn *Chamfer::execute()
 
         TopTools_ListOfShape aLarg;
         aLarg.Append(TopShape.getShape());
-        bool failed = false;
         if (!BRepAlgo::IsValid(aLarg, shape.getShape(), Standard_False, Standard_False)) {
             ShapeFix_ShapeTolerance aSFT;
             aSFT.LimitTolerance(shape.getShape(),
@@ -167,21 +166,16 @@ App::DocumentObjectExecReturn *Chamfer::execute()
                                 Precision::Confusion(),
                                 TopAbs_SHAPE);
         }
-        if (!failed) {
 
-            // store shape before refinement
-            this->rawShape = shape;
-            shape = refineShapeIfActive(shape);
-            shape = getSolid(shape);
-        }
+        // store shape before refinement
+        this->rawShape = shape;
+        shape = refineShapeIfActive(shape);
         if (!isSingleSolidRuleSatisfied(shape.getShape())) {
             return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
         }
+
+        shape = getSolid(shape);
         this->Shape.setValue(shape);
-        if (failed) {
-            return new App::DocumentObjectExecReturn(
-                QT_TRANSLATE_NOOP("Exception", "Resulting shape is invalid"));
-        }
         return App::DocumentObject::StdReturn;
     }
     catch (Standard_Failure& e) {

--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -809,7 +809,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
 
             // store shape before refinement
             this->rawShape = result;
-            solRes = refineShapeIfActive(solRes);
+            solRes = refineShapeIfActive(result);
 
             if (!isSingleSolidRuleSatisfied(solRes.getShape())) {
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
@@ -824,10 +824,10 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             // store shape before refinement
             this->rawShape = prism;
             prism = refineShapeIfActive(prism);
-            prism = getSolid(prism);
             if (!isSingleSolidRuleSatisfied(prism.getShape())) {
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
             }
+            prism = getSolid(prism);
             this->Shape.setValue(prism);
         }
         else {

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -104,7 +104,6 @@ App::DocumentObjectExecReturn *Fillet::execute()
 
         TopTools_ListOfShape aLarg;
         aLarg.Append(baseShape.getShape());
-        bool failed = false;
         if (!BRepAlgo::IsValid(aLarg, shape.getShape(), Standard_False, Standard_False)) {
             ShapeFix_ShapeTolerance aSFT;
             aSFT.LimitTolerance(shape.getShape(),
@@ -113,20 +112,15 @@ App::DocumentObjectExecReturn *Fillet::execute()
                                 TopAbs_SHAPE);
         }
 
-        if (!failed) {
-            // store shape before refinement
-            this->rawShape = shape;
-            shape = refineShapeIfActive(shape);
-            shape = getSolid(shape);
-        }
+        // store shape before refinement
+        this->rawShape = shape;
+        shape = refineShapeIfActive(shape);
         if (!isSingleSolidRuleSatisfied(shape.getShape())) {
             return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
         }
-        this->Shape.setValue(shape);
 
-        if (failed) {
-            return new App::DocumentObjectExecReturn("Resulting shape is invalid");
-        }
+        shape = getSolid(shape);
+        this->Shape.setValue(shape);
         return App::DocumentObject::StdReturn;
     }
     catch (Standard_Failure& e) {

--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -185,17 +185,17 @@ App::DocumentObjectExecReturn *Groove::execute()
         }catch(Standard_Failure &) {
             return new App::DocumentObjectExecReturn("Failed to cut base feature");
         }
-        boolOp = this->getSolid(boolOp);
-        if (boolOp.isNull())
+        TopoShape solid = this->getSolid(boolOp);
+        if (solid.isNull())
             return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
 
         // store shape before refinement
         this->rawShape = boolOp;
         boolOp = refineShapeIfActive(boolOp);
-        boolOp = getSolid(boolOp);
         if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
             return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
         }
+        boolOp = getSolid(boolOp);
         Shape.setValue(boolOp);
         return App::DocumentObject::StdReturn;
     }

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -266,10 +266,10 @@ App::DocumentObjectExecReturn *Loft::execute()
         // store shape before refinement
         this->rawShape = boolOp;
         boolOp = refineShapeIfActive(boolOp);
-        boolOp = getSolid(boolOp);
         if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
             return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
         }
+        boolOp = getSolid(boolOp);
         Shape.setValue(boolOp);
         return App::DocumentObject::StdReturn;
     }

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -234,6 +234,9 @@ App::DocumentObjectExecReturn *Loft::execute()
             result = shapes.front();
 
         if(base.isNull()) {
+            if (!isSingleSolidRuleSatisfied(result.getShape())) {
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
+            }
             Shape.setValue(getSolid(result));
             return App::DocumentObject::StdReturn;
         }
@@ -258,11 +261,11 @@ App::DocumentObjectExecReturn *Loft::execute()
         catch(Standard_Failure&) {
             return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Failed to perform boolean operation"));
         }
-        boolOp = this->getSolid(boolOp);
+        TopoShape solid = getSolid(boolOp);
         // lets check if the result is a solid
-        if (boolOp.isNull())
+        if (solid.isNull()) {
             return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is not a solid"));
-
+        }
         // store shape before refinement
         this->rawShape = boolOp;
         boolOp = refineShapeIfActive(boolOp);

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -400,8 +400,7 @@ App::DocumentObjectExecReturn *Pipe::execute()
             if (boolOp.isNull())
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is not a solid"));
 
-            int solidCount = countSolids(boolOp.getShape());
-            if (solidCount > 1) {
+            if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
                                                                            "Result has multiple solids: that is not currently supported."));
             }
@@ -422,8 +421,7 @@ App::DocumentObjectExecReturn *Pipe::execute()
             if (boolOp.isNull())
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is not a solid"));
 
-            int solidCount = countSolids(boolOp.getShape());
-            if (solidCount > 1) {
+            if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
                                                                            "Result has multiple solids: that is not currently supported."));
             }

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -228,7 +228,11 @@ App::DocumentObjectExecReturn* Revolution::execute()
                 this->rawShape = result;
                 result = refineShapeIfActive(result);
             }
-            this->Shape.setValue(getSolid(result));
+            if (!isSingleSolidRuleSatisfied(result.getShape())) {
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
+            }
+            result = getSolid(result);
+            this->Shape.setValue(result);
         }
         else {
             return new App::DocumentObjectExecReturn(


### PR DESCRIPTION
cherry-picked f2117d4088, 8961dea5ce89 and a40610fdc695

Fixes: #19002
Fixes: #18977

For several PD features the single-solid check fails. The regression is caused by PR 13960. The reason for the failure is that the first solid of the output shape is retrieved and then checked for a single solid. This test will always pass, of course.

The single-solid is fixed for these features:
* Pad
* Pocket (never worked there)
* Fillet
* Chamfer
* Groove (never worked there)
* Revolution (never worked there)
* Loft

Fixes: 935bdf9a0f1a ("PartDesign: Refactor single-solid rule enforcement")