### PR TITLE
Gui: Support enum editor in VarSet dialog

### DIFF
--- a/src/Gui/Dialogs/DlgAddPropertyVarSet.h
+++ b/src/Gui/Dialogs/DlgAddPropertyVarSet.h
@@ -89,6 +89,7 @@ public:
 
 public Q_SLOTS:
     void valueChanged();
+    void valueChangedEnum();
 
 private:
     enum class TransactionOption : bool {
@@ -110,6 +111,11 @@ private:
     void initializeTypes();
 
     void removeSelectionEditor();
+    QVariant getEditorData() const;
+    void setEditorData(const QVariant& data);
+    bool isEnumPropertyItem() const;
+    void addEnumEditor(PropertyEditor::PropertyItem* propertyItem);
+    void addNormalEditor(PropertyEditor::PropertyItem* propertyItem);
     void addEditor(PropertyEditor::PropertyItem* propertyItem);
     bool isTypeWithEditor(const Base::Type& type);
     bool isTypeWithEditor(const std::string& type);


### PR DESCRIPTION
This PR adds supports for adding enum items directly in the VarSet add property dialog.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Closes #15553.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

### Before

It was not possible to add a value to an enumeration property. It was necessary to create the property, then go to the property view, show the hidden properties and then edit the `Enum` property.


https://github.com/user-attachments/assets/db0f7646-35d5-49f3-8700-57be60e20739



### After

The VarSet add property dialog shows the editor for the Enum property immediately and it is possible to create enum items there.


https://github.com/user-attachments/assets/c951b0ae-7529-44bf-b8a8-8725c7521d1b



## Limitations

Note, that it is not possible to select the value of the property; that still needs to be done in the property view. Adding support for that, would be a considerable change to the dialog so for now I consider that out of scope. If that is a feature that is requested, I propose to add a new issue about that and in that case, I would propose an overhaul of the enum editor that allows you to select a value *and* enter items. This would also improve the awkward workflow that is currently in place that requires a user to show hidden properties. For now, let's try to see how users value this workflow.


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
