### PR TITLE
TD: Remove incorrect allocation failure handler

### DIFF
--- a/src/Mod/TechDraw/App/CenterLine.cpp
+++ b/src/Mod/TechDraw/App/CenterLine.cpp
@@ -197,16 +197,13 @@ CenterLine* CenterLine::CenterLineBuilder(const DrawViewPart* partFeat,
         return nullptr;
     }
 
-
-    TechDraw::CenterLine* cl = new TechDraw::CenterLine(ends.first, ends.second);
-    if (cl) {
-        cl->m_type = type;
-        cl->m_mode = mode;
-        cl->m_faces = faces;
-        cl->m_edges = edges;
-        cl->m_verts = verts;
-        cl->m_flip2Line = flip;
-    }
+    auto * cl = new TechDraw::CenterLine(ends.first, ends.second);
+    cl->m_type = type;
+    cl->m_mode = mode;
+    cl->m_faces = faces;
+    cl->m_edges = edges;
+    cl->m_verts = verts;
+    cl->m_flip2Line = flip;
     return cl;
 }
 


### PR DESCRIPTION
In C++ `new` doesn't return a `nullptr` when it fails, it throws a `badalloc` exception. So the check for a null result here is misleading, it's never true. If the allocation fails, an exception is thrown, presumably to be handled by a very high level method that ultimately shuts FreeCAD down (if this allocation fails we are basically out of memory). 