### PR TITLE
BIM: fix visibility handling of objects hosted by additions

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -1417,18 +1417,13 @@ class ViewProviderComponent:
             The name of the property that has changed.
         """
 
-        #print(vobj.Object.Name, " : changing ",prop)
-        #if prop == "Visibility":
-            #for obj in vobj.Object.Additions+vobj.Object.Subtractions:
-            #    if (Draft.getType(obj) == "Window") or (Draft.isClone(obj,"Window",True)):
-            #        obj.ViewObject.Visibility = vobj.Visibility
-            # this would now hide all previous windows... Not the desired behaviour anymore.
+        obj = vobj.Object
         if prop == "DiffuseColor":
-            if hasattr(vobj.Object,"CloneOf"):
-                if vobj.Object.CloneOf and hasattr(vobj.Object.CloneOf,"DiffuseColor"):
-                    if len(vobj.Object.CloneOf.ViewObject.DiffuseColor) > 1:
-                        if vobj.DiffuseColor != vobj.Object.CloneOf.ViewObject.DiffuseColor:
-                            vobj.DiffuseColor = vobj.Object.CloneOf.ViewObject.DiffuseColor
+            if hasattr(obj,"CloneOf"):
+                if obj.CloneOf and hasattr(obj.CloneOf,"DiffuseColor"):
+                    if len(obj.CloneOf.ViewObject.DiffuseColor) > 1:
+                        if vobj.DiffuseColor != obj.CloneOf.ViewObject.DiffuseColor:
+                            vobj.DiffuseColor = obj.CloneOf.ViewObject.DiffuseColor
                             vobj.update()
         elif prop == "ShapeColor":
             # restore DiffuseColor after overridden by ShapeColor
@@ -1437,10 +1432,16 @@ class ViewProviderComponent:
                     d = vobj.DiffuseColor
                     vobj.DiffuseColor = d
         elif prop == "Visibility":
-            for host in vobj.Object.Proxy.getHosts(vobj.Object):
-                if hasattr(host, 'ViewObject'):
-                    host.ViewObject.Visibility = vobj.Visibility
-
+            # do nothing if object is an addition
+            if not [parent for parent in obj.InList if obj in getattr(parent, "Additions", [])]:
+                hostedObjs = obj.Proxy.getHosts(obj)
+                # add objects hosted by additions
+                for addition in getattr(obj, "Additions", []):
+                    if hasattr(addition, "Proxy") and hasattr(addition.Proxy, "getHosts"):
+                        hostedObjs.extend(addition.Proxy.getHosts(addition))
+                for hostedObj in hostedObjs:
+                    if hasattr(hostedObj, "ViewObject"):
+                        hostedObj.ViewObject.Visibility = vobj.Visibility
         return
 
     def attach(self,vobj):


### PR DESCRIPTION
Fixes #19595.

PR to make the visibility of objects hosted by additions depend on the visibility of the parent. This solution is preferable to changing Hosts properties. The latter solution would be hard to undo in case additions are removed.