### PR TITLE
Part: Start listing BoundBox properties for Expression Editor

### DIFF
--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -250,6 +250,43 @@ void PropertyPartShape::getPaths(std::vector<App::ObjectIdentifier> &paths) cons
                     << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("Area")));
     paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
                     << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("Volume")));
+    paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("BoundBox")));
+    
+    // BoundBox sub-properties
+    paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("BoundBox"))
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("XMax")));
+    paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("BoundBox"))
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("XMin")));
+    paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("BoundBox"))
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("YMax")));
+    paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("BoundBox"))
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("YMin")));
+    paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("BoundBox"))
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("ZMax")));
+    paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("BoundBox"))
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("ZMin")));
+    paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("BoundBox"))
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("XLength")));
+    paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("BoundBox"))
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("YLength")));
+    paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("BoundBox"))
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("ZLength")));
+    paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("BoundBox"))
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("DiagonalLength")));
+    paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("BoundBox"))
+                    << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("Center")));
 }
 
 void PropertyPartShape::beforeSave() const


### PR DESCRIPTION
As the title says. It was missing, so this patch adds all needed.

Demo:

https://github.com/user-attachments/assets/edaceba5-2ed6-4867-8568-949ed4ec334d

Resolves: https://github.com/FreeCAD/FreeCAD/issues/22042