### PR TITLE
FEM: Better defaults for mesh export

### DIFF
--- a/src/Mod/Fem/App/AppFemPy.cpp
+++ b/src/Mod/Fem/App/AppFemPy.cpp
@@ -232,8 +232,8 @@ private:
                     else if (file.hasExtension("inp")) {
                         // get Abaqus inp prefs
                         ParameterGrp::handle g = hGrp->GetGroup("Abaqus");
-                        int elemParam = g->GetInt("AbaqusElementChoice", 1);
-                        bool groupParam = g->GetBool("AbaqusWriteGroups", false);
+                        int elemParam = g->GetInt("AbaqusElementChoice", 2);
+                        bool groupParam = g->GetBool("AbaqusWriteGroups", true);
                         // write ABAQUS Output
                         femMesh.writeABAQUS(file.filePath(), elemParam, groupParam);
                     }

--- a/src/Mod/Fem/Gui/DlgSettingsFemExportAbaqus.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemExportAbaqus.ui
@@ -32,18 +32,18 @@
         <item row="0" column="1">
          <widget class="Gui::PrefComboBox" name="comboBoxElemChoiceParam">
           <property name="toolTip">
-           <string>FEM: Only FEM elements will be exported. This means only edges
-not belonging to faces and faces not belonging to volumes.
+           <string>All: All elements will be exported.
 
 Highest: Only the highest elements will be exported. This means volumes for a volume mesh and faces for a shell mesh.
 
-All: All elements will be exported.</string>
+FEM: Only FEM elements will be exported. This means only edges
+not belonging to faces and faces not belonging to volumes.</string>
           </property>
           <property name="statusTip">
            <string/>
           </property>
           <property name="whatsThis">
-           <string>element parameter: FEM: FEM elements only (only edges not belonging to faces and faces not belonging to volumes), Highest: highest elements only, All: all elements</string>
+           <string>element parameter: All: all elements, Highest: highest elements only, FEM: FEM elements only (only edges not belonging to faces and faces not belonging to volumes)</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>AbaqusElementChoice</cstring>
@@ -53,7 +53,7 @@ All: All elements will be exported.</string>
           </property>
           <item>
            <property name="text">
-            <string>FEM</string>
+            <string>All</string>
            </property>
           </item>
           <item>
@@ -63,7 +63,7 @@ All: All elements will be exported.</string>
           </item>
           <item>
            <property name="text">
-            <string>All</string>
+            <string>FEM</string>
            </property>
           </item>
          </widget>

--- a/src/Mod/Fem/Gui/DlgSettingsFemExportAbaqus.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemExportAbaqus.ui
@@ -32,18 +32,18 @@
         <item row="0" column="1">
          <widget class="Gui::PrefComboBox" name="comboBoxElemChoiceParam">
           <property name="toolTip">
-           <string>All: All elements will be exported.
+           <string>FEM: Only FEM elements will be exported. This means only edges
+not belonging to faces and faces not belonging to volumes.
 
 Highest: Only the highest elements will be exported. This means volumes for a volume mesh and faces for a shell mesh.
 
-FEM: Only FEM elements will be exported. This means only edges
-not belonging to faces and faces not belonging to volumes.</string>
+All: All elements will be exported.</string>
           </property>
           <property name="statusTip">
            <string/>
           </property>
           <property name="whatsThis">
-           <string>element parameter: All: all elements, highest: highest elements only, FEM: FEM elements only (only edges not belonging to faces and faces not belonging to volumes)</string>
+           <string>element parameter: FEM: FEM elements only (only edges not belonging to faces and faces not belonging to volumes), Highest: highest elements only, All: all elements</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>AbaqusElementChoice</cstring>
@@ -53,7 +53,7 @@ not belonging to faces and faces not belonging to volumes.</string>
           </property>
           <item>
            <property name="text">
-            <string>All</string>
+            <string>FEM</string>
            </property>
           </item>
           <item>
@@ -63,7 +63,7 @@ not belonging to faces and faces not belonging to volumes.</string>
           </item>
           <item>
            <property name="text">
-            <string>FEM</string>
+            <string>All</string>
            </property>
           </item>
          </widget>
@@ -80,14 +80,14 @@ not belonging to faces and faces not belonging to volumes.</string>
           <property name="toolTip">
            <string>Mesh groups are exported too.
 Every analysis feature and, if there are different materials,
-material consists of two mesh groups, faces and nodes where
+material consists of two mesh groups - faces and nodes where
 the constraint or material is applied.</string>
           </property>
           <property name="text">
            <string/>
           </property>
           <property name="checked">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>AbaqusWriteGroups</cstring>

--- a/src/Mod/Fem/Gui/DlgSettingsFemExportAbaqusImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemExportAbaqusImp.cpp
@@ -61,7 +61,7 @@ void DlgSettingsFemExportAbaqusImp::loadSettings()
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Fem/Abaqus");
-    int index = hGrp->GetInt("AbaqusElementChoice", 0);
+    int index = hGrp->GetInt("AbaqusElementChoice", 2);
     if (index > -1) {
         ui->comboBoxElemChoiceParam->setCurrentIndex(index);
     }

--- a/src/Mod/Fem/femobjects/mesh_gmsh.py
+++ b/src/Mod/Fem/femobjects/mesh_gmsh.py
@@ -256,7 +256,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 name="GroupsOfNodes",
                 group="Mesh Parameters",
                 doc="For each group create not only the elements but the nodes too",
-                value=False,
+                value=True,
             )
         )
         prop.append(


### PR DESCRIPTION
This PR changes some defaults for mesh export:
1. GroupsOfNodes property of the Gmsh mesher enabled by default (without it, node sets are not getting exported which can be confusing)
2. "Which mesh elements to export" preference set to FEM by default (it is usually expected that only the elements used for FEM analyses are exported)
3. "Export group data" preference enabled by default (it's really confusing that other formats get mesh groups exported by default while INP needs explicit setting for it)

@marioalexis84 FYI