### PR TITLE
Measure: Fix quick measure command

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -813,7 +813,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     auto view = new ToolBarItem( root );
     view->setCommand("View");
     *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_ViewGroup" << "Std_AlignToSelection"
-          << "Separator" << "Std_DrawStyle" << "Std_TreeViewActions" << "Std_Measure" << "Std_QuickMeasure";
+          << "Separator" << "Std_DrawStyle" << "Std_TreeViewActions" << "Std_Measure";
 
     // Individual views
     auto individualViews = new ToolBarItem(root, ToolBarItem::DefaultVisibility::Hidden);

--- a/src/Mod/Measure/Gui/Command.cpp
+++ b/src/Mod/Measure/Gui/Command.cpp
@@ -115,6 +115,9 @@ protected:
         }
 
         if (iMsg == 0) {
+            if (quickMeasure) {
+                quickMeasure->print(QString());
+            }
             quickMeasure.reset();
         }
         else {
@@ -125,7 +128,7 @@ protected:
     {
         Gui::Action* action = Gui::Command::createAction();
         action->setCheckable(true);
-        action->setChecked(parameter->GetBool("EnableQuickMeasure", false));
+        action->setChecked(parameter->GetBool("EnableQuickMeasure", true));
         return action;
     }
     void accessParameter()

--- a/src/Mod/Measure/Gui/QuickMeasure.h
+++ b/src/Mod/Measure/Gui/QuickMeasure.h
@@ -47,6 +47,7 @@ class QuickMeasure: public QObject, Gui::SelectionObserver
 public:
     explicit QuickMeasure(QObject* parent = nullptr);
     ~QuickMeasure() override;
+    void print(const QString& message);
 
 private:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
@@ -56,7 +57,6 @@ private:
     void addSelectionToMeasurement();
     bool isObjAcceptable(App::DocumentObject* obj);
     void printResult();
-    void print(const QString& message);
 
     void processSelection();
 


### PR DESCRIPTION
* Clear status bar when switching off quick measure
* Activate quick measure by default
* Remove command from toolbar as there is currently no icon

Replace https://github.com/FreeCAD/FreeCAD/pull/23390