### PR TITLE
Gui: Remove references to the Addon Manager if no Std_AddonMgr

### DIFF
--- a/src/Gui/Dialogs/DlgMacroExecuteImp.cpp
+++ b/src/Gui/Dialogs/DlgMacroExecuteImp.cpp
@@ -127,7 +127,7 @@ DlgMacroExecuteImp::DlgMacroExecuteImp(QWidget* parent, Qt::WindowFlags fl)
     }
     fillUpList();
     ui->LineEditFind->setFocus();
-    ui->addonsButton->setVisible(
+    ui->addonsButton->setEnabled(
         Application::Instance->commandManager().getCommandByName("Std_AddonMgr") != nullptr);
 }
 

--- a/src/Gui/Dialogs/DlgMacroExecuteImp.cpp
+++ b/src/Gui/Dialogs/DlgMacroExecuteImp.cpp
@@ -127,6 +127,8 @@ DlgMacroExecuteImp::DlgMacroExecuteImp(QWidget* parent, Qt::WindowFlags fl)
     }
     fillUpList();
     ui->LineEditFind->setFocus();
+    ui->addonsButton->setVisible(
+        Application::Instance->commandManager().getCommandByName("Std_AddonMgr") != nullptr);
 }
 
 /**

--- a/src/Gui/Dialogs/DlgPreferencePackManagementImp.cpp
+++ b/src/Gui/Dialogs/DlgPreferencePackManagementImp.cpp
@@ -45,7 +45,12 @@ DlgPreferencePackManagementImp::DlgPreferencePackManagementImp(QWidget* parent)
     , ui(new Ui_DlgPreferencePackManagement)
 {
     ui->setupUi(this);
-    connect(ui->pushButtonOpenAddonManager, &QPushButton::clicked, this, &DlgPreferencePackManagementImp::showAddonManager);
+    if (Application::Instance->commandManager().getCommandByName("Std_AddonMgr")) {
+        connect(ui->pushButtonOpenAddonManager, &QPushButton::clicked, this, &DlgPreferencePackManagementImp::showAddonManager);
+    }
+    else {
+        ui->pushButtonOpenAddonManager->hide();
+    }
     connect(this, &DlgPreferencePackManagementImp::packVisibilityChanged, this, &DlgPreferencePackManagementImp::updateTree);
     updateTree();
 }

--- a/src/Gui/Dialogs/DlgPreferencePackManagementImp.cpp
+++ b/src/Gui/Dialogs/DlgPreferencePackManagementImp.cpp
@@ -49,7 +49,7 @@ DlgPreferencePackManagementImp::DlgPreferencePackManagementImp(QWidget* parent)
         connect(ui->pushButtonOpenAddonManager, &QPushButton::clicked, this, &DlgPreferencePackManagementImp::showAddonManager);
     }
     else {
-        ui->pushButtonOpenAddonManager->hide();
+        ui->pushButtonOpenAddonManager->setDisabled(true);
     }
     connect(this, &DlgPreferencePackManagementImp::packVisibilityChanged, this, &DlgPreferencePackManagementImp::updateTree);
     updateTree();

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -130,7 +130,7 @@ DlgSettingsGeneral::DlgSettingsGeneral( QWidget* parent )
     const auto visible = UnitsApi::isMultiUnitLength();
     ui->comboBox_FracInch->setVisible(visible);
     ui->fractionalInchLabel->setVisible(visible);
-    ui->moreThemesLabel->setVisible(
+    ui->moreThemesLabel->setEnabled(
         Application::Instance->commandManager().getCommandByName("Std_AddonMgr") != nullptr);
 }
 

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -130,6 +130,8 @@ DlgSettingsGeneral::DlgSettingsGeneral( QWidget* parent )
     const auto visible = UnitsApi::isMultiUnitLength();
     ui->comboBox_FracInch->setVisible(visible);
     ui->fractionalInchLabel->setVisible(visible);
+    ui->moreThemesLabel->setVisible(
+        Application::Instance->commandManager().getCommandByName("Std_AddonMgr") != nullptr);
 }
 
 /**

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -719,8 +719,10 @@ MenuItem* StdWorkbench::setupMenuBar() const
     auto tool = new MenuItem( menuBar );
     tool->setCommand("&Tools");
 #ifdef BUILD_ADDONMGR
-    *tool << "Std_AddonMgr"
-          << "Separator";
+    if (Application::Instance->commandManager().getCommandByName("Std_AddonMgr")) {
+        *tool << "Std_AddonMgr"
+              << "Separator";
+    }
 #endif
     *tool << "Std_Measure"
           << "Std_QuickMeasure"

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -236,8 +236,12 @@ bool ThemeSelectorWidget::eventFilter(QObject* object, QEvent* event)
 void ThemeSelectorWidget::retranslateUi()
 {
     _titleLabel->setText(QLatin1String("<h2>") + tr("Theme") + QLatin1String("</h2>"));
-    _descriptionLabel->setText(tr("Looking for more themes? You can obtain them using "
-                                  "<a href=\"freecad:Std_AddonMgr\">Addon Manager</a>."));
+    if (Gui::Application::Instance->commandManager().getCommandByName("Std_AddonMgr")) {
+        _descriptionLabel->setText(tr("Looking for more themes? You can obtain them using "
+                                      "<a href=\"freecad:Std_AddonMgr\">Addon Manager</a>."));    }
+    else {
+        _descriptionLabel->hide();
+    }
     _buttons[static_cast<int>(Theme::Dark)]->setText(tr("FreeCAD Dark", "Visual theme name"));
     _buttons[static_cast<int>(Theme::Light)]->setText(tr("FreeCAD Light", "Visual theme name"));
     _buttons[static_cast<int>(Theme::Classic)]->setText(tr("FreeCAD Classic", "Visual theme name"));

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -238,7 +238,8 @@ void ThemeSelectorWidget::retranslateUi()
     _titleLabel->setText(QLatin1String("<h2>") + tr("Theme") + QLatin1String("</h2>"));
     if (Gui::Application::Instance->commandManager().getCommandByName("Std_AddonMgr")) {
         _descriptionLabel->setText(tr("Looking for more themes? You can obtain them using "
-                                      "<a href=\"freecad:Std_AddonMgr\">Addon Manager</a>."));    }
+                                      "<a href=\"freecad:Std_AddonMgr\">Addon Manager</a>."));
+    }
     else {
         _descriptionLabel->hide();
     }


### PR DESCRIPTION
If the Addon Manager was not included in the build, was intentionally disabled, or failed to load, don't attempt to show the Addon Manager commands in the various places in the UI where it appears. This quiets down a stream of errors in the report view, and results in a better UX if the AM was disabled intentionally.