### PR TITLE
Draft: fix size of file button in Hatch task panel

### DIFF
--- a/src/Mod/Draft/Resources/ui/dialogHatch.ui
+++ b/src/Mod/Draft/Resources/ui/dialogHatch.ui
@@ -94,6 +94,13 @@ This setting modifies the Translate property.</string>
      </property>
     </widget>
    </item>
+   <item row="5" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <customwidgets>


### PR DESCRIPTION
Fixes #22790.

To keep the file button at the correct size a vertical bottom spacer is required.