### PR TITLE
[1.0] [Gui] Fix wildcard call disconnects warnings Qt6.9

### DIFF
--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -401,34 +401,39 @@ public:
      */
     void addQObject(QObject* obj, PyObject* pyobj)
     {
-        const auto PyW_unique_name = QString::number(reinterpret_cast <quintptr> (pyobj));
-        auto PyW_invalidator = findChild <QObject *> (PyW_unique_name, Qt::FindDirectChildrenOnly);
+        // static array to contain created connections so they can be safely disconnected later
+        static std::map<QObject*, QMetaObject::Connection> connections = {};
+
+        const auto PyW_uniqueName = QString::number(reinterpret_cast<quintptr>(pyobj));
+        auto PyW_invalidator = findChild<QObject*>(PyW_uniqueName, Qt::FindDirectChildrenOnly);
 
         if (PyW_invalidator == nullptr) {
             PyW_invalidator = new QObject(this);
-            PyW_invalidator->setObjectName(PyW_unique_name);
+            PyW_invalidator->setObjectName(PyW_uniqueName);
 
             Py_INCREF (pyobj);
         }
-        else {
-            PyW_invalidator->disconnect();
+        else if (connections[PyW_invalidator]) {
+            disconnect(connections[PyW_invalidator]);
+            connections.erase(PyW_invalidator);
         }
 
-        auto destroyedFun = [pyobj](){
+        auto destroyedFun = [pyobj]() {
             Base::PyGILStateLocker lock;
-            auto sbk_ptr = reinterpret_cast <SbkObject *> (pyobj);
-            if (sbk_ptr != nullptr) {
-                Shiboken::Object::setValidCpp(sbk_ptr, false);
+
+            if (auto sbkPtr = reinterpret_cast<SbkObject*>(pyobj); sbkPtr != nullptr) {
+                Shiboken::Object::setValidCpp(sbkPtr, false);
             }
             else {
                 Base::Console().DeveloperError("WrapperManager", "A QObject has just been destroyed after its Pythonic wrapper.\n");
             }
+
             Py_DECREF (pyobj);
         };
 
-        QObject::connect(PyW_invalidator, &QObject::destroyed, this, destroyedFun);
-        QObject::connect(obj, &QObject::destroyed, PyW_invalidator, &QObject::deleteLater);
-}
+        connections[PyW_invalidator] = connect(PyW_invalidator, &QObject::destroyed, this, destroyedFun);
+        connect(obj, &QObject::destroyed, PyW_invalidator, &QObject::deleteLater);
+    }
 
 private:
     void wrapQApplication()


### PR DESCRIPTION
Backport of https://github.com/FreeCAD/FreeCAD/commit/1f82156948d7ba63631bbb682f3a80a7a6eed045 except line 407 which had to be changed from:

`        else if (connections.contains(PyW_invalidator)) {`

to:

`        else if (connections[PyW_invalidator]) {`

in order to compile error free. @kadet1090 I assume this had to done due to C++ version?