### PR TITLE
Part: disable dragger for the thickness operation

### DIFF
--- a/src/Mod/Part/Gui/TaskThickness.cpp
+++ b/src/Mod/Part/Gui/TaskThickness.cpp
@@ -116,7 +116,10 @@ ThicknessWidget::ThicknessWidget(Part::Thickness* thickness, QWidget* parent)
 
     d->ui.spinOffset->bind(d->thickness->Value);
 
-    setupGizmos();
+    // The interactive gizmos are implemented for this operation just as a proof
+    // of concept. And so, it is kept disabled until the other operations of the
+    // Part workbench are covered.
+    // setupGizmos();
 }
 
 ThicknessWidget::~ThicknessWidget()


### PR DESCRIPTION
The dragger in the thickness operation was implemented just as a proof of concept and so it should be disabled for now.