### PR TITLE
Materials: Add import for unimplemented fields

### DIFF
--- a/src/Mod/Material/App/MaterialLoader.cpp
+++ b/src/Mod/Material/App/MaterialLoader.cpp
@@ -180,12 +180,23 @@ void MaterialYamlEntry::addToTree(
     QString author = yamlValue(yamlModel["General"], "Author", "");
     QString license = yamlValue(yamlModel["General"], "License", "");
     QString description = yamlValue(yamlModel["General"], "Description", "");
+    QString sourceReference = yamlValue(yamlModel["General"], "ReferenceSource", "");
+    QString sourceURL = yamlValue(yamlModel["General"], "SourceURL", "");
 
     std::shared_ptr<Material> finalModel =
         std::make_shared<Material>(library, directory, uuid, name);
     finalModel->setAuthor(author);
     finalModel->setLicense(license);
     finalModel->setDescription(description);
+    finalModel->setReference(sourceReference);
+    finalModel->setURL(sourceURL);
+
+    if (yamlModel["General"]["Tags"]) {
+        auto tags = readList(yamlModel["General"]["Tags"]);
+        for (auto tag : *tags) {
+            finalModel->addTag(tag.toString());
+        }
+    }
 
     // Add inheritance list
     if (yamlModel["Inherits"]) {

--- a/src/Mod/Material/App/Materials.cpp
+++ b/src/Mod/Material/App/Materials.cpp
@@ -699,6 +699,19 @@ void Material::removeUUID(QSet<QString>& uuidList, const QString& uuid)
     uuidList.remove(uuid);
 }
 
+void Material::addTag(const QString& tag)
+{
+    auto trimmed = tag.trimmed();
+    if (!trimmed.isEmpty()) {
+        _tags.insert(trimmed);
+    }
+}
+
+void Material::removeTag(const QString& tag)
+{
+    _tags.remove(tag);
+}
+
 void Material::addPhysical(const QString& uuid)
 {
     if (hasPhysicalModel(uuid)) {
@@ -1326,6 +1339,12 @@ void Material::saveGeneral(QTextStream& stream) const
     }
     if (!_reference.isEmpty()) {
         stream << "  ReferenceSource: \"" << MaterialValue::escapeString(_reference) << "\"\n";
+    }
+    if (!_tags.isEmpty()) {
+        stream << "  Tags:\n";
+        for (auto tag : _tags) {
+            stream << "    - \"" << tag << "\"\n";
+        }
     }
 }
 

--- a/src/Mod/Material/App/Materials.h
+++ b/src/Mod/Material/App/Materials.h
@@ -282,13 +282,11 @@ public:
     {
         _editState = ModelEdit_None;
     }
-    void addTag(const QString& tag)
+    void addTag(const QString& tag);
+    void removeTag(const QString& tag);
+    bool hasTag(const QString& tag)
     {
-        Q_UNUSED(tag);
-    }
-    void removeTag(const QString& tag)
-    {
-        Q_UNUSED(tag);
+        return _tags.contains(tag);
     }
     void addPhysical(const QString& uuid);
     void removePhysical(const QString& uuid);


### PR DESCRIPTION
Adds import/export support for unimplemented material fields.

This includes reference source and URLs, and tag fields. Tag support remains unimplemented in the editor, but is supported by a number of materials in the FCMat files. They can be accessed in both C++ and Python.
