### PR TITLE
Core: Record module failure information during startup

### DIFF
--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -211,6 +211,17 @@ def InitApplications():
                 Err('During initialization the error "' + str(inst) + '" occurred in '\
                     + InstallFile + '\n')
                 Err('Look into the log file for further information\n')
+                mod_name = os.path.normpath(Dir).split(os.path.sep)[-1].lower()
+                if hasattr(FreeCAD,"__failed_mods__"):
+                    FreeCAD.__failed_mods__.append(mod_name)
+                else:
+                    FreeCAD.__failed_mods__ = [mod_name]
+                if mod_name not in FreeCAD.__fallback_mods__:
+                    Err("Could not evaluate module '" + mod_name + "' for fallbacks\n")
+                elif len(FreeCAD.__fallback_mods__[mod_name]) > 1:
+                    new_path = os.path.normpath(FreeCAD.__fallback_mods__[mod_name][-2])
+                    Err(f"A fallback module was found for module '{mod_name}': {new_path}\n")
+                    Err(f"Rename or remove {os.path.normpath(Dir)} to use the fallback module\n")
             else:
                 Log('Init:      Initializing ' + Dir + '... done\n')
                 return True


### PR DESCRIPTION
This is a first step towards resolving #23148 -- the fundamental problem is that FreeCAD has an order of precedence to its module loading that is opaque to users. Module loading failures are not well-reported, and the possibility of a "fallback" is not provided at all. This presents a problem as we consider moving more modules out of core and into addons, but continuing to ship a base version with core (this is effectively what we are doing with the Addon Manager). If the addon version fails, the user has no idea how to proceed, even though the fix is relatively simple.

This PR represents a first step, by actively storing both the failure information as well as any possible "fallback" information (that is, is there a lower-precedence module that could be loaded instead?). Right now all that being done is a report-view error message describing a step the user could take to resolve the issue, but if the team thinks this is a reasonable approach, I will write a GUI that informs the user about the failure, and offers to take some remediation steps (e.g. move the failing mod out of the way, uninstall it entirely, etc.).

This particular failure is most acute for the Addon Manager because if it breaks, there's no obvious way to uninstall it, but the fundamental problem would affect any built-in mod that is overridden by a user-installed version elsewhere.