### PR TITLE
CAM: Engrave - Reverse and Dual direction

### DIFF
--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -688,7 +688,9 @@ def flipEdge(edge):
             Part.Line(edge.valueAt(edge.LastParameter), edge.valueAt(edge.FirstParameter))
         )
     elif isinstance(edge.Curve, (Part.Line, Part.LineSegment)):
-        return Part.Edge(Part.LineSegment(edge.Vertexes[-1].Point, edge.Vertexes[0].Point))
+        return Part.Edge(
+            Part.LineSegment(edge.valueAt(edge.LastParameter), edge.valueAt(edge.FirstParameter))
+        )
     elif isinstance(edge.Curve, Part.Circle):
         # Create an inverted circle
         circle = Part.Circle(edge.Curve.Center, -edge.Curve.Axis, edge.Curve.Radius)

--- a/src/Mod/CAM/Path/Op/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Engrave.py
@@ -74,11 +74,12 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
     def initOperation(self, obj):
         """initOperation(obj) ... create engraving specific properties."""
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "StartVertex",
             "Path",
             QT_TRANSLATE_NOOP("App::Property", "The vertex index to start the toolpath from"),
         )
+        obj.StartVertex = (0, 0, 99999, 1)
         self.setupAdditionalProperties(obj)
 
     def opOnDocumentRestored(self, obj):
@@ -128,7 +129,7 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
                 else:
                     shapeWires = shape.Wires
                 Path.Log.debug("jobshape has {} edges".format(len(shape.Edges)))
-                self.buildpathocc(obj, shapeWires, self.getZValues(obj))
+                self.buildpathocc(obj, shapeWires, self.getZValues(obj), start_idx=obj.StartVertex)
                 wires.extend(shapeWires)
             self.wires = wires
             Path.Log.debug("processing {} jobshapes -> {} wires".format(len(jobshapes), len(wires)))

--- a/src/Mod/CAM/Path/Op/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Engrave.py
@@ -79,11 +79,45 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
             "Path",
             QT_TRANSLATE_NOOP("App::Property", "The vertex index to start the toolpath from"),
         )
-        obj.StartVertex = (0, 0, 99999, 1)
+        obj.StartVertex = (0, 0, 999999, 1)
+        obj.addProperty(
+            "App::PropertyBool",
+            "Reverse",
+            "Path",
+            QT_TRANSLATE_NOOP("App::Property", "Reverse milling direction"),
+        )
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "CutPattern",
+            "Path",
+            QT_TRANSLATE_NOOP("App::Property", "Set the cut pattern for the operation"),
+        )
+        obj.CutPattern = [
+            QT_TRANSLATE_NOOP("CAM_Engrave", "Directional"),
+            QT_TRANSLATE_NOOP("CAM_Engrave", "Bidirectional"),
+        ]
+        obj.CutPattern = "Bidirectional"
         self.setupAdditionalProperties(obj)
 
     def opOnDocumentRestored(self, obj):
-        # upgrade ...
+        if not hasattr(obj, "Reverse"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "Reverse",
+                "Path",
+                QT_TRANSLATE_NOOP("App::Property", "Reverse milling direction"),
+            )
+        if not hasattr(obj, "CutPattern"):
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "CutPattern",
+                "Path",
+                QT_TRANSLATE_NOOP("App::Property", "Set the cut pattern for the operation"),
+            )
+            obj.CutPattern = [
+                QT_TRANSLATE_NOOP("CAM_Engrave", "Directional"),
+                QT_TRANSLATE_NOOP("CAM_Engrave", "Bidirectional"),
+            ]
         self.setupAdditionalProperties(obj)
 
     def opExecute(self, obj):
@@ -129,7 +163,13 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
                 else:
                     shapeWires = shape.Wires
                 Path.Log.debug("jobshape has {} edges".format(len(shape.Edges)))
-                self.buildpathocc(obj, shapeWires, self.getZValues(obj), start_idx=obj.StartVertex)
+                self.buildpathocc(
+                    obj,
+                    shapeWires,
+                    self.getZValues(obj),
+                    forward=not obj.Reverse,
+                    start_idx=obj.StartVertex,
+                )
                 wires.extend(shapeWires)
             self.wires = wires
             Path.Log.debug("processing {} jobshapes -> {} wires".format(len(jobshapes), len(wires)))

--- a/src/Mod/CAM/Path/Op/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Engrave.py
@@ -128,16 +128,10 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
                 else:
                     shapeWires = shape.Wires
                 Path.Log.debug("jobshape has {} edges".format(len(shape.Edges)))
-                self.commandlist.append(
-                    Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})
-                )
                 self.buildpathocc(obj, shapeWires, self.getZValues(obj))
                 wires.extend(shapeWires)
             self.wires = wires
             Path.Log.debug("processing {} jobshapes -> {} wires".format(len(jobshapes), len(wires)))
-        # the last command is a move to clearance, which is automatically added by PathOp
-        if self.commandlist:
-            self.commandlist.pop()
 
     def opUpdateDepths(self, obj):
         """updateDepths(obj) ... engraving is always done at the top most z-value"""

