### PR TITLE
TD: Switch to non-buffer-based format string interpretation

### DIFF
--- a/src/Mod/TechDraw/App/DimensionFormatter.cpp
+++ b/src/Mod/TechDraw/App/DimensionFormatter.cpp
@@ -27,6 +27,8 @@
 # include <QString>
 #endif
 
+#include <fmt/format.h>
+
 #include <Base/Console.h>
 #include <Base/UnitsApi.h>
 
@@ -275,7 +277,7 @@ QString DimensionFormatter::formatValueToSpec(const double value, QString format
     QString formattedValue;
 
     constexpr auto format = [](QString f, double value){
-        return QString::asprintf(f.toStdString().c_str(), value);
+        return QString::fromStdString(fmt::sprintf(f.toStdString(), value));
     };
 
     QRegularExpression wrRegExp(QStringLiteral("%(?<dec>.*)(?<spec>[wWrR])"));


### PR DESCRIPTION
One of the "critical" error flagged by static analyzers is the use of old buffer-based format string code like `asprintf`. This can be replaced by a non-buffer-based version using `libfmt`, which we already depend on. It requires a round-trip through `std::string`, but is safer. Qt's documentation says: `Warning: We do not recommend using QString::asprintf() in new Qt code. `