### PR TITLE
External geometry and attachment support crossing Parts and Bodies.

### DIFF
--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -28,13 +28,7 @@ name: FreeCAD master CI
 
 on:
   push:
-<<<<<<< HEAD
-    branches: [ SimplerBody ]
-||||||| parent of d45212b926 (fixed CI_master.yml)
-    branches: [ SimplERBody ]
-=======
     branches: [ "SimplerBody" ]
->>>>>>> d45212b926 (fixed CI_master.yml)
   pull_request:
     branches: [ "SimplerBody" ]
   merge_group:

--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -28,11 +28,17 @@ name: FreeCAD master CI
 
 on:
   push:
+<<<<<<< HEAD
     branches: [ SimplerBody ]
+||||||| parent of d45212b926 (fixed CI_master.yml)
+    branches: [ SimplERBody ]
+=======
+    branches: [ "SimplerBody" ]
+>>>>>>> d45212b926 (fixed CI_master.yml)
   pull_request:
-    branches: [ SimplerBody ]
+    branches: [ "SimplerBody" ]
   merge_group:
-    branches: [ SimplerBody ]
+    branches: [ "SimplerBody" ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -27,14 +27,13 @@
 name: FreeCAD master CI
 
 on:
-  workflow_dispatch: ~
   push:
-    branches:
-      - main
-      - releases/**
-  pull_request: ~
-  merge_group: ~
-
+    branches: [ SimplerBody ]
+  pull_request:
+    branches: [ SimplerBody ]
+  merge_group:
+    branches: [ SimplerBody ]
+  workflow_dispatch:
 
 concurrency:
   group: FC-CI-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -95,9 +95,9 @@ jobs:
         include:
           - { target: linux-64, os: ubuntu-22.04 }
           - { target: linux-arm64, os: ubuntu-22.04-arm }
-          - { target: osx-64, os: macos-15-intel }
-          - { target: osx-arm64, os: macos-latest }
           - { target: win-64, os: windows-latest }
+#          - { target: osx-64, os: macos-13 }
+#          - { target: osx-arm64, os: macos-latest }
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,10 +1,8 @@
 name: Build Release
 on:
   release:
-    types: [created]
-  schedule:
-   - cron: "0 0 * * 3"
-  workflow_dispatch:
+    types: [published, created] # Parte se crei una release
+  workflow_dispatch:            # Parte se clicchi "Run workflow" (Manuale)
 
 permissions:
   contents: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "SimplerBody" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "SimplerBody" ]
   schedule:
     - cron: '28 12 * * 6'
 

--- a/.github/workflows/fedora-daily.yml
+++ b/.github/workflows/fedora-daily.yml
@@ -3,7 +3,7 @@ permissions:
   contents: read
 on:
   schedule:
-   - cron: "00 00 * * *"
+   #- cron: "00 00 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/fedora-daily.yml
+++ b/.github/workflows/fedora-daily.yml
@@ -2,7 +2,7 @@ name: Fedora Daily Build
 permissions:
   contents: read
 on:
-  schedule:
+  #schedule:
    #- cron: "00 00 * * *"
   workflow_dispatch:
 

--- a/.github/workflows/fetch_crowdin_translations.yml
+++ b/.github/workflows/fetch_crowdin_translations.yml
@@ -2,8 +2,8 @@ name: Fetch Crowdin Translations
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 1"
+    #schedule:
+    # - cron: "0 0 * * 1"
 
 jobs:
   update-crowdin:

--- a/.github/workflows/push_crowdin_translations.yml
+++ b/.github/workflows/push_crowdin_translations.yml
@@ -2,8 +2,8 @@ name: Push Crowdin Translations
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 1"
+  #schedule:
+  #  - cron: "0 0 * * 1"
 
 jobs:
   update-crowdin:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -12,7 +12,7 @@ on:
   schedule:
     - cron: '20 7 * * 2'
   push:
-    branches: ["main"]
+    branches: ["SimplerBody"]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -40,6 +40,7 @@
 #include "Application.h"
 #include "ElementNamingUtils.h"
 #include "Document.h"
+#include "Part.h"
 #include "DocumentObject.h"
 #include "DocumentObjectPy.h"
 #include "DocumentObjectExtension.h"
@@ -105,51 +106,22 @@ void DocumentObject::printInvalidLinks() const
         // Truncate the invalid object list name strings for readability, if they happen to be very
         // long.
         std::vector<App::DocumentObject*> invalid_linkobjs;
-        std::string objnames, scopenames;
         GeoFeatureGroupExtension::getInvalidLinkObjects(this, invalid_linkobjs);
         for (auto& obj : invalid_linkobjs) {
-            objnames += obj->getNameInDocument();
-            objnames += " ";
-            for (auto& scope : obj->getParents()) {
-                if (scopenames.length() > 80) {
-                    scopenames += "... ";
-                    break;
-                }
-
-                scopenames += scope.first->getNameInDocument();
-                scopenames += " ";
-            }
-
-            if (objnames.length() > 80) {
-                objnames += "... ";
-                break;
-            }
-        }
-
-        if (objnames.empty()) {
-            objnames = "N/A";
-        }
-        else {
-            objnames.pop_back();
-        }
-
-        if (scopenames.empty()) {
-            scopenames = "N/A";
-        }
-        else {
-            scopenames.pop_back();
-        }
-
-        Base::Console().warning("%s: Link(s) to object(s) '%s' go out of the allowed scope '%s'. "
+            std::string objname, scopename;
+            objname= obj->getNameInDocument();
+            if (objname.empty()) objname = "N/A";
+	    const App::Part* scope = App::Part::getPartOfObject(obj);
+            scopename = scope ? scope->getNameInDocument() : "N/A";
+            if (scopename.empty()) scopename = "N/A";
+            Base::Console().warning("%s: Link(s) to object(s) '%s' go out of the allowed scope '%s'. "
                                 "Instead, the linked object(s) reside within '%s'.\n",
                                 getTypeId().getName(),
-                                objnames.c_str(),
+                                objname.c_str(),
                                 getNameInDocument(),
-                                scopenames.c_str());
-    }
-    catch (const Base::Exception& e) {
-        e.reportException();
-    }
+                                scopename.c_str());
+        } 
+    } catch (const Base::Exception& e) {e.reportException();}
 }
 
 App::DocumentObjectExecReturn* DocumentObject::recompute()

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -356,12 +356,14 @@ void GeoFeatureGroupExtension::onCommitTransaction(const App::Document& doc)
     // Cerchiamo i pending touches per questo documento
     auto it = s_docPendingPlacementTouches.find(d);
     if (it == s_docPendingPlacementTouches.end()) {
+        depth--;  // restore before returning
         return;
     }
 
     auto& pending = it->second;
     if (pending.empty()) {
         s_docPendingPlacementTouches.erase(it);
+        depth--;  // restore before returning
         return;
     }
 

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -32,6 +32,8 @@
 #include "Datums.h"
 #include "OriginGroupExtension.h"
 
+#include <cstring> // for std::strcmp
+
 
 using namespace App;
 
@@ -108,6 +110,45 @@ DocumentObject* GeoFeatureGroupExtension::getGroupOfObject(const DocumentObject*
     }
 
     return nullptr;
+}
+
+
+const App::DocumentObject* GeoFeatureGroupExtension::getBoundaryGroupOfObject(const App::DocumentObject* obj)
+{
+    if (!obj) return nullptr;
+
+    // nearest GeoFeatureGroup (upstream meaning)
+    const App::DocumentObject* g =
+        obj->hasExtension(App::GeoFeatureGroupExtension::getExtensionClassTypeId())
+            ? obj
+            : App::GeoFeatureGroupExtension::getGroupOfObject(obj);
+
+    // Skip groups that opted out as a boundary (actsAsGroupBoundary == false)
+    while (g) {
+        auto* ext = g->getExtensionByType<App::GeoFeatureGroupExtension>();
+        if (!ext) break;                 // not a geofeature group (shouldn’t happen) → stop
+        if (ext->actsAsGroupBoundary())  // this one is a boundary → stop here
+            break;
+        // transparent group → climb to its parent group
+        g = App::GeoFeatureGroupExtension::getGroupOfObject(g);
+    }
+
+    return g; // may be nullptr (top level), or the nearest boundary group
+}
+
+
+Base::Placement GeoFeatureGroupExtension::globalGroupPlacementInBoundary(const App::DocumentObject* obj)
+{
+    Base::Placement result;
+    const App::DocumentObject* boundary = getBoundaryGroupOfObject(obj);
+    const App::DocumentObject* container = getGroupOfObject(obj);
+    while (container && container != boundary) {
+        if (auto* prop = dynamic_cast<const App::PropertyPlacement*>(container->getPropertyByName("Placement"))) {
+            result = prop->getValue() * result;
+        }
+        container = getGroupOfObject(container);
+    }
+    return result;
 }
 
 Base::Placement GeoFeatureGroupExtension::globalGroupPlacement()
@@ -256,6 +297,19 @@ void GeoFeatureGroupExtension::extensionOnChanged(const Property* p)
             }
         }
     }
+
+    if (p == &this->placement() && !this->actsAsGroupBoundary()
+        && !getExtendedObject()->isRestoring()
+        && !getExtendedObject()->getDocument()->isPerformingTransaction()) {
+
+        for (auto* obj : this->Group.getValues()) {
+            if (!obj) continue;
+
+            if (auto* prop = obj->getPropertyByName("Placement"))
+                prop->touch();
+        }
+    }
+
 
     App::GroupExtension::extensionOnChanged(p);
 }
@@ -526,13 +580,11 @@ void GeoFeatureGroupExtension::getInvalidLinkObjects(const DocumentObject* obj,
         return;
     }
 
-    // no cross CS link for local links.
+    // 1) Local links must not cross the nearest movable group boundary
     auto result = getScopedObjectsFromLinks(obj, LinkScope::Local);
-    auto group = obj->hasExtension(App::GeoFeatureGroupExtension::getExtensionClassTypeId())
-        ? obj
-        : getGroupOfObject(obj);
+    auto group = GeoFeatureGroupExtension::getBoundaryGroupOfObject(obj);
     for (auto link : result) {
-        if (getGroupOfObject(link) != group) {
+        if (GeoFeatureGroupExtension::getBoundaryGroupOfObject(link) != group) {
             vec.push_back(link);
         }
     }

--- a/src/App/GeoFeatureGroupExtension.h
+++ b/src/App/GeoFeatureGroupExtension.h
@@ -31,6 +31,8 @@
 #include "DocumentObject.h"
 #include "GroupExtension.h"
 #include "PropertyGeo.h"
+#include <map>
+#include <vector>
 
 
 namespace App
@@ -141,6 +143,7 @@ public:
     static void getInvalidLinkObjects(const App::DocumentObject* obj,
                                       std::vector<App::DocumentObject*>& vec);
 
+
 private:
     Base::Placement recursiveGroupPlacement(GeoFeatureGroupExtension* group,
                                             std::unordered_set<GeoFeatureGroupExtension*>& history);
@@ -163,6 +166,14 @@ private:
     static void recursiveCSRelevantLinks(const App::DocumentObject* obj,
                                          std::vector<App::DocumentObject*>& vec);
     bool m_actsAsGroupBoundary = true;
+
+    static std::map<App::Document*, std::vector<App::DocumentObject*>> s_docPendingPlacementTouches;
+
+    static bool s_appSignalsConnected;
+
+    // Slot statico chiamato alla fine di una transazione
+    static void onCommitTransaction(const App::Document& doc);
+
 };
 
 using GeoFeatureGroupExtensionPython =

--- a/src/App/GeoFeatureGroupExtension.h
+++ b/src/App/GeoFeatureGroupExtension.h
@@ -165,7 +165,7 @@ private:
 
     static void recursiveCSRelevantLinks(const App::DocumentObject* obj,
                                          std::vector<App::DocumentObject*>& vec);
-    bool m_actsAsGroupBoundary = true;
+    bool m_actsAsGroupBoundary = false;
 
     static std::map<App::Document*, std::vector<App::DocumentObject*>> s_docPendingPlacementTouches;
 

--- a/src/App/GeoFeatureGroupExtension.h
+++ b/src/App/GeoFeatureGroupExtension.h
@@ -173,6 +173,8 @@ private:
 
     // Slot statico chiamato alla fine di una transazione
     static void onCommitTransaction(const App::Document& doc);
+    static std::unordered_map<App::Document*, int> s_docRecomputeDepth;
+    static const int MAX_RECOMPUTE_DEPTH = 20;
 
 };
 

--- a/src/App/GeoFeatureGroupExtension.h
+++ b/src/App/GeoFeatureGroupExtension.h
@@ -96,6 +96,16 @@ public:
      * system
      */
     Base::Placement globalGroupPlacement();
+    static Base::Placement globalGroupPlacementInBoundary(const App::DocumentObject* obj);
+
+    // New: capability flag — does this group act as a link/scope boundary?
+    // Default: true (current upstream behavior).
+    bool actsAsGroupBoundary() const noexcept { return m_actsAsGroupBoundary; }
+    void setActsAsGroupBoundary(bool v) noexcept { m_actsAsGroupBoundary = v; }
+
+    // New: helper used by selection/validation to hop over transparent groups.
+    // Returns the nearest GeoFeatureGroup that *acts as a boundary*; nullptr = top level.
+    static const App::DocumentObject* getBoundaryGroupOfObject(const App::DocumentObject* obj);
 
     /// Returns true if the given DocumentObject is DocumentObjectGroup but not GeoFeatureGroup
     static bool isNonGeoGroup(const DocumentObject* obj)
@@ -152,6 +162,7 @@ private:
 
     static void recursiveCSRelevantLinks(const App::DocumentObject* obj,
                                          std::vector<App::DocumentObject*>& vec);
+    bool m_actsAsGroupBoundary = true;
 };
 
 using GeoFeatureGroupExtensionPython =

--- a/src/App/Part.cpp
+++ b/src/App/Part.cpp
@@ -59,6 +59,11 @@ Part::Part()
     ADD_PROPERTY(Color, (1.0, 1.0, 1.0, 0.0));  // set transparent -> not used
 
     GroupExtension::initExtension(this);
+
+    if (auto* gext = this->getExtensionByType<App::GeoFeatureGroupExtension>()) {
+        gext->setActsAsGroupBoundary(false); // Parts are transparent boundaries
+    }
+
 }
 
 Part::~Part() = default;
@@ -109,6 +114,19 @@ PyObject* Part::getPyObject()
     }
     return Py::new_reference_to(PythonObject);
 }
+
+
+void App::Part::onDocumentRestored()
+{
+    App::GeoFeature::onDocumentRestored();
+
+    if (auto* gext = this->getExtensionByType<App::GeoFeatureGroupExtension>()) {
+        // imposta a false solo se è "true" (evita di sovrascrivere scelte esplicite salvate)
+        if (gext->actsAsGroupBoundary())
+            gext->setActsAsGroupBoundary(false);
+    }
+}
+
 
 void Part::handleChangedPropertyType(Base::XMLReader& reader,
                                      const char* TypeName,

--- a/src/App/Part.h
+++ b/src/App/Part.h
@@ -101,6 +101,8 @@ public:
     static App::Part* getPartOfObject(const DocumentObject* obj, bool recursive = true);
 
     PyObject* getPyObject() override;
+    void onDocumentRestored() override;
+
 };
 
 // using PartPython = App::FeaturePythonT<Part>;

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1743,7 +1743,18 @@ bool StdCmdPlacement::isActive()
     std::vector<App::DocumentObject*> sel = Gui::Selection().getObjectsOfType(
         App::GeoFeature::getClassTypeId()
     );
-    return !(sel.empty() || std::ranges::any_of(sel, [](auto obj) { return obj->isFreezed(); }));
+    if (sel.empty())
+       return false;
+    for (auto* obj : sel) {
+       if (obj->isFreezed())
+        return false;
+       App::Property* prop = obj->getPropertyByName("Placement");
+       if (!prop)
+          return false;
+       if (prop->testStatus(App::Property::Hidden))
+          return false;
+    }
+    return true;
 }
 
 //===========================================================================

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1743,16 +1743,20 @@ bool StdCmdPlacement::isActive()
     std::vector<App::DocumentObject*> sel = Gui::Selection().getObjectsOfType(
         App::GeoFeature::getClassTypeId()
     );
-    if (sel.empty())
-       return false;
-    for (auto* obj : sel) {
-       if (obj->isFreezed())
+    if (sel.empty()) {
         return false;
-       App::Property* prop = obj->getPropertyByName("Placement");
-       if (!prop)
-          return false;
-       if (prop->testStatus(App::Property::Hidden))
-          return false;
+    }
+    for (auto* obj : sel) {
+        if (obj->isFreezed()) {
+            return false;
+        }
+        App::Property* prop = obj->getPropertyByName("Placement");
+        if (!prop) {
+            return false;
+        }
+        if (prop->testStatus(App::Property::Hidden)) {
+            return false;
+        }
     }
     return true;
 }

--- a/src/Mod/Import/App/ExportOCAF.cpp
+++ b/src/Mod/Import/App/ExportOCAF.cpp
@@ -220,6 +220,7 @@ void ExportOCAF::createNode(
     root_id = hierarchical_label.size();
 }
 
