### PR TITLE
BIM: update Views Panel and Status Bar icons and some more

### DIFF
--- a/src/Gui/Icons/Std_HideObjects.svg
+++ b/src/Gui/Icons/Std_HideObjects.svg
@@ -66,15 +66,15 @@
          id="stop917" />
     </linearGradient>
     <radialGradient
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.56579776,1.5556263,-1.400577,0.53125337,102.03373,-38.341495)"
-       r="26.352777"
-       fy="24.73864"
-       fx="20.945665"
-       cy="24.73864"
+       xlink:href="#linearGradient3814"
+       id="radialGradient3820-8"
        cx="20.945665"
-       id="radialGradient3820-0-2"
-       xlink:href="#linearGradient3814" />
+       cy="24.73864"
+       fx="20.945665"
+       fy="24.73864"
+       r="26.352777"
+       gradientTransform="matrix(0.56579776,1.5556263,-1.400577,0.53125337,40.033725,-30.341495)"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
      id="metadata2874">
@@ -106,7 +106,7 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer3"
+     id="g2"
      style="display:inline">
     <path
        style="fill:url(#linearGradient3771);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
@@ -120,82 +120,79 @@
        style="fill:#2e3436;fill-opacity:0.392157;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
        d="M 43,3 V 13.00002 H 53 Z"
        id="path2993" />
-    <g
-       transform="matrix(0.60952727,0,0,0.50029644,-49.907082,-1.6810936)"
-       id="g3060-2"
-       style="stroke-width:3.5;stroke-miterlimit:4;stroke-dasharray:none">
-      <path
-         style="fill:#204a87;stroke:none"
-         d="M 181.76846,74.564006 V 110.8957 l -17.89251,14.53268 v -36.3317 z"
-         id="path3150-7-8" />
-      <path
-         style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 163.87595,121.79521 17.89251,-14.53268"
-         id="path3930-1" />
-      <path
-         style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 178.78637,114.52887 V 78.197173"
-         id="path3932-0" />
-      <path
-         style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 181.76846,78.197173 -17.89251,14.53268"
-         id="path3934-2" />
-      <path
-         style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 166.85803,85.463513 V 121.79521"
-         id="path3936-5" />
-      <path
-         style="fill:url(#linearGradient921);fill-opacity:1;stroke:none;stroke-width:3.50043;stroke-miterlimit:4;stroke-dasharray:none"
-         d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.532677 z"
-         id="path3152-1-3" />
-      <path
-         style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 160.89386,89.096683 V 121.79521"
-         id="path3938-2" />
-      <path
-         style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 140.01927,107.26253 23.85668,14.53268"
-         id="path3940-4" />
-      <path
-         style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 143.00136,110.8957 V 78.197173"
-         id="path3942-2" />
-      <path
-         style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-         d="M 181.76846,74.564003 V 110.8957 l -17.89251,14.53268 V 89.096683 Z"
-         id="path3150-5" />
-      <path
-         style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 163.87595,92.729853 140.01927,78.197173"
-         id="path3944-9" />
-      <path
-         style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-         d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.53268 z"
-         id="path3152-9" />
-      <path
-         style="fill:#729fcf;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-         d="m 181.76846,74.564003 -17.89251,14.53268 -23.85668,-14.53268 17.89251,-14.53268 23.85668,14.53268"
-         id="path3156-2" />
-    </g>
-    <g
-       id="g1211"
-       transform="matrix(0.68009161,0,0,0.68009161,-41.415906,6.1210315)">
-      <path
-         id="path3016-4"
-         d="m 65,15.948961 c 14.326599,27.813708 42.65526,28.27173 58,0.147085 -14.59152,-27.868192 -42.637019,-28.337211 -58,-0.147085 z"
-         style="fill:url(#radialGradient3820-0-2);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path3016-7-2"
-         d="M 67.000001,15.953823 C 80.338557,41.118611 106.71352,41.533012 121,16.086902 107.41479,-9.1271781 81.303465,-9.5515298 67.000001,15.953823 Z"
-         style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         style="fill:none;stroke:#2e3436;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 79,4 28,25"
-         id="path906" />
-      <path
-         id="path906-6"
-         d="m 79,4 28,25"
-         style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
+  </g>
+  <g
+     transform="matrix(0.60952727,0,0,0.50029644,-49.907082,-1.6810936)"
+     id="g3060-2"
+     style="display:inline;stroke-width:3.5;stroke-miterlimit:4;stroke-dasharray:none">
+    <path
+       style="fill:#204a87;stroke:none"
+       d="M 181.76846,74.564006 V 110.8957 l -17.89251,14.53268 v -36.3317 z"
+       id="path3150-7-8" />
+    <path
+       style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 163.87595,121.79521 17.89251,-14.53268"
+       id="path3930-1" />
+    <path
+       style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 178.78637,114.52887 V 78.197173"
+       id="path3932-0" />
+    <path
+       style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 181.76846,78.197173 -17.89251,14.53268"
+       id="path3934-2" />
+    <path
+       style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 166.85803,85.463513 V 121.79521"
+       id="path3936-5" />
+    <path
+       style="fill:url(#linearGradient921);fill-opacity:1;stroke:none;stroke-width:3.50043;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.532677 z"
+       id="path3152-1-3" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 160.89386,89.096683 V 121.79521"
+       id="path3938-2" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 140.01927,107.26253 23.85668,14.53268"
+       id="path3940-4" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 143.00136,110.8957 V 78.197173"
+       id="path3942-2" />
+    <path
+       style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 181.76846,74.564003 V 110.8957 l -17.89251,14.53268 V 89.096683 Z"
+       id="path3150-5" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 163.87595,92.729853 140.01927,78.197173"
+       id="path3944-9" />
+    <path
+       style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.53268 z"
+       id="path3152-9" />
+    <path
+       style="fill:#729fcf;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="m 181.76846,74.564003 -17.89251,14.53268 -23.85668,-14.53268 17.89251,-14.53268 23.85668,14.53268"
+       id="path3156-2" />
+  </g>
+  <g
+     id="g1"
+     transform="matrix(0.66677918,0,0,0.66666671,1.1313266,0.99999969)"
+     style="display:inline;stroke-width:1.49987">
+    <path
+       id="path3016"
+       d="M 3.0000003,23.948961 C 17.326599,51.762669 45.655264,52.220691 61.000004,24.096046 46.408481,-3.7721464 18.362981,-4.2411648 3.0000003,23.948961 Z"
+       style="fill:url(#radialGradient3820-8);fill-opacity:1;stroke:#2e3436;stroke-width:2.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3016-7"
+       d="M 5.0000005,23.953823 C 18.338557,49.118611 44.713521,49.533012 59.000001,24.086902 45.41479,-1.1271781 19.303465,-1.5515298 5.0000005,23.953823 Z"
+       style="fill:none;stroke:#888a85;stroke-width:2.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#2e3436;stroke-width:5.99949;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.300259,11.37523 46.028901,37.918662"
+       id="path906-2" />
   </g>
 </svg>

--- a/src/Gui/Icons/Std_HideSelection.svg
+++ b/src/Gui/Icons/Std_HideSelection.svg
@@ -1,30 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="64px"
-   height="64px"
+   width="64"
+   height="64"
    id="svg3057"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title861">Std_HideSelection</title>
   <defs
      id="defs3059">
-    <linearGradient
-       id="linearGradient3862">
-      <stop
-         style="stop-color:#729fcf;stop-opacity:1"
-         offset="0"
-         id="stop3864" />
-      <stop
-         style="stop-color:#204a87;stop-opacity:1"
-         offset="1"
-         id="stop3866" />
-    </linearGradient>
     <linearGradient
        id="linearGradient3814">
       <stop
