### PR TITLE
[Arch]  Fix makeStairs Move & Addition Behaviour Consistency

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -1490,12 +1490,29 @@ def makeStairs(baseobj=None, length=None, width=None, height=None, steps=None, n
             else:
                 stepsI = 20
             setProperty(stairs[i], None, width, height, stepsI)
-            if i > 1:
+
+            if lenSelection > 1:  # More than 1 segment
+                # All semgments in a complex stairs moved together by default
+                # regardless MoveWithHost setting in system setting
+                stair.MoveWithHost = True
+
+            # All segment goes to Additions (rather than previously 1st segment
+            # went to Base) - for consistent in MoveWithHost behaviour
+            if i > 0:
                 additions.append(stairs[i])
-                stairs[i].LastSegment = stairs[i - 1]
-            else:
-                if len(stairs) > 1: # i.e. length >1, have a 'master' staircase created
-                    stairs[0].Base = stairs[1]
+                if i > 1:
+                    stairs[i].LastSegment = stairs[i - 1]
+            #else:
+                # Below made '1st segment' of a complex stairs went to Base
+                # Remarked below out, 2025.8.31.
+                # Seems no other Arch object create an Arch object as its Base
+                # and use a 'master' Arch(Stairs) object like Stairs.  Base is
+                # not moved together with host upon onChanged(), unlike
+                # behaviour in objects of Additions.
+                #
+                #if len(stairs) > 1: # i.e. length >1, have a 'master' staircase created
+                #    stairs[0].Base = stairs[1]
+
             i += 1
         if lenSelection > 1:
             stairs[0].Additions = additions
@@ -1554,6 +1571,9 @@ def makeRailing(stairs):
                     baseobj=None, diameter=0, length=0, placement=None,
                     name=translate("Arch", "Railing")
                 )
+                # All semgments in a complex stairs moved together by default
+                # regardless Move With Host setting in system setting
+                lrRail.MoveWithHost = True
                 if outlineLRAll:
                     setattr(stair, stairRailingLR, lrRail)
                     break


### PR DESCRIPTION
I.  Consistent Addition

1. Additions are hidden by onChanged()
2. makeStairs() previously made 1st segment of a Complex Stairs went to Base and the rest segments went to Additions
3. For consistency in grouping and visibility, all segments in go to Additions with this commit

II.  Consistent Move With Host

1. A Complex Stairs has multiple segment (in Additions) and railings (in RailingLeft/Right), they should move togther.
2. All segments and Railing set MoveWithHost to True upon creation, and thus move together, regardless system setting default with this commit



Other Associated Inconsistency

- Other visibility default behaviour as discussed in https://forum.freecad.org/viewtopic.php?p=844965#p844920 were added in previous PRs


Last associated PR/commits :
- https://github.com/FreeCAD/FreeCAD/pull/23556
- https://github.com/FreeCAD/FreeCAD/pull/23586

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
