### PR TITLE
Assembly: toggle grounded: handle case of grounded joint selection.

### DIFF
--- a/src/Mod/Assembly/CommandCreateJoint.py
+++ b/src/Mod/Assembly/CommandCreateJoint.py
@@ -515,6 +515,19 @@ class CommandToggleGrounded:
             # If you select 2 solids (bodies for example) within an assembly.
             # There'll be a single sel but 2 SubElementNames.
             for sub in sel.SubElementNames:
+                # First check if selection is a grounded object
+                resolved = sel.Object.resolveSubElement(sub)
+                if resolved:
+                    obj = resolved[0]
+                    if hasattr(obj, "ObjectToGround"):
+                        commands = (
+                            "doc = App.ActiveDocument\n"
+                            f'doc.removeObject("{obj.Name}")\n'
+                            "doc.recompute()\n"
+                        )
+                        Gui.doCommand(commands)
+                        continue
+
                 ref = [sel.Object, [sub, sub]]
                 moving_part = UtilsAssembly.getMovingPart(assembly, ref)
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/23032

This PR defines the behavior of selecting a grounded joint object and calling the 'toggle grounded' command by deleting the selected grounded joint.

Before the tool would create a bad grounded joint and print and error.