### PR TITLE
Core: Remove outdated tooltip from light source preferences

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsLightSources.ui
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.ui
@@ -22,9 +22,6 @@
        <verstretch>2</verstretch>
       </sizepolicy>
      </property>
-     <property name="toolTip">
-      <string>Adjust the orientation of the directional light source by dragging the handle with the mouse or use the spin boxes for fine tuning.</string>
-     </property>
      <property name="title">
       <string>Preview</string>
      </property>


### PR DESCRIPTION
Removes the tooltip that has been superfluous since the introduction of 3 point lighting.