+<<<<<<< HEAD
 int ExportOCAF::saveShape(
     Part::Feature* part,
     const std::vector<Base::Color>& colors,
@@ -227,6 +228,22 @@ int ExportOCAF::saveShape(
     std::vector<TopLoc_Location>& hierarchical_loc,
     std::vector<App::DocumentObject*>& hierarchical_part
 )
+||||||| parent of b33f579c8b (Reverted ugly commits 6fd6558040bb61cc1a9d35fd360cb1a169276cd3 and f218c5f25cdb8dfe216583dc25e1e0f55e500555)
+int ExportOCAF::saveShape(
+    Part::Feature* part,
+    const std::vector<Base::Color>& colors,
+    std::vector<TDF_Label>& hierarchical_label,
+    std::vector<TopLoc_Location>& hierarchical_loc,
+    std::vector<App::DocumentObject*>& hierarchical_part,
+    const char* labelOverride
+)
+=======
+int ExportOCAF::saveShape(Part::Feature* part,
+                          const std::vector<Base::Color>& colors,
+                          std::vector<TDF_Label>& hierarchical_label,
+                          std::vector<TopLoc_Location>& hierarchical_loc,
+                          std::vector<App::DocumentObject*>& hierarchical_part)
+>>>>>>> b33f579c8b (Reverted ugly commits 6fd6558040bb61cc1a9d35fd360cb1a169276cd3 and f218c5f25cdb8dfe216583dc25e1e0f55e500555)
 {
     const TopoDS_Shape& shape = part->Shape.getValue();
     if (shape.IsNull()) {

--- a/src/Mod/Import/App/ExportOCAF.cpp
+++ b/src/Mod/Import/App/ExportOCAF.cpp
@@ -220,7 +220,6 @@ void ExportOCAF::createNode(
     root_id = hierarchical_label.size();
 }
 
-<<<<<<< HEAD
 int ExportOCAF::saveShape(
     Part::Feature* part,
     const std::vector<Base::Color>& colors,
@@ -228,22 +227,6 @@ int ExportOCAF::saveShape(
     std::vector<TopLoc_Location>& hierarchical_loc,
     std::vector<App::DocumentObject*>& hierarchical_part
 )
-||||||| parent of b33f579c8b (Reverted ugly commits 6fd6558040bb61cc1a9d35fd360cb1a169276cd3 and f218c5f25cdb8dfe216583dc25e1e0f55e500555)
-int ExportOCAF::saveShape(
-    Part::Feature* part,
-    const std::vector<Base::Color>& colors,
-    std::vector<TDF_Label>& hierarchical_label,
-    std::vector<TopLoc_Location>& hierarchical_loc,
-    std::vector<App::DocumentObject*>& hierarchical_part,
-    const char* labelOverride
-)
-=======
-int ExportOCAF::saveShape(Part::Feature* part,
-                          const std::vector<Base::Color>& colors,
-                          std::vector<TDF_Label>& hierarchical_label,
-                          std::vector<TopLoc_Location>& hierarchical_loc,
-                          std::vector<App::DocumentObject*>& hierarchical_part)
->>>>>>> b33f579c8b (Reverted ugly commits 6fd6558040bb61cc1a9d35fd360cb1a169276cd3 and f218c5f25cdb8dfe216583dc25e1e0f55e500555)
 {
     const TopoDS_Shape& shape = part->Shape.getValue();
     if (shape.IsNull()) {

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -34,7 +34,7 @@
 
 #include "AttachExtension.h"
 #include "AttachExtensionPy.h"
-
+#include <App/GeoFeatureGroupExtension.h>
 
 using namespace Part;
 using namespace Attacher;
@@ -154,6 +154,13 @@ AttachExtension::AttachExtension()
         App::Prop_None,
         "Extra placement to apply in addition to attachment (in local coordinates)"
     );
+
+    EXTENSION_ADD_PROPERTY_TYPE(
+        RefPlacement,
+        (Base::Placement()),
+        "Attachment",
+        App::Prop_Transient,
+        "Cumulative placement of the group hierarchy above the object, up to the boundary");
 
     // Only show these properties when applicable. Controlled by extensionOnChanged
     this->MapPathParameter.setStatus(App::Property::Status::Hidden, true);
@@ -335,6 +342,8 @@ bool AttachExtension::changeAttacherType(const char* typeName, bool base)
     throw AttachEngineException(errMsg.str());
 }
 
+
+
 bool AttachExtension::positionBySupport()
 {
     _active = 0;
@@ -345,6 +354,7 @@ bool AttachExtension::positionBySupport()
     }
     updateAttacherVals();
     Base::Placement plaOriginal = getPlacement().getValue();
+    Base::Placement refPlaOriginal = getRefPlacement().getValue();
     try {
         if (_props.attacher->mapMode == mmDeactivated) {
             return false;
@@ -355,8 +365,8 @@ bool AttachExtension::positionBySupport()
 
         Base::Placement basePlacement;
         if (_baseProps.attacher && _baseProps.attacher->mapMode != mmDeactivated) {
-            basePlacement
-                = _baseProps.attacher->calculateAttachedPlacement(Base::Placement(), &subChanged);
+            basePlacement =
+                _baseProps.attacher->calculateAttachedPlacement(Base::Placement(),nullptr,&subChanged);
             if (subChanged) {
                 _baseProps.attachment->setValues(
                     _baseProps.attachment->getValues(),
@@ -364,10 +374,15 @@ bool AttachExtension::positionBySupport()
                 );
             }
         }
-
+        Base::Placement groupPla;
+        if (auto* obj = dynamic_cast<App::DocumentObject*>(getExtendedObject())) {
+            groupPla=App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(obj);
+        }
         subChanged = false;
         _props.attacher->setOffset(AttachmentOffset.getValue() * basePlacement.inverse());
-        auto placement = _props.attacher->calculateAttachedPlacement(plaOriginal, &subChanged);
+        Base::Placement refGroupPla;
+        auto refPla = _props.attacher->calculateAttachedPlacement(refPlaOriginal, &refGroupPla, &subChanged);
+        Base::Placement placement=groupPla.inverse()*refGroupPla*refPla;
         if (subChanged) {
             Base::ObjectStatusLocker<App::Property::Status, App::Property> guard(
                 App::Property::User3,
@@ -375,6 +390,7 @@ bool AttachExtension::positionBySupport()
             );
             AttachmentSupport.setValues(AttachmentSupport.getValues(), _props.attacher->getSubValues());
         }
+        getRefPlacement().setValue(refPla);
         getPlacement().setValue(placement);
         _active = 1;
         return true;
@@ -382,14 +398,17 @@ bool AttachExtension::positionBySupport()
     catch (ExceptionCancel&) {
         // disabled, don't do anything
         getPlacement().setValue(plaOriginal);
+        getRefPlacement().setValue(refPlaOriginal);
         return false;
     }
     catch (Base::Exception&) {
         getPlacement().setValue(plaOriginal);
+        getRefPlacement().setValue(refPlaOriginal);
         throw;
     }
     catch (Standard_Failure&) {
         getPlacement().setValue(plaOriginal);
+        getRefPlacement().setValue(refPlaOriginal);
         throw;
     }
 }
@@ -819,6 +838,18 @@ App::PropertyPlacement& AttachExtension::getPlacement() const
     }
     return *pla;
 }
+
+App::PropertyPlacement& AttachExtension::getRefPlacement() const
+{
+    auto pla = freecad_cast<App::PropertyPlacement*>(
+        getExtendedObject()->getPropertyByName("RefPlacement"));
+    if (!pla) {
+        throw Base::RuntimeError("AttachExtension cannot find placement property");
+    }
+    return *pla;
+}
+
+
 
 PyObject* AttachExtension::getExtensionPyObject()
 {

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -160,7 +160,8 @@ AttachExtension::AttachExtension()
         (Base::Placement()),
         "Attachment",
         App::Prop_Transient,
-        "Cumulative placement of the group hierarchy above the object, up to the boundary");
+        "Cumulative placement of the group hierarchy above the object, up to the boundary"
+    );
 
     // Only show these properties when applicable. Controlled by extensionOnChanged
     this->MapPathParameter.setStatus(App::Property::Status::Hidden, true);
@@ -343,7 +344,6 @@ bool AttachExtension::changeAttacherType(const char* typeName, bool base)
 }
 
 
-
 bool AttachExtension::positionBySupport()
 {
     _active = 0;
@@ -365,8 +365,11 @@ bool AttachExtension::positionBySupport()
 
         Base::Placement basePlacement;
         if (_baseProps.attacher && _baseProps.attacher->mapMode != mmDeactivated) {
-            basePlacement =
-                _baseProps.attacher->calculateAttachedPlacement(Base::Placement(),nullptr,&subChanged);
+            basePlacement = _baseProps.attacher->calculateAttachedPlacement(
+                Base::Placement(),
+                nullptr,
+                &subChanged
+            );
             if (subChanged) {
                 _baseProps.attachment->setValues(
                     _baseProps.attachment->getValues(),
@@ -376,13 +379,14 @@ bool AttachExtension::positionBySupport()
         }
         Base::Placement groupPla;
         if (auto* obj = dynamic_cast<App::DocumentObject*>(getExtendedObject())) {
-            groupPla=App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(obj);
+            groupPla = App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(obj);
         }
         subChanged = false;
         _props.attacher->setOffset(AttachmentOffset.getValue() * basePlacement.inverse());
         Base::Placement refGroupPla;
-        auto refPla = _props.attacher->calculateAttachedPlacement(refPlaOriginal, &refGroupPla, &subChanged);
-        Base::Placement placement=groupPla.inverse()*refGroupPla*refPla;
+        auto refPla
+            = _props.attacher->calculateAttachedPlacement(refPlaOriginal, &refGroupPla, &subChanged);
+        Base::Placement placement = groupPla.inverse() * refGroupPla * refPla;
         if (subChanged) {
             Base::ObjectStatusLocker<App::Property::Status, App::Property> guard(
                 App::Property::User3,
@@ -842,13 +846,13 @@ App::PropertyPlacement& AttachExtension::getPlacement() const
 App::PropertyPlacement& AttachExtension::getRefPlacement() const
 {
     auto pla = freecad_cast<App::PropertyPlacement*>(
-        getExtendedObject()->getPropertyByName("RefPlacement"));
+        getExtendedObject()->getPropertyByName("RefPlacement")
+    );
     if (!pla) {
         throw Base::RuntimeError("AttachExtension cannot find placement property");
     }
     return *pla;
 }
-
 
 
 PyObject* AttachExtension::getExtensionPyObject()

--- a/src/Mod/Part/App/AttachExtension.h
+++ b/src/Mod/Part/App/AttachExtension.h
@@ -94,6 +94,7 @@ public:
     App::PropertyEnumeration MapMode;  // see AttachEngine::eMapMode
     App::PropertyBool MapReversed;     // inverts Z and X internal axes
     App::PropertyPlacement AttachmentOffset;
+    App::PropertyPlacement RefPlacement;
 
     /**
      * @brief MapPathParameter is a parameter value for mmNormalToPath (the
@@ -147,6 +148,7 @@ protected:
     ) override;
 
     App::PropertyPlacement& getPlacement() const;
+    App::PropertyPlacement& getRefPlacement() const;
     void initBase(bool force);
 
     void handleLegacyTangentPlaneOrientation();

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 /***************************************************************************
- *   Copyright (c) 2015 Victor Titov (DeepSOIC) <vv.titov@gmail.com>       *
+ *   Copyright (c)  2025 Walter Steffè  <walter.steffe.it@gmail.com>       *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -65,6 +65,8 @@
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/Datums.h>
+#include <App/GeoFeatureGroupExtension.h>
+
 #include <Base/Console.h>
 
 #include "Attacher.h"
@@ -1126,10 +1128,10 @@ std::vector<App::DocumentObject*> AttachEngine::getRefObjects() const
     return objs;
 }
 
-Base::Placement AttachEngine::calculateAttachedPlacement(
-    const Base::Placement& origPlacement,
-    bool* subChanged
-)
+
+Base::Placement AttachEngine::calculateAttachedPlacement(const Base::Placement& origPlacement,
+                                                         Base::Placement *groupPlacement,
+                                                         bool* subChanged)
 {
     std::map<int, std::pair<std::string, std::string>> subChanges;
     int i = -1;
@@ -1195,6 +1197,7 @@ Base::Placement AttachEngine::calculateAttachedPlacement(
             return pla;
         }
     }
+    if(objs.size()>0) if(groupPlacement) *groupPlacement= App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(objs[0]);
     return _calculateAttachedPlacement(objs, subnames, origPlacement);
 }
 

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -1129,9 +1129,11 @@ std::vector<App::DocumentObject*> AttachEngine::getRefObjects() const
 }
 
 
-Base::Placement AttachEngine::calculateAttachedPlacement(const Base::Placement& origPlacement,
-                                                         Base::Placement *groupPlacement,
-                                                         bool* subChanged)
+Base::Placement AttachEngine::calculateAttachedPlacement(
+    const Base::Placement& origPlacement,
+    Base::Placement* groupPlacement,
+    bool* subChanged
+)
 {
     std::map<int, std::pair<std::string, std::string>> subChanges;
     int i = -1;
@@ -1197,7 +1199,11 @@ Base::Placement AttachEngine::calculateAttachedPlacement(const Base::Placement& 
             return pla;
         }
     }
-    if(objs.size()>0) if(groupPlacement) *groupPlacement= App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(objs[0]);
+    if (objs.size() > 0) {
+        if (groupPlacement) {
+            *groupPlacement = App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(objs[0]);
+        }
+    }
     return _calculateAttachedPlacement(objs, subnames, origPlacement);
 }
 

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 /***************************************************************************
- *   Copyright (c)  2025 Walter Steffè  <walter.steffe.it@gmail.com>       *
+ *   Copyright (c) 2015 Victor Titov (DeepSOIC) <vv.titov@gmail.com>       *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -1127,7 +1127,6 @@ std::vector<App::DocumentObject*> AttachEngine::getRefObjects() const
     }
     return objs;
 }
-
 
 Base::Placement AttachEngine::calculateAttachedPlacement(
     const Base::Placement& origPlacement,

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -253,9 +253,10 @@ public:  // methods
     virtual AttachEngine* copy() const = 0;
 
     Base::Placement calculateAttachedPlacement(
-        const Base::Placement &origPlacement,
-        Base::Placement *origGroupPlacement=nullptr, 
-        bool *subChanged=0);
+        const Base::Placement& origPlacement,
+        Base::Placement* origGroupPlacement = nullptr,
+        bool* subChanged = 0
+    );
 
     virtual Base::Placement _calculateAttachedPlacement(
         const std::vector<App::DocumentObject*>& objs,

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -253,9 +253,9 @@ public:  // methods
     virtual AttachEngine* copy() const = 0;
 
     Base::Placement calculateAttachedPlacement(
-        const Base::Placement& origPlacement,
-        bool* subChanged = 0
-    );
+        const Base::Placement &origPlacement,
+        Base::Placement *origGroupPlacement=nullptr, 
+        bool *subChanged=0);
 
     virtual Base::Placement _calculateAttachedPlacement(
         const std::vector<App::DocumentObject*>& objs,

--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -252,6 +252,8 @@ SET(PartGui_SRCS
     TaskCheckGeometry.h
     TaskAttacher.h
     TaskAttacher.cpp
+    Utils.cpp
+    Utils.h
 )
 
 SET(PartGuiIcon_SVG

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1842,7 +1842,7 @@ void CmdPartOffset::activated(int iMsg)
     );
     doCommand(Doc, "App.ActiveDocument.%s.Value = 1.0", offset.c_str());
 
-    doCommand(Doc, PartGui::getAutoGroupCommandStr(false).toUtf8().constData());
+    doCommand(Doc, PartGui::getAutoGroupCommandStr(false).toUtf8());
 
     updateActive();
 
@@ -1904,7 +1904,7 @@ void CmdPartOffset2D::activated(int iMsg)
     std::string offset = getUniqueObjectName("Offset2D");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make 2D Offset"));
-    doCommand(Doc, "obj =App.ActiveDocument.addObject(\"Part::Offset2D\",\"%s\")", offset.c_str());
+    doCommand(Doc, "obj = App.ActiveDocument.addObject(\"Part::Offset2D\",\"%s\")", offset.c_str());
     doCommand(
         Doc,
         "App.ActiveDocument.%s.Source = App.ActiveDocument.%s",
@@ -1912,7 +1912,7 @@ void CmdPartOffset2D::activated(int iMsg)
         shape->getNameInDocument()
     );
     doCommand(Doc, "App.ActiveDocument.%s.Value = 1.0", offset.c_str());
-    doCommand(Doc, PartGui::getAutoGroupCommandStr(false).toUtf8().constData());
+    doCommand(Doc, PartGui::getAutoGroupCommandStr(false).toUtf8());
 
     updateActive();
     doCommand(Gui, "Gui.ActiveDocument.setEdit('%s')", offset.c_str());
@@ -2118,7 +2118,7 @@ void CmdPartThickness::activated(int iMsg)
     doCommand(Doc, "obj = App.ActiveDocument.addObject(\"Part::Thickness\",\"%s\")", thick.c_str());
     doCommand(Doc, "App.ActiveDocument.%s.Faces = %s", thick.c_str(), selection.c_str());
     doCommand(Doc, "App.ActiveDocument.%s.Value = 1.0", thick.c_str());
-    doCommand(Doc, PartGui::getAutoGroupCommandStr(false).toUtf8().constData());
+    doCommand(Doc, PartGui::getAutoGroupCommandStr(false).toUtf8());
 
     updateActive();
     if (isActiveObjectValid()) {
@@ -2545,8 +2545,8 @@ void CmdPartCoordinateSystem::activated(int iMsg)
         name.c_str()
     );
     doCommand(Doc, "obj.Visibility = True");
-    doCommand(Doc, "obj.ViewObject.doubleClicked()");
     doCommand(Doc, PartGui::getAutoGroupCommandStr().toUtf8());
+    doCommand(Doc, "obj.ViewObject.doubleClicked()");
 }
 
 bool CmdPartCoordinateSystem::isActive()
@@ -2578,8 +2578,8 @@ void CmdPartDatumPlane::activated(int iMsg)
 
     std::string name = getUniqueObjectName("DatumPlane");
     doCommand(Doc, "obj = App.activeDocument().addObject('Part::DatumPlane','%s')", name.c_str());
-    doCommand(Doc, "obj.ViewObject.doubleClicked()");
     doCommand(Doc, PartGui::getAutoGroupCommandStr().toUtf8());
+    doCommand(Doc, "obj.ViewObject.doubleClicked()");
 }
 
 bool CmdPartDatumPlane::isActive()
@@ -2644,8 +2644,8 @@ void CmdPartDatumPoint::activated(int iMsg)
 
     std::string name = getUniqueObjectName("DatumPoint");
     doCommand(Doc, "obj = App.activeDocument().addObject('Part::DatumPoint','%s')", name.c_str());
-    doCommand(Doc, "obj.ViewObject.doubleClicked()");
     doCommand(Doc, PartGui::getAutoGroupCommandStr().toUtf8());
+    doCommand(Doc, "obj.ViewObject.doubleClicked()");
 }
 
 bool CmdPartDatumPoint::isActive()

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -922,6 +922,24 @@ bool CmdPartCompCompoundTools::isActive()
 }
 
 
+namespace {
+    QString getAutoGroupCommandStr()
+        // Helper function to get the python code to add the newly created object to the active Part/Body object if present
+    {
+        App::GeoFeature* activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PDBODYKEY);
+        if (!activeObj) {
+            activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PARTKEY);
+        }
+
+        if (activeObj) {
+            QString activeName = QString::fromLatin1(activeObj->getNameInDocument());
+            return QStringLiteral("App.ActiveDocument.getObject('%1\').addObject(obj)\n").arg(activeName);
+        }
+
+        return QStringLiteral("# Object created at document root.");
+    }
+}
+
 //===========================================================================
 // Part_Compound
 //===========================================================================
@@ -972,8 +990,9 @@ void CmdPartCompound::activated(int iMsg)
     str << "]";
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Compound"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Part::Compound\",\"%s\")", FeatName.c_str());
-    runCommand(Doc, str.str().c_str());
+    doCommand(Doc,"obj = App.activeDocument().addObject(\"Part::Compound\",\"%s\")",FeatName.c_str());
+    doCommand(Doc, getAutoGroupCommandStr().toUtf8());
+    runCommand(Doc,str.str().c_str());
     updateActive();
     commitCommand();
 }

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -923,7 +923,6 @@ bool CmdPartCompCompoundTools::isActive()
 }
 
 
-
 //===========================================================================
 // Part_Compound
 //===========================================================================
@@ -974,7 +973,7 @@ void CmdPartCompound::activated(int iMsg)
     str << "]";
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Compound"));
-    doCommand(Doc, "obj = App.activeDocument().addObject(\"Part::Compound\",\"%s\")",FeatName.c_str());
+    doCommand(Doc, "obj = App.activeDocument().addObject(\"Part::Compound\",\"%s\")", FeatName.c_str());
     doCommand(Doc, PartGui::getAutoGroupCommandStr().toUtf8());
     runCommand(Doc, str.str().c_str());
     updateActive();

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -922,24 +922,28 @@ bool CmdPartCompCompoundTools::isActive()
 }
 
 
-
-namespace {
-    QString getAutoGroupCommandStr()
-        // Helper function to get the python code to add the newly created object to the active Part/Body object if present
-    {
-        App::GeoFeature* activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PDBODYKEY);
-        if (!activeObj) {
-            activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PARTKEY);
-        }
-
-        if (activeObj) {
-            QString activeName = QString::fromLatin1(activeObj->getNameInDocument());
-            return QStringLiteral("App.ActiveDocument.getObject('%1\').addObject(obj)\n").arg(activeName);
-        }
-
-        return QStringLiteral("# Object created at document root.");
+namespace
+{
+QString getAutoGroupCommandStr()
+// Helper function to get the python code to add the newly created object to the active Part/Body
+// object if present
+{
+    App::GeoFeature* activeObj
+        = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PDBODYKEY);
+    if (!activeObj) {
+        activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(
+            PARTKEY
+        );
     }
+
+    if (activeObj) {
+        QString activeName = QString::fromLatin1(activeObj->getNameInDocument());
+        return QStringLiteral("App.ActiveDocument.getObject('%1\').addObject(obj)\n").arg(activeName);
+    }
+
+    return QStringLiteral("# Object created at document root.");
 }
+}  // namespace
 
 //===========================================================================
 // Part_Compound
@@ -991,9 +995,9 @@ void CmdPartCompound::activated(int iMsg)
     str << "]";
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Compound"));
-    doCommand(Doc,"obj = App.activeDocument().addObject(\"Part::Compound\",\"%s\")",FeatName.c_str());
+    doCommand(Doc, "obj = App.activeDocument().addObject(\"Part::Compound\",\"%s\")", FeatName.c_str());
     doCommand(Doc, getAutoGroupCommandStr().toUtf8());
-    runCommand(Doc,str.str().c_str());
+    runCommand(Doc, str.str().c_str());
     updateActive();
     commitCommand();
 }

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -51,6 +51,7 @@
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
 #include <Gui/WaitCursor.h>
+#include "Utils.h"
 
 #include <Mod/Part/App/Datums.h>
 #include <Mod/Part/App/Part2DObject.h>
@@ -922,28 +923,6 @@ bool CmdPartCompCompoundTools::isActive()
 }
 
 
-namespace
-{
-QString getAutoGroupCommandStr()
-// Helper function to get the python code to add the newly created object to the active Part/Body
-// object if present
-{
-    App::GeoFeature* activeObj
-        = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PDBODYKEY);
-    if (!activeObj) {
-        activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(
-            PARTKEY
-        );
-    }
-
-    if (activeObj) {
-        QString activeName = QString::fromLatin1(activeObj->getNameInDocument());
-        return QStringLiteral("App.ActiveDocument.getObject('%1\').addObject(obj)\n").arg(activeName);
-    }
-
-    return QStringLiteral("# Object created at document root.");
-}
-}  // namespace
 
 //===========================================================================
 // Part_Compound
@@ -995,8 +974,8 @@ void CmdPartCompound::activated(int iMsg)
     str << "]";
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Compound"));
-    doCommand(Doc, "obj = App.activeDocument().addObject(\"Part::Compound\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, getAutoGroupCommandStr().toUtf8());
+    doCommand(Doc, "obj = App.activeDocument().addObject(\"Part::Compound\",\"%s\")",FeatName.c_str());
+    doCommand(Doc, PartGui::getAutoGroupCommandStr().toUtf8());
     runCommand(Doc, str.str().c_str());
     updateActive();
     commitCommand();
@@ -2530,7 +2509,6 @@ bool CmdPartSectionCut::isActive()
 // Part_CoordinateSystem
 //===========================================================================
 
-
 DEF_STD_CMD_A(CmdPartCoordinateSystem)
 
 CmdPartCoordinateSystem::CmdPartCoordinateSystem()
@@ -2556,7 +2534,7 @@ void CmdPartCoordinateSystem::activated(int iMsg)
         "obj = App.activeDocument().addObject('Part::LocalCoordinateSystem','%s')",
         name.c_str()
     );
-    doCommand(Doc, getAutoGroupCommandStr().toUtf8());
+    doCommand(Doc, PartGui::getAutoGroupCommandStr().toUtf8());
     doCommand(Doc, "obj.Visibility = True");
     doCommand(Doc, "obj.ViewObject.doubleClicked()");
 }
@@ -2590,7 +2568,7 @@ void CmdPartDatumPlane::activated(int iMsg)
 
     std::string name = getUniqueObjectName("DatumPlane");
     doCommand(Doc, "obj = App.activeDocument().addObject('Part::DatumPlane','%s')", name.c_str());
-    doCommand(Doc, getAutoGroupCommandStr().toUtf8());
+    doCommand(Doc, PartGui::getAutoGroupCommandStr().toUtf8());
     doCommand(Doc, "obj.ViewObject.doubleClicked()");
 }
 
@@ -2623,7 +2601,7 @@ void CmdPartDatumLine::activated(int iMsg)
 
     std::string name = getUniqueObjectName("DatumLine");
     doCommand(Doc, "obj = App.activeDocument().addObject('Part::DatumLine','%s')", name.c_str());
-    doCommand(Doc, getAutoGroupCommandStr().toUtf8());
+    doCommand(Doc, PartGui::getAutoGroupCommandStr().toUtf8());
     doCommand(Doc, "obj.ViewObject.doubleClicked()");
 }
 
@@ -2656,7 +2634,7 @@ void CmdPartDatumPoint::activated(int iMsg)
 
     std::string name = getUniqueObjectName("DatumPoint");
     doCommand(Doc, "obj = App.activeDocument().addObject('Part::DatumPoint','%s')", name.c_str());
-    doCommand(Doc, getAutoGroupCommandStr().toUtf8());
+    doCommand(Doc, PartGui::getAutoGroupCommandStr().toUtf8());
     doCommand(Doc, "obj.ViewObject.doubleClicked()");
 }
 

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1529,7 +1529,8 @@ void CmdPartMakeFace::activated(int iMsg)
     try {
         App::DocumentT doc(sketches.front()->getDocument());
         std::stringstream str;
-        str << "obj = " << doc.getDocumentPython() << R"(.addObject("Part::Face", "Face").Sources = ()";
+        str << "obj = " << doc.getDocumentPython()
+            << R"(.addObject("Part::Face", "Face").Sources = ()";
         for (auto& obj : sketches) {
             str << App::DocumentObjectT(obj).getObjectPython() << ", ";
         }

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -922,6 +922,7 @@ bool CmdPartCompCompoundTools::isActive()
 }
 
 
+
 namespace {
     QString getAutoGroupCommandStr()
         // Helper function to get the python code to add the newly created object to the active Part/Body object if present
@@ -2525,28 +2526,6 @@ bool CmdPartSectionCut::isActive()
 // Part_CoordinateSystem
 //===========================================================================
 
-namespace
-{
-QString getAutoGroupCommandStr()
-// Helper function to get the python code to add the newly created object to the active Part/Body
-// object if present
-{
-    App::GeoFeature* activeObj
-        = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PDBODYKEY);
-    if (!activeObj) {
-        activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(
-            PARTKEY
-        );
-    }
-
-    if (activeObj) {
-        QString activeName = QString::fromLatin1(activeObj->getNameInDocument());
-        return QStringLiteral("App.ActiveDocument.getObject('%1\').addObject(obj)\n").arg(activeName);
-    }
-
-    return QStringLiteral("# Object created at document root.");
-}
-}  // namespace
 
 DEF_STD_CMD_A(CmdPartCoordinateSystem)
 

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -22,16 +22,16 @@
  *                                                                         *
  ***************************************************************************/
 
-# include <BRepAdaptor_Curve.hxx>
-# include <BRep_Tool.hxx>
-# include <Precision.hxx>
-# include <ShapeExtend_Explorer.hxx>
-# include <TopExp_Explorer.hxx>
-# include <TopoDS.hxx>
-# include <TopTools_HSequenceOfShape.hxx>
-# include <QKeyEvent>
-# include <QMessageBox>
-# include <QString>
+#include <BRepAdaptor_Curve.hxx>
+#include <BRep_Tool.hxx>
+#include <Precision.hxx>
+#include <ShapeExtend_Explorer.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopTools_HSequenceOfShape.hxx>
+#include <QKeyEvent>
+#include <QMessageBox>
+#include <QString>
 
 #include <App/Application.h>
 #include <App/Document.h>
@@ -541,7 +541,7 @@ void DlgExtrusion::apply()
             }
 
             FCMD_OBJ_DOC_CMD(sourceObj, "addObject('Part::Extrusion','" << name << "')");
-            QString qname=QString::fromUtf8(name.c_str());
+            QString qname = QString::fromUtf8(name.c_str());
             Gui::Command::runCommand(Gui::Command::Doc, PartGui::getAutoGroupCommandStr(qname).toUtf8());
             auto newObj = sourceObj->getDocument()->getObject(name.c_str());
 

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -48,6 +48,7 @@
 #include <Gui/Utilities.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
+#include <Gui/MDIView.h>
 
 #include <Mod/Part/App/Part2DObject.h>
 
@@ -483,6 +484,22 @@ void DlgExtrusion::accept()
     };
 }
 
+namespace {
+QString getAutoGroupCommandStr(std::string name)
+// Helper function to get the python code to add the newly created object to the active Part object if present
+{
+    App::Part* activePart = Gui::Application::Instance->activeView()->getActiveObject<App::Part*>("part");
+    if (activePart) {
+        QString activePartName = QString::fromLatin1(activePart->getNameInDocument());
+        QString objName        = QString::fromLatin1(name.c_str());
+        return QStringLiteral("App.ActiveDocument.getObject('%1\')."
+            "addObject(App.ActiveDocument.getObject('%2\'))\n")
+            .arg(activePartName).arg(objName);
+    }
+    return QStringLiteral("# Object created at document root.");
+}
+}
+
 void DlgExtrusion::apply()
 {
     try {
@@ -537,7 +554,8 @@ void DlgExtrusion::apply()
                 // label = QStringLiteral("%1_Extrude").arg((*it)->text(0));
             }
 
-            FCMD_OBJ_DOC_CMD(sourceObj, "addObject('Part::Extrusion','" << name << "')");
+            FCMD_OBJ_DOC_CMD(sourceObj,"addObject('Part::Extrusion','" << name << "')");
+            Gui::Command::runCommand(Gui::Command::Doc, getAutoGroupCommandStr(name).toUtf8());
             auto newObj = sourceObj->getDocument()->getObject(name.c_str());
 
             this->writeParametersToFeature(*newObj, sourceObj);

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -531,7 +531,10 @@ void DlgExtrusion::apply()
 
                 continue;
             }
-
+            if (sourceObj->isDerivedFrom<App::Part>()){
+                 FC_WARN("Cannot extrude a Part. Select a Sketch or Shape.");
+                 return;
+            }
             std::string name;
             name = sourceObj->getDocument()->getUniqueObjectName("Extrude").c_str();
             if (addBaseName) {

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -531,9 +531,9 @@ void DlgExtrusion::apply()
 
                 continue;
             }
-            if (sourceObj->isDerivedFrom<App::Part>()){
-                 FC_WARN("Cannot extrude a Part. Select a Sketch or Shape.");
-                 return;
+            if (sourceObj->isDerivedFrom<App::Part>()) {
+                FC_WARN("Cannot extrude a Part. Select a Sketch or Shape.");
+                return;
             }
             std::string name;
             name = sourceObj->getDocument()->getUniqueObjectName("Extrude").c_str();

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -548,11 +548,8 @@ void DlgExtrusion::apply()
 
             auto newObj = sourceObj->getDocument()->getObject(name.c_str());
             this->writeParametersToFeature(*newObj, sourceObj);
-            
-            Gui::Command::runCommand(
-                Gui::Command::Doc,
-                PartGui::getAutoGroupCommandStr(false).toUtf8()
-            );
+
+            Gui::Command::runCommand(Gui::Command::Doc, PartGui::getAutoGroupCommandStr(false).toUtf8());
 
             if (!sourceObj->isDerivedFrom<Part::Part2DObject>()) {
                 Gui::Command::copyVisual(newObj, "ShapeAppearance", sourceObj);

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -540,12 +540,19 @@ void DlgExtrusion::apply()
                 // label = QStringLiteral("%1_Extrude").arg((*it)->text(0));
             }
 
-            FCMD_OBJ_DOC_CMD(sourceObj, "addObject('Part::Extrusion','" << name << "')");
-            QString qname = QString::fromUtf8(name.c_str());
-            Gui::Command::runCommand(Gui::Command::Doc, PartGui::getAutoGroupCommandStr(qname).toUtf8());
-            auto newObj = sourceObj->getDocument()->getObject(name.c_str());
+            Gui::Command::doCommand(
+                Gui::Command::Doc,
+                "obj = App.ActiveDocument.addObject('Part::Extrusion','%s')",
+                name.c_str()
+            );
 
+            auto newObj = sourceObj->getDocument()->getObject(name.c_str());
             this->writeParametersToFeature(*newObj, sourceObj);
+            
+            Gui::Command::runCommand(
+                Gui::Command::Doc,
+                PartGui::getAutoGroupCommandStr(false).toUtf8()
+            );
 
             if (!sourceObj->isDerivedFrom<Part::Part2DObject>()) {
                 Gui::Command::copyVisual(newObj, "ShapeAppearance", sourceObj);

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -22,16 +22,16 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <BRepAdaptor_Curve.hxx>
-#include <BRep_Tool.hxx>
-#include <Precision.hxx>
-#include <ShapeExtend_Explorer.hxx>
-#include <TopExp_Explorer.hxx>
-#include <TopoDS.hxx>
-#include <TopTools_HSequenceOfShape.hxx>
-#include <QKeyEvent>
-#include <QMessageBox>
-
+# include <BRepAdaptor_Curve.hxx>
+# include <BRep_Tool.hxx>
+# include <Precision.hxx>
+# include <ShapeExtend_Explorer.hxx>
+# include <TopExp_Explorer.hxx>
+# include <TopoDS.hxx>
+# include <TopTools_HSequenceOfShape.hxx>
+# include <QKeyEvent>
+# include <QMessageBox>
+# include <QString>
 
 #include <App/Application.h>
 #include <App/Document.h>
@@ -49,6 +49,7 @@
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
 #include <Gui/MDIView.h>
+#include "Utils.h"
 
 #include <Mod/Part/App/Part2DObject.h>
 
@@ -484,28 +485,6 @@ void DlgExtrusion::accept()
     };
 }
 
-namespace
-{
-QString getAutoGroupCommandStr(std::string name)
-// Helper function to get the python code to add the newly created object to the active Part object
-// if present
-{
-    App::Part* activePart = Gui::Application::Instance->activeView()->getActiveObject<App::Part*>(
-        "part"
-    );
-    if (activePart) {
-        QString activePartName = QString::fromLatin1(activePart->getNameInDocument());
-        QString objName = QString::fromLatin1(name.c_str());
-        return QStringLiteral(
-                   "App.ActiveDocument.getObject('%1\')."
-                   "addObject(App.ActiveDocument.getObject('%2\'))\n"
-        )
-            .arg(activePartName)
-            .arg(objName);
-    }
-    return QStringLiteral("# Object created at document root.");
-}
-}  // namespace
 
 void DlgExtrusion::apply()
 {
@@ -562,7 +541,8 @@ void DlgExtrusion::apply()
             }
 
             FCMD_OBJ_DOC_CMD(sourceObj, "addObject('Part::Extrusion','" << name << "')");
-            Gui::Command::runCommand(Gui::Command::Doc, getAutoGroupCommandStr(name).toUtf8());
+            QString qname=QString::fromUtf8(name.c_str());
+            Gui::Command::runCommand(Gui::Command::Doc, PartGui::getAutoGroupCommandStr(qname).toUtf8());
             auto newObj = sourceObj->getDocument()->getObject(name.c_str());
 
             this->writeParametersToFeature(*newObj, sourceObj);

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -484,21 +484,28 @@ void DlgExtrusion::accept()
     };
 }
 
