### PR TITLE
CAM: Update UI strings for consistency

### DIFF
--- a/src/Mod/CAM/Gui/Command.cpp
+++ b/src/Mod/CAM/Gui/Command.cpp
@@ -46,7 +46,7 @@ CmdPathArea::CmdPathArea()
     sAppModule = "Path";
     sGroup = QT_TR_NOOP("CAM");
     sMenuText = QT_TR_NOOP("Area");
-    sToolTipText = QT_TR_NOOP("Creates a feature area from selected objects");
+    sToolTipText = QT_TR_NOOP("Creates a feature area from the selected objects");
     sWhatsThis = "CAM_Area";
     sStatusTip = sToolTipText;
     sPixmap = "CAM_Area";
@@ -140,8 +140,8 @@ CmdPathAreaWorkplane::CmdPathAreaWorkplane()
 {
     sAppModule = "Path";
     sGroup = QT_TR_NOOP("CAM");
-    sMenuText = QT_TR_NOOP("Area workplane");
-    sToolTipText = QT_TR_NOOP("Select a workplane for a FeatureArea");
+    sMenuText = QT_TR_NOOP("Area Workplane");
+    sToolTipText = QT_TR_NOOP("Selects a workplane for a feature area");
     sWhatsThis = "CAM_Area_Workplane";
     sStatusTip = sToolTipText;
     sPixmap = "CAM_Area_Workplane";
@@ -159,14 +159,14 @@ void CmdPathAreaWorkplane::activated(int iMsg)
          getSelection().getSelectionEx(nullptr, Part::Feature::getClassTypeId())) {
         const std::vector<std::string>& subnames = selObj.getSubNames();
         if (subnames.size() > 1) {
-            Base::Console().error("Please select one sub shape object for plane only\n");
+            Base::Console().error("Select one sub shape object for plane only\n");
             return;
         }
         const Part::Feature* pcObj = static_cast<Part::Feature*>(selObj.getObject());
         if (subnames.empty()) {
             if (pcObj->isDerivedFrom<Path::FeatureArea>()) {
                 if (!areaName.empty()) {
-                    Base::Console().error("Please select one FeatureArea only\n");
+                    Base::Console().error("Select one FeatureArea only\n");
                     return;
                 }
                 areaName = pcObj->getNameInDocument();
@@ -179,7 +179,7 @@ void CmdPathAreaWorkplane::activated(int iMsg)
             }
         }
         if (!planeName.empty()) {
-            Base::Console().error("Please select one shape object for plane only\n");
+            Base::Console().error("Select one shape object for plane only\n");
             return;
         }
         else {
@@ -236,7 +236,7 @@ CmdPathCompound::CmdPathCompound()
     sAppModule = "Path";
     sGroup = QT_TR_NOOP("CAM");
     sMenuText = QT_TR_NOOP("Compound");
-    sToolTipText = QT_TR_NOOP("Creates a compound from selected toolpaths");
+    sToolTipText = QT_TR_NOOP("Creates a compound from the selected toolpaths");
     sWhatsThis = "CAM_Compound";
     sStatusTip = sToolTipText;
     sPixmap = "CAM_Compound";
@@ -259,7 +259,7 @@ void CmdPathCompound::activated(int iMsg)
             }
             else {
                 Base::Console().error(
-                    "Only Path objects must be selected before running this command\n");
+                    "Only path objects must be selected before running this command\n");
                 return;
             }
         }
@@ -277,7 +277,7 @@ void CmdPathCompound::activated(int iMsg)
         updateActive();
     }
     else {
-        Base::Console().error("At least one Path object must be selected\n");
+        Base::Console().error("At least one path object must be selected\n");
         return;
     }
 }

--- a/src/Mod/CAM/Gui/DlgJobChooser.ui
+++ b/src/Mod/CAM/Gui/DlgJobChooser.ui
@@ -14,7 +14,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Choose a CAM Job</string>
+   <string>CAM Job Selection</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/Mod/CAM/Gui/DlgProcessorChooser.ui
+++ b/src/Mod/CAM/Gui/DlgProcessorChooser.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Choose a processor</string>
+   <string>Processor Selection</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">

--- a/src/Mod/CAM/Gui/DlgSettingsPathColor.ui
+++ b/src/Mod/CAM/Gui/DlgSettingsPathColor.ui
@@ -33,7 +33,7 @@
    <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBoxDefaultColors">
      <property name="title">
-      <string>Default Path colors</string>
+      <string>Default Path Colors</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="1" column="1">
@@ -323,7 +323,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label_12">
         <property name="text">
-         <string>Path Selection Style</string>
+         <string>Path selection style</string>
         </property>
        </widget>
       </item>
@@ -351,7 +351,7 @@
         </item>
         <item>
          <property name="text">
-          <string>Bounding Box</string>
+          <string>Bounding box</string>
          </property>
         </item>
         <item>
@@ -364,7 +364,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Task Panel Layout</string>
+         <string>Task panel layout</string>
         </property>
        </widget>
       </item>
@@ -388,12 +388,12 @@
         </item>
         <item>
          <property name="text">
-          <string>Multi Panel</string>
+          <string>Multi-panel</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Multi Panel - reversed</string>
+          <string>Multi-panel - reversed</string>
          </property>
         </item>
        </widget>

--- a/src/Mod/CAM/Gui/Resources/panels/AxisMapEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/AxisMapEdit.ui
@@ -34,7 +34,7 @@
    <item row="1" column="0">
     <widget class="QLabel" name="lblAxisMapInput">
      <property name="text">
-      <string>Axis Mapping</string>
+      <string>Axis mapping</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/CAM/Gui/Resources/panels/DlgJobCreate.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgJobCreate.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Create Job</string>
+   <string>New Job</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
@@ -29,7 +29,7 @@
             <bool>true</bool>
            </property>
            <property name="toolTip">
-            <string>Select a template to be used for the job. In case there are no templates you can create one through the popup menu of an existing job. Name the file job_*.json and place it in the macro or the path directory (see preferences) in order to be selectable from this list.</string>
+            <string>Select a template for the job. Templates are creatable from an existing job's context menu. Template files use the `job_*.json` naming convention and are stored in the macro or path directory (path configurable in preferences).</string>
            </property>
           </widget>
          </item>

--- a/src/Mod/CAM/Gui/Resources/panels/DlgJobModelSelect.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgJobModelSelect.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Select Base Models</string>
+   <string>Base Model Selection</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/Mod/CAM/Gui/Resources/panels/DlgJobTemplateExport.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgJobTemplateExport.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QGroupBox" name="postProcessingGroup">
      <property name="toolTip">
-      <string>If enabled, include all post processing settings in the template.</string>
+      <string>If enabled, include all post processing settings in the template</string>
      </property>
      <property name="title">
       <string>Post Processing</string>
@@ -35,7 +35,7 @@
          <enum>Qt::NoFocus</enum>
         </property>
         <property name="toolTip">
-         <string>Hint about the current post processing configuration.</string>
+         <string>Hint about the current post processing configuration</string>
         </property>
        </widget>
       </item>
@@ -45,7 +45,7 @@
    <item>
     <widget class="QGroupBox" name="toolsGroup">
      <property name="toolTip">
-      <string>If enabled, tool controller definitions are stored in the template.</string>
+      <string>If enabled, tool controller definitions are stored in the template</string>
      </property>
      <property name="title">
       <string>Tools</string>
@@ -57,7 +57,7 @@
       <item>
        <widget class="QListWidget" name="toolsList">
         <property name="toolTip">
-         <string>Check all tool controllers which should be included in the template.</string>
+         <string>Check all tool controllers which should be included in the template</string>
         </property>
        </widget>
       </item>
@@ -67,9 +67,7 @@
    <item>
     <widget class="QGroupBox" name="settingsGroup">
      <property name="toolTip">
-      <string>Enable to include values of the SetupSheet in the template.
-
-Any values of the SetupSheet that are changed from their default are preselected. If this field not selected the current SetupSheet was not modified.</string>
+      <string>Includes SetupSheet values in the template. Any SetupSheet values modified from their default are preselected.</string>
      </property>
      <property name="title">
       <string>Setup Sheet</string>
@@ -81,10 +79,10 @@ Any values of the SetupSheet that are changed from their default are preselected
       <item row="1" column="0">
        <widget class="QCheckBox" name="settingOperationHeights">
         <property name="toolTip">
-         <string>Enable to include the default heights for operations in the template.</string>
+         <string>Enable to include the default heights for operations in the template</string>
         </property>
         <property name="text">
-         <string>Operation Heights</string>
+         <string>Operation heights</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -94,7 +92,7 @@ Any values of the SetupSheet that are changed from their default are preselected
       <item row="1" column="1">
        <widget class="QCheckBox" name="settingOperationDepths">
         <property name="text">
-         <string>Operation Depths</string>
+         <string>Operation depths</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -104,10 +102,10 @@ Any values of the SetupSheet that are changed from their default are preselected
       <item row="2" column="0">
        <widget class="QCheckBox" name="settingToolRapid">
         <property name="toolTip">
-         <string>Enable to include the default rapid tool speeds in the template.</string>
+         <string>Enable to include the default rapid tool speeds in the template</string>
         </property>
         <property name="text">
-         <string>Tool Rapid Speeds</string>
+         <string>Tool rapid speeds</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -117,7 +115,7 @@ Any values of the SetupSheet that are changed from their default are preselected
       <item row="2" column="1">
        <widget class="QCheckBox" name="settingCoolant">
         <property name="toolTip">
-         <string>Enable to include the default coolant mode in the template.</string>
+         <string>Enable to include the default coolant mode in the template</string>
         </property>
         <property name="text">
          <string>Coolant Mode</string>
@@ -160,9 +158,9 @@ Note that this option is disabled if a stock object from an existing solid is us
         <property name="toolTip">
          <string>If enabled, the current size settings for the stock object are included in the template.
 
-For Box and Cylinder stocks this means the actual size of the stock solid being created.
+For box and cylinder stocks this means the actual size of the stock solid being created.
 
-For stock from the Base object's bounding box it means the extra material in all directions. A stock object created from such a template will get its basic size from the new job's Base object and apply the stored extra settings.</string>
+For stock from the base object's bounding box it means the extra material in all directions. A stock object created from such a template will get its basic size from the new job's base object and apply the stored extra settings.</string>
         </property>
         <property name="text">
          <string>Extent</string>
@@ -181,14 +179,14 @@ For stock from the Base object's bounding box it means the extra material in all
          <enum>Qt::NoFocus</enum>
         </property>
         <property name="toolTip">
-         <string>Hint about the current stock extent setting.</string>
+         <string>Hint about the current stock extent setting</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QCheckBox" name="stockPlacement">
         <property name="toolTip">
-         <string>If enabled, the current placement of the stock solid is stored in the template.</string>
+         <string>If enabled, the current placement of the stock solid is stored in the template</string>
         </property>
         <property name="text">
          <string>Placement</string>
@@ -207,7 +205,7 @@ For stock from the Base object's bounding box it means the extra material in all
          <enum>Qt::NoFocus</enum>
         </property>
         <property name="toolTip">
-         <string>Hint about the current stock placement.</string>
+         <string>Hint about the current stock placement</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/DlgSelectPostProcessor.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgSelectPostProcessor.ui
@@ -39,7 +39,7 @@
     </rect>
    </property>
    <property name="toolTip">
-    <string>Select one of the post processors. FreeCAD comes with several post processors pre-installed, please make sure at least one of them is enabled in your preferences.</string>
+    <string>Displays available post processors. FreeCAD includes several pre-installed post processors. At least one post processor must be enabled in preferences.</string>
    </property>
   </widget>
  </widget>

--- a/src/Mod/CAM/Gui/Resources/panels/DlgTCChooser.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgTCChooser.ui
@@ -20,13 +20,13 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Choose a Tool Controller</string>
+   <string>Tool Controller Selection</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Tool Controller</string>
+      <string>Tool controller</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/CAM/Gui/Resources/panels/DlgToolControllerEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgToolControllerEdit.ui
@@ -32,7 +32,7 @@
        <item>
         <widget class="QGroupBox" name="groupBox_4">
          <property name="title">
-          <string>Controller Name /  Tool Number</string>
+          <string>Controller Name / Tool Number</string>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
@@ -64,7 +64,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label">
             <property name="text">
-             <string>Horiz. Feed</string>
+             <string>Horizontal feed</string>
             </property>
            </widget>
           </item>
@@ -93,7 +93,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="label_2">
             <property name="text">
-             <string>Vert. Feed</string>
+             <string>Vertical feed</string>
             </property>
            </widget>
           </item>
@@ -122,7 +122,7 @@
           <item row="2" column="0">
            <widget class="QLabel" name="label_5">
             <property name="text">
-             <string>Horiz Rapid</string>
+             <string>Horizontal rapid</string>
             </property>
            </widget>
           </item>
@@ -151,7 +151,7 @@
           <item row="3" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>Vert Rapid</string>
+             <string>Vertical rapid</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/CAM/Gui/Resources/panels/DogboneEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DogboneEdit.ui
@@ -118,17 +118,17 @@
          </property>
          <item>
           <property name="text">
-           <string>adaptive</string>
+           <string>Adaptive</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>custom</string>
+           <string>Custom</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>fixed</string>
+           <string>Fixed</string>
           </property>
          </item>
         </widget>

--- a/src/Mod/CAM/Gui/Resources/panels/DragKnifeEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DragKnifeEdit.ui
@@ -34,7 +34,7 @@
   <item row="1" column="0">
     <widget class="QLabel" name="lblOffSetDistance">
      <property name="text">
-      <string>Offset Distance</string>
+      <string>Offset distance</string>
      </property>
     </widget>
    </item>
@@ -60,7 +60,7 @@
    <item row="2" column="0">
     <widget class="QLabel" name="lblPivotHeight">
      <property name="text">
-      <string>Pivot Height</string>
+      <string>Pivot height</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/CAM/Gui/Resources/panels/DressUpLeadInOutEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DressUpLeadInOutEdit.ui
@@ -25,10 +25,10 @@
      <item row="0" column="0">
       <widget class="QCheckBox" name="chkLeadIn">
        <property name="toolTip">
-        <string>Enable Lead-in move</string>
+        <string>Enable lead-in move</string>
        </property>
        <property name="text">
-        <string>Enable Lead In</string>
+        <string>Enable lead-in</string>
        </property>
       </widget>
      </item>
@@ -58,14 +58,14 @@
      <item row="2" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
-        <string>Length / Radius</string>
+        <string>Length/radius</string>
        </property>
       </widget>
      </item>
      <item row="2" column="1">
       <widget class="Gui::InputField" name="dspLenIn">
        <property name="toolTip">
-        <string>length or radius of the Lead-in</string>
+        <string>Length or radius of the lead-in</string>
        </property>
        <property name="minimum">
         <double>0.100000000000000</double>
@@ -85,7 +85,7 @@
      <item row="3" column="1">
       <widget class="Gui::InputField" name="dspExtendIn">
        <property name="toolTip">
-        <string>extends the leadin distance</string>
+        <string>Extends the lead-in distance</string>
        </property>
        <property name="unit" stdset="0">
         <string notr="true"/>
@@ -99,10 +99,10 @@
      <item row="0" column="0">
       <widget class="QCheckBox" name="chkLeadOut">
        <property name="toolTip">
-        <string>Enable Lead-out move</string>
+        <string>Enable lead-out move</string>
        </property>
        <property name="text">
-        <string>Enable Lead Out</string>
+        <string>Enable lead out</string>
        </property>
       </widget>
      </item>
@@ -132,14 +132,14 @@
      <item row="2" column="0">
       <widget class="QLabel" name="label_6">
        <property name="text">
-        <string>Length / Radius</string>
+        <string>Length/radius</string>
        </property>
       </widget>
      </item>
      <item row="2" column="1">
       <widget class="Gui::InputField" name="dspLenOut">
        <property name="toolTip">
-        <string>length or radius of the Lead-out</string>
+        <string>Length or radius of the lead-out</string>
        </property>
        <property name="minimum">
         <double>0.100000000000000</double>
@@ -159,7 +159,7 @@
      <item row="3" column="1">
       <widget class="Gui::InputField" name="dspExtendOut">
        <property name="toolTip">
-        <string>Extends the leadout distance</string>
+        <string>Extends the lead-out distance</string>
        </property>
        <property name="unit" stdset="0">
         <string notr="true"/>
@@ -182,17 +182,17 @@
         <string>Plunge at rapid speed</string>
        </property>
        <property name="text">
-        <string>Rapid Plunge</string>
+        <string>Rapid plunge</string>
        </property>
       </widget>
      </item>
      <item row="1" column="0">
       <widget class="QCheckBox" name="chkLayers">
        <property name="toolTip">
-        <string>Apply Lead In/Out on all layers</string>
+        <string>Apply lead-in/out on all layers</string>
        </property>
        <property name="text">