@@ -36,70 +25,6 @@
          offset="1"
          id="stop3818" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3878">
-      <stop
-         style="stop-color:#000000;stop-opacity:0.58823532;"
-         offset="0"
-         id="stop3880" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0.58823532;"
-         offset="1"
-         id="stop3882" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3870">
-      <stop
-         style="stop-color:#000000;stop-opacity:0.19607843;"
-         offset="0"
-         id="stop3872" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1"
-         id="stop3874" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3858">
-      <stop
-         style="stop-color:#000000;stop-opacity:0.19607843;"
-         offset="0"
-         id="stop3868" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1"
-         id="stop3862" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3839">
-      <stop
-         style="stop-color:#01d6d6;stop-opacity:1;"
-         offset="0"
-         id="stop3841" />
-      <stop
-         style="stop-color:#01d6d6;stop-opacity:0;"
-         offset="1"
-         id="stop3843" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3838-3"
-       id="linearGradient3844-0"
-       x1="0.1544303"
-       y1="0.43078607"
-       x2="64.94799"
-       y2="64.894638"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.83341111,0,0,0.86929423,6.5373399,6.8175926)" />
-    <linearGradient
-       id="linearGradient3838-3">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0"
-         id="stop3840-1" />
-      <stop
-         style="stop-color:#dde0dd;stop-opacity:0.09302326"
-         offset="1"
-         id="stop3842-2" />
-    </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3814"
        id="radialGradient3820"
@@ -107,39 +32,29 @@
        cy="24.73864"
        fx="20.945665"
        fy="24.73864"
-       r="26.352778"
+       r="26.352777"
        gradientTransform="matrix(0.56579776,1.5556263,-1.400577,0.53125337,40.033725,-30.341495)"
        gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       xlink:href="#linearGradient3862"
-       id="radialGradient3868"
-       cx="44.616356"
-       cy="44.709038"
-       fx="44.616356"
-       fy="44.709038"
-       r="16.079005"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0572796,-0.99508664,0.9062161,0.96285465,-49.688012,40.348834)" />
+    <linearGradient
+       id="linearGradient3765-6">
+      <stop
+         id="stop3767-7"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
+      <stop
+         id="stop3769-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
     <linearGradient
        gradientUnits="userSpaceOnUse"
        y2="18"
        x2="31"
        y1="51"
        x1="35"
-       id="linearGradient3771"
-       xlink:href="#linearGradient3765"
+       id="linearGradient3771-1"
+       xlink:href="#linearGradient3765-6"
        gradientTransform="matrix(0.5518208,0,0,0.55482649,4.4577306,27.600091)" />
-    <linearGradient
-       id="linearGradient3765">
-      <stop
-         id="stop3767"
-         offset="0"
-         style="stop-color:#555753;stop-opacity:1" />
-      <stop
-         id="stop3769"
-         offset="1"
-         style="stop-color:#888a85;stop-opacity:1" />
-    </linearGradient>
   </defs>
   <metadata
      id="metadata3062">
@@ -176,7 +91,7 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
+     id="g1">
     <path
        id="path3016"
        d="M 3.0000003,23.948961 C 17.326599,51.762669 45.655264,52.220691 61.000004,24.096046 46.408481,-3.7721464 18.362981,-4.2411648 3.0000003,23.948961 Z"
@@ -186,24 +101,21 @@
        d="M 5.0000005,23.953823 C 18.338557,49.118611 44.713521,49.533012 59.000001,24.086902 45.41479,-1.1271781 19.303465,-1.5515298 5.0000005,23.953823 Z"
        style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#2e3436;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 17,12 45,37"
+       style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 16.546095,11.594726 29.14726,26.024341"
        id="path906" />
+  </g>
+  <g
+     transform="matrix(1.162122,0,0,1.1558264,-6.7132409,-7.586234)"
+     id="g887"
+     style="display:inline">
     <path
-       id="path906-6"
-       d="M 17,12 45,37"
-       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <g
-       transform="matrix(1.162122,0,0,1.1558264,-6.7132409,-7.586234)"
-       id="g887">
-      <path
-         id="path3761"
-         d="m 8.320476,54.786589 4.414566,4.438612 11.036417,-11.09653 3.310925,6.657918 8.829133,-23.302713 -23.176475,8.877224 6.621851,3.328959 z"
-         style="fill:url(#linearGradient3771);fill-opacity:1;stroke:#2e3436;stroke-width:1.76123;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path3763"
-         d="M 9.8756073,54.786589 21.213017,43.336988 15.494147,40.512417 34.005227,33.40055 26.931887,52.012457 24.122618,46.262437 12.735042,57.661599 Z"
-         style="fill:none;stroke:#888a85;stroke-width:1.32092;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
+       id="path3761"
+       d="m 8.320476,54.786589 4.414566,4.438612 11.036417,-11.09653 3.310925,6.657918 8.829133,-23.302713 -23.176475,8.877224 6.621851,3.328959 z"
+       style="display:inline;fill:url(#linearGradient3771-1);fill-opacity:1;stroke:#2e3436;stroke-width:1.76123;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3763"
+       d="M 9.8756073,54.786589 21.213017,43.336988 15.494147,40.512417 34.005227,33.40055 26.931887,52.012457 24.122618,46.262437 12.735042,57.661599 Z"
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.32092;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/Gui/Icons/Std_SelectVisibleObjects.svg
+++ b/src/Gui/Icons/Std_SelectVisibleObjects.svg
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    id="svg3057"
-   height="64px"
-   width="64px">
+   height="64"
+   width="64"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title861">Std_SelectVisibleObjects</title>
   <defs
@@ -47,74 +47,10 @@
          offset="1"
          style="stop-color:#d3d7cf;stop-opacity:1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3878">
-      <stop
-         id="stop3880"
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0.58823532;" />
-      <stop
-         id="stop3882"
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.58823532;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3870">
-      <stop
-         id="stop3872"
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0.19607843;" />
-      <stop
-         id="stop3874"
-         offset="1"
-         style="stop-color:#000000;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3858">
-      <stop
-         id="stop3868"
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0.19607843;" />
-      <stop
-         id="stop3862"
-         offset="1"
-         style="stop-color:#000000;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3839">
-      <stop
-         id="stop3841"
-         offset="0"
-         style="stop-color:#01d6d6;stop-opacity:1;" />
-      <stop
-         id="stop3843"
-         offset="1"
-         style="stop-color:#01d6d6;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.83341111,0,0,0.86929423,6.5373399,6.8175926)"
-       gradientUnits="userSpaceOnUse"
-       y2="64.894638"
-       x2="64.94799"
-       y1="0.43078607"
-       x1="0.1544303"
-       id="linearGradient3844-0"
-       xlink:href="#linearGradient3838-3" />
-    <linearGradient
-       id="linearGradient3838-3">
-      <stop
-         id="stop3840-1"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1" />
-      <stop
-         id="stop3842-2"
-         offset="1"
-         style="stop-color:#dde0dd;stop-opacity:0.09302326" />
-    </linearGradient>
     <radialGradient
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.56579776,1.5556263,-1.400577,0.53125337,40.033725,-22.341495)"
-       r="26.352778"
+       r="26.352777"
        fy="24.73864"
        fx="20.945665"
        cy="24.73864"
@@ -124,33 +60,13 @@
     <radialGradient
        gradientTransform="matrix(1.0572796,-0.99508664,0.9062161,0.96285465,-49.688012,40.348834)"
        gradientUnits="userSpaceOnUse"
-       r="16.079005"
+       r="16.079004"
        fy="44.709038"
        fx="44.616356"
        cy="44.709038"
        cx="44.616356"
        id="radialGradient3868"
        xlink:href="#linearGradient3862" />
