### PR TITLE
CAM: Add external profiling path to Helix;  add Feedrate radial correction to Threadmilling and Helix. 

### DIFF
--- a/src/Mod/CAM/App/Command.cpp
+++ b/src/Mod/CAM/App/Command.cpp
@@ -91,7 +91,7 @@ bool Command::has(const std::string& attr) const
 {
     std::string a(attr);
     boost::to_upper(a);
-    return Parameters.contains(a);
+    return Parameters.count(a) > 0;
 }
 
 std::string Command::toGCode(int precision, bool padzero) const
@@ -145,61 +145,77 @@ void Command::setFromGCode(const std::string& str)
 {
     Parameters.clear();
     std::string mode = "none";
-    std::string key;
+    std::string key = "";
     std::string value;
     for (unsigned int i = 0; i < str.size(); i++) {
         if ((isdigit(str[i])) || (str[i] == '-') || (str[i] == '.')) {
             value += str[i];
         }
-        else if (isalpha(str[i])) {
-            if (mode == "command") {
-                if (!key.empty() && !value.empty()) {
-                    std::string cmd = key + value;
-                    boost::to_upper(cmd);
-                    Name = cmd;
-                    key = "";
-                    value = "";
-                    mode = "argument";
-                }
-                else {
-                    throw Base::BadFormatError("Badly formatted GCode command");
-                }
-                mode = "argument";
-            }
-            else if (mode == "none") {
-                mode = "command";
-            }
-            else if (mode == "argument") {
-                if (!key.empty() && !value.empty()) {
-                    double val = std::atof(value.c_str());
-                    boost::to_upper(key);
-                    Parameters[key] = val;
-                    key = "";
-                    value = "";
-                }
-                else {
-                    throw Base::BadFormatError("Badly formatted GCode argument");
-                }
-            }
-            else if (mode == "comment") {
-                value += str[i];
-            }
-            key = str[i];
-        }
-        else if (str[i] == '(') {
-            mode = "comment";
-        }
-        else if (str[i] == ')') {
-            key = "(";
-            value += ")";
-        }
         else {
-            // add non-ascii characters only if this is a comment
-            if (mode == "comment") {
-                value += str[i];
-            }
-        }
-    }
+            if (isalpha(str[i])) {
+                if (mode == "command") {
+                    if (!key.empty() && !value.empty()) {
+                        std::string cmd = key + value;
+                        boost::to_upper(cmd);
+                        Name = cmd;
+                        key = "";
+                        value = "";
+                        mode = "argument";
+                    }
+                    else {
+                        throw Base::BadFormatError("Badly formatted GCode command");
+                    } // fi !key
+                    mode = "argument";
+                } // not ==command
+                else {
+                    if (mode == "none") {
+                       mode = "command";
+                    }
+                    else {
+                        if (mode == "argument") {
+                            if ((str[i] =='R' ) && ((str[i-1] =='F') || (str[i-1] =='D'))) {
+                                //  DR,FR pseudo-params for Helix FeedRateAdj
+                            }
+                            else {
+                                if (!key.empty() && !value.empty()) {
+                                     double val = std::atof(value.c_str());
+                                     boost::to_upper(key);
+                                     Parameters[key] = val;
+                                     key = "";
+                                     value = "";
+                                }
+                                else {
+                                     throw Base::BadFormatError("Badly formatted GCode argument");
+                                } // fi !key
+                            } // fi ==R
+                        }
+                        else  if (mode == "comment") {
+                            value += str[i];
+
+                        } // fi ==arg
+                    } // fi ==none 
+                } // fi command
+                key += str[i];
+            
+            } // ie not isalpha
+            else { 
+                if (str[i] == '(') {
+                    mode = "comment";
+                }
+                else {
+                      if (str[i] == ')') {
+                          key = "(";
+                          value += ")";
+                      }
+                      else {
+                          // add non-alphpa, non-numeric only in a comment
+                          if (mode == "comment") value += str[i];
+                      } // fi ==')'
+                }// fi == '('
+            } // fi isalpha
+        } // fi isDigit
+    } // for i
+    
     if (!key.empty() && !value.empty()) {
         if ((mode == "command") || (mode == "comment")) {
             std::string cmd = key + value;
@@ -212,7 +228,7 @@ void Command::setFromGCode(const std::string& str)
             double val = std::atof(value.c_str());
             boost::to_upper(key);
             Parameters[key] = val;
-        }
+        } // fi mode
     }
     else {
         throw Base::BadFormatError("Badly formatted GCode argument");
@@ -351,6 +367,6 @@ void Command::Save(Writer& writer) const
 void Command::Restore(XMLReader& reader)
 {
     reader.readElement("Command");
-    std::string gcode = reader.getAttribute<const char*>("gcode");
+    std::string gcode = reader.getAttribute("gcode");
     setFromGCode(gcode);
 }

--- a/src/Mod/CAM/App/Command.cpp
+++ b/src/Mod/CAM/App/Command.cpp
@@ -164,58 +164,60 @@ void Command::setFromGCode(const std::string& str)
                     }
                     else {
                         throw Base::BadFormatError("Badly formatted GCode command");
-                    } // fi !key
+                    }  // fi !key
                     mode = "argument";
-                } // not ==command
+                }  // not ==command
                 else {
                     if (mode == "none") {
-                       mode = "command";
+                        mode = "command";
                     }
                     else {
                         if (mode == "argument") {
-                            if ((str[i] =='R' ) && ((str[i-1] =='F') || (str[i-1] =='D'))) {
+                            if ((str[i] == 'R') && ((str[i - 1] == 'F') || (str[i - 1] == 'D'))) {
                                 //  DR,FR pseudo-params for Helix FeedRateAdj
                             }
                             else {
                                 if (!key.empty() && !value.empty()) {
-                                     double val = std::atof(value.c_str());
-                                     boost::to_upper(key);
-                                     Parameters[key] = val;
-                                     key = "";
-                                     value = "";
+                                    double val = std::atof(value.c_str());
+                                    boost::to_upper(key);
+                                    Parameters[key] = val;
+                                    key = "";
+                                    value = "";
                                 }
                                 else {
-                                     throw Base::BadFormatError("Badly formatted GCode argument");
-                                } // fi !key
-                            } // fi ==R
+                                    throw Base::BadFormatError("Badly formatted GCode argument");
+                                }  // fi !key
+                            }  // fi ==R
                         }
-                        else  if (mode == "comment") {
+                        else if (mode == "comment") {
                             value += str[i];
 
-                        } // fi ==arg
-                    } // fi ==none 
-                } // fi command
+                        }  // fi ==arg
+                    }  // fi ==none
+                }  // fi command
                 key += str[i];
-            
-            } // ie not isalpha
-            else { 
+
+            }  // ie not isalpha
+            else {
                 if (str[i] == '(') {
                     mode = "comment";
                 }
                 else {
-                      if (str[i] == ')') {
-                          key = "(";
-                          value += ")";
-                      }
-                      else {
-                          // add non-alphpa, non-numeric only in a comment
-                          if (mode == "comment") value += str[i];
-                      } // fi ==')'
-                }// fi == '('
-            } // fi isalpha
-        } // fi isDigit
-    } // for i
-    
+                    if (str[i] == ')') {
+                        key = "(";
+                        value += ")";
+                    }
+                    else {
+                        // add non-alphpa, non-numeric only in a comment
+                        if (mode == "comment") {
+                            value += str[i];
+                        }
+                    }  // fi ==')'
+                }  // fi == '('
+            }  // fi isalpha
+        }  // fi isDigit
+    }  // for i
+
     if (!key.empty() && !value.empty()) {
         if ((mode == "command") || (mode == "comment")) {
             std::string cmd = key + value;
@@ -228,7 +230,7 @@ void Command::setFromGCode(const std::string& str)
             double val = std::atof(value.c_str());
             boost::to_upper(key);
             Parameters[key] = val;
-        } // fi mode
+        }  // fi mode
     }
     else {
         throw Base::BadFormatError("Badly formatted GCode argument");

--- a/src/Mod/CAM/App/CommandPyImp.cpp
+++ b/src/Mod/CAM/App/CommandPyImp.cpp
@@ -53,6 +53,7 @@ std::string CommandPy::representation() const
     }
     str << " ]";
     return str.str();
+
 }
 
 //
@@ -183,6 +184,7 @@ void CommandPy::setParameters(Py::Dict arg)
     PyObject* dict_copy = PyDict_Copy(arg.ptr());
     PyObject *key, *value;
     Py_ssize_t pos = 0;
