### PR TITLE
CAM: use dict constructor for Command in VCarve

### DIFF
--- a/src/Mod/CAM/Path/Op/Vcarve.py
+++ b/src/Mod/CAM/Path/Op/Vcarve.py
@@ -485,10 +485,10 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
             # raise and reposition the head only if new wire starts further than 0.5 mm
             # from current head position
             if not canSkipRepositioning(currentPosition, newPosition):
-                path.append(Path.Command("G0 Z{}".format(obj.SafeHeight.Value)))
+                path.append(Path.Command("G0", {"Z": obj.SafeHeight.Value}))
                 path.append(
                     Path.Command(
-                        "G0 X{} Y{} Z{}".format(newPosition.x, newPosition.y, obj.SafeHeight.Value)
+                        "G0", {"X": newPosition.x, "Y": newPosition.y, "Z": obj.SafeHeight.Value}
                     )
                 )
 
@@ -496,7 +496,7 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
             vSpeed = obj.ToolController.VertFeed.Value
             path.append(
                 Path.Command(
-                    "G1 X{} Y{} Z{} F{}".format(newPosition.x, newPosition.y, newPosition.z, vSpeed)
+                    "G1", {"X": newPosition.x, "Y": newPosition.y, "Z": newPosition.z, "F": vSpeed}
                 )
             )
             for e in wire:


### PR DESCRIPTION
Under certain conditions (rotated model) the vcarve expression can output weird geometry:
<img width="2291" height="1278" alt="grafik" src="https://github.com/user-attachments/assets/ebf4a59f-01f9-412f-b961-5bc33d1fdcdd" />
[vcarve_issue.zip](https://github.com/user-attachments/files/22036290/vcarve_issue.zip)

The issue is the use of `Path.Command(... Z{}".format(..., newPosition.z))` in Vcarve.py. When `newPosition.z` is a very small value, e.g. -1.776357e-15, the E-15 is interpreted as a parameter instead of an exponent, resulting the following clearly wrong GCode:
```
G1 E-15.000000 F0.000000 X45.432000 Y5.000000 Z-1.776357
```
The solution is simple: use the dictionary constructor just as every other operation.