### PR TITLE
Add deduction guide for `Base::Overloads`

### DIFF
--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -383,6 +383,9 @@ struct Overloads: Ts...
     using Ts::operator()...;
 };
 
+template<class... Ts>
+Overloads(Ts...) -> Overloads<Ts...>;
+
 }  // namespace Base
 
 #endif  // SRC_BASE_TOOLS_H_


### PR DESCRIPTION
I was trying to compile FreeCAD using Clang 16, but got the following error:

```
/home/freecad/source/src/Gui/Dialogs/DlgThemeEditor.cpp:63:9: error: no viable constructor or deduction guide for deduction of template arguments of 'Overloads'
        Base::Overloads {
        ^
/home/freecad/source/src/Base/Tools.h:381:8: note: candidate function template not viable: requires 1 argument, but 3 were provided
struct Overloads: Ts...
       ^
/home/freecad/source/src/Base/Tools.h:381:8: note: candidate function template not viable: requires 0 arguments, but 3 were provided
1 error generated.
```

Adding the deduction guide in this PR fixed the build.