### PR TITLE
PD: Fix creation of pad from base feature

### DIFF
--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -352,6 +352,9 @@ Part::TopoShape Feature::getBaseTopoShape(bool silent) const
             throw Base::ValueError("Base feature's shape is not a solid");
         }
     }
+    else if (!result.hasSubShape(TopAbs_SOLID)) {
+        result.setShape(TopoDS_Shape());
+    }
     return result;
 }
 

--- a/src/Mod/PartDesign/App/FeatureBase.cpp
+++ b/src/Mod/PartDesign/App/FeatureBase.cpp
@@ -70,9 +70,6 @@ App::DocumentObjectExecReturn* FeatureBase::execute()
     }
 
     auto shape = Part::Feature::getTopoShape(BaseFeature.getValue(), Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform);
-    if (!shape.countSubShapes(TopAbs_SOLID)) {
-        shape = shape.makeElementSolid();
-    }
     if (shape.isNull()) {
         return new App::DocumentObjectExecReturn(
             QT_TRANSLATE_NOOP("Exception", "BaseFeature has an empty shape"));


### PR DESCRIPTION
In versions prior to 1.0 there was never the requirement that the shape of a FeatureBase must contain a solid. This has changed with 7a4bc95d47 for no obvious reason. This requirement should be dropped again.

In versions prior to 1.0 the method Feature::getBaseShape() was used within the Pad feature to check if the base feature has a solid. This method throws an exception if the shape doesn't have a solid. Since version 1.0 the new method Feature::getBaseTopoShape() is used. As parameter a boolean is passed to either throw an exception or silently return a null shape in case of an error. The implementation of this function is inconsistent: If the parameter is false it throws an exception if the base feature's shape has no solid but if the parameter is true it doesn't check if the shape has a solid and returns it as is.

This leads to incorrect behaviour in the calling instance where the shape of the base feature is tried to be fused with the padded shape. This operation will fail if the shape of the base feature has no solid.

This fixes https://github.com/FreeCAD/FreeCAD/issues/23348
