### PR TITLE
CAM: Adaptive - Helix generator

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathAdaptive.py
+++ b/src/Mod/CAM/CAMTests/TestPathAdaptive.py
@@ -481,9 +481,8 @@ class TestPathAdaptive(PathTestBase):
         adaptive.StepOver = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
-        adaptive.StepDown.Value = (
-            20.0  # Have to set expression to None before numerical value assignment
-        )
+        # Have to set expression to None before numerical value assignment
+        adaptive.StepDown.Value = 20.0
 
         _addViewProvider(adaptive)
         self.doc.recompute()
@@ -514,9 +513,8 @@ class TestPathAdaptive(PathTestBase):
         adaptive.StepOver = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
-        adaptive.StepDown.Value = (
-            20.0  # Have to set expression to None before numerical value assignment
-        )
+        # Have to set expression to None before numerical value assignment
+        adaptive.StepDown.Value = 20.0
 
         _addViewProvider(adaptive)
         self.doc.recompute()
@@ -541,9 +539,8 @@ class TestPathAdaptive(PathTestBase):
         adaptive.StepOver = 75
         adaptive.UseOutline = True
         adaptive.setExpression("StepDown", None)
-        adaptive.StepDown.Value = (
-            20.0  # Have to set expression to None before numerical value assignment
-        )
+        # Have to set expression to None before numerical value assignment
+        adaptive.StepDown.Value = 20.0
 
         _addViewProvider(adaptive)
         self.doc.recompute()
@@ -581,9 +578,8 @@ class TestPathAdaptive(PathTestBase):
         adaptive.StepOver = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
-        adaptive.StepDown.Value = (
-            20.0  # Have to set expression to None before numerical value assignment
-        )
+        # Have to set expression to None before numerical value assignment
+        adaptive.StepDown.Value = 20.0
 
         _addViewProvider(adaptive)
         self.doc.recompute()
@@ -623,9 +619,8 @@ class TestPathAdaptive(PathTestBase):
         adaptive.StepOver = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
-        adaptive.StepDown.Value = (
-            20.0  # Have to set expression to None before numerical value assignment
-        )
+        # Have to set expression to None before numerical value assignment
+        adaptive.StepDown.Value = 20.0
 
         _addViewProvider(adaptive)
         self.doc.recompute()
@@ -665,9 +660,8 @@ class TestPathAdaptive(PathTestBase):
         adaptive.StepOver = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
-        adaptive.StepDown.Value = (
-            20.0  # Have to set expression to None before numerical value assignment
-        )
+        # Have to set expression to None before numerical value assignment
+        adaptive.StepDown.Value = 20.0
 
         _addViewProvider(adaptive)
         self.doc.recompute()
@@ -707,9 +701,8 @@ class TestPathAdaptive(PathTestBase):
         adaptive.StepOver = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
-        adaptive.StepDown.Value = (
-            20.0  # Have to set expression to None before numerical value assignment
-        )
+        # Have to set expression to None before numerical value assignment
+        adaptive.StepDown.Value = 20.0
 
         _addViewProvider(adaptive)
         self.doc.recompute()
@@ -768,13 +761,8 @@ class TestPathAdaptive(PathTestBase):
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         adaptive.ModelAwareExperiment = True
-        adaptive.StepDown.Value = (
-            5.0  # Have to set expression to None before numerical value assignment
-        )
-        # Don't use helix entry- ensures helix moves are counted in the path
-        # boundary calculation. This should be unnecessary, as the helices are
-        # grown out of the cut area, and thus must be inside of it.
-        adaptive.UseHelixArcs = False
+        # Have to set expression to None before numerical value assignment
+        adaptive.StepDown.Value = 5.0
 
         _addViewProvider(adaptive)
         self.doc.recompute()
@@ -836,9 +824,8 @@ class TestPathAdaptive(PathTestBase):
         adaptive.StepOver = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
-        adaptive.StepDown.Value = (
-            5.0  # Have to set expression to None before numerical value assignment
-        )
+        # Have to set expression to None before numerical value assignment
+        adaptive.StepDown.Value = 5.0
         # Add some Z stock to leave so we avoid Face3 in this stepdown at Z=10
         adaptive.setExpression("ZStockToLeave", None)
         adaptive.ZStockToLeave.Value = 1
@@ -898,13 +885,8 @@ class TestPathAdaptive(PathTestBase):
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         adaptive.ModelAwareExperiment = True
-        adaptive.StepDown.Value = (
-            5.0  # Have to set expression to None before numerical value assignment
-        )
-        # Don't use helix entry- ensures helix moves are counted in the path
-        # boundary calculation. This should be unnecessary, as the helices are
-        # grown out of the cut area, and thus must be inside of it.
-        adaptive.UseHelixArcs = False
+        # Have to set expression to None before numerical value assignment
+        adaptive.StepDown.Value = 5.0
 
         _addViewProvider(adaptive)
         self.doc.recompute()
