### PR TITLE
BIM: fix setting of self.Type

### DIFF
--- a/src/Mod/BIM/ArchAxis.py
+++ b/src/Mod/BIM/ArchAxis.py
@@ -66,6 +66,7 @@ class _Axis:
     def __init__(self,obj):
 
         obj.Proxy = self
+        self.Type = "Axis"
         self.setProperties(obj)
 
     def setProperties(self,obj):
@@ -89,7 +90,6 @@ class _Axis:
         if not "Limit" in pl:
             obj.addProperty("App::PropertyLength","Limit","Axis", QT_TRANSLATE_NOOP("App::Property","If not zero, the axes are not represented as one full line but as two lines of the given length"), locked=True)
             obj.Limit=0
-        self.Type = "Axis"
 
     def onDocumentRestored(self,obj):
 
@@ -139,7 +139,7 @@ class _Axis:
 
     def loads(self,state):
 
-        return None
+        self.Type = "Axis"
 
     def getPoints(self,obj):
 

--- a/src/Mod/BIM/ArchAxisSystem.py
+++ b/src/Mod/BIM/ArchAxisSystem.py
@@ -59,6 +59,7 @@ class _AxisSystem:
     def __init__(self,obj):
 
         obj.Proxy = self
+        self.Type = "AxisSystem"
         self.setProperties(obj)
 
     def setProperties(self,obj):
@@ -68,7 +69,6 @@ class _AxisSystem:
             obj.addProperty("App::PropertyLinkList","Axes","AxisSystem", QT_TRANSLATE_NOOP("App::Property","The axes this system is made of"), locked=True)
         if not "Placement" in pl:
             obj.addProperty("App::PropertyPlacement","Placement","AxisSystem",QT_TRANSLATE_NOOP("App::Property","The placement of this axis system"), locked=True)
-        self.Type = "AxisSystem"
 
     def onDocumentRestored(self,obj):
 
@@ -97,7 +97,7 @@ class _AxisSystem:
 
     def loads(self,state):
 
-        return None
+        self.Type = "AxisSystem"
 
     def getPoints(self,obj):
 

--- a/src/Mod/BIM/ArchBuilding.py
+++ b/src/Mod/BIM/ArchBuilding.py
@@ -275,6 +275,7 @@ class _Building(ArchFloor._Floor):
     def __init__(self,obj):
 
         ArchFloor._Floor.__init__(self,obj)
+        self.Type = "Building"
         self.setProperties(obj)
         obj.IfcType = "Building"
 
@@ -285,12 +286,15 @@ class _Building(ArchFloor._Floor):
             obj.addProperty("App::PropertyEnumeration","BuildingType","Arch",QT_TRANSLATE_NOOP("App::Property","The type of this building"), locked=True)
             obj.BuildingType = BuildingTypes
         obj.setEditorMode('Height',2)
-        self.Type = "Building"
 
     def onDocumentRestored(self,obj):
 
         ArchFloor._Floor.onDocumentRestored(self,obj)
         self.setProperties(obj)
+
+    def loads(self,state):
+
+        self.Type = "Building"
 
 
 class _ViewProviderBuilding(ArchFloor._ViewProviderFloor):

--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -210,6 +210,7 @@ class BuildingPart(ArchIFC.IfcProduct):
     def __init__(self,obj):
 
         obj.Proxy = self
+        self.Type = "BuildingPart"
         obj.addExtension('App::GroupExtensionPython')
         #obj.addExtension('App::OriginGroupExtensionPython')
         self.setProperties(obj)
@@ -242,8 +243,6 @@ class BuildingPart(ArchIFC.IfcProduct):
         if not "MaterialsTable" in pl:
             obj.addProperty("App::PropertyMap","MaterialsTable","BuildingPart",QT_TRANSLATE_NOOP("App::Property","A MaterialName:SolidIndexesList map that relates material names with solid indexes to be used when referencing this object from other files"), locked=True)
 
