### PR TITLE
CAM: Engrave - Improve wires sorting

### DIFF
--- a/src/Mod/CAM/Path/Op/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Engrave.py
@@ -58,6 +58,7 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
             | PathOp.FeatureHeights
             | PathOp.FeatureStepDown
             | PathOp.FeatureBaseEdges
+            | PathOp.FeatureBaseFaces
             | PathOp.FeatureCoolant
             | PathOp.FeatureLinking
         )
@@ -104,6 +105,40 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
             "Path",
             QT_TRANSLATE_NOOP("App::Property", "Approximate complex curves to arcs and lines"),
         )
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "SortingMode",
+            "Sorting",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Order processing of the wires\n"
+                "\nManual - Using order from selection without sorting"
+                "\nAutomatic - Sorting wires by the nearest neighbour method, further improved with 2-opt",
+            ),
+        )
+        obj.SortingMode = ("Automatic", "Manual")
+
+        obj.addProperty(
+            "App::PropertyVectorDistance",
+            "StartPoint",
+            "Sorting",
+            QT_TRANSLATE_NOOP("App::Property", "The start point for sorting"),
+        )
+        obj.addProperty(
+            "App::PropertyVectorDistance",
+            "EndPoint",
+            "Sorting",
+            QT_TRANSLATE_NOOP("App::Property", "The end point for sorting"),
+        )
+        obj.addProperty(
+            "App::PropertyBool",
+            "UseEndPoint",
+            "Sorting",
+            QT_TRANSLATE_NOOP("App::Property", "Use end point for sorting"),
+        )
+        obj.setEditorMode("StartPoint", 2)  # hide
+        obj.setEditorMode("EndPoint", 2)  # hide
+        obj.setEditorMode("UseEndPoint", 2)  # hide
         self.setupAdditionalProperties(obj)
 
     def opOnDocumentRestored(self, obj):
@@ -132,12 +167,54 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
                 "Path",
                 QT_TRANSLATE_NOOP("App::Property", "Approximate complex curves to arcs and lines"),
             )
+        if not hasattr(obj, "SortingMode"):
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "SortingMode",
+                "Sorting",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Order processing of the wires\n"
+                    "\nManual - Using order from selection without sorting"
+                    "\nAutomatic - Sorting wires by the nearest neighbour method, further improved with 2-opt",
+                ),
+            )
+            obj.SortingMode = ("Automatic", "Manual")
+        if not hasattr(obj, "StartPoint"):
+            obj.addProperty(
+                "App::PropertyVectorDistance",
+                "StartPoint",
+                "Sorting",
+                QT_TRANSLATE_NOOP("App::Property", "The start point for sorting"),
+            )
+            obj.setEditorMode("StartPoint", 2)  # hide
+        if not hasattr(obj, "EndPoint"):
+            obj.addProperty(
+                "App::PropertyVectorDistance",
+                "EndPoint",
+                "Sorting",
+                QT_TRANSLATE_NOOP("App::Property", "The end point for sorting"),
+            )
+            obj.setEditorMode("EndPoint", 2)  # hide
+        if not hasattr(obj, "UseEndPoint"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "UseEndPoint",
+                "Sorting",
+                QT_TRANSLATE_NOOP("App::Property", "Use end point for sorting"),
+            )
+            obj.setEditorMode("UseEndPoint", 2)  # hide
 
         self.setupAdditionalProperties(obj)
 
     def opExecute(self, obj):
         """opExecute(obj) ... process engraving operation"""
         Path.Log.track()
+
+        SortingMode = 0 if obj.SortingMode == "Automatic" else 2
+        obj.setEditorMode("StartPoint", SortingMode)
+        obj.setEditorMode("EndPoint", SortingMode)
+        obj.setEditorMode("UseEndPoint", SortingMode)
 
         jobshapes = []
 

