### PR TITLE
Sketcher: When scaling only copy relevant constraints

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
@@ -410,6 +410,13 @@ private:
                     continue;
                 }
 
+                // Only consider constraints that apply to the geometry that we are scaling
+                if (std::ranges::none_of(listOfGeoIds, [cstr](const auto& geoId) {
+                        return cstr->involvesGeoId(geoId);
+                    })) {
+                    continue;
+                }
+
                 auto newConstr = std::unique_ptr<Constraint>(cstr->copy());
                 newConstr->First = offsetGeoID(newConstr->First, firstCurveCreated);
 


### PR DESCRIPTION
When using the scale tool to scale some, but not *all*, sketch geometry, ensure that only constraints that involve the scaled geometry are considered. Fixes #22248 and #22247.

@theo-vt can you check me on this and verify whether this is a complete solution to those issues?