### PR TITLE
AssemblyGui: CmakeLists typo

### DIFF
--- a/src/Mod/Assembly/Gui/CMakeLists.txt
+++ b/src/Mod/Assembly/Gui/CMakeLists.txt
@@ -74,7 +74,7 @@ SET(AssemblyGui_SRCS
 if(FREECAD_USE_PCH)
     add_definitions(-D_PreComp_)
     GET_MSVC_PRECOMPILED_SOURCE("PreCompiled.cpp" PCH_SRCS ${AssemblyGui_SRCS})
-    ADD_MSVC_PRECOMPILED_HEADER(PathGui PreCompiled.h PreCompiled.cpp PCH_SRCS)
+    ADD_MSVC_PRECOMPILED_HEADER(AssemblyGui PreCompiled.h PreCompiled.cpp PCH_SRCS)
 endif(FREECAD_USE_PCH)
 
 SET(AssemblyGuiIcon_SVG


### PR DESCRIPTION
A PathGui was in the assembly cmakelists.
To be honest I am not sure what this line is about. But it would not make sense for it to be PathGui.
@chennes perhaps you know better?