@@ -979,13 +961,8 @@ class TestPathAdaptive(PathTestBase):
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         adaptive.ModelAwareExperiment = True
-        adaptive.StepDown.Value = (
-            5.0  # Have to set expression to None before numerical value assignment
-        )
-        # Don't use helix entry- ensures helix moves are counted in the path
-        # boundary calculation. This should be unnecessary, as the helices are
-        # grown out of the cut area, and thus must be inside of it.
-        adaptive.UseHelixArcs = False
+        # Have to set expression to None before numerical value assignment
+        adaptive.StepDown.Value = 5.0
 
         # Create and assign new stock that will create different bounds at
         # different stepdowns

--- a/src/Mod/CAM/CAMTests/TestPathAdaptive.py
+++ b/src/Mod/CAM/CAMTests/TestPathAdaptive.py
@@ -476,7 +476,7 @@ class TestPathAdaptive(PathTestBase):
         # Set additional operation properties
         # setDepthsAndHeights(adaptive)
         adaptive.FinishingProfile = False
-        adaptive.HelixAngle = 75.0
+        adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
         adaptive.StepOver = 75
         adaptive.UseOutline = False
@@ -508,7 +508,7 @@ class TestPathAdaptive(PathTestBase):
         # Set additional operation properties
         # setDepthsAndHeights(adaptive)
         adaptive.FinishingProfile = False
-        adaptive.HelixAngle = 75.0
+        adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
         adaptive.StepOver = 75
         adaptive.UseOutline = False
@@ -534,7 +534,7 @@ class TestPathAdaptive(PathTestBase):
         # Set additional operation properties
         # setDepthsAndHeights(adaptive)
         adaptive.FinishingProfile = False
-        adaptive.HelixAngle = 75.0
+        adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
         adaptive.StepOver = 75
         adaptive.UseOutline = True
@@ -573,7 +573,7 @@ class TestPathAdaptive(PathTestBase):
         # Set additional operation properties
         # setDepthsAndHeights(adaptive)
         adaptive.FinishingProfile = False
-        adaptive.HelixAngle = 75.0
+        adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
         adaptive.StepOver = 75
         adaptive.UseOutline = False
@@ -614,7 +614,7 @@ class TestPathAdaptive(PathTestBase):
         # Set additional operation properties
         # setDepthsAndHeights(adaptive)
         adaptive.FinishingProfile = False
-        adaptive.HelixAngle = 75.0
+        adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
         adaptive.StepOver = 75
         adaptive.UseOutline = False
@@ -655,7 +655,7 @@ class TestPathAdaptive(PathTestBase):
         # Set additional operation properties
         # setDepthsAndHeights(adaptive)
         adaptive.FinishingProfile = False
-        adaptive.HelixAngle = 75.0
+        adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
         adaptive.StepOver = 75
         adaptive.UseOutline = False
@@ -696,7 +696,7 @@ class TestPathAdaptive(PathTestBase):
         # Set additional operation properties
         # setDepthsAndHeights(adaptive)
         adaptive.FinishingProfile = False
-        adaptive.HelixAngle = 75.0
+        adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
         adaptive.StepOver = 75
         adaptive.UseOutline = False
@@ -755,7 +755,7 @@ class TestPathAdaptive(PathTestBase):
         # Set additional operation properties
         setDepthsAndHeights(adaptive, 15, 0)
         adaptive.FinishingProfile = False
-        adaptive.HelixAngle = 75.0
+        adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
         adaptive.StepOver = 75
         adaptive.UseOutline = False
@@ -819,7 +819,7 @@ class TestPathAdaptive(PathTestBase):
         # Set additional operation properties
         setDepthsAndHeights(adaptive, 15, 10)
         adaptive.FinishingProfile = False
-        adaptive.HelixAngle = 75.0
+        adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
         adaptive.StepOver = 75
         adaptive.UseOutline = False
@@ -879,7 +879,7 @@ class TestPathAdaptive(PathTestBase):
         # Set additional operation properties
         setDepthsAndHeights(adaptive, 15, 0)
         adaptive.FinishingProfile = False
-        adaptive.HelixAngle = 75.0
+        adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
         adaptive.StepOver = 75
         adaptive.UseOutline = False
@@ -955,7 +955,7 @@ class TestPathAdaptive(PathTestBase):
         # Set additional operation properties
         setDepthsAndHeights(adaptive, 15, 5)
         adaptive.FinishingProfile = False
-        adaptive.HelixAngle = 75.0
+        adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
         adaptive.StepOver = 75
         adaptive.UseOutline = False

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
@@ -260,14 +260,14 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="9" column="0">
        <widget class="QLabel" name="label_max_stepdown">
         <property name="text">
-         <string>Max stepdown</string>
+         <string>Max pitch</string>
         </property>
        </widget>
       </item>
       <item row="9" column="1">
-       <widget class="Gui::InputField" name="HelixMaxStepdown">
+       <widget class="Gui::InputField" name="HelixMaxPitch">
         <property name="toolTip">
