### PR TITLE
PartDesign: Do not copy visuals from ShapeBinder

### DIFF
--- a/src/Mod/PartDesign/App/ShapeBinder.h
+++ b/src/Mod/PartDesign/App/ShapeBinder.h
@@ -42,7 +42,7 @@ namespace PartDesign
  */
 // TODO Add better documentation (2015-09-11, Fat-Zer)
 
-class PartDesignExport ShapeBinder : public PartDesign::FeatureRefine
+class PartDesignExport ShapeBinder : public Part::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(PartDesign::ShapeBinder);
 


### PR DESCRIPTION
This fixes issue where visuals were copied from ShapeBinder. The regression comes from https://github.com/FreeCAD/FreeCAD/commit/ae46ea5e7bbb762f4e5b8eed3119deff1ca74fca which changed base class of ShapeBinder to be based on `PartDesign::FeatureRefine` which made in turn made it `PartDesign::Feature` which in turn caused the visuals to be copied. Not sure what the intent was, but seems like some change that got in by mistake - the type system of FreeCAD was not updated with that information (the macro still specifies Part::Feature as parent so `isDerivedFrom<PartDesign::Feature>` would actually return false in that case). I guess that the goal was to introduce refine abilities to shape binders, but that change is not present in LS3 and cause at least one known regression. 

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
Fixes: #22142
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
