### PR TITLE
Increase timeout for GUI tests

### DIFF
--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: FreeCAD GUI tests on build dir
         if: inputs.testOnBuildDir
-        timeout-minutes: 15
+        timeout-minutes: 30
         uses: ./.github/workflows/actions/runPythonTests
         with:
           testDescription: "GUI tests on build dir"
@@ -203,7 +203,7 @@ jobs:
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
 
       - name: FreeCAD GUI tests on install
-        timeout-minutes: 15
+        timeout-minutes: 30
         uses: ./.github/workflows/actions/runPythonTests
         with:
           testDescription: "GUI tests on install"


### PR DESCRIPTION
Increase the timeout for the GUI tests step, which are only run on the Ubuntu builds.

At least two PRs are failing after hitting the timeout limit of 15 minutes on the **FreeCAD GUI tests on install** step:
- https://github.com/FreeCAD/FreeCAD/pull/21541: I've ran the GUI test suite in about 6 minutes without issues locally, on a fairly old laptop. This PR adds a GUI test, but the job fails even before running this new test.
- https://github.com/FreeCAD/FreeCAD/pull/20132

As an aside, is there a specific reason why the GUI tests are only run on the Ubuntu CI build?