### PR TITLE
Sketcher: manage legacy negative circle-line distance

### DIFF
--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -2991,10 +2991,10 @@ void ConstraintC2LDistance::errorgrad(double* err, double* grad, double* param)
 
     if (err) {
         if (h < *circle.rad) {
-            *err = *circle.rad - *distance() - h;
+            *err = *circle.rad - std::abs(*distance()) - h;
         }
         else {
-            *err = *circle.rad + *distance() - h;
+            *err = *circle.rad + std::abs(*distance()) - h;
         }
     }
     else if (grad) {

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
@@ -480,6 +480,34 @@ class TestSketcherSolver(unittest.TestCase):
             msg="Reference constraint did not return the expected distance.",
         )
 
+    def testCircleToLineDistance_Legacy_Negative(self):
+        # compare a driving negative distance to an expected positive reference one
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        radius = 20
+        c_idx = sketch.addGeometry(Part.Circle(vec(0, 0), xy_normal, radius))
+        l_idx = sketch.addGeometry(
+            Part.LineSegment(vec(-radius, radius / 2), vec(radius, radius / 2))
+        )
+        sketch.addConstraint(
+            [Sketcher.Constraint("Block", c_idx), Sketcher.Constraint("Block", l_idx)]
+        )
+        expected_distance = radius / 2
+        ref_idx = sketch.addConstraint(
+            [
+                Sketcher.Constraint("Distance", c_idx, l_idx, -expected_distance),
+                Sketcher.Constraint("Distance", c_idx, l_idx, 0),
+            ]
+        )[1]
+        sketch.setDriving(ref_idx, False)
+        self.assertSuccessfulSolve(sketch)
+        actual_distance = sketch.Constraints[ref_idx].Value
+        self.assertAlmostEqual(
+            expected_distance,
+            actual_distance,
+            delta=Precision.confusion(),
+            msg="Negative length constraint did not return the expected distance.",
+        )
+
     def testRemovedExternalGeometryReference(self):
         if "BUILD_PARTDESIGN" in FreeCAD.__cmake__:
             body = self.Doc.addObject("PartDesign::Body", "Body")


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/pull/22023#issuecomment-3009830019

Negative distances are allowed again but act as positives.