### PR TITLE
CAM: remove redundant move after drilling

### DIFF
--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -310,9 +310,6 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
 
         # Cancel canned drilling cycle
         self.commandlist.append(Path.Command("G80"))
-        command = Path.Command("G0", {"Z": obj.SafeHeight.Value})
-        self.commandlist.append(command)
-        machine.addCommand(command)
 
         # Apply feedrates to commands
         PathFeedRate.setFeedRate(self.commandlist, obj.ToolController)


### PR DESCRIPTION
Copied initial change from #22299. Also see [my comment](https://github.com/FreeCAD/FreeCAD/pull/22299#issuecomment-3035171299).

TLDR: this results in an extra move down if `KeepToolDown = False` and is redundant in all cases since there is still a move to clearance height after this move from Base.py (L790-L792).