### PR TITLE
Part: Fix crash in MultiFuse::execute()

### DIFF
--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -103,7 +103,8 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
     const int maxIterations = 1'000'000; // will trigger "not enough shape objects linked" error below if ever reached
     for (int i = 0; shapes.size() == 1 && i < maxIterations; ++i) {
         compoundOfArguments = shapes[0];
-        if (compoundOfArguments.getShape().ShapeType() == TopAbs_COMPOUND) {
+        TopoDS_Shape shape = compoundOfArguments.getShape();
+        if (!shape.IsNull() && shape.ShapeType() == TopAbs_COMPOUND) {
             shapes.clear();
             shapes = compoundOfArguments.getSubTopoShapes();
             argumentsAreInCompound = true;


### PR DESCRIPTION
The processed shape is null and thus it's not allowed to call its ShapeType() method. The crash is not directly related to the fact that there is a cyclic dependency

Fixes https://github.com/FreeCAD/FreeCAD/issues/22879
