### PR TITLE
PartDesign: Change default preference to enable compounds for PD bodies

### DIFF
--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -68,6 +68,22 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkAllowCompoundBody">
+        <property name="text">
+         <string>Allow multiple solids in Part Design bodies by default</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>AllowCompoundDefault</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/PartDesign</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -210,44 +226,6 @@
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/PartDesign/Preview</cstring>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBoxExperimental">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="title">
-      <string>Experimental</string>
-     </property>
-     <property name="flat">
-      <bool>false</bool>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="QLabel" name="warningLabel">
-        <property name="text">
-         <string>These settings are experimental and may result in decreased stability, problems and undefined behaviors</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkAllowCompoundBody">
-        <property name="text">
-         <string>Allow multiple solids in Part Design bodies by default</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>AllowCompoundDefault</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/PartDesign</cstring>
         </property>
        </widget>
       </item>

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -50,7 +50,7 @@ Body::Body() {
         .GetUserParameter()
         .GetGroup("BaseApp/Preferences/Mod/PartDesign");
 
-    auto allowCompoundDefaultValue = hGrp->GetBool("AllowCompoundDefault", false);
+    auto allowCompoundDefaultValue = hGrp->GetBool("AllowCompoundDefault", true);
 
     ADD_PROPERTY(AllowCompound, (allowCompoundDefaultValue));
 }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Sets the default value for new bodies to allow multiple solids.
I am not aware of any issues with this preference enabled which was already in the stable 1.0 release. There are more issues with users trying to create features with multiple solids in a body where they just need to enable the property.

@kadet1090 let me know if this closes the issue https://github.com/FreeCAD/FreeCAD/issues/9747