### PR TITLE
Check and update element references of PropertyLinks after restore

### DIFF
--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -4064,9 +4064,16 @@ int PropertyXLink::checkRestore(std::string* msg) const
 void PropertyXLink::afterRestore()
 {
     assert(_SubList.size() == _ShadowSubList.size());
-    if (!testFlag(LinkRestoreLabel) || !_pcLink || !_pcLink->isAttachedToDocument()) {
+    if (!_pcLink || !_pcLink->isAttachedToDocument()) {
+        return;
+    } else {
+        updateElementReferences(_pcLink, true);
+    }
+
+    if (!testFlag(LinkRestoreLabel)) {
         return;
     }
+
     setFlag(LinkRestoreLabel, false);
     for (size_t i = 0; i < _SubList.size(); ++i) {
         restoreLabelReference(_pcLink, _SubList[i], &_ShadowSubList[i]);


### PR DESCRIPTION
Fixes: https://github.com/FreeCAD/FreeCAD/issues/22784

This PR implements a change which causes PropertyXLink to update it's element references after restoring the link.
The underlying issue that this PR fixes is also present in Link Stage 3, it should be easy to port the fixes over there.

Currently this only works for PropertyXLink, just to directly fix Assembly issues
I will add fixes to the rest of the links soon, I just need to find tests for them.