### PR TITLE
CAM: new simulator navigation

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -89,6 +89,7 @@
 #include "PythonDebugger.h"
 #include "MainWindowPy.h"
 #include "MDIViewPy.h"
+#include "MDIViewWithCamera.h"
 #include "Placement.h"
 #include "SoFCDB.h"
 #include "Selection.h"
@@ -2343,6 +2344,7 @@ void Application::initTypes()
     // views
     Gui::BaseView                               ::init();
     Gui::MDIView                                ::init();
+    Gui::MDIViewWithCamera						::init();
     Gui::View3DInventor                         ::init();
     Gui::AbstractSplitView                      ::init();
     Gui::SplitView3DInventor                    ::init();

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1299,6 +1299,7 @@ SET(View_CPP_SRCS
     MDIView.cpp
     MDIViewPy.cpp
     MDIViewPyWrap.cpp
+    MDIViewWithCamera.cpp
     GraphvizView.cpp
     ImageView.cpp
     ActiveObjectList.cpp
@@ -1307,6 +1308,7 @@ SET(View_HPP_SRCS
     MDIView.h
     MDIViewPy.h
     MDIViewPyWrap.h
+    MDIViewWithCamera.h
     GraphvizView.h
     ImageView.h
     ActiveObjectList.h

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -150,31 +150,26 @@ StdOrthographicCamera::StdOrthographicCamera()
 void StdOrthographicCamera::activated(int iMsg)
 {
     if (iMsg == 1) {
-        auto view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
-        SoCamera* cam = view->getViewer()->getSoRenderManager()->getCamera();
-        if (!cam || cam->getTypeId() != SoOrthographicCamera::getClassTypeId()) {
-
-            doCommand(Command::Gui, "Gui.activeDocument().activeView().setCameraType(\"Orthographic\")");
-        }
+        getGuiApplication()->sendMsgToActiveView("OrthographicCamera");
     }
 }
 
 bool StdOrthographicCamera::isActive()
 {
-    auto view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
-    if (view) {
-        // update the action group if needed
-        bool check = _pcAction->isChecked();
-        SoCamera* cam = view->getViewer()->getSoRenderManager()->getCamera();
-        bool mode = cam ? cam->getTypeId() == SoOrthographicCamera::getClassTypeId() : false;
-
-        if (mode != check) {
-            _pcAction->setChecked(mode);
-        }
-        return true;
+    if (!getGuiApplication()->sendHasMsgToActiveView("OrthographicCamera")) {
+        return false;
     }
 
-    return false;
+    auto view = qobject_cast<MDIViewWithCamera*>(getMainWindow()->activeWindow());
+    if (!view) {
+        return false;
+    }
+
+    const std::string& camera = view->getCamera();
+    const bool mode = camera.find("OrthographicCamera") != std::string_view::npos;
+    _pcAction->setChecked(mode);
+
+    return true;
 }
 
 Action* StdOrthographicCamera::createAction()
@@ -202,32 +197,26 @@ StdPerspectiveCamera::StdPerspectiveCamera()
 void StdPerspectiveCamera::activated(int iMsg)
 {
     if (iMsg == 1) {
-        auto view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
-        SoCamera* cam = view->getViewer()->getSoRenderManager()->getCamera();
-        if (!cam || cam->getTypeId() != SoPerspectiveCamera::getClassTypeId()) {
-
-            doCommand(Command::Gui, "Gui.activeDocument().activeView().setCameraType(\"Perspective\")");
-        }
+        getGuiApplication()->sendMsgToActiveView("PerspectiveCamera");
     }
 }
 
 bool StdPerspectiveCamera::isActive()
 {
-    auto view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
-    if (view) {
-        // update the action group if needed
-        bool check = _pcAction->isChecked();
-        SoCamera* cam = view->getViewer()->getSoRenderManager()->getCamera();
-        bool mode = cam ? cam->getTypeId() == SoPerspectiveCamera::getClassTypeId() : false;
-
-        if (mode != check) {
-            _pcAction->setChecked(mode);
-        }
-
-        return true;
+    if (!getGuiApplication()->sendHasMsgToActiveView("PerspectiveCamera")) {
+        return false;
     }
 
-    return false;
+    auto view = qobject_cast<MDIViewWithCamera*>(getMainWindow()->activeWindow());
+    if (!view) {
+        return false;
+    }
+
+    const std::string& camera = view->getCamera();
+    const bool mode = camera.find("PerspectiveCamera") != std::string_view::npos;
+    _pcAction->setChecked(mode);
+
+    return true;
 }
 
 Action* StdPerspectiveCamera::createAction()
@@ -399,15 +388,12 @@ void StdCmdFreezeViews::activated(int iMsg)
     }
     else if (iMsg == 3) {
         // Create a new view
-        auto* view3d = freecad_cast<View3DInventor*>(getGuiApplication()->activeView());
-        if (!view3d) {
-            Base::Console().developerError(
-                "StdCmdFreezeViews",
-                "Expected the active view to be View3DInventor\n"
-            );
+        auto* view = freecad_cast<MDIViewWithCamera*>(getGuiApplication()->activeView());
+        if (!view) {
             return;
         }
-        const std::string& camera = view3d->getCamera();
+
+        const std::string& camera = view->getCamera();
 
         QList<QAction*> acts = pcAction->actions();
         int index = 1;
@@ -436,16 +422,19 @@ void StdCmdFreezeViews::activated(int iMsg)
         // Activate a view
         QList<QAction*> acts = pcAction->actions();
         QString data = acts[iMsg]->toolTip();
-        MDIView* view = getGuiApplication()->activeView();
-        if (auto* view3D = freecad_cast<View3DInventor*>(view)) {
-            view3D->setCamera(data.toStdString().c_str());
+
+        auto* view = freecad_cast<MDIViewWithCamera*>(getGuiApplication()->activeView());
+        if (!view) {
+            return;
         }
+
+        view->setCamera(data.toStdString().c_str());
     }
 }
 
 bool StdCmdFreezeViews::isActive()
 {
-    auto view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
+    auto view = qobject_cast<MDIViewWithCamera*>(getMainWindow()->activeWindow());
 
     separator->setVisible(savedViews > 0);
     if (view) {
@@ -1445,7 +1434,7 @@ void StdCmdViewHome::activated(int iMsg)
 //===========================================================================
 // Std_ViewBottom
 //===========================================================================
-DEF_3DV_CMD(StdCmdViewBottom)
+DEF_STD_CMD_A(StdCmdViewBottom)
 
 StdCmdViewBottom::StdCmdViewBottom()
     : Command("Std_ViewBottom")
@@ -1463,13 +1452,18 @@ StdCmdViewBottom::StdCmdViewBottom()
 void StdCmdViewBottom::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.activeDocument().activeView().viewBottom()");
+    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewBottom\")");
+}
+
+bool StdCmdViewBottom::isActive()
+{
+    return getGuiApplication()->sendHasMsgToActiveView("ViewBottom");
 }
 
 //===========================================================================
 // Std_ViewFront
 //===========================================================================
-DEF_3DV_CMD(StdCmdViewFront)
+DEF_STD_CMD_A(StdCmdViewFront)
 
 StdCmdViewFront::StdCmdViewFront()
     : Command("Std_ViewFront")
@@ -1487,13 +1481,18 @@ StdCmdViewFront::StdCmdViewFront()
 void StdCmdViewFront::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.activeDocument().activeView().viewFront()");
+    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewFront\")");
+}
+
+bool StdCmdViewFront::isActive()
+{
+    return getGuiApplication()->sendHasMsgToActiveView("ViewFront");
 }
 
 //===========================================================================
 // Std_ViewLeft
 //===========================================================================
-DEF_3DV_CMD(StdCmdViewLeft)
+DEF_STD_CMD_A(StdCmdViewLeft)
 
 StdCmdViewLeft::StdCmdViewLeft()
     : Command("Std_ViewLeft")
@@ -1511,13 +1510,18 @@ StdCmdViewLeft::StdCmdViewLeft()
 void StdCmdViewLeft::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.activeDocument().activeView().viewLeft()");
+    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewLeft\")");
+}
+
+bool StdCmdViewLeft::isActive()
+{
+    return getGuiApplication()->sendHasMsgToActiveView("ViewLeft");
 }
 
 //===========================================================================
 // Std_ViewRear
 //===========================================================================
-DEF_3DV_CMD(StdCmdViewRear)
+DEF_STD_CMD_A(StdCmdViewRear)
 
 StdCmdViewRear::StdCmdViewRear()
     : Command("Std_ViewRear")
@@ -1535,13 +1539,18 @@ StdCmdViewRear::StdCmdViewRear()
 void StdCmdViewRear::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.activeDocument().activeView().viewRear()");
+    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewRear\")");
+}
+
+bool StdCmdViewRear::isActive()
+{
+    return getGuiApplication()->sendHasMsgToActiveView("ViewRear");
 }
 
 //===========================================================================
 // Std_ViewRight
 //===========================================================================
-DEF_3DV_CMD(StdCmdViewRight)
+DEF_STD_CMD_A(StdCmdViewRight)
 
 StdCmdViewRight::StdCmdViewRight()
     : Command("Std_ViewRight")
@@ -1559,13 +1568,18 @@ StdCmdViewRight::StdCmdViewRight()
 void StdCmdViewRight::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.activeDocument().activeView().viewRight()");
+    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewRight\")");
+}
+
+bool StdCmdViewRight::isActive()
+{
+    return getGuiApplication()->sendHasMsgToActiveView("ViewRight");
 }
 
 //===========================================================================
 // Std_ViewTop
 //===========================================================================
-DEF_3DV_CMD(StdCmdViewTop)
+DEF_STD_CMD_A(StdCmdViewTop)
 
 StdCmdViewTop::StdCmdViewTop()
     : Command("Std_ViewTop")
@@ -1583,14 +1597,19 @@ StdCmdViewTop::StdCmdViewTop()
 void StdCmdViewTop::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.activeDocument().activeView().viewTop()");
+    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewTop\")");
+}
+
+bool StdCmdViewTop::isActive()
+{
+    return getGuiApplication()->sendHasMsgToActiveView("ViewTop");
 }
 
 
 //===========================================================================
 // Std_ViewIsometric
 //===========================================================================
-DEF_3DV_CMD(StdCmdViewIsometric)
+DEF_STD_CMD_A(StdCmdViewIsometric)
 
 StdCmdViewIsometric::StdCmdViewIsometric()
     : Command("Std_ViewIsometric")
@@ -1608,13 +1627,18 @@ StdCmdViewIsometric::StdCmdViewIsometric()
 void StdCmdViewIsometric::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.activeDocument().activeView().viewIsometric()");
+    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewAxo\")");
+}
+
+bool StdCmdViewIsometric::isActive()
+{
+    return getGuiApplication()->sendHasMsgToActiveView("ViewAxo");
 }
 
 //===========================================================================
 // Std_ViewDimetric
 //===========================================================================
-DEF_3DV_CMD(StdCmdViewDimetric)
+DEF_STD_CMD_A(StdCmdViewDimetric)
 
 StdCmdViewDimetric::StdCmdViewDimetric()
     : Command("Std_ViewDimetric")
@@ -1631,13 +1655,18 @@ StdCmdViewDimetric::StdCmdViewDimetric()
 void StdCmdViewDimetric::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.activeDocument().activeView().viewDimetric()");
+    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewDimetric\")");
+}
+
+bool StdCmdViewDimetric::isActive()
+{
+    return getGuiApplication()->sendHasMsgToActiveView("ViewDimetric");
 }
 
 //===========================================================================
 // Std_ViewTrimetric
 //===========================================================================
-DEF_3DV_CMD(StdCmdViewTrimetric)
+DEF_STD_CMD_A(StdCmdViewTrimetric)
 
 StdCmdViewTrimetric::StdCmdViewTrimetric()
     : Command("Std_ViewTrimetric")
@@ -1654,7 +1683,12 @@ StdCmdViewTrimetric::StdCmdViewTrimetric()
 void StdCmdViewTrimetric::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.activeDocument().activeView().viewTrimetric()");
+    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewTrimetric\")");
+}
+
+bool StdCmdViewTrimetric::isActive()
+{
+    return getGuiApplication()->sendHasMsgToActiveView("ViewTrimetric");
 }
 
 //===========================================================================
@@ -1728,13 +1762,11 @@ StdCmdViewFitAll::StdCmdViewFitAll()
 void StdCmdViewFitAll::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    // doCommand(Command::Gui,"Gui.activeDocument().activeView().fitAll()");
     doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewFit\")");
 }
 
 bool StdCmdViewFitAll::isActive()
 {
-    // return isViewOfType(Gui::View3DInventor::getClassTypeId());
     return getGuiApplication()->sendHasMsgToActiveView("ViewFit");
 }
 
@@ -2700,15 +2732,16 @@ void StdCmdViewIvIssueCamPos::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
-    auto* view3d = freecad_cast<View3DInventor*>(getGuiApplication()->activeView());
-    if (!view3d) {
+    auto* view = freecad_cast<MDIViewWithCamera*>(getGuiApplication()->activeView());
+    if (!view) {
         Base::Console().developerError(
             "StdCmdViewIvIssueCameraPos",
             "Expected the active view to be View3DInventor\n"
         );
         return;
     }
-    std::string camera = view3d->getCamera();
+
+    std::string camera = view->getCamera();
 
     // remove the #inventor line...
     std::string::size_type pos = camera.find_first_of('\n');
@@ -2730,7 +2763,7 @@ void StdCmdViewIvIssueCamPos::activated(int iMsg)
 
 bool StdCmdViewIvIssueCamPos::isActive()
 {
-    return freecad_cast<View3DInventor*>(getGuiApplication()->activeView());
+    return freecad_cast<MDIViewWithCamera*>(getGuiApplication()->activeView());
 }
 
 
@@ -4319,14 +4352,12 @@ StdStoreWorkingView::StdStoreWorkingView()
 void StdStoreWorkingView::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    if (auto view = dynamic_cast<Gui::View3DInventor*>(Gui::getMainWindow()->activeWindow())) {
-        view->getViewer()->saveHomePosition();
-    }
+    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"StoreWorkingView\")");
 }
 
 bool StdStoreWorkingView::isActive()
 {
-    return dynamic_cast<Gui::View3DInventor*>(Gui::getMainWindow()->activeWindow());
+    return getGuiApplication()->sendHasMsgToActiveView("StoreWorkingView");
 }
 
 //===========================================================================
@@ -4349,17 +4380,12 @@ StdRecallWorkingView::StdRecallWorkingView()
 void StdRecallWorkingView::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    if (auto view = dynamic_cast<Gui::View3DInventor*>(Gui::getMainWindow()->activeWindow())) {
-        if (view->getViewer()->hasHomePosition()) {
-            view->getViewer()->resetToHomePosition();
-        }
-    }
+    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"RecallWorkingView\")");
 }
 
 bool StdRecallWorkingView::isActive()
 {
-    auto view = dynamic_cast<Gui::View3DInventor*>(Gui::getMainWindow()->activeWindow());
-    return view && view->getViewer()->hasHomePosition();
+    return getGuiApplication()->sendHasMsgToActiveView("RecallWorkingView");
 }
 
 //===========================================================================

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -586,14 +586,12 @@ Document::~Document()
         it->deleteSelf();
     }
 
