### PR TITLE
TechDraw: Rework view frames

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandDecorate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandDecorate.cpp
@@ -292,77 +292,6 @@ bool CmdTechDrawImage::isActive()
     return DrawGuiUtil::needPage(this);
 }
 
-//===========================================================================
-// TechDraw_ToggleFrame
-//===========================================================================
-
-DEF_STD_CMD_AC(CmdTechDrawToggleFrame)
-
-CmdTechDrawToggleFrame::CmdTechDrawToggleFrame()
-  : Command("TechDraw_ToggleFrame")
-{
-    sAppModule      = "TechDraw";
-    sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Turn View Frames On/Off");
-    sToolTipText    = QT_TR_NOOP("Turn View Frames On/Off");
-    sWhatsThis      = "TechDraw_Toggle";
-    sStatusTip      = sToolTipText;
-    sPixmap         = "actions/TechDraw_ToggleFrame";
-}
-
-Gui::Action *CmdTechDrawToggleFrame::createAction()
-{
-    Gui::Action *action = Gui::Command::createAction();
-    action->setCheckable(true);
-
-    return action;
-}
-
-void CmdTechDrawToggleFrame::activated(int iMsg)
-{
-    Q_UNUSED(iMsg);
-    TechDraw::DrawPage* page = DrawGuiUtil::findPage(this);
-    if (!page) {
-        return;
-    }
-
-    Gui::Document* activeGui = Gui::Application::Instance->getDocument(page->getDocument());
-    Gui::ViewProvider* vp = activeGui->getViewProvider(page);
-    ViewProviderPage* vpPage = freecad_cast<ViewProviderPage*>(vp);
-
-    if (!vpPage) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("No TechDraw Page"),
-            QObject::tr("Need a TechDraw Page for this command"));
-        return;
-    }
-
-    vpPage->toggleFrameState();
-
-    Gui::Action *action = this->getAction();
-    if (action) {
-        action->setBlockedChecked(!vpPage->getFrameState());
-    }
-}
-
-//! true if the active tab is a TechDraw Page.
-// There is an assumption here that you would only want to toggle the frames on a page when you are
-// currently looking at that page
-bool CmdTechDrawToggleFrame::isActive()
-{
-    auto mvp = qobject_cast<MDIViewPage*>(Gui::getMainWindow()->activeWindow());
-    if (!mvp) {
-        return false;
-    }
-
-    ViewProviderPage* vpp = mvp->getViewProviderPage();
-
-    Gui::Action* action = this->getAction();
-    if (action) {
-        action->setBlockedChecked(vpp && !vpp->getFrameState());
-    }
-
-    return true;
-}
 
 void CreateTechDrawCommandsDecorate()
 {
@@ -371,7 +300,6 @@ void CreateTechDrawCommandsDecorate()
     rcCmdMgr.addCommand(new CmdTechDrawHatch());
     rcCmdMgr.addCommand(new CmdTechDrawGeometricHatch());
     rcCmdMgr.addCommand(new CmdTechDrawImage());
-    rcCmdMgr.addCommand(new CmdTechDrawToggleFrame());
 //    rcCmdMgr.addCommand(new CmdTechDrawLeaderLine());
 //    rcCmdMgr.addCommand(new CmdTechDrawRichTextAnnotation());
 }

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -90,9 +90,6 @@ MDIViewPage::MDIViewPage(ViewProviderPage* pageVp, Gui::Document* doc, QWidget* 
     m_toggleKeepUpdatedAction = new QAction(tr("Toggle &Keep Updated"), this);
     connect(m_toggleKeepUpdatedAction, &QAction::triggered, this, &MDIViewPage::toggleKeepUpdated);
 
-    m_toggleFrameAction = new QAction(tr("Toggle &Frames"), this);
-    connect(m_toggleFrameAction, &QAction::triggered, this, &MDIViewPage::toggleFrame);
-
     m_exportSVGAction = new QAction(tr("&Export SVG"), this);
     connect(m_exportSVGAction, &QAction::triggered, this, qOverload<>(&MDIViewPage::saveSVG));
 
@@ -435,7 +432,6 @@ void MDIViewPage::contextMenuEvent(QContextMenuEvent* event)
     //    Base::Console().message("MDIVP::contextMenuEvent() - reason: %d\n", event->reason());
     if (isContextualMenuEnabled) {
         QMenu menu;
-        menu.addAction(m_toggleFrameAction);
         menu.addAction(m_toggleKeepUpdatedAction);
         menu.addAction(m_exportSVGAction);
         menu.addAction(m_exportDXFAction);
@@ -444,8 +440,6 @@ void MDIViewPage::contextMenuEvent(QContextMenuEvent* event)
         menu.exec(event->globalPos());
     }
 }
