### PR TITLE
[TD]fix editable fields click handles

### DIFF
--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -52,7 +52,6 @@
 #include "DrawGuiUtil.h"
 
 
-
 namespace {
     QFont getFont(QDomElement& elem)
     {
@@ -323,12 +322,13 @@ void QGISVGTemplate::createClickHandles()
         auto item(new TemplateTextField(this, svgTemplate, name.toStdString()));
         auto autoValue = svgTemplate->getAutofillByEditableName(name);
         item->setAutofill(autoValue);
-
+        constexpr double TopPadFactor{0.15};
+        constexpr double BottomPadFactor{0.2};
         QMarginsF padding(
             0.0,
-            0.15 * tightTextRect.height(),
+            TopPadFactor * tightTextRect.height(),
             0.0,
-            0.2 * tightTextRect.height()
+            BottomPadFactor * tightTextRect.height()
         );
         QRectF clickrect = tightTextRect.marginsAdded(padding);
         QPolygonF clickpoly = SVGTransform.map(clickrect);
@@ -339,6 +339,7 @@ void QGISVGTemplate::createClickHandles()
         QPointF bottomRight = clickpoly.at(2);
         item->setLine(bottomLeft, bottomRight);
         item->setLineColor(PreferencesGui::templateClickBoxColor());
+        item->hideLine();
         item->setZValue(ZVALUE::SVGTEMPLATE + 1);
 
         addToGroup(item);

--- a/src/Mod/TechDraw/Gui/TemplateTextField.cpp
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.cpp
@@ -46,17 +46,24 @@ TemplateTextField::TemplateTextField(QGraphicsItem *parent,
                                      const std::string &myFieldName)
     : QGraphicsItemGroup(parent),
       tmplte(myTmplte),
-      fieldNameStr(myFieldName)
+      fieldNameStr(myFieldName),
+      m_rect(new QGraphicsRectItem()),
+      m_line(new QGraphicsPathItem())
 {
-    setToolTip(QObject::tr("Updates text"));
-    m_rect = new QGraphicsRectItem();
+    setFlag(QGraphicsItem::ItemIsFocusable, true);
+    setAcceptHoverEvents(true);
+    setFiltersChildEvents(true);
+
+    setToolTip(QObject::tr("Click to update text"));
+
     addToGroup(m_rect);
     QPen rectPen(Qt::transparent);
     QBrush rectBrush(Qt::NoBrush);
     m_rect->setPen(rectPen);
     m_rect->setBrush(rectBrush);
+    m_rect->setAcceptHoverEvents(true);
 
-    m_line = new QGraphicsPathItem();
+    m_line->hide();
     addToGroup(m_line);
  }
 
@@ -109,7 +116,7 @@ void TemplateTextField::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 }
 
 //void setAutofill(std::string autofillString);
-void TemplateTextField::setAutofill(QString autofillString)
+void TemplateTextField::setAutofill(const QString& autofillString)
 {
     m_autofillString = autofillString;
 }
@@ -130,6 +137,21 @@ void TemplateTextField::setLine(QPointF from, QPointF to)
 void TemplateTextField::setLineColor(QColor color)
 {
     QPen pen(color);
-    pen.setWidth(5);
+    constexpr int LineWidth{5};
+    pen.setWidth(LineWidth);
     m_line->setPen(pen);
 }
+
+void TemplateTextField::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
+{
+    showLine();
+    QGraphicsItemGroup::hoverEnterEvent(event);
+}
+
+void TemplateTextField::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
+{
+    hideLine();
+    QGraphicsItemGroup::hoverLeaveEvent(event);
+}
+
+

--- a/src/Mod/TechDraw/Gui/TemplateTextField.h
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.h
@@ -57,21 +57,27 @@ class TechDrawGuiExport TemplateTextField : public QGraphicsItemGroup
         /// Returns the field name that this TemplateTextField represents
         std::string fieldName() const { return fieldNameStr; }
 
-        void setAutofill(QString autofillString);
+        void setAutofill(const QString& autofillString);
         void setRectangle(QRectF rect);
         void setLine(QPointF from, QPointF to);
         void setLineColor(QColor color);
+        void hideLine() { m_line->hide(); }
+        void showLine() { m_line->show(); }
 
     protected:
-        TechDraw::DrawTemplate *tmplte;
-        std::string fieldNameStr;
-        QString m_autofillString;
-
         /// Need this to properly handle mouse release
-        void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+        void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
 
         /// Trigger the dialog for editing template text
         void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+
+        void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+        void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
+
+    private:
+        TechDraw::DrawTemplate *tmplte;
+        std::string fieldNameStr;
+        QString m_autofillString;
 
         QGraphicsRectItem* m_rect;
         QGraphicsPathItem* m_line;


### PR DESCRIPTION
This PR implements a fix for issue #21855.  It corrects a situation where 
click handles were displayed when view frames were displayed, and when printing or exporting.

