### PR TITLE
CAM: select rows instead of cells in drilling panel

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageBaseHoleGeometryEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageBaseHoleGeometryEdit.ui
@@ -25,6 +25,9 @@ You can add feature for processing by selecting them and then pressing Add. If a
 
 Reset deletes all current items from the list and fills the list with all circular holes eligible for the operation from the model. You can again refine the list afterwards by enabling/disabling, removing and adding features.</string>
        </property>
+       <property name="selectionBehavior">
+        <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
+       </property>
        <attribute name="horizontalHeaderStretchLastSection">
         <bool>true</bool>
        </attribute>


### PR DESCRIPTION
Select by row instead of individal cells in the drilling panel:

<img width="1560" height="630" alt="grafik" src="https://github.com/user-attachments/assets/d76735fd-e6eb-469f-b22d-1121fcc370a4" />


