### PR TITLE
[TD]fix crash in vertex show/hide

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -102,27 +102,21 @@ QGIViewPart::~QGIViewPart()
 QVariant QGIViewPart::itemChange(GraphicsItemChange change, const QVariant& value)
 {
     if (change == ItemSelectedHasChanged && scene()) {
-        //There's nothing special for QGIVP to do when selection changes!
+        bool selectState = value.toBool();
+        if (!selectState && !isUnderMouse()) {
+            // hide everything
+            for (auto& child : childItems()) {
+                if (child->type() == UserType::QGIVertex) {
+                    child->hide();
+                }
+            }
+            return QGIView::itemChange(change, value);
+        }
+        // we are selected
     }
     else if (change == ItemSceneChange && scene()) {
-        QObject::disconnect(m_selectionChangedConnection);
+        // this is means we are finished?
         tidy();
-    }
-    else if (change == QGraphicsItem::ItemSceneHasChanged) {
-        if (scene()) {
-            m_selectionChangedConnection = connect(scene(), &QGraphicsScene::selectionChanged, this, [this]() {
-                // When selection changes, if the mouse is not over the view,
-                // hide any non-selected vertices.
-                if (!isUnderMouse()) {
-                    for (QGraphicsItem* item : m_vertexItems) {
-                        if (item && !item->isSelected()) {
-                            item->setVisible(false);
-                        }
-                    }
-                    update();
-                }
-            });
-        }
     }
 
     return QGIView::itemChange(change, value);
@@ -447,11 +441,9 @@ void QGIViewPart::drawAllEdges()
 
 void QGIViewPart::drawAllVertexes()
 {
-    m_vertexItems.clear();
     // dvp and vp already validated
     auto dvp(static_cast<TechDraw::DrawViewPart*>(getViewObject()));
     auto vp(static_cast<ViewProviderViewPart*>(getViewProvider(getViewObject())));
-
     QColor vertexColor = PreferencesGui::getAccessibleQColor(PreferencesGui::vertexQColor());
 
     const std::vector<TechDraw::VertexPtr>& verts = dvp->getVertexGeometry();
@@ -459,9 +451,8 @@ void QGIViewPart::drawAllVertexes()
     for (int i = 0; vert != verts.end(); ++vert, i++) {
         if ((*vert)->isCenter()) {
             if (showCenterMarks()) {
-                QGICMark* cmItem = new QGICMark(i);
+                auto* cmItem = new QGICMark(i);
                 addToGroup(cmItem);
-                m_vertexItems.append(cmItem);
                 cmItem->setPos(Rez::guiX((*vert)->x()), Rez::guiX((*vert)->y()));
                 cmItem->setThick(0.5F * getLineWidth());//need minimum?
                 cmItem->setSize(getVertexSize() * vp->CenterScale.getValue());
@@ -472,9 +463,8 @@ void QGIViewPart::drawAllVertexes()
         } else {
             //regular Vertex
             if (showVertices()) {
-                QGIVertex* item = new QGIVertex(i);
+                auto* item = new QGIVertex(i);
                 addToGroup(item);
-                m_vertexItems.append(item);
                 item->setPos(Rez::guiX((*vert)->x()), Rez::guiX((*vert)->y()));
                 item->setNormalColor(vertexColor);
                 item->setFillColor(vertexColor);
@@ -1316,11 +1306,12 @@ void QGIViewPart::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
     QGIView::hoverEnterEvent(event);
 
-    for (QGraphicsItem* item : m_vertexItems) {
-        if (item) {
-            item->setVisible(true);
+    for (auto& child : childItems()) {
+        if (child->type() == UserType::QGIVertex) {
+            child->show();
         }
     }
+
     update();
 }
 
@@ -1328,9 +1319,10 @@ void QGIViewPart::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 {
     QGIView::hoverLeaveEvent(event);
 
-    for (QGraphicsItem* item : m_vertexItems) {
-        if (item && !item->isSelected()) {
-            item->setVisible(false);
+    for (auto& child : childItems()) {
+        if (child->type() == UserType::QGIVertex &&
+            !child->isSelected()) {
+            child->hide();
         }
     }
     update();

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -149,7 +149,6 @@ protected:
     bool formatGeomFromCenterLine(std::string cTag, QGIEdge* item);
 
     bool showCenterMarks();
-    QList<QGraphicsItem*> m_vertexItems;
     bool showVertices();
 
 private:


### PR DESCRIPTION
This PR implements a fix to issue #23175.

It removes an unnecessary signal for selection change and uses childItems() to track vertices instead of a local vector of pointers that may go stale.