### PR TITLE
Sketcher: Improve circle constraint position

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -865,4 +865,3 @@ private:
 
 
 #endif  // SKETCHERGUI_DrawSketchController_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -145,8 +145,9 @@ protected:
     };
     //@}
 
-private:
     Base::Vector2d prevCursorPosition;
+
+private:
     Base::Vector2d lastControlEnforcedPosition;
 
     int nOnViewParameter = OnViewParametersT::defaultMethodSize();
@@ -864,3 +865,4 @@ private:
 
 
 #endif  // SKETCHERGUI_DrawSketchController_H
+

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -720,9 +720,7 @@ void DSHCircleController::addConstraints()
             const std::vector<Sketcher::Constraint*>& ConStr =
                 handler->sketchgui->getSketchObject()->Constraints.getValues();
             int index = static_cast<int>(ConStr.size()) - 1;
-            Base::Vector2d dir = handler->secondPoint - handler->centerPoint;
-            Base::Vector2d toPnt = handler->secondPoint + dir * 0.3;
-            handler->moveConstraint(index, toPnt);
+            handler->moveConstraint(index, prevCursorPosition);
         };
 
         // NOTE: if AutoConstraints is empty, we can add constraints directly without any diagnose.
@@ -781,3 +779,4 @@ void DSHCircleController::addConstraints()
 
 
 #endif  // SKETCHERGUI_DrawSketchHandlerCircle_H
+

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -779,4 +779,3 @@ void DSHCircleController::addConstraints()
 
 
 #endif  // SKETCHERGUI_DrawSketchHandlerCircle_H
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/pull/22862#issuecomment-3237460391

Instead of positioning at 1.3 * radius, we just use prevCursorPosition which is the last known mouse position.