### PR TITLE
PartDesign: Update error message about multiple solids

### DIFF
--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -160,7 +160,7 @@ App::DocumentObjectExecReturn *Boolean::execute()
     result = refineShapeIfActive(result);
 
     if (!isSingleSolidRuleSatisfied(result.getShape())) {
-        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compounds' in the body."));
     }
 
     this->Shape.setValue(getSolid(result));
@@ -185,4 +185,5 @@ void Boolean::handleChangedPropertyName(Base::XMLReader &reader, const char * Ty
 }
 
 }
+
 

--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -160,7 +160,7 @@ App::DocumentObjectExecReturn *Boolean::execute()
     result = refineShapeIfActive(result);
 
     if (!isSingleSolidRuleSatisfied(result.getShape())) {
-        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compounds' in the body."));
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compounds' in the active body."));
     }
 
     this->Shape.setValue(getSolid(result));
@@ -185,5 +185,6 @@ void Boolean::handleChangedPropertyName(Base::XMLReader &reader, const char * Ty
 }
 
 }
+
 
 

--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -160,7 +160,7 @@ App::DocumentObjectExecReturn *Boolean::execute()
     result = refineShapeIfActive(result);
 
     if (!isSingleSolidRuleSatisfied(result.getShape())) {
-        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
     }
 
     this->Shape.setValue(getSolid(result));
@@ -185,3 +185,4 @@ void Boolean::handleChangedPropertyName(Base::XMLReader &reader, const char * Ty
 }
 
 }
+

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -171,7 +171,7 @@ App::DocumentObjectExecReturn *Chamfer::execute()
         this->rawShape = shape;
         shape = refineShapeIfActive(shape);
         if (!isSingleSolidRuleSatisfied(shape.getShape())) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
         }
 
         shape = getSolid(shape);
@@ -259,5 +259,6 @@ static App::DocumentObjectExecReturn *validateParameters(int chamferType, double
 
     return App::DocumentObject::StdReturn;
 }
+
 
 

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -171,7 +171,7 @@ App::DocumentObjectExecReturn *Chamfer::execute()
         this->rawShape = shape;
         shape = refineShapeIfActive(shape);
         if (!isSingleSolidRuleSatisfied(shape.getShape())) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids:enable 'Allow Compounds' in the active body."));
         }
 
         shape = getSolid(shape);
@@ -259,6 +259,7 @@ static App::DocumentObjectExecReturn *validateParameters(int chamferType, double
 
     return App::DocumentObject::StdReturn;
 }
+
 
 
 

--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -288,7 +288,7 @@ App::DocumentObjectExecReturn *Draft::execute()
         }
 
         if (!isSingleSolidRuleSatisfied(shape.getShape())) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
         }
 
         this->Shape.setValue(getSolid(shape));
@@ -299,3 +299,4 @@ App::DocumentObjectExecReturn *Draft::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
 }
+

--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -288,7 +288,7 @@ App::DocumentObjectExecReturn *Draft::execute()
         }
 
         if (!isSingleSolidRuleSatisfied(shape.getShape())) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compounds' in the active body."));
         }
 
         this->Shape.setValue(getSolid(shape));
@@ -299,4 +299,5 @@ App::DocumentObjectExecReturn *Draft::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
 }
+
 

--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -812,7 +812,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             solRes = refineShapeIfActive(result);
 
             if (!isSingleSolidRuleSatisfied(solRes.getShape())) {
-                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compounds' in the active body."));
             }
             this->Shape.setValue(getSolid(solRes));
         }

--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -812,7 +812,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             solRes = refineShapeIfActive(result);
 
             if (!isSingleSolidRuleSatisfied(solRes.getShape())) {
-                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
             }
             this->Shape.setValue(getSolid(solRes));
         }

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -116,7 +116,7 @@ App::DocumentObjectExecReturn *Fillet::execute()
         this->rawShape = shape;
         shape = refineShapeIfActive(shape);
         if (!isSingleSolidRuleSatisfied(shape.getShape())) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compounds' in the active body."));
         }
 
         shape = getSolid(shape);
@@ -145,4 +145,5 @@ void Fillet::handleChangedPropertyType(Base::XMLReader &reader, const char * Typ
         DressUp::handleChangedPropertyType(reader, TypeName, prop);
     }
 }
+
 

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -116,7 +116,7 @@ App::DocumentObjectExecReturn *Fillet::execute()
         this->rawShape = shape;
         shape = refineShapeIfActive(shape);
         if (!isSingleSolidRuleSatisfied(shape.getShape())) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
         }
 
         shape = getSolid(shape);
@@ -145,3 +145,4 @@ void Fillet::handleChangedPropertyType(Base::XMLReader &reader, const char * Typ
         DressUp::handleChangedPropertyType(reader, TypeName, prop);
     }
 }
+

--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -193,7 +193,7 @@ App::DocumentObjectExecReturn *Groove::execute()
         this->rawShape = boolOp;
         boolOp = refineShapeIfActive(boolOp);
         if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
         }
         boolOp = getSolid(boolOp);
         Shape.setValue(boolOp);
@@ -384,3 +384,4 @@ void Groove::updateProperties(RevolMethod method)
 
 
 }
+

--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -193,7 +193,7 @@ App::DocumentObjectExecReturn *Groove::execute()
         this->rawShape = boolOp;
         boolOp = refineShapeIfActive(boolOp);
         if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compounds' in the active body."));
         }
         boolOp = getSolid(boolOp);
         Shape.setValue(boolOp);
@@ -384,4 +384,5 @@ void Groove::updateProperties(RevolMethod method)
 
 
 }