--- a/src/Mod/CAM/Path/Op/EngraveBase.py
+++ b/src/Mod/CAM/Path/Op/EngraveBase.py
@@ -82,10 +82,8 @@ class ObjectOp(PathOp.ObjectOp):
         wires = decomposewires
         for wire in wires:
             # offset = wire
+            startIdx = min(start_idx, len(wire.Edges) - 1)
 
-            # reorder the wire
-            if hasattr(obj, "StartVertex"):
-                start_idx = obj.StartVertex
             edges = wire.Edges
 
             # edges = copy.copy(PathOpUtil.orientWire(offset, forward).Edges)
@@ -107,8 +105,6 @@ class ObjectOp(PathOp.ObjectOp):
                     )
 
                 first = True
-                if start_idx > len(edges) - 1:
-                    start_idx = len(edges) - 1
 
                 edges = edges[start_idx:] + edges[:start_idx]
                 for edge in edges:

--- a/src/Mod/CAM/Path/Op/EngraveBase.py
+++ b/src/Mod/CAM/Path/Op/EngraveBase.py
@@ -98,9 +98,9 @@ class ObjectOp(PathOp.ObjectOp):
             for z in zValues:
                 Path.Log.debug(z)
                 if last and wire.isClosed():
-                    # Add step down to next Z for closed profile
+                    # Skip retract and add step down to next Z for closed profile
                     self.appendCommand(
-                        Path.Command("G1", {"X": last.x, "Y": last.y, "Z": last.z}),
+                        Path.Command("G1", {"Z": last.z}),
                         z,
                         relZ,
                         self.vertFeed,
@@ -129,17 +129,13 @@ class ObjectOp(PathOp.ObjectOp):
                         self.commandlist.append(
                             Path.Command(
                                 "G0",
-                                {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid},
+                                {"Z": obj.ClearanceHeight.Value},
                             )
                         )
-                        self.commandlist.append(
-                            Path.Command("G0", {"X": last.x, "Y": last.y, "F": self.horizRapid})
-                        )
-                        self.commandlist.append(
-                            Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid})
-                        )
+                        self.commandlist.append(Path.Command("G0", {"X": last.x, "Y": last.y}))
+                        self.commandlist.append(Path.Command("G0", {"Z": obj.SafeHeight.Value}))
                         self.appendCommand(
-                            Path.Command("G1", {"X": last.x, "Y": last.y, "Z": last.z}),
+                            Path.Command("G1", {"Z": last.z}),
                             z,
                             relZ,
                             self.vertFeed,
@@ -159,10 +155,6 @@ class ObjectOp(PathOp.ObjectOp):
                             # Add gcode for reversed edge
                             self.appendCommand(cmd, z, relZ, self.horizFeed)
                         last = edge.Vertexes[0].Point
-
-            self.commandlist.append(
-                Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})
-            )
 
     def appendCommand(self, cmd, z, relZ, feed):
         params = cmd.Parameters

--- a/src/Mod/CAM/Path/Op/EngraveBase.py
+++ b/src/Mod/CAM/Path/Op/EngraveBase.py
@@ -22,12 +22,11 @@
 # ***************************************************************************
 
 from lazy_loader.lazy_loader import LazyLoader
+import FreeCAD
 import Path
 import Path.Op.Base as PathOp
 import Path.Op.Util as PathOpUtil
 import PathScripts.PathUtils as PathUtils
-
-# import copy
 
 __doc__ = "Base class for all ops in the engrave family."
 
@@ -40,6 +39,8 @@ if False:
     Path.Log.trackModule(Path.Log.thisModule())
 else:
     Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
+translate = FreeCAD.Qt.translate
 
 
 class ObjectOp(PathOp.ObjectOp):
@@ -65,6 +66,10 @@ class ObjectOp(PathOp.ObjectOp):
         Path.Log.track(obj.Label, len(wires), zValues)
 
         tol = self.job.GeometryTolerance.Value if getattr(self, "job", None) else 0.01
+        biDir = getattr(obj, "CutPattern", None) == "Bidirectional"
+
+        # decompose wires to get edges in right order
+        wires = [w for wire in wires for w in PathOpUtil.makeWires(wire.Edges)]
 
         # sort wires, adapted from Area.py
         if len(wires) > 1:
@@ -75,82 +80,67 @@ class ObjectOp(PathOp.ObjectOp):
             locations = PathUtils.sort_locations(locations, ["x", "y"])
             wires = [j["wire"] for j in locations]
 
-        decomposewires = []
         for wire in wires:
-            decomposewires.extend(PathOpUtil.makeWires(wire.Edges))
-
-        wires = decomposewires
-        for wire in wires:
-            # offset = wire
-            startIdx = min(start_idx, len(wire.Edges) - 1)
-
+            wire = PathOpUtil.orientWire(wire, forward=forward)
+            reverseDir = False
             edges = wire.Edges
+            startIdx = min(start_idx, len(wire.Edges) - 1)
+            if wire.isClosed() and startIdx:
+                edges = edges[startIdx:] + edges[:startIdx]
 
