### PR TITLE
Draft: project point in split operation and copy original wire

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_split.py
+++ b/src/Mod/Draft/draftguitools/gui_split.py
@@ -95,7 +95,6 @@ class Split(gui_base_original.Modifier):
         cmd_list = [
             "obj = FreeCAD.ActiveDocument." + wire,
             "new = Draft.split(obj, " + point + ", " + index + ")",
-            "Draft.format_object(new, obj)",
             "FreeCAD.ActiveDocument.recompute()"
         ]
 


### PR DESCRIPTION
Fixes #21829.

The picked point should be projected on the edge.

Additionally:
The new wire is now created as a copy of the original wire. This avoids the inconsistency of #18167.