### PR TITLE
TechDraw: Fix tree view selection not showing on page

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -116,6 +116,8 @@ QGIView::QGIView()
     m_lockHeight = (double) sizeLock.height();
 
     m_lock->hide();
+    m_border->hide();
+    m_label->hide();
 }
 
 void QGIView::isVisible(bool state)
@@ -611,8 +613,6 @@ void QGIView::updateView(bool forceUpdate)
     }
 
     drawBorder(); // Draw the border then hide it so the label knows where to position itself
-    m_border->hide();
-    m_label->hide();
 
     QGIView::draw();
 }


### PR DESCRIPTION
This PR fixes the selection of a view (borders and labels) not showing when selected from the tree view.

## Issues 
#23568 Fully fixed if #23589 merged also

## Demo Video

https://github.com/user-attachments/assets/7bd974f1-cad3-481c-bbc3-3ce8a43314ae
