### PR TITLE
Toponaming: Don't add empty tags past the threshold.

### DIFF
--- a/src/App/ElementMap.cpp
+++ b/src/App/ElementMap.cpp
@@ -1195,7 +1195,7 @@ void ElementMap::addChildElements(long masterTag, const std::vector<MappedChildE
 
         // do child mapping only if the child element count >= 5
         const int threshold {5};
-        if (child.count >= threshold || !child.elementMap) {
+        if ((child.count >= threshold && child.tag != 0) || !child.elementMap) {
             encodeElementName(child.indexedName[0],
                               tmp,
                               ss,


### PR DESCRIPTION
Fixes: https://github.com/FreeCAD/FreeCAD/issues/14720

This stops the ElementMap file from adding extra sections like H,E when the amount of subElements in a face or wire increases to be more than or equal to 5

Also an issue in LS3