### PR TITLE
[TechDraw] Axometric Length Dimension - fix error generated in Report View...

### DIFF
--- a/src/Mod/TechDraw/TechDrawTools/CommandAxoLengthDimension.py
+++ b/src/Mod/TechDraw/TechDrawTools/CommandAxoLengthDimension.py
@@ -113,7 +113,7 @@ class CommandAxoLengthDimension:
                 distanceDim.Arbitrary = True
                 distanceDim.Label = distanceDim.Label.replace('Dimension','Dimension3D')
                 distanceDim.FormatSpec = fomatted3DValue
-            """Text location for 45 degree angled dimensions above the selection"""
+            # Text location for 45 degree angled dimensions above the selection
             if (
                 abs(originalLineAngle) > 29.0
                 and abs(originalLineAngle) < 31.0
@@ -126,7 +126,7 @@ class CommandAxoLengthDimension:
                 distanceDim.Y = abs(
                     float(vertexes[0].Point.x + vertexes[1].Point.y) / 4.8
                 )
-            """Text location for 45 degree angled dimensions below the selection"""
+            # Text location for 45 degree angled dimensions below the selection
             if (
                 abs(originalLineAngle) > 149.0
                 and abs(originalLineAngle) < 151.0


### PR DESCRIPTION
… and improve the location of the dimension text

Fixes #23119 

Currently if the user only selects one edge, a message box informing the user is generated but also the following error is also unnecessarily created in the Report View:

```
Running the Python command 'TechDraw_AxoLengthDimension' failed:
Traceback (most recent call last):
  File "/home/john/freecad-daily-build/Mod/TechDraw/TechDrawTools/CommandAxoLengthDimension.py", line 69, in Activated
    vertexes.append(edges[0].Vertexes[0])

list index out of range
```

Instead of the dimension text being created a long distance from the view centre, with this PR it is generated much closer though not always exactly where expected it's a great improvement on how it's been for since at least 0.21.x.