### PR TITLE
Revert "Gui: Mark mouse move action handled to skip digging nodes"

### DIFF
--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -762,7 +762,6 @@ SoFCUnifiedSelection::handleEvent(SoHandleEventAction * action)
                     this->touch();
                 }
             }
-            action->setHandled();
         }
     }
     // mouse press events for (de)selection


### PR DESCRIPTION
I have tested that PR before without draggers, but with them it does not properly forward the events to dragges rendering them not usable.

Reverts FreeCAD/FreeCAD#18860