### PR TITLE
Part: Fix toponaming issues.

### DIFF
--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -54,17 +54,31 @@ App::DocumentObjectExecReturn *Chamfer::execute()
         TopTools_IndexedDataMapOfShapeListOfShape mapEdgeFace;
         TopExp::MapShapesAndAncestors(baseShape, TopAbs_EDGE, TopAbs_FACE, mapEdgeFace);
         TopTools_IndexedMapOfShape mapOfEdges;
+        std::vector<Part::FilletElement> edges = Edges.getValues();
         TopExp::MapShapes(baseShape, TopAbs_EDGE, mapOfEdges);
+        std::string fullErrMsg = "";
 
         const auto &vals = EdgeLinks.getSubValues();
         const auto &subs = EdgeLinks.getShadowSubs();
         if(subs.size()!=(size_t)Edges.getSize())
             return new App::DocumentObjectExecReturn("Edge link size mismatch");
         size_t i=0;
-        for(const auto &info : Edges.getValues()) {
+        for(const auto &info : edges) {
             auto &sub = subs[i];
-            auto &ref = sub.newName.size()?sub.newName:vals[i];
+            auto &ref = sub.newName.size() ? sub.newName : vals[i];
+            auto &oldName = sub.oldName.size() ? sub.oldName : "";
             ++i;
+
+            if (Data::hasMissingElement(ref.c_str()) || Data::hasMissingElement(oldName.c_str())) {
+                fullErrMsg.append("Missing edge link: ");
+                fullErrMsg.append(ref);
+                fullErrMsg.append("\n");
+
+                auto removeIt = std::remove(edges.begin(), edges.end(), info);
+                edges.erase(removeIt, edges.end());
+
+                continue;
+            }
             // Toponaming project March 2024:  Replaced this code because it wouldn't work:
 //            TopoDS_Shape edge;
 //            try {
@@ -79,6 +93,11 @@ App::DocumentObjectExecReturn *Chamfer::execute()
             const TopoDS_Face& face = TopoDS::Face(mapEdgeFace.FindFromKey(edge).First());
             mkChamfer.Add(radius1, radius2, TopoDS::Edge(edge), face);
         }
+
+        if (fullErrMsg != "") {
+            return new App::DocumentObjectExecReturn(fullErrMsg);
+        }
+        Edges.setValues(edges);
 
         TopoDS_Shape shape = mkChamfer.Shape();
         if (shape.IsNull())

--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -49,7 +49,7 @@ App::DocumentObjectExecReturn *Chamfer::execute()
 
     try {
         TopoShape baseTopoShape = Feature::getTopoShape(link, ShapeOption::ResolveLink | ShapeOption::Transform);
-        auto baseShape = Feature::getShape(link, ShapeOption::ResolveLink | ShapeOption::Transform);
+        auto baseShape = baseTopoShape.getShape();
         BRepFilletAPI_MakeChamfer mkChamfer(baseShape);
         TopTools_IndexedDataMapOfShapeListOfShape mapEdgeFace;
         TopExp::MapShapesAndAncestors(baseShape, TopAbs_EDGE, TopAbs_FACE, mapEdgeFace);

--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -313,7 +313,7 @@ Base::Vector3d Extrusion::calculateShapeNormal(const App::PropertyLink& shapeLin
     return Base::Vector3d(normal.X(), normal.Y(), normal.Z());
 }
 
-void Extrusion::extrudeShape(TopoShape &result, const TopoShape &source, const ExtrusionParameters& params, App::Document* document)
+void Extrusion::extrudeShape(TopoShape &result, const TopoShape &source, const ExtrusionParameters& params)
 {
     gp_Vec vec = gp_Vec(params.dir).Multiplied(params.lengthFwd + params.lengthRev);//total vector of extrusion
 
@@ -355,11 +355,7 @@ void Extrusion::extrudeShape(TopoShape &result, const TopoShape &source, const E
             // test if we need to make faces from wires. If there are faces - we don't.
             if (!myShape.hasSubShape(TopAbs_FACE)) {
                 if (!myShape.Hasher) {
-                    if (result.Hasher) {
-                        myShape.Hasher = result.Hasher;
-                    } else if(document) {
-                        myShape.Hasher = document->getStringHasher();
-                    }
+                    myShape.Hasher = result.Hasher;
                 }
                 myShape = myShape.makeElementFace(nullptr, params.faceMakerClass.c_str());
             }
@@ -379,8 +375,9 @@ App::DocumentObjectExecReturn* Extrusion::execute()
 
     try {
         ExtrusionParameters params = computeFinalParameters();
-        TopoShape result(0);
-        extrudeShape(result, Feature::getTopoShape(link, ShapeOption::ResolveLink | ShapeOption::Transform), params, link->getDocument());
+        TopoShape result(0, getDocument()->getStringHasher());
+        
+        extrudeShape(result, Feature::getTopoShape(link, ShapeOption::ResolveLink | ShapeOption::Transform), params);
         this->Shape.setValue(result);
         return App::DocumentObject::StdReturn;
     }

--- a/src/Mod/Part/App/FeatureExtrusion.h
+++ b/src/Mod/Part/App/FeatureExtrusion.h
@@ -26,6 +26,7 @@
 #include <App/PropertyStandard.h>
 #include <App/PropertyUnits.h>
 
+#include <App/Document.h>
 #include "FaceMakerCheese.h"
 #include "PartFeature.h"
 #include "ExtrusionHelper.h"
@@ -71,7 +72,7 @@ public:
      * @param source: the shape to be extruded
      * @param params: extrusion parameters
      */
-    static void extrudeShape(TopoShape &result, const TopoShape &source, const ExtrusionParameters& params);
+    static void extrudeShape(TopoShape &result, const TopoShape &source, const ExtrusionParameters& params, App::Document* document = nullptr);
 
     /**
      * @brief fetchAxisLink: read AxisLink to obtain the direction and

--- a/src/Mod/Part/App/FeatureExtrusion.h
+++ b/src/Mod/Part/App/FeatureExtrusion.h
@@ -72,7 +72,7 @@ public:
      * @param source: the shape to be extruded
      * @param params: extrusion parameters
      */
-    static void extrudeShape(TopoShape &result, const TopoShape &source, const ExtrusionParameters& params, App::Document* document = nullptr);
+    static void extrudeShape(TopoShape &result, const TopoShape &source, const ExtrusionParameters& params);
 
     /**
      * @brief fetchAxisLink: read AxisLink to obtain the direction and

--- a/src/Mod/Part/App/FeatureFillet.cpp
+++ b/src/Mod/Part/App/FeatureFillet.cpp
@@ -54,8 +54,8 @@ App::DocumentObjectExecReturn *Fillet::execute()
 #if defined(__GNUC__) && defined (FC_OS_LINUX)
         Base::SignalException se;
 #endif
-        auto baseShape = Feature::getShape(link, ShapeOption::ResolveLink | ShapeOption::Transform);
         TopoShape baseTopoShape = Feature::getTopoShape(link, ShapeOption::ResolveLink | ShapeOption::Transform);
+        auto baseShape = baseTopoShape.getShape();
         BRepFilletAPI_MakeFillet mkFillet(baseShape);
         TopTools_IndexedMapOfShape mapOfShape;
         TopExp::MapShapes(baseShape, TopAbs_EDGE, mapOfShape);
@@ -89,7 +89,7 @@ App::DocumentObjectExecReturn *Fillet::execute()
             return new App::DocumentObjectExecReturn("Resulting shape is null");
 
         TopoShape res(0);
-        this->Shape.setValue(res.makeElementShape(mkFillet,baseTopoShape,Part::OpCodes::Fillet));
+        this->Shape.setValue(res.makeElementShape(mkFillet, baseTopoShape, Part::OpCodes::Fillet));
         return Part::FilletBase::execute();
     }
     catch (Standard_Failure& e) {

--- a/src/Mod/Part/App/FeatureFillet.cpp
+++ b/src/Mod/Part/App/FeatureFillet.cpp
@@ -54,22 +54,38 @@ App::DocumentObjectExecReturn *Fillet::execute()
 #if defined(__GNUC__) && defined (FC_OS_LINUX)
         Base::SignalException se;
 #endif
-        TopoShape baseTopoShape = Feature::getTopoShape(link, ShapeOption::ResolveLink | ShapeOption::Transform);
+    TopoShape baseTopoShape = Feature::getTopoShape(link, ShapeOption::ResolveLink | ShapeOption::Transform);
         auto baseShape = baseTopoShape.getShape();
         BRepFilletAPI_MakeFillet mkFillet(baseShape);
         TopTools_IndexedMapOfShape mapOfShape;
         TopExp::MapShapes(baseShape, TopAbs_EDGE, mapOfShape);
         TopTools_IndexedMapOfShape mapOfEdges;
         TopExp::MapShapes(baseShape, TopAbs_EDGE, mapOfEdges);
-        const auto &vals = EdgeLinks.getSubValues();
+        std::vector<Part::FilletElement> edges = Edges.getValues();
+        std::string fullErrMsg = "";
+
+        const auto &vals = EdgeLinks.getSubValues(true);
         const auto &subs = EdgeLinks.getShadowSubs();
         if(subs.size()!=(size_t)Edges.getSize())
             return new App::DocumentObjectExecReturn("Edge link size mismatch");
         size_t i=0;
-        for(const auto &info : Edges.getValues()) {
+        for(const auto &info : edges) {
             auto &sub = subs[i];
-            auto &ref = sub.newName.size()?sub.newName:vals[i];
+            auto &ref = sub.newName.size() ? sub.newName : vals[i];
+            auto &oldName = sub.oldName.size() ? sub.oldName : "";
             ++i;
+
+            if (Data::hasMissingElement(ref.c_str()) || Data::hasMissingElement(oldName.c_str())) {
+                fullErrMsg.append("Missing edge link: ");
+                fullErrMsg.append(ref);
+                fullErrMsg.append("\n");
+
+                auto removeIt = std::remove(edges.begin(), edges.end(), info);
+                edges.erase(removeIt, edges.end());
+
+                continue;
+            }
+
             // Toponaming project March 2024:  Replaced this code because it wouldn't work:
 //            TopoDS_Shape edge;
 //            try {
@@ -77,12 +93,19 @@ App::DocumentObjectExecReturn *Fillet::execute()
 //            }catch(...){}
             auto id = Data::MappedName(ref.c_str()).toIndexedName().getIndex();
             const TopoDS_Edge& edge = TopoDS::Edge(mapOfEdges.FindKey(id));
+
             if(edge.IsNull())
-                return new App::DocumentObjectExecReturn("Invalid edge link");
+                return new App::DocumentObjectExecReturn("Invalid edge link");                
+
             double radius1 = info.radius1;
             double radius2 = info.radius2;
             mkFillet.Add(radius1, radius2, TopoDS::Edge(edge));
         }
+
+        if (fullErrMsg != "") {
+            return new App::DocumentObjectExecReturn(fullErrMsg);
+        }
+        Edges.setValues(edges);
 
         TopoDS_Shape shape = mkFillet.Shape();
         if (shape.IsNull())

--- a/src/Mod/Part/App/FeatureMirroring.cpp
+++ b/src/Mod/Part/App/FeatureMirroring.cpp
@@ -38,6 +38,7 @@
 # include <TopExp_Explorer.hxx>
 #endif
 
+#include <App/Document.h>
 #include <Mod/Part/App/PrimitiveFeature.h>
 #include <App/Link.h>
 #include <App/Datums.h>
@@ -263,7 +264,7 @@ App::DocumentObjectExecReturn *Mirroring::execute()
         auto shape = Feature::getTopoShape(link, ShapeOption::ResolveLink | ShapeOption::Transform);
         if (shape.isNull())
             Standard_Failure::Raise("Cannot mirror empty shape");
-        this->Shape.setValue(TopoShape(0).makeElementMirror(shape,ax2));
+        this->Shape.setValue(TopoShape(0, getDocument()->getStringHasher()).makeElementMirror(shape,ax2));
         copyMaterial(link);
 
         return Part::Feature::execute();

--- a/src/Mod/Part/App/FeatureRevolution.cpp
+++ b/src/Mod/Part/App/FeatureRevolution.cpp
@@ -30,6 +30,7 @@
 # include <TopoDS.hxx>
 #endif
 
+#include <App/Document.h>
 #include <Base/Tools.h>
 #include "FeatureRevolution.h"
 #include "FaceMaker.h"
@@ -161,7 +162,7 @@ App::DocumentObjectExecReturn *Revolution::execute()
             TopLoc_Location loc(mov);
             sourceShape.setShape(sourceShape.getShape().Moved(loc));
         }
-        TopoShape revolve(0);
+        TopoShape revolve(0, getDocument()->getStringHasher());
         revolve.makeElementRevolve(sourceShape,
                                    revAx,
                                    angle,

--- a/src/Mod/Part/App/PartFeatures.cpp
+++ b/src/Mod/Part/App/PartFeatures.cpp
@@ -150,7 +150,7 @@ App::DocumentObjectExecReturn* RuledSurface::execute()
                 return new App::DocumentObjectExecReturn("Invalid link.");
             }
         }
-        TopoShape res(0);
+        TopoShape res(0, getDocument()->getStringHasher());
         res.makeElementRuledSurface(shapes, Orientation.getValue());
         this->Shape.setValue(res);
         return Part::Feature::execute();
@@ -229,7 +229,7 @@ App::DocumentObjectExecReturn* Loft::execute()
         IsRuled isRuled = Ruled.getValue() ? IsRuled::ruled : IsRuled::notRuled;
         IsClosed isClosed = Closed.getValue() ? IsClosed::closed : IsClosed::notClosed;
         int degMax = MaxDegree.getValue();
-        TopoShape result(0);
+        TopoShape result(0, getDocument()->getStringHasher());
         result.makeElementLoft(shapes, isSolid, isRuled, isClosed, degMax);
         if (Linearize.getValue()) {
             result.linearize( LinearizeFace::linearizeFaces, LinearizeEdge::noEdges);
@@ -312,7 +312,7 @@ App::DocumentObjectExecReturn* Sweep::execute()
             }
             spineShapes.push_back(shape);
         }
-        spine = TopoShape().makeElementCompound(spineShapes, 0, TopoShape::SingleShapeCompoundCreationPolicy::returnShape);
+        spine = TopoShape(0, getDocument()->getStringHasher()).makeElementCompound(spineShapes, 0, TopoShape::SingleShapeCompoundCreationPolicy::returnShape);
     }
     std::vector<TopoShape> shapes;
     shapes.push_back(spine);
@@ -427,7 +427,7 @@ App::DocumentObjectExecReturn* Thickness::execute()
     short mode = (short)Mode.getValue();
     short join = (short)Join.getValue();
 
-    this->Shape.setValue(TopoShape(0,getDocument()->getStringHasher())
+    this->Shape.setValue(TopoShape(0, getDocument()->getStringHasher())
                              .makeElementThickSolid(base,
                                                     shapes,
                                                     thickness,

--- a/src/Mod/Part/BOPTools/GeneralFuseResult.py
+++ b/src/Mod/Part/BOPTools/GeneralFuseResult.py
@@ -296,7 +296,7 @@ def myCustomFusionRoutine(list_of_shapes):
                         new_children.append(new_piece)
                         existing_pieces[hash] = (-1, new_piece)
         if changed:
-            return Part.Compound(new_children)
+            return Part.makeCompound(new_children)
         else:
             return None
 
@@ -431,4 +431,4 @@ class GeneralFuseReturnBuilder(FrozenClass):
         self.pieces[piece_index] = new_shape
 
     def getGFReturn(self):
-        return (Part.Compound(self.pieces), [[self.pieces[iPiece] for iPiece in ilist] for ilist in self._pieces_from_source])
+        return (Part.makeCompound(self.pieces), [[self.pieces[iPiece] for iPiece in ilist] for ilist in self._pieces_from_source])

--- a/src/Mod/Part/BOPTools/JoinAPI.py
+++ b/src/Mod/Part/BOPTools/JoinAPI.py
@@ -91,7 +91,7 @@ def connect(list_of_shapes, tolerance = 0.0):
         if largest is not None:
             keepers.append(largest)
 
-    touch_test_list = Part.Compound(keepers)
+    touch_test_list = Part.makeCompound(keepers)
     #add all intersection pieces that touch danglers, triple intersection pieces that touch duals, and so on
     for ii in range(2, ao.largestOverlapCount()+1):
         list_ii_pieces = [piece for piece in ao.pieces if len(ao.sourcesOfPiece(piece)) == ii]
@@ -102,7 +102,7 @@ def connect(list_of_shapes, tolerance = 0.0):
         if len(keepers_2_add) == 0:
             break
         keepers.extend(keepers_2_add)
-        touch_test_list = Part.Compound(keepers_2_add)
+        touch_test_list = Part.makeCompound(keepers_2_add)
 
 
     #merge, and we are done!
@@ -160,7 +160,7 @@ def cutout_legacy(shape_base, shape_tool, tolerance = 0.0):
         result = []
         for sh in shapes_base:
             result.append(cutout(sh, shape_tool))
-        return Part.Compound(result)
+        return Part.makeCompound(result)
 
     shape_base = shapes_base[0]
     pieces = compoundLeaves(shape_base.cut(shape_tool))

--- a/src/Mod/Part/BOPTools/ShapeMerge.py
+++ b/src/Mod/Part/BOPTools/ShapeMerge.py
@@ -152,7 +152,7 @@ def mergeShells(list_of_faces_shells, flag_single = False, split_connections = [
         return Part.makeShell(faces)
     else:
         groups = splitIntoGroupsBySharing(faces, lambda sh: sh.Edges, split_connections)
-        return Part.makeCompound([Part.Shell(group) for group in groups])
+        return Part.makeCompound([Part.makeShell(group) for group in groups])
 
 def mergeWires(list_of_edges_wires, flag_single = False, split_connections = []):
     edges = []

--- a/src/Mod/Part/BOPTools/SplitAPI.py
+++ b/src/Mod/Part/BOPTools/SplitAPI.py
@@ -55,7 +55,7 @@ def booleanFragments(list_of_shapes, mode, tolerance = 0.0):
     elif mode == "Split":
         gr = GeneralFuseResult(list_of_shapes, (pieces,map))
         gr.splitAggregates()
-        return Part.Compound(gr.pieces)
+        return Part.makeCompound(gr.pieces)
     else:
         raise ValueError("Unknown mode: {mode}".format(mode= mode))
 
@@ -69,7 +69,7 @@ def slice(base_shape, tool_shapes, mode, tolerance = 0.0):
     "Split" - wires and shells will be split at intersections, too.
     "CompSolid" - slice a solid and glue it back together to make a compsolid"""
 
-    shapes = [base_shape] + [Part.Compound([tool_shape]) for tool_shape in tool_shapes] # hack: putting tools into compounds will prevent contamination of result with pieces of tools
+    shapes = [base_shape] + [Part.makeCompound([tool_shape]) for tool_shape in tool_shapes] # hack: putting tools into compounds will prevent contamination of result with pieces of tools
     if len(shapes) < 2:
         raise ValueError("No slicing objects supplied!")
     pieces, map = shapes[0].generalFuse(shapes[1:], tolerance)
@@ -77,7 +77,7 @@ def slice(base_shape, tool_shapes, mode, tolerance = 0.0):
     if mode == "Standard":
         result = gr.piecesFromSource(shapes[0])
     elif mode == "CompSolid":
-        solids = Part.Compound(gr.piecesFromSource(shapes[0])).Solids
+        solids = Part.makeCompound(gr.piecesFromSource(shapes[0])).Solids
         if len(solids) < 1:
             raise ValueError("No solids in the result. Can't make compsolid.")
         elif len(solids) == 1:
@@ -86,7 +86,7 @@ def slice(base_shape, tool_shapes, mode, tolerance = 0.0):
     elif mode == "Split":
         gr.splitAggregates(gr.piecesFromSource(shapes[0]))
         result = gr.piecesFromSource(shapes[0])
-    return result[0] if len(result) == 1 else Part.Compound(result)
+    return result[0] if len(result) == 1 else Part.makeCompound(result)
 
 def xor(list_of_shapes, tolerance = 0.0):
     """xor(list_of_shapes, tolerance = 0.0): boolean XOR operation."""
@@ -99,4 +99,4 @@ def xor(list_of_shapes, tolerance = 0.0):
     for piece in gr.pieces:
         if len(gr.sourcesOfPiece(piece)) % 2 == 1:
             pieces_to_keep.append(piece)
-    return Part.Compound(pieces_to_keep)
+    return Part.makeCompound(pieces_to_keep)

--- a/src/Mod/Part/BOPTools/Utils.py
+++ b/src/Mod/Part/BOPTools/Utils.py
@@ -105,11 +105,11 @@ def upgradeToAggregateIfNeeded(list_of_shapes, types = None):
     if "Wire" in types:
         list_of_shapes = [(Part.Wire([shape]) if shape.ShapeType == "Edge" else shape) for shape in list_of_shapes]
     if "Shell" in types:
-        list_of_shapes = [(Part.Shell([shape]) if shape.ShapeType == "Face" else shape) for shape in list_of_shapes]
+        list_of_shapes = [(Part.makeShell([shape]) if shape.ShapeType == "Face" else shape) for shape in list_of_shapes]
     if "CompSolid" in types:
         list_of_shapes = [(Part.CompSolid([shape]) if shape.ShapeType == "Solid" else shape) for shape in list_of_shapes]
     if "Compound" in types:
-        list_of_shapes = [(Part.Compound(upgradeToAggregateIfNeeded(shape.childShapes(), types)) if shape.ShapeType == "Compound" else shape) for shape in list_of_shapes]
+        list_of_shapes = [(Part.makeCompound(upgradeToAggregateIfNeeded(shape.childShapes(), types)) if shape.ShapeType == "Compound" else shape) for shape in list_of_shapes]
     return list_of_shapes
 
 # adapted from http://stackoverflow.com/a/3603824/6285007

--- a/src/Mod/Part/CompoundTools/CompoundFilter.py
+++ b/src/Mod/Part/CompoundTools/CompoundFilter.py
@@ -117,6 +117,7 @@ class _CompoundFilter:
                                          "filter: '{}'".format(obj.FilterType))
                     try:
                         rst.append(shps[i])
+                        len(shps[i].ElementMap) # this should fix some stuff on the c++ side..
                     except IndexError:
                         raise ValueError("Item index '{}' is out of range for this filter: '{}'".format(i, obj.FilterType))
                     flags[i] = True

--- a/src/Mod/Part/Gui/CrossSections.cpp
+++ b/src/Mod/Part/Gui/CrossSections.cpp
@@ -288,7 +288,7 @@ void CrossSections::apply()
         }
 
         Gui::Command::runCommand(Gui::Command::App, QStringLiteral(
-            "comp=Part.Compound(wires)\n"
+            "comp=Part.makeCompound(wires)\n"
             "slice=FreeCAD.getDocument(\"%1\").addObject(\"Part::Feature\",\"%2\")\n"
             "slice.Shape=comp\n"
             "slice.purgeTouched()\n"

--- a/src/Mod/Part/MakeBottle.py
+++ b/src/Mod/Part/MakeBottle.py
@@ -61,7 +61,7 @@ def makeBottle(myWidth=50.0, myHeight=70.0, myThickness=30.0):
 	myBody = myBody.makeThickness([faceToRemove],-myThickness/50 , 1.e-3)
 	myThreading = Part.makeThread(myNeckHeight/10, myNeckRadius*0.06, myHeight/10, myNeckRadius*0.99)
 	myThreading.translate(Base.Vector(0,0,myHeight))
-	myCompound = Part.Compound([myBody, myThreading])
+	myCompound = Part.makeCompound([myBody, myThreading])
 
 	return myCompound
 
@@ -88,7 +88,7 @@ def makeBoreHole():
 	S1 = Part.Shape([C1,C2,L1,L2])
 
 	W=Part.Wire(S1.Edges)
-	F=Part.Face(W)
+	F=Part.makeFace(W)
 	P=F.extrude(Base.Vector(0,0,5))
 
 	# add objects with the shape
@@ -101,7 +101,7 @@ def makeBoreHole():
 
 	c=Part.Circle(Base.Vector(0,0,-1),Base.Vector(0,0,1),2.0)
 	w=Part.Wire(c.toShape())
-	f=Part.Face(w)
+	f=Part.makeFace(w)
 	p=f.extrude(Base.Vector(0,0,7))
 	P=P.cut(p)
 
@@ -113,7 +113,7 @@ def makeBoreHole():
 
 	c=Part.Circle(Base.Vector(0,-11,2.5),Base.Vector(0,1,0),1.0)
 	w=Part.Wire(c.toShape())
-	f=Part.Face(w)
+	f=Part.makeFace(w)
 	p=f.extrude(Base.Vector(0,22,0))
 	P=P.cut(p)
 


### PR DESCRIPTION
fix: https://github.com/FreeCAD/FreeCAD/issues/23150

Part has many different edgecases on multiple features where it falls behind Part Design and the Part workbench in Link Stage 3 when it comes to toponaming. Most features do not use the string hasher, which doesn't cause topological naming problems necessarily, but it does cause larger file sizes. Others do not generate element maps at all, like fillets, chamfers, slice apart and some others. This is a huge issue because it reduces the reliability of this model to be as bad as it was before 1.0.

List of issues:
* extrusions, lofts, sweeps, revolutes, and etc. do not use the string hasher
* slice apart, fillet, and chamfer operations do not generate element maps
* there are probably others that i am forgetting