### PR TITLE
TechDraw: ComplexSection fixes

### DIFF
--- a/src/Mod/TechDraw/App/DrawComplexSection.h
+++ b/src/Mod/TechDraw/App/DrawComplexSection.h
@@ -31,6 +31,7 @@
 #include <gp_Vec.hxx>
 
 #include "DrawViewSection.h"
+#include "GeometryObject.h"
 
 namespace TechDraw
 {
@@ -64,60 +65,84 @@ public:
 //NOLINTEND
 
     TopoDS_Shape makeCuttingTool(double dMax) override;
-    gp_Ax2 getCSFromBase(const std::string& sectionName) const override;
-    bool isBaseValid() const override;
-    TopoDS_Compound findSectionPlaneIntersections(const TopoDS_Shape& cutShape) override;
-    TopoDS_Shape prepareShape(const TopoDS_Shape& cutShape, double shapeSize) override;
-    TopoDS_Shape getShapeToPrepare() const override;
-    TopoDS_Shape getShapeToIntersect() override;
-    gp_Pln getSectionPlane() const override;
-    TopoDS_Compound alignSectionFaces(const TopoDS_Shape& faceIntersections) override;
-    std::pair<Base::Vector3d, Base::Vector3d> sectionLineEnds() override;
-
     void makeSectionCut(const TopoDS_Shape& baseShape) override;
+    TopoDS_Wire closeProfileForCut(const TopoDS_Wire& profileWire,
+                                   double dMax) const;
+    TopoDS_Shape makeCuttingToolFromClosedProfile(const TopoDS_Wire& profileWire, double dMax);
+    TopoDS_Shape cuttingToolFromProfile(const TopoDS_Wire& inProfileWire,
+                                        double dMax) const;
 
-    void waitingForAlign(bool s) { m_waitingForAlign = s; }
-    bool waitingForAlign() const { return m_waitingForAlign; }
 
-    TopoDS_Shape getShapeForDetail() const override;
+    void makeAlignedPieces(const TopoDS_Shape& rawShape);
+    TopoDS_Compound alignSectionFaces(const TopoDS_Shape& faceIntersections) override;
 
+
+    static gp_Vec makeProfileVector(const TopoDS_Wire& profileWire);
+    TopoDS_Wire makeProfileWire() const;
+    static TopoDS_Wire makeProfileWire(App::DocumentObject* toolObj);
+    static TopoDS_Wire makeNoseToTailWire(const TopoDS_Shape& inShape);
+
+
+    TopoDS_Compound findSectionPlaneIntersections(const TopoDS_Shape& cutShape) override;
+    TopoDS_Shape getShapeToIntersect() override;
     bool boxesIntersect(TopoDS_Face& face, TopoDS_Shape& shape);
     TopoDS_Shape shapeShapeIntersect(const TopoDS_Shape& shape0, const TopoDS_Shape& shape1);
     std::vector<TopoDS_Face> faceShapeIntersect(const TopoDS_Face& face, const TopoDS_Shape& shape);
-    TopoDS_Shape extrudeWireToFace(TopoDS_Wire& wire, gp_Dir extrudeDir, double extrudeDist);
-    void makeAlignedPieces(const TopoDS_Shape& rawShape);
     TopoDS_Compound singleToolIntersections(const TopoDS_Shape& cutShape);
     TopoDS_Compound alignedToolIntersections(const TopoDS_Shape& cutShape);
 
-    BaseGeomPtrVector makeSectionLineGeometry();
-    std::pair<Base::Vector3d, Base::Vector3d> sectionArrowDirs();
-    TopoDS_Wire makeSectionLineWire();
+    TopoDS_Shape prepareShape(const TopoDS_Shape& cutShape, double shapeSize) override;
+    TopoDS_Shape getShapeToPrepare() const override;
 
+    gp_Pln getSectionPlane() const override;
+    gp_Ax2 getCSFromBase(const std::string& sectionName) const override;
+
+    std::pair<Base::Vector3d, Base::Vector3d> sectionLineEnds() override;
+    BaseGeomPtrVector makeSectionLineGeometry();
+    std::pair<Base::Vector3d, Base::Vector3d> sectionLineArrowDirs();
+    std::pair<Base::Vector3d, Base::Vector3d> sectionLineArrowDirsMapped();
+    TopoDS_Wire makeSectionLineWire();
     ChangePointVector getChangePointsFromSectionLine() override;
 
+    bool isBaseValid() const override;
     bool validateProfilePosition(const TopoDS_Wire& profileWire, const gp_Ax2& sectionCS) const;
-    bool showSegment(gp_Dir segmentNormal) const;
-    gp_Vec projectVector(const gp_Vec& vec) const;
-
-    TopoDS_Wire makeProfileWire() const;
-    static TopoDS_Wire makeProfileWire(App::DocumentObject* toolObj);
-    static TopoDS_Wire makeNoseToTailWire(const TopoDS_Wire& inWire);
-    static gp_Vec makeProfileVector(const TopoDS_Wire& profileWire);
+    bool validateSketchNormal(App::DocumentObject* sketchObject) const;
+    bool validateProfileAlignment(const TopoDS_Wire& profileWire) const;
     static bool isProfileObject(App::DocumentObject* obj);
     static bool isMultiSegmentProfile(App::DocumentObject* obj);
     static bool isLinearProfile(App::DocumentObject* obj);
     static bool isTrulyEmpty(const TopoDS_Shape& inShape);
     static bool canBuild(gp_Ax2 sectionCS, App::DocumentObject* profileObject);
-    static gp_Vec projectVector(const gp_Vec& vec, gp_Ax2 sectionCS);
+
+    bool showSegment(gp_Dir segmentNormal) const;
+    bool showSegment(const Base::Vector3d& segmentNormal) const;
+    void waitingForAlign(bool s) { m_waitingForAlign = s; }
+    bool waitingForAlign() const { return m_waitingForAlign; }
+
+    TopoDS_Shape getShapeForDetail() const override;
+
     static std::pair<Base::Vector3d, Base::Vector3d> getSegmentEnds(const TopoDS_Edge& segment);
     static std::pair<Base::Vector3d, Base::Vector3d> getWireEnds(const TopoDS_Wire& wire);
+    static int getSegmentIndex(const TopoDS_Face& face, const std::vector<TopoDS_Edge>& edgesAll);
+
+    static std::pair<Base::Vector3d, Base::Vector3d> sketchNormalAndX(App::DocumentObject* sketchObj);
+    static std::pair<int, Base::Vector3d> findNormalForFace(const TopoDS_Face& face,
+                                           const std::vector<std::pair<int, Base::Vector3d>>& normalKV,
+                                           const std::vector<TopoDS_Edge>& segmentEdges);
 
 public Q_SLOTS:
     void onSectionCutFinished() override;
 
 private:
-    bool validateOffsetProfile(TopoDS_Wire profile, Base::Vector3d direction, double angleThresholdDeg) const;
-    Base::Vector3d getReferenceAxis();
+    bool validateOffsetProfile(const TopoDS_Wire& profile,
+                               Base::Vector3d direction,
+                               double angleThresholdDeg) const;
+    TopoDS_Wire closeProfile(const TopoDS_Wire& profileWire,
+                             double dMax) const;
+    TopoDS_Shape profileToSolid(const TopoDS_Wire& closedProfileWire, double dMax) const;
+
+
+    Base::Vector3d getReferenceAxis() const;
 
     // methods refactored out of makeAlignedPieces
     bool getReversers(const gp_Vec& gProfileVector, double& horizReverser, double& verticalReverser);
@@ -126,7 +151,6 @@ private:
                                       const TopoDS_Face& segmentFace,
                                       int iPiece,
                                       Base::Vector3d uOrientedSegmentNormal,
-                                      Base::Vector3d uRotateAxis,
                                       double& pieceVertical);
     TopoDS_Shape movePieceToPaperPlane(const TopoDS_Shape& piece, double sizeMax);
     TopoDS_Shape distributePiece(const TopoDS_Shape& piece,
@@ -139,21 +163,23 @@ private:
 
     std::vector<std::pair<int, Base::Vector3d> >
                     getSegmentViewDirections(const TopoDS_Wire& profileWire,
-                                           Base::Vector3d sectionNormal,
-                                           Base::Vector3d referenceAxis) const;
-
-    std::vector<Base::Vector3d> getPointsForClosingProfile(const TopoDS_Wire& profileWire,
-                                                           double dMax);
-
-    static std::vector<TopoDS_Edge> getUniqueEdges(const TopoDS_Wire& wireIn);
-    static TopoDS_Shape removeEmptyShapes(const TopoDS_Shape& roughTool);
+                                           Base::Vector3d sectionNormal) const;
     static gp_Dir getFaceNormal(TopoDS_Face& face);
     static bool faceContainsEndpoints(const TopoDS_Edge& edgeToMatch,
                                       const TopoDS_Face& faceToSearch);
     static bool normalLess(const std::pair<int, Base::Vector3d>& n1,
                            const std::pair<int, Base::Vector3d>& n2);
