### PR TITLE
GUI: start cleaning up Parameter Editor

### DIFF
--- a/src/Gui/Dialogs/DlgParameter.ui
+++ b/src/Gui/Dialogs/DlgParameter.ui
@@ -60,14 +60,14 @@
      <item>
       <widget class="QLabel" name="quickSearch">
        <property name="text">
-        <string>Quick search</string>
+        <string>Search</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QLineEdit" name="findGroupLE">
        <property name="toolTip">
-        <string>Type in a group name to find it</string>
+        <string>Enter a group name to search</string>
        </property>
        <property name="placeholderText">
         <string>Search group</string>
@@ -83,7 +83,7 @@
      <item>
       <widget class="QPushButton" name="buttonFind">
        <property name="text">
-        <string>Find…</string>
+        <string>Find</string>
        </property>
       </widget>
      </item>
@@ -106,7 +106,7 @@
      <item>
       <widget class="QPushButton" name="buttonSaveToDisk">
        <property name="text">
-        <string>Save to Disk</string>
+        <string>Save</string>
        </property>
        <property name="shortcut">
         <string>Alt+C</string>


### PR DESCRIPTION
Begins to address a few issues brought up in #17351

Partial list copied from ticket: 

- [X] "Quick search". What's the significance of "Quick". Begs the question: Where's the slow search? Delete "Quick".
- [X]  The button is "Find...". What is the significance of the "..."?
- [X] Why "Save to disk"? There's no obvious option to save anywhere else, so "to disk" is noise that should be deleted.