-namespace {
-QString getAutoGroupCommandStr(std::string name)
-// Helper function to get the python code to add the newly created object to the active Part object if present
+namespace
 {
-    App::Part* activePart = Gui::Application::Instance->activeView()->getActiveObject<App::Part*>("part");
+QString getAutoGroupCommandStr(std::string name)
+// Helper function to get the python code to add the newly created object to the active Part object
+// if present
+{
+    App::Part* activePart = Gui::Application::Instance->activeView()->getActiveObject<App::Part*>(
+        "part"
+    );
     if (activePart) {
         QString activePartName = QString::fromLatin1(activePart->getNameInDocument());
-        QString objName        = QString::fromLatin1(name.c_str());
-        return QStringLiteral("App.ActiveDocument.getObject('%1\')."
-            "addObject(App.ActiveDocument.getObject('%2\'))\n")
-            .arg(activePartName).arg(objName);
+        QString objName = QString::fromLatin1(name.c_str());
+        return QStringLiteral(
+                   "App.ActiveDocument.getObject('%1\')."
+                   "addObject(App.ActiveDocument.getObject('%2\'))\n"
+        )
+            .arg(activePartName)
+            .arg(objName);
     }
     return QStringLiteral("# Object created at document root.");
 }
-}
+}  // namespace
 
 void DlgExtrusion::apply()
 {
@@ -554,7 +561,7 @@ void DlgExtrusion::apply()
                 // label = QStringLiteral("%1_Extrude").arg((*it)->text(0));
             }
 
