### PR TITLE
Sketcher: Copy expressions when rotating/moving geometry

### DIFF
--- a/src/Mod/Sketcher/Gui/CMakeLists.txt
+++ b/src/Mod/Sketcher/Gui/CMakeLists.txt
@@ -112,6 +112,8 @@ SET(SketcherGui_SRCS
     TaskSketcherValidation.h
     ShortcutListener.cpp
     ShortcutListener.h
+    SketcherTransformationExpressionHelper.cpp
+    SketcherTransformationExpressionHelper.h
     EditModeInformationOverlayCoinConverter.cpp
     EditModeInformationOverlayCoinConverter.h
     EditModeGeometryCoinConverter.cpp

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -33,6 +33,7 @@
 
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
+#include "SketcherTransformationExpressionHelper.h"
 
 #include "GeometryCreationMode.h"
 #include "Utils.h"
@@ -143,9 +144,17 @@ private:
         try {
             Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Rotate geometries"));
 
+            expressionHelper.storeOriginalExpressions(sketchgui->getSketchObject(), listOfGeoIds);
+
             createShape(false);
 
             commandAddShapeGeometryAndConstraints();
+
+            expressionHelper.copyExpressionsToNewConstraints(sketchgui->getSketchObject(),
+                                                             listOfGeoIds,
+                                                             ShapeGeometry.size(),
+                                                             numberOfCopies,
+                                                             1);
 
             if (deleteOriginal) {
                 deleteOriginalGeos();
@@ -236,6 +245,8 @@ private:
     bool deleteOriginal, cloneConstraints;
     double length, startAngle, endAngle, totalAngle, individualAngle;
     int numberOfCopies;
+
+    SketcherTransformationExpressionHelper expressionHelper;
 
     void deleteOriginalGeos()
     {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
@@ -36,6 +36,7 @@
 
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
+#include "SketcherTransformationExpressionHelper.h"
 
 #include "GeometryCreationMode.h"
 #include "Utils.h"

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
@@ -25,6 +25,7 @@
 #define SKETCHERGUI_DrawSketchHandlerTranslate_H
 
 #include <QApplication>
+#include <map>
 
 #include <Base/Tools.h>
 
@@ -38,6 +39,7 @@
 
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
+#include "SketcherTransformationExpressionHelper.h"
 
 #include "GeometryCreationMode.h"
 #include "Utils.h"
@@ -115,9 +117,17 @@ private:
         try {
             Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Translate geometries"));
 
+            expressionHelper.storeOriginalExpressions(sketchgui->getSketchObject(), listOfGeoIds);
+
             createShape(false);
 
             commandAddShapeGeometryAndConstraints();
+
+            expressionHelper.copyExpressionsToNewConstraints(sketchgui->getSketchObject(),
+                                                             listOfGeoIds,
+                                                             ShapeGeometry.size(),
+                                                             numberOfCopies,
+                                                             secondNumberOfCopies);
 
             if (deleteOriginal) {
                 deleteOriginalGeos();
@@ -226,6 +236,8 @@ private:
 
     bool deleteOriginal, cloneConstraints;
     int numberOfCopies, secondNumberOfCopies;
+
+    SketcherTransformationExpressionHelper expressionHelper;
 
     void deleteOriginalGeos()
     {
@@ -426,6 +438,7 @@ private:
             }
         }
     }
+
 
 public:
     std::list<Gui::InputHint> getToolHints() const override

--- a/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
@@ -49,7 +49,7 @@ void SketcherTransformationExpressionHelper::storeOriginalExpressions(
                     || (cstr->Second == geoId && cstr->Type != Sketcher::Radius
                         && cstr->Type != Sketcher::Diameter && cstr->Type != Sketcher::Weight))) {
 
-                App::ObjectIdentifier spath = sketchObject->Constraints.createPath(i);
+                App::ObjectIdentifier spath = sketchObject->Constraints.createPath(static_cast<int>(i));
                 App::PropertyExpressionEngine::ExpressionInfo expr_info =
                     sketchObject->getExpression(spath);
 

--- a/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
@@ -1,0 +1,143 @@
+/***************************************************************************
+ *   Copyright (c) 2025 FreeCAD Contributors                               *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#include "SketcherTransformationExpressionHelper.h"
+
+#include <Gui/Command.h>
+#include <Mod/Sketcher/App/SketchObject.h>
+
+using namespace SketcherGui;
+
+void SketcherTransformationExpressionHelper::storeOriginalExpressions(
+    Sketcher::SketchObject* sketchObject,
+    const std::vector<int>& listOfGeoIds)
+{
+    if (!sketchObject) {
+        return;
+    }
+
+    const std::vector<Sketcher::Constraint*>& vals = sketchObject->Constraints.getValues();
+
+    originalExpressions.clear();
+
+    for (auto& geoId : listOfGeoIds) {
+        for (size_t i = 0; i < vals.size(); i++) {
+            const auto& cstr = vals[i];
+            if (cstr->isDriving && cstr->isDimensional()
+                && (cstr->First == geoId
+                    || (cstr->Second == geoId && cstr->Type != Sketcher::Radius
+                        && cstr->Type != Sketcher::Diameter && cstr->Type != Sketcher::Weight))) {
+
+                App::ObjectIdentifier spath = sketchObject->Constraints.createPath(i);
+                App::PropertyExpressionEngine::ExpressionInfo expr_info =
+                    sketchObject->getExpression(spath);
+
+                if (expr_info.expression) {
+                    // map expression to geoid as a key
+                    originalExpressions[geoId] =
+                        std::shared_ptr<App::Expression>(expr_info.expression->copy());
+                }
+            }
+        }
+    }
+}
+
+void SketcherTransformationExpressionHelper::copyExpressionsToNewConstraints(
+    Sketcher::SketchObject* sketchObject,
+    const std::vector<int>& listOfGeoIds,
+    size_t shapeGeometrySize,
+    int numberOfCopies,
+    int secondNumberOfCopies)
+{
+    // apply stored expressions to new constraints, but bail out if we haven't stored
+    // anything
+    if (originalExpressions.empty() || !sketchObject) {
+        return;
+    }
+
+    std::string sketchObj = Gui::Command::getObjectCmd(sketchObject);
+
+    const std::vector<Sketcher::Constraint*>& vals = sketchObject->Constraints.getValues();
+
+    for (size_t i = 0; i < vals.size(); i++) {
+        const auto& cstr = vals[i];
+        if (cstr->isDriving && cstr->isDimensional()) {
+
+            bool expressionApplied = false;
+
+            for (const auto& exprPair : originalExpressions) {
+                if (expressionApplied) {
+                    break;  // found a match, stop searching for this constraint
+                }
+
+                int originalGeoId = exprPair.first;
+
+                // index of the original geometry before operation of the sketcher tool
+                int originalIndex = indexOfGeoId(listOfGeoIds, originalGeoId);
+                if (originalIndex >= 0) {
+                    int firstCurveCreated = sketchObject->getHighestCurveIndex() + 1
+                        - static_cast<int>(shapeGeometrySize);
+                    int size = static_cast<int>(listOfGeoIds.size());
+
+                    // check all copies of this geometry as we assign them the same expression
+                    int numberOfCopiesToMake = numberOfCopies == 0 ? 1 : numberOfCopies;
+
+                    for (int k = 0; k < secondNumberOfCopies && !expressionApplied; k++) {
+                        for (int copy = 1; copy <= numberOfCopiesToMake && !expressionApplied;
+                             copy++) {
+                            int expectedNewGeoId = firstCurveCreated + originalIndex
+                                + size * (copy - 1) + size * numberOfCopiesToMake * k;
+
+                            // if this constraint references our copied geometry, apply the
+                            // expression
+                            if (cstr->First == expectedNewGeoId
+                                || (cstr->Second == expectedNewGeoId
+                                    && cstr->Type != Sketcher::Radius
+                                    && cstr->Type != Sketcher::Diameter
+                                    && cstr->Type != Sketcher::Weight)) {
+
+                                Gui::Command::doCommand(Gui::Command::Doc,
+                                                        "%s.setExpression('Constraints[%d]', '%s')",
+                                                        sketchObj.c_str(),
+                                                        static_cast<int>(i),
+                                                        exprPair.second->toString().c_str());
+                                expressionApplied = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void SketcherTransformationExpressionHelper::clear()
+{
+    originalExpressions.clear();
+}
+
+bool SketcherTransformationExpressionHelper::hasStoredExpressions() const
+{
+    return !originalExpressions.empty();
+}

--- a/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
@@ -1,23 +1,24 @@
-/***************************************************************************
- *   Copyright (c) 2025 FreeCAD Contributors                               *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 The FreeCAD Project Association AISBL               *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
  ***************************************************************************/
 
 #include "PreCompiled.h"

--- a/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
@@ -50,7 +50,8 @@ void SketcherTransformationExpressionHelper::storeOriginalExpressions(
                     || (cstr->Second == geoId && cstr->Type != Sketcher::Radius
                         && cstr->Type != Sketcher::Diameter && cstr->Type != Sketcher::Weight))) {
 
-                App::ObjectIdentifier spath = sketchObject->Constraints.createPath(static_cast<int>(i));
+                App::ObjectIdentifier spath =
+                    sketchObject->Constraints.createPath(static_cast<int>(i));
                 App::PropertyExpressionEngine::ExpressionInfo expr_info =
                     sketchObject->getExpression(spath);
 
@@ -79,8 +80,8 @@ void SketcherTransformationExpressionHelper::copyExpressionsToNewConstraints(
     std::string sketchObj = Gui::Command::getObjectCmd(sketchObject);
     const std::vector<Sketcher::Constraint*>& vals = sketchObject->Constraints.getValues();
 
-    CopyCalculationParams params = calculateCopyParams(sketchObject, listOfGeoIds, 
-                                                      shapeGeometrySize, numberOfCopies);
+    CopyCalculationParams params =
+        calculateCopyParams(sketchObject, listOfGeoIds, shapeGeometrySize, numberOfCopies);
     for (size_t i = 0; i < vals.size(); i++) {
         const auto& cstr = vals[i];
         if (!cstr->isDriving || !cstr->isDimensional()) {
@@ -94,9 +95,13 @@ void SketcherTransformationExpressionHelper::copyExpressionsToNewConstraints(
             int originalIndex = indexOfGeoId(listOfGeoIds, originalGeoId);
 
             if (originalIndex >= 0) {
-                expressionApplied = tryApplyExpressionToConstraint(
-                    cstr, i, originalIndex, params, secondNumberOfCopies, 
-                    exprPair.second, sketchObj);
+                expressionApplied = tryApplyExpressionToConstraint(cstr,
+                                                                   i,
+                                                                   originalIndex,
+                                                                   params,
+                                                                   secondNumberOfCopies,
+                                                                   exprPair.second,
+                                                                   sketchObj);
 
                 if (expressionApplied) {
                     break;
@@ -116,16 +121,15 @@ bool SketcherTransformationExpressionHelper::hasStoredExpressions() const
     return !originalExpressions.empty();
 }
 
-SketcherTransformationExpressionHelper::CopyCalculationParams 
-SketcherTransformationExpressionHelper::calculateCopyParams(
-    Sketcher::SketchObject* sketchObject,
-    const std::vector<int>& listOfGeoIds,
-    size_t shapeGeometrySize,
-    int numberOfCopies) const
+SketcherTransformationExpressionHelper::CopyCalculationParams
+SketcherTransformationExpressionHelper::calculateCopyParams(Sketcher::SketchObject* sketchObject,
+                                                            const std::vector<int>& listOfGeoIds,
+                                                            size_t shapeGeometrySize,
+                                                            int numberOfCopies) const
 {
     CopyCalculationParams params;
-    params.firstCurveCreated = sketchObject->getHighestCurveIndex() + 1 
-                              - static_cast<int>(shapeGeometrySize);
+    params.firstCurveCreated =
+        sketchObject->getHighestCurveIndex() + 1 - static_cast<int>(shapeGeometrySize);
     params.size = static_cast<int>(listOfGeoIds.size());
     params.numberOfCopiesToMake = numberOfCopies == 0 ? 1 : numberOfCopies;
     return params;
@@ -149,10 +153,10 @@ bool SketcherTransformationExpressionHelper::tryApplyExpressionToConstraint(
             // if this constraint references our copied geometry, apply the expression
             if (constraintReferencesGeometry(cstr, expectedNewGeoId)) {
                 Gui::Command::doCommand(Gui::Command::Doc,
-                                      "%s.setExpression('Constraints[%d]', '%s')",
-                                      sketchObj.c_str(),
-                                      static_cast<int>(constraintIndex),
-                                      expression->toString().c_str());
+                                        "%s.setExpression('Constraints[%d]', '%s')",
+                                        sketchObj.c_str(),
+                                        static_cast<int>(constraintIndex),
+                                        expression->toString().c_str());
                 return true;
             }
         }
@@ -161,12 +165,10 @@ bool SketcherTransformationExpressionHelper::tryApplyExpressionToConstraint(
 }
 
 bool SketcherTransformationExpressionHelper::constraintReferencesGeometry(
-    const Sketcher::Constraint* cstr, 
+    const Sketcher::Constraint* cstr,
     int geoId) const
 {
     return cstr->First == geoId
-        || (cstr->Second == geoId
-            && cstr->Type != Sketcher::Radius
-            && cstr->Type != Sketcher::Diameter
-            && cstr->Type != Sketcher::Weight);
+        || (cstr->Second == geoId && cstr->Type != Sketcher::Radius
+            && cstr->Type != Sketcher::Diameter && cstr->Type != Sketcher::Weight);
 }

--- a/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.h
+++ b/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.h
@@ -1,0 +1,81 @@
+/***************************************************************************
+ *   Copyright (c) 2025 FreeCAD Contributors                               *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef SKETCHERGUI_SketcherTransformationExpressionHelper_H
+#define SKETCHERGUI_SketcherTransformationExpressionHelper_H
+
+#include <map>
+#include <vector>
+#include <memory>
+
+#include <App/Expression.h>
+#include <App/PropertyExpressionEngine.h>
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "Utils.h"
+
+namespace SketcherGui
+{
+
+/** @brief Helper class for preserving expressions during sketch transformations
+ *
+ * This class provides functionality to preserve expressions when transforming
+ * sketch geometries (translate, rotate, scale, etc.). It stores expressions
+ * from original constraints and applies them to new constraints after transformation.
+ */
+class SketcherGuiExport SketcherTransformationExpressionHelper
+{
+public:
+    /** @brief Store expressions from constraints affecting the given geometry list
+     *
+     * @param sketchObject The sketch object containing the constraints
+     * @param listOfGeoIds List of geometry IDs that are being transformed
+     */
+    void storeOriginalExpressions(Sketcher::SketchObject* sketchObject,
+                                  const std::vector<int>& listOfGeoIds);
+
+    /** @brief Apply stored expressions to new constraints after transformation
+     *
+     * @param sketchObject The sketch object containing the new constraints
+     * @param listOfGeoIds Original list of geometry IDs that were transformed
+     * @param shapeGeometrySize Number of new geometries created
+     * @param numberOfCopies Number of copies made (0 means single operation on the original
+     * geometry)
+     * @param secondNumberOfCopies Number of rows for array operations
+     */
+    void copyExpressionsToNewConstraints(Sketcher::SketchObject* sketchObject,
+                                         const std::vector<int>& listOfGeoIds,
+                                         size_t shapeGeometrySize,
+                                         int numberOfCopies,
+                                         int secondNumberOfCopies);
+
+    void clear();
+    bool hasStoredExpressions() const;
+
+private:
+    // original geo id to expression mapping
+    std::map<int, std::shared_ptr<App::Expression>> originalExpressions;
+};
+
+}  // namespace SketcherGui
+
+#endif  // SKETCHERGUI_SketcherTransformationExpressionHelper_H

--- a/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.h
+++ b/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.h
@@ -73,7 +73,8 @@ public:
     bool hasStoredExpressions() const;
 
 private:
-    struct CopyCalculationParams {
+    struct CopyCalculationParams
+    {
         int firstCurveCreated;
         int size;
         int numberOfCopiesToMake;
@@ -81,18 +82,18 @@ private:
 
     /// calculate parameters needed for copy operations
     CopyCalculationParams calculateCopyParams(Sketcher::SketchObject* sketchObject,
-                                             const std::vector<int>& listOfGeoIds,
-                                             size_t shapeGeometrySize,
-                                             int numberOfCopies) const;
+                                              const std::vector<int>& listOfGeoIds,
+                                              size_t shapeGeometrySize,
+                                              int numberOfCopies) const;
 
     /// try to apply an expression to a constraint if it matches copied geometry
     bool tryApplyExpressionToConstraint(const Sketcher::Constraint* cstr,
-                                       size_t constraintIndex,
-                                       int originalIndex,
-                                       const CopyCalculationParams& params,
-                                       int secondNumberOfCopies,
-                                       const std::shared_ptr<App::Expression>& expression,
-                                       const std::string& sketchObj) const;
+                                        size_t constraintIndex,
+                                        int originalIndex,
+                                        const CopyCalculationParams& params,
+                                        int secondNumberOfCopies,
+                                        const std::shared_ptr<App::Expression>& expression,
+                                        const std::string& sketchObj) const;
 
     /// check if a constraint references the specified geometry ID
     bool constraintReferencesGeometry(const Sketcher::Constraint* cstr, int geoId) const;

--- a/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.h
+++ b/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.h
@@ -72,6 +72,30 @@ public:
     bool hasStoredExpressions() const;
 
 private:
+    struct CopyCalculationParams {
+        int firstCurveCreated;
+        int size;
+        int numberOfCopiesToMake;
+    };
+
+    /// calculate parameters needed for copy operations
+    CopyCalculationParams calculateCopyParams(Sketcher::SketchObject* sketchObject,
+                                             const std::vector<int>& listOfGeoIds,
+                                             size_t shapeGeometrySize,
+                                             int numberOfCopies) const;
+
+    /// try to apply an expression to a constraint if it matches copied geometry
+    bool tryApplyExpressionToConstraint(const Sketcher::Constraint* cstr,
+                                       size_t constraintIndex,
+                                       int originalIndex,
+                                       const CopyCalculationParams& params,
+                                       int secondNumberOfCopies,
+                                       const std::shared_ptr<App::Expression>& expression,
+                                       const std::string& sketchObj) const;
+
+    /// check if a constraint references the specified geometry ID
+    bool constraintReferencesGeometry(const Sketcher::Constraint* cstr, int geoId) const;
+
     // original geo id to expression mapping
     std::map<int, std::shared_ptr<App::Expression>> originalExpressions;
 };

--- a/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.h
+++ b/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.h
@@ -1,23 +1,24 @@
-/***************************************************************************
- *   Copyright (c) 2025 FreeCAD Contributors                               *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 The FreeCAD Project Association AISBL               *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
  ***************************************************************************/
 
 #ifndef SKETCHERGUI_SketcherTransformationExpressionHelper_H


### PR DESCRIPTION
As the title says. Currently we do not copy expressions that were assigned to constraints to the geometry if we use sketcher tools like rotate or translate. So this patch adds it, by copying them and then reconstructing upon added geometry.

Demo:

https://github.com/user-attachments/assets/75e69185-b478-4220-83ec-886cb0292b64

Resolves: https://github.com/FreeCAD/FreeCAD/issues/22253