### PR TITLE
Gui: Change default WB list and default preferences

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
@@ -454,7 +454,7 @@ QStringList DlgSettingsWorkbenchesImp::getDisabledWorkbenches()
     ParameterGrp::handle hGrp;
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Workbenches");
-    disabled_wbs = QString::fromStdString(hGrp->GetASCII("Disabled", "NoneWorkbench,TestWorkbench"));
+    disabled_wbs = QString::fromStdString(hGrp->GetASCII("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench,OpenSCADWorkbench"));
 
     unfiltered_disabled_wbs_list = disabled_wbs.split(QLatin1String(","), Qt::SkipEmptyParts);
 


### PR DESCRIPTION
Change default WB list and default preferences to not include the highlighted WBs (can be activated in the preferences).
<img width="659" height="627" alt="grafik" src="https://github.com/user-attachments/assets/e6c86ef4-fa36-4a8e-a4e2-4072c26bd359" />


Without that, e.g.  a "<none>" Workbench shows up when restarting FreeCAD in safe mode, without menu, toolbars or WB switcher:
<img width="1689" height="500" alt="grafik" src="https://github.com/user-attachments/assets/14945703-f575-47e7-b45a-5a145d5b8d09" />
<img width="2559" height="1362" alt="grafik" src="https://github.com/user-attachments/assets/95e8d10a-2a25-49a2-905e-6bbc4abb6a29" />
