### PR TITLE
Fix test initialization failure

### DIFF
--- a/tests/src/App/Application.cpp
+++ b/tests/src/App/Application.cpp
@@ -2,41 +2,54 @@
 #define FC_OS_MACOSX 1
 #include "App/ProgramOptionsUtilities.h"
 
+#include <src/App/InitApplication.h>
+
+
 using namespace App::Util;
 
 using Spr = std::pair<std::string, std::string>;
 
-TEST(ApplicationTest, fCustomSyntaxLookup)
+
+class ApplicationTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+};
+
+TEST_F(ApplicationTest, fCustomSyntaxLookup)
 {
     Spr res {customSyntax("-display")};
     Spr exp {"display", "null"};
     EXPECT_EQ(res, exp);
 };
-TEST(ApplicationTest, fCustomSyntaxMac)
+TEST_F(ApplicationTest, fCustomSyntaxMac)
 {
     Spr res {customSyntax("-psn_stuff")};
     Spr exp {"psn", "stuff"};
     EXPECT_EQ(res, exp);
 };
-TEST(ApplicationTest, fCustomSyntaxWidgetCount)
+TEST_F(ApplicationTest, fCustomSyntaxWidgetCount)
 {
     Spr res {customSyntax("-widgetcount")};
     Spr exp {"widgetcount", ""};
     EXPECT_EQ(res, exp);
 }
-TEST(ApplicationTest, fCustomSyntaxNotFound)
+TEST_F(ApplicationTest, fCustomSyntaxNotFound)
 {
     Spr res {customSyntax("-displayx")};
     Spr exp {"", ""};
     EXPECT_EQ(res, exp);
 };
-TEST(ApplicationTest, fCustomSyntaxAmpersand)
+TEST_F(ApplicationTest, fCustomSyntaxAmpersand)
 {
     Spr res {customSyntax("@freddie")};
     Spr exp {"response-file", "freddie"};
     EXPECT_EQ(res, exp);
 };
-TEST(ApplicationTest, fCustomSyntaxEmptyIn)
+TEST_F(ApplicationTest, fCustomSyntaxEmptyIn)
 {
     Spr res {customSyntax("")};
     Spr exp {"", ""};

--- a/tests/src/App/Expression.cpp
+++ b/tests/src/App/Expression.cpp
@@ -1,10 +1,22 @@
 #include <gtest/gtest.h>
 
+#include <src/App/InitApplication.h>
+
 #include "App/ExpressionParser.h"
 #include "App/ExpressionTokenizer.h"
 
+
+class Expression: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+};
+
 // clang-format off
-TEST(Expression, tokenize)
+TEST_F(Expression, tokenize)
 {
     EXPECT_EQ(App::ExpressionTokenizer().perform(QStringLiteral(""), 10), QString());
     // 0.0000 deg-
@@ -15,7 +27,7 @@ TEST(Expression, tokenize)
     EXPECT_EQ(App::ExpressionTokenizer().perform(QStringLiteral("0.00000 deg"), 11), QStringLiteral("deg"));
 }
 
-TEST(Expression, tokenizeCompletion)
+TEST_F(Expression, tokenizeCompletion)
 {
     EXPECT_EQ(App::ExpressionTokenizer().perform(QStringLiteral("My Cube"), 7), QStringLiteral("MyCube"));
     EXPECT_EQ(App::ExpressionTokenizer().perform(QStringLiteral("My Cube0"), 8), QStringLiteral("MyCube0"));
@@ -24,7 +36,7 @@ TEST(Expression, tokenizeCompletion)
     EXPECT_EQ(App::ExpressionTokenizer().perform(QStringLiteral("My Cube 1"), 9), QStringLiteral("MyCube1"));
 }
 
-TEST(Expression, tokenizeQuantity)
+TEST_F(Expression, tokenizeQuantity)
 {
     auto result = App::ExpressionParser::tokenize("0.00000 deg");
     EXPECT_EQ(result.size(), 2);
@@ -36,7 +48,7 @@ TEST(Expression, tokenizeQuantity)
     EXPECT_EQ(std::get<2>(result[1]), "deg");
 }
 
-TEST(Expression, tokenizeFunc)
+TEST_F(Expression, tokenizeFunc)
 {
     auto result = App::ExpressionParser::tokenize("sin(0.00000)");
     EXPECT_EQ(result.size(), 3);
@@ -50,7 +62,7 @@ TEST(Expression, tokenizeFunc)
     EXPECT_EQ(std::get<2>(result[2]), ")");
 }
 
-TEST(Expression, tokenizeOne)
+TEST_F(Expression, tokenizeOne)
 {
     auto result = App::ExpressionParser::tokenize("1");
     EXPECT_EQ(result.size(), 1);
@@ -59,7 +71,7 @@ TEST(Expression, tokenizeOne)
     EXPECT_EQ(std::get<2>(result[0]), "1");
 }
 
