### PR TITLE
Copy subvolume before changing its Placement

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -786,7 +786,7 @@ class Component(ArchIFC.IfcProduct):
                     subvolume = o.getLinkedObject().Proxy.getSubVolume(o,host=obj)  # pass host obj (mostly Wall)
                 elif (Draft.getType(o) == "Roof") or (Draft.isClone(o,"Roof")):
                     # roofs define their own special subtraction volume
-                    subvolume = o.Proxy.getSubVolume(o)
+                    subvolume = o.Proxy.getSubVolume(o).copy()
                 elif hasattr(o,"Subvolume") and hasattr(o.Subvolume,"Shape"):
                     # Any other object with a Subvolume property
                     ## TODO - Part.Shape() instead?


### PR DESCRIPTION
Placement property of a cached subvolume was modified each time component, from which it was being subtracted, was recalculated.

I am not sure if this is the right fix but I think it is the right place.

Before:

[Screencast from 2025-06-25 15-14-14.webm](https://github.com/user-attachments/assets/048b7d28-6316-412a-a31e-ca6067cf44c0)


After:

[Screencast from 2025-06-25 15-19-19.webm](https://github.com/user-attachments/assets/496e7e7c-4388-4875-b533-f6badcf41c05)

I remember reading about this problem somewhere, but I cannot find it (maybe forum or another issue).

Fixes #22162.
