### PR TITLE
Core: Fit all : Do not process SoSkipBoundingGroup

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3393,18 +3393,6 @@ SbBox3f View3DInventorViewer::getBoundingBox() const
 
 void View3DInventorViewer::viewAll()
 {
-    SbBox3f box = getBoundingBox();
-
-    if (box.isEmpty()) {
-        return;
-    }
-
-    SbSphere sphere;
-    sphere.circumscribe(box);
-    if (sphere.getRadius() == 0) {
-        return;
-    }
-
     // in the scene graph we may have objects which we want to exclude
     // when doing a fit all. Such objects must be part of the group
     // SoSkipBoundingGroup.
@@ -3420,20 +3408,30 @@ void View3DInventorViewer::viewAll()
         group->mode = SoSkipBoundingGroup::EXCLUDE_BBOX;
     }
 
-    // Set the height angle to 45 deg
-    SoCamera* cam = this->getSoRenderManager()->getCamera();
+    SbBox3f box = getBoundingBox();
 
-    if (cam && cam->getTypeId().isDerivedFrom(SoPerspectiveCamera::getClassTypeId())) {
-        static_cast<SoPerspectiveCamera*>(cam)->heightAngle = (float)(std::numbers::pi / 4.0);  // NOLINT
-    }
+    if (!box.isEmpty()) {
+        SbSphere sphere;
+        sphere.circumscribe(box);
+        if (sphere.getRadius() != 0) {
+            // Set the height angle to 45 deg
+            SoCamera* cam = this->getSoRenderManager()->getCamera();
 
-    if (isAnimationEnabled()) {
-        animatedViewAll(10, 20);  // NOLINT
-    }
+            if (cam && cam->getTypeId().isDerivedFrom(SoPerspectiveCamera::getClassTypeId())) {
+                static_cast<SoPerspectiveCamera*>(cam)->heightAngle =
+                    (float)(std::numbers::pi / 4.0);  // NOLINT
+            }
 
-    // make sure everything is visible
-    if (cam) {
-        cam->viewAll(getSoRenderManager()->getSceneGraph(), this->getSoRenderManager()->getViewportRegion());
+            if (isAnimationEnabled()) {
+                animatedViewAll(10, 20);  // NOLINT
+            }
+
+            // make sure everything is visible
+            if (cam) {
+                cam->viewAll(getSoRenderManager()->getSceneGraph(),
+                             this->getSoRenderManager()->getViewportRegion());
+            }
+        }
     }
 
     for (int i = 0; i < pathlist.getLength(); i++) {


### PR DESCRIPTION
This is the first step in fixing the issue https://github.com/FreeCAD/FreeCAD/issues/22317

The issue that is fixed here is that the original viewAll function was not excluding the SoSkipBoundingGroup in the first test.

Because the code that deactivate the SoSkipBoundinggroup : 

```
    for (int i = 0; i < pathlist.getLength(); i++) {
        SoPath* path = pathlist[i];
        auto group = static_cast<SoSkipBoundingGroup*>(path->getTail());  // NOLINT
        group->mode = SoSkipBoundingGroup::EXCLUDE_BBOX;
    }
```

Was called after the initial check for empty bounding box.

So let's say you have an empty sketch in edit. The coin scene has the 2 axis which are in a SoSkipBoundingGroup. BUT the initial call to boundingbox finds a non-empty box. And so the function proceeds. Then the SoSkipBoundingGroup are hidden. And so the viewport fitall to an empty bounding box in the end. Resulting in a viewport of "0 mm x 0 mm" as in this screenshot : 

<img width="1526" height="1152" alt="image" src="https://github.com/user-attachments/assets/76e57c16-9b28-475a-92bf-8ca111f8cbf8" />

This PR fixes this by correctly setting the SoSkipBoundingGroup to EXCLUDE_BBOX BEFORE the initial test for empty boundingbox.

To fix 22317 we need a second step which is to put the origin point in a SoSkipBoundingGroup which is not the case. That will come in a second PR for review convenience