### PR TITLE
Fix autouic warnings about duplicate names in ui files

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsUI.ui
+++ b/src/Gui/PreferencePages/DlgSettingsUI.ui
@@ -501,7 +501,7 @@
      <property name="title">
       <string>Suggested Actions</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
+     <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
        <widget class="Gui::PrefCheckBox" name="showTaskWatcherCheckBox">
         <property name="text">

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -126,7 +126,7 @@
      <property name="title">
       <string>Features Settings</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout_4">
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>


### PR DESCRIPTION
fix these warnings:
```
 AutoUic: /home/runner/work/FreeCAD/FreeCAD/src/Gui/PreferencePages/DlgSettingsUI.ui: Warning: The name 'gridLayout' (QGridLayout) is already in use, defaulting to 'gridLayout2'.
 AutoUic: /home/runner/work/FreeCAD/FreeCAD/src/Mod/Part/Gui/DlgSettingsGeneral.ui: Warning: The name 'verticalLayout_3' (QVBoxLayout) is already in use, defaulting to 'verticalLayout_31'.
```
