### PR TITLE
[Gui] [Font] hotfix to maintain Mac working as expected..

### DIFF
--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -425,8 +425,12 @@ PythonConsole::PythonConsole(QWidget *parent)
 
     setVisibleLineNumbers(false);
     setEnabledHighlightCurrentLine(false);
+#ifdef FC_OS_MACOSX
     QFont serifFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
     serifFont.setPointSize(10);
+#else
+    QFont serifFont(QLatin1String("Courier"), 10, QFont::Normal);
+#endif
     setFont(serifFont);
 
     // set colors and font from settings

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -464,7 +464,11 @@ ReportOutput::~ReportOutput()
 
 void ReportOutput::restoreFont()
 {
+#ifdef FC_OS_MACOSX
     QFont serifFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+#else
+    QFont serifFont(QLatin1String("Courier"), 10, QFont::Normal);
+#endif
     setFont(serifFont);
 }
 
@@ -854,8 +858,13 @@ void ReportOutput::OnChange(Base::Subject<const char*> &rCaller, const char * sR
     }
     else if (strcmp(sReason, "FontSize") == 0 || strcmp(sReason, "Font") == 0) {
         int fontSize = rclGrp.GetInt("FontSize", 10);
+#ifdef FC_OS_MACOSX
         QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
         font.setPointSize(fontSize);
+#else
+        QString fontFamily = QString::fromLatin1(rclGrp.GetASCII("Font", "Courier").c_str());
+        QFont font(fontFamily, fontSize);
+#endif
         setFont(font);
         QFontMetrics metric(font);
         int width = QtTools::horizontalAdvance(metric, QLatin1String("0000"));

--- a/src/Gui/TextEdit.cpp
+++ b/src/Gui/TextEdit.cpp
@@ -280,9 +280,12 @@ TextEditor::TextEditor(QWidget* parent)
 {
     d = new TextEditorP();
     lineNumberArea = new LineMarker(this);
-
+#ifdef FC_OS_MACOSX
     QFont serifFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
     serifFont.setPointSize(10);
+#else
+    QFont serifFont(QLatin1String("Courier"), 10, QFont::Normal);
+#endif
     setFont(serifFont);
 
     ParameterGrp::handle hPrefGrp = getWindowParameter();
@@ -448,8 +451,13 @@ void TextEditor::OnChange(Base::Subject<const char*> &rCaller,const char* sReaso
 #else
         int fontSize = hPrefGrp->GetInt("FontSize", 10);
 #endif
+#ifdef FC_OS_MACOSX
         QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
         font.setPointSize(fontSize);
+#else
+        QString fontFamily = QString::fromLatin1(hPrefGrp->GetASCII( "Font", "Courier" ).c_str());
+        QFont font(fontFamily, fontSize);
+#endif
         setFont(font);
         lineNumberArea->setFont(font);
     }


### PR DESCRIPTION
 ...while reverting the regression for Windows and Linux users introduced by https://github.com/FreeCAD/FreeCAD/commit/fcd1b923b387d9caa9dbadc28d3cc8af03a43b9c
This is meant as a temporary solution until a long-term one can be reached.

See screenshots of unintended consequences of the original commit https://github.com/FreeCAD/FreeCAD/issues/22882#issue-3285243044