### PR TITLE
Update Help menu. Remove outdated links; add Developers handbook

### DIFF
--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -574,8 +574,8 @@ StdCmdFreeCADDonation::StdCmdFreeCADDonation()
   :Command("Std_FreeCADDonation")
 {
     sGroup        = "Help";
-    sMenuText     = QT_TR_NOOP("Support FreeCA&D");
-    sToolTipText  = QT_TR_NOOP("Support FreeCAD development");
+    sMenuText     = QT_TR_NOOP("Donate to FreeCA&D");
+    sToolTipText  = QT_TR_NOOP("Support the FreeCAD development");
     sWhatsThis    = "Std_FreeCADDonation";
     sStatusTip    = sToolTipText;
     sPixmap       = "internet-web-browser";
@@ -586,8 +586,36 @@ void StdCmdFreeCADDonation::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     ParameterGrp::handle hURLGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Websites");
-    std::string url = hURLGrp->GetASCII("DonatePage", "https://wiki.freecad.org/Donate");
+    std::string url = hURLGrp->GetASCII("DonatePage", "https://www.freecad.org/sponsor");
     hURLGrp->SetASCII("DonatePage", url.c_str());
+    OpenURLInBrowser(url.c_str());
+}
+
+//===========================================================================
+// Std_FreeCADDonation
+//===========================================================================
+
+DEF_STD_CMD(StdCmdDevHandbook)
+
+StdCmdFreeCADDonation::StdCmdDevHandbook()
+    : Command("Std_DevHandbook")
+{
+    sGroup = "Help";
+    sMenuText = QT_TR_NOOP("Developers handbook");
+    sToolTipText = QT_TR_NOOP("Support the FreeCAD development");
+    sWhatsThis = "Std_DevHandbook";
+    sStatusTip = sToolTipText;
+    sPixmap = "internet-web-browser";
+    eType = 0;
+}
+
+void StdCmdFreeCADDonation::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    ParameterGrp::handle hURLGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Websites");
+    std::string url = hURLGrp->GetASCII("DonatePage", "https://freecad.github.io/DevelopersHandbook/");
+    hURLGrp->SetASCII("DevHandbook", url.c_str());
     OpenURLInBrowser(url.c_str());
 }
 
@@ -648,34 +676,6 @@ void StdCmdFreeCADUserHub::activated(int iMsg)
 }
 
 //===========================================================================
-// Std_FreeCADPowerUserHub
-//===========================================================================
-
-DEF_STD_CMD(StdCmdFreeCADPowerUserHub)
-
-StdCmdFreeCADPowerUserHub::StdCmdFreeCADPowerUserHub()
-  :Command("Std_FreeCADPowerUserHub")
-{
-    sGroup        = "Help";
-    sMenuText     = QT_TR_NOOP("&Python Scripting Documentation");
-    sToolTipText  = QT_TR_NOOP("Opens the Python Scripting documentation");
-    sWhatsThis    = "Std_FreeCADPowerUserHub";
-    sStatusTip    = sToolTipText;
-    sPixmap       = "applications-python";
-    eType         = 0;
-}
-
-void StdCmdFreeCADPowerUserHub::activated(int iMsg)
-{
-    Q_UNUSED(iMsg);
-    std::string defaulturl = QCoreApplication::translate(this->className(),"https://wiki.freecad.org/Power_users_hub").toStdString();
-    ParameterGrp::handle hURLGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Websites");
-    std::string url = hURLGrp->GetASCII("PowerUsers", defaulturl.c_str());
-    hURLGrp->SetASCII("PowerUsers", url.c_str());
-    OpenURLInBrowser(url.c_str());
-}
-
-//===========================================================================
 // Std_FreeCADForum
 //===========================================================================
 
@@ -702,59 +702,6 @@ void StdCmdFreeCADForum::activated(int iMsg)
     hURLGrp->SetASCII("UserForum", url.c_str());
     OpenURLInBrowser(url.c_str());
 }
