### PR TITLE
Gui: Allow expressions in the VarSet dialog

### DIFF
--- a/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
@@ -164,10 +164,8 @@ int DlgAddPropertyVarSet::findLabelRow(const char* labelName, QFormLayout* layou
 
 void DlgAddPropertyVarSet::removeExistingWidget(QFormLayout* formLayout, int labelRow)
 {
-    QLayoutItem* existingItem = formLayout->itemAt(labelRow, QFormLayout::FieldRole);
-    if (existingItem != nullptr) {
-        QWidget* existingWidget = existingItem->widget();
-        if (existingWidget != nullptr) {
+    if (QLayoutItem* existingItem = formLayout->itemAt(labelRow, QFormLayout::FieldRole)) {
+        if (QWidget *existingWidget = existingItem->widget()) {
             formLayout->removeWidget(existingWidget);
             existingWidget->deleteLater();
         }
@@ -414,7 +412,7 @@ void DlgAddPropertyVarSet::initializeValue()
 
 void DlgAddPropertyVarSet::setTitle()
 {
-    setWindowTitle(QObject::tr("Add a property to %1").arg(QString::fromStdString(varSet->getFullName())));
+    setWindowTitle(tr("Add a property to %1").arg(QString::fromStdString(varSet->getFullName())));
 }
 
 void DlgAddPropertyVarSet::setOkEnabled(bool enabled)
@@ -584,11 +582,10 @@ bool DlgAddPropertyVarSet::clearBoundProperty()
     // Both a property link and an expression are bound to a property and as a
     // result need the value to be reset.
     using PropertyLinkItem = Gui::PropertyEditor::PropertyLinkItem;
-    bool isPropertyLinkItem = dynamic_cast<PropertyLinkItem*>(propertyItem.get()) != nullptr;
+    bool isPropertyLinkItem = qobject_cast<PropertyLinkItem*>(propertyItem.get()) != nullptr;
     bool valueNeedsReset = isPropertyLinkItem || propertyItem->hasExpression();
 
-    App::Property* prop = propertyItem->getFirstProperty();
-    if (prop) {
+    if (App::Property* prop = propertyItem->getFirstProperty()) {
         propertyItem->unbind();
         propertyItem->removeProperty(prop);
         varSet->removeDynamicProperty(prop->getName());
@@ -636,8 +633,8 @@ void DlgAddPropertyVarSet::onGroupFinished()
     if (isGroupValid() && propertyItem) {
         std::string group = comboBoxGroup.currentText().toStdString();
         std::string doc = ui->lineEditToolTip->text().toStdString();
-        App::Property* prop = propertyItem->getFirstProperty();
-        if (prop && prop->getGroup() != group) {
+        if (App::Property* prop = propertyItem->getFirstProperty();
+            prop && prop->getGroup() != group) {
             varSet->changeDynamicProperty(prop, group.c_str(), doc.c_str());
         }
     }
@@ -787,8 +784,7 @@ void DlgAddPropertyVarSet::accept()
 void DlgAddPropertyVarSet::reject()
 {
     if (propertyItem) {
-        App::Property* prop = propertyItem->getFirstProperty();
-        if (prop) {
+        if (App::Property* prop = propertyItem->getFirstProperty()) {
             App::PropertyContainer* container = prop->getContainer();
             container->removeDynamicProperty(prop->getName());
             closeTransaction(TransactionOption::Abort);

--- a/src/Gui/Dialogs/DlgAddPropertyVarSet.h
+++ b/src/Gui/Dialogs/DlgAddPropertyVarSet.h
@@ -96,9 +96,9 @@ private:
         Abort = true
     };
 
-    enum class FieldChange : bool {
-        Name = false,
-        Type = true
+    enum class FieldChange : std::uint8_t {
+        Name,
+        Type
     };
 
     int findLabelRow(const char* labelName, QFormLayout* layout);


### PR DESCRIPTION
This PR adds support for expressions to the VarSet Add Property Dialog.

Besides this major change, it also provides minor improvements that are related to the major change:
- Prevent a layout shift: #20950
- Showing a correct value for expressions: #19698


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

Closes #19716, #19698, #20950

## Before and After Images

### Before


https://github.com/user-attachments/assets/66ac05b5-a9ed-4365-8061-b22df689c0ba

### After


https://github.com/user-attachments/assets/2c3e8b98-54be-4da0-a758-eb1bf0b69779


<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
