### PR TITLE
Gui: Fix disabling editing Property View

### DIFF
--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -73,6 +73,8 @@ PropertyEditor::PropertyEditor(QWidget* parent)
     delegate = new PropertyItemDelegate(this);
     delegate->setItemEditorFactory(new PropertyItemEditorFactory);
     setItemDelegate(delegate);
+    // prevent a non-persistent editor when pressing F2
+    setEditTriggers(QAbstractItemView::NoEditTriggers);
 
     setAlternatingRowColors(true);
     setRootIsDecorated(false);
@@ -251,21 +253,30 @@ void PropertyEditor::keyPressEvent(QKeyEvent* event)
 
     const auto key = event->key();
     const auto mods = event->modifiers();
-    const bool allowedModifiers =
+
+    const bool allowedDeleteModifiers =
         mods == Qt::NoModifier ||
         mods == Qt::KeypadModifier;
-
 #if defined(Q_OS_MACOS) || defined(Q_OS_MAC)
     const bool isDeleteKey = key == Qt::Key_Backspace || key == Qt::Key_Delete;
 #else
     const bool isDeleteKey = key == Qt::Key_Delete;
 #endif
 
-    if (allowedModifiers && isDeleteKey) {
+    if (allowedDeleteModifiers && isDeleteKey) {
         if (removeSelectedDynamicProperties()) {
             event->accept();
             return;
         }
+    }
+    else if (mods == Qt::NoModifier && key == Qt::Key_F2) {
+        // open a persistent editor on F2
+        event->accept();
+        auto index = model() ? model()->buddy(currentIndex()) : QModelIndex();
+        if (index.isValid()) {
+            openEditor(index);
+        }
+        return;
     }
 
     QTreeView::keyPressEvent(event);


### PR DESCRIPTION
This commit fixes an issue that blocks editing values after pressing F2.

Pressing on F2 opened a non-persistent editor that was subsequently closed by Qt logic. However, the property editor is designed to make use of persistent editors with its own closing logic. 

This commits firstly prevents editing events to prevent F2 to open non-persistent editors. It then adds logic to open a persistent editor on pressing F2.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues

Closes #18390.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
