### PR TITLE
Revert "Measure: Implement quick measure as command and make it toggable"

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -723,7 +723,6 @@ MenuItem* StdWorkbench::setupMenuBar() const
           << "Separator";
 #endif
     *tool << "Std_Measure"
-          << "Std_QuickMeasure"
           << "Std_UnitsCalculator"
           << "Separator"
           << "Std_ViewLoadImage"
@@ -813,7 +812,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     auto view = new ToolBarItem( root );
     view->setCommand("View");
     *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_ViewGroup" << "Std_AlignToSelection"
-          << "Separator" << "Std_DrawStyle" << "Std_TreeViewActions" << "Std_Measure" << "Std_QuickMeasure";
+          << "Separator" << "Std_DrawStyle" << "Std_TreeViewActions" << "Std_Measure";
 
     // Individual views
     auto individualViews = new ToolBarItem(root, ToolBarItem::DefaultVisibility::Hidden);

--- a/src/Mod/Measure/Gui/AppMeasureGui.cpp
+++ b/src/Mod/Measure/Gui/AppMeasureGui.cpp
@@ -32,6 +32,7 @@
 #include <Gui/WidgetFactory.h>
 
 #include "DlgPrefsMeasureAppearanceImp.h"
+#include "QuickMeasure.h"
 #include "QuickMeasurePy.h"
 #include "ViewProviderMeasureAngle.h"
 #include "ViewProviderMeasureDistance.h"
@@ -110,6 +111,10 @@ PyMOD_INIT_FUNC(MeasureGui)
     //    Q_INIT_RESOURCE(Measure);
 
     Base::Interpreter().addType(&MeasureGui::QuickMeasurePy::Type, mod, "QuickMeasure");
+
+    // Create a QuickMeasure instance
+    auto measure = new MeasureGui::QuickMeasure(QApplication::instance());
+    Q_UNUSED(measure)
 
     PyMOD_Return(mod);
 }

--- a/src/Mod/Measure/Gui/Command.cpp
+++ b/src/Mod/Measure/Gui/Command.cpp
@@ -20,13 +20,8 @@
  **************************************************************************/
 
 #include "PreCompiled.h"
-#ifndef _PreComp_
-#include <QApplication>
-#endif
 
-#include <App/Application.h>
 #include <App/Document.h>
-#include <Gui/Action.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Gui/Control.h>
@@ -35,7 +30,6 @@
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
 
-#include "QuickMeasure.h"
 #include "TaskMeasure.h"
 
 
@@ -82,65 +76,6 @@ bool StdCmdMeasure::isActive()
     return false;
 }
 
-
-class StdCmdQuickMeasure: public Gui::Command
-{
-public:
-    StdCmdQuickMeasure()
-        : Command("Std_QuickMeasure")
-    {
-        sGroup = "Measure";
-        sMenuText = QT_TR_NOOP("&Quick measure");
-        sToolTipText = QT_TR_NOOP("Toggle quick measure");
-        sWhatsThis = "Std_QuickMeasure";
-        sStatusTip = QT_TR_NOOP("Toggle quick measure");
-        accessParameter();
-    }
-    ~StdCmdQuickMeasure() override = default;
-    StdCmdQuickMeasure(const StdCmdQuickMeasure&) = delete;
-    StdCmdQuickMeasure(StdCmdQuickMeasure&&) = delete;
-    StdCmdQuickMeasure& operator=(const StdCmdQuickMeasure&) = delete;
-    StdCmdQuickMeasure& operator=(StdCmdQuickMeasure&&) = delete;
-
-    const char* className() const override
-    {
-        return "StdCmdQuickMeasure";
-    }
-
-protected:
-    void activated(int iMsg) override
-    {
-        if (parameter.isValid()) {
-            parameter->SetBool("EnableQuickMeasure", iMsg > 0);
-        }
-
-        if (iMsg == 0) {
-            quickMeasure.reset();
-        }
-        else {
-            quickMeasure = std::make_unique<MeasureGui::QuickMeasure>(QApplication::instance());
-        }
-    }
-    Gui::Action* createAction() override
-    {
-        Gui::Action* action = Gui::Command::createAction();
-        action->setCheckable(true);
-        action->setChecked(parameter->GetBool("EnableQuickMeasure", false));
-        return action;
-    }
-    void accessParameter()
-    {
-        // clang-format off
-        parameter = App::GetApplication().GetUserParameter().
-                    GetGroup("BaseApp/Preferences/Mod/Measure");
-        // clang-format on
-    }
-
-private:
-    std::unique_ptr<MeasureGui::QuickMeasure> quickMeasure;
-    ParameterGrp::handle parameter;
-};
-
 void CreateMeasureCommands()
 {
     Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
@@ -148,5 +83,4 @@ void CreateMeasureCommands()
     auto cmd = new StdCmdMeasure();
     cmd->initAction();
     rcCmdMgr.addCommand(cmd);
-    rcCmdMgr.addCommand(new StdCmdQuickMeasure);
 }


### PR DESCRIPTION
This reverts commit 5d3f9cac3f1db12e5e42eae5a8e551c9c5a0ed26 from https://github.com/FreeCAD/FreeCAD/pull/23291

The commit disabled quick measure by default and introduced a text button:
<img width="480" height="81" alt="image" src="https://github.com/user-attachments/assets/722e0b12-63cf-4968-9954-315093b3f619" />

It didn't clean up the status bar so information by quick measure would stick:
<img width="179" height="56" alt="image" src="https://github.com/user-attachments/assets/e7d93521-c480-481d-94a6-52a8ce6ba41c" />

While the idea to make it possible to disable QM is good, this wasn't ready to be merged with these issues.

Reverting this is a quick and easy way to fix the issues before it comes to a weekly.

FYI @wwmayer @3x380V 