### PR TITLE
Gui: Taskpanel margin and spacings rework

### DIFF
--- a/src/Gui/QSint/actionpanel/actionpanel.cpp
+++ b/src/Gui/QSint/actionpanel/actionpanel.cpp
@@ -22,8 +22,7 @@ ActionPanel::ActionPanel(QWidget *parent) :
     setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
 
     auto *vbl = new QVBoxLayout();
-    vbl->setContentsMargins(4, 8, 4, 8);
-    vbl->setSpacing(8);
+    vbl->setContentsMargins(0, 0, 0, 0);
     setLayout(vbl);
 }
 

--- a/src/Gui/TaskView/TaskEditControl.cpp
+++ b/src/Gui/TaskView/TaskEditControl.cpp
@@ -33,11 +33,14 @@
 using namespace Gui::TaskView;
 
 TaskEditControl::TaskEditControl(QWidget *parent)
-    : TaskWidget(parent), hboxLayout(new QHBoxLayout(this))
+    : TaskWidget(parent)
+    , hboxLayout(new QHBoxLayout(this))
+
     , buttonBox(new QDialogButtonBox(this))
 {
     int topMargin = QApplication::style()->pixelMetric(QStyle::PM_FocusFrameVMargin);
-    hboxLayout->setContentsMargins(0,topMargin,0,0);
+    hboxLayout->setContentsMargins(0, topMargin, 0, 0);
+
     buttonBox->setStandardButtons(QDialogButtonBox::Cancel|QDialogButtonBox::Ok);
     buttonBox->setCenterButtons(true);
     if (QLayout* layout = buttonBox->layout()) {

--- a/src/Gui/TaskView/TaskEditControl.cpp
+++ b/src/Gui/TaskView/TaskEditControl.cpp
@@ -22,8 +22,10 @@
 
 #include "PreCompiled.h"
 
+#include <QApplication>
 #include <QDialogButtonBox>
 #include <QHBoxLayout>
+#include <QStyle>
 
 #include "TaskEditControl.h"
 
@@ -31,13 +33,16 @@
 using namespace Gui::TaskView;
 
 TaskEditControl::TaskEditControl(QWidget *parent)
-    : TaskWidget(parent)
+    : TaskWidget(parent), hboxLayout(new QHBoxLayout(this))
+    , buttonBox(new QDialogButtonBox(this))
 {
-    hboxLayout = new QHBoxLayout(this);
-    buttonBox = new QDialogButtonBox(this);
+    int topMargin = QApplication::style()->pixelMetric(QStyle::PM_FocusFrameVMargin);
+    hboxLayout->setContentsMargins(0,topMargin,0,0);
     buttonBox->setStandardButtons(QDialogButtonBox::Cancel|QDialogButtonBox::Ok);
     buttonBox->setCenterButtons(true);
-
+    if (QLayout* layout = buttonBox->layout()) {
+        layout->setSpacing(0);
+    }
     hboxLayout->addWidget(buttonBox);
 }
 

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -269,15 +269,15 @@ QSize TaskPanel::minimumSizeHint() const
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 TaskView::TaskView(QWidget *parent)
-    : QWidget(parent),ActiveDialog(nullptr),ActiveCtrl(nullptr)
+    : QWidget(parent),mainLayout(new QVBoxLayout(this))
+    , scrollArea(new QScrollArea(this))
+    , taskPanel(new TaskPanel(scrollArea))
+    , ActiveDialog(nullptr),ActiveCtrl(nullptr)
 {
-    mainLayout = new QVBoxLayout(this);
     mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->setSpacing(0);
     this->setLayout(mainLayout);
-    scrollArea = new QScrollArea(this);
 
-    taskPanel = new TaskPanel(scrollArea);
     QSizePolicy sizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     sizePolicy.setHorizontalStretch(0);
     sizePolicy.setVerticalStretch(0);

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -269,7 +269,9 @@ QSize TaskPanel::minimumSizeHint() const
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 TaskView::TaskView(QWidget *parent)
-    : QWidget(parent),mainLayout(new QVBoxLayout(this))
+    : QWidget(parent)
+    , mainLayout(new QVBoxLayout(this))
+
     , scrollArea(new QScrollArea(this))
     , taskPanel(new TaskPanel(scrollArea))
     , ActiveDialog(nullptr),ActiveCtrl(nullptr)


### PR DESCRIPTION
|Changes|Notes|
|--|--|
|![a](https://github.com/user-attachments/assets/ba6f3041-d9bd-41a8-8e60-7d49c411888e) | i don't think margins bring anything useful here in terms aesthetics |
|![b](https://github.com/user-attachments/assets/b8aa572b-26ee-4e3f-91c9-7b2fd644f7b0) | saves vertical space and it makes a lot of sense when overlayed instead of docked|
|![c](https://github.com/user-attachments/assets/83a0c628-bb88-4d9c-8ce4-02b8ba9aa401) | it makes the button more integrated towards the options they are applying |
|![d](https://github.com/user-attachments/assets/942d3b95-0ed8-460f-ad77-769250b3808d) | bringing the header closer also makes them more attached together |
