### PR TITLE
Assembly: Fix 22815

### DIFF
--- a/src/Mod/Assembly/App/AssemblyObjectPyImp.cpp
+++ b/src/Mod/Assembly/App/AssemblyObjectPyImp.cpp
@@ -192,7 +192,7 @@ PyObject* AssemblyObjectPy::exportAsASMT(PyObject* args) const
 Py::List AssemblyObjectPy::getJoints() const
 {
     Py::List ret;
-    std::vector<App::DocumentObject*> list = getAssemblyObjectPtr()->getJoints();
+    std::vector<App::DocumentObject*> list = getAssemblyObjectPtr()->getJoints(false);
 
     for (auto It : list) {
         ret.append(Py::Object(It->getPyObject(), true));


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/22815

The bug was caused by the unsuspecting https://github.com/FreeCAD/FreeCAD/pull/22711

The reason is that in the isActive it's doing getJointsOfType. Which is doing assembly.Joints. Which is calling through the python interface assembly->getJoints().

The issue is that getJoints by default recompute the joints which triggered some sort of update loop.

@chennes 