### PR TITLE
[Sketcher] Ensure All Reference Constraints are Read Only…

### DIFF
--- a/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
+++ b/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
@@ -109,6 +109,7 @@ void PropertyConstraintListItem::initialize()
 
             item->bind(list->createPath(id - 1));
             item->setAutoApply(false);
+            item->setReadOnly(!(*it)->isDriving);
         }
     }
 


### PR DESCRIPTION
…in the Property Editor

Fixes #22665 