### PR TITLE
CI: ccache configuration tweaks.

### DIFF
--- a/.github/workflows/sub_buildPixi.yml
+++ b/.github/workflows/sub_buildPixi.yml
@@ -49,16 +49,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ inputs.allowedToFail }}
     env:
-      CCACHE_DIR: ${{ github.workspace }}/ccache
-      CCACHE_CONFIGPATH: ${{ github.workspace }}/ccache/config
-      CCACHE_MAXSIZE: 1G
       CCACHE_COMPRESS: true
       CCACHE_COMPRESSLEVEL: 5
-      CCACHE_DIRECT: true
+      CCACHE_CONFIGPATH: ${{ github.workspace }}/ccache/config
+      CCACHE_DIR: ${{ github.workspace }}/ccache
+      CCACHE_MAXSIZE: 1G
+      CCACHE_NODIRECT: true
       CCACHE_NOHASHDIR: true
-      config: debug
-      builddir: ${{ github.workspace }}/build/debug/
+      CCACHE_NOINODECACHE: true
+      CCACHE_SLOPPINESS: "include_file_ctime,include_file_mtime,pch_defines,time_macros"
+      builddir: ${{ github.workspace }}/build/release/
       cacheKey: pixi-${{ matrix.os }}
+      config: release
       logdir: ${{ github.workspace }}/logs/
       reportdir: ${{ github.workspace }}/report/
       reportfilename: ${{ inputs.artifactBasename }}-${{ matrix.os }}-report.md
@@ -145,6 +147,7 @@ jobs:
         pixi run build-${{ env.config }}
 
     - name: Print ccache statistics after Build
+      if: always()
       run: |
         pixi run ccache -s
 

--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -50,17 +50,22 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: ${{ inputs.allowedToFail }}
     env:
-      CCACHE_DIR: ${{ github.workspace }}/ccache
-      CCACHE_CONFIGPATH: ${{ github.workspace }}/ccache/config
-      CCACHE_MAXSIZE: 1G
       CCACHE_COMPILERCHECK: "%compiler% -dumpfullversion -dumpversion" # default:mtime
       CCACHE_COMPRESS: true
-      CCACHE_COMPRESSLEVEL: 1
+      CCACHE_COMPRESSLEVEL: 5
+      CCACHE_CONFIGPATH: ${{ github.workspace }}/ccache/config
+      CCACHE_DIR: ${{ github.workspace }}/ccache
+      CCACHE_MAXSIZE: 1G
+      CCACHE_NODIRECT: true
+      CCACHE_NOHASHDIR: true
+      CCACHE_NOINODECACHE: true
+      CCACHE_SLOPPINESS: "include_file_ctime,include_file_mtime,pch_defines,time_macros"
       CC: /usr/bin/gcc
       CXX: /usr/bin/g++
       #CC: /usr/bin/clang
       #CXX: /usr/bin/clang++
       builddir: ${{ github.workspace }}/build/release/
+      config: release
       logdir: /tmp/logs/
       reportdir: /tmp/report/
       reportfilename: ${{ inputs.artifactBasename }}-report.md
@@ -133,7 +138,7 @@ jobs:
       - name: CMake Configure
         uses: ./.github/workflows/actions/linux/configure
         with:
-          extraParameters: -G Ninja --preset release
+          extraParameters: -G Ninja --preset ${{ env.config }}
           builddir: ${{ env.builddir }}
           logFile: ${{ env.logdir }}Cmake.log
           errorFile: ${{ env.logdir }}CmakeErrors.log
@@ -148,6 +153,7 @@ jobs:
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
 
       - name: Print ccache statistics after Build
+        if: always()
         run: |
           ccache -s
 

--- a/.github/workflows/sub_buildWindows.yml
+++ b/.github/workflows/sub_buildWindows.yml
@@ -42,20 +42,22 @@ jobs:
     runs-on: windows-latest
     continue-on-error: ${{ inputs.allowedToFail }}
     env:
-      CCACHE_DIR: C:/FC/cache/
       CCACHE_COMPILERCHECK: "%compiler%" # default:mtime
-      CCACHE_MAXSIZE: 1G
       CCACHE_COMPRESS: true
-      CCACHE_COMPRESSLEVEL: 1
-      CCACHE_NOHASHDIR: true
-      CCACHE_DIRECT: true
-      #CCACHE_SLOPPINESS: "pch_defines,time_macros" # Can't get PCH to work on Windows
+      CCACHE_COMPRESSLEVEL: 5
+      CCACHE_DIR: C:/FC/cache/
       CCACHE_LOGFILE: C:/logs/ccache.log
+      CCACHE_MAXSIZE: 1G
+      CCACHE_NODIRECT: true
+      CCACHE_NOHASHDIR: true
+      CCACHE_NOINODECACHE: true
+      CCACHE_SLOPPINESS: "include_file_ctime,include_file_mtime,pch_defines,time_macros" # Can't get PCH to work on Windows
       ## Have to use C:\ because not enough space on workspace drive
       builddir: C:/FC/build/release/
-      libpackdir: C:/FC/libpack/
       cacheKey: Windows
       ccachebindir: C:/FC/ccache/
+      config: release
+      libpackdir: C:/FC/libpack/
       logdir: C:/logs/
       reportdir: C:/report/
       reportfilename: ${{ inputs.artifactBasename }}-report.md
@@ -119,7 +121,7 @@ jobs:
       - name: Configuring CMake
         run: >
           cmake -B"${{ env.builddir }}" .
-          --preset release
+          --preset ${{ env.config }}
           -DCMAKE_VS_NO_COMPILE_BATCHING=ON
           -DCMAKE_BUILD_TYPE=Release
           -DFREECAD_USE_PCH=OFF
@@ -138,6 +140,7 @@ jobs:
           msbuild ALL_BUILD.vcxproj /m /p:Configuration=Release /p:TrackFileAccess=false /p:CLToolPath=${{ env.ccachebindir }}
 
       - name: Print Ccache statistics after build
+        if: always()
         run: |
           . $env:ccachebindir\ccache -s
 


### PR DESCRIPTION
This PR addresses regressions in CI performance.  The configuration is synchronized across builds.

The biggest impact comes from forcing all builds to `Release` mode.  For reasons yet unknown, builds that contain debug information, including `RelWithDebInfo` builds, are considered not cacheable by `ccache` when run from GitHub workflows.  This despite such builds being completely cacheable locally.

An unfortunate consequence of `Release` builds is that all `assert()` statements or other debug-only functionality is not present on CI. 

## Issues

* None

## Before and After Images

* N/A