### PR TITLE
Core: Fix build with VTK 9.5

### DIFF
--- a/src/3rdParty/salomesmesh/inc/SMDS_UnstructuredGrid.hxx
+++ b/src/3rdParty/salomesmesh/inc/SMDS_UnstructuredGrid.hxx
@@ -96,7 +96,11 @@ public:
   vtkCellLinks* GetLinks()
   {
 #ifdef VTK_CELL_ARRAY_V2
+  #if VTK_VERSION_NUMBER_QUICK >= 90300000000
+    return static_cast<vtkCellLinks*>(vtkUnstructuredGrid::GetLinks());
+  #else
     return static_cast<vtkCellLinks*>(GetCellLinks());
+  #endif
 #else
     return Links;
 #endif

--- a/src/3rdParty/salomesmesh/src/SMDS/SMDS_Mesh.cpp
+++ b/src/3rdParty/salomesmesh/src/SMDS/SMDS_Mesh.cpp
@@ -4713,7 +4713,11 @@ void SMDS_Mesh::dumpGrid(string ficdump)
   }
   ficcon << "-------------------------------- connectivity " <<  nbPoints << endl;
 #ifdef VTK_CELL_ARRAY_V2
+  #if VTK_VERSION_NUMBER_QUICK >= 90300000000
+  vtkCellLinks *links = static_cast<vtkCellLinks*>(myGrid->GetLinks());
+  #else
   vtkCellLinks *links = static_cast<vtkCellLinks*>(myGrid->GetCellLinks());
+  #endif
 #else
   vtkCellLinks *links = myGrid->GetCellLinks();
 #endif

--- a/src/3rdParty/salomesmesh/src/SMDS/SMDS_MeshNode.cpp
+++ b/src/3rdParty/salomesmesh/src/SMDS/SMDS_MeshNode.cpp
@@ -69,7 +69,11 @@ void SMDS_MeshNode::init(int id, int meshId, int shapeId, double x, double y, do
   SMDS_UnstructuredGrid * grid = mesh->getGrid();
   vtkPoints *points = grid->GetPoints();
   points->InsertPoint(myVtkID, x, y, z);
+#if VTK_VERSION_NUMBER_QUICK >= 90300000000
+  SMDS_CellLinks *cellLinks = dynamic_cast<SMDS_CellLinks*>(grid->GetLinks());
+#else
   SMDS_CellLinks *cellLinks = dynamic_cast<SMDS_CellLinks*>(grid->GetCellLinks());
+#endif
   assert(cellLinks);
   cellLinks->ResizeForPoint( myVtkID );
 }
@@ -191,7 +195,11 @@ public:
 SMDS_ElemIteratorPtr SMDS_MeshNode::
 GetInverseElementIterator(SMDSAbs_ElementType type) const
 {
+#if VTK_VERSION_NUMBER_QUICK >= 90300000000
+  vtkCellLinks::Link l = static_cast<vtkCellLinks*>(SMDS_Mesh::_meshList[myMeshId]->getGrid()->GetLinks())->GetLink(myVtkID);
+#else
   vtkCellLinks::Link l = static_cast<vtkCellLinks*>(SMDS_Mesh::_meshList[myMeshId]->getGrid()->GetCellLinks())->GetLink(myVtkID);
+#endif
   //MESSAGE("myID " << myID << " ncells " << l.ncells);
   return SMDS_ElemIteratorPtr(new SMDS_MeshNode_MyInvIterator(SMDS_Mesh::_meshList[myMeshId], l.cells, l.ncells, type));
 }
@@ -251,7 +259,11 @@ elementsIterator(SMDSAbs_ElementType type) const
     return SMDS_MeshElement::elementsIterator(SMDSAbs_Node);
   else
   {
+#if VTK_VERSION_NUMBER_QUICK >= 90300000000
+    vtkCellLinks::Link l = static_cast<vtkCellLinks*>(SMDS_Mesh::_meshList[myMeshId]->getGrid()->GetLinks())->GetLink(myVtkID);
+#else
     vtkCellLinks::Link l = static_cast<vtkCellLinks*>(SMDS_Mesh::_meshList[myMeshId]->getGrid()->GetCellLinks())->GetLink(myVtkID);
+#endif
     return SMDS_ElemIteratorPtr(new SMDS_MeshNode_MyIterator(SMDS_Mesh::_meshList[myMeshId], l.cells, l.ncells, type));
   }
 }
