### PR TITLE
BIM: Load QIcon for Material Editor from bytes

### DIFF
--- a/src/Mod/Material/MaterialEditor.py
+++ b/src/Mod/Material/MaterialEditor.py
@@ -300,7 +300,23 @@ class MaterialEditor:
         card_name_list.insert(0, [None, "", ""])
         self.widget.ComboMaterial.clear()
         for mat in card_name_list:
-            self.widget.ComboMaterial.addItem(QtGui.QIcon(mat[2]), mat[0], mat[1])
+            icon_data = mat[2]
+
+            if icon_data and isinstance(icon_data, bytes):
+                byte_array = QtCore.QByteArray(icon_data)
+                pixmap = QtGui.QPixmap()
+                if pixmap.loadFromData(byte_array):
+                    icon = QtGui.QIcon(pixmap)
+                else:
+                    icon = QtGui.QIcon()
+            elif isinstance(icon_data, str) and icon_data:
+                # if this is string type, then try to load directly
+                icon = QtGui.QIcon(icon_data)
+            else:
+                # fallback to not crash, empty icon
+                icon = QtGui.QIcon()
+
+            self.widget.ComboMaterial.addItem(icon, mat[0], mat[1])
 
     def openProductURL(self):
 


### PR DESCRIPTION
Loading QIcon directly from bytes is not supported in Qt6 it seems, so this patch changes it to load it to pixmap first and then to QIcon directly.

Plus add some alternative options to avoid tracebacks for compatibility, as it seems that in Qt5 it either failed gracefully, or was able to load directly from string/bytes.

Demo:

https://github.com/user-attachments/assets/5e4d717b-fec0-47a6-90ba-620abe801155

Would be cool if somebody with qt5 at hand would test it.

Resolves: https://github.com/FreeCAD/FreeCAD/issues/23220