### PR TITLE
[TechDraw] Improve TaskFillTemplate tool

### DIFF
--- a/src/Mod/TechDraw/CSVdata/FillTemplateFields.csv
+++ b/src/Mod/TechDraw/CSVdata/FillTemplateFields.csv
@@ -1,10 +1,11 @@
 CreatedByChkLst,ScaleChkLst,LabelChkLst,CommentChkLst,CompanyChkLst,LicenseChkLst,CreatedDateChkLst,LastModifiedDateChkLst
 "author_name","fc-sc","drawing_title","freecad_drawing","nomsuperviseur","copyright","datedecreation","fc-date"
-"nomauteur","echelle","document_type","titleline-1","companyname","rights","fecha2","date"
+"nomauteur","echelle","title","titleline-1","companyname","rights","fecha2","date"
 "authorname","масштаб","titre","sous_titre","compagnyname",,"date-1","dateverification"
 "designed_by_name","escala","название","subtitulo","compagny",,"creationdate","дата"
 "designed by name","scale","titulo", "subtitle",,,,"fecha3"
-"nom auteur","fc-scale","drawing_name",,,,,"date-2"
-,,"fc-title",,,,,"checkdate"
-,,"titleline-1",,,,,
+"nom auteur","fc-scale","drawing_name","supplementary_title_1",,,,"date-2"
+"creator",,"fc-title",,,,,"checkdate"
+,,"titleline-1",,,,,"date_of_issue"
 ,,"freecad",,,,,
+,,"document_type",,,,,

--- a/src/Mod/TechDraw/TechDrawTools/TaskFillTemplateFields.py
+++ b/src/Mod/TechDraw/TechDrawTools/TaskFillTemplateFields.py
@@ -140,47 +140,55 @@ class TaskFillTemplateFields:
                 updateCb = QtCore.QT_TRANSLATE_NOOP(
                     "TechDraw_FillTemplateFields", "Update"
                 )
-                updateTxt = (
-                    "                                                       ==>>"
-                )
+                icon_name = "button_right"
+                svg = ":/icons/" + icon_name
+                pix = QtGui.QPixmap(svg)
+                icon = QtGui.QIcon.fromTheme(icon_name, QtGui.QIcon(svg))
                 self.checkBoxList = []
                 self.lineTextList = []
+                dialogRow = 0
+                longestText = 0
                 for key, value in self.texts.items():
                     App.Console.PrintLog("{0} = {1} | ".format(key, value))
                     if str(key).lower() in CreatedByChkLst:
                         t1 = QtGui.QLabel(value)
-                        self.la.addWidget(t1, 0, 0)
+                        self.la.addWidget(t1, dialogRow, 0)
                         self.cb1 = QtGui.QCheckBox(updateCb)
                         self.cb1.setObjectName(key)
                         if hasattr(self.cb1, "setCheckState"):
                             self.cb1.setCheckState(QtCore.Qt.Checked)
                         else:
                             self.cb1.setChecked(QtCore.Qt.Checked)
-                        self.la.addWidget(self.cb1, 0, 1)
-                        u1 = QtGui.QLabel(updateTxt)
-                        self.la.addWidget(u1, 0, 2)
+                        self.la.addWidget(self.cb1, dialogRow, 1)
+                        u1 = QtGui.QLabel("")
+                        u1.setPixmap(pix.scaled(32, 32))
+                        self.la.addWidget(u1, dialogRow, 2)
                         self.s1 = QtGui.QLineEdit()
                         self.s1.setText(App.ActiveDocument.CreatedBy)
-                        self.la.addWidget(self.s1, 0, 3)
+                        self.la.addWidget(self.s1, dialogRow, 3)
                         self.cb1.setObjectName(key)
                         keyLst.append(self.cb1.objectName())
                         self.checkBoxList.append(self.cb1)
                         self.lineTextList.append(self.s1)
                         self.cb1.clicked.connect(self.on_cb1_clicked)
+                        if len(App.ActiveDocument.CreatedBy) > longestText:
+                            longestText = len(App.ActiveDocument.CreatedBy)
+                        dialogRow += 1
                     if str(key).lower() in ScaleChkLst and projgrp_view:
                         t2 = QtGui.QLabel(value)
-                        self.la.addWidget(t2, 1, 0)
+                        self.la.addWidget(t2, dialogRow, 0)
                         self.cb2 = QtGui.QCheckBox(updateCb)
                         self.cb2.setObjectName(key)
                         if hasattr(self.cb2, "setCheckState"):
                             self.cb2.setCheckState(QtCore.Qt.Checked)
                         else:
                             self.cb2.setChecked(QtCore.Qt.Checked)
