### PR TITLE
Draft: more logical placement for 3 point arcs

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -584,12 +584,17 @@ class Arc_3Points(gui_base.GuiCommandBase):
             # proceed with creating the final object.
             # Draw a simple `Part::Feature` if the parameter is `True`.
             Gui.addModule("Draft")
+            Gui.addModule("WorkingPlane")
             _cmd = "Draft.make_arc_3points(["
             _cmd += "FreeCAD." + str(self.points[0])
             _cmd += ", FreeCAD." + str(self.points[1])
             _cmd += ", FreeCAD." + str(self.points[2])
-            _cmd += "], primitive=" + str(params.get_param("UsePartPrimitives")) + ")"
-            _cmd_list = ["circle = " + _cmd,
+            _cmd += "]"
+            _cmd += ", placement=pl"
+            _cmd += ", primitive=" + str(params.get_param("UsePartPrimitives"))
+            _cmd += ")"
+            _cmd_list = ["pl = WorkingPlane.get_working_plane().get_placement()",
+                         "circle = " + _cmd,
                          "Draft.autogroup(circle)"]
             if params.get_param("UsePartPrimitives"):
                 _cmd_list.append("Draft.select(circle)")

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -31,12 +31,11 @@ import math
 
 import FreeCAD as App
 import Part
-import Draft
-import draftutils.utils as utils
+from draftmake import make_circle
+from draftutils import gui_utils
+from draftutils import utils
 from draftutils.messages import _err
 from draftutils.translate import translate
-
-import draftutils.gui_utils as gui_utils
 
 
 def make_arc_3points(points, placement=None, face=False, support=None, primitive=False):
@@ -116,6 +115,6 @@ def make_arc_3points(points, placement=None, face=False, support=None, primitive
         obj.Shape = edge
         return obj
 
-    return Draft.make_circle(edge, placement=placement, face=face, support=support)
+    return make_circle.make_circle(edge, placement=placement, face=face, support=support)
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -39,10 +39,8 @@ from draftutils.translate import translate
 import draftutils.gui_utils as gui_utils
 
 
-def make_arc_3points(points, placement=None, face=False,
-                     support=None, map_mode="Deactivated",
-                     primitive=False):
-    """Draw a circular arc defined by three points in the circumference.
+def make_arc_3points(points, placement=None, face=False, support=None, primitive=False):
+    """Draw a circular arc defined by three points on the circumference.
 
     Parameters
     ----------
@@ -50,17 +48,9 @@ def make_arc_3points(points, placement=None, face=False,
         A list that must be three points.
 
     placement: Base::Placement, optional
-        It defaults to `None`.
-        It is a placement, comprised of a `Base` (`Base::Vector3`),
-        and a `Rotation` (`Base::Rotation`).
-        If it exists it moves the center of the new object to the point
-        indicated by `placement.Base`, while `placement.Rotation`
-        is ignored so that the arc keeps the same orientation
-        with which it was created.
-
-        If both `support` and `placement` are given,
-        `placement.Base` is used for the `AttachmentOffset.Base`,
-        and again `placement.Rotation` is ignored.
+        It is adjusted to match the geometry of the created edge.
+        The Z axis of the adjusted placement will be parallel to the
+        (negative) edge axis. Its Base will match the edge center.
 
     face: bool, optional
         It defaults to `False`.
@@ -72,39 +62,14 @@ def make_arc_3points(points, placement=None, face=False,
         It is a list containing tuples to define the attachment
         of the new object.
 
-        A tuple in the list needs two elements;
-        the first is an external object, and the second is another tuple
-        with the names of sub-elements on that external object
-        likes vertices or faces.
-        ::
-            support = [(obj, ("Face1"))]
-            support = [(obj, ("Vertex1", "Vertex5", "Vertex8"))]
-
-        This parameter sets the `Support` property but it only really affects
-        the position of the new object when the `map_mode`
-        is set to other than `'Deactivated'`.
-
-    map_mode: str, optional
-        It defaults to `'Deactivated'`.
-        It defines the type of `'MapMode'` of the new object.
-        This parameter only works when a `support` is also provided.
-
-        Example: place the new object on a face or another object.
-        ::
-            support = [(obj, ("Face1"))]
-            map_mode = 'FlatFace'
-
-        Example: place the new object on a plane created by three vertices
-        of an object.
-        ::
-            support = [(obj, ("Vertex1", "Vertex5", "Vertex8"))]
-            map_mode = 'ThreePointsPlane'
+        This parameter sets the `Support` property but it only really
+        affects the position of the new object if its `MapMode` is
+        set to other than `'Deactivated'`.
 
     primitive: bool, optional
         It defaults to `False`. If it is `True`, it will create a Part
         primitive instead of a Draft object.
-        In this case, `placement`, `face`, `support`, and `map_mode`
-        are ignored.
+        In this case, `placement`, `face` and `support` are ignored.
 
     Returns
     -------
@@ -130,14 +95,6 @@ def make_arc_3points(points, placement=None, face=False,
         _err(translate("draft","Wrong input: must be list or tuple of 3 points exactly."))
         return None
 
-    if placement is not None:
-        try:
-            utils.type_check([(placement, App.Placement)], name=_name)
-        except TypeError:
-            _err(translate("draft","Placement:") + " {}".format(placement))
-            _err(translate("draft","Wrong input: incorrect type of placement."))
-            return None
-
     p1, p2, p3 = points
 
     try:
@@ -149,41 +106,16 @@ def make_arc_3points(points, placement=None, face=False,
         return None
 
     try:
-        _edge = Part.Arc(p1, p2, p3)
+        edge = Part.Arc(p1, p2, p3).toShape()
     except Part.OCCError as error:
         _err(translate("draft","Cannot generate shape:") + " " + "{}".format(error))
         return None
-
-    edge = _edge.toShape()
-    radius = edge.Curve.Radius
-    center = edge.Curve.Center
 
     if primitive:
         obj = App.ActiveDocument.addObject("Part::Feature", "Arc")
         obj.Shape = edge
         return obj
 
-    rot = App.Rotation(edge.Curve.XAxis,
-                       edge.Curve.YAxis,
-                       edge.Curve.Axis, "ZXY")
-    _placement = App.Placement(center, rot)
-    start = edge.FirstParameter
-    end = math.degrees(edge.LastParameter)
-    obj = Draft.make_circle(radius,
-                            placement=_placement, face=face,
-                            startangle=start, endangle=end,
-                            support=support)
-
-    original_placement = obj.Placement
-
-    if placement and not support:
-        obj.Placement.Base = placement.Base
-    if support:
-        obj.MapMode = map_mode
-        if placement:
-            obj.AttachmentOffset.Base = placement.Base
-            obj.AttachmentOffset.Rotation = original_placement.Rotation
-
-    return obj
+    return Draft.make_circle(edge, placement=placement, face=face, support=support)
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -104,6 +104,14 @@ def make_arc_3points(points, placement=None, face=False, support=None, primitive
         _err(translate("draft","Wrong input: incorrect type of points."))
         return None
 
+    if placement is not None:
+        try:
+            utils.type_check([(placement, App.Placement)], name=_name)
+        except TypeError:
+            _err(translate("draft","Placement:") + " {}".format(placement))
+            _err(translate("draft","Wrong input: incorrect type of placement."))
+            return None
+
     try:
         edge = Part.Arc(p1, p2, p3).toShape()
     except Part.OCCError as error:

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -32,7 +32,6 @@ import math
 import FreeCAD as App
 import Part
 from draftmake import make_circle
-from draftutils import gui_utils
 from draftutils import utils
 from draftutils.messages import _err
 from draftutils.translate import translate


### PR DESCRIPTION
See:
https://github.com/FreeCAD/FreeCAD/issues/22913#issuecomment-3152054244

The placement of 3 point arcs very often was unexpected and typically did not match the placement of circles created on the same working plane.

This PR updates the code to use the placement of the working plane to adjust the placement of the created arc.

Additonally:
* Avoided code duplication by just passing the edge from make_arc_3points to make_circle.
* Removed inconsistent map_mode argument from make_arc_3points and the cryptic code related to it. The handling of the support property is something that has to be reviewed for all Draft commands at some point though.
