### PR TITLE
[Meas]Fix visibility at load

### DIFF
--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -230,8 +230,11 @@ void ViewProviderMeasureBase::setDisplayMode(const char* ModeName)
 
 void ViewProviderMeasureBase::finishRestoring()
 {
-    // Force measurement visibility when loading a document
-    show();
+    if (Visibility.getValue() &&
+        isSubjectVisible()) {
+        show();
+    }
+    ViewProviderDocumentObject::finishRestoring();
 }
 
 
@@ -254,6 +257,7 @@ void ViewProviderMeasureBase::onChanged(const App::Property* prop)
         pLabel->size = FontSize.getValue();
         fieldFontSize.setValue(FontSize.getValue());
     }
+
     ViewProviderDocumentObject::onChanged(prop);
 }
 
@@ -522,6 +526,7 @@ void ViewProviderMeasureBase::onSubjectVisibilityChanged(const App::DocumentObje
         return;
     }
 
+
     std::string propName = prop.getName();
     if (propName == "Visibility") {
         if (!docObj.Visibility.getValue()) {
@@ -531,7 +536,7 @@ void ViewProviderMeasureBase::onSubjectVisibilityChanged(const App::DocumentObje
         else {
             // here, we don't know if we should be visible or not, so we have to check the whole
             // subject
-            setVisible(isSubjectVisible());
+            setVisible(isSubjectVisible() && Visibility.getValue());
         }
     }
 }


### PR DESCRIPTION
This PR implements a fix for issue #17292.

It ensures that measurement is visible only if both the subject and measurement are visible and corrects the error of always showing a measurement at startup.