### PR TITLE
Part: Improve TopoShape::findPlane

### DIFF
--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -3970,7 +3970,7 @@ bool TopoShape::findPlane(gp_Pln& pln, double tol, double atol) const
             else {
                 TopLoc_Location loc;
                 Handle(Geom_Surface) surf = BRep_Tool::Surface(face, loc);
-                GeomLib_IsPlanarSurface check(surf);
+                GeomLib_IsPlanarSurface check(surf, tol);
                 if (check.IsPlanar()) {
                     plane = check.Plan();
                 }


### PR DESCRIPTION
Cherry picked https://github.com/wwmayer/FreeCAD/commit/03c589fb124cbdbd64df796d5f0f911439427a6d

Since OCC 7.7 using GeomLib_IsPlanarSurface without a custom tolerance may fail because the default value is too strict. To fix this problem forward the passed tolerance value to GeomLib_IsPlanarSurface.

This fixes #20633

