### PR TITLE
Sketcher: Constraint symbol size follow-up

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -374,7 +374,6 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(
 
     int sketcherfontSize = hGrp->GetInt("EditSketcherFontSize", defaultFontSizePixels);
     int constraintSymbolSizePref = hGrp->GetInt("ConstraintSymbolSize", defaultFontSizePixels);
-    bool useConstraintSymbolSize = hGrp->GetBool("UseConstraintSymbolSize", false);
 
     double dpi = Client.getApplicationLogicalDPIX();
     double devicePixelRatio = Client.getDevicePixelRatio();
@@ -393,9 +392,7 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(
 
     // Constraint icon size: legacy derives 0.8 * font (when override disabled); if override
     // enabled we use the stored absolute pixel size (defaulting to full font size initially).
-    int symbolSizeToUse =
-        useConstraintSymbolSize ? constraintSymbolSizePref : std::lround(0.8 * sketcherfontSize);
-    Client.drawingParameters.constraintIconSize = std::lround(symbolSizeToUse * devicePixelRatio);
+    int symbolSizeToUse = Client.drawingParameters.constraintIconSize = std::lround(symbolSizeToUse);
 
     auto supportedsizes = Gui::Inventor::MarkerBitmaps::getSupportedSizes("CIRCLE_LINE");
     auto scaledMarkerSize = std::lround(markerSize * devicePixelRatio);
@@ -1239,3 +1236,4 @@ SoSeparator* EditModeCoinManager::getRootEditNode()
 {
     return editModeScenegraphNodes.EditRoot;
 }
+


### PR DESCRIPTION
 Fix HiDPI issue on constraint symbol size that used DPR.