### PR TITLE
Sketcher: Use different colors for touch/window selection

### DIFF
--- a/src/Mod/Sketcher/Gui/CMakeLists.txt
+++ b/src/Mod/Sketcher/Gui/CMakeLists.txt
@@ -154,6 +154,7 @@ SET(SketcherGui_SRCS
     SketcherRegularPolygonDialog.cpp
     SnapManager.cpp
     SnapManager.h
+    StyleParameters.h
     TaskDlgEditSketch.cpp
     TaskDlgEditSketch.h
     ViewProviderPython.cpp

--- a/src/Mod/Sketcher/Gui/StyleParameters.h
+++ b/src/Mod/Sketcher/Gui/StyleParameters.h
@@ -26,10 +26,15 @@
 
 #include <Gui/StyleParameters/ParameterManager.h>
 
-namespace SketcherGui::StyleParameters {
-    // rubberband selection colors
-    DEFINE_STYLE_PARAMETER(SketcherRubberbandTouchSelectionColor, Base::Color(0.0F, 1.0F, 0.0F, 1.0F));   // green for touch selection (right to left)
-    DEFINE_STYLE_PARAMETER(SketcherRubberbandWindowSelectionColor, Base::Color(0.0F, 0.4F, 1.0F, 1.0F));  // blue for window selection (left to right)
-}
+namespace SketcherGui::StyleParameters
+{
+// rubberband selection colors
+DEFINE_STYLE_PARAMETER(
+    SketcherRubberbandTouchSelectionColor,
+    Base::Color(0.0F, 1.0F, 0.0F, 1.0F));  // green for touch selection (right to left)
+DEFINE_STYLE_PARAMETER(
+    SketcherRubberbandWindowSelectionColor,
+    Base::Color(0.0F, 0.4F, 1.0F, 1.0F));  // blue for window selection (left to right)
+}  // namespace SketcherGui::StyleParameters
 
-#endif // SKETCHER_STYLEPARAMETERS_H
+#endif  // SKETCHER_STYLEPARAMETERS_H

--- a/src/Mod/Sketcher/Gui/StyleParameters.h
+++ b/src/Mod/Sketcher/Gui/StyleParameters.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 The FreeCAD Project Association AISBL               *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#ifndef SKETCHER_STYLEPARAMETERS_H
+#define SKETCHER_STYLEPARAMETERS_H
+
+#include <Gui/StyleParameters/ParameterManager.h>
+
+namespace SketcherGui::StyleParameters {
+    // rubberband selection colors
+    DEFINE_STYLE_PARAMETER(SketcherRubberbandTouchSelectionColor, Base::Color(0.0F, 1.0F, 0.0F, 1.0F));   // green for touch selection (right to left)
+    DEFINE_STYLE_PARAMETER(SketcherRubberbandWindowSelectionColor, Base::Color(0.0F, 0.4F, 1.0F, 1.0F));  // blue for window selection (left to right)
+}
+
+#endif // SKETCHER_STYLEPARAMETERS_H


### PR DESCRIPTION
As the title says. I think it was missing, so currently right to left motion makes the box selection in Sketcher green with dashed lines, whereas motion from left to right makes it blue with solid lines.

Demo:

https://github.com/user-attachments/assets/7f0def32-cd0d-4db1-88db-257dc156084b

Resolves: https://github.com/FreeCAD/FreeCAD/issues/19248
