### PR TITLE
PartDesign: Enable selecting a sketch as base plane of another sketch

### DIFF
--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -197,17 +197,18 @@ class SketchPreselection
 {
 public:
     SketchPreselection(Gui::Document* guidocument, PartDesign::Body* activeBody,
-                       std::tuple<Gui::SelectionFilter, Gui::SelectionFilter> filter)
+                       std::tuple<Gui::SelectionFilter, Gui::SelectionFilter, Gui::SelectionFilter> filter)
         : guidocument(guidocument)
         , activeBody(activeBody)
         , faceFilter(std::get<0>(filter))
         , planeFilter(std::get<1>(filter))
+        , sketchFilter(std::get<2>(filter))
     {
     }
 
     bool matches()
     {
-        return faceFilter.match() || planeFilter.match();
+        return faceFilter.match() || planeFilter.match() || sketchFilter.match();
     }
 
     std::string getSupport() const
@@ -231,10 +232,16 @@ public:
             selectedObject = validator.getObject();
             supportString = validator.getSupport();
         }
-        else {
+        else if (planeFilter.match()) {
             SupportPlaneValidator validator(planeFilter.Result[0][0]);
             selectedObject = validator.getObject();
             supportString = validator.getSupport();
+        }
+        else {
+            // For a sketch, the support is the object itself with no sub-element.
+            Gui::SelectionObject sketchSelObject = sketchFilter.Result[0][0];
+            selectedObject = sketchSelObject.getObject();
+            supportString = sketchSelObject.getAsPropertyLinkSubString();
         }
 
         handleIfSupportOutOfBody(selectedObject);
@@ -250,7 +257,16 @@ public:
         FCMD_OBJ_CMD(activeBody, "newObject('Sketcher::SketchObject','" << FeatName << "')");
         auto Feat = activeBody->getDocument()->getObject(FeatName.c_str());
         FCMD_OBJ_CMD(Feat, "AttachmentSupport = " << supportString);
-        FCMD_OBJ_CMD(Feat, "MapMode = '" << Attacher::AttachEngine::getModeName(Attacher::mmFlatFace)<<"'");
+        if (sketchFilter.match()) {
+            FCMD_OBJ_CMD(Feat,
+                         "MapMode = '" << Attacher::AttachEngine::getModeName(Attacher::mmObjectXY)
+                                       << "'");
+        }
+        else {  // For Face or Plane
+            FCMD_OBJ_CMD(Feat,
+                         "MapMode = '" << Attacher::AttachEngine::getModeName(Attacher::mmFlatFace)
+                                       << "'");
+        }
         Gui::Command::updateActive();
         PartDesignGui::setEdit(Feat, activeBody);
     }
@@ -346,6 +362,7 @@ private:
     PartDesign::Body* activeBody;
     Gui::SelectionFilter faceFilter;
     Gui::SelectionFilter planeFilter;
+    Gui::SelectionFilter sketchFilter;
     std::string supportString;
 };
 
@@ -757,8 +774,8 @@ void SketchWorkflow::tryCreateSketch()
         return;
     }
 
-    auto faceOrPlaneFilter = getFaceAndPlaneFilter();
-    SketchPreselection sketchOnFace{ guidocument, activeBody, faceOrPlaneFilter };
+    auto filters = getFilters();
+    SketchPreselection sketchOnFace {guidocument, activeBody, filters};
 
     if (sketchOnFace.matches()) {
         // create Sketch on Face or Plane
@@ -804,7 +821,7 @@ bool SketchWorkflow::shouldAbort(bool shouldMakeBody) const
     return !shouldMakeBody && !activeBody;
 }
 
-std::tuple<Gui::SelectionFilter, Gui::SelectionFilter> SketchWorkflow::getFaceAndPlaneFilter() const
+std::tuple<Gui::SelectionFilter, Gui::SelectionFilter, Gui::SelectionFilter> SketchWorkflow::getFilters() const
 {
     // Hint:
     // The behaviour of this command has changed with respect to a selected sketch:
@@ -815,9 +832,11 @@ std::tuple<Gui::SelectionFilter, Gui::SelectionFilter> SketchWorkflow::getFaceAn
     Gui::SelectionFilter FaceFilter  ("SELECT Part::Feature SUBELEMENT Face COUNT 1");
     Gui::SelectionFilter PlaneFilter ("SELECT App::Plane COUNT 1", activeBody);
     Gui::SelectionFilter PlaneFilter2("SELECT PartDesign::Plane COUNT 1", activeBody);
+    Gui::SelectionFilter SketchFilter("SELECT Sketcher::SketchObject COUNT 1", activeBody);
 
     if (PlaneFilter2.match()) {
         PlaneFilter = PlaneFilter2;
     }
-    return std::make_tuple(FaceFilter, PlaneFilter);
+
+    return std::make_tuple(FaceFilter, PlaneFilter, SketchFilter);
 }

--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -832,7 +832,7 @@ std::tuple<Gui::SelectionFilter, Gui::SelectionFilter, Gui::SelectionFilter> Ske
     Gui::SelectionFilter FaceFilter  ("SELECT Part::Feature SUBELEMENT Face COUNT 1");
     Gui::SelectionFilter PlaneFilter ("SELECT App::Plane COUNT 1", activeBody);
     Gui::SelectionFilter PlaneFilter2("SELECT PartDesign::Plane COUNT 1", activeBody);
-    Gui::SelectionFilter SketchFilter("SELECT Sketcher::SketchObject COUNT 1", activeBody);
+    Gui::SelectionFilter SketchFilter("SELECT Part::2DObject COUNT 1", activeBody);
 
     if (PlaneFilter2.match()) {
         PlaneFilter = PlaneFilter2;

--- a/src/Mod/PartDesign/Gui/SketchWorkflow.h
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.h
@@ -50,7 +50,7 @@ private:
     void tryCreateSketch();
     std::tuple<bool, PartDesign::Body*> shouldCreateBody();
     bool shouldAbort(bool) const;
-    std::tuple<Gui::SelectionFilter, Gui::SelectionFilter> getFaceAndPlaneFilter() const;
+    std::tuple<Gui::SelectionFilter, Gui::SelectionFilter, Gui::SelectionFilter> getFilters() const;
 
 private:
     Gui::Document* guidocument;


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/22888


1 - The New Sketch command now detect if a sketch was selected. And if so it attach the new sketch to the selected one with ObjectXY mode.
2 - Before it was not possible to attach to an empty sketch (or body). But this is wrong because an empty sketch has a placement. So we should still have the modes 'ObjectXY' and so on available. This PR fixes that.