### PR TITLE
CAM: Offset improve (experimental - do not merge)

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathOpUtil.py
+++ b/src/Mod/CAM/CAMTests/TestPathOpUtil.py
@@ -317,7 +317,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         lastAngle = None
         refAngle = math.pi / 3
         for e in wire.Edges:
-            if Part.Circle == type(e.Curve):
+            if isinstance(e.Curve, Part.Circle):
                 self.assertRoughly(5, e.Curve.Radius)
                 self.assertCoincide(Vector(0, 0, -1), e.Curve.Axis)
             else:
@@ -365,15 +365,15 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
 
         wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, True)
         self.assertEqual(8, len(wire.Edges))
-        self.assertEqual(4, len([e for e in wire.Edges if Part.Line == type(e.Curve)]))
-        self.assertEqual(4, len([e for e in wire.Edges if Part.Circle == type(e.Curve)]))
+        self.assertEqual(4, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
+        self.assertEqual(4, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
         for e in wire.Edges:
-            if Part.Line == type(e.Curve):
+            if isinstance(e.Curve, Part.Line):
                 if Path.Geom.isRoughly(e.Vertexes[0].Point.x, e.Vertexes[1].Point.x):
                     self.assertEqual(40, e.Length)
                 if Path.Geom.isRoughly(e.Vertexes[0].Point.y, e.Vertexes[1].Point.y):
                     self.assertEqual(60, e.Length)
-            if Part.Circle == type(e.Curve):
+            if isinstance(e.Curve, Part.Circle):
                 self.assertRoughly(3, e.Curve.Radius)
                 self.assertCoincide(Vector(0, 0, -1), e.Curve.Axis)
         self.assertTrue(PathOpUtil.isWireClockwise(wire))
@@ -381,15 +381,15 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         # change offset orientation
         wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, False)
         self.assertEqual(8, len(wire.Edges))
-        self.assertEqual(4, len([e for e in wire.Edges if Part.Line == type(e.Curve)]))
-        self.assertEqual(4, len([e for e in wire.Edges if Part.Circle == type(e.Curve)]))
+        self.assertEqual(4, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
+        self.assertEqual(4, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
         for e in wire.Edges:
-            if Part.Line == type(e.Curve):
+            if isinstance(e.Curve, Part.Line):
                 if Path.Geom.isRoughly(e.Vertexes[0].Point.x, e.Vertexes[1].Point.x):
                     self.assertEqual(40, e.Length)
                 if Path.Geom.isRoughly(e.Vertexes[0].Point.y, e.Vertexes[1].Point.y):
                     self.assertEqual(60, e.Length)
-            if Part.Circle == type(e.Curve):
+            if isinstance(e.Curve, Part.Circle):
                 self.assertRoughly(3, e.Curve.Radius)
                 self.assertCoincide(Vector(0, 0, +1), e.Curve.Axis)
         self.assertFalse(PathOpUtil.isWireClockwise(wire))
@@ -400,25 +400,25 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
 
         wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, True)
         self.assertEqual(6, len(wire.Edges))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Line == type(e.Curve)]))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Circle == type(e.Curve)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
         length = 60 * math.sin(math.radians(60))
         for e in wire.Edges:
-            if Part.Line == type(e.Curve):
+            if isinstance(e.Curve, Part.Line):
                 self.assertRoughly(length, e.Length)
-            if Part.Circle == type(e.Curve):
+            if isinstance(e.Curve, Part.Circle):
                 self.assertRoughly(3, e.Curve.Radius)
                 self.assertCoincide(Vector(0, 0, -1), e.Curve.Axis)
 
         # change offset orientation
         wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, False)
         self.assertEqual(6, len(wire.Edges))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Line == type(e.Curve)]))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Circle == type(e.Curve)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
         for e in wire.Edges:
-            if Part.Line == type(e.Curve):
+            if isinstance(e.Curve, Part.Line):
                 self.assertRoughly(length, e.Length)
-            if Part.Circle == type(e.Curve):
+            if isinstance(e.Curve, Part.Circle):
                 self.assertRoughly(3, e.Curve.Radius)
                 self.assertCoincide(Vector(0, 0, +1), e.Curve.Axis)
 
@@ -428,26 +428,26 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
 
         wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, True)
         self.assertEqual(6, len(wire.Edges))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Line == type(e.Curve)]))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Circle == type(e.Curve)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
         length = 40
         radius = 20 + 3
         for e in wire.Edges:
-            if Part.Line == type(e.Curve):
+            if isinstance(e.Curve, Part.Line):
                 self.assertRoughly(length, e.Length)
-            if Part.Circle == type(e.Curve):
+            if isinstance(e.Curve, Part.Circle):
                 self.assertRoughly(radius, e.Curve.Radius)
                 self.assertCoincide(Vector(0, 0, -1), e.Curve.Axis)
 
         # change offset orientation
         wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, False)
         self.assertEqual(6, len(wire.Edges))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Line == type(e.Curve)]))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Circle == type(e.Curve)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
         for e in wire.Edges:
