### PR TITLE
Core: Do not clear highlight if filter rejected selection

### DIFF
--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -634,8 +634,14 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo> &infos, bo
                 pPath = detailPath;
                 det = detNext;
                 FC_TRACE("select next " << objectName << ", " << subName);
-                if (ok)
+                if (ok) {
                     type = hasNext ? SoSelectionElementAction::All : SoSelectionElementAction::Append;
+                } else {
+                    // don't apply any visual action when selection fails -
+                    // in a case when we press ctrl and select a geometry that should be
+                    // filtered out, we don't want to apply any visual action
+                    pPath = nullptr;
+                }
             }
         }
     }


### PR DESCRIPTION
When user has specified a filter for a multi selection attempt, for example Ctrl + clicking on a disallowed edge, the visual highlighting of previously selected valid objects (that filter allowed) would disappear, even though they were still internally valid in selection system.

The root cause of that was that when `addSelection()` failed, the code still applied a `SoSelectionElementAction::None` to the scene graph path, which was clearing visual highlighting for all objects in that path, including those valid selection.

So, the fix is to set `pPath` to `nullptr` if selection fails, to prevent any visual action from happening and being applied, in essence leaving correct (and existing) selection untouched.

DEMO below, note that I am using CTRL during selection of not allowed elements. In demo before, valid elements get unhighlighted, but still remain in selection list. In demo after, they are still highlighted, we just ignore the incorrect selection.

Demo before:

https://github.com/user-attachments/assets/f3159aa8-9eda-414f-928e-523f86dbee53

Demo after:

https://github.com/user-attachments/assets/8ee124e5-8561-4065-a0bd-21c046d98037

Resolves: https://github.com/FreeCAD/FreeCAD/issues/20014