### PR TITLE
Draft: fix 2 issues with Draft_SelectPlane

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -39,7 +39,7 @@ from drafttaskpanels import task_selectplane
 from draftutils import gui_utils
 from draftutils import params
 from draftutils import utils
-from draftutils.messages import _msg
+from draftutils.messages import _toolmsg
 from draftutils.todo import todo
 from draftutils.translate import translate
 
@@ -150,7 +150,7 @@ class Draft_SelectPlane:
         # Execute the actual task panel delayed to catch possible active Draft command
         todo.delay(Gui.Control.showDialog, self.taskd)
         todo.delay(form.setFocus, None)
-        _msg(translate(
+        _toolmsg(translate(
                 "draft",
                 "Select 3 vertices, one or more shapes or an object to define a working plane"))
         self.call = self.view.addEventCallback("SoEvent", self.action)
@@ -179,7 +179,7 @@ class Draft_SelectPlane:
         if arg["Type"] == "SoKeyboardEvent" and arg["Key"] == "ESCAPE":
             self.reject()
         if arg["Type"] == "SoMouseButtonEvent" \
-                and (arg["State"] == "DOWN") \
+                and (arg["State"] == "UP") \
                 and (arg["Button"] == "BUTTON1"):
             self.check_selection()
 


### PR DESCRIPTION
Fixes #23306.
The Report View message was changed to `_toolmsg`.  It will therefore only display for users who have enabled that preference.

Fixes #23307.
The selection issue was due to a timing problem. The mouse DOWN event triggered the Python code before the selection was updated, therefore the previous selection instead of the new selection was checked. To solve this the action was switched to the mouse UP event. This event does not trigger after a mouse click that results in a selection, the user has to finalize the command by clicking in an empty 3D View area (which is how it should work according to the documentation). Added advantage is that the user does not receive a warning after every selection change.