### PR TITLE
[BIM] ProjectManager - stop combobox sizeAdjustPolicy warning

### DIFF
--- a/src/Mod/BIM/Resources/ui/dialogProjectManager.ui
+++ b/src/Mod/BIM/Resources/ui/dialogProjectManager.ui
@@ -406,9 +406,6 @@
               <property name="toolTip">
                <string>The main use of this building</string>
               </property>
-              <property name="sizeAdjustPolicy">
-               <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-              </property>
               <property name="minimumContentsLength">
                <number>0</number>
               </property>


### PR DESCRIPTION
This combobox setting is not needed for this dialog.

Fixes #22207 