### PR TITLE
Core: Quantityspinboxes : interpret both separators correctly

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -161,6 +161,7 @@ public:
         const double min = this->minimum;
 
         QString copy = input;
+        copy.replace(QLatin1Char(','), QLatin1Char('.'));
         double value = min;
         bool ok = false;
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/22558

After this PR, the spinboxes interpret correctly both decimal separators. So if user type in : 
1.23 or 1,23 the correct value will be saved. Before in one of the cases the value 123 will be validated instead.

Note, by fixing this we are dropping the support to 'group separators'. So you can no longer type : 
1,000.50

which was imo useless.