-
-void MDIViewPage::toggleFrame() { m_vpPage->toggleFrameState(); }
 
 void MDIViewPage::toggleKeepUpdated()
 {

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -116,7 +116,6 @@ public Q_SLOTS:
     void saveSVG();
     void saveDXF();
     void savePDF();
-    void toggleFrame();
     void toggleKeepUpdated();
     void sceneSelectionChanged();
     void printAll();
@@ -139,7 +138,6 @@ private:
     using Connection = boost::signals2::connection;
     Connection connectDeletedObject;
 
-    QAction *m_toggleFrameAction;
     QAction *m_toggleKeepUpdatedAction;
     QAction *m_exportSVGAction;
     QAction *m_exportDXFAction;

--- a/src/Mod/TechDraw/Gui/PagePrinter.cpp
+++ b/src/Mod/TechDraw/Gui/PagePrinter.cpp
@@ -285,9 +285,8 @@ void PagePrinter::printBannerPage(QPrinter* printer, QPainter& painter, QPageLay
 void PagePrinter::renderPage(ViewProviderPage* vpp, QPainter& painter, QRectF& sourceRect,
                              QRect& targetRect)
 {
-    //turn off view frames for print
-    bool saveState = vpp->getFrameState();
-    vpp->setFrameState(false);
+    // Clear selection to avoid it being rendered to the file
+    vpp->getQGSPage()->clearSelection();
     vpp->setTemplateMarkers(false);
 
     //scene might be drawn in light text.  we need to redraw in normal text.
@@ -301,8 +300,6 @@ void PagePrinter::renderPage(ViewProviderPage* vpp, QPainter& painter, QRectF& s
     vpp->getQGSPage()->render(&painter, targetRect, sourceRect);
 
     // Reset
-    vpp->setFrameState(saveState);
-    vpp->setTemplateMarkers(saveState);
     Preferences::lightOnDark(saveLightOnDark);
 
     vpp->getQGSPage()->refreshViews();

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -78,10 +78,15 @@ const float labelCaptionFudge = 0.2f;   // temp fiddle for devel
 
 QGIView::QGIView()
     :QGraphicsItemGroup(),
+    m_isHovered(false),
     viewObj(nullptr),
     m_innerView(false),
     m_multiselectActivated(false),
-    snapping(false)
+    snapping(false),
+    m_label(new QGCustomLabel()),
+    m_border(new QGCustomBorder()),
+    m_caption(new QGICaption()),
+    m_lock(new QGCustomImage())
 {
     setCacheMode(QGraphicsItem::NoCache);
     setHandlesChildEvents(false);
@@ -98,18 +103,15 @@ QGIView::QGIView()
     m_decorPen.setStyle(Qt::DashLine);
     m_decorPen.setWidth(0); // 0 => 1px "cosmetic pen"
 
-    m_label = new QGCustomLabel();
     addToGroup(m_label);
-    m_border = new QGCustomBorder();
     addToGroup(m_border);
-    m_caption = new QGICaption();
     addToGroup(m_caption);
-    m_lock = new QGCustomImage();
     m_lock->setParentItem(m_border);
     m_lock->load(QStringLiteral(":/icons/TechDraw_Lock.svg"));
     QSize sizeLock = m_lock->imageSize();
     m_lockWidth = (double) sizeLock.width();
     m_lockHeight = (double) sizeLock.height();
+
     m_lock->hide();
 }
 
@@ -201,12 +203,31 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
     }
 
     if (change == ItemSelectedHasChanged && scene()) {
-        if(isSelected()) {
+        bool thisViewIsSelected = value.toBool();
+        bool anyChildSelected = false;
+        if (!thisViewIsSelected) { // Only check children if this view is becoming unselected
+            anyChildSelected = 
+                std::ranges::any_of(childItems(), [](QGraphicsItem* child) {
+                    return child->isSelected();
+                });
+        }
+        if(thisViewIsSelected || anyChildSelected || isSelected()) {
             m_colCurrent = getSelectColor();
+            m_border->show();
+            m_label->show();
+            m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
         } else {
-            m_colCurrent = PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor());
+            if (!m_isHovered) {
+                m_colCurrent = PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor());
+                m_border->hide();
+                m_label->hide();
+                m_lock->hide();
+            } else {
+                m_colCurrent = getPreColor();
+            }
         }
         drawBorder();
+        update();
     }
 
     return QGraphicsItemGroup::itemChange(change, value);
@@ -449,27 +470,46 @@ void QGIView::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
 
 void QGIView::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
-    //    Base::Console().message("QGIV::hoverEnterEvent()\n");
-    Q_UNUSED(event);
-    // TODO don't like this but only solution at the minute (MLP)
+    QGraphicsItemGroup::hoverEnterEvent(event);
+
+    m_isHovered = true; 
+
     if (isSelected()) {
         m_colCurrent = getSelectColor();
-        setFocus();
     } else {
         m_colCurrent = getPreColor();
     }
-    drawBorder();
+
+    m_border->show();
+    m_label->show();
+    
+    m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
+
+    drawBorder(); 
+    update(); 
 }
+
 
 void QGIView::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 {
-    Q_UNUSED(event);
-    if(isSelected()) {
+    QGraphicsItemGroup::hoverLeaveEvent(event);
+
+    m_isHovered = false; 
+
+    if (isSelected()) {
         m_colCurrent = getSelectColor();
+        m_border->show();
+        m_label->show();
+        m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
     } else {
         m_colCurrent = PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor());
+        m_border->hide();
+        m_label->hide();
+        m_lock->hide(); 
     }
-    drawBorder();
+
+    drawBorder(); 
+    update(); 
 }
 
 //sets position in /Gui(graphics), not /App
@@ -523,6 +563,10 @@ void QGIView::updateView(bool forceUpdate)
     if (!TechDraw::DrawUtil::fpCompare(appRotation, guiRotation)) {
         rotateView();
     }
+
+    drawBorder(); // Draw the border then hide it so the label knows where to position itself
+    m_border->hide();
+    m_label->hide();
 
     QGIView::draw();
 }
