### PR TITLE
Assembly: unconnected joints: icon overlay instead of annoying warning.

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -551,6 +551,13 @@ Application::Application(bool GUIenabled)
             {"AxisCross", SoFCPlacementIndicatorKit::AxisCross},
         });
 
+        Base::PyRegisterEnum<Gui::BitmapFactoryInst::Position>(module, "IconPosition", {
+            {"TopLeft",     Gui::BitmapFactoryInst::TopLeft},
+            {"TopRight",    Gui::BitmapFactoryInst::TopRight},
+            {"BottomLeft",  Gui::BitmapFactoryInst::BottomLeft},
+            {"BottomRight", Gui::BitmapFactoryInst::BottomRight}
+        });
+
         CommandActionPy::init_type();
         Base::Interpreter().addType(CommandActionPy::type_object(), module, "CommandAction");
 

--- a/src/Gui/ViewProviderFeaturePython.cpp
+++ b/src/Gui/ViewProviderFeaturePython.cpp
@@ -173,8 +173,6 @@ ViewProviderFeaturePythonImp::getOverlayIcons() const
 
         // Expect a dictionary (dict) from Python
         if (!PyDict_Check(ret.ptr())) {
-            FC_WARN("getOverlayIcons() must return a dict, but returned %s",
-                    Py_TYPE(ret.ptr())->tp_name);
             return overlays;
         }
 
@@ -186,12 +184,10 @@ ViewProviderFeaturePythonImp::getOverlayIcons() const
         while (PyDict_Next(dict.ptr(), &pos, &key, &value)) {
             // Key should be an integer (from the enum)
             if (!PyLong_Check(key)) {
-                FC_WARN("getOverlayIcons() dict key must be of type FreeCADGui.IconPosition (int)");
                 continue;
             }
             // Value should be a string
             if (!PyUnicode_Check(value)) {
-                FC_WARN("getOverlayIcons() dict value must be a string (icon name)");
                 continue;
             }
 

--- a/src/Gui/ViewProviderFeaturePython.cpp
+++ b/src/Gui/ViewProviderFeaturePython.cpp
@@ -158,6 +158,36 @@ QIcon ViewProviderFeaturePythonImp::getIcon() const
     return {};
 }
 