-                        self.la.addWidget(self.cb2, 1, 1)
-                        u2 = QtGui.QLabel(updateTxt)
-                        self.la.addWidget(u2, 1, 2)
+                        self.la.addWidget(self.cb2, dialogRow, 1)
+                        u2 = QtGui.QLabel("")
+                        u2.setPixmap(pix.scaled(32, 32))
+                        self.la.addWidget(u2, dialogRow, 2)
                         self.s2 = QtGui.QLineEdit()
-                        self.la.addWidget(self.s2, 1, 3)
+                        self.la.addWidget(self.s2, dialogRow, 3)
                         self.cb2.setObjectName(key)
                         keyLst.append(self.cb2.objectName())
                         self.checkBoxList.append(self.cb2)
@@ -190,105 +198,124 @@ class TaskFillTemplateFields:
                             self.s2.setText("1 : " + str(int(1 / projgrp_view.Scale)))
                         else:
                             self.s2.setText(str(int(projgrp_view.Scale)) + " : 1")
+                        dialogRow += 1
                     if str(key).lower() in LabelChkLst:
                         t3 = QtGui.QLabel(value)
-                        self.la.addWidget(t3, 2, 0)
+                        self.la.addWidget(t3, dialogRow, 0)
                         self.cb3 = QtGui.QCheckBox(updateCb)
                         self.cb3.setObjectName(key)
                         if hasattr(self.cb3, "setCheckState"):
                             self.cb3.setCheckState(QtCore.Qt.Checked)
                         else:
                             self.cb3.setChecked(QtCore.Qt.Checked)
-                        self.la.addWidget(self.cb3, 2, 1)
-                        u3 = QtGui.QLabel(updateTxt)
-                        self.la.addWidget(u3, 2, 2)
+                        self.la.addWidget(self.cb3, dialogRow, 1)
+                        u3 = QtGui.QLabel("")
+                        u3.setPixmap(pix.scaled(32, 32))
+                        self.la.addWidget(u3, dialogRow, 2)
                         self.s3 = QtGui.QLineEdit()
-                        self.la.addWidget(self.s3, 2, 3)
+                        self.la.addWidget(self.s3, dialogRow, 3)
                         self.s3.setText(App.ActiveDocument.Label)
                         self.cb3.setObjectName(key)
                         keyLst.append(self.cb3.objectName())
                         self.checkBoxList.append(self.cb3)
                         self.lineTextList.append(self.s3)
                         self.cb3.clicked.connect(self.on_cb3_clicked)
+                        if len(App.ActiveDocument.Label) > longestText:
+                            longestText = len(App.ActiveDocument.Label)
+                        dialogRow += 1
                     if str(key).lower() in CommentChkLst:
                         t4 = QtGui.QLabel(value)
-                        self.la.addWidget(t4, 3, 0)
+                        self.la.addWidget(t4, dialogRow, 0)
                         self.cb4 = QtGui.QCheckBox(updateCb)
                         self.cb4.setObjectName(key)
                         if hasattr(self.cb4, "setCheckState"):
                             self.cb4.setCheckState(QtCore.Qt.Checked)
                         else:
                             self.cb4.setChecked(QtCore.Qt.Checked)
-                        self.la.addWidget(self.cb4, 3, 1)
-                        u4 = QtGui.QLabel(updateTxt)
-                        self.la.addWidget(u4, 3, 2)
+                        self.la.addWidget(self.cb4, dialogRow, 1)
+                        u4 = QtGui.QLabel("")
+                        u4.setPixmap(pix.scaled(32, 32))
+                        self.la.addWidget(u4, dialogRow, 2)
                         self.s4 = QtGui.QLineEdit()
-                        self.la.addWidget(self.s4, 3, 3)
+                        self.la.addWidget(self.s4, dialogRow, 3)
                         self.s4.setText(App.ActiveDocument.Comment)
                         self.cb4.setObjectName(key)
                         keyLst.append(self.cb4.objectName())
                         self.checkBoxList.append(self.cb4)
                         self.lineTextList.append(self.s4)
                         self.cb4.clicked.connect(self.on_cb4_clicked)
+                        if len(App.ActiveDocument.Comment) > longestText:
+                            longestText = len(App.ActiveDocument.Comment)
+                        dialogRow += 1
                     if str(key).lower() in CompanyChkLst:
                         t5 = QtGui.QLabel(value)
-                        self.la.addWidget(t5, 4, 0)
+                        self.la.addWidget(t5, dialogRow, 0)
                         self.cb5 = QtGui.QCheckBox(updateCb)
                         self.cb5.setObjectName(key)
                         if hasattr(self.cb5, "setCheckState"):
                             self.cb5.setCheckState(QtCore.Qt.Checked)
                         else:
                             self.cb5.setChecked(QtCore.Qt.Checked)
