### PR TITLE
[TD]allow finding child view outside clip rectangle

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.cpp
@@ -38,6 +38,7 @@
 #include "QGCustomClip.h"
 #include "QGCustomRect.h"
 #include "Rez.h"
+#include "ViewProviderViewClip.h"
 
 
 using namespace TechDrawGui;
@@ -155,6 +156,13 @@ void QGIViewClip::drawClip()
             }
         }
     }
+
+    auto* vpClip = freecad_cast<ViewProviderViewClip*>(getViewProvider(viewClip));
+    if (!vpClip) {
+        return;
+    }
+
+    m_cliparea->setFlag(QGraphicsItem::ItemClipsChildrenToShape, vpClip->ClipChildren.getValue());
 }
 
 

--- a/src/Mod/TechDraw/Gui/ViewProviderViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewClip.cpp
@@ -35,6 +35,7 @@
 #include <Mod/TechDraw/App/DrawProjGroupItem.h>
 
 #include "ViewProviderViewClip.h"
+#include "QGIViewClip.h"
 
 using namespace TechDrawGui;
 
@@ -43,6 +44,9 @@ PROPERTY_SOURCE(TechDrawGui::ViewProviderViewClip, TechDrawGui::ViewProviderDraw
 ViewProviderViewClip::ViewProviderViewClip()
 {
     sPixmap = "actions/TechDraw_ClipGroup";
+
+    ADD_PROPERTY_TYPE(ClipChildren,(true), "Clip", App::Prop_None, "True clips children. False shows entire child views");
+
 
     // Do not show in property editor   why? wf  WF: because DisplayMode applies only to coin and we
     // don't use coin.
@@ -147,3 +151,14 @@ void ViewProviderViewClip::dropObject(App::DocumentObject* docObj)
 
     getObject()->addView(dv);
 }
+
+void ViewProviderViewClip::onChanged(const App::Property* prop)
+{
+    if (prop == &ClipChildren) {
+        QGIView* qgiv = getQView();
+        if (qgiv) {
+            qgiv->updateView(true);
+        }
+    }
+}
+

--- a/src/Mod/TechDraw/Gui/ViewProviderViewClip.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewClip.h
@@ -43,10 +43,14 @@ public:
     /// destructor
     ~ViewProviderViewClip() override;
 
+    App::PropertyBool   ClipChildren;
+
     bool useNewSelectionModel() const override {return false;}
 
     TechDraw::DrawViewClip* getViewObject() const override;
     TechDraw::DrawViewClip* getObject() const;
+
+    void onChanged(const App::Property *prop) override;
 
     /// Hide the object in the view
     void hide() override;


### PR DESCRIPTION
This PR implements a fix for a situation where views that belong to a clip group may become impossible to drag if they are moved outside the clip rectangle.

The fix adds a property to ViewProviderViewClip that controls whether or not to display child views outside of the clip rectangle.

Current:
<img width="1144" height="656" alt="clipChildren_01" src="https://github.com/user-attachments/assets/35648dd3-48b7-4930-ba73-7b667e18dab4" />

With fix and ClipChildren false:
<img width="1126" height="701" alt="clipChildren_02" src="https://github.com/user-attachments/assets/24222d9b-dd46-4d4b-a113-656b479d4c37" />