### PR TITLE
PartDesign: fix the draggers for pad type and hole

### DIFF
--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>550</width>
-    <height>552</height>
+    <height>586</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -271,22 +271,9 @@
        </widget>
       </item>
       <item>
-       <widget class="Gui::PrefCheckBox" name="checkAllowCompoundBody">
-        <property name="text">
-         <string>Allow multiple solids in Part Design bodies by default</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>AllowCompoundDefault</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/PartDesign</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="Gui::PrefCheckBox" name="enableGizmos">
         <property name="text">
-         <string>Show interactive draggers during Part Design tasks</string>
+         <string>Show interactive draggers when editing features</string>
         </property>
         <property name="checked">
          <bool>true</bool>

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -334,11 +334,13 @@ void TaskExtrudeParameters::connectSlots()
 void TaskExtrudeParameters::onModeChanged_Side1(int index)
 {
     onModeChanged(index, Side::First);
+    setGizmoPositions();
 }
 
 void TaskExtrudeParameters::onModeChanged_Side2(int index)
 {
     onModeChanged(index, Side::Second);
+    setGizmoPositions();
 }
 
 void TaskExtrudeParameters::onSelectShapeFacesToggle(bool checked, Side side)
@@ -1391,17 +1393,21 @@ void TaskExtrudeParameters::setGizmoPositions()
     PartDesign::TopoShape shape = extrude->getProfileShape();
     Base::Vector3d center = getMidPointFromProfile(shape);
     std::string sideType = std::string(extrude->SideType.getValueAsString());
+    std::string extrudeType = std::string(extrude->Type.getValueAsString());
+    std::string extrudeType2 = std::string(extrude->Type2.getValueAsString());
     double dir = extrude->Reversed.getValue()? -1 : 1;
 
     lengthGizmo1->Gizmo::setDraggerPlacement(center, extrude->Direction.getValue() * dir);
+    lengthGizmo1->setVisibility(extrudeType == "Length");
     taperAngleGizmo1->placeOverLinearGizmo(lengthGizmo1);
+    taperAngleGizmo1->setVisibility(extrudeType == "Length");
     lengthGizmo2->Gizmo::setDraggerPlacement(center, -extrude->Direction.getValue() * dir);
     lengthGizmo2->setVisibility(
-        sideType == "Two sides"
+        sideType == "Two sides" && extrudeType2 == "Length"
     );
     taperAngleGizmo2->placeOverLinearGizmo(lengthGizmo2);
     taperAngleGizmo2->setVisibility(
-        sideType == "Two sides"
+        sideType == "Two sides" && extrudeType2 == "Length"
     );
 
     Base::Vector3d padDir = extrude->Direction.getValue().Normalized();

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -1250,6 +1250,8 @@ void TaskHoleParameters::setGizmoPositions()
     holeDepthGizmo->setVisibility(
         std::string(hole->DepthType.getValueAsString()) == "Dimension"
     );
+
+    holeDepthGizmo->setDragLength(ui->Depth->rawValue());
 }
 
 


### PR DESCRIPTION
Hides the draggers when the type of the pad/pocket is not dimension and sets the correct dragger length after changing hole depth type.
This PR also removes a duplicate checkbox in the preferences menu that I added by mistake during a rebase.