-         <string>The maximum allowable descent in a single revolution of the helix.</string>
+         <string>The maximum allowable descent in a single revolution of the helix. Set to zero to disable limitation by pitch.</string>
         </property>
         <property name="unit" stdset="0">
          <string notr="true"/>
@@ -277,14 +277,14 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="10" column="0">
        <widget class="QLabel" name="label_7">
         <property name="text">
-         <string>Ramp angle</string>
+         <string>Max ramp angle</string>
         </property>
        </widget>
       </item>
       <item row="10" column="1">
-       <widget class="Gui::InputField" name="HelixAngle">
+       <widget class="Gui::InputField" name="HelixMaxRampAngle">
         <property name="toolTip">
-         <string>Angle of the helix ramp entry</string>
+         <string>The maximum allowable angle of the helix ramp entry. Set to zero to disable limitation by ramp angle.</string>
         </property>
         <property name="unit" stdset="0">
          <string notr="true"/>

--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -32,6 +32,7 @@
 import Path
 import Path.Base.FeedRate as PathFeedRate
 import Path.Base.Generator.helix as helix
+import Path.Base.Generator.spiral as spiral
 import Path.Op.Base as PathOp
 import Path.Op.Util as PathOpUtil
 import PathScripts.PathUtils as PathUtils
@@ -40,6 +41,7 @@ import time
 import json
 import math
 import area
+import Constants
 from FreeCAD import BoundBox
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -166,17 +168,13 @@ def GenerateGCode(op, obj, adaptiveResults):
 
     stepDown = max(obj.StepDown.Value, _ADAPTIVE_MIN_STEPDOWN)
 
-    length = 2 * math.pi * helixRadius
+    if obj.HelixMaxRampAngle < 0:
+        obj.HelixMaxRampAngle = 0
+    elif obj.HelixMaxRampAngle > 90:
+        obj.HelixMaxRampAngle = 90
 
-    if obj.HelixAngle < 0.01:
-        obj.HelixAngle = 1
-    elif obj.HelixAngle > 89.9:
-        obj.HelixAngle = 89.9
-
-    helixAngleRad = math.radians(obj.HelixAngle)
-    depthPerOneCircle = length * math.tan(helixAngleRad)
-    if obj.HelixMaxStepdown.Value != 0 and obj.HelixMaxStepdown.Value < depthPerOneCircle:
-        depthPerOneCircle = obj.HelixMaxStepdown.Value
+    if obj.HelixConeAngle < 0:
+        obj.HelixConeAngle = 0
 
     stepUp = max(obj.LiftDistance.Value, 0)
 
@@ -215,35 +213,63 @@ def GenerateGCode(op, obj, adaptiveResults):
             # Helix ramp
             if helixRadius > 0.01:
                 r = helixRadius - 0.01
+                helixHeight = passStartDepth - passEndDepth
+                cone_angle_rad = math.radians(obj.HelixConeAngle.Value)
+                r_bottom = r - helixHeight * math.tan(cone_angle_rad)
+                if r_bottom < r * 0.5:
+                    # put a limit on how small the cone tip can be
+                    r_bottom = r * 0.5
+                    cone_angle_rad = math.atan((r - r_bottom) / helixHeight)
+
                 op.commandlist.append(Path.Command("(Helix to depth: %f)" % passEndDepth))
                 op.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
 
                 # Prepend parameters for generator to create helix
