### PR TITLE
PartDesign: Change "Move Feature After" to "Move Object After"

### DIFF
--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -833,8 +833,8 @@ CmdPartDesignMoveFeatureInTree::CmdPartDesignMoveFeatureInTree()
 {
     sAppModule      = "PartDesign";
     sGroup          = QT_TR_NOOP("PartDesign");
-    sMenuText = QT_TR_NOOP("Move Feature After…");
-    sToolTipText    = QT_TR_NOOP("Moves the selected feature after another feature in the same body");
+    sMenuText = QT_TR_NOOP("Move Object After…");
+    sToolTipText    = QT_TR_NOOP("Moves the selected object after another object in the same body");
     sWhatsThis      = "PartDesign_MoveFeatureInTree";
     sStatusTip      = sToolTipText;
     sPixmap         = "PartDesign_MoveFeatureInTree";


### PR DESCRIPTION
The current text is inconsistent IMO. The word feature and object refer to the same thing.
<img width="178" height="100" alt="afbeelding" src="https://github.com/user-attachments/assets/af95ba33-6959-437b-b4ec-a96fd193e89e" />