+    getCommandPtr()->Parameters.clear();
     while (PyDict_Next(dict_copy, &pos, &key, &value)) {
         std::string ckey;
         if (PyUnicode_Check(key)) {
@@ -281,7 +283,7 @@ PyObject* CommandPy::getCustomAttributes(const char* attr) const
     if (satt.length() == 1) {
         if (isalpha(satt[0])) {
             boost::to_upper(satt);
-            if (getCommandPtr()->Parameters.contains(satt)) {
+            if (getCommandPtr()->Parameters.count(satt)) {
                 return PyFloat_FromDouble(getCommandPtr()->Parameters[satt]);
             }
             Py_INCREF(Py_None);

--- a/src/Mod/CAM/App/CommandPyImp.cpp
+++ b/src/Mod/CAM/App/CommandPyImp.cpp
@@ -53,7 +53,6 @@ std::string CommandPy::representation() const
     }
     str << " ]";
     return str.str();
-
 }
 
 //

--- a/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
@@ -25,7 +25,7 @@ import Part
 import Path
 import Path.Base.Generator.helix as generator
 import CAMTests.PathTestUtils as PathTestUtils
-import math # for one use of pi
+import math  # for one use of pi
 
 Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 Path.Log.trackModule(Path.Log.thisModule())
@@ -110,8 +110,8 @@ G0 Z20.000000"
         self.assertRaises(TypeError, generator.generate, **args)
 
     def test02(self):
-        '''Require tool fit: hole diameter not greater than tool diam
-        # with zero inner radius'''
+        """Require tool fit: hole diameter not greater than tool diam
+        # with zero inner radius"""
         args = _resetArgs()
         args["hole_radius"] = 2.0
         args["inner_radius"] = 0.0
@@ -119,7 +119,7 @@ G0 Z20.000000"
         self.assertRaises(ValueError, generator.generate, **args)
 
     def test03(self):
-        '''Require tool fits hole'''
+        """Require tool fits hole"""
         # 1. Extra Offset just small enough to leave room for tool should not raise an error
         args = _resetArgs()
         designed_hole_diameter = 10.0
@@ -139,7 +139,7 @@ G0 Z20.000000"
         args["tool_diameter"] = 5.0
         self.assertRaises(ValueError, generator.generate, **args)
 
-        #3. Check plunge with endmill is not blocked. Not ideal but that's machinists choice.
+        # 3. Check plunge with endmill is not blocked. Not ideal but that's machinists choice.
         args["hole_radius"] = 5.0
         args["inner_radius"] = 0.0
         args["tool_diameter"] = 5.0
@@ -147,7 +147,7 @@ G0 Z20.000000"
         self.assertTrue(result)
 
     def test04(self):
-        '''Test step_over : a "percent" value between 0 and 1'''
+        """Test step_over : a "percent" value between 0 and 1"""
         args = _resetArgs()
         args["step_over"] = 50
         self.assertRaises(ValueError, generator.generate, **args)
@@ -155,7 +155,7 @@ G0 Z20.000000"
         self.assertRaises(TypeError, generator.generate, **args)
 
     def test05(self):
-        ''' Test some mistaken inputs are rejected'''
+        """Test some mistaken inputs are rejected"""
         args = _resetArgs()
         args["startAt"] = "Other"
         self.assertRaises(ValueError, generator.generate, **args)
@@ -165,7 +165,7 @@ G0 Z20.000000"
         self.assertRaises(ValueError, generator.generate, **args)
 
     def test07(self):
-        '''Test Basic Helix Generator '''
+        """Test Basic Helix Generator"""
         # verify linear edge is vertical: X
         args = _resetArgs()
         v1 = FreeCAD.Vector(5, 5, 20)
@@ -181,7 +181,7 @@ G0 Z20.000000"
         self.assertRaises(ValueError, generator.generate, **args)
 
     def test08(self):
-        '''Test Helix Generator with horizontal edge'''
+        """Test Helix Generator with horizontal edge"""
         args = _resetArgs()
         v1 = FreeCAD.Vector(10, 5, 5)
         v2 = FreeCAD.Vector(20, 5, 5)
@@ -189,7 +189,7 @@ G0 Z20.000000"
         self.assertRaises(ValueError, generator.generate, **args)
 
     def test09(self):
-        '''Test Helix Generator with inverted vertical edge'''
+        """Test Helix Generator with inverted vertical edge"""
         args = _resetArgs()
         v1 = FreeCAD.Vector(5, 5, 18)
         v2 = FreeCAD.Vector(5, 5, 20)
@@ -198,7 +198,7 @@ G0 Z20.000000"
         self.assertRaises(ValueError, generator.generate, **args)
 
     def test10(self):
-        '''Test Helix Retraction'''
+        """Test Helix Retraction"""
 
         # if center is clear, the second to last move should be a G1 away
         # from the wall
@@ -227,7 +227,7 @@ G0 Z20.000000"
         self.assertTrue(result[-2].Name == "G2")
 
     def test12(self):
-        ''' test "FeedFactor" pseudo-param when using feedRateAdj '''
+        """test "FeedFactor" pseudo-param when using feedRateAdj"""
         args = _resetArgs()
         v1 = FreeCAD.Vector(0, 0, 20)
         v2 = FreeCAD.Vector(0, 0, 18)
@@ -252,7 +252,7 @@ G0 Z20.000000"
         tool_r = args["tool_diameter"] / 2
         # first cut is outside diam, so reduce spindle feedrate
         # first arc is in 3rd gcode command :result[3]
-        path_r = args["hole_radius"]-tool_r
+        path_r = args["hole_radius"] - tool_r
         result = generator.generate(**args)
         self.assertTrue("FR" in result[3].Parameters)
         FF = result[3].Parameters["FR"]
@@ -260,7 +260,7 @@ G0 Z20.000000"
 
         # final cut is inside diam, so increase spindle feedrate
         # last arc in inner helix 3rd gcode from end :result[-3]
-        path_r = args["inner_radius"]+tool_r
+        path_r = args["inner_radius"] + tool_r
         result = generator.generate(**args)
         self.assertTrue("FR" in result[-3].Parameters)
         FF = result[-3].Parameters["FR"]
@@ -277,7 +277,7 @@ G0 Z20.000000"
         self.assertTrue(FR == 200)
 
     def test14(self):
-        ''' test "DescentRate" pseudo-param when using feedRateAdj '''
+        """test "DescentRate" pseudo-param when using feedRateAdj"""
         args = _resetArgs()
         v1 = FreeCAD.Vector(0, 0, 20)
         v2 = FreeCAD.Vector(0, 0, 18)
@@ -294,11 +294,10 @@ G0 Z20.000000"
         args["hole_radius"] = 6.0
         result = generator.generate(**args)
         self.assertTrue("DR" in result[-3].Parameters)
-        DR = result[-3].Parameters["DR" ]
+        DR = result[-3].Parameters["DR"]
         self.assertTrue(DR == 0)  # last two arcs are flat circle, no descent
-        DR = result[-5].Parameters["DR" ] # last true helix arc
+        DR = result[-5].Parameters["DR"]  # last true helix arc
         self.assertTrue(
-            DR == args["step_down"] / (2*math.pi*(args["hole_radius"] - args["tool_diameter"] /2))
+            DR
+            == args["step_down"] / (2 * math.pi * (args["hole_radius"] - args["tool_diameter"] / 2))
         )
-
-

--- a/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
@@ -25,7 +25,7 @@ import Part
 import Path
 import Path.Base.Generator.helix as generator
 import CAMTests.PathTestUtils as PathTestUtils
-
+import math # for one use of pi
 
 Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 Path.Log.trackModule(Path.Log.thisModule())
@@ -35,10 +35,8 @@ def _resetArgs():
     v1 = FreeCAD.Vector(5, 5, 20)
     v2 = FreeCAD.Vector(5, 5, 18)
 
-    edg = Part.makeLine(v1, v2)
-
     return {
-        "edge": edg,
+        "edge": Part.makeLine(v1, v2),
         "hole_radius": 10.0,
         "step_down": 1.0,
         "step_over": 0.5,
@@ -46,38 +44,42 @@ def _resetArgs():
         "inner_radius": 0.0,
         "direction": "CW",
         "startAt": "Inside",
+        "feedRateAdj": False,
     }
 
 
 class TestPathHelixGenerator(PathTestUtils.PathTestBase):
 
+    # DR values pass helix descent rate to blend v,h feeds. Don't appear in o/p
     expectedHelixGCode = "G0 X7.500000 Y5.000000\
 G1 Z20.000000\
-G2 I-2.500000 J0.000000 X2.500000 Y5.000000 Z19.500000\
-G2 I2.500000 J0.000000 X7.500000 Y5.000000 Z19.000000\
-G2 I-2.500000 J0.000000 X2.500000 Y5.000000 Z18.500000\
-G2 I2.500000 J0.000000 X7.500000 Y5.000000 Z18.000000\
-G2 I-2.500000 J0.000000 X2.500000 Y5.000000 Z18.000000\
-G2 I2.500000 J0.000000 X7.500000 Y5.000000 Z18.000000\
-G0 X5.000000 Y5.000000 Z18.000000\
-G0 Z20.000000G0 X10.000000 Y5.000000\
+G2 DR0.063662 I-2.500000 J0.000000 X2.500000 Y5.000000 Z19.500000\
+G2 DR0.063662 I2.500000 J0.000000 X7.500000 Y5.000000 Z19.000000\
+G2 DR0.063662 I-2.500000 J0.000000 X2.500000 Y5.000000 Z18.500000\
+G2 DR0.063662 I2.500000 J0.000000 X7.500000 Y5.000000 Z18.000000\
+G2 DR0.000000 I-2.500000 J0.000000 X2.500000 Y5.000000 Z18.000000\
+G2 DR0.000000 I2.500000 J0.000000 X7.500000 Y5.000000 Z18.000000\
+G1 X5.000000 Y5.000000\
+G0 Z20.000000\
+G0 X10.000000 Y5.000000\
 G1 Z20.000000\
-G2 I-5.000000 J0.000000 X0.000000 Y5.000000 Z19.500000\
-G2 I5.000000 J0.000000 X10.000000 Y5.000000 Z19.000000\
-G2 I-5.000000 J0.000000 X0.000000 Y5.000000 Z18.500000\
-G2 I5.000000 J0.000000 X10.000000 Y5.000000 Z18.000000\
-G2 I-5.000000 J0.000000 X0.000000 Y5.000000 Z18.000000\
-G2 I5.000000 J0.000000 X10.000000 Y5.000000 Z18.000000\
-G0 X5.000000 Y5.000000 Z18.000000\
-G0 Z20.000000G0 X12.500000 Y5.000000\
+G2 DR0.031831 I-5.000000 J0.000000 X0.000000 Y5.000000 Z19.500000\
+G2 DR0.031831 I5.000000 J0.000000 X10.000000 Y5.000000 Z19.000000\
+G2 DR0.031831 I-5.000000 J0.000000 X0.000000 Y5.000000 Z18.500000\
+G2 DR0.031831 I5.000000 J0.000000 X10.000000 Y5.000000 Z18.000000\
+G2 DR0.000000 I-5.000000 J0.000000 X0.000000 Y5.000000 Z18.000000\
+G2 DR0.000000 I5.000000 J0.000000 X10.000000 Y5.000000 Z18.000000\
+G1 X8.750000 Y5.000000G0 Z20.000000\
+G0 X12.500000 Y5.000000\
 G1 Z20.000000\
-G2 I-7.500000 J0.000000 X-2.500000 Y5.000000 Z19.500000\
-G2 I7.500000 J0.000000 X12.500000 Y5.000000 Z19.000000\
-G2 I-7.500000 J0.000000 X-2.500000 Y5.000000 Z18.500000\
-G2 I7.500000 J0.000000 X12.500000 Y5.000000 Z18.000000\
-G2 I-7.500000 J0.000000 X-2.500000 Y5.000000 Z18.000000\
-G2 I7.500000 J0.000000 X12.500000 Y5.000000 Z18.000000\
-G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
+G2 DR0.021221 I-7.500000 J0.000000 X-2.500000 Y5.000000 Z19.500000\
+G2 DR0.021221 I7.500000 J0.000000 X12.500000 Y5.000000 Z19.000000\
+G2 DR0.021221 I-7.500000 J0.000000 X-2.500000 Y5.000000 Z18.500000\
+G2 DR0.021221 I7.500000 J0.000000 X12.500000 Y5.000000 Z18.000000\
+G2 DR0.000000 I-7.500000 J0.000000 X-2.500000 Y5.000000 Z18.000000\
+G2 DR0.000000 I7.500000 J0.000000 X12.500000 Y5.000000 Z18.000000\
+G1 X11.250000 Y5.000000\
+G0 Z20.000000"
 
     def test00(self):
         """Test Basic Helix Generator Return"""
@@ -107,15 +109,17 @@ G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
         args["tool_diameter"] = "5"
         self.assertRaises(TypeError, generator.generate, **args)
 
-        # require tool fit 2: hole diameter not greater than tool diam
-        # with zero inner radius
+    def test02(self):
+        '''Require tool fit: hole diameter not greater than tool diam
+        # with zero inner radius'''
         args = _resetArgs()
         args["hole_radius"] = 2.0
         args["inner_radius"] = 0.0
         args["tool_diameter"] = 5.0
         self.assertRaises(ValueError, generator.generate, **args)
 
-        # require tool fit: actual hole diameter after taking Extra Offset into account >= tool diameter
+    def test03(self):
+        '''Require tool fits hole'''
         # 1. Extra Offset just small enough to leave room for tool should not raise an error
         args = _resetArgs()
         designed_hole_diameter = 10.0
@@ -129,20 +133,29 @@ G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
         # 2. Extra Offset does not leave room for tool, should raise an error
         args = _resetArgs()
         designed_hole_diameter = 10.0
-        extra_offset = 2.50
+        extra_offset = 2.501
         args["hole_radius"] = designed_hole_diameter / 2 - extra_offset
         args["inner_radius"] = extra_offset
         args["tool_diameter"] = 5.0
         self.assertRaises(ValueError, generator.generate, **args)
 
-        # step_over is a percent value between 0 and 1
+        #3. Check plunge with endmill is not blocked. Not ideal but that's machinists choice.
+        args["hole_radius"] = 5.0
+        args["inner_radius"] = 0.0
+        args["tool_diameter"] = 5.0
+        result = generator.generate(**args)
+        self.assertTrue(result)
+
+    def test04(self):
+        '''Test step_over : a "percent" value between 0 and 1'''
         args = _resetArgs()
         args["step_over"] = 50
         self.assertRaises(ValueError, generator.generate, **args)
         args["step_over"] = "50"
         self.assertRaises(TypeError, generator.generate, **args)
 
-        # Other argument testing
+    def test05(self):
+        ''' Test some mistaken inputs are rejected'''
         args = _resetArgs()
         args["startAt"] = "Other"
         self.assertRaises(ValueError, generator.generate, **args)
@@ -152,59 +165,140 @@ G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
         self.assertRaises(ValueError, generator.generate, **args)
 
     def test07(self):
-        """Test Basic Helix Generator verify linear edge is vertical"""
+        '''Test Basic Helix Generator '''
         # verify linear edge is vertical: X
         args = _resetArgs()
         v1 = FreeCAD.Vector(5, 5, 20)
         v2 = FreeCAD.Vector(5.0001, 5, 10)
-        edg = Part.makeLine(v1, v2)
-        args["edge"] = edg
+        args["edge"] = Part.makeLine(v1, v2)
         self.assertRaises(ValueError, generator.generate, **args)
 
         # verify linear edge is vertical: Y
         args = _resetArgs()
         v1 = FreeCAD.Vector(5, 5.0001, 20)
         v2 = FreeCAD.Vector(5, 5, 10)
-        edg = Part.makeLine(v1, v2)
-        args["edge"] = edg
+        args["edge"] = Part.makeLine(v1, v2)
         self.assertRaises(ValueError, generator.generate, **args)
 
     def test08(self):
-        """Test Helix Generator with horizontal edge"""
+        '''Test Helix Generator with horizontal edge'''
         args = _resetArgs()
         v1 = FreeCAD.Vector(10, 5, 5)
         v2 = FreeCAD.Vector(20, 5, 5)
-        edg = Part.makeLine(v1, v2)
-        args["edge"] = edg
+        args["edge"] = Part.makeLine(v1, v2)
         self.assertRaises(ValueError, generator.generate, **args)
 
     def test09(self):
-        """Test Helix Generator with inverted vertical edge"""
+        '''Test Helix Generator with inverted vertical edge'''
         args = _resetArgs()
         v1 = FreeCAD.Vector(5, 5, 18)
         v2 = FreeCAD.Vector(5, 5, 20)
-        edg = Part.makeLine(v1, v2)
-        args["edge"] = edg
+        args["edge"] = Part.makeLine(v1, v2)
 
         self.assertRaises(ValueError, generator.generate, **args)
 
     def test10(self):
-        """Test Helix Retraction"""
+        '''Test Helix Retraction'''
 
-        # if center is clear, the second to last move should be a rapid away
+        # if center is clear, the second to last move should be a G1 away
         # from the wall
         args = _resetArgs()
         v1 = FreeCAD.Vector(0, 0, 20)
         v2 = FreeCAD.Vector(0, 0, 18)
-        edg = Part.makeLine(v1, v2)
-        args["edge"] = edg
-        args["inner_radius"] = 0.0
+        args["edge"] = Part.makeLine(v1, v2)
         args["tool_diameter"] = 5.0
         result = generator.generate(**args)
-        self.assertTrue(result[-2].Name == "G0")
+        self.assertTrue(result[-2].Name == "G1")
 
-        # if center is not clear, retraction is one straight up on the last
-        # move. the second to last move should be a G2
+        # if center is not clear, multiple helical paths
+        # retraction is one straight up on the last move.
+        # the second to last move should be a G1 pulloff to a clear radius
+        args["hole_radius"] = 14.0
+        args["inner_radius"] = 2.0
+        result = generator.generate(**args)
+        self.assertTrue(result[-2].Name == "G1")
+
+        # single annular slot, center not clear
+        # retraction is one straight up on the last move.
+        #  the second to last move should be a G2 since "CW"
+        args["hole_radius"] = 7.0
         args["inner_radius"] = 2.0
         result = generator.generate(**args)
         self.assertTrue(result[-2].Name == "G2")
+
+    def test12(self):
+        ''' test "FeedFactor" pseudo-param when using feedRateAdj '''
+        args = _resetArgs()
+        v1 = FreeCAD.Vector(0, 0, 20)
+        v2 = FreeCAD.Vector(0, 0, 18)
+        args["edge"] = Part.makeLine(v1, v2)
+        args["hole_radius"] = 7.0
+        args["inner_radius"] = 2.0
+        result = generator.generate(**args)
+        # first check it's not present in default run:
+        self.assertTrue("FR" not in result[-2].Parameters)
+
+        # now recalc with feedRateAdj:
+        args["feedRateAdj"] = True
+        result = generator.generate(**args)
+        self.assertTrue("FR" in result[-2].Parameters)
+
+        # create a double helix path with feedRateAdj
+        # default tool is 5mm diam
+        args["hole_radius"] = 8.0
+        args["inner_radius"] = 2.0
+        args["feedRateAdj"] = True
+        args["startAt"] = "Outside"
+        tool_r = args["tool_diameter"] / 2
+        # first cut is outside diam, so reduce spindle feedrate
+        # first arc is in 3rd gcode command :result[3]
+        path_r = args["hole_radius"]-tool_r
+        result = generator.generate(**args)
+        self.assertTrue("FR" in result[3].Parameters)
+        FF = result[3].Parameters["FR"]
+        self.assertTrue(FF == path_r / (path_r + tool_r))
+
+        # final cut is inside diam, so increase spindle feedrate
+        # last arc in inner helix 3rd gcode from end :result[-3]
+        path_r = args["inner_radius"]+tool_r
+        result = generator.generate(**args)
+        self.assertTrue("FR" in result[-3].Parameters)
+        FF = result[-3].Parameters["FR"]
+        self.assertTrue(FF == path_r / (path_r - tool_r))
+
+        # test neg.inner_radius: r = zero: cut-off max F-value=200
+        args["hole_radius"] = 10.5
+        args["tool_diameter"] = 5.0
+        args["inner_radius"] = 0.01
+        args["startAt"] = "Outside"
+        result = generator.generate(**args)
+        self.assertTrue("FR" in result[-3].Parameters)
+        FR = result[-3].Parameters["FR"]
+        self.assertTrue(FR == 200)
+
+    def test14(self):
+        ''' test "DescentRate" pseudo-param when using feedRateAdj '''
+        args = _resetArgs()
+        v1 = FreeCAD.Vector(0, 0, 20)
+        v2 = FreeCAD.Vector(0, 0, 18)
+        args["edge"] = Part.makeLine(v1, v2)
+        # assert no DescentRate  pseudo-param on plunge holes (r=0)
+        args["hole_radius"] = 5.0
+        args["tool_diameter"] = args["hole_radius"] * 2
+        args["inner_radius"] = -args["hole_radius"]
+        args["feedRateAdj"] = True
+        result = generator.generate(**args)
+        self.assertTrue("DR" not in result[-3].Parameters)
+
+        # test DescentRate pseudo-param in helical path (assert zero on final circular arcs)
+        args["hole_radius"] = 6.0
+        result = generator.generate(**args)
+        self.assertTrue("DR" in result[-3].Parameters)
+        DR = result[-3].Parameters["DR" ]
+        self.assertTrue(DR == 0)  # last two arcs are flat circle, no descent
+        DR = result[-5].Parameters["DR" ] # last true helix arc
+        self.assertTrue(
+            DR == args["step_down"] / (2*math.pi*(args["hole_radius"] - args["tool_diameter"] /2))
+        )
+
+

--- a/src/Mod/CAM/CAMTests/TestPathThreadMillingGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathThreadMillingGenerator.py
@@ -31,9 +31,25 @@ def radii(internal, major, minor, toolDia, toolCrest):
     """test radii function for simple testing"""
     return (minor, major)
 
+def _resetArgs():
+    return {
+        "center": FreeCAD.Vector(),
+        "cmd": "G2",
+        "zStart": 0,
+        "zFinal": 1.75,
+        "pitch": 1,
+        "radius": 3,
+        "leadInOut": False,
+        "retractOffset": 2,
+        "start": None,
+        "feedRateAdj": False,
+        "tool_radius": 2,
+    }
+    
 
 class TestPathThreadMillingGenerator(PathTestBase):
     """Test thread milling generator."""
+    # DR passes helix descent rate to blend v,h feeds. Don't appear in o/p GCODE 
 
     def test00(self):
         """Verify thread commands for a single thread"""
@@ -45,25 +61,27 @@ class TestPathThreadMillingGenerator(PathTestBase):
         pitch = 1
         radius = 3
         leadInOut = False
-        elevator = 2
+        retractOffset = 2 # tool axis offset from hole axis for z retraction moves
+        feedRateAdj = False
+        tool_rad = 2
 
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, elevator, None
+            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
         )
 
         gcode = [
             "G0 X0.000000 Y2.000000",
             "G0 Z0.000000",
             "G1 Y3.000000",
-            "G2 J-3.000000 Y-3.000000 Z0.500000",
-            "G2 J3.000000 Y3.000000 Z1.000000",
+            "G2 DR0.053052 J-3.000000 Y-3.000000 Z0.500000",
+            "G2 DR0.053052 J3.000000 Y3.000000 Z1.000000",
             "G1 X0.000000 Y2.000000",
         ]
         self.assertEqual([p.toGCode() for p in path], gcode)
         self.assertCoincide(start, FreeCAD.Vector(0, 2, zFinal))
 
     def test01(self):
-        """Verify thread commands for a thwo threads"""
+        """Verify thread commands for two threads"""
 
         center = FreeCAD.Vector()
         cmd = "G2"
@@ -72,27 +90,29 @@ class TestPathThreadMillingGenerator(PathTestBase):
         pitch = 1
         radius = 3
         leadInOut = False
-        elevator = 2
-
+        retractOffset = 2
+        feedRateAdj = False
+        tool_rad = 2
+        
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, elevator, None
+            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
         )
 
         gcode = [
             "G0 X0.000000 Y2.000000",
             "G0 Z0.000000",
             "G1 Y3.000000",
-            "G2 J-3.000000 Y-3.000000 Z0.500000",
-            "G2 J3.000000 Y3.000000 Z1.000000",
-            "G2 J-3.000000 Y-3.000000 Z1.500000",
-            "G2 J3.000000 Y3.000000 Z2.000000",
+            "G2 DR0.053052 J-3.000000 Y-3.000000 Z0.500000",
+            "G2 DR0.053052 J3.000000 Y3.000000 Z1.000000",
+            "G2 DR0.053052 J-3.000000 Y-3.000000 Z1.500000",
+            "G2 DR0.053052 J3.000000 Y3.000000 Z2.000000",
             "G1 X0.000000 Y2.000000",
         ]
         self.assertEqual([p.toGCode() for p in path], gcode)
         self.assertCoincide(start, FreeCAD.Vector(0, 2, zFinal))
 
     def test02(self):
-        """Verify thread commands for a one and a half threads"""
+        """Verify thread commands for one and a half threads"""
 
         center = FreeCAD.Vector()
         cmd = "G2"
@@ -101,26 +121,28 @@ class TestPathThreadMillingGenerator(PathTestBase):
         pitch = 1
         radius = 3
         leadInOut = False
-        elevator = 2
-
+        retractOffset = 2
+        feedRateAdj = False
+        tool_rad = 2
+        
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, elevator, None
+            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
         )
 
         gcode = [
             "G0 X0.000000 Y2.000000",
             "G0 Z0.000000",
             "G1 Y3.000000",
-            "G2 J-3.000000 Y-3.000000 Z0.500000",
-            "G2 J3.000000 Y3.000000 Z1.000000",
-            "G2 J-3.000000 Y-3.000000 Z1.500000",
+            "G2 DR0.053052 J-3.000000 Y-3.000000 Z0.500000",
+            "G2 DR0.053052 J3.000000 Y3.000000 Z1.000000",
+            "G2 DR0.053052 J-3.000000 Y-3.000000 Z1.500000",
             "G1 X0.000000 Y-2.000000",
         ]
         self.assertEqual([p.toGCode() for p in path], gcode)
         self.assertCoincide(start, FreeCAD.Vector(0, -2, zFinal))
 
     def test03(self):
