### PR TITLE
CAM: Dressup Tag - Automatic for multiprofile

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Tags.py
@@ -1,25 +1,23 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2017 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
 
-# ***************************************************************************
-# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   This program is distributed in the hope that it will be useful,       *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Library General Public License for more details.                  *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with this program; if not, write to the Free Software   *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 from PySide import QtCore, QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
@@ -274,7 +272,7 @@ class PathDressupTagTaskPanel:
 
     def setFields(self):
         self.updateTagsView()
-        self.form.sbCount.setValue(len(self.Positions))
+        self.form.sbCount.setValue(int(len(self.Positions) / self.obj.Proxy.amountClosedWires))
         self.form.ifHeight.setText(
             FreeCAD.Units.Quantity(self.obj.Height, FreeCAD.Units.Length).UserString
         )

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -1,25 +1,23 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2017 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
 
-# ***************************************************************************
-# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   This program is distributed in the hope that it will be useful,       *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Library General Public License for more details.                  *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with this program; if not, write to the Free Software   *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 from Path.Dressup.Gui.TagPreferences import HoldingTagPreferences
 from PathScripts.PathUtils import waiting_effects
@@ -683,6 +681,7 @@ class PathData:
         else:
             self.edges = []
         self.baseWire = self.findBottomWire(self.edges)
+        self.obj.Proxy.amountClosedWires = len(self.baseWire)
 
     def findBottomWire(self, edges):
         minZ, maxZ = self.findZLimits(edges)
@@ -694,13 +693,13 @@ class PathData:
             if Path.Geom.isRoughly(e.Vertexes[0].Point.z, minZ)
             and Path.Geom.isRoughly(e.Vertexes[1].Point.z, minZ)
         ]
-        self.bottomEdges = bottom
-        try:
-            wire = Part.Wire(bottom)
+        self.bottomEdges = Part.sortEdges(bottom)
+        wires = []
+        for edgesSorted in self.bottomEdges:
+            wire = Part.Wire(edgesSorted)
             if wire.isClosed():
-                return wire
-        except Exception:
-            return None
+                wires.append(wire)
+        return wires
 
     def supportsTagGeneration(self):
         return self.baseWire is not None
@@ -719,94 +718,89 @@ class PathData:
                     maxZ = v.Point.z
         return (minZ, maxZ)
 
-    def shortestAndLongestPathEdge(self):
-        edges = sorted(self.bottomEdges, key=lambda e: e.Length)
+    def shortestAndLongestPathEdge(self, wire):
+        edges = sorted(wire.Edges, key=lambda e: e.Length)
         return (edges[0], edges[-1])
 
-    def generateTags(
-        self, obj, count, width=None, height=None, angle=None, radius=None, spacing=None
-    ):
-        Path.Log.track(count, width, height, angle, spacing)
-
-        # copy edge list into python array for (much) faster random access
-        Edges = list(self.baseWire.Edges)
-
-        # for e in Edges:
-        #    debugMarker(e.Vertexes[0].Point, 'base', (0.0, 1.0, 1.0), 0.2)
-
-        if spacing:
-            tagDistance = spacing
-        else:
-            tagDistance = self.baseWire.Length / (count if count else 4)
-
-        W = width if width else self.defaultTagWidth()
-        H = height if height else self.defaultTagHeight()
-        A = angle if angle else self.defaultTagAngle()
-        R = radius if radius else self.defaultTagRadius()
-
-        # start assigning tags on the longest segment
-        shortestEdge, longestEdge = self.shortestAndLongestPathEdge()
-        startIndex = 0
-        for i in range(0, len(Edges)):
-            edge = Edges[i]
-            Path.Log.debug("  %d: %.2f" % (i, edge.Length))
-            if Path.Geom.isRoughly(edge.Length, longestEdge.Length):
-                startIndex = i
-                break
-
-        startEdge = Edges[startIndex]
-        startCount = int(startEdge.Length / tagDistance)
-        if (longestEdge.Length - shortestEdge.Length) > shortestEdge.Length:
-            startCount = int(startEdge.Length / tagDistance) + 1
-
-        lastTagLength = (startEdge.Length + (startCount - 1) * tagDistance) / 2
-        currentLength = startEdge.Length
-
-        minLength = min(2.0 * W, longestEdge.Length)
-
-        Path.Log.debug(
-            "length=%.2f shortestEdge=%.2f(%.2f) longestEdge=%.2f(%.2f) minLength=%.2f"
-            % (
-                self.baseWire.Length,
-                shortestEdge.Length,
-                shortestEdge.Length / self.baseWire.Length,
-                longestEdge.Length,
-                longestEdge.Length / self.baseWire.Length,
-                minLength,
-            )
-        )
-        Path.Log.debug(
-            "   start: index=%-2d count=%d (length=%.2f, distance=%.2f)"
-            % (startIndex, startCount, startEdge.Length, tagDistance)
-        )
-        Path.Log.debug("               -> lastTagLength=%.2f)" % lastTagLength)
-        Path.Log.debug("               -> currentLength=%.2f)" % currentLength)
-
-        edgeDict = {startIndex: startCount}
-
-        for i in range(startIndex + 1, len(Edges)):
-            edge = Edges[i]
-            currentLength, lastTagLength = self.processEdge(
-                i, edge, currentLength, lastTagLength, tagDistance, minLength, edgeDict
-            )
-        for i in range(0, startIndex):
-            edge = Edges[i]
-            currentLength, lastTagLength = self.processEdge(
-                i, edge, currentLength, lastTagLength, tagDistance, minLength, edgeDict
-            )
-
+    def generateTags(self, obj, count, width=None, height=None, angle=None, radius=None):
         tags = []
