### PR TITLE
Assembly: VPAssemblyLink: remove warning leftover

### DIFF
--- a/src/Mod/Assembly/Gui/ViewProviderAssemblyLink.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssemblyLink.cpp
@@ -106,8 +106,6 @@ bool ViewProviderAssemblyLink::onDelete(const std::vector<std::string>& subNames
 {
     Q_UNUSED(subNames)
 
-    Base::Console().warning("onDelete\n");
-
     Gui::Command::doCommand(Gui::Command::Doc,
                             "App.getDocument(\"%s\").getObject(\"%s\").removeObjectsFromDocument()",
                             getObject()->getDocument()->getName(),


### PR DESCRIPTION
No brainer here. Removes a leftover warning printout that has nothing to do in main.