### PR TITLE
[TD]shrink selection frame

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIRichAnno.h
+++ b/src/Mod/TechDraw/Gui/QGIRichAnno.h
@@ -66,7 +66,6 @@ public:
                 const QStyleOptionGraphicsItem * option,
                 QWidget * widget = nullptr ) override;
     QRectF boundingRect() const override;
-    QRectF frameRect() const;
 
     void drawBorder() override;
     void updateView(bool update = false) override;

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -711,7 +711,7 @@ void QGIView::layoutDecorations(const QRectF& contentArea,
                               QPointF& outLabelPos,
                               QPointF& outLockPos) const
 {
-    const qreal padding = 100.0;
+    constexpr double padding{10};
     QRectF paddedContentArea = contentArea.adjusted(-padding, -padding, padding, padding);
 
     double frameWidth = qMax(paddedContentArea.width(), labelRect.width());
@@ -727,7 +727,7 @@ void QGIView::layoutDecorations(const QRectF& contentArea,
 
     double view_width = getViewObject()->getRect().x();
     outCaptionPos = QPointF(view_width - (captionRect.width() / 2),
-                            outLabelPos.y() - captionRect.height());
+                            outLabelPos.y() - captionRect.height() + padding * 2);
 
     outLockPos = QPointF(outFrameRect.left(), outFrameRect.bottom() - m_lockHeight);
 }
@@ -751,7 +751,7 @@ void QGIView::drawBorder()
     QString labelStr = QString::fromStdString(getViewObject()->Label.getValue());
     m_label->setPlainText(labelStr);
 
-    QRectF contentArea = customChildrenBoundingRect();
+    QRectF contentArea = frameRect();
     QRectF captionRect = m_caption->boundingRect();
     QRectF labelRect = m_label->boundingRect();
 
@@ -789,6 +789,40 @@ void QGIView::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, Q
     QGraphicsItemGroup::paint(painter, &myOption, widget);
 }
 
+
+//! this is a specialized version of customChildrenBoundingRect used only for calculating the size
+//! of the frame around selected views.
+//! we could reduce code duplication here, but would incur an execution time cost to make a second
+//! pass through the child items to add/subtract to the result of customChildrenBoundingRect.
+QRectF QGIView::frameRect() const
+{
+    QList<QGraphicsItem*> children = childItems();
+    // exceptions not to be included in determining the frame rectangle
+    QRectF result;
+    for (auto& child : children) {
+        if (!child->isVisible()) {
+            continue;
+        }
+        if (
+            child->type() != UserType::QGIRichAnno &&
+            child->type() != UserType::QGEPath &&
+            child->type() != UserType::QGMText &&
+            child->type() != UserType::QGCustomBorder &&
+            child->type() != UserType::QGCustomLabel &&
+            child->type() != UserType::QGICaption &&
+            child->type() != UserType::QGIVertex &&
+            child->type() != UserType::QGICMark  &&
+            child->type() != UserType::QGIViewDimension &&
+            child->type() != UserType::QGIViewBalloon) {
+            QRectF childRect = mapFromItem(child, child->boundingRect()).boundingRect();
+            result = result.united(childRect);
+        }
+    }
+    return result;
+}
+
+//! this is the original customChildrenBoundingRect - used for calculating the bounding rect of
+//! all the items that have to move with this view.
 QRectF QGIView::customChildrenBoundingRect() const
 {
     QList<QGraphicsItem*> children = childItems();

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -184,6 +184,7 @@ protected:
     void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
     void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
     virtual QRectF customChildrenBoundingRect() const;
+    virtual QRectF frameRect() const;
     void dumpRect(const char* text, QRectF rect);
     bool m_isHovered;
 


### PR DESCRIPTION
This PR implements a fix for the view border size issue identified in the comments of #23540.

Before: 
<img width="790" height="656" alt="overlappingSecondaries_weekly" src="https://github.com/user-attachments/assets/8dbc354e-7e43-424b-9d1c-c8e1026bc9f0" />

After:
<img width="1073" height="681" alt="OverlappingSecondaries_smallFrame" src="https://github.com/user-attachments/assets/90f38a62-652e-4a15-b7d2-cc59775a4531" />
