### PR TITLE
Draft: fix setting of self.Type

### DIFF
--- a/src/Mod/Draft/draftobjects/dimension.py
+++ b/src/Mod/Draft/draftobjects/dimension.py
@@ -217,8 +217,8 @@ class LinearDimension(DimensionBase):
 
     def __init__(self, obj):
         obj.Proxy = self
-        self.set_properties(obj)
         self.Type = "LinearDimension"
+        self.set_properties(obj)
 
     def set_properties(self, obj):
         """Set basic properties only if they don't exist."""
@@ -306,7 +306,6 @@ class LinearDimension(DimensionBase):
         gui_utils.restore_view_object(
             obj, vp_module="view_dimension", vp_class="ViewProviderLinearDimension"
         )
-        self.Type = "LinearDimension"
 
         if not getattr(obj, "ViewObject", None):
             return
@@ -314,6 +313,9 @@ class LinearDimension(DimensionBase):
         if hasattr(vobj, "TextColor"):
             return
         super().update_properties_0v21(obj, vobj)
+
+    def loads(self, state):
+        self.Type = "LinearDimension"
 
     def onChanged(self, obj, prop):
         """Execute when a property is changed.
@@ -513,8 +515,8 @@ class AngularDimension(DimensionBase):
 
     def __init__(self, obj):
         obj.Proxy = self
-        self.set_properties(obj)
         self.Type = "AngularDimension"
+        self.set_properties(obj)
 
     def set_properties(self, obj):
         """Set basic properties only if they don't exist."""
@@ -583,7 +585,6 @@ class AngularDimension(DimensionBase):
         gui_utils.restore_view_object(
             obj, vp_module="view_dimension", vp_class="ViewProviderAngularDimension"
         )
-        self.Type = "AngularDimension"
 
         if not getattr(obj, "ViewObject", None):
             return
@@ -591,6 +592,9 @@ class AngularDimension(DimensionBase):
         if hasattr(vobj, "TextColor"):
             return
         super().update_properties_0v21(obj, vobj)
+
+    def loads(self, state):
+        self.Type = "AngularDimension"
 
     def transform(self, obj, pla):
         """Transform the object by applying a placement."""

--- a/src/Mod/Draft/draftobjects/hatch.py
+++ b/src/Mod/Draft/draftobjects/hatch.py
@@ -39,6 +39,7 @@ class Hatch(DraftObject):
     def __init__(self,obj):
 
         obj.Proxy = self
+        self.Type = "Hatch"
         self.setProperties(obj)
 
     def setProperties(self,obj):
@@ -63,7 +64,6 @@ class Hatch(DraftObject):
             obj.addProperty("App::PropertyBool","Translate","Hatch",
                             QT_TRANSLATE_NOOP("App::Property","If set to False, hatch is applied as is to the faces, without translation (this might give wrong results for non-XY faces)"), locked=True)
             obj.Translate = True
-        self.Type = "Hatch"
 
     def onDocumentRestored(self,obj):
         self.setProperties(obj)
@@ -73,12 +73,10 @@ class Hatch(DraftObject):
         )
 
     def dumps(self):
+        return
 
-        return None
-
-    def loads(self,state):
-
-        return None
+    def loads(self, state):
+        self.Type = "Hatch"
 
     def execute(self,obj):
 

--- a/src/Mod/Draft/draftobjects/label.py
+++ b/src/Mod/Draft/draftobjects/label.py
@@ -45,8 +45,8 @@ class Label(DraftAnnotation):
 
     def __init__(self, obj):
         obj.Proxy = self
-        self.set_properties(obj)
         self.Type = "Label"
+        self.set_properties(obj)
 
     def set_properties(self, obj):
         """Set properties only if they don't exist."""
@@ -234,7 +234,6 @@ class Label(DraftAnnotation):
         """Execute code when the document is restored."""
         super().onDocumentRestored(obj)
         gui_utils.restore_view_object(obj, vp_module="view_label", vp_class="ViewProviderLabel")
-        self.Type = "Label"
 
         if not getattr(obj, "ViewObject", None):
             return
@@ -242,6 +241,9 @@ class Label(DraftAnnotation):
         if hasattr(vobj, "FontName") and hasattr(vobj, "FontSize"):
             return
         self.update_properties_0v21(obj, vobj)
+
+    def loads(self, state):
+        self.Type = "Label"
 
     def update_properties_0v21(self, obj, vobj):
         """Update view properties."""

--- a/src/Mod/Draft/draftobjects/text.py
+++ b/src/Mod/Draft/draftobjects/text.py
@@ -42,8 +42,8 @@ class Text(DraftAnnotation):
 
     def __init__(self, obj):
         obj.Proxy = self
-        self.set_properties(obj)
         self.Type = "Text"
+        self.set_properties(obj)
 
     def set_properties(self, obj):
         """Add properties to the object and set them."""
@@ -77,11 +77,8 @@ class Text(DraftAnnotation):
         """Execute code when the document is restored."""
         super().onDocumentRestored(obj)
         gui_utils.restore_view_object(obj, vp_module="view_text", vp_class="ViewProviderText")
-        # See loads: old_type is None for new objects.
-        old_type = self.Type
-        self.Type = "Text"
-
-        if old_type is None:
+        # See loads:
+        if self.stored_type is None:
             return
         if not getattr(obj, "ViewObject", None):
             return
@@ -96,10 +93,11 @@ class Text(DraftAnnotation):
         _wrn("v0.21, " + obj.Label + ", "
              + translate("draft", "renamed 'DisplayMode' options to 'World/Screen'"))
 
-    def loads(self,state):
+    def loads(self, state):
         # Before update_properties_0v21 the self.Type value was stored.
         # We use this to identify older objects that need to be updated.
-        self.Type = state
+        self.stored_type = state
+        self.Type = "Text"
 
 
 # Alias for compatibility with v0.18 and earlier


### PR DESCRIPTION
Fixes #17750.

`self.Type` should be set in `__init__` and `loads`, and not in `onDocumentRestored`.
