### PR TITLE
BIM+Draft: change object related version info to log messages

### DIFF
--- a/src/Mod/BIM/ArchSchedule.py
+++ b/src/Mod/BIM/ArchSchedule.py
@@ -94,21 +94,21 @@ class _ArchSchedule:
             self.update_properties_1v1(obj)
 
     def update_properties_0v21(self,obj):
-        from draftutils.messages import _wrn
+        from draftutils.messages import _log
         sp = obj.Result
         if sp is not None:
             self.setSchedulePropertySpreadsheet(sp, obj)
         obj.removeProperty("Result")
-        _wrn("v0.21, " + obj.Label + ", " + translate("Arch", "removed property 'Result', and added property 'AutoUpdate'"))
+        _log("v0.21, " + obj.Name + ", removed property 'Result', and added property 'AutoUpdate'")
         if sp is not None:
-            _wrn("v0.21, " + sp.Label + ", " + translate("Arch", "added property 'Schedule'"))
+            _log("v0.21, " + sp.Name + ", added property 'Schedule'")
 
     def update_properties_1v1(self,obj):
-        from draftutils.messages import _wrn
+        from draftutils.messages import _log
         if obj.getTypeIdOfProperty("Description") == "App::PropertyStringList":
             obj.Operation = obj.Description
             obj.removeProperty("Description")
-            _wrn("v1.1, " + obj.Label + ", " + translate("Arch", "renamed property 'Description' to 'Operation'"))
+            _log("v1.1, " + obj.Name + ", renamed property 'Description' to 'Operation'")
         for prop in ("Operation", "Value", "Unit", "Objects", "Filter", "CreateSpreadsheet", "DetailedResults"):
             obj.setGroupOfProperty(prop,"Schedule")
 

--- a/src/Mod/BIM/ArchStairs.py
+++ b/src/Mod/BIM/ArchStairs.py
@@ -48,11 +48,8 @@ from draftutils import params
 if FreeCAD.GuiUp:
     from PySide.QtCore import QT_TRANSLATE_NOOP
     import FreeCADGui
-    from draftutils.translate import translate
 else:
     # \cond
-    def translate(ctxt,txt):
-        return txt
     def QT_TRANSLATE_NOOP(ctxt,txt):
         return txt
     # \endcond
@@ -290,9 +287,14 @@ class _Stairs(ArchComponent.Component):
         obj.removeProperty("OutlineWireLeft")
         obj.removeProperty("OutlineWireRight")
         self.update_properties_to_0v20(obj)
-        from draftutils.messages import _wrn
-        _wrn("v0.20.3, " + obj.Label + ", "
-             + translate("Arch", "removed properties 'OutlineWireLeft' and 'OutlineWireRight', and added properties 'RailingLeft' and 'RailingRight'"))
+        from draftutils.messages import _log
+        _log(
+            "v0.20.3, "
+            + obj.Name
+            + ", "
+            + "removed properties 'OutlineWireLeft' and 'OutlineWireRight', "
+            + "and added properties 'RailingLeft' and 'RailingRight'"
+        )
 
     def update_properties_0v19_to_0v20(self, obj):
         doc = FreeCAD.ActiveDocument
@@ -304,9 +306,13 @@ class _Stairs(ArchComponent.Component):
         obj.RailingLeft = railingLeftObject
         obj.RailingRight = railingRightObject
         self.update_properties_to_0v20(obj)
-        from draftutils.messages import _wrn
-        _wrn("v0.20.3, " + obj.Label + ", "
-             + translate("Arch", "changed the type of properties 'RailingLeft' and 'RailingRight'"))
+        from draftutils.messages import _log
+        _log(
+            "v0.20.3, "
+            + obj.Name
+            + ", "
+            + "changed the type of properties 'RailingLeft' and 'RailingRight'"
+        )
 
     def update_properties_to_0v20(self, obj):
         additions = obj.Additions

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -256,7 +256,7 @@ class _Wall(ArchComponent.Component):
         """Method run when the document is restored. Re-adds the Arch component, and Arch wall properties."""
 
         import DraftGeomUtils