-        <string>Include Layers</string>
+        <string>Include layers</string>
        </property>
       </widget>
      </item>
@@ -202,7 +202,7 @@
         <string>Keep the tool down in the path</string>
        </property>
        <property name="text">
-        <string>Keep Tool Down</string>
+        <string>Keep tool down</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/CAM/Gui/Resources/panels/DressupPathBoundary.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DressupPathBoundary.ui
@@ -42,22 +42,22 @@
            </property>
            <item>
             <property name="text">
-             <string>Create Box</string>
+             <string>Create box</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>Create Cylinder</string>
+             <string>Create cylinder</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>Extend Model's Bounding Box</string>
+             <string>Extend model's bounding box</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>Use Existing Solid</string>
+             <string>Use existing solid</string>
             </property>
            </item>
           </widget>
@@ -84,7 +84,7 @@
          <item row="0" column="1">
           <widget class="QComboBox" name="stockExisting">
            <property name="toolTip">
-            <string>Select the body to be used to constrain the underlying Path.</string>
+            <string>Select the body to be used to constrain the underlying path</string>
            </property>
           </widget>
          </item>
@@ -179,7 +179,7 @@
          <item row="0" column="2">
           <widget class="Gui::InputField" name="stockCylinderRadius">
            <property name="toolTip">
-            <string>Radius of the Cylinder</string>
+            <string>Radius of the cylinder</string>
            </property>
           </widget>
          </item>
@@ -193,7 +193,7 @@
         <item row="1" column="2">
           <widget class="Gui::InputField" name="stockCylinderHeight">
            <property name="toolTip">
-            <string>Height of the Cylinder</string>
+            <string>Height of the cylinder</string>
            </property>
           </widget>
          </item>
@@ -213,7 +213,7 @@
          <item row="0" column="2">
           <widget class="Gui::InputField" name="stockBoxLength">
            <property name="toolTip">
-            <string>Length of the Box</string>
+            <string>Length of the box</string>
            </property>
           </widget>
          </item>
@@ -227,7 +227,7 @@
          <item row="1" column="2">
           <widget class="Gui::InputField" name="stockBoxWidth">
            <property name="toolTip">
-            <string>Width of the Box</string>
+            <string>Width of the box</string>
            </property>
           </widget>
          </item>
@@ -241,7 +241,7 @@
         <item row="2" column="2">
           <widget class="Gui::InputField" name="stockBoxHeight">
            <property name="toolTip">
-            <string>Height of the Box</string>
+            <string>Height of the box</string>
            </property>
           </widget>
          </item>
@@ -257,7 +257,7 @@
       <string>If checked, the path is constrained by the solid. Otherwise the volume of the solid describes a 'keep out' zone</string>
      </property>
      <property name="text">
-      <string>Constrained to Inside</string>
+      <string>Constrained to inside</string>
      </property>
      <property name="checked">
       <bool>true</bool>

--- a/src/Mod/CAM/Gui/Resources/panels/HoldingTagsEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/HoldingTagsEdit.ui
@@ -44,7 +44,7 @@
       <item row="0" column="1">
        <widget class="Gui::InputField" name="ifWidth">
         <property name="toolTip">
-         <string>Width of the resulting holding tag.</string>
+         <string>Width of the resulting holding tag</string>
         </property>
        </widget>
       </item>
@@ -58,7 +58,7 @@
       <item row="2" column="1">
        <widget class="QDoubleSpinBox" name="dsbAngle">
         <property name="toolTip">
-         <string>Plunge angle for ascent and descent of holding tag.</string>
+         <string>Plunge angle for ascent and descent of holding tag</string>
         </property>
         <property name="minimum">
          <double>5.000000000000000</double>
@@ -123,14 +123,14 @@
          <bool>false</bool>
         </property>
         <property name="text">
-         <string>Edit...</string>
+         <string>Edit…</string>
         </property>
        </widget>
       </item>
      <item row="1" column="2">
        <widget class="QPushButton" name="pbAdd">
         <property name="text">
-         <string>Add...</string>
+         <string>Add…</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageBaseGeometryEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageBaseGeometryEdit.ui
@@ -33,7 +33,7 @@
       </sizepolicy>
      </property>
      <property name="toolTip">
-      <string>List of operations with Base Geometry in current Job</string>
+      <string>List of operations with base geometry in the current job</string>
      </property>
     </widget>
    </item>
@@ -96,7 +96,7 @@
    <item row="6" column="0" colspan="3">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>All objects will be processed using the same operation properties.</string>
+      <string>All objects will be processed using the same operation properties</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/src/Mod/CAM/Gui/Resources/panels/PageBaseHoleGeometryEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageBaseHoleGeometryEdit.ui
@@ -21,9 +21,9 @@
        <property name="toolTip">
         <string>Table of hole features and the determined radius of the associated hole.
 
-You can add feature for processing by selecting them and then pressing Add. If a feature is accidentally added to the list it can be removed through Remove and will no longer be processed.
+Add features for processing by selecting them and then pressing 'Add'. If a feature is accidentally added to the list, it can be removed through 'Remove' and will no longer be processed.
 
-Reset deletes all current items from the list and fills the list with all circular holes eligible for the operation from the model. You can again refine the list afterwards by enabling/disabling, removing and adding features.</string>
+Reset deletes all current items from the list and fills the list with all circular holes eligible for the operation from the model. Refine the list afterwards by enabling/disabling, removing and adding features.</string>
        </property>
        <attribute name="horizontalHeaderStretchLastSection">
         <bool>true</bool>

--- a/src/Mod/CAM/Gui/Resources/panels/PageBaseLocationEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageBaseLocationEdit.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTableWidget" name="baseList">
      <property name="toolTip">
-      <string>List of locations to be processed.</string>
+      <string>List of locations to be processed</string>
      </property>
      <column>
       <property name="text">
@@ -37,7 +37,7 @@
       <item row="0" column="1">
        <widget class="QPushButton" name="addLocation">
         <property name="toolTip">
-         <string>Opens a dialog to add arbitrary locations.</string>
+         <string>Opens a dialog to add arbitrary locations</string>
         </property>
         <property name="text">
          <string>Add</string>
@@ -57,7 +57,7 @@
       <item row="0" column="3">
        <widget class="QPushButton" name="editLocation">
         <property name="toolTip">
-         <string>Edit selected location.</string>
+         <string>Edit selected location</string>
         </property>
         <property name="text">
          <string>Edit</string>
@@ -67,7 +67,7 @@
       <item row="1" column="1" colspan="3">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>All locations will be processed using the same operation properties.</string>
+         <string>All locations will be processed using the same operation properties</string>
         </property>
         <property name="textFormat">
          <enum>Qt::AutoText</enum>

--- a/src/Mod/CAM/Gui/Resources/panels/PageDepthsEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageDepthsEdit.ui
@@ -36,14 +36,14 @@
       </size>
      </property>
      <property name="text">
-      <string>Start Depth</string>
+      <string>Start depth</string>
      </property>
     </widget>
    </item>
    <item row="0" column="2">
     <widget class="Gui::QuantitySpinBox" name="startDepth">
      <property name="toolTip">
-      <string>Start Depth of the operation. The highest point in Z-axis the operation needs to process.</string>
+      <string>Start depth of the operation. The highest point in Z-axis the operation needs to process.</string>
      </property>
      <property name="minimum" stdset="0">
       <double>-999999999.000000000000000</double>
@@ -56,7 +56,7 @@
    <item row="0" column="3">
     <widget class="QToolButton" name="startDepthSet">
      <property name="toolTip">
-      <string>Transfer the Z value of the selected feature as the Start Depth for the operation.</string>
+      <string>Transfer the Z value of the selected feature as the start depth for the operation.</string>
      </property>
      <property name="text">
       <string notr="true">...</string>
@@ -82,7 +82,7 @@
       </size>
      </property>
      <property name="text">
-      <string>Final Depth</string>
+      <string>Final depth</string>
      </property>
     </widget>
    </item>
@@ -102,7 +102,7 @@
    <item row="1" column="3">
     <widget class="QToolButton" name="finalDepthSet">
      <property name="toolTip">
-      <string>Transfer the Z value of the selected feature as the Final Depth for the operation.</string>
+      <string>Transfer the Z value of the selected feature as the final depth for the operation.</string>
      </property>
      <property name="text">
       <string notr="true">...</string>
@@ -128,14 +128,14 @@
       </size>
      </property>
      <property name="text">
-      <string>Step Down</string>
+      <string>Step down</string>
      </property>
     </widget>
    </item>
    <item row="2" column="2">
     <widget class="Gui::QuantitySpinBox" name="stepDown">
      <property name="toolTip">
-      <string>The depth in Z-axis the operation moves downwards between layers. This value depends on the tool being used, the material to be cut, available cooling and many other factors. Please consult the tool manufacturers data sheets for the proper value.</string>
+      <string>The depth in Z-axis the operation moves downwards between layers. This value depends on the tool being used, the material to be cut, available cooling and many other factors. Consult the tool manufacturers data sheets for the proper value.</string>
      </property>
      <property name="minimum" stdset="0">
       <double>-999999999.000000000000000</double>
@@ -160,7 +160,7 @@
       </size>
      </property>
      <property name="text">
-      <string>Finish Step Down</string>
+      <string>Finish step down</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageDiametersEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageDiametersEdit.ui
@@ -24,7 +24,7 @@
    <item row="0" column="1">
     <widget class="Gui::QuantitySpinBox" name="minDiameter">
      <property name="toolTip">
-      <string>Start Depth of the operation. The highest point in Z-axis the operation needs to process.</string>
+      <string>Start depth of the operation. The highest point in Z-axis the operation needs to process.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -40,10 +40,10 @@
    <item row="0" column="2">
     <widget class="QToolButton" name="startDepthSet">
      <property name="toolTip">
-      <string>Transfer the Z value of the selected feature as the Start Depth for the operation.</string>
+      <string>Transfer the Z value of the selected feature as the start depth for the operation.</string>
      </property>
      <property name="text">
-      <string notr="true">...</string>
+      <string notr="true">…</string>
      </property>
      <property name="icon">
       <iconset resource="../../../../../Gui/Icons/resource.qrc">
@@ -54,7 +54,7 @@
    <item row="1" column="0">
     <widget class="QLabel" name="finalDepthLabel">
      <property name="text">
-      <string>Max Diameter</string>
+      <string>Max diameter</string>
      </property>
     </widget>
    </item>
@@ -77,10 +77,10 @@
    <item row="1" column="2">
     <widget class="QToolButton" name="finalDepthSet">
      <property name="toolTip">
-      <string>Transfer the Z value of the selected feature as the Final Depth for the operation.</string>
+      <string>Transfer the Z value of the selected feature as the final depth for the operation.</string>
      </property>
      <property name="text">
-      <string notr="true">...</string>
+      <string notr="true">…</string>
      </property>
      <property name="icon">
       <iconset resource="../../../../../Gui/Icons/resource.qrc">

--- a/src/Mod/CAM/Gui/Resources/panels/PageHeightsEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageHeightsEdit.ui
@@ -21,7 +21,7 @@
    <item row="0" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
-      <string>Safe Height</string>
+      <string>Safe height</string>
      </property>
     </widget>
    </item>
@@ -44,7 +44,7 @@
    <item row="1" column="0">
     <widget class="QLabel" name="label_9">
      <property name="text">
-      <string>Clearance Height</string>
+      <string>Clearance height</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
@@ -20,7 +20,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
-         <string>Tool Controller</string>
+         <string>Tool controller</string>
         </property>
        </widget>
       </item>
@@ -61,7 +61,7 @@
          <item>
           <widget class="QLabel" name="threadFitLabel">
            <property name="text">
-            <string>Accuracy vs Performance</string>
+            <string>Accuracy vs performance</string>
            </property>
           </widget>
          </item>
@@ -98,7 +98,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="23" column="0">
        <widget class="QCheckBox" name="ForceInsideOut">
         <property name="text">
-         <string>Force Clearing Inside-out</string>
+         <string>Force clearing inside-out</string>
         </property>
        </widget>
       </item>
@@ -119,7 +119,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="24" column="0">
        <widget class="QCheckBox" name="FinishingProfile">
         <property name="text">
-         <string>Finishing Profile</string>
+         <string>Finishing profile</string>
         </property>
        </widget>
       </item>
@@ -136,7 +136,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="20" column="0">
        <widget class="QLabel" name="label_12">
         <property name="text">
-         <string>XY Stock to Leave</string>
+         <string>XY stock to leave</string>
         </property>
        </widget>
       </item>
@@ -162,7 +162,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="4" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Step Over Percent</string>
+         <string>Step over percent</string>
         </property>
        </widget>
       </item>
@@ -179,21 +179,21 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="10" column="0">
        <widget class="QLabel" name="label_7">
         <property name="text">
-         <string>Helix Ramp Angle</string>
+         <string>Helix ramp angle</string>
         </property>
        </widget>
       </item>
       <item row="25" column="0">
        <widget class="QCheckBox" name="useOutline">
         <property name="text">
-         <string>Use Outline</string>
+         <string>Use outline</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Operation Type</string>
+         <string>Operation type</string>
         </property>
        </widget>
       </item>
@@ -210,7 +210,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="18" column="0">
        <widget class="QLabel" name="label_11">
         <property name="text">
-         <string>Keep Tool Down Ratio</string>
+         <string>Keep tool down ratio</string>
         </property>
        </widget>
       </item>
@@ -227,7 +227,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="12" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>Helix Cone Angle</string>
+         <string>Helix cone angle</string>
         </property>
        </widget>
       </item>
@@ -244,14 +244,14 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="16" column="0">
        <widget class="QLabel" name="label_10">
         <property name="text">
-         <string>Lift Distance</string>
+         <string>Lift distance</string>
         </property>
        </widget>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Cut Region</string>
+         <string>Cut region</string>
         </property>
        </widget>
       </item>
@@ -268,7 +268,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="14" column="0">
        <widget class="QLabel" name="label_9">
         <property name="text">
-         <string>Helix Max Diameter</string>
+         <string>Helix max diameter</string>
         </property>
        </widget>
       </item>
@@ -287,7 +287,7 @@ This option changes that behavior to cut each discrete area to its full depth be
       <item row="21" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Z Stock to Leave</string>
+         <string>Z stock to leave</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpCustomEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpCustomEdit.ui
@@ -32,21 +32,21 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Tool Controller</string>
+         <string>Tool controller</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="toolController">
         <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
+         <string>The tool and its settings to be used for this operation</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Coolant Mode</string>
+         <string>Coolant mode</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpDeburrEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpDeburrEdit.ui
@@ -50,14 +50,14 @@
          </size>
         </property>
         <property name="text">
-         <string>Tool Controller</string>
+         <string>Tool controller</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
        <widget class="QComboBox" name="toolController">
         <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
+         <string>The tool and its settings to be used for this operation</string>
         </property>
        </widget>
       </item>
@@ -82,14 +82,14 @@
          </size>
         </property>
         <property name="text">
-         <string>Coolant Mode</string>
+         <string>Coolant mode</string>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
        <widget class="QComboBox" name="coolantController">
         <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
+         <string>The tool and its settings to be used for this operation</string>
         </property>
        </widget>
       </item>
@@ -135,7 +135,7 @@
      <item>
       <widget class="QComboBox" name="direction">
        <property name="toolTip">
-        <string>The direction in which the profile is performed, clockwise or counterclockwise.</string>
+        <string>The direction in which the profile is performed, clockwise or counterclockwise</string>
        </property>
        <property name="currentText">
         <string>CW</string>
@@ -192,7 +192,7 @@
           <item>
            <widget class="Gui::InputField" name="value_W">
             <property name="toolTip">
-             <string>Width of chamfer cut.</string>
+             <string>Width of chamfer cut</string>
             </property>
             <property name="unit" stdset="0">
              <string>mm</string>
@@ -219,7 +219,7 @@
           <item>
            <widget class="Gui::InputField" name="value_h">
             <property name="toolTip">
-             <string>Extra depth of tool immersion.</string>
+             <string>Extra depth of tool immersion</string>
             </property>
             <property name="unit" stdset="0">
              <string>mm</string>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpDrillingEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpDrillingEdit.ui
@@ -39,31 +39,31 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="toolController">
         <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
+         <string>The tool and its settings to be used for this operation</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Coolant Mode</string>
+         <string>Coolant mode</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
        <widget class="QComboBox" name="coolantController">
         <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
+         <string>The tool and its settings to be used for this operation</string>
         </property>
        </widget>
      </item>
      <item row="8" column="1">
        <widget class="QCheckBox" name="KeepToolDownEnabled">
         <property name="toolTip">
-         <string>Don't retract after every hole</string>
+         <string>Do not retract after every hole</string>
         </property>
         <property name="text">
-         <string>Keep Tool Down</string>
+         <string>Keep tool down</string>
         </property>
        </widget>
       </item>
