### PR TITLE
Material: Add missing include for PCH

### DIFF
--- a/src/Mod/Material/App/Exceptions.cpp
+++ b/src/Mod/Material/App/Exceptions.cpp
@@ -18,7 +18,7 @@
  *   <https://www.gnu.org/licenses/>.                                      *
  *                                                                         *
  **************************************************************************/
-
+#include "PreCompiled.h"
 #include "Exceptions.h"
 
 namespace Materials


### PR DESCRIPTION
We recently split the Exception class into a header and implementation file: the implementation file is missing the MSVC-required `#include "PreCompiled.h"` at the top.