### PR TITLE
BIM: hide base of railings

### DIFF
--- a/src/Mod/BIM/ArchStairs.py
+++ b/src/Mod/BIM/ArchStairs.py
@@ -542,6 +542,8 @@ class _Stairs(ArchComponent.Component):
                     if railingLeftObject.Base:
                         doc.removeObject(railingLeftObject.Base.Name)
                     railingLeftWireObject = doc.addObject("Part::Feature","RailingWire")
+                    if FreeCAD.GuiUp:
+                        railingLeftWireObject.ViewObject.hide()
                     railingLeftObject.Base = railingLeftWireObject
                 # update the Base object shape
                 railingLeftObject.Base.Shape = railWireL
@@ -562,6 +564,8 @@ class _Stairs(ArchComponent.Component):
                     if railingRightObject.Base:
                         doc.removeObject(railingRightObject.Base.Name)
                     railingRightWireObject = doc.addObject("Part::Feature","RailingWire")
+                    if FreeCAD.GuiUp:
+                        railingRightWireObject.ViewObject.hide()
                     railingRightObject.Base = railingRightWireObject
                 # update the Base object shape
                 railingRightObject.Base.Shape = railWireR
@@ -1706,5 +1710,3 @@ class _ViewProviderStairs(ArchComponent.ViewProviderComponent):
                 lst.extend(obj.Subtractions)
             return lst
         return []
-
-


### PR DESCRIPTION
Related to #22436 and #22445.

It makes sense to also hide the base of the  stair railings.