@@ -595,19 +639,15 @@ void QGIView::draw()
         }
     }
     if (isVisible()) {
-        drawBorder();
         show();
     } else {
         hide();
     }
 }
 
-void QGIView::drawCaption()
+void QGIView::prepareCaption()
 {
-    //    Base::Console().message("QGIV::drawCaption()\n");
-    prepareGeometryChange();
-    QRectF displayArea = customChildrenBoundingRect();
-    m_caption->setDefaultTextColor(m_colCurrent);
+    m_caption->setDefaultTextColor(prefNormalColor());
     m_font.setFamily(Preferences::labelFontQString());
     int fontSize = exactFontSize(Preferences::labelFont(),
                                  Preferences::labelFontSizeMM());
@@ -615,39 +655,46 @@ void QGIView::drawCaption()
     m_caption->setFont(m_font);
     QString captionStr = QString::fromUtf8(getViewObject()->Caption.getValue());
     m_caption->setPlainText(captionStr);
-    QRectF captionArea = m_caption->boundingRect();
-    QPointF displayCenter = displayArea.center();
-    m_caption->setX(displayCenter.x() - captionArea.width()/2.);
-    double labelHeight = (1 - labelCaptionFudge) * m_label->boundingRect().height();
-    auto vp = static_cast<ViewProviderDrawingView*>(getViewProvider(getViewObject()));
-    if (getFrameState() || vp->KeepLabel.getValue()) {            //place below label if label visible
-        m_caption->setY(displayArea.bottom() + labelHeight);
-    } else {
-        m_caption->setY(displayArea.bottom() + labelCaptionFudge * Preferences::labelFontSizeMM());
-    }
-    m_caption->show();
 }
