### PR TITLE
FEM: Extract postprocessing data only if available. Fixes #22193

### DIFF
--- a/src/Mod/Fem/App/FemPostFilter.cpp
+++ b/src/Mod/Fem/App/FemPostFilter.cpp
@@ -29,6 +29,7 @@
 #include <vtkAlgorithm.h>
 #include <vtkAlgorithmOutput.h>
 #include <vtkUnstructuredGrid.h>
+#include <vtkInformation.h>
 #endif
 
 #include <App/FeaturePythonPyImp.h>
@@ -40,6 +41,7 @@
 
 #include "FemPostPipeline.h"
 #include "FemPostBranchFilter.h"
+
 
 
 using namespace Fem;
@@ -218,6 +220,17 @@ DocumentObjectExecReturn* FemPostFilter::execute()
     return StdReturn;
 }
 
+bool FemPostFilter::dataIsAvailable()
+{
+    auto algo = getFilterOutput();
+    if (!algo) {
+        return false;
+    }
+
+    vtkInformation* info = algo->GetInputInformation(0,0);
+    return bool(info->Has(vtkDataObject::DATA_OBJECT()));
+}
+
 vtkSmartPointer<vtkDataSet> FemPostFilter::getInputData()
 {
     auto active = m_pipelines[m_activePipeline];
@@ -233,12 +246,21 @@ vtkSmartPointer<vtkDataSet> FemPostFilter::getInputData()
     if (!algo) {
         return nullptr;
     }
+
+    // make sure the data processing is up to date
     if (Frame.getValue() > 0) {
         algo->UpdateTimeStep(Frame.getValue());
     }
     else {
         algo->Update();
     }
+
+    // check if the algorithm has data available
+    vtkInformation* info = algo->GetInputInformation(0,0);
+    if (!bool(info->Has(vtkDataObject::DATA_OBJECT()))){
+        return nullptr;
+    }
+
     return vtkDataSet::SafeDownCast(algo->GetOutputDataObject(0));
 }
 
@@ -472,6 +494,10 @@ void FemPostDataAlongLineFilter::GetAxisData()
     std::vector<double> coords;
     std::vector<double> values;
 
+    if (!dataIsAvailable()) {
+        return;
+    }
+
     vtkSmartPointer<vtkDataObject> data = m_probe->GetOutputDataObject(0);
     vtkDataSet* dset = vtkDataSet::SafeDownCast(data);
     if (!dset) {
@@ -597,6 +623,9 @@ short int FemPostDataAtPointFilter::mustExecute() const
 
 void FemPostDataAtPointFilter::GetPointData()
 {
+    if (!dataIsAvailable())
+        return;
+
     std::vector<double> values;
 
     vtkSmartPointer<vtkDataObject> data = m_probe->GetOutputDataObject(0);

--- a/src/Mod/Fem/App/FemPostFilter.cpp
+++ b/src/Mod/Fem/App/FemPostFilter.cpp
@@ -43,7 +43,6 @@
 #include "FemPostBranchFilter.h"
 
 
-
 using namespace Fem;
 using namespace App;
 
@@ -227,7 +226,7 @@ bool FemPostFilter::dataIsAvailable()
         return false;
     }
 
-    vtkInformation* info = algo->GetInputInformation(0,0);
+    vtkInformation* info = algo->GetInputInformation(0, 0);
     return bool(info->Has(vtkDataObject::DATA_OBJECT()));
 }
 
@@ -256,8 +255,8 @@ vtkSmartPointer<vtkDataSet> FemPostFilter::getInputData()
     }
 
     // check if the algorithm has data available
-    vtkInformation* info = algo->GetInputInformation(0,0);
-    if (!bool(info->Has(vtkDataObject::DATA_OBJECT()))){
+    vtkInformation* info = algo->GetInputInformation(0, 0);
+    if (!bool(info->Has(vtkDataObject::DATA_OBJECT()))) {
         return nullptr;
     }
 
@@ -623,8 +622,9 @@ short int FemPostDataAtPointFilter::mustExecute() const
 
 void FemPostDataAtPointFilter::GetPointData()
 {
-    if (!dataIsAvailable())
+    if (!dataIsAvailable()) {
         return;
+    }
 
     std::vector<double> values;
 

--- a/src/Mod/Fem/App/FemPostFilter.h
+++ b/src/Mod/Fem/App/FemPostFilter.h
@@ -62,6 +62,7 @@ class FemExport FemPostFilter: public Fem::FemPostObject
     PROPERTY_HEADER_WITH_OVERRIDE(Fem::FemPostFilter);
 
 protected:
+    bool dataIsAvailable();
     vtkSmartPointer<vtkDataSet> getInputData();
     std::vector<std::string> getInputVectorFields();
     std::vector<std::string> getInputScalarFields();


### PR DESCRIPTION
Adds a check if data is available in a pipeline before extracting it in onChanged calls. This prevents the vtk error observed in issue #22193 

@FEA-eng FYI

This fixes the occurrence of the bug with data at point mentioned in the issue report. The other mentioned issues with the contour filter I was unable to reproduce, hence not sure if it is affected.