-                        self.la.addWidget(self.cb5, 4, 1)
-                        u5 = QtGui.QLabel(updateTxt)
-                        self.la.addWidget(u5, 4, 2)
+                        self.la.addWidget(self.cb5, dialogRow, 1)
+                        u5 = QtGui.QLabel("")
+                        u5.setPixmap(pix.scaled(32, 32))
+                        self.la.addWidget(u5, dialogRow, 2)
                         self.s5 = QtGui.QLineEdit()
-                        self.la.addWidget(self.s5, 4, 3)
+                        self.la.addWidget(self.s5, dialogRow, 3)
                         self.s5.setText(App.ActiveDocument.Company)
                         self.cb5.setObjectName(key)
                         keyLst.append(self.cb5.objectName())
                         self.checkBoxList.append(self.cb5)
                         self.lineTextList.append(self.s5)
                         self.cb5.clicked.connect(self.on_cb5_clicked)
+                        if len(App.ActiveDocument.Company) > longestText:
+                            longestText = len(App.ActiveDocument.Company)
+                        dialogRow += 1
                     if str(key).lower() in LicenseChkLst:
                         t6 = QtGui.QLabel(value)
-                        self.la.addWidget(t6, 5, 0)
+                        self.la.addWidget(t6, dialogRow, 0)
                         self.cb6 = QtGui.QCheckBox(updateCb)
                         self.cb6.setObjectName(key)
                         if hasattr(self.cb6, "setCheckState"):
                             self.cb6.setCheckState(QtCore.Qt.Checked)
                         else:
                             self.cb6.setChecked(QtCore.Qt.Checked)
-                        self.la.addWidget(self.cb6, 5, 1)
-                        u6 = QtGui.QLabel(updateTxt)
-                        self.la.addWidget(u6, 5, 2)
+                        self.la.addWidget(self.cb6, dialogRow, 1)
+                        u6 = QtGui.QLabel("")
+                        u6.setPixmap(pix.scaled(32, 32))
+                        self.la.addWidget(u6, dialogRow, 2)
                         self.s6 = QtGui.QLineEdit()
-                        self.la.addWidget(self.s6, 5, 3)
+                        self.la.addWidget(self.s6, dialogRow, 3)
                         self.s6.setText(App.ActiveDocument.License)
                         self.cb6.setObjectName(key)
                         keyLst.append(self.cb6.objectName())
                         self.checkBoxList.append(self.cb6)
                         self.lineTextList.append(self.s6)
                         self.cb6.clicked.connect(self.on_cb6_clicked)
+                        if len(App.ActiveDocument.License) > longestText:
+                            longestText = len(App.ActiveDocument.License)
+                        dialogRow += 1
                     if str(key).lower() in LastModifiedDateChkLst:
                         t7 = QtGui.QLabel(value)
-                        self.la.addWidget(t7, 6, 0)
+                        self.la.addWidget(t7, dialogRow, 0)
                         self.cb7 = QtGui.QCheckBox(updateCb)
                         self.cb7.setObjectName(key)
                         if hasattr(self.cb7, "setCheckState"):
                             self.cb7.setCheckState(QtCore.Qt.Checked)
                         else:
                             self.cb7.setChecked(QtCore.Qt.Checked)
-                        self.la.addWidget(self.cb7, 6, 1)
-                        u7 = QtGui.QLabel(updateTxt)
-                        self.la.addWidget(u7, 6, 2)
+                        self.la.addWidget(self.cb7, dialogRow, 1)
+                        u7 = QtGui.QLabel("")
+                        u7.setPixmap(pix.scaled(32, 32))
+                        self.la.addWidget(u7, dialogRow, 2)
                         self.s7 = QtGui.QLineEdit()
-                        self.la.addWidget(self.s7, 6, 3)
+                        self.la.addWidget(self.s7, dialogRow, 3)
                         self.cb7.setObjectName(key)
                         keyLst.append(self.cb7.objectName())
                         self.checkBoxList.append(self.cb7)
                         self.lineTextList.append(self.s7)
                         self.cb7.clicked.connect(self.on_cb7_clicked)
+                        dialogRow += 1
                         try:
                             dt = datetime.datetime.strptime(
                                 App.ActiveDocument.LastModifiedDate,
@@ -321,23 +348,25 @@ class TaskFillTemplateFields:
                             )
                     if str(key).lower() in CreatedDateChkLst:
                         t8 = QtGui.QLabel(value)