-TEST(Expression, tokenizeNum)
+TEST_F(Expression, tokenizeNum)
 {
     auto result = App::ExpressionParser::tokenize("1.2341");
     EXPECT_EQ(result.size(), 1);
@@ -68,7 +80,7 @@ TEST(Expression, tokenizeNum)
     EXPECT_EQ(std::get<2>(result[0]), "1.2341");
 }
 
-TEST(Expression, tokenizeID)
+TEST_F(Expression, tokenizeID)
 {
     auto result = App::ExpressionParser::tokenize("Something");
     EXPECT_EQ(result.size(), 1);
@@ -77,7 +89,7 @@ TEST(Expression, tokenizeID)
     EXPECT_EQ(std::get<2>(result[0]), "Something");
 }
 
-TEST(Expression, tokenizeUnit)
+TEST_F(Expression, tokenizeUnit)
 {
     auto result = App::ExpressionParser::tokenize("km");
     EXPECT_EQ(result.size(), 1);
@@ -86,7 +98,7 @@ TEST(Expression, tokenizeUnit)
     EXPECT_EQ(std::get<2>(result[0]), "km");
 }
 
-TEST(Expression, tokenizeUSUnit)
+TEST_F(Expression, tokenizeUSUnit)
 {
     auto result = App::ExpressionParser::tokenize("\"");
     EXPECT_EQ(result.size(), 1);
@@ -95,7 +107,7 @@ TEST(Expression, tokenizeUSUnit)
     EXPECT_EQ(std::get<2>(result[0]), "\"");
 }
 
-TEST(Expression, tokenizeInt)
+TEST_F(Expression, tokenizeInt)
 {
     auto result = App::ExpressionParser::tokenize("123456");
     EXPECT_EQ(result.size(), 1);
@@ -104,7 +116,7 @@ TEST(Expression, tokenizeInt)
     EXPECT_EQ(std::get<2>(result[0]), "123456");
 }
 
-TEST(Expression, tokenizePi)
+TEST_F(Expression, tokenizePi)
 {
     auto result = App::ExpressionParser::tokenize("pi");
     EXPECT_EQ(result.size(), 1);
@@ -113,7 +125,7 @@ TEST(Expression, tokenizePi)
     EXPECT_EQ(std::get<2>(result[0]), "pi");
 }
 
-TEST(Expression, tokenizeE)
+TEST_F(Expression, tokenizeE)
 {
     auto result = App::ExpressionParser::tokenize("e");
     EXPECT_EQ(result.size(), 1);
@@ -122,7 +134,7 @@ TEST(Expression, tokenizeE)
     EXPECT_EQ(std::get<2>(result[0]), "e");
 }
 
-TEST(Expression, tokenizeConstant)
+TEST_F(Expression, tokenizeConstant)
 {
     auto result = App::ExpressionParser::tokenize("True False true false None");
     EXPECT_EQ(result.size(), 5);
@@ -135,7 +147,7 @@ TEST(Expression, tokenizeConstant)
     EXPECT_EQ(std::get<0>(result[4]), App::ExpressionParser::CONSTANT);
 }
 
-TEST(Expression, tokenizeEqual)
+TEST_F(Expression, tokenizeEqual)
 {
     auto result = App::ExpressionParser::tokenize("==");
     EXPECT_EQ(result.size(), 1);
@@ -144,7 +156,7 @@ TEST(Expression, tokenizeEqual)
     EXPECT_EQ(std::get<2>(result[0]), "==");
 }
 
-TEST(Expression, tokenizeNotEqual)
+TEST_F(Expression, tokenizeNotEqual)
 {
     auto result = App::ExpressionParser::tokenize("!=");
     EXPECT_EQ(result.size(), 1);
@@ -153,7 +165,7 @@ TEST(Expression, tokenizeNotEqual)
     EXPECT_EQ(std::get<2>(result[0]), "!=");
 }
 
-TEST(Expression, tokenizeLessThan)
+TEST_F(Expression, tokenizeLessThan)
 {
     auto result = App::ExpressionParser::tokenize("<");
     EXPECT_EQ(result.size(), 1);
@@ -162,7 +174,7 @@ TEST(Expression, tokenizeLessThan)
     EXPECT_EQ(std::get<2>(result[0]), "<");
 }
 
-TEST(Expression, tokenizeLessThanEqual)
+TEST_F(Expression, tokenizeLessThanEqual)
 {
     auto result = App::ExpressionParser::tokenize("<=");
     EXPECT_EQ(result.size(), 1);
@@ -171,7 +183,7 @@ TEST(Expression, tokenizeLessThanEqual)
     EXPECT_EQ(std::get<2>(result[0]), "<=");
 }
 
-TEST(Expression, tokenizeGreaterThan)
+TEST_F(Expression, tokenizeGreaterThan)
 {
     auto result = App::ExpressionParser::tokenize(">");
     EXPECT_EQ(result.size(), 1);
@@ -180,7 +192,7 @@ TEST(Expression, tokenizeGreaterThan)
     EXPECT_EQ(std::get<2>(result[0]), ">");
 }
 
