### PR TITLE
Added TERMINFO to AppRun

### DIFF
--- a/package/rattler-build/linux/AppDir/AppRun
+++ b/package/rattler-build/linux/AppDir/AppRun
@@ -8,6 +8,7 @@ export PATH_TO_FREECAD_LIBDIR=${HERE}/usr/lib
 # export QT_XKB_CONFIG_ROOT=${HERE}/usr/lib
 export FONTCONFIG_FILE=/etc/fonts/fonts.conf
 export FONTCONFIG_PATH=/etc/fonts
+export TERMINFO=${PREFIX}/share/terminfo
 
 # Fix: Use X to run on Wayland
 export QT_QPA_PLATFORM=xcb


### PR DESCRIPTION
Just added TERMINFO environment variable to AppRun

## Issues
```
$ Freecad-latest.sh 
FreeCAD 1.0.2, Libs: 1.0.2R39319 (Git)
(C) 2001-2025 FreeCAD contributors
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.

Cannot read termcap database;
^^^^^^^^^^^^^^^^^^^^^^^^^^
using dumb terminal settings.

```