-    std::map<const App::DocumentObject*, ViewProviderDocumentObject*>::iterator jt;
-    for (jt = d->_ViewProviderMap.begin(); jt != d->_ViewProviderMap.end(); ++jt) {
-        delete jt->second;
+    for (const auto& vp : d->_ViewProviderMap) {
+        delete vp.second;
     }
-    std::map<std::string, ViewProvider*>::iterator it2;
-    for (it2 = d->_ViewProviderMapAnnotation.begin(); it2 != d->_ViewProviderMapAnnotation.end();
-         ++it2) {
-        delete it2->second;
+
+    for (const auto& va : d->_ViewProviderMapAnnotation) {
+        delete va.second;
     }
 
     // remove the reference from the object
@@ -730,10 +728,9 @@ void Document::resetEdit()
 
 void Document::_resetEdit()
 {
-    std::list<Gui::BaseView*>::iterator it;
     if (d->_editViewProvider) {
-        for (it = d->baseViews.begin(); it != d->baseViews.end(); ++it) {
-            auto activeView = dynamic_cast<View3DInventor*>(*it);
+        for (auto* v : d->baseViews) {
+            auto activeView = dynamic_cast<View3DInventor*>(v);
             if (activeView) {
                 activeView->getViewer()->resetEditingViewProvider();
             }
@@ -816,8 +813,6 @@ void Document::setInEdit(ViewProviderDocumentObject* parentVp, const char* subna
 
 void Document::setAnnotationViewProvider(const char* name, ViewProvider* pcProvider)
 {
-    std::list<Gui::BaseView*>::iterator vIt;
-
     // already in ?
     std::map<std::string, ViewProvider*>::iterator it = d->_ViewProviderMapAnnotation.find(name);
     if (it != d->_ViewProviderMapAnnotation.end()) {
@@ -828,8 +823,8 @@ void Document::setAnnotationViewProvider(const char* name, ViewProvider* pcProvi
     d->_ViewProviderMapAnnotation[name] = pcProvider;
 
     // cycling to all views of the document
-    for (vIt = d->baseViews.begin(); vIt != d->baseViews.end(); ++vIt) {
-        auto activeView = dynamic_cast<View3DInventor*>(*vIt);
+    for (auto* v : d->baseViews) {
+        auto activeView = dynamic_cast<View3DInventor*>(v);
         if (activeView) {
             activeView->getViewer()->addViewProvider(pcProvider);
         }
@@ -849,9 +844,8 @@ ViewProvider* Document::getAnnotationViewProvider(const char* name) const
 
 bool Document::isAnnotationViewProvider(const ViewProvider* vp) const
 {
-    std::map<std::string, ViewProvider*>::const_iterator it;
-    for (it = d->_ViewProviderMapAnnotation.begin(); it != d->_ViewProviderMapAnnotation.end(); ++it) {
-        if (it->second == vp) {
+    for (const auto& va : d->_ViewProviderMapAnnotation) {
+        if (va.second == vp) {
             return true;
         }
     }
@@ -896,12 +890,9 @@ ViewProvider* Document::getViewProvider(const App::DocumentObject* Feat) const
 std::vector<ViewProvider*> Document::getViewProvidersOfType(const Base::Type& typeId) const
 {
     std::vector<ViewProvider*> Objects;
-    for (std::map<const App::DocumentObject*, ViewProviderDocumentObject*>::const_iterator it
-         = d->_ViewProviderMap.begin();
-         it != d->_ViewProviderMap.end();
-         ++it) {
-        if (it->second->isDerivedFrom(typeId)) {
-            Objects.push_back(it->second);
+    for (const auto& vp : d->_ViewProviderMap) {
+        if (vp.second->isDerivedFrom(typeId)) {
+            Objects.push_back(vp.second);
         }
     }
     return Objects;
@@ -1039,10 +1030,9 @@ void Document::slotNewObject(const App::DocumentObject& Obj)
     }
 
     if (pcProvider) {
-        std::list<Gui::BaseView*>::iterator vIt;
         // cycling to all views of the document
-        for (vIt = d->baseViews.begin(); vIt != d->baseViews.end(); ++vIt) {
-            auto activeView = dynamic_cast<View3DInventor*>(*vIt);
+        for (auto* v : d->baseViews) {
+            auto activeView = dynamic_cast<View3DInventor*>(v);
             if (activeView) {
                 activeView->getViewer()->addViewProvider(pcProvider);
             }
@@ -1062,7 +1052,6 @@ void Document::slotNewObject(const App::DocumentObject& Obj)
 
 void Document::slotDeletedObject(const App::DocumentObject& Obj)
 {
-    std::list<Gui::BaseView*>::iterator vIt;
     setModified(true);
 
     // cycling to all views of the document
@@ -1085,8 +1074,8 @@ void Document::slotDeletedObject(const App::DocumentObject& Obj)
 
     if (viewProvider && viewProvider->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
         // go through the views
-        for (vIt = d->baseViews.begin(); vIt != d->baseViews.end(); ++vIt) {
-            auto activeView = dynamic_cast<View3DInventor*>(*vIt);
+        for (auto* v : d->baseViews) {
+            auto activeView = dynamic_cast<View3DInventor*>(v);
             if (activeView) {
                 activeView->getViewer()->removeViewProvider(viewProvider);
             }
@@ -1814,9 +1803,9 @@ unsigned int Document::getMemSize() const
     unsigned int size = 0;
 
     // size of the view providers in the document
-    std::map<const App::DocumentObject*, ViewProviderDocumentObject*>::const_iterator it;
-    for (it = d->_ViewProviderMap.begin(); it != d->_ViewProviderMap.end(); ++it) {
-        size += it->second->getMemSize();
+
+    for (const auto& vp : d->_ViewProviderMap) {
+        size += vp.second->getMemSize();
     }
     return size;
 }
@@ -1864,9 +1853,9 @@ void Document::Restore(Base::XMLReader& reader)
     // hide all elements to avoid to update the 3d view when loading data files
     // RestoreDocFile then restores the visibility status again
     std::map<const App::DocumentObject*, ViewProviderDocumentObject*>::iterator it;
-    for (it = d->_ViewProviderMap.begin(); it != d->_ViewProviderMap.end(); ++it) {
-        it->second->startRestoring();
-        it->second->setStatus(Gui::isRestoring, true);
+    for (const auto& vp : d->_ViewProviderMap) {
+        vp.second->startRestoring();
+        vp.second->setStatus(Gui::isRestoring, true);
     }
 }
 
@@ -2274,18 +2263,17 @@ MDIView* Document::createView(const Base::Type& typeId, CreateViewMode mode)
         // attach the viewproviders. we need to make sure that we only attach the toplevel ones
         // and not viewproviders which are claimed by other providers. To ensure this we first
         // add all providers and then remove the ones already claimed
-        std::map<const App::DocumentObject*, ViewProviderDocumentObject*>::const_iterator It1;
+
         std::vector<App::DocumentObject*> child_vps;
-        for (It1 = d->_ViewProviderMap.begin(); It1 != d->_ViewProviderMap.end(); ++It1) {
-            view3D->getViewer()->addViewProvider(It1->second);
-            std::vector<App::DocumentObject*> children = It1->second->claimChildren3D();
+        for (const auto& vp : d->_ViewProviderMap) {
+            view3D->getViewer()->addViewProvider(vp.second);
+            std::vector<App::DocumentObject*> children = vp.second->claimChildren3D();
             child_vps.insert(child_vps.end(), children.begin(), children.end());
         }
-        std::map<std::string, ViewProvider*>::const_iterator It2;
-        for (It2 = d->_ViewProviderMapAnnotation.begin(); It2 != d->_ViewProviderMapAnnotation.end();
-             ++It2) {
-            view3D->getViewer()->addViewProvider(It2->second);
-            std::vector<App::DocumentObject*> children = It2->second->claimChildren3D();
+
+        for (const auto& va : d->_ViewProviderMapAnnotation) {
+            view3D->getViewer()->addViewProvider(va.second);
+            std::vector<App::DocumentObject*> children = va.second->claimChildren3D();
             child_vps.insert(child_vps.end(), children.begin(), children.end());
         }
 
@@ -2404,14 +2392,12 @@ void Document::onUpdate()
     Base::Console().log("Acti: Gui::Document::onUpdate()");
 #endif
 
-    std::list<Gui::BaseView*>::iterator it;
-
-    for (it = d->baseViews.begin(); it != d->baseViews.end(); ++it) {
-        (*it)->onUpdate();
+    for (auto* v : d->baseViews) {
+        v->onUpdate();
     }
 
-    for (it = d->passiveViews.begin(); it != d->passiveViews.end(); ++it) {
-        (*it)->onUpdate();
+    for (auto* v : d->passiveViews) {
+        v->onUpdate();
     }
 }
 
@@ -2421,14 +2407,12 @@ void Document::onRelabel()
     Base::Console().log("Acti: Gui::Document::onRelabel()");
 #endif
 
-    std::list<Gui::BaseView*>::iterator it;
-
-    for (it = d->baseViews.begin(); it != d->baseViews.end(); ++it) {
-        (*it)->onRelabel(this);
+    for (auto* v : d->baseViews) {
+        v->onRelabel(this);
     }
 
-    for (it = d->passiveViews.begin(); it != d->passiveViews.end(); ++it) {
-        (*it)->onRelabel(this);
+    for (auto* v : d->passiveViews) {
+        v->onRelabel(this);
     }
 
     d->connectChangeDocumentBlocker.unblock();
@@ -2543,19 +2527,16 @@ bool Document::canClose(bool checkModify, bool checkLink)
 std::list<MDIView*> Document::getMDIViews(bool includePassive) const
 {
     std::list<MDIView*> views;
-    for (std::list<BaseView*>::const_iterator it = d->baseViews.begin(); it != d->baseViews.end();
-         ++it) {
-        auto view = dynamic_cast<MDIView*>(*it);
+    for (auto* v : d->baseViews) {
+        auto view = dynamic_cast<MDIView*>(v);
         if (view) {
             views.push_back(view);
         }
     }
 
     if (includePassive) {
-        for (std::list<BaseView*>::const_iterator it = d->passiveViews.begin();
-             it != d->passiveViews.end();
-             ++it) {
-            auto view = dynamic_cast<MDIView*>(*it);
+        for (auto* v : d->passiveViews) {
+            auto view = dynamic_cast<MDIView*>(v);
             if (view) {
                 views.push_back(view);
             }
@@ -2568,19 +2549,16 @@ std::list<MDIView*> Document::getMDIViews(bool includePassive) const
 std::list<MDIView*> Document::getMDIViewsOfType(const Base::Type& typeId, bool includePassive) const
 {
     std::list<MDIView*> views;
-    for (std::list<BaseView*>::const_iterator it = d->baseViews.begin(); it != d->baseViews.end();
-         ++it) {
-        auto view = dynamic_cast<MDIView*>(*it);
+    for (auto* v : d->baseViews) {
+        auto view = dynamic_cast<MDIView*>(v);
         if (view && view->isDerivedFrom(typeId)) {
             views.push_back(view);
         }
     }
 
     if (includePassive) {
-        for (std::list<BaseView*>::const_iterator it = d->passiveViews.begin();
-             it != d->passiveViews.end();
-             ++it) {
-            auto view = dynamic_cast<MDIView*>(*it);
+        for (auto* v : d->passiveViews) {
+            auto view = dynamic_cast<MDIView*>(v);
             if (view && view->isDerivedFrom(typeId)) {
                 views.push_back(view);
             }
@@ -2593,16 +2571,14 @@ std::list<MDIView*> Document::getMDIViewsOfType(const Base::Type& typeId, bool i
 /// send messages to the active view
 bool Document::sendMsgToViews(const char* pMsg)
 {
-    std::list<Gui::BaseView*>::iterator it;
-
-    for (it = d->baseViews.begin(); it != d->baseViews.end(); ++it) {
-        if ((*it)->onMsg(pMsg)) {
+    for (auto* v : d->baseViews) {
+        if (v->onMsg(pMsg)) {
             return true;
         }
     }
 
-    for (it = d->passiveViews.begin(); it != d->passiveViews.end(); ++it) {
-        if ((*it)->onMsg(pMsg)) {
+    for (auto* v : d->passiveViews) {
+        if (v->onMsg(pMsg)) {
             return true;
         }
     }

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1946,8 +1946,8 @@ void Document::RestoreDocFile(Base::Reader& reader)
             saveCameraSettings(ppReturn);
             try {
                 for (const auto& it : getMDIViews()) {
-                    if (auto* view3D = freecad_cast<View3DInventor*>(it)) {
-                        view3D->setCamera(cameraSettings.c_str());
+                    if (auto* viewCamera = freecad_cast<MDIViewWithCamera*>(it)) {
+                        viewCamera->setCamera(cameraSettings.c_str());
                     }
                 }
             }
@@ -2069,8 +2069,8 @@ void Document::SaveDocFile(Base::Writer& writer) const
 
     // save camera settings
     for (const auto& it : getMDIViews()) {
-        if (auto* view3D = freecad_cast<View3DInventor*>(it)) {
-            const std::string& camera = view3D->getCamera();
+        if (auto* viewCamera = freecad_cast<MDIViewWithCamera*>(it)) {
+            const std::string& camera = viewCamera->getCamera();
             if (saveCameraSettings(camera.c_str())) {
                 break;
             }
@@ -2540,7 +2540,7 @@ bool Document::canClose(bool checkModify, bool checkLink)
     return ok;
 }
 
-std::list<MDIView*> Document::getMDIViews() const
+std::list<MDIView*> Document::getMDIViews(bool includePassive) const
 {
     std::list<MDIView*> views;
     for (std::list<BaseView*>::const_iterator it = d->baseViews.begin(); it != d->baseViews.end();
@@ -2551,10 +2551,21 @@ std::list<MDIView*> Document::getMDIViews() const
         }
     }
 
+    if (includePassive) {
+        for (std::list<BaseView*>::const_iterator it = d->passiveViews.begin();
+             it != d->passiveViews.end();
+             ++it) {
+            auto view = dynamic_cast<MDIView*>(*it);
+            if (view) {
+                views.push_back(view);
+            }
+        }
+    }
+
     return views;
 }
 
-std::list<MDIView*> Document::getMDIViewsOfType(const Base::Type& typeId) const
+std::list<MDIView*> Document::getMDIViewsOfType(const Base::Type& typeId, bool includePassive) const
 {
     std::list<MDIView*> views;
     for (std::list<BaseView*>::const_iterator it = d->baseViews.begin(); it != d->baseViews.end();
@@ -2562,6 +2573,17 @@ std::list<MDIView*> Document::getMDIViewsOfType(const Base::Type& typeId) const
         auto view = dynamic_cast<MDIView*>(*it);
         if (view && view->isDerivedFrom(typeId)) {
             views.push_back(view);
+        }
+    }
+
+    if (includePassive) {
+        for (std::list<BaseView*>::const_iterator it = d->passiveViews.begin();
+             it != d->passiveViews.end();
+             ++it) {
+            auto view = dynamic_cast<MDIView*>(*it);
+            if (view && view->isDerivedFrom(typeId)) {
+                views.push_back(view);
+            }
         }
     }
 
@@ -2616,7 +2638,7 @@ MDIView* Document::getActiveView() const
     MDIView* active = getMainWindow()->activeWindow();
 
     // get all MDI views of the document
-    std::list<MDIView*> mdis = getMDIViews();
+    std::list<MDIView*> mdis = getMDIViews(true);
 
     // check whether the active view is part of this document
     bool ok = false;
@@ -2721,7 +2743,7 @@ void Document::setActiveWindow(Gui::MDIView* view)
     }
 
     // get all MDI views of the document
-    std::list<MDIView*> mdis = getMDIViews();
+    std::list<MDIView*> mdis = getMDIViews(true);
 
     // this document is not active
     if (std::ranges::find(mdis, active) == mdis.end()) {

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -243,9 +243,9 @@ public:
     /// call relabel to all attached views
     void onRelabel();
     /// returns a list of all attached MDI views
-    std::list<MDIView*> getMDIViews() const;
+    std::list<MDIView*> getMDIViews(bool includePassive = false) const;
     /// returns a list of all MDI views of a certain type
-    std::list<MDIView*> getMDIViewsOfType(const Base::Type& typeId) const;
+    std::list<MDIView*> getMDIViewsOfType(const Base::Type& typeId, bool includePassive = false) const;
     MDIView* setActiveView(
         const ViewProviderDocumentObject* vp = nullptr,
         Base::Type typeId = Base::Type()

--- a/src/Gui/MDIViewWithCamera.cpp
+++ b/src/Gui/MDIViewWithCamera.cpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 jffmichi <jffmichi[at]gmail.com>
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "MDIViewWithCamera.h"
+
+using namespace Gui;
+
+TYPESYSTEM_SOURCE_ABSTRACT(Gui::MDIViewWithCamera, Gui::MDIView)
+
+MDIViewWithCamera::~MDIViewWithCamera()
+{
+    // nothing to do
+}
+
+#include "moc_MDIViewWithCamera.cpp"

--- a/src/Gui/MDIViewWithCamera.h
+++ b/src/Gui/MDIViewWithCamera.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 jffmichi <jffmichi[at]gmail.com>
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include "MDIView.h"
+
+namespace Gui
+{
+
+class GuiExport MDIViewWithCamera: public MDIView
+{
+    Q_OBJECT
+
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
+
+public:
+    using MDIView::MDIView;
+    ~MDIViewWithCamera() override;
+
+    virtual const std::string& getCamera() const = 0;
+    virtual bool setCamera(const char* pCamera) = 0;
+};
+
+}  // namespace Gui

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1088,6 +1088,25 @@ void MainWindow::showDocumentation(const QString& help)
     }
 }
 
+static View3DInventorViewer* spaceballMotionEventTarget()
+{
+    // check if the active window has a 3d view
+
+    if (auto viewer = getMainWindow()->activeWindow()->findChild<View3DInventorViewer*>()) {
+        return viewer;
+    }
+
+    // check active view for the document
+
+    if (Gui::Document* doc = Application::Instance->activeDocument()) {
+        if (auto view = dynamic_cast<View3DInventor*>(doc->getActiveView())) {
+            return view->getViewer();
+        }
+    }
+
+    return nullptr;
+}
+
 bool MainWindow::event(QEvent* e)
 {
     if (e->type() == QEvent::EnterWhatsThisMode) {
@@ -1162,15 +1181,7 @@ bool MainWindow::event(QEvent* e)
             return true;
         }
         motionEvent->setHandled(true);
-        Gui::Document* doc = Application::Instance->activeDocument();
-        if (!doc) {
-            return true;
-        }
-        auto temp = dynamic_cast<View3DInventor*>(doc->getActiveView());
-        if (!temp) {
-            return true;
-        }
-        View3DInventorViewer* view = temp->getViewer();
+        View3DInventorViewer* view = spaceballMotionEventTarget();
         if (view) {
             Spaceball::MotionEvent anotherEvent(*motionEvent);
             qApp->sendEvent(view, &anotherEvent);

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -90,7 +90,7 @@ void GLOverlayWidget::paintEvent(QPaintEvent*)
 
 /* TRANSLATOR Gui::View3DInventor */
 
-TYPESYSTEM_SOURCE_ABSTRACT(Gui::View3DInventor, Gui::MDIView)
+TYPESYSTEM_SOURCE_ABSTRACT(Gui::View3DInventor, Gui::MDIViewWithCamera)
 
 View3DInventor::View3DInventor(
     Gui::Document* pcDocument,
@@ -98,7 +98,7 @@ View3DInventor::View3DInventor(
     const QOpenGLWidget* sharewidget,
     Qt::WindowFlags wflags
 )
-    : MDIView(pcDocument, parent, wflags)
+    : MDIViewWithCamera(pcDocument, parent, wflags)
     , _viewerPy(nullptr)
 {
     stack = new QStackedWidget(this);
@@ -193,7 +193,7 @@ void View3DInventor::deleteSelf()
 {
     _viewer->setSceneGraph(nullptr);
     _viewer->setDocument(nullptr);
-    MDIView::deleteSelf();
+    MDIViewWithCamera::deleteSelf();
 }
 
 View3DInventor* View3DInventor::clone()
@@ -432,6 +432,14 @@ bool View3DInventor::onMsg(const char* pMsg)
         _viewer->viewAll();
         return true;
     }
+    else if (strcmp("ViewDimetric", pMsg) == 0) {
+        _viewer->setCameraOrientation(Camera::rotation(Camera::Dimetric));
+        return true;
+    }
+    else if (strcmp("ViewTrimetric", pMsg) == 0) {
+        _viewer->setCameraOrientation(Camera::rotation(Camera::Trimetric));
+        return true;
+    }
     else if (strcmp("OrthographicCamera", pMsg) == 0) {
         _viewer->setCameraType(SoOrthographicCamera::getClassTypeId());
         return true;
@@ -465,13 +473,21 @@ bool View3DInventor::onMsg(const char* pMsg)
         return true;
     }
     else if (strcmp("ZoomIn", pMsg) == 0) {
-        View3DInventorViewer* viewer = getViewer();
-        viewer->navigationStyle()->zoomIn();
+        _viewer->navigationStyle()->zoomIn();
         return true;
     }
     else if (strcmp("ZoomOut", pMsg) == 0) {
-        View3DInventorViewer* viewer = getViewer();
-        viewer->navigationStyle()->zoomOut();
+        _viewer->navigationStyle()->zoomOut();
+        return true;
+    }
+    else if (strcmp("StoreWorkingView", pMsg) == 0) {
+        _viewer->saveHomePosition();
+        return true;
+    }
+    else if (strcmp("RecallWorkingView", pMsg) == 0) {
+        if (_viewer->hasHomePosition()) {
+            _viewer->resetToHomePosition();
+        }
         return true;
     }
 
@@ -558,20 +574,38 @@ bool View3DInventor::onHasMsg(const char* pMsg) const
     else if (strcmp("ViewAxo", pMsg) == 0) {
         return true;
     }
+    else if (strcmp("ViewDimetric", pMsg) == 0) {
+        return true;
+    }
+    else if (strcmp("ViewTrimetric", pMsg) == 0) {
+        return true;
+    }
+    else if (strcmp("OrthographicCamera", pMsg) == 0) {
+        return true;
+    }
+    else if (strcmp("PerspectiveCamera", pMsg) == 0) {
+        return true;
+    }
     else if (strncmp("Dump", pMsg, 4) == 0) {
         return true;
     }
     else if (strcmp("AlignToSelection", pMsg) == 0) {
         return true;
     }
-    if (strcmp("ZoomIn", pMsg) == 0) {
+    else if (strcmp("ZoomIn", pMsg) == 0) {
         return true;
     }
-    if (strcmp("ZoomOut", pMsg) == 0) {
+    else if (strcmp("ZoomOut", pMsg) == 0) {
         return true;
     }
-    if (strcmp("AllowsOverlayOnHover", pMsg) == 0) {
+    else if (strcmp("AllowsOverlayOnHover", pMsg) == 0) {
         return true;
+    }
+    else if (strcmp("StoreWorkingView", pMsg) == 0) {
+        return true;
+    }
+    else if (strcmp("RecallWorkingView", pMsg) == 0) {
+        return _viewer->hasHomePosition();
     }
 
     return false;
@@ -588,70 +622,7 @@ const std::string& View3DInventor::getCamera() const
 
 bool View3DInventor::setCamera(const char* pCamera)
 {
-    SoCamera* CamViewer = _viewer->getSoRenderManager()->getCamera();
-    if (!CamViewer) {
-        throw Base::RuntimeError("No camera set so far…");
-    }
-
-    SoInput in;
-    in.setBuffer((void*)pCamera, std::strlen(pCamera));
-
-    SoNode* Cam;
-    SoDB::read(&in, Cam);
-
-    if (!Cam || !Cam->isOfType(SoCamera::getClassTypeId())) {
-        throw Base::RuntimeError("Camera settings failed to read");
-    }
-
-    // this is to make sure to reliably delete the node
-    CoinPtr<SoNode> camPtr {Cam};
-
-    // toggle between perspective and orthographic camera
-    if (Cam->getTypeId() != CamViewer->getTypeId()) {
-        _viewer->setCameraType(Cam->getTypeId());
-        CamViewer = _viewer->getSoRenderManager()->getCamera();
-    }
-
-    SoPerspectiveCamera* CamViewerP = nullptr;
-    SoOrthographicCamera* CamViewerO = nullptr;
-
-    if (CamViewer->getTypeId() == SoPerspectiveCamera::getClassTypeId()) {
-        CamViewerP = static_cast<SoPerspectiveCamera*>(CamViewer);  // safe downward cast, knows the type
-    }
-    else if (CamViewer->getTypeId() == SoOrthographicCamera::getClassTypeId()) {
-        CamViewerO = static_cast<SoOrthographicCamera*>(CamViewer);  // safe downward cast, knows
-                                                                     // the type
-    }
-
-    if (Cam->getTypeId() == SoPerspectiveCamera::getClassTypeId()) {
-        if (CamViewerP) {
-            CamViewerP->position = static_cast<SoPerspectiveCamera*>(Cam)->position;
-            CamViewerP->orientation = static_cast<SoPerspectiveCamera*>(Cam)->orientation;
-            CamViewerP->nearDistance = static_cast<SoPerspectiveCamera*>(Cam)->nearDistance;
-            CamViewerP->farDistance = static_cast<SoPerspectiveCamera*>(Cam)->farDistance;
-            CamViewerP->focalDistance = static_cast<SoPerspectiveCamera*>(Cam)->focalDistance;
-        }
-        else {
-            throw Base::TypeError("Camera type mismatch");
-        }
-    }
-    else if (Cam->getTypeId() == SoOrthographicCamera::getClassTypeId()) {
-        if (CamViewerO) {
-            CamViewerO->viewportMapping = static_cast<SoOrthographicCamera*>(Cam)->viewportMapping;
-            CamViewerO->position = static_cast<SoOrthographicCamera*>(Cam)->position;
-            CamViewerO->orientation = static_cast<SoOrthographicCamera*>(Cam)->orientation;
-            CamViewerO->nearDistance = static_cast<SoOrthographicCamera*>(Cam)->nearDistance;
-            CamViewerO->farDistance = static_cast<SoOrthographicCamera*>(Cam)->farDistance;
-            CamViewerO->focalDistance = static_cast<SoOrthographicCamera*>(Cam)->focalDistance;
-            CamViewerO->aspectRatio = static_cast<SoOrthographicCamera*>(Cam)->aspectRatio;
-            CamViewerO->height = static_cast<SoOrthographicCamera*>(Cam)->height;
-        }
-        else {
-            throw Base::TypeError("Camera type mismatch");
-        }
-    }
-
-    return true;
+    return _viewer->setCamera(pCamera);
 }
 
 void View3DInventor::toggleClippingPlane()
@@ -761,7 +732,7 @@ void View3DInventor::dropEvent(QDropEvent* e)
         getMainWindow()->loadUrls(getAppDocument(), data->urls());
     }
     else {
-        MDIView::dropEvent(e);
+        MDIViewWithCamera::dropEvent(e);
     }
 }
 
@@ -797,7 +768,7 @@ void View3DInventor::setCurrentViewMode(ViewMode mode)
         }
     }
 
-    MDIView::setCurrentViewMode(mode);
+    MDIViewWithCamera::setCurrentViewMode(mode);
 
     // This widget becomes the focus proxy of the embedded GL widget if we leave
     // the 'Child' mode. If we reenter 'Child' mode the focus proxy is reset to 0.
@@ -932,7 +903,7 @@ void View3DInventor::focusInEvent(QFocusEvent*)
 
 void View3DInventor::contextMenuEvent(QContextMenuEvent* e)
 {
-    MDIView::contextMenuEvent(e);
+    MDIViewWithCamera::contextMenuEvent(e);
 }
 
 void View3DInventor::customEvent(QEvent* e)

--- a/src/Gui/View3DInventor.h
+++ b/src/Gui/View3DInventor.h
@@ -28,7 +28,7 @@
 
 #include <Base/Parameter.h>
 
-#include "MDIView.h"
+#include "MDIViewWithCamera.h"
 
 #include "Base/Vector3D.h"
 
@@ -78,7 +78,7 @@ protected:
  *  It consists out of the 3D view
  *  \author Juergen Riegel
  */
-class GuiExport View3DInventor: public MDIView
+class GuiExport View3DInventor: public MDIViewWithCamera
 {
     Q_OBJECT
 
@@ -121,8 +121,8 @@ public:
      */
     void setCurrentViewMode(ViewMode b) override;
     RayPickInfo getObjInfoRay(Base::Vector3d* startvec, Base::Vector3d* dirvec);
-    const std::string& getCamera() const;
-    bool setCamera(const char* pCamera);
+    const std::string& getCamera() const override;
+    bool setCamera(const char* pCamera) override;
     void toggleClippingPlane();
     bool hasClippingPlane() const;
 

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3499,6 +3499,74 @@ void View3DInventorViewer::setCameraType(SoType type)
     lightRotation->rotation.connectFrom(&cam->orientation);
 }
 
+bool View3DInventorViewer::setCamera(const char* pCamera)
+{
+    SoCamera* CamViewer = getSoRenderManager()->getCamera();
+    if (!CamViewer) {
+        throw Base::RuntimeError("No camera set so far…");
+    }
+
+    SoInput in;
+    in.setBuffer((void*)pCamera, std::strlen(pCamera));
+
+    SoNode* Cam;
+    SoDB::read(&in, Cam);
+
+    if (!Cam || !Cam->isOfType(SoCamera::getClassTypeId())) {
+        throw Base::RuntimeError("Camera settings failed to read");
+    }
+
+    // this is to make sure to reliably delete the node
+    CoinPtr<SoNode> camPtr {Cam};
+
+    // toggle between perspective and orthographic camera
+    if (Cam->getTypeId() != CamViewer->getTypeId()) {
+        setCameraType(Cam->getTypeId());
+        CamViewer = getSoRenderManager()->getCamera();
+    }
+
+    SoPerspectiveCamera* CamViewerP = nullptr;
+    SoOrthographicCamera* CamViewerO = nullptr;
+
+    if (CamViewer->getTypeId() == SoPerspectiveCamera::getClassTypeId()) {
+        CamViewerP = static_cast<SoPerspectiveCamera*>(CamViewer);  // safe downward cast, knows the type
+    }
+    else if (CamViewer->getTypeId() == SoOrthographicCamera::getClassTypeId()) {
+        CamViewerO = static_cast<SoOrthographicCamera*>(CamViewer);  // safe downward cast, knows
+                                                                     // the type
+    }
+
+    if (Cam->getTypeId() == SoPerspectiveCamera::getClassTypeId()) {
+        if (CamViewerP) {
+            CamViewerP->position = static_cast<SoPerspectiveCamera*>(Cam)->position;
+            CamViewerP->orientation = static_cast<SoPerspectiveCamera*>(Cam)->orientation;
+            CamViewerP->nearDistance = static_cast<SoPerspectiveCamera*>(Cam)->nearDistance;
+            CamViewerP->farDistance = static_cast<SoPerspectiveCamera*>(Cam)->farDistance;
+            CamViewerP->focalDistance = static_cast<SoPerspectiveCamera*>(Cam)->focalDistance;
+        }
+        else {
+            throw Base::TypeError("Camera type mismatch");
+        }
+    }
+    else if (Cam->getTypeId() == SoOrthographicCamera::getClassTypeId()) {
+        if (CamViewerO) {
+            CamViewerO->viewportMapping = static_cast<SoOrthographicCamera*>(Cam)->viewportMapping;
+            CamViewerO->position = static_cast<SoOrthographicCamera*>(Cam)->position;
+            CamViewerO->orientation = static_cast<SoOrthographicCamera*>(Cam)->orientation;
+            CamViewerO->nearDistance = static_cast<SoOrthographicCamera*>(Cam)->nearDistance;
+            CamViewerO->farDistance = static_cast<SoOrthographicCamera*>(Cam)->farDistance;
+            CamViewerO->focalDistance = static_cast<SoOrthographicCamera*>(Cam)->focalDistance;
+            CamViewerO->aspectRatio = static_cast<SoOrthographicCamera*>(Cam)->aspectRatio;
+            CamViewerO->height = static_cast<SoOrthographicCamera*>(Cam)->height;
+        }
+        else {
+            throw Base::TypeError("Camera type mismatch");
+        }
+    }
+
+    return true;
+}
+
 void View3DInventorViewer::moveCameraTo(const SbRotation& orientation, const SbVec3f& position, int duration)
 {
     SoCamera* camera = getCamera();

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3507,7 +3507,7 @@ bool View3DInventorViewer::setCamera(const char* pCamera)
     }
 
     SoInput in;
-    in.setBuffer((void*)pCamera, std::strlen(pCamera));
+    in.setBuffer(pCamera, std::strlen(pCamera));
 
     SoNode* Cam;
     SoDB::read(&in, Cam);
@@ -3523,45 +3523,33 @@ bool View3DInventorViewer::setCamera(const char* pCamera)
     if (Cam->getTypeId() != CamViewer->getTypeId()) {
         setCameraType(Cam->getTypeId());
         CamViewer = getSoRenderManager()->getCamera();
+
+        assert(Cam->getTypeId() == CamViewer->getTypeId());
     }
 
-    SoPerspectiveCamera* CamViewerP = nullptr;
-    SoOrthographicCamera* CamViewerO = nullptr;
-
-    if (CamViewer->getTypeId() == SoPerspectiveCamera::getClassTypeId()) {
-        CamViewerP = static_cast<SoPerspectiveCamera*>(CamViewer);  // safe downward cast, knows the type
-    }
-    else if (CamViewer->getTypeId() == SoOrthographicCamera::getClassTypeId()) {
-        CamViewerO = static_cast<SoOrthographicCamera*>(CamViewer);  // safe downward cast, knows
-                                                                     // the type
-    }
-
+    // we just made sure the cameras are the same type, now we can safely downcast
     if (Cam->getTypeId() == SoPerspectiveCamera::getClassTypeId()) {
-        if (CamViewerP) {
-            CamViewerP->position = static_cast<SoPerspectiveCamera*>(Cam)->position;
-            CamViewerP->orientation = static_cast<SoPerspectiveCamera*>(Cam)->orientation;
-            CamViewerP->nearDistance = static_cast<SoPerspectiveCamera*>(Cam)->nearDistance;
-            CamViewerP->farDistance = static_cast<SoPerspectiveCamera*>(Cam)->farDistance;
-            CamViewerP->focalDistance = static_cast<SoPerspectiveCamera*>(Cam)->focalDistance;
-        }
-        else {
-            throw Base::TypeError("Camera type mismatch");
-        }
+        auto CamViewerP = static_cast<SoPerspectiveCamera*>(CamViewer);
+        auto CamP = static_cast<SoPerspectiveCamera*>(Cam);
+
+        CamViewerP->position = CamP->position;
+        CamViewerP->orientation = CamP->orientation;
+        CamViewerP->nearDistance = CamP->nearDistance;
+        CamViewerP->farDistance = CamP->farDistance;
+        CamViewerP->focalDistance = CamP->focalDistance;
     }
     else if (Cam->getTypeId() == SoOrthographicCamera::getClassTypeId()) {
-        if (CamViewerO) {
-            CamViewerO->viewportMapping = static_cast<SoOrthographicCamera*>(Cam)->viewportMapping;
-            CamViewerO->position = static_cast<SoOrthographicCamera*>(Cam)->position;
-            CamViewerO->orientation = static_cast<SoOrthographicCamera*>(Cam)->orientation;
-            CamViewerO->nearDistance = static_cast<SoOrthographicCamera*>(Cam)->nearDistance;
-            CamViewerO->farDistance = static_cast<SoOrthographicCamera*>(Cam)->farDistance;
-            CamViewerO->focalDistance = static_cast<SoOrthographicCamera*>(Cam)->focalDistance;
-            CamViewerO->aspectRatio = static_cast<SoOrthographicCamera*>(Cam)->aspectRatio;
-            CamViewerO->height = static_cast<SoOrthographicCamera*>(Cam)->height;
-        }
-        else {
-            throw Base::TypeError("Camera type mismatch");
-        }
+        auto CamViewerO = static_cast<SoOrthographicCamera*>(CamViewer);
+        auto CamO = static_cast<SoOrthographicCamera*>(Cam);
+
+        CamViewerO->viewportMapping = CamO->viewportMapping;
+        CamViewerO->position = CamO->position;
+        CamViewerO->orientation = CamO->orientation;
+        CamViewerO->nearDistance = CamO->nearDistance;
+        CamViewerO->farDistance = CamO->farDistance;
+        CamViewerO->focalDistance = CamO->focalDistance;
+        CamViewerO->aspectRatio = CamO->aspectRatio;
+        CamViewerO->height = CamO->height;
     }
 
     return true;

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -473,6 +473,7 @@ public:
         bool moveToCenter = false
     ) const;
     void setCameraType(SoType type) override;
+    bool setCamera(const char* pCamera);
     void moveCameraTo(const SbRotation& orientation, const SbVec3f& position, int duration = -1);
     /**
      * Zooms the viewport to the size of the bounding box.

--- a/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
+++ b/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
@@ -294,7 +294,7 @@ class CAMSimulation:
                 self.operations.append(op)
                 form.listOperations.addItem(listItem)
         if len(j.Model.OutList) > 0:
-            self.baseShape = j.Model.OutList[0].Shape
+            self.baseShape = Part.makeCompound([o.Shape for o in j.Model.OutList])
         else:
             self.baseShape = None
 
@@ -322,7 +322,7 @@ class CAMSimulation:
     def SimPlay(self):
         """Activate the simulation"""
         self.SetupSimulation()
-        self.millSim.ResetSimulation()
+        self.millSim.ResetSimulation(FreeCADGui.getDocument(self.job.Document))
         for op in self.activeOps:
             tool = PathDressup.toolController(op).Tool
             toolNumber = PathDressup.toolController(op).ToolNumber

--- a/src/Mod/CAM/PathSimulator/AppGL/AppCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/AppCAMSimulator.cpp
@@ -32,6 +32,7 @@
 
 namespace CAMSimulator
 {
+
 class Module: public Py::ExtensionModule<Module>
 {
 public:
@@ -54,7 +55,6 @@ PyObject* initModule()
 
 
 }  // namespace CAMSimulator
-
 
 /* Python entry */
 PyMOD_INIT_FUNC(CAMSimulator)

--- a/src/Mod/CAM/PathSimulator/AppGL/CAMSettings.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/CAMSettings.cpp
@@ -22,51 +22,58 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "Texture.h"
+#include "PreCompiled.h"
 
-// include this last as the defines can mess up other includes
-#include "OpenGlWrapper.h"
+#include "CAMSettings.h"
+
+#include "DlgCAMSimulator.h"
+#include <string_view>
+
+using namespace std::literals;
 
 namespace CAMSimulator
 {
 
-Texture::~Texture()
+CAMSettings::CAMSettings(ParameterGrp::handle hGrp, DlgCAMSimulator& dlg)
+    : hGrp(hGrp)
+    , mDlg(dlg)
 {
-    DestroyTexture();
+    hGrp->Attach(this);
 }
 
-void Texture::DestroyTexture()
+CAMSettings::~CAMSettings()
 {
-    GLDELETE_TEXTURE(mTextureId);
+    hGrp->Detach(this);
 }
 
-bool Texture::LoadImage(unsigned int* image, int _width, int _height)
+void CAMSettings::applySettings()
 {
-    DestroyTexture();
-    width = _width;
-    height = _height;
-    glGenTextures(1, &mTextureId);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
+    OnChange(*hGrp, "DefaultNormalPathColor");
+    OnChange(*hGrp, "DefaultRapidPathColor");
 }
 
-bool Texture::Activate()
+void CAMSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::MessageType Reason)
 {
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    return true;
-}
+    (void)rCaller;
 
-bool Texture::unbind()
-{
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
+    if (Reason == "DefaultNormalPathColor"sv || Reason == "DefaultRapidPathColor"sv) {
+
+        const unsigned long lcol
+            = hGrp->GetUnsigned("DefaultNormalPathColor", 11141375UL);  // dark green (0,170,0)
+        float lr, lg, lb;
+        lr = ((lcol >> 24) & 0xff) / 255.0;
+        lg = ((lcol >> 16) & 0xff) / 255.0;
+        lb = ((lcol >> 8) & 0xff) / 255.0;
+
+        const unsigned long rcol
+            = hGrp->GetUnsigned("DefaultRapidPathColor", 2852126975UL);  // dark red (170,0,0)
+        float rr, rg, rb;
+        rr = ((rcol >> 24) & 0xff) / 255.0;
+        rg = ((rcol >> 16) & 0xff) / 255.0;
+        rb = ((rcol >> 8) & 0xff) / 255.0;
+
+        mDlg.setPathColor(QColor::fromRgbF(lr, lg, lb), QColor::fromRgbF(rr, rg, rb));
+    }
 }
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/CAMSettings.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/CAMSettings.h
@@ -22,51 +22,28 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "Texture.h"
+#pragma once
 
-// include this last as the defines can mess up other includes
-#include "OpenGlWrapper.h"
+#include <Base/Parameter.h>
 
 namespace CAMSimulator
 {
 
-Texture::~Texture()
-{
-    DestroyTexture();
-}
+class DlgCAMSimulator;
 
-void Texture::DestroyTexture()
+class CAMSettings: public ParameterGrp::ObserverType
 {
-    GLDELETE_TEXTURE(mTextureId);
-}
+public:
+    explicit CAMSettings(ParameterGrp::handle hGrp, DlgCAMSimulator& dlg);
+    ~CAMSettings();
 
-bool Texture::LoadImage(unsigned int* image, int _width, int _height)
-{
-    DestroyTexture();
-    width = _width;
-    height = _height;
-    glGenTextures(1, &mTextureId);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
-}
+    void applySettings();
+    void OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::MessageType Reason) override;
 
-bool Texture::Activate()
-{
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    return true;
-}
+private:
+    ParameterGrp::handle hGrp;
 
-bool Texture::unbind()
-{
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
-}
+    DlgCAMSimulator& mDlg;
+};
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/CAMSim.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/CAMSim.cpp
@@ -22,14 +22,12 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <string>
-#include <vector>
-
 
 #include "CAMSim.h"
-#include "DlgCAMSimulator.h"
-#include <Mod/Part/App/BRepMesh.h>
 
+#include "DlgCAMSimulator.h"
+#include <string>
+#include <vector>
 
 using namespace Base;
 
@@ -43,9 +41,9 @@ void CAMSim::BeginSimulation(const Part::TopoShape& stock, float quality)
     DlgCAMSimulator::instance()->startSimulation(stock, quality);
 }
 
-void CAMSim::resetSimulation()
+void CAMSim::resetSimulation(Gui::Document* doc)
 {
-    DlgCAMSimulator::instance()->resetSimulation();
+    DlgCAMSimulator::instance()->resetSimulation(doc);
 }
 
 void CAMSim::addTool(

--- a/src/Mod/CAM/PathSimulator/AppGL/CAMSim.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/CAMSim.cpp
@@ -32,16 +32,18 @@
 
 
 using namespace Base;
-using namespace CAMSimulator;
 
 TYPESYSTEM_SOURCE(CAMSimulator::CAMSim, Base::BaseClass);
+
+namespace CAMSimulator
+{
 
 void CAMSim::BeginSimulation(const Part::TopoShape& stock, float quality)
 {
     DlgCAMSimulator::instance()->startSimulation(stock, quality);
 }
 
-void CAMSimulator::CAMSim::resetSimulation()
+void CAMSim::resetSimulation()
 {
     DlgCAMSimulator::instance()->resetSimulation();
 }
@@ -56,7 +58,7 @@ void CAMSim::addTool(
     DlgCAMSimulator::instance()->addTool(toolProfilePoints, toolNumber, diameter, resolution);
 }
 
-void CAMSimulator::CAMSim::SetBaseShape(const Part::TopoShape& baseShape, float resolution)
+void CAMSim::SetBaseShape(const Part::TopoShape& baseShape, float resolution)
 {
     if (baseShape.isNull()) {
         return;
@@ -70,3 +72,5 @@ void CAMSim::AddCommand(Command* cmd)
     std::string gline = cmd->toGCode();
     DlgCAMSimulator::instance()->addGcodeCommand(gline.c_str());
 }
+
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/CAMSim.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/CAMSim.h
@@ -59,7 +59,7 @@ public:
     CAMSim() = default;
 
     void BeginSimulation(const Part::TopoShape& stock, float resolution);
-    void resetSimulation();
+    void resetSimulation(Gui::Document* doc);
     void addTool(
         const std::vector<float>& toolProfilePoints,
         int toolNumber,

--- a/src/Mod/CAM/PathSimulator/AppGL/CAMSim.pyi
+++ b/src/Mod/CAM/PathSimulator/AppGL/CAMSim.pyi
@@ -7,6 +7,7 @@ from typing import Any
 from Base.BaseClass import BaseClass
 from Base.Metadata import export, no_args
 
+from Gui import Document
 from Part.App.TopoShape import TopoShape
 from CAM.App.Command import Command
 
@@ -35,8 +36,7 @@ class CAMSim(BaseClass):
         """
         ...
 
-    @no_args
-    def ResetSimulation(self) -> None:
+    def ResetSimulation(self, document: Document, /) -> None:
         """
         Clear the simulation and all gcode commands
         """

--- a/src/Mod/CAM/PathSimulator/AppGL/CAMSimPyImp.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/CAMSimPyImp.cpp
@@ -26,10 +26,12 @@
 #include <Base/PlacementPy.h>
 #include <Base/PyWrapParseTupleAndKeywords.h>
 
+#include <Gui/Document.h>
 #include <Mod/Mesh/App/MeshPy.h>
 #include <Mod/CAM/App/CommandPy.h>
 #include <Mod/Part/App/TopoShapePy.h>
 
+#include "DocumentPy.h"
 // inclusion of the generated files (generated out of CAMSimPy.xml)
 #include "CAMSimPy.h"
 #include "CAMSimPy.cpp"
@@ -57,10 +59,15 @@ int CAMSimPy::PyInit(PyObject* /*args*/, PyObject* /*kwd*/)
 }
 
 
-PyObject* CAMSimPy::ResetSimulation()
+PyObject* CAMSimPy::ResetSimulation(PyObject* args)
 {
+    PyObject* pObjDoc;
+    if (!PyArg_ParseTuple(args, "O!", &(Gui::DocumentPy::Type), &pObjDoc)) {
+        return nullptr;
+    }
     CAMSim* sim = getCAMSimPtr();
-    sim->resetSimulation();
+    Gui::Document* doc = static_cast<Gui::DocumentPy*>(pObjDoc)->getDocumentPtr();
+    sim->resetSimulation(doc);
     Py_IncRef(Py_None);
     return Py_None;
 }

--- a/src/Mod/CAM/PathSimulator/AppGL/CAMSimPyImp.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/CAMSimPyImp.cpp
@@ -35,7 +35,8 @@
 #include "CAMSimPy.cpp"
 
 
-using namespace CAMSimulator;
+namespace CAMSimulator
+{
 
 // returns a string which represents the object e.g. when printed in python
 std::string CAMSimPy::representation() const
@@ -173,3 +174,5 @@ int CAMSimPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
 {
     return 0;
 }
+
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/CMakeLists.txt
+++ b/src/Mod/CAM/PathSimulator/AppGL/CMakeLists.txt
@@ -24,8 +24,6 @@ SET(CAMSimulator_SRCS_Module
     DlgCAMSimulator.cpp
     DlgCAMSimulator.h
     PreCompiled.h
-    ViewCAMSimulator.cpp
-    ViewCAMSimulator.h
 )
 
 SET(CAMSimulator_SRCS_Core
@@ -61,6 +59,16 @@ SET(CAMSimulator_SRCS_Core
     Texture.h
     TextureLoader.cpp
     TextureLoader.h
+    ViewCAMSimulator.cpp
+    ViewCAMSimulator.h
+    Dummy3DViewer.cpp
+    Dummy3DViewer.h
+    TopoShapeViewProvider.cpp
+    TopoShapeViewProvider.h
+    CAMSettings.cpp
+    CAMSettings.h
+    View3DSettings.cpp
+    View3DSettings.h
 )
 
 generate_from_py(CAMSim)

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -40,6 +40,9 @@
 #include <QHBoxLayout>
 #include <QPointer>
 
+// include this last as the defines can mess up other includes
+#include "OpenGlWrapper.h"
+
 namespace CAMSimulator
 {
 
@@ -352,7 +355,7 @@ void DlgCAMSimulator::updateWindowScale()
 
 void DlgCAMSimulator::initializeGL()
 {
-    initializeOpenGLFunctions();
+    gOpenGLFunctions.initializeOpenGLFunctions();
 }
 
 void DlgCAMSimulator::paintGL()

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -40,8 +40,6 @@
 #include <QHBoxLayout>
 #include <QPointer>
 
-using namespace MillSim;
-
 namespace CAMSimulator
 {
 
@@ -104,7 +102,7 @@ void DlgCAMSimulator::cloneFrom(const DlgCAMSimulator& from)
     mBase.needsUpdate = true;
 
     const auto state = from.mMillSimulator->GetState();
-    mState = std::make_unique<MillSim::MillSimulationState>(state);
+    mState = std::make_unique<MillSimulationState>(state);
 }
 
 DlgCAMSimulator* DlgCAMSimulator::instance()

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -25,40 +25,51 @@
 
 #include "DlgCAMSimulator.h"
 
-#include "GlUtils.h"
-#include "ViewCAMSimulator.h"
-#include "Gui/View3DInventorViewer.h"
+#include "Dummy3DViewer.h"
+#include "GuiDisplay.h"
 #include "MillSimulation.h"
-#include <Mod/Part/App/BRepMesh.h>
-#include <QDateTime>
+#include "ViewCAMSimulator.h"
+#include <Gui/View3DInventorViewer.h>
+#include <Inventor/nodes/SoCamera.h>
 #include <QSurfaceFormat>
-#include <QPoint>
-#include <QTimerEvent>
-#include <App/Document.h>
-#include <Gui/MainWindow.h>
-#include <Gui/MDIView.h>
-#include <QHBoxLayout>
-#include <QPointer>
+#include <deque>
+#include <limits>
+#include <numeric>
 
 // include this last as the defines can mess up other includes
 #include "OpenGlWrapper.h"
 
+using namespace std::literals;
+
 namespace CAMSimulator
 {
 
-static const float MouseScrollDelta = 120.0F;
-
-static QPointer<ViewCAMSimulator> viewCAMSimulator;
-
-DlgCAMSimulator::DlgCAMSimulator(ViewCAMSimulator& view, QWidget* parent)
-    : QOpenGLWidget(parent)
-    , mView(view)
+float SimShape::maxDimension() const
 {
-    // Under certain conditions, e.g. when docking/undocking the cam simulator, we need to create a
-    // new widget (due to some OpenGL bug). The new widget becomes THE cam simulator.
+    float xmin = NAN, ymin = NAN, zmin = NAN;
+    float xmax = NAN, ymax = NAN, zmax = NAN;
 
-    viewCAMSimulator = &view;
+    for (const auto& v : verts) {
+        xmin = std::fmin(xmin, v.x);
+        ymin = std::fmin(ymin, v.x);
+        zmin = std::fmin(zmin, v.x);
 
+        xmax = std::fmax(xmax, v.x);
+        ymax = std::fmax(ymax, v.x);
+        zmax = std::fmax(zmax, v.x);
+    }
+
+    const float xsize = xmax - xmin;
+    const float ysize = ymax - ymin;
+    const float zsize = zmax - zmin;
+
+    return std::max(std::max(xsize, ysize), zsize);
+}
+
+
+DlgCAMSimulator::DlgCAMSimulator(QWidget* parent)
+    : QOpenGLWidget(parent)
+{
     QSurfaceFormat format = QSurfaceFormat::defaultFormat();
     int samples = Gui::View3DInventorViewer::getNumSamples();
     if (samples > 1) {
@@ -71,20 +82,86 @@ DlgCAMSimulator::DlgCAMSimulator(ViewCAMSimulator& view, QWidget* parent)
     setMouseTracking(true);
 
     mMillSimulator.reset(new MillSimulation);
-
-    mAnimatingTimer.setInterval(0);
-    connect(
-        &mAnimatingTimer,
-        &QTimer::timeout,
-        this,
-        static_cast<void (DlgCAMSimulator::*)()>(&DlgCAMSimulator::update)
-    );
 }
 
 DlgCAMSimulator::~DlgCAMSimulator()
 {
     makeCurrent();
     mMillSimulator = nullptr;
+}
+
+void DlgCAMSimulator::connectTo(GuiDisplay& gui, Dummy3DViewer& dv)
+{
+    // connect to gui
+
+    mGui = &gui;
+    updateGui();
+
+    connect(&gui, &GuiDisplay::play, this, [this](bool b) { mMillSimulator->SetPlaying(b); });
+
+    connect(&gui, &GuiDisplay::singleStep, this, [this] { mMillSimulator->SingleStep(); });
+
+    connect(&gui, &GuiDisplay::speedChanged, this, [this](int speed) {
+        mMillSimulator->SetSpeed(speed);
+    });
+
+    connect(&gui, &GuiDisplay::stageChanged, this, [this](float f) {
+        mMillSimulator->SetSimulationStage(f);
+    });
+
+    connect(&gui, &GuiDisplay::rotateEnableChanged, this, &DlgCAMSimulator::setRotateEnabled);
+
+    connect(&gui, &GuiDisplay::pathVisibleChanged, this, [this](bool b) {
+        mMillSimulator->SetPathVisible(b);
+    });
+
+    connect(&gui, &GuiDisplay::ssaoEnableChanged, this, [this](bool b) {
+        mMillSimulator->EnableSsao(b);
+    });
+
+    connect(&gui, &GuiDisplay::stockVisibleChanged, this, &DlgCAMSimulator::setStockVisible);
+    connect(&gui, &GuiDisplay::baseVisibleChanged, this, &DlgCAMSimulator::setBaseVisible);
+
+    // connect to dummy viewer
+
+    mDummyViewer = &dv;
+
+    mDummyViewer->setStockVisible(mMillSimulator->IsStockVisible());
+    mDummyViewer->setBaseVisible(mMillSimulator->IsBaseVisible());
+
+    // connect gui and dummy viewer
+
+    connect(
+        &gui,
+        &GuiDisplay::viewAll,
+        &dv,
+        static_cast<void (Dummy3DViewer::*)()>(&Dummy3DViewer::viewAll)
+    );
+}
+
+void DlgCAMSimulator::updateGui()
+{
+    if (!mGui) {
+        return;
+    }
+
+    const auto state = mMillSimulator->GetState();
+
+    mGui->setPlaying(state.mSimPlaying);
+    mGui->setSpeed(state.mSimSpeed);
+
+    const float stage = (float)state.mCurStep / state.mNTotalSteps;
+    mGui->setStage(stage, state.mNTotalSteps);
+
+    mGui->setStockVisible(state.mViewItems & VIEWITEM_SIMULATION);
+    mGui->setBaseVisible(state.mViewItems & VIEWITEM_BASE_SHAPE);
+
+    mGui->setPathVisible(state.mViewPath);
+    mGui->setSsaoEnabled(state.mViewSSAO);
+
+    if (mDummyViewer && !mDummyViewer->isAnimating()) {
+        mGui->setRotateEnabled(false);
+    }
 }
 
 void DlgCAMSimulator::cloneFrom(const DlgCAMSimulator& from)
@@ -110,14 +187,7 @@ void DlgCAMSimulator::cloneFrom(const DlgCAMSimulator& from)
 
 DlgCAMSimulator* DlgCAMSimulator::instance()
 {
-    if (!viewCAMSimulator) {
-        auto view = new ViewCAMSimulator(nullptr, nullptr);
-        viewCAMSimulator = view;
-
-        Gui::getMainWindow()->addWindow(view);
-    }
-
-    return &viewCAMSimulator->dlg();
+    return &ViewCAMSimulator::instance().dlg();
 }
 
 void DlgCAMSimulator::setAnimating(bool animating)
@@ -128,31 +198,30 @@ void DlgCAMSimulator::setAnimating(bool animating)
 
     mAnimating = animating;
 
-    if (animating) {
-        mAnimatingTimer.start();
+    if (animating && mAnimatingTimer == 0) {
+        mAnimatingTimer = startTimer(0);
     }
-    else {
-        mAnimatingTimer.stop();
+    else if (!animating && mAnimatingTimer != 0) {
+        killTimer(mAnimatingTimer);
+        mAnimatingTimer = 0;
     }
 }
 
 void DlgCAMSimulator::startSimulation(const Part::TopoShape& stock, float quality)
 {
-    App::Document* doc = App::GetApplication().getActiveDocument();
-    mView.setWindowTitle(tr("%1 - New CAM Simulator").arg(QString::fromUtf8(doc->getName())));
-
     mQuality = quality;
     mNeedsInitialize = true;
 
     setStockShape(stock, 1);
     setAnimating(true);
 
-    Gui::getMainWindow()->setActiveWindow(&mView);
-    mView.show();
+    Q_EMIT simulationStarted();
 }
 
-void DlgCAMSimulator::resetSimulation()
+void DlgCAMSimulator::resetSimulation(Gui::Document* doc)
 {
+    Q_EMIT documentChanged(doc);
+
     mNeedsClear = true;
 
     mGCode.clear();
@@ -180,13 +249,13 @@ void DlgCAMSimulator::addTool(
     mTools.emplace_back(toolProfilePoints, toolNumber, diameter);
 }
 
-static SimShape getMeshData(const Part::TopoShape& tshape, float resolution)
+static SimShape getMeshData(const Part::TopoShape& shape, float resolution)
 {
     SimShape ret;
 
     std::vector<int> normalCount;
     int nVerts = 0;
-    for (auto& shape : tshape.getSubTopoShapes(TopAbs_FACE)) {
+    for (auto& shape : shape.getSubTopoShapes(TopAbs_FACE)) {
         std::vector<Base::Vector3d> points;
         std::vector<Data::ComplexGeoData::Facet> facets;
         shape.getFaces(points, facets, resolution);
@@ -233,64 +302,108 @@ static SimShape getMeshData(const Part::TopoShape& tshape, float resolution)
 void DlgCAMSimulator::setStockShape(const Part::TopoShape& shape, float resolution)
 {
     mStock = getMeshData(shape, resolution);
-}
 
-void DlgCAMSimulator::setBaseShape(const Part::TopoShape& tshape, float resolution)
-{
-    mBase = getMeshData(tshape, resolution);
-}
-
-void DlgCAMSimulator::mouseMoveEvent(QMouseEvent* ev)
-{
-    int modifiers = (ev->modifiers() & Qt::ShiftModifier) != 0 ? MS_KBD_SHIFT : 0;
-    modifiers |= (ev->modifiers() & Qt::ControlModifier) != 0 ? MS_KBD_CONTROL : 0;
-    modifiers |= (ev->modifiers() & Qt::AltModifier) != 0 ? MS_KBD_ALT : 0;
-
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QPoint pnt = ev->pos();
-#else
-    QPoint pnt = ev->position().toPoint();
-#endif
-
-    const qreal ratio = devicePixelRatioF();
-    mMillSimulator->MouseMove(pnt.x() * ratio, pnt.y() * ratio, modifiers);
+    if (mDummyViewer) {
+        mDummyViewer->setStockShape(shape);
+    }
 
     update();
 }
 
-void DlgCAMSimulator::mousePressEvent(QMouseEvent* ev)
+void DlgCAMSimulator::setStockVisible(bool b)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QPoint pnt = ev->pos();
-#else
-    QPoint pnt = ev->position().toPoint();
-#endif
+    if (b == mMillSimulator->IsStockVisible()) {
+        return;
+    }
 
-    const qreal ratio = devicePixelRatioF();
-    mMillSimulator->MousePress(ev->button(), true, pnt.x() * ratio, pnt.y() * ratio);
+    mMillSimulator->SetStockVisible(b);
+
+    if (mDummyViewer) {
+        mDummyViewer->setStockVisible(b);
+    }
 
     update();
 }
 
-void DlgCAMSimulator::mouseReleaseEvent(QMouseEvent* ev)
+void DlgCAMSimulator::setBaseShape(const Part::TopoShape& shape, float resolution)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QPoint pnt = ev->pos();
-#else
-    QPoint pnt = ev->position().toPoint();
-#endif
+    mBase = getMeshData(shape, resolution);
 
-    const qreal ratio = devicePixelRatioF();
-    mMillSimulator->MousePress(ev->button(), false, pnt.x() * ratio, pnt.y() * ratio);
+    if (mDummyViewer) {
+        mDummyViewer->setBaseShape(shape);
+    }
 
     update();
 }
 
-void DlgCAMSimulator::wheelEvent(QWheelEvent* ev)
+void DlgCAMSimulator::setBaseVisible(bool b)
 {
-    mMillSimulator->MouseScroll((float)ev->angleDelta().y() / MouseScrollDelta);
+    if (b == mMillSimulator->IsBaseVisible()) {
+        return;
+    }
+
+    mMillSimulator->SetBaseVisible(b);
+
+    if (mDummyViewer) {
+        mDummyViewer->setBaseVisible(b);
+    }
 
     update();
+}
+
+// this is very similar to DemoMode::getDirection in Gui/DemoMode.cpp
+
+static SbVec3f getRotationDirection(Gui::View3DInventorViewer* viewer)
+{
+    const SbVec3f viewAxis = {0, 0, -1};
+
+    SoCamera* cam = viewer->getSoRenderManager()->getCamera();
+    if (!cam) {
+        return viewAxis;
+    }
+    SbRotation rot = cam->orientation.getValue();
+    SbRotation inv = rot.inverse();
+    SbVec3f vec(viewAxis);
+    inv.multVec(vec, vec);
+    if (vec.length() < std::numeric_limits<float>::epsilon()) {
+        vec = viewAxis;
+    }
+    vec.normalize();
+    return vec;
+}
+
+void DlgCAMSimulator::setRotateEnabled(bool b)
+{
+    if (b) {
+        mDummyViewer->startSpinningAnimation(getRotationDirection(mDummyViewer), 0.5f);
+    }
+    else {
+        mDummyViewer->stopAnimating();
+    }
+}
+
+void DlgCAMSimulator::setBackgroundColor(const QColor& c)
+{
+    mMillSimulator->SetBackgroundColor({c.redF(), c.greenF(), c.blueF()});
+    update();
+}
+
+void DlgCAMSimulator::setPathColor(const QColor& normal, const QColor& rapid)
+{
+    const vec3 vnormal = {normal.redF(), normal.greenF(), normal.blueF()};
+    const vec3 vrapid = {rapid.redF(), rapid.greenF(), rapid.blueF()};
+    mMillSimulator->SetPathColor(vnormal, vrapid);
+}
+
+void DlgCAMSimulator::timerEvent(QTimerEvent* event)
+{
+    (void)event;
+
+    update();
+
+    // TODO: keep things simple for now, should probably only update gui if something changed
+
+    updateGui();
 }
 
 void DlgCAMSimulator::updateResources()
@@ -323,8 +436,13 @@ void DlgCAMSimulator::updateResources()
     // initialize simulator
 
     if (mNeedsInitialize) {
-        mMillSimulator->InitSimulation(mQuality);
+        // TODO: mStock is set when we arrive here, still this could be handled nicer
+        const float maxStockDimension = mStock.maxDimension();
+
+        mMillSimulator->InitSimulation(mQuality, maxStockDimension);
         mNeedsInitialize = false;
+
+        mLastProcessSim = clock::time_point::min();
     }
 
     // update stock and base
@@ -353,6 +471,16 @@ void DlgCAMSimulator::updateWindowScale()
     mMillSimulator->UpdateWindowScale(width() * ratio, height() * ratio);
 }
 
+void DlgCAMSimulator::updateCamera()
+{
+    if (!mDummyViewer) {
+        return;
+    }
+
+    const SoCamera& camera = *mDummyViewer->getCamera();
+    mMillSimulator->UpdateCamera(camera);
+}
+
 void DlgCAMSimulator::initializeGL()
 {
     gOpenGLFunctions.initializeOpenGLFunctions();
@@ -364,9 +492,35 @@ void DlgCAMSimulator::paintGL()
 
     // We need to call updateWindowScale on every render since the devicePixelRatio we get in
     // resizeGL might be wrong on the first resize.
-    updateWindowScale();
 
-    mMillSimulator->ProcessSim((unsigned int)(QDateTime::currentMSecsSinceEpoch()));
+    updateWindowScale();
+    updateCamera();
+
+    const auto now = clock::now();
+    const auto elapsed = mLastProcessSim != clock::time_point::min() ? now - mLastProcessSim : 0s;
+
+#if 0
+
+    static std::deque<clock::duration> q;
+    while (q.size() >= 60) {
+        q.pop_front();
+    }
+
+    q.push_back(elapsed);
+
+    const auto average = std::accumulate(q.begin(), q.end(), clock::duration()) / (float)q.size();
+
+    std::cerr
+        << "elapsed: "
+        << std::chrono::duration_cast<std::chrono::duration<float, std::milli>>(average).count()
+        << "ms" << std::endl;
+
+#endif
+
+
+    mMillSimulator->ProcessSim(elapsed);
+
+    mLastProcessSim = now;
 }
 
 void DlgCAMSimulator::resizeGL(int w, int h)

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.h
@@ -33,7 +33,6 @@
 
 #include <Mod/Part/App/TopoShape.h>
 #include <QOpenGLWidget>
-#include <QOpenGLExtraFunctions>
 #include <QPainter>
 #include <QTimer>
 #include <QExposeEvent>
@@ -76,7 +75,7 @@ public:
     float resolution;
 };
 
-class DlgCAMSimulator: public QOpenGLWidget, public QOpenGLExtraFunctions
+class DlgCAMSimulator: public QOpenGLWidget
 {
     Q_OBJECT
 

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.h
@@ -30,8 +30,8 @@
 
 #include <queue>
 #include <functional>
+#include <chrono>
 
-#include <Mod/Part/App/TopoShape.h>
 #include <QOpenGLWidget>
 #include <QPainter>
 #include <QTimer>
@@ -40,26 +40,32 @@
 #include <QMouseEvent>
 #include <QOpenGLContext>
 
-namespace CAMSimulator
-{
-// use short declaration as using 'include' causes a header loop
-class MillSimulation;
-class MillSimulationState;
-struct Vertex;
-}  // namespace CAMSimulator
+#include <Mod/Part/App/TopoShape.h>
+
+class SoCamera;
 
 namespace Gui
 {
 class MDIView;
-}
+class Document;
+}  // namespace Gui
 
 namespace CAMSimulator
 {
 
+// use short declaration as using 'include' causes a header loop
+class MillSimulation;
+class MillSimulationState;
+struct Vertex;
 class ViewCAMSimulator;
+class GuiDisplay;
+class Dummy3DViewer;
 
 struct SimShape
 {
+public:
+    float maxDimension() const;
+
 public:
     std::vector<Vertex> verts;
     std::vector<GLushort> indices;
@@ -79,17 +85,20 @@ class DlgCAMSimulator: public QOpenGLWidget
 {
     Q_OBJECT
 
+    typedef std::chrono::steady_clock clock;
+
 public:
-    explicit DlgCAMSimulator(ViewCAMSimulator& view, QWidget* parent = nullptr);
+    explicit DlgCAMSimulator(QWidget* parent = nullptr);
     ~DlgCAMSimulator() override;
 
+    void connectTo(GuiDisplay& gui, Dummy3DViewer& dv);
     void cloneFrom(const DlgCAMSimulator& from);
 
     static DlgCAMSimulator* instance();
 
     void setAnimating(bool animating);
     void startSimulation(const Part::TopoShape& stock, float quality);
-    void resetSimulation();
+    void resetSimulation(Gui::Document* doc);
 
     void addGcodeCommand(const char* cmd);
     void addTool(
@@ -99,27 +108,38 @@ public:
         float resolution
     );
 
-    void setStockShape(const Part::TopoShape& tshape, float resolution);
-    void setBaseShape(const Part::TopoShape& tshape, float resolution);
+    void setStockShape(const Part::TopoShape& shape, float resolution);
+    void setStockVisible(bool b);
+    void setBaseShape(const Part::TopoShape& shape, float resolution);
+    void setBaseVisible(bool b);
+
+    void setRotateEnabled(bool b);
+
+    void setBackgroundColor(const QColor& c);
+    void setPathColor(const QColor& normal, const QColor& rapid);
+
+Q_SIGNALS:
+    void documentChanged(Gui::Document* doc);
+    void simulationStarted();
 
 protected:
-    void mouseMoveEvent(QMouseEvent* ev) override;
-    void mousePressEvent(QMouseEvent* ev) override;
-    void mouseReleaseEvent(QMouseEvent* ev) override;
-    void wheelEvent(QWheelEvent* ev) override;
+    void timerEvent(QTimerEvent* event) override;
 
     void updateResources();
     void updateWindowScale();
+    void updateCamera();
 
     void initializeGL() override;
     void paintGL() override;
     void resizeGL(int w, int h) override;
 
+    void updateGui();
+
 private:
     bool mNeedsInitialize = false;
     bool mNeedsClear = false;
     bool mAnimating = false;
-    QTimer mAnimatingTimer;
+    int mAnimatingTimer = 0;
 
     std::unique_ptr<MillSimulation> mMillSimulator;
     float mQuality = 10;
@@ -129,12 +149,15 @@ private:
 
     std::vector<SimTool> mTools;
 
+    const SoCamera* mCamera = nullptr;
     SimShape mStock;
     SimShape mBase;
 
-    ViewCAMSimulator& mView;
-
     std::unique_ptr<MillSimulationState> mState;
+    clock::time_point mLastProcessSim = clock::time_point::min();
+
+    GuiDisplay* mGui = nullptr;
+    Dummy3DViewer* mDummyViewer = nullptr;
 };
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.h
@@ -41,13 +41,13 @@
 #include <QMouseEvent>
 #include <QOpenGLContext>
 
-namespace MillSim
+namespace CAMSimulator
 {
 // use short declaration as using 'include' causes a header loop
 class MillSimulation;
 class MillSimulationState;
 struct Vertex;
-}  // namespace MillSim
+}  // namespace CAMSimulator
 
 namespace Gui
 {
@@ -62,7 +62,7 @@ class ViewCAMSimulator;
 struct SimShape
 {
 public:
-    std::vector<MillSim::Vertex> verts;
+    std::vector<Vertex> verts;
     std::vector<GLushort> indices;
     bool needsUpdate = false;
 };
@@ -122,7 +122,7 @@ private:
     bool mAnimating = false;
     QTimer mAnimatingTimer;
 
-    std::unique_ptr<MillSim::MillSimulation> mMillSimulator;
+    std::unique_ptr<MillSimulation> mMillSimulator;
     float mQuality = 10;
 
     std::vector<std::string> mGCode;
@@ -135,7 +135,7 @@ private:
 
     ViewCAMSimulator& mView;
 
-    std::unique_ptr<MillSim::MillSimulationState> mState;
+    std::unique_ptr<MillSimulationState> mState;
 };
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/Dummy3DViewer.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/Dummy3DViewer.cpp
@@ -22,51 +22,57 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "Texture.h"
+#include "PreCompiled.h"
 
-// include this last as the defines can mess up other includes
-#include "OpenGlWrapper.h"
+#include "Dummy3DViewer.h"
+
+using namespace Gui;
 
 namespace CAMSimulator
 {
 
-Texture::~Texture()
+Dummy3DViewer::Dummy3DViewer(QWidget* parent)
+    : View3DInventorViewer(parent)
 {
-    DestroyTexture();
+    addViewProvider(&stockViewProvider);
+    addViewProvider(&baseViewProvider);
 }
 
-void Texture::DestroyTexture()
+void Dummy3DViewer::cloneFrom(Dummy3DViewer& viewer)
 {
-    GLDELETE_TEXTURE(mTextureId);
+    // move view providers from viewer to us
+
+    stockViewProvider = std::move(viewer.stockViewProvider);
+    baseViewProvider = std::move(viewer.baseViewProvider);
 }
 
-bool Texture::LoadImage(unsigned int* image, int _width, int _height)
+void Dummy3DViewer::setStockShape(const Part::TopoShape& shape)
 {
-    DestroyTexture();
-    width = _width;
-    height = _height;
-    glGenTextures(1, &mTextureId);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
+    stockViewProvider.setShape(shape);
 }
 
-bool Texture::Activate()
+void Dummy3DViewer::setStockVisible(bool b)
 {
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    return true;
+    stockViewProvider.setShapeVisible(b);
 }
 
-bool Texture::unbind()
+void Dummy3DViewer::setBaseShape(const Part::TopoShape& shape)
 {
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
+    baseViewProvider.setShape(shape);
+}
+
+void Dummy3DViewer::setBaseVisible(bool b)
+{
+    baseViewProvider.setShapeVisible(b);
+}
+
+void Dummy3DViewer::paintEvent(QPaintEvent* event)
+{
+    if (discardPaintEvent_) {
+        return;
+    }
+
+    View3DInventorViewer::paintEvent(event);
 }
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/Dummy3DViewer.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/Dummy3DViewer.h
@@ -22,51 +22,35 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "Texture.h"
+#pragma once
 
-// include this last as the defines can mess up other includes
-#include "OpenGlWrapper.h"
+#include "TopoShapeViewProvider.h"
+#include <Gui/View3DInventorViewer.h>
 
 namespace CAMSimulator
 {
 
-Texture::~Texture()
+class Dummy3DViewer: public Gui::View3DInventorViewer
 {
-    DestroyTexture();
-}
+public:
+    Dummy3DViewer(QWidget* parent = nullptr);
 
-void Texture::DestroyTexture()
-{
-    GLDELETE_TEXTURE(mTextureId);
-}
+    void cloneFrom(Dummy3DViewer& viewer);
 
-bool Texture::LoadImage(unsigned int* image, int _width, int _height)
-{
-    DestroyTexture();
-    width = _width;
-    height = _height;
-    glGenTextures(1, &mTextureId);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
-}
+    void setStockShape(const Part::TopoShape& shape);
+    void setStockVisible(bool b);
+    void setBaseShape(const Part::TopoShape& shape);
+    void setBaseVisible(bool b);
 
-bool Texture::Activate()
-{
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    return true;
-}
+protected:
+    void paintEvent(QPaintEvent* event) override;
 
-bool Texture::unbind()
-{
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
-}
+public:
+    bool discardPaintEvent_ = true;
+
+private:
+    TopoShapeViewProvider stockViewProvider;
+    TopoShapeViewProvider baseViewProvider;
+};
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/EndMill.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/EndMill.cpp
@@ -26,7 +26,8 @@
 
 #include "SimShapes.h"
 
-using namespace MillSim;
+namespace CAMSimulator
+{
 
 EndMill::EndMill(int toolid, float diameter)
 {
@@ -112,3 +113,5 @@ void EndMill::MirrorPointBuffer()
         profilePoints[j + 1] = profilePoints[i + 1];
     }
 }
+
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/EndMill.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/EndMill.cpp
@@ -24,8 +24,6 @@
 
 #include "EndMill.h"
 
-#include "SimShapes.h"
-
 namespace CAMSimulator
 {
 
@@ -98,7 +96,7 @@ void EndMill::GenerateDisplayLists(float quality)
     pathShape.ExtrudeProfileLinear(profilePoints.data(), nFullPoints, 0, 1, 0, 0, true, false);
 }
 
-unsigned int EndMill::GenerateArcSegmentDL(float radius, float angleRad, float zShift, Shape* retShape)
+unsigned int EndMill::GenerateArcSegmentDL(float radius, float angleRad, float zShift, Shape* retShape) const
 {
     int nFullPoints = PROFILE_BUFFER_POINTS(nPoints);
     retShape->ExtrudeProfileRadial(profilePoints.data(), nFullPoints, radius, angleRad, zShift, true, true);

--- a/src/Mod/CAM/PathSimulator/AppGL/EndMill.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/EndMill.h
@@ -33,6 +33,7 @@
 
 namespace CAMSimulator
 {
+
 class EndMill
 {
 public:
@@ -50,9 +51,10 @@ public:
     EndMill(const std::vector<float>& toolProfile, int toolid, float diameter);
     virtual ~EndMill();
     void GenerateDisplayLists(float quality);
-    unsigned int GenerateArcSegmentDL(float radius, float angleRad, float zShift, Shape* retShape);
+    unsigned int GenerateArcSegmentDL(float radius, float angleRad, float zShift, Shape* retShape) const;
 
 protected:
     void MirrorPointBuffer();
 };
+
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/EndMill.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/EndMill.h
@@ -31,7 +31,7 @@
 #define PROFILE_BUFFER_SIZE(npoints) (PROFILE_BUFFER_POINTS(npoints) * 2)
 #define MILL_HEIGHT 10
 
-namespace MillSim
+namespace CAMSimulator
 {
 class EndMill
 {
@@ -55,4 +55,4 @@ public:
 protected:
     void MirrorPointBuffer();
 };
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/GCodeParser.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/GCodeParser.cpp
@@ -30,7 +30,8 @@
 
 #include "GCodeParser.h"
 
-using namespace MillSim;
+namespace CAMSimulator
+{
 
 static char TokTypes[] = "GTXYZIJKR";
 
@@ -251,3 +252,5 @@ bool GCodeParser::AddLine(const char* ptr)
     }
     return res;
 }
+
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/GCodeParser.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/GCodeParser.cpp
@@ -30,6 +30,10 @@
 
 #include "GCodeParser.h"
 
+#include <cctype>
+#include <cstdio>
+#include <string>
+
 namespace CAMSimulator
 {
 
@@ -37,15 +41,19 @@ static char TokTypes[] = "GTXYZIJKR";
 
 GCodeParser::~GCodeParser()
 {
-    // Clear the vector
+    Clear();
+}
+
+void GCodeParser::Clear()
+{
     Operations.clear();
+    lastState = {};
+    lastTool = -1;
 }
 
 bool GCodeParser::Parse(const char* filename)
 {
-    Operations.clear();
-    lastState = {eNop, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    lastTool = -1;
+    Clear();
 
     FILE* fl;
     if ((fl = fopen(filename, "rt")) == nullptr) {
@@ -153,9 +161,23 @@ bool GCodeParser::ParseLine(const char* ptr)
     bool validMotion = false;
     bool exitLoop = false;
     int cmd = 0;
+
+    // By default GCode words are not sticky, except for some exceptions. We copy the needed
+    // parameters explicitly (instead of assigning the full lastState).
+
+    MillMotion newState;
+
+    newState.x = lastState.x;
+    newState.y = lastState.y;
+    newState.z = lastState.z;
+
+    newState.tool = lastState.tool;
+
+    newState.retract_mode = lastState.retract_mode;
+    newState.retract_z = lastState.retract_z;
+
     while (*ptr != 0 && !exitLoop) {
         ptr = GetNextToken(ptr, &token);
-        lastLastState = lastState;
         switch (token.letter) {
             case '*':
                 exitLoop = true;
@@ -164,62 +186,64 @@ bool GCodeParser::ParseLine(const char* ptr)
             case 'G':
                 cmd = token.ival;
                 if (cmd == 0 || cmd == 1) {
-                    lastState.cmd = eMoveLiner;
+                    newState.cmd = eMoveLiner;
                 }
                 else if (cmd == 2) {
-                    lastState.cmd = eRotateCW;
+                    newState.cmd = eRotateCW;
                 }
                 else if (cmd == 3) {
-                    lastState.cmd = eRotateCCW;
+                    newState.cmd = eRotateCCW;
                 }
                 else if (cmd == 73 || cmd == 81 || cmd == 82 || cmd == 83) {
-                    lastState.cmd = eDril;
-                    lastState.retract_z = lastState.z;
+                    newState.cmd = eDril;
+                    newState.retract_z = lastState.z;
                 }
                 else if (cmd == 98 || cmd == 99) {
-                    lastState.retract_mode = cmd;
+                    newState.retract_mode = cmd;
                 }
                 else if (cmd == 80) {
-                    lastState.retract_mode = 0;
+                    newState.retract_mode = 0;
                 }
                 break;
 
             case 'T':
-                lastState.tool = token.ival;
+                newState.tool = token.ival;
                 break;
 
             case 'X':
-                lastState.x = token.fval;
+                newState.x = token.fval;
                 validMotion = true;
                 break;
 
             case 'Y':
-                lastState.y = token.fval;
+                newState.y = token.fval;
                 validMotion = true;
                 break;
 
             case 'Z':
-                lastState.z = token.fval;
+                newState.z = token.fval;
                 validMotion = true;
                 break;
 
             case 'I':
-                lastState.i = token.fval;
+                newState.i = token.fval;
                 break;
 
             case 'J':
-                lastState.j = token.fval;
+                newState.j = token.fval;
                 break;
 
             case 'K':
-                lastState.k = token.fval;
+                newState.k = token.fval;
                 break;
 
             case 'R':
-                lastState.r = token.fval;
+                newState.r = token.fval;
                 break;
         }
     }
+
+    lastState = newState;
     return validMotion;
 }
 

--- a/src/Mod/CAM/PathSimulator/AppGL/GCodeParser.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/GCodeParser.h
@@ -23,11 +23,13 @@
  ***************************************************************************/
 
 #pragma once
+
 #include "MillMotion.h"
 #include <vector>
 
 namespace CAMSimulator
 {
+
 struct GCToken
 {
     char letter;
@@ -41,13 +43,15 @@ public:
     GCodeParser()
     {}
     virtual ~GCodeParser();
+
+    void Clear();
+
     bool Parse(const char* filename);
     bool AddLine(const char* ptr);
 
 public:
     std::vector<MillMotion> Operations;
-    MillMotion lastState = {eNop, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    MillMotion lastLastState = {eNop, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    MillMotion lastState;
 
 protected:
     const char* GetNextToken(const char* ptr, GCToken* token);
@@ -56,4 +60,5 @@ protected:
     bool ParseLine(const char* ptr);
     int lastTool = -1;
 };
+
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/GCodeParser.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/GCodeParser.h
@@ -26,7 +26,7 @@
 #include "MillMotion.h"
 #include <vector>
 
-namespace MillSim
+namespace CAMSimulator
 {
 struct GCToken
 {
@@ -56,4 +56,4 @@ protected:
     bool ParseLine(const char* ptr);
     int lastTool = -1;
 };
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/GlUtils.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/GlUtils.cpp
@@ -24,9 +24,9 @@
 
 #include "GlUtils.h"
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 const mat4x4 identityMat = {{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}};
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/GlUtils.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/GlUtils.h
@@ -36,9 +36,9 @@ constexpr auto EPSILON = 0.00001f;
 #define MS_KBD_CONTROL 0x10
 #define MS_KBD_ALT 0x20
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 extern const mat4x4 identityMat;
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.cpp
@@ -24,13 +24,9 @@
 
 #include "GuiDisplay.h"
 
-#include "DlgCAMSimulator.h"
-#include "GlUtils.h"
-#include "MillSimulation.h"
-#include <cstddef>
-#include <QToolTip>
-#include <QPoint>
-#include <QCoreApplication>
+#include "ui_GuiDisplay.h"
+#include <cmath>
+#include <limits>
 
 // include this last as the defines can mess up other includes
 #include "OpenGlWrapper.h"
@@ -38,448 +34,181 @@
 namespace CAMSimulator
 {
 
-// clang-format off
-// NOLINTBEGIN(*-magic-numbers)
-static const std::vector<DefaultGuiItem> defaultGuiItems = {
-    {.name=eGuiItemSlider, .vbo=0, .sx=28, .sy=-80, .actionKey=0, .hidden=false, .flags=0},
-    {.name=eGuiItemThumb, .vbo=0, .sx=328, .sy=-94, .actionKey=1, .hidden=false, .flags=0},
-    {.name=eGuiItemPause, .vbo=0, .sx=28, .sy=-50, .actionKey='P', .hidden=true, .flags=0},
-    {.name=eGuiItemPlay, .vbo=0, .sx=28, .sy=-50, .actionKey='S', .hidden=false, .flags=0},
-    {.name=eGuiItemSingleStep, .vbo=0, .sx=68, .sy=-50, .actionKey='T', .hidden=false, .flags=0},
-    {.name=eGuiItemSlower, .vbo=0, .sx=113, .sy=-50, .actionKey=' ', .hidden=false, .flags=0},
-    {.name=eGuiItemFaster, .vbo=0, .sx=158, .sy=-50, .actionKey='F', .hidden=false, .flags=0},
-    {.name=eGuiItemX, .vbo=0, .sx=208, .sy=-45, .actionKey=0, .hidden=false, .flags=0},
-    {.name=eGuiItem1, .vbo=0, .sx=230, .sy=-50, .actionKey=0, .hidden=false, .flags=0},
-    {.name=eGuiItem5, .vbo=0, .sx=230, .sy=-50, .actionKey=0, .hidden=true, .flags=0},
-    {.name=eGuiItem10, .vbo=0, .sx=230, .sy=-50, .actionKey=0, .hidden=true, .flags=0},
-    {.name=eGuiItem25, .vbo=0, .sx=230, .sy=-50, .actionKey=0, .hidden=true, .flags=0},
-    {.name=eGuiItem50, .vbo=0, .sx=230, .sy=-50, .actionKey=0, .hidden=true, .flags=0},
-    {.name=eGuiItemRotate, .vbo=0, .sx=-140, .sy=-50, .actionKey=' ', .hidden=false, .flags=GUIITEM_CHECKABLE},
-    {.name=eGuiItemPath, .vbo=0, .sx=-100, .sy=-50, .actionKey='L', .hidden=false, .flags=GUIITEM_CHECKABLE},
-    {.name=eGuiItemAmbientOclusion, .vbo=0, .sx=-60, .sy=-50, .actionKey='A', .hidden=false, .flags=GUIITEM_CHECKABLE},
-    {.name=eGuiItemView, .vbo=0, .sx=-180, .sy=-50, .actionKey='V', .hidden=false, .flags=0},
-    {.name=eGuiItemHome, .vbo=0, .sx=-220, .sy=-50, .actionKey='H', .hidden=false, .flags=0},
-};
-// NOLINTEND(*-magic-numbers)
-// clang-format on
-
-#define TEX_SIZE 256
-
-static const std::vector<std::string> guiFileNames = {
-    "Slider.png",
-    "Thumb.png",
-    "Pause.png",
-    "Play.png",
-    "SingleStep.png",
-    "Slower.png",
-    "Faster.png",
-    "x.png",
-    "1.png",
-    "5.png",
-    "10.png",
-    "25.png",
-    "50.png",
-    "Rotate.png",
-    "Path.png",
-    "AmbientOclusion.png",
-    "View.png",
-    "Home.png"
-};
-
-GuiItem::GuiItem(const DefaultGuiItem& item, GuiDisplay& d)
-    : DefaultGuiItem(item)
-    , display(d)
-{}
-
-int GuiItem::posx()
+GuiDisplay::GuiDisplay(QWidget* parent)
+    : QWidget(parent)
+    , ui(new Ui_GuiDisplay)
 {
-    return sx >= 0 ? sx : display.width() + sx;
+    ui->setupUi(this);
+
+    playing = true;
+    setPlaying(false);
+
+    speed = 0;
+    setSpeed(1);
+
+    connect(ui->slowerButton, &QToolButton::clicked, this, &GuiDisplay::onSlowerFasterButtonClicked);
+    connect(ui->fasterButton, &QToolButton::clicked, this, &GuiDisplay::onSlowerFasterButtonClicked);
+    connect(ui->viewAllButton, &QToolButton::clicked, this, &GuiDisplay::viewAll);
+    connect(ui->rotateButton, &QToolButton::toggled, this, &GuiDisplay::rotateEnableChanged);
+    connect(ui->pathButton, &QToolButton::toggled, this, &GuiDisplay::pathVisibleChanged);
+    connect(ui->ssaoButton, &QToolButton::toggled, this, &GuiDisplay::ssaoEnableChanged);
 }
 
-int GuiItem::posy()
+GuiDisplay::~GuiDisplay()
 {
-    return sy >= 0 ? sy : display.height() + sy;
+    delete ui;
 }
 
-void GuiItem::setPosx(int x)
+void GuiDisplay::resizeEvent(QResizeEvent* event)
 {
-    sx = sx >= 0 ? x : x - display.width();
+    QWidget::resizeEvent(event);
+    setMask(childrenRegion());
 }
 
-void GuiItem::setPosy(int y)
+void GuiDisplay::setPlaying(bool b)
 {
-    sy = sy >= 0 ? y : y - display.height();
-}
-
-GuiDisplay::GuiDisplay()
-{
-    for (auto& item : defaultGuiItems) {
-        mItems.emplace_back(item, *this);
-    }
-}
-
-void GuiDisplay::UpdateProjection()
-{
-    mat4x4 projmat;
-    // mat4x4 viewmat;
-    mat4x4_ortho(projmat, 0, mWidth, mHeight, 0, -1, 1);
-    mShader.Activate();
-    mShader.UpdateProjectionMat(projmat);
-    mThumbMaxMotion = mItems[eGuiItemAmbientOclusion].posx()
-        + mItems[eGuiItemAmbientOclusion].texItem.w
-        - mItems[eGuiItemSlider].posx();  // - guiItems[eGuiItemThumb].texItem.w;
-    HStretchGlItem(&(mItems[eGuiItemSlider]), mThumbMaxMotion, 10.0f);
-}
-
-bool GuiDisplay::GenerateGlItem(GuiItem* guiItem)
-{
-    Vertex2D verts[4];
-    int x = guiItem->texItem.tx;
-    int y = guiItem->texItem.ty;
-    int w = guiItem->texItem.w;
-    int h = guiItem->texItem.h;
-
-    verts[0] = {0, (float)h, mTexture.getTexX(x), mTexture.getTexY(y + h)};
-    verts[1] = {(float)w, (float)h, mTexture.getTexX(x + w), mTexture.getTexY(y + h)};
-    verts[2] = {0, 0, mTexture.getTexX(x), mTexture.getTexY(y)};
-    verts[3] = {(float)w, 0, mTexture.getTexX(x + w), mTexture.getTexY(y)};
-
-    // vertex buffer
-    glGenBuffers(1, &(guiItem->vbo));
-    glBindBuffer(GL_ARRAY_BUFFER, guiItem->vbo);
-    glBufferData(GL_ARRAY_BUFFER, 4 * sizeof(Vertex2D), verts, GL_STATIC_DRAW);
-
-    return true;
-}
-
-bool GuiDisplay::HStretchGlItem(GuiItem* guiItem, float newWidth, float edgeWidth)
-{
-    if (guiItem->vbo == 0) {
-        return false;
-    }
-
-    DestroyGlItem(guiItem);
-    Vertex2D verts[12];
-
-    int x = guiItem->texItem.tx;
-    int y = guiItem->texItem.ty;
-    int h = guiItem->texItem.h;
-    int w = guiItem->texItem.w;
-
-    // left edge
-    verts[0] = {0, (float)h, mTexture.getTexX(x), mTexture.getTexY(y + h)};
-    verts[1] = {edgeWidth, (float)h, mTexture.getTexX(x + edgeWidth), mTexture.getTexY(y + h)};
-    verts[2] = {0, 0, mTexture.getTexX(x), mTexture.getTexY(y)};
-    verts[3] = {edgeWidth, 0, mTexture.getTexX(x + edgeWidth), mTexture.getTexY(y)};
-
-    // right edge
-    float px = newWidth - edgeWidth;
-    verts[4] = {px, (float)h, mTexture.getTexX(x + w - edgeWidth), mTexture.getTexY(y + h)};
-    verts[5] = {newWidth, (float)h, mTexture.getTexX(x + w), mTexture.getTexY(y + h)};
-    verts[6] = {px, 0, mTexture.getTexX(x + w - edgeWidth), mTexture.getTexY(y)};
-    verts[7] = {newWidth, 0, mTexture.getTexX(x + w), mTexture.getTexY(y)};
-
-    // center
-    verts[8] = {edgeWidth, (float)h, mTexture.getTexX(x + edgeWidth), mTexture.getTexY(y + h)};
-    verts[9] = {px, (float)h, mTexture.getTexX(x + w - edgeWidth), mTexture.getTexY(y + h)};
-    verts[10] = {edgeWidth, 0, mTexture.getTexX(x + edgeWidth), mTexture.getTexY(y)};
-    verts[11] = {px, 0, mTexture.getTexX(x + w - edgeWidth), mTexture.getTexY(y)};
-
-    guiItem->flags |= GUIITEM_STRETCHED;
-
-    // vertex buffer
-    glGenBuffers(1, &(guiItem->vbo));
-    glBindBuffer(GL_ARRAY_BUFFER, guiItem->vbo);
-    glBufferData(GL_ARRAY_BUFFER, 12 * sizeof(Vertex2D), verts, GL_STATIC_DRAW);
-
-    return true;
-}
-
-void GuiDisplay::SetupVertexAttribs(GuiItem* guiItem)
-{
-    glBindBuffer(GL_ARRAY_BUFFER, guiItem->vbo);
-
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex2D), (void*)offsetof(Vertex2D, x));
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex2D), (void*)offsetof(Vertex2D, tx));
-}
-
-void GuiDisplay::DestroyGlItem(GuiItem* guiItem)
-{
-    GLDELETE_BUFFER((guiItem->vbo));
-}
-
-bool GuiDisplay::InitGui()
-{
-    if (guiInitiated) {
-        return true;
-    }
-
-    // index buffer
-    SetupTooltips();
-    glGenBuffers(1, &mIbo);
-    GLshort indices[18] = {0, 2, 3, 0, 3, 1, 4, 6, 7, 4, 7, 5, 8, 10, 11, 8, 11, 9};
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mIbo);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, 18 * sizeof(GLushort), indices, GL_STATIC_DRAW);
-    TextureLoader tLoader(":/gl_simulator/", guiFileNames, TEX_SIZE);
-    unsigned int* buffer = tLoader.GetRawData();
-    if (buffer == nullptr) {
-        return false;
-    }
-    mTexture.LoadImage(buffer, TEX_SIZE, TEX_SIZE);
-    for (unsigned int i = 0; i < mItems.size(); i++) {
-        auto& item = mItems[i];
-        item.texItem = *tLoader.GetTextureItem(i);
-        GenerateGlItem(&item);
-    }
-
-    mThumbStartX = mItems[eGuiItemSlider].posx() - mItems[eGuiItemThumb].texItem.w / 2;
-    mThumbMaxMotion = (float)mItems[eGuiItemSlider].texItem.w;
-
-    // init shader
-    mShader.CompileShader("GuiDisplay", (char*)VertShader2DTex, (char*)FragShader2dTex);
-    mShader.UpdateTextureSlot(0);
-
-    UpdatePlayState(false);
-    UpdateSimSpeed(1);
-    guiInitiated = true;
-
-    UpdateWindowScale(800, 600);
-    return true;
-}
-
-void GuiDisplay::ResetGui()
-{
-    mShader.Destroy();
-    for (auto& item : mItems) {
-        DestroyGlItem(&item);
-    }
-    mTexture.DestroyTexture();
-    GLDELETE_BUFFER(mIbo);
-    guiInitiated = false;
-}
-
-void GuiDisplay::RenderItem(int itemId)
-{
-    GuiItem* item = &(mItems[itemId]);
-    if (item->hidden) {
+    if (b == playing) {
         return;
     }
 
-    mat4x4 model;
-    mat4x4_translate(model, (float)item->posx(), (float)item->posy(), 0);
-    mShader.UpdateModelMat(model, {});
-    if (item == mPressedItem) {
-        mShader.UpdateObjColor(mPressedColor);
-    }
-    else if (item->mouseOver) {
-        mShader.UpdateObjColor(mHighlightColor);
-    }
-    else if (itemId > 1 && item->actionKey == 0) {
-        mShader.UpdateObjColor(mTextColor);
-    }
-    else if (item->flags & GUIITEM_CHECKED) {
-        mShader.UpdateObjColor(mToggleColor);
-    }
-    else {
-        mShader.UpdateObjColor(mStdColor);
-    }
+    playing = b;
 
-    SetupVertexAttribs(item);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mIbo);
-    int nTriangles = (item->flags & GUIITEM_STRETCHED) == 0 ? 6 : 18;
-    glDrawElements(GL_TRIANGLES, nTriangles, GL_UNSIGNED_SHORT, nullptr);
+    const auto icon = playing ? ":/gl_simulator/Pause.png" : ":/gl_simulator/Play.png";
+    ui->playButton->setIcon(QIcon(QString::fromUtf8(icon)));
 }
 
-void GuiDisplay::SetupTooltips()
+void GuiDisplay::on_playButton_clicked()
 {
-    mItems[eGuiItemPause].toolTip
-        = QCoreApplication::translate("CAM:Simulator:Tooltips", "Pause simulation", nullptr);
-    mItems[eGuiItemPlay].toolTip
-        = QCoreApplication::translate("CAM:Simulator:Tooltips", "Play simulation", nullptr);
-    mItems[eGuiItemSingleStep].toolTip
-        = QCoreApplication::translate("CAM:Simulator:Tooltips", "Single step simulation", nullptr);
-    mItems[eGuiItemSlower].toolTip
-        = QCoreApplication::translate("CAM:Simulator:Tooltips", "Decrease simulation speed", nullptr);
-    mItems[eGuiItemFaster].toolTip
-        = QCoreApplication::translate("CAM:Simulator:Tooltips", "Increase simulation speed", nullptr);
-    mItems[eGuiItemPath].toolTip
-        = QCoreApplication::translate("CAM:Simulator:Tooltips", "Show/Hide tool path", nullptr);
-    mItems[eGuiItemRotate].toolTip = QCoreApplication::translate(
-        "CAM:Simulator:Tooltips",
-        "Toggle turn table animation",
-        nullptr
-    );
-    mItems[eGuiItemAmbientOclusion].toolTip
-        = QCoreApplication::translate("CAM:Simulator:Tooltips", "Toggle ambient occlusion", nullptr);
-    mItems[eGuiItemView].toolTip = QCoreApplication::translate(
-        "CAM:Simulator:Tooltips",
-        "Toggle view simulation/model",
-        nullptr
-    );
-    mItems[eGuiItemHome].toolTip
-        = QCoreApplication::translate("CAM:Simulator:Tooltips", "Reset camera", nullptr);
+    setPlaying(!playing);
+    Q_EMIT play(playing);
 }
 
-void GuiDisplay::MouseCursorPos(int x, int y)
+void GuiDisplay::on_singleStepButton_clicked()
 {
-    GuiItem* prevMouseOver = mMouseOverItem;
-    mMouseOverItem = nullptr;
-    for (auto& item : mItems) {
-        if (item.actionKey == 0) {
-            continue;
-        }
-        bool mouseCursorContained = x > item.posx() && x < (item.posx() + item.texItem.w)
-            && y > item.posy() && y < (item.posy() + item.texItem.h);
-
-        item.mouseOver = !item.hidden && mouseCursorContained;
-
-        if (item.mouseOver) {
-            mMouseOverItem = &item;
-        }
-    }
-    if (mMouseOverItem != prevMouseOver) {
-        if (mMouseOverItem != nullptr && !mMouseOverItem->toolTip.isEmpty()) {
-            const QWidget* w = DlgCAMSimulator::instance();
-            const float ratio = w->devicePixelRatioF();
-            const QPoint pos(x / ratio, y / ratio);
-            const QPoint globPos = w->mapToGlobal(pos);
-            QToolTip::showText(globPos, mMouseOverItem->toolTip);
-        }
-        else {
-            QToolTip::hideText();
-        }
-    }
+    setPlaying(false);
+    Q_EMIT singleStep();
 }
 
-void GuiDisplay::HandleActionItem(GuiItem* guiItem)
+void GuiDisplay::setSpeed(int s)
 {
-    if (guiItem->actionKey >= ' ') {
-        if (guiItem->flags & GUIITEM_CHECKABLE) {
-            guiItem->flags ^= GUIITEM_CHECKED;
-        }
-        bool isChecked = (guiItem->flags & GUIITEM_CHECKED) != 0;
-        mMillSim->HandleGuiAction(guiItem->name, isChecked);
-    }
-}
-
-void GuiDisplay::MousePressed(int button, bool isPressed, bool isSimRunning)
-{
-    if (button == MS_MOUSE_LEFT) {
-        if (isPressed) {
-            if (mMouseOverItem != nullptr) {
-                mPressedItem = mMouseOverItem;
-                HandleActionItem(mPressedItem);
-            }
-        }
-        else  // button released
-        {
-            UpdatePlayState(isSimRunning);
-            if (mPressedItem != nullptr) {
-                MouseCursorPos(mPressedItem->posx() + 1, mPressedItem->posy() + 1);
-                mPressedItem = nullptr;
-            }
-        }
-    }
-}
-
-void GuiDisplay::MouseDrag(int /* buttons */, int dx, int /* dy */)
-{
-    if (mPressedItem == nullptr) {
-        return;
-    }
-    if (mPressedItem->name == eGuiItemThumb) {
-        int newx = mPressedItem->posx() + dx;
-        if (newx < mThumbStartX) {
-            newx = mThumbStartX;
-        }
-        if (newx > ((int)mThumbMaxMotion + mThumbStartX)) {
-            newx = (int)mThumbMaxMotion + mThumbStartX;
-        }
-        if (newx != mPressedItem->posx()) {
-            mMillSim->SetSimulationStage((float)(newx - mThumbStartX) / mThumbMaxMotion);
-            mPressedItem->setPosx(newx);
-        }
-    }
-}
-
-void GuiDisplay::SetMillSimulator(MillSimulation* millSim)
-{
-    mMillSim = millSim;
-}
-
-void GuiDisplay::UpdatePlayState(bool isRunning)
-{
-    mItems[eGuiItemPause].hidden = !isRunning;
-    mItems[eGuiItemPlay].hidden = isRunning;
-}
-
-void GuiDisplay::UpdateSimSpeed(int speed)
-{
-    mItems[eGuiItem1].hidden = speed != 1;
-    mItems[eGuiItem5].hidden = speed != 5;
-    mItems[eGuiItem10].hidden = speed != 10;
-    mItems[eGuiItem25].hidden = speed != 25;
-    mItems[eGuiItem50].hidden = speed != 50;
-}
-
-void GuiDisplay::HandleKeyPress(int key)
-{
-    for (auto& item : mItems) {
-        if (item.actionKey == key) {
-            HandleActionItem(&item);
-        }
-    }
-}
-
-bool GuiDisplay::IsChecked(eGuiItems item)
-{
-    return (mItems[item].flags & GUIITEM_CHECKED) != 0;
-}
-
-void GuiDisplay::UpdateWindowScale(int width, int height)
-{
-    if (!guiInitiated || (width == mWidth && height == mHeight)) {
+    if (s == speed) {
         return;
     }
 
-    mWidth = width;
-    mHeight = height;
-
-    UpdateProjection();
+    speed = s;
+    ui->speedLabel->setText(tr("x%1").arg(speed));
 }
 
-int GuiDisplay::width() const
+static const std::vector<int> speeds = {1, 2, 5, 10, 25, 50};
+
+std::vector<int>::const_iterator findNearestSpeed(int speed)
 {
-    return mWidth;
+    int dist = std::numeric_limits<int>::max();
+    auto ret = speeds.cend();
+
+    for (auto it = speeds.cbegin(); it != speeds.cend(); it++) {
+        const int curdist = std::abs(*it - speed);
+        if (curdist < dist) {
+            dist = curdist;
+            ret = it;
+        }
+    }
+
+    return ret;
 }
 
-int GuiDisplay::height() const
+void GuiDisplay::onSlowerFasterButtonClicked()
 {
-    return mHeight;
+    auto it = findNearestSpeed(speed);
+
+    const bool slower = sender() == ui->slowerButton;
+    const bool faster = !slower;
+
+    if (slower && it != speeds.begin()) {
+        it--;
+    }
+    else if (faster && it != (speeds.end() - 1)) {
+        it++;
+    }
+
+    setSpeed(*it);
+    Q_EMIT speedChanged(*it);
 }
 
-void GuiDisplay::Render(float progress)
+void GuiDisplay::setStage(float f, int total)
 {
-    if (!guiInitiated) {
-        return;
+    ui->stageSlider->setMaximum(total);
+    ui->stageSlider->setValue(f * total);
+}
+
+void GuiDisplay::on_stageSlider_sliderMoved(int value)
+{
+    const float f = (float)value / ui->stageSlider->maximum();
+    Q_EMIT stageChanged(f);
+}
+
+void GuiDisplay::setStockVisible(bool b)
+{
+    stockVisible = b;
+
+    QSignalBlocker blocker(ui->stockModelButton);
+    ui->stockModelButton->setChecked(stockVisible && baseVisible);
+}
+
+void GuiDisplay::setBaseVisible(bool b)
+{
+    baseVisible = b;
+
+    QSignalBlocker blocker(ui->stockModelButton);
+    ui->stockModelButton->setChecked(stockVisible && baseVisible);
+}
+
+void GuiDisplay::on_stockModelButton_clicked()
+{
+    // stock -> base -> both
+    //   ^---------------'
+
+    bool sv, bv;
+
+    if (stockVisible == baseVisible) {
+        sv = true;
+        bv = false;
+    }
+    else if (!baseVisible) {
+        sv = false;
+        bv = true;
+    }
+    else if (!stockVisible) {
+        sv = true;
+        bv = true;
     }
 
-    if (mPressedItem == nullptr || mPressedItem->name != eGuiItemThumb) {
-        mItems[eGuiItemThumb].setPosx((int)(mThumbMaxMotion * progress) + mThumbStartX);
+    if (sv != stockVisible) {
+        setStockVisible(sv);
+        Q_EMIT stockVisibleChanged(sv);
     }
-    glDisable(GL_CULL_FACE);
-    glDisable(GL_DEPTH_TEST);
 
-    mTexture.Activate();
-    mShader.Activate();
-    mShader.UpdateTextureSlot(0);
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    for (int i = 0; i < (int)mItems.size(); i++) {
-        RenderItem(i);
+    if (bv != baseVisible) {
+        setBaseVisible(bv);
+        Q_EMIT baseVisibleChanged(bv);
     }
+}
+
+void GuiDisplay::setRotateEnabled(bool b)
+{
+    ui->rotateButton->setChecked(b);
+}
+
+void GuiDisplay::setPathVisible(bool b)
+{
+    QSignalBlocker blocker(ui->pathButton);
+    ui->pathButton->setChecked(b);
+}
+
+void GuiDisplay::setSsaoEnabled(bool b)
+{
+    QSignalBlocker blocker(ui->ssaoButton);
+    ui->ssaoButton->setChecked(b);
 }
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.cpp
@@ -34,7 +34,8 @@
 // include this last as the defines can mess up other includes
 #include "OpenGlWrapper.h"
 
-using namespace MillSim;
+namespace CAMSimulator
+{
 
 // clang-format off
 // NOLINTBEGIN(*-magic-numbers)
@@ -339,7 +340,7 @@ void GuiDisplay::MouseCursorPos(int x, int y)
     }
     if (mMouseOverItem != prevMouseOver) {
         if (mMouseOverItem != nullptr && !mMouseOverItem->toolTip.isEmpty()) {
-            const QWidget* w = CAMSimulator::DlgCAMSimulator::instance();
+            const QWidget* w = DlgCAMSimulator::instance();
             const float ratio = w->devicePixelRatioF();
             const QPoint pos(x / ratio, y / ratio);
             const QPoint globPos = w->mapToGlobal(pos);
@@ -479,3 +480,5 @@ void GuiDisplay::Render(float progress)
         RenderItem(i);
     }
 }
+
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.cpp
@@ -24,6 +24,7 @@
 
 #include "GuiDisplay.h"
 
+#include "DlgCAMSimulator.h"
 #include "GlUtils.h"
 #include "MillSimulation.h"
 #include <cstddef>

--- a/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.h
@@ -24,131 +24,63 @@
 
 #pragma once
 
-#include "Texture.h"
-#include "Shader.h"
-#include "TextureLoader.h"
-#include <QString>
+#include <QWidget>
 
 namespace CAMSimulator
 {
-class MillSimulation;
+class Ui_GuiDisplay;
 
-enum eGuiItems
+class GuiDisplay: public QWidget
 {
-    eGuiItemSlider,
-    eGuiItemThumb,
-    eGuiItemPause,
-    eGuiItemPlay,
-    eGuiItemSingleStep,
-    eGuiItemSlower,
-    eGuiItemFaster,
-    eGuiItemX,
-    eGuiItem1,
-    eGuiItem5,
-    eGuiItem10,
-    eGuiItem25,
-    eGuiItem50,
-    eGuiItemRotate,
-    eGuiItemPath,
-    eGuiItemAmbientOclusion,
-    eGuiItemView,
-    eGuiItemHome,
-    eGuiItemMax  // this element must be the last item always
-};
-
-struct DefaultGuiItem
-{
-    eGuiItems name;
-    unsigned int vbo = 0;
-    int sx, sy;      // screen location
-    int actionKey;   // action key when item pressed
-    bool hidden {};  // is item hidden
-    unsigned int flags {};
-};
-
-class GuiDisplay;
-
-class GuiItem: public DefaultGuiItem
-{
-public:
-    explicit GuiItem(const DefaultGuiItem& item, GuiDisplay& d);
-
-    int posx();
-    int posy();
-    void setPosx(int x);
-    void setPosy(int y);
+    Q_OBJECT
 
 public:
-    bool mouseOver {};
-    TextureItem texItem {};
-    QString toolTip {};
+    explicit GuiDisplay(QWidget* parent = nullptr);
+    ~GuiDisplay();
 
-    GuiDisplay& display;
-};
+    void setPlaying(bool b);
+    void setSpeed(int s);
+    void setStage(float f, int total);
 
-#define GUIITEM_CHECKABLE 0x01
-#define GUIITEM_CHECKED 0x02
-#define GUIITEM_STRETCHED 0x04
+    void setStockVisible(bool b);
+    void setBaseVisible(bool b);
+    void setRotateEnabled(bool b);
+    void setPathVisible(bool b);
+    void setSsaoEnabled(bool b);
 
-struct Vertex2D
-{
-    float x, y;
-    float tx, ty;
-};
+Q_SIGNALS:
+    void play(bool b);
+    void singleStep();
+    void speedChanged(int s);
+    void stageChanged(float f);
 
-class GuiDisplay
-{
-public:
-    GuiDisplay();
+    void viewAll();
+    void stockVisibleChanged(bool b);
+    void baseVisibleChanged(bool b);
+    void rotateEnableChanged(bool b);
+    void pathVisibleChanged(bool b);
+    void ssaoEnableChanged(bool b);
 
-    bool InitGui();
-    void ResetGui();
-    void Render(float progress);
-    void MouseCursorPos(int x, int y);
-    void HandleActionItem(GuiItem* guiItem);
-    void MousePressed(int button, bool isPressed, bool isRunning);
-    void MouseDrag(int buttons, int dx, int dy);
-    void SetMillSimulator(MillSimulation* millSim);
-    void UpdatePlayState(bool isRunning);
-    void UpdateSimSpeed(int speed);
-    void HandleKeyPress(int key);
-    bool IsChecked(eGuiItems item);
-    void UpdateWindowScale(int width, int height);
+protected:
+    void resizeEvent(QResizeEvent* event) override;
 
-    int width() const;
-    int height() const;
+private Q_SLOTS:
+    void on_playButton_clicked();
+    void on_singleStepButton_clicked();
 
-public:
-    bool guiInitiated = false;
+    void onSlowerFasterButtonClicked();
+    void on_stageSlider_sliderMoved(int value);
+
+    void on_stockModelButton_clicked();
 
 private:
-    void UpdateProjection();
-    bool GenerateGlItem(GuiItem* guiItem);
-    bool HStretchGlItem(GuiItem* guiItem, float newWidth, float edgeWidth);
-    void SetupVertexAttribs(GuiItem* guiItem);
-    void DestroyGlItem(GuiItem* guiItem);
-    void RenderItem(int itemId);
-    void SetupTooltips();
+    Ui_GuiDisplay* ui;
 
-    std::vector<GuiItem> mItems;
+    bool playing = true;
+    int speed = 1;
 
-    int mWidth = -1;
-    int mHeight = -1;
-
-    vec3 mStdColor = {0.8f, 0.8f, 0.4f};
-    vec3 mToggleColor = {0.9f, 0.6f, 0.2f};
-    vec3 mHighlightColor = {1.0f, 1.0f, 0.9f};
-    vec3 mPressedColor = {1.0f, 0.5f, 0.0f};
-    vec3 mTextColor = {1.0f, 0.5f, 0.0f};
-
-    Shader mShader;
-    Texture mTexture;
-    GuiItem* mPressedItem = nullptr;
-    GuiItem* mMouseOverItem = nullptr;
-    MillSimulation* mMillSim = nullptr;
-    unsigned int mIbo = 0;
-    int mThumbStartX = 0;
-    float mThumbMaxMotion = 0;
+    bool stockVisible = true;
+    bool baseVisible = false;
 };
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.h
@@ -29,7 +29,7 @@
 #include "TextureLoader.h"
 #include <QString>
 
-namespace MillSim
+namespace CAMSimulator
 {
 class MillSimulation;
 
@@ -151,4 +151,4 @@ private:
     float mThumbMaxMotion = 0;
 };
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.ui
+++ b/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.ui
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CAMSimulator::GuiDisplay</class>
+ <widget class="QWidget" name="CAMSimulator::GuiDisplay">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>417</width>
+    <height>337</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>259</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QSlider" name="stageSlider">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="playButton">
+       <property name="toolTip">
+        <string>Play simulation</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../Gui/Resources/Path.qrc">
+         <normaloff>:/gl_simulator/Play.png</normaloff>:/gl_simulator/Play.png</iconset>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="singleStepButton">
+       <property name="toolTip">
+        <string>Single step simulation</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../Gui/Resources/Path.qrc">
+         <normaloff>:/gl_simulator/SingleStep.png</normaloff>:/gl_simulator/SingleStep.png</iconset>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="slowerButton">
+       <property name="toolTip">
+        <string>Decrease simulation speed</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../Gui/Resources/Path.qrc">
+         <normaloff>:/gl_simulator/Slower.png</normaloff>:/gl_simulator/Slower.png</iconset>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="fasterButton">
+       <property name="toolTip">
+        <string>Increase simulation speed</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../Gui/Resources/Path.qrc">
+         <normaloff>:/gl_simulator/Faster.png</normaloff>:/gl_simulator/Faster.png</iconset>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="speedLabel">
+       <property name="styleSheet">
+        <string notr="true">color:white</string>
+       </property>
+       <property name="text">
+        <string>x1</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="viewAllButton">
+       <property name="toolTip">
+        <string>Reset camera</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../Gui/Resources/Path.qrc">
+         <normaloff>:/gl_simulator/Home.png</normaloff>:/gl_simulator/Home.png</iconset>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="stockModelButton">
+       <property name="toolTip">
+        <string>Toggle view simulation/model</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../Gui/Resources/Path.qrc">
+         <normaloff>:/gl_simulator/View.png</normaloff>:/gl_simulator/View.png</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="rotateButton">
+       <property name="toolTip">
+        <string>Toggle turn table animation</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../Gui/Resources/Path.qrc">
+         <normaloff>:/gl_simulator/Rotate.png</normaloff>:/gl_simulator/Rotate.png</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="pathButton">
+       <property name="toolTip">
+        <string>Show/hide tool path</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../Gui/Resources/Path.qrc">
+         <normaloff>:/gl_simulator/Path.png</normaloff>:/gl_simulator/Path.png</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="ssaoButton">
+       <property name="toolTip">
+        <string>Toggle ambient occlusion</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../Gui/Resources/Path.qrc">
+         <normaloff>:/gl_simulator/AmbientOclusion.png</normaloff>:/gl_simulator/AmbientOclusion.png</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../Gui/Resources/Path.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/Mod/CAM/PathSimulator/AppGL/MillMotion.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillMotion.h
@@ -26,7 +26,7 @@
 
 #include "EndMill.h"
 #include "linmath.h"
-namespace MillSim
+namespace CAMSimulator
 {
 
 enum eEndMillType
@@ -64,4 +64,4 @@ static inline void MotionPosToVec(vec3 vec, const MillMotion* motion)
     vec[1] = motion->y;
     vec[2] = motion->z;
 }
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/MillMotion.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillMotion.h
@@ -24,8 +24,8 @@
 
 #pragma once
 
-#include "EndMill.h"
 #include "linmath.h"
+
 namespace CAMSimulator
 {
 
@@ -49,19 +49,20 @@ enum eCmdType
 
 struct MillMotion
 {
-    eCmdType cmd;
-    int tool;
-    float x, y, z;
-    float i, j, k;
-    float r;
-    char retract_mode = 0;
-    float retract_z = NAN;
+    eCmdType cmd = eNop;
+    int tool = -1;
+    float x = 0.0f, y = 0.0f, z = 0.0f;
+    float i = 0.0f, j = 0.0f, k = 0.0f;
+    float r = 0.0f;
+    char retract_mode = '\0';
+    float retract_z = 0;
 };
 
-static inline void MotionPosToVec(vec3 vec, const MillMotion* motion)
+static inline void MotionPosToVec(vec3 vec, const MillMotion& motion)
 {
-    vec[0] = motion->x;
-    vec[1] = motion->y;
-    vec[2] = motion->z;
+    vec[0] = motion.x;
+    vec[1] = motion.y;
+    vec[2] = motion.z;
 }
+
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/MillPathLine.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillPathLine.cpp
@@ -7,7 +7,7 @@
 // include this last as the defines can mess up other includes
 #include "OpenGlWrapper.h"
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 void MillPathLine::GenerateModel()
@@ -61,4 +61,4 @@ void MillPathLine::Render()
     glDrawArrays(GL_LINE_STRIP, 0, mNumVerts);
 }
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/MillPathLine.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillPathLine.h
@@ -4,7 +4,7 @@
 
 #include <vector>
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 struct MillPathPosition
@@ -29,4 +29,4 @@ protected:
     int mNumVerts;
 };
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/MillPathSegment.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillPathSegment.cpp
@@ -25,8 +25,7 @@
 #include "MillPathSegment.h"
 
 #include "GlUtils.h"
-#include "SimShapes.h"
-#include "linmath.h"
+#include <cmath>
 #include <iostream>
 #include <numbers>
 
@@ -34,33 +33,37 @@ constexpr auto pi = std::numbers::pi_v<float>;
 
 #define N_MILL_SLICES 8
 #define MAX_SEG_DEG (pi / 2.0f)   // 90 deg
-#define NIN_SEG_DEG (pi / 90.0f)  // 2 deg
+#define MIN_SEG_DEG (pi / 90.0f)  // 2 deg
 #define SWEEP_ARC_PAD 1.05f
 #define PX 0
 #define PY 1
 #define PZ 2
 
+// Maximum ratio of radius to chord length for treating arc as curved
+// Ratios above this indicate the arc is essentially a straight line
+// and should be treated as linear to avoid numerical precision issues
+constexpr float ARC_LINEARIZATION_THRESHOLD = 100000.0f;
 
 namespace CAMSimulator
 {
 
-bool IsVerticalMotion(MillMotion* m1, MillMotion* m2)
+bool IsVerticalMotion(const MillMotion& m1, const MillMotion& m2)
 {
-    return (m1->z != m2->z && EQ_FLOAT(m1->x, m2->x) && EQ_FLOAT(m1->y, m2->y));
+    return (m1.z != m2.z && EQ_FLOAT(m1.x, m2.x) && EQ_FLOAT(m1.y, m2.y));
 }
 
-bool IsArcMotion(MillMotion* m)
+bool IsArcMotion(const MillMotion& m)
 {
-    if (m->cmd != eRotateCCW && m->cmd != eRotateCW) {
+    if (m.cmd != eRotateCCW && m.cmd != eRotateCW) {
         return false;
     }
-    return fabs(m->i) > EPSILON || fabs(m->j) > EPSILON;
+    return fabs(m.i) > EPSILON || fabs(m.j) > EPSILON;
 }
 
 float MillPathSegment::mResolution = 1;
 float MillPathSegment::mSmallRadStep = (pi / 8);
 
-MillPathSegment::MillPathSegment(EndMill* _endmill, MillMotion* from, MillMotion* to)
+MillPathSegment::MillPathSegment(const EndMill& _endmill, const MillMotion& from, const MillMotion& to)
 {
     mat4x4_identity(mShearMat);
     MotionPosToVec(mStartPos, from);
@@ -70,11 +73,11 @@ MillPathSegment::MillPathSegment(EndMill* _endmill, MillMotion* from, MillMotion
     mZDistance = fabsf(mDiff[PY]);
     mXYZDistance = sqrtf(mXYDistance * mXYDistance + mDiff[PZ] * mDiff[PZ]);
     mXYAngle = atan2f(mDiff[PY], mDiff[PX]);
-    endmill = _endmill;
+    endmill = &_endmill;
     mStartAngRad = mStepAngRad = 0;
     if (IsArcMotion(to)) {
         mMotionType = MTCurved;
-        mRadius = sqrtf(to->j * to->j + to->i * to->i);
+        mRadius = sqrtf(to.j * to.j + to.i * to.i);
         mSmallRad = mRadius <= endmill->radius;
 
         if (mSmallRad) {
@@ -82,20 +85,15 @@ MillPathSegment::MillPathSegment(EndMill* _endmill, MillMotion* from, MillMotion
         }
         else {
             mStepAngRad = asinf(mResolution / mRadius);
-            if (mStepAngRad > MAX_SEG_DEG) {
-                mStepAngRad = MAX_SEG_DEG;
-            }
-            else if (mStepAngRad < NIN_SEG_DEG) {
-                mStepAngRad = NIN_SEG_DEG;
-            }
+            mStepAngRad = std::min(std::fmax(mStepAngRad, MAX_SEG_DEG), MIN_SEG_DEG);
         }
 
         MotionPosToVec(mCenter, from);
-        mCenter[PX] += to->i;
-        mCenter[PY] += to->j;
-        mArcDir = to->cmd == eRotateCCW ? -1.f : 1.f;
-        mStartAngRad = atan2f(mCenter[PX] - from->x, from->y - mCenter[PY]);
-        float endAng = atan2f(mCenter[PX] - to->x, to->y - mCenter[PY]);
+        mCenter[PX] += to.i;
+        mCenter[PY] += to.j;
+        mArcDir = to.cmd == eRotateCCW ? -1.f : 1.f;
+        mStartAngRad = atan2f(mCenter[PX] - from.x, from.y - mCenter[PY]);
+        float endAng = atan2f(mCenter[PX] - to.x, to.y - mCenter[PY]);
         mSweepAng = (mStartAngRad - endAng) * mArcDir;
         if (mSweepAng < EPSILON) {
             mSweepAng += pi * 2;
@@ -138,13 +136,14 @@ MillPathSegment::MillPathSegment(EndMill* _endmill, MillMotion* from, MillMotion
             mShearMat[0][2] = mDiff[PZ] / mXYDistance;
         }
     }
+
+    assert(numSimSteps >= 0);
 }
 
 MillPathSegment::~MillPathSegment()
 {
     mShape.FreeResources();
 }
-
 
 void MillPathSegment::AppendPathPoints(std::vector<MillPathPosition>& pointsBuffer)
 {
@@ -242,6 +241,7 @@ void MillPathSegment::GetHeadPosition(vec3 headPos)
     }
     vec3_dup(headPos, mHeadPos);
 }
+
 float MillPathSegment::SetQuality(float quality, float maxStockDimension)
 {
     mResolution = maxStockDimension * 0.05 / quality;
@@ -260,4 +260,5 @@ float MillPathSegment::SetQuality(float quality, float maxStockDimension)
     }
     return mResolution;
 }
+
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/MillPathSegment.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillPathSegment.cpp
@@ -41,7 +41,7 @@ constexpr auto pi = std::numbers::pi_v<float>;
 #define PZ 2
 
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 bool IsVerticalMotion(MillMotion* m1, MillMotion* m2)
@@ -260,4 +260,4 @@ float MillPathSegment::SetQuality(float quality, float maxStockDimension)
     }
     return mResolution;
 }
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/MillPathSegment.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillPathSegment.h
@@ -24,11 +24,11 @@
 
 #pragma once
 
-
-#include "MillMotion.h"
 #include "EndMill.h"
-#include "linmath.h"
+#include "MillMotion.h"
 #include "MillPathLine.h"
+#include "SimShapes.h"
+#include "linmath.h"
 
 namespace CAMSimulator
 {
@@ -40,9 +40,6 @@ enum MotionType
     MTCurved
 };
 
-bool IsVerticalMotion(MillMotion* m1, MillMotion* m2);
-
-
 class MillPathSegment
 {
 public:
@@ -52,9 +49,8 @@ public:
     /// <param name="endmill">Mill object</param>
     /// <param name="from">Start point</param>
     /// <param name="to">End point</param>
-    MillPathSegment(EndMill* endmill, MillMotion* from, MillMotion* to);
+    MillPathSegment(const EndMill& endmill, const MillMotion& from, const MillMotion& to);
     virtual ~MillPathSegment();
-
 
     virtual void AppendPathPoints(std::vector<MillPathPosition>& pointsBuffer);
     virtual void render(int substep);
@@ -62,12 +58,11 @@ public:
     static float SetQuality(float quality, float maxStockDimension);  // 1 minimum, 10 maximum
 
 public:
-    EndMill* endmill = nullptr;
+    const EndMill* endmill = nullptr;
     bool isMultyPart;
     int numSimSteps;
-    int indexInArray;
-    int segmentIndex;
-
+    int indexInArray = -1;
+    int segmentIndex = -1;
 
 protected:
     mat4x4 mShearMat;
@@ -95,4 +90,5 @@ protected:
     vec3 mHeadPos = {0};
     MotionType mMotionType;
 };
+
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/MillPathSegment.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillPathSegment.h
@@ -30,7 +30,7 @@
 #include "linmath.h"
 #include "MillPathLine.h"
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 enum MotionType
@@ -95,4 +95,4 @@ protected:
     vec3 mHeadPos = {0};
     MotionType mMotionType;
 };
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.cpp
@@ -33,7 +33,7 @@
 
 #define DRAG_ZOOM_FACTOR 10
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 MillSimulation::MillSimulation()
@@ -116,8 +116,7 @@ void MillSimulation::InitSimulation(float quality)
         mDestMotion = mCodeParser.Operations[i];
         EndMill* tool = GetTool(mDestMotion.tool);
         if (tool != nullptr) {
-            MillSim::MillPathSegment* segment
-                = new MillSim::MillPathSegment(tool, &mCurMotion, &mDestMotion);
+            MillPathSegment* segment = new MillPathSegment(tool, &mCurMotion, &mDestMotion);
             segment->indexInArray = i;
             segment->segmentIndex = segId++;
             mNTotalSteps += segment->numSimSteps;
@@ -239,7 +238,7 @@ void MillSimulation::GlsimEnd(void)
 
 void MillSimulation::renderSegmentForward(int iSeg)
 {
-    MillSim::MillPathSegment* p = MillPathSegments.at(iSeg);
+    MillPathSegment* p = MillPathSegments.at(iSeg);
     int step = iSeg == mPathStep ? mSubStep : p->numSimSteps;
     int start = p->isMultyPart ? 1 : step;
     for (int i = start; i <= step; i++) {
@@ -252,7 +251,7 @@ void MillSimulation::renderSegmentForward(int iSeg)
 
 void MillSimulation::renderSegmentReversed(int iSeg)
 {
-    MillSim::MillPathSegment* p = MillPathSegments.at(iSeg);
+    MillPathSegment* p = MillPathSegments.at(iSeg);
     int step = iSeg == mPathStep ? mSubStep : p->numSimSteps;
     int end = p->isMultyPart ? 1 : step;
     for (int i = step; i >= end; i--) {
@@ -267,7 +266,7 @@ void MillSimulation::CalcSegmentPositions()
 {
     mSubStep = mCurStep;
     for (mPathStep = 0; mPathStep < mNPathSteps; mPathStep++) {
-        MillSim::MillPathSegment* p = MillPathSegments[mPathStep];
+        MillPathSegment* p = MillPathSegments[mPathStep];
         if (mSubStep < p->numSimSteps) {
             break;
         }
@@ -323,7 +322,7 @@ void MillSimulation::RenderSimulation()
     simDisplay.StartGeometryPass(cutColor, true);
     GlsimRenderTools();
     for (int i = 0; i <= mPathStep; i++) {
-        MillSim::MillPathSegment* p = MillPathSegments.at(i);
+        MillPathSegment* p = MillPathSegments.at(i);
         int step = (i == mPathStep) ? mSubStep : p->numSimSteps;
         int start = p->isMultyPart ? 1 : step;
         for (int j = start; j <= step; j++) {
@@ -342,7 +341,7 @@ void MillSimulation::RenderTool()
 
     vec3 toolPos;
     MotionPosToVec(toolPos, &mDestMotion);
-    MillSim::MillPathSegment* p = MillPathSegments.at(mPathStep);
+    MillPathSegment* p = MillPathSegments.at(mPathStep);
     p->GetHeadPosition(toolPos);
     mat4x4 tmat;
     mat4x4_translate(tmat, toolPos[0], toolPos[1], toolPos[2]);
@@ -407,7 +406,7 @@ void MillSimulation::Render()
            mat4x4_translate_in_place(test, 20, 20, 3);
            mat4x4_rotate_Z(test, test, 30.f * 3.14f / 180.f);
            int dpos = mNPathSteps - mDebug2;
-           MillSim::MillPathSegment* p = MillPathSegments.at(dpos);
+           MillPathSegment* p = MillPathSegments.at(dpos);
            if (mDebug > p->numSimSteps) {
                mDebug = 1;
            }
@@ -725,4 +724,4 @@ const MillSimulationState& MillSimulation::GetState() const
     return *this;
 }
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.cpp
@@ -25,11 +25,13 @@
 #include "MillSimulation.h"
 
 #include "GlUtils.h"
-#include <vector>
+#include <algorithm>
 #include <iostream>
 
 // include this last as the defines can mess up other includes
 #include "OpenGlWrapper.h"
+
+using namespace std::literals;
 
 #define DRAG_ZOOM_FACTOR 10
 
@@ -37,10 +39,7 @@ namespace CAMSimulator
 {
 
 MillSimulation::MillSimulation()
-{
-    mCurMotion = {eNop, -1, 0, 0, 0, 0, 0, 0, 0, '\0', 0.0};
-    guiDisplay.SetMillSimulator(this);
-}
+{}
 
 MillSimulation::~MillSimulation()
 {
@@ -57,15 +56,18 @@ void MillSimulation::ClearMillPathSegments()
 
 void MillSimulation::Clear()
 {
-    mCodeParser.Operations.clear();
+    mCodeParser.Clear();
+
+    ClearMillPathSegments();
+
     for (unsigned int i = 0; i < mToolTable.size(); i++) {
         delete mToolTable[i];
     }
-    ClearMillPathSegments();
-    mStockObject.~StockObject();
     mToolTable.clear();
-    guiDisplay.ResetGui();
+
+    mStockObject.Clear();
     simDisplay.CleanGL();
+
     mCurStep = 0;
     mPathStep = -1;
     mNTotalSteps = 0;
@@ -73,59 +75,55 @@ void MillSimulation::Clear()
     simulationInitiated = false;
 }
 
-
-void MillSimulation::SimNext()
-{
-    static int simDecim = 0;
-
-    simDecim++;
-    if (simDecim < 1) {
-        return;
-    }
-
-    simDecim = 0;
-
-    if (mCurStep < mNTotalSteps) {
-        mCurStep += mSimSpeed;
-        if (mCurStep > mNTotalSteps) {
-            mCurStep = mNTotalSteps;
-        }
-        CalcSegmentPositions();
-        simDisplay.updateDisplay = true;
-    }
-}
-
-void MillSimulation::InitSimulation(float quality)
+void MillSimulation::InitSimulation(float quality, float maxStockDimension)
 {
     ClearMillPathSegments();
     millPathLine.Clear();
-    mViewSSAO = guiDisplay.IsChecked(eGuiItemAmbientOclusion);
+    // mViewSSAO = guiDisplay.IsChecked(eGuiItemAmbientOclusion);
 
-    mDestMotion = mZeroPos;
     // gDestPos = curMillOperation->startPos;
     mCurStep = 0;
     mPathStep = -1;
     mNTotalSteps = 0;
     mSimPlaying = false;
     mSimSpeed = 1;
-    MillPathSegment::SetQuality(quality, simDisplay.maxFar);
+    mTotalElapsed = 0s;
+
+    MillPathSegment::SetQuality(quality, maxStockDimension);
+
     int nOperations = (int)mCodeParser.Operations.size();
     int segId = 0;
-    for (int i = 0; i < nOperations; i++) {
-        mCurMotion = mDestMotion;
-        mDestMotion = mCodeParser.Operations[i];
-        EndMill* tool = GetTool(mDestMotion.tool);
+
+    MillMotion prevMotion = !mCodeParser.Operations.empty() ? mCodeParser.Operations.front()
+                                                            : MillMotion();
+
+    MillPathPosition mpPos;
+    mpPos.X = prevMotion.x;
+    mpPos.Y = prevMotion.y;
+    mpPos.Z = prevMotion.z;
+    mpPos.SegmentId = segId++;
+    millPathLine.MillPathPointsBuffer.push_back(mpPos);
+
+    for (int i = 1; i < nOperations; i++) {
+        const MillMotion curMotion = mCodeParser.Operations[i];
+        const EndMill* tool = GetTool(curMotion.tool);
         if (tool != nullptr) {
-            MillPathSegment* segment = new MillPathSegment(tool, &mCurMotion, &mDestMotion);
+            auto segment = new MillPathSegment(*tool, prevMotion, curMotion);
             segment->indexInArray = i;
             segment->segmentIndex = segId++;
             mNTotalSteps += segment->numSimSteps;
             MillPathSegments.push_back(segment);
             segment->AppendPathPoints(millPathLine.MillPathPointsBuffer);
         }
+
+        prevMotion = curMotion;
     }
+
+    assert(mNTotalSteps >= 0);
+
     mNPathSteps = (int)MillPathSegments.size();
     millPathLine.GenerateModel();
+
     InitDisplay(quality);
 
     simulationInitiated = true;
@@ -178,47 +176,45 @@ bool MillSimulation::ToolExists(int toolid)
 void MillSimulation::GlsimStart()
 {
     glDisable(GL_BLEND);
-    glEnable(GL_STENCIL_TEST);
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+    glEnable(GL_STENCIL_TEST);
 }
 
 void MillSimulation::GlsimToolStep1(void)
 {
     glCullFace(GL_BACK);
     glDepthFunc(GL_LESS);
+    glDepthMask(GL_FALSE);
     glStencilFunc(GL_ALWAYS, 1, 0xFF);
     glStencilOp(GL_ZERO, GL_ZERO, GL_REPLACE);
-    glDepthMask(GL_FALSE);
 }
-
 
 void MillSimulation::GlsimToolStep2(void)
 {
+    glCullFace(GL_FRONT);
+    glDepthFunc(GL_GREATER);
+    glDepthMask(GL_TRUE);
     glStencilFunc(GL_EQUAL, 1, 0xFF);
     glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
-    glDepthFunc(GL_GREATER);
-    glCullFace(GL_FRONT);
-    glDepthMask(GL_TRUE);
 }
 
 void MillSimulation::GlsimClipBack(void)
 {
+    glCullFace(GL_FRONT);
+    glDepthFunc(GL_LESS);
+    glDepthMask(GL_FALSE);
     glStencilFunc(GL_ALWAYS, 1, 0xFF);
     glStencilOp(GL_REPLACE, GL_REPLACE, GL_ZERO);
-    glDepthFunc(GL_LESS);
-    glCullFace(GL_FRONT);
-    glDepthMask(GL_FALSE);
 }
-
 
 void MillSimulation::GlsimRenderStock(void)
 {
+    glCullFace(GL_BACK);
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glDepthFunc(GL_EQUAL);
     glEnable(GL_STENCIL_TEST);
     glStencilFunc(GL_EQUAL, 1, 0xFF);
     glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
-    glDepthFunc(GL_EQUAL);
-    glCullFace(GL_BACK);
 }
 
 void MillSimulation::GlsimRenderTools(void)
@@ -229,11 +225,13 @@ void MillSimulation::GlsimRenderTools(void)
 void MillSimulation::GlsimEnd(void)
 {
     glCullFace(GL_BACK);
-    glStencilFunc(GL_ALWAYS, 1, 0xFF);
-    glDisable(GL_STENCIL_TEST);
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-    glDepthMask(GL_TRUE);
+
     glDepthFunc(GL_LESS);
+    glDepthMask(GL_TRUE);
+
+    glDisable(GL_STENCIL_TEST);
+    glStencilFunc(GL_ALWAYS, 1, 0xFF);
 }
 
 void MillSimulation::renderSegmentForward(int iSeg)
@@ -339,9 +337,8 @@ void MillSimulation::RenderTool()
         return;
     }
 
-    vec3 toolPos;
-    MotionPosToVec(toolPos, &mDestMotion);
     MillPathSegment* p = MillPathSegments.at(mPathStep);
+    vec3 toolPos;
     p->GetHeadPosition(toolPos);
     mat4x4 tmat;
     mat4x4_translate(tmat, toolPos[0], toolPos[1], toolPos[2]);
@@ -384,9 +381,9 @@ void MillSimulation::Render()
     // set background
     glClearColor(bgndColor[0], bgndColor[1], bgndColor[2], 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-    simDisplay.PrepareDisplay(mStockObject.center);
 
     // render the simulation offscreen in an FBO
+
     if (simDisplay.updateDisplay) {
         simDisplay.PrepareFrameBuffer();
         RenderSimulation();
@@ -413,137 +410,58 @@ void MillSimulation::Render()
            p->render(mDebug);
        }*/
 
-    float progress = (float)mCurStep / mNTotalSteps;
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    guiDisplay.Render(progress);
 }
 
-void MillSimulation::ProcessSim(unsigned int time_ms)
+void MillSimulation::ProcessSim(const clock::duration& elapsed)
 {
+    SimNext(elapsed);
+    Render();
+}
 
-    static int ancient = 0;
-    static unsigned int last = 0;
-    static unsigned int msec = 0xFFFFFFFF;
-    static int fps = 0;
-    static int renderTime = 0;
+void MillSimulation::SimNext(const clock::duration& elapsed)
+{
+    // calculate number of steps based on elapsed time
 
-    last = msec == 0xFFFFFFFF ? time_ms : msec;
-    msec = time_ms;
-    if (guiDisplay.IsChecked(eGuiItemRotate)) {
-        simDisplay.RotateEye((msec - last) / 4600.0f);
+    int numSteps = 0;
+
+    if (mSimPlaying) {
+        mTotalElapsed += elapsed;
+
+        const float seconds
+            = std::chrono::duration_cast<std::chrono::duration<float>>(mTotalElapsed).count();
+
+        const float secondsToSteps = mSimSpeed * 60;
+        numSteps = seconds * secondsToSteps;
+
+        const std::chrono::duration<float> processed {(float)numSteps / secondsToSteps};
+        mTotalElapsed -= std::chrono::duration_cast<clock::duration>(processed);
     }
+    else if (mSingleStep) {
+        numSteps = 1;
 
-    if (last / 1000 != msec / 1000) {
-        float calcFps = 1000.0f * fps / (msec - ancient);
-        mFpsStream.str("");
-        mFpsStream << "fps: " << calcFps << "    rendertime:" << renderTime
-                   << "    zpos:" << mDestMotion.z << std::ends;
-        ancient = msec;
-        fps = 0;
-    }
-
-    if (mSimPlaying || mSingleStep) {
-        SimNext();
+        mTotalElapsed = 0s;
         mSingleStep = false;
     }
-
-    Render();
-
-    ++fps;
-}
-
-void MillSimulation::HandleKeyPress(int key)
-{
-    if (key >= '1' && key <= '9') {
-        mSimSpeed = key - '0';
-    }
-    else if (key == 'D') {
-        mDebug++;
-    }
-    else if (key == 'K') {
-        mDebug2++;
-    }
     else {
-        guiDisplay.HandleKeyPress(key);
+        return;
+    }
+
+    // advance simulation
+
+    const int oldStep = mCurStep;
+
+    mCurStep += numSteps;
+    mCurStep = std::clamp(mCurStep, 0, mNTotalSteps);
+    if (mCurStep == mNTotalSteps) {
+        mSimPlaying = false;
+    }
+
+    if (mCurStep != oldStep) {
+        CalcSegmentPositions();
+        simDisplay.updateDisplay = true;
     }
 }
-
-void MillSimulation::HandleGuiAction(eGuiItems actionItem, bool checked)
-{
-    switch (actionItem) {
-        case eGuiItemPlay:
-            mSimPlaying = true;
-            break;
-
-        case eGuiItemPause:
-            mSimPlaying = false;
-            break;
-
-        case eGuiItemSingleStep:
-            mSimPlaying = false;
-            mSingleStep = true;
-            break;
-
-        case eGuiItemSlower:
-            if (mSimSpeed == 50) {
-                mSimSpeed = 25;
-            }
-            else if (mSimSpeed == 25) {
-                mSimSpeed = 10;
-            }
-            else if (mSimSpeed == 10) {
-                mSimSpeed = 5;
-            }
-            else {
-                mSimSpeed = 1;
-            }
-            guiDisplay.UpdateSimSpeed(mSimSpeed);
-            break;
-
-        case eGuiItemFaster:
-            if (mSimSpeed == 1) {
-                mSimSpeed = 5;
-            }
-            else if (mSimSpeed == 5) {
-                mSimSpeed = 10;
-            }
-            else if (mSimSpeed == 10) {
-                mSimSpeed = 25;
-            }
-            else {
-                mSimSpeed = 50;
-            }
-            guiDisplay.UpdateSimSpeed(mSimSpeed);
-            break;
-
-        case eGuiItemPath:
-            mViewPath = checked;
-            simDisplay.updateDisplay = true;
-            break;
-
-        case eGuiItemAmbientOclusion:
-            mViewSSAO = checked;
-            simDisplay.updateDisplay = true;
-            break;
-
-        case eGuiItemView:
-            mViewItems++;
-            if (mViewItems >= VIEWITEM_MAX) {
-                mViewItems = VIEWITEM_SIMULATION;
-            }
-            simDisplay.updateDisplay = true;
-            break;
-
-        case eGuiItemHome:
-            simDisplay.MoveEyeCenter();
-            break;
-
-        default:
-            break;
-    }
-    guiDisplay.UpdatePlayState(mSimPlaying);
-}
-
 
 void MillSimulation::InitDisplay(float quality)
 {
@@ -558,9 +476,6 @@ void MillSimulation::InitDisplay(float quality)
 
     // init 3d display
     simDisplay.InitGL();
-
-    // init gui elements
-    guiDisplay.InitGui();
 }
 
 void MillSimulation::SetBoxStock(float x, float y, float z, float l, float w, float h)
@@ -578,86 +493,39 @@ void MillSimulation::SetArbitraryStock(
     simDisplay.ScaleViewToStock(&mStockObject);
 }
 
+void MillSimulation::SetStockVisible(bool b)
+{
+    if (b == IsStockVisible()) {
+        return;
+    }
+
+    mViewItems ^= VIEWITEM_SIMULATION;
+    simDisplay.updateDisplay = true;
+}
+
+bool MillSimulation::IsStockVisible() const
+{
+    return mViewItems & VIEWITEM_SIMULATION;
+}
+
 void MillSimulation::SetBaseObject(const std::vector<Vertex>& verts, const std::vector<GLushort>& indices)
 {
     mBaseShape.GenerateSolid(verts, indices);
 }
 
-void MillSimulation::MouseDrag(int buttons, int dx, int dy)
+void MillSimulation::SetBaseVisible(bool b)
 {
-    if (buttons == (MS_MOUSE_MID | MS_MOUSE_LEFT) || buttons == MS_KBD_ALT) {
-        simDisplay.TiltEye((float)dy / 100.0f);
-        simDisplay.RotateEye((float)dx / 100.0f);
+    if (b == IsBaseVisible()) {
+        return;
     }
-    else if (buttons == MS_MOUSE_MID || buttons == MS_KBD_SHIFT) {
-        simDisplay.MoveEye(dx, -dy);
-    }
-    else if (buttons == (MS_KBD_CONTROL | MS_KBD_SHIFT)) {
-        Zoom(0.003 * dy);
-    }
-    guiDisplay.MouseDrag(buttons, dx, dy);
+
+    mViewItems ^= VIEWITEM_BASE_SHAPE;
+    simDisplay.updateDisplay = true;
 }
 
-void MillSimulation::MouseMove(int px, int py, int modifiers)
+bool MillSimulation::IsBaseVisible() const
 {
-    if (modifiers != mLastModifiers) {
-        mLastMouseX = px;
-        mLastMouseY = py;
-        mLastModifiers = modifiers;
-    }
-
-    int buttons = mMouseButtonState | modifiers;
-    if (buttons > 0) {
-        int dx = px - mLastMouseX;
-        int dy = py - mLastMouseY;
-        if (dx != 0 || dy != 0) {
-            MouseDrag(buttons, dx, dy);
-            mLastMouseX = px;
-            mLastMouseY = py;
-        }
-    }
-    else {
-        MouseHover(px, py);
-    }
-}
-
-void MillSimulation::MouseScroll(float dy)
-{
-    Zoom(-0.02f * dy);
-}
-
-
-void MillSimulation::MouseHover(int px, int py)
-{
-    guiDisplay.MouseCursorPos(px, py);
-}
-
-void MillSimulation::MousePress(int button, bool isPressed, int px, int py)
-{
-    if (isPressed) {
-        mMouseButtonState |= button;
-    }
-    else {
-        mMouseButtonState &= ~button;
-    }
-
-    if (mMouseButtonState > 0) {
-        mLastMouseX = px;
-        mLastMouseY = py;
-    }
-    guiDisplay.MousePressed(button, isPressed, mSimPlaying);
-}
-
-void MillSimulation::Zoom(float factor)
-{
-    factor += simDisplay.GetEyeFactor();
-    if (factor > 0.6f) {
-        factor = 0.6f;
-    }
-    else if (factor < 0.01f) {
-        factor = 0.01f;
-    }
-    simDisplay.UpdateEyeFactor(factor);
+    return mViewItems & VIEWITEM_BASE_SHAPE;
 }
 
 void MillSimulation::UpdateWindowScale(int width, int height)
@@ -670,11 +538,32 @@ void MillSimulation::UpdateWindowScale(int width, int height)
     mHeight = height;
 
     simDisplay.UpdateWindowScale(width, height);
-    guiDisplay.UpdateWindowScale(width, height);
+}
 
+void MillSimulation::SetPathVisible(bool b)
+{
+    if (b == mViewPath) {
+        return;
+    }
+
+    mViewPath = b;
     simDisplay.updateDisplay = true;
 }
 
+void MillSimulation::EnableSsao(bool b)
+{
+    if (b == mViewSSAO) {
+        return;
+    }
+
+    mViewSSAO = b;
+    simDisplay.updateDisplay = true;
+}
+
+void MillSimulation::UpdateCamera(const SoCamera& camera)
+{
+    simDisplay.UpdateCamera(camera);
+}
 
 bool MillSimulation::LoadGCodeFile(const char* fileName)
 {
@@ -690,29 +579,57 @@ bool MillSimulation::AddGcodeLine(const char* line)
     return mCodeParser.AddLine(line);
 }
 
+void MillSimulation::SetPlaying(bool b)
+{
+    if (b == mSimPlaying) {
+        return;
+    }
+
+    mSimPlaying = b;
+    simDisplay.updateDisplay = true;
+}
+
+void MillSimulation::SingleStep()
+{
+    if (!mSimPlaying && mSingleStep) {
+        return;
+    }
+
+    mSimPlaying = false;
+    mSingleStep = true;
+    simDisplay.updateDisplay = true;
+}
+
+void MillSimulation::SetSpeed(int s)
+{
+    mSimSpeed = s;
+}
+
 void MillSimulation::SetSimulationStage(float stage)
 {
-    int newStep = (int)((float)mNTotalSteps * stage);
+    const int newStep = (int)((float)mNTotalSteps * stage);
     if (newStep == mCurStep) {
         return;
     }
+
     mCurStep = newStep;
-    simDisplay.updateDisplay = true;
     mSingleStep = true;
     CalcSegmentPositions();
+
+    simDisplay.updateDisplay = true;
 }
 
 void MillSimulation::SetState(const MillSimulationState& state)
 {
-    mSimPlaying = state.mSimPlaying;
-    mSingleStep = state.mSingleStep;
-    guiDisplay.UpdatePlayState(mSimPlaying);
+    SetPlaying(state.mSimPlaying);
+    if (state.mSingleStep) {
+        SingleStep();
+    }
 
     const float stage = (float)state.mCurStep / state.mNTotalSteps;
     SetSimulationStage(stage);
 
-    mSimSpeed = state.mSimSpeed;
-    guiDisplay.UpdateSimSpeed(mSimSpeed);
+    SetSpeed(state.mSimSpeed);
 
     mViewItems = state.mViewItems;
     mViewPath = state.mViewPath;
@@ -723,5 +640,18 @@ const MillSimulationState& MillSimulation::GetState() const
 {
     return *this;
 }
+
+void MillSimulation::SetBackgroundColor(const vec3& c)
+{
+    bgndColor[0] = c[0];
+    bgndColor[1] = c[1];
+    bgndColor[2] = c[2];
+}
+
+void MillSimulation::SetPathColor(const vec3& normal, const vec3& rapid)
+{
+    simDisplay.SetPathColor(normal, rapid);
+}
+
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.h
@@ -24,17 +24,14 @@
 
 #pragma once
 
-#include "MillMotion.h"
 #include "GCodeParser.h"
-#include "Shader.h"
-#include "linmath.h"
-#include "StockObject.h"
+#include "MillPathLine.h"
 #include "MillPathSegment.h"
 #include "SimDisplay.h"
-#include "GuiDisplay.h"
-#include "MillPathLine.h"
 #include "SolidObject.h"
-#include <sstream>
+#include "StockObject.h"
+#include "linmath.h"
+#include <chrono>
 #include <vector>
 
 #define VIEWITEM_SIMULATION 1
@@ -62,13 +59,14 @@ struct MillSimulationState
 
 class MillSimulation: private MillSimulationState
 {
+    typedef std::chrono::steady_clock clock;
+
 public:
     MillSimulation();
     ~MillSimulation();
     void ClearMillPathSegments();
     void Clear();
-    void SimNext();
-    void InitSimulation(float quality);
+    void InitSimulation(float quality, float maxStockDimension);
     void AddTool(EndMill* tool);
     void AddTool(const std::vector<float>& toolProfile, int toolid, float diameter);
     bool ToolExists(int toolid);
@@ -77,24 +75,37 @@ public:
     void RenderPath();
     void RenderBaseShape();
     void Render();
-    void ProcessSim(unsigned int time_ms);
-    void HandleKeyPress(int key);
-    void HandleGuiAction(eGuiItems actionItem, bool checked);
+    void ProcessSim(const clock::duration& elapsed);
+    void SimNext(const clock::duration& elapsed);
+
     bool LoadGCodeFile(const char* fileName);
     bool AddGcodeLine(const char* line);
+
+    void SetPlaying(bool b);
+    void SingleStep();
+    void SetSpeed(int s);
+
     void SetSimulationStage(float stage);
     void SetState(const MillSimulationState& state);
     const MillSimulationState& GetState() const;
+
     void SetBoxStock(float x, float y, float z, float l, float w, float h);
     void SetArbitraryStock(const std::vector<Vertex>& verts, const std::vector<GLushort>& indices);
+    void SetStockVisible(bool b);
+    bool IsStockVisible() const;
+
     void SetBaseObject(const std::vector<Vertex>& verts, const std::vector<GLushort>& indices);
-    void MouseDrag(int buttons, int dx, int dy);
-    void MouseMove(int px, int py, int modifiers);
-    void MouseScroll(float dy);
-    void MouseHover(int px, int py);
-    void MousePress(int button, bool isPressed, int px, int py);
-    void Zoom(float factor);
+    void SetBaseVisible(bool b);
+    bool IsBaseVisible() const;
+
+    void SetPathVisible(bool b);
+    void EnableSsao(bool b);
+
     void UpdateWindowScale(int width, int height);
+    void UpdateCamera(const SoCamera& camera);
+
+    void SetBackgroundColor(const vec3& c);
+    void SetPathColor(const vec3& normal, const vec3& rapid);
 
 protected:
     void InitDisplay(float quality);
@@ -114,19 +125,13 @@ protected:
 protected:
     bool simulationInitiated = false;
 
+    // protected:
+public:
     std::vector<EndMill*> mToolTable;
     GCodeParser mCodeParser;
-    GuiDisplay guiDisplay;
     SimDisplay simDisplay;
     MillPathLine millPathLine;
     std::vector<MillPathSegment*> MillPathSegments;
-    std::ostringstream mFpsStream;
-
-    // clang-format off
-    MillMotion mZeroPos = {.cmd=eNop, .tool=-1, .x=0, .y=0, .z=100, .i=0, .j=0, .k=0, .r=0, .retract_mode='\0', .retract_z=0.0};
-    MillMotion mCurMotion = {.cmd=eNop, .tool=-1, .x=0, .y=0, .z=0, .i=0, .j=0, .k=0, .r=0, .retract_mode='\0', .retract_z=0.0};
-    MillMotion mDestMotion = {.cmd=eNop, .tool=-1, .x=0, .y=0, .z=0, .i=0, .j=0, .k=0, .r=0, .retract_mode='\0', .retract_z=0.0};
-    // clang-format on
 
     int mWidth = -1;
     int mHeight = -1;
@@ -140,13 +145,7 @@ protected:
     vec3 toolColor = {0.5f, 0.4f, 0.3f};
     vec3 baseShapeColor = {0.7f, 0.6f, 0.5f};
 
-    int mDebug = 0;
-    int mDebug1 = 0;
-    int mDebug2 = 12;
-
-    int mLastMouseX = 0, mLastMouseY = 0;
-    int mMouseButtonState = 0;
-    int mLastModifiers = 0;
+    clock::duration mTotalElapsed;
 };
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.h
@@ -41,7 +41,7 @@
 #define VIEWITEM_BASE_SHAPE 2
 #define VIEWITEM_MAX 4
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 struct MillSimulationState
@@ -149,4 +149,4 @@ protected:
     int mLastModifiers = 0;
 };
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/OpenGlWrapper.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/OpenGlWrapper.cpp
@@ -26,7 +26,7 @@
 
 #include <iostream>
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 void GLClearError()
@@ -45,4 +45,4 @@ bool GLLogError()
     return isError;
 }
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/OpenGlWrapper.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/OpenGlWrapper.cpp
@@ -29,6 +29,8 @@
 namespace CAMSimulator
 {
 
+QOpenGLExtraFunctions gOpenGLFunctions;
+
 void GLClearError()
 {
     while (glGetError() != GL_NO_ERROR)

--- a/src/Mod/CAM/PathSimulator/AppGL/OpenGlWrapper.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/OpenGlWrapper.h
@@ -118,10 +118,10 @@
 #define GLDELETE_RENDERBUFFER(x) GLDELETE(Renderbuffers, x)
 #define GLDELETE_BUFFER(x) GLDELETE(Buffers, x)
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 void GLClearError();
 bool GLLogError();
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/OpenGlWrapper.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/OpenGlWrapper.h
@@ -29,73 +29,77 @@
 // multiple levels of includes, this file should only be included in source files and not in
 // headers. If OpenGL defines are needed in headers, use <QOpenGLFunctions>.
 
-#include "DlgCAMSimulator.h"
+#include <QOpenGLExtraFunctions>
 
-#define gSimWindow CAMSimulator::DlgCAMSimulator::instance()
-#define glClearColor gSimWindow->glClearColor
-#define glBlendFunc gSimWindow->glBlendFunc
-#define glClear gSimWindow->glClear
-#define glGenBuffers gSimWindow->glGenBuffers
-#define glBindBuffer gSimWindow->glBindBuffer
-#define glBufferData gSimWindow->glBufferData
-#define glGenVertexArrays gSimWindow->glGenVertexArrays
-#define glBindVertexArray gSimWindow->glBindVertexArray
-#define glEnableVertexAttribArray gSimWindow->glEnableVertexAttribArray
-#define glVertexAttribPointer gSimWindow->glVertexAttribPointer
-#define glBindAttribLocation gSimWindow->glBindAttribLocation
-#define glGetAttribLocation gSimWindow->glGetAttribLocation
-#define glShaderSource gSimWindow->glShaderSource
-#define glCompileShader gSimWindow->glCompileShader
-#define glDeleteShader gSimWindow->glDeleteShader
-#define glDeleteProgram gSimWindow->glDeleteProgram
-#define glAttachShader gSimWindow->glAttachShader
-#define glLinkProgram gSimWindow->glLinkProgram
-#define glGetProgramiv gSimWindow->glGetProgramiv
-#define glGetUniformLocation gSimWindow->glGetUniformLocation
-#define glGetError gSimWindow->glGetError
-#define glEnable gSimWindow->glEnable
-#define glColorMask gSimWindow->glColorMask
-#define glCullFace gSimWindow->glCullFace
-#define glDepthFunc gSimWindow->glDepthFunc
-#define glStencilFunc gSimWindow->glStencilFunc
-#define glStencilOp gSimWindow->glStencilOp
-#define glDepthMask gSimWindow->glDepthMask
-#define glDisable gSimWindow->glDisable
-#define glMatrixMode gSimWindow->glMatrixMode
-#define glUseProgram gSimWindow->glUseProgram
-#define glDrawElements gSimWindow->glDrawElements
-#define glDeleteVertexArrays gSimWindow->glDeleteVertexArrays
-#define glUniformMatrix4fv gSimWindow->glUniformMatrix4fv
-#define glUniform3fv gSimWindow->glUniform3fv
-#define glUniform1i gSimWindow->glUniform1i
-#define glCreateShader gSimWindow->glCreateShader
-#define glCreateProgram gSimWindow->glCreateProgram
-#define glDeleteBuffers gSimWindow->glDeleteBuffers
-#define glActiveTexture gSimWindow->glActiveTexture
-#define glBindTexture gSimWindow->glBindTexture
-#define glGenTextures gSimWindow->glGenTextures
-#define glTexParameteri gSimWindow->glTexParameteri
-#define glTexImage2D gSimWindow->glTexImage2D
-#define glDeleteTextures gSimWindow->glDeleteTextures
-#define glPolygonOffset gSimWindow->glPolygonOffset
+namespace CAMSimulator
+{
 
-#define glBindFramebuffer gSimWindow->glBindFramebuffer
-#define glUniform1f gSimWindow->glUniform1f
-#define glGenFramebuffers gSimWindow->glGenFramebuffers
-#define glFramebufferTexture2D gSimWindow->glFramebufferTexture2D
-#define glDrawBuffers gSimWindow->glDrawBuffers
-#define glGenRenderbuffers gSimWindow->glGenRenderbuffers
-#define glBindRenderbuffer gSimWindow->glBindRenderbuffer
-#define glRenderbufferStorage gSimWindow->glRenderbufferStorage
-#define glFramebufferRenderbuffer gSimWindow->glFramebufferRenderbuffer
-#define glCheckFramebufferStatus gSimWindow->glCheckFramebufferStatus
-#define glDeleteFramebuffers gSimWindow->glDeleteFramebuffers
-#define glDeleteRenderbuffers gSimWindow->glDeleteRenderbuffers
-#define glVertexAttribIPointer gSimWindow->glVertexAttribIPointer
-#define glUniform4fv gSimWindow->glUniform4fv
-#define glLineWidth gSimWindow->glLineWidth
-#define glGetShaderiv gSimWindow->glGetShaderiv
-#define glGetShaderInfoLog gSimWindow->glGetShaderInfoLog
+extern QOpenGLExtraFunctions gOpenGLFunctions;
+
+#define glClearColor gOpenGLFunctions.glClearColor
+#define glBlendFunc gOpenGLFunctions.glBlendFunc
+#define glClear gOpenGLFunctions.glClear
+#define glGenBuffers gOpenGLFunctions.glGenBuffers
+#define glBindBuffer gOpenGLFunctions.glBindBuffer
+#define glBufferData gOpenGLFunctions.glBufferData
+#define glGenVertexArrays gOpenGLFunctions.glGenVertexArrays
+#define glBindVertexArray gOpenGLFunctions.glBindVertexArray
+#define glEnableVertexAttribArray gOpenGLFunctions.glEnableVertexAttribArray
+#define glVertexAttribPointer gOpenGLFunctions.glVertexAttribPointer
+#define glBindAttribLocation gOpenGLFunctions.glBindAttribLocation
+#define glGetAttribLocation gOpenGLFunctions.glGetAttribLocation
+#define glShaderSource gOpenGLFunctions.glShaderSource
+#define glCompileShader gOpenGLFunctions.glCompileShader
+#define glDeleteShader gOpenGLFunctions.glDeleteShader
+#define glDeleteProgram gOpenGLFunctions.glDeleteProgram
+#define glAttachShader gOpenGLFunctions.glAttachShader
+#define glLinkProgram gOpenGLFunctions.glLinkProgram
+#define glGetProgramiv gOpenGLFunctions.glGetProgramiv
+#define glGetUniformLocation gOpenGLFunctions.glGetUniformLocation
+#define glGetError gOpenGLFunctions.glGetError
+#define glEnable gOpenGLFunctions.glEnable
+#define glColorMask gOpenGLFunctions.glColorMask
+#define glCullFace gOpenGLFunctions.glCullFace
+#define glDepthFunc gOpenGLFunctions.glDepthFunc
+#define glStencilFunc gOpenGLFunctions.glStencilFunc
+#define glStencilOp gOpenGLFunctions.glStencilOp
+#define glDepthMask gOpenGLFunctions.glDepthMask
+#define glDisable gOpenGLFunctions.glDisable
+#define glMatrixMode gOpenGLFunctions.glMatrixMode
+#define glUseProgram gOpenGLFunctions.glUseProgram
+#define glDrawElements gOpenGLFunctions.glDrawElements
+#define glDeleteVertexArrays gOpenGLFunctions.glDeleteVertexArrays
+#define glUniformMatrix4fv gOpenGLFunctions.glUniformMatrix4fv
+#define glUniform3fv gOpenGLFunctions.glUniform3fv
+#define glUniform1i gOpenGLFunctions.glUniform1i
+#define glCreateShader gOpenGLFunctions.glCreateShader
+#define glCreateProgram gOpenGLFunctions.glCreateProgram
+#define glDeleteBuffers gOpenGLFunctions.glDeleteBuffers
+#define glActiveTexture gOpenGLFunctions.glActiveTexture
+#define glBindTexture gOpenGLFunctions.glBindTexture
+#define glGenTextures gOpenGLFunctions.glGenTextures
+#define glTexParameteri gOpenGLFunctions.glTexParameteri
+#define glTexImage2D gOpenGLFunctions.glTexImage2D
+#define glDeleteTextures gOpenGLFunctions.glDeleteTextures
+#define glPolygonOffset gOpenGLFunctions.glPolygonOffset
+
+#define glBindFramebuffer gOpenGLFunctions.glBindFramebuffer
+#define glUniform1f gOpenGLFunctions.glUniform1f
+#define glGenFramebuffers gOpenGLFunctions.glGenFramebuffers
+#define glFramebufferTexture2D gOpenGLFunctions.glFramebufferTexture2D
+#define glDrawBuffers gOpenGLFunctions.glDrawBuffers
+#define glGenRenderbuffers gOpenGLFunctions.glGenRenderbuffers
+#define glBindRenderbuffer gOpenGLFunctions.glBindRenderbuffer
+#define glRenderbufferStorage gOpenGLFunctions.glRenderbufferStorage
+#define glFramebufferRenderbuffer gOpenGLFunctions.glFramebufferRenderbuffer
+#define glCheckFramebufferStatus gOpenGLFunctions.glCheckFramebufferStatus
+#define glDeleteFramebuffers gOpenGLFunctions.glDeleteFramebuffers
+#define glDeleteRenderbuffers gOpenGLFunctions.glDeleteRenderbuffers
+#define glVertexAttribIPointer gOpenGLFunctions.glVertexAttribIPointer
+#define glUniform4fv gOpenGLFunctions.glUniform4fv
+#define glLineWidth gOpenGLFunctions.glLineWidth
+#define glGetShaderiv gOpenGLFunctions.glGetShaderiv
+#define glGetShaderInfoLog gOpenGLFunctions.glGetShaderInfoLog
 
 #define GL(x) \
     { \
@@ -117,9 +121,6 @@
 #define GLDELETE_VERTEXARRAY(x) GLDELETE(VertexArrays, x)
 #define GLDELETE_RENDERBUFFER(x) GLDELETE(Renderbuffers, x)
 #define GLDELETE_BUFFER(x) GLDELETE(Buffers, x)
-
-namespace CAMSimulator
-{
 
 void GLClearError();
 bool GLLogError();

--- a/src/Mod/CAM/PathSimulator/AppGL/Shader.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/Shader.cpp
@@ -31,9 +31,10 @@
  ***************************************************************************/
 
 #include "Shader.h"
-#include <iostream>
-#include <regex>
+
 #include <Base/Console.h>
+#include <map>
+#include <regex>
 
 // include this last as the defines can mess up other includes
 #include "OpenGlWrapper.h"
@@ -324,6 +325,10 @@ void Shader::Destroy()
     shaderId = 0;
 }
 
+bool Shader::IsValid()
+{
+    return shaderId > 0;
+}
 
 const char* VertShader3DNorm = R"(
     #version 120
@@ -370,7 +375,6 @@ const char* VertShader3DInvNorm = R"(
     }
 )";
 
-
 const char* VertShader2DTex = R"(
     #version 120
 
@@ -403,7 +407,6 @@ const char* FragShader2dTex = R"(
         gl_FragColor = vec4(objectColor, 1.0) * texColor;
     }
 )";
-
 
 const char* FragShaderNorm = R"(
     #version 120

--- a/src/Mod/CAM/PathSimulator/AppGL/Shader.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/Shader.cpp
@@ -38,7 +38,7 @@
 // include this last as the defines can mess up other includes
 #include "OpenGlWrapper.h"
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 Shader* CurrentShader = nullptr;
@@ -662,4 +662,4 @@ const char* FragShader3DLine = R"(
     }
 )";
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/Shader.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/Shader.h
@@ -24,16 +24,15 @@
 
 #pragma once
 
-#include <string>
 #include "linmath.h"
+#include <string>
 
 namespace CAMSimulator
 {
+
 class Shader
 {
 public:
-    Shader()
-    {}
     ~Shader();
 
 public:
@@ -55,13 +54,12 @@ public:
     void UpdateSsaoTexSlot(int ssaoSlot);
     void UpdateKernelVals(int nVals, float* vals);
     void UpdateCurSegment(int curSeg);
+    void UpdateStartEnd(const vec3& start, const vec3& end);
+
     unsigned int CompileShader(const char* name, const char* vertShader, const char* fragShader);
     void Activate();
     void Destroy();
-    bool IsValid()
-    {
-        return shaderId > 0;
-    }
+    bool IsValid();
 
 protected:
     int mModelPos = -1;
@@ -86,6 +84,7 @@ protected:
     int mCurSegmentPos = -1;
     int mScreenWidthPos = -1;
     int mScreenHeightPos = -1;
+    int mStartEndPos = -1;
 
     std::string vertShader;
     std::string fragShader;
@@ -109,6 +108,5 @@ extern const char* FragShaderStdLighting;
 extern const char* FragShaderSSAOBlur;
 extern const char* VertShader3DLine;
 extern const char* FragShader3DLine;
-
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/Shader.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/Shader.h
@@ -27,7 +27,7 @@
 #include <string>
 #include "linmath.h"
 
-namespace MillSim
+namespace CAMSimulator
 {
 class Shader
 {
@@ -111,4 +111,4 @@ extern const char* VertShader3DLine;
 extern const char* FragShader3DLine;
 
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
@@ -38,7 +38,7 @@
 // include this last as the defines can mess up other includes
 #include "OpenGlWrapper.h"
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 void SimDisplay::InitShaders()
@@ -604,4 +604,4 @@ float SimDisplay::GetEyeFactor()
     return mEyeDistFactor;
 }
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
@@ -32,14 +32,18 @@
 
 #include "SimDisplay.h"
 
-#include "linmath.h"
-#include <cmath>
+#include <Inventor/nodes/SoOrthographicCamera.h>
+#include <Inventor/nodes/SoPerspectiveCamera.h>
+#include <algorithm>
+#include <numbers>
 
 // include this last as the defines can mess up other includes
 #include "OpenGlWrapper.h"
 
 namespace CAMSimulator
 {
+
+constexpr auto pi = std::numbers::pi_v<float>;
 
 void SimDisplay::InitShaders()
 {
@@ -99,7 +103,7 @@ void SimDisplay::CreateFboQuad()
     glBufferData(GL_ARRAY_BUFFER, sizeof(quadVertices), &quadVertices[0], GL_STATIC_DRAW);
 }
 
-void SimDisplay::SetupVertexAttribs()
+void SimDisplay::SetupVertexAttribs() const
 {
     glBindBuffer(GL_ARRAY_BUFFER, mFboQuadVBO);
 
@@ -298,15 +302,6 @@ void SimDisplay::CleanGL()
     displayInitiated = false;
 }
 
-void SimDisplay::PrepareDisplay(const vec3& objCenter)
-{
-    mat4x4_look_at(mMatLookAt, eye, target, upvec);
-    mat4x4_translate_in_place(mMatLookAt, mEyeX * mEyeXZFactor, 0, mEyeZ * mEyeXZFactor);
-    mat4x4_rotate_X(mMatLookAt, mMatLookAt, mEyeInclination);
-    mat4x4_rotate_Z(mMatLookAt, mMatLookAt, mEyeRoration);
-    mat4x4_translate_in_place(mMatLookAt, -objCenter[0], -objCenter[1], -objCenter[2]);
-}
-
 void SimDisplay::PrepareFrameBuffer()
 {
     glBindFramebuffer(GL_FRAMEBUFFER, mFbo);
@@ -359,16 +354,8 @@ void SimDisplay::RenderLightObject()
 
 void SimDisplay::ScaleViewToStock(StockObject* obj)
 {
-    mMaxStockDim = fmaxf(obj->size[0], obj->size[1]);
-    maxFar = mMaxStockDim * 16;
-    UpdateProjection();
-
-    vec3_set(eye, 0, 0, 0);
-    mEyeDistFactor = NAN;
-    UpdateEyeFactor(0.1f);
-
-    vec3_set(lightPos, obj->position[0], obj->position[1], obj->position[2] + mMaxStockDim / 3);
-    mlightObject.SetPosition(lightPos);
+    mMaxStockDimension = std::max(std::max(obj->size[0], obj->size[1]), obj->size[2]);
+    UpdateProjectionMatrix();
 }
 
 void SimDisplay::RenderResult(bool recalculate, bool ssao)
@@ -470,6 +457,17 @@ void SimDisplay::RenderResultSSAO(bool recalculate)
     glDrawArrays(GL_TRIANGLES, 0, 6);
 }
 
+void SimDisplay::SetPathColor(const vec3& normal, const vec3& rapid)
+{
+    pathLineColor[0] = normal[0];
+    pathLineColor[1] = normal[1];
+    pathLineColor[2] = normal[2];
+
+    // TODO: Different color for rapid moves is not supported for now.
+
+    (void)rapid;
+}
+
 void SimDisplay::SetupLinePathPass(int curSegment, bool isHidden)
 {
     glEnable(GL_DEPTH_TEST);
@@ -481,79 +479,9 @@ void SimDisplay::SetupLinePathPass(int curSegment, bool isHidden)
     shaderLinePath.Activate();
     pathLineColor[3] = isHidden ? 0.1f : 1.0f;
     shaderLinePath.UpdateObjColorAlpha(pathLineColor);
+    shaderLinePath.UpdateObjColor(pathLineColorPassed);
     shaderLinePath.UpdateCurSegment(curSegment);
     shaderLinePath.UpdateViewMat(mMatLookAt);
-}
-
-void SimDisplay::TiltEye(float tiltStep)
-{
-    mEyeInclination += tiltStep;
-    if (mEyeInclination > pi / 2) {
-        mEyeInclination = pi / 2;
-    }
-    else if (mEyeInclination < -pi / 2) {
-        mEyeInclination = -pi / 2;
-    }
-}
-
-void SimDisplay::RotateEye(float rotStep)
-{
-    mEyeRoration += rotStep;
-    if (mEyeRoration > pi * 2) {
-        mEyeRoration -= pi * 2;
-    }
-    else if (mEyeRoration < 0) {
-        mEyeRoration += pi * 2;
-    }
-    updateDisplay = true;
-}
-
-void SimDisplay::MoveEye(float x, float z)
-{
-    // Exponential calculate maxValue
-    // https://forum.freecad.org/viewtopic.php?t=96939
-    const float arg1 = 124.938F;
-    const float arg2 = 578.754F;
-    const float arg3 = -20.7993F;
-    float maxValueX = arg1 + arg2 * exp(arg3 * mEyeDistFactor);
-    float maxValueZ = maxValueX * 0.4F;
-
-    mEyeX += x;
-    if (mEyeX > maxValueX) {
-        mEyeX = maxValueX;
-    }
-    else if (mEyeX < -maxValueX) {
-        mEyeX = -maxValueX;
-    }
-    mEyeZ += z;
-
-    if (mEyeZ > maxValueZ) {
-        mEyeZ = maxValueZ;
-    }
-    else if (mEyeZ < -maxValueZ) {
-        mEyeZ = -maxValueZ;
-    }
-    updateDisplay = true;
-}
-
-void SimDisplay::MoveEyeCenter()
-{
-    mEyeRoration = 0;
-    mEyeInclination = pi / 6;
-    mEyeX = 0;
-    mEyeZ = 0;
-    UpdateEyeFactor(0.1f);
-}
-
-void SimDisplay::UpdateEyeFactor(float factor)
-{
-    if (mEyeDistFactor == factor) {
-        return;
-    }
-    updateDisplay = true;
-    mEyeDistFactor = factor;
-    mEyeXZFactor = factor * maxFar * 0.005f;
-    eye[1] = -factor * maxFar;
 }
 
 void SimDisplay::UpdateWindowScale(int width, int height)
@@ -572,14 +500,118 @@ void SimDisplay::UpdateWindowScale(int width, int height)
 
     CreateDisplayFbos();
     CreateSsaoFbos();
-    UpdateProjection();
+    UpdateProjectionMatrix();
 }
 
-void SimDisplay::UpdateProjection()
+void SimDisplay::UpdateCamera(const SoCamera& camera)
+{
+    if (!displayInitiated) {
+        return;
+    }
+
+    UpdateCameraView(camera);
+    UpdateCameraProjection(camera);
+}
+
+void SimDisplay::UpdateCameraView(const SoCamera& camera)
+{
+
+    const SbVec3f position = camera.position.getValue();
+    const SbRotation orientation = camera.orientation.getValue();
+
+    if (position == mCameraPosition && orientation == mCameraOrientation) {
+        return;
+    }
+
+    mCameraPosition = position;
+    mCameraOrientation = orientation;
+
+    UpdateViewMatrix();
+}
+
+void SimDisplay::UpdateCameraProjection(const SoCamera& camera)
+{
+    float heightAngle = std::numbers::pi / 4;
+    float height = 100.0f;
+
+    const auto perspective = dynamic_cast<const SoPerspectiveCamera*>(&camera);
+    const auto orthographic = dynamic_cast<const SoOrthographicCamera*>(&camera);
+
+    // TODO: We can't use the values from the camera here because the dummy viewer never actually
+    // renders the scene and therefore the nearDistance and farDistance of the camera are never
+    // updated. Figure out a way to update those values without rendering the scene.
+
+#if 0
+
+    const float nearDistance = camera.nearDistance.getValue();
+    const float farDistance = camera.farDistance.getValue();
+
+#else
+
+    float nearDistance;
+    float farDistance;
+
+#endif
+
+    if (perspective) {
+        heightAngle = perspective->heightAngle.getValue();
+
+        nearDistance = mMaxStockDimension * 0.001f;
+        farDistance = mMaxStockDimension * 10.0f;
+    }
+    else if (orthographic) {
+        height = orthographic->height.getValue();
+
+        nearDistance = -mMaxStockDimension * 10.0f;
+        farDistance = mMaxStockDimension * 10.0f;
+    }
+
+    if ((bool)perspective == mCameraPerspective && heightAngle == mCameraHeightAngle
+        && height == mCameraHeight && nearDistance == mCameraNearDistance
+        && farDistance == mCameraFarDistance) {
+        return;
+    }
+
+    mCameraPerspective = (bool)perspective;
+    mCameraHeightAngle = heightAngle;
+    mCameraHeight = height;
+    mCameraNearDistance = nearDistance;
+    mCameraFarDistance = farDistance;
+
+    UpdateProjectionMatrix();
+}
+
+void SimDisplay::UpdateViewMatrix()
+{
+    SbVec3f up(0, 1, 0);
+    mCameraOrientation.multVec(up, up);
+
+    SbVec3f dir(0, 0, -1);
+    mCameraOrientation.multVec(dir, dir);
+
+    const auto target = mCameraPosition + dir;
+    mat4x4_look_at(mMatLookAt, mCameraPosition.getValue(), target.getValue(), up.getValue());
+
+    updateDisplay = true;
+}
+
+void SimDisplay::UpdateProjectionMatrix()
 {
     // Setup projection
+
+    const float aspect = (float)mWidth / mHeight;
+
     mat4x4 projmat;
-    mat4x4_perspective(projmat, 0.7f, (float)mWidth / mHeight, 1.0f, maxFar);
+
+    if (mCameraPerspective) {
+        mat4x4_perspective(projmat, mCameraHeightAngle, aspect, mCameraNearDistance, mCameraFarDistance);
+    }
+    else {
+        const float h = mCameraHeight;
+        const float w = mCameraHeight * aspect;
+        mat4x4_ortho(projmat, -w / 2, w / 2, -h / 2, h / 2, mCameraNearDistance, mCameraFarDistance);
+    }
+
     shader3D.Activate();
     shader3D.UpdateProjectionMat(projmat);
     shaderInv3D.Activate();
@@ -592,16 +624,12 @@ void SimDisplay::UpdateProjection()
     shaderSSAO.UpdateProjectionMat(projmat);
     shaderLinePath.Activate();
     shaderLinePath.UpdateProjectionMat(projmat);
-    shaderLinePath.UpdateObjColor(pathLineColorPassed);
 
     projmat[2][2] *= 0.99999F;
     shaderGeomCloser.Activate();
     shaderGeomCloser.UpdateProjectionMat(projmat);
-}
 
-float SimDisplay::GetEyeFactor()
-{
-    return mEyeDistFactor;
+    updateDisplay = true;
 }
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.h
@@ -32,7 +32,7 @@
 #include <algorithm>
 #include <numbers>
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 constexpr auto pi = std::numbers::pi_v<float>;
@@ -140,4 +140,4 @@ protected:
     unsigned int mFboRandTexture = 0;
 };
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.h
@@ -26,16 +26,18 @@
 
 #include "Shader.h"
 #include "StockObject.h"
-#include "MillPathLine.h"
-#include <vector>
-#include <random>
-#include <algorithm>
+#include <Inventor/SbRotation.h>
+#include <Inventor/SbVec3f.h>
+#include <QOpenGLFunctions>
 #include <numbers>
+#include <random>
+#include <vector>
+
+class SoCamera;
+class SoPerspectiveCamera;
 
 namespace CAMSimulator
 {
-
-constexpr auto pi = std::numbers::pi_v<float>;
 
 struct Point3D
 {
@@ -49,7 +51,6 @@ public:
     void InitGL();
     void CleanGL();
     void CleanFbos();
-    void PrepareDisplay(const vec3& objCenter);
     void PrepareFrameBuffer();
     void StartDepthPass();
     void StartGeometryPass(const vec3& objColor, bool invertNormals);
@@ -60,19 +61,13 @@ public:
     void RenderResultStandard();
     void RenderResultSSAO(bool recalculate);
     void SetupLinePathPass(int curSegment, bool isHidden);
-    void TiltEye(float tiltStep);
-    void RotateEye(float rotStep);
-    void MoveEye(float x, float z);
-    void MoveEyeCenter();
-    void UpdateEyeFactor(float factor);
     void UpdateWindowScale(int width, int height);
+    void UpdateCamera(const SoCamera& camera);
 
-    void UpdateProjection();
-    float GetEyeFactor();
+    void SetPathColor(const vec3& normal, const vec3& rapid);
 
 public:
     bool updateDisplay = false;
-    float maxFar = 100;
     bool displayInitiated = false;
 
 protected:
@@ -80,10 +75,17 @@ protected:
     void CreateDisplayFbos();
     void CreateSsaoFbos();
     void CreateFboQuad();
-    void SetupVertexAttribs();
+    void SetupVertexAttribs() const;
     void CreateGBufTex(GLenum texUnit, GLint intFormat, GLenum format, GLenum type, GLuint& texid);
     void UniformHemisphere(vec3& randVec);
     void UniformCircle(vec3& randVec);
+
+private:
+    void UpdateCameraView(const SoCamera& camera);
+    void UpdateCameraProjection(const SoCamera& camera);
+
+    void UpdateViewMatrix();
+    void UpdateProjectionMatrix();
 
 protected:
     // shaders
@@ -91,15 +93,12 @@ protected:
     Shader shaderGeom, shaderSSAO, shaderSSAOLighting, shaderSSAOBlur;
     Shader shaderGeomCloser;
     Shader shaderLinePath;
+
     vec3 lightColor = {0.5f, 0.6f, 0.7f};
     vec3 lightPos = {20.0f, 20.0f, 10.0f};
     vec3 ambientCol = {0.2f, 0.2f, 0.25f};
     vec4 pathLineColor = {0.0f, 0.9f, 0.0f, 1.0};
     vec3 pathLineColorPassed = {0.9f, 0.3f, 0.3f};
-
-    vec3 eye = {0, 100, 40};
-    vec3 target = {0, 0, 0};
-    vec3 upvec = {0, 0, 1};
 
     mat4x4 mMatLookAt;
     StockObject mlightObject;
@@ -110,17 +109,15 @@ protected:
     std::mt19937 generator;
     std::uniform_real_distribution<float> distr01;
 
-    float mEyeDistance = 30;
-    float mEyeRoration = 0;
-    float mEyeInclination = pi / 6;  // 30 degree
-    float mEyeStep = pi / 36;        // 5 degree
+    bool mCameraPerspective = true;
+    float mCameraHeightAngle = std::numbers::pi / 4;
+    float mCameraHeight = 100.0f;
+    float mCameraNearDistance = 1.0f;
+    float mCameraFarDistance = 100.0f;
+    float mMaxStockDimension = 100.0f;
 
-    float mMaxStockDim = 100;
-    float mEyeDistFactor = 0.0f;
-    float mEyeXZFactor = 0.01f;
-    float mEyeXZScale = 0;
-    float mEyeX = 0.0f;
-    float mEyeZ = 0.0f;
+    SbVec3f mCameraPosition;
+    SbRotation mCameraOrientation;
 
     // base frame buffer
     unsigned int mFbo = 0;

--- a/src/Mod/CAM/PathSimulator/AppGL/SimShapes.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimShapes.cpp
@@ -31,7 +31,9 @@
 // include this last as the defines can mess up other includes
 #include "OpenGlWrapper.h"
 
-using namespace MillSim;
+namespace CAMSimulator
+{
+
 using std::numbers::pi;
 
 int Shape::lastNumSlices = 0;
@@ -384,3 +386,5 @@ Shape::~Shape()
 {
     FreeResources();
 }
+
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/SimShapes.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimShapes.cpp
@@ -26,6 +26,7 @@
 #include "Shader.h"
 #include <math.h>
 #include <cstddef>
+#include <numbers>
 #include <vector>
 
 // include this last as the defines can mess up other includes

--- a/src/Mod/CAM/PathSimulator/AppGL/SimShapes.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimShapes.cpp
@@ -23,11 +23,11 @@
  ***************************************************************************/
 
 #include "SimShapes.h"
+
 #include "Shader.h"
-#include <math.h>
-#include <cstddef>
+#include <algorithm>
+#include <cmath>
 #include <numbers>
-#include <vector>
 
 // include this last as the defines can mess up other includes
 #include "OpenGlWrapper.h"
@@ -35,7 +35,7 @@
 namespace CAMSimulator
 {
 
-using std::numbers::pi;
+constexpr auto pi = std::numbers::pi_v<float>;
 
 int Shape::lastNumSlices = 0;
 std::vector<float> Shape::sinTable;
@@ -47,7 +47,7 @@ void Shape::GenerateSinTable(int nSlices)
         return;
     }
 
-    float slice = (float)(2 * pi / nSlices);
+    float slice = 2 * pi / nSlices;
     int nvals = nSlices + 1;
     sinTable.resize(nvals);
     cosTable.resize(nvals);
@@ -58,9 +58,8 @@ void Shape::GenerateSinTable(int nSlices)
     lastNumSlices = nvals;
 }
 
-
 void Shape::RotateProfile(
-    float* profPoints,
+    const float* profPoints,
     int nPoints,
     float distance,
     float /* deltaHeight */,
@@ -160,7 +159,7 @@ void Shape::CalculateExtrudeBufferSizes(
 }
 
 void Shape::ExtrudeProfileRadial(
-    float* profPoints,
+    const float* profPoints,
     int nPoints,
     float radius,
     float angleRad,
@@ -258,7 +257,7 @@ void Shape::ExtrudeProfileRadial(
 }
 
 void Shape::ExtrudeProfileLinear(
-    float* profPoints,
+    const float* profPoints,
     int nPoints,
     float fromX,
     float toX,
@@ -349,7 +348,7 @@ void Shape::GenerateModel(const float* vbuffer, const GLushort* ibuffer, int num
     numIndices = nIndices;
 }
 
-void Shape::SetupVertexAttribs()
+void Shape::SetupVertexAttribs() const
 {
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
 
@@ -364,14 +363,17 @@ void Shape::SetModelData(const std::vector<Vertex>& vbuffer, const std::vector<G
     GenerateModel((const float*)vbuffer.data(), ibuffer.data(), (int)vbuffer.size(), (int)ibuffer.size());
 }
 
-void Shape::Render()
+void Shape::Render() const
 {
     SetupVertexAttribs();
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ibo);
     glDrawElements(GL_TRIANGLES, numIndices, GL_UNSIGNED_SHORT, nullptr);
 }
 
-void Shape::Render(const mat4x4& modelMat, const mat4x4& normallMat)  // normals are rotated only
+void Shape::Render(
+    const mat4x4& modelMat,
+    const mat4x4& normallMat
+) const  // normals are rotated only
 {
     CurrentShader->UpdateModelMat(modelMat, normallMat);
     Render();

--- a/src/Mod/CAM/PathSimulator/AppGL/SimShapes.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimShapes.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <QOpenGLFunctions>
+#include <vector>
 #include "linmath.h"
 
 #define SET_DUAL(var, idx, y, z) \
@@ -81,12 +82,12 @@ public:
     int numIndices = 0;
 
 public:
-    void Render();
-    void Render(const mat4x4& modelMat, const mat4x4& normallMat);
+    void Render() const;
+    void Render(const mat4x4& modelMat, const mat4x4& normallMat) const;
     void FreeResources();
     void SetModelData(const std::vector<Vertex>& vbuffer, const std::vector<GLushort>& ibuffer);
     void RotateProfile(
-        float* profPoints,
+        const float* profPoints,
         int nPoints,
         float distance,
         float deltaHeight,
@@ -94,7 +95,7 @@ public:
         bool isHalfTurn
     );
     void ExtrudeProfileRadial(
-        float* profPoints,
+        const float* profPoints,
         int nPoints,
         float radius,
         float angleRad,
@@ -103,7 +104,7 @@ public:
         bool capEnd
     );
     void ExtrudeProfileLinear(
-        float* profPoints,
+        const float* profPoints,
         int nPoints,
         float fromX,
         float toX,
@@ -120,7 +121,7 @@ public:
 
 protected:
     void GenerateModel(const float* vbuffer, const GLushort* ibuffer, int numVerts, int numIndices);
-    void SetupVertexAttribs();
+    void SetupVertexAttribs() const;
     void CalculateExtrudeBufferSizes(
         int nProfilePoints,
         bool capStart,

--- a/src/Mod/CAM/PathSimulator/AppGL/SimShapes.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimShapes.h
@@ -46,7 +46,7 @@
         var[idx++] = z + offs; \
     }
 
-namespace MillSim
+namespace CAMSimulator
 {
 typedef unsigned int uint;
 
@@ -134,4 +134,4 @@ protected:
     );
 };
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/SolidObject.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SolidObject.cpp
@@ -27,7 +27,9 @@
 #include <algorithm>
 
 #define NUM_PROFILE_POINTS 4
-using namespace MillSim;
+
+namespace CAMSimulator
+{
 
 SolidObject::SolidObject()
 {
@@ -41,7 +43,7 @@ SolidObject::~SolidObject()
     shape.FreeResources();
 }
 
-void MillSim::SolidObject::SetPosition(vec3 position)
+void SolidObject::SetPosition(vec3 position)
 {
     mat4x4_translate(mModelMat, position[0], position[1], position[2]);
 }
@@ -78,3 +80,5 @@ void SolidObject::GenerateSolid(const std::vector<Vertex>& verts, const std::vec
     vec3_set(size, l, w, h);
     isValid = true;
 }
+
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/SolidObject.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SolidObject.cpp
@@ -23,7 +23,7 @@
  ***************************************************************************/
 
 #include "SolidObject.h"
-#include "Shader.h"
+
 #include <algorithm>
 
 #define NUM_PROFILE_POINTS 4
@@ -38,6 +38,11 @@ SolidObject::SolidObject()
 }
 
 SolidObject::~SolidObject()
+{
+    Clear();
+}
+
+void SolidObject::Clear()
 {
     isValid = false;
     shape.FreeResources();

--- a/src/Mod/CAM/PathSimulator/AppGL/SolidObject.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/SolidObject.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include <QOpenGLFunctions>
 #include "SimShapes.h"
 #include "linmath.h"
 #include <vector>
@@ -37,6 +36,9 @@ class SolidObject
 public:
     SolidObject();
     virtual ~SolidObject();
+
+    void Clear();
+
     void SetPosition(vec3 position);
 
     /// Calls the display list.
@@ -51,4 +53,5 @@ public:
 protected:
     mat4x4 mModelMat;
 };
+
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/SolidObject.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/SolidObject.h
@@ -29,7 +29,7 @@
 #include "linmath.h"
 #include <vector>
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 class SolidObject
@@ -51,4 +51,4 @@ public:
 protected:
     mat4x4 mModelMat;
 };
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/StockObject.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/StockObject.cpp
@@ -23,7 +23,6 @@
  ***************************************************************************/
 
 #include "StockObject.h"
-#include "Shader.h"
 
 #define NUM_PROFILE_POINTS 4
 

--- a/src/Mod/CAM/PathSimulator/AppGL/StockObject.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/StockObject.cpp
@@ -26,7 +26,9 @@
 #include "Shader.h"
 
 #define NUM_PROFILE_POINTS 4
-using namespace MillSim;
+
+namespace CAMSimulator
+{
 
 StockObject::StockObject()
 {}
@@ -45,3 +47,5 @@ void StockObject::GenerateBoxStock(float x, float y, float z, float l, float w, 
 
     shape.ExtrudeProfileLinear(mProfile, NUM_PROFILE_POINTS, x, x + l, 0, 0, true, true);
 }
+
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/StockObject.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/StockObject.h
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #pragma once
+
 #include "SolidObject.h"
 #include "linmath.h"
 
@@ -39,4 +40,5 @@ public:
 private:
     float mProfile[8] = {};
 };
+
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/StockObject.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/StockObject.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include "SolidObject.h"
-#include "linmath.h"
 
 namespace CAMSimulator
 {

--- a/src/Mod/CAM/PathSimulator/AppGL/StockObject.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/StockObject.h
@@ -26,7 +26,7 @@
 #include "SolidObject.h"
 #include "linmath.h"
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 class StockObject: public SolidObject
@@ -39,4 +39,4 @@ public:
 private:
     float mProfile[8] = {};
 };
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/Texture.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/Texture.cpp
@@ -27,7 +27,7 @@
 // include this last as the defines can mess up other includes
 #include "OpenGlWrapper.h"
 
-namespace MillSim
+namespace CAMSimulator
 {
 Texture::~Texture()
 {
@@ -68,4 +68,4 @@ bool Texture::unbind()
     return true;
 }
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/Texture.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/Texture.h
@@ -55,5 +55,4 @@ protected:
     unsigned int mTextureId = 0;
 };
 
-
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/Texture.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/Texture.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 class Texture
@@ -56,4 +56,4 @@ protected:
 };
 
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/TextureLoader.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/TextureLoader.cpp
@@ -24,7 +24,8 @@
 
 #include "TextureLoader.h"
 
-using namespace MillSim;
+namespace CAMSimulator
+{
 
 TextureItem texItems[] = {
     {1, 40, 0, 0},
@@ -86,19 +87,21 @@ bool TextureLoader::AddImage(TextureItem* texItem, QImage& pixmap, unsigned int*
     return true;
 }
 
-MillSim::TextureLoader::~TextureLoader()
+TextureLoader::~TextureLoader()
 {
     if (mRawData != nullptr) {
         free(mRawData);
     }
 }
 
-unsigned int* MillSim::TextureLoader::GetRawData()
+unsigned int* TextureLoader::GetRawData()
 {
     return mRawData;
 }
 
-TextureItem* MillSim::TextureLoader::GetTextureItem(int i)
+TextureItem* TextureLoader::GetTextureItem(int i)
 {
     return texItems + i;
 }
+
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/TextureLoader.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/TextureLoader.h
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #pragma once
+
 #include <string>
 #include <vector>
 #include <QImage>

--- a/src/Mod/CAM/PathSimulator/AppGL/TextureLoader.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/TextureLoader.h
@@ -27,7 +27,7 @@
 #include <vector>
 #include <QImage>
 
-namespace MillSim
+namespace CAMSimulator
 {
 
 struct TextureItem
@@ -52,4 +52,4 @@ protected:
     std::string mImageFolder;
 };
 
-}  // namespace MillSim
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/TopoShapeViewProvider.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/TopoShapeViewProvider.cpp
@@ -22,51 +22,67 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "Texture.h"
+#include "TopoShapeViewProvider.h"
 
-// include this last as the defines can mess up other includes
-#include "OpenGlWrapper.h"
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoSwitch.h>
+#include <Mod/Part/App/TopoShape.h>
 
 namespace CAMSimulator
 {
 
-Texture::~Texture()
+TopoShapeViewProvider::TopoShapeViewProvider()
 {
-    DestroyTexture();
+    pcSwitch = new SoSwitch;
+    pcRoot->addChild(pcSwitch);
+
+    setShapeVisible(true);
 }
 
-void Texture::DestroyTexture()
+TopoShapeViewProvider& TopoShapeViewProvider::operator=(TopoShapeViewProvider&& vp)
 {
-    GLDELETE_TEXTURE(mTextureId);
+    clear();
+
+    pcShape = vp.pcShape;
+    if (pcShape) {
+        pcSwitch->addChild(pcShape);
+    }
+
+    vp.clear();
+
+    return *this;
 }
 
-bool Texture::LoadImage(unsigned int* image, int _width, int _height)
+void TopoShapeViewProvider::clear()
 {
-    DestroyTexture();
-    width = _width;
-    height = _height;
-    glGenTextures(1, &mTextureId);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
+    if (!pcShape) {
+        return;
+    }
+
+    pcSwitch->removeChild(pcShape);
+    pcShape = nullptr;
 }
 
-bool Texture::Activate()
+void TopoShapeViewProvider::setShape(const Part::TopoShape& shape)
 {
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    return true;
+    clear();
+
+    // create SoNode from TopoShape
+
+    std::stringstream s;
+    shape.exportFaceSet(0.1f, 0.0f, {}, s);
+
+    const auto str = s.str();
+    SoInput in;
+    in.setBuffer(str.data(), str.length());
+
+    SoDB::read(&in, pcShape);
+    pcSwitch->addChild(pcShape);
 }
 
-bool Texture::unbind()
+void TopoShapeViewProvider::setShapeVisible(bool b)
 {
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
+    pcSwitch->whichChild = b ? SO_SWITCH_ALL : SO_SWITCH_NONE;
 }
 
-}  // namespace CAMSimulator
+} /* namespace CAMSimulator */

--- a/src/Mod/CAM/PathSimulator/AppGL/TopoShapeViewProvider.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/TopoShapeViewProvider.h
@@ -22,51 +22,32 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "Texture.h"
+#pragma once
 
-// include this last as the defines can mess up other includes
-#include "OpenGlWrapper.h"
+#include <Gui/ViewProvider.h>
+
+namespace Part
+{
+class TopoShape;
+}
 
 namespace CAMSimulator
 {
 
-Texture::~Texture()
+class TopoShapeViewProvider: public Gui::ViewProvider
 {
-    DestroyTexture();
-}
+public:
+    TopoShapeViewProvider();
+    TopoShapeViewProvider& operator=(TopoShapeViewProvider&& vp);
 
-void Texture::DestroyTexture()
-{
-    GLDELETE_TEXTURE(mTextureId);
-}
+    void clear();
+    void setShape(const Part::TopoShape& shape);
 
-bool Texture::LoadImage(unsigned int* image, int _width, int _height)
-{
-    DestroyTexture();
-    width = _width;
-    height = _height;
-    glGenTextures(1, &mTextureId);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
-}
+    void setShapeVisible(bool b);
 
-bool Texture::Activate()
-{
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    return true;
-}
-
-bool Texture::unbind()
-{
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
-}
+private:
+    SoSwitch* pcSwitch = nullptr;
+    SoNode* pcShape = nullptr;
+};
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/View3DSettings.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/View3DSettings.cpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2024 Shai Seger <shaise at gmail>                       *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#include "View3DSettings.h"
+
+#include "DlgCAMSimulator.h"
+#include "Dummy3DViewer.h"
+#include <string_view>
+
+using namespace std::literals;
+using namespace Gui;
+
+namespace CAMSimulator
+{
+
+View3DSettings::View3DSettings(ParameterGrp::handle hGrp, Dummy3DViewer& view, DlgCAMSimulator& dlg)
+    : Gui::View3DSettings(hGrp, &view)
+    , mView(view)
+    , mDlg(dlg)
+{}
+
+static View3DInventorViewer::Background backgroundType(const ParameterGrp& rGrp)
+{
+    if (rGrp.GetBool("Gradient", true)) {
+        return View3DInventorViewer::Background::LinearGradient;
+    }
+    else if (rGrp.GetBool("RadialGradient", false)) {
+        return View3DInventorViewer::Background::RadialGradient;
+    }
+    else {
+        return View3DInventorViewer::Background::NoGradient;
+    }
+}
+
+static QColor backgroundColor(const ParameterGrp& rGrp)
+{
+    // see View3DSettings::OnChange
+
+    unsigned long col1 = rGrp.GetUnsigned("BackgroundColor", 3940932863UL);
+    unsigned long col2 = rGrp.GetUnsigned("BackgroundColor2", 859006463UL);  // default color (dark blue)
+    unsigned long col3 = rGrp.GetUnsigned("BackgroundColor3", 2880160255UL);  // default color
+                                                                              // (blue/grey)
+    unsigned long col4 = rGrp.GetUnsigned("BackgroundColor4", 1869583359UL);  // default color
+                                                                              // (blue/grey)
+    float r1, g1, b1, r2, g2, b2, r3, g3, b3, r4, g4, b4;
+    r1 = ((col1 >> 24) & 0xff) / 255.0;
+    g1 = ((col1 >> 16) & 0xff) / 255.0;
+    b1 = ((col1 >> 8) & 0xff) / 255.0;
+    r2 = ((col2 >> 24) & 0xff) / 255.0;
+    g2 = ((col2 >> 16) & 0xff) / 255.0;
+    b2 = ((col2 >> 8) & 0xff) / 255.0;
+    r3 = ((col3 >> 24) & 0xff) / 255.0;
+    g3 = ((col3 >> 16) & 0xff) / 255.0;
+    b3 = ((col3 >> 8) & 0xff) / 255.0;
+    r4 = ((col4 >> 24) & 0xff) / 255.0;
+    g4 = ((col4 >> 16) & 0xff) / 255.0;
+    b4 = ((col4 >> 8) & 0xff) / 255.0;
+
+    // TODO: The new cam simulator currently doesn't support gradient background colors. For now we
+    // pick the color in the middle of the screen.
+
+    (void)r4, (void)g4, (void)b4;
+
+    const View3DInventorViewer::Background type = backgroundType(rGrp);
+    const bool useMidColor = rGrp.GetBool("UseBackgroundColorMid", false);
+
+    if (type == View3DInventorViewer::Background::NoGradient) {
+        return QColor::fromRgbF(r1, g1, b1);
+    }
+    else if (useMidColor) {
+        return QColor::fromRgbF(r3, g3, b3);
+    }
+    else {
+        return QColor::fromRgbF((r2 + r3) / 2, (g2 + g3) / 2, (b2 + b3) / 2);
+    }
+}
+
+void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::MessageType Reason)
+{
+    // apply/overwrite settings to dummy viewer
+
+    const ParameterGrp& rGrp = static_cast<ParameterGrp&>(rCaller);
+    if (Reason == "ShowNaviCube"sv) {
+        // always hide the navi cube
+        mView.setEnabledNaviCube(false);
+    }
+    else {
+        Gui::View3DSettings::OnChange(rCaller, Reason);
+    }
+
+    // apply settings to dlg
+
+    if (std::string_view(Reason).starts_with("BackgroundColor") || Reason == "Gradient"sv
+        || Reason == "RadialGradient"sv || Reason == "UseBackgroundColorMid"sv) {
+
+        const QColor bg = backgroundColor(rGrp);
+        mDlg.setBackgroundColor(bg);
+    }
+}
+
+}  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/View3DSettings.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/View3DSettings.h
@@ -22,51 +22,26 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "Texture.h"
+#pragma once
 
-// include this last as the defines can mess up other includes
-#include "OpenGlWrapper.h"
+#include <Gui/View3DSettings.h>
 
 namespace CAMSimulator
 {
 
-Texture::~Texture()
-{
-    DestroyTexture();
-}
+class Dummy3DViewer;
+class DlgCAMSimulator;
 
-void Texture::DestroyTexture()
+class View3DSettings: public Gui::View3DSettings
 {
-    GLDELETE_TEXTURE(mTextureId);
-}
+public:
+    explicit View3DSettings(ParameterGrp::handle hGrp, Dummy3DViewer& view, DlgCAMSimulator& dlg);
 
-bool Texture::LoadImage(unsigned int* image, int _width, int _height)
-{
-    DestroyTexture();
-    width = _width;
-    height = _height;
-    glGenTextures(1, &mTextureId);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
-}
+    void OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::MessageType Reason) override;
 
-bool Texture::Activate()
-{
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, mTextureId);
-    return true;
-}
-
-bool Texture::unbind()
-{
-    glBindTexture(GL_TEXTURE_2D, 0);
-    return true;
-}
+private:
+    Dummy3DViewer& mView;
+    DlgCAMSimulator& mDlg;
+};
 
 }  // namespace CAMSimulator

--- a/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.cpp
@@ -22,17 +22,266 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "PreCompiled.h"
+
 #include "ViewCAMSimulator.h"
+
+#include "CAMSettings.h"
 #include "DlgCAMSimulator.h"
+#include "Dummy3DViewer.h"
+#include "GuiDisplay.h"
+#include "View3DSettings.h"
+#include <App/Document.h>
+#include <Gui/Application.h>
+#include <Gui/Camera.h>
+#include <Gui/Document.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Navigation/NavigationStyle.h>
+#include <Gui/SoFCDB.h>
+#include <Gui/View3DInventor.h>
+#include <Gui/View3DInventorViewer.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
+#include <Inventor/nodes/SoPerspectiveCamera.h>
+#include <QPointer>
+#include <QStackedLayout>
+#include <QStackedWidget>
+#include <string_view>
+
+using namespace std::literals;
+using namespace Gui;
 
 namespace CAMSimulator
 {
 
+static QPointer<ViewCAMSimulator> viewCAMSimulator;
+
 ViewCAMSimulator::ViewCAMSimulator(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wflags)
-    : Gui::MDIView(pcDocument, parent, wflags)
+    : Gui::MDIViewWithCamera(pcDocument, parent, wflags)
 {
-    mDlg = new DlgCAMSimulator(*this);
-    setCentralWidget(mDlg);
+
+    // Under certain conditions, e.g. when docking/undocking the cam simulator, we need to create a
+    // new widget (due to some OpenGL bug). The new widget becomes THE cam simulator.
+
+    viewCAMSimulator = this;
+
+    mDlg = new DlgCAMSimulator;
+    mDlg->setAttribute(Qt::WA_TransparentForMouseEvents);
+
+    mGui = new GuiDisplay;
+    mDummyViewer = new Dummy3DViewer;
+
+    mDlg->connectTo(*mGui, *mDummyViewer);
+
+    connect(mDlg, &DlgCAMSimulator::documentChanged, this, [this](Gui::Document* doc) {
+        setDocument(doc);
+    });
+    connect(mDlg, &DlgCAMSimulator::simulationStarted, this, &ViewCAMSimulator::onSimulationStarted);
+
+    // call apply settings only after mDummyViewer and mDlg have been initialized
+
+    applySettings();
+    initCamera();
+
+    auto stack = new QStackedWidget;
+    static_cast<QStackedLayout*>(stack->layout())->setStackingMode(QStackedLayout::StackAll);
+
+    stack->addWidget(mGui);
+    stack->addWidget(mDlg);
+
+#if 1
+
+    stack->addWidget(mDummyViewer);
+
+    setCentralWidget(stack);
+
+#else
+
+    mDummyViewer->discardPaintEvent_ = false;
+
+    auto container = new QWidget;
+    auto container_layout = new QHBoxLayout;
+    container->setLayout(container_layout);
+    container_layout->addWidget(stack, 1);
+    container_layout->addWidget(mDummyViewer, 1);
+
+    setCentralWidget(container);
+
+#endif
+}
+
+bool ViewCAMSimulator::onMsg(const char* pMsg)
+{
+    // TODO: this is a near 1-to-1 code duplication from View3DInventor.cpp
+
+    if (pMsg == "ViewFit"sv) {
+        mDummyViewer->viewAll();
+        return true;
+    }
+    else if (pMsg == "ViewBottom"sv) {
+        mDummyViewer->setCameraOrientation(Camera::rotation(Camera::Bottom));
+        return true;
+    }
+    else if (pMsg == "ViewFront"sv) {
+        mDummyViewer->setCameraOrientation(Camera::rotation(Camera::Front));
+        return true;
+    }
+    else if (pMsg == "ViewLeft"sv) {
+        mDummyViewer->setCameraOrientation(Camera::rotation(Camera::Left));
+        return true;
+    }
+    else if (pMsg == "ViewRear"sv) {
+        mDummyViewer->setCameraOrientation(Camera::rotation(Camera::Rear));
+        return true;
+    }
+    else if (pMsg == "ViewRight"sv) {
+        mDummyViewer->setCameraOrientation(Camera::rotation(Camera::Right));
+        return true;
+    }
+    else if (pMsg == "ViewTop"sv) {
+        mDummyViewer->setCameraOrientation(Camera::rotation(Camera::Top));
+        return true;
+    }
+    else if (pMsg == "ViewAxo"sv) {
+        mDummyViewer->setCameraOrientation(Camera::rotation(Camera::Isometric));
+        return true;
+    }
+    else if (pMsg == "ViewDimetric"sv) {
+        mDummyViewer->setCameraOrientation(Camera::rotation(Camera::Dimetric));
+        return true;
+    }
+    else if (pMsg == "ViewTrimetric"sv) {
+        mDummyViewer->setCameraOrientation(Camera::rotation(Camera::Trimetric));
+        return true;
+    }
+    else if (pMsg == "OrthographicCamera"sv) {
+        mDummyViewer->setCameraType(SoOrthographicCamera::getClassTypeId());
+        return true;
+    }
+    else if (pMsg == "PerspectiveCamera"sv) {
+        mDummyViewer->setCameraType(SoPerspectiveCamera::getClassTypeId());
+        return true;
+    }
+    else if (pMsg == "ZoomIn"sv) {
+        mDummyViewer->navigationStyle()->zoomIn();
+        return true;
+    }
+    else if (pMsg == "ZoomOut"sv) {
+        mDummyViewer->navigationStyle()->zoomOut();
+        return true;
+    }
+    else if (pMsg == "StoreWorkingView"sv) {
+        mDummyViewer->saveHomePosition();
+        return true;
+    }
+    else if (pMsg == "RecallWorkingView"sv) {
+        if (mDummyViewer->hasHomePosition()) {
+            mDummyViewer->resetToHomePosition();
+        }
+        return true;
+    }
+
+    return false;
+}
+
+bool ViewCAMSimulator::onHasMsg(const char* pMsg) const
+{
+    constexpr std::string_view supported[] = {
+        "ViewFit",
+        "ViewBottom",
+        "ViewFront",
+        "ViewLeft",
+        "ViewRear",
+        "ViewRight",
+        "ViewTop",
+        "ViewAxo",
+        "ViewDimetric",
+        "ViewTrimetric",
+        "OrthographicCamera",
+        "PerspectiveCamera",
+        "ZoomIn",
+        "ZoomOut",
+        "StoreWorkingView",
+    };
+
+    const auto it = std::find(std::begin(supported), std::end(supported), pMsg);
+    if (it != std::end(supported)) {
+        return true;
+    }
+
+    if (pMsg == "RecallWorkingView"sv) {
+        return mDummyViewer->hasHomePosition();
+    }
+
+    return false;
+}
+
+const std::string& ViewCAMSimulator::getCamera() const
+{
+    SoCamera* Cam = mDummyViewer->getSoRenderManager()->getCamera();
+    if (!Cam) {
+        throw Base::RuntimeError("Could not find reference to CAM Simulator camera");
+    }
+    return SoFCDB::writeNodesToString(Cam);
+}
+
+bool ViewCAMSimulator::setCamera(const char* pCamera)
+{
+    return mDummyViewer->setCamera(pCamera);
+}
+
+void ViewCAMSimulator::onSimulationStarted()
+{
+    // fit camera to scene
+
+    mDummyViewer->viewAll();
+
+    // window title and activate
+
+    App::Document* doc = App::GetApplication().getActiveDocument();
+    setWindowTitle(tr("%1 - New CAM Simulator").arg(QString::fromUtf8(doc->getName())));
+
+    Gui::getMainWindow()->setActiveWindow(this);
+    show();
+}
+
+void ViewCAMSimulator::initCamera()
+{
+    Gui::Document* doc = Gui::Application::Instance->activeDocument();
+    if (!doc) {
+        return;
+    }
+
+    auto view = dynamic_cast<View3DInventor*>(doc->getActiveView());
+    if (!view) {
+        return;
+    }
+
+    cloneCamera(*view->getViewer()->getCamera());
+}
+
+void ViewCAMSimulator::cloneCamera(SoCamera& camera)
+{
+    const std::string str = SoFCDB::writeNodesToString(&camera);
+    mDummyViewer->setCamera(str.c_str());
+}
+
+void ViewCAMSimulator::applySettings()
+{
+    assert(mDummyViewer && mDlg);
+
+    const ParameterGrp::handle hGrpView = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/View"
+    );
+
+    const ParameterGrp::handle hGrpCAM = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/CAM"
+    );
+
+    mViewSettings = std::make_unique<CAMSimulator::View3DSettings>(hGrpView, *mDummyViewer, *mDlg);
+    mCAMSettings = std::make_unique<CAMSettings>(hGrpCAM, *mDlg);
+
+    mViewSettings->applySettings();
+    mCAMSettings->applySettings();
 }
 
 ViewCAMSimulator* ViewCAMSimulator::clone()
@@ -41,8 +290,24 @@ ViewCAMSimulator* ViewCAMSimulator::clone()
 
     viewCam->cloneFrom(*this);
     viewCam->mDlg->cloneFrom(*mDlg);
+    viewCam->mDummyViewer->cloneFrom(*mDummyViewer);
+
+    // camera
+
+    SoCamera& camera = *mDummyViewer->getSoRenderManager()->getCamera();
+    viewCam->cloneCamera(camera);
 
     return viewCam;
+}
+
+ViewCAMSimulator& ViewCAMSimulator::instance()
+{
+    if (!viewCAMSimulator) {
+        viewCAMSimulator = new ViewCAMSimulator(nullptr, nullptr);
+        getMainWindow()->addWindow(viewCAMSimulator);
+    }
+
+    return *viewCAMSimulator;
 }
 
 DlgCAMSimulator& ViewCAMSimulator::dlg()

--- a/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.h
@@ -24,13 +24,24 @@
 
 #pragma once
 
-#include <Gui/MDIView.h>
+#include <Gui/MDIViewWithCamera.h>
+
+class SoCamera;
+
+namespace Gui
+{
+class View3DSettings;
+}  // namespace Gui
 
 namespace CAMSimulator
 {
+class GuiDisplay;
 class DlgCAMSimulator;
+class Dummy3DViewer;
+class View3DSettings;
+class CAMSettings;
 
-class ViewCAMSimulator: public Gui::MDIView
+class ViewCAMSimulator: public Gui::MDIViewWithCamera
 {
 public:
     ViewCAMSimulator(
@@ -41,10 +52,30 @@ public:
 
     ViewCAMSimulator* clone() override;
 
+    static ViewCAMSimulator& instance();
     DlgCAMSimulator& dlg();
 
+    bool onMsg(const char* pMsg) override;
+    bool onHasMsg(const char* pMsg) const override;
+
+    const std::string& getCamera() const override;
+    bool setCamera(const char* pCamera) override;
+
+private Q_SLOTS:
+    void onSimulationStarted();
+
+private:
+    void initCamera();
+    void cloneCamera(SoCamera& camera);
+    void applySettings();
+
 protected:
-    DlgCAMSimulator* mDlg;
+    GuiDisplay* mGui = nullptr;
+    DlgCAMSimulator* mDlg = nullptr;
+    Dummy3DViewer* mDummyViewer = nullptr;
+
+    std::unique_ptr<View3DSettings> mViewSettings;
+    std::unique_ptr<CAMSettings> mCAMSettings;
 };
 
 }  // namespace CAMSimulator


### PR DESCRIPTION
should only be merged after #22204

This PR is trying to get the new CAM simulator more in line with the main 3D view with focus on navigation and camera settings.

fixes #22185
fixes #22988
partially fixes #22186

Because the navigation code is very tightly integrated into `View3DInventorViewer`, directly applying the navigation to the new simulator is not really an option. Instead I'm creating a `View3DInventorViewer` and stacking the new simulator on top of it (with transparency for mouse events). Since we're already stacking widgets, stacking another one with the user interface on top was an easy thing to do. This way the UI can be written using Qt instead of OpenGL.

Until someone with enough knowledge of the Inventor API to integrate the new simulator into the main 3D view comes along, this is probably the next best thing.

The following video shows some of the functionality. I'm using a spacemouse for navigation.

[Bildschirmaufnahme_20250813_013200.webm](https://github.com/user-attachments/assets/e2822f62-b6c4-4ab1-9dbf-c932ad6840e9)
