### PR TITLE
FEM: Fix data extraction checkbox typo

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/PostHistogramFieldAppEdit.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/PostHistogramFieldAppEdit.ui
@@ -65,7 +65,7 @@
      <item row="2" column="1">
       <widget class="QCheckBox" name="Extract">
        <property name="text">
-        <string>One field for each frames</string>
+        <string>One field for each frame</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/Fem/Gui/Resources/ui/PostLineplotFieldAppEdit.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/PostLineplotFieldAppEdit.ui
@@ -90,7 +90,7 @@
    <item row="4" column="1">
     <widget class="QCheckBox" name="Extract">
      <property name="text">
-      <string>One Y field for each frames</string>
+      <string>One Y field for each frame</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/femviewprovider/view_post_histogram.py
+++ b/src/Mod/Fem/femviewprovider/view_post_histogram.py
@@ -396,7 +396,7 @@ class VPPostHistogram(view_base_fempostvisualization.VPPostVisualization):
                 name="Cumulative",
                 group="Histogram",
                 doc=QT_TRANSLATE_NOOP(
-                    "FEM", "If be the bars should show the cumulative sum left to right"
+                    "FEM", "If the bars should show the cumulative sum left to right"
                 ),
                 value=False,
             ),


### PR DESCRIPTION
One field for each frames --> One field for each frame

Also fixes one more typo: "If be the bars" --> "If the bars"