-    <linearGradient
-       gradientTransform="matrix(0.5518208,0,0,0.55482649,4.4577306,27.600091)"
-       xlink:href="#linearGradient3765"
-       id="linearGradient3771"
-       x1="35"
-       y1="51"
-       x2="31"
-       y2="18"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3765">
-      <stop
-         style="stop-color:#555753;stop-opacity:1"
-         offset="0"
-         id="stop3767" />
-      <stop
-         style="stop-color:#888a85;stop-opacity:1"
-         offset="1"
-         id="stop3769" />
-    </linearGradient>
     <linearGradient
        xlink:href="#linearGradient919"
        id="linearGradient921"
@@ -159,6 +75,26 @@
        x2="143.52336"
        y2="85.579796"
        gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3765-1">
+      <stop
+         id="stop3767-2"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
+      <stop
+         id="stop3769-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="18"
+       x2="31"
+       y1="51"
+       x1="35"
+       id="linearGradient3771-9-7-3"
+       xlink:href="#linearGradient3765-1"
+       gradientTransform="matrix(0.5518208,0,0,0.55482649,4.4577306,27.600091)" />
   </defs>
   <metadata
      id="metadata3062">
@@ -195,110 +131,108 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
+     id="g929"
+     transform="translate(0.56099874,0.30599931)">
     <g
-       id="g929"
-       transform="translate(0.56099874,0.30599931)">
-      <g
-         style="stroke-width:3.03469;stroke-miterlimit:4;stroke-dasharray:none"
-         id="g902"
-         transform="matrix(0.65904671,0,0,0.65904671,0.63701529,-4.5904668)">
-        <path
-           style="fill:url(#radialGradient3820);fill-opacity:1;stroke:#2e3436;stroke-width:3.03469;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 3.0000003,31.948961 C 17.326599,59.762669 45.655264,60.220691 61.000004,32.096046 46.408481,4.2278536 18.362981,3.7588352 3.0000003,31.948961 Z"
-           id="path3016" />
-        <circle
-           style="fill:url(#radialGradient3868);fill-opacity:1;fill-rule:evenodd;stroke:#204a87;stroke-width:3.03469;stroke-miterlimit:4;stroke-dasharray:none"
-           id="path3808"
-           cx="32"
-           cy="32"
-           r="15" />
-        <circle
-           style="fill:#2e3436;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:3.03469;stroke-miterlimit:4;stroke-dasharray:none"
-           id="path3810"
-           cx="32"
-           cy="32"
-           r="7" />
-        <path
-           style="fill:none;stroke:#888a85;stroke-width:3.03469;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 5.0000005,31.953823 C 18.338557,57.118611 44.713521,57.533012 59.000001,32.086902 45.41479,6.8728219 19.303465,6.4484702 5.0000005,31.953823 Z"
-           id="path3016-7" />
-        <circle
-           style="fill:none;stroke:#729fcf;stroke-width:3.03469;stroke-miterlimit:4;stroke-dasharray:none"
-           id="path3808-0"
-           cx="32"
-           cy="32"
-           r="13" />
-      </g>
+       style="stroke-width:3.03469;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g902"
+       transform="matrix(0.65904671,0,0,0.65904671,0.63701529,-4.5904668)">
+      <path
+         style="fill:url(#radialGradient3820);fill-opacity:1;stroke:#2e3436;stroke-width:3.03469;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 3.0000003,31.948961 C 17.326599,59.762669 45.655264,60.220691 61.000004,32.096046 46.408481,4.2278536 18.362981,3.7588352 3.0000003,31.948961 Z"
+         id="path3016" />
+      <circle
+         style="fill:url(#radialGradient3868);fill-opacity:1;fill-rule:evenodd;stroke:#204a87;stroke-width:3.03469;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path3808"
+         cx="32"
+         cy="32"
+         r="15" />
+      <circle
+         style="fill:#2e3436;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:3.03469;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path3810"
+         cx="32"
+         cy="32"
+         r="7" />
+      <path
+         style="fill:none;stroke:#888a85;stroke-width:3.03469;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 5.0000005,31.953823 C 18.338557,57.118611 44.713521,57.533012 59.000001,32.086902 45.41479,6.8728219 19.303465,6.4484702 5.0000005,31.953823 Z"
+         id="path3016-7" />
+      <circle
+         style="fill:none;stroke:#729fcf;stroke-width:3.03469;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path3808-0"
+         cx="32"
+         cy="32"
+         r="13" />
     </g>
-    <g
-       transform="matrix(0.60952727,0,0,0.50029644,-49.907082,-1.6810936)"
-       id="g3060-2"
-       style="stroke-width:3.5;stroke-miterlimit:4;stroke-dasharray:none">
-      <path
-         style="fill:#204a87;stroke:none"
-         d="M 181.76846,74.564006 V 110.8957 l -17.89251,14.53268 v -36.3317 z"
-         id="path3150-7-8" />
-      <path
-         style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 163.87595,121.79521 17.89251,-14.53268"
-         id="path3930-1" />
-      <path
-         style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 178.78637,114.52887 V 78.197173"
-         id="path3932-0" />
-      <path
-         style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 181.76846,78.197173 -17.89251,14.53268"
-         id="path3934-2" />
-      <path
-         style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 166.85803,85.463513 V 121.79521"
-         id="path3936-5" />
-      <path
-         style="fill:url(#linearGradient921);fill-opacity:1;stroke:none;stroke-width:3.50043;stroke-miterlimit:4;stroke-dasharray:none"
-         d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.532677 z"
-         id="path3152-1-3" />
-      <path
-         style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 160.89386,89.096683 V 121.79521"
-         id="path3938-2" />
-      <path
-         style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 140.01927,107.26253 23.85668,14.53268"
-         id="path3940-4" />
-      <path
-         style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 143.00136,110.8957 V 78.197173"
-         id="path3942-2" />
-      <path
-         style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-         d="M 181.76846,74.564003 V 110.8957 l -17.89251,14.53268 V 89.096683 Z"
-         id="path3150-5" />
-      <path
-         style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 163.87595,92.729853 140.01927,78.197173"
-         id="path3944-9" />
-      <path
-         style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-         d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.53268 z"
-         id="path3152-9" />
-      <path
-         style="fill:#729fcf;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-         d="m 181.76846,74.564003 -17.89251,14.53268 -23.85668,-14.53268 17.89251,-14.53268 23.85668,14.53268"
-         id="path3156-2" />
-    </g>
-    <g
-       id="g887"
-       transform="matrix(1.0662904,0,0,1.060514,-4.7762666,-1.8574072)">
-      <path
-         style="fill:url(#linearGradient3771);fill-opacity:1;stroke:#2e3436;stroke-width:1.76123;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 8.320476,54.786589 4.414566,4.438612 11.036417,-11.09653 3.310925,6.657918 8.829133,-23.302713 -23.176475,8.877224 6.621851,3.328959 z"
-         id="path3761" />
-      <path
-         style="fill:none;stroke:#888a85;stroke-width:1.32092;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 9.8756073,54.786589 21.213017,43.336988 15.494147,40.512417 34.005227,33.40055 26.931887,52.012457 24.122618,46.262437 12.735042,57.661599 Z"
-         id="path3763" />
-    </g>
+  </g>
+  <g
+     transform="matrix(0.60952727,0,0,0.50029644,-49.907082,-1.6810936)"
+     id="g3060-2"
+     style="stroke-width:3.5;stroke-miterlimit:4;stroke-dasharray:none">
+    <path
+       style="fill:#204a87;stroke:none"
+       d="M 181.76846,74.564006 V 110.8957 l -17.89251,14.53268 v -36.3317 z"
+       id="path3150-7-8" />
+    <path
+       style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 163.87595,121.79521 17.89251,-14.53268"
+       id="path3930-1" />
+    <path
+       style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 178.78637,114.52887 V 78.197173"
+       id="path3932-0" />
+    <path
+       style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 181.76846,78.197173 -17.89251,14.53268"
+       id="path3934-2" />
+    <path
+       style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 166.85803,85.463513 V 121.79521"
+       id="path3936-5" />
+    <path
+       style="fill:url(#linearGradient921);fill-opacity:1;stroke:none;stroke-width:3.50043;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.532677 z"
+       id="path3152-1-3" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 160.89386,89.096683 V 121.79521"
+       id="path3938-2" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 140.01927,107.26253 23.85668,14.53268"
+       id="path3940-4" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 143.00136,110.8957 V 78.197173"
+       id="path3942-2" />
+    <path
+       style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 181.76846,74.564003 V 110.8957 l -17.89251,14.53268 V 89.096683 Z"
+       id="path3150-5" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 163.87595,92.729853 140.01927,78.197173"
+       id="path3944-9" />
+    <path
+       style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.53268 z"
+       id="path3152-9" />
+    <path
+       style="fill:#729fcf;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="m 181.76846,74.564003 -17.89251,14.53268 -23.85668,-14.53268 17.89251,-14.53268 23.85668,14.53268"
+       id="path3156-2" />
+  </g>
+  <g
+     transform="matrix(1.0856188,0,0,1.0797624,-5.1290727,-2.8906023)"
+     id="g887-3"
+     style="display:inline;stroke-width:1.07046">
+    <path
+       id="path3761-6"
+       d="m 8.320476,54.786589 4.414566,4.438612 11.036417,-11.09653 3.310925,6.657918 8.829133,-23.302713 -23.176475,8.877224 6.621851,3.328959 z"
+       style="display:inline;fill:url(#linearGradient3771-9-7-3);fill-opacity:1;stroke:#2e3436;stroke-width:1.88532;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3763-0"
+       d="M 9.8756073,54.786589 21.213017,43.336988 15.494147,40.512417 34.005227,33.40055 26.931887,52.012457 24.122618,46.262437 12.735042,57.661599 Z"
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.41399;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/Gui/Icons/Std_ShowSelection.svg
+++ b/src/Gui/Icons/Std_ShowSelection.svg
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="64px"
-   height="64px"
+   width="64"
+   height="64"
    id="svg3057"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title861">Std_ShowSelection</title>
   <defs