-                args = {
+                argsHelix = {
                     "edge": None,
-                    "outer_radius": r,
-                    "pitch": depthPerOneCircle,
+                    "outer_radius": r_bottom,
+                    "pitch": obj.HelixMaxPitch.Value or helixHeight,
                     "retract_height": obj.SafeHeight.Value,
                     "direction": "CCW",
                     "startAt": "Inside",
                     "finish_circle": True,
-                    "cone_angle_rad": math.radians(obj.HelixConeAngle.Value),
+                    "cone_angle_rad": cone_angle_rad,
                     "dir_angle_rad": dirAngleRad,
+                    "ramp_angle_rad": math.radians(obj.HelixMaxRampAngle.Value) or math.pi / 2,
                 }
                 centerTop = FreeCAD.Vector(p1[0], p1[1], passStartDepth)
                 centerBottom = FreeCAD.Vector(p1[0], p1[1], passEndDepth)
-                args["edge"] = Part.makeLine(centerTop, centerBottom)
+                argsHelix["edge"] = Part.makeLine(centerTop, centerBottom)
 
-                helixCommands = helix.generate(**args)
-                while helixCommands[-1].Name == "G0":
-                    # Remove last retract movements
-                    helixCommands.pop()
+                helixCommands = helix.generate(**argsHelix)
+                while helixCommands[-1].Name in Constants.GCODE_MOVE_LINE:
+                    # Remove last retract movements from helix path
+                    del helixCommands[-1]
 
                 op.commandlist.append(helixCommands[1])  # move to helix start point (x,y)
                 op.commandlist.append(Path.Command("G0", {"Z": obj.SafeHeight.Value}))
 
                 PathFeedRate.setFeedRate(helixCommands, obj.ToolController)
                 op.commandlist.extend(helixCommands[2:])
+
+                if cone_angle_rad:
+                    # Add spiral to connect helix and adaptive path
+                    spiralArgs = {
+                        "center": centerBottom,
+                        "outer_radius": r,
+                        "step": op.tool.Diameter.Value * obj.StepOver / 100,
+                        "inner_radius": r_bottom,
+                        "direction": "CCW",
+                        "startAt": "Inside",
+                        "dir_angle_rad": dirAngleRad,
+                    }
+                    spiralCommands = spiral.generate(**spiralArgs)
+                    PathFeedRate.setFeedRate(spiralCommands, obj.ToolController)
+                    # remove first linear movements
+                    while spiralCommands[0].Name in Constants.GCODE_MOVE_LINE:
+                        del spiralCommands[0]
+                    op.commandlist.append(Path.Command("(Spiral to radius: %f)" % r))
+                    op.commandlist.extend(spiralCommands)
 
             else:  # no helix entry
                 # rapid move to start point at clearance height
@@ -1636,20 +1662,22 @@ class PathAdaptive(PathOp.ObjectOp):
         obj.setEditorMode("AdaptiveOutputState", 2)  # hide this property
         obj.addProperty(
             "App::PropertyAngle",
-            "HelixAngle",
+            "HelixMaxRampAngle",
             "AdaptiveHelixEntry",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "Helix ramp entry angle (degrees)",
+                "The maximum allowable helix ramp entry angle (degrees)"
+                "\nSet to zero to disable limitation by ramp angle",
             ),
         )
         obj.addProperty(
             "App::PropertyLength",
-            "HelixMaxStepdown",
+            "HelixMaxPitch",
             "AdaptiveHelixEntry",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "The maximum allowable descent in a single revolution of the helix.",
+                "The maximum allowable descent in a single revolution of the helix"
+                "\nSet to zero to disable limitation by pitch",
             ),
         )
         obj.addProperty(
@@ -1742,7 +1770,7 @@ class PathAdaptive(PathOp.ObjectOp):
         obj.FinishingProfile = True
         obj.Stopped = False
         obj.StopProcessing = False
-        obj.HelixAngle = 5
+        obj.HelixMaxRampAngle = 5
         obj.HelixConeAngle = 0
         obj.HelixMaxDiameterPercent = 100
         obj.HelixMinDiameterPercent = 10
@@ -1873,16 +1901,32 @@ class PathAdaptive(PathOp.ObjectOp):
                     75 if oldD == 0 else 100 * oldD / obj.ToolController.Tool.Diameter.Value
                 )
 
-        if not hasattr(obj, "HelixMaxStepdown"):
+        if hasattr(obj, "HelixAngle"):
+            obj.renameProperty("HelixAngle", "HelixMaxRampAngle")
+
+        if hasattr(obj, "HelixMaxStepdown"):
+            obj.renameProperty("HelixMaxStepdown", "HelixMaxPitch")
+        if not hasattr(obj, "HelixMaxPitch"):
             obj.addProperty(
                 "App::PropertyLength",
-                "HelixMaxStepdown",
+                "HelixMaxPitch",
                 "AdaptiveHelixEntry",
                 QT_TRANSLATE_NOOP(
                     "App::Property",
-                    "The maximum allowable descent in a single revolution of the helix.",
+                    "The maximum allowable descent in a single revolution of the helix"
+                    "Set to zero to disable limitation by pitch",
                 ),
             )
+        helixProps = (
+            "HelixConeAngle",
+            "HelixMaxDiameterPercent",
+            "HelixMinDiameterPercent",
+            "HelixMaxRampAngle",
+            "HelixMaxPitch",
+        )
+        for prop in helixProps:
+            if obj.getGroupOfProperty(prop) != "AdaptiveHelixEntry":
+                obj.setGroupOfProperty(prop, "AdaptiveHelixEntry")
 
         FeatureExtensions.initialize_properties(obj)
 
@@ -1903,7 +1947,7 @@ def SetupProperties():
         "StopProcessing",
         "AdaptiveInputState",
         "AdaptiveOutputState",
-        "HelixAngle",
+        "HelixMaxRampAngle",
         "HelixConeAngle",
         "HelixMaxDiameterPercent",
         "HelixMinDiameterPercent",

--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -30,6 +30,8 @@
 # shape.Wires list is non-empty bypasses this issue.
 
 import Path
+import Path.Base.FeedRate as PathFeedRate
+import Path.Base.Generator.helix as helix
 import Path.Op.Base as PathOp
 import Path.Op.Util as PathOpUtil
 import PathScripts.PathUtils as PathUtils
@@ -166,8 +168,10 @@ def GenerateGCode(op, obj, adaptiveResults):
 
     length = 2 * math.pi * helixRadius
 
