### PR TITLE
PartDesign: Allow open wires for profile normal detection in sketch based features

### DIFF
--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -1352,7 +1352,7 @@ TopoShape Feature::simplifyCompound(TopoShape compoundShape)
                                             TopAbs_COMPSOLID,
                                             TopAbs_FACE,
                                             TopAbs_SHELL,
-                                            TopAbs_SHELL,
+                                            TopAbs_EDGE,
                                             TopAbs_WIRE,
                                             TopAbs_VERTEX};
 

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -1425,8 +1425,9 @@ Base::Vector3d ProfileBased::getProfileNormal() const {
 
     Base::Vector3d SketchVector(0, 0, 1);
     auto obj = getVerifiedObject(true);
-    if (!obj)
+    if (!obj) {
         return SketchVector;
+    }
 
     // get the Sketch plane
     if (obj->isDerivedFrom<Part::Part2DObject>()) {
@@ -1438,7 +1439,7 @@ Base::Vector3d ProfileBased::getProfileNormal() const {
 
     // For newer version, do not do fitting, as it may flip the face normal for
     // some reason.
-    TopoShape shape = getTopoShapeVerifiedFace(true);  //, _ProfileBasedVersion.getValue() <= 0);
+    TopoShape shape = getTopoShapeVerifiedFace(true, true, true);  //, _ProfileBasedVersion.getValue() <= 0);
 
     gp_Pln pln;
     if (shape.findPlane(pln)) {


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

Allows open wires when searching normal of profile in sketch based feature.
I tested lightly and could not find obvious regressions coming from this change, but another way to solve the issue which I have tested is to find the axis of the arc. I have decided to go with this solution because it was the minimal change, but it might be useful to have the specialized arc case.

This pr also includes a minor fix for Part::Feature::simplifyCompound

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

Implements a fix for #22117

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
