### PR TITLE
Gui: Fix too small link icon on high dpi

### DIFF
--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -673,8 +673,10 @@ public:
 
     QIcon getIcon(QPixmap px) {
         static int iconSize = -1;
-        if(iconSize < 0)
-            iconSize = QApplication::style()->standardPixmap(QStyle::SP_DirClosedIcon).width();
+        if (iconSize < 0) {
+            auto sampleIcon = QApplication::style()->standardPixmap(QStyle::SP_DirClosedIcon);
+            iconSize = sampleIcon.width() / sampleIcon.devicePixelRatio();
+        }
 
         if(!isLinked())
             return QIcon();

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -675,7 +675,8 @@ public:
         static int iconSize = -1;
         if (iconSize < 0) {
             auto sampleIcon = QApplication::style()->standardPixmap(QStyle::SP_DirClosedIcon);
-            iconSize = sampleIcon.width() / sampleIcon.devicePixelRatio();
+            double pixelRatio = sampleIcon.devicePixelRatio();
+            iconSize = static_cast<int>(sampleIcon.width() / pixelRatio);
         }
 
         if(!isLinked())


### PR DESCRIPTION
Like #22345 it fixes issue with too small arrow on high DPI displays. The problem was that the code in ViewProviderLink used width that is already multiplied by DPR as size for icon that expects not premultiplied size, which was messing with proportions.

@maxwxyz can you test that it works as it should?

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
Closes #22345
Fixes #6765
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7d1f2761-2432-4878-9d79-ab27be367a17) |![image](https://github.com/user-attachments/assets/802aeb36-833d-4842-83d8-a4003722f5e1)  | 

Not sure why I get pixelated icons in that case, but I had it also before so probably some issue with my way of testing HighDPI stuff.


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
