### PR TITLE
Base: Clean up ParameterManager::LoadDocument

### DIFF
--- a/src/Base/PreCompiled.h
+++ b/src/Base/PreCompiled.h
@@ -104,6 +104,7 @@
 #include <xercesc/util/XMLString.hpp>
 #include <xercesc/util/PlatformUtils.hpp>
 #include <xercesc/sax/SAXParseException.hpp>
+#include <xercesc/sax/EntityResolver.hpp>
 #include <xercesc/sax/ErrorHandler.hpp>
 #include <xercesc/sax/SAXParseException.hpp>
 #include <xercesc/sax/SAXException.hpp>


### PR DESCRIPTION
Even after adding `parser->setDisableDefaultEntityResolution(true);`, CodeQL flags a security warning about entity resolution, so the main work of this PR is to add an explicitly no-op entity resolver to completely block any problematic entity resolution. While modifying that method, I also switched from raw pointers to `std::unique_ptr`, and fixed a typo in a variable name.