-TEST(Expression, tokenizeGreaterThanEqual)
+TEST_F(Expression, tokenizeGreaterThanEqual)
 {
     auto result = App::ExpressionParser::tokenize(">=");
     EXPECT_EQ(result.size(), 1);
@@ -189,7 +201,7 @@ TEST(Expression, tokenizeGreaterThanEqual)
     EXPECT_EQ(std::get<2>(result[0]), ">=");
 }
 
-TEST(Expression, tokenizeMinus)
+TEST_F(Expression, tokenizeMinus)
 {
     auto result = App::ExpressionParser::tokenize("1-1");
     EXPECT_EQ(result.size(), 3);
@@ -198,7 +210,7 @@ TEST(Expression, tokenizeMinus)
     EXPECT_EQ(std::get<2>(result[1]), "-");
 }
 
-TEST(Expression, tokenizeCell1)
+TEST_F(Expression, tokenizeCell1)
 {
     auto result = App::ExpressionParser::tokenize("$A$12");
     EXPECT_EQ(result.size(), 1);
@@ -207,7 +219,7 @@ TEST(Expression, tokenizeCell1)
     EXPECT_EQ(std::get<2>(result[0]), "$A$12");
 }
 
-TEST(Expression, tokenizeCell2)
+TEST_F(Expression, tokenizeCell2)
 {
     auto result = App::ExpressionParser::tokenize("A$12");
     EXPECT_EQ(result.size(), 1);
@@ -216,7 +228,7 @@ TEST(Expression, tokenizeCell2)
     EXPECT_EQ(std::get<2>(result[0]), "A$12");
 }
 
-TEST(Expression, tokenizeCell3)
+TEST_F(Expression, tokenizeCell3)
 {
     auto result = App::ExpressionParser::tokenize("$A12");
     EXPECT_EQ(result.size(), 1);
@@ -225,7 +237,7 @@ TEST(Expression, tokenizeCell3)
     EXPECT_EQ(std::get<2>(result[0]), "$A12");
 }
 
-TEST(Expression, tokenizeString)
+TEST_F(Expression, tokenizeString)
 {
     auto result = App::ExpressionParser::tokenize("<<Test>>");
     EXPECT_EQ(result.size(), 1);
@@ -234,27 +246,27 @@ TEST(Expression, tokenizeString)
     EXPECT_EQ(std::get<2>(result[0]), "<<Test>>");
 }
 
-TEST(Expression, tokenizeExponent)
+TEST_F(Expression, tokenizeExponent)
 {
     // TODO
 }
 
-TEST(Expression, tokenizeNumAndUnit)
+TEST_F(Expression, tokenizeNumAndUnit)
 {
     // TODO
 }
 
-TEST(Expression, tokenizePos)
+TEST_F(Expression, tokenizePos)
 {
     // TODO
 }
 
-TEST(Expression, tokenizeNeg)
+TEST_F(Expression, tokenizeNeg)
 {
     // TODO
 }
 
-TEST(Expression, tokenizePi_rad)
+TEST_F(Expression, tokenizePi_rad)
 {
     EXPECT_EQ(App::ExpressionTokenizer().perform(QStringLiteral("p"), 1), QStringLiteral("p"));
     EXPECT_EQ(App::ExpressionTokenizer().perform(QStringLiteral("pi"), 2), QString());
@@ -265,13 +277,13 @@ TEST(Expression, tokenizePi_rad)
     EXPECT_EQ(App::ExpressionTokenizer().perform(QStringLiteral("pi rad"), 2), QString());
 }
 
-TEST(Expression, toString)
+TEST_F(Expression, toString)
 {
     App::UnitExpression expr{nullptr, Base::Quantity{}, "pi rad"};
     EXPECT_EQ(expr.toString(), "pi rad");
 }
 
-TEST(Expression, test_pi_rad)
+TEST_F(Expression, test_pi_rad)
 {
     auto constant = std::make_unique<App::ConstantExpression>(nullptr, "pi");
     auto unit = std::make_unique<App::UnitExpression>(nullptr, Base::Quantity{}, "rad");
@@ -280,7 +292,7 @@ TEST(Expression, test_pi_rad)
     op.release();
 }
 
-TEST(Expression, test_e_rad)
+TEST_F(Expression, test_e_rad)
 {
     auto constant = std::make_unique<App::ConstantExpression>(nullptr, "e");
     auto unit = std::make_unique<App::UnitExpression>(nullptr, Base::Quantity{}, "rad");

--- a/tests/src/Base/Axis.cpp
+++ b/tests/src/Base/Axis.cpp
@@ -4,21 +4,32 @@
 #include <Base/Placement.h>
 #include <Base/Rotation.h>
 
-TEST(Axis, TestDefault)
+#include <src/App/InitApplication.h>
+
+class Axis: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+};
+
+TEST_F(Axis, TestDefault)
 {
     Base::Axis axis;
     EXPECT_EQ(axis.getBase(), Base::Vector3d());
     EXPECT_EQ(axis.getDirection(), Base::Vector3d());
 }
 