@@ -36,70 +36,6 @@
          offset="1"
          id="stop3818" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3878">
-      <stop
-         style="stop-color:#000000;stop-opacity:0.58823532;"
-         offset="0"
-         id="stop3880" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0.58823532;"
-         offset="1"
-         id="stop3882" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3870">
-      <stop
-         style="stop-color:#000000;stop-opacity:0.19607843;"
-         offset="0"
-         id="stop3872" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1"
-         id="stop3874" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3858">
-      <stop
-         style="stop-color:#000000;stop-opacity:0.19607843;"
-         offset="0"
-         id="stop3868" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1"
-         id="stop3862" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3839">
-      <stop
-         style="stop-color:#01d6d6;stop-opacity:1;"
-         offset="0"
-         id="stop3841" />
-      <stop
-         style="stop-color:#01d6d6;stop-opacity:0;"
-         offset="1"
-         id="stop3843" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3838-3"
-       id="linearGradient3844-0"
-       x1="0.1544303"
-       y1="0.43078607"
-       x2="64.94799"
-       y2="64.894638"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.83341111,0,0,0.86929423,6.5373399,6.8175926)" />
-    <linearGradient
-       id="linearGradient3838-3">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0"
-         id="stop3840-1" />
-      <stop
-         style="stop-color:#dde0dd;stop-opacity:0.09302326"
-         offset="1"
-         id="stop3842-2" />
-    </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3814"
        id="radialGradient3820"
@@ -107,7 +43,7 @@
        cy="24.73864"
        fx="20.945665"
        fy="24.73864"
-       r="26.352778"
+       r="26.352777"
        gradientTransform="matrix(0.56579776,1.5556263,-1.400577,0.53125337,40.033725,-22.341495)"
        gradientUnits="userSpaceOnUse" />
     <radialGradient
@@ -117,7 +53,7 @@
        cy="44.709038"
        fx="44.616356"
        fy="44.709038"
-       r="16.079005"
+       r="16.079004"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.0572796,-0.99508664,0.9062161,0.96285465,-49.688012,40.348834)" />
     <linearGradient
@@ -134,11 +70,11 @@
       <stop
          id="stop3767"
          offset="0"
-         style="stop-color:#555753;stop-opacity:1" />
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
       <stop
          id="stop3769"
          offset="1"
-         style="stop-color:#888a85;stop-opacity:1" />
+         style="stop-color:#ffffff;stop-opacity:1;" />
     </linearGradient>
   </defs>
   <metadata
@@ -176,48 +112,47 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       id="g902"
-       transform="translate(0,-8)">
-      <path
-         style="fill:url(#radialGradient3820);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 3.0000003,31.948961 C 17.326599,59.762669 45.655264,60.220691 61.000004,32.096046 46.408481,4.2278536 18.362981,3.7588352 3.0000003,31.948961 Z"
-         id="path3016" />
-      <circle
-         style="fill:url(#radialGradient3868);fill-opacity:1;fill-rule:evenodd;stroke:#204a87;stroke-width:2"
-         id="path3808"
-         cx="32"
-         cy="32"
-         r="15" />
-      <circle
-         style="fill:#2e3436;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2"
-         id="path3810"
-         cx="32"
-         cy="32"
-         r="7" />
-      <path
-         style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 5.0000005,31.953823 C 18.338557,57.118611 44.713521,57.533012 59.000001,32.086902 45.41479,6.8728219 19.303465,6.4484702 5.0000005,31.953823 Z"
-         id="path3016-7" />
-      <circle
-         style="fill:none;stroke:#729fcf;stroke-width:2"
-         id="path3808-0"
-         cx="32"
-         cy="32"
-         r="13" />
-    </g>
-    <g
-       transform="matrix(1.162122,0,0,1.1558264,-6.7132409,-7.586234)"
-       id="g887">
-      <path
-         id="path3761"
-         d="m 8.320476,54.786589 4.414566,4.438612 11.036417,-11.09653 3.310925,6.657918 8.829133,-23.302713 -23.176475,8.877224 6.621851,3.328959 z"
-         style="fill:url(#linearGradient3771);fill-opacity:1;stroke:#2e3436;stroke-width:1.76123;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path3763"
-         d="M 9.8756073,54.786589 21.213017,43.336988 15.494147,40.512417 34.005227,33.40055 26.931887,52.012457 24.122618,46.262437 12.735042,57.661599 Z"
-         style="fill:none;stroke:#888a85;stroke-width:1.32092;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
+     id="g902"
+     transform="translate(0,-8)"
+     style="display:inline">
+    <path
+       style="fill:url(#radialGradient3820);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 3.0000003,31.948961 C 17.326599,59.762669 45.655264,60.220691 61.000004,32.096046 46.408481,4.2278536 18.362981,3.7588352 3.0000003,31.948961 Z"
+       id="path3016" />
+    <circle
+       style="fill:url(#radialGradient3868);fill-opacity:1;fill-rule:evenodd;stroke:#204a87;stroke-width:2"
+       id="path3808"
+       cx="32"
+       cy="32"
+       r="15" />
+    <circle
+       style="fill:#2e3436;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2"
+       id="path3810"
+       cx="32"
+       cy="32"
+       r="7" />
+    <path
+       style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.0000005,31.953823 C 18.338557,57.118611 44.713521,57.533012 59.000001,32.086902 45.41479,6.8728219 19.303465,6.4484702 5.0000005,31.953823 Z"
+       id="path3016-7" />
+    <circle
+       style="fill:none;stroke:#729fcf;stroke-width:2"
+       id="path3808-0"
+       cx="32"
+       cy="32"
+       r="13" />
+  </g>
+  <g
+     transform="matrix(1.162122,0,0,1.1558264,-6.7132409,-7.586234)"
+     id="g887"
+     style="display:inline">
+    <path
+       id="path3761"
+       d="m 8.320476,54.786589 4.414566,4.438612 11.036417,-11.09653 3.310925,6.657918 8.829133,-23.302713 -23.176475,8.877224 6.621851,3.328959 z"
+       style="display:inline;fill:url(#linearGradient3771);fill-opacity:1;stroke:#2e3436;stroke-width:1.76123;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3763"
+       d="M 9.8756073,54.786589 21.213017,43.336988 15.494147,40.512417 34.005227,33.40055 26.931887,52.012457 24.122618,46.262437 12.735042,57.661599 Z"
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.32092;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/Gui/Icons/WhatsThis.svg
+++ b/src/Gui/Icons/WhatsThis.svg
@@ -2,36 +2,19 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="WhatsThis.svg">
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
-       id="linearGradient3870"
-       inkscape:collect="always">
-      <stop
-         id="stop3872"
-         offset="0"
-         style="stop-color:#555753;stop-opacity:1" />
-      <stop
-         id="stop3874"
-         offset="1"
-         style="stop-color:#888a85;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
        id="linearGradient3825">
       <stop
          style="stop-color:#3465a4;stop-opacity:1;"
