### PR TITLE
[TD]more stringent test for bsplines as circles

### DIFF
--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -1529,13 +1529,14 @@ bool GeometryUtils::getCircleParms(const TopoDS_Edge& occEdge, double& radius, B
         pointsOnCurve.push_back(Base::convertTo<Base::Vector3d>(newpoint));
     }
 
-    auto edgeLong = edgeLength(occEdge);
-    constexpr double LimitFactor{0.001};     // 0.1%  not sure about this value
-    double tolerance = edgeLong * LimitFactor;
+    double tolerance = EWTOLERANCE;     // not as demanding as Precision::Confusion() but more
+                                        // demanding than using the edge length
 
-    isArc = true;
-    if (firstPoint.IsEqual(lastPoint, tolerance)) {
-        isArc = false;
+    isArc = false;
+    if (!firstPoint.IsEqual(lastPoint, tolerance)) {
+        // we were dropping information by not including lastPoint
+        pointsOnCurve.push_back(lastPoint);
+        isArc = true;
     }
 
     int passCount{0};
@@ -1576,6 +1577,7 @@ bool GeometryUtils::getCircleParms(const TopoDS_Edge& occEdge, double& radius, B
         return true;
     }
     catch (Standard_Failure&) {
+        // we think this is a circle, but occt disagrees
         Base::Console().message("Geo::getCircleParms - failed to make a circle\n");
     }
 


### PR DESCRIPTION
This PR implements a fix for issue # 2210.  


<img width="1920" height="1040" alt="StrictCircularSplines" src="https://github.com/user-attachments/assets/703aa60b-67b5-4d2e-9654-6c3d1d60fba9" />
