### PR TITLE
Assembly: Auto close on deleted doc  for dialogs to avoid segfaults

### DIFF
--- a/src/Mod/Assembly/CommandCreateBom.py
+++ b/src/Mod/Assembly/CommandCreateBom.py
@@ -92,7 +92,10 @@ class CommandCreateBom:
 
     def Activated(self):
         self.panel = TaskAssemblyCreateBom()
-        Gui.Control.showDialog(self.panel)
+        dialog = Gui.Control.showDialog(self.panel)
+        if dialog is not None:
+            dialog.setAutoCloseOnDeletedDocument(True)
+            dialog.setDocumentName(App.ActiveDocument.Name)
 
 
 ######### Create Exploded View Task ###########

--- a/src/Mod/Assembly/CommandCreateJoint.py
+++ b/src/Mod/Assembly/CommandCreateJoint.py
@@ -60,6 +60,7 @@ def activateJoint(index):
     dialog = Gui.doCommandEval("dialog")
     if dialog is not None:
         dialog.setAutoCloseOnTransactionChange(True)
+        dialog.setAutoCloseOnDeletedDocument(True)
         dialog.setDocumentName(App.ActiveDocument.Name)
 
 

--- a/src/Mod/Assembly/CommandCreateSimulation.py
+++ b/src/Mod/Assembly/CommandCreateSimulation.py
@@ -90,7 +90,10 @@ class CommandCreateSimulation:
             return
 
         self.panel = TaskAssemblyCreateSimulation()
-        Gui.Control.showDialog(self.panel)
+        dialog = Gui.Control.showDialog(self.panel)
+        if dialog is not None:
+            dialog.setAutoCloseOnDeletedDocument(True)
+            dialog.setDocumentName(App.ActiveDocument.Name)
 
 
 ######### Simulation Object ###########
@@ -267,7 +270,10 @@ class ViewProviderSimulation:
             Gui.ActiveDocument.setEdit(assembly)
 
         panel = TaskAssemblyCreateSimulation(vpDoc.Object)
-        Gui.Control.showDialog(panel)
+        dialog = Gui.Control.showDialog(panel)
+        if dialog is not None:
+            dialog.setAutoCloseOnDeletedDocument(True)
+            dialog.setDocumentName(App.ActiveDocument.Name)
 
         return True
 

--- a/src/Mod/Assembly/CommandCreateView.py
+++ b/src/Mod/Assembly/CommandCreateView.py
@@ -76,7 +76,11 @@ class CommandCreateView:
         Gui.addModule("CommandCreateView")  # NOLINT
         Gui.doCommand("panel = CommandCreateView.TaskAssemblyCreateView()")
         self.panel = Gui.doCommandEval("panel")
-        Gui.doCommandGui("Gui.Control.showDialog(panel)")
+        Gui.doCommandGui("dialog = Gui.Control.showDialog(panel)")
+        dialog = Gui.doCommandEval("dialog")
+        if dialog is not None:
+            dialog.setAutoCloseOnDeletedDocument(True)
+            dialog.setDocumentName(App.ActiveDocument.Name)
 
 
 ######### Exploded View Object ###########
@@ -214,7 +218,10 @@ class ViewProviderExplodedView:
             Gui.ActiveDocument.setEdit(assembly)
 
         panel = TaskAssemblyCreateView(vobj.Object)
-        Gui.Control.showDialog(panel)
+        dialog = Gui.Control.showDialog(panel)
+        if dialog is not None:
+            dialog.setAutoCloseOnDeletedDocument(True)
+            dialog.setDocumentName(App.ActiveDocument.Name)
 
         return True
 

--- a/src/Mod/Assembly/CommandInsertNewPart.py
+++ b/src/Mod/Assembly/CommandInsertNewPart.py
@@ -67,7 +67,10 @@ class CommandInsertNewPart:
 
     def Activated(self):
         panel = TaskAssemblyNewPart()
-        Gui.Control.showDialog(panel)
+        dialog = Gui.Control.showDialog(panel)
+        if dialog is not None:
+            dialog.setAutoCloseOnDeletedDocument(True)
+            dialog.setDocumentName(App.ActiveDocument.Name)
 
 
 class TaskAssemblyNewPart(JointObject.TaskAssemblyCreateJoint):

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -1004,6 +1004,7 @@ class ViewProviderJoint:
         dialog = Gui.Control.showDialog(panel)
         if dialog is not None:
             dialog.setAutoCloseOnTransactionChange(True)
+            dialog.setAutoCloseOnDeletedDocument(True)
             dialog.setDocumentName(App.ActiveDocument.Name)
 
         return True


### PR DESCRIPTION
Currently if we close document on Assembly WB while having dialog opened, it will throw segfault because it is not being auto closed automatically during document close. This in turn resulted in dialog having dangling references to document that was no longer existing, throwing segfaults in random places.

So solution is simple - add `setAutoCloseOnDeletedDocument` for every dialog in Assembly to avoid this situation and close every dialog upon document close.

Basically aligned to the same as Draft WB has for example.

@maxwxyz should be all dialogs, you can check if I missed something.

Resolves: https://github.com/FreeCAD/FreeCAD/issues/23200