### PR TITLE
App: Update setContent call for Qt 6.8

### DIFF
--- a/src/App/Branding.cpp
+++ b/src/App/Branding.cpp
@@ -103,19 +103,24 @@ Branding::XmlConfig Branding::getUserDefines() const
 
 bool Branding::evaluateXML(QIODevice* device, QDomDocument& xmlDocument)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+    if (!xmlDocument.setContent(device)) {
+        return false;
+    }
+#else
     QString errorStr;
     int errorLine;
     int errorColumn;
-
     if (!xmlDocument.setContent(device, true, &errorStr, &errorLine, &errorColumn)) {
         return false;
     }
+#endif
 
     QDomElement root = xmlDocument.documentElement();
     if (root.tagName() != QLatin1String("Branding")) {
         return false;
     }
-    else if (root.hasAttribute(QLatin1String("version"))) {
+    if (root.hasAttribute(QLatin1String("version"))) {
         QString attr = root.attribute(QLatin1String("version"));
         if (attr != QLatin1String("1.0")) {
             return false;


### PR DESCRIPTION
Qt changed the way errors are returned from their XML setContent calls, adding a new method in Qt 6.5, and deprecating the old one in Qt 6.8. I also cleaned up the linter warning in the method.