### PR TITLE
TechDraw: Add number of decimals to dimension task panel

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -25,7 +25,7 @@
 # include <cmath>
 # include <limits>
 # include <QMessageBox>
-#include <regex>
+# include <regex>
 #endif // #ifndef _PreComp_
 
 #include <App/Document.h>

--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -25,6 +25,7 @@
 # include <cmath>
 # include <limits>
 # include <QMessageBox>
+#include <regex>
 #endif // #ifndef _PreComp_
 
 #include <App/Document.h>
@@ -42,8 +43,6 @@
 #include "TaskDimension.h"
 #include "QGIViewDimension.h"
 #include "ViewProviderDimension.h"
-#include <regex>
-
 
 using namespace Gui;
 using namespace TechDraw;

--- a/src/Mod/TechDraw/Gui/TaskDimension.h
+++ b/src/Mod/TechDraw/Gui/TaskDimension.h
@@ -69,12 +69,14 @@ private Q_SLOTS:
     void onDimUseSelectionClicked();
     void onExtUseDefaultClicked();
     void onExtUseSelectionClicked();
+    void onNumDecChanged(int decimals);
 
 private:
     std::unique_ptr<Ui_TaskDimension> ui;
     QGIViewDimension *m_parent;
     Gui::WeakPtrT<ViewProviderDimension> m_dimensionVP;
     std::pair<double, bool> getAngleFromSelection();
+    std::string m_originalFormatChar;
 };
 
 class TaskDlgDimension : public Gui::TaskView::TaskDialog

--- a/src/Mod/TechDraw/Gui/TaskDimension.ui
+++ b/src/Mod/TechDraw/Gui/TaskDimension.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>371</width>
-    <height>698</height>
+    <width>416</width>
+    <height>761</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,13 +15,130 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
+    <widget class="QGroupBox" name="gbFormatting">
+     <property name="title">
+      <string>Dimension</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QGridLayout" name="gridLayout" columnstretch="1,1">
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="leFormatSpecifier">
+          <property name="toolTip">
+           <string>Text to be displayed</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="cbArbitrary">
+          <property name="toolTip">
+           <string>Sets use of 'Format spec' instead of the dimension value</string>
+          </property>
+          <property name="text">
+           <string>Arbitrary text</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>Number of decimals</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QSpinBox" name="sbNumDec"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_11">
+          <property name="text">
+           <string>Format specifier</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="gbTolerancing">
      <property name="title">
       <string>Tolerancing</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <layout class="QGridLayout" name="gridLayout_2">
+       <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,1">
+        <item row="5" column="1">
+         <widget class="QLineEdit" name="leFormatSpecifierUnderTolerance">
+          <property name="toolTip">
+           <string>Specifies the undertolerance format in printf() style, or arbitrary text</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="Gui::QuantitySpinBox" name="qsbOvertolerance" native="true">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Overtolerance value
+If 'Equal tolerance' is checked this is also
+the negated value for 'Undertolerance'.</string>
+          </property>
+          <property name="singleStep" stdset="0">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value" stdset="0">
+           <double>0.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="Gui::QuantitySpinBox" name="qsbUndertolerance" native="true">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Undertolerance value
+If 'Equal tolerance' is checked it will be replaced
+by negative value of 'Overtolerance'.</string>
+          </property>
+          <property name="singleStep" stdset="0">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value" stdset="0">
+           <double>0.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_12">
+          <property name="text">
+           <string>Undertolerance format specifier</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Overtolerance format specifier</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string>Undertolerance</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <widget class="QCheckBox" name="cbTheoreticallyExact">
           <property name="toolTip">
@@ -42,6 +159,13 @@
           </property>
          </widget>
         </item>
+        <item row="4" column="1">
+         <widget class="QLineEdit" name="leFormatSpecifierOverTolerance">
+          <property name="toolTip">
+           <string>Specifies the overtolerance format in printf() style, or arbitrary text</string>
+          </property>
+         </widget>
+        </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
@@ -49,127 +173,7 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
-         <widget class="Gui::QuantitySpinBox" name="qsbOvertolerance">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Overtolerance value
-If 'Equal tolerance' is checked this is also
-the negated value for 'Undertolerance'.</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="singleStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_8">
-          <property name="text">
-           <string>Undertolerance:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="Gui::QuantitySpinBox" name="qsbUndertolerance">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Undertolerance value
-If 'Equal tolerance' is checked it will be replaced
-by negative value of 'Overtolerance'.</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="singleStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="gbFormatting">
-     <property name="title">
-      <string>Formatting</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_11">
-          <property name="text">
-           <string>Format specifier</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="leFormatSpecifier">
-          <property name="toolTip">
-           <string>Text to be displayed</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="cbArbitrary">
-          <property name="toolTip">
-           <string>Sets use of 'Format spec' instead of the dimension value</string>
-          </property>
-          <property name="text">
-           <string>Arbitrary text</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Overtolerance format specifier</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLineEdit" name="leFormatSpecifierOverTolerance">
-          <property name="toolTip">
-           <string>Specifies the overtolerance format in printf() style, or arbitrary text</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_12">
-          <property name="text">
-           <string>Undertolerance format specifier</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QLineEdit" name="leFormatSpecifierUnderTolerance">
-          <property name="toolTip">
-           <string>Specifies the undertolerance format in printf() style, or arbitrary text</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
+        <item row="6" column="0">
          <widget class="QCheckBox" name="cbArbitraryTolerances">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uses the tolerance format spec&lt;/p&gt;&lt;p&gt;instead of the tolerance value&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -191,7 +195,7 @@ by negative value of 'Overtolerance'.</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <layout class="QGridLayout" name="gridLayout_3">
