### PR TITLE
[TD]Fix no delete of cosmetic in clip group

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewClip.h
+++ b/src/Mod/TechDraw/App/DrawViewClip.h
@@ -31,6 +31,7 @@
 
 #include "DrawView.h"
 
+// ?? this (and DrawViewCollection) could use App::GroupExtension instead??
 
 namespace TechDraw
 {

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -748,7 +748,7 @@ QRectF QGIView::boundingRect() const
     return m_border->rect().adjusted(-2., -2., 2., 2.);     //allow for border line width  //TODO: fiddle brect if border off?
 }
 
-QGIView* QGIView::getQGIVByName(std::string name)
+QGIView* QGIView::getQGIVByName(std::string name) const
 {
     QList<QGraphicsItem*> qgItems = scene()->items();
     QList<QGraphicsItem*>::iterator it = qgItems.begin();

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -173,8 +173,10 @@ public:
     template <typename T>
     std::vector<T> getObjects(std::vector<int> indexes);
 
+    bool pseudoEventFilter(QGraphicsItem *watched, QEvent *event) { return sceneEventFilter(watched, event); }
+
 protected:
-    QGIView* getQGIVByName(std::string name);
+    QGIView* getQGIVByName(std::string name) const;
 
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
     // Preselection events:

--- a/src/Mod/TechDraw/Gui/QGIViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.cpp
@@ -25,10 +25,14 @@
 #ifndef _PreComp_
 # include <algorithm>    // std::find
 # include <QGraphicsScene>
+# include <QKeyEvent>
 #endif
+#include <Gui/Selection/Selection.h>
+#include <Gui/Selection/SelectionObject.h>
 
 #include <Base/Console.h>
 #include <Mod/TechDraw/App/DrawViewClip.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
 
 #include "QGIViewClip.h"
 #include "QGCustomClip.h"
@@ -37,10 +41,12 @@
 
 
 using namespace TechDrawGui;
+using namespace TechDraw;
 
 QGIViewClip::QGIViewClip()
 {
     setHandlesChildEvents(false);
+    // setHandlesChildEvents(true);
     setCacheMode(QGraphicsItem::NoCache);
     setAcceptHoverEvents(true);
     setFlag(QGraphicsItem::ItemIsSelectable, true);
@@ -156,3 +162,63 @@ void QGIViewClip::drawClip()
         }
     }
 }
+
+
+bool QGIViewClip::sceneEventFilter(QGraphicsItem *watched, QEvent *event)
+{
+    if (event->type() == QEvent::ShortcutOverride) {
+        // if we accept this event, we should get a regular keystroke event next
+        // which will be processed by QGVPage/QGVNavStyle keypress logic, but not forwarded to
+        // Std_Delete
+        auto* keyEvent = static_cast<QKeyEvent*>(event);
+        if (keyEvent->matches(QKeySequence::Delete))  {
+            if (selectionIsInGroup()) {
+                return forwardEventToSelection(watched, event);
+            }
+        }
+    }
+
+    return QGraphicsItem::sceneEventFilter(watched, event);
+}
+
+
+bool QGIViewClip::selectionIsInGroup() const
+{
+    bool single = false;
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(nullptr, DrawView::getClassTypeId(),
+                                           Gui::ResolveMode::OldStyleElement, single);
+    if (selection.empty()) {
+        return false;
+    }
+
+    auto* clipGroup = freecad_cast<DrawViewClip*>(getViewObject());
+    for (auto& selItem : selection) {
+        auto docObj = selItem.getObject();
+        if (!clipGroup->isViewInClip(docObj)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool QGIViewClip::forwardEventToSelection(QGraphicsItem *watched, QEvent *event) const
+{
+    bool single = false;
+    auto selection = Gui::Selection().getSelectionEx(nullptr, DrawViewPart::getClassTypeId(),
+                                           Gui::ResolveMode::OldStyleElement, single);
+    if (selection.empty()) {
+        return false;
+    }
+
+    // ?? if multiple views (docObjs) are in selection, what do we do? call each in succession while
+    //    summing the returned booleans?
+    App::DocumentObject* docObj = selection[0].getObject();
+    QGIView* qview = getQGIVByName(docObj->getNameInDocument());
+    if (!qview) {
+        return false;
+    }
+
+    return qview->pseudoEventFilter(watched, event);
+}
+

--- a/src/Mod/TechDraw/Gui/QGIViewClip.h
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.h
@@ -42,6 +42,9 @@ public:
 
     enum {Type = UserType::QGIViewClip};
     int type() const override { return Type;}
+    bool sceneEventFilter(QGraphicsItem *watched, QEvent *event) override;
+    bool selectionIsInGroup() const;
+    bool forwardEventToSelection(QGraphicsItem *watched, QEvent *event) const;
 
     void updateView(bool update = false) override;
 

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -111,13 +111,11 @@ QVariant QGIViewPart::itemChange(GraphicsItemChange change, const QVariant& valu
 
 bool QGIViewPart::sceneEventFilter(QGraphicsItem *watched, QEvent *event)
 {
-    // Base::Console().message("QGIVP::sceneEventFilter - event: %d watchedtype: %d\n",
-    //                         event->type(), watched->type() - QGraphicsItem::UserType);
     if (event->type() == QEvent::ShortcutOverride) {
         // if we accept this event, we should get a regular keystroke event next
         // which will be processed by QGVPage/QGVNavStyle keypress logic, but not forwarded to
         // Std_Delete
-        QKeyEvent *keyEvent = static_cast<QKeyEvent*>(event);
+        auto *keyEvent = static_cast<QKeyEvent*>(event);
         if (keyEvent->matches(QKeySequence::Delete))  {
             bool success = removeSelectedCosmetic();
             if (success) {

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -69,7 +69,6 @@ public:
     void paint( QPainter * painter,
                         const QStyleOptionGraphicsItem * option,
                         QWidget * widget = nullptr ) override;
-    bool sceneEventFilter(QGraphicsItem *watched, QEvent *event) override;
 
 
     void toggleCache(bool state) override;
@@ -129,6 +128,7 @@ public:
     virtual double getVertexSize();
 
 protected:
+    bool sceneEventFilter(QGraphicsItem *watched, QEvent *event) override;
     QPainterPath drawPainterPath(TechDraw::BaseGeomPtr baseGeom) const;
     void drawViewPart();
     QGIFace* drawFace(TechDraw::FacePtr f, int idx);

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -565,7 +565,7 @@ QGIView* QGSPage::addDrawViewClip(TechDraw::DrawViewClip* view)
     qview->setViewFeature(view);
     addItemToScene(qview);
     qview->setPosition(Rez::guiX(view->X.getValue()), Rez::guiX(view->Y.getValue()));
-
+    qview->installSceneEventFilter(qview);
     return qview;
 }
 


### PR DESCRIPTION
This PR implements a fix for issue #21117. 

The clip group (parent) was handling DEL key press events that actually belong to a view inside the clip group.

I'm not entirely happy with this solution.  This seems like it should be a fairly common situation and Qt may have a more elegant way of handling it.  