### PR TITLE
Part: Remove mode from Offset, keep in Offset2D

### DIFF
--- a/src/Mod/Part/App/FeatureOffset.cpp
+++ b/src/Mod/Part/App/FeatureOffset.cpp
@@ -33,7 +33,6 @@
 
 using namespace Part;
 
-const char* Part::Offset::ModeEnums[]= {"Skin","Pipe", "RectoVerso",nullptr};
 const char* Part::Offset::JoinEnums[]= {"Arc","Tangent", "Intersection",nullptr};
 
 PROPERTY_SOURCE(Part::Offset, Part::Feature)
@@ -42,8 +41,6 @@ Offset::Offset()
 {
     ADD_PROPERTY_TYPE(Source,(nullptr),"Offset",App::Prop_None,"Source shape");
     ADD_PROPERTY_TYPE(Value,(1.0),"Offset",App::Prop_None,"Offset value");
-    ADD_PROPERTY_TYPE(Mode,(long(0)),"Offset",App::Prop_None,"Mode");
-    Mode.setEnums(ModeEnums);
     ADD_PROPERTY_TYPE(Join,(long(0)),"Offset",App::Prop_None,"Join type");
     Join.setEnums(JoinEnums);
     ADD_PROPERTY_TYPE(Intersection,(false),"Offset",App::Prop_None,"Intersection");
@@ -60,8 +57,6 @@ short Offset::mustExecute() const
     if (Source.isTouched())
         return 1;
     if (Value.isTouched())
-        return 1;
-    if (Mode.isTouched())
         return 1;
     if (Join.isTouched())
         return 1;
@@ -83,25 +78,28 @@ App::DocumentObjectExecReturn *Offset::execute()
     double tol = Precision::Confusion();
     bool inter = Intersection.getValue();
     bool self = SelfIntersection.getValue();
-    short mode = (short)Mode.getValue();
     bool fill = Fill.getValue();
     auto shape = Feature::getTopoShape(source, ShapeOption::ResolveLink | ShapeOption::Transform);
     if(shape.isNull())
         return new App::DocumentObjectExecReturn("Invalid source link");
     auto join = static_cast<JoinType>(Join.getValue());
     this->Shape.setValue(TopoShape(0).makeElementOffset(
-        shape,offset,tol,inter,self,mode,join,fill ? FillType::fill : FillType::noFill));
+        shape,offset,tol,inter,self,0,join,fill ? FillType::fill : FillType::noFill));
     return App::DocumentObject::StdReturn;
 }
 
 
 //-------------------------------------------------------------------------------------------------------
 
+const char* Part::Offset2D::ModeEnums[]= {"Skin","Pipe",nullptr};
 
 PROPERTY_SOURCE(Part::Offset2D, Part::Offset)
 
 Offset2D::Offset2D()
 {
+    ADD_PROPERTY_TYPE(Mode,(long(0)),"Offset",App::Prop_None,"Mode");
+    Mode.setEnums(ModeEnums);
+
     this->SelfIntersection.setStatus(App::Property::Status::Hidden, true);
     this->Mode.setValue(1); //switch to Pipe mode by default, because skin mode does not function properly on closed profiles.
 }
@@ -139,8 +137,6 @@ App::DocumentObjectExecReturn *Offset2D::execute()
     double offset = Value.getValue();
     short mode = (short)Mode.getValue();
     auto openresult = mode == 0 ? OpenResult::allowOpenResult : OpenResult::noOpenResult;
-    if (mode == 2)
-        return new App::DocumentObjectExecReturn("Mode 'Recto-Verso' is not supported for 2D offset.");
     auto join = static_cast<JoinType>(Join.getValue());
     auto fill = Fill.getValue() ? FillType::fill : FillType::noFill;
     bool inter = Intersection.getValue();

--- a/src/Mod/Part/App/FeatureOffset.h
+++ b/src/Mod/Part/App/FeatureOffset.h
@@ -41,7 +41,6 @@ public:
 
     App::PropertyLink  Source;
     App::PropertyFloat Value;
-    App::PropertyEnumeration Mode;
     App::PropertyEnumeration Join;
     App::PropertyBool Intersection;
     App::PropertyBool SelfIntersection;
@@ -58,7 +57,6 @@ public:
     //@}
 
 private:
-    static const char* ModeEnums[];
     static const char* JoinEnums[];
 };
 
@@ -69,6 +67,8 @@ public:
     Offset2D();
     ~Offset2D() override;
 
+    App::PropertyEnumeration Mode;
+
     /** @name methods override feature */
     //@{
     /// recalculate the feature
@@ -78,6 +78,9 @@ public:
         return "PartGui::ViewProviderOffset2D";
     }
     //@}
+
+private: 
+    static const char* ModeEnums[];
 };
 
 }

--- a/src/Mod/Part/Gui/TaskOffset.ui
+++ b/src/Mod/Part/Gui/TaskOffset.ui
@@ -47,11 +47,6 @@
        <string>Pipe</string>
       </property>
      </item>
-     <item>
-      <property name="text">
-       <string>Recto verso</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item row="2" column="0">


### PR DESCRIPTION
This removes the mode setting from Offset as it isn't implemented in OCCT.
Since Offset2D inherits from Offset, I moved the mode to Offset2D.
The third mode isn't available in Offset2D so I removed that completely.

I've exported some test models using 1.0.0 and the models keeps the mode in the offset2d features.
[offset-tests.zip](https://github.com/user-attachments/files/22051928/offset-tests.zip)

The ui for offset2d looks the same as previously and the offset feature looks like this:
<img width="302" height="349" alt="image" src="https://github.com/user-attachments/assets/d0d984b5-5555-4179-92c2-dae7098073b7" />

Fixes part of https://github.com/FreeCAD/FreeCAD/issues/6885