### PR TITLE
Sketcher: Add missing finishEditing() for points

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -541,6 +541,7 @@ void EditModeGeometryCoinManager::updateGeometryColor(const GeoListFacade& geoli
         }
 
         editModeScenegraphNodes.PointsMaterials[l]->diffuseColor.finishEditing();
+        editModeScenegraphNodes.PointsCoordinate[l]->point.finishEditing();
     }
 
     editModeScenegraphNodes.RootCrossMaterials->diffuseColor.finishEditing();


### PR DESCRIPTION
I noticed that the bounding box depth in an empty scene with just a sketch did not always adjust to the highlight depth when a point was highlighted, causing the point to disappear because it was outside the coin clipping volume. I think there was a missing `finishEditing()` so I added it. This apparently triggers the bounding box to have the correct depth. Basically fixing #22216 again but in a better way. The original workaround (#22343) that adds more slack is still relevant for the axis cross and dimensions.