### PR TITLE
TechDraw: Add number decimals and reference dimension options to dimension task panel

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -146,6 +146,17 @@ TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *di
     connect(ui->cbArbitraryTolerances, &QCheckBox::stateChanged, this, &TaskDimension::onArbitraryTolerancesChanged);
 #endif
 
+    // Reference
+    std::regex refRegex("\\(%\\.([0-9]+)([fFrRgGwWeE])\\)");
+    if (std::regex_search(currentFormat, refRegex)) {
+        ui->cbReference->setChecked(true);
+    } else {
+        ui->cbReference->setChecked(false);
+    }
+
+    connect(ui->cbReference, &QCheckBox::stateChanged, this, &TaskDimension::onReferenceChanged);
+
+
     // Display Style
     if (dimensionVP) {
         ui->cbArrowheads->setChecked(dimensionVP->FlipArrowheads.getValue());
@@ -257,6 +268,32 @@ void TaskDimension::onNumDecChanged(int decimals)
     ui->leFormatSpecifier->setText(QString::fromStdString(newFormatSpec));
     ui->leFormatSpecifier->blockSignals(false);
 
+    onFormatSpecifierChanged();
+}
+
+void TaskDimension::onReferenceChanged()
+{
+    std::string currentFormat = ui->leFormatSpecifier->text().toUtf8().constData();
+    std::string newFormat = currentFormat;
+    bool isChecked = ui->cbReference->isChecked();
+
+    // Find a format specifier
+    std::regex specRegex("%\\.([0-9]+)([fFrRgGwWeE])");
+    // Find a reference format specifier
+    std::regex refRegex("\\((%\\.([0-9]+)([fFrRgGwWeE]))\\)");
+    
+    if (isChecked) {
+        newFormat = std::regex_replace(currentFormat, specRegex, "($&)");
+
+    } else {
+        newFormat = std::regex_replace(currentFormat, refRegex, "$1");
+    }
+
+    // Update UI
+    ui->leFormatSpecifier->blockSignals(true);
+    ui->leFormatSpecifier->setText(QString::fromStdString(newFormat));
+    ui->leFormatSpecifier->blockSignals(false);
+    
     onFormatSpecifierChanged();
 }
 

--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -148,11 +148,8 @@ TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *di
 
     // Reference
     std::regex refRegex("\\(%\\.([0-9]+)([fFrRgGwWeE])\\)");
-    if (std::regex_search(currentFormat, refRegex)) {
-        ui->cbReference->setChecked(true);
-    } else {
-        ui->cbReference->setChecked(false);
-    }
+    const bool hasReference = std::regex_search(currentFormat, refRegex);
+    ui->cbReference->setChecked(hasReference);
 
     connect(ui->cbReference, &QCheckBox::stateChanged, this, &TaskDimension::onReferenceChanged);
 

--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -281,7 +281,6 @@ void TaskDimension::onReferenceChanged()
     
     if (isChecked) {
         newFormat = std::regex_replace(currentFormat, specRegex, "($&)");
-
     } else {
         newFormat = std::regex_replace(currentFormat, refRegex, "$1");
     }

--- a/src/Mod/TechDraw/Gui/TaskDimension.h
+++ b/src/Mod/TechDraw/Gui/TaskDimension.h
@@ -70,6 +70,7 @@ private Q_SLOTS:
     void onExtUseDefaultClicked();
     void onExtUseSelectionClicked();
     void onNumDecChanged(int decimals);
+    void onReferenceChanged();
 
 private:
     std::unique_ptr<Ui_TaskDimension> ui;

--- a/src/Mod/TechDraw/Gui/TaskDimension.h
+++ b/src/Mod/TechDraw/Gui/TaskDimension.h
@@ -69,12 +69,16 @@ private Q_SLOTS:
     void onDimUseSelectionClicked();
     void onExtUseDefaultClicked();
     void onExtUseSelectionClicked();
+    void onNumDecChanged(int decimals);
 
 private:
     std::unique_ptr<Ui_TaskDimension> ui;
     QGIViewDimension *m_parent;
     Gui::WeakPtrT<ViewProviderDimension> m_dimensionVP;
     std::pair<double, bool> getAngleFromSelection();
+    std::string m_originalFormatChar;
+    std::string m_formatPrefix;
+    std::string m_formatSuffix;
 };
 
 class TaskDlgDimension : public Gui::TaskView::TaskDialog

--- a/src/Mod/TechDraw/Gui/TaskDimension.ui
+++ b/src/Mod/TechDraw/Gui/TaskDimension.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>371</width>
-    <height>698</height>
+    <height>729</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,11 +17,109 @@
    <item>
     <widget class="QGroupBox" name="gbTolerancing">
      <property name="title">
-      <string>Tolerancing</string>
+      <string>Dimension</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <layout class="QGridLayout" name="gridLayout_2">
+       <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,1">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_11">
+          <property name="text">
+           <string>Format specifier</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="leFormatSpecifier">
+          <property name="toolTip">
+           <string>Text to be displayed</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="cbArbitrary">
+          <property name="toolTip">
+           <string>Sets use of 'Format spec' instead of the dimension value</string>
+          </property>
+          <property name="text">
+           <string>Arbitrary text</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>Number of decimals</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QSpinBox" name="sbNumDecimals">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Increments the number of decimals of the selected dimenesion&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbFormatting">
+     <property name="title">
+      <string>Tolerancing</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QGridLayout" name="gridLayout" columnstretch="1,1">
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="cbEqualTolerance">
+          <property name="toolTip">
+           <string>Assign same value to over and under tolerance</string>
+          </property>
+          <property name="text">
+           <string>Equal tolerance</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QLineEdit" name="leFormatSpecifierOverTolerance">
+          <property name="toolTip">
+           <string>Specifies the overtolerance format in printf() style, or arbitrary text</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QCheckBox" name="cbArbitraryTolerances">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uses the tolerance format spec&lt;/p&gt;&lt;p&gt;instead of the tolerance value&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Arbitrary tolerance text</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_12">
+          <property name="text">
+           <string>Undertolerance format specifier</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Overtolerance format specifier</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <widget class="QCheckBox" name="cbTheoreticallyExact">
           <property name="toolTip">