-            FCMD_OBJ_DOC_CMD(sourceObj,"addObject('Part::Extrusion','" << name << "')");
+            FCMD_OBJ_DOC_CMD(sourceObj, "addObject('Part::Extrusion','" << name << "')");
             Gui::Command::runCommand(Gui::Command::Doc, getAutoGroupCommandStr(name).toUtf8());
             auto newObj = sourceObj->getDocument()->getObject(name.c_str());
 

--- a/src/Mod/Part/Gui/DlgFilletEdges.cpp
+++ b/src/Mod/Part/Gui/DlgFilletEdges.cpp
@@ -63,6 +63,7 @@
 #include <Gui/Window.h>
 #include <Mod/Part/App/FeatureChamfer.h>
 #include <Mod/Part/App/FeatureFillet.h>
+#include "Utils.h"
 
 #include "DlgFilletEdges.h"
 #include "ui_DlgFilletEdges.h"
@@ -1065,10 +1066,11 @@ bool DlgFilletEdges::accept()
     QString code;
     if (!d->fillet) {
         code = QStringLiteral(
-                   "FreeCAD.ActiveDocument.addObject(\"%1\",\"%2\")\n"
+                   "obj = FreeCAD.ActiveDocument.addObject(\"%1\",\"%2\")\n"
                    "FreeCAD.ActiveDocument.%2.Base = FreeCAD.ActiveDocument.%3\n"
         )
                    .arg(type, name, shape);
+        code += PartGui::getAutoGroupCommandStr(false).toUtf8();
     }
     code += QStringLiteral("__fillets__ = []\n");
     for (int i = 0; i < model->rowCount(); ++i) {

--- a/src/Mod/Part/Gui/DlgPrimitives.cpp
+++ b/src/Mod/Part/Gui/DlgPrimitives.cpp
@@ -53,6 +53,7 @@
 #include <Mod/Part/App/FeaturePartBox.h>
 #include <Mod/Part/App/FeaturePartCircle.h>
 #include <Mod/Part/App/Tools.h>
+#include "Utils.h"
 
 #include "DlgPrimitives.h"
 #include "ui_DlgPrimitives.h"
@@ -64,23 +65,6 @@ using namespace PartGui;
 namespace PartGui
 {
 
-QString getAutoGroupCommandStr(QString objectName)
-// Helper function to get the python code to add the newly created object to the active Part object
-// if present
-{
-    App::Part* activePart = Gui::Application::Instance->activeView()->getActiveObject<App::Part*>(
-        "part"
-    );
-    if (activePart) {
-        QString activeObjectName = QString::fromUtf8(activePart->getNameInDocument());
-        return QStringLiteral(
-                   "App.ActiveDocument.getObject('%1\')."
-                   "addObject(App.ActiveDocument.getObject('%2\'))\n"
-        )
-            .arg(activeObjectName, objectName);
-    }
-    return QStringLiteral("# Object %1 created at document root").arg(objectName);
-}
 
 const char* gce_ErrorStatusText(gce_ErrorType et)
 {
@@ -2308,7 +2292,7 @@ void DlgPrimitives::tryCreatePrimitive(const QString& placement)
     QString prim = tr("Create %1").arg(ui->PrimitiveTypeCB->currentText());
     Gui::Application::Instance->activeDocument()->openCommand(prim.toUtf8());
     Gui::Command::runCommand(Gui::Command::Doc, cmd.toUtf8());
-    Gui::Command::runCommand(Gui::Command::Doc, getAutoGroupCommandStr(name).toUtf8());
+    Gui::Command::runCommand(Gui::Command::Doc, PartGui::getAutoGroupCommandStr(name).toUtf8());
     Gui::Application::Instance->activeDocument()->commitCommand();
     Gui::Command::runCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
     Gui::Command::runCommand(Gui::Command::Gui, "Gui.SendMsgToActiveView(\"ViewFit\")");

--- a/src/Mod/Part/Gui/DlgRevolution.cpp
+++ b/src/Mod/Part/Gui/DlgRevolution.cpp
@@ -47,6 +47,8 @@
 #include <Gui/Utilities.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
+#include "Utils.h"
+
 #include <Mod/Part/App/FeatureRevolution.h>
 
 #include <Mod/Part/App/Part2DObject.h>
@@ -469,7 +471,8 @@ void DlgRevolution::accept()
 
 
             QString code = QStringLiteral(
-                               "FreeCAD.ActiveDocument.addObject(\"%1\",\"%2\")\n"
+                               "obj = FreeCAD.ActiveDocument.addObject(\"%1\",\"%2\")\n"
+                               "%14"  // auto-grouping
                                "FreeCAD.ActiveDocument.%2.Source = FreeCAD.ActiveDocument.%3\n"
                                "FreeCAD.ActiveDocument.%2.Axis = (%4,%5,%6)\n"
                                "FreeCAD.ActiveDocument.%2.Base = (%7,%8,%9)\n"
@@ -492,6 +495,8 @@ void DlgRevolution::accept()
                                    strAxisLink,  //%12
                                    symmetric
                                )  //%13
+                               .arg(PartGui::getAutoGroupCommandStr(false)) //%14
+
                 ;
             Gui::Command::runCommand(Gui::Command::App, code.toLatin1());
 

--- a/src/Mod/Part/Gui/DlgRevolution.cpp
+++ b/src/Mod/Part/Gui/DlgRevolution.cpp
@@ -494,8 +494,8 @@ void DlgRevolution::accept()
                                    solid,        //%11
                                    strAxisLink,  //%12
                                    symmetric
-                               )  //%13
-                               .arg(PartGui::getAutoGroupCommandStr(false)) //%14
+                               )                                             //%13
+                               .arg(PartGui::getAutoGroupCommandStr(false))  //%14
 
                 ;
             Gui::Command::runCommand(Gui::Command::App, code.toLatin1());

--- a/src/Mod/Part/Gui/DlgRevolution.cpp
+++ b/src/Mod/Part/Gui/DlgRevolution.cpp
@@ -494,8 +494,8 @@ void DlgRevolution::accept()
                                    solid,        //%11
                                    strAxisLink,  //%12
                                    symmetric
-                               )                                             //%13
-                               .arg(PartGui::getAutoGroupCommandStr(false))  //%14
+                               )  //%13
+                               .arg(PartGui::getAutoGroupCommandStr(false)) //%14
 
                 ;
             Gui::Command::runCommand(Gui::Command::App, code.toLatin1());

--- a/src/Mod/Part/Gui/DlgScale.cpp
+++ b/src/Mod/Part/Gui/DlgScale.cpp
@@ -49,6 +49,8 @@
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
 
+#include "Utils.h"
+
 #include "ui_DlgScale.h"
 #include "DlgScale.h"
 
@@ -250,10 +252,17 @@ void DlgScale::apply()
                 // label = QStringLiteral("%1_Scale").arg((*it)->text(0));
             }
 
-            FCMD_OBJ_DOC_CMD(sourceObj, "addObject('Part::Scale','" << name << "')");
-            auto newObj = sourceObj->getDocument()->getObject(name.c_str());
+            Gui::Command::doCommand(
+                Gui::Command::Doc,
+                "obj = App.ActiveDocument.addObject('Part::Scale','%s')",
+                name.c_str()
+            );
 
+
+            auto newObj = sourceObj->getDocument()->getObject(name.c_str());
             this->writeParametersToFeature(*newObj, sourceObj);
+
+            Gui::Command::runCommand(Gui::Command::Doc, PartGui::getAutoGroupCommandStr(false).toUtf8());
 
             Gui::Command::copyVisual(newObj, "ShapeAppearance", sourceObj);
             Gui::Command::copyVisual(newObj, "LineColor", sourceObj);

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -61,6 +61,7 @@
 #include <Mod/Part/App/DatumFeature.h>
 #include <Mod/Part/App/FeatureMirroring.h>
 #include <App/Datums.h>
+#include "Utils.h"
 
 #include "Mirroring.h"
 
