### PR TITLE
Navigation: Prevent showing context menu after panning or rubber band selection

### DIFF
--- a/src/Gui/Navigation/BlenderNavigationStyle.cpp
+++ b/src/Gui/Navigation/BlenderNavigationStyle.cpp
@@ -299,6 +299,13 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = false;
     }
 
+    // Reset flags when newmode is IDLE and the buttons are released
+    if (newmode == IDLE && !button1down && !button2down && !button3down) {
+        hasPanned = false;
+        hasDragged = false;
+        hasZoomed = false;
+    }
+    
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/Navigation/BlenderNavigationStyle.cpp
+++ b/src/Gui/Navigation/BlenderNavigationStyle.cpp
@@ -295,7 +295,9 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent * const ev)
 
     // Prevent interrupting rubber-band selection in sketcher
     if (viewer->isEditing() && curmode == NavigationStyle::SELECTION && newmode != NavigationStyle::IDLE) {
-        newmode = NavigationStyle::SELECTION;
+        if (!button1down || !button2down) { // Allow canceling rubber-band in sketcher if both button 1 and button 2 are pressed
+            newmode = NavigationStyle::SELECTION;
+        }
         processed = false;
     }
 

--- a/src/Gui/Navigation/CADNavigationStyle.cpp
+++ b/src/Gui/Navigation/CADNavigationStyle.cpp
@@ -315,6 +315,13 @@ SbBool CADNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = false;
     }
 
+    // Reset flags when newmode is IDLE and the buttons are released
+    if (newmode == IDLE && !button1down && !button2down && !button3down) {
+        hasPanned = false;
+        hasDragged = false;
+        hasZoomed = false;
+    }
+    
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/Navigation/InventorNavigationStyle.cpp
+++ b/src/Gui/Navigation/InventorNavigationStyle.cpp
@@ -297,6 +297,13 @@ SbBool InventorNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = false;
     }
 
+    // Reset flags when newmode is IDLE and the buttons are released
+    if (newmode == IDLE && !button1down && !button2down && !button3down) {
+        hasPanned = false;
+        hasDragged = false;
+        hasZoomed = false;
+    }
+    
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -1591,6 +1591,14 @@ void NavigationStyle::syncModifierKeys(const SoEvent * const ev)
 void NavigationStyle::setViewingMode(const ViewerMode newmode)
 {
     const ViewerMode oldmode = this->currentmode;
+
+    // Reset flags when changing from IDLE to another mode or if the mode is IDLE and the buttons are released
+    if ((oldmode == IDLE && newmode != IDLE) || (newmode == IDLE && !button1down && !button2down && !button3down)) {
+        hasPanned = false;
+        hasDragged = false;
+        hasZoomed = false;
+    }
+    
     if (newmode == oldmode) {
 
         // The rotation center could have been changed even if the mode has not changed
@@ -1599,12 +1607,6 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
         }
 
         return;
-    }
-
-    if (newmode == NavigationStyle::IDLE) {
-        hasPanned = false;
-        hasDragged = false;
-        hasZoomed = false;
     }
 
     switch (newmode) {

--- a/src/Gui/Navigation/OpenCascadeNavigationStyle.cpp
+++ b/src/Gui/Navigation/OpenCascadeNavigationStyle.cpp
@@ -273,6 +273,13 @@ SbBool OpenCascadeNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = false;
     }
 
+    // Reset flags when newmode is IDLE and the buttons are released
+    if (newmode == IDLE && !button1down && !button2down && !button3down) {
+        hasPanned = false;
+        hasDragged = false;
+        hasZoomed = false;
+    }
+    
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/Navigation/OpenSCADNavigationStyle.cpp
+++ b/src/Gui/Navigation/OpenSCADNavigationStyle.cpp
@@ -268,6 +268,13 @@ SbBool OpenSCADNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = false;
     }
 
+    // Reset flags when newmode is IDLE and the buttons are released
+    if (newmode == IDLE && !button1down && !button2down && !button3down) {
+        hasPanned = false;
+        hasDragged = false;
+        hasZoomed = false;
+    }
+    
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/Navigation/RevitNavigationStyle.cpp
+++ b/src/Gui/Navigation/RevitNavigationStyle.cpp
@@ -292,7 +292,9 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent * const ev)
 
     // Prevent interrupting rubber-band selection in sketcher
     if (viewer->isEditing() && curmode == NavigationStyle::SELECTION && newmode != NavigationStyle::IDLE) {
-        newmode = NavigationStyle::SELECTION;
+        if (!button1down || !button2down) { // Allow canceling rubber-band in sketcher if both button 1 and button 2 are pressed
+            newmode = NavigationStyle::SELECTION;
+        }
         processed = false;
     }
 

--- a/src/Gui/Navigation/RevitNavigationStyle.cpp
+++ b/src/Gui/Navigation/RevitNavigationStyle.cpp
@@ -296,6 +296,13 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = false;
     }
 
