### PR TITLE
MeshPart: Update UI strings for consistency

### DIFF
--- a/src/Mod/MeshPart/App/AppMeshPart.cpp
+++ b/src/Mod/MeshPart/App/AppMeshPart.cpp
@@ -44,6 +44,6 @@ PyMOD_INIT_FUNC(MeshPart)
         PyMOD_Return(nullptr);
     }
     PyObject* mod = MeshPart::initModule();
-    Base::Console().log("Loading MeshPart module... done\n");
+    Base::Console().log("Loading MeshPart module… done\n");
     PyMOD_Return(mod);
 }

--- a/src/Mod/MeshPart/App/MeshFlattening.cpp
+++ b/src/Mod/MeshPart/App/MeshFlattening.cpp
@@ -132,7 +132,7 @@ FaceUnwrapper::FaceUnwrapper(const TopoDS_Face& face)
     const Handle(Poly_Triangulation) & triangulation = BRep_Tool::Triangulation(face, location);
 
     if (triangulation.IsNull()) {
-        throw std::runtime_error("null triangulation in face construction");
+        throw std::runtime_error("Null triangulation in face construction");
     }
 
     Standard_Integer numNodes = triangulation->NbNodes();
@@ -185,7 +185,7 @@ ColMat<double, 3> FaceUnwrapper::interpolateFlatFace(const TopoDS_Face& face)
 {
     if (this->uv_nodes.size() == 0) {
         throw(std::runtime_error("no uv-coordinates found, interpolating with nurbs is only "
-                                 "possible if the Flattener was constructed with a nurbs."));
+                                 "possible if the flattener was constructed with a nurbs."));
     }
 
     // extract xyz poles, knots, weights, degree
@@ -243,7 +243,7 @@ FaceUnwrapper::FaceUnwrapper(ColMat<double, int(3)> xyz_nodes, ColMat<long int, 
 std::vector<ColMat<double, 3>> FaceUnwrapper::getFlatBoundaryNodes()
 {
     if (this->ze_nodes.size() == 0) {
-        throw(std::runtime_error("flat vertices not xet computed"));
+        throw(std::runtime_error("Flat vertices not yet computed"));
     }
 
     ColMat<double, 3> flat_vertices;

--- a/src/Mod/MeshPart/Gui/AppMeshPartGui.cpp
+++ b/src/Mod/MeshPart/Gui/AppMeshPartGui.cpp
@@ -74,7 +74,7 @@ PyMOD_INIT_FUNC(MeshPartGui)
     }
 
     PyObject* mod = MeshPartGui::initModule();
-    Base::Console().log("Loading GUI of MeshPart module... done\n");
+    Base::Console().log("Loading GUI of MeshPart module… done\n");
 
     // clang-format off
     // instantiating the commands

--- a/src/Mod/MeshPart/Gui/Command.cpp
+++ b/src/Mod/MeshPart/Gui/Command.cpp
@@ -56,7 +56,7 @@ CmdMeshPartMesher::CmdMeshPartMesher()
 {
     sAppModule = "MeshPart";
     sGroup = QT_TR_NOOP("Mesh");
-    sMenuText = QT_TR_NOOP("Create mesh from shape...");
+    sMenuText = QT_TR_NOOP("Creates a mesh from a shape");
     sToolTipText = QT_TR_NOOP("Tessellate shape");
     sWhatsThis = "MeshPart_Mesher";
     sStatusTip = sToolTipText;
@@ -81,9 +81,9 @@ CmdMeshPartTrimByPlane::CmdMeshPartTrimByPlane()
 {
     sAppModule = "Mesh";
     sGroup = QT_TR_NOOP("Mesh");
-    sMenuText = QT_TR_NOOP("Trim mesh with a plane");
+    sMenuText = QT_TR_NOOP("Trim Mesh");
     sToolTipText = QT_TR_NOOP("Trims a mesh with a plane");
-    sStatusTip = QT_TR_NOOP("Trims a mesh with a plane");
+    sStatusTip = sToolTipText;
 }
 
 void CmdMeshPartTrimByPlane::activated(int)
@@ -94,14 +94,14 @@ void CmdMeshPartTrimByPlane::activated(int)
         QMessageBox::warning(Gui::getMainWindow(),
                              qApp->translate("MeshPart_TrimByPlane", "Select plane"),
                              qApp->translate("MeshPart_TrimByPlane",
-                                             "Please select a plane at which you trim the mesh."));
+                                             "Select a plane to trim the mesh with."));
         return;
     }
 
     QMessageBox msgBox(Gui::getMainWindow());
     msgBox.setIcon(QMessageBox::Question);
     msgBox.setWindowTitle(qApp->translate("MeshPart_TrimByPlane", "Trim by plane"));