-    static TopoDS_Wire closeProfile(const TopoDS_Wire& profileWire, Base::Vector3d referenceAxis, double dMax);
-    static TopoDS_Shape profileToSolid(const TopoDS_Wire& closedProfileWire, Base::Vector3d referenceAxis, double dMax);
+    static bool pointOnFace(Base::Vector3d point, const TopoDS_Face& face);
+
+
+    TopoDS_Edge mapEdgeToBase(const TopoDS_Edge& inEdge);
+    TopoDS_Edge mapEdgeToBase(const Base::Vector3d& inVector);
+    static std::vector<TopoDS_Edge> getUniqueEdges(const TopoDS_Wire& wireIn);
+
+    static TopoDS_Shape removeEmptyShapes(const TopoDS_Shape& roughTool);
+
+    static bool isFacePlanar(const TopoDS_Face& face);
+
 
     TopoDS_Shape m_toolFaceShape;
     TopoDS_Shape m_alignResult;

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -482,8 +482,8 @@ bool DrawViewDetail::debugDetail() const
 void DrawViewDetail::handleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop)
 {
     if (prop == &AnchorPoint) {
-        // AnchorPoint was PropertyVector but is now PropertyPosition
-        App::PropertyVector tmp;
+        // AnchorPoint was PropertyVector, then briefly PropertyPosition, now back to PropertyVector
+        App::PropertyPosition tmp;
         if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {
             tmp.setContainer(this);
             tmp.Restore(reader);
@@ -494,7 +494,7 @@ void DrawViewDetail::handleChangedPropertyType(Base::XMLReader &reader, const ch
     }
 
     if (prop == &Radius) {
-        // Radius was PropertyFloat but is now PropertyLength
+        // Radius was PropertyFloat, then briefly PropertyLength, now back to PropertyFloat
         App::PropertyLength tmp;
         if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {
             tmp.setContainer(this);

--- a/src/Mod/TechDraw/App/DrawViewDetail.h
+++ b/src/Mod/TechDraw/App/DrawViewDetail.h
@@ -57,8 +57,8 @@ public:
     ~DrawViewDetail() override;
 
     App::PropertyLink   BaseView;
-    App::PropertyPosition AnchorPoint;
-    App::PropertyLength   Radius;
+    App::PropertyVector AnchorPoint;
+    App::PropertyFloat   Radius;
     App::PropertyString Reference;
 
     App::PropertyBool   ShowMatting;

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -1516,8 +1516,8 @@ void DrawViewPart::resetReferenceVerts()
 void DrawViewPart::handleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop)
 {
     if (prop == &Direction) {
-        // Direction was PropertyVector but is now PropertyDirection
-        App::PropertyVector tmp;
+        // Direction was PropertyVector, then briefly PropertyDirection, now back to PropertyVector
+        App::PropertyDirection tmp;
         if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {
             tmp.setContainer(this);
             tmp.Restore(reader);
@@ -1528,8 +1528,8 @@ void DrawViewPart::handleChangedPropertyType(Base::XMLReader &reader, const char
     }
 
     if (prop == &XDirection) {
-        // XDirection was PropertyFloat but is now PropertyLength
-        App::PropertyVector tmp;
+        // XDirection was PropertyVector, then briefly PropertyDirection, now back to PropertyVector
+        App::PropertyDirection tmp;
         if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {
             tmp.setContainer(this);
             tmp.Restore(reader);

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -115,8 +115,8 @@ public:
 
     App::PropertyLinkList Source;
     App::PropertyXLinkList XSource;
-    App::PropertyDirection Direction;  // the projection direction
-    App::PropertyDirection XDirection;
+    App::PropertyVector Direction;  // the projection direction.  where you are looking from.
+    App::PropertyVector XDirection;
     App::PropertyBool Perspective;
     App::PropertyDistance Focus;
 

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -164,7 +164,7 @@ DrawViewSection::DrawViewSection()
                       "2D View source for this Section");
     BaseView.setScope(App::LinkScope::Global);
 
-    // default of (0, -1, 0) matches 'Front' direction in DVP
+    // default of (0, -1, 0) matches default 'Front' direction in DVP
     ADD_PROPERTY_TYPE(SectionNormal,
                       (0, -1, 0),
                       sgroup,
@@ -182,6 +182,8 @@ DrawViewSection::DrawViewSection()
                       sgroup,
                       App::Prop_None,
                       "Orientation of this Section in the Base View");
+    SectionDirection.setStatus(App::Property::Hidden, true);
+    SectionDirection.setStatus(App::Property::ReadOnly, true);
 
     // properties related to the cut operation
     ADD_PROPERTY_TYPE(FuseBeforeCut,
@@ -259,8 +261,6 @@ DrawViewSection::DrawViewSection()
     Direction.setStatus(App::Property::ReadOnly, true);
     Direction.setValue(SectionNormal.getValue());
 
-    SectionDirection.setStatus(App::Property::Hidden, true);
-    SectionDirection.setStatus(App::Property::ReadOnly, true);
 }
 
 DrawViewSection::~DrawViewSection()
@@ -299,8 +299,7 @@ void DrawViewSection::onChanged(const App::Property* prop)
         return;
     }
 
-    if (prop == &SectionNormal ||
-        prop == &XDirection) {
+    if (prop == &SectionNormal) {
         Direction.setValue(SectionNormal.getValue());
         return;
     }
@@ -568,7 +567,7 @@ void DrawViewSection::makeSectionCut(const TopoDS_Shape& baseShape)
 
 //! position, scale and rotate shape for buildGeometryObject
 //! save the cut shape for further processing
-TopoDS_Shape DrawViewSection::prepareShape(const TopoDS_Shape& rawShape, double shapeSize)
+TopoDS_Shape DrawViewSection::prepareShape(const TopoDS_Shape& uncenteredCutShape, double shapeSize)
 {
     (void)shapeSize;// shapeSize is not used in this base class, but is
                     // interesting for derived classes
@@ -578,11 +577,11 @@ TopoDS_Shape DrawViewSection::prepareShape(const TopoDS_Shape& rawShape, double 
         Base::Vector3d origin(0.0, 0.0, 0.0);
         m_projectionCS = getProjectionCS(origin);
         gp_Pnt inputCenter;
-        inputCenter = ShapeUtils::findCentroid(rawShape, m_projectionCS);
+        inputCenter = ShapeUtils::findCentroid(uncenteredCutShape, m_projectionCS);
         Base::Vector3d centroid(inputCenter.X(), inputCenter.Y(), inputCenter.Z());
 
-        m_cutShapeRaw = rawShape;
-        preparedShape = ShapeUtils::moveShape(rawShape, centroid * -1.0);
+        m_cutShapeRaw = uncenteredCutShape;
+        preparedShape = ShapeUtils::moveShape(uncenteredCutShape, centroid * -1.0);
         m_cutShape = preparedShape;
         m_saveCentroid = centroid;
 
@@ -1067,7 +1066,7 @@ void DrawViewSection::setCSFromBase(const Base::Vector3d& localUnit)
     Base::Vector3d vXDir(newSectionCS.XDirection().X(),
                          newSectionCS.XDirection().Y(),
                          newSectionCS.XDirection().Z());
-    XDirection.setValue(vXDir);// XDir is for projection
+    XDirection.setValue(vXDir);
 }
 
 // reset the section CS based on an XY vector in current section CS
@@ -1230,9 +1229,11 @@ void DrawViewSection::setupObject()
 
 void DrawViewSection::handleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop)
 {
+    DrawViewPart::handleChangedPropertyType(reader, TypeName, prop);
+
     if (prop == &SectionOrigin) {
-        // SectionOrigin was PropertyVector but is now PropertyPosition
-        App::PropertyVector tmp;
+        // SectionOrigin was PropertyVector then briefly PropertyPosition, now back to PropertyVector
+        App::PropertyPosition tmp;
         if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {
             tmp.setContainer(this);
             tmp.Restore(reader);
@@ -1243,13 +1244,14 @@ void DrawViewSection::handleChangedPropertyType(Base::XMLReader &reader, const c
     }
 
     if (prop == &SectionNormal) {
-        // Radius was PropertyVector but is now PropertyDirection
-        App::PropertyVector tmp;
+        // Radius was PropertyVector, then briefly PropertyDirection, then PropertyVector
+        App::PropertyDirection tmp;
         if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {
             tmp.setContainer(this);
             tmp.Restore(reader);
             auto tmpValue = tmp.getValue();
             SectionNormal.setValue(tmpValue);
+            Direction.setValue(tmpValue);
         }
         return;
     }

--- a/src/Mod/TechDraw/App/DrawViewSection.h
+++ b/src/Mod/TechDraw/App/DrawViewSection.h
@@ -87,8 +87,8 @@ public:
 
 //NOLINTBEGIN
     App::PropertyLink BaseView;
-    App::PropertyDirection SectionNormal;
-    App::PropertyPosition SectionOrigin;
+    App::PropertyVector SectionNormal;
+    App::PropertyVector SectionOrigin;
     App::PropertyString SectionSymbol;
 
 
@@ -196,7 +196,7 @@ protected:
     bool trimAfterCut() const;
 
     TopoDS_Shape m_cutShape;        // centered, scaled, rotated result of cut
-    TopoDS_Shape m_cutShapeRaw;     // raw result of cut w/o center/scale/rotate
+    TopoDS_Shape m_cutShapeRaw;     // copy of input to prepare shape
 
     void onDocumentRestored() override;
     void setupObject() override;

--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -395,7 +395,7 @@ void GeometryObject::projectShapeWithPolygonAlgo(const TopoDS_Shape& input, cons
 //of the main hlr routine. Only the visible hard edges are returned, so this method
 //is only suitable for simple shapes that have no hidden edges, like faces or wires.
 //TODO: allow use of perspective projector
-TopoDS_Shape GeometryObject::projectSimpleShape(const TopoDS_Shape& shape, const gp_Ax2& CS)
+TopoDS_Shape GeometryObject::projectSimpleShape(const TopoDS_Shape& shape, const gp_Ax2& CS, bool invertYRequired)
 {
     //    Base::Console().message("GO::()\n");
     if (shape.IsNull()) {
@@ -412,7 +412,9 @@ TopoDS_Shape GeometryObject::projectSimpleShape(const TopoDS_Shape& shape, const
     HLRBRep_HLRToShape hlrToShape(brep_hlr);
     TopoDS_Shape hardEdges = hlrToShape.VCompound();
     BRepLib::BuildCurves3d(hardEdges);
-    hardEdges =ShapeUtils::invertGeometry(hardEdges);
+    if (invertYRequired) {
+        hardEdges =ShapeUtils::invertGeometry(hardEdges);
+    }
 
     return hardEdges;
 }

--- a/src/Mod/TechDraw/App/GeometryObject.h
+++ b/src/Mod/TechDraw/App/GeometryObject.h
@@ -82,7 +82,7 @@ public:
 
     void projectShape(const TopoDS_Shape& input, const gp_Ax2& viewAxis);
     void projectShapeWithPolygonAlgo(const TopoDS_Shape& input, const gp_Ax2& viewAxis);
-    static TopoDS_Shape projectSimpleShape(const TopoDS_Shape& shape, const gp_Ax2& CS);
+    static TopoDS_Shape projectSimpleShape(const TopoDS_Shape& shape, const gp_Ax2& CS, bool invertYRequired = true);
     static TopoDS_Shape simpleProjection(const TopoDS_Shape& shape, const gp_Ax2& projCS);
     static TopoDS_Shape projectFace(const TopoDS_Shape& face, const gp_Ax2& CS);
     void makeTDGeometry();

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -827,17 +827,10 @@ void QGIViewPart::drawComplexSectionLine(TechDraw::DrawViewSection* viewSection,
     else {
         sectionLine->clearChangePoints();
     }
-    if (dcs->ProjectionStrategy.isValue("Offset")) {
-        Base::Vector3d arrowDirOffset = viewSection->SectionNormal.getValue();
-        arrowDirOffset =
-            -viewPart->projectPoint(arrowDirOffset);//arrows are opposite section normal
-        sectionLine->setDirection(arrowDirOffset.x, -arrowDirOffset.y);//invert y for Qt
-    }
-    else {
-        std::pair<Base::Vector3d, Base::Vector3d> dirsAligned = dcs->sectionArrowDirs();
-        sectionLine->setArrowDirections(dirsAligned.first, dirsAligned.second);
-    }
 
+    std::pair<Base::Vector3d, Base::Vector3d> dirsDCS = dcs->sectionLineArrowDirsMapped();
+    sectionLine->setArrowDirections(dirsDCS.first, dirsDCS.second);
+    
     //set the general parameters
     sectionLine->setPos(0.0, 0.0);
 


### PR DESCRIPTION
This PR implements a number of fixes to ComplexSection.  Specifically, it 

- improves handling of profile not orthogonal (+/-) to section normal
- fixes handling of profile not on same plane as section normals
- fixes the direction of section line arrows.
