### PR TITLE
Gui: Fix missing PCH include

### DIFF
--- a/src/Gui/Inventor/SoToggleSwitch.cpp
+++ b/src/Gui/Inventor/SoToggleSwitch.cpp
@@ -21,6 +21,8 @@
  *                                                                          *
  ***************************************************************************/
 
+#include "PreCompiled.h"
+
 #include "SoToggleSwitch.h"
 
 SO_NODE_SOURCE(SoToggleSwitch)


### PR DESCRIPTION
Missing PCH include in the new `src/Gui/Inventor/SoToggleSwitch.cpp` file. CC @captain0xff 