-            # edges = copy.copy(PathOpUtil.orientWire(offset, forward).Edges)
-            # Path.Log.track("wire: {} offset: {}".format(len(wire.Edges), len(edges)))
-            # edges = Part.sortEdges(edges)[0]
-            # Path.Log.track("edges: {}".format(len(edges)))
+            startPoint = edges[0].valueAt(edges[0].FirstParameter)
 
-            last = None
-
-            for z in zValues:
+            for indexZ, z in enumerate(zValues):
                 Path.Log.debug(z)
-                if last and wire.isClosed():
+                if indexZ and (wire.isClosed() or biDir):
                     # Skip retract and add step down to next Z for closed profile
                     self.appendCommand(
-                        Path.Command("G1", {"Z": last.z}),
+                        Path.Command("G1", {"Z": startPoint.z}),
                         z,
                         relZ,
                         self.vertFeed,
                     )
 
-                first = True
+                edgesDir = reversed(edges) if reverseDir and indexZ else edges
 
-                edges = edges[start_idx:] + edges[:start_idx]
-                for edge in edges:
-                    Path.Log.debug(
-                        "points: {} -> {}".format(edge.Vertexes[0].Point, edge.Vertexes[-1].Point)
-                    )
-                    Path.Log.debug(
-                        "valueat {} -> {}".format(
-                            edge.valueAt(edge.FirstParameter),
-                            edge.valueAt(edge.LastParameter),
-                        )
-                    )
-                    if first and (not last or not wire.isClosed()):
+                for indexE, edge in enumerate(edgesDir):
+                    if indexE == 0 and (indexZ == 0 or (not wire.isClosed() and not biDir)):
                         Path.Log.debug("processing first edge entry")
                         # Add moves to first point of wire
-                        last = edge.Vertexes[0].Point
-
                         self.commandlist.append(
-                            Path.Command(
-                                "G0",
-                                {"Z": obj.ClearanceHeight.Value},
-                            )
+                            Path.Command("G0", {"Z": obj.ClearanceHeight.Value})
                         )
-                        self.commandlist.append(Path.Command("G0", {"X": last.x, "Y": last.y}))
+                        self.commandlist.append(
+                            Path.Command("G0", {"X": startPoint.x, "Y": startPoint.y})
+                        )
                         self.commandlist.append(Path.Command("G0", {"Z": obj.SafeHeight.Value}))
                         self.appendCommand(
-                            Path.Command("G1", {"Z": last.z}),
+                            Path.Command("G1", {"Z": startPoint.z}),
                             z,
                             relZ,
                             self.vertFeed,
                         )
-                    first = False
+                        lastPoint = startPoint
 
-                    if Path.Geom.pointsCoincide(last, edge.valueAt(edge.FirstParameter)):
-                        # if Path.Geom.pointsCoincide(last, edge.Vertexes[0].Point):
-                        # Edge not reversed
-                        for cmd in Path.Geom.cmdsForEdge(edge, flip=False, tol=tol):
-                            # Add gcode for edge
-                            self.appendCommand(cmd, z, relZ, self.horizFeed)
-                        last = edge.Vertexes[-1].Point
+                    if len(edges) == 1:
+                        # wire with one edge
+                        flip = reverseDir
+                    elif Path.Geom.pointsCoincide(lastPoint, edge.valueAt(edge.FirstParameter)):
+                        flip = False
+                        lastPoint = edge.valueAt(edge.LastParameter)
+                    elif Path.Geom.pointsCoincide(lastPoint, edge.valueAt(edge.LastParameter)):
+                        flip = True
+                        lastPoint = edge.valueAt(edge.FirstParameter)
                     else:
-                        # Edge reversed
-                        for cmd in Path.Geom.cmdsForEdge(edge, flip=True, tol=tol):
-                            # Add gcode for reversed edge
-                            self.appendCommand(cmd, z, relZ, self.horizFeed)
-                        last = edge.Vertexes[0].Point
+                        Path.Log.warning("Error while checks points coincide")
+                        return
+
+                    for cmd in Path.Geom.cmdsForEdge(edge, flip=flip, tol=tol):
+                        # Add gcode for edge
+                        self.appendCommand(cmd, z, relZ, self.horizFeed)
+
+                if biDir and not wire.isClosed():
+                    reverseDir = not reverseDir
 
     def appendCommand(self, cmd, z, relZ, feed):
         params = cmd.Parameters


### PR DESCRIPTION
### Changes:
- Fixed error in `Path.Geom.flipEdge()`
For `LineSegment` used vertexes indexes instead of `valueAt()`
 
- Added property `Pattern` with two options: `Directional` and `Bidirectional`
   - `Directional` is old behavior
   - `Bidirectional` allows to swap direction after step down to exclude retraction
Also this will be used in next pull request, which allow reverse wires while sorting to optimize path

- Added property `Reverse` to forcing change direction
Can be useful if processing only one wire and need to change mill direction

<img width="742" height="251" alt="Screenshot_20251202_110059_lossy" src="https://github.com/user-attachments/assets/ceb67511-5898-42e7-a1af-e15833d84d20" />

https://github.com/user-attachments/assets/2a86433f-5947-4df0-9a0c-1db63323a645