-    msgBox.setText(qApp->translate("MeshPart_TrimByPlane", "Select the side you want to keep."));
+    msgBox.setText(qApp->translate("MeshPart_TrimByPlane", "Select the side to keep."));
     QPushButton* inner =
         msgBox.addButton(qApp->translate("MeshPart_TrimByPlane", "Below"), QMessageBox::ActionRole);
     QPushButton* outer =
@@ -186,8 +186,8 @@ CmdMeshPartSection::CmdMeshPartSection()
 {
     sAppModule = "MeshPart";
     sGroup = QT_TR_NOOP("Mesh");
-    sMenuText = QT_TR_NOOP("Create section from mesh and plane");
-    sToolTipText = QT_TR_NOOP("Section");
+    sMenuText = QT_TR_NOOP("Section");
+    sToolTipText = QT_TR_NOOP("Creates a section from a mesh and plane");
     sWhatsThis = "MeshPart_Section";
     sStatusTip = sToolTipText;
 }
@@ -201,7 +201,7 @@ void CmdMeshPartSection::activated(int)
             Gui::getMainWindow(),
             qApp->translate("MeshPart_Section", "Select plane"),
             qApp->translate("MeshPart_Section",
-                            "Please select a plane at which you section the mesh."));
+                            "Select a plane to section the mesh with."));
         return;
     }
 
@@ -271,8 +271,8 @@ CmdMeshPartCrossSections::CmdMeshPartCrossSections()
 {
     sAppModule = "MeshPart";
     sGroup = QT_TR_NOOP("MeshPart");
-    sMenuText = QT_TR_NOOP("Cross-sections...");
-    sToolTipText = QT_TR_NOOP("Cross-sections");
+    sMenuText = QT_TR_NOOP("Cross-Sections");
+    sToolTipText = QT_TR_NOOP("Applies cross-sections to the mesh");
     sWhatsThis = "MeshPart_CrossSections";
     sStatusTip = sToolTipText;
     // sPixmap       = "MeshPart_CrossSections";
@@ -307,9 +307,8 @@ CmdMeshPartCurveOnMesh::CmdMeshPartCurveOnMesh()
 {
     sAppModule = "MeshPart";
     sGroup = QT_TR_NOOP("Mesh");
-    sMenuText = QT_TR_NOOP("Curve on mesh...");
-    sToolTipText = QT_TR_NOOP("Creates an approximated curve on top of a mesh.\n"
-                              "This command only works with a 'mesh' object.");
+    sMenuText = QT_TR_NOOP("Curve on Mesh");
+    sToolTipText = QT_TR_NOOP("Creates an approximated curve on top of a mesh object");
     sWhatsThis = "MeshPart_CurveOnMesh";
     sStatusTip = sToolTipText;
     sPixmap = "MeshPart_CurveOnMesh";

--- a/src/Mod/MeshPart/Gui/Command.cpp
+++ b/src/Mod/MeshPart/Gui/Command.cpp
@@ -56,7 +56,8 @@ CmdMeshPartMesher::CmdMeshPartMesher()
 {
     sAppModule = "MeshPart";
     sGroup = QT_TR_NOOP("Mesh");
-    sMenuText = QT_TR_NOOP("Creates a mesh from a shape");
+    sMenuText = QT_TR_NOOP("Mesh From Shape");
+
     sToolTipText = QT_TR_NOOP("Tessellate shape");
     sWhatsThis = "MeshPart_Mesher";
     sStatusTip = sToolTipText;

--- a/src/Mod/MeshPart/Gui/Command.cpp
+++ b/src/Mod/MeshPart/Gui/Command.cpp
@@ -91,10 +91,10 @@ void CmdMeshPartTrimByPlane::activated(int)
     Base::Type partType = Base::Type::fromName("Part::Plane");
     std::vector<App::DocumentObject*> plane = getSelection().getObjectsOfType(partType);
     if (plane.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             qApp->translate("MeshPart_TrimByPlane", "Select plane"),
-                             qApp->translate("MeshPart_TrimByPlane",
-                                             "Select a plane to trim the mesh with."));
+        QMessageBox::warning(
+            Gui::getMainWindow(),
+            qApp->translate("MeshPart_TrimByPlane", "Select plane"),
+            qApp->translate("MeshPart_TrimByPlane", "Select a plane to trim the mesh with."));
         return;
     }
 
@@ -200,8 +200,7 @@ void CmdMeshPartSection::activated(int)
         QMessageBox::warning(
             Gui::getMainWindow(),
             qApp->translate("MeshPart_Section", "Select plane"),
-            qApp->translate("MeshPart_Section",
-                            "Select a plane to section the mesh with."));
+            qApp->translate("MeshPart_Section", "Select a plane to section the mesh with."));
         return;
     }
 

