### PR TITLE
Sketcher: Unset labels that are below confusion point before enforcing

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -697,6 +697,7 @@ protected:
         onViewParameter->isSet = false;
         onViewParameter->hasFinishedEditing = false;
         onViewParameter->setColor(colorManager.dimConstrDeactivatedColor);
+        onViewParameter->setLockedAppearance(false);
     }
 
     void setOnViewParameterValue(OnViewParameter index,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -613,9 +613,8 @@ void DSHArcControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchPo
                 if (fourthParam->isSet) {
                     onSketchPos.y = fourthParam->getValue();
                 }
-                if (thirdParam->isSet && fourthParam->isSet
-                    && (onSketchPos - handler->firstPoint).Length() < Precision::Confusion()
-                    && thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
+                if (thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing
+                    && (onSketchPos - handler->firstPoint).Length() < Precision::Confusion()) {
                     unsetOnViewParameter(thirdParam.get());
                     unsetOnViewParameter(fourthParam.get());
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -591,7 +591,7 @@ void DSHArcControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchPo
 
                 if (thirdParam->isSet) {
                     radius = thirdParam->getValue();
-                    if (radius < Precision::Confusion()) {
+                    if (radius < Precision::Confusion() && thirdParam->hasFinishedEditing) {
                         unsetOnViewParameter(thirdParam.get());
                         return;
                     }
@@ -614,7 +614,8 @@ void DSHArcControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchPo
                     onSketchPos.y = fourthParam->getValue();
                 }
                 if (thirdParam->isSet && fourthParam->isSet
-                    && (onSketchPos - handler->firstPoint).Length() < Precision::Confusion()) {
+                    && (onSketchPos - handler->firstPoint).Length() < Precision::Confusion()
+                    && thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
                     unsetOnViewParameter(thirdParam.get());
                     unsetOnViewParameter(fourthParam.get());
                 }
@@ -626,7 +627,8 @@ void DSHArcControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchPo
             if (handler->constructionMethod() == DrawSketchHandlerArc::ConstructionMethod::Center) {
                 if (fifthParam->isSet) {
                     double arcAngle = Base::toRadians(fifthParam->getValue());
-                    if (fmod(fabs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()) {
+                    if (fmod(fabs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()
+                        && fifthParam->hasFinishedEditing) {
                         unsetOnViewParameter(fifthParam.get());
                         return;
                     }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
@@ -660,7 +660,7 @@ void DSHArcSlotControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
 
             if (thirdParam->isSet) {
                 radius = thirdParam->getValue();
-                if (radius < Precision::Confusion()) {
+                if (radius < Precision::Confusion() && thirdParam->hasFinishedEditing) {
                     unsetOnViewParameter(thirdParam.get());
                     return;
                 }
@@ -679,7 +679,8 @@ void DSHArcSlotControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
 
             if (fifthParam->isSet) {
                 double arcAngle = Base::toRadians(fifthParam->getValue());
-                if (fmod(fabs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()) {
+                if (fmod(fabs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()
+                    && fifthParam->hasFinishedEditing) {
                     unsetOnViewParameter(fifthParam.get());
                 }
                 else {
@@ -697,12 +698,13 @@ void DSHArcSlotControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
 
             if (sixthParam->isSet) {
                 double radius2 = sixthParam->getValue();
-                if ((fabs(radius2) < Precision::Confusion()
-                     && handler->constructionMethod()
-                         == DrawSketchHandlerArcSlot::ConstructionMethod::ArcSlot)
-                    || (fabs(handler->radius - radius2) < Precision::Confusion()
-                        && handler->constructionMethod()
-                            == DrawSketchHandlerArcSlot::ConstructionMethod::RectangleSlot)) {
+                if (((fabs(radius2) < Precision::Confusion()
+                      && handler->constructionMethod()
+                          == DrawSketchHandlerArcSlot::ConstructionMethod::ArcSlot)
+                     || (fabs(handler->radius - radius2) < Precision::Confusion()
+                         && handler->constructionMethod()
+                             == DrawSketchHandlerArcSlot::ConstructionMethod::RectangleSlot))
+                    && sixthParam->hasFinishedEditing) {
                     unsetOnViewParameter(sixthParam.get());
                 }
                 else {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -1057,9 +1057,8 @@ void DSHBSplineControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
                 onSketchPos.y = prevPoint.y + sin(angle) * length;
             }
 
-            if (thirdParam->isSet && fourthParam->isSet
-                && (onSketchPos - prevPoint).Length() < Precision::Confusion()
-                && thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
+            if (thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing
+                && (onSketchPos - prevPoint).Length() < Precision::Confusion()) {
                 unsetOnViewParameter(thirdParam.get());
                 unsetOnViewParameter(fourthParam.get());
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -1036,7 +1036,7 @@ void DSHBSplineControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
 
             if (thirdParam->isSet) {
                 length = thirdParam->getValue();
-                if (length < Precision::Confusion()) {
+                if (length < Precision::Confusion() && thirdParam->hasFinishedEditing) {
                     unsetOnViewParameter(thirdParam.get());
                     return;
                 }
@@ -1058,7 +1058,8 @@ void DSHBSplineControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
             }
 
             if (thirdParam->isSet && fourthParam->isSet
-                && (onSketchPos - prevPoint).Length() < Precision::Confusion()) {
+                && (onSketchPos - prevPoint).Length() < Precision::Confusion()
+                && thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
                 unsetOnViewParameter(thirdParam.get());
                 unsetOnViewParameter(fourthParam.get());
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -484,7 +484,7 @@ void DSHCircleControllerBase::doEnforceControlParameters(Base::Vector2d& onSketc
                 == DrawSketchHandlerCircle::ConstructionMethod::Center) {
                 if (thirdParam->isSet) {
                     double radius = (handler->isDiameter ? 0.5 : 1) * thirdParam->getValue();
-                    if (radius < Precision::Confusion()) {
+                    if (radius < Precision::Confusion() && thirdParam->hasFinishedEditing) {
                         unsetOnViewParameter(thirdParam.get());
                         return;
                     }
@@ -509,7 +509,8 @@ void DSHCircleControllerBase::doEnforceControlParameters(Base::Vector2d& onSketc
                 }
 
                 if (thirdParam->isSet && fourthParam->isSet
-                    && (onSketchPos - handler->firstPoint).Length() < Precision::Confusion()) {
+                    && (onSketchPos - handler->firstPoint).Length() < Precision::Confusion()
+                    && thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
                     unsetOnViewParameter(thirdParam.get());
                     unsetOnViewParameter(fourthParam.get());
                 }
@@ -527,7 +528,8 @@ void DSHCircleControllerBase::doEnforceControlParameters(Base::Vector2d& onSketc
                 onSketchPos.y = sixthParam->getValue();
             }
             if (fifthParam->isSet && sixthParam->isSet
-                && areCollinear(handler->firstPoint, handler->secondPoint, onSketchPos)) {
+                && areCollinear(handler->firstPoint, handler->secondPoint, onSketchPos)
+                && fifthParam->hasFinishedEditing && sixthParam->hasFinishedEditing) {
                 unsetOnViewParameter(fifthParam.get());
                 unsetOnViewParameter(sixthParam.get());
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -508,9 +508,8 @@ void DSHCircleControllerBase::doEnforceControlParameters(Base::Vector2d& onSketc
                     onSketchPos.y = fourthParam->getValue();
                 }
 
-                if (thirdParam->isSet && fourthParam->isSet
-                    && (onSketchPos - handler->firstPoint).Length() < Precision::Confusion()
-                    && thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
+                if (thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing
+                    && (onSketchPos - handler->firstPoint).Length() < Precision::Confusion()) {
                     unsetOnViewParameter(thirdParam.get());
                     unsetOnViewParameter(fourthParam.get());
                 }
@@ -527,9 +526,8 @@ void DSHCircleControllerBase::doEnforceControlParameters(Base::Vector2d& onSketc
             if (sixthParam->isSet) {
                 onSketchPos.y = sixthParam->getValue();
             }
-            if (fifthParam->isSet && sixthParam->isSet
-                && areCollinear(handler->firstPoint, handler->secondPoint, onSketchPos)
-                && fifthParam->hasFinishedEditing && sixthParam->hasFinishedEditing) {
+            if (fifthParam->hasFinishedEditing && sixthParam->hasFinishedEditing
+                && areCollinear(handler->firstPoint, handler->secondPoint, onSketchPos)) {
                 unsetOnViewParameter(fifthParam.get());
                 unsetOnViewParameter(sixthParam.get());
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -558,7 +558,7 @@ void DSHEllipseControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
 
                 if (thirdParam->isSet) {
                     length = thirdParam->getValue();
-                    if (length < Precision::Confusion()) {
+                    if (length < Precision::Confusion() && thirdParam->hasFinishedEditing) {
                         unsetOnViewParameter(thirdParam.get());
                         return;
                     }
@@ -582,7 +582,8 @@ void DSHEllipseControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
                 }
 
                 if (thirdParam->isSet && fourthParam->isSet
-                    && (onSketchPos - handler->apoapsis).Length() < Precision::Confusion()) {
+                    && (onSketchPos - handler->apoapsis).Length() < Precision::Confusion()
+                    && thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
                     unsetOnViewParameter(thirdParam.get());
                     unsetOnViewParameter(fourthParam.get());
                 }
@@ -613,7 +614,8 @@ void DSHEllipseControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
                 }
 
                 if (fifthParam->isSet && sixthParam->isSet
-                    && areCollinear(handler->apoapsis, handler->periapsis, onSketchPos)) {
+                    && areCollinear(handler->apoapsis, handler->periapsis, onSketchPos)
+                    && fifthParam->hasFinishedEditing && sixthParam->hasFinishedEditing) {
                     unsetOnViewParameter(fifthParam.get());
                     unsetOnViewParameter(sixthParam.get());
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -581,9 +581,8 @@ void DSHEllipseControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
                     onSketchPos.y = fourthParam->getValue();
                 }
 
-                if (thirdParam->isSet && fourthParam->isSet
-                    && (onSketchPos - handler->apoapsis).Length() < Precision::Confusion()
-                    && thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
+                if (thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing
+                    && (onSketchPos - handler->apoapsis).Length() < Precision::Confusion()) {
                     unsetOnViewParameter(thirdParam.get());
                     unsetOnViewParameter(fourthParam.get());
                 }
@@ -613,9 +612,8 @@ void DSHEllipseControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
                     onSketchPos.y = sixthParam->getValue();
                 }
 
-                if (fifthParam->isSet && sixthParam->isSet
-                    && areCollinear(handler->apoapsis, handler->periapsis, onSketchPos)
-                    && fifthParam->hasFinishedEditing && sixthParam->hasFinishedEditing) {
+                if (fifthParam->hasFinishedEditing && sixthParam->hasFinishedEditing
+                    && areCollinear(handler->apoapsis, handler->periapsis, onSketchPos)) {
                     unsetOnViewParameter(fifthParam.get());
                     unsetOnViewParameter(sixthParam.get());
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -486,9 +486,8 @@ void DSHLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchP
                 }
             }
 
-            if (thirdParam->isSet && fourthParam->isSet
-                && (onSketchPos - handler->startPoint).Length() < Precision::Confusion()
-                && thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
+            if (thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing
+                && (onSketchPos - handler->startPoint).Length() < Precision::Confusion()) {
                 unsetOnViewParameter(thirdParam.get());
                 unsetOnViewParameter(fourthParam.get());
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -424,7 +424,8 @@ void DSHLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchP
                         // Both cannot be 0
                         if (fourthParam->isSet) {
                             double width = fourthParam->getValue();
-                            if (fabs(width) < Precision::Confusion()) {
+                            if (fabs(width) < Precision::Confusion()
+                                && fourthParam->hasFinishedEditing) {
                                 unsetOnViewParameter(thirdParam.get());
                                 return;
                             }
@@ -440,7 +441,8 @@ void DSHLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchP
                         // Both cannot be 0
                         if (thirdParam->isSet) {
                             double length = thirdParam->getValue();
-                            if (fabs(length) < Precision::Confusion()) {
+                            if (fabs(length) < Precision::Confusion()
+                                && thirdParam->hasFinishedEditing) {
                                 unsetOnViewParameter(fourthParam.get());
                                 return;
                             }
@@ -460,7 +462,7 @@ void DSHLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchP
 
                 if (thirdParam->isSet) {
                     length = thirdParam->getValue();
-                    if (length < Precision::Confusion()) {
+                    if (length < Precision::Confusion() && thirdParam->hasFinishedEditing) {
                         unsetOnViewParameter(thirdParam.get());
                         return;
                     }
@@ -485,7 +487,8 @@ void DSHLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchP
             }
 
             if (thirdParam->isSet && fourthParam->isSet
-                && (onSketchPos - handler->startPoint).Length() < Precision::Confusion()) {
+                && (onSketchPos - handler->startPoint).Length() < Precision::Confusion()
+                && thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
                 unsetOnViewParameter(thirdParam.get());
                 unsetOnViewParameter(fourthParam.get());
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -1185,9 +1185,12 @@ void DSHOffsetControllerBase::adaptDrawingToOnViewParameterChange(int labelindex
 {
     switch (labelindex) {
         case OnViewParameter::First: {
-            if (value == 0.) {
-                // Do not accept 0.
+            if (value == 0. && onViewParameters[OnViewParameter::First]->hasFinishedEditing) {
+                // Do not accept 0, but only if user has finished editing the OVP.
                 unsetOnViewParameter(onViewParameters[OnViewParameter::First].get());
+
+                // reset offsetLengthSet so mouse can control the offset again
+                handler->offsetLengthSet = false;
 
                 Gui::NotifyUserError(
                     handler->sketchgui->getSketchObject(),
@@ -1246,8 +1249,29 @@ void DSHOffsetController::adaptParameters(Base::Vector2d onSketchPos)
                 setOnViewParameterValue(OnViewParameter::First, handler->offsetLength);
             }
 
+            Base::Vector3d dimensionEndpoint;
+            if (handler->offsetLengthSet && firstParam->isSet) {
+                // if user has typed a value, calculate correct endpoint based on typed value
+                Base::Vector2d direction = handler->endpoint - handler->pointOnSourceWire;
+                if (direction.Length() > Precision::Confusion()) {
+                    direction.Normalize();
+                    Base::Vector2d correctedEndpoint =
+                        handler->pointOnSourceWire + direction * handler->offsetLength;
+                    dimensionEndpoint =
+                        Base::Vector3d(correctedEndpoint.x, correctedEndpoint.y, 0.);
+                }
+                else {
+                    dimensionEndpoint =
+                        Base::Vector3d(handler->endpoint.x, handler->endpoint.y, 0.);
+                }
+            }
+            else {
+                // use mouse pos when user hasn't typed a value
+                dimensionEndpoint = Base::Vector3d(handler->endpoint.x, handler->endpoint.y, 0.);
+            }
+
             firstParam->setPoints(
-                Base::Vector3d(handler->endpoint.x, handler->endpoint.y, 0.),
+                dimensionEndpoint,
                 Base::Vector3d(handler->pointOnSourceWire.x, handler->pointOnSourceWire.y, 0.));
         } break;
         default:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -383,7 +383,7 @@ void DSHPolygonControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
 
             if (thirdParam->isSet) {
                 length = thirdParam->getValue();
-                if (length < Precision::Confusion()) {
+                if (length < Precision::Confusion() && thirdParam->hasFinishedEditing) {
                     unsetOnViewParameter(thirdParam.get());
                     return;
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -1984,7 +1984,8 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
                 if (onViewParameters[OnViewParameter::Third]->isSet) {
                     double length = onViewParameters[OnViewParameter::Third]->getValue();
-                    if (fabs(length) < Precision::Confusion()) {
+                    if (fabs(length) < Precision::Confusion()
+                        && onViewParameters[OnViewParameter::Third]->hasFinishedEditing) {
                         unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
                         return;
                     }
@@ -1999,7 +2000,8 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 }
                 if (onViewParameters[OnViewParameter::Fourth]->isSet) {
                     double width = onViewParameters[OnViewParameter::Fourth]->getValue();
-                    if (fabs(width) < Precision::Confusion()) {
+                    if (fabs(width) < Precision::Confusion()
+                        && onViewParameters[OnViewParameter::Fourth]->hasFinishedEditing) {
                         unsetOnViewParameter(onViewParameters[OnViewParameter::Fourth].get());
                         return;
                     }
@@ -2022,7 +2024,8 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
 
                 if (onViewParameters[OnViewParameter::Third]->isSet) {
                     length = onViewParameters[OnViewParameter::Third]->getValue();
-                    if (length < Precision::Confusion()) {
+                    if (length < Precision::Confusion()
+                        && onViewParameters[OnViewParameter::Third]->hasFinishedEditing) {
                         unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
                         return;
                     }
@@ -2047,7 +2050,9 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 }
                 if (onViewParameters[OnViewParameter::Third]->isSet
                     && onViewParameters[OnViewParameter::Fourth]->isSet
-                    && (onSketchPos - handler->center).Length() < Precision::Confusion()) {
+                    && (onSketchPos - handler->center).Length() < Precision::Confusion()
+                    && onViewParameters[OnViewParameter::Third]->hasFinishedEditing
+                    && onViewParameters[OnViewParameter::Fourth]->hasFinishedEditing) {
                     unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
                     unsetOnViewParameter(onViewParameters[OnViewParameter::Fourth].get());
                 }
@@ -2066,7 +2071,8 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 else {
                     if (onViewParameters[OnViewParameter::Sixth]->isSet) {
                         double thickness = onViewParameters[OnViewParameter::Sixth]->getValue();
-                        if (thickness <= -std::min(handler->width, handler->length) / 2) {
+                        if (thickness <= -std::min(handler->width, handler->length) / 2
+                            && onViewParameters[OnViewParameter::Sixth]->hasFinishedEditing) {
                             unsetOnViewParameter(onViewParameters[OnViewParameter::Sixth].get());
                             return;
                         }
@@ -2086,7 +2092,8 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
 
                 if (onViewParameters[OnViewParameter::Fifth]->isSet) {
                     width = onViewParameters[OnViewParameter::Fifth]->getValue();
-                    if (width < Precision::Confusion()) {
+                    if (width < Precision::Confusion()
+                        && onViewParameters[OnViewParameter::Fifth]->hasFinishedEditing) {
                         unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
                         return;
                     }
@@ -2096,7 +2103,8 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 if (onViewParameters[OnViewParameter::Sixth]->isSet) {
                     double angle =
                         Base::toRadians(onViewParameters[OnViewParameter::Sixth]->getValue());
-                    if (fmod(angle, std::numbers::pi) < Precision::Confusion()) {
+                    if (fmod(angle, std::numbers::pi) < Precision::Confusion()
+                        && onViewParameters[OnViewParameter::Sixth]->hasFinishedEditing) {
                         unsetOnViewParameter(onViewParameters[OnViewParameter::Sixth].get());
                         return;
                     }
@@ -2123,7 +2131,8 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 double width = dir.Length();
                 if (onViewParameters[OnViewParameter::Fifth]->isSet) {
                     width = onViewParameters[OnViewParameter::Fifth]->getValue();
-                    if (width < Precision::Confusion()) {
+                    if (width < Precision::Confusion()
+                        && onViewParameters[OnViewParameter::Fifth]->hasFinishedEditing) {
                         unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
                         return;
                     }
@@ -2133,7 +2142,8 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 if (onViewParameters[OnViewParameter::Sixth]->isSet) {
                     double c =
                         Base::toRadians(onViewParameters[OnViewParameter::Sixth]->getValue());
-                    if (fmod(c, std::numbers::pi) < Precision::Confusion()) {
+                    if (fmod(c, std::numbers::pi) < Precision::Confusion()
+                        && onViewParameters[OnViewParameter::Sixth]->hasFinishedEditing) {
                         unsetOnViewParameter(onViewParameters[OnViewParameter::Sixth].get());
                         return;
                     }
@@ -2160,7 +2170,8 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
 
                 if (onViewParameters[OnViewParameter::Sixth]->isSet) {
                     double thickness = onViewParameters[OnViewParameter::Sixth]->getValue();
-                    if (thickness <= -std::min(handler->width, handler->length) / 2) {
+                    if (thickness <= -std::min(handler->width, handler->length) / 2
+                        && onViewParameters[OnViewParameter::Sixth]->hasFinishedEditing) {
                         unsetOnViewParameter(onViewParameters[OnViewParameter::Sixth].get());
                         return;
                     }
@@ -2187,7 +2198,8 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 else {
                     if (onViewParameters[OnViewParameter::Eighth]->isSet) {
                         double thickness = onViewParameters[OnViewParameter::Eighth]->getValue();
-                        if (thickness <= -std::min(handler->width, handler->length) / 2) {
+                        if (thickness <= -std::min(handler->width, handler->length) / 2
+                            && onViewParameters[OnViewParameter::Eighth]->hasFinishedEditing) {
                             unsetOnViewParameter(onViewParameters[OnViewParameter::Eighth].get());
                             return;
                         }
@@ -2210,7 +2222,8 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
         case SelectMode::SeekFifth: {
             if (onViewParameters[OnViewParameter::Eighth]->isSet) {
                 double thickness = onViewParameters[OnViewParameter::Eighth]->getValue();
-                if (thickness <= -std::min(handler->width, handler->length) / 2) {
+                if (thickness <= -std::min(handler->width, handler->length) / 2
+                    && onViewParameters[OnViewParameter::Eighth]->hasFinishedEditing) {
                     unsetOnViewParameter(onViewParameters[OnViewParameter::Eighth].get());
                     return;
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -2048,11 +2048,9 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 if (onViewParameters[OnViewParameter::Fourth]->isSet) {
                     onSketchPos.y = onViewParameters[OnViewParameter::Fourth]->getValue();
                 }
-                if (onViewParameters[OnViewParameter::Third]->isSet
-                    && onViewParameters[OnViewParameter::Fourth]->isSet
-                    && (onSketchPos - handler->center).Length() < Precision::Confusion()
-                    && onViewParameters[OnViewParameter::Third]->hasFinishedEditing
-                    && onViewParameters[OnViewParameter::Fourth]->hasFinishedEditing) {
+                if (onViewParameters[OnViewParameter::Third]->hasFinishedEditing
+                    && onViewParameters[OnViewParameter::Fourth]->hasFinishedEditing
+                    && (onSketchPos - handler->center).Length() < Precision::Confusion()) {
                     unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
                     unsetOnViewParameter(onViewParameters[OnViewParameter::Fourth].get());
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -607,7 +607,8 @@ void DSHRotateControllerBase::doEnforceControlParameters(Base::Vector2d& onSketc
 
             if (thirdParam->isSet) {
                 double arcAngle = Base::toRadians(thirdParam->getValue());
-                if (fmod(fabs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()) {
+                if (fmod(fabs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()
+                    && thirdParam->hasFinishedEditing) {
                     unsetOnViewParameter(thirdParam.get());
                     return;
                 }
@@ -620,7 +621,8 @@ void DSHRotateControllerBase::doEnforceControlParameters(Base::Vector2d& onSketc
 
             if (fourthParam->isSet) {
                 double arcAngle = Base::toRadians(fourthParam->getValue());
-                if (fmod(fabs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()) {
+                if (fmod(fabs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()
+                    && fourthParam->hasFinishedEditing) {
                     unsetOnViewParameter(fourthParam.get());
                     return;
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
@@ -435,7 +435,7 @@ void DSHSlotControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchP
 
             if (thirdParam->isSet) {
                 length = thirdParam->getValue();
-                if (length < Precision::Confusion()) {
+                if (length < Precision::Confusion() && thirdParam->hasFinishedEditing) {
                     unsetOnViewParameter(thirdParam.get());
                     return;
                 }
@@ -456,7 +456,7 @@ void DSHSlotControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchP
             if (fifthParam->isSet) {
                 double radius = fifthParam->getValue();
 
-                if (radius < Precision::Confusion()) {
+                if (radius < Precision::Confusion() && fifthParam->hasFinishedEditing) {
                     unsetOnViewParameter(fifthParam.get());
                     return;
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
@@ -613,7 +613,7 @@ void DSHTranslateControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
 
             if (thirdParam->isSet) {
                 length = thirdParam->getValue();
-                if (length < Precision::Confusion()) {
+                if (length < Precision::Confusion() && thirdParam->hasFinishedEditing) {
                     unsetOnViewParameter(thirdParam.get());
                     return;
                 }
@@ -639,7 +639,7 @@ void DSHTranslateControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
 
             if (fifthParam->isSet) {
                 length = fifthParam->getValue();
-                if (length < Precision::Confusion()) {
+                if (length < Precision::Confusion() && fifthParam->hasFinishedEditing) {
                     unsetOnViewParameter(fifthParam.get());
                     return;
                 }


### PR DESCRIPTION
As the title says, currently if user tries to type "0", nothing gets typed because the OVP automatically invalidates the "0" as an invalid value in most of the cases.

The solution to that is to only validate it if user has finished editing OVP, not earlier when they are only typing.

Demo:

https://github.com/user-attachments/assets/c6a3bff1-90f8-40b6-99a4-1c1be8996479


Resolves: https://github.com/FreeCAD/FreeCAD/issues/22545