### PR TITLE
TechDraw: Use Label for empty Caption when KeepLabel is active

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -699,8 +699,32 @@ void QGIView::prepareCaption()
                                  Preferences::labelFontSizeMM());
     m_font.setPixelSize(fontSize);
     m_caption->setFont(m_font);
-    QString captionStr = QString::fromUtf8(getViewObject()->Caption.getValue());
-    m_caption->setPlainText(captionStr);
+
+    // Check for Null
+     auto* feature = getViewObject();
+    if (!feature) {
+        m_caption->setPlainText(QString());
+        return;
+    }
+
+    std::string captionValue = feature->Caption.getValue();
+    std::string labelValue = feature->Label.getValue();
+    bool keepLabel = false; // Default to false for safety
+
+    Gui::ViewProvider* vp = QGIView::getViewProvider(feature);
+    auto* vpdv = dynamic_cast<ViewProviderDrawingView*>(vp);
+    if (vpdv) {
+        keepLabel = vpdv->KeepLabel.getValue();
+    }
+
+    QString stringToDisplay;
+    if (keepLabel && captionValue.empty()) {
+        stringToDisplay = QString::fromStdString(labelValue);
+    } else {
+        stringToDisplay = QString::fromStdString(captionValue);
+    }
+
+    m_caption->setPlainText(stringToDisplay);
 }
 
 void QGIView::layoutDecorations(const QRectF& contentArea,


### PR DESCRIPTION
Recent view frames PR broke the KeepLabel property. 

The caption property should be used for permanent labelling of the view, as its positioning relative to the view is intentionally designed for this purpose. 

This PR uses the Label text for the Caption when KeepLabel is active and the Caption is empty, as per suggestion from @WandererFan in https://github.com/FreeCAD/FreeCAD/issues/23540

## Issues
Fix https://github.com/FreeCAD/FreeCAD/issues/23540

## Demo Video

https://github.com/user-attachments/assets/6d53ed53-11b9-4c27-80b8-a9f80ca5f661