+
+void QGIView::layoutDecorations(const QRectF& contentArea,
+                              const QRectF& captionRect,
+                              const QRectF& labelRect,
+                              QRectF& outFrameRect,
+                              QPointF& outCaptionPos,
+                              QPointF& outLabelPos,
+                              QPointF& outLockPos) const
+{
+    const qreal padding = 100.0;
+    QRectF paddedContentArea = contentArea.adjusted(-padding, -padding, padding, padding);
+
+    double frameWidth = qMax(paddedContentArea.width(), labelRect.width());
+    double frameHeight = paddedContentArea.height() + (captionRect.height() / 2) + labelRect.height();
+
+    outFrameRect = QRectF(paddedContentArea.center().x() - (frameWidth / 2),
+                          paddedContentArea.top(),
+                          frameWidth,
+                          frameHeight);
+
+    outLabelPos = QPointF(outFrameRect.center().x() - (labelRect.width() / 2),
+                          outFrameRect.bottom() - labelRect.height());
+
+    double view_width = getViewObject()->getRect().x();
+    outCaptionPos = QPointF(view_width - (captionRect.width() / 2),
+                            outLabelPos.y() - captionRect.height());
+
+    outLockPos = QPointF(outFrameRect.left(), outFrameRect.bottom() - m_lockHeight);
+}
+
 
 void QGIView::drawBorder()
 {
-    //    Base::Console().message("QGIV::drawBorder() - %s\n", getViewName());
+    // Base::Console().message("QGIV::drawBorder() - %s\n", getViewName());
     auto feat = getViewObject();
     if (!feat)
         return;
 
-    drawCaption();   //always draw caption
-
-    auto vp = static_cast<ViewProviderDrawingView*>(getViewProvider(getViewObject()));
-    if (!getFrameState() && !vp->KeepLabel.getValue()) {
-        m_label->hide();
-        m_border->hide();
-        m_lock->hide();
-        return;
-    }
-
-    m_label->hide();
-    m_border->hide();
-    m_lock->hide();
+    prepareCaption();
 
     m_label->setDefaultTextColor(m_colCurrent);
     m_font.setFamily(Preferences::labelFontQString());
@@ -655,55 +702,34 @@ void QGIView::drawBorder()
                                  Preferences::labelFontSizeMM());
     m_font.setPixelSize(fontSize);
     m_label->setFont(m_font);
-
-    QString labelStr = QString::fromStdString( getViewObject()->Label.getValue() );
+    QString labelStr = QString::fromStdString(getViewObject()->Label.getValue());
     m_label->setPlainText(labelStr);
-    QRectF labelArea = m_label->boundingRect();                //m_label coords
-    double labelWidth = m_label->boundingRect().width();
-    double labelHeight = (1 - labelCaptionFudge) * m_label->boundingRect().height();
 
-    QBrush b(Qt::NoBrush);
-    m_border->setBrush(b);
+    QRectF contentArea = customChildrenBoundingRect();
+    QRectF captionRect = m_caption->boundingRect();
+    QRectF labelRect = m_label->boundingRect();
+
+
+    QRectF finalFrameRect;
+    QPointF finalCaptionPos, finalLabelPos, finalLockPos;
+
+    layoutDecorations(contentArea, captionRect, labelRect,
+                      finalFrameRect, finalCaptionPos, finalLabelPos, finalLockPos);
+
+
+    m_caption->setPos(finalCaptionPos);
+    m_label->setPos(finalLabelPos);
+    m_lock->setPos(finalLockPos);
+    m_lock->setZValue(ZVALUE::LOCK);
+
+    m_border->setBrush(Qt::NoBrush);
     m_decorPen.setColor(m_colCurrent);
     m_border->setPen(m_decorPen);
