### PR TITLE
CAM: Have Boundary Dressup find heighest Safe Height from Array

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Boundary.py
@@ -21,6 +21,7 @@
 # ***************************************************************************
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
+from Path.Op.Gui.Array import ObjectArray
 import FreeCAD
 import Path
 import Path.Base.Util as PathUtil
@@ -189,8 +190,24 @@ class PathBoundary:
 
         tc = PathDressup.toolController(self.baseOp)
 
-        self.safeHeight = float(PathUtil.opProperty(self.baseOp, "SafeHeight"))
-        self.clearanceHeight = float(PathUtil.opProperty(self.baseOp, "ClearanceHeight"))
+        if isinstance(self.baseOp.Proxy, ObjectArray) and isinstance(self.baseOp.Base, list):
+            safeHeight = -1
+            clearanceHeight = -1
+
+            # find the heighest SafeHeight for the most safety.
+            for feature in self.baseOp.Base:
+                if feature.SafeHeight.Value > safeHeight:
+                    safeHeight = feature.SafeHeight.Value
+
+                if feature.ClearanceHeight.Value > clearanceHeight:
+                    clearanceHeight = feature.ClearanceHeight.Value
+
+            self.safeHeight = safeHeight
+            self.clearanceHeight = clearanceHeight
+        else:
+            self.safeHeight = float(PathUtil.opProperty(self.baseOp, "SafeHeight"))
+            self.clearanceHeight = float(PathUtil.opProperty(self.baseOp, "ClearanceHeight"))
+
         self.strG0ZsafeHeight = Path.Command(  # was a Feed rate with G1
             "G0", {"Z": self.safeHeight, "F": tc.VertRapid.Value}
         )


### PR DESCRIPTION
This changes how the Boundary Dressup checks for Safe Height and Clearance. If based on an Array Dressup it will iterate through all of it Bases and get which ever Safety Height is greatest.

## Issues
Discussed in #11180

## Before and After Images
Before it raised an Exception
```
  File "/usr/lib/freecad/Mod/Path/Path/Dressup/Boundary.py", line 159, in execute
    self.safeHeight = float(PathUtil.opProperty(self.baseOp, "SafeHeight"))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<class 'TypeError'>: float() argument must be a string or a real number, not 'NoneType'
```
This fixes the error in addition to getting the safest safety height.

![image](https://github.com/user-attachments/assets/0f5a8978-


test model, rename to .FCStd [CAM Boundry Array.zip](https://github.com/user-attachments/files/21047790/CAM.Boundry.Array.zip)


