### PR TITLE
BIM: fix IFC buttons visibility on Properties Editor

### DIFF
--- a/src/Mod/BIM/BimStatus.py
+++ b/src/Mod/BIM/BimStatus.py
@@ -117,8 +117,6 @@ def setStatusIcons(show=True):
         if show:
             if statuswidget:
                 statuswidget.show()
-                if hasattr(statuswidget, "propertybuttons"):
-                    statuswidget.propertybuttons.show()
             else:
                 statuswidget = FreeCADGui.UiLoader().createWidget("Gui::ToolBar")
                 statuswidget.setObjectName("BIMStatusWidget")
@@ -185,10 +183,15 @@ def setStatusIcons(show=True):
                 # ifc widgets
                 try:
                     from nativeifc import ifc_status
-                except:
-                    pass
+                except Exception as e:
+                    FreeCAD.Console.PrintError(f"BIM: Failed to import ifc_status: {e}\n")
                 else:
                     ifc_status.set_status_widget(statuswidget)
+
+                    # Update buttons on properties editor visibility on workbench switch
+                    mw.workbenchActivated.connect(
+                        lambda: ifc_status.set_prop_buttons_visibility(statuswidget)
+                    )
 
                 # nudge button
                 nudge = QtGui.QPushButton(nudgeLabelsM[-1])

--- a/src/Mod/BIM/nativeifc/ifc_status.py
+++ b/src/Mod/BIM/nativeifc/ifc_status.py
@@ -58,40 +58,52 @@ def set_status_widget(statuswidget):
     lock_button.setChecked(checked)
     on_toggle_lock(checked, noconvert=True)
     lock_button.triggered.connect(on_toggle_lock)
-    set_properties_editor(statuswidget)
+    set_prop_buttons_visibility(statuswidget)
 
 
 def set_properties_editor(statuswidget):
     """Adds additional buttons to the properties editor"""
 
     if hasattr(statuswidget, "propertybuttons"):
+        return
+
+    from PySide import QtCore, QtGui  # lazy loading
+
+    mw = FreeCADGui.getMainWindow()
+    editor = mw.findChild(QtGui.QTabWidget,"propertyTab")
+    if editor:
+        pTabCornerWidget = QtGui.QWidget()
+        pButton1 = QtGui.QToolButton(pTabCornerWidget)
+        pButton1.setText("")
+        pButton1.setToolTip(translate("BIM","Add IFC property..."))
+        pButton1.setIcon(QtGui.QIcon(":/icons/IFC.svg"))
+        pButton1.clicked.connect(on_add_property)
+        pButton2 = QtGui.QToolButton(pTabCornerWidget)
+        pButton2.setText("")
+        pButton2.setToolTip(translate("BIM","Add standard IFC Property Set..."))
+        pButton2.setIcon(QtGui.QIcon(":/icons/BIM_IfcProperties.svg"))
+        pButton2.clicked.connect(on_add_pset)
+        pHLayout = QtGui.QHBoxLayout(pTabCornerWidget)
+        pHLayout.addWidget(pButton1)
+        pHLayout.addWidget(pButton2)
+        pHLayout.setSpacing(2)
+        pHLayout.setContentsMargins(2, 2, 0, 0)
+        pHLayout.insertStretch(0)
+        editor.setCornerWidget(pTabCornerWidget, QtCore.Qt.BottomRightCorner)
+        statuswidget.propertybuttons = pTabCornerWidget
+        pTabCornerWidget.hide()
+
+
+def set_prop_buttons_visibility(statuswidget):
+    """Shows or hides buttons on properties editor depending on active workbench."""
+
+    if not hasattr(statuswidget, "propertybuttons"):
+        set_properties_editor(statuswidget)
+
+    if FreeCADGui.activeWorkbench().name() == "BIMWorkbench":
         statuswidget.propertybuttons.show()
     else:
-        from PySide import QtCore, QtGui  # lazy loading
-
-        mw = FreeCADGui.getMainWindow()
-        editor = mw.findChild(QtGui.QTabWidget,"propertyTab")
-        if editor:
-            pTabCornerWidget = QtGui.QWidget()
-            pButton1 = QtGui.QToolButton(pTabCornerWidget)
-            pButton1.setText("")
-            pButton1.setToolTip(translate("BIM","Add IFC property..."))
-            pButton1.setIcon(QtGui.QIcon(":/icons/IFC.svg"))
-            pButton1.clicked.connect(on_add_property)
-            pButton2 = QtGui.QToolButton(pTabCornerWidget)
-            pButton2.setText("")
-            pButton2.setToolTip(translate("BIM","Add standard IFC Property Set..."))
-            pButton2.setIcon(QtGui.QIcon(":/icons/BIM_IfcProperties.svg"))
-            pButton2.clicked.connect(on_add_pset)
-            pHLayout = QtGui.QHBoxLayout(pTabCornerWidget)
-            pHLayout.addWidget(pButton1)
-            pHLayout.addWidget(pButton2)
-            pHLayout.setSpacing(2)
-            pHLayout.setContentsMargins(2, 2, 0, 0)
-            pHLayout.insertStretch(0)
-            editor.setCornerWidget(pTabCornerWidget, QtCore.Qt.BottomRightCorner)
-            statuswidget.propertybuttons = pTabCornerWidget
-            QtCore.QTimer.singleShot(0,pTabCornerWidget.show)
+        statuswidget.propertybuttons.hide()
 
 
 def on_add_property():


### PR DESCRIPTION
[BIM: Support for property sets in Native IFC](https://github.com/FreeCAD/FreeCAD/pull/18067) eased the ability to manage IFC properties and PSets.
However, the newly added buttons (IFC icon and Document with </>) at the bottom of the Properties Editor are shown all the time, which is not adequate from a UX perspective:
- most non-BIM users have no clue what these buttons are for and won't probably ever use them. They clutters the Properties Editor for no reason.
- the Native IFC features are still [WIP and not finished](https://wiki.freecad.org/index.php?title=Native_IFC), so they should probably only be shown in the BIM Workbench whose users may be slightly more aware of their use.

This change refactors a bit the `set_properties_editor()` function so it only takes care of the creation of the buttons (previously it also controlled when to show the `propertybuttons`). A new function `set_prop_buttons_visibility()` is added to take care of their visibility.
The very long `setStatusIcons()` function in `BimStatus.py` now checks for Workbench changes and calls this visibility function for `statuswidget`.

This only concerns version 1.1, no backport needed.

Please do test.

## Issues

No recorded issue was found. If you do, please add ;D

## Before (top) and after (bottom): 

![before](https://github.com/user-attachments/assets/2687fbb4-9187-497c-b2cd-9bff42cffea4)

---

![after](https://github.com/user-attachments/assets/240de7c7-1f13-4a41-aefe-d9b96f5be405)