@@ -366,6 +367,7 @@ bool Mirroring::accept()
         QString code = QStringLiteral(
                            "__doc__=FreeCAD.getDocument(\"%1\")\n"
                            "__doc__.addObject(\"Part::Mirroring\")\n"
+                           "%11"   //auto-grouping
                            "__doc__.ActiveObject.Source=__doc__.getObject(\"%2\")\n"
                            "__doc__.ActiveObject.Label=u\"%3\"\n"
                            "__doc__.ActiveObject.Normal=(%4,%5,%6)\n"
@@ -380,7 +382,8 @@ bool Mirroring::accept()
                            .arg(basex)
                            .arg(basey)
                            .arg(basez)
-                           .arg(selectionString);
+                           .arg(selectionString)
+                           .arg( PartGui::getAutoGroupCommandStr(false) );
         Gui::Command::runCommand(Gui::Command::App, code.toLatin1());
         QByteArray from = shape.toLatin1();
         Gui::Command::copyVisual("ActiveObject", "ShapeAppearance", from);

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -367,7 +367,7 @@ bool Mirroring::accept()
         QString code = QStringLiteral(
                            "__doc__=FreeCAD.getDocument(\"%1\")\n"
                            "__doc__.addObject(\"Part::Mirroring\")\n"
-                           "%11"   //auto-grouping
+                           "%11"  // auto-grouping
                            "__doc__.ActiveObject.Source=__doc__.getObject(\"%2\")\n"
                            "__doc__.ActiveObject.Label=u\"%3\"\n"
                            "__doc__.ActiveObject.Normal=(%4,%5,%6)\n"
@@ -383,7 +383,7 @@ bool Mirroring::accept()
                            .arg(basey)
                            .arg(basez)
                            .arg(selectionString)
-                           .arg( PartGui::getAutoGroupCommandStr(false) );
+                           .arg(PartGui::getAutoGroupCommandStr(false));
         Gui::Command::runCommand(Gui::Command::App, code.toLatin1());
         QByteArray from = shape.toLatin1();
         Gui::Command::copyVisual("ActiveObject", "ShapeAppearance", from);

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -367,12 +367,12 @@ bool Mirroring::accept()
         QString code = QStringLiteral(
                            "__doc__=FreeCAD.getDocument(\"%1\")\n"
                            "obj = __doc__.addObject(\"Part::Mirroring\")\n"
-                           "%11"  // auto-grouping
                            "__doc__.ActiveObject.Source=__doc__.getObject(\"%2\")\n"
                            "__doc__.ActiveObject.Label=u\"%3\"\n"
                            "__doc__.ActiveObject.Normal=(%4,%5,%6)\n"
                            "__doc__.ActiveObject.Base=(%7,%8,%9)\n"
                            "__doc__.ActiveObject.MirrorPlane=(%10)\n"
+                           "%11"  // auto-grouping
                            "del __doc__"
         )
                            .arg(this->document, shape, label)

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -366,7 +366,7 @@ bool Mirroring::accept()
 
         QString code = QStringLiteral(
                            "__doc__=FreeCAD.getDocument(\"%1\")\n"
-                           "__doc__.addObject(\"Part::Mirroring\")\n"
+                           "obj = __doc__.addObject(\"Part::Mirroring\")\n"
                            "%11"  // auto-grouping
                            "__doc__.ActiveObject.Source=__doc__.getObject(\"%2\")\n"
                            "__doc__.ActiveObject.Label=u\"%3\"\n"

--- a/src/Mod/Part/Gui/TaskLoft.cpp
+++ b/src/Mod/Part/Gui/TaskLoft.cpp
@@ -45,6 +45,7 @@
 
 #include <Mod/Part/App/PartFeature.h>
 
+#include "Utils.h"
 #include "TaskLoft.h"
 #include "ui_TaskLoft.h"
 
@@ -210,13 +211,20 @@ bool LoftWidget::accept()
     try {
         QString cmd;
         cmd = QStringLiteral(
-                  "App.getDocument('%5').addObject('Part::Loft','Loft')\n"
+                  "obj = App.getDocument('%5').addObject('Part::Loft','Loft')\n"
                   "App.getDocument('%5').ActiveObject.Sections=[%1]\n"
                   "App.getDocument('%5').ActiveObject.Solid=%2\n"
                   "App.getDocument('%5').ActiveObject.Ruled=%3\n"
                   "App.getDocument('%5').ActiveObject.Closed=%4\n"
+                  "%5"  // auto-grouping
         )
-                  .arg(list, solid, ruled, closed, QString::fromLatin1(d->document.c_str()));
+                  .arg(list, 
+                       solid, 
+                       ruled, 
+                       closed, 
+                       QString::fromLatin1(d->document.c_str()),
+                       PartGui::getAutoGroupCommandStr(false)
+                   );
 
         Gui::Document* doc = Gui::Application::Instance->getDocument(d->document.c_str());
         if (!doc) {

--- a/src/Mod/Part/Gui/TaskLoft.cpp
+++ b/src/Mod/Part/Gui/TaskLoft.cpp
@@ -216,7 +216,7 @@ bool LoftWidget::accept()
                   "App.getDocument('%5').ActiveObject.Solid=%2\n"
                   "App.getDocument('%5').ActiveObject.Ruled=%3\n"
                   "App.getDocument('%5').ActiveObject.Closed=%4\n"
-                  "%5"  // auto-grouping
+                  "%6"  // auto-grouping
         )
                   .arg(
                       list,

--- a/src/Mod/Part/Gui/TaskLoft.cpp
+++ b/src/Mod/Part/Gui/TaskLoft.cpp
@@ -218,13 +218,14 @@ bool LoftWidget::accept()
                   "App.getDocument('%5').ActiveObject.Closed=%4\n"
                   "%5"  // auto-grouping
         )
-                  .arg(list, 
-                       solid, 
-                       ruled, 
-                       closed, 
-                       QString::fromLatin1(d->document.c_str()),
-                       PartGui::getAutoGroupCommandStr(false)
-                   );
+                  .arg(
+                      list,
+                      solid,
+                      ruled,
+                      closed,
+                      QString::fromLatin1(d->document.c_str()),
+                      PartGui::getAutoGroupCommandStr(false)
+                  );
 
         Gui::Document* doc = Gui::Application::Instance->getDocument(d->document.c_str());
         if (!doc) {

--- a/src/Mod/Part/Gui/TaskShapeBuilder.cpp
+++ b/src/Mod/Part/Gui/TaskShapeBuilder.cpp
@@ -45,6 +45,7 @@
 #include <Gui/Selection/SelectionObject.h>
 #include <Mod/Part/App/PartFeature.h>
 
+#include "Utils.h"
 #include "TaskShapeBuilder.h"
 #include "ui_TaskShapeBuilder.h"
 #include "BoxSelection.h"
@@ -258,10 +259,14 @@ void ShapeBuilderWidget::createEdgeFromVertex()
     cmd = QStringLiteral(
               "_=Part.makeLine(%1, %2)\n"
               "if _.isNull(): raise RuntimeError('Failed to create edge')\n"
-              "App.ActiveDocument.addObject('Part::Feature','Edge').Shape=_\n"
+              "obj = App.ActiveDocument.addObject('Part::Feature','Edge').Shape=_\n"
+              "%3"  // auto-grouping
               "del _\n"
     )
-              .arg(elements[0], elements[1]);
+              .arg(elements[0], 
+                   elements[1], 
+                   PartGui::getAutoGroupCommandStr(false)
+              );
 
     try {
         Gui::Application::Instance->activeDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Edge"));
@@ -301,10 +306,13 @@ void ShapeBuilderWidget::createWireFromEdge()
     cmd = QStringLiteral(
               "_=Part.Wire(Part.__sortEdges__(%1))\n"
               "if _.isNull(): raise RuntimeError('Failed to create a wire')\n"
-              "App.ActiveDocument.addObject('Part::Feature','Wire').Shape=_\n"
+              "obj = App.ActiveDocument.addObject('Part::Feature','Wire').Shape=_\n"
+              "%2"  // auto-grouping
               "del _\n"
     )
-              .arg(list);
+              .arg(list, 
+                   PartGui::getAutoGroupCommandStr(false)
+               );
     try {
         Gui::Application::Instance->activeDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Wire"));
         Gui::Command::runCommand(Gui::Command::App, cmd.toLatin1());
@@ -345,19 +353,25 @@ void ShapeBuilderWidget::createFaceFromVertex()
         cmd = QStringLiteral(
                   "_=Part.Face(Part.makePolygon(%1, True))\n"
                   "if _.isNull(): raise RuntimeError('Failed to create face')\n"
-                  "App.ActiveDocument.addObject('Part::Feature','Face').Shape=_\n"
+                  "obj = App.ActiveDocument.addObject('Part::Feature','Face').Shape=_\n"
+                  "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(list);
+                  .arg(list,
+                       PartGui::getAutoGroupCommandStr(false)
+                   );
     }
     else {
         cmd = QStringLiteral(
                   "_=Part.makeFilledFace(Part.makePolygon(%1, True).Edges)\n"
                   "if _.isNull(): raise RuntimeError('Failed to create face')\n"
-                  "App.ActiveDocument.addObject('Part::Feature','Face').Shape=_\n"
+                  "obj = App.ActiveDocument.addObject('Part::Feature','Face').Shape=_\n"
+                  "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(list);
+                  .arg(list,
+                       PartGui::getAutoGroupCommandStr(false)
+                   );
     }
 
     try {
@@ -399,19 +413,25 @@ void ShapeBuilderWidget::createFaceFromEdge()
         cmd = QStringLiteral(
                   "_=Part.Face(Part.Wire(Part.__sortEdges__(%1)))\n"
                   "if _.isNull(): raise RuntimeError('Failed to create face')\n"
-                  "App.ActiveDocument.addObject('Part::Feature','Face').Shape=_\n"
+                  "obj = App.ActiveDocument.addObject('Part::Feature','Face').Shape=_\n"
+                  "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(list);
+                  .arg(list,
+                       PartGui::getAutoGroupCommandStr(false)
+                   );
     }
     else {
         cmd = QStringLiteral(
                   "_=Part.makeFilledFace(Part.__sortEdges__(%1))\n"
                   "if _.isNull(): raise RuntimeError('Failed to create face')\n"
-                  "App.ActiveDocument.addObject('Part::Feature','Face').Shape=_\n"
+                  "obj = App.ActiveDocument.addObject('Part::Feature','Face').Shape=_\n"
+                  "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(list);
+                  .arg(list,
+                       PartGui::getAutoGroupCommandStr(false)
+                   );
     }
 
     try {
@@ -463,19 +483,25 @@ void ShapeBuilderWidget::createShellFromFace()
         cmd = QStringLiteral(
                   "_=Part.Shell(%1)\n"
                   "if _.isNull(): raise RuntimeError('Failed to create shell')\n"
-                  "App.ActiveDocument.addObject('Part::Feature','Shell').Shape=_.removeSplitter()\n"
+                  "obj = App.ActiveDocument.addObject('Part::Feature','Shell').Shape=_.removeSplitter()\n"
+                  "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(list);
+                  .arg(list,
+                       PartGui::getAutoGroupCommandStr(false)
+                   );
     }
     else {
         cmd = QStringLiteral(
                   "_=Part.Shell(%1)\n"
                   "if _.isNull(): raise RuntimeError('Failed to create shell')\n"
-                  "App.ActiveDocument.addObject('Part::Feature','Shell').Shape=_\n"
+                  "obj = App.ActiveDocument.addObject('Part::Feature','Shell').Shape=_\n"
+                  "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(list);
+                  .arg(list,
+                       PartGui::getAutoGroupCommandStr(false)
+                   );
     }
 
     try {
@@ -518,10 +544,13 @@ void ShapeBuilderWidget::createSolidFromShell()
                   "shell')\n"
                   "_=Part.Solid(shell)\n"
                   "if _.isNull(): raise RuntimeError('Failed to create solid')\n"
-                  "App.ActiveDocument.addObject('Part::Feature','Solid').Shape=_.removeSplitter()\n"
+                  "obj = App.ActiveDocument.addObject('Part::Feature','Solid').Shape=_.removeSplitter()\n"
+                  "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(line);
+                  .arg(line,
+                       PartGui::getAutoGroupCommandStr(false)
+                   );
     }
     else {
         cmd = QStringLiteral(
@@ -530,10 +559,13 @@ void ShapeBuilderWidget::createSolidFromShell()
                   "shell')\n"
                   "_=Part.Solid(shell)\n"
                   "if _.isNull(): raise RuntimeError('Failed to create solid')\n"
-                  "App.ActiveDocument.addObject('Part::Feature','Solid').Shape=_\n"
+                  "obj = App.ActiveDocument.addObject('Part::Feature','Solid').Shape=_\n"
+                  "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(line);
+                  .arg(line,
+                       PartGui::getAutoGroupCommandStr(false)
+                   );
     }
 
     try {

--- a/src/Mod/Part/Gui/TaskShapeBuilder.cpp
+++ b/src/Mod/Part/Gui/TaskShapeBuilder.cpp
@@ -263,10 +263,7 @@ void ShapeBuilderWidget::createEdgeFromVertex()
               "%3"  // auto-grouping
               "del _\n"
     )
-              .arg(elements[0], 
-                   elements[1], 
-                   PartGui::getAutoGroupCommandStr(false)
-              );
+              .arg(elements[0], elements[1], PartGui::getAutoGroupCommandStr(false));
 
     try {
         Gui::Application::Instance->activeDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Edge"));
@@ -310,9 +307,7 @@ void ShapeBuilderWidget::createWireFromEdge()
               "%2"  // auto-grouping
               "del _\n"
     )
-              .arg(list, 
-                   PartGui::getAutoGroupCommandStr(false)
-               );
+              .arg(list, PartGui::getAutoGroupCommandStr(false));
     try {
         Gui::Application::Instance->activeDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Wire"));
         Gui::Command::runCommand(Gui::Command::App, cmd.toLatin1());
@@ -357,9 +352,7 @@ void ShapeBuilderWidget::createFaceFromVertex()
                   "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(list,
-                       PartGui::getAutoGroupCommandStr(false)
-                   );
+                  .arg(list, PartGui::getAutoGroupCommandStr(false));
     }
     else {
         cmd = QStringLiteral(
@@ -369,9 +362,7 @@ void ShapeBuilderWidget::createFaceFromVertex()
                   "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(list,
-                       PartGui::getAutoGroupCommandStr(false)
-                   );
+                  .arg(list, PartGui::getAutoGroupCommandStr(false));
     }
 
     try {
@@ -417,9 +408,7 @@ void ShapeBuilderWidget::createFaceFromEdge()
                   "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(list,
-                       PartGui::getAutoGroupCommandStr(false)
-                   );
+                  .arg(list, PartGui::getAutoGroupCommandStr(false));
     }
     else {
         cmd = QStringLiteral(
@@ -429,9 +418,7 @@ void ShapeBuilderWidget::createFaceFromEdge()
                   "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(list,
-                       PartGui::getAutoGroupCommandStr(false)
-                   );
+                  .arg(list, PartGui::getAutoGroupCommandStr(false));
     }
 
     try {
@@ -483,13 +470,12 @@ void ShapeBuilderWidget::createShellFromFace()
         cmd = QStringLiteral(
                   "_=Part.Shell(%1)\n"
                   "if _.isNull(): raise RuntimeError('Failed to create shell')\n"
-                  "obj = App.ActiveDocument.addObject('Part::Feature','Shell').Shape=_.removeSplitter()\n"
+                  "obj = "
+                  "App.ActiveDocument.addObject('Part::Feature','Shell').Shape=_.removeSplitter()\n"
                   "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(list,
-                       PartGui::getAutoGroupCommandStr(false)
-                   );
+                  .arg(list, PartGui::getAutoGroupCommandStr(false));
     }
     else {
         cmd = QStringLiteral(
@@ -499,9 +485,7 @@ void ShapeBuilderWidget::createShellFromFace()
                   "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(list,
-                       PartGui::getAutoGroupCommandStr(false)
-                   );
+                  .arg(list, PartGui::getAutoGroupCommandStr(false));
     }
 
     try {
@@ -544,13 +528,12 @@ void ShapeBuilderWidget::createSolidFromShell()
                   "shell')\n"
                   "_=Part.Solid(shell)\n"
                   "if _.isNull(): raise RuntimeError('Failed to create solid')\n"
-                  "obj = App.ActiveDocument.addObject('Part::Feature','Solid').Shape=_.removeSplitter()\n"
+                  "obj = "
+                  "App.ActiveDocument.addObject('Part::Feature','Solid').Shape=_.removeSplitter()\n"
                   "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(line,
-                       PartGui::getAutoGroupCommandStr(false)
-                   );
+                  .arg(line, PartGui::getAutoGroupCommandStr(false));
     }
     else {
         cmd = QStringLiteral(
@@ -563,9 +546,7 @@ void ShapeBuilderWidget::createSolidFromShell()
                   "%2"  // auto-grouping
                   "del _\n"
         )
-                  .arg(line,
-                       PartGui::getAutoGroupCommandStr(false)
-                   );
+                  .arg(line, PartGui::getAutoGroupCommandStr(false));
     }
 
     try {

--- a/src/Mod/Part/Gui/TaskSweep.cpp
+++ b/src/Mod/Part/Gui/TaskSweep.cpp
@@ -404,11 +404,11 @@ bool SweepWidget::accept()
         QString cmd;
         cmd = QStringLiteral(
                   "obj = App.getDocument('%5').addObject('Part::Sweep','Sweep')\n"
-                  "%6"  // auto-grouping
                   "App.getDocument('%5').ActiveObject.Sections=[%1]\n"
                   "App.getDocument('%5').ActiveObject.Spine=%2\n"
                   "App.getDocument('%5').ActiveObject.Solid=%3\n"
                   "App.getDocument('%5').ActiveObject.Frenet=%4\n"
+                  "%6"  // auto-grouping
         )
                   .arg(
                       list,

--- a/src/Mod/Part/Gui/TaskSweep.cpp
+++ b/src/Mod/Part/Gui/TaskSweep.cpp
@@ -53,6 +53,7 @@
 #include <Gui/WaitCursor.h>
 #include <Mod/Part/App/PartFeature.h>
 
+#include "Utils.h"
 #include "TaskSweep.h"
 #include "ui_TaskSweep.h"
 
@@ -402,7 +403,8 @@ bool SweepWidget::accept()
         Gui::WaitCursor wc;
         QString cmd;
         cmd = QStringLiteral(
-                  "App.getDocument('%5').addObject('Part::Sweep','Sweep')\n"
+                  "obj = App.getDocument('%5').addObject('Part::Sweep','Sweep')\n"
+                  "%6"  // auto-grouping
                   "App.getDocument('%5').ActiveObject.Sections=[%1]\n"
                   "App.getDocument('%5').ActiveObject.Spine=%2\n"
                   "App.getDocument('%5').ActiveObject.Solid=%3\n"
@@ -413,7 +415,8 @@ bool SweepWidget::accept()
                       QLatin1String(selection.c_str()),
                       solid,
                       frenet,
-                      QString::fromLatin1(d->document.c_str())
+                      QString::fromLatin1(d->document.c_str()),
+                      PartGui::getAutoGroupCommandStr(false)
                   );
 
         Gui::Document* doc = Gui::Application::Instance->getDocument(d->document.c_str());

--- a/src/Mod/Part/Gui/Utils.cpp
+++ b/src/Mod/Part/Gui/Utils.cpp
@@ -34,16 +34,15 @@
 #include "Utils.h"
 
 
-FC_LOG_LEVEL_INIT("PartGui",true,true)
-
-
+FC_LOG_LEVEL_INIT("PartGui", true, true)
 
 
 //===========================================================================
 // Helper for Body
 //===========================================================================
 
-namespace PartGui {
+namespace PartGui
+{
 
 QString getAutoGroupCommandStr(bool useActiveBody)
 // Helper function to get the python code to add the newly created object to the active Part/Body
@@ -51,10 +50,14 @@ QString getAutoGroupCommandStr(bool useActiveBody)
 {
     App::GeoFeature* activeObj = nullptr;
     if (useActiveBody) {
-        activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PDBODYKEY);
+        activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(
+            PDBODYKEY
+        );
     }
     if (!activeObj) {
-        activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PARTKEY);
+        activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(
+            PARTKEY
+        );
     }
     if (activeObj) {
         QString activeName = QString::fromLatin1(activeObj->getNameInDocument());
@@ -67,16 +70,19 @@ QString getAutoGroupCommandStr(QString objectName)
 // Helper function to get the python code to add the newly created object to the active Part object
 // if present
 {
-    App::Part* activePart =
-        Gui::Application::Instance->activeView()->getActiveObject<App::Part*>("part");
+    App::Part* activePart = Gui::Application::Instance->activeView()->getActiveObject<App::Part*>(
+        "part"
+    );
     if (activePart) {
         QString activeObjectName = QString::fromLatin1(activePart->getNameInDocument());
-        return QStringLiteral("App.ActiveDocument.getObject('%1\')."
-                              "addObject(App.ActiveDocument.getObject('%2\'))\n")
+        return QStringLiteral(
+                   "App.ActiveDocument.getObject('%1\')."
+                   "addObject(App.ActiveDocument.getObject('%2\'))\n"
+        )
             .arg(activeObjectName, objectName);
     }
     return QStringLiteral("# Object %1 created at document root").arg(objectName);
 }
 
 
-} /* PartDesignGui */
+}  // namespace PartGui

--- a/src/Mod/Part/Gui/Utils.cpp
+++ b/src/Mod/Part/Gui/Utils.cpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Walter Steffè  <walter.steffe.it@gmail.com>         *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "FCGlobal.h"
+
+#include <QMessageBox>
+#include <QString>
+#include <App/GeoFeature.h>
+#include <App/Part.h>
+#include <Gui/Application.h>
+#include <Gui/MDIView.h>
+#include <Gui/ActiveObjectList.h>
+
+#include "Utils.h"
+
+
+FC_LOG_LEVEL_INIT("PartGui",true,true)
+
+
+
+
+//===========================================================================
+// Helper for Body
+//===========================================================================
+
+namespace PartGui {
+
+QString getAutoGroupCommandStr(bool useActiveBody)
+// Helper function to get the python code to add the newly created object to the active Part/Body
+// object if present
+{
+    App::GeoFeature* activeObj = nullptr;
+    if (useActiveBody) {
+        activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PDBODYKEY);
+    }
+    if (!activeObj) {
+        activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PARTKEY);
+    }
+    if (activeObj) {
+        QString activeName = QString::fromLatin1(activeObj->getNameInDocument());
+        return QStringLiteral("App.ActiveDocument.getObject('%1\').addObject(obj)\n").arg(activeName);
+    }
+    return QStringLiteral("# Object created at document root.");
+}
+
+QString getAutoGroupCommandStr(QString objectName)
+// Helper function to get the python code to add the newly created object to the active Part object
+// if present
+{
+    App::Part* activePart =
+        Gui::Application::Instance->activeView()->getActiveObject<App::Part*>("part");
+    if (activePart) {
+        QString activeObjectName = QString::fromLatin1(activePart->getNameInDocument());
+        return QStringLiteral("App.ActiveDocument.getObject('%1\')."
+                              "addObject(App.ActiveDocument.getObject('%2\'))\n")
+            .arg(activeObjectName, objectName);
+    }
+    return QStringLiteral("# Object %1 created at document root").arg(objectName);
+}
+
+
+} /* PartDesignGui */

--- a/src/Mod/Part/Gui/Utils.cpp
+++ b/src/Mod/Part/Gui/Utils.cpp
@@ -63,7 +63,7 @@ QString getAutoGroupCommandStr(bool useActiveBody)
         QString activeName = QString::fromLatin1(activeObj->getNameInDocument());
         return QStringLiteral("App.ActiveDocument.getObject('%1\').addObject(obj)\n").arg(activeName);
     }
-    return QStringLiteral("# Object created at document root.");
+    return QStringLiteral("# Object created at document root.\n");
 }
 
 QString getAutoGroupCommandStr(QString objectName)

--- a/src/Mod/Part/Gui/Utils.h
+++ b/src/Mod/Part/Gui/Utils.h
@@ -21,10 +21,15 @@
  *                                                                          *
  ***************************************************************************/
 
-#pragma once
+#ifndef PARTGUI_UTILS_H
+#define PARTGUI_UTILS_H
+
+#include <Mod/Part/PartGlobal.h>
 
 namespace PartGui
 {
-QString getAutoGroupCommandStr(bool useActiveBody = true);
-QString getAutoGroupCommandStr(QString objectName);
+QString PartGuiExport getAutoGroupCommandStr(bool useActiveBody = true);
+QString PartGuiExport getAutoGroupCommandStr(QString objectName);
 }  // namespace PartGui
+
+#endif

--- a/src/Mod/Part/Gui/Utils.h
+++ b/src/Mod/Part/Gui/Utils.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Walter Steffè  <walter.steffe.it@gmail.com>         *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+namespace PartGui
+{
+QString getAutoGroupCommandStr(bool useActiveBody = true);
+QString getAutoGroupCommandStr(QString objectName);
+}  // namespace PartGui

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -44,6 +44,10 @@ Body::Body()
     ADD_PROPERTY_TYPE(AllowCompound, (true), "Base", App::Prop_None, "Allow multiple solids in Body");
 
     _GroupTouched.setStatus(App::Property::Output, true);
+
+    if (auto* gext = this->getExtensionByType<App::GeoFeatureGroupExtension>()) {
+        gext->setActsAsGroupBoundary(false); // Bodies are transparent boundaries
+    }
 }
 
 /*
@@ -605,6 +609,9 @@ void Body::onDocumentRestored()
         Tip.touch();
     }
 
+    if (auto* gext = this->getExtensionByType<App::GeoFeatureGroupExtension>()) {
+        gext->setActsAsGroupBoundary(false); // Bodies are transparent boundaries
+    }
     DocumentObject::onDocumentRestored();
 }
 
@@ -619,3 +626,4 @@ bool Body::isSolid()
     }
     return false;
 }
+

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -46,7 +46,7 @@ Body::Body()
     _GroupTouched.setStatus(App::Property::Output, true);
 
     if (auto* gext = this->getExtensionByType<App::GeoFeatureGroupExtension>()) {
-        gext->setActsAsGroupBoundary(false); // Bodies are transparent boundaries
+        gext->setActsAsGroupBoundary(false);  // Bodies are transparent boundaries
     }
 }
 
@@ -610,7 +610,7 @@ void Body::onDocumentRestored()
     }
 
     if (auto* gext = this->getExtensionByType<App::GeoFeatureGroupExtension>()) {
-        gext->setActsAsGroupBoundary(false); // Bodies are transparent boundaries
+        gext->setActsAsGroupBoundary(false);  // Bodies are transparent boundaries
     }
     DocumentObject::onDocumentRestored();
 }
@@ -626,4 +626,3 @@ bool Body::isSolid()
     }
     return false;
 }
-

--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -35,10 +35,12 @@
 #include <TopoDS_Shape.hxx>
 
 #include <App/Document.h>
+#include <App/GeoFeatureGroupExtension.h>
 #include <Base/Tools.h>
 #include <Mod/Part/App/ExtrusionHelper.h>
 #include "Mod/Part/App/TopoShapeOpCode.h"
 #include <Mod/Part/App/PartFeature.h>
+#include <Mod/Part/App/Tools.h>
 
 #include "FeatureExtrude.h"
 
@@ -849,7 +851,13 @@ TopoShape FeatureExtrude::generateSingleExtrusionSide(
         || method == "UpToShape") {
         // Note: This will return an unlimited planar face if support is a datum plane
         TopoShape supportface = getTopoShapeSupportFace();
-        auto invObjLoc = getLocation().Inverted();
+        auto objLoc=getLocation();
+        auto invObjLoc = objLoc.Inverted();
+        Base::Placement groupPla=App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(this);
+        TopLoc_Location groupLoc=Part::Tools::fromPlacement(groupPla);
+        auto globalObjLoc=groupLoc*objLoc;
+        auto invGlobalObjLoc = globalObjLoc.Inverted();
+
         supportface.move(invObjLoc);
 
         if (!supportface.hasSubShape(TopAbs_WIRE)) {
@@ -861,11 +869,11 @@ TopoShape FeatureExtrude::generateSingleExtrusionSide(
         // Find a valid shape, face or datum plane to extrude up to
         if (method == "UpToFace") {
             getUpToFaceFromLinkSub(upToShape, upToFacePropHandle);
-            upToShape.move(invObjLoc);
+            upToShape.move(invGlobalObjLoc);
         }
         else if (method == "UpToShape") {
             faceCount = getUpToShapeFromLinkSubList(upToShape, upToShapePropHandle);
-            upToShape.move(invObjLoc);
+            upToShape.move(invGlobalObjLoc);
             if (faceCount == 0) {
                 // No shape selected, use the base
                 upToShape = base;

--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -851,11 +851,11 @@ TopoShape FeatureExtrude::generateSingleExtrusionSide(
         || method == "UpToShape") {
         // Note: This will return an unlimited planar face if support is a datum plane
         TopoShape supportface = getTopoShapeSupportFace();
-        auto objLoc=getLocation();
+        auto objLoc = getLocation();
         auto invObjLoc = objLoc.Inverted();
-        Base::Placement groupPla=App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(this);
-        TopLoc_Location groupLoc=Part::Tools::fromPlacement(groupPla);
-        auto globalObjLoc=groupLoc*objLoc;
+        Base::Placement groupPla = App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(this);
+        TopLoc_Location groupLoc = Part::Tools::fromPlacement(groupPla);
+        auto globalObjLoc = groupLoc * objLoc;
         auto invGlobalObjLoc = globalObjLoc.Inverted();
 
         supportface.move(invObjLoc);

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -705,9 +705,12 @@ Part::Feature* ProfileBased::getBaseObject(bool silent) const
         err = "No base set, no sketch support either";
     }
 
-    PartDesign::Body* body= Feature::getFeatureBody();
-    if(body && spt) if(!body->hasObject(spt))
-        return nullptr;
+    PartDesign::Body* body = Feature::getFeatureBody();
+    if (body && spt) {
+        if (!body->hasObject(spt)) {
+            return nullptr;
+        }
+    }
 
     if (!silent && err) {
         throw Base::RuntimeError(err);
@@ -735,7 +738,7 @@ void ProfileBased::getUpToFaceFromLinkSub(TopoShape& upToFace, const App::Proper
     }
 
     Base::Placement groupPla;
-    groupPla=App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(ref);
+    groupPla = App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(ref);
 
     if (ref->isDerivedFrom<App::Plane>()) {
         upToFace = makeShapeFromPlane(ref);
@@ -756,10 +759,9 @@ void ProfileBased::getUpToFaceFromLinkSub(TopoShape& upToFace, const App::Proper
     }
 
     if (!groupPla.isIdentity()) {
-        TopLoc_Location groupLoc=Part::Tools::fromPlacement(groupPla);
+        TopLoc_Location groupLoc = Part::Tools::fromPlacement(groupPla);
         upToFace.move(groupLoc);
     }
-
 }
 
 int ProfileBased::getUpToShapeFromLinkSubList(
@@ -775,8 +777,8 @@ int ProfileBased::getUpToShapeFromLinkSubList(
     for (auto& subSet : subSets) {
         auto ref = subSet.first;
         Base::Placement groupPla;
-        groupPla=App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(ref);
-        TopLoc_Location groupLoc=Part::Tools::fromPlacement(groupPla);
+        groupPla = App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(ref);
+        TopLoc_Location groupLoc = Part::Tools::fromPlacement(groupPla);
         if (ref->isDerivedFrom<App::Plane>()) {
             faceList.push_back(makeTopoShapeFromPlane(ref));
             ret++;
@@ -795,9 +797,9 @@ int ProfileBased::getUpToShapeFromLinkSubList(
                 );
 
 
-                for (auto face : baseShape.getSubTopoShapes(TopAbs_FACE)){
+                for (auto face : baseShape.getSubTopoShapes(TopAbs_FACE)) {
                     if (!groupPla.isIdentity()) {
-                       face.move(groupLoc);
+                        face.move(groupLoc);
                     }
                     faceList.push_back(face);
                     ret++;
@@ -818,7 +820,7 @@ int ProfileBased::getUpToShapeFromLinkSubList(
                         throw Base::ValueError("SketchBased: Failed to extract face");
                     }
                     if (!groupPla.isIdentity()) {
-                       face.move(groupLoc);
+                        face.move(groupLoc);
                     }
                     faceList.push_back(face);
                     ret++;

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -56,6 +56,7 @@
 #include <Mod/Part/App/FaceMakerCheese.h>
 
 #include "FeatureSketchBased.h"
+#include "Body.h"
 #include "DatumLine.h"
 #include "DatumPlane.h"
 #include "Mod/Part/App/Geometry.h"
@@ -701,6 +702,10 @@ Part::Feature* ProfileBased::getBaseObject(bool silent) const
     else {
         err = "No base set, no sketch support either";
     }
+
+    PartDesign::Body* body= Feature::getFeatureBody();
+    if(body && spt) if(!body->hasObject(spt))
+        return nullptr;
 
     if (!silent && err) {
         throw Base::RuntimeError(err);

--- a/src/Mod/PartDesign/CMakeLists.txt
+++ b/src/Mod/PartDesign/CMakeLists.txt
@@ -7,6 +7,7 @@ endif(BUILD_GUI)
 set(PartDesign_Scripts
     __init__.py
     Init.py
+    TestPartDesignApp.py
 )
 
 if(BUILD_GUI)

--- a/src/Mod/PartDesign/CMakeLists.txt
+++ b/src/Mod/PartDesign/CMakeLists.txt
@@ -7,7 +7,6 @@ endif(BUILD_GUI)
 set(PartDesign_Scripts
     __init__.py
     Init.py
-    TestPartDesignApp.py
 )
 
 if(BUILD_GUI)

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -467,7 +467,7 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
                 auto link = obj;
                 auto linkSub = parentSub;
                 topParent->resolveRelativeLink(linkSub,link,sub);
-                if (link)
+                if (link) {
                     links[link].push_back(sub);
                 }
             }
@@ -487,16 +487,6 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
             binder = dynamic_cast<PartDesign::SubShapeBinder*>(App::GetApplication().getActiveDocument()->getObject(FeatName.c_str()));
             if (pcActivePart)
                 Gui::cmdAppObject(pcActivePart, std::ostringstream() << "addObject(" << Gui::Command::getObjectCmd(binder) << ")");
-        }
-        else {
-            doCommand(
-                Command::Doc,
-                "App.ActiveDocument.addObject('PartDesign::SubShapeBinder','%s')",
-                FeatName.c_str()
-            );
-            binder = dynamic_cast<PartDesign::SubShapeBinder*>(
-                App::GetApplication().getActiveDocument()->getObject(FeatName.c_str())
-            );
         }
         if (!binder) {
             return;

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -423,11 +423,13 @@ static bool checkContainer(App::DocumentObject* container, const ObjSet& valueSe
 
 // Centralized container lookup with explicit parameters (no hidden deps).
 // Writes: container, parent, parentSub. Returns void; container==nullptr if none.
-static void findContainerForNewSubShapeBinder(App::Document* doc,
-                                              const ObjSet& valueSet,
-                                              App::DocumentObject*& container,
-                                              App::DocumentObject*& parent,
-                                              std::string& parentSub)
+static void findContainerForNewSubShapeBinder(
+    App::Document* doc,
+    const ObjSet& valueSet,
+    App::DocumentObject*& container,
+    App::DocumentObject*& parent,
+    std::string& parentSub
+)
 {
     container = nullptr;
     if (!doc) {
@@ -465,9 +467,11 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
     std::string parentSub;
     std::set<App::DocumentObject*> valueSet;
     std::map<App::DocumentObject*, std::vector<std::string>> values;
-    for (auto &sel : Gui::Selection().getCompleteSelection(Gui::ResolveMode::NoResolve)) {
-        if (!sel.pObject) continue;
-        auto &subs = values[sel.pObject];
+    for (auto& sel : Gui::Selection().getCompleteSelection(Gui::ResolveMode::NoResolve)) {
+        if (!sel.pObject) {
+            continue;
+        }
+        auto& subs = values[sel.pObject];
         if (sel.SubName && sel.SubName[0]) {
             subs.emplace_back(sel.SubName);
             valueSet.insert(sel.pObject->getSubObject(sel.SubName));
@@ -485,18 +489,19 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
 
     if (targetContainer && parent) {
         decltype(values) links;
-        for (auto &v : values) {
-            App::DocumentObject *obj = v.first;
+        for (auto& v : values) {
+            App::DocumentObject* obj = v.first;
             if (v.second.empty()) {
                 links.emplace(obj, v.second);
                 continue;
             }
-            for (auto &sub : v.second) {
+            for (auto& sub : v.second) {
                 auto link = obj;
                 auto linkSub = parentSub;
-                parent->resolveRelativeLink(linkSub,link,sub);
-                if (link)
+                parent->resolveRelativeLink(linkSub, link, sub);
+                if (link) {
                     links[link].push_back(sub);
+                }
             }
         }
         values = std::move(links);
@@ -510,31 +515,42 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
 
     std::string FeatName = Gui::Command::getUniqueObjectName(
         "Binder",
-        pcActiveBody ? static_cast<App::DocumentObject*>(pcActiveBody) : pcActivePart);
+        pcActiveBody ? static_cast<App::DocumentObject*>(pcActiveBody) : pcActivePart
+    );
 
-    PartDesign::SubShapeBinder *binder = nullptr;
+    PartDesign::SubShapeBinder* binder = nullptr;
     try {
         openCommand(QT_TRANSLATE_NOOP("Command", "Create Sub-Shape Binder"));
         if (pcActiveBody) {
-            FCMD_OBJ_CMD(pcActiveBody,"newObject('PartDesign::SubShapeBinder','" << FeatName << "')");
-            binder = dynamic_cast<PartDesign::SubShapeBinder*>(pcActiveBody->getObject(FeatName.c_str()));
-        } else {
-            doCommand(Command::Doc,
-                    "App.ActiveDocument.addObject('PartDesign::SubShapeBinder','%s')",FeatName.c_str());
+            FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::SubShapeBinder','" << FeatName << "')");
             binder = dynamic_cast<PartDesign::SubShapeBinder*>(
-                    App::GetApplication().getActiveDocument()->getObject(FeatName.c_str()));
+                pcActiveBody->getObject(FeatName.c_str())
+            );
+        }
+        else {
+            doCommand(
+                Command::Doc,
+                "App.ActiveDocument.addObject('PartDesign::SubShapeBinder','%s')",
+                FeatName.c_str()
+            );
+            binder = dynamic_cast<PartDesign::SubShapeBinder*>(
+                App::GetApplication().getActiveDocument()->getObject(FeatName.c_str())
+            );
             if (pcActivePart) {
-                Gui::cmdAppObject(pcActivePart,
-                                  std::ostringstream()
-                                      << "addObject(" << Gui::Command::getObjectCmd(binder) << ")");
+                Gui::cmdAppObject(
+                    pcActivePart,
+                    std::ostringstream() << "addObject(" << Gui::Command::getObjectCmd(binder) << ")"
+                );
             }
         }
-        if (!binder)
+        if (!binder) {
             return;
+        }
         binder->setLinks(std::move(values));
         updateActive();
         commitCommand();
-    } catch (Base::Exception &e) {
+    }
+    catch (Base::Exception& e) {
         e.reportException();
         QMessageBox::critical(
             Gui::getMainWindow(),

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -42,6 +42,7 @@
 #include <Gui/MainWindow.h>
 #include <Gui/Selection/Selection.h>
 #include <Gui/Selection/SelectionObject.h>
+#include <Gui/MDIView.h>
 #include <Mod/Sketcher/App/SketchObject.h>
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/FeatureBoolean.h>
@@ -397,36 +398,76 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
-    App::DocumentObject* parent = nullptr;
+    App::DocumentObject *topParent = nullptr;
     std::string parentSub;
-    std::map<App::DocumentObject*, std::vector<std::string>> values;
-    for (auto& sel : Gui::Selection().getCompleteSelection(Gui::ResolveMode::NoResolve)) {
+    std::set<App::DocumentObject *> valueSet;
+    std::map<App::DocumentObject *, std::vector<std::string> > values;
+    for (auto &sel : Gui::Selection().getCompleteSelection(Gui::ResolveMode::NoResolve)) {
         if (!sel.pObject) {
             continue;
         }
-        auto& subs = values[sel.pObject];
+        auto &subs = values[sel.pObject];
         if (sel.SubName && sel.SubName[0]) {
             subs.emplace_back(sel.SubName);
+            valueSet.insert(sel.pObject->getSubObject(sel.SubName));
+        } else {
+            valueSet.insert(sel.pObject);
         }
     }
 
+    auto checkContainer = [&](App::DocumentObject *container) {
+        // Check the potential container to add in the newly created binder.
+        // We check if the container or any of its parent objects is selected
+        // (i.e. for binding), and exclude the container to avoid cyclic
+        // reference.
+        if (!container)
+            return false;
+        if (valueSet.count(container)) {
+            topParent = nullptr;
+            parentSub.clear();
+            return false;
+        }
+        auto inlist = container->getInListEx(true);
+        for (auto obj : valueSet) {
+            if (inlist.count(obj)) {
+                topParent = nullptr;
+                parentSub.clear();
+                return false;
+            }
+        }
+        return true;
+    };
+
     std::string FeatName;
-    PartDesign::Body* pcActiveBody = PartDesignGui::getBody(false, true, true, &parent, &parentSub);
-    FeatName = getUniqueObjectName("Binder", pcActiveBody);
-    if (parent) {
+    Gui::MDIView *activeView = Gui::Application::Instance->activeView();
+    PartDesign::Body *pcActiveBody= nullptr;
+    if (activeView)
+        pcActiveBody = activeView->getActiveObject<PartDesign::Body*>(PDBODYKEY, &topParent, &parentSub);
+    if (!checkContainer(pcActiveBody)) pcActiveBody = nullptr;
+    
+    App::Part *pcActivePart = nullptr;
+    if (!pcActiveBody && activeView) {
+        pcActivePart = activeView->getActiveObject<App::Part*>(PARTKEY, &topParent, &parentSub);
+        if (!checkContainer(pcActivePart))
+            pcActivePart = nullptr;
+    }
+
+    FeatName = Gui::Command::getUniqueObjectName("Binder", pcActiveBody ?
+            static_cast<App::DocumentObject*>(pcActiveBody) : pcActivePart);
+
+    if (topParent) {
         decltype(values) links;
-        for (auto& v : values) {
-            App::DocumentObject* obj = v.first;
-            if (obj != parent) {
-                auto& subs = links[obj];
-                subs.insert(subs.end(), v.second.begin(), v.second.end());
+        for (auto &v : values) {
+            App::DocumentObject *obj = v.first;
+            if (v.second.empty()) {
+                links.emplace(obj, v.second);
                 continue;
             }
             for (auto& sub : v.second) {
                 auto link = obj;
                 auto linkSub = parentSub;
-                parent->resolveRelativeLink(linkSub, link, sub);
-                if (link && link != pcActiveBody) {
+                topParent->resolveRelativeLink(linkSub,link,sub);
+                if (link)
                     links[link].push_back(sub);
                 }
             }
@@ -438,10 +479,14 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
     try {
         openCommand(QT_TRANSLATE_NOOP("Command", "Create Sub-Shape Binder"));
         if (pcActiveBody) {
-            FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::SubShapeBinder','" << FeatName << "')");
-            binder = dynamic_cast<PartDesign::SubShapeBinder*>(
-                pcActiveBody->getObject(FeatName.c_str())
-            );
+            FCMD_OBJ_CMD(pcActiveBody,"newObject('PartDesign::SubShapeBinder','" << FeatName << "')");
+            binder = dynamic_cast<PartDesign::SubShapeBinder*>(pcActiveBody->getObject(FeatName.c_str()));
+        } else {
+            doCommand(Command::Doc,
+                    "App.ActiveDocument.addObject('PartDesign::SubShapeBinder','%s')",FeatName.c_str());
+            binder = dynamic_cast<PartDesign::SubShapeBinder*>(App::GetApplication().getActiveDocument()->getObject(FeatName.c_str()));
+            if (pcActivePart)
+                Gui::cmdAppObject(pcActivePart, std::ostringstream() << "addObject(" << Gui::Command::getObjectCmd(binder) << ")");
         }
         else {
             doCommand(
@@ -1070,18 +1115,13 @@ void prepareProfileBased(
         base_worker(features.front(), {});
     };
 
-    // if there is a sketch selected which is from another body or part we need to bring up the
-    // pick task dialog to decide how those are handled
-    bool extReference = std::find_if(
-                            status.begin(),
-                            status.end(),
-                            [](const PartDesignGui::TaskFeaturePick::featureStatus& s) {
-                                return s == PartDesignGui::TaskFeaturePick::otherBody
-                                    || s == PartDesignGui::TaskFeaturePick::otherPart
-                                    || s == PartDesignGui::TaskFeaturePick::notInBody;
-                            }
-                        )
-        != status.end();
+    //if there is a sketch selected which is from another body or part we need to bring up the
+    //pick task dialog to decide how those are handled
+    bool extReference = std::find_if( status.begin(), status.end(),
+            [] (const PartDesignGui::TaskFeaturePick::featureStatus& s) {
+                return s == PartDesignGui::TaskFeaturePick::otherPart;
+            }
+        ) != status.end();
 
     // TODO Clean this up (2015-10-20, Fat-Zer)
     if (pcActiveBody && !bNoSketchWasSelected && extReference) {

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -136,7 +136,8 @@ App::OriginGroupExtension* ReferenceSelection::getBoundaryOriginGroupExtension()
 }
 
 
-bool ReferenceSelection::allowOrigin(App::OriginGroupExtension* originGroup, App::DocumentObject* pObj) const
+bool ReferenceSelection::allowOrigin(App::OriginGroupExtension* originGroup,
+                                     App::DocumentObject* pObj) const
 {
     bool fits = false;
     if (type.testFlag(AllowSelection::FACE) && pObj->isDerivedFrom<App::Plane>()) {
@@ -146,12 +147,13 @@ bool ReferenceSelection::allowOrigin(App::OriginGroupExtension* originGroup, App
         fits = true;
     }
 
-    if (fits) { // check that it actually belongs to the chosen group
-        try { // here are some throwers
-            if (originGroup ) {
-                if (originGroup->hasObject(pObj, true)) {
-                    return true;
-                }
+    if (fits) {  // check that it actually belongs to the chosen group
+        try {    // here are some throwers
+            if (!originGroup) {
+                return true;
+            }
+            if (originGroup->hasObject(pObj, true)) {
+                return true;
             }
         }
         catch (const Base::Exception&) {
@@ -160,15 +162,16 @@ bool ReferenceSelection::allowOrigin(App::OriginGroupExtension* originGroup, App
     return false;  // The Plane/Axis doesn't fits our needs
 }
 
-bool ReferenceSelection::allowDatum(App::OriginGroupExtension* originGroup, App::DocumentObject* pObj) const
+bool ReferenceSelection::allowDatum(App::OriginGroupExtension* originGroup,
+                                    App::DocumentObject* pObj) const
 {
-
-    if (originGroup ) {
-        if (originGroup->hasObject(pObj, true)) {
-                    return true;
-        }
+    if (!originGroup) {
+        return true;
     }
-    if (type.testFlag(AllowSelection::FACE) && (pObj->isDerivedFrom<PartDesign::Plane>()))
+    if (originGroup->hasObject(pObj, true)) {
+        return true;
+    }
+    if (type.testFlag(AllowSelection::FACE) && (pObj->isDerivedFrom<PartDesign::Plane>())) {
         return true;
     }
     if (type.testFlag(AllowSelection::EDGE) && (pObj->isDerivedFrom<PartDesign::Line>())) {
@@ -177,7 +180,6 @@ bool ReferenceSelection::allowDatum(App::OriginGroupExtension* originGroup, App:
     if (type.testFlag(AllowSelection::POINT) && (pObj->isDerivedFrom<PartDesign::Point>())) {
         return true;
     }
-
     return false;
 }
 

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -114,16 +114,15 @@ App::OriginGroupExtension* ReferenceSelection::getBoundaryOriginGroupExtension()
 {
     const App::DocumentObject* originGroupObject = nullptr;
 
-    auto* body = support ? PartDesign::Body::findBodyOf(support)
-                         : PartDesignGui::getBody(false);
-    if (body) { // Search for Part of the body
+    auto* body = support ? PartDesign::Body::findBodyOf(support) : PartDesignGui::getBody(false);
+    if (body) {  // Search for Part of the body
         originGroupObject = App::OriginGroupExtension::getBoundaryGroupOfObject(body);
     }
-    else if (support) { // if no body search part for support
+    else if (support) {  // if no body search part for support
         originGroupObject = App::OriginGroupExtension::getBoundaryGroupOfObject(support);
     }
-    else { // fallback to active part
-        App::DocumentObject* part=PartDesignGui::getActivePart();
+    else {  // fallback to active part
+        App::DocumentObject* part = PartDesignGui::getActivePart();
         originGroupObject = App::OriginGroupExtension::getBoundaryGroupOfObject(part);
     }
 
@@ -136,8 +135,7 @@ App::OriginGroupExtension* ReferenceSelection::getBoundaryOriginGroupExtension()
 }
 
 
-bool ReferenceSelection::allowOrigin(App::OriginGroupExtension* originGroup,
-                                     App::DocumentObject* pObj) const
+bool ReferenceSelection::allowOrigin(App::OriginGroupExtension* originGroup, App::DocumentObject* pObj) const
 {
     bool fits = false;
     if (type.testFlag(AllowSelection::FACE) && pObj->isDerivedFrom<App::Plane>()) {
@@ -162,8 +160,7 @@ bool ReferenceSelection::allowOrigin(App::OriginGroupExtension* originGroup,
     return false;  // The Plane/Axis doesn't fits our needs
 }
 
-bool ReferenceSelection::allowDatum(App::OriginGroupExtension* originGroup,
-                                    App::DocumentObject* pObj) const
+bool ReferenceSelection::allowDatum(App::OriginGroupExtension* originGroup, App::DocumentObject* pObj) const
 {
     if (!originGroup) {
         return true;

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.h
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.h
@@ -56,14 +56,9 @@ public:
     bool allow(App::Document* pDoc, App::DocumentObject* pObj, const char* sSubName) override;
 
 private:
-    PartDesign::Body* getBody() const;
-    App::OriginGroupExtension* getOriginGroupExtension(PartDesign::Body* body) const;
-    bool allowOrigin(
-        PartDesign::Body* body,
-        App::OriginGroupExtension* originGroup,
-        App::DocumentObject* pObj
-    ) const;
-    bool allowDatum(PartDesign::Body* body, App::DocumentObject* pObj) const;
+    App::OriginGroupExtension* getBoundaryOriginGroupExtension() const;
+    bool allowOrigin(App::OriginGroupExtension* originGroup, App::DocumentObject* pObj) const;
+    bool allowDatum(App::OriginGroupExtension* originGroup, App::DocumentObject* pObj) const;
     bool allowPartFeature(App::DocumentObject* pObj, const char* sSubName) const;
     bool isEdge(App::DocumentObject* pObj, const char* sSubName) const;
     bool isFace(App::DocumentObject* pObj, const char* sSubName) const;

--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -190,9 +190,9 @@ private:
 
 App::GeoFeatureGroupExtension* getBoundaryGroupExtensionOfBody(const PartDesign::Body* activeBody)
 {
-    App::GeoFeatureGroupExtension *geoGroup{nullptr};
+    App::GeoFeatureGroupExtension* geoGroup {nullptr};
     if (activeBody) {
-        auto group( App::GeoFeatureGroupExtension::getBoundaryGroupOfObject(activeBody) );
+        auto group(App::GeoFeatureGroupExtension::getBoundaryGroupOfObject(activeBody));
         if (group) {
             geoGroup = group->getExtensionByType<App::GeoFeatureGroupExtension>();
         }
@@ -307,9 +307,9 @@ private:
 
     void handleIfSupportOutOfBody(App::DocumentObject* selectedObject)
     {
-        App::GeoFeatureGroupExtension *bodyGroup = getBoundaryGroupExtensionOfBody(activeBody);
-        if (bodyGroup && !bodyGroup->hasObject(selectedObject,true)) {
-            if ( !selectedObject->isDerivedFrom ( App::Plane::getClassTypeId() ) )  {
+        App::GeoFeatureGroupExtension* bodyGroup = getBoundaryGroupExtensionOfBody(activeBody);
+        if (bodyGroup && !bodyGroup->hasObject(selectedObject, true)) {
+            if (!selectedObject->isDerivedFrom(App::Plane::getClassTypeId())) {
                 // TODO check here if the plane associated with right part/body (2015-09-01, Fat-Zer)
 
                 // check the prerequisites for the selected objects
@@ -416,20 +416,24 @@ public:
 
     void findDatumPlanes()
     {
-        App::GeoFeatureGroupExtension *boundaryGroup = getBoundaryGroupExtensionOfBody(activeBody);
-        const std::vector<Base::Type> types = { PartDesign::Plane::getClassTypeId(), App::Plane::getClassTypeId() };
+        App::GeoFeatureGroupExtension* boundaryGroup = getBoundaryGroupExtensionOfBody(activeBody);
+        const std::vector<Base::Type> types
+            = {PartDesign::Plane::getClassTypeId(), App::Plane::getClassTypeId()};
         auto datumPlanes = appdocument->getObjectsOfType(types);
 
         for (auto plane : datumPlanes) {
             if (std::find(planes.begin(), planes.end(), plane) != planes.end()) {
                 continue;  // Skip if already in planes (for base planes)
             }
-            if(App::OriginGroupExtension::getGroupOfObject(plane))
+            if (App::OriginGroupExtension::getGroupOfObject(plane)) {
                 continue;
-            if(boundaryGroup) 
-                if(!boundaryGroup->hasObject(plane,true))
+            }
+            if (boundaryGroup) {
+                if (!boundaryGroup->hasObject(plane, true)) {
                     continue;
-            planes.push_back ( plane );
+                }
+            }
+            planes.push_back(plane);
             // Check whether this plane belongs to the active body
             if (activeBody->hasObject(plane, true)) {
                 if (!activeBody->isAfterInsertPoint(plane)) {
@@ -439,23 +443,28 @@ public:
                 else {
                     status.push_back(PartDesignGui::TaskFeaturePick::afterTip);
                 }
-            } else {
-                PartDesign::Body *planeBody = PartDesign::Body::findBodyOf (plane);
-                App::Part *activePart = PartDesignGui::getActivePart();
+            }
+            else {
+                PartDesign::Body* planeBody = PartDesign::Body::findBodyOf(plane);
+                App::Part* activePart = PartDesignGui::getActivePart();
                 auto planePart = PartDesignGui::getPartFor(plane, false);
-                if ( planeBody ) {
-                    if ( !activePart || (activePart && activePart->hasObject ( planeBody, true ) )) {
-                        status.push_back ( PartDesignGui::TaskFeaturePick::otherBody );
-                    } else if (planePart) {
-                        status.push_back ( PartDesignGui::TaskFeaturePick::otherPart );
-                    } else {
-                        status.push_back ( PartDesignGui::TaskFeaturePick::notInBody );
+                if (planeBody) {
+                    if (!activePart || (activePart && activePart->hasObject(planeBody, true))) {
+                        status.push_back(PartDesignGui::TaskFeaturePick::otherBody);
                     }
-                } else {
+                    else if (planePart) {
+                        status.push_back(PartDesignGui::TaskFeaturePick::otherPart);
+                    }
+                    else {
+                        status.push_back(PartDesignGui::TaskFeaturePick::notInBody);
+                    }
+                }
+                else {
                     if (planePart) {
-                        status.push_back ( PartDesignGui::TaskFeaturePick::otherPart );
-                    } else {
-                        status.push_back ( PartDesignGui::TaskFeaturePick::notInPart );
+                        status.push_back(PartDesignGui::TaskFeaturePick::otherPart);
+                    }
+                    else {
+                        status.push_back(PartDesignGui::TaskFeaturePick::notInPart);
                     }
                 }
             }

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -29,6 +29,7 @@
 #include <App/DocumentObject.h>
 #include <App/Origin.h>
 #include <App/Part.h>
+#include <App/GeoFeatureGroupExtension.h>
 #include <Gui/MainWindow.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/Selection/Selection.h>
@@ -123,10 +124,16 @@ bool TaskDlgDatumParameters::accept()
     // check the prerequisites for the selected objects
     // the user has to decide which option we should take if external references are used
     bool extReference = false;
+    
+    // Determine the “owner boundary” from the active Body, but make Body transparent.
+    const App::DocumentObject* pcActiveGroupObject =
+        App::GeoFeatureGroupExtension::getBoundaryGroupOfObject(static_cast<const App::DocumentObject*>(pcActiveBody));
+    auto pcActiveGroup = pcActiveGroupObject->getExtensionByType<App::OriginGroupExtension>();
+
     for (App::DocumentObject* obj : pcDatum->AttachmentSupport.getValues()) {
-        if (pcActiveBody && !pcActiveBody->hasObject(obj)
-            && !pcActiveBody->getOrigin()->hasObject(obj)) {
+        if (pcActiveBody && !pcActiveBody->hasObject(obj) && pcActiveGroup) if(!pcActiveGroup->hasObject(obj)) {
             extReference = true;
+            break;
         }
     }
 
@@ -146,12 +153,14 @@ bool TaskDlgDatumParameters::accept()
             std::vector<std::string> subs = pcDatum->AttachmentSupport.getSubValues();
             int index = 0;
             for (App::DocumentObject* obj : pcDatum->AttachmentSupport.getValues()) {
-                if (pcActiveBody && !pcActiveBody->hasObject(obj)
-                    && !pcActiveBody->getOrigin()->hasObject(obj)) {
+                if (pcActiveBody
+                    && !pcActiveBody->hasObject(obj)
+                    && pcActiveGroup
+                    && !pcActiveGroup->hasObject(obj)) {
                     auto* copy = PartDesignGui::TaskFeaturePick::makeCopy(
-                        obj,
-                        subs[index],
-                        dlg.radioIndependent->isChecked()
+                         obj,
+                         subs[index],
+                         dlg.radioIndependent->isChecked()
                     );
                     if (copy) {
                         copyObjects.push_back(copy);

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -124,16 +124,20 @@ bool TaskDlgDatumParameters::accept()
     // check the prerequisites for the selected objects
     // the user has to decide which option we should take if external references are used
     bool extReference = false;
-    
+
     // Determine the “owner boundary” from the active Body, but make Body transparent.
-    const App::DocumentObject* pcActiveGroupObject =
-        App::GeoFeatureGroupExtension::getBoundaryGroupOfObject(static_cast<const App::DocumentObject*>(pcActiveBody));
+    const App::DocumentObject* pcActiveGroupObject
+        = App::GeoFeatureGroupExtension::getBoundaryGroupOfObject(
+            static_cast<const App::DocumentObject*>(pcActiveBody)
+        );
     auto pcActiveGroup = pcActiveGroupObject->getExtensionByType<App::OriginGroupExtension>();
 
     for (App::DocumentObject* obj : pcDatum->AttachmentSupport.getValues()) {
-        if (pcActiveBody && !pcActiveBody->hasObject(obj) && pcActiveGroup) if(!pcActiveGroup->hasObject(obj)) {
-            extReference = true;
-            break;
+        if (pcActiveBody && !pcActiveBody->hasObject(obj) && pcActiveGroup) {
+            if (!pcActiveGroup->hasObject(obj)) {
+                extReference = true;
+                break;
+            }
         }
     }
 
@@ -153,14 +157,12 @@ bool TaskDlgDatumParameters::accept()
             std::vector<std::string> subs = pcDatum->AttachmentSupport.getSubValues();
             int index = 0;
             for (App::DocumentObject* obj : pcDatum->AttachmentSupport.getValues()) {
-                if (pcActiveBody
-                    && !pcActiveBody->hasObject(obj)
-                    && pcActiveGroup
+                if (pcActiveBody && !pcActiveBody->hasObject(obj) && pcActiveGroup
                     && !pcActiveGroup->hasObject(obj)) {
                     auto* copy = PartDesignGui::TaskFeaturePick::makeCopy(
-                         obj,
-                         subs[index],
-                         dlg.radioIndependent->isChecked()
+                        obj,
+                        subs[index],
+                        dlg.radioIndependent->isChecked()
                     );
                     if (copy) {
                         copyObjects.push_back(copy);

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -72,11 +72,13 @@ const QString TaskFeaturePick::getFeatureStatusString(const featureStatus st)
         case isUsed:
             return tr("Sketch already used by other feature");
         case otherBody:
-            return tr("Belongs to another body");
+            return tr("In other body");
         case otherPart:
-            return tr("Belongs to another part");
+            return tr("In other part");
         case notInBody:
-            return tr("Doesn't belong to any body");
+            return tr("Not in a body");
+        case notInPart:
+            return tr("Not in a body or part");
         case basePlane:
             return tr("Base plane");
         case afterTip:

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -102,8 +102,6 @@ TaskFeaturePick::TaskFeaturePick(
 
     // clang-format off
     connect(ui->checkUsed, &QCheckBox::toggled, this, &TaskFeaturePick::onUpdate);
-    connect(ui->checkOtherBody, &QCheckBox::toggled, this, &TaskFeaturePick::onUpdate);
-    connect(ui->checkOtherPart, &QCheckBox::toggled, this, &TaskFeaturePick::onUpdate);
     connect(ui->radioIndependent, &QRadioButton::toggled, this, &TaskFeaturePick::onUpdate);
     connect(ui->radioDependent, &QRadioButton::toggled, this, &TaskFeaturePick::onUpdate);
     connect(ui->radioXRef, &QRadioButton::toggled, this, &TaskFeaturePick::onUpdate);
@@ -206,13 +204,13 @@ void TaskFeaturePick::updateList()
                 item->setHidden(true);
                 break;
             case otherBody:
-                item->setHidden(!ui->checkOtherBody->isChecked());
+                item->setHidden(false);
                 break;
             case otherPart:
-                item->setHidden(!ui->checkOtherPart->isChecked());
+                item->setHidden(false);
                 break;
             case notInBody:
-                item->setHidden(!ui->checkOtherPart->isChecked());
+                item->setHidden(false);
                 break;
             case basePlane:
                 item->setHidden(false);
@@ -229,9 +227,6 @@ void TaskFeaturePick::updateList()
 void TaskFeaturePick::onUpdate(bool)
 {
     bool enable = false;
-    if (ui->checkOtherBody->isChecked() || ui->checkOtherPart->isChecked()) {
-        enable = true;
-    }
 
     ui->radioDependent->setEnabled(enable);
     ui->radioIndependent->setEnabled(enable);
@@ -287,42 +282,7 @@ std::vector<App::DocumentObject*> TaskFeaturePick::buildFeatures()
                                .getDocument(documentName.c_str())
                                ->getObject(t.toLatin1().data());
 
-                // build the dependent copy or reference if wanted by the user
-                if (status == otherBody || status == otherPart || status == notInBody) {
-                    if (!ui->radioXRef->isChecked()) {
-                        auto copy = makeCopy(obj, "", ui->radioIndependent->isChecked());
-
-                        if (status == otherBody) {
-                            activeBody->addObject(copy);
-                        }
-                        else if (status == otherPart) {
-                            auto oBody = PartDesignGui::getBodyFor(obj, false);
-                            if (!oBody) {
-                                activePart->addObject(copy);
-                            }
-                            else {
-                                activeBody->addObject(copy);
-                            }
-                        }
-                        else if (status == notInBody) {
-                            activeBody->addObject(copy);
-                            // doesn't supposed to get here anything but sketch but to be on the
-                            // safe side better to check
-                            if (copy->isDerivedFrom<Sketcher::SketchObject>()) {
-                                Sketcher::SketchObject* sketch
-                                    = static_cast<Sketcher::SketchObject*>(copy);
-                                PartDesignGui::fixSketchSupport(sketch);
-                            }
-                        }
-                        result.push_back(copy);
-                    }
-                    else {
-                        result.push_back(obj);
-                    }
-                }
-                else {
-                    result.push_back(obj);
-                }
+                result.push_back(obj);
             }
 
             index++;
@@ -584,8 +544,6 @@ void TaskFeaturePick::slotDeleteDocument(const Gui::Document&)
 
 void TaskFeaturePick::showExternal(bool val)
 {
-    ui->checkOtherBody->setChecked(val);
-    ui->checkOtherPart->setChecked(val);
     updateList();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.h
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.h
@@ -54,6 +54,7 @@ public:
         otherBody,
         otherPart,
         notInBody,
+        notInPart,
         basePlane,
         afterTip
     };

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.ui
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.ui
@@ -37,20 +37,6 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QCheckBox" name="checkOtherBody">
-        <property name="text">
-         <string>From other bodies of the same part</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="checkOtherPart">
-        <property name="text">
-         <string>From different parts or free features</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="Line" name="line">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -453,7 +453,8 @@ bool TaskPipeParameters::accept()
     App::DocumentObject* auxSpine = pipe->AuxiliarySpine.getValue();
 
     // Determine the “owner boundary” from the active Body, but make Body transparent.
-    const App::DocumentObject* pcActiveGroupObject =App::OriginGroupExtension::getBoundaryGroupOfObject(pcActiveBody);
+    const App::DocumentObject* pcActiveGroupObject
+        = App::OriginGroupExtension::getBoundaryGroupOfObject(pcActiveBody);
     auto pcActiveGroup = pcActiveGroupObject->getExtensionByType<App::OriginGroupExtension>();
 
 
@@ -472,17 +473,23 @@ bool TaskPipeParameters::accept()
         }
     }
 
-    if (spine && !pcActiveBody->hasObject(spine) && pcActiveGroup) if(!pcActiveGroup->hasObject(spine)) {
-        extReference = true;
-    }
-    else if (auxSpine && !pcActiveBody->hasObject(auxSpine) && pcActiveGroup) if(!pcActiveGroup->hasObject(auxSpine)) {
-        extReference = true;
-    }
-    else {
-        for (App::DocumentObject* obj : pipe->Sections.getValues()) {
-            if (!pcActiveBody->hasObject(obj)  && pcActiveGroup) if(!pcActiveGroup->hasObject(obj)) {
+    if (spine && !pcActiveBody->hasObject(spine) && pcActiveGroup) {
+        if (!pcActiveGroup->hasObject(spine)) {
+            extReference = true;
+        }
+        else if (auxSpine && !pcActiveBody->hasObject(auxSpine) && pcActiveGroup) {
+            if (!pcActiveGroup->hasObject(auxSpine)) {
                 extReference = true;
-                break;
+            }
+            else {
+                for (App::DocumentObject* obj : pipe->Sections.getValues()) {
+                    if (!pcActiveBody->hasObject(obj) && pcActiveGroup) {
+                        if (!pcActiveGroup->hasObject(obj)) {
+                            extReference = true;
+                            break;
+                        }
+                    }
+                }
             }
         }
     }
@@ -498,23 +505,31 @@ bool TaskPipeParameters::accept()
         }
 
         if (!dlg.radioXRef->isChecked()) {
-            if (spine && !pcActiveBody->hasObject(spine) && pcActiveGroup) if(!pcActiveGroup->hasObject(spine)) {
-                pipe->Spine.setValue(
-                    PartDesignGui::TaskFeaturePick::makeCopy(spine, "", dlg.radioIndependent->isChecked()),
-                    pipe->Spine.getSubValues()
-                );
-                copies.push_back(pipe->Spine.getValue());
-            }
-            else if (auxSpine && !pcActiveBody->hasObject(auxSpine) && pcActiveGroup) if(!pcActiveGroup->hasObject(auxSpine)) {
-                pipe->AuxiliarySpine.setValue(
-                    PartDesignGui::TaskFeaturePick::makeCopy(
-                        auxSpine,
-                        "",
-                        dlg.radioIndependent->isChecked()
-                    ),
-                    pipe->AuxiliarySpine.getSubValues()
-                );
-                copies.push_back(pipe->AuxiliarySpine.getValue());
+            if (spine && !pcActiveBody->hasObject(spine) && pcActiveGroup) {
+                if (!pcActiveGroup->hasObject(spine)) {
+                    pipe->Spine.setValue(
+                        PartDesignGui::TaskFeaturePick::makeCopy(
+                            spine,
+                            "",
+                            dlg.radioIndependent->isChecked()
+                        ),
+                        pipe->Spine.getSubValues()
+                    );
+                    copies.push_back(pipe->Spine.getValue());
+                }
+                else if (auxSpine && !pcActiveBody->hasObject(auxSpine) && pcActiveGroup) {
+                    if (!pcActiveGroup->hasObject(auxSpine)) {
+                        pipe->AuxiliarySpine.setValue(
+                            PartDesignGui::TaskFeaturePick::makeCopy(
+                                auxSpine,
+                                "",
+                                dlg.radioIndependent->isChecked()
+                            ),
+                            pipe->AuxiliarySpine.getSubValues()
+                        );
+                        copies.push_back(pipe->AuxiliarySpine.getValue());
+                    }
+                }
             }
 
             std::vector<App::PropertyLinkSubList::SubSet> subSets;

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -29,6 +29,7 @@
 #include <App/Application.h>
 #include <App/DocumentObject.h>
 #include <App/Origin.h>
+#include <App/GeoFeatureGroupExtension.h>
 #include <Gui/CommandT.h>
 #include <Gui/Document.h>
 #include <Gui/MainWindow.h>
@@ -451,6 +452,11 @@ bool TaskPipeParameters::accept()
     App::DocumentObject* spine = pipe->Spine.getValue();
     App::DocumentObject* auxSpine = pipe->AuxiliarySpine.getValue();
 
+    // Determine the “owner boundary” from the active Body, but make Body transparent.
+    const App::DocumentObject* pcActiveGroupObject =App::OriginGroupExtension::getBoundaryGroupOfObject(pcActiveBody);
+    auto pcActiveGroup = pcActiveGroupObject->getExtensionByType<App::OriginGroupExtension>();
+
+
     // If a spine isn't set but user entered a label then search for the appropriate document object
     QString label = ui->spineBaseEdit->text();
     if (!spine && !label.isEmpty()) {
@@ -466,16 +472,15 @@ bool TaskPipeParameters::accept()
         }
     }
 
-    if (spine && !pcActiveBody->hasObject(spine) && !pcActiveBody->getOrigin()->hasObject(spine)) {
+    if (spine && !pcActiveBody->hasObject(spine) && pcActiveGroup) if(!pcActiveGroup->hasObject(spine)) {
         extReference = true;
     }
-    else if (auxSpine && !pcActiveBody->hasObject(auxSpine)
-             && !pcActiveBody->getOrigin()->hasObject(auxSpine)) {
+    else if (auxSpine && !pcActiveBody->hasObject(auxSpine) && pcActiveGroup) if(!pcActiveGroup->hasObject(auxSpine)) {
         extReference = true;
     }
     else {
         for (App::DocumentObject* obj : pipe->Sections.getValues()) {
-            if (!pcActiveBody->hasObject(obj) && !pcActiveBody->getOrigin()->hasObject(obj)) {
+            if (!pcActiveBody->hasObject(obj)  && pcActiveGroup) if(!pcActiveGroup->hasObject(obj)) {
                 extReference = true;
                 break;
             }
@@ -493,15 +498,14 @@ bool TaskPipeParameters::accept()
         }
 
         if (!dlg.radioXRef->isChecked()) {
-            if (!pcActiveBody->hasObject(spine) && !pcActiveBody->getOrigin()->hasObject(spine)) {
+            if (spine && !pcActiveBody->hasObject(spine) && pcActiveGroup) if(!pcActiveGroup->hasObject(spine)) {
                 pipe->Spine.setValue(
                     PartDesignGui::TaskFeaturePick::makeCopy(spine, "", dlg.radioIndependent->isChecked()),
                     pipe->Spine.getSubValues()
                 );
                 copies.push_back(pipe->Spine.getValue());
             }
-            else if (!pcActiveBody->hasObject(auxSpine)
-                     && !pcActiveBody->getOrigin()->hasObject(auxSpine)) {
+            else if (auxSpine && !pcActiveBody->hasObject(auxSpine) && pcActiveGroup) if(!pcActiveGroup->hasObject(auxSpine)) {
                 pipe->AuxiliarySpine.setValue(
                     PartDesignGui::TaskFeaturePick::makeCopy(
                         auxSpine,

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -59,4 +59,3 @@ from PartDesignTests.TestSketch import TestSketch
 
 # Topological naming problem
 from PartDesignTests.TestTopologicalNamingProblem import TestTopologicalNamingProblem
-

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -59,3 +59,4 @@ from PartDesignTests.TestSketch import TestSketch
 
 # Topological naming problem
 from PartDesignTests.TestTopologicalNamingProblem import TestTopologicalNamingProblem
+

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -93,6 +93,7 @@
 #include <App/ObjectIdentifier.h>
 #include <App/Datums.h>
 #include <App/Part.h>
+#include <App/GeoFeatureGroupExtension.h>
 #include <Base/Console.h>
 #include <Base/Reader.h>
 #include <Base/Tools.h>
@@ -4202,34 +4203,18 @@ bool SketchObject::isExternalAllowed(App::Document* pDoc, App::DocumentObject* p
         return true;// prohibiting this reference won't remove the problem anyway...
     }
 
-
-    // Note: Checking for the body of the support doesn't work when the support are the three base
-    // planes
-    Part::BodyBase* body_this = Part::BodyBase::findBodyOf(this);
-    Part::BodyBase* body_obj = Part::BodyBase::findBodyOf(pObj);
-
+    auto group_this = App::GeoFeatureGroupExtension::getBoundaryGroupOfObject(this);
+    auto group_obj = App::GeoFeatureGroupExtension::getBoundaryGroupOfObject(pObj);
     // DatumElements in an LCS, get body from the parent LCS
-    if (!body_obj && pObj->isDerivedFrom<App::DatumElement>()) {
+    if (!group_obj && pObj->isDerivedFrom<App::DatumElement>()) {
         auto* datum = static_cast<const App::DatumElement*>(pObj);
         if (auto* lcs = datum->getLCS()) {
-            body_obj = Part::BodyBase::findBodyOf(lcs);
+            group_obj = App::GeoFeatureGroupExtension::getBoundaryGroupOfObject(lcs);
         }
     }
 
-    App::Part* part_this = App::Part::getPartOfObject(this);
-    App::Part* part_obj = App::Part::getPartOfObject(pObj);
-    if (part_this == part_obj) {// either in the same part, or in the root of document
-        if (!body_this) {
-            return true;
-        }
-        else if (body_this == body_obj) {
-            return true;
-        }
-        else {
-            if (rsn)
-                *rsn = rlOtherBody;
-            return false;
-        }
+    if (group_this == group_obj) {// either in the same part, or in the root of document
+        return true;
     }
     else {
         // cross-part link. Disallow, should be done via shapebinders only
@@ -9201,7 +9186,8 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
         }
     }
 
-    Base::Placement Plm = Placement.getValue();
+    Base::Placement grpPlm = App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(this);
+    Base::Placement Plm = grpPlm*Placement.getValue();
     Base::Vector3d Pos = Plm.getPosition();
     Base::Rotation Rot = Plm.getRotation();
     Base::Rotation invRot = Rot.inverse();
@@ -9245,6 +9231,8 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
         const std::string &SubElement=SubElements[i];
         const std::string &key = keys[i];
 
+        Base::Placement objPlm = invPlm*App::GeoFeatureGroupExtension::globalGroupPlacementInBoundary(Obj);
+
         bool beingCreated = false;
         if (extToAdd) {
             beingCreated = extToAdd->obj == Obj && extToAdd->subname == SubElement;
@@ -9283,7 +9271,7 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
             GeomAPI_ProjectPointOnSurf proj(P, gPlane);
             P = proj.NearestPoint();
             Base::Vector3d p(P.X(), P.Y(), P.Z());
-            invPlm.multVec(p, p);
+            objPlm.multVec(p, p);
 
             auto* point = new Part::GeomPoint(p);
             GeometryFacade::setConstruction(point, true);
@@ -9383,11 +9371,11 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
             if (projection && !refSubShape.IsNull()) {
                 switch (refSubShape.ShapeType()) {
                 case TopAbs_FACE: {
-                    processFace(invRot, invPlm, mov, sketchPlane, gPlane, sketchAx3, aProjFace, geos, refSubShape);
+                    processFace(invRot, objPlm, mov, sketchPlane, gPlane, sketchAx3, aProjFace, geos, refSubShape);
                 } break;
                 case TopAbs_EDGE: {
                     const TopoDS_Edge& edge = TopoDS::Edge(refSubShape);
-                    processEdge(edge, geos, gPlane, invPlm, mov, sketchPlane, invRot, sketchAx3, aProjFace);
+                    processEdge(edge, geos, gPlane, objPlm, mov, sketchPlane, invRot, sketchAx3, aProjFace);
                 } break;
                 case TopAbs_VERTEX: {
                     importVertex(refSubShape);
@@ -9415,7 +9403,7 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
                 auto edges = intersectionShape.getSubTopoShapes(TopAbs_EDGE);
                 for (const auto& s : edges) {
                     TopoDS_Edge edge = TopoDS::Edge(s.getShape());
-                    processEdge(edge, geos, gPlane, invPlm, mov, sketchPlane, invRot, sketchAx3, aProjFace);
+                    processEdge(edge, geos, gPlane, objPlm, mov, sketchPlane, invRot, sketchAx3, aProjFace);
                 }
                 // Section of some face (e.g. sphere) produce more than one arcs
                 // from the same circle. So we try to fit the arcs with a single

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -34,8 +34,10 @@
 #include <QWidgetAction>
 
 
+#include <App/GeoFeature.h>
 #include <App/DocumentObjectGroup.h>
 #include <App/Datums.h>
+#include <Gui/ActiveObjectList.h>
 #include <Gui/Action.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
@@ -48,6 +50,7 @@
 #include <Gui/QuantitySpinBox.h>
 #include <Gui/Selection/SelectionFilter.h>
 #include <Gui/Selection/SelectionObject.h>
+#include <Gui/MDIView.h>
 #include <Mod/Part/App/Attacher.h>
 #include <Mod/Part/App/Part2DObject.h>
 #include <Mod/Part/Gui/AttacherTexts.h>
@@ -149,6 +152,24 @@ Attacher::eMapMode SuggestAutoMapMode(Attacher::SuggestResult::eSuggestResult* p
 /* Sketch commands =======================================================*/
 DEF_STD_CMD_A(CmdSketcherNewSketch)
 
+namespace {
+    QString getAutoGroupCommandStr()
+        // Helper function to get the python code to add the newly created object to the active Part/Body object if present
+    {
+        App::GeoFeature* activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PDBODYKEY);
+        if (!activeObj) {
+            activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PARTKEY);
+        }
+
+        if (activeObj) {
+            QString activeName = QString::fromLatin1(activeObj->getNameInDocument());
+            return QStringLiteral("App.ActiveDocument.getObject('%1\').addObject(obj)\n").arg(activeName);
+        }
+
+        return QStringLiteral("# Object created at document root.");
+    }
+}
+
 CmdSketcherNewSketch::CmdSketcherNewSketch()
     : Command("Sketcher_NewSketch")
 {
@@ -246,9 +267,8 @@ void CmdSketcherNewSketch::activated(int iMsg)
         std::string FeatName = getUniqueObjectName("Sketch");
 
         openCommand(QT_TRANSLATE_NOOP("Command", "Create a new sketch on a face"));
-        doCommand(Doc,
-                  "App.activeDocument().addObject('Sketcher::SketchObject', '%s')",
-                  FeatName.c_str());
+        doCommand(Doc,"obj = App.activeDocument().addObject('Sketcher::SketchObject', '%s')", FeatName.c_str());
+        doCommand(Doc, getAutoGroupCommandStr().toUtf8());
         if (mapmode < Attacher::mmDummy_NumberOfModes)
             doCommand(Gui,
                       "App.activeDocument().%s.MapMode = \"%s\"",
@@ -289,16 +309,16 @@ void CmdSketcherNewSketch::activated(int iMsg)
         openCommand(QT_TRANSLATE_NOOP("Command", "Create a new sketch"));
         if (groupSelected) {
             doCommand(Doc,
-                    "App.activeDocument().getObject('%s').addObject(App.activeDocument().addObject('Sketcher::SketchObject', '%s'))",
+                    "obj = App.activeDocument().getObject('%s').addObject(App.activeDocument().addObject('Sketcher::SketchObject', '%s'))",
                     groupName.c_str(),
                     FeatName.c_str());
         }
         else {
             doCommand(Doc,
-                  "App.activeDocument().addObject('Sketcher::SketchObject', '%s')",
+                  "obj = App.activeDocument().addObject('Sketcher::SketchObject', '%s')",
                   FeatName.c_str());
         }
-
+        doCommand(Doc, getAutoGroupCommandStr().toUtf8());
         doCommand(Doc,
                   "App.activeDocument().%s.Placement = App.Placement(App.Vector(%f, %f, %f), "
                   "App.Rotation(%f, %f, %f, %f))",
@@ -1025,8 +1045,7 @@ void CmdSketcherMergeSketches::activated(int iMsg)
     std::string FeatName = getUniqueObjectName("Sketch");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Merge sketches"));
-    doCommand(
-        Doc, "App.activeDocument().addObject('Sketcher::SketchObject', '%s')", FeatName.c_str());
+    doCommand(Doc, "App.activeDocument().addObject('Sketcher::SketchObject', '%s')", FeatName.c_str());
 
     Sketcher::SketchObject* mergesketch =
         static_cast<Sketcher::SketchObject*>(doc->getObject(FeatName.c_str()));

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -54,6 +54,7 @@
 #include <Mod/Part/App/Attacher.h>
 #include <Mod/Part/App/Part2DObject.h>
 #include <Mod/Part/Gui/AttacherTexts.h>
+#include <Mod/Part/Gui/Utils.h>
 #include <Mod/Sketcher/App/Constraint.h>
 #include <Mod/Sketcher/App/SketchObject.h>
 
@@ -151,24 +152,6 @@ Attacher::eMapMode SuggestAutoMapMode(Attacher::SuggestResult::eSuggestResult* p
 
 /* Sketch commands =======================================================*/
 DEF_STD_CMD_A(CmdSketcherNewSketch)
-
-namespace {
-    QString getAutoGroupCommandStr()
-        // Helper function to get the python code to add the newly created object to the active Part/Body object if present
-    {
-        App::GeoFeature* activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PDBODYKEY);
-        if (!activeObj) {
-            activeObj = Gui::Application::Instance->activeView()->getActiveObject<App::GeoFeature*>(PARTKEY);
-        }
-
-        if (activeObj) {
-            QString activeName = QString::fromLatin1(activeObj->getNameInDocument());
-            return QStringLiteral("App.ActiveDocument.getObject('%1\').addObject(obj)\n").arg(activeName);
-        }
-
-        return QStringLiteral("# Object created at document root.");
-    }
-}
 
 CmdSketcherNewSketch::CmdSketcherNewSketch()
     : Command("Sketcher_NewSketch")
@@ -268,7 +251,7 @@ void CmdSketcherNewSketch::activated(int iMsg)
 
         openCommand(QT_TRANSLATE_NOOP("Command", "Create a new sketch on a face"));
         doCommand(Doc,"obj = App.activeDocument().addObject('Sketcher::SketchObject', '%s')", FeatName.c_str());
-        doCommand(Doc, getAutoGroupCommandStr().toUtf8());
+        doCommand(Doc, PartGui::getAutoGroupCommandStr().toUtf8());
         if (mapmode < Attacher::mmDummy_NumberOfModes)
             doCommand(Gui,
                       "App.activeDocument().%s.MapMode = \"%s\"",
@@ -318,7 +301,7 @@ void CmdSketcherNewSketch::activated(int iMsg)
                   "obj = App.activeDocument().addObject('Sketcher::SketchObject', '%s')",
                   FeatName.c_str());
         }
-        doCommand(Doc, getAutoGroupCommandStr().toUtf8());
+        doCommand(Doc, PartGui::getAutoGroupCommandStr().toUtf8());
         doCommand(Doc,
                   "App.activeDocument().%s.Placement = App.Placement(App.Vector(%f, %f, %f), "
                   "App.Rotation(%f, %f, %f, %f))",


### PR DESCRIPTION
The main problem solved by this PR is that in the current implementation the sketch environment does't allow using, as a reference or as constructive element, a geometrical entity defined in another body.
This is a big drawback because the main reason for using a multybody model instead of making an assembly with each solid in a separate Part (the old way) is the possibilty of referencing geometries of other bodies. If this is precluded the multibody environment isn't very useful. 
This problem may be mitigated with the automatic creation of subshape-binders (already implemented in Link branch and under development in FC/main) but I think that direct references (not intermediated by subshape binders) which are made availalable by this PR are a better solution.

