### PR TITLE
CI: use Debug in CI builds.

### DIFF
--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -55,12 +55,12 @@ jobs:
       CCACHE_MAXSIZE: 1G
       CCACHE_COMPILERCHECK: "%compiler% -dumpfullversion -dumpversion" # default:mtime
       CCACHE_COMPRESS: true
-      CCACHE_COMPRESSLEVEL: 1
+      CCACHE_COMPRESSLEVEL: 5
       CC: /usr/bin/gcc
       CXX: /usr/bin/g++
       #CC: /usr/bin/clang
       #CXX: /usr/bin/clang++
-      builddir: ${{ github.workspace }}/build/release/
+      builddir: ${{ github.workspace }}/build/debug/
       logdir: /tmp/logs/
       reportdir: /tmp/report/
       reportfilename: ${{ inputs.artifactBasename }}-report.md
@@ -133,7 +133,7 @@ jobs:
       - name: CMake Configure
         uses: ./.github/workflows/actions/linux/configure
         with:
-          extraParameters: -G Ninja --preset release
+          extraParameters: -G Ninja --preset debug
           builddir: ${{ env.builddir }}
           logFile: ${{ env.logdir }}Cmake.log
           errorFile: ${{ env.logdir }}CmakeErrors.log

--- a/.github/workflows/sub_buildWindows.yml
+++ b/.github/workflows/sub_buildWindows.yml
@@ -46,13 +46,13 @@ jobs:
       CCACHE_COMPILERCHECK: "%compiler%" # default:mtime
       CCACHE_MAXSIZE: 1G
       CCACHE_COMPRESS: true
-      CCACHE_COMPRESSLEVEL: 1
+      CCACHE_COMPRESSLEVEL: 5
       CCACHE_NOHASHDIR: true
       CCACHE_DIRECT: true
       #CCACHE_SLOPPINESS: "pch_defines,time_macros" # Can't get PCH to work on Windows
       CCACHE_LOGFILE: C:/logs/ccache.log
       ## Have to use C:\ because not enough space on workspace drive
-      builddir: C:/FC/build/release/
+      builddir: C:/FC/build/debug/
       libpackdir: C:/FC/libpack/
       cacheKey: Windows
       ccachebindir: C:/FC/ccache/
@@ -119,9 +119,9 @@ jobs:
       - name: Configuring CMake
         run: >
           cmake -B"${{ env.builddir }}" .
-          --preset release
+          --preset debug
           -DCMAKE_VS_NO_COMPILE_BATCHING=ON
-          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_BUILD_TYPE=Debug
           -DFREECAD_USE_PCH=OFF
           -DFREECAD_RELEASE_PDB=OFF
           -DFREECAD_LIBPACK_DIR="${{ env.libpackdir }}"
@@ -135,7 +135,7 @@ jobs:
       - name: Compiling sources
         run: |
           cd $env:builddir
-          msbuild ALL_BUILD.vcxproj /m /p:Configuration=Release /p:TrackFileAccess=false /p:CLToolPath=${{ env.ccachebindir }}
+          msbuild ALL_BUILD.vcxproj /m /p:Configuration=Debug /p:TrackFileAccess=false /p:CLToolPath=${{ env.ccachebindir }}
 
       - name: Print Ccache statistics after build
         run: |
@@ -145,7 +145,7 @@ jobs:
         if: false # Disabled because seems to not function on Windows build
         timeout-minutes: 1
         run: |
-          . ${{ env.builddir }}\tests\Release\Tests_run --gtest_output=json:${{ env.reportdir }}gtest_results.json # 2>&1 | tee -filepath ${{ env.logdir }}\unitTests.log
+          . ${{ env.builddir }}\tests\Debug\Tests_run --gtest_output=json:${{ env.reportdir }}gtest_results.json # 2>&1 | tee -filepath ${{ env.logdir }}\unitTests.log
 
       - name: FreeCAD CLI tests
         run: |


### PR DESCRIPTION
The Release presets are currently being used for Windows and Ubuntu builds.  This can lead to longer builds with unnecessary optimization, but also removes the `assert()` statements.  This PR switches to Debug builds for these benefits.  A consequence is likely larger artifacts.  To address this, the compression level has been increased to 5.

* Uses the Debug CMake preset
* Sets compression level to 5 on Ubuntu and Windows

This PR changes the configuration and will likely take a while to propagate through PRs, consequently will likely have an impact on CI builds that use the Release configuration.

## Issues

* None

## Before and After Images

* N/A