-        """Verify thread commands for a one and 3 quarter threads"""
+        """Verify thread commands for one and 3 quarter threads"""
 
         center = FreeCAD.Vector()
         cmd = "G2"
@@ -129,21 +151,23 @@ class TestPathThreadMillingGenerator(PathTestBase):
         pitch = 1
         radius = 3
         leadInOut = False
-        elevator = 2
-
+        retractOffset = 2
+        feedRateAdj = False
+        tool_rad = 2
+        
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, elevator, None
+            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
         )
 
         gcode = [
             "G0 X0.000000 Y2.000000",
             "G0 Z0.000000",
             "G1 Y3.000000",
-            "G2 J-3.000000 Y-3.000000 Z0.500000",
-            "G2 J3.000000 Y3.000000 Z1.000000",
-            "G2 J-3.000000 Y-3.000000 Z1.500000",
+            "G2 DR0.053052 J-3.000000 Y-3.000000 Z0.500000",
+            "G2 DR0.053052 J3.000000 Y3.000000 Z1.000000",
+            "G2 DR0.053052 J-3.000000 Y-3.000000 Z1.500000",
             #'(------- finish-thread -------)',
-            "G2 J3.000000 X-3.000000 Y0.000000 Z1.750000",
+            "G2 DR0.053052 J3.000000 X-3.000000 Y0.000000 Z1.750000",
             #'(------- finish-thread -------)',
             "G1 X-2.000000 Y0.000000",
         ]
@@ -151,7 +175,7 @@ class TestPathThreadMillingGenerator(PathTestBase):
         self.assertCoincide(start, FreeCAD.Vector(-2, 0, zFinal))
 
     def test04(self):
-        """Verify thread commands for a one and 3 quarter threads - CCW"""
+        """Verify thread commands for one and 3 quarter threads - CCW"""
 
         center = FreeCAD.Vector()
         cmd = "G3"
@@ -160,21 +184,23 @@ class TestPathThreadMillingGenerator(PathTestBase):
         pitch = 1
         radius = 3
         leadInOut = False
-        elevator = 2
-
+        retractOffset = 2
+        feedRateAdj = False
+        tool_rad = 2
+        
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, elevator, None
+            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
         )
 
         gcode = [
             "G0 X0.000000 Y2.000000",
             "G0 Z0.000000",
             "G1 Y3.000000",
-            "G3 J-3.000000 Y-3.000000 Z0.500000",
-            "G3 J3.000000 Y3.000000 Z1.000000",
-            "G3 J-3.000000 Y-3.000000 Z1.500000",
+            "G3 DR0.053052 J-3.000000 Y-3.000000 Z0.500000",
+            "G3 DR0.053052 J3.000000 Y3.000000 Z1.000000",
+            "G3 DR0.053052 J-3.000000 Y-3.000000 Z1.500000",
             #'(------- finish-thread -------)',
-            "G3 J3.000000 X3.000000 Y0.000000 Z1.750000",
+            "G3 DR0.053052 J3.000000 X3.000000 Y0.000000 Z1.750000",
             #'(------- finish-thread -------)',
             "G1 X2.000000 Y0.000000",
         ]
@@ -182,7 +208,7 @@ class TestPathThreadMillingGenerator(PathTestBase):
         self.assertCoincide(start, FreeCAD.Vector(2, 0, zFinal))
 
     def test10(self):
-        """Verify lead in/out commands for a single thread"""
+        """Verify lead in/out commands for a single turn"""
 
         center = FreeCAD.Vector()
         cmd = "G2"
@@ -191,22 +217,24 @@ class TestPathThreadMillingGenerator(PathTestBase):
         pitch = 1
         radius = 3
         leadInOut = True
-        elevator = 2
-
+        retractOffset = 2
+        feedRateAdj = False
+        tool_rad = 2
+        
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, elevator, None
+            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
         )
 
         gcode = [
             "G0 X0.000000 Y2.000000",
             "G0 Z0.000000",
             #'(------- lead-in -------)',
-            "G2 J0.500000 Y3.000000",
+            "G2 DR0.053052 J0.500000 Y3.000000",
             #'(------- lead-in -------)',
-            "G2 J-3.000000 Y-3.000000 Z0.500000",
-            "G2 J3.000000 Y3.000000 Z1.000000",
+            "G2 DR0.053052 J-3.000000 Y-3.000000 Z0.500000",
+            "G2 DR0.053052 J3.000000 Y3.000000 Z1.000000",
             #'(------- lead-out -------)',
-            "G2 I0.000000 J-0.500000 X0.000000 Y2.000000",
+            "G2 DR0.053052 I0.000000 J-0.500000 X0.000000 Y2.000000",
             #'(------- lead-out -------)',
         ]
         self.assertEqual([p.toGCode() for p in path], gcode)
@@ -222,24 +250,45 @@ class TestPathThreadMillingGenerator(PathTestBase):
         pitch = 1
         radius = 3
         leadInOut = True
-        elevator = 2
-
+        retractOffset = 2
+        feedRateAdj = False
+        tool_rad = 2
+        
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, elevator, None
+            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
         )
 
         gcode = [
             "G0 X0.000000 Y2.000000",
             "G0 Z0.000000",
             #'(------- lead-in -------)',
-            "G2 J0.500000 Y3.000000",
+            "G2 DR0.053052 J0.500000 Y3.000000",
             #'(------- lead-in -------)',
-            "G2 J-3.000000 Y-3.000000 Z0.500000",
-            "G2 J3.000000 Y3.000000 Z1.000000",
-            "G2 J-3.000000 Y-3.000000 Z1.500000",
+            "G2 DR0.053052 J-3.000000 Y-3.000000 Z0.500000",
+            "G2 DR0.053052 J3.000000 Y3.000000 Z1.000000",
+            "G2 DR0.053052 J-3.000000 Y-3.000000 Z1.500000",
             #'(------- lead-out -------)',
-            "G2 I0.000000 J0.500000 X0.000000 Y-2.000000",
+            "G2 DR0.053052 I0.000000 J0.500000 X0.000000 Y-2.000000",
             #'(------- lead-out -------)',
         ]
         self.assertEqual([p.toGCode() for p in path], gcode)
         self.assertCoincide(start, FreeCAD.Vector(0, -2, zFinal))
+
+    def test13(self):
+        """Verify FeedRadAdj """
+        args = _resetArgs()
+
+        # first check it's not present with default feedRateAdj=False:
+        result, start = threadmilling.generate(**args)
+        self.assertTrue("FR" not in result[-2].Parameters)
+
+        # now recalc with feedRateAdj:
+        args["feedRateAdj"] = True
+        result, start  = threadmilling.generate(**args)
+
+        self.assertTrue("FR" in result[-2].Parameters)
+        FR = result[-2].Parameters["FR" ]
+        #print("FR = ",FR)
+        self.assertTrue(FR == 0.600000) #radius / (radius + tool_rad)  #  (hole_rad-tool_rad)/hole_rad 
+
+

--- a/src/Mod/CAM/CAMTests/TestPathThreadMillingGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathThreadMillingGenerator.py
@@ -31,6 +31,7 @@ def radii(internal, major, minor, toolDia, toolCrest):
     """test radii function for simple testing"""
     return (minor, major)
 
+
 def _resetArgs():
     return {
         "center": FreeCAD.Vector(),
@@ -45,11 +46,12 @@ def _resetArgs():
         "feedRateAdj": False,
         "tool_radius": 2,
     }
-    
+
 
 class TestPathThreadMillingGenerator(PathTestBase):
     """Test thread milling generator."""
-    # DR passes helix descent rate to blend v,h feeds. Don't appear in o/p GCODE 
+
+    # DR passes helix descent rate to blend v,h feeds. Don't appear in o/p GCODE
 
     def test00(self):
         """Verify thread commands for a single thread"""
