### PR TITLE
Materials: Add support for embedded images

### DIFF
--- a/src/Mod/Material/Gui/BaseDelegate.cpp
+++ b/src/Mod/Material/Gui/BaseDelegate.cpp
@@ -126,7 +126,7 @@ void BaseDelegate::paintImage(QPainter* painter,
     QImage img;
     if (!propertyValue.isEmpty()) {
         QByteArray by = QByteArray::fromBase64(propertyValue.toUtf8());
-        img = QImage::fromData(by, "PNG").scaled(64, 64, Qt::KeepAspectRatio);
+        img = QImage::fromData(by).scaled(64, 64, Qt::KeepAspectRatio);
     }
     QRect target(option.rect);
     if (target.width() > target.height()) {

--- a/src/Mod/Material/Gui/ImageEdit.cpp
+++ b/src/Mod/Material/Gui/ImageEdit.cpp
@@ -134,7 +134,7 @@ ImageEdit::ImageEdit(const QString& propertyName,
             QString value = _property->getString();
             if (!value.isEmpty()) {
                 QByteArray by = QByteArray::fromBase64(value.toUtf8());
-                QImage img = QImage::fromData(by, "PNG");
+                QImage img = QImage::fromData(by);
                 _pixmap = QPixmap::fromImage(img);
             }
             showPixmap();

--- a/src/Mod/Material/Gui/MaterialsEditor.cpp
+++ b/src/Mod/Material/Gui/MaterialsEditor.cpp
@@ -940,12 +940,11 @@ bool MaterialsEditor::updateTexturePreview() const
         try {
             auto property = _material->getAppearanceProperty(QStringLiteral("TextureImage"));
             if (!property->isNull()) {
-                // Base::Console().log("Has 'TextureImage'\n");
                 auto propertyValue = property->getString();
                 if (!propertyValue.isEmpty()) {
                     QByteArray by = QByteArray::fromBase64(propertyValue.toUtf8());
-                    image = QImage::fromData(by, "PNG");  //.scaled(64, 64, Qt::KeepAspectRatio);
-                    hasImage = true;
+                    image = QImage::fromData(by);
+                    hasImage = !image.isNull();
                 }
             }
         }
@@ -962,9 +961,11 @@ bool MaterialsEditor::updateTexturePreview() const
                     if (!image.load(filePath)) {
                         Base::Console().log("Unable to load image '%s'\n",
                                             filePath.toStdString().c_str());
-                        // return;  // ???
+                        hasImage = false;
                     }
-                    hasImage = true;
+                    else {
+                        hasImage = !image.isNull();
+                    }
                 }
             }
             catch (const Materials::PropertyNotFound&) {


### PR DESCRIPTION
Adds support for file types other than PNG to embedded images in materials. Adds checks to prevent crashing when an unsupported image type is used.

This uses the built in Qt function features to detect image type instead of forcing a PNG image type. It also checks the results before trying to set the preview, which was the cause of the crash.

## Issues
Fixes #22292

## Before and After Images
