### PR TITLE
Fix crash on out-of-bound vector access (#22397)

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -8632,9 +8632,6 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
     auto SubElements = ExternalGeometry.getSubValues();
     assert(externalGeoRef.size() == Objects.size());
     auto keys = externalGeoRef;
-    if (Types.size() != Objects.size()) {
-        Types.resize(Objects.size(), 0);
-    }
 
     // re-check for any missing geometry element. The code here has a side
     // effect that the linked external geometry will continue to work even if
@@ -8694,6 +8691,10 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
     Handle(Geom_Plane) gPlane = new Geom_Plane(sketchPlane);
     BRepBuilderAPI_MakeFace mkFace(sketchPlane);
     TopoDS_Shape aProjFace = mkFace.Shape();
+
+    if (Types.size() != Objects.size()) {
+        Types.resize(Objects.size(), 0);
+    }
 
     std::set<std::string> refSet;
     // We use a vector here to keep the order (roughly) the same as ExternalGeometry


### PR DESCRIPTION
In [Sketcher::SketchObject::rebuildExternalGeometry](https://github.com/FreeCAD/FreeCAD/blob/82698073f176d889578d61c1c58d2270f5da3a40/src/Mod/Sketcher/App/SketchObject.cpp#L8625), 
there are some scenarios of missing references that trigger an out-of-bounds access. 

There are two vectors, `Objects` and `Types`, and a [for loop](https://github.com/FreeCAD/FreeCAD/blob/82698073f176d889578d61c1c58d2270f5da3a40/src/Mod/Sketcher/App/SketchObject.cpp#L8702) that iterates over the former. 
When there are not enough items in the other one, the out-of-bounds condition is triggered, and then a libstdc++ assertion crashes the program.

There is already a resize operation to make `Types` match `Objects`' size [at the beiginning of the method](https://github.com/FreeCAD/FreeCAD/blob/82698073f176d889578d61c1c58d2270f5da3a40/src/Mod/Sketcher/App/SketchObject.cpp#L8635),
but it effectively fails to prevent this case as in some cases [items are added to the `Objects` vector](https://github.com/FreeCAD/FreeCAD/blob/82698073f176d889578d61c1c58d2270f5da3a40/src/Mod/Sketcher/App/SketchObject.cpp#L8658).

As there is no code involving `Types`, that resize can be safely moved below the push_back call, right before the loop. 

## Issues
This fixes #22397. I think there's an underlying issue but at least the program does not crash anymore and the geometry can be fixed. 

## Missing items?: 
I think a unit test would be a good addition, but in all honesty I'm not entirely sure about what's the condition that triggers this in the first place. 