-
-    QRectF displayArea = customChildrenBoundingRect();
-    double displayWidth = displayArea.width();
-    double displayHeight = displayArea.height();
-    QPointF displayCenter = displayArea.center();
-    m_label->setX(displayCenter.x() - labelArea.width()/2.);
-    m_label->setY(displayArea.bottom());
-
-    double frameWidth = displayWidth;
-    if (labelWidth > displayWidth) {
-        frameWidth = labelWidth;
-    }
-    double frameHeight = labelHeight + displayHeight;
-
-    QRectF frameArea = QRectF(displayCenter.x() - frameWidth/2.,
-                              displayArea.top(),
-                              frameWidth,
-                              frameHeight);
-
-    double lockX = frameArea.left();
-    double lockY = frameArea.bottom() - m_lockHeight;
-    if (feat->isLocked() &&
-        feat->showLock()) {
-        m_lock->setZValue(ZVALUE::LOCK);
-        m_lock->setPos(lockX, lockY);
-        m_lock->show();
-    } else {
-        m_lock->hide();
-    }
+    m_border->setPos(0., 0.);
+    // Adjust the final border to make space for the label
+    m_border->setRect(finalFrameRect.adjusted(-2, -2, 2, -labelRect.height() + 2));
 
     prepareGeometryChange();
-    m_border->setRect(frameArea.adjusted(-2, -2, 2,2));
-    m_border->setPos(0., 0.);
-
-    m_label->show();
-    if (getFrameState()) {
-        m_border->show();
-    }
 }
 
 void QGIView::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -726,14 +752,12 @@ QRectF QGIView::customChildrenBoundingRect() const
         if (!child->isVisible()) {
             continue;
         }
-        if (child->type() != UserType::QGIViewDimension &&
-            child->type() != UserType::QGILeaderLine &&
+        if (            
             child->type() != UserType::QGIRichAnno &&
             child->type() != UserType::QGEPath &&
             child->type() != UserType::QGMText &&
             child->type() != UserType::QGCustomBorder &&
             child->type() != UserType::QGCustomLabel &&
-            child->type() != UserType::QGIWeldSymbol &&
             child->type() != UserType::QGICaption &&
             child->type() != UserType::QGICMark) {
             QRectF childRect = mapFromItem(child, child->boundingRect()).boundingRect();
@@ -745,7 +769,18 @@ QRectF QGIView::customChildrenBoundingRect() const
 
 QRectF QGIView::boundingRect() const
 {
-    return m_border->rect().adjusted(-2., -2., 2., 2.);     //allow for border line width  //TODO: fiddle brect if border off?
+    QRectF totalRect = customChildrenBoundingRect();
+    totalRect = totalRect.united(m_border->rect());
+    totalRect = totalRect.united(m_label->boundingRect().translated(m_label->pos()));
+    totalRect = totalRect.united(m_caption->boundingRect().translated(m_caption->pos()));
+
+    if (m_lock && m_lock->isVisible()) {
+        totalRect = totalRect.united(m_border->mapRectToParent(m_lock->boundingRect().translated(m_lock->pos())));
+    }
+    if (totalRect.isEmpty()) {
+        return QRectF(0, 0, 1, 1);
+    }
+    return totalRect;
 }
 
 QGIView* QGIView::getQGIVByName(std::string name)
@@ -811,23 +846,6 @@ void QGIView::removeChild(QGIView* child)
         prepareGeometryChange();
         scene()->removeItem(child);
     }
-}
-
-bool QGIView::getFrameState()
-{
-    //    Base::Console().message("QGIV::getFrameState() - %s\n", getViewName());
-    TechDraw::DrawView* dv = getViewObject();
-    if (!dv) return true;
-
-    TechDraw::DrawPage* page = dv->findParentPage();
-    if (!page) return true;
-
-    Gui::Document* activeGui = Gui::Application::Instance->getDocument(page->getDocument());
-    Gui::ViewProvider* vp = activeGui->getViewProvider(page);
-    ViewProviderPage* vpp = freecad_cast<ViewProviderPage*>(vp);
-    if (!vpp) return true;
-
-    return vpp->getFrameState();
 }
 
 void QGIView::hideFrame()

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -99,7 +99,6 @@ public:
 
     void hideFrame();               //used by derived classes that don't display a frame
 
