### PR TITLE
CMake: add FREECAD_3DCONNEXION_SUPPORT to CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -177,6 +177,10 @@
             "type": "FILEPATH",
             "value": "$env{CONDA_PREFIX}"
           },
+          "FREECAD_3DCONNEXION_SUPPORT": {
+            "type": "STRING",
+            "value": "Both"
+          },
           "OCC_INCLUDE_DIR": {
             "type": "FILEPATH",
             "value": "$env{CONDA_PREFIX}/include/opencascade"
@@ -203,6 +207,10 @@
           "CMAKE_PREFIX_PATH": {
             "type": "FILEPATH",
             "value": "$env{CONDA_PREFIX}/Library"
+          },
+          "FREECAD_3DCONNEXION_SUPPORT": {
+            "type": "STRING",
+            "value": "Both"
           },
           "OCC_INCLUDE_DIR": {
             "type": "FILEPATH",


### PR DESCRIPTION
Recent changes to 3Dconnexion SpaceMouse support requires setting the appropriate configuration to `FREECAD_3DCONNEXION_SUPPORT`.  This adds the the appropriate settings for macOS and Windows, which will fix support on the weekly builds.

## Issues

* None

## Before and After Images

* N/A