+
 

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -2182,7 +2182,7 @@ App::DocumentObjectExecReturn* Hole::execute()
 
         if (!isSingleSolidRuleSatisfied(result.getShape())) {
             return new App::DocumentObjectExecReturn(
-                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
+                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
         }
         this->Shape.setValue(result);
 
@@ -2768,3 +2768,4 @@ int Hole::baseProfileOption_bitmaskToIdx(int bitmask)
 
 
 } // namespace PartDesign
+

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -2182,7 +2182,7 @@ App::DocumentObjectExecReturn* Hole::execute()
 
         if (!isSingleSolidRuleSatisfied(result.getShape())) {
             return new App::DocumentObjectExecReturn(
-                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
+                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compounds' in the active body."));
         }
         this->Shape.setValue(result);
 
@@ -2768,4 +2768,5 @@ int Hole::baseProfileOption_bitmaskToIdx(int bitmask)
 
 
 } // namespace PartDesign
+
 

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -274,7 +274,7 @@ App::DocumentObjectExecReturn *Loft::execute()
 
         if(base.isNull()) {
             if (!isSingleSolidRuleSatisfied(result.getShape())) {
-                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
             }
             Shape.setValue(getSolid(result));
             return App::DocumentObject::StdReturn;
@@ -346,3 +346,4 @@ void Loft::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeNa
         ProfileBased::handleChangedPropertyType(reader, TypeName, prop);
     }
 }
+

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -274,7 +274,7 @@ App::DocumentObjectExecReturn *Loft::execute()
 
         if(base.isNull()) {
             if (!isSingleSolidRuleSatisfied(result.getShape())) {
-                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compounds' in the active body."));
             }
             Shape.setValue(getSolid(result));
             return App::DocumentObject::StdReturn;
@@ -346,4 +346,5 @@ void Loft::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeNa
         ProfileBased::handleChangedPropertyType(reader, TypeName, prop);
     }
 }
+
 

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -402,7 +402,7 @@ App::DocumentObjectExecReturn *Pipe::execute()
 
             if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
-                                                                           "Result has multiple solids: enable compounds in a Body."));
+                                                                           "Result has multiple solids: enable 'Allow Compounds' in the active body."));
             }
 
             // store shape before refinement
@@ -637,4 +637,5 @@ void Pipe::handleChangedPropertyName(Base::XMLReader& reader,
         ProfileBased::handleChangedPropertyName(reader, TypeName, PropName);
     }
 }
+
 

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -402,7 +402,7 @@ App::DocumentObjectExecReturn *Pipe::execute()
 
             if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
-                                                                           "Result has multiple solids: that is not currently supported."));
+                                                                           "Result has multiple solids: enable compounds in a Body."));
             }
 
             // store shape before refinement
@@ -637,3 +637,4 @@ void Pipe::handleChangedPropertyName(Base::XMLReader& reader,
         ProfileBased::handleChangedPropertyName(reader, TypeName, PropName);
     }
 }
+

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -229,7 +229,7 @@ App::DocumentObjectExecReturn* Revolution::execute()
                 result = refineShapeIfActive(result);
             }
             if (!isSingleSolidRuleSatisfied(result.getShape())) {
-                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: that is not currently supported."));
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
             }
             result = getSolid(result);
             this->Shape.setValue(result);
@@ -415,3 +415,4 @@ void Revolution::updateProperties(RevolMethod method)
 }
 
 }
+

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -229,7 +229,7 @@ App::DocumentObjectExecReturn* Revolution::execute()
                 result = refineShapeIfActive(result);
             }
             if (!isSingleSolidRuleSatisfied(result.getShape())) {
-                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable compounds in a Body."));
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compounds' in the active body."));
             }
             result = getSolid(result);
             this->Shape.setValue(result);
@@ -415,4 +415,5 @@ void Revolution::updateProperties(RevolMethod method)
 }
 
 }
+
 

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -410,7 +410,7 @@ App::DocumentObjectExecReturn* Transformed::execute()
 
     supportShape = refineShapeIfActive((supportShape));
     if (!isSingleSolidRuleSatisfied(supportShape.getShape())) {
-        Base::Console().warning("Transformed: Result has multiple solids. Only keeping the first.\n");
+        Base::Console().warning("Transformed: Result has multiple solids. Only keeping the first. Or enable compounds in a Body.\n");
     }
 
     this->Shape.setValue(getSolid(supportShape));  // picking the first solid
@@ -440,3 +440,4 @@ TopoDS_Shape Transformed::getRemainingSolids(const TopoDS_Shape& shape)
 }
 
 }  // namespace PartDesign
+

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -410,7 +410,7 @@ App::DocumentObjectExecReturn* Transformed::execute()
 
     supportShape = refineShapeIfActive((supportShape));
     if (!isSingleSolidRuleSatisfied(supportShape.getShape())) {
-        Base::Console().warning("Transformed: Result has multiple solids. Only keeping the first. Or enable compounds in a Body.\n");
+        Base::Console().warning("Transformed: Result has multiple solids. Only keeping the first. Or enable 'Allow Compounds' in the active body.\n");
     }
 
     this->Shape.setValue(getSolid(supportShape));  // picking the first solid
@@ -440,4 +440,5 @@ TopoDS_Shape Transformed::getRemainingSolids(const TopoDS_Shape& shape)
 }
 
 }  // namespace PartDesign
+
 


### PR DESCRIPTION
The "Result has multiple solids: that is not currently supported" error message has to be updated to reflect that it's currently possible to have multiple solids in a Body with proper settings.

The new text is: "Result has multiple solids: enable compounds in a Body"