### PR TITLE
FEM: Amplitude support for rigid body constraint

### DIFF
--- a/src/Mod/Fem/App/FemConstraintRigidBody.cpp
+++ b/src/Mod/Fem/App/FemConstraintRigidBody.cpp
@@ -109,6 +109,17 @@ ConstraintRigidBody::ConstraintRigidBody()
                       App::Prop_Output,
                       "Z-direction rotation/moment mode");
 
+    ADD_PROPERTY_TYPE(EnableAmplitude,
+                      (false),
+                      "ConstraintRigidBody",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude of the rigid body boundary condition or load");
+    ADD_PROPERTY_TYPE(AmplitudeValues,
+                      (std::vector<std::string> {"0, 0", "1, 1"}),
+                      "ConstraintRigidBody",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude values");
+
     TranslationalModeX.setEnums(boundaryModeEnum);
     TranslationalModeY.setEnums(boundaryModeEnum);
     TranslationalModeZ.setEnums(boundaryModeEnum);

--- a/src/Mod/Fem/App/FemConstraintRigidBody.h
+++ b/src/Mod/Fem/App/FemConstraintRigidBody.h
@@ -37,6 +37,9 @@ public:
     /// Constructor
     ConstraintRigidBody();
 
+    App::PropertyBool EnableAmplitude;
+    App::PropertyStringList AmplitudeValues;
+
     // Rigid Body parameters
     App::PropertyPosition ReferenceNode;
     App::PropertyPosition Displacement;

--- a/src/Mod/Fem/femsolver/calculix/write_amplitude.py
+++ b/src/Mod/Fem/femsolver/calculix/write_amplitude.py
@@ -44,6 +44,7 @@ def write_amplitude(f, ccxwriter):
         ccxwriter.member.cons_heatflux,
         ccxwriter.member.cons_temperature,
         ccxwriter.member.cons_bodyheatsource,
+        ccxwriter.member.cons_rigidbody,
     ]
 
     for constraint_list in constraint_lists:

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_rigidbody_step.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_rigidbody_step.py
@@ -65,12 +65,17 @@ def write_constraint(f, femobj, rb_obj, ccxwriter):
     ref_node_idx = node_count + 2 * rb_obj_idx + 1
     rot_node_idx = node_count + 2 * rb_obj_idx + 2
 
+    if rb_obj.EnableAmplitude:
+        rb_amplitude = f", AMPLITUDE={rb_obj.Name}"
+    else:
+        rb_amplitude = ""
+
     def write_mode(mode, node, dof, constraint, load):
         if mode == "Constraint":
-            f.write("*BOUNDARY\n")
+            f.write(f"*BOUNDARY{rb_amplitude}\n")
             f.write(f"{node},{dof},{dof},{constraint:.13G}\n")
         elif mode == "Load":
-            f.write("*CLOAD\n")
+            f.write(f"*CLOAD{rb_amplitude}\n")
             f.write(f"{node},{dof},{load:.13G}\n")
 
     mode = [rb_obj.TranslationalModeX, rb_obj.TranslationalModeY, rb_obj.TranslationalModeZ]


### PR DESCRIPTION
This PR is a follow-up on #22851 - I thought it would make sense to add amplitude support to rigid body constraints as well. The logic is the same as in the previous PR. Of course, it was compiled and tested.