### PR TITLE
Sheet: Verify that UnitExpression is valid

### DIFF
--- a/src/Mod/Spreadsheet/Gui/PropertiesDialog.cpp
+++ b/src/Mod/Spreadsheet/Gui/PropertiesDialog.cpp
@@ -221,12 +221,19 @@ void PropertiesDialog::displayUnitChanged(const QString& text)
 
     QPalette palette = ui->displayUnit->palette();
     try {
-        std::unique_ptr<UnitExpression> e(
+        std::unique_ptr<UnitExpression> expr(
             App::ExpressionParser::parseUnit(sheet, text.toUtf8().constData()));
 
-        displayUnit = DisplayUnit(text.toUtf8().constData(), e->getUnit(), e->getScaler());
-        palette.setColor(QPalette::Text, Qt::black);
-        displayUnitOk = true;
+        if (expr) {
+            displayUnit = DisplayUnit(text.toStdString(), expr->getUnit(), expr->getScaler());
+            palette.setColor(QPalette::Text, Qt::black);
+            displayUnitOk = true;
+        }
+        else {
+            displayUnit = DisplayUnit();
+            palette.setColor(QPalette::Text, text.size() == 0 ? Qt::black : Qt::red);
+            displayUnitOk = false;
+        }
     }
     catch (...) {
         displayUnit = DisplayUnit();


### PR DESCRIPTION
The crash happens because the UnitExpression is null and thus segfaults when trying to access the unit and scalar value. This fixes https://github.com/FreeCAD/FreeCAD/issues/23222
