### PR TITLE
Core: Fix alpha-transparency issue in face color override.

### DIFF
--- a/src/Gui/Selection/SoFCSelectionContext.cpp
+++ b/src/Gui/Selection/SoFCSelectionContext.cpp
@@ -149,11 +149,19 @@ bool SoFCSelectionContextEx::setColors(
     return true;
 }
 
-uint32_t SoFCSelectionContextEx::packColor(const Base::Color &c, bool &hasTransparency) {
-    float trans = std::max(trans0,c.a);
-    if(trans>0)
+uint32_t SoFCSelectionContextEx::packColor(const Base::Color& c, bool& hasTransparency)
+{
+    // Convert Base::Color's alpha (opacity) to transparency for Coin3D.
+    float transparency = 1.0f - c.a;
+
+    // Apply any external transparency override (e.g., from picking).
+    float final_transparency = std::max(trans0, transparency);
+
+    if (final_transparency > 0.0f) {
         hasTransparency = true;
-    return SbColor(c.r,c.g,c.b).getPackedValue(trans);
+    }
+
+    return SbColor(c.r, c.g, c.b).getPackedValue(final_transparency);
 }
 
 bool SoFCSelectionContextEx::applyColor(int idx, std::vector<uint32_t> &packedColors, bool &hasTransparency) {

--- a/src/Gui/TaskElementColors.cpp
+++ b/src/Gui/TaskElementColors.cpp
@@ -173,7 +173,7 @@ public:
             }
             auto color = v.second;
             QColor c;
-            c.setRgbF(color.r, color.g, color.b, 1.0 - color.a);
+            c.setRgbF(color.r, color.g, color.b, color.a);
             px.fill(c);
             auto item = new QListWidgetItem(
                 QIcon(px),
@@ -636,3 +636,4 @@ bool TaskElementColors::reject()
 }
 
 #include "moc_TaskElementColors.cpp"
+


### PR DESCRIPTION
Reported in https://github.com/FreeCAD/FreeCAD/issues/23444#issuecomment-3241268211

There is a bug with transparency / alpha and it's getting switched back and forth. See bug in video : 

https://github.com/user-attachments/assets/428d086c-ccc8-4989-bcda-0ad3d0f47962

The reason is that since Base::Color is now ALPHA based, the colors need to be converted before packing for coin.

@kadet1090 