### PR TITLE
Gui: Update header in about dialog before the 1.1 release

### DIFF
--- a/src/Doc/CONTRIBUTORS
+++ b/src/Doc/CONTRIBUTORS
@@ -21,10 +21,10 @@ Benjamin Alterauge
 Benjamin Bræstrup Sayoc
 Benjamin Nauck (hyarion)
 Bernd Hahnebach
-bgbsww
 blobfish (tanderson69)
 bluecd
 Brad Collette (sliptonic)
+† Brad McLean (bgbsww) 1966-2024
 breathewind
 Bruce Lacey
 Bruno Gonçalves Pirajá

--- a/src/Doc/LICENSE.html
+++ b/src/Doc/LICENSE.html
@@ -5,10 +5,10 @@
 		<title>FreeCAD License</title>
 	</head>
 <body>
-<h1>FreeCAD license</h1>
+<h1>FreeCAD License</h1>
 <p>The FreeCAD application is licensed under the terms of the LGPL2+ license, as stated below.</p>
 
-<h2>Third-party libraries licenses</h2>
+<h2>Third-Party Libraries Licenses</h2>
 <p>The different libraries used in FreeCAD and their respective licenses are described on the <a href="https://wiki.freecad.org/Third_Party_Libraries">Third Party Libraries wiki page</a>.</p>
 
 <hr>

--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -322,9 +322,6 @@ void AboutDialog::showCredits()
     hlayout->addWidget(textField);
 
     QString creditsHTML = QStringLiteral("<html><body><p>");
-    //: Header for bgbsww
-    creditsHTML +=
-        tr("This version of FreeCAD is dedicated to the memory of Brad McLean, aka bgbsww.");
     //: Header for the Credits tab of the About screen
     creditsHTML += QStringLiteral("</p><h1>");
     creditsHTML += tr("Credits");

--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -321,16 +321,13 @@ void AboutDialog::showCredits()
     textField->setOpenLinks(false);
     hlayout->addWidget(textField);
 
-    QString creditsHTML = QStringLiteral("<html><body><p>");
     //: Header for the Credits tab of the About screen
-    creditsHTML += QStringLiteral("</p><h1>");
-    creditsHTML += tr("Credits");
-    creditsHTML += QStringLiteral("</h1><p>");
-    creditsHTML += tr("FreeCAD would not be possible without the contributions of");
-    creditsHTML += QStringLiteral(":</p><h2>");
-    //: Header for the list of individual people in the Credits list.
-    creditsHTML += tr("Individuals");
-    creditsHTML += QStringLiteral("</h2><ul>");
+    QString creditsHTML =
+        QStringLiteral("<html><body><h1>%1</h1><p>%2</p><h2>%3</h2><ul>")
+            .arg(tr("Credits", "Header for the Credits tab of the About screen"))
+            .arg(tr("FreeCAD would not be possible without the contributions of:"))
+            .arg(
+                tr("Individuals", "Header for the list of individual people in the Credits list."));
 
     QTextStream stream(&creditsFile);
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/Main/FreeCADGuiPy.cpp
+++ b/src/Main/FreeCADGuiPy.cpp
@@ -336,9 +336,9 @@ PyMOD_INIT_FUNC(FreeCADGui)
         Base::Interpreter().loadModule("FreeCAD");
         App::Application::Config()["AppIcon"] = "freecad";
         App::Application::Config()["SplashScreen"] = "freecadsplash";
-        App::Application::Config()["CopyrightInfo"] = "\xc2\xa9 Juergen Riegel, Werner Mayer, Yorik van Havre and others 2001-2024\n";
+        App::Application::Config()["CopyrightInfo"] = "\xc2\xa9 Juergen Riegel, Werner Mayer, Yorik van Havre and others 2001-2025\n";
         App::Application::Config()["LicenseInfo"] = "FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.\n";
-        App::Application::Config()["CreditsInfo"] = "FreeCAD wouldn't be possible without FreeCAD community.\n";
+        App::Application::Config()["CreditsInfo"] = "FreeCAD would not be possible without the FreeCAD community.\n";
         // clang-format on
 
         // it's possible that the GUI is already initialized when the Gui version of the executable

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -190,7 +190,7 @@ int main(int argc, char** argv)
     App::Application::Config()["ExeName"] = "FreeCAD";
     App::Application::Config()["ExeVendor"] = "FreeCAD";
     App::Application::Config()["AppDataSkipVendor"] = "true";
-    App::Application::Config()["MaintainerUrl"] = "https://www.freecad.org/wiki/Main_Page";
+    App::Application::Config()["MaintainerUrl"] = "https://freecad.org";
 
     // set the banner (for logging and console)
     App::Application::Config()["CopyrightInfo"] = sBanner;


### PR DESCRIPTION
- Removes the 1.0 addition and updates the contributors list.
- Changes main link in the about dialog to the main site (freecad.org) instead of Wiki Main_Page
- Apply text guidelines to the about dialog files
