### PR TITLE
FEM: Restore and harmonize FEM Task selection hints

### DIFF
--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
@@ -136,8 +136,12 @@ TaskFemConstraintContact::TaskFemConstraintContact(ViewProviderFemConstraintCont
         ui->lw_referencesSlave->addItem(makeRefText(Objects[0], SubElements[0]));
     }
 
-    ui->lbl_info->setText(tr("Select slave geometry of type: ") + QString::fromUtf8("<b>%1</b>; ").arg(tr("Face")) + tr("click Add or Remove"));
-    ui->lbl_info_2->setText(tr("Select master geometry of type: ") + QString::fromUtf8("<b>%1</b>; ").arg(tr("Face")) + tr("click Add or Remove"));
+    ui->lbl_info->setText(tr("Select slave geometry of type: ")
+                          + QString::fromUtf8("<b>%1</b>; ").arg(tr("Face"))
+                          + tr("click Add or Remove"));
+    ui->lbl_info_2->setText(tr("Select master geometry of type: ")
+                            + QString::fromUtf8("<b>%1</b>; ").arg(tr("Face"))
+                            + tr("click Add or Remove"));
 
     // Selection buttons
     connect(ui->btnAddSlave,

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
@@ -136,6 +136,9 @@ TaskFemConstraintContact::TaskFemConstraintContact(ViewProviderFemConstraintCont
         ui->lw_referencesSlave->addItem(makeRefText(Objects[0], SubElements[0]));
     }
 
+    ui->lbl_info->setText(tr("Select slave geometry of type: ") + QString::fromUtf8("<b>%1</b>; ").arg(tr("Face")) + tr("click Add or Remove"));
+    ui->lbl_info_2->setText(tr("Select master geometry of type: ") + QString::fromUtf8("<b>%1</b>; ").arg(tr("Face")) + tr("click Add or Remove"));
+
     // Selection buttons
     connect(ui->btnAddSlave,
             &QToolButton::clicked,

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_info_2">
      <property name="text">
-      <string>Select master face, click Add or Remove</string>
+      <string>Select master geometry of type: Face; click Add or Remove</string>
      </property>
     </widget>
    </item>
@@ -76,7 +76,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Select slave face, click Add or Remove</string>
+      <string>Select slave geometry of type: Face; click Add or Remove</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -161,7 +161,8 @@ TaskFemConstraintDisplacement::TaskFemConstraintDisplacement(
     ui->DisplacementZFormulaCB->setChecked(bStates[8]);
     ui->FlowForceCB->setChecked(bStates[9]);
 
-    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
+    ui->lbl_info->setText(tr("Select geometry of type: ")
+                          + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
 
     // Selection buttons
     buttonGroup->addButton(ui->btnAdd, static_cast<int>(SelectionChangeModes::refAdd));

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -161,6 +161,8 @@ TaskFemConstraintDisplacement::TaskFemConstraintDisplacement(
     ui->DisplacementZFormulaCB->setChecked(bStates[8]);
     ui->FlowForceCB->setChecked(bStates[9]);
 
+    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
+
     // Selection buttons
     buttonGroup->addButton(ui->btnAdd, static_cast<int>(SelectionChangeModes::refAdd));
     buttonGroup->addButton(ui->btnRemove, static_cast<int>(SelectionChangeModes::refRemove));

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.ui
@@ -38,7 +38,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Click Add or Remove and select geometric elements</string>
+        <string>Select geometry of type: Vertex, Edge, Face</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
@@ -82,7 +82,8 @@ TaskFemConstraintFixed::TaskFemConstraintFixed(ViewProviderFemConstraintFixed* C
         ui->lw_references->setCurrentRow(0, QItemSelectionModel::ClearAndSelect);
     }
 
-    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
+    ui->lbl_info->setText(tr("Select geometry of type: ")
+                          + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
 
     // Selection buttons
     buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
@@ -82,6 +82,8 @@ TaskFemConstraintFixed::TaskFemConstraintFixed(ViewProviderFemConstraintFixed* C
         ui->lw_references->setCurrentRow(0, QItemSelectionModel::ClearAndSelect);
     }
 
+    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
+
     // Selection buttons
     buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);
     buttonGroup->addButton(ui->btnRemove, (int)SelectionChangeModes::refRemove);

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Click Add or Remove and select geometric elements</string>
+    <string>Select geometry of type: Vertex, Edge, Face</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
@@ -370,7 +370,8 @@ TaskFemConstraintFluidBoundary::TaskFemConstraintFluidBoundary(
     ui->buttonDirection->blockSignals(false);
     ui->checkReverse->blockSignals(false);
 
-    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Face")));
+    ui->lbl_info->setText(tr("Select geometry of type: ")
+                          + QString::fromUtf8("<b>%1</b>").arg(tr("Face")));
 
     updateUI();
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
@@ -370,6 +370,8 @@ TaskFemConstraintFluidBoundary::TaskFemConstraintFluidBoundary(
     ui->buttonDirection->blockSignals(false);
     ui->checkReverse->blockSignals(false);
 
+    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Face")));
+
     updateUI();
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.ui
@@ -67,7 +67,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Select multiple faces, click Add or Remove</string>
+    <string>Select geometry of type: Face</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
@@ -86,6 +86,8 @@ TaskFemConstraintForce::TaskFemConstraintForce(ViewProviderFemConstraintForce* C
     ui->lineDirection->setText(dir.isEmpty() ? QString() : dir);
     ui->checkReverse->setChecked(reversed);
 
+    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
+
     // create a context menu for the listview of the references
     createActions(ui->listReferences);
     connect(deleteAction, &QAction::triggered, this, &TaskFemConstraintForce::onReferenceDeleted);

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
@@ -86,7 +86,8 @@ TaskFemConstraintForce::TaskFemConstraintForce(ViewProviderFemConstraintForce* C
     ui->lineDirection->setText(dir.isEmpty() ? QString() : dir);
     ui->checkReverse->setChecked(reversed);
 
-    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
+    ui->lbl_info->setText(tr("Select geometry of type: ")
+                          + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
 
     // create a context menu for the listview of the references
     createActions(ui->listReferences);

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.ui
@@ -29,7 +29,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Click Add or Remove and select geometric elements</string>
+        <string>Select geometry of type: Vertex, Edge, Face</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -144,8 +144,9 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(
     if (!Objects.empty()) {
         ui->lw_references->setCurrentRow(0, QItemSelectionModel::ClearAndSelect);
     }
-    
-    ui->lbl_references->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Edge, Face")));
+
+    ui->lbl_references->setText(tr("Select geometry of type: ")
+                                + QString::fromUtf8("<b>%1</b>").arg(tr("Edge, Face")));
 
     // Selection buttons
     buttonGroup->addButton(ui->btnAdd, static_cast<int>(SelectionChangeModes::refAdd));

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -144,6 +144,8 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(
     if (!Objects.empty()) {
         ui->lw_references->setCurrentRow(0, QItemSelectionModel::ClearAndSelect);
     }
+    
+    ui->lbl_references->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Edge, Face")));
 
     // Selection buttons
     buttonGroup->addButton(ui->btnAdd, static_cast<int>(SelectionChangeModes::refAdd));

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_references">
      <property name="text">
-      <string>Click Add or Remove and select faces</string>
+    <string>Select  geometry of type: Edge, Face</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
@@ -92,6 +92,8 @@ TaskFemConstraintPlaneRotation::TaskFemConstraintPlaneRotation(
         ui->lw_references->setCurrentRow(0, QItemSelectionModel::ClearAndSelect);
     }
 
+    ui->lbl_info->setText(tr("Select single geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Face")));
+
     // Selection buttons
     connect(ui->btnAdd,
             &QToolButton::clicked,

--- a/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
@@ -92,7 +92,8 @@ TaskFemConstraintPlaneRotation::TaskFemConstraintPlaneRotation(
         ui->lw_references->setCurrentRow(0, QItemSelectionModel::ClearAndSelect);
     }
 
-    ui->lbl_info->setText(tr("Select single geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Face")));
+    ui->lbl_info->setText(tr("Select single geometry of type: ")
+                          + QString::fromUtf8("<b>%1</b>").arg(tr("Face")));
 
     // Selection buttons
     connect(ui->btnAdd,

--- a/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Select a single face, click Add or Remove</string>
+    <string>Select single geometry of type: Face</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
@@ -70,6 +70,8 @@ TaskFemConstraintPressure::TaskFemConstraintPressure(
     bool reversed = pcConstraint->Reversed.getValue();
     ui->checkBoxReverse->setChecked(reversed);
 
+    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Edge, Face")));
+
     ui->lw_references->clear();
     for (std::size_t i = 0; i < Objects.size(); i++) {
         ui->lw_references->addItem(makeRefText(Objects[i], SubElements[i]));

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
@@ -70,7 +70,8 @@ TaskFemConstraintPressure::TaskFemConstraintPressure(
     bool reversed = pcConstraint->Reversed.getValue();
     ui->checkBoxReverse->setChecked(reversed);
 
-    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Edge, Face")));
+    ui->lbl_info->setText(tr("Select geometry of type: ")
+                          + QString::fromUtf8("<b>%1</b>").arg(tr("Edge, Face")));
 
     ui->lw_references->clear();
     for (std::size_t i = 0; i < Objects.size(); i++) {

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Click Add or Remove and select faces</string>
+    <string>Select geometry of type: Edge, Face</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintRigidBody.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintRigidBody.cpp
@@ -248,6 +248,8 @@ TaskFemConstraintRigidBody::TaskFemConstraintRigidBody(
     buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);
     buttonGroup->addButton(ui->btnRemove, (int)SelectionChangeModes::refRemove);
 
+    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
+
     updateUI();
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintRigidBody.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintRigidBody.cpp
@@ -248,7 +248,8 @@ TaskFemConstraintRigidBody::TaskFemConstraintRigidBody(
     buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);
     buttonGroup->addButton(ui->btnRemove, (int)SelectionChangeModes::refRemove);
 
-    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
+    ui->lbl_info->setText(tr("Select geometry of type: ")
+                          + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
 
     updateUI();
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintRigidBody.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintRigidBody.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Click Add or Remove and select geometric elements</string>
+    <string>Select geometry of type: Vertex, Edge, Face</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
@@ -99,6 +99,8 @@ TaskFemConstraintSpring::TaskFemConstraintSpring(ViewProviderFemConstraintSpring
         ui->lw_references->setCurrentRow(0, QItemSelectionModel::ClearAndSelect);
     }
 
+    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Face")));
+
     // Selection buttons
     buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);
     buttonGroup->addButton(ui->btnRemove, (int)SelectionChangeModes::refRemove);

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
@@ -99,7 +99,8 @@ TaskFemConstraintSpring::TaskFemConstraintSpring(ViewProviderFemConstraintSpring
         ui->lw_references->setCurrentRow(0, QItemSelectionModel::ClearAndSelect);
     }
 
-    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Face")));
+    ui->lbl_info->setText(tr("Select geometry of type: ")
+                          + QString::fromUtf8("<b>%1</b>").arg(tr("Face")));
 
     // Selection buttons
     buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Click Add or Remove and select faces</string>
+    <string>Select geometry of type: Face</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
@@ -97,7 +97,8 @@ TaskFemConstraintTemperature::TaskFemConstraintTemperature(
         ui->lw_references->setCurrentRow(0, QItemSelectionModel::ClearAndSelect);
     }
 
-    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
+    ui->lbl_info->setText(tr("Select geometry of type: ")
+                          + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
 
     // create a context menu for the listview of the references
     createActions(ui->lw_references);

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
@@ -97,6 +97,8 @@ TaskFemConstraintTemperature::TaskFemConstraintTemperature(
         ui->lw_references->setCurrentRow(0, QItemSelectionModel::ClearAndSelect);
     }
 
+    ui->lbl_info->setText(tr("Select geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Vertex, Edge, Face")));
+
     // create a context menu for the listview of the references
     createActions(ui->lw_references);
     connect(deleteAction,

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.ui
@@ -29,7 +29,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Click Add or Remove and select geometric elements</string>
+    <string>Select geometry of type: Vertex, Edge, Face</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
@@ -153,6 +153,8 @@ TaskFemConstraintTransform::TaskFemConstraintTransform(
 
     ui->lw_Rect->clear();
 
+    ui->lbl_info_2->setText(tr("Select single geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Face")));
+
     // Transformable surfaces
     Gui::Command::doCommand(Gui::Command::Doc,
                             TaskFemConstraintTransform::getSurfaceReferences(

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
@@ -153,7 +153,8 @@ TaskFemConstraintTransform::TaskFemConstraintTransform(
 
     ui->lw_Rect->clear();
 
-    ui->lbl_info_2->setText(tr("Select single geometry of type: ") + QString::fromUtf8("<b>%1</b>").arg(tr("Face")));
+    ui->lbl_info_2->setText(tr("Select single geometry of type: ")
+                            + QString::fromUtf8("<b>%1</b>").arg(tr("Face")));
 
     // Transformable surfaces
     Gui::Command::doCommand(Gui::Command::Doc,

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.ui
@@ -41,7 +41,7 @@
    <item>
     <widget class="QLabel" name="lbl_info_2">
      <property name="text">
-      <string>Select a face, click Add or Remove</string>
+    <string>Select single geometry of type: Face</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/femguiutils/selection_widgets.py
+++ b/src/Mod/Fem/femguiutils/selection_widgets.py
@@ -299,9 +299,9 @@ class GeometryElementsSelection(QtGui.QWidget):
         # label
         self.lb_help = QtGui.QLabel()
         self.lb_help.setWordWrap(True)
-        selectHelpText = self.tr(
-            "Select geometry of type: {}{}{}"
-        ).format("<b>", self.sel_elem_text, "</b>")
+        selectHelpText = self.tr("Select geometry of type: {}{}{}").format(
+            "<b>", self.sel_elem_text, "</b>"
+        )
         self.lb_help.setText(selectHelpText)
         # list
         self.list_References = QtGui.QListWidget()
@@ -321,8 +321,8 @@ class GeometryElementsSelection(QtGui.QWidget):
         subLayout.addWidget(self.pushButton_Remove)
         # main layout
         mainLayout = QtGui.QVBoxLayout()
-        mainLayout.addLayout(subLayout)
         mainLayout.addWidget(self.lb_help)
+        mainLayout.addLayout(subLayout)
         mainLayout.addWidget(self.list_References)
 
         tip1 = self.tr(

--- a/src/Mod/Fem/femguiutils/selection_widgets.py
+++ b/src/Mod/Fem/femguiutils/selection_widgets.py
@@ -296,6 +296,13 @@ class GeometryElementsSelection(QtGui.QWidget):
         # button
         self.pushButton_Add = QtGui.QPushButton(self.tr("Add"))
         self.pushButton_Remove = QtGui.QPushButton(self.tr("Remove"))
+        # label
+        self.lb_help = QtGui.QLabel()
+        self.lb_help.setWordWrap(True)
+        selectHelpText = self.tr(
+            "Select geometry of type: {}{}{}"
+        ).format("<b>", self.sel_elem_text, "</b>")
+        self.lb_help.setText(selectHelpText)
         # list
         self.list_References = QtGui.QListWidget()
         # radiobutton down the list
@@ -315,6 +322,7 @@ class GeometryElementsSelection(QtGui.QWidget):
         # main layout
         mainLayout = QtGui.QVBoxLayout()
         mainLayout.addLayout(subLayout)
+        mainLayout.addWidget(self.lb_help)
         mainLayout.addWidget(self.list_References)
 
         tip1 = self.tr(


### PR DESCRIPTION
# The problem
Last contributions moved long details about geometry selection to tooltip, which is good solution.
However, no visible text at all makes dialogs aesthetic and not very convienient.
<img width="355" height="516" alt="image" src="https://github.com/user-attachments/assets/2c1df748-6b17-4d25-91bd-521950f7c33e" />

See #21480 for more details.

# Solution
Single line about type of selectable geometry was added. 
Longer details about selection are still shown in tooltip, when 'Add' button is hovered.

<img width="418" height="492" alt="image" src="https://github.com/user-attachments/assets/1541e423-2450-45df-9982-d3a1fa5f7987" />


FEM Tasks, where geometry is to be selected, were harmonized to have same 'selection hint phrase'.

### Before
<img width="428" height="163" alt="image" src="https://github.com/user-attachments/assets/d77c89a7-9e94-44a7-bdd1-2bacc3b94f1b" />

### Now
<img width="434" height="244" alt="image" src="https://github.com/user-attachments/assets/6e1f5aa1-2a83-4709-87ac-22eaf0e284c6" />

## Issues
fixes #21480 
