### PR TITLE
Base: Disable default entity resolution

### DIFF
--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -2094,6 +2094,7 @@ void ParameterManager::CheckDocument() const
         parser.setValidationScheme(XercesDOMParser::Val_Auto);
         parser.setDoNamespaces(true);
         parser.setDoSchema(true);
+        parser.setDisableDefaultEntityResolution(true);
 
         DOMTreeErrorReporter errHandler;
         parser.setErrorHandler(&errHandler);


### PR DESCRIPTION
Fixes CWE-611, guards against XML external entity attacks.