### PR TITLE
Gui: Hold the GIL when clearing the form attribute

### DIFF
--- a/src/Gui/TaskView/TaskDialogPython.cpp
+++ b/src/Gui/TaskView/TaskDialogPython.cpp
@@ -634,6 +634,7 @@ void TaskDialogPython::appendForm(QWidget* form, const QPixmap& icon)
 
 void TaskDialogPython::clearForm()
 {
+    Base::PyGILStateLocker lock;
     try {
         // The widgets stored in the 'form' attribute will be deleted.
         // Thus, set this attribute to None to make sure that when using


### PR DESCRIPTION
From @wwmayer https://github.com/wwmayer/FreeCAD/tree/issue_22863

Inside TaskDialogPython::clearForm() the interpreter may execute a lot of things where at the some point the GIL must be hold.

This very likely fixes https://github.com/FreeCAD/FreeCAD/issues/22863

