### PR TITLE
Gui: Fix about image path

### DIFF
--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -164,11 +164,7 @@ QPixmap AboutDialog::aboutImage() const
         about_image.load(fi.filePath(), "PNG");
     }
 
-    // Use dev or generic version of image depending on current build version.
-    const auto& suffix = App::Application::Config()["BuildVersionSuffix"];
-    const auto about_path_key = (suffix == "dev") ? "AboutImageDev" : "AboutImage";
-    const auto& about_path = App::Application::Config()[about_path_key];
-
+    const std::string about_path = App::Application::Config()["AboutImage"];
     if (!about_path.empty() && about_image.isNull()) {
         QString path = QString::fromStdString(about_path);
         if (QDir(path).isRelative()) {


### PR DESCRIPTION
Merge of #18599 accidentally didn't drop change to DlgAbout path. Nothing sets AboutImageDev congfig key, so partially revert it.

Fixes: #18599