@@ -43,7 +26,6 @@
          id="stop3829" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3817">
       <stop
          style="stop-color:#204a87;stop-opacity:1"
@@ -55,7 +37,6 @@
          id="stop3821" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3817"
        id="linearGradient3823"
        x1="45"
@@ -63,9 +44,8 @@
        x2="40"
        y2="993.36218"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(2,0)" />
+       gradientTransform="translate(2)" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3825"
        id="linearGradient3831"
        x1="44"
@@ -73,18 +53,8 @@
        x2="43"
        y2="1039.3622"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(2,0)" />
+       gradientTransform="translate(2)" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3765"
-       id="linearGradient3771"
-       x1="35"
-       y1="51"
-       x2="31"
-       y2="18"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
        id="linearGradient3765">
       <stop
          style="stop-color:#d3d7cf;stop-opacity:1;"
@@ -96,45 +66,15 @@
          id="stop3769" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.25881905,-0.96592583,0.96592583,0.25881905,-18.514167,1044.6082)"
-       y2="19.247454"
-       x2="49.928913"
-       y1="47.315048"
-       x1="10.862176"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3849"
-       xlink:href="#linearGradient3870"
-       inkscape:collect="always" />
+       y2="18"
+       x2="31"
+       y1="51"
+       x1="35"
+       id="linearGradient3771-0-8"
+       xlink:href="#linearGradient3765"
+       gradientTransform="matrix(0.5518208,0,0,0.55482649,4.4577306,27.600091)" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="2.1876116"
-     inkscape:cx="-17.318519"
-     inkscape:cy="88.84512"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="837"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:snap-global="true"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3005"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata7">
     <rdf:RDF>
@@ -143,62 +83,48 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
+     id="g1"
      transform="translate(0,-988.36218)">
     <path
-       style="fill:none;stroke:#0b1521;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 34,1000.4737 c 4.063356,-4.35208 5.945884,-5.86192 12.441368,-6.11149 10.077279,0.5307 11.683617,7.03199 11.551427,12.07709 -0.351392,6.7038 -6.753894,8.6997 -12.020912,10.2707 l 0,10.9925"
-       id="path4479"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       style="fill:none;stroke:#0b1521;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34,1000.4737 c 4.063356,-4.35208 5.945884,-5.86192 12.441368,-6.11149 10.077279,0.5307 11.683617,7.03199 11.551427,12.07709 -0.351392,6.7038 -6.753894,8.6997 -12.020912,10.2707 v 10.9925"
+       id="path4479" />
     <path
-       style="fill:none;stroke:#0b1521;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 46,1040.8004 0,3.507"
-       id="path4479-3"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       style="fill:none;stroke:#0b1521;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 46,1040.8004 v 3.507"
+       id="path4479-3" />
     <path
-       style="fill:none;stroke:url(#linearGradient3823);stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 34,1000.4737 c 4.063356,-4.35211 5.945884,-5.86195 12.441368,-6.11152 10.077279,0.5307 11.683617,7.03202 11.551427,12.07712 -0.351392,6.7038 -6.753894,8.6997 -12.020912,10.2707 l 0,10.9925"
-       id="path4479-36"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       style="fill:none;stroke:url(#linearGradient3823);stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34,1000.4737 c 4.063356,-4.35211 5.945884,-5.86195 12.441368,-6.11152 10.077279,0.5307 11.683617,7.03202 11.551427,12.07712 -0.351392,6.7038 -6.753894,8.6997 -12.020912,10.2707 v 10.9925"
+       id="path4479-36" />
     <path
-       style="fill:none;stroke:url(#linearGradient3831);stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 46,1040.8004 0,3.507"
-       id="path4479-3-7"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       style="fill:none;stroke:url(#linearGradient3831);stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 46,1040.8004 v 3.507"
+       id="path4479-3-7" />
     <path
-       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 33.111112,999.74646 c 4.063356,-4.35216 5.945884,-5.862 12.441368,-6.11157 10.077279,0.5307 11.683617,7.03211 11.551427,12.07721 -0.351392,6.7038 -6.753894,8.6997 -12.020912,10.2707 l 0,10.9925"
-       id="path4479-36-5"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 33.111112,999.74646 c 4.063356,-4.35216 5.945884,-5.862 12.441368,-6.11157 10.077279,0.5307 11.683617,7.03211 11.551427,12.07721 -0.351392,6.7038 -6.753894,8.6997 -12.020912,10.2707 v 10.9925"
+       id="path4479-36-5" />
     <path
-       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 45.111112,1040.0732 0,3.507"
-       id="path4479-3-7-3"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 45.111112,1040.0732 v 3.507"
+       id="path4479-3-7-3" />
+  </g>
+  <g
+     transform="matrix(0.46379479,-1.7135627,1.7215288,0.45666036,-67.832629,50.17702)"
+     id="g887"
+     style="display:inline;stroke-width:0.651792">
     <path
-       style="fill:url(#linearGradient3849);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 30.627952,1050.5289 9.797959,-5.6569 -14.142136,-24.4949 13.144024,-2.6897 L 3,991.36218 7.5844325,1036.0722 16.485816,1026.034 z"
-       id="path3761"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccc" />
+       id="path3761-6"
+       d="m 8.320476,54.786589 4.414566,4.438612 11.036417,-11.09653 3.310925,6.657918 8.829133,-23.302713 -23.176475,8.877224 6.621851,3.328959 z"
+       style="display:inline;fill:url(#linearGradient3771-0-8);fill-opacity:1;stroke:#2e3436;stroke-width:1.14795;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 31.357351,1047.8067 -14.615677,-25.1865 -7.5997383,8.6929 -3.6991987,-35.71999 29.084846,21.06359 -11.32819,2.2351 14.504345,25.2508 z"
-       id="path3763"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccc" />
+       id="path3763-1"
+       d="M 9.8756073,54.786589 21.213017,43.336988 15.494147,40.512417 34.005227,33.40055 26.931887,52.012457 24.122618,46.262437 12.735042,57.661599 Z"
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.860964;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/Mod/BIM/Resources/icons/BIM_Background.svg
+++ b/src/Mod/BIM/Resources/icons/BIM_Background.svg
@@ -2,7 +2,7 @@
 <svg
    width="64"
    height="64"
