### PR TITLE
Refactor identifier validation

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -588,7 +588,7 @@ std::string Application::getUniqueDocumentName(const char* Name, bool tempDoc) c
     if (!Name || *Name == '\0') {
         return {};
     }
-    std::string CleanName = Base::Tools::getIdentifier(Name);
+    std::string CleanName = Base::Tools::getPyIdentifier(Name);
 
     // name in use?
     auto pos = DocMap.find(CleanName);
@@ -3621,7 +3621,7 @@ void Application::getVerboseCommonInfo(QTextStream& str, const std::map<std::str
     const QString deskSess =
         QProcessEnvironment::systemEnvironment().value(QStringLiteral("DESKTOP_SESSION"),
                                                     QString());
-  
+
     const QString major = getValueOrEmpty(mConfig, "BuildVersionMajor");
     const QString minor = getValueOrEmpty(mConfig, "BuildVersionMinor");
     const QString point = getValueOrEmpty(mConfig, "BuildVersionPoint");

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -588,7 +588,7 @@ std::string Application::getUniqueDocumentName(const char* Name, bool tempDoc) c
     if (!Name || *Name == '\0') {
         return {};
     }
-    std::string CleanName = Base::Tools::getPyIdentifier(Name);
+    std::string CleanName = ExpressionParser::getFCIdentifier(Name);
 
     // name in use?
     auto pos = DocMap.find(CleanName);

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3587,7 +3587,7 @@ std::string Document::getUniqueObjectName(const char* proposedName) const
     if (!proposedName || *proposedName == '\0') {
         return {};
     }
-    std::string cleanName = Base::Tools::getPyIdentifier(proposedName);
+    std::string cleanName = ExpressionParser::getFCIdentifier(proposedName);
 
     if (!d->objectNameManager.containsName(cleanName)) {
         // Not in use yet, name is OK

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3082,7 +3082,7 @@ DocumentObject* Document::addObject(const char* sType,
                AddObjectOption::SetNewStatus
                    | (isPartial ? AddObjectOption::SetPartialStatus : AddObjectOption::UnsetPartialStatus)
                    | (isNew ? AddObjectOption::DoSetup : AddObjectOption::None)
-                   | AddObjectOption::ActivateObject, 
+                   | AddObjectOption::ActivateObject,
                viewType);
 
     // return the Object
@@ -3149,7 +3149,7 @@ void Document::_addObject(DocumentObject* pcObject, const char* pObjectName, Add
     else {
         ObjectName = getUniqueObjectName(pcObject->getTypeId().getName());
     }
- 
+
     // insert in the name map
     d->objectMap[ObjectName] = pcObject;
     d->objectNameManager.addExactName(ObjectName);
@@ -3165,7 +3165,7 @@ void Document::_addObject(DocumentObject* pcObject, const char* pObjectName, Add
     }
     d->objectIdMap[pcObject->_Id] = pcObject;
     d->objectArray.push_back(pcObject);
-     
+
      // do no transactions if we do a rollback!
     if (!d->rollback) {
         // Undo stuff
@@ -3184,9 +3184,9 @@ void Document::_addObject(DocumentObject* pcObject, const char* pObjectName, Add
     if (!isPerformingTransaction() && options.testFlag(AddObjectOption::DoSetup)) {
         pcObject->setupObject();
     }
- 
+
     if (options.testFlag(AddObjectOption::SetNewStatus)) {
-        pcObject->setStatus(ObjectStatus::New, true);    
+        pcObject->setStatus(ObjectStatus::New, true);
     }
     if (options.testFlag(AddObjectOption::SetPartialStatus) || options.testFlag(AddObjectOption::UnsetPartialStatus)) {
         pcObject->setStatus(ObjectStatus::PartialObject, options.testFlag(AddObjectOption::SetPartialStatus));
@@ -3198,15 +3198,15 @@ void Document::_addObject(DocumentObject* pcObject, const char* pObjectName, Add
     pcObject->_pcViewProviderName = viewType ? viewType : "";
 
     signalNewObject(*pcObject);
- 
+
     // do no transactions if we do a rollback!
     if (!d->rollback && d->activeUndoTransaction) {
         signalTransactionAppend(*pcObject, d->activeUndoTransaction);
     }
- 
+
     if (options.testFlag(AddObjectOption::ActivateObject)) {
         d->activeObject = pcObject;
-        signalActivatedObject(*pcObject);    
+        signalActivatedObject(*pcObject);
     }
 }
 
@@ -3239,7 +3239,7 @@ void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions optio
         FC_ERR("Cannot delete " << pcObject->getFullName() << " while recomputing");
         return;
     }
-    
+
     TransactionLocker tlock;
 
     _checkTransaction(pcObject, nullptr, __LINE__);
@@ -3249,7 +3249,7 @@ void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions optio
         FC_ERR("Internal error, could not find " << pcObject->getFullName() << " to remove");
     }
 
-    if (options.testFlag(RemoveObjectOption::PreserveChildrenVisibility) 
+    if (options.testFlag(RemoveObjectOption::PreserveChildrenVisibility)
         && !d->rollback && d->activeUndoTransaction && pcObject->hasChildElement()) {
         // Preserve link group sub object global visibilities. Normally those
         // claimed object should be hidden in global coordinate space. However,
@@ -3257,7 +3257,7 @@ void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions optio
         // children, which may now in the global space. When the parent is
         // undeleted, having its children shown in both the local and global
         // coordinate space is very confusing. Hence, we preserve the visibility
-        // here        
+        // here
         for (auto& sub : pcObject->getSubObjects()) {
             if (sub.empty()) {
                 continue;
@@ -3304,7 +3304,7 @@ void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions optio
     }
 
     std::unique_ptr<DocumentObject> tobedestroyed;
-    if ((options.testFlag(RemoveObjectOption::MayDestroyOutOfTransaction) && !d->rollback && !d->activeUndoTransaction) 
+    if ((options.testFlag(RemoveObjectOption::MayDestroyOutOfTransaction) && !d->rollback && !d->activeUndoTransaction)
         || (options.testFlag(RemoveObjectOption::DestroyOnRollback) && d->rollback)) {
         // if not saved in undo -> delete object later
         std::unique_ptr<DocumentObject> delobj(pos->second);
@@ -3320,13 +3320,13 @@ void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions optio
             break;
         }
     }
-    
+
     // In case the object gets deleted the pointer must be nullified
     if (tobedestroyed) {
         tobedestroyed->pcNameInDocument = nullptr;
     }
 
-    // Erase last to avoid invalidating pcObject->pcNameInDocument 
+    // Erase last to avoid invalidating pcObject->pcNameInDocument
     // when it is still needed in Transaction::addObjectNew
     d->objectMap.erase(pos);
 }
@@ -3587,7 +3587,7 @@ std::string Document::getUniqueObjectName(const char* proposedName) const
     if (!proposedName || *proposedName == '\0') {
         return {};
     }
-    std::string cleanName = Base::Tools::getIdentifier(proposedName);
+    std::string cleanName = Base::Tools::getPyIdentifier(proposedName);
 
     if (!d->objectNameManager.containsName(cleanName)) {
         // Not in use yet, name is OK

--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -210,7 +210,7 @@ Property* DynamicProperty::addDynamicProperty(PropertyContainer& pc,
                   "Property " << pc.getFullName() << '.' << name << " already exists");
     }
 
-    if (Base::Tools::getIdentifier(name) != name) {
+    if (!Base::Tools::isValidPyIdentifier(name)) {
         FC_THROWM(Base::NameError, "Invalid property name '" << name << "'");
     }
 
@@ -316,7 +316,7 @@ bool DynamicProperty::removeDynamicProperty(const char* name)
 
 std::string DynamicProperty::getUniquePropertyName(const PropertyContainer& pc, const char* Name) const
 {
-    std::string cleanName = Base::Tools::getIdentifier(Name);
+    std::string cleanName = Base::Tools::getPyIdentifier(Name);
 
     // We test if the property already exists by finding it, which is not much more expensive than
     // having a separate propertyExists(name) method. This avoids building the UniqueNameManager
@@ -433,7 +433,7 @@ bool DynamicProperty::renameDynamicProperty(Property* prop,
                   "Property " << container->getFullName() << '.' << newName << " already exists");
     }
 
-    if (Base::Tools::getIdentifier(newName) != newName) {
+    if (!Base::Tools::isValidPyIdentifier(newName)) {
         FC_THROWM(Base::NameError, "Invalid property name '" << newName << "'");
     }
 

--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -29,12 +29,12 @@
 #endif
 
 #include <Base/Reader.h>
-#include <Base/Tools.h>
 #include <Base/UniqueNameManager.h>
 #include <Base/Writer.h>
 
 #include "DynamicProperty.h"
 #include "Application.h"
+#include "ExpressionParser.h"
 #include "Property.h"
 #include "PropertyContainer.h"
 
@@ -210,7 +210,7 @@ Property* DynamicProperty::addDynamicProperty(PropertyContainer& pc,
                   "Property " << pc.getFullName() << '.' << name << " already exists");
     }
 
-    if (!Base::Tools::isValidPyIdentifier(name)) {
+    if (!ExpressionParser::isValidFCIdentifier(name)) {
         FC_THROWM(Base::NameError, "Invalid property name '" << name << "'");
     }
 
@@ -316,7 +316,7 @@ bool DynamicProperty::removeDynamicProperty(const char* name)
 
 std::string DynamicProperty::getUniquePropertyName(const PropertyContainer& pc, const char* Name) const
 {
-    std::string cleanName = Base::Tools::getPyIdentifier(Name);
+    std::string cleanName = ExpressionParser::getFCIdentifier(Name);
 
     // We test if the property already exists by finding it, which is not much more expensive than
     // having a separate propertyExists(name) method. This avoids building the UniqueNameManager
@@ -433,7 +433,7 @@ bool DynamicProperty::renameDynamicProperty(Property* prop,
                   "Property " << container->getFullName() << '.' << newName << " already exists");
     }
 
-    if (!Base::Tools::isValidPyIdentifier(newName)) {
+    if (!ExpressionParser::isValidFCIdentifier(newName)) {
         FC_THROWM(Base::NameError, "Invalid property name '" << newName << "'");
     }
 

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -3881,6 +3881,23 @@ bool ExpressionParser::isTokenAUnit(const std::string & str)
     return (status == 0 && token == UNIT);
 }
 
+std::string ExpressionParser::getFCIdentifier(const std::string& str)
+{
+    std::stringstream result;
+    std::string PyIdentifier = Base::Tools::getPyIdentifier(str);
+    if (ExpressionParser::isTokenAConstant(PyIdentifier)
+        || ExpressionParser::isTokenAUnit(PyIdentifier)) {
+        result << "_";
+    }
+    result << PyIdentifier;
+    return result.str();
+}
+
+bool ExpressionParser::isValidFCIdentifier(const std::string& str)
+{
+    return (str == ExpressionParser::getFCIdentifier(str));
+}
+
 #if defined(__clang__)
 # pragma clang diagnostic pop
 #endif

--- a/src/App/ExpressionParser.h
+++ b/src/App/ExpressionParser.h
@@ -615,6 +615,8 @@ AppExport ObjectIdentifier parsePath(const App::DocumentObject* owner, const cha
 AppExport bool isTokenAnIndentifier(const std::string& str);
 AppExport bool isTokenAConstant(const std::string& str);
 AppExport bool isTokenAUnit(const std::string& str);
+AppExport std::string getFCIdentifier(const std::string& str);
+AppExport bool isValidFCIdentifier(const std::string& str);
 AppExport std::vector<std::tuple<int, int, std::string>> tokenize(const std::string& str);
 
 /// Convenient class to mark begin of importing

--- a/src/Base/Tools.cpp
+++ b/src/Base/Tools.cpp
@@ -88,7 +88,7 @@ std::string unicodeCharToStdString(UChar32 c)
 
 };  // namespace
 
-std::string Base::Tools::getIdentifier(const std::string& name)
+std::string Base::Tools::getPyIdentifier(const std::string& name)
 {
     if (name.empty()) {
         return "_";
@@ -125,6 +125,11 @@ std::string Base::Tools::getIdentifier(const std::string& name)
     }
 
     return result.str();
+}
+
+bool Base::Tools::isValidPyIdentifier(const std::string& name)
+{
+    return (name == getPyIdentifier(name));
 }
 
 std::wstring Base::Tools::widen(const std::string& str)

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -348,8 +348,9 @@ struct BaseExport Tools
 {
     /**
      * Given an arbitrary string, ensure that it conforms to Python3 identifier rules, replacing
-     * invalid characters with an underscore. If the first character is invalid, prepends an
-     * underscore to the name. See https://unicode.org/reports/tr31/ for complete naming rules.
+     * invalid characters with an underscore. If the first character is invalid or the string is
+     * a reserved keyword, prepends an underscore to the name.
+     * See https://unicode.org/reports/tr31/ for complete naming rules.
      * @param String to be checked and sanitized.
      * @return A std::string that is a valid Python 3 identifier.
      */

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -354,7 +354,8 @@ struct BaseExport Tools
      * @param String to be checked and sanitized.
      * @return A std::string that is a valid Python 3 identifier.
      */
-    static std::string getIdentifier(const std::string& name);
+    static std::string getPyIdentifier(const std::string& name);
+    static bool isValidPyIdentifier(const std::string& name);
     static std::wstring widen(const std::string& str);
     static std::string narrow(const std::wstring& str);
     static std::string escapedUnicodeFromUtf8(const char* s);

--- a/src/Gui/Dialogs/DlgAddProperty.cpp
+++ b/src/Gui/Dialogs/DlgAddProperty.cpp
@@ -99,8 +99,8 @@ void DlgAddProperty::accept()
     std::string name = ui->edtName->text().toUtf8().constData();
     std::string group = ui->edtGroup->text().toUtf8().constData();
     if(name.empty() || group.empty()
-            || name != Base::Tools::getIdentifier(name)
-            || group != Base::Tools::getIdentifier(group))
+            || !Base::Tools::isValidPyIdentifier(name)
+            || !Base::Tools::isValidPyIdentifier(group))
     {
         QMessageBox::critical(getMainWindow(),
             QObject::tr("Invalid name"),

--- a/src/Gui/Dialogs/DlgAddProperty.cpp
+++ b/src/Gui/Dialogs/DlgAddProperty.cpp
@@ -29,7 +29,6 @@
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/ExpressionParser.h>
-#include <Base/Tools.h>
 
 #include "Dialogs/DlgAddProperty.h"
 #include "ui_DlgAddProperty.h"
@@ -98,9 +97,7 @@ void DlgAddProperty::accept()
 {
     std::string name = ui->edtName->text().toUtf8().constData();
     std::string group = ui->edtGroup->text().toUtf8().constData();
-    if(name.empty() || group.empty()
-            || !Base::Tools::isValidPyIdentifier(name)
-            || !Base::Tools::isValidPyIdentifier(group))
+    if(!App::ExpressionParser::isValidFCIdentifier(name) || !App::ExpressionParser::isValidFCIdentifier(group))
     {
         QMessageBox::critical(getMainWindow(),
             QObject::tr("Invalid name"),

--- a/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
@@ -488,7 +488,7 @@ bool DlgAddPropertyVarSet::isNameValid()
     std::string name = ui->lineEditName->text().toStdString();
 
     return !name.empty() &&
-        name == Base::Tools::getIdentifier(name) &&
+        Base::Tools::isValidPyIdentifier(name) &&
         !App::ExpressionParser::isTokenAConstant(name) &&
         !App::ExpressionParser::isTokenAUnit(name) &&
         !propertyExists(name);
@@ -497,7 +497,7 @@ bool DlgAddPropertyVarSet::isNameValid()
 bool DlgAddPropertyVarSet::isGroupValid()
 {
     std::string group = comboBoxGroup.currentText().toStdString();
-    return !group.empty() && group == Base::Tools::getIdentifier(group);
+    return !group.empty() && Base::Tools::isValidPyIdentifier(group);
 }
 
 bool DlgAddPropertyVarSet::isTypeValid()
@@ -526,7 +526,7 @@ void DlgAddPropertyVarSet::showStatusMessage()
     else if (name.empty()) {
         error.clear();
     }
-    else if (name != Base::Tools::getIdentifier(name)) {
+    else if (!Base::Tools::isValidPyIdentifier(name)) {
         error = tr("Invalid property name '%1'").arg(text);
     }
     else if (propertyExists(name)) {

--- a/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/Dialogs/DlgAddPropertyVarSet.cpp
@@ -487,17 +487,14 @@ bool DlgAddPropertyVarSet::isNameValid()
 {
     std::string name = ui->lineEditName->text().toStdString();
 
-    return !name.empty() &&
-        Base::Tools::isValidPyIdentifier(name) &&
-        !App::ExpressionParser::isTokenAConstant(name) &&
-        !App::ExpressionParser::isTokenAUnit(name) &&
+    return App::ExpressionParser::isValidFCIdentifier(name) &&
         !propertyExists(name);
 }
 
 bool DlgAddPropertyVarSet::isGroupValid()
 {
     std::string group = comboBoxGroup.currentText().toStdString();
-    return !group.empty() && Base::Tools::isValidPyIdentifier(group);
+    return App::ExpressionParser::isValidFCIdentifier(group);
 }
 
 bool DlgAddPropertyVarSet::isTypeValid()
@@ -526,7 +523,7 @@ void DlgAddPropertyVarSet::showStatusMessage()
     else if (name.empty()) {
         error.clear();
     }
-    else if (!Base::Tools::isValidPyIdentifier(name)) {
+    else if (!App::ExpressionParser::isValidFCIdentifier(name)) {
         error = tr("Invalid property name '%1'").arg(text);
     }
     else if (propertyExists(name)) {

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -39,7 +39,6 @@
 #include <App/ExpressionParser.h>
 #include <App/VarSet.h>
 #include <Base/Console.h>
-#include <Base/Tools.h>
 
 #include "Dialogs/DlgExpressionInput.h"
 #include "ui_DlgExpressionInput.h"
@@ -459,7 +458,7 @@ public:
 };
 
 static constexpr const char* InvalidIdentifierMessage =
-    QT_TR_NOOP("must contain only alphanumeric characters, underscore, and must not start with a digit");
+    QT_TR_NOOP("must not be empty, must not be a reserved word, must contain only alphanumeric characters, underscore and must not start with a digit");
 
 bool DlgExpressionInput::isPropertyNameValid(const QString& nameProp,
                                              const App::DocumentObject* obj,
@@ -475,23 +474,8 @@ bool DlgExpressionInput::isPropertyNameValid(const QString& nameProp,
     }
 
     std::string name = nameProp.toStdString();
-    if (name.empty()) {
-        message = withPrefix(tr("the name cannot be empty"));
-        return false;
-    }
-
-    if (!Base::Tools::isValidPyIdentifier(name)) {
+    if (!ExpressionParser::isValidFCIdentifier(name)) {
         message = withPrefix(tr(InvalidIdentifierMessage));
-        return false;
-    }
-
-    if (ExpressionParser::isTokenAUnit(name)) {
-        message = withPrefix(tr("%1 is a unit").arg(nameProp));
-        return false;
-    }
-
-    if (ExpressionParser::isTokenAConstant(name)) {
-        message = withPrefix(tr("%1 is a constant").arg(nameProp));
         return false;
     }
 
@@ -842,13 +826,9 @@ bool DlgExpressionInput::isGroupNameValid(const QString& nameGroup,
         return tr("Invalid group name: %1").arg(detail);
     };
 
-    if(nameGroup.isEmpty()) {
-        message = withPrefix(tr("the name cannot be empty"));
-        return false;
-    }
     std::string name = nameGroup.toStdString();
 
-    if (!Base::Tools::isValidPyIdentifier(name)) {
+    if (!ExpressionParser::isValidFCIdentifier(name)) {
         message = withPrefix(tr(InvalidIdentifierMessage));
         return false;
     }

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -480,7 +480,7 @@ bool DlgExpressionInput::isPropertyNameValid(const QString& nameProp,
         return false;
     }
 
-    if (name != Base::Tools::getIdentifier(name)) {
+    if (!Base::Tools::isValidPyIdentifier(name)) {
         message = withPrefix(tr(InvalidIdentifierMessage));
         return false;
     }
@@ -848,7 +848,7 @@ bool DlgExpressionInput::isGroupNameValid(const QString& nameGroup,
     }
     std::string name = nameGroup.toStdString();
 
-    if (name != Base::Tools::getIdentifier(name)) {
+    if (!Base::Tools::isValidPyIdentifier(name)) {
         message = withPrefix(tr(InvalidIdentifierMessage));
         return false;
     }

--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -41,6 +41,7 @@
 #include <Mod/Sketcher/App/GeometryFacade.h>
 #include <Mod/Sketcher/App/SketchObject.h>
 #include <App/Datums.h>
+#include <App/ExpressionParser.h>
 
 #include "EditDatumDialog.h"
 #include "CommandSketcherTools.h"
@@ -59,7 +60,7 @@ using namespace SketcherGui;
 bool SketcherGui::checkConstraintName(const Sketcher::SketchObject* sketch,
                                       std::string constraintName)
 {
-    if (!Base::Tools::isValidPyIdentifier(constraintName)) {
+    if (!App::ExpressionParser::isValidFCIdentifier(constraintName)) {
         Gui::NotifyUserError(
             sketch,
             QT_TRANSLATE_NOOP("Notifications", "Value Error"),

--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -59,7 +59,7 @@ using namespace SketcherGui;
 bool SketcherGui::checkConstraintName(const Sketcher::SketchObject* sketch,
                                       std::string constraintName)
 {
-    if (constraintName != Base::Tools::getIdentifier(constraintName)) {
+    if (!Base::Tools::isValidPyIdentifier(constraintName)) {
         Gui::NotifyUserError(
             sketch,
             QT_TRANSLATE_NOOP("Notifications", "Value Error"),

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -146,10 +146,8 @@ bool PropertySheet::isValidCellAddressName(const std::string& candidate)
 
 bool PropertySheet::isValidAlias(const std::string& candidate)
 {
-    /* Ensure it only contains allowed characters */
-    static const boost::regex gen("^[A-Za-z][_A-Za-z0-9]*$");
-    boost::cmatch cm;
-    if (!boost::regex_match(candidate.c_str(), cm, gen)) {
+    /* Check if it is a valid identifier and not an unit or constant */
+    if (!ExpressionParser::isValidFCIdentifier(candidate)) {
         return false;
     }
 
@@ -160,12 +158,6 @@ bool PropertySheet::isValidAlias(const std::string& candidate)
 
     /* Check if it would be a valid cell address name, e.g. "A2" or "C3" */
     if (isValidCellAddressName(candidate)) {
-        return false;
-    }
-
-    /* Check to make sure it doesn't clash with a reserved name */
-    if (ExpressionParser::isTokenAUnit(candidate)
-        || ExpressionParser::isTokenAConstant(candidate)) {
         return false;
     }
 

--- a/tests/src/Base/Tools.cpp
+++ b/tests/src/Base/Tools.cpp
@@ -155,5 +155,10 @@ TEST(BaseToolsSuite, TestGetIdentifier)
 
     // Full-width digit (U+FF11, looks like '1')
     EXPECT_EQ(Base::Tools::getIdentifier("１start"), "_１start");
+
+    // python reserved keyword
+    EXPECT_EQ(Base::Tools::getIdentifier("while"), "_while");
+    // valid reserved keywords from expression engine should be accepted
+    EXPECT_EQ(Base::Tools::getIdentifier("mm"), "mm");
 }
 // NOLINTEND(cppcoreguidelines-*,readability-*)

--- a/tests/src/Base/Tools.cpp
+++ b/tests/src/Base/Tools.cpp
@@ -113,52 +113,53 @@ TEST(BaseToolsSuite, TestEscapeQuotesFromString)
     EXPECT_EQ(Base::Tools::escapeQuotesFromString("\""), "\\\"");
     EXPECT_EQ(Base::Tools::escapeQuotesFromString("\\"), "\\");
 }
-TEST(BaseToolsSuite, TestGetIdentifier)
+TEST(BaseToolsSuite, TestGetPyIdentifier)
 {
     // ASCII and edge cases
-    EXPECT_EQ(Base::Tools::getIdentifier("valid"), "valid");
-    EXPECT_EQ(Base::Tools::getIdentifier("_valid"), "_valid");
-    EXPECT_EQ(Base::Tools::getIdentifier("1invalid"), "_1invalid");
-    EXPECT_EQ(Base::Tools::getIdentifier(""), "_");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("valid"), "valid");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("_valid"), "_valid");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("1invalid"), "_1invalid");
+    EXPECT_EQ(Base::Tools::getPyIdentifier(""), "_");
 
     // Unicode letters (valid start and continue)
-    EXPECT_EQ(Base::Tools::getIdentifier("πValue"), "πValue");  // Greek lowercase
-    EXPECT_EQ(Base::Tools::getIdentifier("Δx"), "Δx");          // Greek uppercase
-    EXPECT_EQ(Base::Tools::getIdentifier("ǅz"), "ǅz");          // Titlecase letter
-    EXPECT_EQ(Base::Tools::getIdentifier("ʰindex"), "ʰindex");  // Modifier letter
-    EXPECT_EQ(Base::Tools::getIdentifier("名字"), "名字");      // CJK characters (Lo)
-    EXPECT_EQ(Base::Tools::getIdentifier("ⅨCount"), "ⅨCount");  // Letter number (Nl)
+    EXPECT_EQ(Base::Tools::getPyIdentifier("πValue"), "πValue");  // Greek lowercase
+    EXPECT_EQ(Base::Tools::getPyIdentifier("Δx"), "Δx");          // Greek uppercase
+    EXPECT_EQ(Base::Tools::getPyIdentifier("ǅz"), "ǅz");          // Titlecase letter
+    EXPECT_EQ(Base::Tools::getPyIdentifier("ʰindex"), "ʰindex");  // Modifier letter
+    EXPECT_EQ(Base::Tools::getPyIdentifier("名字"), "名字");      // CJK characters (Lo)
+    EXPECT_EQ(Base::Tools::getPyIdentifier("ⅨCount"), "ⅨCount");  // Letter number (Nl)
 
     // Digits not valid as first char
-    EXPECT_EQ(Base::Tools::getIdentifier("٢ndPlace"), "_٢ndPlace");  // Arabic-Indic digit (Nd)
+    EXPECT_EQ(Base::Tools::getPyIdentifier("٢ndPlace"), "_٢ndPlace");  // Arabic-Indic digit (Nd)
 
     // Connector punctuation
-    EXPECT_EQ(Base::Tools::getIdentifier("valid_name"), "valid_name");
-    EXPECT_EQ(Base::Tools::getIdentifier("valid‿name"), "valid‿name");
-    EXPECT_EQ(Base::Tools::getIdentifier("valid﹍name"), "valid﹍name");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("valid_name"), "valid_name");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("valid‿name"), "valid‿name");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("valid﹍name"), "valid﹍name");
 
     // Combining marks (Mn, Mc)
-    EXPECT_EQ(Base::Tools::getIdentifier("éclair"), "éclair");  // 'e' + combining acute accent (Mn)
-    EXPECT_EQ(Base::Tools::getIdentifier("devा"), "devा");      // Devanagari vowel sign (Mc)
+    EXPECT_EQ(Base::Tools::getPyIdentifier("éclair"),
+              "éclair");                                      // 'e' + combining acute accent (Mn)
+    EXPECT_EQ(Base::Tools::getPyIdentifier("devा"), "devा");  // Devanagari vowel sign (Mc)
 
     // Invalid symbols
-    EXPECT_EQ(Base::Tools::getIdentifier("hello!"), "hello_");
-    EXPECT_EQ(Base::Tools::getIdentifier("foo-bar"), "foo_bar");
-    EXPECT_EQ(Base::Tools::getIdentifier("a🙂b"), "a_b");  // Emoji replaced
-    EXPECT_EQ(Base::Tools::getIdentifier("a*b&c"), "a_b_c");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("hello!"), "hello_");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("foo-bar"), "foo_bar");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("a🙂b"), "a_b");  // Emoji replaced
+    EXPECT_EQ(Base::Tools::getPyIdentifier("a*b&c"), "a_b_c");
 
     // Edge: starts with underscore, includes mixed types
-    EXPECT_EQ(Base::Tools::getIdentifier("_नमस्ते123"), "_नमस्ते123");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("_नमस्ते123"), "_नमस्ते123");
 
     // Starts with invalid character
-    EXPECT_EQ(Base::Tools::getIdentifier("💡idea"), "_idea");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("💡idea"), "_idea");
 
     // Full-width digit (U+FF11, looks like '1')
-    EXPECT_EQ(Base::Tools::getIdentifier("１start"), "_１start");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("１start"), "_１start");
 
     // python reserved keyword
-    EXPECT_EQ(Base::Tools::getIdentifier("while"), "_while");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("while"), "_while");
     // valid reserved keywords from expression engine should be accepted
-    EXPECT_EQ(Base::Tools::getIdentifier("mm"), "mm");
+    EXPECT_EQ(Base::Tools::getPyIdentifier("mm"), "mm");
 }
 // NOLINTEND(cppcoreguidelines-*,readability-*)


### PR DESCRIPTION
this PR is a follow up to #22490 so it includes it, while checking it out I relized that `getIdentifier` does not check if the name is a reserved word either from python or the expression parser. I added a check for python keywords to `getIdentifier` and renamed it to `getPyIdentifier` then added another layer in `ExpressionParser` that checks for expression keywords