-        self.Type = "BuildingPart"
-
     def onDocumentRestored(self,obj):
 
         self.setProperties(obj)
@@ -254,7 +253,7 @@ class BuildingPart(ArchIFC.IfcProduct):
 
     def loads(self,state):
 
-        return None
+        self.Type = "BuildingPart"
 
     def onBeforeChange(self,obj,prop):
 
@@ -861,7 +860,7 @@ class ViewProviderBuildingPart:
     def activate(self, action=None):
         from draftutils.utils import toggle_working_plane
         vobj = self.Object.ViewObject
-        
+
         if (not hasattr(vobj,"DoubleClickActivates")) or vobj.DoubleClickActivates:
             if toggle_working_plane(self.Object, action, restore=True):
                 print("Setting active working plane to: ", self.Object.Label)

--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -185,8 +185,8 @@ class Component(ArchIFC.IfcProduct):
 
     def __init__(self, obj):
         obj.Proxy = self
-        Component.setProperties(self, obj)
         self.Type = "Component"
+        Component.setProperties(self,obj)
 
     def setProperties(self, obj):
         """Give the component its component specific properties, such as material.
@@ -240,7 +240,6 @@ class Component(ArchIFC.IfcProduct):
 
         self.Subvolume = None
         #self.MoveWithHost = False
-        self.Type = "Component"
 
     def onDocumentRestored(self, obj):
         """Method run when the document is restored. Re-add the Arch component properties.
@@ -277,13 +276,10 @@ class Component(ArchIFC.IfcProduct):
             obj.Shape = shape
 
     def dumps(self):
-        # for compatibility with 0.17
-        if hasattr(self,"Type"):
-            return self.Type
-        return "Component"
+        return None
 
     def loads(self,state):
-        return None
+        self.Type = "Component"
 
     def onBeforeChange(self,obj,prop):
         """Method called before the object has a property changed.

--- a/src/Mod/BIM/ArchCurtainWall.py
+++ b/src/Mod/BIM/ArchCurtainWall.py
@@ -82,6 +82,7 @@ class CurtainWall(ArchComponent.Component):
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
+        self.Type = "CurtainWall"
         self.setProperties(obj)
         obj.IfcType = "Curtain Wall"
 
@@ -184,12 +185,14 @@ class CurtainWall(ArchComponent.Component):
         if not "OverrideEdges" in pl:  # PropertyStringList
             obj.addProperty("App::PropertyStringList","OverrideEdges","CurtainWall",QT_TRANSLATE_NOOP("App::Property","Input are index numbers of edges of Base ArchSketch/Sketch geometries (in Edit mode).  Selected edges are used to create the shape of this Arch Curtain Wall (instead of using all edges by default).  [ENHANCED by ArchSketch] GUI 'Edit Curtain Wall' Tool is provided in external Add-on ('SketchArch') to let users to select the edges interactively.  'Toponaming-Tolerant' if ArchSketch is used in Base (and SketchArch Add-on is installed).  Warning : Not 'Toponaming-Tolerant' if just Sketch is used. Property is ignored if Base ArchSketch provided the selected edges."), locked=True)
 
-        self.Type = "CurtainWall"
-
     def onDocumentRestored(self,obj):
 
         ArchComponent.Component.onDocumentRestored(self,obj)
         self.setProperties(obj)
+
+    def loads(self,state):
+
+        self.Type = "CurtainWall"
 
     def onChanged(self,obj,prop):
 

--- a/src/Mod/BIM/ArchEquipment.py
+++ b/src/Mod/BIM/ArchEquipment.py
@@ -152,7 +152,7 @@ class _Equipment(ArchComponent.Component):
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
-        obj.Proxy = self
+        self.Type = "Equipment"
         self.setProperties(obj)
         from ArchIFC import IfcTypes
         if "Furniture" in IfcTypes:
@@ -198,7 +198,6 @@ class _Equipment(ArchComponent.Component):
         obj.setEditorMode("VerticalArea",2)
         obj.setEditorMode("HorizontalArea",2)
         obj.setEditorMode("PerimeterLength",2)
-        self.Type = "Equipment"
 
     def onDocumentRestored(self,obj):
 
@@ -207,6 +206,10 @@ class _Equipment(ArchComponent.Component):
 
         # Add features in the SketchArch External Add-on, if present
         self.addSketchArchFeatures(obj)
+
+    def loads(self,state):
+
+        self.Type = "Equipment"
 
     def onChanged(self,obj,prop):
 

--- a/src/Mod/BIM/ArchFence.py
+++ b/src/Mod/BIM/ArchFence.py
@@ -50,6 +50,7 @@ class _Fence(ArchComponent.Component):
     def __init__(self, obj):
 
         ArchComponent.Component.__init__(self, obj)
+        self.Type = "Fence"
         self.setProperties(obj)
         # Does a IfcType exist?
         # obj.IfcType = "Fence"
@@ -82,19 +83,15 @@ class _Fence(ArchComponent.Component):
                 "App::Property", "The number of posts used to build the fence"), locked=True)
             obj.setEditorMode("NumberOfPosts", 1)
 
-        self.Type = "Fence"
-
     def dumps(self):
         if hasattr(self, 'sectionFaceNumbers'):
             return self.sectionFaceNumbers
-
         return None
 
     def loads(self, state):
         if state is not None and isinstance(state, tuple):
             self.sectionFaceNumbers = state[0]
-
-        return None
+        self.Type = "Fence"
 
     def execute(self, obj):
         import Part

--- a/src/Mod/BIM/ArchFloor.py
+++ b/src/Mod/BIM/ArchFloor.py
@@ -196,7 +196,9 @@ class _Floor(ArchIFC.IfcProduct):
     """
 
     def __init__(self,obj):
