### PR TITLE
PartDesign: Try to auto-fix any invalid generated helix

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -36,6 +36,7 @@
 # include <BRepOffsetAPI_MakePipeShell.hxx>
 # include <BRepPrimAPI_MakeRevol.hxx>
 # include <ShapeFix_ShapeTolerance.hxx>
+# include <ShapeFix_Solid.hxx>
 # include <Precision.hxx>
 # include <TopoDS.hxx>
 # include <TopoDS_Face.hxx>
@@ -258,6 +259,13 @@ App::DocumentObjectExecReturn* Helix::execute()
         }
 
         fix.LimitTolerance(result, Precision::Confusion() * size * Tolerance.getValue() ); // significant precision reduction due to helical approximation - needed to allow fusion to succeed
+
+        // try to auto-fix possible invalid result
+        ShapeFix_Solid fixer;
+        fixer.Init(TopoDS::Solid(result));
+        if (fixer.Perform()) {
+            result = fixer.Solid();
+        }
 
         AddSubShape.setValue(result);
 


### PR DESCRIPTION
Sometime the helix shape is invalid due to self-intersecting or degenerated edges. The OCC ShapeFix_Solid is able to improve the shape quality so use it when the shape is detected invalid by the BRepCheck_Analyser.

Fix #22294