### PR TITLE
TechDraw: Fix view frames resizing on select/hover

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -759,6 +759,7 @@ QRectF QGIView::customChildrenBoundingRect() const
             child->type() != UserType::QGCustomBorder &&
             child->type() != UserType::QGCustomLabel &&
             child->type() != UserType::QGICaption &&
+            child->type() != UserType::QGIVertex &&
             child->type() != UserType::QGICMark) {
             QRectF childRect = mapFromItem(child, child->boundingRect()).boundingRect();
             result = result.united(childRect);


### PR DESCRIPTION
The view frames would resize when selected, and when hovered/unhovered. This way because the vertices were being calculated in the view bounding rect size. This PR makes the vertices ignored when calculating the view bounding rect size, and fixes the problem.

## Issues
No linked issues

## Problem Demo

https://github.com/user-attachments/assets/4041f544-3df3-46ee-8eb2-8b540fd373eb
