### PR TITLE
PartDesign: TaskExtrudeParameters improve ui by letting line visible

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -757,7 +757,6 @@ void TaskExtrudeParameters::updateWholeUI(Type type, Side side)
     const bool isSide2GroupVisible = (sidesMode == SidesMode::TwoSides);
     ui->side1Label->setVisible(isSide2GroupVisible);
     ui->side2Label->setVisible(isSide2GroupVisible);
-    ui->line1->setVisible(isSide2GroupVisible);
     ui->line2->setVisible(isSide2GroupVisible);
     ui->typeLabel2->setVisible(isSide2GroupVisible);
     ui->changeMode2->setVisible(isSide2GroupVisible);
@@ -1364,5 +1363,6 @@ bool TaskDlgExtrudeParameters::reject()
 }
 
 #include "moc_TaskExtrudeParameters.cpp"
+
 
 


### PR DESCRIPTION
Before/after : 
<img width="878" height="395" alt="image" src="https://github.com/user-attachments/assets/d4d7d0b8-7064-4729-849b-e173840fba1d" />

Makes the new UI easier on the eye

@kadet1090 
