### PR TITLE
Exporting mesh to Z88 format no longer breaks all export and configs

### DIFF
--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -202,11 +202,14 @@ QString FileDialog::getSaveFileName (QWidget * parent, const QString & caption, 
 
         QStringList filterSuffixes;
         getSuffixesDescription(filterSuffixes, filterToSearch);
-        QString fiSuffix = QLatin1String("*.") + fi.suffix();  // To match with filterSuffixes
-        if (fi.suffix().isEmpty() || !filterSuffixes.contains(fiSuffix)) {
+        const QString fiSuffix = fi.suffix();
+        const QString dotSuffix = QLatin1String("*.") + fiSuffix;  // To match with filterSuffixes
+        if (fiSuffix.isEmpty() || !filterSuffixes.contains(dotSuffix)) {
             // there is no suffix or not a suffix that matches the filter, so
             // default to the first suffix of the filter
-            dirName += filterSuffixes[0].mid(1);
+            if (!filterSuffixes.isEmpty()) {
+                dirName += filterSuffixes[0].mid(1);
+            }
         }
     }
 

--- a/src/Mod/Fem/Init.py
+++ b/src/Mod/Fem/Init.py
@@ -84,12 +84,10 @@ FreeCAD.addExportType(
     "feminout.importYamlJsonMesh",
 )
 
-FreeCAD.addImportType("FEM mesh Z88 (*i1.txt *I1.TXT)", "feminout.importZ88Mesh")
-FreeCAD.addExportType("FEM mesh Z88 (*i1.txt)", "feminout.importZ88Mesh")
+FreeCAD.addImportType("FEM mesh Z88 (*.txt *.TXT)", "feminout.importZ88Mesh")
+FreeCAD.addExportType("FEM mesh Z88 (*.txt)", "feminout.importZ88Mesh")
 
-FreeCAD.addImportType(
-    "FEM result Z88 displacements (*o2.txt *O2.TXT)", "feminout.importZ88O2Results"
-)
+FreeCAD.addImportType("FEM result Z88 displacements (*.txt *.TXT)", "feminout.importZ88O2Results")
 
 if "BUILD_FEM_VTK" in FreeCAD.__cmake__:
     FreeCAD.addImportType(


### PR DESCRIPTION
1. Fix crash in FileDialog::getSaveFileName
2. Fix file suffixes in FEM module

This fixes https://github.com/FreeCAD/FreeCAD/issues/23353