### PR TITLE
Core: Datums: Make getDirection and getBasePoint aware of LCS position

### DIFF
--- a/src/App/Datums.cpp
+++ b/src/App/Datums.cpp
@@ -92,8 +92,14 @@ bool DatumElement::isOriginFeature() const
 
 Base::Vector3d DatumElement::getBasePoint() const
 {
-    Base::Placement plc = Placement.getValue();
-    return plc.getPosition();
+    Base::Vector3d pos = Placement.getValue().getPosition();
+
+    const auto* lcs = getLCS();
+    if (lcs && !lcs->isOrigin()) {
+        pos += lcs->Placement.getValue().getPosition();
+    }
+
+    return pos;
 }
 
 Base::Vector3d DatumElement::getDirection() const
@@ -102,6 +108,13 @@ Base::Vector3d DatumElement::getDirection() const
     Base::Placement plc = Placement.getValue();
     Base::Rotation rot = plc.getRotation();
     rot.multVec(dir, dir);
+
+    const auto* lcs = getLCS();
+    if (lcs && !lcs->isOrigin()) {
+        Base::Rotation lcsRot = lcs->Placement.getValue().getRotation();
+        lcsRot.multVec(dir, dir);
+    }
+
     return dir;
 }
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/23437