### PR TITLE
Change links to weekly releases

### DIFF
--- a/.github/workflows/auto-close_stale_issues_and_pull-requests.yml
+++ b/.github/workflows/auto-close_stale_issues_and_pull-requests.yml
@@ -41,7 +41,7 @@ jobs:
           remove-stale-when-updated: true
           ascending: true
           stale-issue-message: |
-            Hi! This issue hasn’t seen activity in a while. If it’s still relevant, please update to the latest FreeCAD weekly build [download here](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds) to see if the problem is resolved.
+            Hi! This issue hasn’t seen activity in a while. If it’s still relevant, please update to the latest FreeCAD weekly build [download here](https://github.com/FreeCAD/FreeCAD/releases/) to see if the problem is resolved.
 
             If the issue persists, let us know by adding a comment with any updates or details. Otherwise, we’ll close this issue automatically in 14 days to keep our backlog tidy. Feel free to comment anytime to keep it open. Closed issues can always be reopened.
             Thanks for helping improve FreeCAD!
@@ -68,7 +68,7 @@ jobs:
           ascending: true
           stale-issue-message: |
             Hi! This issue hasn’t seen activity in a while despite the need for further feedback.
-            If it’s still relevant, please update to the latest FreeCAD weekly build [download here](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds) to see if the problem is resolved.
+            If it’s still relevant, please update to the latest FreeCAD weekly build [download here](https://github.com/FreeCAD/FreeCAD/releases/) to see if the problem is resolved.
 
             If the issue persists, let us know by adding a comment with any updates or details. Otherwise, we’ll close this issue automatically in 14 days to keep our backlog tidy. Feel free to comment anytime to keep it open. Closed issues can always be reopened.
             Thanks for helping improve FreeCAD!
@@ -95,7 +95,7 @@ jobs:
           ascending: true
           stale-issue-message: |
             Hi! This issue hasn’t seen activity in a while. We automatically check each issue after 190 days without activity to keep the backlog tidy.
-            If it’s still relevant, please update to the latest FreeCAD weekly build [download here](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds) to see if the issue is already resolved.
+            If it’s still relevant, please update to the latest FreeCAD weekly build [download here](https://github.com/FreeCAD/FreeCAD/releases/) to see if the issue is already resolved.
 
             If the issue is still relevant, let us know by adding a comment.
             Otherwise, we’ll close this issue automatically in 60 days.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://freecad.org"><img src="/src/Gui/Icons/freecad.svg" height="100px" width="100px"></a>
 
-### Your own 3D parametric modeler
+### Your own 3D Parametric Modeler
 
 [Website](https://www.freecad.org) •
 [Documentation](https://wiki.freecad.org) •
@@ -44,12 +44,12 @@ Installing
 ----------
 
 Precompiled packages for stable releases are available for Windows, macOS and Linux on the
-[Releases page](https://github.com/FreeCAD/FreeCAD/releases).
+[latest releases page](https://github.com/FreeCAD/FreeCAD/releases/latest).
 
 On most Linux distributions, FreeCAD is also directly installable from the 
 software center application.
 
-For development releases visit the [weekly-builds page](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds).
+For weekly development releases visit the [releases page](https://github.com/FreeCAD/FreeCAD/releases/).
 
 Other options are described on the [wiki Download page](https://wiki.freecad.org/Download).
 
@@ -73,7 +73,7 @@ To report an issue please:
 
 - Consider posting to the [Forum](https://forum.freecad.org), [Discord](https://discord.com/invite/w2cTKGzccC) channel, or [Reddit](https://www.reddit.com/r/FreeCAD) to verify the issue; 
 - Search the existing [issues](https://github.com/FreeCAD/FreeCAD/issues) for potential duplicates; 
-- Use the most updated stable or [development versions](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds) of FreeCAD; 
+- Use the most updated stable or [development versions](https://github.com/FreeCAD/FreeCAD/releases/) of FreeCAD; 
 - Post version info from `Help > About FreeCAD > Copy to clipboard`; 
 - Restart FreeCAD in safe mode `Help > Restart in safe mode` and try to reproduce the issue again. If the issue is resolved it can be fixed by deleting the FreeCAD config files.
 - Start recording a macro `Macro > Macro recording...` and repeat all steps. Stop recording after the issue occurs and upload the saved macro or copy the macro code in the issue; 
@@ -86,7 +86,6 @@ For more details see:
 - [Reporting Issues and Requesting Features](https://github.com/FreeCAD/FreeCAD/issues/new/choose)
 - [Contributing](https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md)
 - [Help Forum](https://forum.freecad.org/viewforum.php?f=3)
-- [Developers Handbook](https://freecad.github.io/DevelopersHandbook/)
 
 > [!NOTE]
 The [FPA](https://fpa.freecad.org) offers developers the opportunity
@@ -106,7 +105,7 @@ View these pages for more information:
 - [Frequent questions](https://wiki.freecad.org/FAQ/en)
 - [Workbenches](https://wiki.freecad.org/Workbenches)
 - [Scripting](https://wiki.freecad.org/Power_users_hub)
-- [Development](https://wiki.freecad.org/Developer_hub)
+- [Developers Handbook](https://freecad.github.io/DevelopersHandbook/)
 
 The [FreeCAD forum](https://forum.freecad.org) is a great place
 to find help and solve specific problems when learning to use FreeCAD.


### PR DESCRIPTION
Change links to weekly releases on readme and stale action comments.
Also applies text style to readme and replaces the link to the wiki with the Developers Handbook.