### PR TITLE
Update clang-tidy checks to remove avoid-do-while

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,7 +3,7 @@ Checks:          'clang-diagnostic-*,clang-analyzer-*,boost-*,bugprone-*,
 performance-*,readability-*,portability-*,modernize-*,cppcoreguidelines-*,google-explicit-constructor,
 concurrency-*,-modernize-use-trailing-return-type, -modernize-use-nodiscard,-readability-identifier-length,
 -readability-redundant-access-specifiers,-readability-qualified-auto,
--cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,
+-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-do-while,
 -readability-convert-member-functions-to-static,-bugprone-easily-swappable-parameters,
 -cppcoreguidelines-pro-type-static-cast-downcast'
 WarningsAsErrors: ''


### PR DESCRIPTION
While the advice is good, the overwhelming majority of "do-while" warnings that come up in our codebase are macros using a standard pattern using a do-while loop to encapsulate the macro's work. Maintainers can manually address any actual use of `do...while` during code review.