### PR TITLE
Sketcher: Fix construction lines becoming solid after box selection

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1086,8 +1086,10 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                     doBoxSelection(DoubleClick::prvCursorPos, cursorPos, viewer);
                     rubberband->setWorking(false);
 
+                    // use draw(false, false) to avoid solver geometry with outdated construction flags
+                    draw(false, false);
+
                     // a redraw is required in order to clear the rubberband
-                    draw(true, false);
                     const_cast<Gui::View3DInventorViewer*>(viewer)->redraw();
                     setSketchMode(STATUS_NONE);
                     return true;


### PR DESCRIPTION
Currently if user tries to use box selection while having transformed normal line to a construction line, the line becomes solid unless it gets moved or new geometry is created.

The root cause of that is the `draw(true, false)` call which uses outdated solver geometry where construction=false is being specified. Solver updates lazily, which results in construction lines in normal sublayer instead of construction.

So, this patch changes it to `draw(false, false)` after box selection. This ensures the redraw uses current SketchObject geometry with up-to-date construction flags. This should be safe, as box selection is purely visual and we do not need geometry calculations in this operation.

Demo before:

https://github.com/user-attachments/assets/1a784669-0be2-4e0b-ad58-37ec055fae8c

Demo after:

https://github.com/user-attachments/assets/14c2414d-fb3c-46c8-bdff-3bb1f8641567

Resolves: https://github.com/freecad/freecad/issues/13366