### PR TITLE
Start: Fix bug causing <none> to show in wb selector

### DIFF
--- a/src/Mod/Start/StartMigrator.py
+++ b/src/Mod/Start/StartMigrator.py
@@ -26,11 +26,19 @@ import FreeCAD
 
 def _remove_from_list(prefs, pref_name):
     # Remove Start and Web from a preference that consists of a comma-separated list of workbenches
-    mods = prefs.GetString(pref_name, "").split(",")
+    # and ensure that the list was not empty
+
+    is_empty_string = "<IS_EMPTY>"
+    mods = prefs.GetString(pref_name, is_empty_string).split(",")
+
+    if is_empty_string in mods:
+        return
+
     if "StartWorkbench" in mods:
         mods.remove("StartWorkbench")
     if "WebWorkbench" in mods:
         mods.remove("WebWorkbench")
+
     prefs.SetString(pref_name, ",".join(mods))
 
 


### PR DESCRIPTION
The problem was that the migration script didn't check if `Disabled` had actually been assigned. The result is that it writes an empty string to the preference making the actual default value (where `<none>` is included) to return an empty string instead.

As there is no function for checking if a property exists, I opted to use a tag that should never be present in these lists instead.

Checking for `""` does not work as an empty string is valid and should be allowed