### PR TITLE
Sketcher: assign the old geometries' GeometryId[s] to new geometries after scaling

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -11630,6 +11630,24 @@ std::vector<Base::Vector3d> SketchObject::getOpenVertices() const
 
 // SketchGeometryExtension interface
 
+size_t setGeometryIdHelper(int GeoId, long id, std::vector<Part::Geometry*>& newVals, size_t searchOffset = 0, bool returnOnMatch = false)
+{
+    // deep copy
+    for (size_t i = searchOffset; i < newVals.size(); i++) {
+        newVals[i] = newVals[i]->clone();
+
+        if ((int)i == GeoId) {
+            auto gf = GeometryFacade::getFacade(newVals[i]);
+
+            gf->setId(id);
+
+            if (returnOnMatch) {
+                return i;
+            }
+        }
+    }
+    return 0;
+}
 int SketchObject::setGeometryId(int GeoId, long id)
 {
     // no need to check input data validity as this is an sketchobject managed operation.
@@ -11640,18 +11658,35 @@ int SketchObject::setGeometryId(int GeoId, long id)
 
     const std::vector<Part::Geometry*>& vals = getInternalGeometry();
 
+    std::vector<Part::Geometry*> newVals(vals);
+    setGeometryIdHelper(GeoId, id, newVals);
+
+    // There is not actual internal transaction going on here, however neither the geometry indices
+    // nor the vertices need to be updated so this is a convenient way of preventing it.
+    {
+        Base::StateLocker lock(internaltransaction, true);
+        this->Geometry.setValues(std::move(newVals));
+    }
+
+    return 0;
+}
+int SketchObject::setGeometryIds(std::vector<std::pair<int, long>> GeoIdsToIds)
+{
+    Base::StateLocker lock(managedoperation, true);
+
+    std::sort(GeoIdsToIds.begin(), GeoIdsToIds.end());
+
+    size_t searchOffset = 0;
+
+    const std::vector<Part::Geometry*>& vals = getInternalGeometry();
 
     std::vector<Part::Geometry*> newVals(vals);
 
-    // deep copy
-    for (size_t i = 0; i < newVals.size(); i++) {
-        newVals[i] = newVals[i]->clone();
+    for (size_t i = 0; i < GeoIdsToIds.size(); ++i) {
+        int GeoId = GeoIdsToIds[i].first;
+        long id = GeoIdsToIds[i].second;
+        searchOffset = setGeometryIdHelper(GeoId, id, newVals, i != GeoIdsToIds.size()-1);
 
-        if ((int)i == GeoId) {
-            auto gf = GeometryFacade::getFacade(newVals[i]);
-
-            gf->setId(id);
-        }
     }
 
     // There is not actual internal transaction going on here, however neither the geometry indices

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -893,6 +893,7 @@ public:
 
 public:  // geometry extension functionalities for single element sketch object user convenience
     int setGeometryId(int GeoId, long id);
+    int setGeometryIds(std::vector<std::pair<int, long>> GeoIdsToIds);
     int getGeometryId(int GeoId, long& id) const;
 
 protected:

--- a/src/Mod/Sketcher/App/SketchObject.pyi
+++ b/src/Mod/Sketcher/App/SketchObject.pyi
@@ -868,6 +868,12 @@ class SketchObject(Part2DObject):
         """
         ...
 
+    def setGeometryIds(GeoIdsToIds: List[Tuple[int, int]]):
+        """
+        Sets the GeometryId of the SketchGeometryExtension of the geometries with the provided GeoIds
+        Expects a list of pairs (GeoId, id)
+        """
+
     def getGeometryId():
         """
         Gets the GeometryId of the SketchGeometryExtension of the geometry with the provided GeoId

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -2447,6 +2447,49 @@ PyObject* SketchObjectPy::setGeometryId(PyObject* args)
 
     Py_Return;
 }
+PyObject* SketchObjectPy::setGeometryIds(PyObject* args)
+{
+    PyObject* pyList;
+
+    // Parse arguments: list of pairs, Base::VectorPy, optional relative flag
+    if (!PyArg_ParseTuple(args, "O!", &PyList_Type, &pyList)) {
+        return nullptr;
+    }
+
+    // Convert Python list to std::vector<std::pair<int, long>>
+    std::vector<std::pair<int, long>> geoIdsToIds;
+    Py_ssize_t listSize = PyList_Size(pyList);
+
+    for (Py_ssize_t i = 0; i < listSize; ++i) {
+        PyObject* pyPair = PyList_GetItem(pyList, i);  // Borrowed reference
+
+        if (!PyTuple_Check(pyPair) || PyTuple_Size(pyPair) != 2) {
+            PyErr_SetString(PyExc_ValueError, "List must contain pairs (geoId, id).");
+            return nullptr;
+        }
+
+        int geoId = PyLong_AsInt(PyTuple_GetItem(pyPair, 0));
+        long id = PyLong_AsLong(PyTuple_GetItem(pyPair, 1));
+
+        if (PyErr_Occurred()) {
+            PyErr_SetString(PyExc_ValueError, "Invalid geoId or id in the list.");
+            return nullptr;
+        }
+
+        geoIdsToIds.emplace_back(geoId, id);
+    }
+
+    // Call the C++ method
+    if (this->getSketchObjectPtr()->setGeometryIds(geoIdsToIds)) {
+        std::stringstream str;
+        str << "Not able to set geometry Ids of geometries with the given indices: ";
+        PyErr_SetString(PyExc_ValueError, str.str().c_str());
+        return nullptr;
+    }
+
+    Py_Return;
+}
+
 
 Py::Long SketchObjectPy::getDoF() const
 {


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

When the sketch's autoscale is applied or the scale tool is used, the new scaled geometries created to replace the base geometries now take their predecessor's GeometryId so that features down the line do not break on edit.

This pr also adds a function (+python api) to SketchObject to change multiple geometries ids rather than going one at a time.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
Implements a fix for #22246


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