@@ -350,7 +362,11 @@ void SMDS_MeshNode::AddInverseElement(const SMDS_MeshElement* ME)
   const SMDS_MeshCell *cell = dynamic_cast<const SMDS_MeshCell*> (ME);
   assert(cell);
   SMDS_UnstructuredGrid* grid = SMDS_Mesh::_meshList[myMeshId]->getGrid();
+#if VTK_VERSION_NUMBER_QUICK >= 90300000000
+  vtkCellLinks *Links = static_cast<vtkCellLinks*>(grid->GetLinks());
+#else
   vtkCellLinks *Links = static_cast<vtkCellLinks*>(grid->GetCellLinks());
+#endif
   Links->ResizeCellList(myVtkID, 1);
   Links->AddCellReference(cell->getVtkId(), myVtkID);
 }
@@ -366,7 +382,11 @@ void SMDS_MeshNode::ClearInverseElements()
 
 bool SMDS_MeshNode::emptyInverseElements()
 {
+#if VTK_VERSION_NUMBER_QUICK >= 90300000000
+  vtkCellLinks::Link l = static_cast<vtkCellLinks*>(SMDS_Mesh::_meshList[myMeshId]->getGrid()->GetLinks())->GetLink(myVtkID);
+#else
   vtkCellLinks::Link l = static_cast<vtkCellLinks*>(SMDS_Mesh::_meshList[myMeshId]->getGrid()->GetCellLinks())->GetLink(myVtkID);
+#endif
   return (l.ncells == 0);
 }
 
@@ -378,7 +398,11 @@ bool SMDS_MeshNode::emptyInverseElements()
 
 int SMDS_MeshNode::NbInverseElements(SMDSAbs_ElementType type) const
 {
+#if VTK_VERSION_NUMBER_QUICK >= 90300000000
+  vtkCellLinks::Link l = static_cast<vtkCellLinks*>(SMDS_Mesh::_meshList[myMeshId]->getGrid()->GetLinks())->GetLink(myVtkID);
+#else
   vtkCellLinks::Link l = static_cast<vtkCellLinks*>(SMDS_Mesh::_meshList[myMeshId]->getGrid()->GetCellLinks())->GetLink(myVtkID);
+#endif
 
   if ( type == SMDSAbs_All )
     return l.ncells;

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshEditor.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshEditor.cpp
@@ -11348,7 +11348,11 @@ bool SMESH_MeshEditor::DoubleNodesOnGroupBoundaries( const std::vector<TIDSorted
             {
               int oldId = *itn;
               //MESSAGE("     node " << oldId);
+#if VTK_VERSION_NUMBER_QUICK >= 90300000000
+              vtkCellLinks::Link l = static_cast<vtkCellLinks*>(grid->GetLinks())->GetLink(oldId);
+#else
               vtkCellLinks::Link l = static_cast<vtkCellLinks*>(grid->GetCellLinks())->GetLink(oldId);
+#endif
               for (int i=0; i<l.ncells; i++)
                 {
                   int vtkId = l.cells[i];
@@ -11708,7 +11712,11 @@ bool SMESH_MeshEditor::DoubleNodesOnGroupBoundaries( const std::vector<TIDSorted
         {
           int oldId = itnod->first;
           //MESSAGE("     node " << oldId);
+#if VTK_VERSION_NUMBER_QUICK >= 90300000000
+          vtkCellLinks::Link l = static_cast<vtkCellLinks*>(grid->GetLinks())->GetLink(oldId);
+#else
           vtkCellLinks::Link l = static_cast<vtkCellLinks*>(grid->GetCellLinks())->GetLink(oldId);
+#endif
           for (int i = 0; i < l.ncells; i++)
             {
               int vtkId = l.cells[i];


### PR DESCRIPTION
This patch fixes freecad build with VTK 9.5 (but may break older versions since I did not add version guards and did not test it).

Replacing `vtkUnstructuredGrid::GetCellLinks` with `vtkUnstructuredGrid::GetLinks` is necessary since the former has been deprecated in VTK 9.3 and silently removed in 9.5:
https://gitlab.kitware.com/vtk/vtk/-/blob/master/Documentation/release/9.3.md

Also since salomesmesh is in the 3rdParty directory I have no idea if this should be actually patched in this repo or pulled from somewhere else :shrug: 