+    // Reset flags when newmode is IDLE and the buttons are released
+    if (newmode == IDLE && !button1down && !button2down && !button3down) {
+        hasPanned = false;
+        hasDragged = false;
+        hasZoomed = false;
+    }
+    
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/Navigation/SolidWorksNavigationStyle.cpp
+++ b/src/Gui/Navigation/SolidWorksNavigationStyle.cpp
@@ -295,6 +295,13 @@ SbBool SolidWorksNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = false;
     }
 
+    // Reset flags when newmode is IDLE and the buttons are released
+    if (newmode == IDLE && !button1down && !button2down && !button3down) {
+        hasPanned = false;
+        hasDragged = false;
+        hasZoomed = false;
+    }
+    
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/Navigation/TinkerCADNavigationStyle.cpp
+++ b/src/Gui/Navigation/TinkerCADNavigationStyle.cpp
@@ -245,6 +245,13 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = false;
     }
 
+    // Reset flags when newmode is IDLE and the buttons are released
+    if (newmode == IDLE && !button1down && !button2down && !button3down) {
+        hasPanned = false;
+        hasDragged = false;
+        hasZoomed = false;
+    }
+    
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/Navigation/TouchpadNavigationStyle.cpp
+++ b/src/Gui/Navigation/TouchpadNavigationStyle.cpp
@@ -272,6 +272,13 @@ SbBool TouchpadNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = false;
     }
 
+    // Reset flags when newmode is IDLE and the buttons are released
+    if (newmode == IDLE && !button1down && !button2down && !button3down) {
+        hasPanned = false;
+        hasDragged = false;
+        hasZoomed = false;
+    }
+    
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -644,6 +644,8 @@ ViewProviderSketch::ViewProviderSketch()
     updateColorPropertiesVisibility();
 
     pcSketchFacesToggle->addChild(pcSketchFaces);
+
+    blockContextMenu = false;
 }
 
 ViewProviderSketch::~ViewProviderSketch()
@@ -1141,6 +1143,7 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                 case STATUS_SKETCH_UseRubberBand:
                     doBoxSelection(DoubleClick::prvCursorPos, cursorPos, viewer);
                     rubberband->setWorking(false);
+                    blockContextMenu = true;
 
                     // use draw(false, false) to avoid solver geometry with outdated construction flags
                     draw(false, false);
@@ -1162,6 +1165,8 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
     // Right mouse button ****************************************************
     else if (Button == 2) {
         if (pressed) {
+            blockContextMenu = false;
+            
             // Do things depending on the mode of the user interaction
             switch (Mode) {
                 case STATUS_NONE: {
@@ -3714,6 +3719,8 @@ void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int Mo
     cameraSensor.setData(camSensorData);
     cameraSensor.setDeleteCallback(&ViewProviderSketch::camSensDeleteCB, camSensorData);
     cameraSensor.attach(viewer->getCamera());
+
+    blockContextMenu = false;
 }
 
 void ViewProviderSketch::unsetEditViewer(Gui::View3DInventorViewer* viewer)
@@ -3727,6 +3734,8 @@ void ViewProviderSketch::unsetEditViewer(Gui::View3DInventorViewer* viewer)
     viewer->removeGraphicsItem(rubberband.get());
     viewer->setEditing(false);
     viewer->setSelectionEnabled(true);
+
+    blockContextMenu = false;
 }
 
 void ViewProviderSketch::camSensDeleteCB(void* data, SoSensor *s)
@@ -4365,6 +4374,8 @@ bool ViewProviderSketch::isInEditMode() const
 }
 void ViewProviderSketch::generateContextMenu()
 {
+    if (blockContextMenu) return;
+    
     int selectedEdges = 0;
     int selectedLines = 0;
     int selectedConics = 0;

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -991,6 +991,8 @@ private:
 
     SoNodeSensor cameraSensor;
     int viewOrientationFactor;  // stores if sketch viewed from front or back
+
+    bool blockContextMenu;
 };
 
 }  // namespace SketcherGui


### PR DESCRIPTION
Fixes #22931 and similar problems in other navigation styles.
Fixes #18015.

Postpones resetting `hasPanned`, `hasDragged` and `hasZoomed` until the navigation mode changes from IDLE to something else or if all mouse buttons have been released. This preserves information about the last navigation action while in IDLE mode until all mouse buttons have been released. This is needed for the blender style because when panning with LMB and RMB if LMB is released the mode goes to IDLE. But to prevent showing the context menu after releasing RMB we must know if the user has panned before IDLE mode.

To prevent showing the context menu after rubber band selection in sketcher mode I added a boolean that if set, prevents showing the context menu until RMB is pressed down again. So if RMB is held down while rubber banding and released directly after stopping the rubber band selection, the context menu won't be shown.