### PR TITLE
Draft: fix handling of MouseDelay

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -143,6 +143,8 @@ class Arc(gui_base_original.Creator):
         if arg["Type"] == "SoKeyboardEvent":
             if arg["Key"] == "ESCAPE":
                 self.finish()
+        elif not self.ui.mouse:
+            pass
         elif arg["Type"] == "SoLocation2Event":  # mouse movement detection
             self.point, ctrlPoint, info = gui_tool_utils.getPoint(self, arg)
             # this is to make sure radius is what you see on screen

--- a/src/Mod/Draft/draftguitools/gui_beziers.py
+++ b/src/Mod/Draft/draftguitools/gui_beziers.py
@@ -93,6 +93,8 @@ class BezCurve(gui_lines.Line):
             if arg["Key"] == "ESCAPE":
                 self.finish()
             return
+        if not self.ui.mouse:
+            return
         if arg["Type"] == "SoLocation2Event":  # mouse movement detection
             self.point, ctrlPoint, info = gui_tool_utils.getPoint(self, arg, noTracker=True)
             # existing points + this pointer position
@@ -282,6 +284,8 @@ class CubicBezCurve(gui_lines.Line):
         if arg["Type"] == "SoKeyboardEvent":
             if arg["Key"] == "ESCAPE":
                 self.finish()
+            return
+        if not self.ui.mouse:
             return
         if arg["Type"] == "SoLocation2Event":  # mouse movement detection
             self.point, ctrlPoint, info = gui_tool_utils.getPoint(self, arg, noTracker=True)

--- a/src/Mod/Draft/draftguitools/gui_ellipses.py
+++ b/src/Mod/Draft/draftguitools/gui_ellipses.py
@@ -163,6 +163,8 @@ class Ellipse(gui_base_original.Creator):
         if arg["Type"] == "SoKeyboardEvent":
             if arg["Key"] == "ESCAPE":
                 self.finish()
+        elif not self.ui.mouse:
+            pass
         elif arg["Type"] == "SoLocation2Event":  # mouse movement detection
             self.point, ctrlPoint, info = gui_tool_utils.getPoint(self, arg, noTracker=True)
             self.rect.update(self.point)

--- a/src/Mod/Draft/draftguitools/gui_mirror.py
+++ b/src/Mod/Draft/draftguitools/gui_mirror.py
@@ -133,6 +133,8 @@ class Mirror(gui_base_original.Modifier):
         if arg["Type"] == "SoKeyboardEvent":
             if arg["Key"] == "ESCAPE":
                 self.finish()
+        elif not self.ui.mouse:
+            pass
         elif arg["Type"] == "SoLocation2Event":  # mouse movement detection
             self.point, ctrlPoint, info = gui_tool_utils.getPoint(self, arg)
             if len(self.node) > 0:

--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -161,6 +161,8 @@ class Offset(gui_base_original.Modifier):
         if arg["Type"] == "SoKeyboardEvent":
             if arg["Key"] == "ESCAPE":
                 self.finish()
