### PR TITLE
TechDraw: Remove duplicate import

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -27,7 +27,6 @@
 #include <QKeyEvent>
 #include <cstdio>
 #include <qmath.h>
-#include <cstdio>
 #endif// #ifndef _PreComp_
 
 #include <App/Application.h>


### PR DESCRIPTION
Remove duplicate `cstdio` import from  #21483.