### PR TITLE
FEM: Add property to disable PaStiX mixed precision for the ccx solver

### DIFF
--- a/src/Mod/Fem/femobjects/solver_calculix.py
+++ b/src/Mod/Fem/femobjects/solver_calculix.py
@@ -330,6 +330,15 @@ class SolverCalculiX(base_fempythonobject.BaseFemPythonObject):
                 value=False,
             )
         )
+        prop.append(
+            _PropHelper(
+                type="App::PropertyBool",
+                name="DisablePastixMixedPrecision",
+                group="Solver",
+                doc="Disable mixed precision for PaStiX matrix solver",
+                value=True,
+            )
+        )
         return prop
 
     def onDocumentRestored(self, obj):

--- a/src/Mod/Fem/femsolver/calculix/calculixtools.py
+++ b/src/Mod/Fem/femsolver/calculix/calculixtools.py
@@ -116,6 +116,8 @@ class CalculiXTools:
             "AnalysisNumCPUs", QThread.idealThreadCount()
         )
         env.insert("OMP_NUM_THREADS", str(num_cpu))
+        if getattr(self.obj, "DisablePastixMixedPrecision", True):
+            env.insert("PASTIX_MIXED_PRECISION","0")
         self.process.setProcessEnvironment(env)
         self.process.setWorkingDirectory(self.obj.WorkingDirectory)
 

--- a/src/Mod/Fem/femsolver/calculix/solver.py
+++ b/src/Mod/Fem/femsolver/calculix/solver.py
@@ -433,6 +433,15 @@ class _BaseSolverCalculix:
             )
             obj.ExcludeBendingStiffness = False
 
+        if not hasattr(obj, "DisablePastixMixedPrecision"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "DisablePastixMixedPrecision",
+                "Fem",
+                "Disable mixed precision for PaStiX matrix solver",
+                locked=True,
+            )
+            obj.DisablePastixMixedPrecision = True
 
 class Proxy(solverbase.Proxy, _BaseSolverCalculix):
     """The Fem::FemSolver's Proxy python type, add solver specific properties"""


### PR DESCRIPTION
Adds new property `DisablePastixMixedPrecision` (true by default) that sets the environment variable PASTIX_MIXED_PRECISION for the ccx solver to 0. This is the recommended setting in most cases due to some issues as explained here: https://github.com/Dhondtguido/CalculiX/issues/104

@marioalexis84 Please check if this env variable is set correctly here. There are no errors after compiling, but I don't know how to see if this gets written correctly when starting the ccx solver (and can't check if the aforementioned issue is present because I don't have PaStiX in my Ubuntu build of ccx).