### PR TITLE
Sketcher: Introduce Select All (Ctrl + A)

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1299,16 +1299,31 @@ StdCmdSelectAll::StdCmdSelectAll()
     sWhatsThis    = "Std_SelectAll";
     sStatusTip    = sToolTipText;
     sPixmap       = "edit-select-all";
-    //sAccel        = "Ctrl+A"; // supersedes shortcuts for text edits
+    sAccel        = "Ctrl+A"; // supersedes shortcuts for text edits
+    
+    // this cmd only alters selection, not doc or 3d view
+    eType         = AlterSelection;
 }
 
 void StdCmdSelectAll::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+    
+    auto* activeDoc = Application::Instance->activeDocument();
+    if (activeDoc) {
+        auto* editingVP = activeDoc->getInEdit();
+        if (editingVP && editingVP->selectAll()) {
+            return;
+        }
+    }
+    
+    // fallback to doc level select
     SelectionSingleton& rSel = Selection();
     App::Document* doc = App::GetApplication().getActiveDocument();
-    std::vector<App::DocumentObject*> objs = doc->getObjectsOfType(App::DocumentObject::getClassTypeId());
-    rSel.setSelection(doc->getName(), objs);
+    if (doc) {
+        std::vector<App::DocumentObject*> objs = doc->getObjectsOfType(App::DocumentObject::getClassTypeId());
+        rSel.setSelection(doc->getName(), objs);
+    }
 }
 
 bool StdCmdSelectAll::isActive()

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2638,7 +2638,7 @@ void ViewProviderSketch::updateColor()
 
 bool ViewProviderSketch::selectAll()
 {
-    // logic of this func has been stolen from partly from doBoxSelection()
+    // logic of this func has been stolen partly from doBoxSelection()
     if (!isInEditMode()) {
         return false;
     }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -42,6 +42,8 @@
 #include <limits>
 #endif
 
+#include <fmt/format.h>
+
 #include <Base/Console.h>
 #include <Base/Vector3D.h>
 #include <Gui/Application.h>
@@ -2666,89 +2668,63 @@ bool ViewProviderSketch::selectAll()
 
         if ((*it)->is<Part::GeomPoint>()) {
             VertexId++;
-            std::stringstream ss;
-            ss << "Vertex" << VertexId + 1;
-            addSelection2(ss.str());
+            addSelection2(fmt::format("Vertex{}", VertexId + 1));
         }
         else if ((*it)->is<Part::GeomLineSegment>()) {
             VertexId++; // start
-            std::stringstream ss1;
-            ss1 << "Vertex" << VertexId + 1;
-            addSelection2(ss1.str());
+            addSelection2(fmt::format("Vertex{}", VertexId + 1));
 
             VertexId++; // end
-            std::stringstream ss2;
-            ss2 << "Vertex" << VertexId + 1;
-            addSelection2(ss2.str());
+            addSelection2(fmt::format("Vertex{}", VertexId + 1));
 
-            std::stringstream ss_edge;
             if (GeoId >= 0) {
-                ss_edge << "Edge" << GeoId + 1;
+                addSelection2(fmt::format("Edge{}", GeoId + 1));
             } else {
-                ss_edge << "ExternalEdge" << -GeoId - 1;
+                addSelection2(fmt::format("ExternalEdge{}", -GeoId - 1));
             }
-            addSelection2(ss_edge.str());
         }
         else if ((*it)->isDerivedFrom<Part::GeomConic>()) {
             VertexId++;
-            std::stringstream ss;
-            ss << "Vertex" << VertexId + 1;
-            addSelection2(ss.str());
+            addSelection2(fmt::format("Vertex{}", VertexId + 1));
 
-            std::stringstream ss_edge;
             if (GeoId >= 0) {
-                ss_edge << "Edge" << GeoId + 1;
+                addSelection2(fmt::format("Edge{}", GeoId + 1));
             } else {
-                ss_edge << "ExternalEdge" << -GeoId - 1;
+                addSelection2(fmt::format("ExternalEdge{}", -GeoId - 1));
             }
-            addSelection2(ss_edge.str());
         }
         else if ((*it)->isDerivedFrom<Part::GeomCurve>()) {
             if (auto arc = dynamic_cast<const Part::GeomArcOfCircle*>(*it)) {
                 VertexId++; // start
-                std::stringstream ss1;
-                ss1 << "Vertex" << VertexId + 1;
-                addSelection2(ss1.str());
+                addSelection2(fmt::format("Vertex{}", VertexId + 1));
 
                 VertexId++; // end
-                std::stringstream ss2;
-                ss2 << "Vertex" << VertexId + 1;
-                addSelection2(ss2.str());
+                addSelection2(fmt::format("Vertex{}", VertexId + 1));
 
                 VertexId++; // center
-                std::stringstream ss3;
-                ss3 << "Vertex" << VertexId + 1;
-                addSelection2(ss3.str());
+                addSelection2(fmt::format("Vertex{}", VertexId + 1));
             } else {
                 // for other curves, select available vertices
                 VertexId++;
-                std::stringstream ss;
-                ss << "Vertex" << VertexId + 1;
-                addSelection2(ss.str());
+                addSelection2(fmt::format("Vertex{}", VertexId + 1));
             }
 
-            std::stringstream ss_edge;
             if (GeoId >= 0) {
-                ss_edge << "Edge" << GeoId + 1;
+                addSelection2(fmt::format("Edge{}", GeoId + 1));
             } else {
-                ss_edge << "ExternalEdge" << -GeoId - 1;
+                addSelection2(fmt::format("ExternalEdge{}", -GeoId - 1));
             }
-            addSelection2(ss_edge.str());
         }
     }
 
     // select constraints too
     const std::vector<Sketcher::Constraint*>& constraints = sketchObject->Constraints.getValues();
     for (size_t i = 0; i < constraints.size(); ++i) {
-        std::stringstream ss;
-        ss << "Constraint" << i + 1;
-        addSelection2(ss.str());
+        addSelection2(fmt::format("Constraint{}", i + 1));
     }
 
     // get root point if they exist
-    std::stringstream ss_root;
-    ss_root << "RootPoint";
-    addSelection2(ss_root.str());
+    addSelection2("RootPoint");
 
     return true;
 }


### PR DESCRIPTION
As the title says, this allows selecting all geometries on the sketch with CTRL + A shortcut, plus also allows to select "Select All" option from Edit menu.

Demo:

https://github.com/user-attachments/assets/1aef2b64-c4d7-4028-b0be-57987ebd93a7

Resolves: https://github.com/FreeCAD/FreeCAD/issues/12746
