### PR TITLE
BIM: Remove wrong IfcType for Column/Beam

### DIFF
--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -126,10 +126,7 @@ def makeStructure(baseobj=None,length=None,width=None,height=None,name=None):
                 obj.Width = w
                 obj.Length = h
 
-    if not height and not length:
-        obj.IfcType = "Building Element Proxy"
-        obj.Label = name if name else translate("Arch","Structure")
-    elif obj.Length > obj.Height:
+    if obj.Length > obj.Height:
         obj.IfcType = "Beam"
         obj.Label = name if name else translate("Arch","Beam")
     elif obj.Height > obj.Length:


### PR DESCRIPTION
Removes check on function parameters for height & length (first introduced in commit 5217b24), relying on values assigned in "obj".

If those params are present, they're assigned to "obj" anyway, so the check is redundant.

Fixes #22585

## Notes

My first contribution to FreeCAD.

I couldn't see how the code this commit removes had any relevance to the pref added in 5217b24, and wondered if it was just an accidental inclusion from some other change @yorikvanhavre was working on at the time.

Naturally I'm happy to be corrected if I've missed something. 

## Issues

Fixes #22585