-            if Part.Line == type(e.Curve):
+            if isinstance(e.Curve, Part.Line):
                 self.assertRoughly(length, e.Length)
-            if Part.Circle == type(e.Curve):
+            if isinstance(e.Curve, Part.Circle):
                 self.assertRoughly(radius, e.Curve.Radius)
                 self.assertCoincide(Vector(0, 0, +1), e.Curve.Axis)
 
@@ -476,7 +476,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
 
         wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, True)
         self.assertEqual(4, len(wire.Edges))
-        self.assertEqual(4, len([e for e in wire.Edges if Part.Line == type(e.Curve)]))
+        self.assertEqual(4, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         for e in wire.Edges:
             if Path.Geom.isRoughly(e.Vertexes[0].Point.x, e.Vertexes[1].Point.x):
                 self.assertRoughly(34, e.Length)
@@ -487,7 +487,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         # change offset orientation
         wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, False)
         self.assertEqual(4, len(wire.Edges))
-        self.assertEqual(4, len([e for e in wire.Edges if Part.Line == type(e.Curve)]))
+        self.assertEqual(4, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         for e in wire.Edges:
             if Path.Geom.isRoughly(e.Vertexes[0].Point.x, e.Vertexes[1].Point.x):
                 self.assertRoughly(34, e.Length)
@@ -501,7 +501,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
 
         wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, True)
         self.assertEqual(3, len(wire.Edges))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Line == type(e.Curve)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         length = 48 * math.sin(math.radians(60))
         for e in wire.Edges:
             self.assertRoughly(length, e.Length)
@@ -510,7 +510,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         # change offset orientation
         wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, False)
         self.assertEqual(3, len(wire.Edges))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Line == type(e.Curve)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         for e in wire.Edges:
             self.assertRoughly(length, e.Length)
         self.assertTrue(PathOpUtil.isWireClockwise(wire))
@@ -521,26 +521,26 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
 
         wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, True)
         self.assertEqual(6, len(wire.Edges))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Line == type(e.Curve)]))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Circle == type(e.Curve)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
         length = 40
         radius = 20 - 3
         for e in wire.Edges:
-            if Part.Line == type(e.Curve):
+            if isinstance(e.Curve, Part.Line):
                 self.assertRoughly(length, e.Length)
-            if Part.Circle == type(e.Curve):
+            if isinstance(e.Curve, Part.Circle):
                 self.assertRoughly(radius, e.Curve.Radius)
                 self.assertCoincide(Vector(0, 0, +1), e.Curve.Axis)
 
         # change offset orientation
         wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, False)
         self.assertEqual(6, len(wire.Edges))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Line == type(e.Curve)]))
-        self.assertEqual(3, len([e for e in wire.Edges if Part.Circle == type(e.Curve)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
+        self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
         for e in wire.Edges:
-            if Part.Line == type(e.Curve):
+            if isinstance(e.Curve, Part.Line):
                 self.assertRoughly(length, e.Length)
-            if Part.Circle == type(e.Curve):
+            if isinstance(e.Curve, Part.Circle):
                 self.assertRoughly(radius, e.Curve.Radius)
                 self.assertCoincide(Vector(0, 0, -1), e.Curve.Axis)
 
@@ -642,7 +642,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertCoincide(Vector(-x, y, 0), wire.Edges[0].Vertexes[0].Point)
         self.assertCoincide(Vector(+x, y, 0), wire.Edges[-1].Vertexes[1].Point)
 
-        rEdges = [e for e in wire.Edges if Part.Circle == type(e.Curve)]
+        rEdges = [e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]
 
         self.assertEqual(1, len(rEdges))
         self.assertCoincide(Vector(0, 20, 0), rEdges[0].Curve.Center)
@@ -654,7 +654,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertCoincide(Vector(+x, y, 0), wire.Edges[0].Vertexes[0].Point)
         self.assertCoincide(Vector(-x, y, 0), wire.Edges[-1].Vertexes[1].Point)
 
-        rEdges = [e for e in wire.Edges if Part.Circle == type(e.Curve)]
+        rEdges = [e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]
 
         self.assertEqual(1, len(rEdges))
         self.assertCoincide(Vector(0, 20, 0), rEdges[0].Curve.Center)
@@ -686,7 +686,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertCoincide(Vector(-x, y, 0), wire.Edges[0].Vertexes[0].Point)
         self.assertCoincide(Vector(+x, y, 0), wire.Edges[-1].Vertexes[1].Point)
 
-        rEdges = [e for e in wire.Edges if Part.Circle == type(e.Curve)]
+        rEdges = [e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]
 
         self.assertEqual(1, len(rEdges))
         self.assertCoincide(Vector(0, 20, 0), rEdges[0].Curve.Center)
@@ -698,7 +698,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertCoincide(Vector(+x, y, 0), wire.Edges[0].Vertexes[0].Point)
         self.assertCoincide(Vector(-x, y, 0), wire.Edges[-1].Vertexes[1].Point)
 
-        rEdges = [e for e in wire.Edges if Part.Circle == type(e.Curve)]
+        rEdges = [e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]
 
         self.assertEqual(1, len(rEdges))
         self.assertCoincide(Vector(0, 20, 0), rEdges[0].Curve.Center)
@@ -781,6 +781,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
     def test46(self):
         """Check offsetting multiple inside edges."""
         obj = self.doc.getObjectsByLabel("offset-edge")[0]
+        offset = 2
 
         w = getWireInside(obj)
         length = 20 * math.cos(math.pi / 6)
@@ -793,32 +794,32 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         ]
         self.assertEqual(2, len(lEdges))
 
-        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, True)
+        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, offset, True)
 