+
         obj.Proxy = self
+        self.Type = "Floor"
         self.Object = obj
         _Floor.setProperties(self,obj)
         self.IfcType = "Building Storey"
@@ -216,7 +218,6 @@ class _Floor(ArchIFC.IfcProduct):
         if not hasattr(obj,"Placement"):
             # obj can be a Part Feature and already has a placement
             obj.addProperty("App::PropertyPlacement","Placement","Base",QT_TRANSLATE_NOOP("App::Property","The placement of this object"), locked=True)
-        self.Type = "Floor"
 
     def onDocumentRestored(self,obj):
         """Method run when the document is restored. Re-adds the properties."""
@@ -229,7 +230,7 @@ class _Floor(ArchIFC.IfcProduct):
 
     def loads(self,state):
 
-        return None
+        self.Type = "Floor"
 
     def onChanged(self,obj,prop):
         """Method called when the object has a property changed.

--- a/src/Mod/BIM/ArchFrame.py
+++ b/src/Mod/BIM/ArchFrame.py
@@ -58,6 +58,7 @@ class _Frame(ArchComponent.Component):
 
     def __init__(self,obj):
         ArchComponent.Component.__init__(self,obj)
+        self.Type = "Frame"
         self.setProperties(obj)
         obj.IfcType = "Railing"
 
@@ -82,12 +83,15 @@ class _Frame(ArchComponent.Component):
             obj.Edges = ["All edges","Vertical edges","Horizontal edges","Bottom horizontal edges","Top horizontal edges"]
         if not "Fuse" in pl:
             obj.addProperty("App::PropertyBool","Fuse","Frame",QT_TRANSLATE_NOOP("App::Property","If true, geometry is fused, otherwise a compound"), locked=True)
-        self.Type = "Frame"
 
     def onDocumentRestored(self,obj):
 
         ArchComponent.Component.onDocumentRestored(self,obj)
         self.setProperties(obj)
+
+    def loads(self,state):
+
+        self.Type = "Frame"
 
     def execute(self,obj):
 

--- a/src/Mod/BIM/ArchGrid.py
+++ b/src/Mod/BIM/ArchGrid.py
@@ -58,6 +58,7 @@ class ArchGrid:
     def __init__(self,obj):
 
         obj.Proxy = self
+        self.Type = "Grid"
         self.setProperties(obj)
 
     def setProperties(self,obj):
@@ -88,7 +89,6 @@ class ArchGrid:
             obj.addProperty("App::PropertyBool","Reorient","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'When in edge midpoint mode, if this grid must reorient its children along edge normals or not'), locked=True)
         if not "HiddenFaces" in pl:
             obj.addProperty("App::PropertyIntegerList","HiddenFaces","Grid",QT_TRANSLATE_NOOP("Arch_Grid",'The indices of faces to hide'), locked=True)
-        self.Type = "Grid"
 
     def onDocumentRestored(self,obj):
 
@@ -251,7 +251,7 @@ class ArchGrid:
 
     def loads(self,state):
 
-        return None
+        self.Type = "Grid"
 
 
 class ViewProviderArchGrid:

--- a/src/Mod/BIM/ArchPanel.py
+++ b/src/Mod/BIM/ArchPanel.py
@@ -67,6 +67,7 @@ class _Panel(ArchComponent.Component):
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
+        self.Type = "Panel"
         self.setProperties(obj)
         obj.IfcType = "Plate"
 
@@ -104,7 +105,6 @@ class _Panel(ArchComponent.Component):
             obj.FaceMaker = ["None","Simple","Cheese","Bullseye"]
         if not "Normal" in pl:
             obj.addProperty("App::PropertyVector","Normal","Panel",QT_TRANSLATE_NOOP("App::Property","The normal extrusion direction of this object (keep (0,0,0) for automatic normal)"), locked=True)
-        self.Type = "Panel"
         obj.setEditorMode("VerticalArea",2)
         obj.setEditorMode("HorizontalArea",2)
 
@@ -112,6 +112,10 @@ class _Panel(ArchComponent.Component):
 
         ArchComponent.Component.onDocumentRestored(self,obj)
         self.setProperties(obj)
+
+    def loads(self,state):
+
+        self.Type = "Panel"
 
     def execute(self,obj):
 

--- a/src/Mod/BIM/ArchPipe.py
+++ b/src/Mod/BIM/ArchPipe.py
@@ -61,6 +61,7 @@ class _ArchPipe(ArchComponent.Component):
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
+        self.Type = "Pipe"
         self.setProperties(obj)
         # IfcPipeSegment is new in IFC4
         from ArchIFC import IfcTypes
@@ -94,12 +95,15 @@ class _ArchPipe(ArchComponent.Component):
         if not "ProfileType" in pl:
             obj.addProperty("App::PropertyEnumeration", "ProfileType", "Pipe", QT_TRANSLATE_NOOP("App::Property","If not based on a profile, this controls the profile of this pipe"), locked=True)
             obj.ProfileType = ["Circle", "Square", "Rectangle"]
-        self.Type = "Pipe"
 
     def onDocumentRestored(self,obj):
 
         ArchComponent.Component.onDocumentRestored(self,obj)
         self.setProperties(obj)
+
+    def loads(self,state):
+
+        self.Type = "Pipe"
 
     def onChanged(self, obj, prop):
         if prop == "IfcType":

--- a/src/Mod/BIM/ArchPrecast.py
+++ b/src/Mod/BIM/ArchPrecast.py
@@ -62,6 +62,7 @@ class _Precast(ArchComponent.Component):
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
+        self.Type = "Precast"
         _Precast.setProperties(self,obj)
 
     def setProperties(self,obj):
@@ -75,12 +76,15 @@ class _Precast(ArchComponent.Component):
             obj.addProperty("App::PropertyDistance","Height","Structure",QT_TRANSLATE_NOOP("App::Property","The height of this element"), locked=True)
         if not "Nodes" in pl:
             obj.addProperty("App::PropertyVectorList","Nodes","Structure",QT_TRANSLATE_NOOP("App::Property","The structural nodes of this element"), locked=True)
-        self.Type = "Precast"
 
     def onDocumentRestored(self,obj):
 
         ArchComponent.Component.onDocumentRestored(self,obj)
         _Precast.setProperties(self,obj)
+
+    def loads(self,state):
+
+        self.Type = "Precast"
 
     def execute(self,obj):
 

--- a/src/Mod/BIM/ArchProject.py
+++ b/src/Mod/BIM/ArchProject.py
@@ -66,6 +66,7 @@ class _Project(ArchIFC.IfcContext):
 
     def __init__(self, obj):
         obj.Proxy = self
+        self.Type = "Project"
         self.setProperties(obj)
         obj.IfcType = "Project"
 
@@ -80,11 +81,18 @@ class _Project(ArchIFC.IfcContext):
         pl = obj.PropertiesList
         if not hasattr(obj,"Group"):
             obj.addExtension("App::GroupExtensionPython")
-        self.Type = "Project"
 
     def onDocumentRestored(self, obj):
         """Method run when the document is restored. Re-add the properties."""
         self.setProperties(obj)
+
+    def dumps(self):
+
+        return None
+
+    def loads(self,state):
+
+        self.Type = "Project"
 
     def addObject(self,obj,child):
 

--- a/src/Mod/BIM/ArchRebar.py
+++ b/src/Mod/BIM/ArchRebar.py
@@ -70,6 +70,7 @@ class _Rebar(ArchComponent.Component):
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
+        self.Type = "Rebar"
         self.setProperties(obj)
         obj.IfcType = "Reinforcing Bar"
 
@@ -113,12 +114,15 @@ class _Rebar(ArchComponent.Component):
                 QT_TRANSLATE_NOOP("App::Property", "The rebar mark"),
                 locked=True,
             )
-        self.Type = "Rebar"
 
     def onDocumentRestored(self,obj):
 
         ArchComponent.Component.onDocumentRestored(self,obj)
         self.setProperties(obj)
+
+    def loads(self,state):
+
+        self.Type = "Rebar"
 
     def getBaseAndAxis(self,wire):
 

--- a/src/Mod/BIM/ArchReference.py
+++ b/src/Mod/BIM/ArchReference.py
@@ -63,8 +63,8 @@ class ArchReference:
     def __init__(self, obj):
 
         obj.Proxy = self
-        ArchReference.setProperties(self, obj)
         self.Type = "Reference"
+        ArchReference.setProperties(self, obj)
         self.reload = True
 
 
@@ -90,7 +90,6 @@ class ArchReference:
         if not "FuseArch" in pl:
             t = QT_TRANSLATE_NOOP("App::Property","Fuse objects of same material")
             obj.addProperty("App::PropertyBool","FuseArch", "Reference", t, locked=True)
-        self.Type = "Reference"
 
 
     def onDocumentRestored(self, obj):
@@ -109,7 +108,7 @@ class ArchReference:
 
     def loads(self, state):
 
-        return None
+        self.Type = "Reference"
 
 
     def onChanged(self, obj, prop):

--- a/src/Mod/BIM/ArchRoof.py
+++ b/src/Mod/BIM/ArchRoof.py
@@ -153,9 +153,9 @@ class _Roof(ArchComponent.Component):
     '''The Roof object'''
     def __init__(self, obj):
         ArchComponent.Component.__init__(self, obj)
+        self.Type = "Roof"
         self.setProperties(obj)
         obj.IfcType = "Roof"
-        obj.Proxy = self
 
     def setProperties(self, obj):
         pl = obj.PropertiesList
@@ -227,11 +227,13 @@ class _Roof(ArchComponent.Component):
                             "Roof",
                             QT_TRANSLATE_NOOP("App::Property", "An optional object that defines a volume to be subtracted from walls. If field is set - it has a priority over auto-generated subvolume"),
                             locked=True)
-        self.Type = "Roof"
 
     def onDocumentRestored(self, obj):
         ArchComponent.Component.onDocumentRestored(self, obj)
         self.setProperties(obj)
+
+    def loads(self,state):
+        self.Type = "Roof"
 
     def flipEdges(self, edges):
         edges.reverse()
@@ -784,7 +786,7 @@ class _Roof(ArchComponent.Component):
                     # TODO 2025.6.15: See github issue #21633: Find better way
                     #      to test and maybe to split suface point up and down
                     #      and extrude separately
-                    
+
                     # Not sure if it is pointing towards and/or above horizon
                     # (upward or downward), or it is curve surface, just add.
                     faces.append(f)

--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -820,6 +820,7 @@ class _SectionPlane:
 
     def __init__(self,obj):
         obj.Proxy = self
+        self.Type = "SectionPlane"
         self.setProperties(obj)
 
     def setProperties(self,obj):
@@ -841,7 +842,6 @@ class _SectionPlane:
             obj.UseMaterialColorForFill = False
         if not "Depth" in pl:
             obj.addProperty("App::PropertyLength","Depth","SectionPlane",QT_TRANSLATE_NOOP("App::Property","Geometry further than this value will be cut off. Keep zero for unlimited."), locked=True)
-        self.Type = "SectionPlane"
 
     def onDocumentRestored(self,obj):
 
@@ -883,7 +883,7 @@ class _SectionPlane:
 
     def loads(self,state):
 
-        return None
+        self.Type = "SectionPlane"
 
 
 class _ViewProviderSectionPlane:

--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -504,6 +504,7 @@ class _Site(ArchIFC.IfcProduct):
 
     def __init__(self,obj):
         obj.Proxy = self
+        self.Type = "Site"
         self.setProperties(obj)
         obj.IfcType = "Site"
         obj.CompositionType = "ELEMENT"
@@ -576,7 +577,6 @@ class _Site(ArchIFC.IfcProduct):
             obj.addProperty("App::PropertyInteger","TimeZone","Site",QT_TRANSLATE_NOOP("App::Property","The time zone where this site is located"), locked=True)
         if not "EPWFile" in pl:
             obj.addProperty("App::PropertyFileIncluded","EPWFile","Site",QT_TRANSLATE_NOOP("App::Property","An optional EPW File for the location of this site. Refer to the Site documentation to know how to obtain one"), locked=True)
-        self.Type = "Site"
 
     def onDocumentRestored(self,obj):
         """Method run when the document is restored. Re-adds the properties."""
@@ -758,7 +758,7 @@ class _Site(ArchIFC.IfcProduct):
 
     def loads(self,state):
 
-        return None
+        self.Type = "Site"
 
 
 class _ViewProviderSite:

--- a/src/Mod/BIM/ArchSpace.py
+++ b/src/Mod/BIM/ArchSpace.py
@@ -190,6 +190,7 @@ class _Space(ArchComponent.Component):
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
+        self.Type = "Space"
         self.setProperties(obj)
         obj.IfcType = "Space"
         obj.CompositionType = "ELEMENT"
@@ -231,12 +232,15 @@ class _Space(ArchComponent.Component):
         if not "AreaCalculationType" in pl:
             obj.addProperty("App::PropertyEnumeration", "AreaCalculationType",  "Space",QT_TRANSLATE_NOOP("App::Property","Defines the calculation type for the horizontal area and its perimeter length"), locked=True)
             obj.AreaCalculationType = AreaCalculationType
-        self.Type = "Space"
 
     def onDocumentRestored(self,obj):
 
         ArchComponent.Component.onDocumentRestored(self,obj)
         self.setProperties(obj)
+
+    def loads(self,state):
+
+        self.Type = "Space"
 
     def execute(self,obj):
 

--- a/src/Mod/BIM/ArchStairs.py
+++ b/src/Mod/BIM/ArchStairs.py
@@ -67,6 +67,7 @@ class _Stairs(ArchComponent.Component):
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
+        self.Type = "Stairs"
         self.setProperties(obj)
         obj.IfcType = "Stair"
 
@@ -226,8 +227,6 @@ class _Stairs(ArchComponent.Component):
         if not hasattr(self,"ArchSkPropSetListPrev"):
             self.ArchSkPropSetListPrev = []
 
-        self.Type = "Stairs"
-
 
     def dumps(self):  # Supercede Arch.Component.dumps()
         dump = super().dumps()
@@ -249,6 +248,7 @@ class _Stairs(ArchComponent.Component):
         elif state[0] != 'Stairs':  # model before merging super.dumps/loads()
             self.ArchSkPropSetPickedUuid = state[0]
             self.ArchSkPropSetListPrev = state[1]
+        self.Type = "Stairs"
 
 
     def onDocumentRestored(self,obj):
@@ -337,7 +337,7 @@ class _Stairs(ArchComponent.Component):
 
         self.pseudosteps = []
         self.pseudorisers = []
-        
+
         self.structures = []
         pl = obj.Placement
         landings = 0 # TODO Any use? 2018.7.15
@@ -1306,7 +1306,7 @@ class _Stairs(ArchComponent.Component):
                 lProfile[-1] = lProfile[-1].add(-vRiserThickness)
                 resHeight1 = structureThickness/math.cos(ang)
                 dh = s2 - float(hgt)/numOfSteps
-                
+
                 resHeight2 = ((numOfSteps-1)*vHeight.Length) - dh
 
                 if endstairsup == "toFlightThickness":
@@ -1362,7 +1362,7 @@ class _Stairs(ArchComponent.Component):
                 struct = struct.extrude(evec)
 
         elif structure in ["One stringer","Two stringers"]:
-            # setup stringerWidth 
+            # setup stringerWidth
             if not stringerWidth:
                 stringerWidth = obj.StringerWidth.Value
 

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -667,6 +667,7 @@ class _Structure(ArchComponent.Component):
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
+        self.Type = "Structure"
         self.setProperties(obj)
         obj.IfcType = "Beam"
 
@@ -730,8 +731,6 @@ class _Structure(ArchComponent.Component):
         if not hasattr(self,"ArchSkPropSetListPrev"):
             self.ArchSkPropSetListPrev = []
 
-        self.Type = "Structure"
-
 
     def dumps(self):  # Supercede Arch.Component.dumps()
         dump = super().dumps()
@@ -753,6 +752,7 @@ class _Structure(ArchComponent.Component):
         elif state[0] != 'Structure':  # model before merging super.dumps/loads()
             self.ArchSkPropSetPickedUuid = state[0]
             self.ArchSkPropSetListPrev = state[1]
+        self.Type = "Structure"
 
 
     def onDocumentRestored(self,obj):
@@ -1086,7 +1086,7 @@ class _Structure(ArchComponent.Component):
     def onChanged(self,obj,prop):
 
         # check the flag indicating if we are currently in the process of
-        # restoring document; if not, no further code is run as getExtrusionData() 
+        # restoring document; if not, no further code is run as getExtrusionData()
         # below return error when some properties are not added by onDocumentRestored()
         if FreeCAD.ActiveDocument.Restoring:
             return
@@ -1530,9 +1530,14 @@ class _StructuralSystem(ArchComponent.Component): # OBSOLETE - All Arch objects 
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
+        self.Type = "StructuralSystem"
+
         obj.addProperty("App::PropertyLinkList","Axes","Arch",QT_TRANSLATE_NOOP("App::Property","Axes systems this structure is built on"), locked=True)
         obj.addProperty("App::PropertyIntegerList","Exclude","Arch",QT_TRANSLATE_NOOP("App::Property","The element numbers to exclude when this structure is based on axes"), locked=True)
         obj.addProperty("App::PropertyBool","Align","Arch",QT_TRANSLATE_NOOP("App::Property","If true the element are aligned with axes"), locked=True).Align = False
+
+    def loads(self,state):
+
         self.Type = "StructuralSystem"
 
     def execute(self,obj):

--- a/src/Mod/BIM/ArchTruss.py
+++ b/src/Mod/BIM/ArchTruss.py
@@ -62,6 +62,7 @@ class Truss(ArchComponent.Component):
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
+        self.Type = "Truss"
         self.setProperties(obj)
         obj.IfcType = "Beam"
 
@@ -125,12 +126,15 @@ class Truss(ArchComponent.Component):
             obj.addProperty("App::PropertyEnumeration","RodMode","Truss",
                             QT_TRANSLATE_NOOP("App::Property","How to draw the rods"), locked=True)
             obj.RodMode = rodmodes
-        self.Type = "Truss"
 
     def onDocumentRestored(self,obj):
 
         ArchComponent.Component.onDocumentRestored(self,obj)
         self.setProperties(obj)
+
+    def loads(self,state):
+
+        self.Type = "Truss"
 
     def onChanged(self,obj,prop):
 

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -149,6 +149,7 @@ class _Wall(ArchComponent.Component):
 
     def __init__(self, obj):
         ArchComponent.Component.__init__(self, obj)
+        self.Type = "Wall"
         self.setProperties(obj)
         obj.IfcType = "Wall"
 
@@ -229,7 +230,6 @@ class _Wall(ArchComponent.Component):
         if not hasattr(self,"ArchSkPropSetListPrev"):
             self.ArchSkPropSetListPrev = []
         self.connectEdges = []
-        self.Type = "Wall"
 
     def dumps(self):
         dump = super().dumps()
@@ -250,6 +250,7 @@ class _Wall(ArchComponent.Component):
         elif state[0] != 'Wall':  # model before merging super.dumps/loads()
             self.ArchSkPropSetPickedUuid = state[0]
             self.ArchSkPropSetListPrev = state[1]
+        self.Type = "Wall"
 
     def onDocumentRestored(self,obj):
         """Method run when the document is restored. Re-adds the Arch component, and Arch wall properties."""

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -98,6 +98,7 @@ class _Window(ArchComponent.Component):
     def __init__(self,obj):
 
         ArchComponent.Component.__init__(self,obj)
+        self.Type = "Window"
         self.setProperties(obj)
         obj.IfcType = "Window"
         obj.MoveWithHost = True
@@ -178,7 +179,6 @@ class _Window(ArchComponent.Component):
         obj.setEditorMode("VerticalArea",2)
         obj.setEditorMode("HorizontalArea",2)
         obj.setEditorMode("PerimeterLength",2)
-        self.Type = "Window"
 
     def onDocumentRestored(self,obj):
 
@@ -194,6 +194,10 @@ class _Window(ArchComponent.Component):
         self.atthOff = None
         if hasattr(obj, 'AttachmentOffsetXyzAndRotation'):
             self.atthOff = obj.AttachmentOffsetXyzAndRotation.Base
+
+    def loads(self,state):
+
+        self.Type = "Window"
 
     def onBeforeChange(self,obj,prop):
 

--- a/src/Mod/BIM/nativeifc/ifc_objects.py
+++ b/src/Mod/BIM/nativeifc/ifc_objects.py
@@ -123,7 +123,7 @@ class ifc_object:
         the object references a Type that has a Classification property,
         so we move copy the Type's property to our actual object.
         """
-        
+
         if not getattr(obj, "Type", None):
             return
 
@@ -170,9 +170,8 @@ class ifc_object:
         return getattr(self, "Type", None)
 
     def loads(self, state):
-        if state and hasattr(state, "Type"):
+        if state:
             self.Type = state
-        return None
 
     def execute(self, obj):
         from . import ifc_generator  # lazy import


### PR DESCRIPTION
Fixes #21364.

`self.Type` should be set in `__init__` and `loads`, and not in `onDocumentRestored`.

Additionally:
fixed mistake in `loads` in ifc_objects.py.