-    obj.HelixAngle = min(89.99, max(obj.HelixAngle.Value, 0.01))
-    obj.HelixConeAngle = max(obj.HelixConeAngle, 0)
+    if obj.HelixAngle < 0.01:
+        obj.HelixAngle = 1
+    elif obj.HelixAngle > 89.9:
+        obj.HelixAngle = 89.9
 
     helixAngleRad = math.radians(obj.HelixAngle)
     depthPerOneCircle = length * math.tan(helixAngleRad)
@@ -203,294 +207,53 @@ def GenerateGCode(op, obj, adaptiveResults):
         )
 
         for passEndDepth in depthParams.data:
-            pass_start_angle = math.atan2(
-                region["StartPoint"][1] - region["HelixCenterPoint"][1],
-                region["StartPoint"][0] - region["HelixCenterPoint"][0],
-            )
-
-            passDepth = passStartDepth - passEndDepth
-
             p1 = region["HelixCenterPoint"]
             p2 = region["StartPoint"]
             helixRadius = math.dist(p1[:2], p2[:2])
+            dirAngleRad = math.atan2(p2[1] - p1[1], p2[0] - p1[0])
 
             # Helix ramp
             if helixRadius > 0.01:
                 r = helixRadius - 0.01
                 op.commandlist.append(Path.Command("(Helix to depth: %f)" % passEndDepth))
+                op.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
 
-                if obj.UseHelixArcs is False:
-                    helix_down_angle = passDepth / depthPerOneCircle * 2 * math.pi
+                # Prepend parameters for generator to create helix
+                args = {
+                    "edge": None,
+                    "outer_radius": r,
+                    "pitch": depthPerOneCircle,
+                    "retract_height": obj.SafeHeight.Value,
+                    "direction": "CCW",
+                    "startAt": "Inside",
+                    "finish_circle": True,
+                    "cone_angle_rad": math.radians(obj.HelixConeAngle.Value),
+                    "dir_angle_rad": dirAngleRad,
+                }
+                centerTop = FreeCAD.Vector(p1[0], p1[1], passStartDepth)
+                centerBottom = FreeCAD.Vector(p1[0], p1[1], passEndDepth)
+                args["edge"] = Part.makeLine(centerTop, centerBottom)
 
-                    r_bottom = r - (passStartDepth - passEndDepth) * math.tan(
-                        math.radians(obj.HelixConeAngle.Value)
-                    )
-                    r_bottom = max(
-                        r_bottom, r * 0.5
-                    )  # put a limit on how small the cone tip can be
-                    step_over = obj.StepOver * 0.01 * op.tool.Diameter.Value
-                    spiral_out_angle = (r - r_bottom) / step_over * 2 * math.pi
+                helixCommands = helix.generate(**args)
+                while helixCommands[-1].Name == "G0":
+                    # Remove last retract movements
+                    helixCommands.pop()
 
-                    helix_base_angle = pass_start_angle - helix_down_angle - spiral_out_angle
-                    helix_angular_progress = 0
+                op.commandlist.append(helixCommands[1])  # move to helix start point (x,y)
+                op.commandlist.append(Path.Command("G0", {"Z": obj.SafeHeight.Value}))
 
