### PR TITLE
PartDesign: only warn on refine failure

### DIFF
--- a/src/Mod/PartDesign/App/FeatureRefine.h
+++ b/src/Mod/PartDesign/App/FeatureRefine.h
@@ -61,7 +61,7 @@ protected:
      * computation is necessary.
      */
     bool onlyHaveRefined();
-    TopoShape refineShapeIfActive(const TopoShape& oldShape, const RefineErrorPolicy onError = RefineErrorPolicy::Raise) const;
+    TopoShape refineShapeIfActive(const TopoShape& oldShape, const RefineErrorPolicy onError = RefineErrorPolicy::Warn) const;
 };
 
 using FeatureRefinePython = App::FeaturePythonT<FeatureRefine>;


### PR DESCRIPTION
As discussed in #20827 this PR change the default error policy for refined feature so it only warns on failure.