### PR TITLE
Base: Switch from toTimeSpec to toTimeZone for Qt 6.9 compatibility

### DIFF
--- a/src/Base/Tools.cpp
+++ b/src/Base/Tools.cpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <sstream>
 #include <QDateTime>
+#include <QTimeZone>
 #endif
 
 #include "PyExport.h"
@@ -244,7 +245,7 @@ std::string Base::Tools::joinList(const std::vector<std::string>& vec, const std
 std::string Base::Tools::currentDateTimeString()
 {
     return QDateTime::currentDateTime()
-        .toTimeSpec(Qt::OffsetFromUTC)
+        .toTimeZone(QTimeZone::systemTimeZone())
         .toString(Qt::ISODate)
         .toStdString();
 }


### PR DESCRIPTION
`toTimeSpec` was deprecated in Qt 6.9 in favor of `toTimeZone` (added in Qt 5.14).