### PR TITLE
Gui: Make LinkIcon DPR aware

### DIFF
--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -1731,14 +1731,17 @@ QIcon ViewProviderLink::getIcon() const {
 QPixmap ViewProviderLink::getOverlayPixmap() const {
     auto ext = getLinkExtension();
     constexpr int px = 12;
+    const qreal dpr = qApp->devicePixelRatio();
+    const QSize size = QSize(px * dpr, px * dpr);
+
     if(ext && ext->getLinkedObjectProperty() && ext->_getElementCountValue())
-        return BitmapFactory().pixmapFromSvg("LinkArrayOverlay", QSizeF(px,px));
+        return BitmapFactory().pixmapFromSvg("LinkArrayOverlay", size);
     else if(hasSubElement)
-        return BitmapFactory().pixmapFromSvg("LinkSubElement", QSizeF(px,px));
+        return BitmapFactory().pixmapFromSvg("LinkSubElement", size);
     else if(hasSubName)
-        return BitmapFactory().pixmapFromSvg("LinkSubOverlay", QSizeF(px,px));
+        return BitmapFactory().pixmapFromSvg("LinkSubOverlay", size);
     else
-        return BitmapFactory().pixmapFromSvg("LinkOverlay", QSizeF(px,px));
+        return BitmapFactory().pixmapFromSvg("LinkOverlay", size);
 }
 
 void ViewProviderLink::onChanged(const App::Property* prop) {


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
I don't know why but it works...
BitmapFactory should already use DPR.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fixes #6765
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
<img width="432" alt="Bildschirmfoto 2025-07-05 um 14 07 49" src="https://github.com/user-attachments/assets/4fc14e12-f59a-4aeb-9c1e-7d5afc5dec94" />



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
