### PR TITLE
[Stylesheet] Update dark theme tree color and tab bar background

### DIFF
--- a/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
@@ -168,7 +168,7 @@
         <FCParamGroup Name="TreeView">
           <FCInt Name="FontSize" Value="11"/>
           <FCInt Name="ItemBackgroundPadding" Value="11"/>
-          <FCUInt Name="TreeActiveColor" Value="556083711"/>
+          <FCUInt Name="TreeActiveColor" Value="899696639"/>
           <FCUInt Name="TreeEditColor" Value="1434171135"/>
         </FCParamGroup>
         <FCParamGroup Name="View">

--- a/src/Gui/Stylesheets/FreeCAD.qss
+++ b/src/Gui/Stylesheets/FreeCAD.qss
@@ -1785,9 +1785,14 @@ QTabBar#mdiAreaTabBar::tab:bottom:selected {
   border-top: @3DViewBackgroundRefColor;
 }
 
-QTabBar {
+/*tabbar for files. */
+QTabBar#mdiAreaTabBar {
   qproperty-drawBase: 1;/*tabbar for files. */
-   background-color: @PrimaryColor;
+  background-color: @PrimaryColor;
+}
+
+QTabBar {
+  qproperty-drawBase: 0;/*tabbar for files. */
 }
 
 QTabWidget::tab-bar {

--- a/src/Gui/Stylesheets/FreeCAD.qss
+++ b/src/Gui/Stylesheets/FreeCAD.qss
@@ -1787,6 +1787,7 @@ QTabBar#mdiAreaTabBar::tab:bottom:selected {
 
 QTabBar {
   qproperty-drawBase: 1;/*tabbar for files. */
+   background-color: @PrimaryColor;
 }
 
 QTabWidget::tab-bar {


### PR DESCRIPTION
Changed the TreeActiveColor value in the FreeCAD Dark preference pack for improved visibility. Set the QTabBar background color to use @PrimaryColor in the stylesheet for fixing drawbase issues.

Tabbar fix:
<img width="596" height="465" alt="image" src="https://github.com/user-attachments/assets/3b30a381-4300-4257-9602-3b5fe5565934" />

Treeview fix:
How it is now:
<img width="863" height="221" alt="image" src="https://github.com/user-attachments/assets/915f0987-27e5-4452-bf73-b043396fbace" />
<img width="563" height="765" alt="image" src="https://github.com/user-attachments/assets/630da1b0-0d6b-4a38-b418-d14a51bec6d9" />
too:
<img width="477" height="993" alt="image" src="https://github.com/user-attachments/assets/b2edbf6a-23f5-48a5-9f7e-afa96066a23c" />

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
