### PR TITLE
Draft: fix display of Building US dim text

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -588,7 +588,8 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
             unit = vobj.UnitOverride
 
         # Special representation if we use 'Building US' scheme
-        if (not unit and obj.Document.UnitSystem == "Building US (ft-in, sqft, cft)") \
+        doc = obj.Document
+        if (not unit and doc.UnitSystem == doc.getEnumerationsOfProperty("UnitSystem")[5]) \
                 or (unit == "arch"):
             self.string = App.Units.Quantity(length, App.Units.Length).UserString
             if self.string.count('"') > 1:


### PR DESCRIPTION
Fixes #23669

The code was not yet updated to handle per-document unit settings. It still checked a parameter instead of the UnitSystem of the document.