### PR TITLE
Gui: Add editing a property tooltip in Property View

### DIFF
--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -714,6 +714,7 @@ enum MenuAction
     MA_RemoveProp,
     MA_RenameProp,
     MA_AddProp,
+    MA_EditPropTooltip,
     MA_EditPropGroup,
     MA_Transient,
     MA_Output,
@@ -774,6 +775,7 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
         if (prop->testStatus(App::Property::PropDynamic)
             && !prop->testStatus(App::Property::LockDynamic)) {
             menu.addAction(tr("Rename Property"))->setData(QVariant(MA_RenameProp));
+            menu.addAction(tr("Edit Property Tooltip"))->setData(QVariant(MA_EditPropTooltip));
         }
     }
 
@@ -932,6 +934,33 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
             Gui::Dialog::DlgAddProperty dlg(Gui::getMainWindow(), std::move(containers));
             dlg.exec();
             return;
+        }
+        case MA_EditPropTooltip: {
+            if (props.size() != 1) {
+                break;
+            }
+
+            App::Property* prop = *props.begin();
+            if (!prop->testStatus(App::Property::PropDynamic)
+                || prop->testStatus(App::Property::LockDynamic)) {
+                break;
+            }
+
+            bool ok = false;
+            const QString currentTooltip = QString::fromUtf8(prop->getDocumentation());
+            QString newTooltip = QInputDialog::getMultiLineText(Gui::getMainWindow(),
+                                                         tr("Edit property tooltip"),
+                                                         tr("Tooltip:"),
+                                                         currentTooltip,
+                                                         &ok);
+            if (!ok || newTooltip == currentTooltip) {
+                break;
+            }
+
+            prop->getContainer()->changeDynamicProperty(prop,
+                                                        prop->getGroup(),
+                                                        newTooltip.toUtf8().constData());
+            break;
         }
         case MA_RenameProp: {
             if (props.size() != 1) {


### PR DESCRIPTION
This PR adds a way to edit the tooltip of a property in the Property View.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
Closes #17419.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
### Before

<img width="1099" height="889" alt="before-edit-tooltip" src="https://github.com/user-attachments/assets/65add46e-ce66-4e93-94b4-3a80541ff42e" />

### After

<img width="1099" height="891" alt="after-edit-tooltip" src="https://github.com/user-attachments/assets/740d87cc-f301-452d-b14b-6c832a8f1990" />

(Note that I tried to capture the context menu and the dialog at once, just for showing everything in one image. Normally, the context menu is not visible anymore if the dialog has appeared.)

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
