### PR TITLE
CAM: Post Process only selected Operations

### DIFF
--- a/src/Mod/CAM/Path/Post/Command.py
+++ b/src/Mod/CAM/Path/Post/Command.py
@@ -61,7 +61,7 @@ def _resolve_post_processor_name(job):
     if valid_name and PostProcessor.exists(valid_name):
         return valid_name
     else:
-        raise ValueError(f"Post processor not identified.")
+        raise ValueError("Post processor not identified.")
 
 
 class DlgSelectPostProcessor:
@@ -108,12 +108,14 @@ class CommandPathPost:
             "Pixmap": "CAM_Post",
             "MenuText": QT_TRANSLATE_NOOP("CAM_Post", "Post Process"),
             "Accel": "P, P",
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_Post", "Post Process the selected Job"),
+            "ToolTip": QT_TRANSLATE_NOOP(
+                "CAM_Post", "Post Process the selected Job or selected operations"
+            ),
         }
 
     def IsActive(self):
         selected = FreeCADGui.Selection.getSelectionEx()
-        if len(selected) != 1:
+        if len(selected) == 0:
             return False
 
         selected_object = selected[0].Object
@@ -203,6 +205,12 @@ class CommandPathPost:
         Path.Log.debug(self.candidate.Name)
         FreeCAD.ActiveDocument.openTransaction("Post Process the Selected Job")
 
+        selected = FreeCADGui.Selection.getSelection()
+        if len(selected) > 0:
+            operations = [
+                op for op in selected if hasattr(op, "Path") and not op.Name.startswith("Job")
+            ]
+
         postprocessor_name = _resolve_post_processor_name(self.candidate)
         Path.Log.debug(f"Post Processor: {postprocessor_name}")
 
@@ -211,7 +219,9 @@ class CommandPathPost:
             return
 
         # get a postprocessor
-        postprocessor = PostProcessorFactory.get_post_processor(self.candidate, postprocessor_name)
+        postprocessor = PostProcessorFactory.get_post_processor(
+            self.candidate, postprocessor_name, operations
+        )
 
         post_data = postprocessor.export()
         # None is returned if there was an error during argument processing

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -82,7 +82,7 @@ class PostProcessorFactory:
     """Factory class for creating post processors."""
 
     @staticmethod
-    def get_post_processor(job, postname):
+    def get_post_processor(job, postname, operations):
         # Log initial debug message
         Path.Log.debug("PostProcessorFactory.get_post_processor()")
 
@@ -113,13 +113,13 @@ class PostProcessorFactory:
                 except AttributeError:
                     # Return an instance of WrapperPost if no valid module is found
                     Path.Log.debug(f"Post processor {postname} is a script")
-                    return WrapperPost(job, module_path, module_name)
+                    return WrapperPost(job, module_path, module_name, operations)
 
 
 class PostProcessor:
     """Base Class.  All non-legacy postprocessors should inherit from this class."""
 
-    def __init__(self, job, tooltip, tooltipargs, units, *args, **kwargs):
+    def __init__(self, job, operations, tooltip, tooltipargs, units, *args, **kwargs):
         self._tooltip = tooltip
         self._tooltipargs = tooltipargs
         self._units = units
@@ -127,6 +127,11 @@ class PostProcessor:
         self._args = args
         self._kwargs = kwargs
         self.reinitialize()
+
+        if operations:
+            self._operations = operations
+        else:
+            self._operations = job.Operations.Group
 
     @classmethod
     def exists(cls, processor):
@@ -193,7 +198,8 @@ class PostProcessor:
                 sublist = [__fixtureSetup(index, f, self._job)]
 
                 # Now generate the gcode
-                for obj in self._job.Operations.Group:
+                # for obj in self._job.Operations.Group:
+                for obj in self._operations:
                     tc = PathUtil.toolControllerForOp(obj)
                     if tc is not None and PathUtil.activeForOp(obj):
                         if tc.ToolNumber != currTool:
@@ -230,7 +236,8 @@ class PostProcessor:
                     postlist.append((toolstring, sublist))
 
             Path.Log.track(self._job.PostProcessorOutputFile)
-            for idx, obj in enumerate(self._job.Operations.Group):
+            # for idx, obj in enumerate(self._job.Operations.Group):
+            for idx, obj in enumerate(self._operations):
                 Path.Log.track(obj.Label)
 
                 # check if the operation is active
@@ -276,7 +283,8 @@ class PostProcessor:
             currTool = None
 
             # Now generate the gcode
-            for obj in self._job.Operations.Group:
+            # for obj in self._job.Operations.Group:
+            for obj in self._operations:
 
                 # check if the operation is active
                 if not PathUtil.activeForOp(obj):
@@ -465,10 +473,13 @@ class PostProcessor:
 class WrapperPost(PostProcessor):
     """Wrapper class for old post processors that are scripts."""
 
-    def __init__(self, job, script_path, module_name, *args, **kwargs):
-        super().__init__(job, tooltip=None, tooltipargs=None, units=None, *args, **kwargs)
+    def __init__(self, job, script_path, module_name, operations, *args, **kwargs):
+        super().__init__(
+            job, operations, tooltip=None, tooltipargs=None, units=None, *args, **kwargs
+        )
         self.script_path = script_path
         self.module_name = module_name
+        self.operations = operations
         Path.Log.debug(f"WrapperPost.__init__({script_path})")
         self.load_script()
 


### PR DESCRIPTION
https://forum.freecad.org/viewtopic.php?t=98611

If you need to export only one or few `Operations` you should disable all other `Operations`
This PR added possibility to Post Process only selected `Operations` from `Job`

After this changes
- If select one or several `Operations`, only selected operations will be export
- If you select `Job` or any other object inside `Job`, all operations will be export