+std::vector<std::string> ViewProviderFeaturePythonImp::getOverlayIcons() const
+{
+    std::vector<std::string> overlays;
+    _FC_PY_CALL_CHECK(getOverlayIcons, return overlays);
+
+    Base::PyGILStateLocker lock;
+    try {
+        Py::Object ret(Base::pyCall(py_getOverlayIcons.ptr()));
+        if (ret.isNone()) {
+            return overlays;
+        }
+
+        Py::Sequence list(ret);
+        for (const auto& item : list) {
+            overlays.push_back(Py::String(item).as_std_string("utf-8"));
+        }
+    }
+    catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+        }
+        else {
+            Base::PyException e;
+            e.reportException();
+        }
+    }
+
+    return overlays;
+}
+
 bool ViewProviderFeaturePythonImp::claimChildren(std::vector<App::DocumentObject*> &children) const
 {
     _FC_PY_CALL_CHECK(claimChildren,return(false));

--- a/src/Gui/ViewProviderFeaturePython.h
+++ b/src/Gui/ViewProviderFeaturePython.h
@@ -238,8 +238,9 @@ public:
         if (!overlayMap.empty()) {
             // Use the static instance of BitmapFactory to perform the merge
             for (const auto& [position, name] : overlayMap) {
+                static const QSize overlayIconSize  { 10, 10 };
                 QPixmap overlayPixmap =
-                    Gui::BitmapFactory().pixmapFromSvg(name.c_str(), QSize(10, 10));
+                    Gui::BitmapFactory().pixmapFromSvg(name.c_str(), overlayIconSize);
                 if (!overlayPixmap.isNull()) {
                     currentIcon =
                         Gui::BitmapFactoryInst::mergePixmap(currentIcon, overlayPixmap, position);

--- a/src/Gui/ViewProviderFeaturePython.h
+++ b/src/Gui/ViewProviderFeaturePython.h
@@ -244,7 +244,7 @@ public:
                     continue;
                 }
                 static const QSize overlayIconSize  { 10, 10 };
-                QPixmap overlayPixmap = Gui::BitmapFactory().pixmapFromSvg(name.c_str(), overlayIconSize));
+                QPixmap overlayPixmap = Gui::BitmapFactory().pixmapFromSvg(name.c_str(), overlayIconSize);
                 if (!overlayPixmap.isNull()) {
                     currentIcon =
                         Gui::BitmapFactoryInst::mergePixmap(currentIcon,

--- a/src/Gui/ViewProviderFeaturePython.h
+++ b/src/Gui/ViewProviderFeaturePython.h
@@ -243,9 +243,8 @@ public:
                     ++i;
                     continue;
                 }
-
-                QPixmap overlayPixmap =
-                    Gui::BitmapFactory().pixmapFromSvg(name.c_str(), QSize(10, 10));
+                static const QSize overlayIconSize  { 10, 10 };
+                QPixmap overlayPixmap = Gui::BitmapFactory().pixmapFromSvg(name.c_str(), overlayIconSize));
                 if (!overlayPixmap.isNull()) {
                     currentIcon =
                         Gui::BitmapFactoryInst::mergePixmap(currentIcon,

--- a/src/Gui/ViewProviderFeaturePython.h
+++ b/src/Gui/ViewProviderFeaturePython.h
@@ -30,6 +30,7 @@
 
 #include "ViewProviderGeometryObject.h"
 #include "Document.h"
+#include "BitmapFactory.h"
 
 class SoSensor;
 class SoDragger;
@@ -55,6 +56,8 @@ public:
 
     // Returns the icon
     QIcon getIcon() const;
+    // returns a vector of icon names to be used in the 4 positions.
+    std::vector<std::string> getOverlayIcons() const;
     bool claimChildren(std::vector<App::DocumentObject*>&) const;
     ValueT useNewSelectionModel() const;
     void onSelectionChanged(const SelectionChanges&);
@@ -138,6 +141,7 @@ private:
 
 #define FC_PY_VIEW_OBJECT \
     FC_PY_ELEMENT(getIcon) \
+    FC_PY_ELEMENT(getOverlayIcons) \
     FC_PY_ELEMENT(claimChildren) \
     FC_PY_ELEMENT(useNewSelectionModel) \
     FC_PY_ELEMENT(getElementPicked) \
@@ -222,6 +226,40 @@ public:
         else
             icon = ViewProviderT::mergeGreyableOverlayIcons(icon);
         return icon;
+    }
+
+    QIcon mergeColorfulOverlayIcons(const QIcon& orig) const override
+    {
+        QIcon currentIcon = orig;
+
+        // Get the list of overlay names from the Python implementation
+        std::vector<std::string> overlayNames = imp->getOverlayIcons();
+
+        if (!overlayNames.empty()) {
+            // Use the static instance of BitmapFactory to perform the merge
+            size_t i = 0;
+            for (const auto& name : overlayNames) {
+                if (name.empty()) {
+                    ++i;
+                    continue;
+                }
+
+                QPixmap overlayPixmap =
+                    Gui::BitmapFactory().pixmapFromSvg(name.c_str(), QSize(10, 10));
+                if (!overlayPixmap.isNull()) {
+                    currentIcon =
+                        Gui::BitmapFactoryInst::mergePixmap(currentIcon,
+                                                            overlayPixmap,
+                                                            static_cast<Gui::BitmapFactoryInst::Position>(i));
+                }
+                ++i;
+                if (i > 3) {
+                    break;
+                }
+            }
+        }
+
+        return ViewProviderT::mergeColorfulOverlayIcons(currentIcon);
     }
 
     std::vector<App::DocumentObject*> claimChildren() const override {

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -941,9 +941,6 @@ void AssemblyObject::removeUnconnectedJoints(std::vector<App::DocumentObject*>& 
                 App::DocumentObject* obj2 = getMovingPartFromRef(this, joint, "Reference2");
                 if (!isObjInSetOfObjRefs(obj1, connectedParts)
                     || !isObjInSetOfObjRefs(obj2, connectedParts)) {
-                    Base::Console().warning(
-                        "%s is unconnected to a grounded part so it is ignored.\n",
-                        joint->getFullName());
                     return true;  // Remove joint if any connected object is not in connectedParts
                 }
                 return false;

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -939,11 +939,8 @@ void AssemblyObject::removeUnconnectedJoints(std::vector<App::DocumentObject*>& 
             [&](App::DocumentObject* joint) {
                 App::DocumentObject* obj1 = getMovingPartFromRef(this, joint, "Reference1");
                 App::DocumentObject* obj2 = getMovingPartFromRef(this, joint, "Reference2");
-                if (!isObjInSetOfObjRefs(obj1, connectedParts)
-                    || !isObjInSetOfObjRefs(obj2, connectedParts)) {
-                    return true;  // Remove joint if any connected object is not in connectedParts
-                }
-                return false;
+                return (!isObjInSetOfObjRefs(obj1, connectedParts)
+                    || !isObjInSetOfObjRefs(obj2, connectedParts));
             }),
         joints.end());
 }

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -932,17 +932,17 @@ void AssemblyObject::removeUnconnectedJoints(std::vector<App::DocumentObject*>& 
     }
 
     // Filter out unconnected joints
-    joints.erase(
-        std::remove_if(
-            joints.begin(),
-            joints.end(),
-            [&](App::DocumentObject* joint) {
-                App::DocumentObject* obj1 = getMovingPartFromRef(this, joint, "Reference1");
-                App::DocumentObject* obj2 = getMovingPartFromRef(this, joint, "Reference2");
-                return (!isObjInSetOfObjRefs(obj1, connectedParts)
-                    || !isObjInSetOfObjRefs(obj2, connectedParts));
-            }),
-        joints.end());
+    joints.erase(std::remove_if(joints.begin(),
+                                joints.end(),
+                                [&](App::DocumentObject* joint) {
+                                    App::DocumentObject* obj1 =
+                                        getMovingPartFromRef(this, joint, "Reference1");
+                                    App::DocumentObject* obj2 =
+                                        getMovingPartFromRef(this, joint, "Reference2");
+                                    return (!isObjInSetOfObjRefs(obj1, connectedParts)
+                                            || !isObjInSetOfObjRefs(obj2, connectedParts));
+                                }),
+                 joints.end());
 }
 
 void AssemblyObject::traverseAndMarkConnectedParts(App::DocumentObject* currentObj,

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -212,6 +212,32 @@ bool ViewProviderAssembly::canDragObjectToTarget(App::DocumentObject* obj,
     return true;
 }
 
+void ViewProviderAssembly::updateData(const App::Property* prop)
+{
+    auto* obj = static_cast<Assembly::AssemblyObject*>(pcObject);
+    if (prop == &obj->Group) {
+        // Defer the icon update until the event loop is idle.
+        // This ensures the assembly has had a chance to recompute its
+        // connectivity state before we query it.
+        QTimer::singleShot(0, [obj]() {
+            if (!obj || !obj->isAttachedToDocument()) {
+                return;
+            }
+
+            std::vector<App::DocumentObject*> joints = obj->getJoints(false);
+            for (auto* joint : joints) {
+                Gui::ViewProvider* jointVp = Gui::Application::Instance->getViewProvider(joint);
+                if (jointVp) {
+                    jointVp->signalChangeIcon();
+                }
+            }
+        });
+    }
+    else {
+        Gui::ViewProviderPart::updateData(prop);
+    }
+}
+
 bool ViewProviderAssembly::setEdit(int mode)
 {
     if (mode == ViewProvider::Default) {

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -219,15 +219,35 @@ void ViewProviderAssembly::updateData(const App::Property* prop)
         // Defer the icon update until the event loop is idle.
         // This ensures the assembly has had a chance to recompute its
         // connectivity state before we query it.
-        QTimer::singleShot(0, [obj]() {
+
+        // We can't capture the raw 'obj' pointer because it may be deleted
+        // by the time the timer fires. Instead, we capture the names of the
+        // document and the object, and look them up again.
+        if (!obj->getDocument()) {
+            return;  // Should not happen, but a good safeguard
+        }
+        const std::string docName = obj->getDocument()->getName();
+        const std::string objName = obj->getNameInDocument();
+
+        QTimer::singleShot(0, [docName, objName]() {
+            // Re-acquire the document and the object safely.
+            App::Document* doc = App::GetApplication().getDocument(docName.c_str());
+            if (!doc) {
+                return;  // Document was closed
+            }
+
+            auto* pcObj = doc->getObject(objName.c_str());
+            auto* obj = static_cast<Assembly::AssemblyObject*>(pcObj);
+
+            // Now we can safely check if the object still exists and is attached.
             if (!obj || !obj->isAttachedToDocument()) {
                 return;
             }
 
             std::vector<App::DocumentObject*> joints = obj->getJoints(false);
             for (auto* joint : joints) {
-                if (Gui::ViewProvider* jointVp =
-                        Gui::Application::Instance->getViewProvider(joint)) {
+                Gui::ViewProvider* jointVp = Gui::Application::Instance->getViewProvider(joint);
+                if (jointVp) {
                     jointVp->signalChangeIcon();
                 }
             }

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -226,8 +226,7 @@ void ViewProviderAssembly::updateData(const App::Property* prop)
 
             std::vector<App::DocumentObject*> joints = obj->getJoints(false);
             for (auto* joint : joints) {
-                Gui::ViewProvider* jointVp = Gui::Application::Instance->getViewProvider(joint);
-                if (jointVp) {
+                if (Gui::ViewProvider* jointVp = Gui::Application::Instance->getViewProvider(joint)) {
                     jointVp->signalChangeIcon();
                 }
             }

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -226,7 +226,8 @@ void ViewProviderAssembly::updateData(const App::Property* prop)
 
             std::vector<App::DocumentObject*> joints = obj->getJoints(false);
             for (auto* joint : joints) {
-                if (Gui::ViewProvider* jointVp = Gui::Application::Instance->getViewProvider(joint)) {
+                if (Gui::ViewProvider* jointVp =
+                        Gui::Application::Instance->getViewProvider(joint)) {
                     jointVp->signalChangeIcon();
                 }
             }

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.h
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.h
@@ -107,6 +107,8 @@ public:
     bool onDelete(const std::vector<std::string>& subNames) override;
     bool canDelete(App::DocumentObject* obj) const override;
 
+    void updateData(const App::Property*) override;
+
     /** @name enter/exit edit mode */
     //@{
     bool setEdit(int ModNum) override;

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -951,14 +951,19 @@ class ViewProviderJoint:
 
     def getOverlayIcons(self):
         """
-        Return a list of overlay icon names to be merged by the C++ framework.
+        Return a dictionary of overlay icons.
+        Keys are positions from Gui.IconPosition.
+        Values are the icon resource names.
         """
-        overlays = ["", ""]
+
+        overlays = {}
 
         assembly = self.app_obj.Proxy.getAssembly(self.app_obj)
-        part = UtilsAssembly.getMovingPart(assembly, self.app_obj.Reference1)
-        if part is not None and not assembly.isPartConnected(part):
-            overlays.append("Part_Detached")
+        # Assuming Reference1 corresponds to the first part link
+        if hasattr(self.app_obj, "Reference1"):
+            part = UtilsAssembly.getMovingPart(assembly, self.app_obj.Reference1)
+            if part is not None and not assembly.isPartConnected(part):
+                overlays[Gui.IconPosition.BottomLeft] = "Part_Detached"
 
         return overlays
 

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -573,6 +573,9 @@ class Joint:
         for obj in joint.InList:
             if obj.isDerivedFrom("Assembly::AssemblyObject"):
                 return obj
+            elif obj.isDerivedFrom("Assembly::AssemblyLink"):
+                return self.getAssembly(obj)
+
         return None
 
     def setJointType(self, joint, newType):
@@ -945,6 +948,19 @@ class ViewProviderJoint:
             return ":/icons/Assembly_CreateJointPulleys.svg"
 
         return ":/icons/Assembly_CreateJoint.svg"
+
+    def getOverlayIcons(self):
+        """
+        Return a list of overlay icon names to be merged by the C++ framework.
+        """
+        overlays = ["", ""]
+
+        assembly = self.app_obj.Proxy.getAssembly(self.app_obj)
+        part = UtilsAssembly.getMovingPart(assembly, self.app_obj.Reference1)
+        if part is not None and not assembly.isPartConnected(part):
+            overlays.append("Part_Detached")
+
+        return overlays
 
     def dumps(self):
         """When saving the document this object gets stored using Python's json module.\


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/22643

use the same icon overlay as the Part 'unnatached'.

See the joints icons in the screenshot :
<img width="1096" height="672" alt="image" src="https://github.com/user-attachments/assets/a9a339a6-b702-458d-9c22-771a2648a197" />

The warning is then removed.