### PR TITLE
FEM: Add offset property for CalculiX's shell section

### DIFF
--- a/src/Mod/Fem/femobjects/element_geometry2D.py
+++ b/src/Mod/Fem/femobjects/element_geometry2D.py
@@ -49,3 +49,11 @@ class ElementGeometry2D(base_femelement.BaseFemElement):
             "set thickness of the shell elements",
         )
         obj.setPropertyStatus("Thickness", "LockDynamic")
+        
+        obj.addProperty(
+            "App::PropertyFloat",
+            "Offset",
+            "ShellThickness",
+            "set thickness offset of the shell elements",
+        )
+        obj.Offset = 0.0

--- a/src/Mod/Fem/femsolver/calculix/write_femelement_geometry.py
+++ b/src/Mod/Fem/femsolver/calculix/write_femelement_geometry.py
@@ -114,7 +114,8 @@ def write_femelement_geometry(f, ccxwriter):
             elif "shellthickness_obj" in matgeoset:  # shell mesh
                 shellth_obj = matgeoset["shellthickness_obj"]
                 if ccxwriter.solver_obj.ModelSpace == "3D":
-                    section_def = f"*SHELL SECTION, {elsetdef}{material}\n"
+                    offset = shellth_obj.Offset
+                    section_def = f"*SHELL SECTION, {elsetdef}{material}, OFFSET={offset:.13G}\n"
                 else:
                     section_def = f"*SOLID SECTION, {elsetdef}{material}\n"
                 thickness = shellth_obj.Thickness.getValueAs("mm").Value


### PR DESCRIPTION
fixes #22384

Adds a unitless Offset property to shell sections. By default, it's 0 (no offset).