-    virtual bool getFrameState();
     virtual void toggleCache(bool state);
     virtual void updateView(bool update = false);
     virtual void drawBorder();
@@ -111,7 +110,7 @@ public:
     virtual void setGroupSelection(bool isSelected, const std::vector<std::string> &subNames);
 
     virtual void draw();
-    virtual void drawCaption();
+    virtual void prepareCaption();
     virtual void rotateView();
     void makeMark(double xPos, double yPos, QColor color = Qt::red);
     void makeMark(Base::Vector3d pos, QColor color = Qt::red);
@@ -182,6 +181,8 @@ protected:
     void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
     virtual QRectF customChildrenBoundingRect() const;
     void dumpRect(const char* text, QRectF rect);
+    bool m_isHovered;
+
 
     Base::Reference<ParameterGrp> getParmGroupCol();
 
@@ -213,6 +214,13 @@ private:
 
     bool m_snapped{false};
 
+    void layoutDecorations(const QRectF& contentArea,
+                       const QRectF& captionRect,
+                       const QRectF& labelRect,
+                       QRectF& outFrameRect,
+                       QPointF& outCaptionPos,
+                       QPointF& outLabelPos,
+                       QPointF& outLockPos) const;
 };
 
 } // namespace

--- a/src/Mod/TechDraw/Gui/QGIViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.cpp
@@ -83,9 +83,7 @@ void QGIViewClip::draw()
     }
 
     drawClip();
-    if (getFrameState()) {
-        drawBorder();
-    }
+    drawBorder();
 }
 
 void QGIViewClip::drawClip()

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -71,7 +71,6 @@ public:
                         QWidget * widget = nullptr ) override;
     bool sceneEventFilter(QGraphicsItem *watched, QEvent *event) override;
 
-
     void toggleCache(bool state) override;
     void toggleCosmeticLines(bool state);
     void setViewPartFeature(TechDraw::DrawViewPart *obj);
@@ -134,6 +133,8 @@ protected:
     QGIFace* drawFace(TechDraw::FacePtr f, int idx);
 
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
+    void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
 
     TechDraw::DrawHatch* faceIsHatched(int i, std::vector<TechDraw::DrawHatch*> hatchObjs) const;
     TechDraw::DrawGeomHatch* faceIsGeomHatched(int i, std::vector<TechDraw::DrawGeomHatch*> geomObjs) const;
@@ -148,12 +149,14 @@ protected:
     bool formatGeomFromCenterLine(std::string cTag, QGIEdge* item);
 
     bool showCenterMarks();
+    QList<QGraphicsItem*> m_vertexItems;
     bool showVertices();
 
 private:
     QList<QGraphicsItem*> deleteItems;
     PathBuilder* m_pathBuilder;
     TechDraw::LineGenerator* m_dashedLineGenerator;
+    QMetaObject::Connection m_selectionChangedConnection;
 
 };
 

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -1079,8 +1079,6 @@ void QGSPage::saveSvg(QString filename)
 
     Gui::Selection().clearSelection();
 
-    bool saveState = m_vpPage->getFrameState();
-    m_vpPage->setFrameState(false);
     m_vpPage->setTemplateMarkers(false);
     setExportingSvg(true);
 
@@ -1108,8 +1106,6 @@ void QGSPage::saveSvg(QString filename)
     render(&p, targetRect, sourceRect);//note: scene render, not item render!
     p.end();
 
