### PR TITLE
PartDesign: Fix small typo in multiple solids error

### DIFF
--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -260,7 +260,3 @@ static App::DocumentObjectExecReturn *validateParameters(int chamferType, double
     return App::DocumentObject::StdReturn;
 }
 
-
-
-
-


### PR DESCRIPTION
adds missing space after ":"