### PR TITLE
[TechDraw] fix regression from PR19502

### DIFF
--- a/src/Mod/TechDraw/App/DimensionFormatter.cpp
+++ b/src/Mod/TechDraw/App/DimensionFormatter.cpp
@@ -250,7 +250,7 @@ std::string DimensionFormatter::getFormattedDimensionValue(const Format partial)
         tolerance.remove(plus);
 
         return (labelText +
-                 QStringLiteral(" \xC2\xB1 ") +          // +/- symbol
+                 QString::fromUtf8(" \xC2\xB1 ") +          // +/- symbol
                  tolerance).toStdString();
 
         // Unreachable code??


### PR DESCRIPTION
As reported on the forum https://forum.freecad.org/viewtopic.php?t=98341 there was a regression in PR #19502 with regard to the plus/minus symbol having `Â` before it. This PR fixes that so it shows correctly as:

<img width="116" height="47" alt="Screenshot from 2025-07-14 00-25-17" src="https://github.com/user-attachments/assets/35aa0449-af9f-4ef6-9ff4-239cd62db558" />
