### PR TITLE
CI: ccache update

### DIFF
--- a/.github/workflows/sub_buildPixi.yml
+++ b/.github/workflows/sub_buildPixi.yml
@@ -118,6 +118,8 @@ jobs:
         cache: false
 
     - name: Restore Compiler Cache
+      id: cache-restore
+      if: always()
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ${{ env.CCACHE_DIR }}
@@ -200,6 +202,7 @@ jobs:
         reportFile: ${{env.reportdir}}${{ env.reportfilename }}
 
     - name: Save Compiler Cache
+      id: cache-save
       if: always()
       uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:

--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -107,9 +107,10 @@ jobs:
           compiler: ${{ env.CXX }}
           qt_major_version: 5
       - name: Restore Compiler Cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: cache-restore
+        if: always()
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          save-always: true
           path: ${{ env.CCACHE_DIR }}
           key: FC-${{ steps.genCacheKey.outputs.cacheKey }}-${{ github.ref }}-${{ github.run_id }}
           restore-keys: |
@@ -190,6 +191,15 @@ jobs:
           testCommand: xvfb-run FreeCAD -t 0
           logFile: ${{ env.logdir }}TestGUIInstall.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+
+      - name: Save Compiler Cache
+        id: cache-save
+        if: always()
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: FC-${{ env.cacheKey }}-${{ github.ref }}-${{ github.run_id }}
+
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -100,12 +100,14 @@ jobs:
           mkdir -p ${{ env.logdir }}
           mkdir -p ${{ env.reportdir }}
           echo "reportFile=${{ env.reportfilename }}" >> $GITHUB_OUTPUT
+
       - name: Generate cache key
         id: genCacheKey
         uses: ./.github/workflows/actions/linux/generateCacheKey
         with:
           compiler: ${{ env.CXX }}
           qt_major_version: 5
+
       - name: Restore Compiler Cache
         id: cache-restore
         if: always()
@@ -116,15 +118,18 @@ jobs:
           restore-keys: |
             FC-${{ steps.genCacheKey.outputs.cacheKey }}-${{ github.ref }}-
             FC-${{ steps.genCacheKey.outputs.cacheKey }}-
+
       - name: Print CCache statistics before build, reset stats and print config
         run: |
           ccache -s
           ccache -z
           ccache -p
+
       - name: Install cmake
         uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
           cmake-version: '3.31.6'
+
       - name: CMake Configure
         uses: ./.github/workflows/actions/linux/configure
         with:
@@ -133,6 +138,7 @@ jobs:
           logFile: ${{ env.logdir }}Cmake.log
           errorFile: ${{ env.logdir }}CmakeErrors.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+
       - name: CMake Build
         uses: ./.github/workflows/actions/linux/build
         with:
@@ -140,9 +146,11 @@ jobs:
           logFile: ${{ env.logdir }}Build.log
           errorFile: ${{ env.logdir }}BuildErrors.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+
       - name: Print ccache statistics after Build
         run: |
           ccache -s
+
       - name: FreeCAD CLI tests on build dir
         if: inputs.testOnBuildDir
         timeout-minutes: 10
@@ -152,6 +160,7 @@ jobs:
           testCommand: ${{ env.builddir }}/bin/FreeCADCmd -t 0
           logFile: ${{ env.logdir }}TestCLIBuild.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+
       - name: FreeCAD GUI tests on build dir
         if: inputs.testOnBuildDir
         timeout-minutes: 15
@@ -161,6 +170,7 @@ jobs:
           testCommand: xvfb-run ${{ env.builddir }}/bin/FreeCAD -t 0
           logFile: ${{ env.logdir }}TestGUIBuild.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+
       - name: C++ tests
         timeout-minutes: 1
         uses: ./.github/workflows/actions/runCPPTests/runAllTests
@@ -168,6 +178,7 @@ jobs:
           reportdir: ${{ env.reportdir }}
           builddir: ${{ env.builddir }}
           reportFile: ${{ env.reportdir }}${{ env.reportfilename }}
+
       - name: CMake Install
         uses: ./.github/workflows/actions/linux/install
         with:
@@ -175,6 +186,7 @@ jobs:
           logFile: ${{ env.logdir }}Install.log
           errorFile: ${{ env.logdir }}InstallErrors.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+
       - name: FreeCAD CLI tests on install
         timeout-minutes: 10
         uses: ./.github/workflows/actions/runPythonTests
@@ -183,6 +195,7 @@ jobs:
           testCommand: FreeCADCmd -t 0
           logFile: ${{ env.logdir }}TestCLIInstall.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+
       - name: FreeCAD GUI tests on install
         timeout-minutes: 15
         uses: ./.github/workflows/actions/runPythonTests
