### PR TITLE
CAM: Add missing initializers

### DIFF
--- a/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.h
@@ -66,7 +66,7 @@ struct GuiItem
     unsigned int flags {};
     bool mouseOver {};
     TextureItem texItem {};
-    QString toolTip;
+    QString toolTip {};
 
     int posx()
     {

--- a/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.cpp
@@ -32,7 +32,7 @@ namespace MillSim
 
 MillSimulation::MillSimulation()
 {
-    mCurMotion = {eNop, -1, 0, 0, 0, 0, 0, 0, 0};
+    mCurMotion = {eNop, -1, 0, 0, 0, 0, 0, 0, 0, '\0', 0.0};
     guiDisplay.SetMillSimulator(this);
 }
 


### PR DESCRIPTION
Silence compiler warnings about missing these fields.