### PR TITLE
Sketcher: Enable "Auto remove redundant constraints" by default

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -110,7 +110,7 @@ Requires to re-enter edit mode to take effect.</string>
          <string>Auto remove redundant constraints</string>
         </property>
         <property name="checked">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>AutoRemoveRedundants</cstring>

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -863,7 +863,7 @@ TaskSketcherConstraints::TaskSketcherConstraints(ViewProviderSketch* sketchView)
     {
         QSignalBlocker block(this);
         action1->setChecked(sketchView->Autoconstraints.getValue());
-        action2->setChecked(hGrp->GetBool("AutoRemoveRedundants", false));
+        action2->setChecked(hGrp->GetBool("AutoRemoveRedundants", true));
         action3->setChecked(hGrp->GetBool("VisualisationTrackingFilter", false));
         action4->setChecked(hGrp->GetBool("ExtendedConstraintInformation", false));
         action5->setChecked(hGrp->GetBool("HideInternalAlignment", false));
@@ -1045,7 +1045,7 @@ void TaskSketcherConstraints::onSettingsAutoRemoveRedundantChanged(bool value)
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Sketcher");
 
-    if (hGrp->GetBool("AutoRemoveRedundants", false) != value) {
+    if (hGrp->GetBool("AutoRemoveRedundants", true) != value) {
         hGrp->SetBool("AutoRemoveRedundants", value);
     }
 }
@@ -1760,3 +1760,4 @@ void TaskSketcherConstraints::onFilterListItemChanged(QListWidgetItem* item)
 
 #include "moc_TaskSketcherConstraints.cpp"
 // clang-format on
+

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1760,4 +1760,3 @@ void TaskSketcherConstraints::onFilterListItemChanged(QListWidgetItem* item)
 
 #include "moc_TaskSketcherConstraints.cpp"
 // clang-format on
-

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -124,7 +124,7 @@ bool SketcherGui::tryAutoRecompute(Sketcher::SketchObject* obj, bool& autoremove
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Sketcher");
     bool autoRecompute = hGrp->GetBool("AutoRecompute", false);
-    bool autoRemoveRedundants = hGrp->GetBool("AutoRemoveRedundants", false);
+    bool autoRemoveRedundants = hGrp->GetBool("AutoRemoveRedundants", true);
 
     // We need to make sure the solver has right redundancy information before trying to remove the
     // redundants. for example if a non-driving constraint has been added.


### PR DESCRIPTION
Enables the "Auto remove redundants" option by default. Many new users struggle with overconstraints occurring far too often. This setting reduces them to a manageable level and I think it would be good to have it on by default.