### PR TITLE
Assembly: Insert tool : fix error when removing object

### DIFF
--- a/src/Mod/Assembly/CommandInsertLink.py
+++ b/src/Mod/Assembly/CommandInsertLink.py
@@ -548,7 +548,7 @@ class TaskAssemblyInsertLink(QtCore.QObject):
 
                         self.decrement_counter(item)
                         del self.insertionStack[i]
-                        self.form.partList.setItemSelected(item, False)
+                        item.setSelected(False)
 
                         return True
             else:


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/22700

@chennes small QT6 syntax fix.
By the way are all our builds using Qt6 now? Is it ok to use qt6 syntax only ?