### PR TITLE
Sketcher: Fix #13927

### DIFF
--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -484,7 +484,12 @@ void ToolBarManager::setupConnection()
                     || hParam == hStatusBar
                     || hParam == hMenuBarRight
                     || hParam == hMenuBarLeft) {
-                timer.start(100);
+                if (blockRestore) {
+                    blockRestore = false;
+                }
+                else {
+                    timer.start(100);
+                }
             }
         });
 }
@@ -1274,6 +1279,7 @@ void ToolBarManager::setState(const QString& name, State state)
         auto show = visibility(policy == ToolBarItem::DefaultVisibility::Visible);
 
         if (show != value) {
+            blockRestore = true;
             hPref->SetBool(name.toStdString().c_str(), value);
         }
     };

--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -1269,8 +1269,13 @@ void ToolBarManager::setState(const QString& name, State state)
         return hPref->GetBool(name.toStdString().c_str(), defaultvalue);
     };
 
-    auto saveVisibility = [this, name](bool value) {
-        hPref->SetBool(name.toStdString().c_str(), value);
+    auto saveVisibility = [this, visibility, name](bool value,
+                                                 ToolBarItem::DefaultVisibility policy) {
+        auto show = visibility(policy == ToolBarItem::DefaultVisibility::Visible);
+
+        if (show != value) {
+            hPref->SetBool(name.toStdString().c_str(), value);
+        }
     };
 
     auto showhide = [visibility](QToolBar* toolbar, ToolBarItem::DefaultVisibility policy) {
@@ -1288,10 +1293,9 @@ void ToolBarManager::setState(const QString& name, State state)
     QToolBar* tb = findToolBar(toolBars(), name);
     if (tb) {
 
+        auto policy = getToolbarPolicy(tb);
+
         if (state == State::RestoreDefault) {
-
-            auto policy = getToolbarPolicy(tb);
-
             if(policy == ToolBarItem::DefaultVisibility::Unavailable) {
                 tb->hide();
                 tb->toggleViewAction()->setVisible(false);
@@ -1303,9 +1307,6 @@ void ToolBarManager::setState(const QString& name, State state)
             }
         }
         else if (state == State::ForceAvailable) {
-
-            auto policy = getToolbarPolicy(tb);
-
             tb->toggleViewAction()->setVisible(true);
 
             // Unavailable policy defaults to a Visible toolbars when made available
@@ -1326,7 +1327,7 @@ void ToolBarManager::setState(const QString& name, State state)
         }
         else if (state == State::SaveState) {
             auto show = tb->isVisible();
-            saveVisibility(show);
+            saveVisibility(show, policy);
         }
     }
 }

--- a/src/Gui/ToolBarManager.h
+++ b/src/Gui/ToolBarManager.h
@@ -234,6 +234,7 @@ private:
     int _toolBarIconSize = 0;
     int _statusBarIconSize = 0;
     int _menuBarIconSize = 0;
+    bool blockRestore = false;
 };
 
 } // namespace Gui


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/13927

The issue came from this line 
https://github.com/FreeCAD/FreeCAD/blame/1881686e7233da28da105885c931d02c30f25593/src/Mod/Sketcher/Gui/Workbench.cpp#L207

The fix is to save only if the value has changed. This way we avoid saving the 'Sketcher' toolbar visibility, which was triggering a 100ms timer and which set the toolbar back to visible.