-TEST(Axis, TestCustom)
+TEST_F(Axis, TestCustom)
 {
     Base::Axis axis(Base::Vector3d(0, 0, 1), Base::Vector3d(1, 1, 1));
     EXPECT_EQ(axis.getBase(), Base::Vector3d(0, 0, 1));
     EXPECT_EQ(axis.getDirection(), Base::Vector3d(1, 1, 1));
 }
 
-TEST(Axis, TestSetter)
+TEST_F(Axis, TestSetter)
 {
     Base::Axis axis;
     axis.setBase(Base::Vector3d(0, 0, 1));
@@ -27,7 +38,7 @@ TEST(Axis, TestSetter)
     EXPECT_EQ(axis.getDirection(), Base::Vector3d(1, 1, 1));
 }
 
-TEST(Axis, TestAssign)
+TEST_F(Axis, TestAssign)
 {
     Base::Axis axis;
     Base::Axis move;
@@ -38,7 +49,7 @@ TEST(Axis, TestAssign)
     EXPECT_EQ(move.getDirection(), Base::Vector3d(1, 1, 1));
 }
 
-TEST(Axis, TestReverse)
+TEST_F(Axis, TestReverse)
 {
     Base::Axis axis(Base::Vector3d(0, 0, 1), Base::Vector3d(1, 1, 1));
     axis.reverse();
@@ -46,7 +57,7 @@ TEST(Axis, TestReverse)
     EXPECT_EQ(axis.getDirection(), Base::Vector3d(-1, -1, -1));
 }
 
-TEST(Axis, TestReversed)
+TEST_F(Axis, TestReversed)
 {
     Base::Axis axis(Base::Vector3d(0, 0, 1), Base::Vector3d(1, 1, 1));
     Base::Axis rev(axis.reversed());
@@ -55,7 +66,7 @@ TEST(Axis, TestReversed)
     EXPECT_EQ(rev.getDirection(), Base::Vector3d(-1, -1, -1));
 }
 
-TEST(Axis, TestMove)
+TEST_F(Axis, TestMove)
 {
     Base::Axis axis(Base::Vector3d(0, 0, 1), Base::Vector3d(1, 1, 1));
     axis.move(Base::Vector3d(1, 2, 3));
@@ -63,7 +74,7 @@ TEST(Axis, TestMove)
     EXPECT_EQ(axis.getDirection(), Base::Vector3d(1, 1, 1));
 }
 
-TEST(Axis, TestMult)
+TEST_F(Axis, TestMult)
 {
     Base::Axis axis(Base::Vector3d(0, 0, 1), Base::Vector3d(0, 0, 1));
     axis *= Base::Placement(Base::Vector3d(1, 1, 1), Base::Rotation(1, 0, 0, 0));

--- a/tests/src/Gui/Assistant.cpp
+++ b/tests/src/Gui/Assistant.cpp
@@ -2,5 +2,17 @@
 
 #include "Gui/Assistant.h"
 
-TEST(Assistant, first)
+#include <src/App/InitApplication.h>
+
+
+class Assistant: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+};
+
+TEST_F(Assistant, first)
 {}

--- a/tests/src/Gui/Camera.cpp
+++ b/tests/src/Gui/Camera.cpp
@@ -11,6 +11,9 @@
 #include <Gui/Camera.h>
 #include <Gui/Utilities.h>
 
