### PR TITLE
Sketcher: improve Make Internals property tooltip

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -11716,4 +11716,3 @@ template class SketcherExport FeaturePythonT<Sketcher::SketchObject>;
 }// namespace App
 
 // clang-format on
-

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -173,7 +173,8 @@ SketchObject::SketchObject() : geoLastId(0)
                       (false),
                       "Internal Geometry",
                       App::Prop_None,
-                      "Enable a sketch's internal geometry (e.g. closed wires defining faces) to be used for feature creation.");
+                      "Enables selection of closed profiles within a sketch as input for operations.");
+
 
     Geometry.setOrderRelevant(true);
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -173,7 +173,7 @@ SketchObject::SketchObject() : geoLastId(0)
                       (false),
                       "Internal Geometry",
                       App::Prop_None,
-                      "Make internal geometry, e.g. split intersecting edges, face of closed wires.");
+                      "Enable a sketch's internal geometry (e.g. closed wires defining faces) to be used for feature creation.");
 
     Geometry.setOrderRelevant(true);
 
@@ -11716,3 +11716,4 @@ template class SketcherExport FeaturePythonT<Sketcher::SketchObject>;
 }// namespace App
 
 // clang-format on
+

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -173,8 +173,7 @@ SketchObject::SketchObject() : geoLastId(0)
                       (false),
                       "Internal Geometry",
                       App::Prop_None,
-                      "Enables selection of closed profiles within a sketch as input for operations.");
-
+                      "Enables selection of closed profiles within a sketch as input for operations");
 
     Geometry.setOrderRelevant(true);
 


### PR DESCRIPTION
Proposal to improve the `MakeInternals` property tooltip from Sketch objects for clarity.

Other suggestions welcome.