### PR TITLE
Sketcher: Port and fix internal faces from RealThunder's branch

### DIFF
--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -80,6 +80,7 @@ enum ViewStatus {
     isRestoring = 2,
     UpdatingView = 3,
     TouchDocument = 4,
+    SecondaryView = 5,
 };
 
 

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -152,7 +152,7 @@ App::Property* ViewProviderDocumentObject::addDynamicProperty(
 
 void ViewProviderDocumentObject::onBeforeChange(const App::Property* prop)
 {
-    if (isAttachedToDocument()) {
+    if (isAttachedToDocument() && !testStatus(SecondaryView)) {
         App::DocumentObject* obj = getObject();
         App::Document* doc = obj ? obj->getDocument() : nullptr;
         if (doc) {
@@ -175,7 +175,7 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
             Visibility.getValue() ? show() : hide();
             Visibility.setStatus(App::Property::User2, false);
         }
-        if (!Visibility.testStatus(App::Property::User1)
+        if (!Visibility.testStatus(App::Property::User1) && !testStatus(SecondaryView)
                 && getObject()
                 && getObject()->Visibility.getValue()!=Visibility.getValue())
         {
@@ -331,8 +331,8 @@ void ViewProviderDocumentObject::attach(App::DocumentObject *pcObj)
     // save Object pointer
     pcObject = pcObj;
 
-    if(pcObj && pcObj->isAttachedToDocument() &&
-       Visibility.getValue()!=pcObj->Visibility.getValue())
+    if (pcObj && pcObj->isAttachedToDocument() && !testStatus(SecondaryView)
+        && Visibility.getValue()!=pcObj->Visibility.getValue())
         pcObj->Visibility.setValue(Visibility.getValue());
 
     // Retrieve the supported display modes of the view provider

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -156,6 +156,12 @@ public:
     /// Get the python wrapper for that ViewProvider
     PyObject* getPyObject() override;
 
+    virtual void setShapePropertyName(const char* propName);
+    const char* getShapePropertyName() const;
+
+    Part::TopoShape getShape() const;
+    void updateVisual();
+
 protected:
     bool setEdit(int ModNum) override;
     void unsetEdit(int ModNum) override;
@@ -165,7 +171,6 @@ protected:
     /// get called by the container whenever a property has been changed
     void onChanged(const App::Property* prop) override;
     bool loadParameter();
-    void updateVisual();
     void handleChangedPropertyName(Base::XMLReader& reader,
                                    const char* TypeName,
                                    const char* PropName) override;
@@ -187,8 +192,15 @@ protected:
     SoBrepEdgeSet     * lineset;
     SoBrepPointSet    * nodeset;
 
+    Gui::CoinPtr<SoGroup> pFaceRoot;
+    Gui::CoinPtr<SoGroup> pFaceEdgeRoot;
+    Gui::CoinPtr<SoGroup> pEdgeRoot;
+    Gui::CoinPtr<SoGroup> pVertexRoot;
+
     bool VisualTouched;
     bool NormalsFromUV;
+
+    std::string shapePropName;
 
 private:
     Gui::ViewProviderFaceTexture texture;

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -113,6 +113,7 @@ void SketcherSettings::saveSettings()
     ui->checkBoxHorVerAuto->onSave();
     ui->checkBoxLineGroup->onSave();
     ui->checkBoxAddExtGeo->onSave();
+    ui->checkBoxMakeInternals->onSave();
 
     enum
     {
@@ -190,8 +191,7 @@ void SketcherSettings::loadSettings()
     ui->checkBoxHorVerAuto->onRestore();
     setProperty("checkBoxHorVerAuto", ui->checkBoxHorVerAuto->isChecked());
     ui->checkBoxAddExtGeo->onRestore();
-    setProperty("checkBoxLineGroup", ui->checkBoxLineGroup->isChecked());
-    ui->checkBoxAddExtGeo->onRestore();
+    ui->checkBoxMakeInternals->onRestore();
 
     // Dimensioning constraints mode
     ui->dimensioningMode->clear();
@@ -597,6 +597,8 @@ void SketcherSettingsAppearance::saveSettings()
     ui->ExternalWidth->onSave();
     ui->ExternalDefiningWidth->onSave();
 
+    ui->InternalFaceColor->onSave();
+
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Sketcher/View");
     QVariant data = ui->EdgePattern->itemData(ui->EdgePattern->currentIndex());
@@ -651,6 +653,9 @@ void SketcherSettingsAppearance::loadSettings()
     ui->InternalWidth->onRestore();
     ui->ExternalWidth->onRestore();
     ui->ExternalDefiningWidth->onRestore();
+
+    ui->InternalFaceColor->setAllowTransparency(true);
+    ui->InternalFaceColor->onRestore();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Sketcher/View");

--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -234,6 +234,22 @@ Requires to re-enter edit mode to take effect.</string>
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBoxMakeInternals">
+        <property name="toolTip">
+         <string>If checked faces and other internal geometries will be generated on sketch closed wires.</string>
+        </property>
+        <property name="text">
+         <string>Auto generate faces</string>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Sketcher</cstring>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>MakeInternals</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
@@ -872,83 +872,112 @@
      <property name="title">
       <string>Colors Outside Sketcher</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_8">
+     <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout_4">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_18">
-          <property name="text">
-           <string>Vertex</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="Gui::PrefColorButton" name="SketchVertexColor">
-          <property name="toolTip">
-           <string>Color of vertices outside edit mode</string>
-          </property>
-          <property name="color" stdset="0">
-           <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SketchVertexColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_17">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Edge</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="Gui::PrefColorButton" name="SketchEdgeColor">
-          <property name="toolTip">
-           <string>Color of edges outside edit mode</string>
-          </property>
-          <property name="color" stdset="0">
-           <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SketchEdgeColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="QLabel" name="label_18">
+        <property name="text">
+         <string>Vertex</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefColorButton" name="SketchVertexColor">
+        <property name="toolTip">
+         <string>Color of vertices outside edit mode</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>255</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SketchVertexColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_17">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Edge</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefColorButton" name="SketchEdgeColor">
+        <property name="toolTip">
+         <string>Color of edges outside edit mode</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>255</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SketchEdgeColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
+         <string>Face</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefColorButton" name="InternalFaceColor">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Color of sketch faces.</string>
+        </property>
+        <property name="color" stdset="0">
+         <color alpha="62">
+          <red>84</red>
+          <green>171</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SketchFaceColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Sketcher/General</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -190,6 +190,8 @@ private:
                                  float g,
                                  float b);
 
+        void updateShapeAppearanceProperty(const std::string& string, App::Property* property);
+
         void updateEscapeKeyBehaviour(const std::string& string, App::Property* property);
 
         void updateAutoRecompute(const std::string& string, App::Property* property);
@@ -748,6 +750,16 @@ protected:
     void startRestoring() override;
     void finishRestoring() override;
 
+    bool getElementPicked(const SoPickedPoint* pp, std::string& subname) const override;
+    bool getDetailPath(const char* subname,
+                       SoFullPath* pPath,
+                       bool append,
+                       SoDetail*& det) const override;
+    const char* getDefaultDisplayMode() const override;
+
+    void reattach(App::DocumentObject*) override;
+    void beforeDelete() override;
+
 private:
     /// function to handle OCCT BSpline weight calculation singularities and representation
     void scaleBSplinePoleCirclesAndUpdateSolverAndSketchObjectGeometry(
@@ -825,6 +837,8 @@ private:
     //@}
 
     void slotToolWidgetChanged(QWidget* newwidget);
+
+    void updateColorPropertiesVisibility();
 
     /** @name Attorney functions*/
     //@{
@@ -941,6 +955,8 @@ private:
     std::string editDocName;
     std::string editObjName;
     std::string editSubName;
+
+    std::unique_ptr<PartGui::ViewProviderPart> pInternalView;
 
     ShortcutListener* listener;
 


### PR DESCRIPTION
This PR fix "MakeInternals" property of sketches. After this PR, if you enable this property, the sketches will have faces that can be selected and padded.

Note this does not modify PartDesign tools UI. So there is no way to specify which face of the sketch you want to extrude if you start the tool first without selection.

I don't know if we can consider that it fixes the issue https://github.com/FreeCAD/FreeCAD/issues/12820. @maxwxyz ?