+        for wire in self.baseWire:
+            Path.Log.track(count, width, height, angle)
 
-        for i, count in edgeDict.items():
-            edge = Edges[i]
-            Path.Log.debug(" %d: %d" % (i, count))
-            # debugMarker(edge.Vertexes[0].Point, 'base', (1.0, 0.0, 0.0), 0.2)
-            # debugMarker(edge.Vertexes[1].Point, 'base', (0.0, 1.0, 0.0), 0.2)
-            if 0 != count:
-                distance = (edge.LastParameter - edge.FirstParameter) / count
-                for j in range(0, count):
-                    tag = edge.Curve.value((j + 0.5) * distance)
-                    tags.append(Tag(j, tag.x, tag.y, W, H, A, R, True))
+            # copy edge list into python array for (much) faster random access
+            Edges = list(wire.Edges)
+
+            # for e in Edges:
+            #    debugMarker(e.Vertexes[0].Point, 'base', (0.0, 1.0, 1.0), 0.2)
+
+            tagDistance = wire.Length / (count if count else 4)
+
+            W = width if width else self.defaultTagWidth()
+            H = height if height else self.defaultTagHeight()
+            A = angle if angle else self.defaultTagAngle()
+            R = radius if radius else self.defaultTagRadius()
+
+            # start assigning tags on the longest segment
+            shortestEdge, longestEdge = self.shortestAndLongestPathEdge(wire)
+            startIndex = 0
+            for i in range(len(Edges)):
+                edge = Edges[i]
+                Path.Log.debug("  %d: %.2f" % (i, edge.Length))
+                if Path.Geom.isRoughly(edge.Length, longestEdge.Length):
+                    startIndex = i
+                    break
+
+            startEdge = Edges[startIndex]
+            startCount = int(startEdge.Length / tagDistance)
+            if (longestEdge.Length - shortestEdge.Length) > shortestEdge.Length:
+                startCount = int(startEdge.Length / tagDistance) + 1
+
+            lastTagLength = (startEdge.Length + (startCount - 1) * tagDistance) / 2
+            currentLength = startEdge.Length
+
+            minLength = min(2.0 * W, longestEdge.Length)
+
+            Path.Log.debug(
+                "length=%.2f shortestEdge=%.2f(%.2f) longestEdge=%.2f(%.2f) minLength=%.2f"
+                % (
+                    wire.Length,
+                    shortestEdge.Length,
+                    shortestEdge.Length / wire.Length,
+                    longestEdge.Length,
+                    longestEdge.Length / wire.Length,
+                    minLength,
+                )
+            )
+            Path.Log.debug(
+                "   start: index=%-2d count=%d (length=%.2f, distance=%.2f)"
+                % (startIndex, startCount, startEdge.Length, tagDistance)
+            )
+            Path.Log.debug("               -> lastTagLength=%.2f)" % lastTagLength)
+            Path.Log.debug("               -> currentLength=%.2f)" % currentLength)
+
+            edgeDict = {startIndex: startCount}
+
+            for i in range(startIndex + 1, len(Edges)):
+                edge = Edges[i]
+                currentLength, lastTagLength = self.processEdge(
+                    i, edge, currentLength, lastTagLength, tagDistance, minLength, edgeDict
+                )
+            for i in range(0, startIndex):
+                edge = Edges[i]
+                currentLength, lastTagLength = self.processEdge(
+                    i, edge, currentLength, lastTagLength, tagDistance, minLength, edgeDict
+                )
+
+            for i, counter in edgeDict.items():
+                edge = Edges[i]
+                Path.Log.debug(" %d: %d" % (i, counter))
+                # debugMarker(edge.Vertexes[0].Point, 'base', (1.0, 0.0, 0.0), 0.2)
+                # debugMarker(edge.Vertexes[1].Point, 'base', (0.0, 1.0, 0.0), 0.2)
+                if counter:
+                    distance = (edge.LastParameter - edge.FirstParameter) / counter
+                    for j in range(0, counter):
+                        tag = edge.Curve.value((j + 0.5) * distance)
+                        tags.append(Tag(j, tag.x, tag.y, W, H, A, R, True))
 
         return tags
 