-                    helixStart = [
-                        region["HelixCenterPoint"][0] + r * math.cos(helix_base_angle),
-                        region["HelixCenterPoint"][1] + r * math.sin(helix_base_angle),
-                    ]
-
-                    # rapid move to start point
-                    op.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
-                    op.commandlist.append(
-                        Path.Command(
-                            "G0",
-                            {
-                                "X": helixStart[0],
-                                "Y": helixStart[1],
-                                "Z": obj.ClearanceHeight.Value,
-                            },
-                        )
-                    )
-
-                    # rapid move to safe height
-                    op.commandlist.append(
-                        Path.Command(
-                            "G0",
-                            {
-                                "X": helixStart[0],
-                                "Y": helixStart[1],
-                                "Z": obj.SafeHeight.Value,
-                            },
-                        )
-                    )
-
-                    # move to start depth
-                    op.commandlist.append(
-                        Path.Command(
-                            "G1",
-                            {
-                                "X": helixStart[0],
-                                "Y": helixStart[1],
-                                "Z": passStartDepth,
-                                "F": op.vertFeed,
-                            },
-                        )
-                    )
-
-                    # helix down
-                    while helix_angular_progress < helix_down_angle:
-                        progress = helix_angular_progress / helix_down_angle
-                        r_current = r * (1 - progress) + r_bottom * progress
-                        x = region["HelixCenterPoint"][0] + r_current * math.cos(
-                            helix_angular_progress + helix_base_angle
-                        )
-                        y = region["HelixCenterPoint"][1] + r_current * math.sin(
-                            helix_angular_progress + helix_base_angle
-                        )
-                        z = passStartDepth - progress * (passStartDepth - passEndDepth)
-                        op.commandlist.append(
-                            Path.Command("G1", {"X": x, "Y": y, "Z": z, "F": op.vertFeed})
-                        )
-                        helix_angular_progress = min(
-                            helix_angular_progress + math.pi / 16, helix_down_angle
-                        )
-
-                    # spiral out, plus a full extra circle
-                    max_angle = helix_down_angle + spiral_out_angle + 2 * math.pi
-                    while helix_angular_progress < max_angle:
-                        if spiral_out_angle == 0:
-                            progress = 1
-                        else:
-                            progress = min(
-                                1, (helix_angular_progress - helix_down_angle) / spiral_out_angle
-                            )
-                        r_current = r_bottom * (1 - progress) + r * progress
-                        x = region["HelixCenterPoint"][0] + r_current * math.cos(
-                            helix_angular_progress + helix_base_angle
-                        )
-                        y = region["HelixCenterPoint"][1] + r_current * math.sin(
-                            helix_angular_progress + helix_base_angle
-                        )
-                        z = passEndDepth
-                        op.commandlist.append(
-                            Path.Command("G1", {"X": x, "Y": y, "Z": z, "F": op.horizFeed})
-                        )
-                        helix_angular_progress = min(
-                            helix_angular_progress + math.pi / 16, max_angle
-                        )
-                else:
-                    # Use arcs for helix - no conical shape support
-                    helixStart = [
-                        region["HelixCenterPoint"][0] + r,
-                        region["HelixCenterPoint"][1],
-                    ]
-
-                    # rapid move to start point
-                    op.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
-                    op.commandlist.append(
-                        Path.Command(
-                            "G0",
-                            {
-                                "X": helixStart[0],
-                                "Y": helixStart[1],
-                                "Z": obj.ClearanceHeight.Value,
-                            },
-                        )
-                    )
-
-                    # rapid move to safe height
-                    op.commandlist.append(
-                        Path.Command(
-                            "G0",
-                            {
-                                "X": helixStart[0],
-                                "Y": helixStart[1],
-                                "Z": obj.SafeHeight.Value,
-                            },
-                        )
-                    )
-
-                    # move to start depth
-                    op.commandlist.append(
-                        Path.Command(
-                            "G1",
-                            {
-                                "X": helixStart[0],
-                                "Y": helixStart[1],
-                                "Z": passStartDepth,
-                                "F": op.vertFeed,
-                            },
-                        )
-                    )
-
-                    x = region["HelixCenterPoint"][0] + r
-                    y = region["HelixCenterPoint"][1]
-
-                    curDep = passStartDepth
-                    while curDep > (passEndDepth + depthPerOneCircle):
-                        op.commandlist.append(
-                            Path.Command(
-                                "G2",
-                                {
-                                    "X": x - (2 * r),
-                                    "Y": y,
-                                    "Z": curDep - (depthPerOneCircle / 2),
-                                    "I": -r,
-                                    "F": op.vertFeed,
-                                },
-                            )
-                        )
-                        op.commandlist.append(
-                            Path.Command(
-                                "G2",
-                                {
-                                    "X": x,
-                                    "Y": y,
-                                    "Z": curDep - depthPerOneCircle,
-                                    "I": r,
-                                    "F": op.vertFeed,
-                                },
-                            )
-                        )
-                        curDep = curDep - depthPerOneCircle
-
-                    lastStep = curDep - passEndDepth
-                    if lastStep > (depthPerOneCircle / 2):
-                        op.commandlist.append(
-                            Path.Command(
-                                "G2",
-                                {
-                                    "X": x - (2 * r),
-                                    "Y": y,
-                                    "Z": curDep - (lastStep / 2),
-                                    "I": -r,
-                                    "F": op.vertFeed,
-                                },
-                            )
-                        )
-                        op.commandlist.append(
-                            Path.Command(
-                                "G2",
-                                {
-                                    "X": x,
-                                    "Y": y,
-                                    "Z": passEndDepth,
-                                    "I": r,
-                                    "F": op.vertFeed,
-                                },
-                            )
-                        )
-                    else:
-                        op.commandlist.append(
-                            Path.Command(
-                                "G2",
-                                {
-                                    "X": x - (2 * r),
-                                    "Y": y,
-                                    "Z": passEndDepth,
-                                    "I": -r,
-                                    "F": op.vertFeed,
-                                },
-                            )
-                        )
-                        op.commandlist.append(
-                            Path.Command(
-                                "G1",
-                                {"X": x, "Y": y, "Z": passEndDepth, "F": op.vertFeed},
-                            )
-                        )
-
-                    # one more circle at target depth to make sure center is cleared
-                    op.commandlist.append(
-                        Path.Command(
-                            "G2",
-                            {
-                                "X": x - (2 * r),
-                                "Y": y,
-                                "Z": passEndDepth,
-                                "I": -r,
-                                "F": op.horizFeed,
-                            },
-                        )
-                    )
-                    op.commandlist.append(
-                        Path.Command(
-                            "G2",
-                            {
-                                "X": x,
-                                "Y": y,
-                                "Z": passEndDepth,
-                                "I": r,
-                                "F": op.horizFeed,
-                            },
-                        )
-                    )
+                PathFeedRate.setFeedRate(helixCommands, obj.ToolController)
+                op.commandlist.extend(helixCommands[2:])
 
             else:  # no helix entry