--- a/src/Mod/MeshPart/Gui/CrossSections.ui
+++ b/src/Mod/MeshPart/Gui/CrossSections.ui
@@ -11,13 +11,13 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Cross sections</string>
+   <string>Cross Sections</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
    <item row="0" column="0">
     <widget class="QGroupBox" name="planeBox">
      <property name="title">
-      <string>Guiding plane</string>
+      <string>Guiding Plane</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
@@ -49,7 +49,7 @@
         <item>
          <widget class="QLabel" name="label">
           <property name="text">
-           <string>Position:</string>
+           <string>Position</string>
           </property>
          </widget>
         </item>
@@ -106,7 +106,7 @@
         <item row="1" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
-           <string>Distance:</string>
+           <string>Distance</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/MeshPart/Gui/CurveOnMesh.cpp
+++ b/src/Mod/MeshPart/Gui/CurveOnMesh.cpp
@@ -620,7 +620,7 @@ void CurveOnMeshHandler::Private::vertexCallback(void* ud, SoEventCallback* cb)
                             }
                             else if (self->d_ptr->mesh != mesh) {
                                 Gui::getMainWindow()->statusBar()->showMessage(
-                                    tr("Wrong mesh picked"));
+                                    tr("Wrong mesh selected"));
                                 return;
                             }
 