+#include <src/App/InitApplication.h>
+
+
 /*
  This comment was previously used to get the hard coded axonometric view quaternions
  in the Camera class.
@@ -134,7 +137,16 @@ std::array<double, 3> getProjectedLengths(const SbRotation& rot)
 
 }  // namespace
 
-TEST(CameraPrecalculatedQuaternions, testIsometric)
+class CameraPrecalculatedQuaternions: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+};
+
+TEST_F(CameraPrecalculatedQuaternions, testIsometric)
 {
     // Use the formula to get the isometric rotation
     double alpha = toRadians(45.0f);
@@ -146,7 +158,7 @@ TEST(CameraPrecalculatedQuaternions, testIsometric)
     EXPECT_TRUE(actual.isSame(expected, 1e-6));
 }
 
-TEST(CameraPrecalculatedQuaternions, testDimetric)
+TEST_F(CameraPrecalculatedQuaternions, testDimetric)
 {
     // Use the formula to get the dimetric rotation
     double alpha = std::asin(std::sqrt(1.0 / 8.0));
@@ -158,7 +170,7 @@ TEST(CameraPrecalculatedQuaternions, testDimetric)
     EXPECT_TRUE(actual.isSame(expected, 1e-6));
 }
 
-TEST(CameraPrecalculatedQuaternions, testTrimetric)
+TEST_F(CameraPrecalculatedQuaternions, testTrimetric)
 {
     // Use the formula to get the trimetric rotation
     double alpha = toRadians(30.0);
@@ -170,7 +182,17 @@ TEST(CameraPrecalculatedQuaternions, testTrimetric)
     EXPECT_TRUE(actual.isSame(expected, 1e-6));
 }
 
-TEST(CameraRotation, testIsometricProjection)
+
+class CameraRotation: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+};
+
+TEST_F(CameraRotation, testIsometricProjection)
 {
     auto rot = Gui::Camera::isometric();
     auto lengths = getProjectedLengths(rot);
@@ -181,7 +203,7 @@ TEST(CameraRotation, testIsometricProjection)
     EXPECT_NEAR(lengths[1], lengths[2], 1e-6);  // Y == Z
 }
 
-TEST(CameraRotation, testDimetricProjection)
+TEST_F(CameraRotation, testDimetricProjection)
 {
     const auto rot = Gui::Camera::dimetric();
     const auto lengths = getProjectedLengths(rot);
@@ -203,7 +225,7 @@ TEST(CameraRotation, testDimetricProjection)
     EXPECT_EQ(similarCount, 1);  // Exactly two are equal
 }
 
-TEST(CameraRotation, testTrimetricProjection)
+TEST_F(CameraRotation, testTrimetricProjection)
 {
     auto rot = Gui::Camera::trimetric();
     auto lengths = getProjectedLengths(rot);

--- a/tests/src/Mod/Material/App/TestMaterialFilter.cpp
+++ b/tests/src/Mod/Material/App/TestMaterialFilter.cpp
@@ -45,10 +45,9 @@
 
 class TestMaterialFilter : public ::testing::Test {
 protected:
-    static void SetUpTestSuite() {
-        if (App::Application::GetARGC() == 0) {
-            tests::initApplication();
-        }
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
     }
 
     void SetUp() override {
@@ -72,6 +71,14 @@ protected:
         hGrp->SetBool("UseMaterialsFromConfigDir", false);
         hGrp->SetBool("UseMaterialsFromCustomDir", true);
 
+        auto param = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Mod/Material/Editor");
+        param->SetBool("ShowFavorites", true);
+        param->SetBool("ShowRecent", true);
+        param->SetBool("ShowEmptyFolders", false);
+        param->SetBool("ShowEmptyLibraries", true);
+        param->SetBool("ShowLegacy", false);
+
         _materialManager->refresh();
 
         _library = _materialManager->getLibrary(QStringLiteral("Custom"));
@@ -88,19 +95,33 @@ protected:
         hGrp->SetBool("UseMaterialsFromConfigDir", _useUserDir);
         hGrp->SetBool("UseMaterialsFromCustomDir", _useCustomDir);
 
+        hGrp = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Mod/Material/Editor");
+        hGrp->SetBool("ShowFavorites", _includeFavorites);
+        hGrp->SetBool("ShowRecent", _includeRecent);
+        hGrp->SetBool("ShowEmptyFolders", _includeFolders);
+        hGrp->SetBool("ShowEmptyLibraries", _includeLibraries);
+        hGrp->SetBool("ShowLegacy", _includeLegacy);
+
         _materialManager->refresh();
     }
 
-    Materials::ModelManager* _modelManager;
-    Materials::MaterialManager* _materialManager;
+    Materials::ModelManager* _modelManager {};
+    Materials::MaterialManager* _materialManager {};
     std::shared_ptr<Materials::MaterialLibrary> _library;
     QString _testMaterialUUID;
 
     std::string _customDir;
-    bool _useBuiltInDir;
-    bool _useWorkbenchDir;
-    bool _useUserDir;
-    bool _useCustomDir;
+    bool _useBuiltInDir {};
+    bool _useWorkbenchDir {};
+    bool _useUserDir {};
+    bool _useCustomDir {};
+
+    bool _includeFavorites {};
+    bool _includeRecent {};
+    bool _includeFolders {};
+    bool _includeLibraries {};
+    bool _includeLegacy {};
 
     const char* UUIDAcrylicLegacy = ""; // This can't be known until it is loaded
     const char* UUIDAluminumAppearance = "3c6d0407-66b3-48ea-a2e8-ee843edf0311";

--- a/tests/src/Mod/Mesh/App/Mesh.cpp
+++ b/tests/src/Mod/Mesh/App/Mesh.cpp
@@ -2,8 +2,19 @@
 #include <Mod/Mesh/App/Mesh.h>
 #include <Mod/Mesh/App/Core/Grid.h>
 
+#include <src/App/InitApplication.h>
+
+class MeshTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+};
+
 // NOLINTBEGIN(cppcoreguidelines-*,readability-*)
-TEST(MeshTest, TestDefault)
+TEST_F(MeshTest, TestDefault)
 {
     MeshCore::MeshKernel kernel;
     Base::Vector3f p1 {0, 0, 0};
@@ -16,7 +27,7 @@ TEST(MeshTest, TestDefault)
     EXPECT_EQ(kernel.CountFacets(), 1);
 }
 
-TEST(MeshTest, TestGrid1OfPlanarMesh)
+TEST_F(MeshTest, TestGrid1OfPlanarMesh)
 {
     MeshCore::MeshKernel kernel;
     Base::Vector3f p1 {0, 0, 0};
@@ -36,7 +47,7 @@ TEST(MeshTest, TestGrid1OfPlanarMesh)
     EXPECT_EQ(countZ, 1);
 }
 
-TEST(MeshTest, TestGrid2OfPlanarMesh)
+TEST_F(MeshTest, TestGrid2OfPlanarMesh)
 {
     MeshCore::MeshKernel kernel;
     Base::Vector3f p1 {0, 0, 0};
@@ -56,7 +67,7 @@ TEST(MeshTest, TestGrid2OfPlanarMesh)
     EXPECT_EQ(countZ, 1);
 }
 
-TEST(MeshTest, TestGrid1OfAlmostPlanarMesh)
+TEST_F(MeshTest, TestGrid1OfAlmostPlanarMesh)
 {
     MeshCore::MeshKernel kernel;
     Base::Vector3f p1 {0, 0, 0};
@@ -76,7 +87,7 @@ TEST(MeshTest, TestGrid1OfAlmostPlanarMesh)
     EXPECT_EQ(countZ, 1);
 }
 
-TEST(MeshTest, TestGrid2OfAlmostPlanarMesh)
+TEST_F(MeshTest, TestGrid2OfAlmostPlanarMesh)
 {
     MeshCore::MeshKernel kernel;
     Base::Vector3f p1 {0, 0, 0};

--- a/tests/src/Mod/MeshPart/App/MeshPart.cpp
+++ b/tests/src/Mod/MeshPart/App/MeshPart.cpp
@@ -5,6 +5,9 @@
 #include <TopAbs_ShapeEnum.hxx>
 #include <QObject>
 
+#include <src/App/InitApplication.h>
+
+
 QT_WARNING_PUSH
 QT_WARNING_DISABLE_CLANG("-Wextra-semi")
 QT_WARNING_DISABLE_CLANG("-Woverloaded-virtual")
@@ -17,8 +20,16 @@ QT_WARNING_DISABLE_CLANG("-Woverloaded-virtual")
 #include <StdMeshers_QuadranglePreference.hxx>
 QT_WARNING_POP
 
+class SMesh: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+};
 // NOLINTBEGIN
-TEST(SMesh, testMefisto)
+TEST_F(SMesh, testMefisto)
 {
     TopoDS_Solid box = BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Solid();
 
@@ -64,7 +75,7 @@ TEST(SMesh, testMefisto)
     delete gen;
 }
 
-TEST(SMesh, testStdMeshers)
+TEST_F(SMesh, testStdMeshers)
 {
     TopoDS_Solid box = BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Solid();
 

--- a/tests/src/Mod/Part/App/TopoDS_Shape.cpp
+++ b/tests/src/Mod/Part/App/TopoDS_Shape.cpp
@@ -9,9 +9,20 @@
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Vertex.hxx>
 
+#include <src/App/InitApplication.h>
+
+class TestTopoDS_Shape: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+};
+
 // NOLINTBEGIN
 // clang-format off
-TEST(TopoDS_Shape, TestCastEdgeToVertex)
+TEST_F(TestTopoDS_Shape, TestCastEdgeToVertex)
 {
     BRepBuilderAPI_MakeEdge mkEdge(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0));
     TopoDS_Edge edge = mkEdge.Edge();
@@ -20,7 +31,7 @@ TEST(TopoDS_Shape, TestCastEdgeToVertex)
     EXPECT_TRUE(vertex.IsNull());
 }
 
-TEST(TopoDS_Shape, TestCastNullVertex)
+TEST_F(TestTopoDS_Shape, TestCastNullVertex)
 {
     TopoDS_Vertex vertex1;
     TopoDS_Vertex vertex2;
@@ -28,7 +39,7 @@ TEST(TopoDS_Shape, TestCastNullVertex)
     EXPECT_TRUE(vertex2.IsNull());
 }
 
-TEST(TopoDS_Shape, TestCastNullEdge)
+TEST_F(TestTopoDS_Shape, TestCastNullEdge)
 {
     TopoDS_Edge edge;
     TopoDS_Vertex vertex;
@@ -36,7 +47,7 @@ TEST(TopoDS_Shape, TestCastNullEdge)
     EXPECT_TRUE(vertex.IsNull());
 }
 
-TEST(TopoDS_Shape, TestExploreNullShape)
+TEST_F(TestTopoDS_Shape, TestExploreNullShape)
 {
     TopoDS_Face face;
     TopExp_Explorer xp(face, TopAbs_FACE);

--- a/tests/src/Mod/Part/App/TopoShapeCache.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeCache.cpp
@@ -15,7 +15,16 @@
 
 // NOLINTBEGIN(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
-TEST(ShapeRelationKey, HistoryTraceTypeComparison)
+class ShapeRelationKey: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+};
+
+TEST_F(ShapeRelationKey, HistoryTraceTypeComparison)
 {
     // Arrange
     Data::MappedName mappedName {"mappedName"};

--- a/tests/src/Mod/Sketcher/App/Constraint.cpp
+++ b/tests/src/Mod/Sketcher/App/Constraint.cpp
@@ -7,8 +7,9 @@
 
 #include <gtest/gtest.h>
 #include <xercesc/util/PlatformUtils.hpp>
-#include <fmt/core.h>
 #include <QTemporaryFile>
+
+#include <src/App/InitApplication.h>
 
 
 // Ensure Xerces is initialized before running tests which uses xml
@@ -34,8 +35,16 @@ public:
 ::testing::Environment* const xercesEnv =
     ::testing::AddGlobalTestEnvironment(new XercesEnvironment);
 
+class ConstraintPointsAccess: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+};
 
-TEST(ConstraintPointsAccess, testDefaultGeoElementIdsAreSane)  // NOLINT
+TEST_F(ConstraintPointsAccess, testDefaultGeoElementIdsAreSane)  // NOLINT
 {
     // Arrange
     auto constraint = Sketcher::Constraint();
@@ -65,7 +74,7 @@ TEST(ConstraintPointsAccess, testDefaultGeoElementIdsAreSane)  // NOLINT
 }
 
 #if SKETCHER_CONSTRAINT_USE_LEGACY_ELEMENTS
-TEST(ConstraintPointsAccess, testOldWriteIsReadByNew)  // NOLINT
+TEST_F(ConstraintPointsAccess, testOldWriteIsReadByNew)  // NOLINT
 {
     // Arrange
     auto constraint = Sketcher::Constraint();
@@ -87,7 +96,7 @@ TEST(ConstraintPointsAccess, testOldWriteIsReadByNew)  // NOLINT
               Sketcher::GeoElementId(Sketcher::GeoElementId(45, Sketcher::PointPos::mid)));
 }
 
-TEST(ConstraintPointsAccess, testNewWriteIsReadByOld)  // NOLINT
+TEST_F(ConstraintPointsAccess, testNewWriteIsReadByOld)  // NOLINT
 {
     // Arrange
     auto constraint = Sketcher::Constraint();
@@ -107,7 +116,7 @@ TEST(ConstraintPointsAccess, testNewWriteIsReadByOld)  // NOLINT
 }
 #endif
 
-TEST(ConstraintPointsAccess, testThreeElementsByDefault)  // NOLINT
+TEST_F(ConstraintPointsAccess, testThreeElementsByDefault)  // NOLINT
 {
     // Arrange
     auto constraint = Sketcher::Constraint();
@@ -118,7 +127,7 @@ TEST(ConstraintPointsAccess, testThreeElementsByDefault)  // NOLINT
     EXPECT_EQ(constraint.getElementsSize(), 3);
 }
 
-TEST(ConstraintPointsAccess, testFourElementsWhenAddingOne)  // NOLINT
+TEST_F(ConstraintPointsAccess, testFourElementsWhenAddingOne)  // NOLINT
 {
     // Arrange
     auto constraint = Sketcher::Constraint();
@@ -131,7 +140,7 @@ TEST(ConstraintPointsAccess, testFourElementsWhenAddingOne)  // NOLINT
 }
 
 #if SKETCHER_CONSTRAINT_USE_LEGACY_ELEMENTS
-TEST(ConstraintPointsAccess, testElementSerializationWhenAccessingOldWay)  // NOLINT
+TEST_F(ConstraintPointsAccess, testElementSerializationWhenAccessingOldWay)  // NOLINT
 {
     // Arrange
     auto constraint = Sketcher::Constraint();
@@ -160,7 +169,7 @@ TEST(ConstraintPointsAccess, testElementSerializationWhenAccessingOldWay)  // NO
 }
 #endif
 
-TEST(ConstraintPointsAccess, testElementSerializationWhenAccessingNewWay)  // NOLINT
+TEST_F(ConstraintPointsAccess, testElementSerializationWhenAccessingNewWay)  // NOLINT
 {
     // Arrange
     auto constraint = Sketcher::Constraint();
@@ -186,7 +195,7 @@ TEST(ConstraintPointsAccess, testElementSerializationWhenAccessingNewWay)  // NO
 }
 
 #if SKETCHER_CONSTRAINT_USE_LEGACY_ELEMENTS
-TEST(ConstraintPointsAccess, testElementSerializationWhenMixingOldAndNew)  // NOLINT
+TEST_F(ConstraintPointsAccess, testElementSerializationWhenMixingOldAndNew)  // NOLINT
 {
     // Arrange
     auto constraint = Sketcher::Constraint();
@@ -220,7 +229,7 @@ TEST(ConstraintPointsAccess, testElementSerializationWhenMixingOldAndNew)  // NO
 }
 #endif
 
-TEST(ConstraintPointsAccess, testElementsRestoredFromSerialization)  // NOLINT
+TEST_F(ConstraintPointsAccess, testElementsRestoredFromSerialization)  // NOLINT
 {
     // Arrange
     Sketcher::Constraint constraint;
@@ -260,8 +269,8 @@ TEST(ConstraintPointsAccess, testElementsRestoredFromSerialization)  // NOLINT
     inputFile.close();
 }
 
-TEST(ConstraintPointsAccess,
-     testElementsRestoredFromSerializationWithoutNewElementStorage)  // NOLINT
+TEST_F(ConstraintPointsAccess,
+       testElementsRestoredFromSerializationWithoutNewElementStorage)  // NOLINT
 {
     // Arrange
 
@@ -326,8 +335,8 @@ TEST(ConstraintPointsAccess,
     inputFile.close();
 }
 
-TEST(ConstraintPointsAccess,
-     testLegacyIsPreferedDuringSerializationWithoutLegacyElementStorage)  // NOLINT
+TEST_F(ConstraintPointsAccess,
+       testLegacyIsPreferedDuringSerializationWithoutLegacyElementStorage)  // NOLINT
 {
     // Arrange
 
@@ -389,7 +398,7 @@ TEST(ConstraintPointsAccess,
     inputFile.close();
 }
 
-TEST(ConstraintPointsAccess, testLegacyIsPreferedDuringSerializationIfContradicting)  // NOLINT
+TEST_F(ConstraintPointsAccess, testLegacyIsPreferedDuringSerializationIfContradicting)  // NOLINT
 {
     // Arrange
 
@@ -468,7 +477,7 @@ TEST(ConstraintPointsAccess, testLegacyIsPreferedDuringSerializationIfContradict
     inputFile.close();
 }
 
-TEST(ConstraintPointsAccess, testSubstituteIndex)  // NOLINT
+TEST_F(ConstraintPointsAccess, testSubstituteIndex)  // NOLINT
 {
     // Arrange
     Sketcher::Constraint constraint;
@@ -486,7 +495,7 @@ TEST(ConstraintPointsAccess, testSubstituteIndex)  // NOLINT
     EXPECT_EQ(constraint.getElement(2), Sketcher::GeoElementId(99, Sketcher::PointPos::mid));
 }
 
-TEST(ConstraintPointsAccess, testSubstituteIndexAndPos)  // NOLINT
+TEST_F(ConstraintPointsAccess, testSubstituteIndexAndPos)  // NOLINT
 {
     // Arrange
     Sketcher::Constraint constraint;
@@ -504,7 +513,7 @@ TEST(ConstraintPointsAccess, testSubstituteIndexAndPos)  // NOLINT
               Sketcher::GeoElementId(10, Sketcher::PointPos::mid));  // unchanged
 }
 
-TEST(ConstraintPointsAccess, testInvolvesGeoId)  // NOLINT
+TEST_F(ConstraintPointsAccess, testInvolvesGeoId)  // NOLINT
 {
     // Arrange
     Sketcher::Constraint constraint;
@@ -517,7 +526,7 @@ TEST(ConstraintPointsAccess, testInvolvesGeoId)  // NOLINT
     EXPECT_FALSE(constraint.involvesGeoId(99));
 }
 
-TEST(ConstraintPointsAccess, testInvolvesGeoIdAndPosId)  // NOLINT
+TEST_F(ConstraintPointsAccess, testInvolvesGeoIdAndPosId)  // NOLINT
 {
     // Arrange
     Sketcher::Constraint constraint;
@@ -533,7 +542,7 @@ TEST(ConstraintPointsAccess, testInvolvesGeoIdAndPosId)  // NOLINT
 }
 
 #if SKETCHER_CONSTRAINT_USE_LEGACY_ELEMENTS
-TEST(ConstraintPointsAccess, testLegacyWriteReflectedInInvolvesAndSubstitute)  // NOLINT
+TEST_F(ConstraintPointsAccess, testLegacyWriteReflectedInInvolvesAndSubstitute)  // NOLINT
 {
     // Arrange
     Sketcher::Constraint constraint;
@@ -554,7 +563,7 @@ TEST(ConstraintPointsAccess, testLegacyWriteReflectedInInvolvesAndSubstitute)  /
     EXPECT_FALSE(constraint.involvesGeoId(10));
 }
 
-TEST(ConstraintPointsAccess, testSubstituteUpdatesLegacyFieldsToo)  // NOLINT
+TEST_F(ConstraintPointsAccess, testSubstituteUpdatesLegacyFieldsToo)  // NOLINT
 {
     // Arrange
     Sketcher::Constraint constraint;


### PR DESCRIPTION
We've had an intermittent CI failure: using ASAN I was able to track it down to some tests that weren't initializing the application before running. While not 100% of these tests actually need to initialize the typesystem, etc., it's safer to just do so.

I also added the code needed to save and restore the Materials preferences so that those tests don't depend on the state of the user's preferences. This didn't affect CI, but could affect local runs.