+        elif not self.ui.mouse:
+            pass
         elif arg["Type"] == "SoLocation2Event":
             self.point, ctrlPoint, info = gui_tool_utils.getPoint(self, arg)
             if (gui_tool_utils.hasMod(arg, gui_tool_utils.get_mod_constrain_key())

--- a/src/Mod/Draft/draftguitools/gui_points.py
+++ b/src/Mod/Draft/draftguitools/gui_points.py
@@ -79,6 +79,8 @@ class Point(gui_base_original.Creator):
         It should automatically update the coordinates in the widgets
         of the task panel.
         """
+        if not self.ui.mouse:
+            return
         event = event_cb.getEvent()
         mousepos = event.getPosition().getValue()
         ctrl = event.wasCtrlDown()
@@ -101,6 +103,8 @@ class Point(gui_base_original.Creator):
         It should act as if the Enter key was pressed, or the OK button
         was pressed in the task panel.
         """
+        if not self.ui.mouse:
+            return
         if event_cb:
             event = event_cb.getEvent()
             if (event.getState() != coin.SoMouseButtonEvent.DOWN or

--- a/src/Mod/Draft/draftguitools/gui_polygons.py
+++ b/src/Mod/Draft/draftguitools/gui_polygons.py
@@ -113,6 +113,8 @@ class Polygon(gui_base_original.Creator):
         if arg["Type"] == "SoKeyboardEvent":
             if arg["Key"] == "ESCAPE":
                 self.finish()
+        elif not self.ui.mouse:
+            pass
         elif arg["Type"] == "SoLocation2Event":  # mouse movement detection
             self.point, ctrlPoint, info = gui_tool_utils.getPoint(self, arg)
             self.polygonTrack.update(ctrlPoint)

--- a/src/Mod/Draft/draftguitools/gui_rectangles.py
+++ b/src/Mod/Draft/draftguitools/gui_rectangles.py
@@ -158,6 +158,8 @@ class Rectangle(gui_base_original.Creator):
         if arg["Type"] == "SoKeyboardEvent":
             if arg["Key"] == "ESCAPE":
                 self.finish()
+        elif not self.ui.mouse:
+            pass
         elif arg["Type"] == "SoLocation2Event":  # mouse movement detection
             self.point, ctrlPoint, info = gui_tool_utils.getPoint(self, arg, noTracker=True)
             self.rect.update(self.point)

--- a/src/Mod/Draft/draftguitools/gui_rotate.py
+++ b/src/Mod/Draft/draftguitools/gui_rotate.py
@@ -102,6 +102,8 @@ class Rotate(gui_base_original.Modifier):
         """
         if arg["Type"] == "SoKeyboardEvent" and arg["Key"] == "ESCAPE":
             self.finish()
+        elif not self.ui.mouse:
+            pass
         elif arg["Type"] == "SoLocation2Event":
             self.handle_mouse_move_event(arg)
         elif (arg["Type"] == "SoMouseButtonEvent"

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -1387,6 +1387,8 @@ class Snapper:
         self.callbackMove = None
 
         def move(event_cb):
+            if not self.ui.mouse:
+                return
             event = event_cb.getEvent()
             mousepos = event.getPosition()
             ctrl = event.wasCtrlDown()
@@ -1413,6 +1415,8 @@ class Snapper:
             accept()
 
         def click(event_cb):
+            if not self.ui.mouse:
+                return
             event = event_cb.getEvent()
             if event.getButton() == 1:
                 if event.getState() == coin.SoMouseButtonEvent.DOWN:

--- a/src/Mod/Draft/draftguitools/gui_splines.py
+++ b/src/Mod/Draft/draftguitools/gui_splines.py
@@ -85,6 +85,8 @@ class BSpline(gui_lines.Line):
             if arg["Key"] == "ESCAPE":
                 self.finish()
             return
+        if not self.ui.mouse:
+            return
         if arg["Type"] == "SoLocation2Event":  # mouse movement detection
             self.point, ctrlPoint, info = gui_tool_utils.getPoint(self, arg, noTracker=True)
             self.bsplinetrack.update(self.node + [self.point])

--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -201,6 +201,8 @@ class Trimex(gui_base_original.Modifier):
         if arg["Type"] == "SoKeyboardEvent":
             if arg["Key"] == "ESCAPE":
                 self.finish()
+        elif not self.ui.mouse:
+            pass
         elif arg["Type"] == "SoLocation2Event":  # mouse movement detection
             self.shift = gui_tool_utils.hasMod(arg, gui_tool_utils.get_mod_constrain_key())
             self.alt = gui_tool_utils.hasMod(arg, gui_tool_utils.get_mod_alt_key())


### PR DESCRIPTION
The MouseDelay sets a point value to None. In some cases this point was then still used resulting in attribute errors.

See:
https://github.com/FreeCAD/FreeCAD/issues/19531#issuecomment-2651341711