-        x = length / 2 - 2 * math.cos(math.pi / 6)
-        y = -5 - 2 * math.sin(math.pi / 6)
+        x = length / 2 - offset / math.cos(math.pi / 6)
+        y = -5
 
-        self.assertCoincide(Vector(+x, y, 0), wire.Edges[0].Vertexes[0].Point)
-        self.assertCoincide(Vector(-x, y, 0), wire.Edges[-1].Vertexes[1].Point)
+        self.assertCoincide(Vector(+x, y, 0), wire.OrderedVertexes[0].Point)
+        self.assertCoincide(Vector(-x, y, 0), wire.OrderedVertexes[-1].Point)
 
-        rEdges = [e for e in wire.Edges if Part.Circle == type(e.Curve)]
+        rEdges = [e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]
         self.assertEqual(0, len(rEdges))
 
         # offset the other way
-        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, False)
+        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, offset, False)
 
-        self.assertCoincide(Vector(-x, y, 0), wire.Edges[0].Vertexes[0].Point)
-        self.assertCoincide(Vector(+x, y, 0), wire.Edges[-1].Vertexes[1].Point)
+        self.assertCoincide(Vector(-x, y, 0), wire.OrderedVertexes[0].Point)
+        self.assertCoincide(Vector(+x, y, 0), wire.OrderedVertexes[-1].Point)
 
-        rEdges = [e for e in wire.Edges if Part.Circle == type(e.Curve)]
+        rEdges = [e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]
         self.assertEqual(0, len(rEdges))
 
     def test47(self):
         """Check offsetting multiple backwards inside edges."""
-        # This is exactly the same as test36 except that the wire is flipped to make
+        # This is exactly the same as test46 except that the wire is flipped to make
         # sure it's orientation doesn't matter
         obj = self.doc.getObjectsByLabel("offset-edge")[0]
-
+        offset = 2
         w = getWireInside(obj)
         length = 20 * math.cos(math.pi / 6)
 
@@ -831,15 +832,15 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertEqual(2, len(lEdges))
 
         w = Path.Geom.flipWire(Part.Wire(lEdges))
-        wire = PathOpUtil.offsetWire(w, obj.Shape, 2, True)
+        wire = PathOpUtil.offsetWire(w, obj.Shape, offset, True)
 
-        x = length / 2 - 2 * math.cos(math.pi / 6)
-        y = -5 - 2 * math.sin(math.pi / 6)
+        x = length / 2 - offset / math.cos(math.pi / 6)
+        y = -5
 
-        self.assertCoincide(Vector(+x, y, 0), wire.Edges[0].Vertexes[0].Point)
-        self.assertCoincide(Vector(-x, y, 0), wire.Edges[-1].Vertexes[1].Point)
+        self.assertCoincide(Vector(+x, y, 0), wire.OrderedVertexes[0].Point)
+        self.assertCoincide(Vector(-x, y, 0), wire.OrderedVertexes[-1].Point)
 
-        rEdges = [e for e in wire.Edges if Part.Circle == type(e.Curve)]
+        rEdges = [e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]
         self.assertEqual(0, len(rEdges))
 
         # offset the other way
@@ -848,7 +849,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertCoincide(Vector(-x, y, 0), wire.Edges[0].Vertexes[0].Point)
         self.assertCoincide(Vector(+x, y, 0), wire.Edges[-1].Vertexes[1].Point)
 
-        rEdges = [e for e in wire.Edges if Part.Circle == type(e.Curve)]
+        rEdges = [e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]
         self.assertEqual(0, len(rEdges))
 
     def test50(self):


### PR DESCRIPTION
Try to fix #16495

Function `_orientEdges()` using `Path.Geom.flipEdge()` to change edge direction
But `Path.Geom.flipEdge()` can not process ellipses

https://github.com/FreeCAD/FreeCAD/blob/18517c78e58de67aa9ee25eac1ae10e905463bf7/src/Mod/CAM/Path/Op/Util.py#L319-L324

`_orientEdges()` using only to get start and end point of wire
But there is more simple way to get this: `wire.OrderedVertexes[0]` and `wire.OrderedVertexes[-1]`

> [!WARNING]
This pull request is experimental and not intended for merge in main branch