### PR TITLE
Add "Clear Recent files list" item

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -871,7 +871,6 @@ RecentFilesAction::RecentFilesAction ( Command* pcCmd, QObject * parent )
     auto clearFun = [this, hGrp = _pimpl->handle](){
         const size_t recentFilesListSize = hGrp->GetASCIIs("MRU").size();
         for (size_t i = 0; i < recentFilesListSize; i++)
-
         {
             const QByteArray key = QStringLiteral("MRU%1").arg(i).toLocal8Bit();
             hGrp->SetASCII(key.data(), "");

--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -858,6 +858,32 @@ RecentFilesAction::RecentFilesAction ( Command* pcCmd, QObject * parent )
 {
     _pimpl = std::make_unique<Private>(this, "User parameter:BaseApp/Preferences/RecentFiles");
     restore();
+
+    sep.setSeparator(true);
+    sep.setToolTip({});
+    this->groupAction()->addAction(&sep);
+
+    //: Empties the list of recent files
+    clearRecentFilesListAction.setText(tr("Clear Recent Files"));
+    clearRecentFilesListAction.setToolTip({});
+    this->groupAction()->addAction(&clearRecentFilesListAction);
+
+    auto clearFun = [this, hGrp = _pimpl->handle](){
+        const int recentFilesListSize = hGrp->GetASCIIs("MRU").size();
+        for (int i = 0; i < recentFilesListSize; i++)
+        {
+            const QByteArray key = QStringLiteral("MRU%1").arg(i).toLocal8Bit();
+            hGrp->SetASCII(key.data(), "");
+        }
+        restore();
+        clearRecentFilesListAction.setEnabled(false);
+    };
+
+    connect(&clearRecentFilesListAction, &QAction::triggered,
+            this, clearFun);
+
+    connect(&clearRecentFilesListAction, &QAction::triggered,
+            this, &RecentFilesAction::recentFilesListModified);
 }
 
 RecentFilesAction::~RecentFilesAction()
@@ -878,6 +904,10 @@ void RecentFilesAction::appendFile(const QString& filename)
     save();
 
     _pimpl->trySaveUserParameter();
+
+    clearRecentFilesListAction.setEnabled(true);
+
+    Q_EMIT recentFilesListModified();
 }
 
 static QString numberToLabel(int number) {
@@ -921,6 +951,7 @@ void RecentFilesAction::setFiles(const QStringList& files)
     // if less file names than actions
     numRecentFiles = std::min<int>(numRecentFiles, this->visibleItems);
     for (int index = numRecentFiles; index < recentFiles.count(); index++) {
+        if (recentFiles[index] == &sep || recentFiles[index] == &clearRecentFilesListAction) continue;
         recentFiles[index]->setVisible(false);
         recentFiles[index]->setText(QString());
         recentFiles[index]->setToolTip(QString());

--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -869,8 +869,9 @@ RecentFilesAction::RecentFilesAction ( Command* pcCmd, QObject * parent )
     this->groupAction()->addAction(&clearRecentFilesListAction);
 
     auto clearFun = [this, hGrp = _pimpl->handle](){
-        const int recentFilesListSize = hGrp->GetASCIIs("MRU").size();
-        for (int i = 0; i < recentFilesListSize; i++)
+        const size_t recentFilesListSize = hGrp->GetASCIIs("MRU").size();
+        for (size_t i = 0; i < recentFilesListSize; i++)
+
         {
             const QByteArray key = QStringLiteral("MRU%1").arg(i).toLocal8Bit();
             hGrp->SetASCII(key.data(), "");
@@ -951,7 +952,9 @@ void RecentFilesAction::setFiles(const QStringList& files)
     // if less file names than actions
     numRecentFiles = std::min<int>(numRecentFiles, this->visibleItems);
     for (int index = numRecentFiles; index < recentFiles.count(); index++) {
-        if (recentFiles[index] == &sep || recentFiles[index] == &clearRecentFilesListAction) continue;
+        if (recentFiles[index] == &sep || recentFiles[index] == &clearRecentFilesListAction) {
+            continue;
+        }
         recentFiles[index]->setVisible(false);
         recentFiles[index]->setText(QString());
         recentFiles[index]->setToolTip(QString());

--- a/src/Gui/Action.h
+++ b/src/Gui/Action.h
@@ -241,7 +241,7 @@ public:
     void resizeList(int);
 
 Q_SIGNALS:
-    void recentFilesListModified(void);
+    void recentFilesListModified();
 
 private:
     void setFiles(const QStringList&);

--- a/src/Gui/Action.h
+++ b/src/Gui/Action.h
@@ -240,6 +240,9 @@ public:
     void activateFile(int);
     void resizeList(int);
 
+Q_SIGNALS:
+    void recentFilesListModified(void);
+
 private:
     void setFiles(const QStringList&);
     QStringList files() const;
@@ -249,6 +252,8 @@ private:
 private:
     int visibleItems; /**< Number of visible items */
     int maximumItems; /**< Number of maximum items */
+
+    QAction sep, clearRecentFilesListAction;
 
     class Private;
     friend class Private;

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -33,6 +33,7 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QScrollArea>
+#include <QTimer>
 #include <QWidget>
 #include <QStackedWidget>
 #endif
@@ -47,9 +48,11 @@
 #include <App/Application.h>
 #include <Base/Interpreter.h>
 #include <Base/Tools.h>
+#include <Gui/Action.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Gui/Document.h>
+#include <Gui/MainWindow.h>
 #include <Gui/ModuleIO.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
@@ -183,6 +186,14 @@ StartView::StartView(QWidget* parent)
     configureCustomFolderListWidget(customFolderListWidget);
     configureExamplesListWidget(examplesListWidget);
     configureRecentFilesListWidget(recentFilesListWidget, _recentFilesLabel);
+
+    QTimer::singleShot(2000, [this, recentFilesListWidget](){
+        auto updateFun = [this, recentFilesListWidget](){
+            configureRecentFilesListWidget(recentFilesListWidget, _recentFilesLabel); };
+        auto recentFiles = Gui::getMainWindow()->findChild <Gui::RecentFilesAction *> ();
+        if (recentFiles != nullptr)
+            connect(recentFiles, &Gui::RecentFilesAction::recentFilesListModified,
+                    this, updateFun); });
 
     retranslateUi();
 }

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -187,13 +187,15 @@ StartView::StartView(QWidget* parent)
     configureExamplesListWidget(examplesListWidget);
     configureRecentFilesListWidget(recentFilesListWidget, _recentFilesLabel);
 
-    QTimer::singleShot(2000, [this, recentFilesListWidget](){
-        auto updateFun = [this, recentFilesListWidget](){
-            configureRecentFilesListWidget(recentFilesListWidget, _recentFilesLabel); };
-        auto recentFiles = Gui::getMainWindow()->findChild <Gui::RecentFilesAction *> ();
-        if (recentFiles != nullptr)
-            connect(recentFiles, &Gui::RecentFilesAction::recentFilesListModified,
-                    this, updateFun); });
+    QTimer::singleShot(2000, [this, recentFilesListWidget]() {
+        auto updateFun = [this, recentFilesListWidget]() {
+            configureRecentFilesListWidget(recentFilesListWidget, _recentFilesLabel);
+        };
+        auto recentFiles = Gui::getMainWindow()->findChild<Gui::RecentFilesAction*>();
+        if (recentFiles != nullptr) {
+            connect(recentFiles, &Gui::RecentFilesAction::recentFilesListModified, this, updateFun);
+        }
+    });
 
     retranslateUi();
 }


### PR DESCRIPTION
Related to #12842.




This commit adds:




- The "_Clear Recent files_" item to the list of recent files in the menu
- A signal, notifying that the list of recent files has been changed
- Connects _StartView_ with this signal, so whenever a file is loaded, the _StartView_ widget is updated accordingly.





The thing here is that when the workbench is created, the menu is still on the way. I set a timer to connect to this signal later. If somebody knows a better option, let me know.

