### PR TITLE
Sketcher: guard handler pointer in Offset editor path to avoid Enter/…

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -632,7 +632,9 @@ protected:
 
         // if the state changed and is not the last state (End). And is init (ie tool has not
         // reset)
-        if (!handler->isLastState() && handler->state() != currentstate && firstMoveInit) {
+        // Defend against null handler pointer that can occur during teardown
+        if (handler && !handler->isLastState() && handler->state() != currentstate
+            && firstMoveInit) {
             // mode has changed, so reprocess the previous position to the new widget state
             handler->mouseMove(prevCursorPosition);
         }


### PR DESCRIPTION
## Summary
Sketcher: guard handler pointer in Offset editor path to avoid Enter/Tab crash

Defend against null handler during teardown. Fixes #23628.

## Details
- Repro: Sketcher → Offset tool → type numeric value → press Enter or Tab → crash.
- Cause: `finishControlsChanged()` dereferenced a null handler pointer during teardown.
- Fix: Add null check before calling `handler->mouseMove(prevCursorPosition)`.

## Issues
Fixes #23628.
