### PR TITLE
[Points] Add e57 to import file extensions

### DIFF
--- a/src/Mod/Points/Gui/Command.cpp
+++ b/src/Mod/Points/Gui/Command.cpp
@@ -81,7 +81,7 @@ void CmdPointsImport::activated(int iMsg)
         Gui::getMainWindow(),
         QString(),
         QString(),
-        QStringLiteral("%1 (*.asc *.pcd *.ply);;%2 (*.*)")
+        QStringLiteral("%1 (*.asc *.pcd *.ply *.e57);;%2 (*.*)")
             .arg(QObject::tr("Point formats"), QObject::tr("All Files")));
     if (fn.isEmpty()) {
         return;


### PR DESCRIPTION
Tested successfully using `bunnyDouble.e57` from https://sourceforge.net/projects/e57-3d-imgfmt/files/E57Example-data/bunnyDouble.e57/download

Fixes #22443 