-                # rapid move to clearance height
-                op.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
-                op.commandlist.append(
-                    Path.Command(
-                        "G0",
-                        {
-                            "X": region["StartPoint"][0],
-                            "Y": region["StartPoint"][1],
-                            "Z": obj.ClearanceHeight.Value,
-                        },
-                    )
-                )
+                # rapid move to start point at clearance height
+                z = obj.ClearanceHeight.Value
+                op.commandlist.append(Path.Command("G0", {"Z": z}))
+                op.commandlist.append(Path.Command("G0", {"X": p2[0], "Y": p2[1], "Z": z}))
+
                 # straight plunge to target depth
-                op.commandlist.append(
-                    Path.Command(
-                        "G1",
-                        {
-                            "X": region["StartPoint"][0],
-                            "Y": region["StartPoint"][1],
-                            "Z": passEndDepth,
-                            "F": op.vertFeed,
-                        },
-                    )
-                )
+                parameters = {"X": p2[0], "Y": p2[1], "Z": passEndDepth, "F": op.vertFeed}
+                op.commandlist.append(Path.Command("G1", parameters))
 
             lz = passEndDepth
             z = obj.ClearanceHeight.Value
@@ -509,9 +272,8 @@ def GenerateGCode(op, obj, adaptiveResults):
                         if z != lz:
                             op.commandlist.append(Path.Command("G1", {"Z": z, "F": op.vertFeed}))
 
-                        op.commandlist.append(
-                            Path.Command("G1", {"X": x, "Y": y, "F": op.horizFeed})
-                        )
+                        parameters = {"X": x, "Y": y, "F": op.horizFeed}
+                        op.commandlist.append(Path.Command("G1", parameters))
 
                     elif motionType == area.AdaptiveMotionType.LinkClear:
                         z = passEndDepth + stepUp
