### PR TITLE
Gui: Restore proper object names for panels

### DIFF
--- a/src/Gui/DockWindowManager.cpp
+++ b/src/Gui/DockWindowManager.cpp
@@ -276,10 +276,7 @@ QDockWidget* DockWindowManager::addDockWindow(const char* name, QWidget* widget,
 
     // set object name and window title needed for i18n stuff
     dw->setObjectName(QString::fromUtf8(name));
-    QString title = widget->windowTitle();
-    if (title.isEmpty())
-        title = QDockWidget::tr(name);
-    dw->setWindowTitle(title);
+    dw->setWindowTitle(widget->windowTitle());
     dw->setFeatures(QDockWidget::DockWidgetClosable
                     | QDockWidget::DockWidgetMovable
                     | QDockWidget::DockWidgetFloatable);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -555,7 +555,8 @@ bool MainWindow::setupTaskView()
         auto taskView = new Gui::TaskView::TaskView(this);
         bool restore = group->GetBool("RestoreWidth", taskView->shouldRestoreWidth());
         taskView->setRestoreWidth(restore);
-        taskView->setObjectName(QString::fromLatin1(QT_TRANSLATE_NOOP("QDockWidget","Tasks")));
+        taskView->setObjectName(QStringLiteral("Tasks"));
+        taskView->setWindowTitle(QDockWidget::tr("Tasks"));
         taskView->setMinimumWidth(210);
 
         DockWindowManager* pDockMgr = DockWindowManager::instance();
@@ -571,8 +572,8 @@ bool MainWindow::setupSelectionView()
     // Selection view
     if (d->hiddenDockWindows.find("Std_SelectionView") == std::string::npos) {
         auto pcSelectionView = new SelectionView(nullptr, this);
-        pcSelectionView->setObjectName
-            (QString::fromLatin1(QT_TRANSLATE_NOOP("QDockWidget","Selection view")));
+        pcSelectionView->setObjectName(QStringLiteral("Selection view"));
+        pcSelectionView->setWindowTitle(QDockWidget::tr("Selection View"));
         pcSelectionView->setMinimumWidth(210);
 
         DockWindowManager* pDockMgr = DockWindowManager::instance();
@@ -589,8 +590,8 @@ bool MainWindow::setupReportView()
     if (d->hiddenDockWindows.find("Std_ReportView") == std::string::npos) {
         auto pcReport = new ReportOutput(this);
         pcReport->setWindowIcon(BitmapFactory().pixmap("MacroEditor"));
-        pcReport->setObjectName
-            (QString::fromLatin1(QT_TRANSLATE_NOOP("QDockWidget","Report View")));
+        pcReport->setObjectName(QStringLiteral("Report view"));
+        pcReport->setWindowTitle(QDockWidget::tr("Report View"));
 
         DockWindowManager* pDockMgr = DockWindowManager::instance();
         pDockMgr->registerDockWindow("Std_ReportView", pcReport);
@@ -609,8 +610,8 @@ bool MainWindow::setupPythonConsole()
     if (d->hiddenDockWindows.find("Std_PythonView") == std::string::npos) {
         auto pcPython = new PythonConsole(this);
         pcPython->setWindowIcon(Gui::BitmapFactory().iconFromTheme("applications-python"));
-        pcPython->setObjectName
-            (QString::fromLatin1(QT_TRANSLATE_NOOP("QDockWidget","Python Console")));
+        pcPython->setObjectName(QStringLiteral("Python console"));
+        pcPython->setWindowTitle(QDockWidget::tr("Python Console"));
 
         DockWindowManager* pDockMgr = DockWindowManager::instance();
         pDockMgr->registerDockWindow("Std_PythonView", pcPython);
@@ -633,7 +634,8 @@ bool MainWindow::updateTreeView(bool show)
                 }
 
                 auto tree = new TreeDockWidget(0,getMainWindow());
-                tree->setObjectName(QStringLiteral(QT_TRANSLATE_NOOP("QDockWidget","Tree view")));
+                tree->setObjectName(QStringLiteral("Tree view"));
+                tree->setWindowTitle(QDockWidget::tr("Tree View"));
                 tree->setMinimumWidth(210);
                 widget = tree;
                 return widget;
@@ -659,7 +661,8 @@ bool MainWindow::updatePropertyView(bool show)
                 }
 
                 auto pcPropView = new PropertyDockView(0, getMainWindow());
-                pcPropView->setObjectName(QStringLiteral(QT_TRANSLATE_NOOP("QDockWidget","Property view")));
+                pcPropView->setObjectName(QStringLiteral("Property view"));
+                pcPropView->setWindowTitle(QDockWidget::tr("Property View"));
                 pcPropView->setMinimumWidth(210);
                 widget = pcPropView;
                 return widget;
@@ -687,7 +690,8 @@ bool MainWindow::updateTaskView(bool show)
                 }
 
                 widget = new TaskView::TaskView(getMainWindow());
-                widget->setObjectName(QStringLiteral(QT_TRANSLATE_NOOP("QDockWidget","Task List")));
+                widget->setObjectName(QStringLiteral("Task List"));
+                widget->setWindowTitle(QDockWidget::tr("Task List"));
                 return widget;
             });
 
@@ -712,7 +716,8 @@ bool MainWindow::updateComboView(bool show)
                 }
 
                 pcComboView = new ComboView(nullptr, getMainWindow());
-                pcComboView->setObjectName(QStringLiteral(QT_TRANSLATE_NOOP("QDockWidget", "Model")));
+                pcComboView->setObjectName(QStringLiteral("Model"));
+                pcComboView->setWindowTitle(QDockWidget::tr("Model"));
                 pcComboView->setMinimumWidth(150);
                 widget = pcComboView;
                 return widget;
@@ -738,7 +743,8 @@ bool MainWindow::updateDAGView(bool show)
                 }
 
                 auto dagDockWindow = new DAG::DockWindow(nullptr, getMainWindow());
-                dagDockWindow->setObjectName(QStringLiteral(QT_TRANSLATE_NOOP("QDockWidget","DAG View")));
+                dagDockWindow->setObjectName(QStringLiteral("DAG View"));
+                dagDockWindow->setWindowTitle(QDockWidget::tr("DAG View"));
                 widget = dagDockWindow;
                 return widget;
             });


### PR DESCRIPTION
The #22976 PR introduced minor regression for addons by changing the object name. Object name should never be translated and marking it as `QT_TRANSLATE_NOOP` while technically correct is highly misleading suggesting that it is user facing string that can be changed without breaking stuff.

This PR restores old names and removes the mechanism that used `objectName` property for user facing strings that is incorrect.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
https://forum.freecad.org/viewtopic.php?t=98998

<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