@@ -32,13 +130,10 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="cbEqualTolerance">
+        <item row="5" column="1">
+         <widget class="QLineEdit" name="leFormatSpecifierUnderTolerance">
           <property name="toolTip">
-           <string>Assign same value to over and under tolerance</string>
-          </property>
-          <property name="text">
-           <string>Equal tolerance</string>
+           <string>Specifies the undertolerance format in printf() style, or arbitrary text</string>
           </property>
          </widget>
         </item>
@@ -50,7 +145,7 @@
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="Gui::QuantitySpinBox" name="qsbOvertolerance">
+         <widget class="Gui::QuantitySpinBox" name="qsbOvertolerance" native="true">
           <property name="minimumSize">
            <size>
             <width>0</width>
@@ -62,13 +157,10 @@
 If 'Equal tolerance' is checked this is also
 the negated value for 'Undertolerance'.</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="singleStep">
+          <property name="singleStep" stdset="0">
            <double>0.100000000000000</double>
           </property>
-          <property name="value">
+          <property name="value" stdset="0">
            <double>0.000000000000000</double>
           </property>
          </widget>
@@ -81,7 +173,7 @@ the negated value for 'Undertolerance'.</string>
          </widget>
         </item>
         <item row="3" column="1">
-         <widget class="Gui::QuantitySpinBox" name="qsbUndertolerance">
+         <widget class="Gui::QuantitySpinBox" name="qsbUndertolerance" native="true">
           <property name="minimumSize">
            <size>
             <width>0</width>
@@ -93,89 +185,11 @@ the negated value for 'Undertolerance'.</string>
 If 'Equal tolerance' is checked it will be replaced
 by negative value of 'Overtolerance'.</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="singleStep">
+          <property name="singleStep" stdset="0">
            <double>0.100000000000000</double>
           </property>
-          <property name="value">
+          <property name="value" stdset="0">
            <double>0.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="gbFormatting">
-     <property name="title">
-      <string>Formatting</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_11">
-          <property name="text">
-           <string>Format specifier</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="leFormatSpecifier">
-          <property name="toolTip">
-           <string>Text to be displayed</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="cbArbitrary">
-          <property name="toolTip">
-           <string>Sets use of 'Format spec' instead of the dimension value</string>
-          </property>
-          <property name="text">
-           <string>Arbitrary text</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Overtolerance format specifier</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLineEdit" name="leFormatSpecifierOverTolerance">
-          <property name="toolTip">
-           <string>Specifies the overtolerance format in printf() style, or arbitrary text</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_12">
-          <property name="text">
-           <string>Undertolerance format specifier</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QLineEdit" name="leFormatSpecifierUnderTolerance">
-          <property name="toolTip">
-           <string>Specifies the undertolerance format in printf() style, or arbitrary text</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QCheckBox" name="cbArbitraryTolerances">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uses the tolerance format spec&lt;/p&gt;&lt;p&gt;instead of the tolerance value&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>Arbitrary tolerance text</string>
           </property>
          </widget>
         </item>
@@ -214,7 +228,7 @@ by negative value of 'Overtolerance'.</string>
           <property name="toolTip">
            <string>Color of the dimension</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -231,7 +245,7 @@ by negative value of 'Overtolerance'.</string>
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="Gui::QuantitySpinBox" name="qsbFontSize">
+         <widget class="Gui::QuantitySpinBox" name="qsbFontSize" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -247,13 +261,10 @@ by negative value of 'Overtolerance'.</string>
           <property name="toolTip">
            <string>Font size for text</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="minimum">
+          <property name="minimum" stdset="0">
            <double>0.000000000000000</double>
           </property>
-          <property name="value">
+          <property name="value" stdset="0">
            <double>4.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">

--- a/src/Mod/TechDraw/Gui/TaskDimension.ui
+++ b/src/Mod/TechDraw/Gui/TaskDimension.ui
@@ -66,6 +66,16 @@
           </property>
          </widget>
         </item>
+        <item row="3" column="0">
+         <widget class="QCheckBox" name="cbReference">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Encloses the dimension value in parentheses () to indicate it is for reference only&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Reference</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>


### PR DESCRIPTION
This PR adds 2 new options to the TechDraw dimension task panel.
1) A spinbox to adjust the number of decimal places in the dimension
2) A checkbox to make the dimension a reference ()

This PR also shuffles some of the 2 upper Group Boxes to be more logical in their arrangement. See before and after images.

## Issues
Closes #23460


## Before and After Images
Before
<img width="366" height="694" alt="20250831_22h12m15s_grim" src="https://github.com/user-attachments/assets/1286f98a-048b-40e8-8c58-cab8ea2c19a9" />

After
<img width="372" height="669" alt="20250831_22h02m16s_grim" src="https://github.com/user-attachments/assets/36fa1a85-a8cf-4603-89a0-cbf890b7feb7" />


## Demo of Functionality
This video demos the robustness of the tools. They are able to work around suffixes and prefixes


https://github.com/user-attachments/assets/c1a8b7e7-11e8-4ffd-8380-1ad242a878c8

## Comments
This PR doubles on functionality from the commands "Increase/Decrease Decimals". However, the dimension task panel can only edit one dimension at a time. So commands should not be removed yet.