@@ -1853,15 +1615,6 @@ class PathAdaptive(PathOp.ObjectOp):
         )
         obj.setEditorMode("StopProcessing", 2)  # hide this property
         obj.addProperty(
-            "App::PropertyBool",
-            "UseHelixArcs",
-            "Adaptive",
-            QT_TRANSLATE_NOOP(
-                "App::Property",
-                "Use Arcs (G2) for helix ramp",
-            ),
-        )
-        obj.addProperty(
             "App::PropertyPythonObject",
             "AdaptiveInputState",
             "Adaptive",
@@ -1998,7 +1751,6 @@ class PathAdaptive(PathOp.ObjectOp):
         obj.StockToLeave = 0
         obj.ZStockToLeave = 0
         obj.KeepToolDownRatio = 3.0
-        obj.UseHelixArcs = False
         obj.UseOutline = False
         obj.UseRestMachining = False
         obj.OrderCutsByRegion = False
@@ -2149,7 +1901,6 @@ def SetupProperties():
         "FinishingProfile",
         "Stopped",
         "StopProcessing",
-        "UseHelixArcs",
         "AdaptiveInputState",
         "AdaptiveOutputState",
         "HelixAngle",

--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -1637,7 +1637,7 @@ class PathAdaptive(PathOp.ObjectOp):
         obj.addProperty(
             "App::PropertyAngle",
             "HelixAngle",
-            "Adaptive",
+            "AdaptiveHelixEntry",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "Helix ramp entry angle (degrees)",
@@ -1646,7 +1646,7 @@ class PathAdaptive(PathOp.ObjectOp):
         obj.addProperty(
             "App::PropertyLength",
             "HelixMaxStepdown",
-            "Adaptive",
+            "AdaptiveHelixEntry",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "The maximum allowable descent in a single revolution of the helix.",
@@ -1655,7 +1655,7 @@ class PathAdaptive(PathOp.ObjectOp):
         obj.addProperty(
             "App::PropertyAngle",
             "HelixConeAngle",
-            "Adaptive",
+            "AdaptiveHelixEntry",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "Helix cone angle (degrees)",
@@ -1664,7 +1664,7 @@ class PathAdaptive(PathOp.ObjectOp):
         obj.addProperty(
             "App::PropertyPercent",
             "HelixMaxDiameterPercent",
-            "Adaptive",
+            "AdaptiveHelixEntry",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "Maximum (and nominal) helix entry diameter, as a percentage of the tool diameter",
@@ -1673,7 +1673,7 @@ class PathAdaptive(PathOp.ObjectOp):
         obj.addProperty(
             "App::PropertyPercent",
             "HelixMinDiameterPercent",
-            "Adaptive",
+            "AdaptiveHelixEntry",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "Minimum acceptable helix entry diameter, as a percentage of the tool diameter",
@@ -1784,7 +1784,7 @@ class PathAdaptive(PathOp.ObjectOp):
             obj.addProperty(
                 "App::PropertyAngle",
                 "HelixConeAngle",
-                "Adaptive",
+                "AdaptiveHelixEntry",
                 "Helix cone angle (degrees)",
             )
 
@@ -1852,7 +1852,7 @@ class PathAdaptive(PathOp.ObjectOp):
             obj.addProperty(
                 "App::PropertyPercent",
                 "HelixMaxDiameterPercent",
-                "Adaptive",
+                "AdaptiveHelixEntry",
                 QT_TRANSLATE_NOOP(
                     "App::Property",
                     "Maximum (and nominal) helix entry diameter, as a percentage of the tool diameter",
@@ -1861,7 +1861,7 @@ class PathAdaptive(PathOp.ObjectOp):
             obj.addProperty(
                 "App::PropertyPercent",
                 "HelixMinDiameterPercent",
-                "Adaptive",
+                "AdaptiveHelixEntry",
                 QT_TRANSLATE_NOOP(
                     "App::Property",
                     "Minimum acceptable helix entry diameter, as a percentage of the tool diameter",
@@ -1877,7 +1877,7 @@ class PathAdaptive(PathOp.ObjectOp):
             obj.addProperty(
                 "App::PropertyLength",
                 "HelixMaxStepdown",
-                "Adaptive",
+                "AdaptiveHelixEntry",
                 QT_TRANSLATE_NOOP(
                     "App::Property",
                     "The maximum allowable descent in a single revolution of the helix.",

--- a/src/Mod/CAM/Path/Op/Gui/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Gui/Adaptive.py
@@ -45,7 +45,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         return form
 
     def initPage(self, obj):
-        self.form.HelixMaxStepdown.setProperty("unit", obj.HelixMaxStepdown.getUserPreferred()[2])
+        self.form.HelixMaxPitch.setProperty("unit", obj.HelixMaxPitch.getUserPreferred()[2])
 
         self.form.LiftDistance.setProperty("unit", obj.LiftDistance.getUserPreferred()[2])
         self.form.KeepToolDownRatio.setProperty("unit", obj.KeepToolDownRatio.getUserPreferred()[2])
@@ -59,8 +59,8 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.stepOverPercent.valueChanged)
         signals.append(self.form.Tolerance.valueChanged)
-        signals.append(self.form.HelixAngle.valueChanged)
-        signals.append(self.form.HelixMaxStepdown.valueChanged)
+        signals.append(self.form.HelixMaxRampAngle.valueChanged)
+        signals.append(self.form.HelixMaxPitch.valueChanged)
         signals.append(self.form.HelixConeAngle.valueChanged)
         signals.append(self.form.HelixMaxDiameterPercent.valueChanged)
         signals.append(self.form.HelixMinDiameterPercent.valueChanged)
@@ -87,11 +87,11 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.stepOverPercent.setValue(obj.StepOver)
         self.form.Tolerance.setValue(int(obj.Tolerance * 100))
 
-        self.form.HelixAngle.setText(
-            FreeCAD.Units.Quantity(obj.HelixAngle, FreeCAD.Units.Angle).UserString
+        self.form.HelixMaxRampAngle.setText(
+            FreeCAD.Units.Quantity(obj.HelixMaxRampAngle, FreeCAD.Units.Angle).UserString
         )
 
-        self.form.HelixMaxStepdown.setProperty("rawValue", obj.HelixMaxStepdown.Value)
+        self.form.HelixMaxPitch.setProperty("rawValue", obj.HelixMaxPitch.Value)
 
         self.form.HelixConeAngle.setText(
             FreeCAD.Units.Quantity(obj.HelixConeAngle, FreeCAD.Units.Angle).UserString
@@ -138,8 +138,8 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             obj.HelixMinDiameterPercent = self.form.HelixMinDiameterPercent.value()
 
         obj.Tolerance = 1.0 * self.form.Tolerance.value() / 100.0
-        PathGuiUtil.updateInputField(obj, "HelixAngle", self.form.HelixAngle)
-        PathGuiUtil.updateInputField(obj, "HelixMaxStepdown", self.form.HelixMaxStepdown)
+        PathGuiUtil.updateInputField(obj, "HelixMaxRampAngle", self.form.HelixMaxRampAngle)
+        PathGuiUtil.updateInputField(obj, "HelixMaxPitch", self.form.HelixMaxPitch)
         PathGuiUtil.updateInputField(obj, "HelixConeAngle", self.form.HelixConeAngle)
         PathGuiUtil.updateInputField(obj, "LiftDistance", self.form.LiftDistance)
 


### PR DESCRIPTION
Step **2/2** of changes to get identical names and behavior of helix ramp entry in **Helix** and **Adaptive** operations

#### Changes:
- Use helix generator to create helix entry
- Move helix properties to **AdaptiveHelixEntry** group
- New properties names `HelixMaxRampAngle` and `HelixMaxPitch`

<img width="1105" height="634" alt="Screenshot_20260417_215743_hor" src="https://github.com/user-attachments/assets/49f309b0-bcd0-4300-be2d-eb8acd4b851c" />
