### PR TITLE
Gui: fix file dialog type filters being too long (fixes #23139)

### DIFF
--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -129,8 +129,8 @@ using namespace Gui::DockWnd;
  * protected:
  *   void activated(int)
  *   {
- *     QString filter ... // make a filter of all supported file formats
- *     QStringList FileList = QFileDialog::getOpenFileNames( filter,QString(), getMainWindow() );
+ *     QStringList filters ... // make a filter list of all supported file formats
+ *     QStringList FileList = QFileDialog::getOpenFileNames( filters, QString(), getMainWindow() );
  *     for ( QStringList::Iterator it = FileList.begin(); it != FileList.end(); ++it ) {
  *       getGuiApplication()->open((*it).latin1());
  *     }

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -97,47 +97,39 @@ void StdCmdOpen::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     // fill the list of registered endings
-    QString formatList;
-    const char* supported = QT_TR_NOOP("Supported formats");
-    const char* allFiles = QT_TR_NOOP("All files (*.*)");
-    formatList = QObject::tr(supported);
-    formatList += QLatin1String(" (");
+    QStringList formatList;
 
-    std::vector<std::string> filetypes = App::GetApplication().getImportTypes();
-    // Make sure FCStd is the very first fileformat
-    auto it = std::ranges::find(filetypes, "FCStd");
-    if (it != filetypes.end()) {
-        filetypes.erase(it);
-        filetypes.insert(filetypes.begin(), "FCStd");
+    QString allSupportedFormats = QObject::tr("Supported formats") + QStringLiteral(" (");
+    // Cram all formats FreeCAD can import under one label
+    const auto filetypes = App::GetApplication().getImportTypes();
+    for (const auto& type : filetypes) {
+        allSupportedFormats += QStringLiteral(" *.");
+        allSupportedFormats += QString::fromStdString(type);
     }
-    for (it = filetypes.begin(); it != filetypes.end(); ++it) {
-        formatList += QLatin1String(" *.");
-        formatList += QLatin1String(it->c_str());
-    }
-    formatList += QLatin1String(" *.FCBak");
+    allSupportedFormats += QLatin1String(" *.FCBak)");
+    formatList += allSupportedFormats;
 
-    formatList += QLatin1String(");;");
-
-    std::map<std::string, std::string> FilterList = App::GetApplication().getImportFilters();
-    std::map<std::string, std::string>::iterator jt;
-    // Make sure the format name for FCStd is the very first in the list
-    for (jt = FilterList.begin(); jt != FilterList.end(); ++jt) {
-        if (jt->first.find("*.FCStd") != std::string::npos) {
-            QString fcstdFilter = QLatin1String(jt->first.c_str());
+    const auto importFilters = App::GetApplication().getImportFilters();
+    // Make sure FCStd is the second entry in the format list
+    auto fcstdIt = importFilters.cend();
+    for (auto it = importFilters.cbegin(); it != importFilters.cend(); ++it) {
+        if (const auto fc = it->first.find("*.FCStd"); fc != std::string::npos) {
+            fcstdIt = it;
+            QString fcstdFilter = QString::fromStdString(it->first);
             if (!fcstdFilter.contains(QStringLiteral("*.FCBak"), Qt::CaseInsensitive)) {
                 fcstdFilter.replace(")", QStringLiteral(" *.FCBak)"));
             }
             formatList += fcstdFilter;
-            formatList += QLatin1String(";;");
-            FilterList.erase(jt);
             break;
         }
     }
-    for (jt = FilterList.begin(); jt != FilterList.end(); ++jt) {
-        formatList += QLatin1String(jt->first.c_str());
-        formatList += QLatin1String(";;");
+    for (auto it = importFilters.cbegin(); it != importFilters.cend(); ++it) {
+        if (it != fcstdIt) {
+            formatList += QString::fromStdString(it->first);
+        }
     }
-    formatList += QObject::tr(allFiles);
+
+    formatList += QObject::tr("All files") + QStringLiteral(" (*.*)");
 
     QString selectedFilter;
     QStringList fileList = FileDialog::getOpenFileNames(
@@ -231,34 +223,27 @@ void StdCmdImport::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     // fill the list of registered endings
-    QString formatList;
-    const char* supported = QT_TR_NOOP("Supported formats");
-    const char* allFiles = QT_TR_NOOP("All files (*.*)");
-    formatList = QObject::tr(supported);
-    formatList += QLatin1String(" (");
+    QStringList formatList;
 
-    std::vector<std::string> filetypes = App::GetApplication().getImportTypes();
-    std::vector<std::string>::const_iterator it;
-    for (it = filetypes.begin(); it != filetypes.end(); ++it) {
-        if (*it != "FCStd") {
-            // ignore the project file format
-            formatList += QLatin1String(" *.");
-            formatList += QLatin1String(it->c_str());
+    QString allSupportedFormats = QObject::tr("Supported formats") + QStringLiteral(" (");
+    const auto filetypes = App::GetApplication().getImportTypes();
+    for (const auto& type : filetypes) {
+        if (type != "FCStd") {
+            allSupportedFormats += QStringLiteral(" *.");
+            allSupportedFormats += QString::fromStdString(type);
+        }
+    }
+    allSupportedFormats += QLatin1Char(')');
+    formatList += allSupportedFormats;
+
+    const auto importFilters = App::GetApplication().getImportFilters();
+    for (auto it = importFilters.cbegin(); it != importFilters.cend(); ++it) {
+        if (it->first.find("*.FCStd") == std::string::npos) {
+            formatList += QString::fromStdString(it->first);
         }
     }
 
-    formatList += QLatin1String(");;");
-
-    std::map<std::string, std::string> FilterList = App::GetApplication().getImportFilters();
-    std::map<std::string, std::string>::const_iterator jt;
-    for (jt = FilterList.begin(); jt != FilterList.end(); ++jt) {
-        // ignore the project file format
-        if (jt->first.find("(*.FCStd)") == std::string::npos) {
-            formatList += QLatin1String(jt->first.c_str());
-            formatList += QLatin1String(";;");
-        }
-    }
-    formatList += QObject::tr(allFiles);
+    formatList += QObject::tr("All files") + QStringLiteral(" (*.*)");
 
     Base::Reference<ParameterGrp> hPath = App::GetApplication()
                                               .GetUserParameter()

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -474,7 +474,6 @@ void StdCmdExport::activated(int iMsg)
             filterList << QString::fromStdString(filter.first);
         }
     }
-    QString formatList = filterList.join(QLatin1String(";;"));
     Base::Reference<ParameterGrp> hPath = App::GetApplication()
                                               .GetUserParameter()
                                               .GetGroup("BaseApp")
@@ -537,7 +536,7 @@ void StdCmdExport::activated(int iMsg)
         getMainWindow(),
         QObject::tr("Export File"),
         defaultFilename,
-        formatList,
+        filterList,
         &selectedFilter
     );
     if (!filename.isEmpty()) {
@@ -603,7 +602,7 @@ void StdCmdMergeProjects::activated(int iMsg)
         Gui::getMainWindow(),
         QString::fromUtf8(QT_TR_NOOP("Merge Document")),
         FileDialog::getWorkingDirectory(),
-        QString::fromUtf8(QT_TR_NOOP("%1 document (*.FCStd)")).arg(exe)
+        QStringList(QString::fromUtf8(QT_TR_NOOP("%1 document (*.FCStd)")).arg(exe))
     );
     if (!project.isEmpty()) {
         FileDialog::setWorkingDirectory(project);
@@ -695,7 +694,7 @@ void StdCmdExportDependencyGraph::activated(int iMsg)
         Gui::getMainWindow(),
         Gui::GraphvizView::tr("Export Graph"),
         QString(),
-        format
+        QStringList(format)
     );
     if (!fn.isEmpty()) {
         QFile file(fn);

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -462,7 +462,7 @@ void StdCmdFreezeViews::onSaveViews()
         getMainWindow(),
         QObject::tr("Save Frozen Views"),
         QString(),
-        QStringLiteral("%1 (*.cam)").arg(QObject::tr("Frozen views"))
+        QStringList(QStringLiteral("%1 (*.cam)").arg(QObject::tr("Frozen views")))
     );
     if (fn.isEmpty()) {
         return;
@@ -524,7 +524,7 @@ void StdCmdFreezeViews::onRestoreViews()
         getMainWindow(),
         QObject::tr("Restore Frozen Views"),
         QString(),
-        QStringLiteral("%1 (*.cam)").arg(QObject::tr("Frozen views"))
+        QStringList(QStringLiteral("%1 (*.cam)").arg(QObject::tr("Frozen views")))
     );
     if (fn.isEmpty()) {
         return;

--- a/src/Gui/Dialogs/DlgParameterImp.cpp
+++ b/src/Gui/Dialogs/DlgParameterImp.cpp
@@ -609,7 +609,7 @@ void ParameterGroup::onExportToFile()
         this,
         tr("Export Parameter to File"),
         QString(),
-        QStringLiteral("XML (*.FCParam)")
+        QStringList(QStringLiteral("XML (*.FCParam)"))
     );
     if (!file.isEmpty()) {
         QTreeWidgetItem* item = currentItem();
@@ -627,7 +627,7 @@ void ParameterGroup::onImportFromFile()
         this,
         tr("Import Parameter From File"),
         QString(),
-        QStringLiteral("XML (*.FCParam)")
+        QStringList(QStringLiteral("XML (*.FCParam)"))
     );
     if (!file.isEmpty()) {
         QTreeWidgetItem* item = currentItem();

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1656,7 +1656,7 @@ bool Document::saveAs()
         getMainWindow(),
         QObject::tr("Save %1 Document").arg(exe),
         name,
-        QStringLiteral("%1 %2 (*.FCStd)").arg(exe, QObject::tr("Document"))
+        QStringList(QStringLiteral("%1 %2 (*.FCStd)").arg(exe, QObject::tr("Document")))
     );
 
     if (!fn.isEmpty()) {
@@ -1786,7 +1786,7 @@ bool Document::saveCopy()
         getMainWindow(),
         QObject::tr("Save %1 Document").arg(exe),
         name,
-        QObject::tr("%1 document (*.FCStd)").arg(exe)
+        QStringList(QObject::tr("%1 document (*.FCStd)").arg(exe))
     );
     if (!fn.isEmpty()) {
         const char* DocName = App::GetApplication().getDocumentName(getDocument());

--- a/src/Gui/EditorView.cpp
+++ b/src/Gui/EditorView.cpp
@@ -377,7 +377,7 @@ bool EditorView::saveAs()
         this,
         QObject::tr("Save Macro"),
         QString(),
-        QStringLiteral("%1 (*.FCMacro);;Python (*.py)").arg(tr("FreeCAD macro"))
+        QStringList(QStringLiteral("%1 (*.FCMacro);;Python (*.py)").arg(tr("FreeCAD macro")))
     );
     if (fn.isEmpty()) {
         return false;

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -246,20 +246,78 @@ void FileDialog::accept()
     QFileDialog::accept();
 }
 
-void FileDialog::getSuffixesDescription(QStringList& suffixes, const QString* suffixDescriptions)
+static void getSuffixesDescription(QStringList& suffixes, const QString& suffixDescriptions)
 {
     QRegularExpression rx;
     // start the raw string with a (
     // match a *, a . and at least one word character (a-z, A-Z, 0-9, _) with \*\.\w+
     // end the raw string with a )
-    rx.setPattern(QLatin1String(R"(\*\.\w+)"));
+    rx.setPattern(QStringLiteral(R"(\*\.\w+)"));
 
-    QRegularExpressionMatchIterator i = rx.globalMatch(*suffixDescriptions);
+    QRegularExpressionMatchIterator i = rx.globalMatch(suffixDescriptions);
     while (i.hasNext()) {
         QRegularExpressionMatch match = i.next();
         QString suffix = match.captured(0);
         suffixes << suffix;
     }
+}
+
+static QString formatFilter(const QString& filter)
+{
+    // Since we explicitly ask Qt to hide the extension filters as to avoid
+    // overflowing the screen with an excessively long filter list (see #23139),
+    // locate the extension filters and duplicate them so they remain
+    // visible *if they're short enough*.
+    const qsizetype MaxFiltersLength = 128;
+    const auto start = filter.lastIndexOf(QLatin1Char('('));
+    const auto end = filter.lastIndexOf(QLatin1Char(')'));
+    QString formatted(filter);
+    if (end - start <= MaxFiltersLength) {
+        auto filterPart = QStringView(filter).mid(start + 1, end - start - 1);
+        QList<QStringView> extensions = filterPart.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        // Deduplicate the extensions which usually come in both *.ext & *.EXT variants.
+        // Keeps the first case encountered for a given extension set, which is assumed
+        // to be contiguous in the filter string. Less flexible but much cheaper than
+        // maintaing a (hash) set of extensions seen so far.
+        QString dedupExtensions;
+        dedupExtensions.reserve(filterPart.length());
+        dedupExtensions += QLatin1Char('(');
+        for (auto it = extensions.cbegin(); it != extensions.cend(); ++it) {
+            if (it == extensions.cbegin() || it->compare(*(it - 1), Qt::CaseInsensitive) != 0) {
+                if (it != extensions.cbegin()) {
+                    dedupExtensions += QLatin1Char(' ');
+                }
+                dedupExtensions += *it;
+            }
+        }
+        dedupExtensions += QStringLiteral(") ");
+        formatted.insert(start, dedupExtensions);
+    }
+    return formatted;
+}
+
+static QStringList formatFilters(const QStringList& filters)
+{
+    QStringList formatted;
+    formatted.reserve(filters.length());
+    for (const auto& filter : filters) {
+        formatted += formatFilter(filter);
+    }
+    return formatted;
+}
+
+static QString unformatFilter(const QStringList& unformattedFilters, const QString& formattedFilter)
+{
+    // This function is uboptimal as this only matches the filter name and not the extension list.
+    // To be removed when format handling is reworked.
+    const auto selectedName
+        = QStringView(formattedFilter).left(formattedFilter.indexOf(QLatin1Char('('))).trimmed();
+    for (const auto& filter : unformattedFilters) {
+        if (QStringView(filter).left(filter.indexOf(QLatin1Char('('))).trimmed() == selectedName) {
+            return filter;
+        }
+    }
+    return {};
 }
 
 /**
@@ -275,8 +333,23 @@ QString FileDialog::getSaveFileName(
     Options options
 )
 {
-    ActionDisabler actionDisabler {};
+    return getSaveFileName(parent, caption, dir, filter.split(QStringLiteral(";;")), selectedFilter, options);
+}
 
+/**
+ * This is a convenience static function that will return a file name selected by the user. The file
+ * does not have to exist.
+ */
+QString FileDialog::getSaveFileName(
+    QWidget* parent,
+    const QString& caption,
+    const QString& dir,
+    const QStringList& filters,
+    QString* selectedFilter,
+    Options options
+)
+{
+    ActionDisabler actionDisabler {};
     QString dirName = dir;
     bool hasFilename = false;
     if (dirName.isEmpty()) {
@@ -286,7 +359,7 @@ QString FileDialog::getSaveFileName(
         QFileInfo fi(dir);
         if (fi.isRelative()) {
             dirName = getPreferredDialogDirectory();
-            dirName += QLatin1String("/");
+            dirName += QStringLiteral("/");
             dirName += fi.fileName();
         }
         if (!fi.fileName().isEmpty()) {
@@ -295,12 +368,12 @@ QString FileDialog::getSaveFileName(
 
         // get the suffix for the filter: use the selected filter if there is one,
         // otherwise find the first valid suffix in the complete list of filters
-        const QString* filterToSearch;
+        QString filterToSearch;
         if (selectedFilter && !selectedFilter->isEmpty()) {
-            filterToSearch = selectedFilter;
+            filterToSearch = *selectedFilter;
         }
         else {
-            filterToSearch = &filter;
+            filterToSearch = filters.join(QLatin1Char(';'));
         }
 
         QStringList filterSuffixes;
@@ -321,6 +394,8 @@ QString FileDialog::getSaveFileName(
         windowTitle = FileDialog::tr("Save As");
     }
 
+    QStringList formattedFilters = formatFilters(filters);
+    options |= QFileDialog::HideNameFilterDetails;
 
     // NOTE: We must not change the specified file name afterwards as we may return the name of an
     // already existing file. Hence we must extract the first matching suffix from the filter list
@@ -343,22 +418,35 @@ QString FileDialog::getSaveFileName(
         if (hasFilename) {
             dlg.selectFile(dirName);
         }
-        dlg.setNameFilters(filter.split(QLatin1String(";;")));
+        dlg.setNameFilters(formattedFilters);
         if (selectedFilter && !selectedFilter->isEmpty()) {
             dlg.selectNameFilter(*selectedFilter);
         }
         dlg.onSelectedFilter(dlg.selectedNameFilter());
-        dlg.setOption(QFileDialog::HideNameFilterDetails, false);
         dlg.setOption(QFileDialog::DontConfirmOverwrite, false);
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {
-                *selectedFilter = dlg.selectedNameFilter();
+                *selectedFilter = unformatFilter(filters, dlg.selectedNameFilter());
             }
             file = dlg.selectedFiles().constFirst();
         }
     }
     else {
-        file = QFileDialog::getSaveFileName(parent, windowTitle, dirName, filter, selectedFilter, options);
+        QString formattedSelectedFilter;
+        if (selectedFilter && !selectedFilter->isEmpty()) {
+            formattedSelectedFilter = formatFilter(*selectedFilter);
+        }
+        file = QFileDialog::getSaveFileName(
+            parent,
+            windowTitle,
+            dirName,
+            formattedFilters.join(QStringLiteral(";;")),
+            &formattedSelectedFilter,
+            options
+        );
+        if (selectedFilter) {
+            *selectedFilter = unformatFilter(filters, formattedSelectedFilter);
+        }
         file = QDir::fromNativeSeparators(file);
     }
 
@@ -410,6 +498,22 @@ QString FileDialog::getOpenFileName(
     Options options
 )
 {
+    return getOpenFileName(parent, caption, dir, filter.split(QStringLiteral(";;")), selectedFilter, options);
+}
+
+/**
+ * This is a convenience static function that returns an existing file selected by the user.
+ * If the user pressed Cancel, it returns a null string.
+ */
+QString FileDialog::getOpenFileName(
+    QWidget* parent,
+    const QString& caption,
+    const QString& dir,
+    const QStringList& filters,
+    QString* selectedFilter,
+    Options options
+)
+{
     ActionDisabler actionDisabler {};
     QString dirName = dir;
     if (dirName.isEmpty()) {
@@ -420,6 +524,9 @@ QString FileDialog::getOpenFileName(
     if (windowTitle.isEmpty()) {
         windowTitle = FileDialog::tr("Open");
     }
+
+    QStringList formattedFilters = formatFilters(filters);
+    options |= QFileDialog::HideNameFilterDetails;
 
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
@@ -436,20 +543,33 @@ QString FileDialog::getOpenFileName(
         dlg.setFileMode(QFileDialog::ExistingFile);
         dlg.setAcceptMode(QFileDialog::AcceptOpen);
         dlg.setDirectory(dirName);
-        dlg.setNameFilters(filter.split(QLatin1String(";;")));
-        dlg.setOption(QFileDialog::HideNameFilterDetails, false);
+        dlg.setNameFilters(formattedFilters);
         if (selectedFilter && !selectedFilter->isEmpty()) {
             dlg.selectNameFilter(*selectedFilter);
         }
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {
-                *selectedFilter = dlg.selectedNameFilter();
+                *selectedFilter = unformatFilter(filters, dlg.selectedNameFilter());
             }
             file = dlg.selectedFiles().constFirst();
         }
     }
     else {
-        file = QFileDialog::getOpenFileName(parent, windowTitle, dirName, filter, selectedFilter, options);
+        QString formattedSelectedFilter;
+        if (selectedFilter && !selectedFilter->isEmpty()) {
+            formattedSelectedFilter = formatFilter(*selectedFilter);
+        }
+        file = QFileDialog::getOpenFileName(
+            parent,
+            windowTitle,
+            dirName,
+            formattedFilters.join(QStringLiteral(";;")),
+            &formattedSelectedFilter,
+            options
+        );
+        if (selectedFilter) {
+            *selectedFilter = unformatFilter(filters, formattedSelectedFilter);
+        }
         file = QDir::fromNativeSeparators(file);
     }
 
@@ -475,6 +595,22 @@ QStringList FileDialog::getOpenFileNames(
     Options options
 )
 {
+    return getOpenFileNames(parent, caption, dir, filter.split(QStringLiteral(";;")), selectedFilter, options);
+}
+
+/**
+ * This is a convenience static function that will return one or more existing files selected by the
+ * user.
+ */
+QStringList FileDialog::getOpenFileNames(
+    QWidget* parent,
+    const QString& caption,
+    const QString& dir,
+    const QStringList& filters,
+    QString* selectedFilter,
+    Options options
+)
+{
     ActionDisabler actionDisabler {};
     QString dirName = dir;
     if (dirName.isEmpty()) {
@@ -485,6 +621,9 @@ QStringList FileDialog::getOpenFileNames(
     if (windowTitle.isEmpty()) {
         windowTitle = FileDialog::tr("Open");
     }
+
+    QStringList formattedFilters = formatFilters(filters);
+    options |= QFileDialog::HideNameFilterDetails;
 
     QStringList files;
     if (DialogOptions::dontUseNativeFileDialog()) {
@@ -501,20 +640,33 @@ QStringList FileDialog::getOpenFileNames(
         dlg.setFileMode(QFileDialog::ExistingFiles);
         dlg.setAcceptMode(QFileDialog::AcceptOpen);
         dlg.setDirectory(dirName);
-        dlg.setNameFilters(filter.split(QLatin1String(";;")));
-        dlg.setOption(QFileDialog::HideNameFilterDetails, false);
+        dlg.setNameFilters(formattedFilters);
         if (selectedFilter && !selectedFilter->isEmpty()) {
-            dlg.selectNameFilter(*selectedFilter);
+            dlg.selectNameFilter(formatFilter(*selectedFilter));
         }
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {
-                *selectedFilter = dlg.selectedNameFilter();
+                *selectedFilter = unformatFilter(filters, dlg.selectedNameFilter());
             }
             files = dlg.selectedFiles();
         }
     }
     else {
-        files = QFileDialog::getOpenFileNames(parent, windowTitle, dirName, filter, selectedFilter, options);
+        QString formattedSelectedFilter;
+        if (selectedFilter && !selectedFilter->isEmpty()) {
+            formattedSelectedFilter = formatFilter(*selectedFilter);
+        }
+        files = QFileDialog::getOpenFileNames(
+            parent,
+            windowTitle,
+            dirName,
+            formattedFilters.join(QStringLiteral(";;")),
+            &formattedSelectedFilter,
+            options
+        );
+        if (selectedFilter) {
+            *selectedFilter = unformatFilter(filters, formattedSelectedFilter);
+        }
         for (auto& file : files) {
             file = QDir::fromNativeSeparators(file);
         }

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -21,6 +21,17 @@
  ***************************************************************************/
 
 
+#include <memory>
+
+#include <FCConfig.h>
+
+#ifdef FC_OS_WIN32
+// windows.h must be kept above commdlg.h and shlobj.h
+# include <windows.h>
+# include <commdlg.h>
+# include <shlobj.h>
+#endif
+
 #include <QApplication>
 #include <QButtonGroup>
 #include <QCompleter>
@@ -262,63 +273,285 @@ static void getSuffixesDescription(QStringList& suffixes, const QString& suffixD
     }
 }
 
-static QString formatFilter(const QString& filter)
+static bool getPreferShowFilterExtensions()
 {
-    // Since we explicitly ask Qt to hide the extension filters as to avoid
-    // overflowing the screen with an excessively long filter list (see #23139),
-    // locate the extension filters and duplicate them so they remain
-    // visible *if they're short enough*.
-    const qsizetype MaxFiltersLength = 128;
-    const auto start = filter.lastIndexOf(QLatin1Char('('));
-    const auto end = filter.lastIndexOf(QLatin1Char(')'));
-    QString formatted(filter);
-    if (end - start <= MaxFiltersLength) {
-        auto filterPart = QStringView(filter).mid(start + 1, end - start - 1);
-        QList<QStringView> extensions = filterPart.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    bool show = true;
+#ifdef FC_OS_WIN32
+    SHELLFLAGSTATE shellFlags;
+    SHGetSettings(&shellFlags, SSF_SHOWEXTENSIONS);
+    show = shellFlags.fShowExtensions;
+#endif
+
+    ParameterGrp::handle group = App::GetApplication()
+                                     .GetUserParameter()
+                                     .GetGroup("BaseApp")
+                                     ->GetGroup("Preferences")
+                                     ->GetGroup("Dialog");
+    return group->GetBool("ShowFilterExtensions", show);
+}
+
+struct FilterSpec
+{
+    QString name;
+    QStringList extensions;
+
+    bool operator==(const FilterSpec& rhs) const
+    {
+        return name == rhs.name && extensions == rhs.extensions;
+    }
+
+    static FilterSpec fromFilterString(const QString& filter)
+    {
+        const auto start = filter.lastIndexOf(QLatin1Char('('));
+        const auto end = filter.lastIndexOf(QLatin1Char(')'));
+        const auto name = filter.left(start).trimmed();
+        const auto extensionsPart = filter.mid(start + 1, end - start - 1);
+        return {name, extensionsPart.split(QLatin1Char(' '), Qt::SkipEmptyParts)};
+    }
+
+    QString getDisplayName(bool showExtensions) const
+    {
+        // Avoid overflowing the screen with an excessively long filter list (see #23139).
+        const qsizetype MaxFiltersLength = 128;
+        const qsizetype TypicalMaxExtensionLength = 12;
+
+        if (!showExtensions) {
+            return name;
+        }
+
+        QString formatted(name);
+        formatted += QLatin1Char(' ');
+
         // Deduplicate the extensions which usually come in both *.ext & *.EXT variants.
-        // Keeps the first case encountered for a given extension set, which is assumed
-        // to be contiguous in the filter string. Less flexible but much cheaper than
-        // maintaing a (hash) set of extensions seen so far.
+        // Keeps the first case encountered for a given extension set.
+        // O(n^2) in complexity but the extension lists are usually short.
+        QList<QStringView> seen;
+        seen.reserve(extensions.size());
+        const auto wasSeen = [&seen](QStringView ext) -> bool {
+            for (QStringView extSeen : seen) {
+                if (extSeen.compare(ext, Qt::CaseInsensitive) == 0) {
+                    return true;
+                }
+            }
+            return false;
+        };
         QString dedupExtensions;
-        dedupExtensions.reserve(filterPart.length());
-        dedupExtensions += QLatin1Char('(');
+        dedupExtensions.reserve(extensions.length() * TypicalMaxExtensionLength);
         for (auto it = extensions.cbegin(); it != extensions.cend(); ++it) {
-            if (it == extensions.cbegin() || it->compare(*(it - 1), Qt::CaseInsensitive) != 0) {
+            if (!wasSeen(*it)) {
+                seen.append(*it);
                 if (it != extensions.cbegin()) {
                     dedupExtensions += QLatin1Char(' ');
                 }
                 dedupExtensions += *it;
             }
         }
-        dedupExtensions += QStringLiteral(") ");
-        formatted.insert(start, dedupExtensions);
+
+        if (dedupExtensions.size() <= MaxFiltersLength) {
+            formatted += QLatin1Char('(');
+            formatted += dedupExtensions;
+            formatted += QLatin1Char(')');
+        }
+
+        return formatted;
     }
-    return formatted;
+
+    QString toQtFilter(bool showExtensions) const
+    {
+        return getDisplayName(showExtensions) + QStringLiteral(" (")
+            + extensions.join(QLatin1Char(' ')) + QLatin1Char(')');
+    }
+};
+
+class FilterSpecList: public QList<FilterSpec>
+{
+public:
+    static FilterSpecList fromFilterStringList(const QStringList& filterStringList)
+    {
+        FilterSpecList specs;
+        specs.reserve(filterStringList.length());
+        for (const auto& filterString : filterStringList) {
+            specs += FilterSpec::fromFilterString(filterString);
+        }
+        return specs;
+    }
+
+    QStringList toQtFilterList(bool showExtensions) const
+    {
+        QStringList qtFilters;
+        for (const auto& filterSpec : *this) {
+            qtFilters += filterSpec.toQtFilter(showExtensions);
+        }
+        return qtFilters;
+    }
+
+    qsizetype indexOfFilterString(const QString& filterString) const
+    {
+        return indexOf(FilterSpec::fromFilterString(filterString));
+    }
+};
+
+enum class NativeFileDialogMode
+{
+    OpenSingle,
+    OpenMultiple,
+    Save,
+};
+
+#ifdef FC_OS_WIN32
+static std::unique_ptr<wchar_t[]> qStringToWCharArray(const QString& s, size_t reserveSize = 0)
+{
+    const size_t stringSize = s.size();
+    wchar_t* result = new wchar_t[qMax(stringSize + 1, reserveSize)];
+    s.toWCharArray(result);
+    result[stringSize] = 0;
+    return std::unique_ptr<wchar_t[]>(result);
 }
 
-static QStringList formatFilters(const QStringList& filters)
+/* Use the legacy Get{Open,Save}FileNameW functions as the Vista+ IFileDialog forces
+ * extension display in filter lists, leading to exceedingly long entries as seen in
+ * issue #23139.
+ * Note neither this legacy function set nor IFileDialog are valid for UWP WinRT,
+ * for which Windows::Storage::Pickers::FileOpenPicker will have to be used instead.
+ */
+static QStringList nativeFileDialog(
+    NativeFileDialogMode mode,
+    QWidget* parent,
+    const QString& caption,
+    QString& dir,
+    const FilterSpecList& filterSpecs,
+    qsizetype* selectedFilterIndex,
+    FileDialog::Options options
+)
 {
-    QStringList formatted;
-    formatted.reserve(filters.length());
-    for (const auto& filter : filters) {
-        formatted += formatFilter(filter);
-    }
-    return formatted;
-}
+    const bool showExtensions = getPreferShowFilterExtensions();
 
-static QString unformatFilter(const QStringList& unformattedFilters, const QString& formattedFilter)
-{
-    // This function is uboptimal as this only matches the filter name and not the extension list.
-    // To be removed when format handling is reworked.
-    const auto selectedName
-        = QStringView(formattedFilter).left(formattedFilter.indexOf(QLatin1Char('('))).trimmed();
-    for (const auto& filter : unformattedFilters) {
-        if (QStringView(filter).left(filter.indexOf(QLatin1Char('('))).trimmed() == selectedName) {
-            return filter;
+    OPENFILENAMEW ofn;
+    memset(&ofn, 0, sizeof(OPENFILENAMEW));
+    ofn.lStructSize = sizeof(OPENFILENAMEW);
+    if (parent) {
+        ofn.hwndOwner = HWND(parent->winId());
+    }
+
+    QString flatFilter;
+    for (const auto& filterSpec : filterSpecs) {
+        flatFilter += filterSpec.getDisplayName(showExtensions);
+        flatFilter += QLatin1Char('\0');
+        flatFilter += filterSpec.extensions.join(QLatin1Char(';'));
+        flatFilter += QLatin1Char('\0');
+    }
+    flatFilter += QLatin1Char('\0');
+    auto ofnFilter = qStringToWCharArray(flatFilter);
+    ofn.lpstrFilter = ofnFilter.get();
+
+    if (selectedFilterIndex && *selectedFilterIndex >= 0) {
+        ofn.nFilterIndex = *selectedFilterIndex + 1;  // OPENFILENAMEW index is 1-based
+    }
+
+    constexpr const DWORD SelectionBufferSize = 65535;
+    auto selectedFile = std::make_unique<wchar_t[]>(SelectionBufferSize);
+    selectedFile[0] = L'\0';
+    ofn.nMaxFile = SelectionBufferSize;
+    ofn.lpstrFile = selectedFile.get();
+
+    auto initialDir = qStringToWCharArray(QDir::toNativeSeparators(dir));
+    ofn.lpstrInitialDir = initialDir.get();
+
+    auto title = qStringToWCharArray(caption);
+    ofn.lpstrTitle = title.get();
+
+    ofn.Flags = OFN_NOCHANGEDIR | OFN_HIDEREADONLY | OFN_EXPLORER | OFN_PATHMUSTEXIST;
+    if (mode == NativeFileDialogMode::OpenSingle || mode == NativeFileDialogMode::OpenMultiple) {
+        ofn.Flags |= OFN_FILEMUSTEXIST;
+    }
+
+    BOOL ok = FALSE;
+    if (mode == NativeFileDialogMode::OpenSingle) {
+        ok = ::GetOpenFileNameW(&ofn);
+    }
+    else if (mode == NativeFileDialogMode::OpenMultiple) {
+        ofn.Flags |= OFN_ALLOWMULTISELECT;
+        ok = ::GetOpenFileNameW(&ofn);
+    }
+    else /* (mode == NativeFileDialogMode::Save) */ {
+        ok = ::GetSaveFileNameW(&ofn);
+    }
+
+    QStringList selected;
+    if (ok) {
+        if (selectedFilterIndex) {
+            *selectedFilterIndex = ofn.nFilterIndex - 1;
+        }
+        const QString dir = QDir::cleanPath(QString::fromWCharArray(ofn.lpstrFile));
+        selected += dir;
+        if (ofn.Flags & OFN_ALLOWMULTISELECT) {
+            const wchar_t* ptr = ofn.lpstrFile + dir.size() + 1;
+            if (*ptr) {
+                selected.clear();
+                const QString path = dir + u'/';
+                while (*ptr) {
+                    const QString fileName = QString::fromWCharArray(ptr);
+                    selected += path + fileName;
+                    ptr += fileName.size() + 1;
+                }
+            }
         }
     }
-    return {};
+    return selected;
 }
+#else
+static QStringList nativeFileDialog(
+    NativeFileDialogMode mode,
+    QWidget* parent,
+    const QString& caption,
+    QString& dir,
+    const FilterSpecList& filterSpecs,
+    qsizetype* selectedFilterIndex,
+    FileDialog::Options options
+)
+{
+    const bool showExtensions = getPreferShowFilterExtensions();
+    const auto qtFilterList = filterSpecs.toQtFilterList(showExtensions);
+    QString selectedQtFilter = (selectedFilterIndex != nullptr && *selectedFilterIndex >= 0)
+        ? qtFilterList[*selectedFilterIndex]
+        : "";
+    QStringList selected;
+    if (mode == NativeFileDialogMode::OpenSingle) {
+        selected = {QFileDialog::getOpenFileName(
+            parent,
+            caption,
+            dir,
+            qtFilterList.join(QStringLiteral(";;")),
+            &selectedQtFilter,
+            options
+        )};
+    }
+    else if (mode == NativeFileDialogMode::OpenMultiple) {
+        selected = QFileDialog::getOpenFileNames(
+            parent,
+            caption,
+            dir,
+            qtFilterList.join(QStringLiteral(";;")),
+            &selectedQtFilter,
+            options
+        );
+    }
+    else /* (mode == NativeFileDialogMode::Save) */ {
+        selected = {QFileDialog::getSaveFileName(
+            parent,
+            caption,
+            dir,
+            qtFilterList.join(QStringLiteral(";;")),
+            &selectedQtFilter,
+            options
+        )};
+    }
+    if (selectedFilterIndex != nullptr) {
+        *selectedFilterIndex = qtFilterList.indexOf(selectedQtFilter);
+    }
+    return selected;
+}
+#endif
 
 /**
  * This is a convenience static function that will return a file name selected by the user. The file
@@ -394,7 +627,11 @@ QString FileDialog::getSaveFileName(
         windowTitle = FileDialog::tr("Save As");
     }
 
-    QStringList formattedFilters = formatFilters(filters);
+    const auto filterSpecList = FilterSpecList::fromFilterStringList(filters);
+    qsizetype selectedFilterIndex = (selectedFilter != nullptr && !selectedFilter->isEmpty())
+        ? filterSpecList.indexOfFilterString(*selectedFilter)
+        : -1;
+
     options |= QFileDialog::HideNameFilterDetails;
 
     // NOTE: We must not change the specified file name afterwards as we may return the name of an
@@ -402,6 +639,8 @@ QString FileDialog::getSaveFileName(
     // and append it before showing the file dialog.
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
+        const bool showExtensions = getPreferShowFilterExtensions();
+        const auto qtFilterList = filterSpecList.toQtFilterList(showExtensions);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -418,34 +657,31 @@ QString FileDialog::getSaveFileName(
         if (hasFilename) {
             dlg.selectFile(dirName);
         }
-        dlg.setNameFilters(formattedFilters);
-        if (selectedFilter && !selectedFilter->isEmpty()) {
-            dlg.selectNameFilter(*selectedFilter);
+        dlg.setNameFilters(qtFilterList);
+        if (selectedFilterIndex >= 0) {
+            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
         }
         dlg.onSelectedFilter(dlg.selectedNameFilter());
         dlg.setOption(QFileDialog::DontConfirmOverwrite, false);
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {
-                *selectedFilter = unformatFilter(filters, dlg.selectedNameFilter());
+                *selectedFilter = filters[qtFilterList.indexOf(dlg.selectedNameFilter())];
             }
             file = dlg.selectedFiles().constFirst();
         }
     }
     else {
-        QString formattedSelectedFilter;
-        if (selectedFilter && !selectedFilter->isEmpty()) {
-            formattedSelectedFilter = formatFilter(*selectedFilter);
-        }
-        file = QFileDialog::getSaveFileName(
+        file = nativeFileDialog(
+            NativeFileDialogMode::Save,
             parent,
             windowTitle,
             dirName,
-            formattedFilters.join(QStringLiteral(";;")),
-            &formattedSelectedFilter,
+            filterSpecList,
+            &selectedFilterIndex,
             options
-        );
-        if (selectedFilter) {
-            *selectedFilter = unformatFilter(filters, formattedSelectedFilter);
+        )[0];
+        if (selectedFilter && selectedFilterIndex >= 0) {
+            *selectedFilter = filters[selectedFilterIndex];
         }
         file = QDir::fromNativeSeparators(file);
     }
@@ -525,11 +761,17 @@ QString FileDialog::getOpenFileName(
         windowTitle = FileDialog::tr("Open");
     }
 
-    QStringList formattedFilters = formatFilters(filters);
+    const auto filterSpecList = FilterSpecList::fromFilterStringList(filters);
+    qsizetype selectedFilterIndex = (selectedFilter && !selectedFilter->isEmpty())
+        ? filterSpecList.indexOfFilterString(*selectedFilter)
+        : -1;
+
     options |= QFileDialog::HideNameFilterDetails;
 
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
+        const bool showExtensions = getPreferShowFilterExtensions();
+        const auto qtFilterList = filterSpecList.toQtFilterList(showExtensions);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -543,32 +785,29 @@ QString FileDialog::getOpenFileName(
         dlg.setFileMode(QFileDialog::ExistingFile);
         dlg.setAcceptMode(QFileDialog::AcceptOpen);
         dlg.setDirectory(dirName);
-        dlg.setNameFilters(formattedFilters);
-        if (selectedFilter && !selectedFilter->isEmpty()) {
-            dlg.selectNameFilter(*selectedFilter);
+        dlg.setNameFilters(qtFilterList);
+        if (selectedFilterIndex >= 0) {
+            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
         }
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {
-                *selectedFilter = unformatFilter(filters, dlg.selectedNameFilter());
+                *selectedFilter = filters[qtFilterList.indexOf(dlg.selectedNameFilter())];
             }
             file = dlg.selectedFiles().constFirst();
         }
     }
     else {
-        QString formattedSelectedFilter;
-        if (selectedFilter && !selectedFilter->isEmpty()) {
-            formattedSelectedFilter = formatFilter(*selectedFilter);
-        }
-        file = QFileDialog::getOpenFileName(
+        file = nativeFileDialog(
+            NativeFileDialogMode::OpenSingle,
             parent,
             windowTitle,
             dirName,
-            formattedFilters.join(QStringLiteral(";;")),
-            &formattedSelectedFilter,
+            filterSpecList,
+            &selectedFilterIndex,
             options
-        );
-        if (selectedFilter) {
-            *selectedFilter = unformatFilter(filters, formattedSelectedFilter);
+        )[0];
+        if (selectedFilter && selectedFilterIndex >= 0) {
+            *selectedFilter = filters[selectedFilterIndex];
         }
         file = QDir::fromNativeSeparators(file);
     }
@@ -622,11 +861,17 @@ QStringList FileDialog::getOpenFileNames(
         windowTitle = FileDialog::tr("Open");
     }
 
-    QStringList formattedFilters = formatFilters(filters);
+    const auto filterSpecList = FilterSpecList::fromFilterStringList(filters);
+    qsizetype selectedFilterIndex = (selectedFilter != nullptr && !selectedFilter->isEmpty())
+        ? filterSpecList.indexOfFilterString(*selectedFilter)
+        : -1;
+
     options |= QFileDialog::HideNameFilterDetails;
 
     QStringList files;
     if (DialogOptions::dontUseNativeFileDialog()) {
+        const bool showExtensions = getPreferShowFilterExtensions();
+        const auto qtFilterList = filterSpecList.toQtFilterList(showExtensions);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -640,32 +885,29 @@ QStringList FileDialog::getOpenFileNames(
         dlg.setFileMode(QFileDialog::ExistingFiles);
         dlg.setAcceptMode(QFileDialog::AcceptOpen);
         dlg.setDirectory(dirName);
-        dlg.setNameFilters(formattedFilters);
-        if (selectedFilter && !selectedFilter->isEmpty()) {
-            dlg.selectNameFilter(formatFilter(*selectedFilter));
+        dlg.setNameFilters(qtFilterList);
+        if (selectedFilterIndex >= 0) {
+            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
         }
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {
-                *selectedFilter = unformatFilter(filters, dlg.selectedNameFilter());
+                *selectedFilter = filters[qtFilterList.indexOf(dlg.selectedNameFilter())];
             }
             files = dlg.selectedFiles();
         }
     }
     else {
-        QString formattedSelectedFilter;
-        if (selectedFilter && !selectedFilter->isEmpty()) {
-            formattedSelectedFilter = formatFilter(*selectedFilter);
-        }
-        files = QFileDialog::getOpenFileNames(
+        files = nativeFileDialog(
+            NativeFileDialogMode::OpenMultiple,
             parent,
             windowTitle,
             dirName,
-            formattedFilters.join(QStringLiteral(";;")),
-            &formattedSelectedFilter,
+            filterSpecList,
+            &selectedFilterIndex,
             options
         );
-        if (selectedFilter) {
-            *selectedFilter = unformatFilter(filters, formattedSelectedFilter);
+        if (selectedFilter && selectedFilterIndex >= 0) {
+            *selectedFilter = filters[selectedFilterIndex];
         }
         for (auto& file : files) {
             file = QDir::fromNativeSeparators(file);

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -38,6 +38,7 @@
 #include <QCryptographicHash>
 #include <QDialogButtonBox>
 #include <QDir>
+#include <QFileSystemModel>
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QLineEdit>

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -69,6 +69,7 @@ public:
         QString* selectedFilter = nullptr,
         Options options = Options()
     );
+    [[deprecated("Use getSaveFileName with a QStringList filter list instead")]]
     static QString getOpenFileName(
         QWidget* parent = nullptr,
         const QString& caption = QString(),
@@ -85,6 +86,7 @@ public:
         QString* selectedFilter = nullptr,
         Options options = Options()
     );
+    [[deprecated("Use getSaveFileName with a QStringList filter list instead")]]
     static QString getSaveFileName(
         QWidget* parent = nullptr,
         const QString& caption = QString(),
@@ -107,6 +109,7 @@ public:
         QString* selectedFilter = nullptr,
         Options options = Options()
     );
+    [[deprecated("Use getSaveFileName with a QStringList filter list instead")]]
     static QStringList getOpenFileNames(
         QWidget* parent = nullptr,
         const QString& caption = QString(),

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -65,7 +65,23 @@ public:
         QWidget* parent = nullptr,
         const QString& caption = QString(),
         const QString& dir = QString(),
+        const QStringList& filters = QStringList(),
+        QString* selectedFilter = nullptr,
+        Options options = Options()
+    );
+    static QString getOpenFileName(
+        QWidget* parent = nullptr,
+        const QString& caption = QString(),
+        const QString& dir = QString(),
         const QString& filter = QString(),
+        QString* selectedFilter = nullptr,
+        Options options = Options()
+    );
+    static QString getSaveFileName(
+        QWidget* parent = nullptr,
+        const QString& caption = QString(),
+        const QString& dir = QString(),
+        const QStringList& filters = QStringList(),
         QString* selectedFilter = nullptr,
         Options options = Options()
     );
@@ -82,6 +98,14 @@ public:
         const QString& caption = QString(),
         const QString& dir = QString(),
         Options options = ShowDirsOnly
+    );
+    static QStringList getOpenFileNames(
+        QWidget* parent = nullptr,
+        const QString& caption = QString(),
+        const QString& dir = QString(),
+        const QStringList& filters = QStringList(),
+        QString* selectedFilter = nullptr,
+        Options options = Options()
     );
     static QStringList getOpenFileNames(
         QWidget* parent = nullptr,
@@ -111,7 +135,6 @@ private:
     bool hasSuffix(const QString&) const;
     static QList<QUrl> fetchSidebarUrls();
     static QString workingDirectory;
-    static void getSuffixesDescription(QStringList& suffixes, const QString* suffixDescriptions);
 };
 
 // ----------------------------------------------------------------------

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -23,15 +23,15 @@
 
 #pragma once
 
-#include <QCompleter>
 #include <QFileDialog>
 #include <QFileIconProvider>
-#include <QFileSystemModel>
 #include <QPointer>
 #include <FCGlobal.h>
 
 class QButtonGroup;
+class QCompleter;
 class QDialogButtonBox;
+class QFileSystemModel;
 class QGridLayout;
 class QGroupBox;
 class QHBoxLayout;

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -454,7 +454,7 @@ FreeCAD.addImportType("Inventor V2.1 (*.iv *.IV)", "FreeCADGui")
 FreeCAD.addImportType(
     "VRML V2.0 (*.wrl *.WRL *.vrml *.VRML *.wrz *.WRZ *.wrl.gz *.WRL.GZ)", "FreeCADGui"
 )
-FreeCAD.addImportType("Python (*.py *.FCMacro *.FCScript *.fcmacro *.fcscript)", "FreeCADGui")
+FreeCAD.addImportType("Python (*.py *.FCMacro *.fcmacro *.FCScript *.fcscript)", "FreeCADGui")
 FreeCAD.addExportType("Inventor V2.1 (*.iv)", "FreeCADGui")
 FreeCAD.addExportType("VRML V2.0 (*.wrl *.vrml *.wrz *.wrl.gz)", "FreeCADGui")
 FreeCAD.addExportType("X3D Extensible 3D (*.x3d *.x3dz)", "FreeCADGui")

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -504,7 +504,7 @@ bool GraphvizView::onMsg(const char* pMsg)
             this,
             tr("Export Graph"),
             QString(),
-            filter.join(QLatin1String(";;")),
+            filter,
             &selectedFilter
         );
         if (!fn.isEmpty()) {
@@ -602,13 +602,8 @@ void GraphvizView::printPdf()
     filter << QStringLiteral("%1 (*.pdf)").arg(tr("PDF format"));
 
     QString selectedFilter;
-    QString fn = Gui::FileDialog::getSaveFileName(
-        this,
-        tr("Export Graph"),
-        QString(),
-        filter.join(QLatin1String(";;")),
-        &selectedFilter
-    );
+    QString fn
+        = Gui::FileDialog::getSaveFileName(this, tr("Export graph"), QString(), filter, &selectedFilter);
     if (!fn.isEmpty()) {
         QByteArray buffer = exportGraph(selectedFilter);
         if (buffer.isEmpty()) {

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -284,7 +284,7 @@ void MDIView::printPdf()
         this,
         tr("Export PDF"),
         QString(),
-        QStringLiteral("%1 (*.pdf)").arg(tr("PDF file"))
+        QStringList(QStringLiteral("%1 (*.pdf)").arg(tr("PDF file")))
     );
     if (!filename.isEmpty()) {
         QPrinter printer(QPrinter::ScreenResolution);

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -1405,7 +1405,7 @@ void PythonConsole::onSaveHistoryAs()
         this,
         tr("Save History"),
         cMacroPath,
-        QStringLiteral("%1 (*.FCMacro *.py)").arg(tr("Macro Files"))
+        QStringList(QStringLiteral("%1 (*.FCMacro *.py)").arg(tr("Macro Files")))
     );
     if (!fn.isEmpty()) {
         int dot = fn.indexOf(QLatin1Char('.'));
@@ -1429,7 +1429,7 @@ void PythonConsole::onInsertFileName()
         Gui::getMainWindow(),
         tr("Insert file name"),
         QString(),
-        QStringLiteral("%1 (*.*)").arg(tr("All Files"))
+        QStringList(QStringLiteral("%1 (*.*)").arg(tr("All Files")))
     );
     if (!fn.isEmpty()) {
         insertPlainText(fn);

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -288,7 +288,7 @@ void View3DInventor::printPdf()
         this,
         tr("Export PDF"),
         QString(),
-        QStringLiteral("%1 (*.pdf)").arg(tr("PDF file"))
+        QStringList(QStringLiteral("%1 (*.pdf)").arg(tr("PDF file")))
     );
     if (!filename.isEmpty()) {
         Gui::WaitCursor wc;

--- a/src/Mod/Draft/Init.py
+++ b/src/Mod/Draft/Init.py
@@ -29,7 +29,7 @@ translate = FreeCAD.Qt.translate
 # add Import/Export types
 App.addImportType("Autodesk DXF 2D (*.dxf *.DXF)", "importDXF")
 App.addImportType("SVG as geometry (*.svg *.SVG)", "importSVG")
-App.addImportType("Open CAD Format (*.oca *.gcad *.OCA *.GCAD)", "importOCA")
+App.addImportType("Open CAD Format (*.oca *.OCA *.gcad *.GCAD)", "importOCA")
 App.addImportType("Common airfoil data (*.dat *.DAT)", "importAirfoilDAT")
 App.addExportType("Autodesk DXF 2D (*.dxf)", "importDXF")
 App.addTranslatableExportType(translate("FileFormat", "Flattened SVG"), ["svg"], "importSVG")

--- a/src/Mod/Fem/Init.py
+++ b/src/Mod/Fem/Init.py
@@ -107,7 +107,7 @@ FreeCAD.addImportType("FEM result Z88 displacements (*.txt *.TXT)", "feminout.im
 
 if "BUILD_FEM_VTK" in FreeCAD.__cmake__:
     FreeCAD.addImportType(
-        "FEM result VTK (*.vtk *.VTK *.vtu *.VTU *.pvtu *.PVTU *.vtm *.VTM, *.pvd)",
+        "FEM result VTK (*.vtk *.VTK *.vtu *.VTU *.pvtu *.PVTU *.vtm *.VTM *.pvd *.PVD)",
         "feminout.importVTKResults",
     )
     FreeCAD.addTranslatableExportType(

--- a/src/Mod/Import/Gui/Command.cpp
+++ b/src/Mod/Import/Gui/Command.cpp
@@ -58,7 +58,7 @@ void FCCmdImportReadBREP::activated(int iMsg)
         Gui::getMainWindow(),
         QString(),
         QString(),
-        QLatin1String("BREP (*.brep *.rle)")
+        QStringList(QLatin1String("BREP (*.brep *.rle)"))
     );
     if (fn.isEmpty()) {
         abortCommand();
@@ -103,7 +103,7 @@ void ImportStep::activated(int iMsg)
         Gui::getMainWindow(),
         QString(),
         QString(),
-        QLatin1String("STEP (*.stp *.step)")
+        QStringList(QLatin1String("STEP (*.stp *.step)"))
     );
     if (!fn.isEmpty()) {
         openCommand(QT_TRANSLATE_NOOP("Command", "Part ImportSTEP Create"));
@@ -153,7 +153,7 @@ void ImportIges::activated(int iMsg)
         Gui::getMainWindow(),
         QString(),
         QString(),
-        QLatin1String("IGES (*.igs *.iges)")
+        QStringList(QLatin1String("IGES (*.igs *.iges)"))
     );
     if (!fn.isEmpty()) {
         openCommand(QT_TRANSLATE_NOOP("Command", "ImportIGES Create"));

--- a/src/Mod/Material/Gui/ImageEdit.cpp
+++ b/src/Mod/Material/Gui/ImageEdit.cpp
@@ -183,7 +183,7 @@ void ImageEdit::onFileSelect(bool checked)
     }
 }
 
-QString ImageEdit::selectFile(const QString& filePatterns)
+QString ImageEdit::selectFile(const QStringList& filePatterns)
 {
     QFileDialog::Options dlgOpt;
     if (Gui::DialogOptions::dontUseNativeFileDialog()) {
@@ -203,7 +203,10 @@ QString ImageEdit::selectFile(const QString& filePatterns)
 
 void ImageEdit::onFileSelectImage()
 {
-    QString fn = selectFile(tr("Image files (*.jpg *.jpeg *.png *.bmp);;All files (*)"));
+    QStringList filterList;
+    filterList << tr("Image files (*.jpg *.jpeg *.png *.bmp)");
+    filterList << tr("All files (*)");
+    QString fn = selectFile(filterList);
     if (!fn.isEmpty()) {
         fn = QDir::fromNativeSeparators(fn);
 
@@ -215,7 +218,10 @@ void ImageEdit::onFileSelectImage()
 
 void ImageEdit::onFileSelectSVG()
 {
-    QString fn = selectFile(tr("Image files (*.svg);;All files (*)"));
+    QStringList filterList;
+    filterList << tr("Image files (*.svg)");
+    filterList << tr("All files (*)");
+    QString fn = selectFile(filterList);
     if (!fn.isEmpty()) {
         fn = QDir::fromNativeSeparators(fn);
 

--- a/src/Mod/Material/Gui/ImageEdit.h
+++ b/src/Mod/Material/Gui/ImageEdit.h
@@ -93,7 +93,7 @@ private:
     void showPixmap();
     void showSVG();
 
-    QString selectFile(const QString& filePatterns);
+    QString selectFile(const QStringList& filePatterns);
     void onFileSelectImage();
     void onFileSelectSVG();
 };

--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -370,7 +370,7 @@ void CmdMeshImport::activated(int)
         Gui::getMainWindow(),
         QObject::tr("Import Mesh"),
         QString(),
-        filter.join(QLatin1String(";;"))
+        filter
     );
     for (const auto& it : fn) {
         std::string unicodepath = Base::Tools::escapedUnicodeFromUtf8(it.toUtf8().data());
@@ -448,7 +448,7 @@ void CmdMeshExport::activated(int)
         Gui::getMainWindow(),
         QObject::tr("Export Mesh"),
         dir,
-        filter.join(QLatin1String(";;")),
+        filter,
         &format
     );
     if (!fn.isEmpty()) {

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1083,13 +1083,8 @@ void CmdPartImport::activated(int iMsg)
     filter << QStringLiteral("BREP (*.brp *.brep)");
 
     QString select;
-    QString fn = Gui::FileDialog::getOpenFileName(
-        Gui::getMainWindow(),
-        QString(),
-        QString(),
-        filter.join(QLatin1String(";;")),
-        &select
-    );
+    QString fn
+        = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), filter, &select);
     if (!fn.isEmpty()) {
         Gui::WaitCursor wc;
         App::Document* pDoc = getDocument();
@@ -1157,13 +1152,8 @@ void CmdPartExport::activated(int iMsg)
     filter << QStringLiteral("BREP (*.brp *.brep)");
 
     QString select;
-    QString fn = Gui::FileDialog::getSaveFileName(
-        Gui::getMainWindow(),
-        QString(),
-        QString(),
-        filter.join(QLatin1String(";;")),
-        &select
-    );
+    QString fn
+        = Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QString(), QString(), filter, &select);
     if (!fn.isEmpty()) {
         App::Document* pDoc = getDocument();
         if (!pDoc) {  // no document
@@ -1213,12 +1203,7 @@ void CmdPartImportCurveNet::activated(int iMsg)
     filter << QStringLiteral("BREP (*.brp *.brep)");
     filter << QStringLiteral("%1 (*.*)").arg(QObject::tr("All Files"));
 
-    QString fn = Gui::FileDialog::getOpenFileName(
-        Gui::getMainWindow(),
-        QString(),
-        QString(),
-        filter.join(QLatin1String(";;"))
-    );
+    QString fn = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), filter);
     if (!fn.isEmpty()) {
         QFileInfo fi;
         fi.setFile(fn);

--- a/src/Mod/Part/Gui/DlgPartImportIgesImp.cpp
+++ b/src/Mod/Part/Gui/DlgPartImportIgesImp.cpp
@@ -63,13 +63,11 @@ void DlgPartImportIgesImp::OnApply()
 
 void DlgPartImportIgesImp::onChooseFileName()
 {
-    QString fn = Gui::FileDialog::getOpenFileName(
-                     Gui::getMainWindow(),
-                     QString(),
-                     QString(),
-                     QStringLiteral("%1 (*.igs *.iges);;%2 (*.*)")
-    )
-                     .arg(tr("IGES"), tr("All Files"));
+    QStringList filterList;
+    filterList << QStringLiteral("%1 (*.igs *.iges)").arg(QLatin1String("IGES"));
+    filterList << QStringLiteral("%1 (*.*)").arg(tr("All Files"));
+    QString fn
+        = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), filterList);
     if (!fn.isEmpty()) {
         ui->FileName->setText(fn);
     }

--- a/src/Mod/Part/Gui/DlgPartImportStepImp.cpp
+++ b/src/Mod/Part/Gui/DlgPartImportStepImp.cpp
@@ -63,13 +63,11 @@ void DlgPartImportStepImp::OnApply()
 
 void DlgPartImportStepImp::onChooseFileName()
 {
-    QString fn = Gui::FileDialog::getOpenFileName(
-                     Gui::getMainWindow(),
-                     QString(),
-                     QString(),
-                     QStringLiteral("%1 (*.stp *.step);;%2 (*.*)")
-    )
-                     .arg(QLatin1String("STEP"), tr("All Files"));
+    QStringList filterList;
+    filterList << QStringLiteral("%1 (*.stp *.step)").arg(QLatin1String("STEP"));
+    filterList << QStringLiteral("%1 (*.*)").arg(tr("All Files"));
+    QString fn
+        = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), filterList);
     if (!fn.isEmpty()) {
         ui->FileName->setText(fn);
     }

--- a/src/Mod/Points/Gui/Command.cpp
+++ b/src/Mod/Points/Gui/Command.cpp
@@ -77,13 +77,11 @@ void CmdPointsImport::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
-    QString fn = Gui::FileDialog::getOpenFileName(
-        Gui::getMainWindow(),
-        QString(),
-        QString(),
-        QStringLiteral("%1 (*.asc *.pcd *.ply *.e57);;%2 (*.*)")
-            .arg(QObject::tr("Point formats"), QObject::tr("All Files"))
-    );
+    QStringList formatList;
+    formatList << QStringLiteral("%1 (*.asc *.pcd *.ply *.e57)").arg(QObject::tr("Point formats"));
+    formatList << QStringLiteral("%1 (*.*)").arg(QObject::tr("All Files"));
+    QString fn
+        = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), formatList);
     if (fn.isEmpty()) {
         return;
     }
@@ -165,13 +163,11 @@ void CmdPointsExport::activated(int iMsg)
         Points::Feature::getClassTypeId()
     );
     for (auto point : points) {
-        QString fn = Gui::FileDialog::getSaveFileName(
-            Gui::getMainWindow(),
-            QString(),
-            QString(),
-            QStringLiteral("%1 (*.asc *.pcd *.ply);;%2 (*.*)")
-                .arg(QObject::tr("Point formats"), QObject::tr("All Files"))
-        );
+        QStringList formatList;
+        formatList << QStringLiteral("%1 (*.asc *.pcd *.ply)").arg(QObject::tr("Point formats"));
+        formatList << QStringLiteral("%1 (*.*)").arg(QObject::tr("All Files"));
+        QString fn
+            = Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QString(), QString(), formatList);
         if (fn.isEmpty()) {
             break;
         }

--- a/src/Mod/Robot/Gui/CommandExport.cpp
+++ b/src/Mod/Robot/Gui/CommandExport.cpp
@@ -94,7 +94,7 @@ void CmdRobotExportKukaCompact::activated(int)
         Gui::getMainWindow(),
         QObject::tr("Export program"),
         QString(),
-        filter.join(QLatin1String(";;"))
+        filter
     );
     if (fn.isEmpty()) {
         return;
@@ -175,7 +175,7 @@ void CmdRobotExportKukaFull::activated(int)
         Gui::getMainWindow(),
         QObject::tr("Export program"),
         QString(),
-        filter.join(QLatin1String(";;"))
+        filter
     );
     if (fn.isEmpty()) {
         return;

--- a/src/Mod/Spreadsheet/Gui/Command.cpp
+++ b/src/Mod/Spreadsheet/Gui/Command.cpp
@@ -195,7 +195,9 @@ void CmdSpreadsheetImport::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     QString selectedFilter;
-    QString formatList = QObject::tr("CSV (*.csv *.CSV);;All (*)");
+    QStringList formatList;
+    formatList << QObject::tr("CSV (*.csv *.CSV)");
+    formatList << QObject::tr("All (*)");
     QString fileName = Gui::FileDialog::getOpenFileName(
         Gui::getMainWindow(),
         QObject::tr("Import file"),

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -297,7 +297,7 @@ void SheetView::printPdf()
         this,
         tr("Export PDF"),
         QString(),
-        QStringLiteral("%1 (*.pdf)").arg(tr("PDF file"))
+        QStringList(QStringLiteral("%1 (*.pdf)").arg(tr("PDF file")))
     );
     if (!filename.isEmpty()) {
         QPrinter printer(QPrinter::ScreenResolution);

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -104,7 +104,9 @@ void ViewProviderSheet::exportAsFile()
 {
     auto* sheet = getObject<Spreadsheet::Sheet>();
     QString selectedFilter;
-    QString formatList = QObject::tr("CSV (*.csv *.CSV);;All (*)");
+    QStringList formatList;
+    formatList << QObject::tr("CSV (*.csv *.CSV)");
+    formatList << QObject::tr("All (*)");
     QString fileName = Gui::FileDialog::getSaveFileName(
         Gui::getMainWindow(),
         QObject::tr("Export File"),

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -179,7 +179,7 @@ void CmdTechDrawPageTemplate::activated(int iMsg)
     QString templateDir = Preferences::defaultTemplateDir();
     QString templateFileName = Gui::FileDialog::getOpenFileName(
         Gui::getMainWindow(), QString::fromUtf8(QT_TR_NOOP("Select a template file")), templateDir,
-        QString::fromUtf8(QT_TR_NOOP("Template (*.svg)")));
+        QStringList(QString::fromUtf8(QT_TR_NOOP("Template (*.svg)"))));
     Gui::FileDialog::setWorkingDirectory(work_dir);// Don't overwrite WD with templateDir
 
     if (templateFileName.isEmpty()) {
@@ -440,11 +440,13 @@ void CmdTechDrawView::activated(int iMsg)
                 }
             }
 
+            QStringList filterList;
+            filterList << QStringLiteral("%1 (*.svg *.svgz *.jpg *.jpeg *.png *.bmp)").arg(QObject::tr("SVG or Image files"));
+            filterList << QStringLiteral("%1 (*.*)").arg(QObject::tr("All Files"));
             QString filename = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(),
                 QObject::tr("Select a SVG or Image file to open"),
                 Preferences::defaultSymbolDir(),
-                QStringLiteral("%1 (*.svg *.svgz *.jpg *.jpeg *.png *.bmp);;%2 (*.*)")
-                .arg(QObject::tr("SVG or Image files"), QObject::tr("All Files")));
+                filterList);
 
             if (!filename.isEmpty()) {
                 if (filename.endsWith(QStringLiteral(".svg"), Qt::CaseInsensitive)
@@ -1547,11 +1549,13 @@ void CmdTechDrawSymbol::activated(int iMsg)
     std::string PageName = page->getNameInDocument();
 
     // Reading an image
+    QStringList filterList;
+    filterList << QStringLiteral("%1 (*.svg *.svgz)").arg(QObject::tr("Scalable vector graphic"));
+    filterList << QStringLiteral("%1 (*.*)").arg(QObject::tr("All files"));
     QString filename = Gui::FileDialog::getOpenFileName(
         Gui::getMainWindow(), QObject::tr("Choose an SVG file to open"),
         Preferences::defaultSymbolDir(),
-        QStringLiteral("%1 (*.svg *.svgz);;%2 (*.*)")
-            .arg(QObject::tr("Scalable vector graphic"), QObject::tr("All files")));
+        filterList);
 
     if (!filename.isEmpty()) {
         std::string FeatName = getUniqueObjectName("Symbol");
@@ -1883,7 +1887,7 @@ void CmdTechDrawExportPageDXF::activated(int iMsg)
     QString defaultDir;
     QString fileName = Gui::FileDialog::getSaveFileName(
         Gui::getMainWindow(), QString::fromUtf8(QT_TR_NOOP("Save DXF file")), defaultDir,
-        QStringLiteral("DXF (*.dxf)"));
+        QStringList(QStringLiteral("DXF (*.dxf)")));
 
     if (fileName.isEmpty()) {
         return;

--- a/src/Mod/TechDraw/Gui/CommandDecorate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandDecorate.cpp
@@ -319,10 +319,13 @@ void CmdTechDrawImage::activated(int iMsg)
     std::string PageName = page->getNameInDocument();
 
     // Reading an image
+    QStringList filterList;
+    filterList << QString::fromUtf8(QT_TR_NOOP("Image files (*.jpg *.jpeg *.png *.bmp)"));
+    filterList << QString::fromUtf8(QT_TR_NOOP("All files (*)"));
     QString fileName = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(),
         QString::fromUtf8(QT_TR_NOOP("Select an image file")),
         Preferences::defaultSymbolDir(),
-        QString::fromUtf8(QT_TR_NOOP("Image files (*.jpg *.jpeg *.png *.bmp);;All files (*)")));
+        filterList);
     if (fileName.isEmpty()) {
         return;
     }

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -508,7 +508,7 @@ void MDIViewPage::saveSVG()
     QString fn =
         Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QObject::tr("Export page as SVG"),
 
-                                         defaultFileName(), filter.join(QLatin1String(";;")));
+                                         defaultFileName(), filter);
     if (fn.isEmpty()) {
         return;
     }
@@ -530,7 +530,7 @@ void MDIViewPage::saveDXF()
     QString fn =
         Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QObject::tr("Export page as DXF"),
 
-                                         defaultFileName(), filter.join(QLatin1String(";;")));
+                                         defaultFileName(), filter);
     if (fn.isEmpty()) {
         return;
     }
@@ -586,7 +586,7 @@ QString MDIViewPage::getPdfFileName() const
     QString fn =
         Gui::FileDialog::getSaveFileName(Gui::getMainWindow(),
                                          QObject::tr("Export Page as PDF"),
-                                         QString(), filter.join(QLatin1String(";;")));
+                                         QString(), filter);
     if (fn.isEmpty()) {
         return {};
     }


### PR DESCRIPTION
#23139 shines the light on open/import/save/export dialog file type filters being too long, especially the wildcard `Supported formats` entry.

This PR rectifies this at the `FileDialog::get{Open,Save}FileName{,s}()` level to handle most cases, although parts of FC's code do not call this and use `QFileDialog` directly.

Uses the `QFileDialog::HideNameFilterDetails` flag to hide the actual extension filter lists, and runs all filters through a `formatFilter()` function to:
1. still show the extension list if it is deemed short enough (currently <= 128 chars in its original form, feedback welcome on that threshold)
2. deduplicate the extensions, as many have both lowercase and uppercase variants (only relevant on case-sensitive platforms)
   * this dedup is not flawless as it (as of right now anyway) does linear iteration over the extension filters and expects differing cases of the same ext to be contiguous, but most filter strings comply with this requirement anyway

The `FileDialog` functions used to force-unset the `HideNameFilterDetails` flag, I'm not quite sure why as AFAIU this flag is never set by default, nor used in FC. Setting it smoothes out platform differences [as outlined in a previous comment of mine](https://github.com/FreeCAD/FreeCAD/pull/23183#issuecomment-3199927048), and allows for this PR's behaviour.

## Issues
* #23139

This PR conflicts with #23183 on the account of solving the same issue.

## Before and After Images

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f6aae637-eb3b-42e5-bb90-f12c747e65e2" />

<img width="669" height="1079" alt="image" src="https://github.com/user-attachments/assets/e5348c23-6de3-4424-b90f-c7499c0b8530" />