### PR TITLE
FEM: Amplitude support for final temperature field

### DIFF
--- a/src/Mod/Fem/App/FemConstraintInitialTemperature.cpp
+++ b/src/Mod/Fem/App/FemConstraintInitialTemperature.cpp
@@ -37,6 +37,16 @@ ConstraintInitialTemperature::ConstraintInitialTemperature()
     ADD_PROPERTY(initialTemperature, (300.0));
     ADD_PROPERTY(EnableFinalTemperature, (false));
     ADD_PROPERTY(FinalTemperature, (300.0));
+    ADD_PROPERTY_TYPE(EnableAmplitude,
+                      (false),
+                      "",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude of the final temperature field");
+    ADD_PROPERTY_TYPE(AmplitudeValues,
+                      (std::vector<std::string> {"0, 0", "1, 1"}),
+                      "",
+                      (App::PropertyType)(App::Prop_None),
+                      "Amplitude values");
 }
 
 App::DocumentObjectExecReturn* ConstraintInitialTemperature::execute()

--- a/src/Mod/Fem/App/FemConstraintInitialTemperature.h
+++ b/src/Mod/Fem/App/FemConstraintInitialTemperature.h
@@ -45,6 +45,9 @@ public:
     App::PropertyBool EnableFinalTemperature;
     App::PropertyTemperature FinalTemperature;
 
+    App::PropertyBool EnableAmplitude;
+    App::PropertyStringList AmplitudeValues;
+
     /// recalculate the object
     App::DocumentObjectExecReturn* execute() override;
 

--- a/src/Mod/Fem/femsolver/calculix/write_amplitude.py
+++ b/src/Mod/Fem/femsolver/calculix/write_amplitude.py
@@ -45,6 +45,7 @@ def write_amplitude(f, ccxwriter):
         ccxwriter.member.cons_temperature,
         ccxwriter.member.cons_bodyheatsource,
         ccxwriter.member.cons_rigidbody,
+        ccxwriter.member.cons_initialtemperature,
     ]
 
     for constraint_list in constraint_lists:

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_finaltemperature.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_finaltemperature.py
@@ -60,7 +60,10 @@ def write_constraint(f, femobj, inittemp_obj, ccxwriter):
 
         finaltemp = inittemp_obj.FinalTemperature.getValueAs("K")
 
-        f.write("*TEMPERATURE\n")
+        if inittemp_obj.EnableAmplitude:
+            f.write(f"*TEMPERATURE, AMPLITUDE={inittemp_obj.Name}\n")
+        else:
+            f.write("*TEMPERATURE\n")
         if inittemp_obj.References:
             f.write(f"{inittemp_obj.Name},{finaltemp}\n")
         else:


### PR DESCRIPTION
follow-up on #23277

adds amplitude support for final temperature in the same way as done for multiple other constraints previously (last one was rigid body constraint in #22898)

@marioalexis84 FYI