### PR TITLE
Sketcher: Fix external geometry out-of-bounds vector access

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -8701,7 +8701,6 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
     auto SubElements = ExternalGeometry.getSubValues();
     assert(externalGeoRef.size() == Objects.size());
     auto keys = externalGeoRef;
-    Types.resize(Objects.size(), 0);
 
     // re-check for any missing geometry element. The code here has a side
     // effect that the linked external geometry will continue to work even if
@@ -8722,7 +8721,6 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
             if(elementName.oldName.size()
                     && !App::GeoFeature::hasMissingElement(elementName.oldName.c_str()))
             {
-                Types.push_back(static_cast<int>(ExtType::Projection));
                 Objects.push_back(obj);
                 SubElements.push_back(elementName.oldName);
                 keys.push_back(ref);


### PR DESCRIPTION
Ensures that the check for missing external geometry also appends to `Types`, so that indexed access later on doesn't crash anymore.

It seems like these vectors should generally stay synchronized, but there are still quite a few places where one is is modified, while others aren't. I'm not sufficiently familiar with this code to judge whether there are more problems here. This PR just fixes the case that has been crashing for me.

I'm not sure if this crash has been reported previously.