### PR TITLE
Sketcher: Fix segfault where DatumLine does not have a refSubSHape

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -8879,7 +8879,7 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
                     "Datum feature type is not yet supported as external geometry for a sketch");
             }
 
-            if (projection) {
+            if (projection && !refSubShape.IsNull()) {
                 switch (refSubShape.ShapeType()) {
                 case TopAbs_FACE: {
                     processFace(invRot, invPlm, mov, sketchPlane, gPlane, sketchAx3, aProjFace, geos, refSubShape);
@@ -8905,7 +8905,7 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
             }
             int projSize = geos.size();
 
-            if (intersection) {
+            if (intersection && !refSubShape.IsNull()) {
                 FCBRepAlgoAPI_Section maker(refSubShape, sketchPlane);
                 maker.Approximation(Standard_True);
                 if (!maker.IsDone())


### PR DESCRIPTION
This fixes a segfault and a subsequent FreeCAD crash upon modifying sketches followed by Datum Lines. I've fixed this on my own, no previous issue was created. Forum post here: https://forum.freecad.org/viewtopic.php?t=99174

## Issues
No issue created beforehand. Link to forum topic: https://forum.freecad.org/viewtopic.php?t=99174

## Before and After Images
No changes to the GUI


