### PR TITLE
Update colors in FreeCAD Dark preference pack

### DIFF
--- a/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
@@ -52,8 +52,9 @@
           <FCParamGroup Name="Draft">
             <FCInt Name="gridTransparency" Value="0"/>
             <FCUInt Name="constructioncolor" Value="746455039"/>
-            <FCUInt Name="gridColor" Value="1230002175"/>
+            <FCUInt Name="gridColor" Value="1668118271"/>
             <FCUInt Name="snapcolor" Value="4289331455"/>
+            <FCUInt Name="DefaultTextColor" Value="1111638783"/>
           </FCParamGroup>
           <FCParamGroup Name="Measure">
             <FCParamGroup Name="Appearance">
@@ -168,7 +169,7 @@
         <FCParamGroup Name="TreeView">
           <FCInt Name="FontSize" Value="11"/>
           <FCInt Name="ItemBackgroundPadding" Value="11"/>
-          <FCUInt Name="TreeActiveColor" Value="556083711"/>
+          <FCUInt Name="TreeActiveColor" Value="899696639"/>
           <FCUInt Name="TreeEditColor" Value="1434171135"/>
         </FCParamGroup>
         <FCParamGroup Name="View">
@@ -188,7 +189,9 @@
           <FCUInt Name="CursorTextColor" Value="2914369023"/>
           <FCUInt Name="DeactivatedConstrDimColor" Value="2257491711"/>
           <FCUInt Name="DefaultShapeColor" Value="1920565503"/>
-          <FCUInt Name="EditedEdgeColor" Value="4059297279"/>
+          <FCUInt Name="DefaultShapeLineColor" Value="1111638783"/>
+          <FCUInt Name="DefaultShapeVertexColor" Value="1111638783"/>
+          <FCUInt Name="EditedEdgeColor" Value="1111638783"/>
           <FCUInt Name="EditedVertexColor" Value="4199699199"/>
           <FCUInt Name="ExprBasedConstrDimColor" Value="4252898559"/>
           <FCUInt Name="ExternalColor" Value="3428706559"/>
@@ -204,6 +207,7 @@
           <FCUInt Name="SelectionColor" Value="899696639"/>
           <FCUInt Name="SketchEdgeColor" Value="4059297279"/>
           <FCUInt Name="SketchVertexColor" Value="4059297279"/>
+          <FCUInt Name="AxisLetterColor" Value="0"/>
         </FCParamGroup>
       </FCParamGroup>
     </FCParamGroup>

--- a/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
@@ -191,7 +191,7 @@
           <FCUInt Name="DefaultShapeColor" Value="1920565503"/>
           <FCUInt Name="DefaultShapeLineColor" Value="1111638783"/>
           <FCUInt Name="DefaultShapeVertexColor" Value="1111638783"/>
-          <FCUInt Name="EditedEdgeColor" Value="1111638783"/>
+          <FCUInt Name="EditedEdgeColor" Value="4294967295"/>
           <FCUInt Name="EditedVertexColor" Value="4199699199"/>
           <FCUInt Name="ExprBasedConstrDimColor" Value="4252898559"/>
           <FCUInt Name="ExternalColor" Value="3428706559"/>


### PR DESCRIPTION
Adjusted several color values for grid, tree view, and sketch elements in the FreeCAD Dark.cfg preference pack. Added new color parameters for DefaultTextColor, DefaultShapeLineColor, DefaultShapeVertexColor, and AxisLetterColor to improve visual consistency. 
These line colors are also the edges of solids, so we cannot change them to white, although this would be way better when they are not edges but lines.

Preferences got removed here https://github.com/FreeCAD/FreeCAD/pull/17799

Part
new:
<img width="1557" height="1217" alt="image" src="https://github.com/user-attachments/assets/0033dfac-9ddc-40f2-bebb-74ad16e05626" />
old:
<img width="1321" height="939" alt="image" src="https://github.com/user-attachments/assets/6905b717-62d5-4983-a40b-c841d6b1a598" />

Draft
old:
<img width="1971" height="1067" alt="image" src="https://github.com/user-attachments/assets/06bfebbb-5e33-4010-829a-ee37274cb816" />
new:
<img width="2015" height="1079" alt="image" src="https://github.com/user-attachments/assets/34a4b400-9ac2-4c32-9b4f-e0b945ce51bc" />

Active treeview Item:
<img width="435" height="299" alt="image" src="https://github.com/user-attachments/assets/15080a48-33bb-4048-88e0-49f76e340114" />

Solids look like this:
<img width="1743" height="1621" alt="image" src="https://github.com/user-attachments/assets/a2505797-a17a-493c-97ee-e4b09b3b7917" />

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
