### PR TITLE
Sketcher: Circle DSH: move diameter constraint. Fix #22267

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -146,8 +146,8 @@ private:
             case SelectMode::SeekSecond: {
                 if (constructionMethod() == ConstructionMethod::ThreeRim) {
                     centerPoint = (onSketchPos - firstPoint) / 2 + firstPoint;
-                    secondPoint = onSketchPos;
                 }
+                secondPoint = onSketchPos;
 
                 radius = (onSketchPos - centerPoint).Length();
 
@@ -716,6 +716,11 @@ void DSHCircleController::addConstraints()
                                       firstCurve,
                                       handler->radius);
             }
+            
+            const std::vector<Sketcher::Constraint*>& ConStr =
+                handler->sketchgui->getSketchObject()->Constraints.getValues();
+            int index = static_cast<int>(ConStr.size()) - 1;
+            handler->moveConstraint(index, handler->secondPoint);
         };
 
         // NOTE: if AutoConstraints is empty, we can add constraints directly without any diagnose.

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -720,7 +720,9 @@ void DSHCircleController::addConstraints()
             const std::vector<Sketcher::Constraint*>& ConStr =
                 handler->sketchgui->getSketchObject()->Constraints.getValues();
             int index = static_cast<int>(ConStr.size()) - 1;
-            handler->moveConstraint(index, handler->secondPoint);
+            Base::Vector2d dir = handler->secondPoint - handler->centerPoint;
+            Base::Vector2d toPnt = handler->secondPoint + dir * 0.3;
+            handler->moveConstraint(index, toPnt);
         };
 
         // NOTE: if AutoConstraints is empty, we can add constraints directly without any diagnose.
@@ -779,3 +781,4 @@ void DSHCircleController::addConstraints()
 
 
 #endif  // SKETCHERGUI_DrawSketchHandlerCircle_H
+

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -781,4 +781,3 @@ void DSHCircleController::addConstraints()
 
 
 #endif  // SKETCHERGUI_DrawSketchHandlerCircle_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -716,7 +716,7 @@ void DSHCircleController::addConstraints()
                                       firstCurve,
                                       handler->radius);
             }
-            
+
             const std::vector<Sketcher::Constraint*>& ConStr =
                 handler->sketchgui->getSketchObject()->Constraints.getValues();
             int index = static_cast<int>(ConStr.size()) - 1;


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/22267

By moving the constraint to the mouse position after validation.