### PR TITLE
FEM: Remove automatic Nlgeom when nonlinear material is already present

### DIFF
--- a/src/Mod/Fem/femcommands/commands.py
+++ b/src/Mod/Fem/femcommands/commands.py
@@ -1078,7 +1078,6 @@ class _SolverCalculiX(CommandManager):
                     has_nonlinear_material_obj = True
 
             if has_nonlinear_material_obj:
-                FreeCADGui.doCommand(f"{cm.cli_name}.GeometricalNonlinearity = 'nonlinear'")
                 FreeCADGui.doCommand(f"{cm.cli_name}.MaterialNonlinearity = 'nonlinear'")
 
 


### PR DESCRIPTION
follow-up on #12703 (it was still happening when the solver was added after the nonlinear material - now it won't happen anymore)

@marioalexis84 FYI