### PR TITLE
Gui: Fix null check issue in navlib

### DIFF
--- a/src/Gui/3Dconnexion/navlib/NavlibCmds.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibCmds.cpp
@@ -43,6 +43,8 @@
 #include <Gui/Workbench.h>
 #include <Gui/WorkbenchManager.h>
 
+#include <gsl/pointers>
+
 constexpr uint8_t LCD_ICON_SIZE = 24u;
 
 NavlibInterface::ParsedData NavlibInterface::parseCommandId(const std::string& commandId) const
@@ -131,8 +133,11 @@ TDxCommand NavlibInterface::getCCommand(const Gui::Command& command,
     if (commandName.empty() || commandId.empty())
         return TDxCommand();
 
+    gsl::not_null<const char*> commandToolTip =
+        command.getToolTipText() ? command.getToolTipText() : "";
+
     std::string commandDescription =
-        parameter == -1 ? command.getToolTipText() : qAction.toolTip().toStdString();
+        parameter == -1 ? std::string(commandToolTip) : qAction.toolTip().toStdString();
 
     auto newEnd = std::remove(commandName.begin(), commandName.end(), '&');
     commandName.erase(newEnd, commandName.end());

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1,5 +1,16 @@
 add_library(FreeCADGui SHARED)
 
+if ( EXISTS "${CMAKE_SOURCE_DIR}/src/3rdParty/GSL/include" )
+    include_directories( ${CMAKE_SOURCE_DIR}/src/3rdParty/GSL/include )
+else()
+    find_package(Microsoft.GSL)
+    if( Microsoft.GSL_FOUND )
+        message( STATUS "Found Microsoft.GSL: version ${Microsoft.GSL_VERSION}" )
+    else()
+        message( SEND_ERROR "The C++ Guidelines Support Library (GSL) submodule is not available. Please run git submodule update --init" )
+    endif()
+endif()
+
 add_subdirectory(Stylesheets)
 add_subdirectory(PreferencePacks)
 add_subdirectory(PreferencePackTemplates)


### PR DESCRIPTION
This change makes sure the program doesn't crash when tooltips are missing for commands.
Related: https://github.com/FreeCAD/FreeCAD/pull/22956

I used GSL's `gsl::not_null` to show the intent without comments, ut I can change it if requested.