### PR TITLE
Gui: Increase orthographicFocalDistance to get more near and far distance slack

### DIFF
--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -722,7 +722,14 @@ void NavigationStyle::reorientCamera(SoCamera* camera, const SbRotation& rotatio
         SbVec3f direction;
         camera->orientation.getValue().multVec(SbVec3f(0, 0, -1), direction);
         
+#if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 405)
+        // Large focal distance puts the camera far away which causes Coin's auto clipping
+        // calculations to add more slack (more space between near and far plane) and thus reduces
+        // chances or hidden geometry.
+        constexpr float orthographicFocalDistance = 1000;
+#else
         constexpr float orthographicFocalDistance = 1;
+#endif
         camera->position = getFocalPoint() - orthographicFocalDistance * direction;
         camera->focalDistance = orthographicFocalDistance;
     }


### PR DESCRIPTION
This is a workaround that I believe significantly reduces the problems in #22216, #21950 and point 1 and 2 in #21915. The real fix is https://github.com/coin3d/coin/pull/577.

The way Coin adds slack is by multiplying the near and far distance but if they are close to 0 then it may not be enough.
By increasing the `orthographicFocalDistance` we get bigger values for the near and far distance and thus more slack which prevents flickering.

This PR might make rotating in some very large or small scenes a bit less stable until a Coin 4.0.5 release.


