### PR TITLE
Redesign DXF import UI, add Part primitives and Draft object import modes

### DIFF
--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -430,6 +430,12 @@ PyMethodDef ApplicationPy::Methods[] = {
    "Remove all children from a group node.\n"
    "\n"
    "node : object"},
+  {"suspendWaitCursor", (PyCFunction) ApplicationPy::sSuspendWaitCursor, METH_VARARGS,
+   "suspendWaitCursor() -> None\n\n"
+   "Temporarily suspends the application's wait cursor and event filter."},
+  {"resumeWaitCursor",  (PyCFunction) ApplicationPy::sResumeWaitCursor, METH_VARARGS,
+   "resumeWaitCursor() -> None\n\n"
+   "Resumes the application's wait cursor and event filter."},
   {nullptr, nullptr, 0, nullptr}    /* Sentinel */
 };
 
@@ -1812,4 +1818,24 @@ PyObject* ApplicationPy::sSetUserEditMode(PyObject * /*self*/, PyObject *args)
     bool ok = Application::Instance->setUserEditMode(std::string(mode));
 
     return Py::new_reference_to(Py::Boolean(ok));
+}
+
+PyObject* ApplicationPy::sSuspendWaitCursor(PyObject * /*self*/, PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
+    WaitCursor::suspend();
+    Py_RETURN_NONE;
+}
+
+PyObject* ApplicationPy::sResumeWaitCursor(PyObject * /*self*/, PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
+    WaitCursor::resume();
+    Py_RETURN_NONE;
 }

--- a/src/Gui/ApplicationPy.h
+++ b/src/Gui/ApplicationPy.h
@@ -111,6 +111,9 @@ public:
     static PyObject* sGetUserEditMode          (PyObject *self,PyObject *args);
     static PyObject* sSetUserEditMode          (PyObject *self,PyObject *args);
 
+    static PyObject* sSuspendWaitCursor        (PyObject *self, PyObject *args);
+    static PyObject* sResumeWaitCursor         (PyObject *self, PyObject *args);
+
     static PyMethodDef    Methods[];
     // clang-format on
 };

--- a/src/Gui/WaitCursor.cpp
+++ b/src/Gui/WaitCursor.cpp
@@ -189,3 +189,16 @@ void WaitCursor::setIgnoreEvents(FilterEventsFlags flags)
 {
     WaitCursorP::getInstance()->setIgnoreEvents(flags);
 }
+
+void WaitCursor::suspend()
+{
+    // Calling setBusy(false) will restore the cursor and remove the event filter.
+    WaitCursorP::getInstance()->setBusy(false);
+}
+
+void WaitCursor::resume()
+{
+    // Calling setBusy(true) will set the wait cursor and reinstall the event filter.
+    // The WaitCursorP's internal state `isOn` correctly handles this call.
+    WaitCursorP::getInstance()->setBusy(true);
+}

--- a/src/Gui/WaitCursor.h
+++ b/src/Gui/WaitCursor.h
@@ -75,6 +75,19 @@ public:
     FilterEventsFlags ignoreEvents() const;
     void setIgnoreEvents(FilterEventsFlags flags = AllEvents);
 
