### PR TITLE
CAM: Adaptive: Fix NULL input shapes when top of stock equals top of model

### DIFF
--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -1191,7 +1191,10 @@ def _getWorkingEdges(op, obj):
         user_depths=None,
     )
 
-    depths = [d for d in depthParams.data if d < op.stock.Shape.BoundBox.ZMax]
+    # d < op.stock.Shape.BoundBox.ZMax may be true even if slicing at that
+    # height causes no projection, which results in a NULL shape. Use the
+    # operation tolerance to prevent that.
+    depths = [d for d in depthParams.data if d - op.stock.Shape.BoundBox.ZMax < -obj.Tolerance]
 
     # Get the stock outline at each stepdown. Used to calculate toolpaths and
     # for calculating cut regions in some instances


### PR DESCRIPTION
Fixes #22073

Apparently there's some imprecision in `BoundBox.ZMax`, so the naive check of `depth < x.BoundMox.ZMax` is insufficient to ensure that slicing at `depth` will result in a valid shape- sometimes off by O(1e-14). This PR changes that check to use the operation tolerance to ensure a valid shape is returned when we try to slice the stock.