@@ -881,8 +875,11 @@ class PathData:
         return height
 
     def defaultTagWidth(self):
-        width = self.shortestAndLongestPathEdge()[1].Length / 10
-        return HoldingTagPreferences.defaultWidth(width)
+        maxWidth = 0
+        for wire in self.baseWire:
+            width = self.shortestAndLongestPathEdge(wire)[1].Length / 10
+            maxWidth = width if width > maxWidth else maxWidth
+        return HoldingTagPreferences.defaultWidth(maxWidth)
 
     def defaultTagAngle(self):
         return HoldingTagPreferences.defaultAngle()
@@ -892,7 +889,9 @@ class PathData:
 
     def sortedTags(self, tags):
         ordered = []
-        for edge in self.bottomEdges:
+        allEdges = [e for be in self.bottomEdges for e in be]
+
+        for edge in allEdges:
             ts = [
                 t
                 for t in tags
@@ -921,11 +920,12 @@ class PathData:
     def pointIsOnPath(self, p):
         v = Part.Vertex(self.pointAtBottom(p))
         Path.Log.debug("pt = (%f, %f, %f)" % (v.X, v.Y, v.Z))
-        for e in self.bottomEdges:
-            indent = "{} ".format(e.distToShape(v)[0])
-            debugEdge(e, indent, True)
-            if Path.Geom.isRoughly(0.0, v.distToShape(e)[0], 0.1):
-                return True
+        for sortedEdges in self.bottomEdges:
+            for e in sortedEdges:
+                indent = "{} ".format(e.distToShape(v)[0])
+                debugEdge(e, indent, True)
+                if Path.Geom.isRoughly(0.0, v.distToShape(e)[0], 0.1):
+                    return True
         return False
 
     def pointAtBottom(self, p):
@@ -994,6 +994,7 @@ class ObjectTagDressup:
         self.pathData = None
         self.toolRadius = None
         self.mappers = []
+        self.amountClosedWires = 1
 
         obj.Proxy = self
         obj.Base = base
@@ -1043,7 +1044,6 @@ class ObjectTagDressup:
                     obj.Height.Value,
                     obj.Angle,
                     obj.Radius.Value,
-                    None,
                 )
                 obj.Positions = [tag.originAt(self.pathData.minZ) for tag in self.tags]
                 obj.Disabled = []


### PR DESCRIPTION
At this moment `DressupTag` can place tags automatically only for one closed Path
If there is several closed path, button `Replace All` is disabled

This PR add possibility to automatically place tags for several closed Paths

<img width="742" height="579" alt="465768830-f5f21d8f-de55-4851-9f62-9c4052af3e1a_lossy" src="https://github.com/user-attachments/assets/ec1e1c2f-135c-4c2b-8a3e-5b4f7f3d8081" />

![output](https://github.com/user-attachments/assets/a074399c-88ba-437e-9f42-fb2432de61df)