+    /**
+     * @brief Suspends the wait cursor state by restoring the normal cursor
+     * and removing the event filter. To be used before showing an interactive
+     * dialog during a long operation.
+     */
+    static void suspend();
+
+    /**
+     * @brief Resumes the wait cursor state by setting the wait cursor
+     * and reinstalling the event filter, if a WaitCursor is active.
+     */
+    static void resume();
+
 private:
     FilterEventsFlags filter;
     static int instances;

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -20,6 +20,7 @@ SET(Draft_SRCS_base
 SET(Draft_import
     importAirfoilDAT.py
     importDXF.py
+    DxfImportDialog.py
     importDWG.py
     importOCA.py
     importSVG.py

--- a/src/Mod/Draft/DxfImportDialog.py
+++ b/src/Mod/Draft/DxfImportDialog.py
@@ -1,0 +1,116 @@
+import FreeCAD
+import FreeCADGui
+from PySide import QtCore, QtGui
+
+class DxfImportDialog:
+    """
+    A controller class that creates, manages, and shows the DXF import dialog.
+    """
+    def __init__(self, entity_counts, parent=None):
+        # Step 1: Load the UI from the resource file. This returns a new QDialog instance.
+        self.dialog = FreeCADGui.PySideUic.loadUi(":/ui/preferences-dxf-import.ui")
+
+        # Now, all widgets like "label_Summary" are attributes of self.dialog
+
+        self.entity_counts = entity_counts
+        self.total_entities = sum(entity_counts.values())
+
+        self.setup_ui()
+        self.connect_signals()
+        self.load_settings_and_set_initial_state()
+
+    def setup_ui(self):
+        """Perform initial UI setup."""
+        self.dialog.label_Summary.setText(f"File contains approximately {self.total_entities} geometric entities.")
+        self.dialog.label_Warning.hide()
+
+    def connect_signals(self):
+        """Connect signals from the dialog's widgets to our methods."""
+        buttonBox = self.dialog.findChild(QtGui.QDialogButtonBox, "buttonBox")
+        if buttonBox:
+            # Connect to our custom slots INSTEAD of the dialog's built-in ones
+            buttonBox.accepted.connect(self.on_accept)
+            buttonBox.rejected.connect(self.on_reject)
+            FreeCAD.Console.PrintLog("DxfImportDialog: OK and Cancel buttons connected.\n")
+        else:
+            FreeCAD.Console.PrintWarning("DxfImportDialog: Could not find buttonBox!\n")
+
+        self.dialog.radio_ImportAs_Draft.toggled.connect(self.update_warning_label)
+        self.dialog.radio_ImportAs_Primitives.toggled.connect(self.update_warning_label)
+        self.dialog.radio_ImportAs_Shapes.toggled.connect(self.update_warning_label)
+        self.dialog.radio_ImportAs_Fused.toggled.connect(self.update_warning_label)
+
+    def on_accept(self):
+        """Custom slot to debug the OK button click."""
+        FreeCAD.Console.PrintLog("DxfImportDialog: 'OK' button clicked. Calling self.dialog.accept().\n")
+        # Manually call the original slot
+        self.dialog.accept()
+        FreeCAD.Console.PrintLog("DxfImportDialog: self.dialog.accept() has been called.\n")
+
+    def on_reject(self):
+        """Custom slot to debug the Cancel button click."""
+        FreeCAD.Console.PrintLog("DxfImportDialog: 'Cancel' button clicked. Calling self.dialog.reject().\n")
+        # Manually call the original slot
+        self.dialog.reject()
+        FreeCAD.Console.PrintLog("DxfImportDialog: self.dialog.reject() has been called.\n")
+
+    def load_settings_and_set_initial_state(self):
+        """Load saved preferences and set the initial state of the dialog."""
+        hGrp = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+
+        mode = hGrp.GetInt("DxfImportMode", 2)
+
+        if mode == 0:
+            self.dialog.radio_ImportAs_Draft.setChecked(True)
+        elif mode == 1:
+            self.dialog.radio_ImportAs_Primitives.setChecked(True)
+        elif mode == 3:
+            self.dialog.radio_ImportAs_Fused.setChecked(True)
+        else:
+            self.dialog.radio_ImportAs_Shapes.setChecked(True)
+
+        is_legacy = hGrp.GetBool("dxfUseLegacyImporter", False)
+        if is_legacy:
+            self.dialog.radio_ImportAs_Primitives.setEnabled(False)
+            self.dialog.radio_ImportAs_Draft.setEnabled(True)
+            self.dialog.radio_ImportAs_Shapes.setEnabled(True)
+            self.dialog.radio_ImportAs_Fused.setEnabled(True)
+        else:
+            self.dialog.radio_ImportAs_Draft.setEnabled(False)
+            self.dialog.radio_ImportAs_Primitives.setEnabled(False)
+            self.dialog.radio_ImportAs_Shapes.setEnabled(True)
+            self.dialog.radio_ImportAs_Fused.setEnabled(True)
+
+        self.update_warning_label()
+
+    def update_warning_label(self):
+        """Updates the warning label based on selection and entity count."""
+        self.dialog.label_Warning.hide()
+        current_mode = self.get_selected_mode()
+
+        if self.total_entities > 5000 and (current_mode == 0 or current_mode == 1):
+            self.dialog.label_Warning.setText("Warning: Importing over 5000 entities as editable objects can be very slow.")
+            self.dialog.label_Warning.show()
+        elif self.total_entities > 20000 and current_mode == 2:
+            self.dialog.label_Warning.setText("Warning: Importing over 20,000 entities as individual shapes may be slow.")
+            self.dialog.label_Warning.show()
+
+    def exec_(self):
+        FreeCAD.Console.PrintLog("DxfImportDialog: Calling self.dialog.exec_()...\n")
+        result = self.dialog.exec_()
+        FreeCAD.Console.PrintLog("DxfImportDialog: self.dialog.exec_() returned with result: {}\n".format(result))
+        # QDialog.Accepted is usually 1, Rejected is 0.
+        FreeCAD.Console.PrintLog("(Note: QDialog.Accepted = {}, QDialog.Rejected = {})\n".format(QtGui.QDialog.Accepted, QtGui.QDialog.Rejected))
+        return result
+
+    def get_selected_mode(self):
+        """Return the integer value of the selected import mode."""
+        if self.dialog.radio_ImportAs_Draft.isChecked(): return 0
+        if self.dialog.radio_ImportAs_Primitives.isChecked(): return 1
+        if self.dialog.radio_ImportAs_Fused.isChecked(): return 3
+        if self.dialog.radio_ImportAs_Shapes.isChecked(): return 2
+        return 2
+
+    def get_show_dialog_again(self):
+        """Return True if the dialog should be shown next time."""
+        return not self.dialog.checkBox_ShowDialogAgain.isChecked()

--- a/src/Mod/Draft/DxfImportDialog.py
+++ b/src/Mod/Draft/DxfImportDialog.py
@@ -76,8 +76,8 @@ class DxfImportDialog:
             self.dialog.radio_ImportAs_Shapes.setEnabled(True)
             self.dialog.radio_ImportAs_Fused.setEnabled(True)
         else:
-            self.dialog.radio_ImportAs_Draft.setEnabled(False)
-            self.dialog.radio_ImportAs_Primitives.setEnabled(False)
+            self.dialog.radio_ImportAs_Draft.setEnabled(True)
+            self.dialog.radio_ImportAs_Primitives.setEnabled(True)
             self.dialog.radio_ImportAs_Shapes.setEnabled(True)
             self.dialog.radio_ImportAs_Fused.setEnabled(True)
 

--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -185,6 +185,7 @@
         <file>ui/preferences-draftvisual.ui</file>
         <file>ui/preferences-dwg.ui</file>
         <file>ui/preferences-dxf.ui</file>
+        <file>ui/preferences-dxf-import.ui</file>
         <file>ui/preferences-oca.ui</file>
         <file>ui/preferences-svg.ui</file>
         <file>ui/TaskPanel_CircularArray.ui</file>

--- a/src/Mod/Draft/Resources/ui/preferences-dxf-import.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf-import.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox_ImportAs">
      <property name="title">
-      <string>Import as</string>
+      <string>Import As</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_ImportAs">
       <item>
@@ -26,10 +26,10 @@
          <string>Creates fully parametric Draft objects. Block definitions are imported as
 reusable objects (Part Compounds) and instances become `App::Link` objects,
 maintaining the block structure. Best for full integration with the Draft
-Workbench. (Legacy importer only)</string>
+workbench.</string>
         </property>
         <property name="text">
-         <string>Editable draft objects</string>
+         <string>Editable Draft objects</string>
         </property>
        </widget>
       </item>
@@ -39,10 +39,10 @@ Workbench. (Legacy importer only)</string>
          <string>Creates parametric Part objects (e.g., Part::Line, Part::Circle). Block
 definitions are imported as reusable objects (Part Compounds) and instances
 become `App::Link` objects, maintaining the block structure. Best for
-script-based post-processing. (Not yet implemented)</string>
+script-based post-processing.</string>
         </property>
         <property name="text">
-         <string>Editable part primitives</string>
+         <string>Editable Part primitives</string>
         </property>
        </widget>
       </item>
@@ -54,7 +54,7 @@ imported as reusable objects (Part Compounds) and instances become `App::Link`
 objects, maintaining the block structure. Good for referencing and measuring.</string>
         </property>
         <property name="text">
-         <string>Individual part shapes (recommended)</string>
+         <string>Individual Part shapes (recommended)</string>
         </property>
        </widget>
       </item>
@@ -66,7 +66,7 @@ structures are not preserved; their geometry becomes part of the layer's
 shape. Best for viewing very large files with maximum performance.</string>
         </property>
         <property name="text">
-         <string>Fused part shapes (fastest)</string>
+         <string>Fused Part shapes (fastest)</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Draft/Resources/ui/preferences-dxf-import.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf-import.ui
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DxfImportDialog</class>
+ <widget class="QDialog" name="DxfImportDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>480</width>
+    <height>280</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>DXF Import</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox_ImportAs">
+     <property name="title">
+      <string>Import as</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_ImportAs">
+      <item>
+       <widget class="QRadioButton" name="radio_ImportAs_Draft">
+        <property name="toolTip">
+         <string>Creates fully parametric Draft objects. Block definitions are imported as
+reusable objects (Part Compounds) and instances become `App::Link` objects,
+maintaining the block structure. Best for full integration with the Draft
+Workbench. (Legacy importer only)</string>
+        </property>
+        <property name="text">
+         <string>Editable draft objects</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radio_ImportAs_Primitives">
+        <property name="toolTip">
+         <string>Creates parametric Part objects (e.g., Part::Line, Part::Circle). Block
+definitions are imported as reusable objects (Part Compounds) and instances
+become `App::Link` objects, maintaining the block structure. Best for
+script-based post-processing. (Not yet implemented)</string>
+        </property>
+        <property name="text">
+         <string>Editable part primitives</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radio_ImportAs_Shapes">
+        <property name="toolTip">
+         <string>Creates a non-parametric shape for each DXF entity. Block definitions are
+imported as reusable objects (Part Compounds) and instances become `App::Link`
+objects, maintaining the block structure. Good for referencing and measuring.</string>
+        </property>
+        <property name="text">
+         <string>Individual part shapes (recommended)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radio_ImportAs_Fused">
+        <property name="toolTip">
+         <string>Merges all geometry per layer into a single, non-editable shape. Block
+structures are not preserved; their geometry becomes part of the layer's
+shape. Best for viewing very large files with maximum performance.</string>
+        </property>
+        <property name="text">
+         <string>Fused part shapes (fastest)</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame_Summary">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_Summary">
+      <property name="leftMargin">
+       <number>5</number>
+      </property>
+      <property name="topMargin">
+       <number>5</number>
+      </property>
+      <property name="rightMargin">
+       <number>5</number>
+      </property>
+      <property name="bottomMargin">
+       <number>5</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label_Summary">
+        <property name="text">
+         <string>File summary</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_Warning">
+        <property name="styleSheet">
+         <string notr="true">color: #c00;</string>
+        </property>
+        <property name="text">
+         <string>Warning</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_ShowDialogAgain">
+     <property name="text">
+      <string>Do not show this dialog again</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -105,7 +105,7 @@ the 'dxf_library' addon from the Addon Manager.</string>
    <item>
     <widget class="QGroupBox" name="groupBox_ImportAs">
      <property name="title">
-      <string>Import as</string>
+      <string>Import As</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_ImportAs">
       <item>
@@ -117,10 +117,10 @@ the 'dxf_library' addon from the Addon Manager.</string>
          <string>Creates fully parametric Draft objects. Block definitions are imported as
 reusable objects (Part Compounds) and instances become `App::Link` objects,
 maintaining the block structure. Best for full integration with the Draft
-Workbench. </string>
+workbench. </string>
         </property>
         <property name="text">
-         <string>Editable draft objects (Highest fidelity, slowest)</string>
+         <string>Editable Draft objects (highest fidelity, slowest)</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>dxfImportAsDraft</cstring>
@@ -145,10 +145,10 @@ Workbench. </string>
          <string>Creates parametric Part objects (e.g., Part::Line, Part::Circle). Block
 definitions are imported as reusable objects (Part Compounds) and instances
 become `App::Link` objects, maintaining the block structure. Best for
-script-based post-processing and Part Workbench integration.</string>
+script-based post-processing and Part workbench integration.</string>
         </property>
         <property name="text">
-         <string>Editable part primitives (High fidelity, slower)</string>
+         <string>Editable Part primitives (high fidelity, slower)</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>dxfImportAsPrimitives</cstring>
@@ -172,7 +172,7 @@ imported as reusable objects (Part Compounds) and instances become `App::Link`
 objects, maintaining the block structure. Good for referencing and measuring.</string>
         </property>
         <property name="text">
-         <string>Individual part shapes (Balanced, recommended)</string>
+         <string>Individual Part shapes (balanced, recommended)</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -199,7 +199,7 @@ structures are not preserved; their geometry becomes part of the layer's
 shape. Best for importing and viewing very large files with maximum performance.</string>
         </property>
         <property name="text">
-         <string>Fused part shapes (Lowest fidelity, fastest)</string>
+         <string>Fused Part shapes (lowest fidelity, fastest)</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>dxfImportAsFused</cstring>
@@ -221,7 +221,7 @@ shape. Best for importing and viewing very large files with maximum performance.
    <item>
     <widget class="QGroupBox" name="groupBox_ImportSettings">
      <property name="title">
-      <string>Import settings</string>
+      <string>Import Settings</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_ImportSettings">
       <item>
@@ -229,7 +229,7 @@ shape. Best for importing and viewing very large files with maximum performance.
         <item>
          <widget class="QLabel" name="label_dxfScaling">
           <property name="text">
-           <string>Global scaling factor:</string>
+           <string>Global scaling factor</string>
           </property>
          </widget>
         </item>
@@ -250,7 +250,7 @@ shape. Best for importing and viewing very large files with maximum performance.
          <widget class="Gui::PrefDoubleSpinBox" name="spinBox_dxfScaling">
           <property name="toolTip">
            <string>Scale factor to apply to DXF files on import. The factor is the conversion
-between the unit of your DXF file and millimeters. Example: for files in
+between the DXF file's unit and millimeters. Example: for files in
 millimeters: 1, in centimeters: 10, in meters: 1000, in inches: 25.4,
 in feet: 304.8</string>
           </property>
@@ -276,7 +276,7 @@ in feet: 304.8</string>
       <item>
        <widget class="QLabel" name="label_ImportContent">
         <property name="text">
-         <string>Import:</string>
+         <string>Import</string>
         </property>
        </widget>
       </item>
@@ -285,7 +285,7 @@ in feet: 304.8</string>
         <item row="0" column="0">
          <widget class="Gui::PrefCheckBox" name="checkBox_dxftext">
           <property name="toolTip">
-           <string>If checked, text, mtext, and dimension entities will be imported as Draft objects.</string>
+           <string>If checked, text, mtext, and dimension entities will be imported as Draft objects</string>
           </property>
           <property name="text">
            <string>Texts and dimensions</string>
@@ -301,7 +301,7 @@ in feet: 304.8</string>
         <item row="0" column="1">
          <widget class="Gui::PrefCheckBox" name="checkBox_dxfImportPoints">
           <property name="toolTip">
-           <string>If checked, point entities will be imported.</string>
+           <string>If checked, point entities will be imported</string>
           </property>
           <property name="text">
            <string>Points</string>
@@ -321,7 +321,7 @@ in feet: 304.8</string>
          <widget class="Gui::PrefCheckBox" name="checkBox_dxflayout">
           <property name="toolTip">
            <string>If checked, entities from the paper space will also be imported. By default,
-only model space is imported.</string>
+only model space is imported</string>
           </property>
           <property name="text">
            <string>Paper space objects</string>
@@ -338,7 +338,7 @@ only model space is imported.</string>
          <widget class="Gui::PrefCheckBox" name="checkBox_dxfstarblocks">
           <property name="toolTip">
            <string>If checked, anonymous blocks (whose names begin with *) will also be imported.
-These are often used for hatches and dimensions.</string>
+These are often used for hatches and dimensions</string>
           </property>
           <property name="text">
            <string>Anonymous blocks (*-blocks)</string>
@@ -376,7 +376,7 @@ These are often used for hatches and dimensions.</string>
       <item>
        <widget class="QLabel" name="label_Appearance">
         <property name="text">
-         <string>Appearance:</string>
+         <string>Appearance</string>
         </property>
        </widget>
       </item>
@@ -386,7 +386,7 @@ These are often used for hatches and dimensions.</string>
          <widget class="Gui::PrefCheckBox" name="checkBox_dxfGetOriginalColors">
           <property name="toolTip">
            <string>If checked, colors will be set as specified in the DXF file whenever
-possible. Otherwise, default FreeCAD colors are applied.</string>
+possible. Otherwise, default FreeCAD colors are applied</string>
           </property>
           <property name="text">
            <string>Use colors from the DXF file</string>
@@ -408,7 +408,7 @@ possible. Otherwise, default FreeCAD colors are applied.</string>
            <bool>false</bool>
           </property>
           <property name="toolTip">
-           <string>If checked, imported texts will get the standard Draft Text size, instead of
+           <string>If checked, imported texts will get the standard Draft text size, instead of
 the size defined in the DXF document. (Legacy importer only)</string>
           </property>
           <property name="text">
@@ -427,7 +427,7 @@ the size defined in the DXF document. (Legacy importer only)</string>
       <item>
        <widget class="QLabel" name="label_AdvancedProcessing">
         <property name="text">
-         <string>Advanced processing:</string>
+         <string>Advanced processing</string>
         </property>
        </widget>
       </item>
@@ -480,10 +480,10 @@ representing that width. (Legacy importer only)</string>
           </property>
           <property name="toolTip">
            <string>If checked, the legacy importer will attempt to create Sketcher objects
-instead of Draft or Part objects. This overrides the 'Import as' setting.</string>
+instead of Draft or Part objects. This overrides the 'Import As' setting</string>
           </property>
           <property name="text">
-           <string>Create sketches (legacy importer only)</string>
+           <string>Create sketches</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>dxfCreateSketch</cstring>

--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -6,27 +6,28 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>649</width>
-    <height>800</height>
+    <width>600</width>
+    <height>880</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>DXF</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QVBoxLayout" name="verticalLayout_Main">
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_General">
      <property name="title">
-      <string>General options</string>
+      <string>General</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_General">
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBox_dxfShowDialog">
         <property name="toolTip">
-         <string>This preferences dialog will be shown when importing/ exporting DXF files</string>
+         <string>If checked, this preferences dialog will be shown each time you import or export
+a DXF file.</string>
         </property>
         <property name="text">
-         <string>Show this dialog when importing and exporting</string>
+         <string>Show the importer dialog when importing a file</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -42,14 +43,10 @@
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBox_dxfUseLegacyImporter">
         <property name="toolTip">
-         <string>Python importer is used, otherwise the newer C++ is used.
-Note: C++ importer is faster, but is not as featureful yet</string>
+         <string>Use the legacy Python importer. This importer is more feature-complete but slower and requires an external library.</string>
         </property>
         <property name="text">
-         <string>Use legacy Python importer</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
+         <string>Use legacy importer</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>dxfUseLegacyImporter</cstring>
@@ -62,11 +59,10 @@ Note: C++ importer is faster, but is not as featureful yet</string>
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBox_dxfUseLegacyExporter">
         <property name="toolTip">
-         <string>Python exporter is used, otherwise the newer C++ is used.
-Note: C++ exporter is faster, but is not as featureful yet</string>
+         <string>Use the legacy Python exporter. This exporter is more feature-complete but slower and requires an external library.</string>
         </property>
         <property name="text">
-         <string>Use legacy Python exporter</string>
+         <string>Use legacy exporter</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>dxfUseLegacyExporter</cstring>
@@ -80,227 +76,160 @@ Note: C++ exporter is faster, but is not as featureful yet</string>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_1">
+    <widget class="QGroupBox" name="groupBox_AutoUpdate">
      <property name="title">
       <string>Automatic update (legacy importer/exporter only)</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_1">
+     <layout class="QVBoxLayout" name="verticalLayout_AutoUpdate">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_1">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_dxfAllowDownload">
-          <property name="toolTip">
-           <string>Allow FreeCAD to download the Python converter for DXF import and export.
-You can also do this manually by installing the &quot;dxf_library&quot; workbench
-from the Addon Manager.</string>
-          </property>
-          <property name="text">
-           <string>Allow FreeCAD to automatically download and update the DXF libraries</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>dxfAllowDownload</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="Gui::PrefCheckBox" name="checkBox_dxfAllowDownload">
+        <property name="toolTip">
+         <string>If checked, FreeCAD is allowed to download and update the Python libraries
+required by the legacy importer. This can also be done manually by installing
+the 'dxf_library' addon from the Addon Manager.</string>
+        </property>
+        <property name="text">
+         <string>Allow FreeCAD to automatically download and update the DXF libraries</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>dxfAllowDownload</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="GroupBox_2">
+    <widget class="QGroupBox" name="groupBox_ImportAs">
      <property name="title">
-      <string>Import options</string>
+      <string>Import as</string>
      </property>
-     <layout class="QVBoxLayout">
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <property name="topMargin">
-       <number>9</number>
-      </property>
-      <property name="rightMargin">
-       <number>9</number>
-      </property>
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
+     <layout class="QVBoxLayout" name="verticalLayout_ImportAs">
       <item>
-       <widget class="QLabel" name="label_ImporterMissing">
-        <property name="font">
-         <font>
-          <italic>true</italic>
-         </font>
+       <widget class="Gui::PrefRadioButton" name="radio_ImportAs_Draft">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Creates fully parametric Draft objects. Block definitions are imported as
+reusable objects (Part Compounds) and instances become `App::Link` objects,
+maintaining the block structure. Best for full integration with the Draft
+Workbench. (Legacy importer only)</string>
         </property>
         <property name="text">
-         <string>Some options are not yet available for the new importer</string>
+         <string>Editable draft objects (Highest fidelity, slowest)</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DxfImportMode</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+        <property name="prefRadioButtonGroup" stdset="0">
+         <string>DxfImportMode</string>
+        </property>
+        <property name="prefRadioButtonValue" stdset="0">
+         <number>0</number>
         </property>
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="label_Import">
-          <property name="text">
-           <string>Import</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_dxftext">
-          <property name="toolTip">
-           <string>If unchecked, texts and mtexts won't be imported</string>
-          </property>
-          <property name="text">
-           <string>Texts and dimensions</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>dxftext</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_dxfImportPoints">
-          <property name="toolTip">
-           <string>If unchecked, points won't be imported</string>
-          </property>
-          <property name="text">
-           <string>points</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>dxfImportPoints</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_dxflayout">
-          <property name="toolTip">
-           <string>If checked, paper space objects will be imported too</string>
-          </property>
-          <property name="text">
-           <string>Layouts</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>dxflayout</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_dxfstarblocks">
-          <property name="toolTip">
-           <string>If you want the non-named blocks (beginning with a *) to be imported too</string>
-          </property>
-          <property name="text">
-           <string>*blocks</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>dxfstarblocks</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="Gui::PrefRadioButton" name="radio_ImportAs_Primitives">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Creates parametric Part objects (e.g., Part::Line, Part::Circle). Block
+definitions are imported as reusable objects (Part Compounds) and instances
+become `App::Link` objects, maintaining the block structure. Best for
+script-based post-processing. (Not yet implemented)</string>
+        </property>
+        <property name="text">
+         <string>Editable part primitives (High fidelity, slower)</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DxfImportMode</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+        <property name="prefRadioButtonGroup" stdset="0">
+         <string>DxfImportMode</string>
+        </property>
+        <property name="prefRadioButtonValue" stdset="0">
+         <number>1</number>
+        </property>
+       </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QLabel" name="label_Create">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Create</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefRadioButton" name="radioButton_dxfCreatePart">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="toolTip">
-           <string>Only standard Part objects will be created (fastest)</string>
-          </property>
-          <property name="text">
-           <string>Simple Part shapes</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>dxfCreatePart</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefRadioButton" name="radioButton_dxfCreateDraft">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="toolTip">
-           <string>Parametric Draft objects will be created whenever possible</string>
-          </property>
-          <property name="text">
-           <string>Draft objects</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>dxfCreateDraft</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefRadioButton" name="radioButton_dxfCreateSketch">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="toolTip">
-           <string>Sketches will be created whenever possible</string>
-          </property>
-          <property name="text">
-           <string>Sketches</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>dxfCreateSketch</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="Gui::PrefRadioButton" name="radio_ImportAs_Shapes">
+        <property name="toolTip">
+         <string>Creates a non-parametric shape for each DXF entity. Block definitions are
+imported as reusable objects (Part Compounds) and instances become `App::Link`
+objects, maintaining the block structure. Good for referencing and measuring.</string>
+        </property>
+        <property name="text">
+         <string>Individual part shapes (Balanced, recommended)</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DxfImportMode</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+        <property name="prefRadioButtonGroup" stdset="0">
+         <string>DxfImportMode</string>
+        </property>
+        <property name="prefRadioButtonValue" stdset="0">
+         <number>2</number>
+        </property>
+       </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <widget class="Gui::PrefRadioButton" name="radio_ImportAs_Fused">
+        <property name="toolTip">
+         <string>Merges all geometry per layer into a single, non-editable shape. Block
+structures are not preserved; their geometry becomes part of the layer's
+shape. Best for viewing very large files with maximum performance.</string>
+        </property>
+        <property name="text">
+         <string>Fused part shapes (Lowest fidelity, fastest)</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DxfImportMode</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+        <property name="prefRadioButtonGroup" stdset="0">
+         <string>DxfImportMode</string>
+        </property>
+        <property name="prefRadioButtonValue" stdset="0">
+         <number>3</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_ImportSettings">
+     <property name="title">
+      <string>Import settings</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_ImportSettings">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_Scaling">
         <item>
          <widget class="QLabel" name="label_dxfScaling">
-          <property name="toolTip">
-           <string/>
-          </property>
           <property name="text">
-           <string>Scale factor to apply to imported files</string>
+           <string>Global scaling factor:</string>
           </property>
          </widget>
         </item>
@@ -320,13 +249,13 @@ from the Addon Manager.</string>
         <item>
          <widget class="Gui::PrefDoubleSpinBox" name="spinBox_dxfScaling">
           <property name="toolTip">
-           <string>Scale factor to apply to DXF files on import.
-The factor is the conversion between the unit of your DXF file and millimeters.
-Example: for files in millimeters: 1, in centimeters: 10,
-                             in meters: 1000, in inches: 25.4, in feet: 304.8</string>
+           <string>Scale factor to apply to DXF files on import. The factor is the conversion
+between the unit of your DXF file and millimeters. Example: for files in
+millimeters: 1, in centimeters: 10, in meters: 1000, in inches: 25.4,
+in feet: 304.8</string>
           </property>
           <property name="decimals">
-           <number>12</number>
+           <number>6</number>
           </property>
           <property name="maximum">
            <double>999999.999998999992386</double>
@@ -345,15 +274,125 @@ Example: for files in millimeters: 1, in centimeters: 10,
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
+       <widget class="QLabel" name="label_ImportContent">
+        <property name="text">
+         <string>Import:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QGridLayout" name="gridLayout_Import">
+        <item row="0" column="0">
+         <widget class="Gui::PrefCheckBox" name="checkBox_dxftext">
+          <property name="toolTip">
+           <string>If checked, text, mtext, and dimension entities will be imported as Draft objects.</string>
+          </property>
+          <property name="text">
+           <string>Texts and dimensions</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>dxftext</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="Gui::PrefCheckBox" name="checkBox_dxfImportPoints">
+          <property name="toolTip">
+           <string>If checked, point entities will be imported.</string>
+          </property>
+          <property name="text">
+           <string>Points</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>dxfImportPoints</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="Gui::PrefCheckBox" name="checkBox_dxflayout">
+          <property name="toolTip">
+           <string>If checked, entities from the paper space will also be imported. By default,
+only model space is imported.</string>
+          </property>
+          <property name="text">
+           <string>Paper space objects</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>dxflayout</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="Gui::PrefCheckBox" name="checkBox_dxfstarblocks">
+          <property name="toolTip">
+           <string>If checked, anonymous blocks (whose names begin with *) will also be imported.
+These are often used for hatches and dimensions.</string>
+          </property>
+          <property name="text">
+           <string>Anonymous blocks (*-blocks)</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>dxfstarblocks</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="Gui::PrefCheckBox" name="checkBox_importDxfHatches">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>If checked, the boundaries of hatch objects will be imported as closed wires.
+(Legacy importer only)</string>
+          </property>
+          <property name="text">
+           <string>Hatch boundaries</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>importDxfHatches</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_Appearance">
+        <property name="text">
+         <string>Appearance:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QGridLayout" name="gridLayout_Appearance">
+        <item row="0" column="0">
          <widget class="Gui::PrefCheckBox" name="checkBox_dxfGetOriginalColors">
           <property name="toolTip">
-           <string>Colors will set as specified in the DXF file whenever possible.
-Otherwise default colors will be applied.</string>
+           <string>If checked, colors will be set as specified in the DXF file whenever
+possible. Otherwise, default FreeCAD colors are applied.</string>
           </property>
           <property name="text">
            <string>Use colors from the DXF file</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>dxfGetOriginalColors</cstring>
@@ -363,63 +402,14 @@ Otherwise default colors will be applied.</string>
           </property>
          </widget>
         </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_joingeometry">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="toolTip">
-           <string>FreeCAD will try to join coincident objects into wires.
-Note that this can take a while!</string>
-          </property>
-          <property name="text">
-           <string>Join geometry</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>joingeometry</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_groupLayers">
-          <property name="toolTip">
-           <string>Objects from the same layers will be joined into Part Compounds,
-turning the display faster, but making them less easily editable.</string>
-          </property>
-          <property name="text">
-           <string>Merge layer contents into blocks</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>groupLayers</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
+        <item row="0" column="1">
          <widget class="Gui::PrefCheckBox" name="checkBox_dxfStdSize">
           <property name="enabled">
            <bool>false</bool>
           </property>
           <property name="toolTip">
-           <string>Imported texts will get the standard Draft Text size,
-instead of the size they have in the DXF document</string>
+           <string>If checked, imported texts will get the standard Draft Text size, instead of
+the size defined in the DXF document. (Legacy importer only)</string>
           </property>
           <property name="text">
            <string>Use standard font size for texts</string>
@@ -435,61 +425,42 @@ instead of the size they have in the DXF document</string>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_dxfUseDraftVisGroups">
-          <property name="toolTip">
-           <string>If this is checked, DXF layers will be imported as Draft Layers</string>
-          </property>
-          <property name="text">
-           <string>Use layers</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>dxfUseDraftVisGroups</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="QLabel" name="label_AdvancedProcessing">
+        <property name="text">
+         <string>Advanced processing:</string>
+        </property>
+       </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_10">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_importDxfHatches">
+       <layout class="QGridLayout" name="gridLayout_Advanced">
+        <item row="0" column="0">
+         <widget class="Gui::PrefCheckBox" name="checkBox_joingeometry">
           <property name="enabled">
            <bool>false</bool>
           </property>
           <property name="toolTip">
-           <string>Hatches will be converted into simple wires</string>
+           <string>If checked, the legacy importer will attempt to join coincident geometric
+objects into wires. This can be slow for large files. (Legacy importer only)</string>
           </property>
           <property name="text">
-           <string>Import hatch boundaries as wires</string>
+           <string>Join geometry</string>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>importDxfHatches</cstring>
+           <cstring>joingeometry</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/Draft</cstring>
           </property>
          </widget>
         </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_11">
-        <item>
+        <item row="0" column="1">
          <widget class="Gui::PrefCheckBox" name="checkBox_renderPolylineWidth">
           <property name="enabled">
            <bool>false</bool>
           </property>
           <property name="toolTip">
-           <string>If polylines have a width defined, they will be rendered
-as closed wires with correct width</string>
+           <string>If checked, polylines that have a width property will be rendered as faces
+representing that width. (Legacy importer only)</string>
           </property>
           <property name="text">
            <string>Render polylines with width</string>
@@ -502,31 +473,39 @@ as closed wires with correct width</string>
           </property>
          </widget>
         </item>
+        <item row="1" column="0">
+         <widget class="Gui::PrefCheckBox" name="checkBox_dxfCreateSketch">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>If checked, the legacy importer will attempt to create Sketcher objects
+instead of Draft or Part objects. This overrides the 'Import as' setting.</string>
+          </property>
+          <property name="text">
+           <string>Create sketches (legacy importer only)</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>dxfCreateSketch</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_3">
+    <widget class="QGroupBox" name="groupBox_ExportOptions">
      <property name="title">
       <string>Export options</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
+     <layout class="QVBoxLayout" name="verticalLayout_Export">
       <item>
-       <widget class="QLabel" name="label_ExporterMissing">
-        <property name="font">
-         <font>
-          <italic>true</italic>
-         </font>
-        </property>
-        <property name="text">
-         <string>Some options are not yet available for the new exporter</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_12">
+       <layout class="QHBoxLayout" name="horizontalLayout_Discretize">
         <item>
          <widget class="Gui::PrefCheckBox" name="checkBox_DiscretizeEllipses">
           <property name="toolTip">
@@ -598,7 +577,7 @@ If it is set to '0' the whole spline is treated as a straight segment.</string>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_13">
+       <layout class="QHBoxLayout" name="horizontalLayout_Export3D">
         <item>
          <widget class="Gui::PrefCheckBox" name="checkBox_dxfmesh">
           <property name="enabled">
@@ -621,7 +600,7 @@ If it is set to '0' the whole spline is treated as a straight segment.</string>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_14">
+       <layout class="QHBoxLayout" name="horizontalLayout_ExportTechDraw">
         <item>
          <widget class="Gui::PrefCheckBox" name="checkBox_dxfExportBlocks">
           <property name="toolTip">
@@ -645,7 +624,7 @@ This might fail for post DXF R12 templates.</string>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_15">
+       <layout class="QHBoxLayout" name="horizontalLayout_Project">
         <item>
          <widget class="Gui::PrefCheckBox" name="checkBox_dxfproject">
           <property name="enabled">
@@ -671,21 +650,20 @@ This might fail for post DXF R12 templates.</string>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer_1">
+    <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>0</height>
       </size>
      </property>
     </spacer>
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
    <class>Gui::PrefCheckBox</class>
@@ -693,13 +671,13 @@ This might fail for post DXF R12 templates.</string>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
+   <class>Gui::PrefRadioButton</class>
+   <extends>QRadioButton</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefRadioButton</class>
-   <extends>QRadioButton</extends>
+   <class>Gui::PrefDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>
@@ -708,71 +686,23 @@ This might fail for post DXF R12 templates.</string>
   <connection>
    <sender>checkBox_dxfUseLegacyImporter</sender>
    <signal>toggled(bool)</signal>
-   <receiver>label_Create</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>checkBox_dxfUseLegacyImporter</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>radioButton_dxfCreatePart</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>checkBox_dxfUseLegacyImporter</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>radioButton_dxfCreateDraft</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>checkBox_dxfUseLegacyImporter</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>radioButton_dxfCreateSketch</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>checkBox_dxfUseLegacyImporter</sender>
-   <signal>toggled(bool)</signal>
    <receiver>checkBox_joingeometry</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkBox_dxfUseLegacyImporter</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>checkBox_renderPolylineWidth</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -820,7 +750,55 @@ This might fail for post DXF R12 templates.</string>
   <connection>
    <sender>checkBox_dxfUseLegacyImporter</sender>
    <signal>toggled(bool)</signal>
-   <receiver>checkBox_renderPolylineWidth</receiver>
+   <receiver>checkBox_dxfCreateSketch</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkBox_dxfCreateSketch</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>groupBox_ImportAs</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkBox_dxfUseLegacyExporter</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>checkBox_dxfmesh</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkBox_dxfUseLegacyExporter</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>checkBox_dxfproject</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -111,19 +111,19 @@ the 'dxf_library' addon from the Addon Manager.</string>
       <item>
        <widget class="Gui::PrefRadioButton" name="radio_ImportAs_Draft">
         <property name="enabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="toolTip">
          <string>Creates fully parametric Draft objects. Block definitions are imported as
 reusable objects (Part Compounds) and instances become `App::Link` objects,
 maintaining the block structure. Best for full integration with the Draft
-Workbench. (Legacy importer only)</string>
+Workbench. </string>
         </property>
         <property name="text">
          <string>Editable draft objects (Highest fidelity, slowest)</string>
         </property>
         <property name="prefEntry" stdset="0">
-         <cstring>DxfImportMode</cstring>
+         <cstring>dxfImportAsDraft</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Draft</cstring>
@@ -139,19 +139,19 @@ Workbench. (Legacy importer only)</string>
       <item>
        <widget class="Gui::PrefRadioButton" name="radio_ImportAs_Primitives">
         <property name="enabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="toolTip">
          <string>Creates parametric Part objects (e.g., Part::Line, Part::Circle). Block
 definitions are imported as reusable objects (Part Compounds) and instances
 become `App::Link` objects, maintaining the block structure. Best for
-script-based post-processing. (Not yet implemented)</string>
+script-based post-processing and Part Workbench integration.</string>
         </property>
         <property name="text">
          <string>Editable part primitives (High fidelity, slower)</string>
         </property>
         <property name="prefEntry" stdset="0">
-         <cstring>DxfImportMode</cstring>
+         <cstring>dxfImportAsPrimitives</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Draft</cstring>
@@ -178,7 +178,7 @@ objects, maintaining the block structure. Good for referencing and measuring.</s
          <bool>true</bool>
         </property>
         <property name="prefEntry" stdset="0">
-         <cstring>DxfImportMode</cstring>
+         <cstring>dxfImportAsShapes</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Draft</cstring>
@@ -196,13 +196,13 @@ objects, maintaining the block structure. Good for referencing and measuring.</s
         <property name="toolTip">
          <string>Merges all geometry per layer into a single, non-editable shape. Block
 structures are not preserved; their geometry becomes part of the layer's
-shape. Best for viewing very large files with maximum performance.</string>
+shape. Best for importing and viewing very large files with maximum performance.</string>
         </property>
         <property name="text">
          <string>Fused part shapes (Lowest fidelity, fastest)</string>
         </property>
         <property name="prefEntry" stdset="0">
-         <cstring>DxfImportMode</cstring>
+         <cstring>dxfImportAsFused</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Draft</cstring>

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -4612,8 +4612,6 @@ class DxfDraftPostProcessor:
             if not shape.isValid():
                 return None, None
 
-            FCC.PrintMessage(f"DEBUG: {part_obj.Label} ({part_obj.Name}) is Part::Feature (ShapeType: {shape.ShapeType})\n")
-
             # Determine specific Draft object type based on the ShapeType of the TopoDS_Shape.
             if shape.ShapeType == "Wire": # If the TopoDS_Shape is a Wire (from DXF POLYLINE).
                 # Create a Part::Part2DObjectPython as the Python-extensible base for Draft Wire.

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -4431,15 +4431,6 @@ class DxfImportReporter:
         FCC.PrintMessage(output_string)
 
 
-def post_process_to_draft(doc, new_objects):
-    """
-    Entry point for the DXF post-processing workflow.
-    Instantiates and runs the DxfDraftPostProcessor.
-    """
-    processor = DxfDraftPostProcessor(doc, new_objects)
-    processor.run()
-
-
 class DxfDraftPostProcessor:
     """
     Handles the post-processing of DXF files imported as Part objects,
@@ -4852,8 +4843,11 @@ class DxfDraftPostProcessor:
             if group and not group.Group:
                 try:
                     self.doc.removeObject(group.Name)
-                except Exception:
-                    pass
+                except Exception as e:
+                    FCC.PrintWarning(
+                        "DXF Post-Processor: Could not remove temporary group "
+                        f"'{group.Name}': {e}\n"
+                    )
 
     def _get_canonical_angles(self, start_angle_deg, end_angle_deg, radius_mm):
         """

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -4518,6 +4518,13 @@ class DxfDraftPostProcessor:
             # property.
             new_obj.Shape = part_obj.Shape
             Draft.Wire(new_obj) # Attach the Python proxy. It will find Shape, Placement.
+
+            # Manually transfer the parametric data from the Part::Line primitive
+            # to the new Draft.Wire's 'Points' property.
+            start_point = FreeCAD.Vector(part_obj.X1.Value, part_obj.Y1.Value, part_obj.Z1.Value)
+            end_point = FreeCAD.Vector(part_obj.X2.Value, part_obj.Y2.Value, part_obj.Z2.Value)
+            new_obj.Points = [start_point, end_point]
+
             obj_type_str = "Line"
 
         elif part_obj.isDerivedFrom("Part::Circle"):

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -53,6 +53,7 @@
 #include <gp_Vec.hxx>
 #endif
 
+#include <fstream>
 #include <App/Annotation.h>
 #include <App/Application.h>
 #include <App/Document.h>
@@ -80,6 +81,35 @@ using namespace Import;
 using BRepAdaptor_HCurve = BRepAdaptor_Curve;
 #endif
 
+std::map<std::string, int> ImpExpDxfRead::PreScan(const std::string& filepath)
+{
+    std::map<std::string, int> counts;
+    std::ifstream ifs(filepath);
+    if (!ifs) {
+        // Could throw an exception or log an error
+        return counts;
+    }
+
+    std::string line;
+    bool next_is_entity_name = false;
+
+    while (std::getline(ifs, line)) {
+        // Simple trim for Windows-style carriage returns
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+
+        if (next_is_entity_name) {
+            // The line after a "  0" group code is the entity type
+            counts[line]++;
+            next_is_entity_name = false;
+        }
+        else if (line == "  0") {
+            next_is_entity_name = true;
+        }
+    }
+    return counts;
+}
 
 //******************************************************************************
 // reading

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -957,7 +957,7 @@ void ImpExpDxfRead::OnReadLine(const Base::Vector3d& start,
         case ImportMode::FusedShapes:
             // For these modes, we want a generic Part::Feature wrapping the TopoDS_Shape.
             // PrimitiveType::None will lead to a generic Part::Feature in AddGeometry.
-            builder.type = GeometryBuilder::PrimitiveType::Line;
+            builder.type = GeometryBuilder::PrimitiveType::None;
             break;
     }
 

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -1279,7 +1279,8 @@ void ImpExpDxfRead::OnReadInsert(const Base::Vector3d& point,
 void ImpExpDxfRead::OnReadDimension(const Base::Vector3d& start,
                                     const Base::Vector3d& end,
                                     const Base::Vector3d& point,
-                                    double /*rotation*/)
+                                    int dimensionType,
+                                    double rotation)
 {
     if (shouldSkipEntity() || !m_importAnnotations) {
         return;
@@ -1303,6 +1304,20 @@ void ImpExpDxfRead::OnReadDimension(const Base::Vector3d& start,
 
         p->addDynamicProperty("App::PropertyVector", "Dimline", "Data", "Point on dimension line");
         static_cast<App::PropertyVector*>(p->getPropertyByName("Dimline"))->setValue(point);
+
+        p->addDynamicProperty("App::PropertyInteger",
+                              "DxfDimensionType",
+                              "Internal",
+                              "Original dimension type flag");
+        static_cast<App::PropertyInteger*>(p->getPropertyByName("DxfDimensionType"))
+            ->setValue(dimensionType);
+
+        p->addDynamicProperty("App::PropertyAngle",
+                              "DxfRotation",
+                              "Internal",
+                              "Original dimension rotation");
+        // rotation is already in radians from the caller
+        static_cast<App::PropertyAngle*>(p->getPropertyByName("DxfRotation"))->setValue(rotation);
 
         p->addDynamicProperty("App::PropertyPlacement", "Placement", "Base", "Object placement");
         Base::Placement pl;

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -100,6 +100,7 @@ public:
     void OnReadDimension(const Base::Vector3d& start,
                          const Base::Vector3d& end,
                          const Base::Vector3d& point,
+                         int dimensionType,
                          double rotation) override;
     void OnReadPolyline(std::list<VertexInfo>& /*vertices*/, int flags) override;
 

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -40,6 +40,15 @@ class BRepAdaptor_Curve;
 
 namespace Import
 {
+
+enum class ImportMode
+{
+    EditableDraft,
+    EditablePrimitives,
+    IndividualShapes,
+    FusedShapes
+};
+
 class ImportExport ImpExpDxfRead: public CDxfRead
 {
 public:
@@ -108,6 +117,7 @@ public:
     void FinishImport() override;
 
 private:
+    ImportMode m_importMode = ImportMode::IndividualShapes;
     bool shouldSkipEntity() const
     {
         // This entity is in paper space, and the user setting says to ignore it.
@@ -370,7 +380,6 @@ protected:
 
     private:
         const EntityCollector* previousEntityCollector;
-        const eEntityMergeType_t previousMmergeOption;
     };
 #endif
     class BlockDefinitionCollector: public EntityCollector

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -162,6 +162,8 @@ private:
     void ComposeBlocks();
     void ComposeParametricBlock(const std::string& blockName, std::set<std::string>& composed);
     void ComposeFlattenedBlock(const std::string& blockName, std::set<std::string>& composed);
+    Part::Compound* createParametricPolylineCompound(const TopoDS_Wire& wire, const char* name);
+    Part::Feature* createFlattenedPolylineFeature(const TopoDS_Wire& wire, const char* name);
 
 protected:
     PyObject* getDraftModule()

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -61,7 +61,7 @@ public:
     {
         Py_XDECREF(DraftModule);
     }
-
+    static std::map<std::string, int> PreScan(const std::string& filepath);
     void StartImport() override;
 
     Py::Object getStatsAsPyObject();

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2331,7 +2331,7 @@ bool CDxfRead::ReadDimension()
     switch ((eDimensionType_t)dimensionType) {
         case eLinear:
         case eAligned:
-            OnReadDimension(start, end, linePosition, Base::toRadians(rotation));
+            OnReadDimension(start, end, linePosition, dimensionType, Base::toRadians(rotation));
             break;
         default:
             UnsupportedFeature("Dimension type '%d'", dimensionType);

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -938,6 +938,7 @@ public:
     virtual void OnReadDimension(const Base::Vector3d& /*start*/,
                                  const Base::Vector3d& /*end*/,
                                  const Base::Vector3d& /*point*/,
+                                 int /*dimensionType*/,
                                  double /*rotation*/)
     {}
     virtual void OnReadPolyline(std::list<VertexInfo>& /*vertices*/, int /*flags*/)

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -94,6 +94,7 @@ public:
         add_keyword_method("insert",
                            &Module::insert,
                            "insert(string,string) -- Insert the file into the given document.");
+        add_varargs_method("preScanDxf", &Module::preScanDxf, "preScanDxf(filepath) -> dict");
         add_varargs_method("readDXF",
                            &Module::readDXF,
                            "readDXF(filename,[document,ignore_errors,option_source]): Imports a "
@@ -112,6 +113,26 @@ public:
     }
 
 private:
+    Py::Object preScanDxf(const Py::Tuple& args)
+    {
+        char* filepath_char = nullptr;
+        if (!PyArg_ParseTuple(args.ptr(), "et", "utf-8", &filepath_char)) {
+            throw Py::Exception();
+        }
+        std::string filepath(filepath_char);
+        PyMem_Free(filepath_char);
+
+#include <Mod/Import/App/dxf/ImpExpDxf.h>
+
+        std::map<std::string, int> counts = Import::ImpExpDxfRead::PreScan(filepath);
+
+        Py::Dict result;
+        for (const auto& pair : counts) {
+            result.setItem(Py::String(pair.first), Py::Long(pair.second));
+        }
+        return result;
+    }
+
     Py::Object importOptions(const Py::Tuple& args)
     {
         char* Name {};


### PR DESCRIPTION
This is yet another step towards achieving feature parity with the DXF legacy importer, with the ultimate goal of deprecating it and having only one importer.

Goals:
- Improve the UX for importing DXF files
- Streamline the options for import: both from a user (simplify import process), and developer POV (simplify code and maintainability) 
- Narrow down the feature gap between modern and legacy importer

Changes:
- Redesigns, enhances and simplifies import modes and settings
- Adds dedicated DXF import dialog to avoid loading the full settings page. Shows UI warning if the imported file exceeds a given entity count threshold, combined with a higher fidelity import mode
- Adds Part primitives import mode, as a middle ground between performance and import fidelity
- Adds Draft objects import mode, to get closer to feature parity with the legacy importer

## Issues

Fixes: https://github.com/FreeCAD/FreeCAD/issues/16543
Fixes: https://github.com/FreeCAD/FreeCAD/issues/21956
Fixes: https://github.com/FreeCAD/FreeCAD/issues/13751
Fixes: https://github.com/FreeCAD/FreeCAD/issues/11877
Fixes: https://github.com/FreeCAD/FreeCAD/issues/13620
Fixes: https://github.com/FreeCAD/FreeCAD/issues/7551
Fixes: https://github.com/FreeCAD/FreeCAD/issues/11874

Addresses https://github.com/FreeCAD/FreeCAD/issues/13599 for the importer (full feature parity nearly achieved)

## Before and After Images

### Before

<img width="997" height="948" alt="image" src="https://github.com/user-attachments/assets/a56a01b9-ce05-45ae-a14d-07fa301e3b84" />

_Original importer preferences dialog_

### After
![New importer dialog](https://github.com/user-attachments/assets/7caef03e-9aed-4047-8028-c4a6108d69a4)
_New importer dialog (shown as a preference upon import)_

![Redesigned importer preferences dialog](https://github.com/user-attachments/assets/075af3cd-d12a-45f2-ae60-239f13016d40)
_Redesigned importer preferences dialog_

[ImportModesFinal.webm](https://github.com/user-attachments/assets/8d546829-0ead-42af-9397-af709b92239c)

_UX redesign and import modes tour. Notice that on the last import as Draft objects I used the same model but with purged unused blocks, so that the import time would not make the video unnecessarily longer_

## Implementation details

### Import modes

One of the main goals of this PR is to distill the vast array of import settings and the consequential explosion of results depending on the combination of those, into four import modes. These modes should be easily understandable by the user, cover most use cases, and produce repeatable results: 

*   **Editable draft objects**
    Creates fully parametric `Draft` objects like `Draft.Line` and `Draft.Arc`. This mode provides the highest fidelity and editability within the Draft workbench but can be slower for very large files.

*   **Editable part primitives**
    Creates parametric `Part` objects like `Part::Line` and `Part::Circle`. This provides good parametric control and is ideal for script-based post-processing. More complex objects, such as polylines, are built as a `Part::Compound` with segment children being individual `Part` objects.

*   **Individual part shapes** (default)
    Creates a non-parametric `Part::Feature` for each DXF entity. This mode offers a good balance between performance and the ability to reference and measure individual objects. Block structures are preserved.

*   **Fused part shapes**
    Merges all geometry on each layer into a single, non-editable shape. This is the fastest mode for viewing very large files but results in a complete loss of individual object structure and parametricity.

> [!IMPORTANT]
> The DXF importer's higher-order conversion modes, "Editable Draft objects" and "Editable Part primitives," operate on a **best effort** basis to create the most parametric objects possible (e.g. `Draft.Line` or `Part.Circle`). When a direct parametric equivalent is not available (for example, with polylines containing curves in Draft mode, or for 3D faces),  it will fall back to creating a non-parametric but visually correct `Part::Feature` shape.

#### Import mode notes

- The main two criteria that differentiate the modes are performance (essentially import processing speed) and editability.
- The modes are ordered bottom to top in increasing order: Fused part shapes is the quickest and less editable, Editable draft objects is the slowest and most editable.
- For small to medium sized DXF files, the difference in import time between the tree first models will not be noticeable (in the order of seconds).
- The most noticeable difference in import time will be in the Editable draft objects mode. E.g. as a relative comparison figure: a 1.5 Mb DXF file with over 5000 DXF entities takes 8 seconds to import as Editable part primitives and 130 seconds to import as Editable draft objects.

####  Opinionated or forced decisions

- Layers are now unconditionally imported and are used for grouping the resulting objects. In practical terms, the setting to enable/disable the use layers has been removed. Layers an intrinsical and ubiquitous feature of the DXF format, and most use cases will contemplate their use. Importing them by design reduces the code complexity and maintainability. It also reduces the combination of results, making the import more predictable to the user.
- Polylines are not always converted to parametric objects in the Editable draft objects mode. See more details in the dedicated section below.
- Sketch import mode has not been implemented for the modern importer, due to its complexity (adding constraints would be a project in itself, for instance) and due to the fact that it has been considered a less common case for which there is a workaround (https://wiki.freecad.org/Draft_Draft2Sketch).
- The initial attempt of implementing Draft objects import was made with the `Draft.make_*` API. As that did not work well, the changes instantiate objects and add the view providers manually. More details on the next section.

#### Draft mode import peculiarities

The `Draft.make_*` functions to create objects are nout used since they posed some challenges for batch post-processing.

1.  **Efficiency:** each `Draft.make_*` call appears to trigger a document recompute (`doc.recompute()`). In a script that processes hundreds or thousands of objects, this would be extremely slow. The post-processor creates all objects first and then performs a single recompute at the end.
2.  **Unwanted GUI side effects:** these functions can interact with the GUI, such as changing the selection or causing screen updates. This is undesirable in a background process. The major issues were related to reparenting objects, and objects falling to the root of the document.

The current low-level approach (`doc.addObject`, attaching the proxy, and setting properties) provides a faster and more controlled way to create the objects, at the expense of bypassing the higher-level API.

### Dedicated import dialog

A dedicated DXF import dialog now appears before the import begins, allowing the user to configure settings for the current session.

![image](https://github.com/user-attachments/assets/1de5b9a9-57dd-488a-ab53-e30f7ecf9178)
_DXF import dialog, showing warning if one of the two higher order import modes are chosen, and the DXF entity count exceeds a threshold_

*   The dialog shows the chosen import mode and a checkbox to disable showing the dialog on future imports.
*   It performs a quick pre-scan of the DXF file to count the number of different entity types, presenting this summary to the user.
*   The dialog includes a warning section that can alert the user to potential issues, such as a very high entity count, which might lead to long processing times.
*   This workflow replaces the previous behavior where the import started immediately after the file was selected, often blocking the UI without warning while the file was being processed. The user now has explicit control to confirm or cancel the import after reviewing the settings and file summary.

Addresses issue https://github.com/FreeCAD/FreeCAD/issues/13751

### Improve long operation feedback

*   The DXF importer now calls FreeCAD's `suspendWaitCursor()` and `resumeWaitCursor()` Python API around the code that shows the import dialog.
*   This new API was added specifically for this purpose. It acts as a workaround to improve the user experience by preventing the wait cursor (spinning wheel) from appearing and covering the import dialog.
*   While the import process itself remains single-threaded, this change ensures the user can fully interact with the dialog without the UI being visually blocked by a premature and persistent wait cursor.

The new API additions are confined within one commit: https://github.com/FreeCAD/FreeCAD/pull/22251/commits/4d4ac63fed0310418c844cb51865374bc23c06ed

### Polyline representation

When importing a DXF file containing polylines (which can be a mix of straight lines and arcs), the importer creates different types of objects in FreeCAD depending on the chosen import mode.

#### Import As: "Editable Draft objects"

- Each DXF polyline becomes a **single `Draft.Wire` object**, but its behavior depends on its contents:
  - For polylines with only straight lines: The object is a fully parametric and editable Draft.Wire. Its shape can be edited by modifying its vertices in the Points property.
  - For polylines containing any arcs (curves): The object is a non-parametric, 'read-only' shape. This preserves the exact curved geometry, but its vertices cannot be edited.

#### Import As: "Editable Part primitives"

- Each DXF polyline becomes a **`Part::Compound`** that contains many individual objects inside it.
- The compound acts as a container. In the tree view, you can expand it to see and select each segment of the original polyline as a separate, fully parametric `Part::Line` or `Part::Circle` object. The properties of each segment, such as a circle's radius or a line's endpoints, can be modified.

## Not addressed in this PR

These items have been intendedly not addressed, or will be addressed in follow-up PRs:

1. Draft objects are imported as `Part::Part2DObject`. However, a recent change makes all Draft objects `Part::FeaturePython`: https://github.com/FreeCAD/FreeCAD/pull/21636. This will be addressed in a subsequent PR.
1. Polylines that contains a mixture of lines and arc-based segments in Draft objects import mode are non-parametric.
1. A few DXF files produce OCCT warnings such as the one below. These cannot be silenced and appear to be harmless
   ```
   <Part> ViewProviderExt.cpp(1306): Cannot compute Inventor representation for the shape of sample_arch_dxf#Arc554: BRepMesh_IncrementalMesh::initParameters : invalid parameter value
   ```
1. As mentioned on https://github.com/FreeCAD/FreeCAD/pull/22045, unused blocks are always imported. This can significantly increase import time if the unused blocks count is large, and/or if the unused blocks are large. We now do a quick prescan of the file being imported, so we could theoretically read the unused blocks in advance and have a setting to control whether they need to be imported or not. This has been left for a follow-up PR, as the current one was already becoming too large
1. The legacy import code should be better segregated to a separate file, as `importDXF.py` is becoming quite big
1. The stats reporter does not mention which import mode it ran on. This will be addressed on a subsequent PR.
1. In Individual shapes import mode, all objects are named `ShapeNNN`. An improvement would be to name them after their corresponding DXF entity (e.g. `LineNNN`, `ArcNNN`, etc). This will be addressed in a subsequent PR.
1. Conversion to `Draft.BSpline`s will be addressed in a subsequent PR.

