### PR TITLE
Core: Set ::Remove flag before calling breakLinks

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3282,6 +3282,8 @@ void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions optio
         pcObject->unsetupObject();
     }
     signalDeletedObject(*pcObject);
+    signalTransactionRemove(*pcObject, d->rollback ? nullptr : d->activeUndoTransaction);
+    breakDependency(pcObject, true);
 
     // TODO Check me if it's needed (2015-09-01, Fat-Zer)
     // remove the tip if needed
@@ -3298,15 +3300,7 @@ void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions optio
 
     // do no transactions if we do a rollback!
     if (!d->rollback && d->activeUndoTransaction) {
-        // Undo stuff
-        signalTransactionRemove(*pcObject, d->activeUndoTransaction);
-        breakDependency(pcObject, true);
         d->activeUndoTransaction->addObjectNew(pcObject);
-    }
-    else {
-        // for a rollback delete the object
-        signalTransactionRemove(*pcObject, 0);
-        breakDependency(pcObject, true);
     }
 
     std::unique_ptr<DocumentObject> tobedestroyed;


### PR DESCRIPTION

PR #21481 changed the order of some operations for some code paths and made the ::Remove documentObject flag to false before calling breakLinks which results in a segfault in some cases (see https://github.com/FreeCAD/FreeCAD/pull/21481#issuecomment-3120749542)

This PR ensures that the ::Remove flag is set to true before calling breakLinks

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
