### PR TITLE
TechDraw: Fix selections not clearing

### DIFF
--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -140,6 +140,7 @@ bool QGSPage::itemClearsSelection(int itemTypeIn)
     const std::vector<int> ClearingTypes {
         13,  // MysteryType
         UserType::QGITemplate,
+        UserType::QGIProjGroup,
         UserType::QGIDrawingTemplate,
         UserType::QGISVGTemplate
     };


### PR DESCRIPTION
The TechDraw selections were not clearing due to the ProjGroup bounding rect absorbing clicks that should otherwise go to the sheet.

This PR adds QGIVProjGroup to list in QGSPage::itemClearsSelection() as per suggestion from @WandererFan in https://github.com/FreeCAD/FreeCAD/issues/23456#issuecomment-3242598144

<img width="1091" height="727" alt="20250901_01h00m11s_grim" src="https://github.com/user-attachments/assets/d8598a2f-5576-40ed-8824-06c9102668e9" />

## Issues
Fix #23456