@@ -92,7 +92,7 @@
      <item row="8" column="4">
       <widget class="QLabel" name="Offsetlabel">
        <property name="text">
-        <string>Extend Depth</string>
+        <string>Extend depth</string>
        </property>
       </widget>
      </item>
@@ -112,12 +112,12 @@
        </item>
        <item>
         <property name="text">
-         <string>Drill Tip</string>
+         <string>Drill tip</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>2x Drill Tip</string>
+         <string>2x drill tip</string>
         </property>
        </item>
       </widget>
@@ -166,7 +166,7 @@
      <item row="2" column="1">
       <widget class="QCheckBox" name="chipBreakEnabled">
        <property name="text">
-        <string>Chip Break</string>
+        <string>Chip break</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpEngraveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpEngraveEdit.ui
@@ -26,28 +26,28 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Tool Controller</string>
+         <string>Tool controller</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="toolController">
         <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
+         <string>The tool and its settings to be used for this operation</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Coolant Mode</string>
+         <string>Coolant mode</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
        <widget class="QComboBox" name="coolantController">
         <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
+         <string>The tool and its settings to be used for this operation</string>
         </property>
        </widget>
       </item>
@@ -60,14 +60,14 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Start at Vertex</string>
+         <string>Start at vertex</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
        <widget class="QSpinBox" name="startVertex">
         <property name="toolTip">
-         <string>Specify the vertex number of the underlying shape string at which engraving should start.</string>
+         <string>Specify the vertex number of the underlying shape string at which engraving should start</string>
         </property>
         <property name="maximum">
          <number>999999</number>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
@@ -33,7 +33,7 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="toolController">
         <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
+         <string>The tool and its settings to be used for this operation</string>
         </property>
        </widget>
       </item>
@@ -47,7 +47,7 @@
       <item row="1" column="1">
        <widget class="QComboBox" name="coolantController">
         <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
+         <string>The tool and its settings to be used for this operation</string>
         </property>
        </widget>
       </item>
@@ -67,7 +67,7 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="startSide">
         <property name="toolTip">
-         <string>Specify if the helix operation should start at the inside and work its way outwards, or start at the outside and work its way to the center.</string>
+         <string>Specify if the helix operation should start at the inside and work its way outwards, or start at the outside and work its way to the center</string>
         </property>
         <item>
          <property name="text">
@@ -91,7 +91,7 @@
       <item row="2" column="1">
        <widget class="QComboBox" name="cutMode">
         <property name="toolTip">
-         <string>The direction for the helix, clockwise or counterclockwise.</string>
+         <string>The direction for the helix, clockwise or counterclockwise</string>
         </property>
         <item>
          <property name="text">
@@ -134,7 +134,7 @@
       <item row="5" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Extra Offset</string>
+         <string>Extra offset</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpPocketExtEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpPocketExtEdit.ui
@@ -19,7 +19,7 @@
      <item>
       <widget class="QCheckBox" name="enableExtensions">
        <property name="text">
-        <string>Enable Extensions</string>
+        <string>Enable extensions</string>
        </property>
        <property name="checkable">
         <bool>true</bool>
@@ -65,7 +65,7 @@
             <string>Extend the corner between two edges of a pocket. Selected adjacent edges are combined.</string>
            </property>
            <property name="text">
-            <string>Extend Corners</string>
+            <string>Extend corners</string>
            </property>
            <property name="checked">
             <bool>true</bool>
@@ -75,14 +75,14 @@
          <item row="3" column="0">
           <widget class="QLabel" name="label">
            <property name="text">
-            <string>Default Length</string>
+            <string>Default length</string>
            </property>
           </widget>
          </item>
          <item row="3" column="1">
           <widget class="Gui::QuantitySpinBox" name="defaultLength">
            <property name="toolTip">
-            <string>Set the extent of the dimension -the default value is half the tool diameter</string>
+            <string>Set the extent of the dimension. The default value is half the tool diameter.</string>
            </property>
            <property name="minimum">
             <double>-999999999.000000000000000</double>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpPocketFullEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpPocketFullEdit.ui
@@ -26,7 +26,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="toolController_label">
         <property name="text">
-         <string>Tool Controller</string>
+         <string>Tool controller</string>
         </property>
        </widget>
       </item>
@@ -69,7 +69,7 @@
         <property name="toolTip">
          <string>Specify if the facing should be restricted by the actual shape of the selected face (or the part if no face is selected), or if the bounding box should be faced off.
 
-The latter can be used to face of the entire stock area to ensure uniform heights for the following operations</string>
+The latter can be used to face of the entire stock area to ensure uniform heights for the following operations.</string>
         </property>
        </widget>
       </item>
@@ -175,7 +175,7 @@ The latter can be used to face of the entire stock area to ensure uniform height
       <item row="3" column="0">
        <widget class="QLabel" name="stepOverPercent_label">
         <property name="text">
-         <string>Step Over Percent</string>
+         <string>Step over percent</string>
         </property>
        </widget>
       </item>
@@ -201,7 +201,7 @@ The latter can be used to face of the entire stock area to ensure uniform height
       <item row="4" column="0">
        <widget class="QLabel" name="extraOffset_label">
         <property name="text">
-         <string>Material Allowance</string>
+         <string>Material allowance</string>
         </property>
        </widget>
       </item>
@@ -224,7 +224,7 @@ The latter can be used to face of the entire stock area to ensure uniform height
          <string>Specify if this operation uses a starting point</string>
         </property>
         <property name="text">
-         <string>Use Start Point</string>
+         <string>Use start point</string>
         </property>
        </widget>
       </item>
@@ -234,21 +234,21 @@ The latter can be used to face of the entire stock area to ensure uniform height
          <string>If selected the operation uses the outline of the selected base geometry and ignores all holes and islands</string>
         </property>
         <property name="text">
-         <string>Use Outline</string>
+         <string>Use outline</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
        <widget class="QCheckBox" name="clearEdges">
         <property name="text">
-         <string>Clear Edges</string>
+         <string>Clear edges</string>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
        <widget class="QCheckBox" name="minTravel">
         <property name="text">
-         <string>Min Travel</string>
+         <string>Min travel</string>
         </property>
        </widget>
       </item>
@@ -258,7 +258,7 @@ The latter can be used to face of the entire stock area to ensure uniform height
          <string>Check to skip machining regions that have already been cleared by previous operations</string>
         </property>
         <property name="text">
-         <string>Use Rest Machining</string>
+         <string>Use rest machining</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpProbeEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpProbeEdit.ui
@@ -32,7 +32,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Tool Controller</string>
+         <string>Tool controller</string>
         </property>
        </widget>
       </item>
@@ -49,7 +49,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Probe Grid Points</string>
+      <string>Probe grid points</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
@@ -98,7 +98,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
-         <string>X Offset</string>
+         <string>X offset</string>
         </property>
        </widget>
       </item>
@@ -112,7 +112,7 @@
      <item row="2" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Y Offset</string>
+         <string>Y offset</string>
         </property>
        </widget>
       </item>
@@ -135,7 +135,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>File Name</string>
+         <string>File name</string>
         </property>
        </widget>
       </item>
@@ -152,7 +152,7 @@
       <item row="0" column="2">
        <widget class="QToolButton" name="SetOutputFileName">
         <property name="text">
-         <string notr="true">...</string>
+         <string notr="true">…</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpProfileFullEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpProfileFullEdit.ui
@@ -26,7 +26,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Tool Controller</string>
+         <string>Tool controller</string>
         </property>
        </widget>
       </item>
@@ -40,7 +40,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Coolant Mode</string>
+         <string>Coolant mode</string>
         </property>
        </widget>
       </item>
@@ -60,14 +60,14 @@
       <item row="0" column="0">
        <widget class="QLabel" name="cutSideLabel">
         <property name="text">
-         <string>Cut Side</string>
+         <string>Cut side</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="cutSide">
         <property name="toolTip">
-         <string>Specify if the profile should be performed inside or outside the base geometry features. This only matters if Use Compensation is checked (the default)</string>
+         <string>Specify if the profile should be performed inside or outside the base geometry features. This only matters if 'Use compensation' is checked (the default).</string>
         </property>
         <item>
          <property name="text">
@@ -98,7 +98,7 @@
       <item row="2" column="0">
        <widget class="QLabel" name="extraOffsetLabel">
         <property name="text">
-         <string>Extra Offset</string>
+         <string>Extra offset</string>
         </property>
        </widget>
       </item>
@@ -118,7 +118,7 @@
       <item row="3" column="0">
        <widget class="QLabel" name="numPassesLabel">
         <property name="text">
-         <string>Number of Passes</string>
+         <string>Number of passes</string>
         </property>
        </widget>
       </item>
@@ -128,14 +128,14 @@
 		 <number>1</number>
         </property>
         <property name="toolTip">
-         <string>The number of passes to do. If more than one, requires a non-zero value for Pass Stepover.</string>
+         <string>The number of passes to do. If more than one, requires a non-zero value for 'Pass stepover'.</string>
         </property>
        </widget>
       </item>
       <item row="4" column="0">
        <widget class="QLabel" name="stepoverLabel">
         <property name="text">
-         <string>Pass Stepover</string>
+         <string>Pass stepover</string>
         </property>
        </widget>
       </item>
@@ -148,7 +148,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string>If doing multiple passes, the extra offset of each additional pass.</string>
+         <string>If doing multiple passes, the extra offset of each additional pass</string>
         </property>
        </widget>
       </item>
@@ -174,14 +174,14 @@
          <string>Check if this profile operation should also process holes in the base geometry. Found holes are automatically offset on the opposite cut side and performed in the opposite direction as perimeters. Note that this does not include cylindrical holes, the assumption being that they will get drilled</string>
         </property>
         <property name="text">
-         <string>Process Holes</string>
+         <string>Process holes</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QCheckBox" name="useCompensation">
         <property name="toolTip">
-         <string>If checked, the profile operation is offset by the tool radius. The offset direction is determined by the Cut Side</string>
+         <string>If checked, the profile operation is offset by the tool radius. The offset direction is determined by 'Cut side'.</string>
         </property>
         <property name="text">
          <string>Use Compensation</string>
@@ -191,10 +191,10 @@
       <item row="1" column="1">
        <widget class="QCheckBox" name="processCircles">
         <property name="toolTip">
-         <string>Check if you want this profile operation to also be applied to cylindrical holes, which normally get drilled. This can be useful if no drill of adequate size is available or the number of holes don't warrant a tool change. Note that the cut side and direction is reversed in respect to the specified values</string>
+         <string>Check if you want this profile operation to also be applied to cylindrical holes, which normally get drilled. This can be useful if no drill of adequate size is available or the number of holes don't warrant a tool change. Note that the cut side and direction is reversed in respect to the specified values.</string>
         </property>
         <property name="text">
-         <string>Process Circles</string>
+         <string>Process circles</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpSlotEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpSlotEdit.ui
@@ -32,14 +32,14 @@
       <item row="0" column="0">
        <widget class="QLabel" name="toolController_label">
         <property name="text">
-         <string>Tool Controller</string>
+         <string>Tool controller</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="toolController">
         <property name="toolTip">
-         <string> The tool and its settings to be used for this operation </string>
+         <string> The tool and its settings to be used for this operation</string>
         </property>
        </widget>
       </item>
@@ -49,7 +49,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="coolantController_label">
         <property name="text">
-         <string>Coolant Mode</string>
+         <string>Coolant mode</string>
         </property>
        </widget>
       </item>
@@ -68,7 +68,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="geo1Reference_label">
         <property name="text">
-         <string>Start Feature Reference</string>
+         <string>Start feature reference</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -94,32 +94,32 @@
         </property>
         <item>
          <property name="text">
-          <string>Center of Mass</string>
+          <string>Center of mass</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Center of Bounding Box</string>
+          <string>Center of bounding box</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Lowest Point</string>
+          <string>Lowest point</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Highest Point</string>
+          <string>Highest point</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Long Edge</string>
+          <string>Long edge</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Short Edge</string>
+          <string>Short edge</string>
          </property>
         </item>
         <item>
@@ -166,22 +166,22 @@
         </property>
         <item>
          <property name="text">
-          <string>Center of Mass</string>
+          <string>Center of mass</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Center of Bounding Box</string>
+          <string>Center of bounding box</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Lowest Point</string>
+          <string>Lowest point</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Highest Point</string>
+          <string>Highest point</string>
          </property>
         </item>
         <item>
@@ -219,13 +219,13 @@
          </font>
         </property>
         <property name="toolTip">
-         <string>No Base Geometry selected</string>
+         <string>No base geometry Selected</string>
         </property>
         <property name="styleSheet">
          <string notr="true">color:blue</string>
         </property>
         <property name="text">
-         <string>No Base Geometry selected.</string>
+         <string>No base geometry selected</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -238,10 +238,10 @@
       <item>
        <widget class="QLabel" name="usingCustomPoints">
         <property name="toolTip">
-         <string>Currently using custom point inputs in the Property View of the Data tab</string>
+         <string>Currently using custom point inputs in the property view of the data tab</string>
         </property>
         <property name="text">
-         <string>Currently using custom point inputs available in the Property View of the Data tab.</string>
+         <string>Currently using custom point inputs available in the property view of the data tab</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -272,7 +272,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Extend Path Start</string>
+         <string>Extend path start</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -342,7 +342,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="layerMode_label">
         <property name="text">
-         <string>Layer Mode</string>
+         <string>Layer mode</string>
         </property>
        </widget>
       </item>
@@ -371,18 +371,18 @@
       <item row="1" column="0">
        <widget class="QLabel" name="pathOrientation_label">
         <property name="text">
-         <string>Path Orientation</string>
+         <string>Path orientation</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
        <widget class="QComboBox" name="pathOrientation">
         <property name="toolTip">
-         <string>Choose the path orientation with regard to the feature(s) selected</string>
+         <string>Choose the path orientation with regard to the features selected</string>
         </property>
         <item>
          <property name="text">
-          <string>Start to End</string>
+          <string>Start to end</string>
          </property>
         </item>
         <item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpSurfaceEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpSurfaceEdit.ui
@@ -33,21 +33,21 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="toolController">
         <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
+         <string>The tool and its settings to be used for this operation</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="coolantController_label">
         <property name="text">
-         <string>Coolant Mode</string>
+         <string>Coolant mode</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
        <widget class="QComboBox" name="coolantController">
         <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
+         <string>The tool and its settings to be used for this operation</string>
         </property>
        </widget>
       </item>
@@ -60,84 +60,84 @@
       <item row="0" column="0">
        <widget class="QLabel" name="boundBoxSelect_label">
         <property name="text">
-         <string>Bounding Box</string>
+         <string>Bounding box</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1" colspan="2">
        <widget class="QComboBox" name="boundBoxSelect">
         <property name="toolTip">
-         <string>Select the overall boundary for the operation.</string>
+         <string>Select the overall boundary for the operation</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="scanType_label">
         <property name="text">
-         <string>Scan Type</string>
+         <string>Scan type</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1" colspan="2">
        <widget class="QComboBox" name="scanType">
         <property name="toolTip">
-         <string>Planar: Flat, 3D surface scan.  Rotational: 4th-axis rotational scan.</string>
+         <string>Planar: flat, 3D surface scan. Rotational: 4th-axis rotational scan.</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="layerMode_label">
         <property name="text">
-         <string>Layer Mode</string>
+         <string>Layer mode</string>
         </property>
        </widget>
       </item>
       <item row="2" column="1" colspan="2">
        <widget class="QComboBox" name="layerMode">
         <property name="toolTip">
-         <string>Complete the operation in a single pass at depth, or multiple passes to final depth.</string>
+         <string>Complete the operation in a single pass at depth, or multiple passes to final depth</string>
         </property>
        </widget>
       </item>
       <item row="3" column="0">
        <widget class="QLabel" name="cutPattern_label">
         <property name="text">
-         <string>Cut Pattern</string>
+         <string>Cut pattern</string>
         </property>
        </widget>
       </item>
       <item row="3" column="1" colspan="2">
        <widget class="QComboBox" name="cutPattern">
         <property name="toolTip">
-         <string>Set the geometric clearing pattern to use for the operation.</string>
+         <string>Set the geometric clearing pattern to use for the operation</string>
         </property>
        </widget>
       </item>
       <item row="4" column="0">
        <widget class="QLabel" name="profileEdges_label">
         <property name="text">
-         <string>Profile Edges</string>
+         <string>Profile edges</string>
         </property>
        </widget>
       </item>
       <item row="4" column="1" colspan="2">
        <widget class="QComboBox" name="profileEdges">
         <property name="toolTip">
-         <string>Profile the edges of the selection.</string>
+         <string>Profile the edges of the selection</string>
         </property>
        </widget>
       </item>
       <item row="5" column="0">
        <widget class="QLabel" name="avoidLastX_Faces_label">
         <property name="text">
