### PR TITLE
[CAM] Correctly process Adaptive extensions

### DIFF
--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -1032,7 +1032,10 @@ def _workingEdgeHelperManual(op, obj, depths):
     for ext in extensions:
         if not ext.avoid:
             if wire := ext.getWire():
-                selectedRegions += [f for f in ext.getExtensionFaces(wire)]
+                # NOTE: Can NOT just make a face directly, since that just gives
+                # the outside profile and removes internal holes
+                for f in ext.getExtensionFaces(wire):
+                    selectedRegions.extend(f.Faces)
 
     for base, subs in obj.Base:
         for sub in subs:


### PR DESCRIPTION
Previous rework to Adaptive caused the Extensions feature to incorrectly be processed as shells instead of faces- this change ensures extensions are faces.

Fixes https://github.com/FreeCAD/FreeCAD/issues/22177

This fix is the same idea as the one proposed in the bug report, but addresses the face vs shell issue earlier in the processing.