@@ -659,7 +659,7 @@ void CurveOnMeshHandler::Private::vertexCallback(void* ud, SoEventCallback* cb)
                 }
             }
             else {
-                Gui::getMainWindow()->statusBar()->showMessage(tr("No point was picked"));
+                Gui::getMainWindow()->statusBar()->showMessage(tr("No point was selected"));
             }
         }
         else if (mbe->getButton() == SoMouseButtonEvent::BUTTON2

--- a/src/Mod/MeshPart/Gui/TaskCurveOnMesh.ui
+++ b/src/Mod/MeshPart/Gui/TaskCurveOnMesh.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Curve on mesh</string>
+   <string>Curve on Mesh</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0" colspan="2">
@@ -22,7 +22,7 @@
         <property name="text">
          <string>Press 'Start', then pick points on the mesh; when enough points have been set, right-click and choose 'Create'. Repeat this process to create more splines. Close this task panel to complete the operation.
 
-This command only works with a 'mesh' object, not a regular face or surface. To convert an object to a mesh use the tools of the Mesh Workbench.</string>
+This command only works with a 'mesh' object, not a regular face or surface. To convert an object to a mesh use the tools of the Mesh workbench.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -276,14 +276,14 @@ bool Tessellation::accept()
             QMessageBox::critical(
                 this,
                 windowTitle(),
-                tr("You have selected a body without tip.\n"
-                   "Either set the tip of the body or select a different shape, please."));
+                tr("Error: body without a tip selected.\n"
+                   "Either set the tip of the body or select a different shapee."));
         }
         else if (partWithNoFace) {
             QMessageBox::critical(this,
                                   windowTitle(),
-                                  tr("You have selected a shape without faces.\n"
-                                     "Select a different shape, please."));
+                                  tr("Error: shape without faces selected.\n"
+                                     "Select a different shape."));
         }
         else {
             QMessageBox::critical(this, windowTitle(), tr("Select a shape for meshing, first."));

--- a/src/Mod/MeshPart/Gui/Tessellation.ui
+++ b/src/Mod/MeshPart/Gui/Tessellation.ui
@@ -17,7 +17,7 @@
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBoxMeshingOptions">
      <property name="title">
-      <string>Meshing options</string>
+      <string>Meshing Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
       <item row="0" column="0" colspan="3">
@@ -38,7 +38,7 @@
             <item row="0" column="0">
              <widget class="QLabel" name="labelSurfaceDeviation">
               <property name="text">
-               <string>Surface deviation:</string>
+               <string>Surface deviation</string>
               </property>
              </widget>
             </item>
@@ -64,7 +64,7 @@
             <item row="1" column="0">
              <widget class="QLabel" name="labelAngularDeviation">
               <property name="text">
-               <string>Angular deviation:</string>
+               <string>Angular deviation</string>
               </property>
              </widget>
             </item>
@@ -96,7 +96,7 @@
            <widget class="QCheckBox" name="relativeDeviation">
             <property name="toolTip">
              <string>The maximal linear deviation of a mesh segment will be the specified
-Surface deviation multiplied by the length of the current mesh segment (edge)</string>
+surface deviation multiplied by the length of the current mesh segment (edge)</string>
             </property>
             <property name="text">
              <string>Relative surface deviation</string>
@@ -153,7 +153,7 @@ this feature (e.g. the format OBJ).</string>
             <item>
              <widget class="QCheckBox" name="checkMaximumEdgeLength">
               <property name="text">
-               <string>Maximum edge length:</string>
+               <string>Maximum edge length</string>
               </property>
               <property name="checked">
                <bool>true</bool>
@@ -266,7 +266,7 @@ The smallest value is 0.</string>
               <item row="0" column="0">
                <widget class="QLabel" name="labelGrading">
                 <property name="text">
-                 <string>Mesh size grading:</string>
+                 <string>Mesh size grading</string>
                 </property>
                </widget>
               </item>
@@ -299,7 +299,7 @@ A value in the range of 0.1-1.</string>
               <item row="1" column="0">
                <widget class="QLabel" name="labelEdgeElements">
                 <property name="text">
-                 <string>Elements per edge:</string>
+                 <string>Elements per edge</string>
                 </property>
                </widget>
               </item>
@@ -332,7 +332,7 @@ A value in the range of 0.2-10.</string>
               <item row="2" column="0">
                <widget class="QLabel" name="labelCurvatureElements">
                 <property name="text">
-                 <string>Elements per curvature radius:</string>
+                 <string>Elements per curvature radius</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
Part of a larger set of PRs for all workbenches in FreeCAD which edits all user facings strings to adhere to the guidelines in https://freecad.github.io/DevelopersHandbook/designguide/naming.html

- Fix ellipsis
- Casing fixes
- Command name fixes
- Tooltip fixes
- Remove colons from .ui files