### PR TITLE
CAM: Fix: custom shape attributes not showing in toolbit editor

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathToolShapeDoc.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolShapeDoc.py
@@ -34,6 +34,7 @@ class TestPathToolShapeDoc(unittest.TestCase):
         mock_doc.Objects = [mock_obj]
         mock_obj.Label = "MockObjectLabel"
         mock_obj.Name = "MockObjectName"
+        mock_obj.getTypeIdOfProperty = MagicMock(return_value="App::PropertyString")
         # Ensure mock_doc also has a Name attribute used in tests/code
         mock_doc.Name = "Document_Mock"  # Used in closeDocument calls
 
@@ -91,7 +92,13 @@ class TestPathToolShapeDoc(unittest.TestCase):
         setattr(mock_obj, "Length", "50 mm")
         params = doc.get_object_properties(mock_obj, ["Diameter", "Length"])
         # Expecting just the values, not tuples
-        self.assertEqual(params, {"Diameter": "10 mm", "Length": "50 mm"})
+        self.assertEqual(
+            params,
+            {
+                "Diameter": ("10 mm", "App::PropertyString"),
+                "Length": ("50 mm", "App::PropertyString"),
+            },
+        )
         mock_freecad.Console.PrintWarning.assert_not_called()
 
     def test_doc_get_object_properties_missing(self):
@@ -105,7 +112,13 @@ class TestPathToolShapeDoc(unittest.TestCase):
             delattr(mock_obj, "Height")
         params = doc_patched.get_object_properties(mock_obj, ["Diameter", "Height"])
         # Expecting just the values, not tuples
-        self.assertEqual(params, {"Diameter": "10 mm", "Height": None})  # Height is missing
+        self.assertEqual(
+            params,
+            {
+                "Diameter": ("10 mm", "App::PropertyString"),
+                "Height": (None, "App::PropertyString"),
+            },
+        )  # Height is missing
 
     @patch("FreeCAD.openDocument")
     @patch("FreeCAD.getDocument")

--- a/src/Mod/CAM/Path/Tool/shape/doc.py
+++ b/src/Mod/CAM/Path/Tool/shape/doc.py
@@ -23,7 +23,7 @@
 import FreeCAD
 import Path
 import Path.Base.Util as PathUtil
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Tuple
 import tempfile
 import os
 
@@ -69,33 +69,38 @@ def get_object_properties(
     obj: "FreeCAD.DocumentObject",
     props: List[str] | None = None,
     group: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> Dict[str, Tuple[Any, str]]:
     """
-    Extract properties matching expected_params from a FreeCAD PropertyBag.
+    Extract properties from a FreeCAD PropertyBag, including their types.
 
     Issues warnings for missing parameters but does not raise an error.
 
     Args:
         obj: The PropertyBag to extract properties from.
-        expected_params (List[str]): A list of property names to look for.
+        props (List[str], optional): A list of property names to look for.
+                                     If None, all properties in obj.PropertiesList are considered.
+        group (str, optional): If provided, only properties belonging to this group are extracted.
 
     Returns:
-        Dict[str, Any]: A dictionary mapping property names to their values.
-                        Values are FreeCAD native types.
+        Dict[str, Tuple[Any, str]]: A dictionary mapping property names to a tuple
+                                    (value, type_id). Values are FreeCAD native types.
+                                    If a property is missing, its value will be None.
     """
     properties = {}
     for name in props or obj.PropertiesList:
         if group and not obj.getGroupOfProperty(name) == group:
             continue
         if hasattr(obj, name):
-            properties[name] = getattr(obj, name)
+            value = getattr(obj, name)
+            type_id = obj.getTypeIdOfProperty(name)
+            properties[name] = value, type_id
         else:
             # Log a warning if a parameter expected by the shape class is missing
             Path.Log.debug(
                 f"Parameter '{name}' not found on object '{obj.Label}' "
                 f"({obj.Name}). Default value will be used by the shape class."
             )
-            properties[name] = None  # Indicate missing value
+            properties[name] = None, "App::PropertyString"
     return properties
 
 

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/editor.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/editor.py
@@ -22,9 +22,9 @@
 
 """Widget for editing a ToolBit object."""
 
+from PySide import QtGui, QtCore
 import FreeCAD
 import FreeCADGui
-from PySide import QtGui, QtCore
 from ...shape.ui.shapewidget import ShapeWidget
 from ...docobject.ui import DocumentObjectEditorWidget
 from ..models.base import ToolBit


### PR DESCRIPTION
This PR fixes that properties of custom ToolBitShapes that are not part of the ToolBitShape schema are not shown in the toolbit editor.

Before:
![image](https://github.com/user-attachments/assets/013ed5a8-3159-4b81-bff9-98ad6067a785)

After (note the non-schema attribute "Stickout"):
![image](https://github.com/user-attachments/assets/6c9cb86c-2582-4c33-af4d-75abde67fa98)
