### PR TITLE
Gui: Widen the default customize dialog

### DIFF
--- a/src/Gui/Dialogs/DlgKeyboard.ui
+++ b/src/Gui/Dialogs/DlgKeyboard.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>642</width>
+    <width>736</width>
     <height>376</height>
    </rect>
   </property>
@@ -17,7 +17,7 @@
    <item>
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <widget class="QWidget" name="layoutWidget">
       <layout class="QGridLayout" name="gridLayout">
@@ -59,7 +59,7 @@
         <widget class="QTreeWidget" name="commandTreeWidget">
          <property name="minimumSize">
           <size>
-           <width>220</width>
+           <width>400</width>
            <height>0</height>
           </size>
          </property>
@@ -272,10 +272,10 @@ same time. The one with the highest priority will be triggered.</string>
          <item>
           <spacer>
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
+            <enum>QSizePolicy::Policy::Expanding</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>

--- a/src/Gui/Dialogs/DlgToolbars.ui
+++ b/src/Gui/Dialogs/DlgToolbars.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>576</width>
+    <width>736</width>
     <height>352</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Toolbars</string>
@@ -23,9 +29,9 @@
       </sizepolicy>
      </property>
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
-     <widget class="QWidget" name="">
+     <widget class="QWidget" name="layoutWidget">
       <layout class="QGridLayout" name="gridLayout_2">
        <property name="leftMargin">
         <number>0</number>
@@ -60,6 +66,12 @@
        </item>
        <item row="2" column="0" colspan="2">
         <widget class="QTreeWidget" name="commandTreeWidget">
+         <property name="minimumSize">
+          <size>
+           <width>350</width>
+           <height>0</height>
+          </size>
+         </property>
          <property name="rootIsDecorated">
           <bool>false</bool>
          </property>
@@ -72,17 +84,17 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="">
+     <widget class="QWidget" name="layoutWidget">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
           <spacer>
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
+            <enum>QSizePolicy::Policy::Expanding</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -208,10 +220,10 @@
          <item>
           <spacer>
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
+            <enum>QSizePolicy::Policy::Expanding</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -269,10 +281,10 @@
          <item>
           <spacer>
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
+            <enum>QSizePolicy::Policy::Fixed</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -306,7 +318,7 @@
          <item>
           <spacer>
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>


### PR DESCRIPTION
Fix #22160

New defaults to accomodate wide keyboard and toolbar tabs in the Custumize dialog.


<img width="824" height="452" alt="20250725_00h25m39s_grim" src="https://github.com/user-attachments/assets/2deed616-92a1-4c05-95f6-c6ee0c70d269" />

<img width="802" height="438" alt="20250725_00h25m46s_grim" src="https://github.com/user-attachments/assets/2f72b257-2960-4da4-9dce-70eec96bbaf4" />
