### PR TITLE
Sketcher: Coinmanager: remove dpi

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -378,7 +378,6 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(
 
     int sketcherfontSize = hGrp->GetInt("EditSketcherFontSize", defaultFontSizePixels);
 
-    double dpi = Client.getApplicationLogicalDPIX();
     double devicePixelRatio = Client.getDevicePixelRatio();
 
     // simple scaling factor for hardcoded pixel values in the Sketcher
@@ -388,11 +387,9 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(
     // SoDatumLabel takes the size in points, not in pixels. This is because it uses QFont
     // internally. Coin, at least our coin at this time, takes pixels, not points.
 
-    Client.drawingParameters.coinFontSize =
-        std::lround(sketcherfontSize * devicePixelRatio);  // this is in pixels
+    Client.drawingParameters.coinFontSize = std::lround(sketcherfontSize * devicePixelRatio);  // in pixels
     Client.drawingParameters.labelFontSize =
-        std::lround(sketcherfontSize * devicePixelRatio * 72.0f
-                    / dpi);  // this is in points, as SoDatumLabel uses points
+        std::lround(sketcherfontSize * devicePixelRatio * 0.75);  // in points, as SoDatumLabel uses points
     Client.drawingParameters.constraintIconSize =
         std::lround(0.8 * sketcherfontSize * devicePixelRatio);
 
@@ -1158,3 +1155,4 @@ SoSeparator* EditModeCoinManager::getRootEditNode()
 {
     return editModeScenegraphNodes.EditRoot;
 }
+


### PR DESCRIPTION
https://github.com/FreeCAD/FreeCAD/pull/21098 made so changes to fix rendering on HiDPI screens.
The main change was to add DevicePixelRatio (= screen scaling, for example 2 for 200% scaling).

The issue I see is that the code was using 
`double dpi = Client.getApplicationLogicalDPIX();`

Which is (behind layers of attorney classes and call which are very annoying to navigate)
`int(QApplication::primaryScreen()->logicalDotsPerInchX());`

This shows 2 issues. 
- First it's using 'primaryScreen'.
Which according to Qt doc is supposed to be the screen where the app is located. But [that apparantly is buggy](https://forum.qt.io/topic/115821/qguiapplication-primaryscreen-not-telling-me-what-i-need-to-know) so this may be adding inconsistencies in behavior.

- It may be redundant with devicePixelRatio. While it appears to be taking DevicePixelRatio into account, I wouldn't be surprised if it's not the case in all situation.

Now the first issue that I see is that https://github.com/FreeCAD/FreeCAD/pull/21098 did this change : 

```
    Client.drawingParameters.coinFontSize = std::lround(sketcherfontSize * 96.0f / dpi);
    Client.drawingParameters.labelFontSize = std::lround(sketcherfontSize * 72.0f / dpi);
    Client.drawingParameters.constraintIconSize = std::lround(0.8 * sketcherfontSize);
```
to : 
```
    Client.drawingParameters.coinFontSize = std::lround(sketcherfontSize * devicePixelRatio);
    Client.drawingParameters.labelFontSize = std::lround(sketcherfontSize * devicePixelRatio * 72.0f  / dpi);
    Client.drawingParameters.constraintIconSize = std::lround(0.8 * sketcherfontSize * devicePixelRatio);
```
See how the PR removed the `96 / dpi` from coinFontSize but not the `72 / dpi` from labelFontSize. This is inconsistent. If you have a dpi = 96 it changes nothing. But if the dpi value is different then it's not good anymore: the dimensions text and arrows appear very small : 
<img width="2570" height="1033" alt="image" src="https://github.com/user-attachments/assets/eb37b9be-f116-4288-b4fe-b698ded696b4" />

So I think the reliance on logical dpi should be removed completely. It makes no sense to keep it only in one place.