### PR TITLE
Remove boost::filesystem includes

### DIFF
--- a/src/App/BackupPolicy.h
+++ b/src/App/BackupPolicy.h
@@ -23,7 +23,6 @@
 
 #include "FCGlobal.h"
 
-#include <boost/filesystem.hpp>
 #include <boost/regex.hpp>
 #include <string>
 #include <Base/FileInfo.h>

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -25,7 +25,6 @@
 #ifndef _PreComp_
 #include <bitset>
 #include <stack>
-#include <boost/filesystem.hpp>
 #include <deque>
 #include <iostream>
 #include <utility>

--- a/src/App/ElementMap.cpp
+++ b/src/App/ElementMap.cpp
@@ -16,6 +16,7 @@
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/io/ios_state.hpp>
 
 
 FC_LOG_LEVEL_INIT("ElementMap", true, 2);  // NOLINT

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/io/ios_state.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/math/special_functions/trunc.hpp>
 

--- a/src/App/PreCompiled.h
+++ b/src/App/PreCompiled.h
@@ -97,9 +97,6 @@
 #include <boost/bind/bind.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/filesystem/exception.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 #include <boost/scope_exit.hpp>
 
 #include <fmt/format.h>

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -29,7 +29,6 @@
 #include <string>
 #include <vector>
 #include <boost/dynamic_bitset.hpp>
-#include <boost/filesystem/path.hpp>
 #include <Base/Uuid.h>
 
 #include "Property.h"

--- a/src/Base/PreCompiled.h
+++ b/src/Base/PreCompiled.h
@@ -113,9 +113,6 @@
 #include <xercesc/sax2/SAX2XMLReader.hpp>
 #include <xercesc/sax2/XMLReaderFactory.hpp>
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/exception.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/lexical_cast.hpp>

--- a/src/Base/QuantityPyImp.cpp
+++ b/src/Base/QuantityPyImp.cpp
@@ -23,6 +23,7 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 #include <cmath>
+#include <functional>
 #include <limits>
 #include <optional>
 #include <sstream>

--- a/src/Gui/PreCompiled.h
+++ b/src/Gui/PreCompiled.h
@@ -88,9 +88,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/filesystem/exception.hpp>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/program_options.hpp>

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -33,7 +33,6 @@
 # include <QMessageBox>
 # include <QString>
 # include <algorithm>
-# include <boost/filesystem.hpp>
 #endif
 
 #include <App/Document.h>

--- a/src/Tools/bindings/templates/templateClassPyExport.py
+++ b/src/Tools/bindings/templates/templateClassPyExport.py
@@ -368,9 +368,6 @@ public:
 // Every change you make here gets lost in the next full rebuild!
 // This File is normally built as an include in @self.export.Name@Imp.cpp! It's not intended to be in a project!
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/exception.hpp>
 #include <Base/PyObjectBase.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>


### PR DESCRIPTION
We no longer use Boost::filesystem, these includes are purely vestigial. Keeping the includes around is breaking the Windows-on-ARM build.