### PR TITLE
BIM: fix handling of Project coin nodes

### DIFF
--- a/src/Mod/BIM/ArchProject.py
+++ b/src/Mod/BIM/ArchProject.py
@@ -129,9 +129,12 @@ class _ViewProviderProject(ArchIFCView.IfcContextView):
         https://forum.freecad.org/viewtopic.php?f=10&t=74731
         """
 
+        from pivy import coin
+        from draftutils import gui_utils
+
         if not hasattr(self, "displaymodes_cleaned"):
-            if vobj.RootNode.getNumChildren() > 2:
-                main_switch = vobj.RootNode.getChild(2)  # The display mode switch.
+            if vobj.RootNode.getNumChildren():
+                main_switch = gui_utils.find_coin_node(vobj.RootNode, coin.SoSwitch)  # The display mode switch.
                 if main_switch is not None and main_switch.getNumChildren() == 4:  # Check if all display modes are available.
                     for node in tuple(main_switch.getChildren()):
                         node.removeAllChildren()

--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -978,19 +978,12 @@ class _ViewProviderSite:
         """
 
         from pivy import coin
-
-        def find_node(parent, nodetype):
-            for i in range(parent.getNumChildren()):
-                if isinstance(parent.getChild(i), nodetype):
-                    return parent.getChild(i)
-            return None
+        from draftutils import gui_utils
 
         if not hasattr(self, "terrain_switches"):
-            if vobj.RootNode.getNumChildren() > 2:
-                main_switch = find_node(vobj.RootNode, coin.SoSwitch)
-                if not main_switch:
-                    return
-                if main_switch.getNumChildren() == 4:   # Check if all display modes are available.
+            if vobj.RootNode.getNumChildren():
+                main_switch = gui_utils.find_coin_node(vobj.RootNode, coin.SoSwitch)  # The display mode switch.
+                if main_switch is not None and main_switch.getNumChildren() == 4:  # Check if all display modes are available.
                     self.terrain_switches = []
                     for node in tuple(main_switch.getChildren()):
                         new_switch = coin.SoSwitch()


### PR DESCRIPTION
The index of the ArchProject coin DisplayMode Switch node has changed in V1.1. The same solution as already used for ArchSite has been adopted. For both files a function from the Draft WB is now used (previously copied from the code of ArchSite).

Test file created with version 0.21.2 (project-building-floor):
[pbf0212.FCStd.zip](https://github.com/user-attachments/files/20969693/pbf0212.FCStd.zip)
