### PR TITLE
Mesh: Fix crash MeshPy::setPoint & MeshPy::movePoint

### DIFF
--- a/src/Mod/Mesh/App/MeshPyImp.cpp
+++ b/src/Mod/Mesh/App/MeshPyImp.cpp
@@ -903,7 +903,13 @@ PyObject* MeshPy::setPoint(PyObject* args)
 
     PY_TRY
     {
-        getMeshObjectPtr()->setPoint(index, static_cast<Base::VectorPy*>(pnt)->value());
+        MeshObject* mesh = getMeshObjectPtr();
+        if (index >= mesh->countPoints()) {
+            Base::IndexError exc("index out of range");
+            exc.setPyException();
+            return nullptr;
+        }
+        mesh->setPoint(index, static_cast<Base::VectorPy*>(pnt)->value());
     }
     PY_CATCH;
 
@@ -935,7 +941,14 @@ PyObject* MeshPy::movePoint(PyObject* args)
         return nullptr;
     } while (false);
 
-    getMeshObjectPtr()->movePoint(index, vec);
+    MeshObject* mesh = getMeshObjectPtr();
+    if (index >= mesh->countPoints()) {
+        Base::IndexError exc("index out of range");
+        exc.setPyException();
+        return nullptr;
+    }
+
+    mesh->movePoint(index, vec);
     Py_Return;
 }
 


### PR DESCRIPTION
From @wwmayer https://github.com/wwmayer/FreeCAD/tree/issue_18823

Fixes https://github.com/FreeCAD/FreeCAD/issues/18823
