### PR TITLE
Part: do not copy visual of sketch

### DIFF
--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -49,6 +49,8 @@
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
 
+#include <Mod/Part/App/Part2DObject.h>
+
 #include "ui_DlgExtrusion.h"
 #include "DlgExtrusion.h"
 
@@ -492,9 +494,11 @@ void DlgExtrusion::apply()
 
             this->writeParametersToFeature(*newObj, sourceObj);
 
-            Gui::Command::copyVisual(newObj, "ShapeAppearance", sourceObj);
-            Gui::Command::copyVisual(newObj, "LineColor", sourceObj);
-            Gui::Command::copyVisual(newObj, "PointColor", sourceObj);
+            if (!sourceObj->isDerivedFrom<Part::Part2DObject>()) {
+                Gui::Command::copyVisual(newObj, "ShapeAppearance", sourceObj);
+                Gui::Command::copyVisual(newObj, "LineColor", sourceObj);
+                Gui::Command::copyVisual(newObj, "PointColor", sourceObj);
+            }
 
             FCMD_OBJ_HIDE(sourceObj);
         }
@@ -792,3 +796,4 @@ void TaskExtrusion::clicked(int id)
 }
 
 #include "moc_DlgExtrusion.cpp"
+

--- a/src/Mod/Part/Gui/DlgRevolution.cpp
+++ b/src/Mod/Part/Gui/DlgRevolution.cpp
@@ -49,6 +49,8 @@
 #include <Gui/WaitCursor.h>
 #include <Mod/Part/App/FeatureRevolution.h>
 
+#include <Mod/Part/App/Part2DObject.h>
+
 #include "DlgRevolution.h"
 #include "ui_DlgRevolution.h"
 
@@ -434,11 +436,15 @@ void DlgRevolution::accept()
                      symmetric) //%13
                 ;
             Gui::Command::runCommand(Gui::Command::App, code.toLatin1());
-            QByteArray to = name.toLatin1();
-            QByteArray from = shape.toLatin1();
-            Gui::Command::copyVisual(to, "ShapeAppearance", from);
-            Gui::Command::copyVisual(to, "LineColor", from);
-            Gui::Command::copyVisual(to, "PointColor", from);
+
+            auto newObj = activeDoc->getObject(name.toStdString().c_str());
+            auto sourceObj = activeDoc->getObject(shape.toStdString().c_str());
+
+            if (!sourceObj->isDerivedFrom<Part::Part2DObject>()) {
+                Gui::Command::copyVisual(newObj, "ShapeAppearance", sourceObj);
+                Gui::Command::copyVisual(newObj, "LineColor", sourceObj);
+                Gui::Command::copyVisual(newObj, "PointColor", sourceObj);
+            }
         }
 
         activeDoc->commitTransaction();
@@ -585,3 +591,4 @@ bool TaskRevolution::accept()
 }
 
 #include "moc_DlgRevolution.cpp"
+


### PR DESCRIPTION
Do not copy visual of sketch when making an extrusion or revolution.
Fix https://github.com/FreeCAD/FreeCAD/issues/20076
Fix https://github.com/FreeCAD/FreeCAD/issues/23644