### PR TITLE
[TD]Ensure changed expression value is processed

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -150,16 +150,9 @@ void DrawProjGroup::onChanged(const App::Property* prop)
         }
     }
 
-    //        if ( ScaleType.isValue("Automatic") ||
-    //             ScaleType.isValue("Custom") ){
-    //            //just documenting that nothing is required here
-    //            //DrawView::onChanged will sort out Scale hidden/readonly/etc
-    //        }
-
     if (prop == &Rotation) {
         if (!DrawUtil::fpCompare(Rotation.getValue(), 0.0)) {
             Rotation.setValue(0.0);
-            purgeTouched();
         }
         return;
     }
@@ -169,8 +162,6 @@ void DrawProjGroup::onChanged(const App::Property* prop)
 
 App::DocumentObjectExecReturn* DrawProjGroup::execute()
 {
-    //    Base::Console().message("DPG::execute() - %s - waitingForChildren: %d\n",
-    //                            getNameInDocument(), waitingForChildren());
     if (!keepUpdated())
         return App::DocumentObject::StdReturn;
 
@@ -490,13 +481,11 @@ App::DocumentObject* DrawProjGroup::addProjection(const char* viewProjType)
         }
         else {//Front
             Anchor.setValue(view);
-            Anchor.purgeTouched();
             requestPaint();//make sure the group object is on the Gui page
             view->LockPosition.setValue(
                 true);//lock "Front" position within DPG (note not Page!).
             view->LockPosition.setStatus(App::Property::ReadOnly,
                                             true);//Front should stay locked.
-            view->LockPosition.purgeTouched();
         }
     }
     return view;
@@ -984,8 +973,6 @@ void DrawProjGroup::updateChildrenScale()
         }
 
         view->Scale.setValue(getScale());
-        view->Scale.purgeTouched();
-        view->purgeTouched();
     }
 }
 
@@ -1128,9 +1115,7 @@ void DrawProjGroup::updateSecondaryDirs()
         ProjDirection type = static_cast<ProjDirection>(v->Type.getValue());
         data = saveVals[type];
         v->Direction.setValue(data.first);
-        v->Direction.purgeTouched();
         v->XDirection.setValue(data.second);
-        v->XDirection.purgeTouched();
     }
     recomputeChildren();
 }

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -94,8 +94,8 @@ DrawView::DrawView():
     m_overrideKeepUpdated(false)
 {
     static const char *group = "Base";
-    ADD_PROPERTY_TYPE(X, (0.0), group, (App::PropertyType)(App::Prop_None), "X position");
-    ADD_PROPERTY_TYPE(Y, (0.0), group, (App::PropertyType)(App::Prop_None), "Y position");
+    ADD_PROPERTY_TYPE(X, (0.0), group, App::Prop_None, "X position");
+    ADD_PROPERTY_TYPE(Y, (0.0), group, App::Prop_None, "Y position");
     ADD_PROPERTY_TYPE(LockPosition, (false), group, App::Prop_Output, "Lock View position to parent Page or Group");
     ADD_PROPERTY_TYPE(Rotation, (0.0), group, App::Prop_Output, "Rotation in degrees counterclockwise");
 
@@ -109,9 +109,6 @@ DrawView::DrawView():
     setScaleAttribute();
 }
 
-DrawView::~DrawView()
-{
-}
 
 App::DocumentObjectExecReturn *DrawView::execute()
 {
@@ -120,8 +117,7 @@ App::DocumentObjectExecReturn *DrawView::execute()
         return App::DocumentObject::execute();
     }
     handleXYLock();
-    //should not be necessary to purgeTouched here, but it prevents a superfluous feature recompute
-    purgeTouched();                           //this should not be necessary!
+
     requestPaint();
     return App::DocumentObject::execute();
 }
@@ -133,7 +129,6 @@ void DrawView::checkScale()
         if (ScaleType.isValue("Page")) {
             if(std::abs(page->Scale.getValue() - Scale.getValue()) > std::numeric_limits<float>::epsilon()) {
                 Scale.setValue(page->Scale.getValue());
-                Scale.purgeTouched();
             }
         }
     }
@@ -209,15 +204,12 @@ void DrawView::onChanged(const App::Property* prop)
     } else if (prop == &LockPosition) {
         handleXYLock();
         requestPaint();         //change lock icon
-        LockPosition.purgeTouched();
     } else if ((prop == &Caption) ||
         (prop == &Label)) {
         requestPaint();
     } else if ( prop == &X ||
                 prop == &Y ) {
         //X,Y changes are only interesting to DPGI and Gui side
-        X.purgeTouched();
-        Y.purgeTouched();
     }
 
     App::PropertyLink *ownerProp = getOwnerProperty();
@@ -244,20 +236,16 @@ void DrawView::handleXYLock()
     if (isLocked()) {
         if (!X.testStatus(App::Property::ReadOnly)) {
             X.setStatus(App::Property::ReadOnly, true);
-            X.purgeTouched();
         }
         if (!Y.testStatus(App::Property::ReadOnly)) {
             Y.setStatus(App::Property::ReadOnly, true);
-            Y.purgeTouched();
         }
     } else {
         if (X.testStatus(App::Property::ReadOnly)) {
             X.setStatus(App::Property::ReadOnly, false);
-            X.purgeTouched();
         }
         if (Y.testStatus(App::Property::ReadOnly)) {
             Y.setStatus(App::Property::ReadOnly, false);
-            Y.purgeTouched();
         }
     }
 }

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -52,7 +52,7 @@ class TechDrawExport DrawView : public App::DocumentObject
 public:
     /// Constructor
     DrawView();
-    ~DrawView() override;
+    ~DrawView() override = default;
 
     App::PropertyDistance X;
     App::PropertyDistance Y;

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -397,7 +397,6 @@ void DrawViewDetail::postHlrTasks(void)
     if (ScaleType.isValue("Automatic") && !checkFit()) {
         double newScale = autoScale();
         Scale.setValue(newScale);
-        Scale.purgeTouched();
         detailExec(m_saveShape, m_saveDvp, m_saveDvs);
     }
 

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -471,7 +471,6 @@ void DrawViewPart::postHlrTasks()
     if (ScaleType.isValue("Automatic") && !checkFit()) {
         double newScale = autoScale();
         Scale.setValue(newScale);
-        Scale.purgeTouched();
         partExec(m_saveShape);
     }
 

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -652,7 +652,6 @@ void DrawViewSection::postHlrTasks()
     if (ScaleType.isValue("Automatic") && !checkFit()) {
         double newScale = autoScale();
         Scale.setValue(newScale);
-        Scale.purgeTouched();
         sectionExec(m_saveShape);
     }
     overrideKeepUpdated(false);


### PR DESCRIPTION
This PR implements a fix for issue #22499. 

Previously, the "touched" status for some properties was purged to avoid superfluous recomputes.   There may be circumstances where this PR reintroduces extra computes, but this was not observed during development.