### PR TITLE
OpenSCAD: fix executable path lookup

### DIFF
--- a/src/Mod/OpenSCAD/OpenSCADUtils.py
+++ b/src/Mod/OpenSCAD/OpenSCADUtils.py
@@ -115,9 +115,7 @@ def searchforopenscadexe():
 
 def getopenscadversion(osfilename=None):
     if not osfilename:
-        osfilename = FreeCAD.ParamGet(\
-            "User parameter:BaseApp/Preferences/Mod/OpenSCAD").\
-            GetString('openscadexecutable')
+        osfilename = getopenscadexe()
     if osfilename and os.path.isfile(osfilename):
         with subprocess.Popen([osfilename, '-v'],\
             stdout = subprocess.PIPE,stderr=subprocess.PIPE, universal_newlines=True) as p:
@@ -158,7 +156,7 @@ def callopenscad(inputfilename,outputfilename=None, outputext='csg', keepname=Fa
             return stdoutd
 
     preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/OpenSCAD")
-    osfilename = preferences.GetString('openscadexecutable')
+    osfilename = getopenscadexe()
     transferMechanism = preferences.GetInt('transfermechanism',0)
     if transferMechanism == 0: # Use the Python temp-directory creation function
         transferDirectory = tempfile.gettempdir()
@@ -200,9 +198,7 @@ def call_openscad_with_pipes(input_filename, output_filename, output_extension, 
         openscad_data = datafile.read()
         # On the command line this looks like:
         #   $ cat myfile.scad | openscad --export-format csg -o - -
-        preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/OpenSCAD")
-        openscad_executable = preferences.GetString('openscadexecutable')
-        p = subprocess.Popen([openscad_executable,"--export-format","csg", "-o", "-", "-"],
+        p = subprocess.Popen([getopenscadexe(), "--export-format", "csg", "-o", "-", "-"],
                              stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)


### PR DESCRIPTION
When `openscadexecutable` parameter is empty some operations (like Mesh workbench -> Union, which uses OpenSCAD workbench internally) fail. You may see how it fails in screenshots section.

In OpenSCAD utils there was multiple places where `openscadexecutable` was loaded to get executable path. I've made it more consistent by using `getopenscadexe` function which was already there.

## Issues
I don't know about any open issues on that topic, but I've found similar forum post https://forum.freecad.org/viewtopic.php?style=1&t=75375

## Before and After Images

Here is a screenshot with error when I try to apply Union operation to two mesh objects:

<details>
<img width="1469" height="1297" alt="image" src="https://github.com/user-attachments/assets/1b790ed4-7500-4f06-a22c-bbde2ed6f368" />
</details>

Here is the screenshot with patch applied, where Union operation succeeds:

<details>
<img width="1466" height="1298" alt="image" src="https://github.com/user-attachments/assets/2a523371-2819-4224-bf73-6ccf0e16edfd" />
</details>

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
