### PR TITLE
FEM: Add support for amplitudes with CalculiX

### DIFF
--- a/src/Mod/Fem/App/FemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/App/FemConstraintDisplacement.cpp
@@ -148,6 +148,16 @@ ConstraintDisplacement::ConstraintDisplacement()
                       "ConstraintDisplacement",
                       App::Prop_None,
                       "Rotation in local Z direction");
+    ADD_PROPERTY_TYPE(EnableAmplitude,
+                      (false),
+                      "ConstraintDisplacement",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude of the displacement boundary condition");
+    ADD_PROPERTY_TYPE(AmplitudeValues,
+                      (std::vector<std::string> {"0, 0", "1, 1"}),
+                      "ConstraintFDisplacement",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude values");
 }
 
 App::DocumentObjectExecReturn* ConstraintDisplacement::execute()

--- a/src/Mod/Fem/App/FemConstraintDisplacement.h
+++ b/src/Mod/Fem/App/FemConstraintDisplacement.h
@@ -40,6 +40,9 @@ public:
     /// Constructor
     ConstraintDisplacement();
 
+    App::PropertyBool EnableAmplitude;
+    App::PropertyStringList AmplitudeValues;
+
     // Displacement parameters
     App::PropertyDistance xDisplacement;
     App::PropertyDistance yDisplacement;

--- a/src/Mod/Fem/App/FemConstraintForce.cpp
+++ b/src/Mod/Fem/App/FemConstraintForce.cpp
@@ -54,6 +54,16 @@ ConstraintForce::ConstraintForce()
 
     // by default use the null vector to indicate an invalid value
     naturalDirectionVector = Base::Vector3d(0, 0, 0);
+    ADD_PROPERTY_TYPE(EnableAmplitude,
+                      (false),
+                      "ConstraintForce",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude of the force load");
+    ADD_PROPERTY_TYPE(AmplitudeValues,
+                      (std::vector<std::string> {"0, 0", "1, 1"}),
+                      "ConstraintForce",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude values");
 }
 
 App::DocumentObjectExecReturn* ConstraintForce::execute()

--- a/src/Mod/Fem/App/FemConstraintForce.h
+++ b/src/Mod/Fem/App/FemConstraintForce.h
@@ -38,6 +38,8 @@ public:
     /// Constructor
     ConstraintForce();
 
+    App::PropertyBool EnableAmplitude;
+    App::PropertyStringList AmplitudeValues;
     App::PropertyForce Force;
     App::PropertyLinkSub Direction;
     App::PropertyBool Reversed;

--- a/src/Mod/Fem/App/FemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/App/FemConstraintHeatflux.cpp
@@ -56,6 +56,16 @@ ConstraintHeatflux::ConstraintHeatflux()
                       App::Prop_None,
                       "Cavity radiation");
     ADD_PROPERTY_TYPE(CavityName, ("cav"), "ConstraintHeatflux", App::Prop_None, "Cavity name");
+    ADD_PROPERTY_TYPE(EnableAmplitude,
+                      (false),
+                      "ConstraintHeatflux",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude of the heat flux load");
+    ADD_PROPERTY_TYPE(AmplitudeValues,
+                      (std::vector<std::string> {"0, 0", "1, 1"}),
+                      "ConstraintHeatflux",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude values");
 }
 
 App::DocumentObjectExecReturn* ConstraintHeatflux::execute()

--- a/src/Mod/Fem/App/FemConstraintHeatflux.h
+++ b/src/Mod/Fem/App/FemConstraintHeatflux.h
@@ -39,6 +39,9 @@ class FemExport ConstraintHeatflux: public Fem::Constraint
 public:
     ConstraintHeatflux();
 
+    App::PropertyBool EnableAmplitude;
+    App::PropertyStringList AmplitudeValues;
+
     App::PropertyTemperature AmbientTemp;
     /*App::PropertyFloat FaceTemp;*/
     App::PropertyThermalTransferCoefficient FilmCoef;

--- a/src/Mod/Fem/App/FemConstraintPressure.cpp
+++ b/src/Mod/Fem/App/FemConstraintPressure.cpp
@@ -34,6 +34,16 @@ ConstraintPressure::ConstraintPressure()
 {
     ADD_PROPERTY(Pressure, (0.0));
     ADD_PROPERTY(Reversed, (0));
+    ADD_PROPERTY_TYPE(EnableAmplitude,
+                      (false),
+                      "ConstraintPressure",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude of the pressure load");
+    ADD_PROPERTY_TYPE(AmplitudeValues,
+                      (std::vector<std::string> {"0, 0", "1, 1"}),
+                      "ConstraintPressure",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude values");
 }
 
 App::DocumentObjectExecReturn* ConstraintPressure::execute()

--- a/src/Mod/Fem/App/FemConstraintPressure.h
+++ b/src/Mod/Fem/App/FemConstraintPressure.h
@@ -37,6 +37,8 @@ class FemExport ConstraintPressure: public Fem::Constraint
 public:
     ConstraintPressure();
 
+    App::PropertyBool EnableAmplitude;
+    App::PropertyStringList AmplitudeValues;
     App::PropertyPressure Pressure;
     App::PropertyBool Reversed;
 

--- a/src/Mod/Fem/App/FemConstraintTemperature.cpp
+++ b/src/Mod/Fem/App/FemConstraintTemperature.cpp
@@ -44,6 +44,16 @@ ConstraintTemperature::ConstraintTemperature()
                       (App::PropertyType)(App::Prop_None),
                       "Type of constraint, temperature or concentrated heat flux");
     ConstraintType.setEnums(ConstraintTypes);
+    ADD_PROPERTY_TYPE(EnableAmplitude,
+                      (false),
+                      "ConstraintTemperature",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude of the temperature boundary condition");
+    ADD_PROPERTY_TYPE(AmplitudeValues,
+                      (std::vector<std::string> {"0, 0", "1, 1"}),
+                      "ConstraintTemperature",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude values");
 }
 
 App::DocumentObjectExecReturn* ConstraintTemperature::execute()

--- a/src/Mod/Fem/App/FemConstraintTemperature.h
+++ b/src/Mod/Fem/App/FemConstraintTemperature.h
@@ -40,6 +40,9 @@ public:
     /// Constructor
     ConstraintTemperature();
 
+    App::PropertyBool EnableAmplitude;
+    App::PropertyStringList AmplitudeValues;
+
     // Temperature parameters
     App::PropertyTemperature Temperature;
     App::PropertyPower CFlux;

--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -273,6 +273,7 @@ SET(FemSolverCalculix_SRCS
     femsolver/calculix/write_femelement_geometry.py
     femsolver/calculix/write_femelement_material.py
     femsolver/calculix/write_femelement_matgeosets.py
+    femsolver/calculix/write_amplitude.py
     femsolver/calculix/write_footer.py
     femsolver/calculix/write_mesh.py
     femsolver/calculix/write_step_equation.py

--- a/src/Mod/Fem/femobjects/constraint_bodyheatsource.py
+++ b/src/Mod/Fem/femobjects/constraint_bodyheatsource.py
@@ -78,7 +78,24 @@ class ConstraintBodyHeatSource(base_fempythonobject.BaseFemPythonObject):
                 value=["Dissipation Rate", "Total Power"],
             )
         )
-
+        prop.append(
+            _PropHelper(
+                type="App::PropertyBool",
+                name="EnableAmplitude",
+                group="Constraint Body Heat Source",
+                doc="Amplitude of the body heat source",
+                value=False,
+            )
+        )
+        prop.append(
+            _PropHelper(
+                type="App::PropertyStringList",
+                name="AmplitudeValues",
+                group="Constraint Body Heat Source",
+                doc="Amplitude values",
+                value=["0, 0", "1, 1"],
+            )
+        )
         return prop
 
     def onDocumentRestored(self, obj):

--- a/src/Mod/Fem/femsolver/calculix/write_amplitude.py
+++ b/src/Mod/Fem/femsolver/calculix/write_amplitude.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *   Copyright (c) 2025 Jakub Michalski <jakub.j.michalski[at]gmail.com>         *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+__title__ = "FreeCAD FEM calculix amplitude"
+__author__ = "Jakub Michalski"
+__url__ = "https://www.freecad.org"
+
+def write_amplitude(f, ccxwriter):
+
+    # write amplitude definitions for all analysis features that use them
+
+    def write_obj_amplitude(obj):
+        if obj.EnableAmplitude:
+            f.write(f"*AMPLITUDE, NAME={obj.Name}\n")
+            for value in obj.AmplitudeValues:
+                f.write(f"{value}\n")
+            f.write("\n")
+
+    constraint_lists = [
+        ccxwriter.member.cons_force,
+        ccxwriter.member.cons_pressure,
+        ccxwriter.member.cons_displacement,
+        ccxwriter.member.cons_heatflux,
+        ccxwriter.member.cons_temperature,
+        ccxwriter.member.cons_bodyheatsource,
+    ]
+
+    for constraint_list in constraint_lists:
+        for entry in constraint_list:
+            write_obj_amplitude(entry["Object"])

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_bodyheatsource.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_bodyheatsource.py
@@ -96,6 +96,9 @@ def write_constraint(f, femobj, bodyheatsource_obj, ccxwriter):
         volume = ref_feat.getSubObject(ref_sub_obj).Volume
         heat = bodyheatsource_obj.TotalPower / FreeCAD.Units.Quantity(volume, "mm^3")
     # write to file
-    f.write("*DFLUX\n")
+    if bodyheatsource_obj.EnableAmplitude:
+    	f.write(f"*DFLUX, AMPLITUDE={bodyheatsource_obj.Name}\n")
+    else:
+    	f.write("*DFLUX\n")
     f.write("{},BF,{:.13G}\n".format(bodyheatsource_obj.Name, heat.getValueAs("t/(mm*s^3)").Value))
     f.write("\n")

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_displacement.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_displacement.py
@@ -66,7 +66,10 @@ def write_constraint(f, femobj, disp_obj, ccxwriter):
 
     # floats read from ccx should use {:.13G}, see comment in writer module
 
-    f.write("*BOUNDARY\n")
+    if disp_obj.EnableAmplitude:
+    	f.write(f"*BOUNDARY, AMPLITUDE={disp_obj.Name}\n")
+    else:
+    	f.write("*BOUNDARY\n")
     if not disp_obj.xFree:
         f.write(
             "{},1,1,{}\n".format(

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_force.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_force.py
@@ -35,7 +35,7 @@ def get_sets_name():
 
 
 def get_before_write_meshdata_constraint():
-    return "*CLOAD\n"
+    return ""
 
 
 def get_after_write_meshdata_constraint():
@@ -46,6 +46,10 @@ def write_meshdata_constraint(f, femobj, force_obj, ccxwriter):
 
     # floats read from ccx should use {:.13G}, see comment in writer module
 
+    if force_obj.EnableAmplitude:
+    	f.write(f"*CLOAD, AMPLITUDE={force_obj.Name}\n")
+    else:
+    	f.write("*CLOAD\n")
     direction_vec = femobj["Object"].DirectionVector
     dir_zero_tol = 1e-15  # TODO: should this be more generally for more values?
     # be careful with raising the tolerance, a big load would have an impact

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_heatflux.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_heatflux.py
@@ -76,7 +76,12 @@ def write_meshdata_constraint(f, femobj, heatflux_obj, ccxwriter):
     else:
         return
 
-    f.write(f"*{heatflux_key_word}\n")
+    if heatflux_obj.EnableAmplitude:
+        heatflux_amplitude = f", AMPLITUDE={heatflux_obj.Name}"
+    else:
+        heatflux_amplitude = ""
+
+    f.write(f"*{heatflux_key_word}{heatflux_amplitude}\n")
     for ref_shape in femobj["HeatFluxFaceTable"]:
         elem_string = ref_shape[0]
         face_table = ref_shape[1]

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_pressure.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_pressure.py
@@ -48,12 +48,14 @@ def write_meshdata_constraint(f, femobj, prs_obj, ccxwriter):
 
     # floats read from ccx should use {:.13G}, see comment in writer module
 
+    if prs_obj.EnableAmplitude:
+    	f.write(f"*DLOAD, AMPLITUDE={prs_obj.Name}\n")
+    else:
+    	f.write("*DLOAD\n")
     rev = -1 if prs_obj.Reversed else 1
     # the pressure has to be output in MPa
     pressure_quantity = FreeCAD.Units.Quantity(prs_obj.Pressure.getValueAs("MPa"))
     press_rev = rev * pressure_quantity
-
-    f.write("*DLOAD\n")
     for ref_shape in femobj["PressureFaces"]:
         # the loop is needed for compatibility reason
         # in deprecated method get_pressure_obj_faces_depreciated

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_temperature.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_temperature.py
@@ -68,8 +68,12 @@ def write_constraint(f, femobj, temp_obj, ccxwriter):
     # floats read from ccx should use {:.13G}, see comment in writer module
 
     NumberOfNodes = len(femobj["Nodes"])
+    if temp_obj.EnableAmplitude:
+        temp_amplitude = f", AMPLITUDE={temp_obj.Name}"
+    else:
+        temp_amplitude = ""
     if temp_obj.ConstraintType == "Temperature":
-        f.write("*BOUNDARY\n")
+        f.write(f"*BOUNDARY{temp_amplitude}\n")
         f.write(
             "{},11,11,{}\n".format(
                 temp_obj.Name, FreeCAD.Units.Quantity(temp_obj.Temperature.getValueAs("K"))
@@ -77,7 +81,7 @@ def write_constraint(f, femobj, temp_obj, ccxwriter):
         )
         f.write("\n")
     elif temp_obj.ConstraintType == "CFlux":
-        f.write("*CFLUX\n")
+        f.write(f"*CFLUX{temp_amplitude}\n")
         # CFLUX has to be specified in mW
         f.write(
             "{},11,{}\n".format(

--- a/src/Mod/Fem/femsolver/calculix/writer.py
+++ b/src/Mod/Fem/femsolver/calculix/writer.py
@@ -60,6 +60,7 @@ from . import write_femelement_material
 from . import write_femelement_matgeosets
 from . import write_footer
 from . import write_mesh
+from . import write_amplitude
 from . import write_step_equation
 from . import write_step_output
 from .. import writerbase
@@ -180,6 +181,9 @@ class FemInputWriterCcx(writerbase.FemInputWriter):
         self.write_constraints_propdata(inpfile, self.member.cons_tie, con_tie)
         self.write_constraints_propdata(inpfile, self.member.cons_transform, con_transform)
         self.write_constraints_propdata(inpfile, self.member.cons_rigidbody, con_rigidbody)
+
+        # amplitudes
+        write_amplitude.write_amplitude(inpfile, self)
 
         # step equation
         write_step_equation.write_step_equation(inpfile, self)


### PR DESCRIPTION
fixes #11648

Adds two new properties to constraints that may support amplitudes:
EnableAmplitude - enables amplitude
AmplitudeValues - a list of amplitude data points (linear ramp for 1 s by default)

This was compiled and tested with various possible configurations (multiple constraints of the same and different types with and without amplitudes). The number of changed files is due to how many constraint types can support amplitudes.