### PR TITLE
Link: make OverrideMaterial use the per-face override.

### DIFF
--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2059,18 +2059,57 @@ void ViewProviderLink::checkIcon(const App::LinkBaseExtension *ext) {
     }
 }
 
-void ViewProviderLink::applyMaterial() {
-    if(OverrideMaterial.getValue())
-        linkView->setMaterial(-1,&ShapeMaterial.getValue());
+void ViewProviderLink::applyMaterial()
+{
+    if (OverrideMaterial.getValue()) {
+        // Dispatch a generic Coin3D action to the linked object's scene graph.
+        // If the linked object is a Part shape, its SoBrepFaceSet node will
+        // handle this action and apply the color to all its faces.
+        // This is decoupled and respects the core/module architecture.
+
+        // 1. Get the material from our property.
+        const auto& material = ShapeMaterial.getValue();
+
+        // 2. Prepare the color for the rendering action. The action's ultimate
+        // consumer (SoBrepFaceSet) expects a Base::Color where .a is transparency,
+        // so we must perform the conversion here at the boundary.
+        Base::Color renderColor = material.diffuseColor;
+        renderColor.a = 1.0f - material.transparency;
+
+        // 3. Create a map with the "Face" wildcard to signify "all faces".
+        std::map<std::string, Base::Color> colorMap;
+        colorMap["Face"] = renderColor;
+
+        // 4. Create and dispatch the action. We use a secondary context action,
+        // which is the established mechanism for this kind of override.
+        SoSelectionElementAction action(SoSelectionElementAction::Color,
+                                        true);  // true for secondary
+        action.swapColors(colorMap);
+        linkView->getLinkRoot()->doAction(&action);
+
+        // 5. Ensure the old global override mechanism is not used.
+        linkView->setMaterial(-1, nullptr);
+    }
     else {
-        for(int i=0;i<linkView->getSize();++i) {
-            if(MaterialList.getSize()>i &&
-               OverrideMaterialList.getSize()>i && OverrideMaterialList[i])
-                linkView->setMaterial(i,&MaterialList[i]);
-            else
-                linkView->setMaterial(i,nullptr);
+        // OVERRIDE IS DISABLED:
+        // We must clear the per-face override we just applied.
+
+        // 1. Dispatch an empty Color action to clear the secondary context.
+        SoSelectionElementAction action(SoSelectionElementAction::Color, true);
+        linkView->getLinkRoot()->doAction(&action);
+
+        // 2. Re-apply any other material settings (e.g., for array elements,
+        // or clear the old global override if it was set).
+        linkView->setMaterial(-1, nullptr);
+        for (int i = 0; i < linkView->getSize(); ++i) {
+            if (MaterialList.getSize() > i && OverrideMaterialList.getSize() > i
+                && OverrideMaterialList[i]) {
+                linkView->setMaterial(i, &MaterialList[i]);
+            }
+            else {
+                linkView->setMaterial(i, nullptr);
+            }
         }
-        linkView->setMaterial(-1,nullptr);
     }
 }
 

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -685,9 +685,9 @@ std::map<std::string,Base::Color> ViewProviderPartExt::getElementColors(const ch
             bool singleColor = true;
             for (int i = 0; i < size; ++i) {
                 Base::Color faceColor = ShapeAppearance.getDiffuseColor(i);
-                face_color.setTransparency(ShapeAppearance.getTransparency(i));
+                faceColor.setTransparency(ShapeAppearance.getTransparency(i));
                 if (faceColor != color) {
-                    ret[std::string(element, 4) + std::to_string(i + 1)] = face_color;
+                    ret[std::string(element, 4) + std::to_string(i + 1)] = faceColor;
                 }
                 Base::Color firstFaceColor = ShapeAppearance.getDiffuseColor(0);
                 firstFaceColor.setTransparency(ShapeAppearance.getTransparency(0));
@@ -1402,5 +1402,6 @@ void ViewProviderPartExt::handleChangedPropertyName(Base::XMLReader& reader,
         Gui::ViewProviderGeometryObject::handleChangedPropertyName(reader, TypeName, PropName);
     }
 }
+
 
 

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -683,17 +683,19 @@ std::map<std::string,Base::Color> ViewProviderPartExt::getElementColors(const ch
             auto color = ShapeAppearance.getDiffuseColor();
             color.setTransparency(Base::fromPercent(Transparency.getValue()));
             bool singleColor = true;
-            for(int i=0;i<size;++i) {
-                if (ShapeAppearance.getDiffuseColor(i) != color) {
-                    ret[std::string(element, 4) + std::to_string(i + 1)] =
-                        ShapeAppearance.getDiffuseColor(i);
+            for (int i = 0; i < size; ++i) {
+                Base::Color face_color = ShapeAppearance.getDiffuseColor(i);
+                face_color.setTransparency(ShapeAppearance.getTransparency(i));
+                if (face_color != color) {
+                    ret[std::string(element, 4) + std::to_string(i + 1)] = face_color;
                 }
-                singleColor = singleColor
-                    && ShapeAppearance.getDiffuseColor(0) == ShapeAppearance.getDiffuseColor(i);
+                Base::Color first_face_color = ShapeAppearance.getDiffuseColor(0);
+                first_face_color.setTransparency(ShapeAppearance.getTransparency(0));
+                singleColor = singleColor && (face_color == first_face_color);
             }
-            if(size && singleColor) {
+            if (size > 0 && singleColor) {
                 color = ShapeAppearance.getDiffuseColor(0);
-                color.setTransparency(Base::fromPercent(0.0F));
+                color.setTransparency(ShapeAppearance.getTransparency(0));
                 ret.clear();
             }
             ret["Face"] = color;
@@ -1400,3 +1402,4 @@ void ViewProviderPartExt::handleChangedPropertyName(Base::XMLReader& reader,
         Gui::ViewProviderGeometryObject::handleChangedPropertyName(reader, TypeName, PropName);
     }
 }
+

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -684,14 +684,14 @@ std::map<std::string,Base::Color> ViewProviderPartExt::getElementColors(const ch
             color.setTransparency(Base::fromPercent(Transparency.getValue()));
             bool singleColor = true;
             for (int i = 0; i < size; ++i) {
-                Base::Color face_color = ShapeAppearance.getDiffuseColor(i);
+                Base::Color faceColor = ShapeAppearance.getDiffuseColor(i);
                 face_color.setTransparency(ShapeAppearance.getTransparency(i));
-                if (face_color != color) {
+                if (faceColor != color) {
                     ret[std::string(element, 4) + std::to_string(i + 1)] = face_color;
                 }
-                Base::Color first_face_color = ShapeAppearance.getDiffuseColor(0);
-                first_face_color.setTransparency(ShapeAppearance.getTransparency(0));
-                singleColor = singleColor && (face_color == first_face_color);
+                Base::Color firstFaceColor = ShapeAppearance.getDiffuseColor(0);
+                firstFaceColor.setTransparency(ShapeAppearance.getTransparency(0));
+                singleColor = singleColor && (faceColor == firstFaceColor);
             }
             if (size > 0 && singleColor) {
                 color = ShapeAppearance.getDiffuseColor(0);
@@ -1402,4 +1402,5 @@ void ViewProviderPartExt::handleChangedPropertyName(Base::XMLReader& reader,
         Gui::ViewProviderGeometryObject::handleChangedPropertyName(reader, TypeName, PropName);
     }
 }
+
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/23444

<img width="1767" height="811" alt="image" src="https://github.com/user-attachments/assets/f8c02c3c-89ba-4127-9405-458b883c982a" />

@realthunder can you please evaluate this ?
The idea here is that it changes the MaterialOverride behavior. Instead of doing the limited general override, it's using the per-face mechanism on all faces.