### PR TITLE
Part: Add error handling to TopoShape::isLinearEdge

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -5241,15 +5241,15 @@ bool TopoShape::isLinearEdge(Base::Vector3d* dir, Base::Vector3d* base) const
         return false;
     }
 
-    if (!GeomCurve::isLinear(BRepAdaptor_Curve(TopoDS::Edge(getShape())).Curve().Curve(),
-                             dir,
-                             base)) {
+    auto tdsEdge = TopoDS::Edge(getShape());
+    if (tdsEdge.IsNull()) {
         return false;
     }
 
     // BRep_Tool::Curve() will transform the returned geometry, so no need to
     // check the shape's placement.
-    return true;
+    auto curve = BRepAdaptor_Curve(tdsEdge).Curve().Curve();
+    return curve && GeomCurve::isLinear(curve);
 }
 
 bool TopoShape::isPlanarFace(double tol) const


### PR DESCRIPTION
Fix #22733 by making sure that the resolved `Geom_Curve` is valid before checking if it is linear. There are several alternative places where we could be checking this, and/or handling the exception that is raised if we fail to check this. I picked what seemed to be the least intrusive option.