### PR TITLE
Sketcher: Revert DPI adjustment error #22941

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -386,8 +386,9 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(
 
     Client.drawingParameters.coinFontSize =
         std::lround(sketcherfontSize * devicePixelRatio);  // in pixels
-    Client.drawingParameters.labelFontSize = std::lround(
-        sketcherfontSize * devicePixelRatio  * 72.0f / dpi);  // in points, as SoDatumLabel uses points
+    Client.drawingParameters.labelFontSize =
+        std::lround(sketcherfontSize * devicePixelRatio * 72.0f
+                    / dpi);  // in points, as SoDatumLabel uses points
     Client.drawingParameters.constraintIconSize =
         std::lround(0.8 * sketcherfontSize * devicePixelRatio);
 
@@ -1235,4 +1236,3 @@ SoSeparator* EditModeCoinManager::getRootEditNode()
 {
     return editModeScenegraphNodes.EditRoot;
 }
-

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -374,6 +374,7 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(
 
     int sketcherfontSize = hGrp->GetInt("EditSketcherFontSize", defaultFontSizePixels);
 
+    double dpi = Client.getApplicationLogicalDPIX();
     double devicePixelRatio = Client.getDevicePixelRatio();
 
     // simple scaling factor for hardcoded pixel values in the Sketcher
@@ -386,7 +387,7 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(
     Client.drawingParameters.coinFontSize =
         std::lround(sketcherfontSize * devicePixelRatio);  // in pixels
     Client.drawingParameters.labelFontSize = std::lround(
-        sketcherfontSize * devicePixelRatio * 0.75);  // in points, as SoDatumLabel uses points
+        sketcherfontSize * devicePixelRatio  * 72.0f / dpi);  // in points, as SoDatumLabel uses points
     Client.drawingParameters.constraintIconSize =
         std::lround(0.8 * sketcherfontSize * devicePixelRatio);
 
@@ -1234,3 +1235,4 @@ SoSeparator* EditModeCoinManager::getRootEditNode()
 {
     return editModeScenegraphNodes.EditRoot;
 }
+


### PR DESCRIPTION
Revert https://github.com/FreeCAD/FreeCAD/pull/22941

After a long search on DPI, it appears that that PR was based on a wrong assumption and should be reverted. The `* 72 / dpi` was correct, it was turning pixels into points. While the other `* 96.0f / dpi` was indeed not needed. So https://github.com/FreeCAD/FreeCAD/pull/21098 did the correct job in leaving that while removing the other.

@chennes sorry for the back and forth