### PR TITLE
[TD]fix weld symbol not attached to leader

### DIFF
--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -466,11 +466,6 @@ void QGSPage::addItemToParent(QGIView* item, QGIView* parent)
     assert(item);
     assert(parent);
 
-    if (item->type() == UserType::QGIWeldSymbol) {
-        // don't touch these
-        return;
-    }
-
     // original parenting logic here
     QPointF posRef(0., 0.);
     if (item->type() == UserType::QGIViewDimension ||
@@ -733,17 +728,14 @@ void QGSPage::addRichAnnoToParent(QGIRichAnno* anno, QGIView* parent)
     anno->setZValue(ZVALUE::DIMENSION);
 }
 
-// ?? why does this not get parented to its leader here??
-// the taskdialog sets the Leader property in the weld feature.
-// the weld symbol draws itself based on the leader's geometry, but is not added to the leader's
-// group(?why?)
+
 QGIView* QGSPage::addWeldSymbol(TechDraw::DrawWeldSymbol* weldFeat)
 {
-    QGIWeldSymbol *weldView = new QGIWeldSymbol;
-    weldView->setViewFeature(weldFeat);
-    addItem(weldView);
+    auto *weldQGItem = new QGIWeldSymbol;
+    weldQGItem->setViewFeature(weldFeat);
+    addItemToScene(weldQGItem);
 
-    return weldView;
+    return weldQGItem;
 }
 
 


### PR DESCRIPTION
This PR implements a fix for issue #20209.

It corrects the setting of scene parentage at weld symbol creation.