@@ -61,12 +63,22 @@ class TestPathThreadMillingGenerator(PathTestBase):
         pitch = 1
         radius = 3
         leadInOut = False
-        retractOffset = 2 # tool axis offset from hole axis for z retraction moves
+        retractOffset = 2  # tool axis offset from hole axis for z retraction moves
         feedRateAdj = False
         tool_rad = 2
 
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
+            center,
+            cmd,
+            zStart,
+            zFinal,
+            pitch,
+            radius,
+            leadInOut,
+            retractOffset,
+            None,
+            feedRateAdj,
+            tool_rad,
         )
 
         gcode = [
@@ -93,9 +105,19 @@ class TestPathThreadMillingGenerator(PathTestBase):
         retractOffset = 2
         feedRateAdj = False
         tool_rad = 2
-        
+
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
+            center,
+            cmd,
+            zStart,
+            zFinal,
+            pitch,
+            radius,
+            leadInOut,
+            retractOffset,
+            None,
+            feedRateAdj,
+            tool_rad,
         )
 
         gcode = [
@@ -124,9 +146,19 @@ class TestPathThreadMillingGenerator(PathTestBase):
         retractOffset = 2
         feedRateAdj = False
         tool_rad = 2
-        
+
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
+            center,
+            cmd,
+            zStart,
+            zFinal,
+            pitch,
+            radius,
+            leadInOut,
+            retractOffset,
+            None,
+            feedRateAdj,
+            tool_rad,
         )
 
         gcode = [
@@ -154,9 +186,19 @@ class TestPathThreadMillingGenerator(PathTestBase):
         retractOffset = 2
         feedRateAdj = False
         tool_rad = 2
-        
+
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
+            center,
+            cmd,
+            zStart,
+            zFinal,
+            pitch,
+            radius,
+            leadInOut,
+            retractOffset,
+            None,
+            feedRateAdj,
+            tool_rad,
         )
 
         gcode = [
@@ -187,9 +229,19 @@ class TestPathThreadMillingGenerator(PathTestBase):
         retractOffset = 2
         feedRateAdj = False
         tool_rad = 2
-        
+
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
+            center,
+            cmd,
+            zStart,
+            zFinal,
+            pitch,
+            radius,
+            leadInOut,
+            retractOffset,
+            None,
+            feedRateAdj,
+            tool_rad,
         )
 
         gcode = [
@@ -220,9 +272,19 @@ class TestPathThreadMillingGenerator(PathTestBase):
         retractOffset = 2
         feedRateAdj = False
         tool_rad = 2
-        
+
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
+            center,
+            cmd,
+            zStart,
+            zFinal,
+            pitch,
+            radius,
+            leadInOut,
+            retractOffset,
+            None,
+            feedRateAdj,
+            tool_rad,
         )
 
         gcode = [
@@ -253,9 +315,19 @@ class TestPathThreadMillingGenerator(PathTestBase):
         retractOffset = 2
         feedRateAdj = False
         tool_rad = 2
-        
+
         path, start = threadmilling.generate(
-            center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, None, feedRateAdj, tool_rad
+            center,
+            cmd,
+            zStart,
+            zFinal,
+            pitch,
+            radius,
+            leadInOut,
+            retractOffset,
+            None,
+            feedRateAdj,
+            tool_rad,
         )
 
         gcode = [
@@ -275,7 +347,7 @@ class TestPathThreadMillingGenerator(PathTestBase):
         self.assertCoincide(start, FreeCAD.Vector(0, -2, zFinal))
 
     def test13(self):
-        """Verify FeedRadAdj """
+        """Verify FeedRadAdj"""
         args = _resetArgs()
 
         # first check it's not present with default feedRateAdj=False:
@@ -284,11 +356,11 @@ class TestPathThreadMillingGenerator(PathTestBase):
 
         # now recalc with feedRateAdj:
         args["feedRateAdj"] = True
-        result, start  = threadmilling.generate(**args)
+        result, start = threadmilling.generate(**args)
 
         self.assertTrue("FR" in result[-2].Parameters)
-        FR = result[-2].Parameters["FR" ]
-        #print("FR = ",FR)
-        self.assertTrue(FR == 0.600000) #radius / (radius + tool_rad)  #  (hole_rad-tool_rad)/hole_rad 
-
-
+        FR = result[-2].Parameters["FR"]
+        # print("FR = ",FR)
+        self.assertTrue(
+            FR == 0.600000
+        )  # radius / (radius + tool_rad)  #  (hole_rad-tool_rad)/hole_rad

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
@@ -17,10 +17,10 @@
    <item row="0" column="0">
     <widget class="QFrame" name="frame">
      <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+      <enum>QFrame::Shape::StyledPanel</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+      <enum>QFrame::Shadow::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
@@ -55,103 +55,118 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QWidget" name="widget">
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Start from</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="startSide">
+       <property name="toolTip">
+        <string>Specify if the helix operation should start at the inside and work its way outwards, or start at the outside and work its way to the center.</string>
+       </property>
+       <item>
         <property name="text">
-         <string>Start from</string>
+         <string>Inside</string>
         </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="startSide">
-        <property name="toolTip">
-         <string>Specify if the helix operation should start at the inside and work its way outwards, or start at the outside and work its way to the center.</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Inside</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Outside</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
+       </item>
+       <item>
         <property name="text">
-         <string>Direction</string>
+         <string>Outside</string>
         </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="cutMode">
-        <property name="toolTip">
-         <string>The direction for the helix, clockwise or counterclockwise.</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Climb</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Conventional</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_4">
+       </item>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Direction</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="cutMode">
+       <property name="toolTip">
+        <string>The direction for the helix, clockwise or counterclockwise.</string>
+       </property>
+       <item>
         <property name="text">
-         <string>Step over percent</string>
+         <string>Climb</string>
         </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QSpinBox" name="stepOverPercent">
-        <property name="toolTip">
-         <string>Specify the percent of the tool diameter each helix will be offset to the previous one. A step over of 100% means no overlap of the individual cuts.</string>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="singleStep">
-         <number>10</number>
-        </property>
-        <property name="value">
-         <number>100</number>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_6">
+       </item>
+       <item>
         <property name="text">
-         <string>Extra Offset</string>
+         <string>Conventional</string>
         </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="Gui::InputField" name="extraOffset">
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+       </item>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Step over percent</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QSpinBox" name="stepOverPercent">
+       <property name="toolTip">
+        <string>Specify the percent of the tool diameter each helix will be offset to the previous one. A step over of 100% means no overlap of the individual cuts.</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>100</number>
+       </property>
+       <property name="singleStep">
+        <number>10</number>
+       </property>
+       <property name="value">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Extra Offset</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="Gui::InputField" name="extraOffset">
+       <property name="unit" stdset="0">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Start Radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="Gui::InputField" name="startRadius">
+       <property name="minimum" stdset="0">
+        <double>-999999999.000000000000000</double>
+       </property>
+       <property name="maximum" stdset="0">
+        <double>999999999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
-  <item row="3" column="0">
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -161,7 +176,19 @@
      </property>
     </spacer>
    </item>
-   </layout>
+   <item row="2" column="0">
+    <widget class="QCheckBox" name="feedRateCheckBox">
+     <property name="toolTip">
+      <string>Calculate spindle feed-rate compensation to keep tool cutting edge speed roughly constant as helix radius varies.
+Reduces spindle feedrate when outer edge is cutting
+Increases spindle rate when cutting outside in to maintain tool speed on inner cuts.</string>
+     </property>
+     <property name="text">
+      <string>Apply feed rate correction</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpThreadMillingEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpThreadMillingEdit.ui
@@ -75,7 +75,7 @@
          <number>50</number>
         </property>
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
        </widget>
       </item>
@@ -87,11 +87,7 @@
        </widget>
       </item>
       <item row="4" column="1">
-       <widget class="Gui::QuantitySpinBox" name="threadMajor">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
+       <widget class="Gui::QuantitySpinBox" name="threadMajor" native="true"/>
       </item>
       <item row="5" column="0">
        <widget class="QLabel" name="label_2">
@@ -101,11 +97,7 @@
        </widget>
       </item>
       <item row="5" column="1">
-       <widget class="Gui::QuantitySpinBox" name="threadMinor">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
+       <widget class="Gui::QuantitySpinBox" name="threadMinor" native="true"/>
       </item>
       <item row="6" column="0">
        <widget class="QLabel" name="threadPitchLabel">
@@ -115,16 +107,12 @@
        </widget>
       </item>
       <item row="6" column="1">
-       <widget class="Gui::QuantitySpinBox" name="threadPitch">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
+       <widget class="Gui::QuantitySpinBox" name="threadPitch" native="true"/>
       </item>
       <item row="7" column="1">
        <widget class="QSpinBox" name="threadTPI">
         <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -151,25 +139,12 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QSpinBox" name="opPasses">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
          <string>Direction</string>
         </property>
        </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="opDirection"/>
       </item>
       <item row="2" column="0">
        <widget class="QCheckBox" name="leadInOut">
@@ -178,13 +153,38 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="opDirection"/>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="opPasses">
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="feedRateCheckBox">
+         <property name="text">
+          <string>Apply feed rate correction</string>
+         </property>
+         <property name="toolTip">
+          <string>Apply spindle feed-rate adjustment to ensure selected tool-tip cutting speed.
+    Reduces spindle feedrate when cutting internal threads.
+    Increases spindle rate when cutting external threads.</string>
+         </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
-  <item row="3" column="0">
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -194,7 +194,7 @@
      </property>
     </spacer>
    </item>
-   </layout>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/CAM/Path/Base/FeedRate.py
+++ b/src/Mod/CAM/Path/Base/FeedRate.py
@@ -24,6 +24,7 @@ import FreeCAD
 import Path
 import Path.Base.MachineState as PathMachineState
 import Part
+import math
 
 __title__ = "Feed Rate Helper Utility"
 __author__ = "sliptonic (Brad Collette)"
@@ -41,7 +42,7 @@ else:
     Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
 
-def setFeedRate(commandlist, ToolController):
+def setFeedRate(commandlist_arg, ToolController):
     """Set the appropriate feed rate for a list of Path commands using the information from a Tool Controller
 
     Every motion command in the list will have a feed rate parameter added or overwritten based
@@ -51,35 +52,63 @@ def setFeedRate(commandlist, ToolController):
     def _isVertical(currentposition, command):
         x = command.Parameters["X"] if "X" in command.Parameters else currentposition.x
         y = command.Parameters["Y"] if "Y" in command.Parameters else currentposition.y
+        return Path.Geom.isRoughly(x,currentposition.x) and Path.Geom.isRoughly(y,currentposition.y)
+
+    def _isHorizontal(currentposition, command):
         z = command.Parameters["Z"] if "Z" in command.Parameters else currentposition.z
-        endpoint = FreeCAD.Vector(x, y, z)
-        if Path.Geom.pointsCoincide(currentposition, endpoint):
-            return True
-        return Path.Geom.isVertical(Part.makeLine(currentposition, endpoint))
+        return Path.Geom.isRoughly(z,currentposition.z)
+
 
     machine = PathMachineState.MachineState()
 
-    for command in commandlist:
+    hFeed = ToolController.HorizFeed.Value
+    vFeed = ToolController.VertFeed.Value
+
+    for command in commandlist_arg:
         if command.Name not in Path.Geom.CmdMoveAll:
             continue
 
-        if _isVertical(machine.getPosition(), command):
+        params = command.Parameters
+
+        if _isVertical(machine.getPosition(), command): # also true for plunge helix
             rate = (
                 ToolController.VertRapid.Value
                 if command.Name in Path.Geom.CmdMoveRapid
-                else ToolController.VertFeed.Value
+                else vFeed
             )
         else:
-            rate = (
-                ToolController.HorizRapid.Value
-                if command.Name in Path.Geom.CmdMoveRapid
-                else ToolController.HorizFeed.Value
-            )
+            if "FR" in params:
+                hFeed_adj = hFeed * params["FR"]
+            else: hFeed_adj = hFeed
 
-        params = command.Parameters
+            if _isHorizontal(machine.getPosition(), command):
+                rate = (
+                    ToolController.HorizRapid.Value
+                    if command.Name in Path.Geom.CmdMoveRapid
+                    else hFeed_adj
+                )
+            elif (command.Name in ["G2", "G3"]):
+                if ("DR" in params):
+                    if params["DR"]==0:
+                         rate = hFeed_adj
+                    elif abs(params["DR"]) > 2: # > 60 deg., steep helix: use V feedrate
+                         rate = vFeed
+                    else:
+                        descentAngle = math.atan(abs(params["DR"])) # DR is signed, neg down
+                        rate = math.sqrt(vFeed * vFeed + hFeed_adj * hFeed_adj)  # vector sum
+                        # ensure v,h feedrates not exceeded by "FR" rate
+                        rate = min(rate, vFeed / math.sin(descentAngle))
+                        rate = min(rate, hFeed_adj / math.cos(descentAngle))
+                        # TODO modify pocket/contour arcs or ramps to use this code.
+            else:
+                rate = hFeed  # fallback=hFeed:  non v, non h, non arc eg. ramp dressup?
+
+        params.pop("FR", None)
+        params.pop("DR", None)
+
         params["F"] = rate
         command.Parameters = params
 
         machine.addCommand(command)
 
-    return commandlist
+    return  commandlist_arg

--- a/src/Mod/CAM/Path/Base/FeedRate.py
+++ b/src/Mod/CAM/Path/Base/FeedRate.py
@@ -52,12 +52,13 @@ def setFeedRate(commandlist_arg, ToolController):
     def _isVertical(currentposition, command):
         x = command.Parameters["X"] if "X" in command.Parameters else currentposition.x
         y = command.Parameters["Y"] if "Y" in command.Parameters else currentposition.y
-        return Path.Geom.isRoughly(x,currentposition.x) and Path.Geom.isRoughly(y,currentposition.y)
+        return Path.Geom.isRoughly(x, currentposition.x) and Path.Geom.isRoughly(
+            y, currentposition.y
+        )
 
     def _isHorizontal(currentposition, command):
         z = command.Parameters["Z"] if "Z" in command.Parameters else currentposition.z
-        return Path.Geom.isRoughly(z,currentposition.z)
-
+        return Path.Geom.isRoughly(z, currentposition.z)
 
     machine = PathMachineState.MachineState()
 
@@ -70,16 +71,15 @@ def setFeedRate(commandlist_arg, ToolController):
 
         params = command.Parameters
 
-        if _isVertical(machine.getPosition(), command): # also true for plunge helix
+        if _isVertical(machine.getPosition(), command):  # also true for plunge helix
             rate = (
-                ToolController.VertRapid.Value
-                if command.Name in Path.Geom.CmdMoveRapid
-                else vFeed
+                ToolController.VertRapid.Value if command.Name in Path.Geom.CmdMoveRapid else vFeed
             )
         else:
             if "FR" in params:
                 hFeed_adj = hFeed * params["FR"]
-            else: hFeed_adj = hFeed
+            else:
+                hFeed_adj = hFeed
 
             if _isHorizontal(machine.getPosition(), command):
                 rate = (
@@ -87,14 +87,14 @@ def setFeedRate(commandlist_arg, ToolController):
                     if command.Name in Path.Geom.CmdMoveRapid
                     else hFeed_adj
                 )
-            elif (command.Name in ["G2", "G3"]):
-                if ("DR" in params):
-                    if params["DR"]==0:
-                         rate = hFeed_adj
-                    elif abs(params["DR"]) > 2: # > 60 deg., steep helix: use V feedrate
-                         rate = vFeed
+            elif command.Name in ["G2", "G3"]:
+                if "DR" in params:
+                    if params["DR"] == 0:
+                        rate = hFeed_adj
+                    elif abs(params["DR"]) > 2:  # > 60 deg., steep helix: use V feedrate
+                        rate = vFeed
                     else:
-                        descentAngle = math.atan(abs(params["DR"])) # DR is signed, neg down
+                        descentAngle = math.atan(abs(params["DR"]))  # DR is signed, neg down
                         rate = math.sqrt(vFeed * vFeed + hFeed_adj * hFeed_adj)  # vector sum
                         # ensure v,h feedrates not exceeded by "FR" rate
                         rate = min(rate, vFeed / math.sin(descentAngle))
@@ -111,4 +111,4 @@ def setFeedRate(commandlist_arg, ToolController):
 
         machine.addCommand(command)
 
-    return  commandlist_arg
+    return commandlist_arg

--- a/src/Mod/CAM/Path/Base/Generator/helix.py
+++ b/src/Mod/CAM/Path/Base/Generator/helix.py
@@ -143,13 +143,18 @@ def generate(
         if abs(outer_path_radius - inner_path_radius) < Path.Preferences.defaultGeometryTolerance():
             radii = [outer_path_radius]  # below tolerance cutoff, just use outer radius
         else:
-            if (outer_path_radius < inner_path_radius): raise ValueError(
-                "Outer path radius {0} less then inner radius {1}".format(outer_path_radius,inner_path_radius)
-            )
+            if outer_path_radius < inner_path_radius:
+                raise ValueError(
+                    "Outer path radius {0} less then inner radius {1}".format(
+                        outer_path_radius, inner_path_radius
+                    )
+                )
             num_steps = int(ceil((outer_path_radius - inner_path_radius) / step_over_distance) + 1)
             radii = linspace(outer_path_radius, inner_path_radius, num_steps)
             if (startAt == "Outside") and (inner_radius <= 0):
-                radii = delete(radii, -1)  # remove air cut, but inner_radius<0 useful for setting step spacing
+                radii = delete(
+                    radii, -1
+                )  # remove air cut, but inner_radius<0 useful for setting step spacing
     Path.Log.debug("Radii: {}".format(radii))
     # calculate the number of full and partial turns required
     # Each full turn is two 180 degree arcs. Zsteps is equally spaced step
@@ -164,14 +169,20 @@ def generate(
         HxCommandList.append(Path.Command("G1", {"Z": startPoint.z}))
 
         # instantaneous descent rate is used combine V,H feedrates for gcode "F "
-        if r == 0 : descentRate = None  # prevent div zero if mill plunge cut
-        else: descentRate=step_down/(2*math.pi*r)
+        if r == 0:
+            descentRate = None  # prevent div zero if mill plunge cut
+        else:
+            descentRate = step_down / (2 * math.pi * r)
 
         # FeedRateCheckbox.checked
         if not feedRateAdj:
             feedRateRatio = 0
-        elif (startAt == "Inside") or (r == radii[0]):  # first cut, always adj for outer wall chip-load
-            feedRateRatio = r / (r + tool_radius)  # classic (hole_rad - tool_rad)/hole_rad adjustment
+        elif (startAt == "Inside") or (
+            r == radii[0]
+        ):  # first cut, always adj for outer wall chip-load
+            feedRateRatio = r / (
+                r + tool_radius
+            )  # classic (hole_rad - tool_rad)/hole_rad adjustment
         elif (r - tool_radius) * 200 < r:
             feedRateRatio = 200  # prevent div zero
         else:  # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
@@ -180,48 +191,56 @@ def generate(
         adjParamDict = {}
         if r != 0:  # r == 0 is plunge cut at vert feedrate, feedRateAdj irrel
             adjParamDict["DR"] = descentRate
-            if feedRateAdj :
-                adjParamDict ["FR"] = feedRateRatio
+            if feedRateAdj:
+                adjParamDict["FR"] = feedRateRatio
 
         # Note: if (r == -tool_radius), helix is plugne, hence VH_gradient==0; feedrate==vFeed , OK
         paramDict = dict(adjParamDict)
         for i in range(1, turncount + 1):
             paramDict = dict(adjParamDict)
-            paramDict.update({
+            paramDict.update(
+                {
+                    "X": startPoint.x - r,
+                    "Y": startPoint.y,
+                    "Z": zsteps[2 * i - 1],
+                    "I": -r,
+                    "J": 0.0,
+                }
+            )
+            HxCommandList.append(Path.Command(arc_cmd, paramDict))
+
+            paramDict.update(
+                {
+                    "X": startPoint.x + r,
+                    "Z": zsteps[2 * i],
+                    "I": r,
+                }
+            )
+            HxCommandList.append(Path.Command(arc_cmd, paramDict))
+
+        if r != 0:
+            adjParamDict["DR"] = 0  # last two arcs are circular, not helical
+        paramDict = dict(adjParamDict)
+        paramDict.update(
+            {
                 "X": startPoint.x - r,
                 "Y": startPoint.y,
-                "Z": zsteps[2 * i - 1],
+                "Z": endPoint.z,
                 "I": -r,
                 "J": 0.0,
-            })
-            HxCommandList.append(Path.Command(arc_cmd, paramDict))
-
-            paramDict.update({
-                "X": startPoint.x + r,
-                "Z": zsteps[2 * i],
-                "I": r,
-            })
-            HxCommandList.append(Path.Command(arc_cmd, paramDict))
-
-        if r != 0 : adjParamDict["DR"] = 0   # last two arcs are circular, not helical
-        paramDict = dict(adjParamDict)
-        paramDict.update({
-            "X": startPoint.x - r,
-            "Y": startPoint.y,
-            "Z": endPoint.z,
-            "I": -r,
-            "J": 0.0,
-        })
+            }
+        )
         HxCommandList.append(Path.Command(arc_cmd, paramDict))
 
-        paramDict.update({
-            "X": startPoint.x + r,
-            "I": r,
-        })
+        paramDict.update(
+            {
+                "X": startPoint.x + r,
+                "I": r,
+            }
+        )
         HxCommandList.append(Path.Command(arc_cmd, paramDict))
 
         return HxCommandList
-
 
     def retract():
         # try to move to a safe place to retract without leaving a dwell mark
@@ -237,9 +256,7 @@ def generate(
             retractcommands.append(Path.Command("G1", {"X": endPoint.x, "Y": endPoint.y}))
         elif prev_r is not None:
             dwell_r = (r + prev_r) / 2
-            retractcommands.append(
-                Path.Command("G1",{"X": endPoint.x + dwell_r, "Y": endPoint.y})
-            )
+            retractcommands.append(Path.Command("G1", {"X": endPoint.x + dwell_r, "Y": endPoint.y}))
             # else annular slot, no pulloff, just retract along wall
 
         retractcommands.append(Path.Command("G0", {"Z": startPoint.z}))

--- a/src/Mod/CAM/Path/Base/Generator/helix.py
+++ b/src/Mod/CAM/Path/Base/Generator/helix.py
@@ -21,8 +21,9 @@
 # ***************************************************************************
 
 
-from numpy import ceil, linspace, isclose
+from numpy import ceil, linspace, isclose, delete
 import Path
+import math
 
 __title__ = "Helix toolpath Generator"
 __author__ = "sliptonic (Brad Collette)"
@@ -47,6 +48,7 @@ def generate(
     inner_radius=0.0,
     direction="CW",
     startAt="Outside",
+    feedRateAdj=False,
 ):
     """generate(edge, hole_radius, inner_radius, step_over) ... generate helix commands.
     hole_radius, inner_radius: outer and inner radius of the hole
@@ -68,11 +70,12 @@ def generate(
             tool_diameter,
             direction,
             startAt,
+            feedRateAdj,
         )
     )
 
-    # inner_radius contains not a radius but the value from Extra Offset, which is the distance between the hole radius as designed and the hole radius to be cut.
-    # hole_radius contains the designed hole radius - inner_radius.
+    # hole_radius contains the designed hole radius - OffsetExtra.
+    # inner_radius contains the start radius + OffsetExtra.
 
     if type(hole_radius) not in [float, int]:
         raise TypeError("Invalid type for hole radius")
@@ -83,20 +86,28 @@ def generate(
     if type(inner_radius) not in [float, int]:
         raise TypeError("inner_radius must be a float")
 
+    if inner_radius < -tool_diameter / 2:
+        # inner_radius also depends on StartRadius
+        raise ValueError(
+            "inner_radius {0} with a tool of diameter {1} gives a negative helix radius !".format(
+                inner_radius, tool_diameter
+            )
+        )
+
     if type(tool_diameter) not in [float, int]:
         raise TypeError("tool_diameter must be a float")
 
-    if not hole_radius * 2 > tool_diameter:
+    if not hole_radius * 2 >= tool_diameter:  # will allow plunge cut, zero radius helix
         raise ValueError(
             "Cannot helix a hole of diameter {0} with a tool of diameter {1}".format(
                 2 * hole_radius, tool_diameter
             )
         )
 
-    elif startAt not in ["Inside", "Outside"]:
+    if startAt not in ["Inside", "Outside"]:
         raise ValueError("Invalid value for parameter 'startAt'")
 
-    elif direction not in ["CW", "CCW"]:
+    if direction not in ["CW", "CCW"]:
         raise ValueError("Invalid value for parameter 'direction'")
 
     if type(step_over) not in [float, int]:
@@ -115,27 +126,30 @@ def generate(
     if startPoint.z < endPoint.z:
         raise ValueError("start point is below end point")
 
-    if hole_radius <= tool_diameter:
-        Path.Log.debug("(single helix mode)\n")
-        radii = [hole_radius - tool_diameter / 2]
-        if radii[0] <= 0:
+    tool_radius = tool_diameter / 2
+    if hole_radius < tool_diameter:
+        Path.Log.debug("(single helix path)\n")
+        radii = [hole_radius - tool_radius]
+        if radii[0] < 0:
             raise ValueError(
-                "Cannot helix a hole of diameter {0} with a tool of diameter {1}".format(
+                "Cannot creatre a helical path of diameter {0} with a tool of diameter {1}".format(
                     2 * hole_radius, tool_diameter
                 )
             )
-        outer_radius = hole_radius
-
     else:
-        Path.Log.debug("(annulus mode / full hole)\n")
-        outer_radius = hole_radius - tool_diameter / 2
-        step_radius = inner_radius + tool_diameter / 2
-        if abs((outer_radius - step_radius) / step_over_distance) < 1e-5:
-            radii = [(outer_radius + inner_radius) / 2]
+        Path.Log.debug("(annular clearance or entire hole)\n")
+        outer_path_radius = hole_radius - tool_radius
+        inner_path_radius = inner_radius + tool_radius
+        if abs(outer_path_radius - inner_path_radius) < Path.Preferences.defaultGeometryTolerance():
+            radii = [outer_path_radius]  # below tolerance cutoff, just use outer radius
         else:
-            nr = max(int(ceil((outer_radius - inner_radius) / step_over_distance)), 2)
-            radii = linspace(outer_radius, step_radius, nr)
-
+            if (outer_path_radius < inner_path_radius): raise ValueError(
+                "Outer path radius {0} less then inner radius {1}".format(outer_path_radius,inner_path_radius)
+            )
+            num_steps = int(ceil((outer_path_radius - inner_path_radius) / step_over_distance) + 1)
+            radii = linspace(outer_path_radius, inner_path_radius, num_steps)
+            if (startAt == "Outside") and (inner_radius <= 0):
+                radii = delete(radii, -1)  # remove air cut, but inner_radius<0 useful for setting step spacing
     Path.Log.debug("Radii: {}".format(radii))
     # calculate the number of full and partial turns required
     # Each full turn is two 180 degree arcs. Zsteps is equally spaced step
@@ -144,84 +158,89 @@ def generate(
     zsteps = linspace(startPoint.z, endPoint.z, 2 * turncount + 1)
 
     def helix_cut_r(r):
-        commandlist = []
+        HxCommandList = []
         arc_cmd = "G2" if direction == "CW" else "G3"
-        commandlist.append(Path.Command("G0", {"X": startPoint.x + r, "Y": startPoint.y}))
-        commandlist.append(Path.Command("G1", {"Z": startPoint.z}))
+        HxCommandList.append(Path.Command("G0", {"X": startPoint.x + r, "Y": startPoint.y}))
+        HxCommandList.append(Path.Command("G1", {"Z": startPoint.z}))
+
+        # instantaneous descent rate is used combine V,H feedrates for gcode "F "
+        if r == 0 : descentRate = None  # prevent div zero if mill plunge cut
+        else: descentRate=step_down/(2*math.pi*r)
+
+        # FeedRateCheckbox.checked
+        if not feedRateAdj:
+            feedRateRatio = 0
+        elif (startAt == "Inside") or (r == radii[0]):  # first cut, always adj for outer wall chip-load
+            feedRateRatio = r / (r + tool_radius)  # classic (hole_rad - tool_rad)/hole_rad adjustment
+        elif (r - tool_radius) * 200 < r:
+            feedRateRatio = 200  # prevent div zero
+        else:  # startAt outside: increase spindle feed rate to maintain inner-cut chip-load
+            feedRateRatio = r / (r - tool_radius)
+
+        adjParamDict = {}
+        if r != 0:  # r == 0 is plunge cut at vert feedrate, feedRateAdj irrel
+            adjParamDict["DR"] = descentRate
+            if feedRateAdj :
+                adjParamDict ["FR"] = feedRateRatio
+
+        # Note: if (r == -tool_radius), helix is plugne, hence VH_gradient==0; feedrate==vFeed , OK
+        paramDict = dict(adjParamDict)
         for i in range(1, turncount + 1):
-            commandlist.append(
-                Path.Command(
-                    arc_cmd,
-                    {
-                        "X": startPoint.x - r,
-                        "Y": startPoint.y,
-                        "Z": zsteps[2 * i - 1],
-                        "I": -r,
-                        "J": 0.0,
-                    },
-                )
-            )
-            commandlist.append(
-                Path.Command(
-                    arc_cmd,
-                    {
-                        "X": startPoint.x + r,
-                        "Y": startPoint.y,
-                        "Z": zsteps[2 * i],
-                        "I": r,
-                        "J": 0.0,
-                    },
-                )
-            )
-        commandlist.append(
-            Path.Command(
-                arc_cmd,
-                {
-                    "X": startPoint.x - r,
-                    "Y": startPoint.y,
-                    "Z": endPoint.z,
-                    "I": -r,
-                    "J": 0.0,
-                },
-            )
-        )
-        commandlist.append(
-            Path.Command(
-                arc_cmd,
-                {
-                    "X": startPoint.x + r,
-                    "Y": startPoint.y,
-                    "Z": endPoint.z,
-                    "I": r,
-                    "J": 0.0,
-                },
-            )
-        )
-        return commandlist
+            paramDict = dict(adjParamDict)
+            paramDict.update({
+                "X": startPoint.x - r,
+                "Y": startPoint.y,
+                "Z": zsteps[2 * i - 1],
+                "I": -r,
+                "J": 0.0,
+            })
+            HxCommandList.append(Path.Command(arc_cmd, paramDict))
+
+            paramDict.update({
+                "X": startPoint.x + r,
+                "Z": zsteps[2 * i],
+                "I": r,
+            })
+            HxCommandList.append(Path.Command(arc_cmd, paramDict))
+
+        if r != 0 : adjParamDict["DR"] = 0   # last two arcs are circular, not helical
+        paramDict = dict(adjParamDict)
+        paramDict.update({
+            "X": startPoint.x - r,
+            "Y": startPoint.y,
+            "Z": endPoint.z,
+            "I": -r,
+            "J": 0.0,
+        })
+        HxCommandList.append(Path.Command(arc_cmd, paramDict))
+
+        paramDict.update({
+            "X": startPoint.x + r,
+            "I": r,
+        })
+        HxCommandList.append(Path.Command(arc_cmd, paramDict))
+
+        return HxCommandList
+
 
     def retract():
-        # try to move to a safe place to retract without leaving a dwell
-        # mark
+        # try to move to a safe place to retract without leaving a dwell mark
         retractcommands = []
-        # Calculate retraction
-        if hole_radius <= tool_diameter:  # simple case where center is clear
-            center_clear = True
-
-        elif startAt == "Inside" and inner_radius == 0.0:  # middle is clear
-            center_clear = True
+        if tool_diameter >= hole_radius:
+            center_clear = True  # single cut operation
         else:
-            center_clear = False
+            center_clear = (startAt == "Inside") and (inner_radius <= 0.0)
+            # hole centre is already clear (hole inner radius<=tool_radius)
 
-        if center_clear:
+        # use G1 since tool tip still in contact with workpiece.
+        if center_clear and (prev_r is None):
+            retractcommands.append(Path.Command("G1", {"X": endPoint.x, "Y": endPoint.y}))
+        elif prev_r is not None:
+            dwell_r = (r + prev_r) / 2
             retractcommands.append(
-                Path.Command("G0", {"X": endPoint.x, "Y": endPoint.y, "Z": endPoint.z})
+                Path.Command("G1",{"X": endPoint.x + dwell_r, "Y": endPoint.y})
             )
-
-        # Technical Debt.
-        # If the operation is clearing multiple passes in annulus mode (inner
-        # radius > 0.0 and len(radii) > 1) then there is a derivable
-        # safe place which does not touch the inner or outer wall on all radii except
-        # the first.  This is left as a future improvement.
+            # else annular slot, no pulloff, just retract along wall
 
         retractcommands.append(Path.Command("G0", {"Z": startPoint.z}))
 
@@ -231,8 +250,9 @@ def generate(
         radii = radii[::-1]
 
     commands = []
+    prev_r = None
     for r in radii:
         commands.extend(helix_cut_r(r))
         commands.extend(retract())
-
+        prev_r = r
     return commands

--- a/src/Mod/CAM/Path/Base/Generator/threadmilling.py
+++ b/src/Mod/CAM/Path/Base/Generator/threadmilling.py
@@ -60,7 +60,7 @@ class _Thread(object):
         self.internalThread = internal
 
     def overshoots(self, z):
-        """overshoots(z) ... returns true if adding another half helix goes beyond the thread bounds. Negative pitch spirals down """
+        """overshoots(z) ... returns true if adding another half helix goes beyond the thread bounds. Negative pitch spirals down"""
         if self.pitch < 0:
             return z + self.halfPitch < self.zFinal
         return z + self.halfPitch > self.zFinal
@@ -88,15 +88,28 @@ class _Thread(object):
         return self.arcOpposite()
 
 
-def generate(center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, start, feedRateAdj, tool_radius):
+def generate(
+    center,
+    cmd,
+    zStart,
+    zFinal,
+    pitch,
+    radius,
+    leadInOut,
+    retractOffset,
+    start,
+    feedRateAdj,
+    tool_radius,
+):
     """generate(center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, start, feedRateAdj, tooldiam)
     ... returns the g-code to mill the given internal thread"""
     thread = _Thread(cmd, zStart, zFinal, pitch, radius > retractOffset)
 
-
     # FeedRateCheckbox.checked
-    r = radius # radius of path, ie spindle axis path radius
-    descentRate=abs(thread.halfPitch/(math.pi*r))   # helix vertical gradient d(xy)/dz;  halfPitch is signed
+    r = radius  # radius of path, ie spindle axis path radius
+    descentRate = abs(
+        thread.halfPitch / (math.pi * r)
+    )  # helix vertical gradient d(xy)/dz;  halfPitch is signed
     if not feedRateAdj:
         feedRateRatio = 0
     elif thread.internalThread:  # always adj for outer tip feedrate
@@ -110,9 +123,9 @@ def generate(center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffse
     if r != 0:  # r == 0 is plunge cut at vert feedrate, feedRateAdj irrel
         adjParamDict["DR"] = descentRate
         if feedRateAdj:
-            adjParamDict ["FR"] = feedRateRatio
+            adjParamDict["FR"] = feedRateRatio
 
-    #print("gen: adjParamDict = ",adjParamDict)
+    # print("gen: adjParamDict = ",adjParamDict)
     paramDict = dict(adjParamDict)
 
     yMin = center.y - radius
@@ -125,18 +138,22 @@ def generate(center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffse
     if leadInOut:
         _comment(ThrCommandList, "lead-in")
         if start is None:
-            ThrCommandList.append(Path.Command("G0", {"X": center.x, "Y": center.y + retractOffset}))
+            ThrCommandList.append(
+                Path.Command("G0", {"X": center.x, "Y": center.y + retractOffset})
+            )
             ThrCommandList.append(Path.Command("G0", {"Z": thread.zStart}))
         else:
             paramDict = dict(adjParamDict)
-            paramDict.update({
-                "X": center.x,
-                "Y": center.y + retractOffset,
-                "Z": thread.zStart,
-                "I": (center.x - start.x) / 2,
-                "J": (center.y - start.y + retractOffset) / 2,
-                "K": (thread.zStart - start.z) / 2,
-            })
+            paramDict.update(
+                {
+                    "X": center.x,
+                    "Y": center.y + retractOffset,
+                    "Z": thread.zStart,
+                    "I": (center.x - start.x) / 2,
+                    "J": (center.y - start.y + retractOffset) / 2,
+                    "K": (thread.zStart - start.z) / 2,
+                }
+            )
             ThrCommandList.append(Path.Command(thread.arcOpposite(), paramDict))
 
         paramDict = dict(adjParamDict)
@@ -145,11 +162,15 @@ def generate(center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffse
         _comment(ThrCommandList, "lead-in")
     else:
         if start is None:
-            ThrCommandList.append(Path.Command("G0", {"X": center.x, "Y": center.y + retractOffset}))
+            ThrCommandList.append(
+                Path.Command("G0", {"X": center.x, "Y": center.y + retractOffset})
+            )
             ThrCommandList.append(Path.Command("G0", {"Z": thread.zStart}))
         else:
             ThrCommandList.append(
-                Path.Command("G0", {"X": center.x, "Y": center.y + retractOffset, "Z": thread.zStart})
+                Path.Command(
+                    "G0", {"X": center.x, "Y": center.y + retractOffset, "Z": thread.zStart}
+                )
             )
         ThrCommandList.append(Path.Command("G1", {"Y": yMax}))
 
@@ -160,7 +181,7 @@ def generate(center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffse
         if thread.overshoots(z):
             break
 
-        if (i & 0x01):
+        if i & 0x01:
             y = yMax
         else:
             y = yMin
@@ -187,7 +208,7 @@ def generate(center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffse
         _comment(ThrCommandList, "finish-thread")
         paramDict = dict(adjParamDict)
         paramDict.update({"X": x, "Y": y, "Z": thread.zFinal, "J": j})
-        ThrCommandList.append(Path.Command(thread.cmd,paramDict))
+        ThrCommandList.append(Path.Command(thread.cmd, paramDict))
         _comment(ThrCommandList, "finish-thread")
 
     a = math.atan2(y - center.y, x - center.x)
@@ -204,7 +225,7 @@ def generate(center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffse
         _comment(ThrCommandList, "lead-out")
         paramDict = dict(adjParamDict)
         paramDict.update({"X": retractX, "Y": retractY, "I": -dx / 2, "J": -dy / 2})
-        ThrCommandList.append(Path.Command(thread.LeadInOutCmd(),paramDict))
+        ThrCommandList.append(Path.Command(thread.LeadInOutCmd(), paramDict))
         _comment(ThrCommandList, "lead-out")
     else:
         ThrCommandList.append(Path.Command("G1", {"X": retractX, "Y": retractY}))

--- a/src/Mod/CAM/Path/Base/Generator/threadmilling.py
+++ b/src/Mod/CAM/Path/Base/Generator/threadmilling.py
@@ -39,10 +39,10 @@ else:
 translate = FreeCAD.Qt.translate
 
 
-def _comment(path, msg):
+def _comment(commandlist, msg):
     """Nice for debugging to insert markers into generated g-code"""
     if False:
-        path.append(Path.Command("(------- {} -------)".format(msg)))
+        commandlist.append(Path.Command("(------- {} -------)".format(msg)))
 
 
 class _Thread(object):
@@ -54,16 +54,16 @@ class _Thread(object):
             self.pitch = pitch
         else:
             self.pitch = -pitch
-        self.hPitch = self.pitch / 2
+        self.halfPitch = self.pitch / 2
         self.zStart = zStart
         self.zFinal = zFinal
-        self.internal = internal
+        self.internalThread = internal
 
     def overshoots(self, z):
-        """overshoots(z) ... returns true if adding another half helix goes beyond the thread bounds"""
+        """overshoots(z) ... returns true if adding another half helix goes beyond the thread bounds. Negative pitch spirals down """
         if self.pitch < 0:
-            return z + self.hPitch < self.zFinal
-        return z + self.hPitch > self.zFinal
+            return z + self.halfPitch < self.zFinal
+        return z + self.halfPitch > self.zFinal
 
     def adjustX(self, x, dx):
         """adjustX(x, dx) ... move x by dx, the direction depends on the thread settings"""
@@ -72,127 +72,141 @@ class _Thread(object):
         return x - dx
 
     def adjustY(self, y, dy):
-        """adjustY(y, dy) ... move y by dy, the direction depends on the thread settings"""
-        if self.isG3():
-            return y - dy
+        """adjustY(y, dy) ... move y by dy, same for both directions"""
         return y - dy
 
     def isG3(self):
         """isG3() ... returns True if this is a G3 command"""
         return self.cmd in ["G3", "G03", "g3", "g03"]
 
-    def isUp(self):
-        """isUp() ... returns True if the thread goes from the bottom up"""
-        return self.pitch > 0
-
-    def g4Opposite(self):
+    def arcOpposite(self):
         return "G2" if self.isG3() else "G3"
 
-    def g4LeadInOut(self):
-        if self.internal:
+    def LeadInOutCmd(self):
+        if self.internalThread:
             return self.cmd
-        return self.g4Opposite()
-
-    def g4Start2Elevator(self):
-        return self.g4Opposite()
+        return self.arcOpposite()
 
 
-def generate(center, cmd, zStart, zFinal, pitch, radius, leadInOut, elevator, start):
-    """generate(center, cmd, zStart, zFinal, pitch, radius, leadInOut, elevator, start) ... returns the g-code to mill the given internal thread"""
-    thread = _Thread(cmd, zStart, zFinal, pitch, radius > elevator)
+def generate(center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, start, feedRateAdj, tool_radius):
+    """generate(center, cmd, zStart, zFinal, pitch, radius, leadInOut, retractOffset, start, feedRateAdj, tooldiam)
+    ... returns the g-code to mill the given internal thread"""
+    thread = _Thread(cmd, zStart, zFinal, pitch, radius > retractOffset)
+
+
+    # FeedRateCheckbox.checked
+    r = radius # radius of path, ie spindle axis path radius
+    descentRate=abs(thread.halfPitch/(math.pi*r))   # helix vertical gradient d(xy)/dz;  halfPitch is signed
+    if not feedRateAdj:
+        feedRateRatio = 0
+    elif thread.internalThread:  # always adj for outer tip feedrate
+        feedRateRatio = r / (r + tool_radius)  #  (hole_rad-tool_rad)/hole_rad
+    elif (r - tool_radius) * 200 < r:
+        feedRateRatio = 200  # prevent div zero
+    else:  # external thread: increase spindle feed rate to maintain inner-cut chip-load
+        feedRateRatio = r / (r - tool_radius)
+
+    adjParamDict = {}
+    if r != 0:  # r == 0 is plunge cut at vert feedrate, feedRateAdj irrel
+        adjParamDict["DR"] = descentRate
+        if feedRateAdj:
+            adjParamDict ["FR"] = feedRateRatio
+
+    #print("gen: adjParamDict = ",adjParamDict)
+    paramDict = dict(adjParamDict)
 
     yMin = center.y - radius
     yMax = center.y + radius
 
-    path = []
-    # at this point the tool is at a safe heiht (depending on the previous thread), so we can move
+    ThrCommandList = []
+    # at this point the tool is at a safe height (depending on the previous thread), so we can move
     # into position first, and then drop to the start height. If there is any material in the way this
     # op hasn't been setup properly.
     if leadInOut:
-        _comment(path, "lead-in")
+        _comment(ThrCommandList, "lead-in")
         if start is None:
-            path.append(Path.Command("G0", {"X": center.x, "Y": center.y + elevator}))
-            path.append(Path.Command("G0", {"Z": thread.zStart}))
+            ThrCommandList.append(Path.Command("G0", {"X": center.x, "Y": center.y + retractOffset}))
+            ThrCommandList.append(Path.Command("G0", {"Z": thread.zStart}))
         else:
-            path.append(
-                Path.Command(
-                    thread.g4Start2Elevator(),
-                    {
-                        "X": center.x,
-                        "Y": center.y + elevator,
-                        "Z": thread.zStart,
-                        "I": (center.x - start.x) / 2,
-                        "J": (center.y + elevator - start.y) / 2,
-                        "K": (thread.zStart - start.z) / 2,
-                    },
-                )
-            )
-        path.append(
-            Path.Command(
-                thread.g4LeadInOut(),
-                {"Y": yMax, "J": (yMax - (center.y + elevator)) / 2},
-            )
-        )
-        _comment(path, "lead-in")
+            paramDict = dict(adjParamDict)
+            paramDict.update({
+                "X": center.x,
+                "Y": center.y + retractOffset,
+                "Z": thread.zStart,
+                "I": (center.x - start.x) / 2,
+                "J": (center.y - start.y + retractOffset) / 2,
+                "K": (thread.zStart - start.z) / 2,
+            })
+            ThrCommandList.append(Path.Command(thread.arcOpposite(), paramDict))
+
+        paramDict = dict(adjParamDict)
+        paramDict.update({"Y": yMax, "J": (yMax - (center.y + retractOffset)) / 2})
+        ThrCommandList.append(Path.Command(thread.LeadInOutCmd(), paramDict))
+        _comment(ThrCommandList, "lead-in")
     else:
         if start is None:
-            path.append(Path.Command("G0", {"X": center.x, "Y": center.y + elevator}))
-            path.append(Path.Command("G0", {"Z": thread.zStart}))
+            ThrCommandList.append(Path.Command("G0", {"X": center.x, "Y": center.y + retractOffset}))
+            ThrCommandList.append(Path.Command("G0", {"Z": thread.zStart}))
         else:
-            path.append(
-                Path.Command("G0", {"X": center.x, "Y": center.y + elevator, "Z": thread.zStart})
+            ThrCommandList.append(
+                Path.Command("G0", {"X": center.x, "Y": center.y + retractOffset, "Z": thread.zStart})
             )
-        path.append(Path.Command("G1", {"Y": yMax}))
+        ThrCommandList.append(Path.Command("G1", {"Y": yMax}))
 
     z = thread.zStart
-    r = -radius
+    j = -radius
     i = 0
     while not Path.Geom.isRoughly(z, thread.zFinal):
         if thread.overshoots(z):
             break
-        if 0 == (i & 0x01):
-            y = yMin
-        else:
-            y = yMax
-        path.append(Path.Command(thread.cmd, {"Y": y, "Z": z + thread.hPitch, "J": r}))
-        r = -r
-        i = i + 1
-        z = z + thread.hPitch
 
+        if (i & 0x01):
+            y = yMax
+        else:
+            y = yMin
+
+        paramDict = dict(adjParamDict)
+        paramDict.update({"Y": y, "Z": z + thread.halfPitch, "J": j})
+        ThrCommandList.append(Path.Command(thread.cmd, paramDict))
+
+        j = -j
+        i += 1
+        z += thread.halfPitch
+
+    # find remaining fractional arc segment to end of thread
     if Path.Geom.isRoughly(z, thread.zFinal):
         x = center.x
         y = yMin if (i & 0x01) else yMax
     else:
-        n = math.fabs(thread.zFinal - thread.zStart) / thread.hPitch
-        k = n - int(n)
-        dy = math.cos(k * math.pi)
-        dx = math.sin(k * math.pi)
-        y = thread.adjustY(center.y, r * dy)
-        x = thread.adjustX(center.x, r * dx)
-        _comment(path, "finish-thread")
-        path.append(Path.Command(thread.cmd, {"X": x, "Y": y, "Z": thread.zFinal, "J": r}))
-        _comment(path, "finish-thread")
+        numSemiArcs = math.fabs(thread.zFinal - thread.zStart) / thread.halfPitch
+        arcFraction = numSemiArcs - int(numSemiArcs)
+        dy = j * math.cos(arcFraction * math.pi)
+        dx = j * math.sin(arcFraction * math.pi)
+        y = thread.adjustY(center.y, dy)
+        x = thread.adjustX(center.x, dx)
+        _comment(ThrCommandList, "finish-thread")
+        paramDict = dict(adjParamDict)
+        paramDict.update({"X": x, "Y": y, "Z": thread.zFinal, "J": j})
+        ThrCommandList.append(Path.Command(thread.cmd,paramDict))
+        _comment(ThrCommandList, "finish-thread")
 
     a = math.atan2(y - center.y, x - center.x)
-    dx = math.cos(a) * (radius - elevator)
-    dy = math.sin(a) * (radius - elevator)
+    dx = math.cos(a) * (radius - retractOffset)
+    dy = math.sin(a) * (radius - retractOffset)
     Path.Log.debug("")
     Path.Log.debug("a={}: dx={:.2f}, dy={:.2f}".format(a / math.pi * 180, dx, dy))
 
-    elevatorX = x - dx
-    elevatorY = y - dy
-    Path.Log.debug("({:.2f}, {:.2f}) -> ({:.2f}, {:.2f})".format(x, y, elevatorX, elevatorY))
+    retractX = x - dx
+    retractY = y - dy
+    Path.Log.debug("({:.2f}, {:.2f}) -> ({:.2f}, {:.2f})".format(x, y, retractX, retractY))
 
     if leadInOut:
-        _comment(path, "lead-out")
-        path.append(
-            Path.Command(
-                thread.g4LeadInOut(),
-                {"X": elevatorX, "Y": elevatorY, "I": -dx / 2, "J": -dy / 2},
-            )
-        )
-        _comment(path, "lead-out")
+        _comment(ThrCommandList, "lead-out")
+        paramDict = dict(adjParamDict)
+        paramDict.update({"X": retractX, "Y": retractY, "I": -dx / 2, "J": -dy / 2})
+        ThrCommandList.append(Path.Command(thread.LeadInOutCmd(),paramDict))
+        _comment(ThrCommandList, "lead-out")
     else:
-        path.append(Path.Command("G1", {"X": elevatorX, "Y": elevatorY}))
+        ThrCommandList.append(Path.Command("G1", {"X": retractX, "Y": retractY}))
 
-    return (path, FreeCAD.Vector(elevatorX, elevatorY, thread.zFinal))
+    return (ThrCommandList, FreeCAD.Vector(retractX, retractY, thread.zFinal))

--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -24,8 +24,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD
 import Path
 import Path.Op.Base as PathOp
-from Path.Base import Drillable
-from PathScripts import PathUtils
+import Path.Base.Drillable as Drillable
 
 # lazily loaded modules
 from lazy_loader.lazy_loader import LazyLoader
@@ -179,16 +178,15 @@ class ObjectOp(PathOp.ObjectOp):
                             {
                                 "x": pos.x,
                                 "y": pos.y,
-                                "r": self.holeDiameter(obj, base, sub),
+                                "d": self.holeDiameter(obj, base, sub),
                             }
                         )
 
         if haveLocations(self, obj):
             for location in obj.Locations:
-                holes.append({"x": location.x, "y": location.y, "r": 0})
+                holes.append({"x": location.x, "y": location.y, "d": 0})
 
         if len(holes) > 0:
-            holes = PathUtils.sort_locations(holes, ["x", "y"])
             self.circularHoleExecute(obj, holes)
 
     def circularHoleExecute(self, obj, holes):

--- a/src/Mod/CAM/Path/Op/Gui/Helix.py
+++ b/src/Mod/CAM/Path/Op/Gui/Helix.py
@@ -69,9 +69,11 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         if obj.StepOver != self.form.stepOverPercent.value():
             obj.StepOver = self.form.stepOverPercent.value()
         PathGuiUtil.updateInputField(obj, "OffsetExtra", self.form.extraOffset)
+        PathGuiUtil.updateInputField(obj, "StartRadius", self.form.startRadius)
 
         self.updateToolController(obj, self.form.toolController)
         self.updateCoolant(obj, self.form.coolantController)
+        obj.FeedRateAdj = self.form.feedRateCheckBox.checkState() == QtCore.Qt.Checked
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
@@ -87,17 +89,25 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         self.form.extraOffset.setText(
             FreeCAD.Units.Quantity(obj.OffsetExtra.Value, FreeCAD.Units.Length).UserString
         )
+        self.form.startRadius.setText(
+            FreeCAD.Units.Quantity(obj.StartRadius.Value, FreeCAD.Units.Length).UserString
+        )
+        self.form.feedRateCheckBox.setCheckState(
+            QtCore.Qt.Checked if obj.FeedRateAdj else QtCore.Qt.Unchecked
+        )
 
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
         signals = []
 
         signals.append(self.form.stepOverPercent.editingFinished)
+        signals.append(self.form.startRadius.editingFinished)
         signals.append(self.form.extraOffset.editingFinished)
         signals.append(self.form.cutMode.currentIndexChanged)
         signals.append(self.form.startSide.currentIndexChanged)
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.coolantController.currentIndexChanged)
+        signals.append(self.form.feedRateCheckBox.stateChanged)
 
         return signals
 

--- a/src/Mod/CAM/Path/Op/Gui/ThreadMilling.py
+++ b/src/Mod/CAM/Path/Op/Gui/ThreadMilling.py
@@ -103,6 +103,7 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         obj.Direction = self.form.opDirection.currentData()
         obj.Passes = self.form.opPasses.value()
         obj.LeadInOut = self.form.leadInOut.checkState() == QtCore.Qt.Checked
+        obj.FeedRateAdj = self.form.feedRateCheckBox.checkState() == QtCore.Qt.Checked
         obj.TPI = self.form.threadTPI.value()
 
         try:
@@ -134,10 +135,13 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         self.form.leadInOut.setCheckState(
             QtCore.Qt.Checked if obj.LeadInOut else QtCore.Qt.Unchecked
         )
+        self.form.feedRateCheckBox.setCheckState(
+            QtCore.Qt.Checked if obj.FeedRateAdj else QtCore.Qt.Unchecked
+        )
 
-        self.majorDia.updateWidget()
-        self.minorDia.updateWidget()
-        self.pitch.updateWidget()
+        self.majorDia.updateSpinBox()
+        self.minorDia.updateSpinBox()
+        self.pitch.updateSpinBox()
 
         self.setupToolController(obj, self.form.toolController)
         self._updateFromThreadType()
@@ -184,7 +188,7 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
                 self.form.threadPitchLabel.setEnabled(False)
                 self.form.threadTPI.setEnabled(True)
                 self.form.threadTPILabel.setEnabled(True)
-                self.pitch.updateWidget(0)
+                self.pitch.updateSpinBox(0)
             fillThreads(
                 self.form,
                 PathThreadMilling.ThreadTypeData[self.form.threadType.currentData()],
@@ -205,7 +209,7 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
 
             if self._isThreadMetric():
                 pitch = float(thread["pitch"])
-                self.pitch.updateWidget(pitch)
+                self.pitch.updateSpinBox(pitch)
 
             if self._isThreadImperial():
                 tpi = int(thread["tpi"])
@@ -213,8 +217,8 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
                 minor = minor * 25.4
                 major = major * 25.4
 
-            self.majorDia.updateWidget(major)
-            self.minorDia.updateWidget(minor)
+            self.majorDia.updateSpinBox(major)
+            self.minorDia.updateSpinBox(minor)
 
         self.setDirty()
 
@@ -229,11 +233,7 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         signals.append(self.form.threadTPI.editingFinished)
         signals.append(self.form.opDirection.currentIndexChanged)
         signals.append(self.form.opPasses.editingFinished)
-        if hasattr(self.form.leadInOut, "checkStateChanged"):  # Qt version >= 6.7.0
-            signals.append(self.form.leadInOut.checkStateChanged)
-        else:  # Qt version < 6.7.0
-            signals.append(self.form.leadInOut.stateChanged)
-
+        signals.append(self.form.leadInOut.stateChanged)
         signals.append(self.form.toolController.currentIndexChanged)
 
         return signals

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -22,6 +22,7 @@
 
 import Path.Base.Generator.helix as helix
 from PathScripts.PathUtils import fmt
+from PathScripts.PathUtils import sort_locations
 from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD
 import Part
@@ -29,7 +30,7 @@ import Path
 import Path.Base.FeedRate as PathFeedRate
 import Path.Op.Base as PathOp
 import Path.Op.CircularHoleBase as PathCircularHoleBase
-
+from math import sqrt
 
 __title__ = "CAM Helix Operation"
 __author__ = "Lorenz Hüdepohl"
@@ -169,10 +170,10 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             ),
         )
         obj.addProperty(
-            "App::PropertyLength",
+            "App::PropertyDistance",
             "StartRadius",
             "Helix Drill",
-            QT_TRANSLATE_NOOP("App::Property", "Starting Radius"),
+            QT_TRANSLATE_NOOP("App::Property", "Start Radius"),
         )
         obj.addProperty(
             "App::PropertyDistance",
@@ -183,6 +184,15 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 "Extra value to stay away from final profile- good for roughing toolpath",
             ),
         )
+        obj.addProperty(
+            "App::PropertyBool",
+            "FeedRateAdj",
+            "Helix Drill",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Apply radial feed-rate adjustment to correct tooltip speed",
+            ),
+        )
 
         ENUMS = self.helixOpPropertyEnumerations()
         for n in ENUMS:
@@ -190,13 +200,17 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         obj.StepOver = 50
 
     def opOnDocumentRestored(self, obj):
-        if not hasattr(obj, "StartRadius"):
-            obj.addProperty(
-                "App::PropertyLength",
-                "StartRadius",
-                "Helix Drill",
-                QT_TRANSLATE_NOOP("App::Property", "Starting Radius"),
-            )
+        for prop in obj.PropertiesList:
+            if (str(prop) == "StartRadius") and (obj.getTypeIdOfProperty(str(prop)) == "App::PropertyLength"):
+                tmpRad = obj.StartRadius.Value
+                obj.removeProperty("StartRadius") # ensure PropertyDistance, not Length
+                obj.addProperty(
+                    "App::PropertyDistance",
+                    "StartRadius",
+                    "Helix Drill",
+                    QT_TRANSLATE_NOOP("App::Property", "Start Radius"),
+                )
+                obj.StartRadius.Value = tmpRad
 
         if not hasattr(obj, "OffsetExtra"):
             obj.addProperty(
@@ -206,6 +220,17 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 QT_TRANSLATE_NOOP(
                     "App::Property",
                     "Extra value to stay away from final profile- good for roughing toolpath",
+                ),
+            )
+
+        if not hasattr(obj, "FeedRateAdj"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "FeedRateAdj",
+                "Helix Drill",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Apply radial feed-rate adjustment to correct tooltip speed",
                 ),
             )
 
@@ -241,6 +266,8 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
 
         self.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
 
+        holes = sort_locations(holes, ["x", "y"])
+
         tool = obj.ToolController.Tool
         tooldiamter = tool.Diameter.Value if hasattr(tool.Diameter, "Value") else tool.Diameter
 
@@ -253,10 +280,19 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "inner_radius": obj.StartRadius.Value + obj.OffsetExtra.Value,
             "direction": obj.Direction,
             "startAt": obj.StartSide,
+            "feedRateAdj": obj.FeedRateAdj,
         }
 
         for hole in holes:
-            args["hole_radius"] = (hole["r"] / 2) - (obj.OffsetExtra.Value)
+            if (obj.StartRadius.Value < (hole["d"] / 2)):
+                args["hole_radius"] = (hole["d"] / 2)
+                args["inner_radius"] = obj.StartRadius.Value
+            else:
+                args["inner_radius"] = (hole["d"] / 2)
+                args["hole_radius"] = obj.StartRadius.Value
+
+            args["inner_radius"] += obj.OffsetExtra.Value
+            args["hole_radius"] -= obj.OffsetExtra.Value
             startPoint = FreeCAD.Vector(hole["x"], hole["y"], obj.StartDepth.Value)
             endPoint = FreeCAD.Vector(hole["x"], hole["y"], obj.FinalDepth.Value)
             args["edge"] = Part.makeLine(startPoint, endPoint)
@@ -277,9 +313,9 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 Path.Command("G0", {"X": startPoint.x, "Y": startPoint.y, "Z": startPoint.z})
             )
 
-            results = helix.generate(**args)
+            helix_commands = helix.generate(**args)
 
-            for command in results:
+            for command in helix_commands:
                 self.commandlist.append(command)
 
         PathFeedRate.setFeedRate(self.commandlist, obj.ToolController)
@@ -292,6 +328,7 @@ def SetupProperties():
     setup.append("StartSide")
     setup.append("StepOver")
     setup.append("StartRadius")
+    setup.append("FeedRateAdj")
     return setup
 
 

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -201,9 +201,11 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
 
     def opOnDocumentRestored(self, obj):
         for prop in obj.PropertiesList:
-            if (str(prop) == "StartRadius") and (obj.getTypeIdOfProperty(str(prop)) == "App::PropertyLength"):
+            if (str(prop) == "StartRadius") and (
+                obj.getTypeIdOfProperty(str(prop)) == "App::PropertyLength"
+            ):
                 tmpRad = obj.StartRadius.Value
-                obj.removeProperty("StartRadius") # ensure PropertyDistance, not Length
+                obj.removeProperty("StartRadius")  # ensure PropertyDistance, not Length
                 obj.addProperty(
                     "App::PropertyDistance",
                     "StartRadius",
@@ -284,11 +286,11 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         }
 
         for hole in holes:
-            if (obj.StartRadius.Value < (hole["d"] / 2)):
-                args["hole_radius"] = (hole["d"] / 2)
+            if obj.StartRadius.Value < (hole["d"] / 2):
+                args["hole_radius"] = hole["d"] / 2
                 args["inner_radius"] = obj.StartRadius.Value
             else:
-                args["inner_radius"] = (hole["d"] / 2)
+                args["inner_radius"] = hole["d"] / 2
                 args["hole_radius"] = obj.StartRadius.Value
 
             args["inner_radius"] += obj.OffsetExtra.Value

--- a/src/Mod/CAM/Path/Op/ThreadMilling.py
+++ b/src/Mod/CAM/Path/Op/ThreadMilling.py
@@ -220,7 +220,7 @@ def retractRadius(obj, center, internal, tool):
             dy = 0
     else:
         dy = float(obj.MajorDiameter + tool.Diameter) / 2
-        dy += tool.Diameter /4  # arbitrary extra clearance on external
+        dy += tool.Diameter / 4  # arbitrary extra clearance on external
 
     return dy
 
@@ -321,7 +321,7 @@ class ObjectThreadMilling(PathCircularHoleBase.ObjectOp):
         return PathOp.FeatureBaseGeometry
 
     def opOnDocumentRestored(self, obj):
-        if not hasattr(obj,"FeedRateAdj"):
+        if not hasattr(obj, "FeedRateAdj"):
             obj.addProperty(
                 "App::PropertyBool",
                 "FeedRateAdj",
@@ -329,7 +329,7 @@ class ObjectThreadMilling(PathCircularHoleBase.ObjectOp):
                 QT_TRANSLATE_NOOP(
                     "App::Property",
                     "Adjust spindle feedrate to ensure correct tool tip cutting speed",
-                )
+                ),
             )
 
     def initCircularHoleOperation(self, obj):
@@ -480,7 +480,7 @@ class ObjectThreadMilling(PathCircularHoleBase.ObjectOp):
                 retractOffset,
                 start,
                 obj.FeedRateAdj,
-                float(self.tool.Diameter)/2,
+                float(self.tool.Diameter) / 2,
             )
 
             if not useFeedRatePy:
@@ -512,7 +512,9 @@ class ObjectThreadMilling(PathCircularHoleBase.ObjectOp):
                 return
 
             for hole in holes:
-                self.commandlist.append(Path.Command("(Begin Thread at Y = "+str(hole["y"])+")"))
+                self.commandlist.append(
+                    Path.Command("(Begin Thread at Y = " + str(hole["y"]) + ")")
+                )
                 self.executeThreadMill(
                     obj,
                     FreeCAD.Vector(hole["x"], hole["y"], 0),

--- a/src/Mod/CAM/Path/Op/ThreadMilling.py
+++ b/src/Mod/CAM/Path/Op/ThreadMilling.py
@@ -28,6 +28,7 @@ import Path.Op.Base as PathOp
 import Path.Op.CircularHoleBase as PathCircularHoleBase
 import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
+import Path.Base.FeedRate as PathFeedRate
 
 __title__ = "CAM Thread Milling Operation"
 __author__ = "sliptonic (Brad Collette)"
@@ -204,11 +205,11 @@ def threadPasses(count, radii, internal, majorDia, minorDia, toolDia, toolCrest)
     return passes
 
 
-def elevatorRadius(obj, center, internal, tool):
-    """elevatorLocation(obj, center, internal, tool) ... return suitable location for the tool elevator"""
+def retractRadius(obj, center, internal, tool):
+    """retractRadius(obj, center, internal, tool) ... return suitable radius for the tool retraction"""
     Path.Log.track(center, internal, tool.Diameter)
     if internal:
-        dy = float(obj.MinorDiameter - tool.Diameter) / 2 - 1
+        dy = float(obj.MinorDiameter - tool.Diameter) / 2
         if dy < 0:
             if obj.MinorDiameter < tool.Diameter:
                 Path.Log.error(
@@ -218,7 +219,8 @@ def elevatorRadius(obj, center, internal, tool):
                 )
             dy = 0
     else:
-        dy = float(obj.MajorDiameter + tool.Diameter) / 2 + 1
+        dy = float(obj.MajorDiameter + tool.Diameter) / 2
+        dy += tool.Diameter /4  # arbitrary extra clearance on external
 
     return dy
 
@@ -318,6 +320,18 @@ class ObjectThreadMilling(PathCircularHoleBase.ObjectOp):
         Path.Log.track()
         return PathOp.FeatureBaseGeometry
 
+    def opOnDocumentRestored(self, obj):
+        if not hasattr(obj,"FeedRateAdj"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "FeedRateAdj",
+                "Operation",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Adjust spindle feedrate to ensure correct tool tip cutting speed",
+                )
+            )
+
     def initCircularHoleOperation(self, obj):
         Path.Log.track()
         obj.addProperty(
@@ -398,6 +412,15 @@ class ObjectThreadMilling(PathCircularHoleBase.ObjectOp):
             ),
         )
         obj.addProperty(
+            "App::PropertyBool",
+            "FeedRateAdj",
+            "Operation",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Adjust spindle feedrate to ensure correct tool tip cutting speed",
+            ),
+        )
+        obj.addProperty(
             "App::PropertyLink",
             "ClearanceOp",
             "Operation",
@@ -419,12 +442,13 @@ class ObjectThreadMilling(PathCircularHoleBase.ObjectOp):
             passes.append(rMajor - rPass * i)
         return list(reversed(passes))
 
-    def executeThreadMill(self, obj, loc, gcode, zStart, zFinal, pitch):
-        Path.Log.track(obj.Label, loc, gcode, zStart, zFinal, pitch)
-        elevator = elevatorRadius(obj, loc, _isThreadInternal(obj), self.tool)
+    def executeThreadMill(self, obj, holeXY, arcCmd, zStart, zFinal, pitch):
+        Path.Log.track(obj.Label, holeXY, arcCmd, zStart, zFinal, pitch)
+        retractOffset = retractRadius(obj, holeXY, _isThreadInternal(obj), self.tool)
 
-        move2clearance = Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})
-        self.commandlist.append(move2clearance)
+        useFeedRatePy = True  ### make permanent when tested.
+        move2clearanceHt = Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})
+        self.commandlist.append(move2clearanceHt)
 
         start = None
         for radius in threadPasses(
@@ -441,33 +465,38 @@ class ObjectThreadMilling(PathCircularHoleBase.ObjectOp):
                 # and not obj.LeadInOut:
                 # external thread without lead in/out have to go up and over
                 # in other words we need a move to clearance and not take any
-                # shortcuts when moving to the elevator position
-                self.commandlist.append(move2clearance)
+                # shortcuts when moving to the retract position
+                self.commandlist.append(move2clearanceHt)
                 start = None
+
             commands, start = threadmilling.generate(
-                loc,
-                gcode,
+                holeXY,
+                arcCmd,
                 zStart,
                 zFinal,
                 pitch,
                 radius,
                 obj.LeadInOut,
-                elevator,
+                retractOffset,
                 start,
+                obj.FeedRateAdj,
+                float(self.tool.Diameter)/2,
             )
 
-            for cmd in commands:
-                p = cmd.Parameters
-                if cmd.Name in ["G0"]:
-                    p.update({"F": self.vertRapid})
-                if cmd.Name in ["G1", "G2", "G3"]:
-                    p.update({"F": self.horizFeed})
-                cmd.Parameters = p
+            if not useFeedRatePy:
+                for cmd in commands:
+                    p = cmd.Parameters
+                    if cmd.Name in ["G0"]:
+                        p.update({"F": self.vertRapid})
+                    if cmd.Name in ["G1", "G2", "G3"]:
+                        p.update({"F": self.horizFeed})
+                    cmd.Parameters = p
+            else:
+                PathFeedRate.setFeedRate(commands, obj.ToolController)
+
             self.commandlist.extend(commands)
 
-        self.commandlist.append(
-            Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})
-        )
+        self.commandlist.append(move2clearanceHt)
 
     def circularHoleExecute(self, obj, holes):
         Path.Log.track()
