### PR TITLE
Core: Enhance 'Expression editor' input and resize behavior

### DIFF
--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -115,7 +115,7 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
     }
     else {
         ui->expression->setMinimumWidth(300);
-        ui->expression->setMinimumHeight(50);
+        ui->expression->setMinimumHeight(80);
         ui->msg->setWordWrap(true);
         ui->msg->setMaximumHeight(200);
         ui->msg->setMinimumWidth(280);

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -79,22 +79,22 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
     initializeVarSets();
 
     // Connect signal(s)
-    connect(ui->expression, &ExpressionLineEdit::textChanged,
+    connect(ui->expression, &ExpressionTextEdit::textChanged,
         this, &DlgExpressionInput::textChanged);
     connect(discardBtn, &QPushButton::clicked,
         this, &DlgExpressionInput::setDiscarded);
 
     if (expression) {
-        ui->expression->setText(QString::fromStdString(expression->toString()));
+        ui->expression->setPlainText(QString::fromStdString(expression->toString()));
     }
     else {
         QVariant text = parent->property("text");
         if (text.canConvert<QString>()) {
-            ui->expression->setText(text.toString());
+            ui->expression->setPlainText(text.toString());
         }
     }
 
-    // Set document object on line edit to create auto completer
+    // Set document object on text edit to create auto completer
     DocumentObject * docObj = path.getDocumentObject();
     ui->expression->setDocumentObject(docObj);
 
@@ -114,7 +114,7 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
         setAttribute(Qt::WA_TranslucentBackground, true);
     }
     else {
-        ui->expression->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        ui->expression->setMinimumHeight(50);
         ui->horizontalSpacer_3->changeSize(0, 2);
         ui->verticalLayout->setContentsMargins(9, 9, 9, 9);
         this->adjustSize();
@@ -360,8 +360,10 @@ void DlgExpressionInput::checkExpression(const QString& text)
 
 static const bool NoCheckExpr = false;
 
-void DlgExpressionInput::textChanged(const QString &text)
+void DlgExpressionInput::textChanged()
 {
+    const QString& text = ui->expression->toPlainText();
+
     if (text.isEmpty()) {
         okBtn->setDisabled(true);
         discardBtn->setDefault(true);
@@ -371,17 +373,6 @@ void DlgExpressionInput::textChanged(const QString &text)
     okBtn->setDefault(true);
 
     try {
-        //resize the input field according to text size
-        QFontMetrics fm(ui->expression->font());
-        int width = QtTools::horizontalAdvance(fm, text) + 15;
-        if (width < minimumWidth)
-            ui->expression->setMinimumWidth(minimumWidth);
-        else
-            ui->expression->setMinimumWidth(width);
-
-        if(this->width() < ui->expression->minimumWidth())
-            setMinimumWidth(ui->expression->minimumWidth());
-
         checkExpression(text);
         if (varSetsVisible) {
             // If varsets are visible, check whether the varset info also
@@ -917,7 +908,7 @@ void DlgExpressionInput::updateVarSetInfo(bool checkExpr)
     if (checkExpr) {
         // We have to check the text of the expression as well
         try {
-            checkExpression(ui->expression->text());
+            checkExpression(ui->expression->toPlainText());
         }
         catch (Base::Exception&) {
             okBtn->setEnabled(false);

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -937,8 +937,8 @@ void DlgExpressionInput::setMsgText()
     // find words longer than length of msg widget
     // then insert newline to wrap it
     std::string wrappedMsg{};
-    static constexpr int msgContentMargins = 50;
-    const int maxWordLength = (ui->msg->width() - msgContentMargins) / msgFontMetrics.averageCharWidth(); 
+    const int msgContentWidth = ui->msg->width() * 0.85; // 0.85 is a magic number for some padding
+    const int maxWordLength = msgContentWidth / msgFontMetrics.averageCharWidth(); 
 
     const auto wrappableWordPattern = std::regex{ "\\S{" + std::to_string(maxWordLength) + "}" };
     auto it = std::sregex_iterator{ this->message.cbegin(), this->message.cend(), wrappableWordPattern };
@@ -953,6 +953,14 @@ void DlgExpressionInput::setMsgText()
     wrappedMsg += this->message.substr(lastPos);
 
     ui->msg->setText(QString::fromStdString(wrappedMsg));
+    
+    // elide text if it is going out of widget bounds 
+    // note: this is only 'rough elide', as this text is usually not very long;
+    const int msgLinesLimit = 3;
+    if (wrappedMsg.size() > msgContentWidth / msgFontMetrics.averageCharWidth() * msgLinesLimit) {
+        const QString elidedMsg = msgFontMetrics.elidedText(QString::fromStdString(wrappedMsg), Qt::ElideRight, msgContentWidth * msgLinesLimit);
+        ui->msg->setText(elidedMsg);
+    }
 }
 
 #include "moc_DlgExpressionInput.cpp"

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -119,7 +119,6 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
         ui->msg->setWordWrap(true);
         ui->msg->setMaximumHeight(200);
         ui->msg->setMinimumWidth(280);
-        ui->horizontalSpacer_3->changeSize(0, 2);
         ui->verticalLayout->setContentsMargins(9, 9, 9, 9);
         this->adjustSize();
         // It is strange that (at least on Linux) DlgExpressionInput will shrink

--- a/src/Gui/Dialogs/DlgExpressionInput.h
+++ b/src/Gui/Dialogs/DlgExpressionInput.h
@@ -111,7 +111,7 @@ private:
                           QString& message) const;
 
 private Q_SLOTS:
-    void textChanged(const QString & text);
+    void textChanged();
     void setDiscarded();
     void onCheckVarSets(int state);
     void onVarSetSelected(int index);

--- a/src/Gui/Dialogs/DlgExpressionInput.h
+++ b/src/Gui/Dialogs/DlgExpressionInput.h
@@ -77,7 +77,6 @@ public:
     bool discardedFormula() const { return discarded; }
 
     QPoint expressionPosition() const;
-    void   setExpressionInputSize(int width, int height);
 
 public Q_SLOTS:
     void show();
@@ -86,6 +85,7 @@ public Q_SLOTS:
 protected:
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
 private:
     Base::Type getTypePath();
@@ -109,6 +109,7 @@ private:
                              const App::DocumentObject* obj, QString& message) const;
     bool isGroupNameValid(const QString& nameGroup,
                           QString& message) const;
+    void setMsgText();
 
 private Q_SLOTS:
     void textChanged();
@@ -127,7 +128,7 @@ private:
     const Base::Unit impliedUnit;
     NumberRange numberRange;
 
-    int minimumWidth;
+    std::string message;
 
     bool varSetsVisible;
     QPushButton* okBtn = nullptr;

--- a/src/Gui/Dialogs/DlgExpressionInput.ui
+++ b/src/Gui/Dialogs/DlgExpressionInput.ui
@@ -46,6 +46,26 @@
         <number>0</number>
        </property>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <item>
+          <widget class="Gui::ExpressionTextEdit" name="expression">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Ignored" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>10</width>
+             <height>10</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <widget class="QFrame" name="ctrlArea">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -152,26 +172,6 @@
         </size>
        </property>
       </spacer>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <widget class="Gui::ExpressionTextEdit" name="expression">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="MinimumExpanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>10</width>
-         <height>10</height>
-        </size>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>

--- a/src/Gui/Dialogs/DlgExpressionInput.ui
+++ b/src/Gui/Dialogs/DlgExpressionInput.ui
@@ -18,7 +18,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>300</width>
+    <width>350</width>
     <height>0</height>
    </size>
   </property>
@@ -48,7 +48,7 @@
        <item>
         <widget class="QFrame" name="ctrlArea">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -71,6 +71,12 @@
           </property>
           <item>
            <widget class="QLabel" name="label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>Result</string>
             </property>
@@ -78,6 +84,12 @@
           </item>
           <item>
            <widget class="QLabel" name="msg">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="palette">
              <palette>
               <active>
@@ -130,6 +142,9 @@
        <property name="orientation">
         <enum>Qt::Orientation::Horizontal</enum>
        </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Policy::Fixed</enum>
+       </property>
        <property name="sizeHint" stdset="0">
         <size>
          <width>0</width>
@@ -145,7 +160,7 @@
      <item>
       <widget class="Gui::ExpressionTextEdit" name="expression">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Expanding">
+        <sizepolicy hsizetype="Ignored" vsizetype="MinimumExpanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>

--- a/src/Gui/Dialogs/DlgExpressionInput.ui
+++ b/src/Gui/Dialogs/DlgExpressionInput.ui
@@ -173,19 +173,6 @@
        </property>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>2</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
     </layout>
    </item>
    <item>

--- a/src/Gui/Dialogs/DlgExpressionInput.ui
+++ b/src/Gui/Dialogs/DlgExpressionInput.ui
@@ -143,9 +143,9 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_5">
      <item>
-      <widget class="Gui::ExpressionLineEdit" name="expression">
+      <widget class="Gui::ExpressionTextEdit" name="expression">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+        <sizepolicy hsizetype="Ignored" vsizetype="Expanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -312,24 +312,41 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Ok|QDialogButtonBox::StandardButton::Reset</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::StandardButton::Ok|QDialogButtonBox::StandardButton::Reset</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Gui::ExpressionLineEdit</class>
-   <extends>QLineEdit</extends>
+   <class>Gui::ExpressionTextEdit</class>
+   <extends>QTextEdit</extends>
    <header>ExpressionCompleter.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -1085,6 +1085,11 @@ void ExpressionTextEdit::setExactMatch(bool enabled)
     }
 }
 
+QSize ExpressionTextEdit::sizeHint() const
+{
+    return QSize(200, 30);
+}
+
 void ExpressionTextEdit::setDocumentObject(const App::DocumentObject* currentDocObj)
 {
     if (completer) {

--- a/src/Gui/ExpressionCompleter.h
+++ b/src/Gui/ExpressionCompleter.h
@@ -78,6 +78,9 @@ public:
 public Q_SLOTS:
     void slotUpdate(const QString &prefix, int pos);
 
+Q_SIGNALS:
+    void completerSlotUpdated();
+
 private:
     void init();
     QString pathFromIndex ( const QModelIndex & index ) const override;
@@ -139,6 +142,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     void slotTextChanged();
     void slotCompleteText(const QString & completionPrefix);
+    void adjustCompleterToCursor();
 private:
     ExpressionCompleter * completer;
     bool block;

--- a/src/Gui/ExpressionCompleter.h
+++ b/src/Gui/ExpressionCompleter.h
@@ -130,6 +130,7 @@ public:
     bool completerActive() const;
     void hideCompleter();
     void setExactMatch(bool enabled=true);
+    QSize sizeHint() const override;
 protected:
     void keyPressEvent(QKeyEvent * event) override;
     void contextMenuEvent(QContextMenuEvent * event) override;

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -618,7 +618,6 @@ void QuantitySpinBox::openFormulaDialog()
 
     QPoint pos = mapToGlobal(QPoint(0,0));
     box->move(pos-box->expressionPosition());
-    box->setExpressionInputSize(width(), height());
     Gui::adjustDialogPosition(box);
 
     Q_EMIT showFormulaDialog(true);

--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -206,7 +206,6 @@ void ExpressionSpinBox::openFormulaDialog()
 
     QPoint pos = spinbox->mapToGlobal(QPoint(0,0));
     box->move(pos-box->expressionPosition());
-    box->setExpressionInputSize(spinbox->width(), spinbox->height());
     Gui::adjustDialogPosition(box);
 }
 

--- a/src/Gui/Stylesheets/FreeCAD.qss
+++ b/src/Gui/Stylesheets/FreeCAD.qss
@@ -804,7 +804,7 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-specific-widgets
 report view
 --------------------------------------------------------------------------- */
 QTextEdit {
-  background-color: @PrimaryColor;
+  background-color: @TextEditFieldBackgroundColor;
   border-top: 1px solid @GeneralBorderColor;
 }
 

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -1606,7 +1606,6 @@ void ExpLineEdit::openFormulaDialog()
 
     QPoint pos = mapToGlobal(QPoint(0,0));
     box->move(pos-box->expressionPosition());
-    box->setExpressionInputSize(width(), height());
     Gui::adjustDialogPosition(box);
 }
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
**'Expression editor' usage is enhanced with better resize behavior. Expression input is changed from _line edit_ to _text edit_.**

## The Problem:
'Expression editor' uses _line edit_ as input, which is not convenient for longer formulas. In practice, resizing the dialog works only horizontally:

![Animation07081](https://github.com/user-attachments/assets/34d2531b-4482-403e-9be2-1cfc025dd49e)

When formula is longer, the dialog resizes horizontally, even out of screen. The same situation is with 'Result' label:

![Animation070812](https://github.com/user-attachments/assets/6b1628fb-41c0-4551-a27b-b5c069ba3497)

## Solution:
Instead of _line edit_, now fully resizable _text edit_ is used for input. It allows to resize input size if needed. Also, if formula gets longer, its text is being wrapped. 'Result' message was moved below input widget.

Similar mechanism is provided for 'Result' message. Long text is being wrapped. To avoid oversizing the dialog, 'Result' text is elided up to ~3 newlines.

![anim1](https://github.com/user-attachments/assets/ca97a850-fbfa-4195-b113-f5dde299df42)

Input completer was changed to display below current cursor, with respect to not hover out input widget (display completer below/above cursor):

![anim2](https://github.com/user-attachments/assets/47391004-4239-4553-b9c6-5572cdcbf789)

Note: _Stylesheets_ (colouring) of `QPlainTextEdit` were not updated in this PR. GIFs above were recorded under different UI styles, that is why some differences are visible.
## Issues
fixes #12518 #12591 
related #21031 