### PR TITLE
App: Fix safe mode and home directory

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2569,12 +2569,12 @@ void Application::initConfig(int argc, char ** argv)
         mConfig["KeepDeprecatedPaths"] = "1";
     }
 
+    if (vm.contains("safe-mode")) {
+        mConfig["SafeMode"] = "1";
+    }
+
     // extract home paths
     _appDirs = std::make_unique<ApplicationDirectories>(mConfig);
-
-    if (vm.contains("safe-mode")) {
-        SafeMode::StartSafeMode();
-    }
 
 #   ifdef FC_DEBUG
     mConfig["Debug"] = "1";

--- a/src/App/ApplicationDirectories.h
+++ b/src/App/ApplicationDirectories.h
@@ -56,6 +56,10 @@ namespace App {
         /// `App::ApplicationDirectories` class.
         const std::filesystem::path& getHomePath() const;
 
+        /// Get the user's home directory. This should not be used for many things, use caution when
+        /// deciding to use it for anything, there are usually better places.
+        const std::filesystem::path& getUserHomePath() const;
+
         /// Temp path is the location of all temporary files: it is not guaranteed to preserve
         /// information between runs of the program, but *is* guaranteed to exist for the duration
         /// of a single program execution (that is, files are not deleted from it *during* the run).
@@ -174,6 +178,10 @@ namespace App {
 
     protected:
 
+        /// Override all application directories with temp directories. Returns true on success and
+        /// false if the temp directory creation failed.
+        bool startSafeMode(std::map<std::string,std::string>& mConfig);
+
         /// Take a path and add a version to it, if it's possible to do so. A version can be
         /// appended only if a) the versioned subdirectory already exists, or b) pathToCheck/subdirs
         /// does NOT yet exist. This does not actually create any directories, just determines
@@ -228,6 +236,7 @@ namespace App {
         std::filesystem::path _userConfig;
         std::filesystem::path _userAppData;
         std::filesystem::path _userMacro;
+        std::filesystem::path _userHome;
         std::filesystem::path _resource;
         std::filesystem::path _library;
         std::filesystem::path _help;


### PR DESCRIPTION
The recent change to a versioned app directory broke Safe Mode because `mConfig` is no longer the source of truth for app directories. In the long term, safe mode should probably be directly integrated into the `ApplicationDirectories` class, but we are at an interim stage in the implementation of that class, where using `mConfig` directly is still supported (and used in various places). For 1.1 that is the intended behavior. Following the release further work is planned to *only* access directory information via the `ApplicationDirectories` class.

This also fixes a bug/misunderstanding between the definitions of "user home" and "app home".

Fixes #23566