### PR TITLE
CAM: fix missing SpindleDirection in new TC

### DIFF
--- a/src/Mod/CAM/Path/Tool/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Controller.py
@@ -150,7 +150,6 @@ class ToolController:
     def onDocumentRestored(self, obj):
         obj.setEditorMode("Placement", 2)
 
-
     def onDelete(self, obj, arg2=None):
         if hasattr(obj.Tool, "InList") and len(obj.Tool.InList) == 1:
             if hasattr(obj.Tool.Proxy, "onDelete"):

--- a/src/Mod/CAM/Path/Tool/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Controller.py
@@ -150,6 +150,7 @@ class ToolController:
     def onDocumentRestored(self, obj):
         obj.setEditorMode("Placement", 2)
 
+
     def onDelete(self, obj, arg2=None):
         if hasattr(obj.Tool, "InList") and len(obj.Tool.InList) == 1:
             if hasattr(obj.Tool.Proxy, "onDelete"):
@@ -245,7 +246,6 @@ class ToolController:
 
     def execute(self, obj):
         Path.Log.track(obj.Name)
-
         args = {
             "toolnumber": obj.ToolNumber,
             "toollabel": obj.Label,
@@ -306,6 +306,8 @@ def Create(
 
         if hasattr(obj.Tool, "SpindleDirection"):
             obj.SpindleDir = obj.Tool.SpindleDirection
+        else:
+            obj.SpindleDir = "None"
 
     obj.ToolNumber = toolNumber
     return obj


### PR DESCRIPTION
Recent redesign of tools and toolcontrollers fails to correctly open previously created files  This breaks any paths created with previous code by failing to initialise  the new SpindleDirection attribute. 
This breaks existing files, it is a regression.

https://github.com/FreeCAD/FreeCAD/issues/22464

This enum defined thus:

```
        # Enumeration lists for App::PropertyEnumeration properties
        enums = {
            "SpindleDir": [
                (translate("CAM_ToolController", "Forward"), "Forward"),
                (translate("CAM_ToolController", "Reverse"), "Reverse"),
                (translate("CAM_ToolController", "None"), "None"),
            ],  # this is the direction that the profile runs
        }

```
This PR initialises SpindleDir  to "None" , if it is not present and thus fixes the bug.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