-                        self.la.addWidget(t8, 7, 0)
+                        self.la.addWidget(t8, dialogRow, 0)
                         self.cb8 = QtGui.QCheckBox(updateCb)
                         self.cb8.setObjectName(key)
                         if hasattr(self.cb8, "setCheckState"):
                             self.cb8.setCheckState(QtCore.Qt.Checked)
                         else:
                             self.cb8.setChecked(QtCore.Qt.Checked)
-                        self.la.addWidget(self.cb8, 7, 1)
-                        u8 = QtGui.QLabel(updateTxt)
-                        self.la.addWidget(u8, 7, 2)
+                        self.la.addWidget(self.cb8, dialogRow, 1)
+                        u8 = QtGui.QLabel("")
+                        u8.setPixmap(pix.scaled(32, 32))
+                        self.la.addWidget(u8, dialogRow, 2)
                         self.s8 = QtGui.QLineEdit()
-                        self.la.addWidget(self.s8, 7, 3)
+                        self.la.addWidget(self.s8, dialogRow, 3)
                         self.cb8.setObjectName(key)
                         keyLst.append(self.cb8.objectName())
                         self.checkBoxList.append(self.cb8)
                         self.lineTextList.append(self.s8)
                         self.cb8.clicked.connect(self.on_cb8_clicked)
+                        dialogRow += 1
                         try:
                             dt = datetime.datetime.strptime(
                                 App.ActiveDocument.CreationDate, "%Y-%m-%dT%H:%M:%SZ"
@@ -367,6 +396,7 @@ class TaskFillTemplateFields:
                                     date.today().year,
                                 )
                             )
+                App.Console.PrintLog("\n")
                 if len(keyLst) > 1:
                     self.cbAll = QtGui.QCheckBox(
                         QtCore.QT_TRANSLATE_NOOP(
@@ -378,7 +408,7 @@ class TaskFillTemplateFields:
                         self.cbAll.setCheckState(QtCore.Qt.Checked)
                     else:
                         self.cbAll.setChecked(QtCore.Qt.Checked)
-                    self.la.addWidget(self.cbAll, 8, 1)
+                    self.la.addWidget(self.cbAll, dialogRow, 1)
                     self.cbAll.clicked.connect(self.on_cbAll_clicked)
 
                 if len(keyLst) > 0:
@@ -395,8 +425,12 @@ class TaskFillTemplateFields:
                     QtCore.QObject.connect(
                         self.okbox, QtCore.SIGNAL("rejected()"), self.close
                     )
+                    self.okbox.button(QtGui.QDialogButtonBox.Ok).setText("&Ok")
+                    self.okbox.button(QtGui.QDialogButtonBox.Cancel).setText("&Cancel")
                     self.button = self.okbox.button(QtGui.QDialogButtonBox.Ok)
                     self.button.setEnabled(True)
+                    self.dialog.resize(600 + longestText, dialogRow * 50 + 75)
+                    self.dialog.move(400, 200 * (400 / (dialogRow * 50 + 75)))
                     QtCore.QMetaObject.connectSlotsByName(self.dialog)
                     self.dialog.show()
                     self.dialog.exec_()
@@ -426,9 +460,9 @@ class TaskFillTemplateFields:
         else:
             for cbEach in self.checkBoxList:
                 if hasattr(cbEach, "setCheckState"):
-                    cbEach.setCheckState(QtCore.Qt.Checked)
+                    cbEach.setCheckState(QtCore.Qt.Unchecked)
                 else:
-                    cbEach.setChecked(QtCore.Qt.Checked)
+                    cbEach.setChecked(QtCore.Qt.Unchecked)
             self.button.setEnabled(False)
 
     def on_cb1_clicked(self):
@@ -501,4 +535,3 @@ class TaskFillTemplateFields:
     def close(self):
         self.dialog.hide()
         return True
-


### PR DESCRIPTION
## Before and After Images
![Current](https://github.com/user-attachments/assets/16b6eb02-ba99-40cb-8d22-6e73aa850f52)


![usingPR](https://github.com/user-attachments/assets/038a85ec-8839-4e18-82d6-907dc0df125c)


The `TaskFillTemplate` tool dialog now auto shrinks/expands depending on how many fields are available to update and the longest number of characters in any of the fields. The `FillTemplateFields.csv` has been updated to allow for the change in the minimal/advanced templates in comparison to the previous versions, this change in particular is worth backporting to the Releases/FreeCAD-1-0 branch which I'll raise in a separate PR.

@FEA-eng has been giving constructive feedback in the following forum thread: https://forum.freecad.org/viewtopic.php?p=835269#p835269
