### PR TITLE
CMake: remove unused PYSIDE_WRAP_UI macro

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
+++ b/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
@@ -178,38 +178,6 @@ macro(SetupShibokenAndPyside)
 endmacro(SetupShibokenAndPyside)
 
 
-# Macros similar to FindQt4.cmake's WRAP_UI and WRAP_RC, for the automatic generation of Python
-# code from Qt4's user interface ('.ui') and resource ('.qrc') files. These macros are called:
-# - PYSIDE_WRAP_UI
-# - PYSIDE_WRAP_RC
-
-MACRO(PYSIDE_WRAP_UI outfiles)
-  if (NOT PYSIDE_UIC_EXECUTABLE)
-    message(FATAL_ERROR "Qt uic is required for generating ${ARGN}")
-  endif()
-  FOREACH(it ${ARGN})
-    GET_FILENAME_COMPONENT(outfile ${it} NAME_WE)
-    GET_FILENAME_COMPONENT(infile ${it} ABSOLUTE)
-    SET(outfile ${CMAKE_CURRENT_BINARY_DIR}/ui_${outfile}.py)
-    if(WIN32 OR APPLE)
-        ADD_CUSTOM_COMMAND(OUTPUT ${outfile}
-          COMMAND ${PYSIDE_UIC_EXECUTABLE} ${UICOPTIONS} ${infile} -o ${outfile}
-          MAIN_DEPENDENCY ${infile}
-        )
-    else()
-        # Especially on Open Build Service we don't want changing date like
-        # pyside2-uic generates in comments at beginning., which is why
-        # we follow the tool command with a POSIX-friendly sed.
-        ADD_CUSTOM_COMMAND(OUTPUT ${outfile}
-          COMMAND "${PYSIDE_UIC_EXECUTABLE}" ${UICOPTIONS} "${infile}" -o "${outfile}"
-          COMMAND sed "/^# /d" "${outfile}" >"${outfile}.tmp" && mv "${outfile}.tmp" "${outfile}"
-          MAIN_DEPENDENCY "${infile}"
-        )
-    endif()
-    list(APPEND ${outfiles} ${outfile})
-  ENDFOREACH(it)
-ENDMACRO (PYSIDE_WRAP_UI)
-
 MACRO(PYSIDE_WRAP_RC outfiles)
   if (NOT PYSIDE_RCC_EXECUTABLE)
     message(FATAL_ERROR "Qt rcc is required for generating ${ARGN}")


### PR DESCRIPTION
Removal of dead code, probably leftover from Qt4 time.