-   viewBox="0 0 16.933333 16.933333"
+   viewBox="0 0 16 16"
    version="1.1"
    id="svg8"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -27,10 +27,10 @@
     <linearGradient
        xlink:href="#linearGradient888"
        id="linearGradient848"
-       x1="5"
-       y1="55"
-       x2="55"
-       y2="5"
+       x1="0"
+       y1="16"
+       x2="16"
+       y2="0"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
@@ -53,6 +53,7 @@
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/BIM/Resources/icons/BIM_Background.svg</dc:identifier>
         <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
       </cc:Work>
       <cc:License
@@ -72,24 +73,20 @@
       </cc:License>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <path
-       style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:0.932327;stroke:#000000;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
-       d="M 15.610416,2.3812502 2.3812502,15.610416 H 15.610416 Z"
-       id="path840" />
-    <path
-       style="color:#000000;overflow:visible;fill:url(#linearGradient848);fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
-       d="M 4.9999999,4.9999999 V 55.000001 L 55.000001,4.9999999 Z"
-       transform="scale(0.26458333)"
-       id="rect833" />
-    <path
-       id="path1"
-       style="color:#000000;overflow:visible;fill:none;fill-opacity:1;stroke:#808080;stroke-width:0.52916667;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
-       d="M 1.8515625,13.273438 C 5.6588542,9.4661458 9.4661458,5.6588542 13.273438,1.8515625 c -3.8072922,0 -7.6145838,0 -11.4218755,0 0,3.8072917 0,7.6145833 0,11.4218755 z" />
-    <path
-       id="path1-7"
-       style="color:#000000;overflow:visible;fill:none;fill-opacity:0.932327;stroke:#c0c0c0;stroke-width:0.52916667;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
-       d="m 3.6601562,15.082031 c 3.8072917,0 7.6145838,0 11.4218748,0 0,-3.807291 0,-7.6145831 0,-11.4218748 C 11.27474,7.4674479 7.4674479,11.27474 3.6601562,15.082031 Z" />
-  </g>
+  <path
+     style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:0.932327;stroke:#2e3436;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+     d="m 14.75,2.25 -12.5,12.5 h 12.5 z"
+     id="path840-0" />
+  <path
+     style="color:#000000;overflow:visible;fill:url(#linearGradient848);fill-opacity:1;stroke:#2e3436;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+     d="M 1.25,13.75 13.75,1.25 H 1.25 Z"
+     id="rect833-2" />
+  <path
+     id="path1-3"
+     style="color:#000000;overflow:visible;fill:none;fill-opacity:1;stroke:#808080;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+     d="M 1.75,12.5 12.5,1.75 H 1.75 Z" />
+  <path
+     id="path1-7-7"
+     style="color:#000000;overflow:visible;fill:none;fill-opacity:0.932327;stroke:#c0c0c0;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+     d="M 3.5,14.25 H 14.25 V 3.5 Z" />
 </svg>

--- a/src/Mod/BIM/Resources/icons/BIM_TogglePanels.svg
+++ b/src/Mod/BIM/Resources/icons/BIM_TogglePanels.svg
@@ -14,78 +14,6 @@
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title1">Terminal</title>
-  <defs
-     id="defs1308">
-    <linearGradient
-       id="linearGradient18">
-      <stop
-         style="stop-color:#4e9a06;stop-opacity:1;"
-         offset="0"
-         id="stop17" />
-      <stop
-         style="stop-color:#181f10;stop-opacity:1;"
-         offset="1"
-         id="stop18" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient1">
-      <stop
-         style="stop-color:#4e9a06;stop-opacity:1;"
-         offset="0"
-         id="stop1" />
-      <stop
-         style="stop-color:#172a04;stop-opacity:1;"
-         offset="1"
-         id="stop2" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2206">
-      <stop
-         style="stop-color:#777973;stop-opacity:1.0000000;"
-         offset="0.0000000"
-         id="stop2208" />
-      <stop
-         style="stop-color:#cbccca;stop-opacity:1.0000000;"
-         offset="1.0000000"
-         id="stop2210" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient2206"
-       id="linearGradient3080"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.94928252,0,0,0.93918318,2.7997684,3.9439835)"
-       x1="29.870447"
-       y1="32.28574"
-       x2="24.841814"
-       y2="14.157946" />
-    <linearGradient
-       xlink:href="#linearGradient1"
-       id="linearGradient2"
-       x1="6.7350527"
-       y1="25.726682"
-       x2="44.430041"
-       y2="25.726682"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99862522,0,0,1.0102174,0.03517192,0.1756917)" />
-    <linearGradient
-       xlink:href="#linearGradient18"
-       id="linearGradient4"
-       x1="7.5632453"
-       y1="36.024754"
-       x2="47.587044"
-       y2="5.7833366"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.99603576,-6.0633115e-8,0.84173619)" />
-    <linearGradient
-       xlink:href="#linearGradient1"
-       id="linearGradient3"
-       gradientUnits="userSpaceOnUse"
-       x1="4.254189"
-       y1="25.283258"
-       x2="44.430041"
-       y2="25.726682"
-       gradientTransform="matrix(0.99111559,0,0,0.99102939,0.2277939,0.29935716)" />
-  </defs>
   <metadata
      id="metadata1311">
     <rdf:RDF>
@@ -95,12 +23,6 @@
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title>Terminal</dc:title>
-        <dc:date>2005-10-15</dc:date>
-        <dc:creator>
-          <cc:Agent>
-            <dc:title>Andreas Nilsson</dc:title>
-          </cc:Agent>
-        </dc:creator>
         <dc:subject>
           <rdf:Bag>
             <rdf:li>terminal</rdf:li>
@@ -109,11 +31,7 @@
             <rdf:li>command line</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:contributor>
-          <cc:Agent>
-            <dc:title>Jakub Steiner</dc:title>
-          </cc:Agent>
-        </dc:contributor>
+        <dc:identifier>FreeCAD/src/Mod/BIM/Resources/icons/BIM_TogglePanels.svg</dc:identifier>
         <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:rights>
           <cc:Agent>
@@ -145,72 +63,20 @@
       </cc:License>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1"
