### PR TITLE
Mesh: Add boost/agorithm/string.hpp to PCH

### DIFF
--- a/src/Mod/Mesh/App/PreCompiled.h
+++ b/src/Mod/Mesh/App/PreCompiled.h
@@ -60,6 +60,7 @@
 #include <vector>
 
 // boost
+#include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/lexical_cast.hpp>


### PR DESCRIPTION
Mesh compilation fails on MSVC with PCH enabled because `boost::starts_with` is defined in a header not previously included in the PCH file.