### PR TITLE
Mesh: fix #18801 - simply call `gmsh` if gmsh executable path is empty

### DIFF
--- a/src/Mod/Mesh/Gui/RemeshGmsh.cpp
+++ b/src/Mod/Mesh/Gui/RemeshGmsh.cpp
@@ -184,6 +184,9 @@ void GmshWidget::accept()
     if (writeProject(inpFile, outFile)) {
         // ./gmsh - -bin -2 /tmp/mesh.geo -o /tmp/best.stl
         QString proc = d->ui.fileChooser->fileName();
+        if (proc.isEmpty()) {
+            proc = QLatin1String("gmsh");
+        }
         QStringList args;
         args << QLatin1String("-")
              << QLatin1String("-bin")

--- a/src/Mod/Mesh/Gui/RemeshGmsh.ui
+++ b/src/Mod/Mesh/Gui/RemeshGmsh.ui
@@ -137,6 +137,9 @@
         </item>
         <item>
          <widget class="Gui::PrefFileChooser" name="fileChooser">
+          <property name="toolTip">
+           <string>Leave empty to use default gmsh executable</string>
+          </property>
           <property name="prefEntry" stdset="0">
            <cstring>gmshExe</cstring>
           </property>


### PR DESCRIPTION
fix #18801 by just calling `gmsh` so the user doesn't need to manually provide the executable path, we provide gmsh with most (all?) of our distributions so this gives a better user experience