### PR TITLE
Sketcher: fix cropping of some icons on hidpi screens

### DIFF
--- a/src/Gui/ToolHandler.cpp
+++ b/src/Gui/ToolHandler.cpp
@@ -197,17 +197,14 @@ void ToolHandler::addCursorTail(std::vector<QPixmap>& pixmaps)
     int newIconWidth = baseCursorWidth + tailWidth;
     int newIconHeight = baseCursorHeight;
 
-    QPixmap newIcon(newIconWidth, newIconHeight);
+    QPixmap newIcon(newIconWidth * pixelRatio, newIconHeight * pixelRatio);
+    newIcon.setDevicePixelRatio(pixelRatio);
     newIcon.fill(Qt::transparent);
 
     QPainter qp;
     qp.begin(&newIcon);
 
-    qp.drawPixmap(QPointF(0, 0),
-                    baseIcon.scaled(baseCursorWidth * pixelRatio,
-                                    baseCursorHeight * pixelRatio,
-                                    Qt::KeepAspectRatio,
-                                    Qt::SmoothTransformation));
+    qp.drawPixmap(QPointF(0, 0), baseIcon);
 
     // Iterate through pixmaps and them to the cursor pixmap
     qreal currentIconX = baseCursorWidth;
@@ -215,7 +212,7 @@ void ToolHandler::addCursorTail(std::vector<QPixmap>& pixmaps)
 
     for (auto& icon : pixmaps) {
         currentIconY = baseCursorHeight - icon.height();
-        qp.drawPixmap(QPointF(currentIconX, currentIconY), icon);
+        qp.drawPixmap(QPointF(currentIconX, currentIconY) / pixelRatio, icon);
         currentIconX += icon.width();
     }
 

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1338,7 +1338,7 @@ private:
                                                           QSizeF(iconWidth, iconWidth));
         QPainter cursorPainter;
         cursorPainter.begin(&cursorPixmap);
-        cursorPainter.drawPixmap(16 * pixelRatio, 16 * pixelRatio, icon);
+        cursorPainter.drawPixmap(16, 16, icon);
         cursorPainter.end();
         int hotX = 8;
         int hotY = 8;
@@ -1626,7 +1626,7 @@ public:
         QPixmap icon = Gui::BitmapFactory().pixmapFromSvg("Constraint_Dimension", QSizeF(iconWidth, iconWidth));
         QPainter cursorPainter;
         cursorPainter.begin(&cursorPixmap);
-        cursorPainter.drawPixmap(16 * pixelRatio, 16 * pixelRatio, icon);
+        cursorPainter.drawPixmap(16, 16, icon);
         cursorPainter.end();
         int hotX = 8;
         int hotY = 8;

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2756,6 +2756,8 @@ QImage EditModeConstraintCoinManager::renderConstrIcon(const QString& type,
                                               pxMap);  // Cache for speed, avoiding pixmapFromSvg
     }
     QImage icon = pxMap.toImage();
+    // The pixmap was already scaled so we don't need to scale the image
+    icon.setDevicePixelRatio(1.0f);
 
     QFont font = ViewProviderSketchCoinAttorney::getApplicationFont(viewProvider);
     font.setPixelSize(static_cast<int>(1.0 * drawingParameters.constraintIconSize));


### PR DESCRIPTION
fixes https://github.com/FreeCAD/FreeCAD/issues/21926 and https://github.com/FreeCAD/FreeCAD/issues/23128

As seen from the image (at 200% scaling) neither the grouped constraints nor the tool indicator is cropped
<img width="1920" height="908" alt="image" src="https://github.com/user-attachments/assets/5452386f-1ea6-4e31-8809-48ab279c9afd" />

This should fix the regressions introduced by https://github.com/FreeCAD/FreeCAD/pull/20594
