### PR TITLE
PD: fix hole thread depth being reset when changing to through all

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1710,7 +1710,6 @@ void Hole::onChanged(const App::Property* prop)
             if (isNotDimension) {
                 // if through all, set the depth accordingly
                 Depth.setValue(getThroughAllLength());
-                ThreadDepth.setValue(getThroughAllLength());
             }
             updateThreadDepthParam();
         }


### PR DESCRIPTION
_Originally posted by @pierreporte in https://github.com/FreeCAD/FreeCAD/issues/22573#issuecomment-3259858979_

> There is still the issue when hole depth is through all, that resets the thread depth to hole depth after task validation. It is needed to use the property view to adjust manually the value (the above picture was made in this situation). When using modeled threads there is no reset.



the property is being wrongly set by the line removed in this PR, but it is correctly updated by the updateThreadDepthParam below, so this line is just messing things up.