### PR TITLE
Part: Assign proper row and column to compound body property in prefs

### DIFF
--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -68,7 +68,7 @@
         </property>
        </widget>
       </item>
-      <item>
+      <item row="3" column="0">
        <widget class="Gui::PrefCheckBox" name="checkAllowCompoundBody">
         <property name="text">
          <string>Allow multiple solids in Part Design bodies by default</string>


### PR DESCRIPTION
As the title says, really small fix to the overlapping preferences for Part/Part Design preferences.

Before:

<img width="647" height="468" alt="image" src="https://github.com/user-attachments/assets/1477583a-77ee-41c0-8caf-30c4ef0060a8" />

After:

<img width="641" height="214" alt="image" src="https://github.com/user-attachments/assets/04a42000-cfd5-4d15-8830-f184fd6cf882" />

Resolves: https://github.com/FreeCAD/FreeCAD/issues/23239