### PR TITLE
Sketcher: fix constraint icon size

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -393,8 +393,7 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(
     Client.drawingParameters.labelFontSize =
         std::lround(sketcherfontSize * devicePixelRatio * 72.0f
                     / dpi);  // this is in points, as SoDatumLabel uses points
-    Client.drawingParameters.constraintIconSize =
-        std::lround(0.8 * sketcherfontSize * devicePixelRatio);
+    Client.drawingParameters.constraintIconSize = std::lround(0.8 * sketcherfontSize);
 
 
     auto supportedsizes = Gui::Inventor::MarkerBitmaps::getSupportedSizes("CIRCLE_LINE");
@@ -1158,3 +1157,4 @@ SoSeparator* EditModeCoinManager::getRootEditNode()
 {
     return editModeScenegraphNodes.EditRoot;
 }
+


### PR DESCRIPTION
Fix regression from https://github.com/FreeCAD/FreeCAD/pull/21098

That PR made regression for some people, reported there : https://github.com/FreeCAD/FreeCAD/issues/21745 (I do not link to the issue because I am not sure this is fixing 100% of the problem.)

I tested on a 
- window 11
- 14in screen
- 3000x2000 px
- 200% scaling
- DPI reads 96 (`Client.getApplicationLogicalDPIX();`)

One of the problem reported in the issue, and that I was able to reproduce, is that the constraint icon size was scaled.

On my end the constraint icons appeared twice too big.
The normal size should be about half of the toolbar icon : 
<img width="125" height="55" alt="image" src="https://github.com/user-attachments/assets/41137e03-9745-4d4c-b33f-6ea73df9aba4" />

The size I see after 21098 : 
<img width="247" height="111" alt="image" src="https://github.com/user-attachments/assets/f579398c-c39b-4a7f-a973-26fc2fab3f00" />

After some test changing the scaling, it appears that icon sizes do NOT need to have the DevicePixelRatio applied to them. Coin probably handles scaling them correctly already.

@maxwxyz 