### PR TITLE
Gui: Don't use this pointer after valueChanged in EditableDatumLabel

### DIFF
--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -205,6 +205,11 @@ void EditableDatumLabel::startEdit(double val, QObject* eventFilteringObj, bool 
         value = spinBox->rawValue();
 
         isSet = true;
+
+        if (this->hasFinishedEditing) {
+            this->setLockedAppearance(true);
+        }
+
         Q_EMIT this->valueChanged(value);
     };
 
@@ -237,12 +242,6 @@ bool EditableDatumLabel::eventFilter(QObject* watched, QEvent* event)
                     // regular enter
                     this->hasFinishedEditing = true;
                     Q_EMIT this->spinBox->valueChanged(this->value);
-
-                    // only set lock state if it passed validation
-                    // (validation can unset isSet if value didn't pass
-                    // confusion point for example)
-                    if (this->isSet)
-                        this->setLockedAppearance(true);
                     return true;
                 }
             }


### PR DESCRIPTION
Simple fix for such a simple error I didn't see. Basically, `valueChanged` signal can result in EditableDatumLabel being deleted (for example, when we are on the last OVP and all of the OVPs have been accepted). This could result in crashes as reported in previous issues, because just after emitting this signal we were trying to use `this` pointer, which wasn't available anymore as we deleted EditableDatumLabel obj that was attached to it, so in essence we were dereferencing some random address.

Fix for that is simple - move the check for `hasFinishedEditing` flag to check locked appearance in `validateAndFinish` lambda, as it already does validation and this way we will avoid referencing internals (which could be deallocated) after emitting this signal.

@chennes @lagnat @ElementW is it possible any of you could test this change and confirm it fixes the problems on your side?

Resolves: https://github.com/FreeCAD/FreeCAD/issues/23058
Resolves: https://github.com/FreeCAD/FreeCAD/issues/23155