### PR TITLE
Draft: Call autogroup in make_hatch to put hatch in active group if any

### DIFF
--- a/src/Mod/Draft/draftmake/make_hatch.py
+++ b/src/Mod/Draft/draftmake/make_hatch.py
@@ -26,6 +26,7 @@ import FreeCAD
 from draftobjects.hatch import Hatch
 if FreeCAD.GuiUp:
     from draftviewproviders.view_hatch import ViewProviderDraftHatch
+    import draftutils.gui_utils as gui_utils
 
 def make_hatch(baseobject, filename, pattern, scale, rotation, translate=True):
 
@@ -46,4 +47,6 @@ def make_hatch(baseobject, filename, pattern, scale, rotation, translate=True):
     obj.Translate = translate
     if FreeCAD.GuiUp:
         ViewProviderDraftHatch(obj.ViewObject)
+        gui_utils.format_object(obj)
+        gui_utils.autogroup(obj)
     return obj


### PR DESCRIPTION
As the title says - this patch adds autogroup to hatch, so when created it will be put in active group.

Before:

https://github.com/user-attachments/assets/f4f32f52-7a81-4447-989e-206c28fb15c8

After:

https://github.com/user-attachments/assets/3a09d599-3a36-4921-b647-0969dd35654a


Resolves: https://github.com/FreeCAD/FreeCAD/issues/23089