-         <string>Avoid Last X Faces</string>
+         <string>Avoid last X faces</string>
         </property>
        </widget>
       </item>
       <item row="5" column="1" colspan="2">
        <widget class="QSpinBox" name="avoidLastX_Faces">
         <property name="toolTip">
-         <string>Avoid cutting the last 'N' faces in the Base Geometry list of selected faces.</string>
+         <string>Avoid cutting the last 'n' faces in the base geometry list of selected faces</string>
         </property>
        </widget>
       </item>
@@ -159,7 +159,7 @@
            </sizepolicy>
           </property>
           <property name="toolTip">
-           <string>Additional offset to the selected bounding box along the X axis.</string>
+           <string>Additional offset to the selected bounding box along the X axis</string>
           </property>
           <property name="unit" stdset="0">
            <string notr="true">mm</string>
@@ -169,7 +169,7 @@
         <item>
          <widget class="Gui::InputField" name="boundBoxExtraOffsetY">
           <property name="toolTip">
-           <string>Additional offset to the selected bounding box along the Y axis.</string>
+           <string>Additional offset to the selected bounding box along the Y axis</string>
           </property>
           <property name="unit" stdset="0">
            <string notr="true">mm</string>
@@ -181,7 +181,7 @@
       <item row="8" column="0">
        <widget class="QLabel" name="dropCutterDirSelect_label">
         <property name="text">
-         <string>Drop Cutter Direction</string>
+         <string>Drop cutter direction</string>
         </property>
        </widget>
       </item>
@@ -202,7 +202,7 @@
       <item row="9" column="1" colspan="2">
        <widget class="Gui::InputField" name="depthOffset">
         <property name="toolTip">
-         <string>Set the Z-axis depth offset from the target surface.</string>
+         <string>Set the Z-axis depth offset from the target surface</string>
         </property>
         <property name="unit" stdset="0">
          <string notr="true">mm</string>
@@ -212,7 +212,7 @@
       <item row="10" column="0">
        <widget class="QLabel" name="stepOver_label">
         <property name="text">
-         <string>Step over</string>
+         <string>Stepover</string>
         </property>
        </widget>
       </item>
@@ -251,10 +251,10 @@ A step over of 100% results in no overlap between two different cycles.</string>
       <item row="14" column="0">
        <widget class="QCheckBox" name="useStartPoint">
         <property name="toolTip">
-         <string>Make True, if specifying a Start Point</string>
+         <string>Set to true if specifying a start point</string>
         </property>
         <property name="text">
-         <string>Use Start Point</string>
+         <string>Use start point</string>
         </property>
        </widget>
       </item>
@@ -264,17 +264,17 @@ A step over of 100% results in no overlap between two different cycles.</string>
          <string>Enable optimization of linear paths (co-linear points). Removes unnecessary co-linear points from G-code output.</string>
         </property>
         <property name="text">
-         <string>Optimize Linear Paths</string>
+         <string>Optimize linear paths</string>
         </property>
        </widget>
       </item>
       <item row="15" column="0">
        <widget class="QCheckBox" name="boundaryEnforcement">
         <property name="toolTip">
-         <string>If true, the cutter will remain inside the boundaries of the model or selected face(s)</string>
+         <string>If true, the cutter will remain inside the boundaries of the model or selected faces</string>
         </property>
         <property name="text">
-         <string>Boundary Enforcement</string>
+         <string>Boundary enforcement</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -287,7 +287,7 @@ A step over of 100% results in no overlap between two different cycles.</string>
          <string>Enable separate optimization of transitions between, and breaks within, each step over path.</string>
         </property>
         <property name="text">
-         <string>Optimize StepOver Transitions</string>
+         <string>Optimize stepover transitions</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpTappingEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpTappingEdit.ui
@@ -42,12 +42,12 @@
        </item>
        <item>
         <property name="text">
-         <string>Tap Tip</string>
+         <string>Tap tip</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>2x Tap Tip</string>
+         <string>2x tap tip</string>
         </property>
        </item>
       </widget>
@@ -62,7 +62,7 @@
      <item row="5" column="4">
       <widget class="QLabel" name="Offsetlabel">
        <property name="text">
-        <string>Extend Depth</string>
+        <string>Extend depth</string>
        </property>
       </widget>
      </item>
@@ -93,7 +93,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Coolant Mode</string>
+         <string>Coolant mode</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpThreadMillingEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpThreadMillingEdit.ui
@@ -82,7 +82,7 @@
       <item row="4" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Major Diameter</string>
+         <string>Major diameter</string>
         </property>
        </widget>
       </item>
@@ -96,7 +96,7 @@
       <item row="5" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Minor Diameter</string>
+         <string>Minor diameter</string>
         </property>
        </widget>
       </item>
@@ -174,7 +174,7 @@
       <item row="2" column="0">
        <widget class="QCheckBox" name="leadInOut">
         <property name="text">
-         <string>Lead In/Out</string>
+         <string>Lead in/out</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpVcarveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpVcarveEdit.ui
@@ -94,14 +94,14 @@
         <string/>
        </property>
        <property name="text">
-        <string>Filter Colinear lines</string>
+        <string>Filter colinear lines</string>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
       <widget class="QSpinBox" name="colinearFilter">
        <property name="toolTip">
-        <string>Sets how aggressively colinear segments are filtered from the Voronoi diagram. Valid values are 0 - 90 degrees (larger numbers filter more). Default = 10</string>
+        <string>Sets how aggressively colinear segments are filtered from the voronoi diagram. Valid values are 0 - 90 degrees (larger numbers filter more). Default = 10</string>
        </property>
        <property name="maximum">
         <number>90</number>
@@ -150,7 +150,7 @@
      <item row="2" column="0">
       <widget class="QCheckBox" name="optimizeMovementsEnabled">
        <property name="toolTip">
-        <string>Optimize path to avoid raising endmill when moving to adjacent edges. May result in sub-millimeter inaccuracies. </string>
+        <string>Optimize path to avoid raising endmill when moving to adjacent edges. May result in sub-millimeter inaccuracies.</string>
        </property>
        <property name="text">
         <string>Optimize movements</string>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpWaterlineEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpWaterlineEdit.ui
@@ -26,14 +26,14 @@
       <item row="0" column="0">
        <widget class="QLabel" name="toolController_label">
         <property name="text">
-         <string>Tool Controller</string>
+         <string>Tool controller</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="toolController">
         <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
+         <string>The tool and its settings to be used for this operation</string>
         </property>
        </widget>
       </item>
@@ -43,7 +43,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="coolantController_label">
         <property name="text">
-         <string>Coolant Mode</string>
+         <string>Coolant mode</string>
         </property>
        </widget>
       </item>
@@ -63,7 +63,7 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="algorithmSelect">
         <property name="toolTip">
-         <string>Select the algorithm to use: OCL Dropcutter*, or Experimental (Not OCL based).</string>
+         <string>Select the algorithm to use: 'OCL Dropcutter*', or 'Experimental' (not OCL based).</string>
         </property>
        </widget>
       </item>
@@ -76,7 +76,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Bounding Box</string>
+         <string>Bounding box</string>
         </property>
        </widget>
       </item>
@@ -88,14 +88,14 @@
          </font>
         </property>
         <property name="toolTip">
-         <string>Select the overall boundary for the operation.</string>
+         <string>Select the overall boundary for the operation</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="layerMode_label">
         <property name="text">
-         <string>Layer Mode</string>
+         <string>Layer mode</string>
         </property>
        </widget>
       </item>
@@ -107,14 +107,14 @@
          </font>
         </property>
         <property name="toolTip">
-         <string>Complete the operation in a single pass at depth, or multiple passes to final depth.</string>
+         <string>Complete the operation in a single pass at depth, or multiple passes to final depth</string>
         </property>
        </widget>
       </item>
       <item row="3" column="0">
        <widget class="QLabel" name="cutPattern_label">
         <property name="text">
-         <string>Cut Pattern</string>
+         <string>Cut pattern</string>
         </property>
        </widget>
       </item>
@@ -126,7 +126,7 @@
          </font>
         </property>
         <property name="toolTip">
-         <string>Set the geometric clearing pattern to use for the operation.</string>
+         <string>Set the geometric clearing pattern to use for the operation</string>
         </property>
        </widget>
       </item>
@@ -139,14 +139,14 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Boundary Adjustment</string>
+         <string>Boundary adjustment</string>
         </property>
        </widget>
       </item>
       <item row="4" column="1">
        <widget class="Gui::InputField" name="boundaryAdjustment">
         <property name="toolTip">
-         <string>Set the Z-axis depth offset from the target surface.</string>
+         <string>Set the Z-axis depth offset from the target surface</string>
         </property>
         <property name="unit" stdset="0">
          <string notr="true">mm</string>
@@ -204,7 +204,7 @@ A step over of 100% results in no overlap between two different cycles.</string>
          <string>Enable optimization of linear paths (co-linear points). Removes unnecessary co-linear points from G-code output.</string>
         </property>
         <property name="text">
-         <string>Optimize Linear Paths</string>
+         <string>Optimize linear paths</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
@@ -115,7 +115,7 @@
         </rect>
        </property>
        <attribute name="label">
-        <string>Template Export</string>
+        <string>Template export</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_13"/>
       </widget>
@@ -131,7 +131,7 @@
     <item row="0" column="0">
      <widget class="QLabel" name="label_9">
       <property name="text">
-       <string>Output File</string>
+       <string>Output file</string>
       </property>
      </widget>
     </item>
@@ -169,7 +169,7 @@ See the file save policy below on how to deal with name conflicts.</string>
     <item row="0" column="2">
      <widget class="QToolButton" name="postProcessorSetOutputFile">
       <property name="text">
-       <string notr="true">...</string>
+       <string notr="true">…</string>
       </property>
      </widget>
     </item>
@@ -193,7 +193,7 @@ See the file save policy below on how to deal with name conflicts.</string>
     <item row="2" column="1" colspan="2">
      <widget class="QLineEdit" name="postProcessorArguments">
       <property name="toolTip">
-       <string>Optional arguments passed to the Post Processor. The arguments are specific for each Post Processor, please see its documentation for details.</string>
+       <string>Optional arguments passed to the post processor. The arguments are specific for each post processor, please see its documentation for details.</string>
       </property>
      </widget>
     </item>
@@ -232,7 +232,7 @@ Ordering by operation will do each operation in all coordinate systems before mo
        <item row="2" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
-          <string>Order By</string>
+          <string>Order by</string>
          </property>
         </widget>
        </item>
@@ -394,7 +394,7 @@ FreeCAD has no knowledge of where a particular coordinate system exists within t
        <item row="3" column="0">
         <widget class="QCheckBox" name="splitOutput">
          <property name="toolTip">
-          <string>If multiple coordinate systems are in use, setting this to TRUE will cause the G-code to be written to multiple output files as controlled by the 'order by' property. For example, if ordering by Fixture, the first output file will be for the first fixture and separate file for the second.</string>
+          <string>If multiple coordinate systems are in use, setting this to TRUE will cause the G-code to be written to multiple output files as controlled by the 'order by' property. For example, if ordering by fixture, the first output file will be for the first fixture and separate file for the second.</string>
          </property>
          <property name="whatsThis">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If True, post processing will create multiple output files based on the &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; setting.
@@ -475,22 +475,22 @@ If &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; is se
                </property>
                <item>
                 <property name="text">
-                 <string>Create Box</string>
+                 <string>Create box</string>
                 </property>
                </item>
                <item>
                 <property name="text">
-                 <string>Create Cylinder</string>
+                 <string>Create cylinder</string>
                 </property>
                </item>
                <item>
                 <property name="text">
-                 <string>Extend Model's Bounding Box</string>
+                 <string>Extend model's bounding box</string>
                 </property>
                </item>
                <item>
                 <property name="text">
-                 <string>Use Existing Solid</string>
+                 <string>Use existing solid</string>
                 </property>
                </item>
               </widget>
@@ -511,7 +511,7 @@ If &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; is se
                 </sizepolicy>
                </property>
                <property name="toolTip">
-                <string>Assign Stock Material</string>
+                <string>Assign stock material</string>
                </property>
                <property name="text">
                 <string/>
@@ -754,7 +754,7 @@ If &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; is se
            <item row="2" column="0">
             <widget class="QCheckBox" name="linkStockAndModel">
              <property name="text">
-              <string>Link Stock and Model</string>
+              <string>Link stock and model</string>
              </property>
             </widget>
            </item>
@@ -1038,7 +1038,7 @@ If &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; is se
         </rect>
        </property>
        <attribute name="label">
-        <string>Default Values</string>
+        <string>Default values</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout_13">
         <item row="0" column="0">
@@ -1050,7 +1050,7 @@ If &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; is se
            <item row="0" column="0">
             <widget class="QLabel" name="label_3">
              <property name="text">
-              <string>Start Depth</string>
+              <string>Start depth</string>
              </property>
             </widget>
            </item>
@@ -1066,7 +1066,7 @@ Default: OpStartDepth</string>
            <item row="1" column="0">
             <widget class="QLabel" name="label_4">
              <property name="text">
-              <string>Final Depth</string>
+              <string>Final depth</string>
              </property>
             </widget>
            </item>
@@ -1082,7 +1082,7 @@ Default: OpFinalDepth</string>
            <item row="2" column="0">
             <widget class="QLabel" name="label_6">
              <property name="text">
-              <string>Step Down</string>
+              <string>Step down</string>
              </property>
             </widget>
            </item>
@@ -1186,7 +1186,7 @@ Default: &quot;5mm&quot;</string>
            <item row="0" column="0">
             <widget class="QLabel" name="label_17">
              <property name="text">
-              <string>Coolant Mode</string>
+              <string>Coolant mode</string>
              </property>
             </widget>
            </item>
@@ -1267,7 +1267,7 @@ Default: &quot;5mm&quot;</string>
                <string>Feed</string>
               </property>
               <property name="toolTip">
-               <string>Horizontal Feed</string>
+               <string>Horizontal feed</string>
               </property>
               <property name="icon">
                <iconset theme="object-flip-horizontal">
@@ -1279,7 +1279,7 @@ Default: &quot;5mm&quot;</string>
                <string>Feed</string>
               </property>
               <property name="toolTip">
-               <string>Vertical Feed</string>
+               <string>Vertical feed</string>
               </property>
               <property name="icon">
                <iconset theme="object-flip-vertical">
@@ -1367,7 +1367,7 @@ Default: &quot;5mm&quot;</string>
               </sizepolicy>
              </property>
              <property name="toolTip">
-              <string>Rapid horizontal speed assigned as HorizRapid to new ToolController.</string>
+              <string>Rapid horizontal speed assigned as HorizRapid to new ToolController</string>
              </property>
             </widget>
            </item>
@@ -1387,7 +1387,7 @@ Default: &quot;5mm&quot;</string>
               </sizepolicy>
              </property>
              <property name="toolTip">
-              <string>Rapid vertical speed assigned to VertRapid of new ToolController.</string>
+              <string>Rapid vertical speed assigned to VertRapid of new ToolController</string>
              </property>
             </widget>
            </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PropertyBag.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PropertyBag.ui
@@ -52,14 +52,14 @@
       <item>
        <widget class="QPushButton" name="modify">
         <property name="text">
-         <string>Modify...</string>
+         <string>Modify…</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QPushButton" name="add">
         <property name="text">
-         <string>Add...</string>
+         <string>Add…</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PropertyCreate.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PropertyCreate.ui
@@ -24,14 +24,14 @@
    <item row="0" column="1">
     <widget class="QLineEdit" name="propertyName">
      <property name="toolTip">
-      <string>Name of property. Can only contain letters, numbers, and underscores. MixedCase names will display with spaces "Mixed Case"</string>
+      <string>Name of the property. Can only contain letters, numbers, and underscores. MixedCase names will display with spaces "Mixed Case"</string>
      </property>
     </widget>
    </item>
    <item row="1" column="1">
     <widget class="QComboBox" name="propertyGroup">
      <property name="toolTip">
-      <string>The category group the property belongs to.</string>
+      <string>The category group the property belongs to</string>
      </property>
      <property name="editable">
       <bool>true</bool>
@@ -48,7 +48,7 @@
    <item row="2" column="1">
     <widget class="QComboBox" name="propertyType">
      <property name="toolTip">
-      <string>The type of the property value.</string>
+      <string>The type of the property value</string>
      </property>
     </widget>
    </item>
@@ -69,7 +69,7 @@
    <item row="4" column="1">
     <widget class="QTextEdit" name="propertyInfo">
      <property name="toolTip">
-      <string>ToolTip to be displayed when user hovers mouse over property.</string>
+      <string>ToolTip to be displayed when user hovers mouse over property</string>
      </property>
      <property name="tabChangesFocus">
       <bool>true</bool>
@@ -114,7 +114,7 @@
       <item>
        <widget class="QCheckBox" name="createAnother">
         <property name="toolTip">
