### PR TITLE
FEM: Add cavity radiation with CalculiX

### DIFF
--- a/src/Mod/Fem/App/FemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/App/FemConstraintHeatflux.cpp
@@ -50,6 +50,8 @@ ConstraintHeatflux::ConstraintHeatflux()
                       App::Prop_None,
                       "Type of constraint, surface convection, radiation or surface heat flux");
     ConstraintType.setEnums(ConstraintTypes);
+    ADD_PROPERTY_TYPE(CavityRadiation, (false), "ConstraintHeatflux", App::Prop_None, "Cavity radiation");
+    ADD_PROPERTY_TYPE(CavityName, ("cav"), "ConstraintHeatflux", App::Prop_None, "Cavity name");
 }
 
 App::DocumentObjectExecReturn* ConstraintHeatflux::execute()

--- a/src/Mod/Fem/App/FemConstraintHeatflux.h
+++ b/src/Mod/Fem/App/FemConstraintHeatflux.h
@@ -45,6 +45,8 @@ public:
     App::PropertyFloat Emissivity;
     App::PropertyHeatFlux DFlux;
     App::PropertyEnumeration ConstraintType;
+    App::PropertyBool CavityRadiation;
+    App::PropertyString CavityName;
 
     /// recalculate the object
     App::DocumentObjectExecReturn* execute() override;

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_heatflux.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_heatflux.py
@@ -49,14 +49,20 @@ def write_meshdata_constraint(f, femobj, heatflux_obj, ccxwriter):
     if heatflux_obj.ConstraintType == "Convection":
         heatflux_key_word = "FILM"
         heatflux_facetype = "F"
+        heatflux_facesubtype = ""
         heatflux_values = "{:.13G},{:.13G}".format(
             heatflux_obj.AmbientTemp.getValueAs("K").Value,
             heatflux_obj.FilmCoef.getValueAs("t/s^3/K").Value,
         )
 
     elif heatflux_obj.ConstraintType == "Radiation":
-        heatflux_key_word = "RADIATE"
         heatflux_facetype = "R"
+        if heatflux_obj.CavityRadiation:
+            heatflux_key_word = f"RADIATE, CAVITY={heatflux_obj.CavityName}"
+            heatflux_facesubtype = "CR"
+        else:
+            heatflux_key_word = "RADIATE"
+            heatflux_facesubtype = ""
         heatflux_values = "{:.13G},{:.13G}".format(
             heatflux_obj.AmbientTemp.getValueAs("K").Value, heatflux_obj.Emissivity
         )
@@ -64,6 +70,7 @@ def write_meshdata_constraint(f, femobj, heatflux_obj, ccxwriter):
     elif heatflux_obj.ConstraintType == "DFlux":
         heatflux_key_word = "DFLUX"
         heatflux_facetype = "S"
+        heatflux_facesubtype = ""
         heatflux_values = "{:.13G}".format(heatflux_obj.DFlux.getValueAs("t/s^3").Value)
 
     f.write(f"*{heatflux_key_word}\n")
@@ -73,4 +80,4 @@ def write_meshdata_constraint(f, femobj, heatflux_obj, ccxwriter):
         f.write(f"** Heat flux on face {elem_string}\n")
         for i in face_table:
             # OvG: Only write out the VolumeIDs linked to a particular face
-            f.write(f"{i[0]},{heatflux_facetype}{i[1]},{heatflux_values}\n")
+            f.write(f"{i[0]},{heatflux_facetype}{i[1]}{heatflux_facesubtype},{heatflux_values}\n")


### PR DESCRIPTION
fixes #22592

Adds two new properties to FEM heat flux load to support advanced type of radiation interaction. One property enables cavity (surface-to-surface) radiation while the other defines the cavity name needed to specify which heat flux loads form the cavity.