### PR TITLE
Simplify repr() function

### DIFF
--- a/src/Base/ProgressIndicatorPy.cpp
+++ b/src/Base/ProgressIndicatorPy.cpp
@@ -71,8 +71,7 @@ ProgressIndicatorPy::~ProgressIndicatorPy() = default;
 
 Py::Object ProgressIndicatorPy::repr()
 {
-    std::string s = "Base.ProgressIndicator";
-    return Py::String(s);  // NOLINT
+    return Py::String("Base.ProgressIndicator");
 }
 
 Py::Object ProgressIndicatorPy::start(const Py::Tuple& args)

--- a/src/Gui/MDIViewPy.cpp
+++ b/src/Gui/MDIViewPy.cpp
@@ -91,12 +91,10 @@ MDIViewPy::~MDIViewPy()
 
 Py::Object MDIViewPy::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
     if (!_view)
         throw Py::RuntimeError("Cannot print representation of deleted object");
-    s_out << _view->getTypeId().getName();
-    return Py::String(s_out.str());
+
+    return Py::String(_view->getTypeId().getName());
 }
 
 Py::Object MDIViewPy::printView(const Py::Tuple& args)

--- a/src/Gui/MainWindowPy.cpp
+++ b/src/Gui/MainWindowPy.cpp
@@ -121,12 +121,10 @@ MainWindowPy::~MainWindowPy()
 
 Py::Object MainWindowPy::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
     if (!_mw)
         throw Py::RuntimeError("Cannot print representation of deleted object");
-    s_out << "MainWindow";
-    return Py::String(s_out.str());
+
+    return Py::String("MainWindow");
 }
 
 Py::Object MainWindowPy::getWindows(const Py::Tuple& args)

--- a/src/Gui/PythonConsolePy.cpp
+++ b/src/Gui/PythonConsolePy.cpp
@@ -57,10 +57,7 @@ Py::Object PythonStdout::getattr(const char *name)
 
 Py::Object PythonStdout::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "PythonStdout";
-    return Py::String(s_out.str());
+    return Py::String("PythonStdout");
 }
 
 Py::Object PythonStdout::write(const Py::Tuple& args)
@@ -121,10 +118,7 @@ Py::Object PythonStderr::getattr(const char *name)
 
 Py::Object PythonStderr::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "PythonStderr";
-    return Py::String(s_out.str());
+    return Py::String("PythonStderr");
 }
 
 Py::Object PythonStderr::write(const Py::Tuple& args)
@@ -182,10 +176,7 @@ Py::Object OutputStdout::getattr(const char *name)
 
 Py::Object OutputStdout::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "OutputStdout";
-    return Py::String(s_out.str());
+    return Py::String("OutputStdout");
 }
 
 Py::Object OutputStdout::write(const Py::Tuple& args)
@@ -243,10 +234,7 @@ Py::Object OutputStderr::getattr(const char *name)
 
 Py::Object OutputStderr::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "OutputStderr";
-    return Py::String(s_out.str());
+    return Py::String("OutputStderr");
 }
 
 Py::Object OutputStderr::write(const Py::Tuple& args)
@@ -297,10 +285,7 @@ PythonStdin::~PythonStdin() = default;
 
 Py::Object PythonStdin::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "PythonStdin";
-    return Py::String(s_out.str());
+    return Py::String("PythonStdin");
 }
 
 Py::Object PythonStdin::getattr(const char *name)

--- a/src/Gui/PythonDebugger.cpp
+++ b/src/Gui/PythonDebugger.cpp
@@ -167,10 +167,7 @@ PythonDebugStdout::~PythonDebugStdout() = default;
 
 Py::Object PythonDebugStdout::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "PythonDebugStdout";
-    return Py::String(s_out.str());
+    return Py::String("PythonDebugStdout");
 }
 
 Py::Object PythonDebugStdout::write(const Py::Tuple& args)
@@ -210,10 +207,7 @@ PythonDebugStderr::~PythonDebugStderr() = default;
 
 Py::Object PythonDebugStderr::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "PythonDebugStderr";
-    return Py::String(s_out.str());
+    return Py::String("PythonDebugStderr");
 }
 
 Py::Object PythonDebugStderr::write(const Py::Tuple& args)
@@ -248,10 +242,7 @@ PythonDebugExcept::~PythonDebugExcept() = default;
 
 Py::Object PythonDebugExcept::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "PythonDebugExcept";
-    return Py::String(s_out.str());
+    return Py::String("PythonDebugExcept");
 }
 
 Py::Object PythonDebugExcept::excepthook(const Py::Tuple& args)

--- a/src/Gui/Selection/SelectionFilterPy.cpp
+++ b/src/Gui/Selection/SelectionFilterPy.cpp
@@ -47,10 +47,7 @@ SelectionFilterPy::~SelectionFilterPy() = default;
 
 Py::Object SelectionFilterPy::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "SelectionFilter";
-    return Py::String(s_out.str());
+    return Py::String("SelectionFilter");
 }
 
 Py::Object SelectionFilterPy::match()

--- a/src/Gui/SplitView3DInventor.cpp
+++ b/src/Gui/SplitView3DInventor.cpp
@@ -307,11 +307,10 @@ Py::Object AbstractSplitViewPy::cast_to_base(const Py::Tuple&)
 
 Py::Object AbstractSplitViewPy::repr()
 {
-    std::ostringstream s_out;
     if (!getSplitViewPtr())
         throw Py::RuntimeError("Cannot print representation of deleted object");
-    s_out << "AbstractSplitView";
-    return Py::String(s_out.str());
+
+    return Py::String("AbstractSplitView");
 }
 
 // Since with PyCXX it's not possible to make a sub-class of MDIViewPy