@@ -482,11 +511,11 @@ class ObjectThreadMilling(PathCircularHoleBase.ObjectOp):
                 Path.Log.error("Cannot create thread with pitch {}".format(pitch))
                 return
 
-            # rapid to clearance height
-            for loc in holes:
+            for hole in holes:
+                self.commandlist.append(Path.Command("(Begin Thread at Y = "+str(hole["y"])+")"))
                 self.executeThreadMill(
                     obj,
-                    FreeCAD.Vector(loc["x"], loc["y"], 0),
+                    FreeCAD.Vector(hole["x"], hole["y"], 0),
                     cmd,
                     zStart,
                     zFinal,


### PR DESCRIPTION
CAM: Add external profiling path to Helix;  add Feedrate radial correction to Threadmilling and Helix.  

Now, setting StartRadius larger than the hole diameter will enable a helix or helical clearance outside the "hole". In fact Helix will latch onto any circle, it does not check the 3D model for holes. Previously helix could not work on the outside of a cylinder. Same features as for holes with usual step over, offset etc. 

Fixes Command::setParameters bug which was merging new entries without clearing old content. 

## Issues
Ext Helix : https://forum.freecad.org/viewtopic.php?t=98189
Explanation of the need for feedrate radial correction: https://www.youtube.com/watch?v=6wLU97gVo5k
Fix bug https://github.com/FreeCAD/FreeCAD/issues/21070

## Before and After Images
Trivial: adds "Feedrate adjustment" to Threadmilling and Helix edit dialogues. 

Additional unit tests for new features on Threadmilling and Helix. 

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.
