### PR TITLE
CI: fix macOS on x86_64 weekly builds

### DIFF
--- a/package/rattler-build/conda_build_config.yaml
+++ b/package/rattler-build/conda_build_config.yaml
@@ -1,9 +1,0 @@
-c_compiler:               # [win]
-  - vs2022                # [win]
-cxx_compiler:             # [win]
-  - vs2022                # [win]
-
-c_stdlib_version:         # [osx and x86_64]
-  - "10.13"               # [osx and x86_64]
-MACOSX_DEPLOYMENT_TARGET: # [osx and x86_64]
-  - "10.13"               # [osx and x86_64]

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -90,7 +90,7 @@ requirements:
 
     - if: osx and x86_64
       then:
-        - ${{ stdlib('c') }}
+        - __osx >=10.13
 
     - if: build_platform != target_platform
       then:

--- a/package/rattler-build/variants.yaml
+++ b/package/rattler-build/variants.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- if: win
+  then: vs2022
+cxx_compiler:
+- if: win
+  then: vs2022
+
+c_stdlib_version:
+- if: osx and x86_64
+  then: "10.13"
+MACOSX_SDK_VERSION:
+- if: osx and x86_64
+  then: "10.13"
+MACOSX_DEPLOYMENT_TARGET:
+- if: osx and x86_64
+  then: "10.13"


### PR DESCRIPTION
Despite claims of compatibility with 'conda_build_config.yaml', rattler-build does not support all of the necessary capabilities to set the minimum macOS version. Converting the 'conda_build_config.yaml' to the rattler-build 'variants.yaml' corrects the issue.

## Issues

* #22501 

## Before and After Images

None.