-         <string>Check if you want to create several properties in a batch.</string>
+         <string>Check to create several properties in a batch</string>
         </property>
         <property name="text">
          <string>Create another</string>

--- a/src/Mod/CAM/Gui/Resources/panels/SetupGlobal.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/SetupGlobal.ui
@@ -33,7 +33,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label">
             <property name="text">
-             <string>Start Depth</string>
+             <string>Start depth</string>
             </property>
            </widget>
           </item>
@@ -49,7 +49,7 @@ Default: OpStartDepth</string>
           <item row="1" column="0">
            <widget class="QLabel" name="label_2">
             <property name="text">
-             <string>Final Depth</string>
+             <string>Final depth</string>
             </property>
            </widget>
           </item>
@@ -65,7 +65,7 @@ Default: OpFinalDepth</string>
           <item row="2" column="0">
            <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>Step Down</string>
+             <string>Step down</string>
             </property>
            </widget>
           </item>
@@ -202,7 +202,7 @@ Default: "5mm"</string>
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Rapid horizontal speed assigned as HorizRapid to new ToolController.</string>
+             <string>Rapid horizontal speed assigned as HorizRapid to new ToolController</string>
             </property>
            </widget>
           </item>
@@ -258,7 +258,7 @@ Default: "5mm"</string>
           <item row="0" column="0">
            <widget class="QLabel" name="label_10">
             <property name="text">
-             <string>Coolant Mode</string>
+             <string>Coolant mode</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/CAM/Gui/Resources/panels/ShapeSelector.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/ShapeSelector.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Select a Tool Shape</string>
+   <string>Tool Shape Selection</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
    <item>
@@ -31,7 +31,7 @@
          </rect>
         </property>
         <attribute name="label">
-         <string>Standard Tools</string>
+         <string>Standard tools</string>
         </attribute>
        </widget>
        <widget class="QWidget" name="customTools">
@@ -44,7 +44,7 @@
          </rect>
         </property>
         <attribute name="label">
-         <string>My Tools</string>
+         <string>My tools</string>
         </attribute>
        </widget>
       </widget>

--- a/src/Mod/CAM/Gui/Resources/panels/SurfaceEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/SurfaceEdit.ui
@@ -42,13 +42,13 @@
         <normaloff>:/icons/CAM_BaseGeometry.svg</normaloff>:/icons/CAM_BaseGeometry.svg</iconset>
       </attribute>
       <attribute name="label">
-       <string>Base Geometry</string>
+       <string>Base geometry</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
        <item row="0" column="0" colspan="3">
         <widget class="QListWidget" name="baseList">
          <property name="toolTip">
-          <string>Drag to reorder, then update.</string>
+          <string>Drag to reorder, then update</string>
          </property>
          <property name="dragDropMode">
           <enum>QAbstractItemView::DragDrop</enum>
@@ -64,17 +64,17 @@
        <item row="1" column="0">
         <widget class="QPushButton" name="addBase">
          <property name="toolTip">
-          <string>Add item selected in window.</string>
+          <string>Add item selected in window</string>
          </property>
          <property name="text">
-          <string>add</string>
+          <string>Add</string>
          </property>
         </widget>
        </item>
        <item row="1" column="1">
         <widget class="QPushButton" name="deleteBase">
          <property name="toolTip">
-          <string>Remove Item selected in list, then update.</string>
+          <string>Remove item selected in list, then update</string>
          </property>
          <property name="text">
           <string>Remove</string>
@@ -84,7 +84,7 @@
        <item row="1" column="2">
         <widget class="QPushButton" name="reorderBase">
          <property name="toolTip">
-          <string>Update the path with the removed and reordered items.</string>
+          <string>Update the path with the removed and reordered items</string>
          </property>
          <property name="text">
           <string>Update</string>
@@ -133,7 +133,7 @@
        <item row="0" column="1">
         <widget class="QLabel" name="label_3">
          <property name="text">
-          <string>Start Depth</string>
+          <string>Start depth</string>
          </property>
         </widget>
        </item>
@@ -147,7 +147,7 @@
        <item row="1" column="1">
         <widget class="QLabel" name="label_4">
          <property name="text">
-          <string>Final Depth</string>
+          <string>Final depth</string>
          </property>
         </widget>
        </item>
@@ -161,7 +161,7 @@
        <item row="2" column="1">
         <widget class="QLabel" name="label_2">
          <property name="text">
-          <string>Step Down</string>
+          <string>Step down</string>
          </property>
         </widget>
        </item>
@@ -175,7 +175,7 @@
        <item row="3" column="1">
         <widget class="QLabel" name="label_13">
          <property name="text">
-          <string>Finish Step Down</string>
+          <string>Finish step down</string>
          </property>
         </widget>
        </item>
@@ -211,7 +211,7 @@
        <item row="0" column="1">
         <widget class="QLabel" name="label_5">
          <property name="text">
-          <string>Safe Height</string>
+          <string>Safe height</string>
          </property>
         </widget>
        </item>
@@ -225,7 +225,7 @@
        <item row="1" column="1">
         <widget class="QLabel" name="label_6">
          <property name="text">
-          <string>Clearance Height</string>
+          <string>Clearance height</string>
          </property>
         </widget>
        </item>
@@ -260,7 +260,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label_8">
             <property name="text">
-             <string>Tool Controller</string>
+             <string>Tool controller</string>
             </property>
            </widget>
           </item>
@@ -270,7 +270,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="label_9">
             <property name="text">
-             <string>Coolant Mode</string>
+             <string>Coolant mode</string>
             </property>
            </widget>
           </item>
@@ -304,12 +304,12 @@
            <widget class="QComboBox" name="algorithmSelect">
             <item>
              <property name="text">
-              <string>OCL Dropcutter</string>
+              <string>OCL dropcutter</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>OCL Waterline</string>
+              <string>OCL waterline</string>
              </property>
             </item>
            </widget>

--- a/src/Mod/CAM/Gui/Resources/panels/TaskCAMSimulator.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/TaskCAMSimulator.ui
@@ -28,7 +28,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Accuracy:</string>
+        <string>Accuracy</string>
        </property>
       </widget>
      </item>
@@ -83,7 +83,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Job:</string>
+        <string>Job</string>
        </property>
       </widget>
      </item>
@@ -100,7 +100,7 @@
      <item>
       <widget class="QToolButton" name="toolButtonPlay">
        <property name="toolTip">
-        <string>Activate / resume simulation</string>
+        <string>Activate/resume simulation</string>
        </property>
        <property name="text">
         <string>Play</string>

--- a/src/Mod/CAM/Gui/Resources/panels/TaskPathCamoticsSim.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/TaskPathCamoticsSim.ui
@@ -72,7 +72,7 @@
    <item>
     <widget class="QPushButton" name="btnMakeFile">
      <property name="text">
-      <string>Make CAMotics File</string>
+      <string>New CAMotics File</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/CAM/Gui/Resources/panels/TaskPathSimulator.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/TaskPathSimulator.ui
@@ -52,7 +52,7 @@
      <item>
       <widget class="QToolButton" name="toolButtonPlay">
        <property name="toolTip">
-        <string>Activate / resume simulation</string>
+        <string>Activate/resume simulation</string>
        </property>
        <property name="text">
         <string>Play</string>
@@ -112,7 +112,7 @@
      <item>
       <widget class="QToolButton" name="toolButtonFF">
        <property name="toolTip">
-        <string>Run simulation till end without animation</string>
+        <string>Run the simulation until it ends without an animation</string>
        </property>
        <property name="text">
         <string>Fast Forward</string>
@@ -177,7 +177,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Speed:</string>
+        <string>Speed</string>
        </property>
       </widget>
      </item>
@@ -226,7 +226,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Accuracy:</string>
+        <string>Accuracy</string>
        </property>
       </widget>
      </item>
@@ -275,7 +275,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Job:</string>
+        <string>Job</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/CAM/Gui/Resources/panels/ToolBitEditor.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/ToolBitEditor.ui
@@ -104,7 +104,7 @@
                <item row="1" column="0">
                 <widget class="QLabel" name="label_4">
                  <property name="text">
-                  <string>Coating:</string>
+                  <string>Coating</string>
                  </property>
                 </widget>
                </item>
@@ -114,7 +114,7 @@
                <item row="3" column="0">
                 <widget class="QLabel" name="label_3">
                  <property name="text">
-                  <string>Hardness:</string>
+                  <string>Hardness</string>
                  </property>
                 </widget>
                </item>
@@ -124,7 +124,7 @@
                <item row="2" column="0">
                 <widget class="QLabel" name="label_2">
                  <property name="text">
-                  <string>Materials:</string>
+                  <string>Materials</string>
                  </property>
                 </widget>
                </item>
@@ -137,7 +137,7 @@
                <item row="4" column="0">
                 <widget class="QLabel" name="label">
                  <property name="text">
-                  <string>Supplier:</string>
+                  <string>Supplier</string>
                  </property>
                 </widget>
                </item>

--- a/src/Mod/CAM/Gui/Resources/panels/ToolBitLibraryEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/ToolBitLibraryEdit.ui
@@ -49,7 +49,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Add existing Tool Bit to this library.</string>
+        <string>Adds the existing tool bit to the library</string>
        </property>
        <property name="text">
         <string>Add Existing</string>
@@ -69,7 +69,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Delete selected Tool Bit(s) from the library.</string>
+        <string>Deletes the selected tool bits from the library</string>
        </property>
        <property name="text">
         <string>Remove</string>
@@ -96,7 +96,7 @@
            </size>
           </property>
           <property name="toolTip">
-           <string>Add New Tool Table</string>
+           <string>Add new tool table</string>
           </property>
           <property name="text">
            <string/>
@@ -143,7 +143,7 @@
             </size>
           </property>
           <property name="toolTip">
-            <string>Save the current Library</string>
+            <string>Save the current library</string>
           </property>
           <property name="text">
            <string/>
@@ -194,7 +194,7 @@
          <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>Table of Tool Bits of the library.</string>
+         <string>Table of tool bits of the library</string>
         </property>
         <property name="frameShape">
          <enum>QFrame::Box</enum>

--- a/src/Mod/CAM/Gui/Resources/panels/ToolEditor.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/ToolEditor.ui
@@ -64,7 +64,7 @@
       <item row="3" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
-         <string>Length Offset</string>
+         <string>Length offset</string>
         </property>
        </widget>
       </item>
@@ -100,28 +100,28 @@
       <item row="3" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Flat Radius</string>
+         <string>Flat radius</string>
         </property>
        </widget>
       </item>
       <item row="4" column="0">
        <widget class="QLabel" name="label_7">
         <property name="text">
-         <string>Corner Radius</string>
+         <string>Corner radius</string>
         </property>
        </widget>
       </item>
       <item row="5" column="0">
        <widget class="QLabel" name="label_9">
         <property name="text">
-         <string>Point/Tip Angle</string>
+         <string>Point/tip angle</string>
         </property>
        </widget>
       </item>
       <item row="6" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>Cutting Edge Height</string>
+         <string>Cutting edge height</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/ZCorrectEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/ZCorrectEdit.ui
@@ -61,7 +61,7 @@
           <item row="0" column="2">
            <widget class="QToolButton" name="SetProbePointFileName">
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true">…</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/CAM/Gui/Resources/preferences/Advanced.ui
+++ b/src/Mod/CAM/Gui/Resources/preferences/Advanced.ui
@@ -61,7 +61,7 @@
       <item>
        <widget class="Gui::PrefCheckBox" name="WarningSuppressVelocity">
         <property name="toolTip">
-         <string>Suppress warning whenever a Path selection mode is activated</string>
+         <string>Suppress warning whenever a path selection mode is activated</string>
         </property>
         <property name="text">
          <string>Suppress feed rate warning</string>
@@ -80,7 +80,7 @@
       <item>
        <widget class="Gui::PrefCheckBox" name="WarningSuppressSelectionMode">
         <property name="toolTip">
-         <string>Suppress warning whenever a Path selection mode is activated</string>
+         <string>Suppress warning whenever a path selection mode is activated</string>
         </property>
         <property name="text">
          <string>Suppress selection mode warning</string>
@@ -114,7 +114,7 @@
       <item>
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>If OpenCAMLib is installed with Python bindings it can be used by some additional 3D operations. NOTE: Enabling OpenCAMLib here requires a restart of FreeCAD to take effect.</string>
+         <string>If OpenCAMLib is installed with Python bindings, it can be used by some additional 3D operations. NOTE: Enabling OpenCAMLib here requires a restart of FreeCAD to take effect.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/Mod/CAM/Gui/Resources/preferences/PathDressupHoldingTags.ui
+++ b/src/Mod/CAM/Gui/Resources/preferences/PathDressupHoldingTags.ui
@@ -23,7 +23,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Default Width</string>
+         <string>Default width</string>
         </property>
        </widget>
       </item>
@@ -39,7 +39,7 @@ If the width is set to 0 the dressup will try to guess a reasonable value based 
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Default Height</string>
+         <string>Default height</string>
         </property>
        </widget>
       </item>
@@ -55,14 +55,14 @@ If the specified height is 0 the dressup will use half the height of the part. S
       <item row="2" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Default Angle</string>
+         <string>Default angle</string>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
        <widget class="QDoubleSpinBox" name="dsbAngle">
         <property name="toolTip">
-         <string>Plunge angle for ascent and descent of holding tag.</string>
+         <string>Plunge angle for ascent and descent of holding tag</string>
         </property>
         <property name="suffix">
          <string notr="true"> °</string>
@@ -84,7 +84,7 @@ If the specified height is 0 the dressup will use half the height of the part. S
       <item row="3" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
-         <string>Default Radius</string>
+         <string>Default radius</string>
         </property>
        </widget>
       </item>
@@ -109,14 +109,14 @@ If the radius is bigger than that which the tag shape itself supports, the resul
       <item row="0" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Initial # Tags</string>
+         <string>Initial # tags</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
        <widget class="QSpinBox" name="sbCount">
         <property name="toolTip">
-         <string>Specify the number of tags generated when a new dressup is created.</string>
+         <string>Specify the number of tags generated when a new dressup is created</string>
         </property>
         <property name="minimum">
          <number>2</number>

--- a/src/Mod/CAM/Gui/Resources/preferences/PathJob.ui
+++ b/src/Mod/CAM/Gui/Resources/preferences/PathJob.ui
@@ -57,7 +57,7 @@ If left empty the macro directory is used.</string>
           <item row="0" column="3">
            <widget class="QToolButton" name="tbDefaultFilePath">
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true">…</string>
             </property>
            </widget>
           </item>
@@ -71,7 +71,7 @@ If left empty the macro directory is used.</string>
           <item row="1" column="1">
            <widget class="QLineEdit" name="leDefaultJobTemplate">
             <property name="toolTip">
-             <string>The default template to be selected when creating a new Job.
+             <string>The default template to be selected when creating a new job.
 
 This can be helpful when almost all jobs will be processed by the same machine with a similar setup.
 
@@ -82,7 +82,7 @@ If left empty no template will be preselected.</string>
           <item row="1" column="3">
            <widget class="QToolButton" name="tbDefaultJobTemplate">
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true">…</string>
             </property>
            </widget>
           </item>
@@ -100,21 +100,21 @@ If left empty no template will be preselected.</string>
             <item row="0" column="0">
              <widget class="QLabel" name="label_6">
               <property name="text">
-               <string>Default Geometry Tolerance</string>
+               <string>Default geometry tolerance</string>
               </property>
              </widget>
             </item>
             <item row="0" column="1">
              <widget class="Gui::InputField" name="geometryTolerance">
               <property name="toolTip">
-               <string>Default value for new Jobs, used for computing Paths.  Smaller increases accuracy, but slows down computation</string>
+               <string>Default value for new jobs, used for computing Paths. Smaller increases accuracy, but slows down computation</string>
               </property>
              </widget>
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="label_12">
               <property name="text">
-               <string>Default Curve Accuracy</string>
+               <string>Default curve accuracy</string>
               </property>
              </widget>
             </item>
@@ -151,7 +151,7 @@ If left empty no template will be preselected.</string>
        </rect>
       </property>
       <attribute name="label">
-       <string>Post Processor</string>
+       <string>Post processor</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
@@ -174,7 +174,7 @@ If left empty no template will be preselected.</string>
             <item>
              <widget class="QLabel" name="label_4">
               <property name="text">
-               <string>Default Path</string>
+               <string>Default path</string>
               </property>
              </widget>
             </item>
@@ -216,7 +216,7 @@ See the file save policy below on how to deal with name conflicts.</string>
             <item>
              <widget class="QToolButton" name="tbOutputFile">
               <property name="text">
-               <string notr="true">...</string>
+               <string notr="true">…</string>
               </property>
              </widget>
             </item>
@@ -227,7 +227,7 @@ See the file save policy below on how to deal with name conflicts.</string>
             <item>
              <widget class="QLabel" name="label_5">
               <property name="text">