-     transform="matrix(0.89775931,0,0,1.0391947,3.2717033,15.319603)">
-    <g
-       id="g3056"
-       transform="matrix(1.3000412,0,0,1.3000412,-1.2583651,-18.445746)">
-      <rect
-         ry="4.7744656"
-         rx="4.8170815"
-         y="7.3464041"
-         x="3.2450914"
-         height="38.377842"
-         width="44.674904"
-         id="rect1316"
-         style="display:inline;fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1.59267;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         ry="4.7744656"
-         rx="4.8170815"
-         y="7.3464041"
-         x="3.2450914"
-         height="38.377842"
-         width="44.674904"
-         id="rect3"
-         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:url(#linearGradient3080);fill-opacity:1;fill-rule:evenodd;stroke:#eeeeec;stroke-width:1.59274;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
-         d="m 8.0625,8.9375 h 35.041016 c 1.794533,0 3.224609,1.427677 3.224609,3.183594 v 28.828125 c 0,1.755916 -1.430076,3.183593 -3.224609,3.183593 H 8.0625 c -1.7945337,0 -3.2265625,-1.428485 -3.2265625,-3.183593 V 12.121094 C 4.8359375,10.365986 6.2679663,8.9375 8.0625,8.9375 Z" />
-      <rect
-         ry="1.6300802"
-         rx="1.6016922"
-         y="11.787557"
-         x="7.5291123"
-         height="28.755348"
-         width="36.106865"
-         id="rect1314"
-         style="display:inline;fill:url(#linearGradient2);fill-opacity:1;fill-rule:evenodd;stroke:#555753;stroke-width:1.59263;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         ry="1.6300802"
-         rx="1.6016922"
-         y="11.787557"
-         x="7.5291123"
-         height="28.755348"
-         width="36.106865"
-         id="rect4"
-         style="font-variation-settings:normal;display:inline;opacity:1;fill:url(#linearGradient3);fill-opacity:1;fill-rule:evenodd;stroke:#73d216;stroke-width:1.59274;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
-         d="M 9.1308594,13.378906 H 42.035156 l 0.0098,0.03906 v 25.49414 l -0.0098,0.03906 H 9.1308594 l -0.00977,-0.03906 v -25.49414 z" />
-      <g
-         transform="matrix(0.93776916,0,0,1.0022883,2.6436508,3.2282312)"
-         style="display:inline;opacity:1"
-         id="g2286">
-        <path
-           id="path1345"
-           style="display:inline;fill:none;stroke:url(#linearGradient4);stroke-width:1.64274;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 8.0151607,12.259177 H 39.993438 Z m 0,3.035255 H 39.993438 Z m 0,2.299435 H 39.993438 Z m 0,3.035255 H 39.993438 Z m 0,3.035255 H 39.993438 Z m 0,3.036693 H 39.993438 Z m 0,3.035255 H 39.993438 Z m 0,3.035255 H 39.993438 Z" />
-      </g>
-      <path
-         id="text1340"
-         d="M 12.670084,24.150029 V 21.10756 l 9.021843,4.044943 v 1.848675 l -9.021843,4.071479 v -3.033431 l 6.993087,-1.846621 z m 18.970466,9.987224 v 1.966489 H 20.692226 V 34.137253 H 31.64055"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.585px;line-height:125%;font-family:'Bitstream Vera Sans Mono';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#ffffff;fill-opacity:1;stroke:#6ed66e;stroke-width:1.5929;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:0.278689" />
-      <rect
-         ry="0.11987002"
-         rx="0.11602388"
-         y="12.897901"
-         x="8.814373"
-         height="26.530636"
-         width="33.532314"
-         id="rect1340"
-         style="display:inline;opacity:1;fill:none;stroke:#2e3436;stroke-width:1.59274;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    </g>
-  </g>
+  <path
+     id="rect887-5"
+     style="display:inline;overflow:visible;fill:#eeeeec;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linejoin:round;stroke-dasharray:none;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
+     d="M 5,5 H 59 V 59 H 5 Z" />
+  <path
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="M 14,38 24,32 14,26"
+     id="path904-2-0" />
+  <path
+     id="rect887-5-2"
+     style="display:inline;overflow:visible;fill:none;stroke:#c0c0c0;stroke-width:2;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
+     d="M 7,7 H 57 V 57 H 7 Z" />
+  <path
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="M 24,50 H 40"
+     id="path891-2-3-0-3" />
 </svg>

--- a/src/Mod/BIM/Resources/icons/BIM_Views.svg
+++ b/src/Mod/BIM/Resources/icons/BIM_Views.svg
@@ -2,254 +2,53 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
+   width="64"
+   height="64"
    id="svg2985"
    version="1.1"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="BIM_Views.svg">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2987">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient3815">
-      <stop
-         style="stop-color:#d3d7cf;stop-opacity:1;"
-         offset="0"
-         id="stop3817" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="1"
-         id="stop3819" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3815"
-       id="linearGradient3821-3"
-       x1="74.313408"
-       y1="43.419685"
-       x2="48.388607"
-       y2="23.542751"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-24.008315,-25.992831)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3815"
-       id="linearGradient872"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(61.520727,32.775794)"
-       x1="74.313408"
-       y1="43.419685"
-       x2="48.388607"
-       y2="23.542751" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3815"
-       id="linearGradient889"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.79648498,0,0,0.78163648,68.161781,8.3798279)"
-       x1="74.313408"
-       y1="43.419685"
-       x2="48.388607"
-       y2="23.542751" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3815"
-       id="linearGradient915"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.79648498,0,0,0.78163648,68.728175,8.4090819)"
-       x1="74.313408"
-       y1="43.419685"
-       x2="48.388607"
-       y2="23.542751" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3815"
-       id="linearGradient915-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.78163648,-0.79648498,0,56.674107,96.546573)"
-       x1="74.313408"
-       y1="43.419685"
-       x2="48.388607"
-       y2="23.542751" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3815"
-       id="linearGradient915-0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(73.350303,-18.830688)"
-       x1="74.313408"
-       y1="43.419685"
-       x2="48.388607"
-       y2="23.542751" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3815"
-       id="linearGradient953"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.79648498,0,0,0.78163648,68.728175,8.4090819)"
-       x1="74.313408"
-       y1="43.419685"
-       x2="48.388607"
-       y2="23.542751" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3815"
-       id="linearGradient953-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.79648498,0,0,0.78163648,55.984414,8.4090819)"
-       x1="74.313408"
-       y1="43.419685"
-       x2="48.388607"
-       y2="23.542751" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3815"
-       id="linearGradient953-5-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.79648498,0,0,0.78163648,43.240655,8.4090819)"
-       x1="74.313408"
-       y1="43.419685"
-       x2="48.388607"
-       y2="23.542751" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3815"
-       id="linearGradient953-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.78163648,0.79648498,0,7.9916249,-5.7864176)"
-       x1="74.313408"
-       y1="43.419685"
-       x2="48.388607"
-       y2="23.542751" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3815"
-       id="linearGradient953-6-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.78163648,0.79648498,0,7.9916255,6.7197661)"
-       x1="74.313408"
-       y1="43.419685"
-       x2="48.388607"
-       y2="23.542751" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3815"
-       id="linearGradient953-6-3-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.78163648,0.79648498,0,7.9916253,19.225949)"
-       x1="74.313408"
-       y1="43.419685"
-       x2="48.388607"
-       y2="23.542751" />
-  </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="6.6796358"
-     inkscape:cx="34.716092"
-     inkscape:cy="30.877422"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1051"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:snap-bbox="true"
-     inkscape:snap-global="false"
-     inkscape:snap-nodes="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2985"
-       units="px"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true"
-       spacingx="1"
-       spacingy="1"
-       originx="0"
-       originy="0" />
-  </sodipodi:namedview>
-  <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
-    <rect
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient889);fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1.57805169;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       id="rect887"
-       width="47.301254"
-       height="43.192417"
-       x="7.9047585"
-       y="8.3199625" />
-    <path
-       style="opacity:1;vector-effect:none;fill:url(#linearGradient953);fill-opacity:1;fill-rule:evenodd;stroke:#b7bec2;stroke-width:1.57805169;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-       d="M 44.413569,9.1061759 V 50.733911"
-       id="path941"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="opacity:1;vector-effect:none;fill:url(#linearGradient953-6);fill-opacity:1;fill-rule:evenodd;stroke:#b7bec2;stroke-width:1.57805169;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-       d="M 8.701961,18.074901 H 54.387729"
-       id="path941-9"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="opacity:1;vector-effect:none;fill:url(#linearGradient953-5);fill-opacity:1;fill-rule:evenodd;stroke:#b7bec2;stroke-width:1.57805169;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-       d="M 31.669809,9.1061759 V 50.733911"
-       id="path941-2"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="opacity:1;vector-effect:none;fill:url(#linearGradient953-6-3);fill-opacity:1;fill-rule:evenodd;stroke:#b7bec2;stroke-width:1.57805169;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-       d="M 8.701961,30.581083 H 54.387729"
-       id="path941-9-4"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="opacity:1;vector-effect:none;fill:url(#linearGradient953-5-8);fill-opacity:1;fill-rule:evenodd;stroke:#b7bec2;stroke-width:1.57805169;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-       d="M 18.926051,9.1061759 V 50.733911"
-       id="path941-2-3"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="opacity:1;vector-effect:none;fill:url(#linearGradient953-6-3-7);fill-opacity:1;fill-rule:evenodd;stroke:#b7bec2;stroke-width:1.57805169;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-       d="M 8.701961,43.087267 H 54.387729"
-       id="path941-9-4-5"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1.57805169;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-       d="M 14.776508,24.496433 V 43.693064 H 33.916231"
-       id="path891"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccc" />
-    <path
-       style="opacity:1;vector-effect:none;fill:url(#linearGradient915);fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1.57805169;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-       d="m 15.156383,23.90936 -4.054187,7.898705 7.452548,0.0585 z"
-       id="path904"
-       inkscape:connector-curvature="0" />
-    <path
-       style="opacity:1;vector-effect:none;fill:url(#linearGradient915-8);fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1.57805169;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-       d="m 40.879372,43.973485 -8.048753,-3.978605 -0.05962,7.313615 z"
-       id="path904-2"
-       inkscape:connector-curvature="0" />
-  </g>
+     id="defs2987" />
+  <path
+     id="rect887-5"
+     style="display:inline;overflow:visible;fill:#eeeeec;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linejoin:round;stroke-dasharray:none;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
+     d="M 5,5 H 59 V 59 H 5 Z" />
+  <path
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="M 15,31 V 49 H 33"
+     id="path891-2" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="m 41,49 -8,-4 v 8 z"
+     id="path904-2-0" />
+  <path
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="M 31,13 H 51"
+     id="path891-2-3" />
+  <path
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="M 31,19 H 51"
+     id="path891-2-3-0" />
+  <path
+     id="rect887-5-2"
+     style="display:inline;overflow:visible;fill:none;stroke:#c0c0c0;stroke-width:2;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
+     d="M 7,7 H 57 V 57 H 7 Z" />
+  <path
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="M 31,25 H 51"
+     id="path891-2-3-0-9" />
+  <path
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="M 31,31 H 51"
+     id="path891-2-3-0-3" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="m 15,23 -4,8 h 8 z"
+     id="path904-2-0-3" />
   <metadata
      id="metadata5826">
     <rdf:RDF>
