### PR TITLE
Part: Fix 2D Offset of Face

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -2747,8 +2747,9 @@ TopoShape& TopoShape::makeElementOffset2D(const TopoShape& shape,
                     haveWires = true;
                     break;
                 case TopAbs_FACE: {
-                    auto outerWire = s.splitWires(&sourceWires);
-                    sourceWires.push_back(outerWire);
+                    std::ranges::copy(s.getSubTopoShapes(TopAbs_WIRE),
+                                      std::back_inserter(sourceWires));
+
                     haveFaces = true;
                 } break;
                 default:


### PR DESCRIPTION
With TNP mitigation implementation handling of TopAbs_FACE was changed in the method computing 2D offset of shape. It used to be very simple iteration over face wires and it was instead changed to much more complicated splitWires method. The intent of that change was to ensure stability of the result, but it breaks existing models.

The problem is caused by OCC bug within offseting mechanism that is dependent on wire order. Here the outer wire is moved to the end which can cause issues.

Another issue is that for some reason, if circle is enclosed by other shape the offset does not create proper 2D offset but moves the circle in Z direction.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes: #14379 

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
