### PR TITLE
Draft: check if autogroup exists

### DIFF
--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -122,6 +122,10 @@ def autogroup(obj):
     # autogroup code
     if Gui.draftToolBar.autogroup is not None:
         active_group = App.ActiveDocument.getObject(Gui.draftToolBar.autogroup)
+        if active_group is None:
+            # Layer/group does not exixt (anymore)
+            Gui.draftToolBar.setAutoGroup()  # Change active layer/group in Tray to None.
+            return
         if obj in active_group.InListRecursive:
             return
         if not obj in active_group.Group:


### PR DESCRIPTION
Fixes #23594
Regression caused by #22295

We need to look at a better solution in the future where the active layer/group is stored in the document and the Draft Tray gets updated when you switch documents.