@@ -258,15 +57,8 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
         <cc:license
            rdf:resource="" />
-        <dc:date>Tue Jun 10 10:21:01 2014 -0300</dc:date>
-        <dc:creator>
-          <cc:Agent>
-            <dc:title>[Yorik van Havre]</dc:title>
-          </cc:Agent>
-        </dc:creator>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -277,22 +69,14 @@
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_VisGroup.svg</dc:identifier>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
-        <dc:contributor>
-          <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
-          </cc:Agent>
-        </dc:contributor>
+        <dc:identifier>FreeCAD/src/Mod/BIM/Resources/icons/BIM_Views.svg</dc:identifier>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:subject>
           <rdf:Bag>
-            <rdf:li>page</rdf:li>
             <rdf:li>pages</rdf:li>
-            <rdf:li>rectangles</rdf:li>
             <rdf:li>stack</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:description>Three pages or rectangles stacked on top of each other</dc:description>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/src/Mod/BIM/bimcommands/BimLayers.py
+++ b/src/Mod/BIM/bimcommands/BimLayers.py
@@ -90,7 +90,7 @@ class BIM_Layers:
         self.dialog.buttonDelete.setIcon(QtGui.QIcon(":/icons/delete.svg"))
         self.dialog.buttonSelectAll.setIcon(QtGui.QIcon(":/icons/edit-select-all.svg"))
         self.dialog.buttonToggle.setIcon(QtGui.QIcon(":/icons/dagViewVisible.svg"))
-        self.dialog.buttonIsolate.setIcon(QtGui.QIcon(":/icons/view-refresh.svg"))
+        self.dialog.buttonIsolate.setIcon(QtGui.QIcon(":/icons/Std_ShowSelection.svg"))
         self.dialog.buttonCancel.setIcon(QtGui.QIcon(":/icons/edit_Cancel.svg"))
         self.dialog.buttonOK.setIcon(QtGui.QIcon(":/icons/edit_OK.svg"))
         self.dialog.buttonAssign.setIcon(QtGui.QIcon(":/icons/button_right.svg"))

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -111,10 +111,10 @@ class BIM_Views:
             self.dialog.buttonAddProxy.setIcon(QtGui.QIcon(":/icons/Draft_SelectPlane.svg"))
             self.dialog.buttonDelete.setIcon(QtGui.QIcon(":/icons/delete.svg"))
             self.dialog.buttonToggle.setIcon(QtGui.QIcon(":/icons/dagViewVisible.svg"))
-            self.dialog.buttonIsolate.setIcon(QtGui.QIcon(":/icons/view-refresh.svg"))
-            self.dialog.buttonSaveView.setIcon(QtGui.QIcon(":/icons/view-perspective.svg"))
+            self.dialog.buttonIsolate.setIcon(QtGui.QIcon(":/icons/Std_ShowSelection.svg"))
+            self.dialog.buttonSaveView.setIcon(QtGui.QIcon(":/icons/Std_ViewScreenShot.svg"))
             self.dialog.buttonRename.setIcon(
-                QtGui.QIcon(":/icons/accessories-text-editor.svg")
+                QtGui.QIcon(":/icons/edit-edit.svg")
             )
 
             # set tooltips

--- a/src/Mod/Draft/draftguitools/gui_layers.py
+++ b/src/Mod/Draft/draftguitools/gui_layers.py
@@ -202,7 +202,7 @@ class LayerManager:
         self.dialog.buttonDelete.setIcon(QtGui.QIcon(":/icons/delete.svg"))
         self.dialog.buttonSelectAll.setIcon(QtGui.QIcon(":/icons/edit-select-all.svg"))
         self.dialog.buttonToggle.setIcon(QtGui.QIcon(":/icons/dagViewVisible.svg"))
-        self.dialog.buttonIsolate.setIcon(QtGui.QIcon(":/icons/view-refresh.svg"))
+        self.dialog.buttonIsolate.setIcon(QtGui.QIcon(":/icons/Std_ShowSelection.svg"))
         self.dialog.buttonCancel.setIcon(QtGui.QIcon(":/icons/edit_Cancel.svg"))
         self.dialog.buttonOK.setIcon(QtGui.QIcon(":/icons/edit_OK.svg"))
 


### PR DESCRIPTION
### Issues
Part of [BIM - Icon updates task ](https://github.com/FreeCAD/FreeCAD/issues/13895)

Icons used for the BIM Status Bar are updated and simplified:
- `BIM_Views` has the same square format as its `BIM_Background` neighbor and includes a list-like item
- `BIM_TogglePanels` has the same format as well and a simpler `>_` without the matrix-ish terminal.

Icons used for the contextual menu of the BIM Views Panel are changed so it's more obvious what they are for:
- `Isolate` uses the general GUI `Std_ShowSelection` icon with a cursor.
-  `SaveView` uses the general GUI `Std_ViewScreenShot` icon with a camera.
-  `Rename` uses the general GUI `edit-edit` icon with a pencil.
Similar uses of `Isolate` in BIM and Draft Layers where updated as well for consistency.

While at it, Standard GUI icons with cursor arrows for show/hide selection where made consistent, now all icons with arrows use the same white one (except for `view-unselectable.svg`). The diagonal bar on hide icons is simplified too.

### Before (left) and After (right) Images

![BIM](https://github.com/user-attachments/assets/294916be-50f1-4b0a-9833-213d1f135352)