--- a/src/Gui/TaskView/TaskDialogPython.cpp
+++ b/src/Gui/TaskView/TaskDialogPython.cpp
@@ -104,10 +104,7 @@ ControlPy::~ControlPy() = default;
 
 Py::Object ControlPy::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "Control Task Dialog";
-    return Py::String(s_out.str());
+    return Py::String("Control Task Dialog");
 }
 
 Py::Object ControlPy::showDialog(const Py::Tuple& args)
@@ -369,10 +366,7 @@ TaskDialogPy::~TaskDialogPy() = default;
 
 Py::Object TaskDialogPy::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "Task Dialog";
-    return Py::String(s_out.str());
+    return Py::String("Task Dialog");
 }
 
 Py::Object TaskDialogPy::getattr(const char * attr)

--- a/src/Gui/UiLoader.cpp
+++ b/src/Gui/UiLoader.cpp
@@ -561,10 +561,7 @@ UiLoaderPy::~UiLoaderPy() = default;
 
 Py::Object UiLoaderPy::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "Ui loader";
-    return Py::String(s_out.str());
+    return Py::String("Ui loader");
 }
 
 Py::Object UiLoaderPy::load(const Py::Tuple& args)

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -254,12 +254,10 @@ View3DInventor* View3DInventorPy::getView3DInventorPtr()
 
 Py::Object View3DInventorPy::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
     if (!getView3DInventorPtr())
         throw Py::RuntimeError("Cannot print representation of deleted object");
-    s_out << "View3DInventor";
-    return Py::String(s_out.str());
+
+    return Py::String("View3DInventor");
 }
 
 View3DInventorPy::method_varargs_handler View3DInventorPy::pycxx_handler = nullptr;

--- a/src/Gui/View3DViewerPy.cpp
+++ b/src/Gui/View3DViewerPy.cpp
@@ -130,11 +130,10 @@ View3DInventorViewerPy::~View3DInventorViewerPy()
 
 Py::Object View3DInventorViewerPy::repr()
 {
-    std::ostringstream s_out;
     if (!_viewer)
         throw Py::RuntimeError("Cannot print representation of deleted object");
-    s_out << "View3DInventorViewer";
-    return Py::String(s_out.str());
+
+    return Py::String("View3DInventorViewer");
 }
 
 View3DInventorViewerPy::method_varargs_handler View3DInventorViewerPy::pycxx_handler = nullptr;

--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -517,10 +517,7 @@ bool PyResource::connect(const char* sender, const char* signal, PyObject* cb)
 
 Py::Object PyResource::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
-    s_out << "Resource object";
-    return Py::String(s_out.str());
+    return Py::String("Resource object");
 }
 
 /**

--- a/src/Mod/Sandbox/App/DocumentProtectorPy.cpp
+++ b/src/Mod/Sandbox/App/DocumentProtectorPy.cpp
@@ -63,12 +63,10 @@ DocumentProtectorPy::~DocumentProtectorPy()
 
 Py::Object DocumentProtectorPy::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
     if (!_dp)
         throw Py::RuntimeError("Cannot print representation of deleted object");
-    s_out << "Document protector";
-    return Py::String(s_out.str());
+
+    return Py::String("Document protector");
 }
 
 DocumentProtectorPy::method_varargs_handler DocumentProtectorPy::pycxx_handler = 0;
@@ -190,12 +188,10 @@ Py::Object DocumentObjectProtectorPy::getObject() const
 
 Py::Object DocumentObjectProtectorPy::repr()
 {
-    std::string s;
-    std::ostringstream s_out;
     if (!_dp)
         throw Py::RuntimeError("Cannot print representation of deleted object");
-    s_out << "Document object protector";
-    return Py::String(s_out.str());
+
+    return Py::String("Document object protector");
 }
 
 Py::Object DocumentObjectProtectorPy::getattr(const char * attr)

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -643,12 +643,11 @@ SheetViewPy::~SheetViewPy() = default;
 
 Py::Object SheetViewPy::repr()
 {
-    std::ostringstream s_out;
     if (!getSheetViewPtr()) {
         throw Py::RuntimeError("Cannot print representation of deleted object");
     }
-    s_out << "SheetView";
-    return Py::String(s_out.str());
+
+    return Py::String("SheetView");
 }
 
 // Since with PyCXX it's not possible to make a sub-class of MDIViewPy

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -1121,12 +1121,11 @@ MDIViewPagePy::~MDIViewPagePy() {}
 
 Py::Object MDIViewPagePy::repr()
 {
-    std::ostringstream s_out;
     if (!getMDIViewPagePtr()) {
         throw Py::RuntimeError("Cannot print representation of deleted object");
     }
-    s_out << "MDI view page";
-    return Py::String(s_out.str());
+
+    return Py::String("MDI view page");
 }
 
 // Since with PyCXX it is not possible to make a sub-class of MDIViewPy


### PR DESCRIPTION
This commit simplifies this function all over the source code. Should I add `// NOLINT`?



In `src/Gui/View3DViewerPy.cpp` the last line is removed and added, I don't know how and why. It seems to be a trick of _Qt Creator_.






