### PR TITLE
TechDraw: Avoid unnecessary recompute when deleting dimensions from page

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -35,6 +35,7 @@
 #include <Base/Parameter.h>
 #include <App/Application.h>
 #include <App/DocumentObject.h>
+#include <App/Document.h>
 #include <Gui/ActionFunction.h>
 #include <Gui/Control.h>
 #include <Gui/MainWindow.h>
@@ -307,17 +308,24 @@ bool ViewProviderDimension::onDelete(const std::vector<std::string> & parms)
     Q_UNUSED(parms)
     auto dlg = Gui::Control().activeDialog();
     auto ourDlg = qobject_cast<TaskDlgDimension*>(dlg);
-    if (ourDlg)  {
+    if (ourDlg) {
         QString bodyMessage;
         QTextStream bodyMessageStream(&bodyMessage);
         bodyMessageStream << qApp->translate("TaskDimension",
             "You cannot delete this dimension now because\nthere is an open task dialog.");
         QMessageBox::warning(Gui::getMainWindow(),
-            qApp->translate("TaskDimension", "Can Not Delete"), bodyMessage,
+            qApp->translate("TaskDimension", "Cannot Delete"), bodyMessage,
             QMessageBox::Ok);
         return false;
     }
-    return true;
+    if (auto* dimObj = getObject()) {
+        if (App::Document* doc = dimObj->getDocument()) {
+            doc->openTransaction("Delete Dimension");
+            doc->removeObject(dimObj->getNameInDocument());
+            doc->commitTransaction();
+        }
+    }
+    return false;
 }
 
 


### PR DESCRIPTION
## Summary
Several tools unnecessarily recompute the whole document (i.e. content that is not in the TechDraw page) (issue #22259)

The way I have tested this is:
- Create a drawing of a body. Let's call it Body1.
- Create an invalid sketch separate from Body1 (e.g. two lines that are both perpendicular and parallel). Error messages will pop up. This sketch will not be used in TechDraw in any way.
- Now use the tools in TechDraw and every time it unnecessarily recomputes the whole document, the sketch error messages will conveniently show.

## Issues
#22259 (partial fix, there are still many more unnecessary recomputes)

## Before and After Videos
Before:

https://github.com/user-attachments/assets/480e64b2-d225-4f60-9ed5-c1ea8da35f0f

After:

https://github.com/user-attachments/assets/50a3251b-6252-4c39-9601-447d2078ccca

## Reviewers
Previously the function `ViewProviderDimension::onDelete` would return `true` to signal for a deletion. This would cause a recompute of the entire document. Now `ViewProviderDimension::onDelete` deletes the object itself without returning true. 
Perhaps there is a better way to achieve this, I am quite new to the codebase.