### PR TITLE
Add solvers' versions to About info

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -3760,6 +3760,16 @@ void Application::getVerboseCommonInfo(QTextStream& str, const std::map<std::str
 #endif
         << '\n';
 #endif
+
+    QStringList solvers;
+    for (const std::string &solver : {"Calculix", "ElmerSolver", "MYSTRAN"})
+        if (auto version = getValueOrEmpty(mConfig, solver); !version.isEmpty())
+            solvers << QStringLiteral("%1 %2").arg(QString::fromStdString(solver)).arg(version);
+
+    if (!solvers.isEmpty())
+        str << solvers.join(QStringLiteral(", ")) << '\n';
+
+
     QLocale loc;
     str << "Locale: " << QLocale::languageToString(loc.language()) << "/"
 #if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)

--- a/src/Gui/Dialogs/DlgAbout.h
+++ b/src/Gui/Dialogs/DlgAbout.h
@@ -90,6 +90,7 @@ protected:
     void showPrivacyPolicy();
     void showOrHideImage(const QRect& rect);
     void addModuleInfo(QTextStream& inout_str, const QString& modPath, bool& inout_first);
+    void findSolversVersions();
 
 protected:
     QPixmap aboutImage() const;


### PR DESCRIPTION
Closes #18856.


This commit must be carefully checked before merge by people who use solvers.


_ElmerGrid_ and _z88_ don't report their versions to command-line.




```ruby
OS: Ubuntu 24.04.1 LTS (KDE/plasma/xcb)
Architecture: x86_64
Version: 1.1.0dev.42864 (Git)
Build date: 2025/08/06 21:02:16
Build type: Unknown
Branch: master
Hash: a9cd5a4982f153e8be4d595d0bbdb1c5b5c112cf
Python 3.12.3, Qt 5.15.13, Coin 4.0.2, Vtk 9.1.0, boost 1_83, Eigen3 3.4.0, PySide 5.15.13
shiboken 5.15.13, SMESH 7.7.1.0, xerces-c 3.2.4, OCC 7.6.3
Calculix 2.21, ElmerSolver 9.0, MYSTRAN 13.3
Locale: English/United States (en_US)
Navigation Style/Orbit Style/Rotation Mode: OpenSCAD/Trackball/Window center
Stylesheet/Theme/QtStyle: unset/FreeCAD Classic/Fusion
Logical DPI/Physical DPI/Pixel Ratio: 96.2463/96.2463/1
```