-               <string>File Save Policy</string>
+               <string>File save policy</string>
               </property>
              </widget>
             </item>
@@ -248,12 +248,12 @@ See the file save policy below on how to deal with name conflicts.</string>
               </property>
               <item>
                <property name="text">
-                <string>Open File Dialog</string>
+                <string>Open file dialog</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Open File Dialog on conflict</string>
+                <string>Open file dialog on conflict</string>
                </property>
               </item>
               <item>
@@ -285,7 +285,7 @@ See the file save policy below on how to deal with name conflicts.</string>
           <item row="0" column="0">
            <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>Post Processors Selection</string>
+             <string>Post processors selection</string>
             </property>
            </widget>
           </item>
@@ -302,14 +302,14 @@ See the file save policy below on how to deal with name conflicts.</string>
           <item row="1" column="0">
            <widget class="QLabel" name="label">
             <property name="text">
-             <string>Default Post Processor</string>
+             <string>Default post processor</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
            <widget class="QComboBox" name="defaultPostProcessor">
             <property name="toolTip">
-             <string>Select one of the post processors as the default.</string>
+             <string>Select one of the post processors as the default</string>
             </property>
             <property name="prefEntry" stdset="0">
              <string notr="true">DefaultPostProcessor</string>
@@ -322,14 +322,14 @@ See the file save policy below on how to deal with name conflicts.</string>
           <item row="3" column="0">
            <widget class="QLabel" name="label_2">
             <property name="text">
-             <string>Default Arguments</string>
+             <string>Default arguments</string>
             </property>
            </widget>
           </item>
           <item row="3" column="1">
            <widget class="QLineEdit" name="defaultPostProcessorArgs">
             <property name="toolTip">
-             <string>Optional arguments passed to the default Post Processor specified above. See the Post Processor's documentation for supported arguments.</string>
+             <string>Optional arguments passed to the default post processor specified above. See the post processor's documentation for supported arguments.</string>
             </property>
             <property name="prefEntry" stdset="0">
              <cstring>DefaultPostProcessorArgs</cstring>
@@ -392,17 +392,17 @@ See the file save policy below on how to deal with name conflicts.</string>
             </property>
             <item>
              <property name="text">
-              <string>Create Box</string>
+              <string>Create box</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Create Cylinder</string>
+              <string>Create cylinder</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Extend Model's Bounding Box</string>
+              <string>Extend model's bounding box</string>
              </property>
             </item>
            </widget>
@@ -650,7 +650,7 @@ See the file save policy below on how to deal with name conflicts.</string>
        <item>
         <widget class="QCheckBox" name="toolsAbsolutePaths">
          <property name="toolTip">
-          <string>References to Tool Bits and their shapes can either be stored with an absolute path or with a relative path to the search path.
+          <string>References to tool bits and their shapes can either be stored with an absolute path or with a relative path to the search path.
 Generally it is recommended to use relative paths due to their flexibility and robustness to layout changes.
 Should multiple tools or tool shapes with the same name exist in different directories it can be required to use absolute paths.</string>
          </property>

--- a/src/Mod/CAM/Gui/TaskDlgPathCompound.ui
+++ b/src/Mod/CAM/Gui/TaskDlgPathCompound.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Paths list</string>
+   <string>Paths List</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/Mod/CAM/Path/Base/Gui/PropertyBag.py
+++ b/src/Mod/CAM/Path/Base/Gui/PropertyBag.py
@@ -414,10 +414,10 @@ class PropertyBagCreateCommand(object):
 
     def GetResources(self):
         return {
-            "MenuText": translate("CAM_PropertyBag", "PropertyBag"),
+            "MenuText": translate("CAM_PropertyBag", "Property Bag"),
             "ToolTip": translate(
                 "CAM_PropertyBag",
-                "Creates an object which can be used to store reference properties.",
+                "Creates an object which can be used to store reference properties",
             ),
         }
 
@@ -443,4 +443,4 @@ class PropertyBagCreateCommand(object):
 if FreeCAD.GuiUp:
     FreeCADGui.addCommand("CAM_PropertyBag", PropertyBagCreateCommand())
 
-FreeCAD.Console.PrintLog("Loading PathPropertyBagGui ... done\n")
+FreeCAD.Console.PrintLog("Loading PathPropertyBagGui… done\n")

--- a/src/Mod/CAM/Path/Dressup/Gui/Array.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Array.py
@@ -73,7 +73,7 @@ class CommandPathDressupArray:
         selection = FreeCADGui.Selection.getSelection()
         if len(selection) != 1:
             Path.Log.error(
-                translate("CAM_DressupArray", "Please select one toolpath object") + "\n"
+                translate("CAM_DressupArray", "Select one toolpath object") + "\n"
             )
             return
         baseObject = selection[0]

--- a/src/Mod/CAM/Path/Dressup/Gui/AxisMap.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/AxisMap.py
@@ -252,7 +252,7 @@ class CommandPathDressup:
             "Pixmap": "CAM_Dressup",
             "MenuText": QT_TRANSLATE_NOOP("CAM_DressupAxisMap", "Axis Map"),
             "Accel": "",
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_DressupAxisMap", "Remap one axis to another."),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_DressupAxisMap", "Remaps one axis to another"),
         }
 
     def IsActive(self):
@@ -268,7 +268,7 @@ class CommandPathDressup:
         selection = FreeCADGui.Selection.getSelection()
         if len(selection) != 1:
             FreeCAD.Console.PrintError(
-                translate("CAM_Dressup", "Please select one toolpath object\n")
+                translate("CAM_Dressup", "Select one toolpath object\n")
             )
             return
         if not selection[0].isDerivedFrom("Path::Feature"):
@@ -277,7 +277,7 @@ class CommandPathDressup:
             )
             return
         if selection[0].isDerivedFrom("Path::FeatureCompoundPython"):
-            FreeCAD.Console.PrintError(translate("CAM_Dressup", "Please select a toolpath object"))
+            FreeCAD.Console.PrintError(translate("CAM_Dressup", "Select a toolpath object"))
             return
 
         # everything ok!
@@ -306,4 +306,4 @@ if FreeCAD.GuiUp:
     # register the FreeCAD command
     FreeCADGui.addCommand("CAM_DressupAxisMap", CommandPathDressup())
 
-FreeCAD.Console.PrintLog("Loading PathDressup... done\n")
+FreeCAD.Console.PrintLog("Loading PathDressup… done\n")

--- a/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
@@ -259,7 +259,7 @@ class CommandPathDressupPathBoundary:
             "MenuText": QT_TRANSLATE_NOOP("CAM_DressupPathBoundary", "Boundary"),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "CAM_DressupPathBoundary",
-                "Creates a Boundary Dress-up from a selected toolpath",
+                "Creates a boundary dress-up from a selected toolpath",
             ),
         }
 

--- a/src/Mod/CAM/Path/Dressup/Gui/Dogbone.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Dogbone.py
@@ -434,7 +434,7 @@ class ObjectDressup(object):
             "App::PropertyIntegerList",
             "BoneBlacklist",
             "Dressup",
-            QT_TRANSLATE_NOOP("App::Property", "Bones that aren't dressed up"),
+            QT_TRANSLATE_NOOP("App::Property", "Bones that are not dressed up"),
         )
         obj.BoneBlacklist = []
         obj.setEditorMode("BoneBlacklist", 2)  # hide this one
@@ -1322,7 +1322,7 @@ class CommandDressupDogbone(object):
             "MenuText": QT_TRANSLATE_NOOP("CAM_DressupDogbone", "Dogbone"),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "CAM_DressupDogbone",
-                "Creates a Dogbone Dress-up object from a selected toolpath",
+                "Creates a dogbone dress-up object from a selected toolpath",
             ),
         }
 
@@ -1339,7 +1339,7 @@ class CommandDressupDogbone(object):
         selection = FreeCADGui.Selection.getSelection()
         if len(selection) != 1:
             FreeCAD.Console.PrintError(
-                translate("CAM_DressupDogbone", "Please select one toolpath object") + "\n"
+                translate("CAM_DressupDogbone", "Select one toolpath object") + "\n"
             )
             return
         baseObject = selection[0]
@@ -1367,4 +1367,4 @@ class CommandDressupDogbone(object):
 #
 #    FreeCADGui.addCommand("CAM_DressupDogbone", CommandDressupDogbone())
 
-FreeCAD.Console.PrintLog("Loading DressupDogbone... done\n")
+FreeCAD.Console.PrintLog("Loading DressupDogbone… done\n")

--- a/src/Mod/CAM/Path/Dressup/Gui/DogboneII.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/DogboneII.py
@@ -303,7 +303,7 @@ class ViewProviderDressup(object):
 
 def Create(base, name="DressupDogbone"):
     """
-    Create(obj, name='DressupDogbone') ... dresses the given Path.Op.Profile object with dogbones.
+    Create(obj, name='DressupDogbone')… dresses the given Path.Op.Profile object with dogbones.
     """
     obj = DogboneII.Create(base, name)
     job = PathUtils.findParentJob(base)
@@ -323,7 +323,7 @@ class CommandDressupDogboneII(object):
             "MenuText": QT_TRANSLATE_NOOP("CAM_DressupDogbone", "Dogbone"),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "CAM_DressupDogbone",
-                "Creates a Dogbone Dress-up object from a selected toolpath",
+                "Creates a dogbone dress-up object from a selected toolpath",
             ),
         }
 
@@ -340,7 +340,7 @@ class CommandDressupDogboneII(object):
         selection = FreeCADGui.Selection.getSelection()
         if len(selection) != 1:
             FreeCAD.Console.PrintError(
-                translate("CAM_DressupDogbone", "Please select one toolpath object") + "\n"
+                translate("CAM_DressupDogbone", "Select one toolpath object") + "\n"
             )
             return
         baseObject = selection[0]
@@ -367,4 +367,4 @@ if FreeCAD.GuiUp:
 
     FreeCADGui.addCommand("CAM_DressupDogbone", CommandDressupDogboneII())
 
-FreeCAD.Console.PrintLog("Loading DressupDogboneII ... done\n")
+FreeCAD.Console.PrintLog("Loading DressupDogboneII… done\n")

--- a/src/Mod/CAM/Path/Dressup/Gui/Dragknife.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Dragknife.py
@@ -576,7 +576,7 @@ class CommandDressupDragknife:
     def GetResources(self):
         return {
             "Pixmap": "CAM_Dressup",
-            "MenuText": QT_TRANSLATE_NOOP("CAM_DressupDragKnife", "DragKnife"),
+            "MenuText": QT_TRANSLATE_NOOP("CAM_DressupDragKnife", "Drag Knife"),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "CAM_DressupDragKnife",
                 "Modifies a toolpath to add dragknife corner actions",
@@ -596,7 +596,7 @@ class CommandDressupDragknife:
         selection = FreeCADGui.Selection.getSelection()
         if len(selection) != 1:
             FreeCAD.Console.PrintError(
-                translate("CAM_DressupDragKnife", "Please select one toolpath object") + "\n"
+                translate("CAM_DressupDragKnife", "Select one toolpath object") + "\n"
             )
             return
         if not selection[0].isDerivedFrom("Path::Feature"):
@@ -606,7 +606,7 @@ class CommandDressupDragknife:
             return
         if selection[0].isDerivedFrom("Path::FeatureCompoundPython"):
             FreeCAD.Console.PrintError(
-                translate("CAM_DressupDragKnife", "Please select a toolpath object")
+                translate("CAM_DressupDragKnife", "Select a toolpath object")
             )
             return
 
@@ -639,4 +639,4 @@ if FreeCAD.GuiUp:
     # register the FreeCAD command
     FreeCADGui.addCommand("CAM_DressupDragKnife", CommandDressupDragknife())
 
-FreeCAD.Console.PrintLog("Loading CAM_DressupDragKnife... done\n")
+FreeCAD.Console.PrintLog("Loading CAM_DressupDragKnife… done\n")

--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -76,45 +76,45 @@ class ObjectDressup:
             "App::PropertyBool",
             "KeepToolDown",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "Keep the Tool Down in toolpath"),
+            QT_TRANSLATE_NOOP("App::Property", "Keep the tool down in toolpath"),
         )
         obj.addProperty(
             "App::PropertyDistance",
             "LengthIn",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "Length or Radius of the approach"),
+            QT_TRANSLATE_NOOP("App::Property", "Length or radius of the approach"),
         )
         obj.addProperty(
             "App::PropertyDistance",
             "LengthOut",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "Length or Radius of the exit"),
+            QT_TRANSLATE_NOOP("App::Property", "Length or radius of the exit"),
         )
         obj.addProperty(
             "App::PropertyEnumeration",
             "StyleIn",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "The Style of motion into the toolpath"),
+            QT_TRANSLATE_NOOP("App::Property", "The style of motion into the toolpath"),
         )
         obj.StyleIn = lead_styles
         obj.addProperty(
             "App::PropertyEnumeration",
             "StyleOut",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "The Style of motion out of the toolpath"),
+            QT_TRANSLATE_NOOP("App::Property", "The style of motion out of the toolpath"),
         )
         obj.StyleOut = lead_styles
         obj.addProperty(
             "App::PropertyDistance",
             "ExtendLeadIn",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "Extends LeadIn distance"),
+            QT_TRANSLATE_NOOP("App::Property", "Extends lead in distance"),
         )
         obj.addProperty(
             "App::PropertyDistance",
             "ExtendLeadOut",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "Extends LeadOut distance"),
+            QT_TRANSLATE_NOOP("App::Property", "Extends lead out distance"),
         )
         obj.addProperty(
             "App::PropertyBool",
@@ -126,7 +126,7 @@ class ObjectDressup:
             "App::PropertyBool",
             "IncludeLayers",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "Apply LeadInOut to layers within an operation"),
+            QT_TRANSLATE_NOOP("App::Property", "Apply Lead in/out to layers within an operation"),
         )
         obj.Proxy = self
 
@@ -162,13 +162,13 @@ class ObjectDressup:
 
         if obj.LengthIn <= 0:
             Path.Log.error(
-                translate("CAM_DressupLeadInOut", "Length/Radius positive not Null") + "\n"
+                translate("CAM_DressupLeadInOut", "Length/radius positive not Null") + "\n"
             )
             obj.LengthIn = 0.1
 
         if obj.LengthOut <= 0:
             Path.Log.error(
-                translate("CAM_DressupLeadInOut", "Length/Radius positive not Null") + "\n"
+                translate("CAM_DressupLeadInOut", "Length/radius positive not Null") + "\n"
             )
             obj.LengthOut = 0.1
 
@@ -176,7 +176,7 @@ class ObjectDressup:
         obj.Path = self.generateLeadInOutCurve(obj)
 
     def onDocumentRestored(self, obj):
-        """onDocumentRestored(obj) ... Called automatically when document is restored."""
+        """onDocumentRestored(obj)… Called automatically when document is restored."""
         lead_styles = [
             QT_TRANSLATE_NOOP("CAM_DressupLeadInOut", "Arc"),
             QT_TRANSLATE_NOOP("CAM_DressupLeadInOut", "Tangent"),
@@ -188,7 +188,7 @@ class ObjectDressup:
                 "App::PropertyEnumeration",
                 "StyleIn",
                 "Path",
-                QT_TRANSLATE_NOOP("App::Property", "The Style of motion into the toolpath"),
+                QT_TRANSLATE_NOOP("App::Property", "The style of motion into the toolpath"),
             )
             obj.StyleIn = lead_styles
             obj.StyleIn = obj.StyleOn
@@ -199,7 +199,7 @@ class ObjectDressup:
                 "App::PropertyEnumeration",
                 "StyleOut",
                 "Path",
-                QT_TRANSLATE_NOOP("App::Property", "The Style of motion out of the toolpath"),
+                QT_TRANSLATE_NOOP("App::Property", "The style of motion out of the toolpath"),
             )
             obj.StyleOut = lead_styles
             obj.StyleOut = obj.StyleOff
@@ -210,7 +210,7 @@ class ObjectDressup:
                 "App::PropertyDistance",
                 "LengthIn",
                 "Path",
-                QT_TRANSLATE_NOOP("App::Property", "Length or Radius of the approach"),
+                QT_TRANSLATE_NOOP("App::Property", "Length or radius of the approach"),
             )
             obj.LengthIn = obj.Length
             obj.removeProperty("Length")
@@ -491,10 +491,10 @@ class CommandPathDressupLeadInOut:
     def GetResources(self):
         return {
             "Pixmap": "CAM_Dressup",
-            "MenuText": QT_TRANSLATE_NOOP("CAM_DressupLeadInOut", "LeadInOut"),
+            "MenuText": QT_TRANSLATE_NOOP("CAM_DressupLeadInOut", "Lead In/Out"),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "CAM_DressupLeadInOut",
-                "Creates a Cutter Radius Compensation G41/G42 Entry Dressup object from a selected path",
+                "Creates a cutter radius compensation G41/G42 entry dressup object from a selected path",
             ),
         }
 
