### PR TITLE
Core: do not make unique labels for Origin objects

### DIFF
--- a/src/App/Origin.h
+++ b/src/App/Origin.h
@@ -52,6 +52,11 @@ public:
     {
         return true;
     }
+
+    bool allowDuplicateLabel() const override
+    {
+        return true;
+    }
 };
 
 }  // namespace App


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/22517

Before : 
<img width="555" height="289" alt="image" src="https://github.com/user-attachments/assets/193cfeea-f4c8-43aa-9a8b-268e2d3d7fd2" />

After : 
<img width="631" height="285" alt="image" src="https://github.com/user-attachments/assets/f932516b-f52c-44bf-a46f-11e1806671ed" />
