### PR TITLE
CAM: RestMachining with BoundaryDressup

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Boundary.py
@@ -94,6 +94,15 @@ class DressupPathBoundary(object):
                 "Set distance which will attempts to avoid unnecessary retractions.",
             ),
         )
+        obj.addProperty(
+            "App::PropertyBool",
+            "RestMachiningPass",
+            "Boundary",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Apply boundary to Rest Machining.",
+            ),
+        )
 
         self.obj = obj
         self.safeHeight = None
@@ -131,6 +140,16 @@ class DressupPathBoundary(object):
             if obj.KeepToolDown:
                 obj.RetractThreshold = 999999
             obj.removeProperty("KeepToolDown")
+        if not hasattr(obj, "RestMachiningPass"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "RestMachiningPass",
+                "Boundary",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Apply boundary to Rest Machining.",
+                ),
+            )
 
     def onDelete(self, obj, args):
         if obj.Base:

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -492,6 +492,8 @@ def getClearedAreas(currentOp, bbox):
         baseOp = PathDressup.baseOp(op)
         if baseOp.Name == currentOp.Name:
             break
+        if getattr(op, "RestMachiningPass", None):
+            op = baseOp
         if getattr(baseOp, "Active", False) and op.Path:
             tool = baseOp.ToolController.Tool
             diameter = tool.Diameter.getValueAs("mm")


### PR DESCRIPTION
Added property `RestMachiningPass` to `BoundaryDressup`
Allows to skip area excluded by `Boundary`path for RestMachining feature

https://forum.freecad.org/viewtopic.php?t=98860

test project: [a4xem_1-1.zip](https://github.com/user-attachments/files/26325840/a4xem_1-1.zip)

<img width="1943" height="663" alt="Screenshot_20260328_215347_hor" src="https://github.com/user-attachments/assets/e2fc9d02-bd06-42d1-8bde-8488ddfabf43" />

