### PR TITLE
CAM: Path.Base.Language - isStraight() and isArc()

### DIFF
--- a/src/Mod/CAM/Path/Base/Language.py
+++ b/src/Mod/CAM/Path/Base/Language.py
@@ -37,7 +37,7 @@ class Instruction(object):
 
     def __init__(self, begin, cmd, param=None):
         self.begin = begin
-        if type(cmd) == Path.Command:
+        if isinstance(cmd, Path.Command):
             self.cmd = Path.Name
             self.param = Path.Parameters
         else:
@@ -130,6 +130,12 @@ class MoveStraight(Instruction):
     def isMove(self):
         return True
 
+    def isStraight(self):
+        return True
+
+    def isArc(self):
+        return False
+
     def isRapid(self):
         return self.cmd in Path.Geom.CmdMoveRapid
 
@@ -158,6 +164,9 @@ class MoveArc(Instruction):
 
     def isArc(self):
         return True
+
+    def isStraight(self):
+        return False
 
     def isCW(self):
         return self.arcDirection() < 0

--- a/src/Mod/CAM/Path/Base/Language.py
+++ b/src/Mod/CAM/Path/Base/Language.py
@@ -72,8 +72,15 @@ class Instruction(object):
         return False
 
     def isPlunge(self):
-        """isPlunge() ... return true if this moves up or down"""
-        return self.isMove() and not Path.Geom.isRoughly(self.begin.z, self.z(self.begin.z))
+        """isPlunge() ... return true if this moves is vertical"""
+        if self.isMove():
+            if (
+                Path.Geom.isRoughly(self.begin.x, self.x(self.begin.x))
+                and Path.Geom.isRoughly(self.begin.y, self.y(self.begin.y))
+                and not Path.Geom.isRoughly(self.begin.z, self.z(self.begin.z))
+            ):
+                return True
+        return False
 
     def leadsInto(self, instr):
         """leadsInto(instr) ... return true if instr is a continuation of self"""


### PR DESCRIPTION
This changes adds methods for intuitive determination the type of move commands from class `MoveStraight` and `MoveArc`:
- `isStraight()` return `True` if command is `G1`
- `isArc()` return `True` if command is `G2` or `G3`

Example of use:
```
# process straight move
if instr.isStraight():
    ...
    ...
    ...
# process arc move
elif instr.isArc():
    ...
    ...
    ...
```

The changes are quite simple and I already use this in #21971 and #22137
If possible, I ask to consider in priority

Thanks