@@ -509,7 +509,7 @@ class CommandPathDressupLeadInOut:
         selection = FreeCADGui.Selection.getSelection()
         if len(selection) != 1:
             Path.Log.error(
-                translate("CAM_DressupLeadInOut", "Please select one toolpath object") + "\n"
+                translate("CAM_DressupLeadInOut", "Select one toolpath object") + "\n"
             )
             return
         baseObject = selection[0]
@@ -519,7 +519,7 @@ class CommandPathDressupLeadInOut:
             )
             return
         if baseObject.isDerivedFrom("Path::FeatureCompoundPython"):
-            Path.Log.error(translate("CAM_DressupLeadInOut", "Please select a Profile object"))
+            Path.Log.error(translate("CAM_DressupLeadInOut", "Select a Profile object"))
             return
 
         # everything ok!
@@ -547,4 +547,4 @@ if App.GuiUp:
     # register the FreeCAD command
     FreeCADGui.addCommand("CAM_DressupLeadInOut", CommandPathDressupLeadInOut())
 
-Path.Log.notice("Loading CAM_DressupLeadInOut... done\n")
+Path.Log.notice("Loading CAM_DressupLeadInOut… done\n")

--- a/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
@@ -60,7 +60,7 @@ class ObjectDressup:
             "App::PropertyAngle",
             "Angle",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "Angle of ramp."),
+            QT_TRANSLATE_NOOP("App::Property", "Angle of ramp"),
         )
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -861,10 +861,10 @@ class CommandPathDressupRampEntry:
     def GetResources(self):
         return {
             "Pixmap": "CAM_Dressup",
-            "MenuText": QT_TRANSLATE_NOOP("CAM_DressupRampEntry", "RampEntry"),
+            "MenuText": QT_TRANSLATE_NOOP("CAM_DressupRampEntry", "Ramp Entry"),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "CAM_DressupRampEntry",
-                "Creates a Ramp Entry Dress-up object from a selected toolpath",
+                "Creates a ramp entry dress-up object from a selected toolpath",
             ),
         }
 
@@ -880,7 +880,7 @@ class CommandPathDressupRampEntry:
         selection = FreeCADGui.Selection.getSelection()
         if len(selection) != 1:
             Path.Log.error(
-                translate("CAM_DressupRampEntry", "Please select one toolpath object") + "\n"
+                translate("CAM_DressupRampEntry", "Select one toolpath object") + "\n"
             )
             return
         baseObject = selection[0]
@@ -890,7 +890,7 @@ class CommandPathDressupRampEntry:
             )
             return
         if baseObject.isDerivedFrom("Path::FeatureCompoundPython"):
-            Path.Log.error(translate("CAM_DressupRampEntry", "Please select a Profile object"))
+            Path.Log.error(translate("CAM_DressupRampEntry", "Select a Profile object"))
             return
 
         # everything ok!
@@ -918,4 +918,4 @@ if FreeCAD.GuiUp:
     # register the FreeCAD command
     FreeCADGui.addCommand("CAM_DressupRampEntry", CommandPathDressupRampEntry())
 
-Path.Log.notice("Loading CAM_DressupRampEntry... done\n")
+Path.Log.notice("Loading CAM_DressupRampEntry… done\n")

--- a/src/Mod/CAM/Path/Dressup/Gui/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Tags.py
@@ -549,7 +549,7 @@ class CommandPathDressupTag:
             "Pixmap": "CAM_Dressup",
             "MenuText": QT_TRANSLATE_NOOP("CAM_DressupTag", "Tag"),
             "ToolTip": QT_TRANSLATE_NOOP(
-                "CAM_DressupTag", "Creates a Tag Dress-up object from a selected toolpath"
+                "CAM_DressupTag", "Creates a tag dress-up object from a selected toolpath"
             ),
         }
 

--- a/src/Mod/CAM/Path/Dressup/Gui/ZCorrect.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/ZCorrect.py
@@ -334,7 +334,7 @@ class CommandPathDressup:
             "Pixmap": "CAM_Dressup",
             "MenuText": QT_TRANSLATE_NOOP("CAM_DressupZCorrect", "Z Depth Correction"),
             "Accel": "",
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_DressupZCorrect", "Use Probe Map to correct Z depth"),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_DressupZCorrect", "Corrects Z depth using a probe map"),
         }
 
     def IsActive(self):
@@ -349,7 +349,7 @@ class CommandPathDressup:
         selection = FreeCADGui.Selection.getSelection()
         if len(selection) != 1:
             FreeCAD.Console.PrintError(
-                translate("CAM_Dressup", "Please select one toolpath object\n")
+                translate("CAM_Dressup", "Select one toolpath object\n")
             )
             return
         if not selection[0].isDerivedFrom("Path::Feature"):
@@ -358,7 +358,7 @@ class CommandPathDressup:
             )
             return
         if selection[0].isDerivedFrom("Path::FeatureCompoundPython"):
-            FreeCAD.Console.PrintError(translate("CAM_Dressup", "Please select a toolpath object"))
+            FreeCAD.Console.PrintError(translate("CAM_Dressup", "Select a toolpath object"))
             return
 
         # everything ok!
@@ -382,4 +382,4 @@ if FreeCAD.GuiUp:
     # register the FreeCAD command
     FreeCADGui.addCommand("CAM_DressupZCorrect", CommandPathDressup())
 
-FreeCAD.Console.PrintLog("Loading PathDressup... done\n")
+FreeCAD.Console.PrintLog("Loading PathDressup… done\n")

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -380,7 +380,7 @@ class MapWireToTag:
         # if there are no edges connected to entry/exit, it means the plunge in/out is vertical
         # we need to add in the missing segment and collect the new entry/exit edges.
         if not self.entryEdges:
-            Path.Log.debug("fill entryEdges ...")
+            Path.Log.debug("fill entryEdges…")
             self.realEntry = sorted(self.edgePoints, key=lambda p: (p - self.entry).Length)[0]
             self.entryEdges = list(
                 [e for e in edges if Path.Geom.edgeConnectsTo(e, self.realEntry)]
@@ -389,7 +389,7 @@ class MapWireToTag:
         else:
             self.realEntry = None
         if not self.exitEdges:
-            Path.Log.debug("fill exitEdges ...")
+            Path.Log.debug("fill exitEdges…")
             self.realExit = sorted(self.edgePoints, key=lambda p: (p - self.exit).Length)[0]
             self.exitEdges = list([e for e in edges if Path.Geom.edgeConnectsTo(e, self.realExit)])
             edges.append(Part.Edge(Part.LineSegment(self.realExit, self.exit)))
@@ -1206,7 +1206,7 @@ class ObjectTagDressup:
         try:
             self.processTags(obj)
         except Exception as e:
-            Path.Log.error("processing tags failed clearing all tags ... '%s'" % (e.args[0]))
+            Path.Log.error("processing tags failed clearing all tags… '%s'" % (e.args[0]))
             obj.Path = PathUtils.getPathWithPlacement(obj.Base)
 
         # update disabled in case there are some additional ones
@@ -1245,7 +1245,7 @@ class ObjectTagDressup:
             Path.Log.error(
                 translate(
                     "CAM_DressupTag",
-                    "Cannot insert holding tags for this path - please select a Profile path",
+                    "Cannot insert holding tags for this path - select a profile path",
                 )
                 + "\n"
             )
@@ -1293,14 +1293,14 @@ class ObjectTagDressup:
 
 def Create(baseObject, name="DressupTag"):
     """
-    Create(basePath, name='DressupTag') ... create tag dressup object for the given base path.
+    Create(basePath, name='DressupTag') … create tag dressup object for the given base path.
     """
     if not baseObject.isDerivedFrom("Path::Feature"):
         Path.Log.error(translate("CAM_DressupTag", "The selected object is not a path") + "\n")
         return None
 
     if baseObject.isDerivedFrom("Path::FeatureCompoundPython"):
-        Path.Log.error(translate("CAM_DressupTag", "Please select a Profile object"))
+        Path.Log.error(translate("CAM_DressupTag", "Select a profile object"))
         return None
 
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
@@ -1311,4 +1311,4 @@ def Create(baseObject, name="DressupTag"):
     return obj
 
 
-Path.Log.notice("Loading CAM_DressupTag... done\n")
+Path.Log.notice("Loading CAM_DressupTag… done\n")

--- a/src/Mod/CAM/Path/Main/Gui/Camotics.py
+++ b/src/Mod/CAM/Path/Main/Gui/Camotics.py
@@ -309,7 +309,7 @@ class CommandCamoticsSimulate:
             "Pixmap": "CAM_Camotics",
             "MenuText": QT_TRANSLATE_NOOP("CAM_Camotics", "CAMotics"),
             "Accel": "P, C",
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_Camotics", "Simulate using CAMotics"),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_Camotics", "Simulates using CAMotics"),
             "CmdType": "ForEdit",
         }
 
@@ -331,4 +331,4 @@ if FreeCAD.GuiUp:
     FreeCADGui.addCommand("CAM_Camotics", CommandCamoticsSimulate())
 
 
-FreeCAD.Console.PrintLog("Loading PathCamoticsSimulateGui ... done\n")
+FreeCAD.Console.PrintLog("Loading PathCamoticsSimulateGui… done\n")

--- a/src/Mod/CAM/Path/Main/Gui/Fixture.py
+++ b/src/Mod/CAM/Path/Main/Gui/Fixture.py
@@ -151,7 +151,7 @@ class CommandPathFixture:
         return {
             "Pixmap": "CAM_Datums",
             "MenuText": QT_TRANSLATE_NOOP("CAM_Fixture", "Fixture"),
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_Fixture", "Creates a Fixture Offset"),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_Fixture", "Creates a fixture offset"),
         }
 
     def IsActive(self):
@@ -187,4 +187,4 @@ if FreeCAD.GuiUp:
     FreeCADGui.addCommand("CAM_Fixture", CommandPathFixture())
 
 
-FreeCAD.Console.PrintLog("Loading PathFixture... done\n")
+FreeCAD.Console.PrintLog("Loading PathFixture… done\n")

--- a/src/Mod/CAM/Path/Main/Gui/Inspect.py
+++ b/src/Mod/CAM/Path/Main/Gui/Inspect.py
@@ -127,7 +127,7 @@ class GCodeEditorDialog(QtGui.QDialog):
         lab.setText(
             translate(
                 "CAM_Inspect",
-                "<b>Note</b>: This dialog shows Path Commands in FreeCAD base units (mm/s). \n Values will be converted to the desired unit during post processing.",
+                "<b>Note</b>: This dialog shows path commands in FreeCAD base units (mm/s). \n Values will be converted to the desired unit during post processing.",
             )
         )
         lab.setWordWrap(True)
@@ -252,7 +252,7 @@ class CommandPathInspect:
     def GetResources(self):
         return {
             "Pixmap": "CAM_Inspect",
-            "MenuText": QT_TRANSLATE_NOOP("CAM_Inspect", "Inspect toolPath Commands"),
+            "MenuText": QT_TRANSLATE_NOOP("CAM_Inspect", "Inspect Toolpath"),
             "Accel": "P, I",
             "ToolTip": QT_TRANSLATE_NOOP(
                 "CAM_Inspect", "Inspects the contents of a toolpath object"
@@ -268,12 +268,12 @@ class CommandPathInspect:
         selection = FreeCADGui.Selection.getSelection()
         if len(selection) != 1:
             FreeCAD.Console.PrintError(
-                translate("CAM_Inspect", "Please select exactly one path object") + "\n"
+                translate("CAM_Inspect", "Select exactly one path object") + "\n"
             )
             return
         if not (selection[0].isDerivedFrom("Path::Feature")):
             FreeCAD.Console.PrintError(
-                translate("CAM_Inspect", "Please select exactly one path object") + "\n"
+                translate("CAM_Inspect", "Select exactly one path object") + "\n"
             )
             return
 

--- a/src/Mod/CAM/Path/Main/Gui/JobCmd.py
+++ b/src/Mod/CAM/Path/Main/Gui/JobCmd.py
@@ -56,7 +56,7 @@ class CommandJobCreate:
             "Pixmap": "CAM_Job",
             "MenuText": QT_TRANSLATE_NOOP("CAM_Job", "Job"),
             "Accel": "P, J",
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_Job", "Creates a CAM Job"),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_Job", "Creates a CAM job"),
         }
 
     def IsActive(self):
@@ -101,7 +101,7 @@ class CommandJobTemplateExport:
             "MenuText": QT_TRANSLATE_NOOP("CAM_ExportTemplate", "Export Template"),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "CAM_ExportTemplate",
-                "Exports CAM Job as a template to be used for other jobs",
+                "Exports the CAM job as a template to be used for other jobs",
             ),
         }
 
@@ -200,4 +200,4 @@ if FreeCAD.GuiUp:
     FreeCADGui.addCommand("CAM_Job", CommandJobCreate())
     FreeCADGui.addCommand("CAM_ExportTemplate", CommandJobTemplateExport())
 
-FreeCAD.Console.PrintLog("Loading PathJobCmd... done\n")
+FreeCAD.Console.PrintLog("Loading PathJobCmd… done\n")

--- a/src/Mod/CAM/Path/Main/Gui/SanityCmd.py
+++ b/src/Mod/CAM/Path/Main/Gui/SanityCmd.py
@@ -50,9 +50,9 @@ class CommandCAMSanity:
     def GetResources(self):
         return {
             "Pixmap": "CAM_Sanity",
-            "MenuText": QT_TRANSLATE_NOOP("CAM_Sanity", "Check the CAM job for common errors"),
+            "MenuText": QT_TRANSLATE_NOOP("CAM_Sanity", "Sanity Check"),
             "Accel": "P, S",
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_Sanity", "Check the CAM job for common errors"),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_Sanity", "Checks the CAM job for common errors"),
         }
 
     def IsActive(self):

--- a/src/Mod/CAM/Path/Main/Gui/Simulator.py
+++ b/src/Mod/CAM/Path/Main/Gui/Simulator.py
@@ -612,7 +612,7 @@ class CommandPathSimulate:
             "Pixmap": "CAM_Simulator",
             "MenuText": QtCore.QT_TRANSLATE_NOOP("CAM_Simulator", "CAM Simulator"),
             "Accel": "P, M",
-            "ToolTip": QtCore.QT_TRANSLATE_NOOP("CAM_Simulator", "Simulate G-code on stock"),
+            "ToolTip": QtCore.QT_TRANSLATE_NOOP("CAM_Simulator", "Simulates G-code on stock"),
         }
 
     def IsActive(self):
@@ -630,4 +630,4 @@ class CommandPathSimulate:
 if FreeCAD.GuiUp:
     # register the FreeCAD command
     FreeCADGui.addCommand("CAM_Simulator", CommandPathSimulate())
-    FreeCAD.Console.PrintLog("Loading PathSimulator Gui... done\n")
+    FreeCAD.Console.PrintLog("Loading PathSimulator Gui… done\n")

--- a/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
+++ b/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
@@ -349,7 +349,7 @@ class CommandCAMSimulate:
             "Pixmap": "CAM_SimulatorGL",
             "MenuText": QtCore.QT_TRANSLATE_NOOP("CAM_Simulator", "New CAM Simulator"),
             "Accel": "P, N",
-            "ToolTip": QtCore.QT_TRANSLATE_NOOP("CAM_Simulator", "Simulate G-code on stock"),
+            "ToolTip": QtCore.QT_TRANSLATE_NOOP("CAM_Simulator", "Simulates G-code on stock"),
         }
 
     def IsActive(self):
@@ -369,4 +369,4 @@ class CommandCAMSimulate:
 if FreeCAD.GuiUp:
     # register the FreeCAD command
     FreeCADGui.addCommand("CAM_SimulatorGL", CommandCAMSimulate())
-    FreeCAD.Console.PrintLog("Loading PathSimulator Gui... done\n")
+    FreeCAD.Console.PrintLog("Loading PathSimulator Gui… done\n")

--- a/src/Mod/CAM/Path/Op/Gui/Array.py
+++ b/src/Mod/CAM/Path/Op/Gui/Array.py
@@ -45,7 +45,7 @@ class ObjectArray:
             "App::PropertyLinkList",
             "Base",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "The toolpath(s) to array"),
+            QT_TRANSLATE_NOOP("App::Property", "The toolpaths to array"),
         )
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -59,7 +59,7 @@ class ObjectArray:
             "Path",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "The spacing between the array copies in Linear pattern",
+                "The spacing between the array copies in linear pattern",
             ),
         )
         obj.addProperty(
@@ -67,7 +67,7 @@ class ObjectArray:
             "CopiesX",
             "Path",
             QT_TRANSLATE_NOOP(
-                "App::Property", "The number of copies in X direction in Linear pattern"
+                "App::Property", "The number of copies in X direction in linear pattern"
             ),
         )
         obj.addProperty(
@@ -75,28 +75,28 @@ class ObjectArray:
             "CopiesY",
             "Path",
             QT_TRANSLATE_NOOP(
-                "App::Property", "The number of copies in Y direction in Linear pattern"
+                "App::Property", "The number of copies in Y direction in linear pattern"
             ),
         )
         obj.addProperty(
             "App::PropertyAngle",
             "Angle",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "Total angle in Polar pattern"),
