### PR TITLE
[TD]fix ISOLineSpacing preference not applied

### DIFF
--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -524,9 +524,13 @@ int Preferences::BreakLineStyle()
     return getPreferenceGroup("Decorations")->GetInt("LineStyleBreak", 0) + 1;
 }
 
-int Preferences::LineSpacingISO()
+
+// LineSpacingISO is stored as a double in DlgPrefsTechDrawDimensionsImp.cpp but was being accessed
+// as an int here, so the default was always returned. If we make DlgPrefsTechDrawDimensionsImp handle
+// ints, then anybody who had set a custom spacing would need to update their preference.
+float Preferences::LineSpacingISO()
 {
-    return getPreferenceGroup("Dimensions")->GetInt("LineSpacingFactorISO", 2);
+    return getPreferenceGroup("Dimensions")->GetFloat("LineSpacingFactorISO", 2);
 }
 
 std::string Preferences::currentLineDefFile()

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -129,7 +129,7 @@ public:
     static int LineCapStyle();
     static int LineCapIndex();
 
-    static int LineSpacingISO();
+    static float LineSpacingISO();
 
     static std::string currentLineDefFile();
     static std::string currentElementDefFile();


### PR DESCRIPTION
This PR implements a fix for issue #23425.

The fix changes the return type of a preference getter to match the type stored by the preference dialog.