### PR TITLE
Sketcher: Fix increment of parabola constraint tag

### DIFF
--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -4162,8 +4162,6 @@ int Sketch::addInternalAlignmentParabolaFocalDistance(int geoId1, int geoId2)
 
         int tag = ++ConstraintsCounter;
         GCSsys.addConstraintP2PCoincident(p1, vertexpoint, tag);
-
-        tag = ++ConstraintsCounter;
         GCSsys.addConstraintP2PCoincident(p2, focuspoint, tag);
 
         return ConstraintsCounter;


### PR DESCRIPTION
It is an invisible and unstated assumption of the redundant-constraint removal code that the "tag" of a constraint can be used as the index into the `SketchObject`'s `Constraint` list. This is true for all objects except a parabola, which, when creating its internal alignment focus constraints, incremented the `ConstraintCounter` for *each* of the internal constraints, instead of only once.

Fixes #22192.