-
-//===========================================================================
-// Std_FreeCADFAQ
-//===========================================================================
-
-DEF_STD_CMD(StdCmdFreeCADFAQ)
-
-StdCmdFreeCADFAQ::StdCmdFreeCADFAQ()
-  :Command("Std_FreeCADFAQ")
-{
-    sGroup        = "Help";
-    sMenuText     = QT_TR_NOOP("FreeCAD FA&Q");
-    sToolTipText  = QT_TR_NOOP("Opens the Frequently Asked Questions");
-    sWhatsThis    = "Std_FreeCADFAQ";
-    sStatusTip    = sToolTipText;
-    sPixmap       = "internet-web-browser";
-    eType         = 0;
-}
-
-void StdCmdFreeCADFAQ::activated(int iMsg)
-{
-    Q_UNUSED(iMsg);
-    std::string defaulturl = QCoreApplication::translate(this->className(),"https://wiki.freecad.org/Frequently_asked_questions").toStdString();
-    ParameterGrp::handle hURLGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Websites");
-    std::string url = hURLGrp->GetASCII("FAQ", defaulturl.c_str());
-    hURLGrp->SetASCII("FAQ", url.c_str());
-    OpenURLInBrowser(url.c_str());
-}
-
-//===========================================================================
-// Std_PythonWebsite
-//===========================================================================
-
-DEF_STD_CMD(StdCmdPythonWebsite)
-
-StdCmdPythonWebsite::StdCmdPythonWebsite()
-  :Command("Std_PythonWebsite")
-{
-    sGroup        = "Help";
-    sMenuText     = QT_TR_NOOP("Python Website");
-    sToolTipText  = QT_TR_NOOP("The official Python website");
-    sWhatsThis    = "Std_PythonWebsite";
-    sStatusTip    = QT_TR_NOOP("Python Website");
-    sPixmap       = "applications-python";
-    eType         = 0;
-}
-
-void StdCmdPythonWebsite::activated(int iMsg)
-{
-    Q_UNUSED(iMsg);
-    OpenURLInBrowser("https://www.python.org");
-}
-
 
 //===========================================================================
 // Std_ReportBug
@@ -996,15 +943,13 @@ void CreateStdCommands()
     rcCmdMgr.addCommand(new StdCmdFreeCADWebsite());
     rcCmdMgr.addCommand(new StdCmdFreeCADDonation());
     rcCmdMgr.addCommand(new StdCmdFreeCADUserHub());
-    rcCmdMgr.addCommand(new StdCmdFreeCADPowerUserHub());
     rcCmdMgr.addCommand(new StdCmdFreeCADForum());
-    rcCmdMgr.addCommand(new StdCmdFreeCADFAQ());
-    rcCmdMgr.addCommand(new StdCmdPythonWebsite());
     rcCmdMgr.addCommand(new StdCmdReportBug());
     rcCmdMgr.addCommand(new StdCmdTextDocument());
     rcCmdMgr.addCommand(new StdCmdUnitsCalculator());
     rcCmdMgr.addCommand(new StdCmdUserEditMode());
     rcCmdMgr.addCommand(new StdCmdReloadStyleSheet());
+    rcCmdMgr.addCommand(new StdCmdDevHandbook());
     //rcCmdMgr.addCommand(new StdCmdDownloadOnlineHelp());
     //rcCmdMgr.addCommand(new StdCmdDescription());
 }

--- a/src/Gui/PreferencePackTemplates/Shortcuts.cfg
+++ b/src/Gui/PreferencePackTemplates/Shortcuts.cfg
@@ -642,9 +642,7 @@
           <FCText Name="Std_Expressions"></FCText>
           <FCText Name="Std_FaceSelection"></FCText>
           <FCText Name="Std_FreeCADDonation"></FCText>
-          <FCText Name="Std_FreeCADFAQ"></FCText>
           <FCText Name="Std_FreeCADForum"></FCText>
-          <FCText Name="Std_FreeCADPowerUserHub"></FCText>
           <FCText Name="Std_FreeCADUserHub"></FCText>
           <FCText Name="Std_FreeCADWebsite"></FCText>
           <FCText Name="Std_FreezeViews"></FCText>
@@ -690,7 +688,6 @@
           <FCText Name="Std_ProjectInfo"></FCText>
           <FCText Name="Std_ProjectUtil"></FCText>
           <FCText Name="Std_PythonHelp"></FCText>
-          <FCText Name="Std_PythonWebsite"></FCText>
           <FCText Name="Std_Quit">Ctrl+Q</FCText>
           <FCText Name="Std_RandomColor"></FCText>
           <FCText Name="Std_RecallWorkingView">End</FCText>

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -767,11 +767,11 @@ MenuItem* StdWorkbench::setupMenuBar() const
     // Help
     auto help = new MenuItem( menuBar );
     help->setCommand("&Help");
-    *help << "Std_OnlineHelp" << "Std_WhatsThis" << "Separator"
+    *help << "Std_WhatsThis" << "Separator"
           // Start page and additional separator are dynamically inserted here
-          << "Std_FreeCADUserHub" << "Std_FreeCADForum" << "Std_FreeCADFAQ" << "Std_ReportBug" << "Separator"
+          << "Std_FreeCADUserHub" << "Std_FreeCADForum" << "Std_ReportBug" << "Separator"
           << "Std_RestartInSafeMode" << "Separator"
-          << "Std_FreeCADPowerUserHub" << "Std_PythonHelp" << "Separator"
+          << "Std_DevHandbook" << "Std_PythonHelp" << "Separator"
           << "Std_FreeCADWebsite" << "Std_FreeCADDonation" << "Std_About";
 
     return menuBar;


### PR DESCRIPTION
As discussed, updates the Help menu:
- removes multiple links to outdated wiki pages
- adds link to the Developers Handbook
- Update links