-    m_vpPage->setFrameState(saveState);
-    m_vpPage->setTemplateMarkers(saveState);
     setExportingSvg(false);
     if (templateVisible && svgTemplate) {
         svgTemplate->show();

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -83,15 +83,12 @@ ViewProviderPage::ViewProviderPage()
     static const char* group = "Grid";
 
     // NOLINTBEGIN
-    ADD_PROPERTY_TYPE(ShowFrames, (true), group, App::Prop_None,
-                      "Show or hide View frames and Labels on this Page");
     ADD_PROPERTY_TYPE(ShowGrid, (PreferencesGui::showGrid()), group, App::Prop_None,
                       "Show or hide a grid on this Page");
     ADD_PROPERTY_TYPE(GridSpacing, (PreferencesGui::gridSpacing()), group,
                       (App::PropertyType::Prop_None), "Grid line spacing in mm");
     // NOLINTEND
 
-    ShowFrames.setStatus(App::Property::Hidden, true);
     // Do not show in property editor   why? wf  WF: because DisplayMode applies only to coin and we
     // don't use coin.
     DisplayMode.setStatus(App::Property::Hidden, true);
@@ -435,19 +432,6 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren() const
 }
 
 bool ViewProviderPage::isShow() const { return Visibility.getValue(); }
-
-bool ViewProviderPage::getFrameState() const { return ShowFrames.getValue(); }
-
-void ViewProviderPage::setFrameState(bool state) { ShowFrames.setValue(state); }
-
-void ViewProviderPage::toggleFrameState()
-{
-    if (m_graphicsScene) {
-        setFrameState(!getFrameState());
-        m_graphicsScene->refreshViews();
-        setTemplateMarkers(getFrameState());
-    }
-}
 
 void ViewProviderPage::setTemplateMarkers(bool state) const
 {

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.h
@@ -122,9 +122,6 @@ public:
 
     Gui::MDIView* getMDIView() const override;
 
-    bool getFrameState() const;
-    void setFrameState(bool state);
-    void toggleFrameState();
     void setTemplateMarkers(bool state) const;
 
     bool canDelete(App::DocumentObject* obj) const override;

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -227,7 +227,6 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     *views << "Separator";
     *views << "TechDraw_ShareView";
     *views << "Separator";
-    *views << "TechDraw_ToggleFrame";
     *views << "Separator";
     *views << "TechDraw_ProjectShape";
 
@@ -388,7 +387,6 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     decor->setCommand("TechDraw Decoration");
     *decor << "TechDraw_Hatch";
     *decor << "TechDraw_GeometricHatch";
-    *decor << "TechDraw_ToggleFrame";
 
     Gui::ToolBarItem* anno = new Gui::ToolBarItem(root);
     anno->setCommand("TechDraw Annotation");
@@ -488,7 +486,6 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     decor->setCommand("TechDraw Decoration");
     *decor << "TechDraw_Hatch";
     *decor << "TechDraw_GeometricHatch";
-    *decor << "TechDraw_ToggleFrame";
 
     Gui::ToolBarItem* anno = new Gui::ToolBarItem(root);
     anno->setCommand("TechDraw Annotation");


### PR DESCRIPTION
## Summary

This PR overhauls the TechDraw view frame experience, replacing the cluttered, static frame system with a modern, interactive "hover-to-reveal" model. This addresses key usability issues like visual clutter, poor layout logic, and confusing user interaction.

The new implementation provides a cleaner interface and more intuitive behavior, aligning TechDraw more closely with user expectations and other CAD software.

### Key Improvements:

*   **Hover-to-Reveal UI**: Frames, labels, and vertices are now hidden by default and appear only on hover, decluttering the page and improving focus.

*   **Smart Frame Layout**:
    *   The frame now dynamically expands to include child items like dimensions.
    *   The view **label** (temporary UI aid) is positioned cleanly *below* the frame.
    *   The view **caption** (a drawing property) is now located *inside* the frame.

*   **Improved Usability**:
    *   Increased padding makes views easier to select and drag.
    *   The view is now draggable by its frame *or* its label.
    *   Decorations now use theme colors to distinguish them from drawing geometry.

*   **Obsolete Feature Removal**: The now-redundant "Toggle Frames" command and its associated UI have been completely removed to avoid confusion.

## Issues
Fix #18355
Fix #22866

## Demo Video
https://www.youtube.com/watch?v=CND540tvB5c

## For Reviewers
I realise it would be better to add features in separate commits, but as i'm still learning git workflow and the scope creeped as I worked on this feature, I was at a stage where I had all the changes done but no commits yet. I wasn't too sure on patching, as lots of the features are semi-dependant on each other (at least the way i've implemented them). 

If it's really important they be in seperate commits, I could try. 