### PR TITLE
Theme: bring back visual feedback on toolbar button press and hover

### DIFF
--- a/src/Gui/Stylesheets/FreeCAD.qss
+++ b/src/Gui/Stylesheets/FreeCAD.qss
@@ -1290,8 +1290,26 @@ QToolButton:hover {
   background-color: @GeneralBackgroundHoverColor;
 }
 
+/*
+ * Hover state: Add a visible border to create the frame effect.
+ * This rule is more specific than the theme's general QToolButton:hover, so it will apply only to
+ * toolbar buttons.
+ */
+QToolBar QToolButton:hover {
+    border: 1px solid @ButtonBorderColor;
+}
+
 QToolButton:pressed {
   background-color: @GeneralBackgroundHoverColor;
+}
+
+/*
+ * Pressed state: Add an "inset" border style and gradient to create the "pushed in" look.
+ */
+QToolBar QToolButton:hover:pressed {
+    border: 1px solid @ButtonBorderColor;
+    border-style: inset;
+    background-color: @PrimaryColorDarken2;
 }
 
 QToolButton:selected {


### PR DESCRIPTION
And also on toolbar button hover.

Fixes: https://github.com/FreeCAD/FreeCAD/issues/22747

Restores the 1.0 behavior. See the 1.0 video in the linked issue for comparison.

### Before

https://github.com/user-attachments/assets/d77ff7e3-f24d-4613-a590-8d77ed112f30

### After

#### Light
[light.webm](https://github.com/user-attachments/assets/3885f9b9-f98b-49b6-9a3d-d54adf700254)

#### Dark
[dark.webm](https://github.com/user-attachments/assets/dead7933-da6b-4747-9698-0303f4c97e34)