-        from draftutils.messages import _wrn
+        from draftutils.messages import _log
 
         ArchComponent.Component.onDocumentRestored(self,obj)
         self.setProperties(obj)
@@ -274,15 +274,15 @@ class _Wall(ArchComponent.Component):
                 and not obj.Base.isDerivedFrom("Sketcher::SketchObject") \
                 and DraftGeomUtils.get_shape_normal(obj.Base.Shape) != Vector(0, 0, 1):
             obj.Normal = Vector(0, 0, 1)
-            _wrn(
+            _log(
                 "v1.0, "
-                + obj.Label
+                + obj.Name
                 + ", "
-                + translate("Arch", "changed 'Normal' to [0, 0, 1] to preserve extrusion direction")
+                + "changed 'Normal' to [0, 0, 1] to preserve extrusion direction"
             )
 
         if hasattr(obj,"ArchSketchData") and obj.ArchSketchData and Draft.getType(obj.Base) == "ArchSketch":
-            if hasattr(obj,"Width"):	# TODO need test?
+            if hasattr(obj,"Width"):  # TODO need test?
                 obj.setEditorMode("Width", ["ReadOnly"])
             if hasattr(obj,"Align"):
                 obj.setEditorMode("Align", ["ReadOnly"])

--- a/src/Mod/Draft/draftobjects/array.py
+++ b/src/Mod/Draft/draftobjects/array.py
@@ -39,8 +39,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD as App
 import DraftVecUtils
 
-from draftutils.messages import _wrn
-from draftutils.translate import translate
+from draftutils.messages import _log
 
 from draftobjects.draftlink import DraftLink
 
@@ -71,9 +70,9 @@ class Array(DraftLink):
             return
 
         if not hasattr(obj, "Count"):
-            _wrn("v0.21, " + obj.Label + ", " + translate("draft", "added property 'Count'"))
+            _log("v0.21, " + obj.Name + ", added property 'Count'")
         if not hasattr(obj, "PlacementList"):
-            _wrn("v1.1, " + obj.Label + ", " + translate("draft", "added hidden property 'PlacementList'"))
+            _log("v1.1, " + obj.Name + ", added hidden property 'PlacementList'")
 
         self.set_general_properties(obj)
         self.execute(obj) # Required to update Count and/or PlacementList.

--- a/src/Mod/Draft/draftobjects/clone.py
+++ b/src/Mod/Draft/draftobjects/clone.py
@@ -33,8 +33,7 @@ import FreeCAD as App
 import DraftVecUtils
 from draftobjects.base import DraftObject
 from draftutils import gui_utils
-from draftutils.messages import _wrn
-from draftutils.translate import translate
+from draftutils.messages import _log
 
 
 class Clone(DraftObject):
@@ -72,7 +71,7 @@ class Clone(DraftObject):
         if hasattr(obj, "ForceCompound"):
             return
         self.set_properties(obj)
-        _wrn("v1.1, " + obj.Label + ", " + translate("draft", "added 'ForceCompound' property"))
+        _log("v1.1, " + obj.Name + ", added 'ForceCompound' property")
 
     def join(self, obj, shapes):
         fuse = getattr(obj, "Fuse", False)

--- a/src/Mod/Draft/draftobjects/dimension.py
+++ b/src/Mod/Draft/draftobjects/dimension.py
@@ -110,8 +110,7 @@ import WorkingPlane
 from draftobjects.draft_annotation import DraftAnnotation
 from draftutils import gui_utils
 from draftutils import utils
-from draftutils.messages import _wrn
-from draftutils.translate import translate
+from draftutils.messages import _log
 
 
 class DimensionBase(DraftAnnotation):
@@ -198,10 +197,8 @@ class DimensionBase(DraftAnnotation):
         """Update view properties."""
         vobj.Proxy.set_text_properties(vobj, vobj.PropertiesList)
         vobj.TextColor = vobj.LineColor
-        _wrn("v0.21, " + obj.Label + ", "
-             + translate("draft", "added view property 'TextColor'"))
-        _wrn("v0.21, " + obj.Label + ", "
-             + translate("draft", "renamed 'DisplayMode' options to 'World/Screen'"))
+        _log("v0.21, " + obj.Name + ", added view property 'TextColor'")
+        _log("v0.21, " + obj.Name + ", renamed 'DisplayMode' options to 'World/Screen'")
 
 
 class LinearDimension(DimensionBase):

--- a/src/Mod/Draft/draftobjects/draft_annotation.py
+++ b/src/Mod/Draft/draftobjects/draft_annotation.py
@@ -37,8 +37,7 @@ through Coin (pivy).
 
 ## \addtogroup draftobjects
 # @{
-from draftutils.messages import _wrn
-from draftutils.translate import translate
+from draftutils.messages import _log
 
 
 class DraftAnnotation(object):
@@ -78,11 +77,9 @@ class DraftAnnotation(object):
         multiplier = None
         if not hasattr(vobj, "ScaleMultiplier"):
             multiplier = 1.00
-            _wrn("v0.19, " + obj.Label + ", "
-                 + translate("draft", "added view property 'ScaleMultiplier'"))
+            _log("v0.19, " + obj.Name + ", added view property 'ScaleMultiplier'")
         if not hasattr(vobj, "AnnotationStyle"):
-            _wrn("v0.19, " + obj.Label + ", "
-                 + translate("draft", "added view property 'AnnotationStyle'"))
+            _log("v0.19, " + obj.Name + ", added view property 'AnnotationStyle'")
         vobj.Proxy.set_annotation_properties(vobj, vobj.PropertiesList)
         if multiplier is not None:
             vobj.ScaleMultiplier = multiplier
@@ -112,12 +109,7 @@ class DraftAnnotation(object):
                 vobj.ArrowSizeEnd = vobj.ArrowSize
             vobj.setPropertyStatus("ArrowSize", "-LockDynamic")
             vobj.removeProperty("ArrowSize")
-        _wrn(
-            "v1.1, "
-            + obj.Label
-            + ", "
-            + translate("draft", "migrated view properties")
-        )
+        _log("v1.1, " + obj.Name + ", migrated view properties")
 
     def dumps(self):
 

--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -39,7 +39,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 from draftutils import gui_utils
-from draftutils.messages import _wrn
+from draftutils.messages import _log
 
 from draftobjects.base import DraftObject
 
@@ -167,8 +167,7 @@ class DraftLink(DraftObject):
             # all models should use 'use_link' by default
             # and this won't be run.
             self.use_link = bool(self.useLink)
-            _wrn("v0.19, {}, 'useLink' will be migrated "
-                 "to 'use_link'".format(obj.Label))
+            _log("v0.19, {}, 'useLink' will be migrated to 'use_link'".format(obj.Name))
             del self.useLink
 
     def onDocumentRestored(self, obj):

--- a/src/Mod/Draft/draftobjects/label.py
+++ b/src/Mod/Draft/draftobjects/label.py
@@ -36,7 +36,7 @@ import FreeCAD as App
 from FreeCAD import Units as U
 from draftobjects.draft_annotation import DraftAnnotation
 from draftutils import gui_utils
-from draftutils.messages import _wrn
+from draftutils.messages import _log
 from draftutils.translate import translate
 
 
@@ -259,12 +259,9 @@ class Label(DraftAnnotation):
         # switched: "2D text" becomes "World" and "3D text" becomes "Screen".
         # It should be the other way around:
         vobj.DisplayMode = "World" if vobj.DisplayMode == "Screen" else "Screen"
-        _wrn("v0.21, " + obj.Label + ", "
-             + translate("draft", "renamed view property 'TextFont' to 'FontName'"))
-        _wrn("v0.21, " + obj.Label + ", "
-             + translate("draft", "renamed view property 'TextSize' to 'FontSize'"))
-        _wrn("v0.21, " + obj.Label + ", "
-             + translate("draft", "renamed 'DisplayMode' options to 'World/Screen'"))
+        _log("v0.21, " + obj.Name + ", renamed view property 'TextFont' to 'FontName'")
+        _log("v0.21, " + obj.Name + ", renamed view property 'TextSize' to 'FontSize'")
+        _log("v0.21, " + obj.Name + ", renamed 'DisplayMode' options to 'World/Screen'")
 
     def onChanged(self, obj, prop):
         """Execute when a property is changed."""

--- a/src/Mod/Draft/draftobjects/layer.py
+++ b/src/Mod/Draft/draftobjects/layer.py
@@ -33,8 +33,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD as App
 from draftutils import gui_utils
 from draftutils import utils
-from draftutils.messages import _wrn
-from draftutils.translate import translate
+from draftutils.messages import _log
 
 
 class Layer:
@@ -73,7 +72,7 @@ class Layer:
             self.set_properties(obj)
             if group_removed:
                 obj.Group = grp
-                _wrn("v1.0, " + obj.Label + ", " + translate("draft", "changed 'Group' property type"))
+                _log("v1.0, " + obj.Name + ", changed 'Group' property type")
 
         gui_utils.restore_view_object(
             obj, vp_module="view_layer", vp_class="ViewProviderLayer", format=False
@@ -99,7 +98,7 @@ class Layer:
             if hasattr(vobj, "OverrideShapeColorChildren"):  # v0.19 - v0.21
                 vobj.OverrideShapeAppearanceChildren = vobj.OverrideShapeColorChildren
                 vobj.removeProperty("OverrideShapeColorChildren")
-            _wrn("v1.0, " + obj.Label + ", " + translate("draft", "updated view properties"))
+            _log("v1.0, " + obj.Name + ", updated view properties")
 
     def dumps(self):
         """Return a tuple of objects to save or None."""

--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -67,7 +67,7 @@ import FreeCAD as App
 import DraftVecUtils
 import lazy_loader.lazy_loader as lz
 
-from draftutils.messages import _wrn, _err
+from draftutils.messages import _err, _log, _wrn
 from draftutils.translate import translate
 def QT_TRANSLATE_NOOP(ctx,txt): return txt
 from draftobjects.base import DraftObject
@@ -578,19 +578,25 @@ class PathArray(DraftLink):
             return
 
         if hasattr(obj, "PathObj"):
-            _wrn("v0.19, " + obj.Label + ", " + translate("draft", "migrated 'PathObj' property to 'PathObject'"))
+            _log("v0.19, " + obj.Name + ", migrated 'PathObj' property to 'PathObject'")
         if hasattr(obj, "PathSubs"):
-            _wrn("v0.19, " + obj.Label + ", " + translate("draft", "migrated 'PathSubs' property to 'PathSubelements'"))
+            _log("v0.19, " + obj.Name + ", migrated 'PathSubs' property to 'PathSubelements'")
         if hasattr(obj, "Xlate"):
-            _wrn("v0.19, " + obj.Label + ", " + translate("draft", "migrated 'Xlate' property to 'ExtraTranslation'"))
+            _log("v0.19, " + obj.Name + ", migrated 'Xlate' property to 'ExtraTranslation'")
         if not hasattr(obj, "Fuse"):
-            _wrn("v1.0, " + obj.Label + ", " + translate("draft", "added 'Fuse' property"))
+            _log("v1.0, " + obj.Name + ", added 'Fuse' property")
         if obj.getGroupOfProperty("Count") != "Spacing":
-            _wrn("v1.1, " + obj.Label + ", " + translate("draft", "moved 'Count' property to 'Spacing' subsection"))
+            _log("v1.1, " + obj.Name + ", moved 'Count' property to 'Spacing' subsection")
         if not hasattr(obj, "ReversePath"):
-            _wrn("v1.1, " + obj.Label + ", " + translate("draft", "added 'ReversePath', 'SpacingMode', 'SpacingUnit', 'UseSpacingPattern' and 'SpacingPattern' properties"))
+            _log(
+                "v1.1, "
+                + obj.Name
+                + ", "
+                + "added 'ReversePath', 'SpacingMode', 'SpacingUnit', 'UseSpacingPattern' "
+                + "and 'SpacingPattern' properties"
+            )
         if not hasattr(obj, "PlacementList"):
-            _wrn("v1.1, " + obj.Label + ", " + translate("draft", "added hidden property 'PlacementList'"))
+            _log("v1.1, " + obj.Name + ", added hidden property 'PlacementList'")
 
         self.set_properties(obj)
         obj.setGroupOfProperty("Count", "Spacing")
@@ -647,7 +653,10 @@ def placements_on_path(shapeRotation, pathwire, count, xlate, align,
         totalDist += e.Length
         ends.append(totalDist)
 
-    if startOffset > (totalDist - 1e-6):
+    # if align is True the length of the path cannot be zero:
+    minLength = 1e-6 if align else -1e-12
+
+    if startOffset > (totalDist - minLength):
         if startOffset != 0:
             _wrn(
                 translate(
@@ -657,7 +666,7 @@ def placements_on_path(shapeRotation, pathwire, count, xlate, align,
             )
         startOffset = 0
 
-    if endOffset > (totalDist - startOffset - 1e-6):
+    if endOffset > (totalDist - startOffset - minLength):
         if endOffset != 0:
             _wrn(
                 translate(

--- a/src/Mod/Draft/draftobjects/pathtwistedarray.py
+++ b/src/Mod/Draft/draftobjects/pathtwistedarray.py
@@ -48,8 +48,7 @@ object in the Arch Workbench.
 # \brief Provides the object code for the TwistedArray object.
 
 import draftgeoutils.geo_arrays as geo
-from draftutils.messages import _wrn
-from draftutils.translate import translate
+from draftutils.messages import _log
 def QT_TRANSLATE_NOOP(ctx,txt): return txt
 from draftobjects.draftlink import DraftLink
 
@@ -157,9 +156,9 @@ class PathTwistedArray(DraftLink):
             return
 
         if not hasattr(obj, "Fuse"):
-            _wrn("v1.0, " + obj.Label + ", " + translate("draft", "added 'Fuse' property"))
+            _log("v1.0, " + obj.Name + ", added 'Fuse' property")
         if not hasattr(obj, "PlacementList"):
-            _wrn("v1.1, " + obj.Label + ", " + translate("draft", "added hidden property 'PlacementList'"))
+            _log("v1.1, " + obj.Name + ", added hidden property 'PlacementList'")
 
         self.set_properties(obj)
         self.execute(obj) # Required to update PlacementList.

--- a/src/Mod/Draft/draftobjects/pointarray.py
+++ b/src/Mod/Draft/draftobjects/pointarray.py
@@ -34,7 +34,7 @@ import FreeCAD as App
 import DraftVecUtils
 import draftutils.utils as utils
 
-from draftutils.messages import _wrn, _err
+from draftutils.messages import _err, _log
 from draftutils.translate import translate
 from draftobjects.draftlink import DraftLink
 
@@ -155,13 +155,13 @@ class PointArray(DraftLink):
             return
 
         if not hasattr(obj, "ExtraPlacement"):
-            _wrn("v0.19, " + obj.Label + ", " + translate("draft", "added 'ExtraPlacement' property"))
+            _log("v0.19, " + obj.Name + ", added 'ExtraPlacement' property")
         if hasattr(obj, "PointList"):
-            _wrn("v0.19, " + obj.Label + ", " + translate("draft", "migrated 'PointList' property to 'PointObject'"))
+            _log("v0.19, " + obj.Name + ", migrated 'PointList' property to 'PointObject'")
         if not hasattr(obj, "Fuse"):
-            _wrn("v1.0, " + obj.Label + ", " + translate("draft", "added 'Fuse' property"))
+            _log("v1.0, " + obj.Name + ", added 'Fuse' property")
         if not hasattr(obj, "PlacementList"):
-            _wrn("v1.1, " + obj.Label + ", " + translate("draft", "added hidden property 'PlacementList'"))
+            _log("v1.1, " + obj.Name + ", added hidden property 'PlacementList'")
 
         self.set_properties(obj)
         if hasattr(obj, "PointList"):

--- a/src/Mod/Draft/draftobjects/shapestring.py
+++ b/src/Mod/Draft/draftobjects/shapestring.py
@@ -36,7 +36,7 @@ import Part
 from draftgeoutils import faces
 from draftobjects.base import DraftObject
 from draftutils import gui_utils
-from draftutils.messages import _err, _wrn
+from draftutils.messages import _err, _log
 from draftutils.translate import translate
 
 
@@ -117,10 +117,14 @@ class ShapeString(DraftObject):
         obj.KeepLeftMargin = True
         obj.ScaleToSize = False
         obj.Tracking = old_tracking
-        _wrn("v1.0, " + obj.Label + ", "
-             + translate("draft", "added 'Fuse', 'Justification', 'JustificationReference', 'KeepLeftMargin', 'ObliqueAngle' and 'ScaleToSize'  properties"))
-        _wrn("v1.0, " + obj.Label + ", "
-             + translate("draft", "changed 'Tracking' property type"))
+        _log(
+            "v1.0, "
+            + obj.Name
+            + ", "
+            + "added 'Fuse', 'Justification', 'JustificationReference', 'KeepLeftMargin', "
+            + "'ObliqueAngle' and 'ScaleToSize' properties"
+          )
+        _log("v1.0, " + obj.Name + ", changed 'Tracking' property type")
 
     def execute(self, obj):
         if self.props_changed_placement_only():

--- a/src/Mod/Draft/draftobjects/text.py
+++ b/src/Mod/Draft/draftobjects/text.py
@@ -33,8 +33,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD as App
 from draftobjects.draft_annotation import DraftAnnotation
 from draftutils import gui_utils
-from draftutils.messages import _wrn
-from draftutils.translate import translate
+from draftutils.messages import _log
 
 
 class Text(DraftAnnotation):
@@ -95,8 +94,7 @@ class Text(DraftAnnotation):
         # switched: "2D text" becomes "World" and "3D text" becomes "Screen".
         # It should be the other way around:
         vobj.DisplayMode = "World" if vobj.DisplayMode == "Screen" else "Screen"
-        _wrn("v0.21, " + obj.Label + ", "
-             + translate("draft", "renamed 'DisplayMode' options to 'World/Screen'"))
+        _log("v0.21, " + obj.Name + ", renamed 'DisplayMode' options to 'World/Screen'")
 
     def update_properties_1v1(self, obj, vobj):
         if hasattr(vobj, "LineWidth"):
@@ -105,12 +103,7 @@ class Text(DraftAnnotation):
         if hasattr(vobj, "LineColor"):
             vobj.setPropertyStatus("LineColor", "-LockDynamic")
             vobj.removeProperty("LineColor")
-        _wrn(
-            "v1.1, "
-            + obj.Label
-            + ", "
-            + translate("draft", "removed view properties")
-        )
+        _log("v1.1, " + obj.Name + ", removed view properties")
 
     def loads(self, state):
         # Before update_properties_0v21 the self.Type value was stored.

--- a/src/Mod/Draft/draftobjects/wire.py
+++ b/src/Mod/Draft/draftobjects/wire.py
@@ -36,8 +36,7 @@ import DraftVecUtils
 from draftobjects.base import DraftObject
 from draftutils import gui_utils
 from draftutils import params
-from draftutils.messages import _wrn
-from draftutils.translate import translate
+from draftutils.messages import _log
 
 
 class Wire(DraftObject):
@@ -124,12 +123,7 @@ class Wire(DraftObject):
         if hasattr(vobj, "EndArrow"):
             vobj.setPropertyStatus("EndArrow", "-LockDynamic")
             vobj.removeProperty("EndArrow")
-        _wrn(
-            "v1.1, "
-            + obj.Label
-            + ", "
-            + translate("draft", "migrated view properties")
-        )
+        _log("v1.1, " + obj.Name + ", migrated view properties")
 
     def execute(self, obj):
         if self.props_changed_placement_only(obj): # Supplying obj is required because of `Base` and `Tool`.


### PR DESCRIPTION
To inform the user warnings are shown if an object has new or modified properties in the current version. These warnings can however be confusing, especially if there are many. With this PR they are turned into log messages. They have also been moved out of translation, and instead of the object Label the object Name is displayed.

Additionally:
With this PR zero path length warnings for path arrays are only displayed if their Align property is True.

See: #21180.
