### PR TITLE
FEM: Add support for CalculiX membrane elements

### DIFF
--- a/src/Mod/Fem/femsolver/calculix/solver.py
+++ b/src/Mod/Fem/femsolver/calculix/solver.py
@@ -423,6 +423,15 @@ class _BaseSolverCalculix:
             )
             obj.BucklingAccuracy = 0.01
 
+        if not hasattr(obj, "ExcludeBendingStiffness"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "ExcludeBendingStiffness",
+                "Fem",
+                "Exclude bending stiffness to replace shells with membranes",
+                locked=True,
+            )
+            obj.ExcludeBendingStiffness = False
 
 class Proxy(solverbase.Proxy, _BaseSolverCalculix):
     """The Fem::FemSolver's Proxy python type, add solver specific properties"""

--- a/src/Mod/Fem/femsolver/calculix/write_femelement_geometry.py
+++ b/src/Mod/Fem/femsolver/calculix/write_femelement_geometry.py
@@ -115,7 +115,10 @@ def write_femelement_geometry(f, ccxwriter):
                 shellth_obj = matgeoset["shellthickness_obj"]
                 if ccxwriter.solver_obj.ModelSpace == "3D":
                     offset = shellth_obj.Offset
-                    section_def = f"*SHELL SECTION, {elsetdef}{material}, OFFSET={offset:.13G}\n"
+                    if ccxwriter.solver_obj.ExcludeBendingStiffness:
+                        section_def = f"*MEMBRANE SECTION, {elsetdef}{material}, OFFSET={offset:.13G}\n"
+                    else:
+                        section_def = f"*SHELL SECTION, {elsetdef}{material}, OFFSET={offset:.13G}\n"
                 else:
                     section_def = f"*SOLID SECTION, {elsetdef}{material}\n"
                 thickness = shellth_obj.Thickness.getValueAs("mm").Value

--- a/src/Mod/Fem/femsolver/calculix/write_mesh.py
+++ b/src/Mod/Fem/femsolver/calculix/write_mesh.py
@@ -48,7 +48,10 @@ def write_mesh(ccxwriter):
 
     # Use 2D elements if model space is not set to 3D
     if ccxwriter.solver_obj.ModelSpace == "3D":
-        face_variant = "shell"
+        if ccxwriter.solver_obj.ExcludeBendingStiffness:
+            face_variant = "membrane"
+        else:
+            face_variant = "shell"
     elif ccxwriter.solver_obj.ModelSpace == "plane stress":
         face_variant = "stress"
     elif ccxwriter.solver_obj.ModelSpace == "plane strain":


### PR DESCRIPTION
fixes #22911

Adds a new property that can be used to exclude bending stiffness and thus replace shell elements with membrane elements.