+            QT_TRANSLATE_NOOP("App::Property", "Total angle in polar pattern"),
         )
         obj.addProperty(
             "App::PropertyInteger",
             "Copies",
             "Path",
             QT_TRANSLATE_NOOP(
-                "App::Property", "The number of copies in Linear 1D and Polar pattern"
+                "App::Property", "The number of copies in linear 1D and polar pattern"
             ),
         )
         obj.addProperty(
             "App::PropertyVector",
             "Centre",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "The centre of rotation in Polar pattern"),
+            QT_TRANSLATE_NOOP("App::Property", "The centre of rotation in polar pattern"),
         )
         obj.addProperty(
             "App::PropertyBool",
@@ -144,7 +144,7 @@ class ObjectArray:
             "App::PropertyString",
             "CycleTime",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "Operations Cycle Time Estimation"),
+            QT_TRANSLATE_NOOP("App::Property", "Operations cycle time estimation"),
         )
 
         obj.setEditorMode("CycleTime", 1)  # read-only
@@ -217,7 +217,7 @@ class ObjectArray:
                 "App::PropertyString",
                 "CycleTime",
                 "Path",
-                QT_TRANSLATE_NOOP("App::Property", "Operations Cycle Time Estimation"),
+                QT_TRANSLATE_NOOP("App::Property", "Operations cycle time estimation"),
             )
             obj.CycleTime = self.getCycleTimeEstimate(obj)
 
@@ -236,7 +236,7 @@ class ObjectArray:
                     (
                         "CAM -> Path Modification -> Array operation is deprecated "
                         "and will be removed in future FreeCAD versions.\n\n"
-                        "Please use CAM -> Path Dressup -> Array instead.\n\n"
+                        "Use CAM -> Path Dressup -> Array instead.\n\n"
                         "DO NOT USE CURRENT ARRAY OPERATION WHEN MACHINING WITH COOLANT!\n"
                         "Due to a bug - coolant will not be enabled for array paths."
                     ),
@@ -486,7 +486,7 @@ class CommandPathArray:
         return {
             "Pixmap": "CAM_Array",
             "MenuText": QT_TRANSLATE_NOOP("CAM_Array", "Array"),
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_Array", "Creates an array from selected toolpath(s)"),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_Array", "Creates an array from selected toolpaths"),
         }
 
     def IsActive(self):

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -1292,8 +1292,8 @@ class CommandSetStartPoint:
     def GetResources(self):
         return {
             "Pixmap": "CAM_StartPoint",
-            "MenuText": QT_TRANSLATE_NOOP("PathOp", "Pick Start Point"),
-            "ToolTip": QT_TRANSLATE_NOOP("PathOp", "Pick Start Point"),
+            "MenuText": QT_TRANSLATE_NOOP("PathOp", "Start Point Selection"),
+            "ToolTip": QT_TRANSLATE_NOOP("PathOp", "Selects the start point"),
         }
 
     def IsActive(self):
@@ -1416,4 +1416,4 @@ def SetupOperation(name, objFactory, opPageClass, pixmap, menuText, toolTip, set
 
 FreeCADGui.addCommand("CAM_SetStartPoint", CommandSetStartPoint())
 
-FreeCAD.Console.PrintLog("Loading PathOpGui... done\n")
+FreeCAD.Console.PrintLog("Loading PathOpGui… done\n")

--- a/src/Mod/CAM/Path/Op/Gui/Comment.py
+++ b/src/Mod/CAM/Path/Op/Gui/Comment.py
@@ -101,7 +101,7 @@ class CommandPathComment:
         return {
             "Pixmap": "CAM_Comment",
             "MenuText": QT_TRANSLATE_NOOP("CAM_Comment", "Comment"),
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_Comment", "Add a Comment to your CNC program"),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_Comment", "Adds a Comment to the CNC program"),
         }
 
     def IsActive(self):
@@ -112,7 +112,7 @@ class CommandPathComment:
         return False
 
     def Activated(self):
-        FreeCAD.ActiveDocument.openTransaction("Create a Comment in your CNC program")
+        FreeCAD.ActiveDocument.openTransaction("Create a Comment in the CNC program")
         FreeCADGui.addModule("Path.Op.Gui.Comment")
         snippet = """
 import Path
@@ -134,4 +134,4 @@ if FreeCAD.GuiUp:
     FreeCADGui.addCommand("CAM_Comment", CommandPathComment())
 
 
-FreeCAD.Console.PrintLog("Loading PathComment... done\n")
+FreeCAD.Console.PrintLog("Loading PathComment… done\n")

--- a/src/Mod/CAM/Path/Op/Gui/Copy.py
+++ b/src/Mod/CAM/Path/Op/Gui/Copy.py
@@ -147,4 +147,4 @@ if FreeCAD.GuiUp:
     # register the FreeCAD command
     FreeCADGui.addCommand("CAM_Copy", CommandPathCopy())
 
-FreeCAD.Console.PrintLog("Loading PathCopy... done\n")
+FreeCAD.Console.PrintLog("Loading PathCopy… done\n")

--- a/src/Mod/CAM/Path/Op/Gui/PathShapeTC.py
+++ b/src/Mod/CAM/Path/Op/Gui/PathShapeTC.py
@@ -62,21 +62,21 @@ def _addBaseProperties(obj):
         "App::PropertyString",
         "Comment",
         "Path",
-        QT_TRANSLATE_NOOP("App::Property", "An optional comment for this Operation"),
+        QT_TRANSLATE_NOOP("App::Property", "An optional comment for this operation"),
         locked=True,
     )
     obj.addProperty(
         "App::PropertyString",
         "UserLabel",
         "Path",
-        QT_TRANSLATE_NOOP("App::Property", "User Assigned Label"),
+        QT_TRANSLATE_NOOP("App::Property", "User assigned label"),
         locked=True,
     )
     obj.addProperty(
         "App::PropertyString",
         "CycleTime",
         "Path",
-        QT_TRANSLATE_NOOP("App::Property", "Operations Cycle Time Estimation"),
+        QT_TRANSLATE_NOOP("App::Property", "Operations cycle time estimation"),
         locked=True,
     )
     obj.setEditorMode("CycleTime", 1)  # Set property read-only
@@ -180,9 +180,9 @@ class CommandPathShapeTC:
     def GetResources(self):
         return {
             "Pixmap": "CAM_ShapeTC",
-            "MenuText": QT_TRANSLATE_NOOP("CAM_PathShapeTC", "Path from Shape TC"),
+            "MenuText": QT_TRANSLATE_NOOP("CAM_PathShapeTC", "Path From Shape TC"),
             "ToolTip": QT_TRANSLATE_NOOP(
-                "CAM_PathShapeTC", "Creates path from selected shapes with tool controller"
+                "CAM_PathShapeTC", "Creates a path from the selected shapes with the tool controller"
             ),
         }
 

--- a/src/Mod/CAM/Path/Op/Gui/SimpleCopy.py
+++ b/src/Mod/CAM/Path/Op/Gui/SimpleCopy.py
@@ -55,12 +55,12 @@ class CommandPathSimpleCopy:
         selection = FreeCADGui.Selection.getSelection()
         if len(selection) != 1:
             FreeCAD.Console.PrintError(
-                translate("CAM_SimpleCopy", "Please select exactly one toolpath object") + "\n"
+                translate("CAM_SimpleCopy", "Select exactly one toolpath object") + "\n"
             )
             return
         if not (selection[0].isDerivedFrom("Path::Feature")):
             FreeCAD.Console.PrintError(
-                translate("CAM_SimpleCopy", "Please select exactly one toolpath object") + "\n"
+                translate("CAM_SimpleCopy", "Select exactly one toolpath object") + "\n"
             )
             return
 

--- a/src/Mod/CAM/Path/Op/Gui/Stop.py
+++ b/src/Mod/CAM/Path/Op/Gui/Stop.py
@@ -37,7 +37,7 @@ class Stop:
             "App::PropertyEnumeration",
             "Stop",
             "Path",
-            QT_TRANSLATE_NOOP("App::Property", "Add Optional or Mandatory Stop to the program"),
+            QT_TRANSLATE_NOOP("App::Property", "Add an optional or mandatory stop to the program"),
         )
         obj.Stop = ["Optional", "Mandatory"]
         obj.Proxy = self
@@ -107,7 +107,7 @@ class CommandPathStop:
             "Pixmap": "CAM_Stop",
             "MenuText": QT_TRANSLATE_NOOP("CAM_Stop", "Stop"),
             "ToolTip": QT_TRANSLATE_NOOP(
-                "CAM_Stop", "Add Optional or Mandatory Stop to the program"
+                "CAM_Stop", "Adds an optional or mandatory stop to the program"
             ),
         }
 
@@ -142,4 +142,4 @@ if FreeCAD.GuiUp:
     FreeCADGui.addCommand("CAM_Stop", CommandPathStop())
 
 
-FreeCAD.Console.PrintLog("Loading PathStop... done\n")
+FreeCAD.Console.PrintLog("Loading PathStop… done\n")

--- a/src/Mod/CAM/Path/Post/Command.py
+++ b/src/Mod/CAM/Path/Post/Command.py
@@ -108,7 +108,7 @@ class CommandPathPost:
             "Pixmap": "CAM_Post",
             "MenuText": QT_TRANSLATE_NOOP("CAM_Post", "Post Process"),
             "Accel": "P, P",
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_Post", "Post Process the selected Job"),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_Post", "Post Processes the selected job"),
         }
 
     def IsActive(self):
@@ -262,4 +262,4 @@ if FreeCAD.GuiUp:
     # register the FreeCAD command
     FreeCADGui.addCommand("CAM_Post", CommandPathPost())
 
-FreeCAD.Console.PrintLog("Loading PathPost... done\n")
+FreeCAD.Console.PrintLog("Loading PathPost… done\n")

--- a/src/Mod/CAM/Path/Tool/Gui/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Gui/Controller.py
@@ -140,8 +140,8 @@ class CommandPathToolController(object):
     def GetResources(self):
         return {
             "Pixmap": "CAM_LengthOffset",
-            "MenuText": QT_TRANSLATE_NOOP("CAM_ToolController", "Add Tool Controller to the Job"),
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_ToolController", "Add Tool Controller"),
+            "MenuText": QT_TRANSLATE_NOOP("CAM_ToolController", "Tool Controller"),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_ToolController", "Adds a new tool controller to the active job"),
         }
 
     def selectedJob(self):
@@ -364,4 +364,4 @@ if FreeCAD.GuiUp:
     # register the FreeCAD command
     FreeCADGui.addCommand("CAM_ToolController", CommandPathToolController())
 
-FreeCAD.Console.PrintLog("Loading PathToolControllerGui... done\n")
+FreeCAD.Console.PrintLog("Loading PathToolControllerGui… done\n")

--- a/src/Mod/CAM/Path/Tool/library/ui/cmd.py
+++ b/src/Mod/CAM/Path/Tool/library/ui/cmd.py
@@ -48,8 +48,8 @@ class CommandToolBitLibraryDockOpen:
     def GetResources(self):
         return {
             "Pixmap": "CAM_ToolTable",
-            "MenuText": QT_TRANSLATE_NOOP("CAM_ToolBitDock", "ToolBit Dock"),
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_ToolBitDock", "Toggle the Toolbit Dock"),
+            "MenuText": QT_TRANSLATE_NOOP("CAM_ToolBitDock", "Toolbit Dock"),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_ToolBitDock", "Toggles the toolbit dock"),
             "Accel": "P, T",
             "CmdType": "ForEdit",
         }
@@ -73,9 +73,9 @@ class CommandLibraryEditorOpen:
     def GetResources(self):
         return {
             "Pixmap": "CAM_ToolTable",
-            "MenuText": QT_TRANSLATE_NOOP("CAM_ToolBitLibraryOpen", "ToolBit Library editor"),
+            "MenuText": QT_TRANSLATE_NOOP("CAM_ToolBitLibraryOpen", "ToolBit Library Editor"),
             "ToolTip": QT_TRANSLATE_NOOP(
-                "CAM_ToolBitLibraryOpen", "Open an editor to manage ToolBit libraries"
+                "CAM_ToolBitLibraryOpen", "Opens an editor to manage toolbit libraries"
             ),
             "CmdType": "ForEdit",
         }
@@ -95,4 +95,4 @@ if FreeCAD.GuiUp:
 BarList = ["CAM_ToolBitDock"]
 MenuList = ["CAM_ToolBitLibraryOpen", "CAM_ToolBitDock"]
 
-FreeCAD.Console.PrintLog("Loading PathToolBitLibraryCmd... done\n")
+FreeCAD.Console.PrintLog("Loading PathToolBitLibraryCmd… done\n")

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/cmd.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/cmd.py
@@ -49,8 +49,8 @@ class CommandToolBitCreate:
     def GetResources(self):
         return {
             "Pixmap": "CAM_ToolBit",
-            "MenuText": QT_TRANSLATE_NOOP("CAM_ToolBitCreate", "Create Tool"),
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_ToolBitCreate", "Creates a new ToolBit object"),
+            "MenuText": QT_TRANSLATE_NOOP("CAM_ToolBitCreate", "New Tool"),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_ToolBitCreate", "Creates a new toolbit object"),
         }
 
     def IsActive(self):
@@ -73,14 +73,14 @@ class CommandToolBitSave:
 
     def GetResources(self):
         if self.saveAs:
-            menuTxt = QT_TRANSLATE_NOOP("CAM_ToolBitSaveAs", "Save Tool as...")
+            menuTxt = QT_TRANSLATE_NOOP("CAM_ToolBitSaveAs", "Save Tool As…")
         else:
             menuTxt = QT_TRANSLATE_NOOP("CAM_ToolBitSave", "Save Tool")
         return {
             "Pixmap": "CAM_ToolBit",
             "MenuText": menuTxt,
             "ToolTip": QT_TRANSLATE_NOOP(
-                "CAM_ToolBitSave", "Save an existing ToolBit object to a file"
+                "CAM_ToolBitSave", "Saves an existing toolbit object to a file"
             ),
         }
 
@@ -123,7 +123,7 @@ class CommandToolBitLoad:
             "Pixmap": "CAM_ToolBit",
             "MenuText": QT_TRANSLATE_NOOP("CAM_ToolBitLoad", "Load Tool"),
             "ToolTip": QT_TRANSLATE_NOOP(
-                "CAM_ToolBitLoad", "Load an existing ToolBit object from a file"
+                "CAM_ToolBitLoad", "Loads an existing toolbit object from a file"
             ),
         }
 

--- a/src/Mod/CAM/PathCommands.py
+++ b/src/Mod/CAM/PathCommands.py
@@ -59,7 +59,7 @@ class _CommandSelectLoop:
             "MenuText": QT_TRANSLATE_NOOP("CAM_SelectLoop", "Finish Selecting Loop"),
             "Accel": "P, L",
             "ToolTip": QT_TRANSLATE_NOOP(
-                "CAM_SelectLoop", "Complete the selection of edges that form a loop"
+                "CAM_SelectLoop", "Completes the selection of edges that form a loop"
             ),
             "CmdType": "ForEdit",
         }
@@ -143,11 +143,11 @@ class _ToggleOperation:
         return {
             "Pixmap": "CAM_OpActive",
             "MenuText": QT_TRANSLATE_NOOP(
-                "CAM_OpActiveToggle", "Toggle the Active State of the Operation"
+                "CAM_OpActiveToggle", "Toggle Operation Active"
             ),
             "Accel": "P, X",
             "ToolTip": QT_TRANSLATE_NOOP(
-                "CAM_OpActiveToggle", "Toggle the Active State of the Operation"
+                "CAM_OpActiveToggle", "Toggles the active state of the operation"
             ),
             "CmdType": "ForEdit",
         }
@@ -185,8 +185,8 @@ class _CopyOperation:
     def GetResources(self):
         return {
             "Pixmap": "CAM_OpCopy",
-            "MenuText": QT_TRANSLATE_NOOP("CAM_OperationCopy", "Copy the operation in the job"),
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_OperationCopy", "Copy the operation in the job"),
+            "MenuText": QT_TRANSLATE_NOOP("CAM_OperationCopy", "Copy Operation"),
+            "ToolTip": QT_TRANSLATE_NOOP("CAM_OperationCopy", "Copies the operation in the job"),
             "CmdType": "ForEdit",
         }
 


### PR DESCRIPTION
Part of a larger set of PRs for all workbenches in FreeCAD which edits all user facings strings to adhere to the guidelines in https://freecad.github.io/DevelopersHandbook/designguide/naming.html