### PR TITLE
Mesh: Revert Triangle menu text to Add Triangle

### DIFF
--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -715,7 +715,7 @@ CmdMeshAddFacet::CmdMeshAddFacet()
 {
     sAppModule = "Mesh";
     sGroup = QT_TR_NOOP("Mesh");
-    sMenuText = QT_TR_NOOP("Triangle");
+    sMenuText = QT_TR_NOOP("Add Triangle");
     sToolTipText = QT_TR_NOOP("Adds a triangle manually to a mesh");
     sWhatsThis = "Mesh_AddFacet";
     sStatusTip = sToolTipText;
@@ -1869,3 +1869,4 @@ void CreateMeshCommands()
     rcCmdMgr.addCommand(new CmdMeshSplitComponents());
     rcCmdMgr.addCommand(new CmdMeshScale());
 }
+


### PR DESCRIPTION
The command does not create a loose triangle, but adds a triangle to an existing mesh.