### PR TITLE
BIM: add interactive sun position and ray visualization to Arch Site

### DIFF
--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -1290,7 +1290,6 @@ class _ViewProviderSite:
         import Part
         import datetime
         from pivy import coin
-        import Draft
 
         obj = vobj.Object
 


### PR DESCRIPTION
## Motivation

The existing solar diagram in the `ArchSite` object provides good context for the sun's annual path, but lacks the ability to analyze the sun's position at a specific moment. This makes it difficult to perform precise shadow studies or design sun-responsive elements like shading devices.

This PR introduces a new interactive feature to address this gap, allowing for direct, albeit basic, solar analysis.

It takes inspiration in @Francisco-Rosa's new [Solar workbench](https://github.com/Francisco-Rosa/Solar). However, this feature is intended mostly as a built-in MVP for FreeCAD's BIM workbench. Further, more complex analysis and features will be better served by more specialized workbenches (e.g. the Solar or Optics workbenches).

<img width="1373" height="849" alt="image" src="https://github.com/user-attachments/assets/a27e6f6e-162a-4234-8a76-654e4ef5e3c6" />

_Standalone sun position and sunray_

<img width="1373" height="849" alt="image" src="https://github.com/user-attachments/assets/d9d28ffb-4541-4d4b-b3a7-90efbcfb2153" />

_Sun position and sun path diagram enabled and superposed_

[Sun path.webm](https://github.com/user-attachments/assets/622f6d3b-96e2-42b1-8ffb-4451cf71fc4e)

_Interactive sun position with sun path diagram enabled and superposed_



## Implementation details

This extends the `ArchSite`'s `ViewProvider` with the following components:

1.  **New view properties:** A new "Sun" group has been added to the `ArchSite`'s View properties, containing:
    *   `ShowSunPosition`: A master toggle for the feature.
    *   `SunDateMonth`, `SunDateDay`, `SunTimeHour`: Constrained integer and float properties that allow the user to select a specific date and time, with the UI preventing out-of-range values.
    *   `ShowHourLabels`: An optional boolean to display text labels for key hours.

2.  **Dual visual representation:**
    *   **Pivy/Coin3D Graphics:** For visual feedback, the sun's position (sphere), its daily path (a color-coded curve), and hourly markers are rendered directly in the scene graph using Pivy. The color scheme for the daily path is theme-aware, ensuring enough contrast on both light and dark backgrounds.
    *   **`Draft.Line` Object:** A selectable and actionable "Sun Ray" is created as a standard `Draft.Line` object with an arrowhead, indicating direction.

3.  **Actionable sun ray data object:**
    *   The `SunRay` object is parented to its `ArchSite` for a clean model hierarchy.
    *   It contains read-only properties for the calculated **`Altitude`**, **`Azimuth`**, and **`Time`**, making this data accessible for scripts or expressions.

4.  **Backend Logic:** The core astronomical calculations leverage the existing `ladybug` or `pysolar` libraries.

## User-facing changes

*   Users can now select an `ArchSite` object, navigate to the "View" tab in the Property Editor, and enable `ShowSunPosition`.
*   By adjusting the date and time properties, the 3D view will update in real-time, showing:
    *   A yellow sphere at the sun's location on the diagram.
    *   A color-coded arc representing the sun's path for that day (blue for morning, yellow for midday, orange for afternoon).
    *   Small markers at each full hour along the path.
    *   An optional text label for key hours (9h, 12h, 15h).
*   A new, selectable `Draft.Line` object named "Sun Ray" is created. This object can be snapped to with Draft tools, allowing for manual projection of shadow lines for detailed analysis.

## Additional notes

- This feature, in the same way as the existing sun path diagram, requires installation of the ladybug module to work.
- Pysolar support has been added as a fallback, in the same way as the previously existent code. However, this branch has only been tested with ladybug.
- This PR works best with the changes in https://github.com/FreeCAD/FreeCAD/pull/22496 for proper default scaling of the diagram.
- This feature is independent from the existing sun path diagram. However, its size does depend in that of the sun path diagram, so that both can be enabled either independently or at the same time.
- When shown at the same time, the sun sphere and arc path will match the corresponding position of the sun path diagram
- The sun path diagram has been made more visually appealing by using curves. That provides a better positioning match between the sun sphere/arc and the diagram. This has been applied on a separate commit for easier review: https://github.com/FreeCAD/FreeCAD/pull/22516/commits/5cba049c0031bf1a554d9147f7e04a814f5a176e