### PR TITLE
CI: add debug entitlement to macOS weekly builds.

### DIFF
--- a/package/rattler-build/osx/entitlements.plist
+++ b/package/rattler-build/osx/entitlements.plist
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
On macOS the weekly builds cannot be attached to by a debugger due to a lack of the appropriate entitlement.  This PR adds the entitlement to these builds.

## Issues

* None

## Before and After Images

* N/A