### PR TITLE
PartDesign: Change 1 missed dialog title to Title Case

### DIFF
--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -735,7 +735,7 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
         items.push_back(QString::fromUtf8(body->Label.getValue()));
     }
     QString text = QInputDialog::getItem(Gui::getMainWindow(),
-        qApp->translate("PartDesign_MoveFeature", "Select body"),
+        qApp->translate("PartDesign_MoveFeature", "Select Body"),
         qApp->translate("PartDesign_MoveFeature", "Select a body from the list"),
         items, 0, false, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if (!ok)


### PR DESCRIPTION
"Select body" -> "Select Body":
<img width="216" height="148" alt="afbeelding" src="https://github.com/user-attachments/assets/ff7094cc-9435-4efa-957b-5c2a15cbaefd" />