--- a/src/Mod/CAM/Path/Op/EngraveBase.py
+++ b/src/Mod/CAM/Path/Op/EngraveBase.py
@@ -27,7 +27,7 @@ import Path
 import Path.Base.Generator.linking as linking
 import Path.Op.Base as PathOp
 import Path.Op.Util as PathOpUtil
-import PathScripts.PathUtils as PathUtils
+import tsp_solver
 
 __doc__ = "Base class for all ops in the engrave family."
 
@@ -106,14 +106,61 @@ class ObjectOp(PathOp.ObjectOp):
             for se in Part.sortEdges(wire.Edges)
         ]
 
-        # sort wires, adapted from Area.py
-        if len(wires) > 1:
-            locations = []
-            for w in wires:
-                locations.append({"x": w.BoundBox.Center.x, "y": w.BoundBox.Center.y, "wire": w})
+        # sorting wires
+        if len(wires) > 1 and getattr(obj, "SortingMode", None) == "Automatic":
+            endPoint = obj.EndPoint if obj.UseEndPoint else None
+            if len(zValues) % 2 == 0 and biDir:  # sorting pairs points
+                pairs = []
+                for indexWire, wire in enumerate(wires):
+                    indexAlt = -1 if not wire.isClosed() else 0
+                    pairs.append(
+                        {
+                            "x": wire.Vertexes[0].X,
+                            "y": wire.Vertexes[0].Y,
+                            "xAlt": wire.Vertexes[indexAlt].X,
+                            "yAlt": wire.Vertexes[indexAlt].Y,
+                            "index": indexWire,
+                        }
+                    )
 
-            locations = PathUtils.sort_locations(locations, ["x", "y"])
-            wires = [j["wire"] for j in locations]
+                sortedPairs = tsp_solver.solvePairs(
+                    pairs, routeStartPoint=obj.StartPoint, routeEndPoint=endPoint
+                )
+                orderedWires = []
+                for pair in sortedPairs:
+                    x = wires[pair["index"]].Vertexes[0].X
+                    y = wires[pair["index"]].Vertexes[0].Y
+                    if pair["x"] != x or pair["y"] != y:
+                        orderedWires.append(Path.Geom.flipWire(wires[pair["index"]]))
+                    else:
+                        orderedWires.append(wires[pair["index"]])
+
+            else:  # sorting tunnels
+                tunnels = []
+                for wire in wires:
+                    indexEnd = -1 if not wire.isClosed() else 0
+                    tunnels.append(
+                        {
+                            "startX": wire.Vertexes[0].X,
+                            "startY": wire.Vertexes[0].Y,
+                            "endX": wire.Vertexes[indexEnd].X,
+                            "endY": wire.Vertexes[indexEnd].Y,
+                        }
+                    )
+                sortedTunnels = tsp_solver.solveTunnels(
+                    tunnels,
+                    allowFlipping=biDir,
+                    routeStartPoint=obj.StartPoint,
+                    routeEndPoint=endPoint,
+                )
+                orderedWires = []
+                for tunnel in sortedTunnels:
+                    if tunnel["flipped"]:
+                        orderedWires.append(Path.Geom.flipWire(wires[tunnel["index"]]))
+                    else:
+                        orderedWires.append(wires[tunnel["index"]])
+
+            wires = orderedWires
 
         tool_pos = None  # tracks tool position between entry moves
 


### PR DESCRIPTION
### Changes:
- `Manual` or `Automatic` sorting
- `Automatic` sorting with `Bidirectional` cut pattern allows to select optimal start point from open wire

[Link to forum discussion](https://forum.freecad.org/viewtopic.php?p=844366#p844366)
[Macro to measure Path](https://raw.githubusercontent.com/tarman3/FreeCAD_Macros/refs/heads/main/PathLength.FCMacro)

<img width="1062" height="525" alt="Screenshot_20250830_221659_hor" src="https://github.com/user-attachments/assets/24ece6a8-c1e7-46de-93d5-f45e67089421" />