### PR TITLE
 Split Material Exceptions.h into source and header

### DIFF
--- a/src/Mod/Material/App/CMakeLists.txt
+++ b/src/Mod/Material/App/CMakeLists.txt
@@ -77,7 +77,7 @@ SET(MaterialsAPI_Files
 )
 
 SET(Python_SRCS
-    Exceptions.h
+    Exceptions.cpp
     Array2D.pyi
     Array2DPyImp.cpp
     Array3D.pyi

--- a/src/Mod/Material/App/Exceptions.cpp
+++ b/src/Mod/Material/App/Exceptions.cpp
@@ -1,0 +1,132 @@
+/***************************************************************************
+ *   Copyright (c) 2023 David Carter <dcarter@david.carter.ca>             *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include "Exceptions.h"
+
+namespace Materials
+{
+
+Uninitialized::Uninitialized() : Base::Exception("Uninitialized") {}
+Uninitialized::Uninitialized(const char* msg) : Base::Exception(msg) {}
+Uninitialized::Uninitialized(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+Uninitialized::~Uninitialized() noexcept = default;
+
+ModelNotFound::ModelNotFound() : Base::Exception("Model not found") {}
+ModelNotFound::ModelNotFound(const char* msg) : Base::Exception(msg) {}
+ModelNotFound::ModelNotFound(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+ModelNotFound::~ModelNotFound() noexcept = default;
+
+InvalidMaterialType::InvalidMaterialType() : Base::Exception("Invalid material type") {}
+InvalidMaterialType::InvalidMaterialType(const char* msg) : Base::Exception(msg) {}
+InvalidMaterialType::InvalidMaterialType(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+InvalidMaterialType::~InvalidMaterialType() noexcept = default;
+
+MaterialNotFound::MaterialNotFound() : Base::Exception("Material not found") {}
+MaterialNotFound::MaterialNotFound(const char* msg) : Base::Exception(msg) {}
+MaterialNotFound::MaterialNotFound(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+MaterialNotFound::~MaterialNotFound() noexcept = default;
+
+MaterialExists::MaterialExists() : Base::Exception("Material already exists") {}
+MaterialExists::MaterialExists(const char* msg) : Base::Exception(msg) {}
+MaterialExists::MaterialExists(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+MaterialExists::~MaterialExists() noexcept = default;
+
+MaterialReadError::MaterialReadError() : Base::Exception("Unable to read material") {}
+MaterialReadError::MaterialReadError(const char* msg) : Base::Exception(msg) {}
+MaterialReadError::MaterialReadError(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+MaterialReadError::~MaterialReadError() noexcept = default;
+
+PropertyNotFound::PropertyNotFound() : Base::Exception("Property not found") {}
+PropertyNotFound::PropertyNotFound(const char* msg) : Base::Exception(msg) {}
+PropertyNotFound::PropertyNotFound(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+PropertyNotFound::~PropertyNotFound() noexcept = default;
+
+LibraryNotFound::LibraryNotFound() : Base::Exception("Library not found") {}
+LibraryNotFound::LibraryNotFound(const char* msg) : Base::Exception(msg) {}
+LibraryNotFound::LibraryNotFound(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+LibraryNotFound::~LibraryNotFound() noexcept = default;
+
+CreationError::CreationError() : Base::Exception("Unable to create object") {}
+CreationError::CreationError(const char* msg) : Base::Exception(msg) {}
+CreationError::CreationError(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+CreationError::~CreationError() noexcept = default;
+
+InvalidModel::InvalidModel() : Base::Exception("Invalid model") {}
+InvalidModel::InvalidModel(const char* msg) : Base::Exception(msg) {}
+InvalidModel::InvalidModel(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+InvalidModel::~InvalidModel() noexcept = default;
+
+InvalidMaterial::InvalidMaterial() : Base::Exception("Invalid material") {}
+InvalidMaterial::InvalidMaterial(const char* msg) : Base::Exception(msg) {}
+InvalidMaterial::InvalidMaterial(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+InvalidMaterial::~InvalidMaterial() noexcept = default;
+
+InvalidProperty::InvalidProperty() : Base::Exception("Invalid property") {}
+InvalidProperty::InvalidProperty(const char* msg) : Base::Exception(msg) {}
+InvalidProperty::InvalidProperty(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+InvalidProperty::~InvalidProperty() noexcept = default;
+
+InvalidLibrary::InvalidLibrary() : Base::Exception("Invalid library") {}
+InvalidLibrary::InvalidLibrary(const char* msg) : Base::Exception(msg) {}
+InvalidLibrary::InvalidLibrary(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+InvalidLibrary::~InvalidLibrary() noexcept = default;
+
+InvalidIndex::InvalidIndex() : Base::Exception("Invalid index") {}
+InvalidIndex::InvalidIndex(const char* msg) : Base::Exception(msg) {}
+InvalidIndex::InvalidIndex(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+InvalidIndex::~InvalidIndex() noexcept = default;
+
+UnknownValueType::UnknownValueType() : Base::Exception("Unknown value type") {}
+UnknownValueType::UnknownValueType(const char* msg) : Base::Exception(msg) {}
+UnknownValueType::UnknownValueType(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+UnknownValueType::~UnknownValueType() noexcept = default;
+
+DeleteError::DeleteError() : Base::Exception("Unable to delete object") {}
+DeleteError::DeleteError(const char* msg) : Base::Exception(msg) {}
+DeleteError::DeleteError(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+DeleteError::~DeleteError() noexcept = default;
+
+RenameError::RenameError() : Base::Exception("Unable to rename object") {}
+RenameError::RenameError(const char* msg) : Base::Exception(msg) {}
+RenameError::RenameError(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+RenameError::~RenameError() noexcept = default;
+
+ReplacementError::ReplacementError() : Base::Exception("Unable to replace object") {}
+ReplacementError::ReplacementError(const char* msg) : Base::Exception(msg) {}
+ReplacementError::ReplacementError(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+ReplacementError::~ReplacementError() noexcept = default;
+
+UpdateError::UpdateError() : Base::Exception("Unable to update object") {}
+UpdateError::UpdateError(const char* msg) : Base::Exception(msg) {}
+UpdateError::UpdateError(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+UpdateError::~UpdateError() noexcept = default;
+
+MoveError::MoveError() : Base::Exception("Unable to move object") {}
+MoveError::MoveError(const char* msg) : Base::Exception(msg) {}
+MoveError::MoveError(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+MoveError::~MoveError() noexcept = default;
+
+ConnectionError::ConnectionError() : Base::Exception("Unable to connect") {}
+ConnectionError::ConnectionError(const char* msg) : Base::Exception(msg) {}
+ConnectionError::ConnectionError(const QString& msg) : Base::Exception(msg.toStdString().c_str()) {}
+ConnectionError::~ConnectionError() noexcept = default;
+
+} // namespace Materials

--- a/src/Mod/Material/App/Exceptions.h
+++ b/src/Mod/Material/App/Exceptions.h
@@ -33,316 +33,190 @@ namespace Materials
 class Uninitialized: public Base::Exception
 {
 public:
-    Uninitialized()
-        : Base::Exception("Uninitialized")
-    {}
-    explicit Uninitialized(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit Uninitialized(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~Uninitialized() noexcept override = default;
+    Uninitialized();
+    explicit Uninitialized(const char* msg);
+    explicit Uninitialized(const QString& msg);
+    ~Uninitialized() noexcept override;
 };
 
 class ModelNotFound: public Base::Exception
 {
 public:
-    ModelNotFound()
-        : Base::Exception("Model not found")
-    {}
-    explicit ModelNotFound(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit ModelNotFound(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~ModelNotFound() noexcept override = default;
+    ModelNotFound();
+    explicit ModelNotFound(const char* msg);
+    explicit ModelNotFound(const QString& msg);
+    ~ModelNotFound() noexcept override;
 };
 
 class InvalidMaterialType: public Base::Exception
 {
 public:
-    InvalidMaterialType()
-        : Base::Exception("Invalid material type")
-    {}
-    explicit InvalidMaterialType(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit InvalidMaterialType(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~InvalidMaterialType() noexcept override = default;
+    InvalidMaterialType();
+    explicit InvalidMaterialType(const char* msg);
+    explicit InvalidMaterialType(const QString& msg);
+    ~InvalidMaterialType() noexcept override;
 };
 
 class MaterialNotFound: public Base::Exception
 {
 public:
-    MaterialNotFound()
-        : Base::Exception("Material not found")
-    {}
-    explicit MaterialNotFound(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit MaterialNotFound(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~MaterialNotFound() noexcept override = default;
+    MaterialNotFound();
+    explicit MaterialNotFound(const char* msg);
+    explicit MaterialNotFound(const QString& msg);
+    ~MaterialNotFound() noexcept override;
 };
 
 class MaterialExists: public Base::Exception
 {
 public:
-    MaterialExists()
-        : Base::Exception("Material already exists")
-    {}
-    explicit MaterialExists(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit MaterialExists(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~MaterialExists() noexcept override = default;
+    MaterialExists();
+    explicit MaterialExists(const char* msg);
+    explicit MaterialExists(const QString& msg);
+    ~MaterialExists() noexcept override;
 };
 
 class MaterialReadError: public Base::Exception
 {
 public:
-    MaterialReadError()
-        : Base::Exception("Unable to read material")
-    {}
-    explicit MaterialReadError(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit MaterialReadError(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~MaterialReadError() noexcept override = default;
+    MaterialReadError();
+    explicit MaterialReadError(const char* msg);
+    explicit MaterialReadError(const QString& msg);
+    ~MaterialReadError() noexcept override;
 };
 
 class PropertyNotFound: public Base::Exception
 {
 public:
-    PropertyNotFound()
-        : Base::Exception("Property not found")
-    {}
-    explicit PropertyNotFound(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit PropertyNotFound(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~PropertyNotFound() noexcept override = default;
+    PropertyNotFound();
+    explicit PropertyNotFound(const char* msg);
+    explicit PropertyNotFound(const QString& msg);
+    ~PropertyNotFound() noexcept override;
 };
 
 class LibraryNotFound: public Base::Exception
 {
 public:
-    LibraryNotFound()
-        : Base::Exception("Library not found")
-    {}
-    explicit LibraryNotFound(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit LibraryNotFound(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~LibraryNotFound() noexcept override = default;
+    LibraryNotFound();
+    explicit LibraryNotFound(const char* msg);
+    explicit LibraryNotFound(const QString& msg);
+    ~LibraryNotFound() noexcept override;
 };
 
 class CreationError: public Base::Exception
 {
 public:
-    CreationError()
-        : Base::Exception("Unable to create object")
-    {}
-    explicit CreationError(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit CreationError(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~CreationError() noexcept override = default;
+    CreationError();
+    explicit CreationError(const char* msg);
+    explicit CreationError(const QString& msg);
+    ~CreationError() noexcept override;
 };
 
 class InvalidModel: public Base::Exception
 {
 public:
-    InvalidModel()
-        : Base::Exception("Invalid model")
-    {}
-    explicit InvalidModel(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit InvalidModel(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~InvalidModel() noexcept override = default;
+    InvalidModel();
+    explicit InvalidModel(const char* msg);
+    explicit InvalidModel(const QString& msg);
+    ~InvalidModel() noexcept override;
 };
 
 class InvalidMaterial: public Base::Exception
 {
 public:
-    InvalidMaterial()
-        : Base::Exception("Invalid material")
-    {}
-    explicit InvalidMaterial(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit InvalidMaterial(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~InvalidMaterial() noexcept override = default;
+    InvalidMaterial();
+    explicit InvalidMaterial(const char* msg);
+    explicit InvalidMaterial(const QString& msg);
+    ~InvalidMaterial() noexcept override;
 };
 
 class InvalidProperty: public Base::Exception
 {
 public:
-    InvalidProperty()
-        : Base::Exception("Invalid property")
-    {}
-    explicit InvalidProperty(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit InvalidProperty(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~InvalidProperty() noexcept override = default;
+    InvalidProperty();
+    explicit InvalidProperty(const char* msg);
+    explicit InvalidProperty(const QString& msg);
+    ~InvalidProperty() noexcept override;
 };
 
 class InvalidLibrary: public Base::Exception
 {
 public:
-    InvalidLibrary()
-        : Base::Exception("Invalid library")
-    {}
-    explicit InvalidLibrary(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit InvalidLibrary(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~InvalidLibrary() noexcept override = default;
+    InvalidLibrary();
+    explicit InvalidLibrary(const char* msg);
+    explicit InvalidLibrary(const QString& msg);
+    ~InvalidLibrary() noexcept override;
 };
 
 class InvalidIndex: public Base::Exception
 {
 public:
-    InvalidIndex()
-        : Base::Exception("Invalid index")
-    {}
-    explicit InvalidIndex(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit InvalidIndex(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~InvalidIndex() noexcept override = default;
+    InvalidIndex();
+    explicit InvalidIndex(const char* msg);
+    explicit InvalidIndex(const QString& msg);
+    ~InvalidIndex() noexcept override;
 };
 
 class UnknownValueType: public Base::Exception
 {
 public:
-    UnknownValueType()
-        : Base::Exception("Unknown value type")
-    {}
-    explicit UnknownValueType(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit UnknownValueType(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~UnknownValueType() noexcept override = default;
+    UnknownValueType();
+    explicit UnknownValueType(const char* msg);
+    explicit UnknownValueType(const QString& msg);
+    ~UnknownValueType() noexcept override;
 };
 
 class DeleteError: public Base::Exception
 {
 public:
-    DeleteError()
-        : Base::Exception("Unable to delete object")
-    {}
-    explicit DeleteError(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit DeleteError(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~DeleteError() noexcept override = default;
+    DeleteError();
+    explicit DeleteError(const char* msg);
+    explicit DeleteError(const QString& msg);
+    ~DeleteError() noexcept override;
 };
 
 class RenameError: public Base::Exception
 {
 public:
-    RenameError()
-        : Base::Exception("Unable to rename object")
-    {}
-    explicit RenameError(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit RenameError(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~RenameError() noexcept override = default;
+    RenameError();
+    explicit RenameError(const char* msg);
+    explicit RenameError(const QString& msg);
+    ~RenameError() noexcept override;
 };
 
 class ReplacementError: public Base::Exception
 {
 public:
-    ReplacementError()
-        : Base::Exception("Unable to replace object")
-    {}
-    explicit ReplacementError(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit ReplacementError(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~ReplacementError() noexcept override = default;
+    ReplacementError();
+    explicit ReplacementError(const char* msg);
+    explicit ReplacementError(const QString& msg);
+    ~ReplacementError() noexcept override;
 };
 
 class UpdateError: public Base::Exception
 {
 public:
-    UpdateError()
-        : Base::Exception("Unable to update object")
-    {}
-    explicit UpdateError(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit UpdateError(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~UpdateError() noexcept override = default;
+    UpdateError();
+    explicit UpdateError(const char* msg);
+    explicit UpdateError(const QString& msg);
+    ~UpdateError() noexcept override;
 };
 
 class MoveError: public Base::Exception
 {
 public:
-    MoveError()
-        : Base::Exception("Unable to move object")
-    {}
-    explicit MoveError(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit MoveError(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~MoveError() noexcept override = default;
+    MoveError();
+    explicit MoveError(const char* msg);
+    explicit MoveError(const QString& msg);
+    ~MoveError() noexcept override;
 };
 
 class ConnectionError: public Base::Exception
 {
 public:
-    ConnectionError()
-        : Base::Exception("Unable to connect")
-    {}
-    explicit ConnectionError(const char* msg)
-        : Base::Exception(msg)
-    {}
-    explicit ConnectionError(const QString& msg)
-        : Base::Exception(msg.toStdString().c_str())
-    {}
-    ~ConnectionError() noexcept override = default;
+    ConnectionError();
+    explicit ConnectionError(const char* msg);
+    explicit ConnectionError(const QString& msg);
+    ~ConnectionError() noexcept override;
 };
 
 }  // namespace Materials

--- a/src/Mod/Material/Gui/MaterialTreeWidget.cpp
+++ b/src/Mod/Material/Gui/MaterialTreeWidget.cpp
@@ -474,9 +474,6 @@ void MaterialTreeWidget::saveRecents()
 
 void MaterialTreeWidget::addRecent(const QString& uuid)
 {
-    if (uuid.isEmpty()) {
-        return;
-    }
     // Ensure it is a material. New, unsaved materials will not be
     try {
         auto material = Materials::MaterialManager::getManager().getMaterial(uuid);


### PR DESCRIPTION
This fixes #18168 and #18170. The former issue was worked around with #18271, but it can be reverted now.

Credits go to @wwmayer who initially thought that this could be the issue in https://github.com/FreeCAD/FreeCAD/issues/18168#issuecomment-2521716247.