+       <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,1">
         <item row="0" column="0">
          <widget class="QCheckBox" name="cbArrowheads">
           <property name="toolTip">
@@ -205,7 +209,7 @@ by negative value of 'Overtolerance'.</string>
         <item row="1" column="0">
          <widget class="QLabel" name="label_5">
           <property name="text">
-           <string>Color:</string>
+           <string>Color</string>
           </property>
          </widget>
         </item>
@@ -214,7 +218,7 @@ by negative value of 'Overtolerance'.</string>
           <property name="toolTip">
            <string>Color of the dimension</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -231,7 +235,7 @@ by negative value of 'Overtolerance'.</string>
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="Gui::QuantitySpinBox" name="qsbFontSize">
+         <widget class="Gui::QuantitySpinBox" name="qsbFontSize" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -247,13 +251,10 @@ by negative value of 'Overtolerance'.</string>
           <property name="toolTip">
            <string>Font size for text</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="minimum">
+          <property name="minimum" stdset="0">
            <double>0.000000000000000</double>
           </property>
-          <property name="value">
+          <property name="value" stdset="0">
            <double>4.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
@@ -310,7 +311,7 @@ by negative value of 'Overtolerance'.</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_5">
       <item>
-       <layout class="QGridLayout" name="gridLayout_4">
+       <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,1">
         <item row="0" column="0">
          <widget class="QRadioButton" name="rbOverride">
           <property name="toolTip">
@@ -334,7 +335,7 @@ by negative value of 'Overtolerance'.</string>
            <string>Angle of dimension line with drawing X axis (degrees)</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
           </property>
           <property name="minimum">
            <double>-360.000000000000000</double>
@@ -377,7 +378,7 @@ by negative value of 'Overtolerance'.</string>
            <string>Angle of extension lines with drawing X axis (degrees)</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
           </property>
           <property name="minimum">
            <double>-360.000000000000000</double>

--- a/src/Mod/TechDraw/Gui/TaskDimension.ui
+++ b/src/Mod/TechDraw/Gui/TaskDimension.ui
@@ -47,7 +47,11 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QSpinBox" name="sbNumDec"/>
+         <widget class="QSpinBox" name="sbNumDec">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adjusts the number of decimal places of the selected dimension&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
         </item>
         <item row="1" column="0">
          <widget class="QLabel" name="label_11">


### PR DESCRIPTION
In TechDraw, there is an  `Increase/Decrease Decimals` command in the toolbar and menu. This is a tool that should probably not occupy the toolbar are very least, perhaps not the menu either.

This PR:
1) Adds the option to increase/decrease decimal places in the dimension task panel.
2) Shuffles around some of the content of the dimension task panel to be grouped more logically.
3) Makes the dimension task panel gridlayouts keep 1:1 column width ratio when resizing the panel.

It should be noted that the task dimension tool cannot do batch manipulation across multiple dimensions at once due to a limitation in the way the dimesion task panel works, whereas the existing toolbar and menu commands can. I would suggest if the toolbar command is removed, the menu command be kept to keep the batch manipulation option. This would still achieve the goal of slowly cleaning the TechDraw toolbar to be less intimidating to new users.

Another point to mention is that @PaddleStroke has added this command to the context menus of dimensions in AstoCAD. So if that were brought over, I think the command could be removed from the toolbar **and** the menu.

Pending DWG review, I can remove the `Increase/Decrease Decimals` command in the toolbar in another commit.

## Before Image

<img width="439" height="686" alt="20250806_21h47m28s_grim" src="https://github.com/user-attachments/assets/f3fb0b40-45af-4450-889a-d6f38d256adb" />

## After Image

<img width="428" height="699" alt="20250806_21h47m15s_grim" src="https://github.com/user-attachments/assets/be6fe799-34bc-4956-8ea6-e7a5bc108bf4" />