@@ -208,6 +221,7 @@ jobs:
           path: |
             ${{ env.logdir }}
             /var/crash/*FreeCAD*
+
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/sub_buildWindows.yml
+++ b/.github/workflows/sub_buildWindows.yml
@@ -54,6 +54,7 @@ jobs:
       ## Have to use C:\ because not enough space on workspace drive
       builddir: C:/FC/build/release/
       libpackdir: C:/FC/libpack/
+      cacheKey: Windows
       ccachebindir: C:/FC/ccache/
       logdir: C:/logs/
       reportdir: C:/report/
@@ -90,14 +91,16 @@ jobs:
         with:
           libpackdir: ${{ env.libpackdir }}
       - name: Restore compiler cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: cache-restore
+        if: always()
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          save-always: true
           path: ${{ env.CCACHE_DIR }}
-          key: FC-Windows-${{ github.ref }}-${{ github.run_id }}
+          key: FC-${{ env.cacheKey }}-${{ github.ref }}-${{ github.run_id }}
           restore-keys: |
-            FC-Windows-${{ github.ref }}-
-            FC-Windows-
+            FC-${{ env.cacheKey }}-${{ github.ref }}-
+            FC-${{ env.cacheKey }}-
+
       - name: Print Ccache statistics before build, reset stats and print config
         run: |
           . $env:ccachebindir\ccache -s
@@ -136,6 +139,15 @@ jobs:
       - name: FreeCAD CLI tests
         run: |
           . ${{ env.builddir }}\bin\FreeCADCmd -t 0 # 2>&1 | tee -filepath ${{ env.logdir }}\integrationTests.log
+
+      - name: Save Compiler Cache
+        id: cache-save
+        if: always()
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: FC-${{ env.cacheKey }}-${{ github.ref }}-${{ github.run_id }}
+
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/sub_buildWindows.yml
+++ b/.github/workflows/sub_buildWindows.yml
@@ -72,6 +72,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
+
       - name: Make needed directories, files and initializations
         id: Init
         run: |
@@ -82,14 +83,17 @@ jobs:
           mkdir ${{ env.logdir }}
           mkdir ${{ env.reportdir }}
           echo "reportFile=${{ env.reportfilename }}" >> $GITHUB_OUTPUT
+
       - name: Get Ccache
         uses: ./.github/workflows/actions/windows/getCcache
         with:
           ccachebindir: ${{ env.ccachebindir }}
+
       - name: Get Libpack
         uses: ./.github/workflows/actions/windows/getLibpack
         with:
           libpackdir: ${{ env.libpackdir }}
+
       - name: Restore compiler cache
         id: cache-restore
         if: always()
@@ -106,10 +110,12 @@ jobs:
           . $env:ccachebindir\ccache -s
           . $env:ccachebindir\ccache -z
           . $env:ccachebindir\ccache -p
+
       - name: Install cmake
         uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
           cmake-version: '3.31.6'
+
       - name: Configuring CMake
         run: >
           cmake -B"${{ env.builddir }}" .
@@ -122,20 +128,25 @@ jobs:
           -DFREECAD_COPY_DEPEND_DIRS_TO_BUILD=ON
           -DFREECAD_COPY_LIBPACK_BIN_TO_BUILD=ON
           -DFREECAD_COPY_PLUGINS_BIN_TO_BUILD=ON
+
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
+
       - name: Compiling sources
         run: |
           cd $env:builddir
           msbuild ALL_BUILD.vcxproj /m /p:Configuration=Release /p:TrackFileAccess=false /p:CLToolPath=${{ env.ccachebindir }}
+
       - name: Print Ccache statistics after build
         run: |
           . $env:ccachebindir\ccache -s
+
       - name: C++ unit tests
         if: false # Disabled because seems to not function on Windows build
         timeout-minutes: 1
         run: |
           . ${{ env.builddir }}\tests\Release\Tests_run --gtest_output=json:${{ env.reportdir }}gtest_results.json # 2>&1 | tee -filepath ${{ env.logdir }}\unitTests.log
+
       - name: FreeCAD CLI tests
         run: |
           . ${{ env.builddir }}\bin\FreeCADCmd -t 0 # 2>&1 | tee -filepath ${{ env.logdir }}\integrationTests.log


### PR DESCRIPTION
The action `actions/cache` is emitting a warning that `save-always` is no longer a functional option.  This PR addresses this by implementing the recommended `if: always()` approach.

CI runs are frequently taking 2-4 hours.  A common factor is missed caches, either from a failure to retrieve the cache, or by compiler cache misses.  This PR may address the former and improve the latter.

## Issues

* None

## Before and After Images

N/A