### PR TITLE
CAM: Array op - Multi tool controllers and coolant

### DIFF
--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -7,6 +7,7 @@
         <file>icons/CAM_Area_Workplane.svg</file>
         <file>icons/CAM_Area.svg</file>
         <file>icons/CAM_Array.svg</file>
+        <file>icons/CAM_ArrayMTC.svg</file>
         <file>icons/CAM_BFastForward.svg</file>
         <file>icons/CAM_BPause.svg</file>
         <file>icons/CAM_BPlay.svg</file>

--- a/src/Mod/CAM/Gui/Resources/icons/CAM_ArrayMTC.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/CAM_ArrayMTC.svg
@@ -1,0 +1,633 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64px"
+   height="64px"
+   id="svg2816"
+   version="1.1"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   sodipodi:docname="CAM_ArrayMultiTC.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2818">
+    <linearGradient
+       id="linearGradient4513">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3681">
+      <stop
+         id="stop3697"
+         offset="0"
+         style="stop-color:#fff110;stop-opacity:1;" />
+      <stop
+         style="stop-color:#cf7008;stop-opacity:1;"
+         offset="1"
+         id="stop3685" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective2824" />
+    <inkscape:perspective
+       id="perspective3622"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3622-9"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3653"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3675"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3697"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3720"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3742"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3764"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3785"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3806"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3806-3"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3835"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3614"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3614-8"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3643"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3643-3"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3672"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3672-5"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3701"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3701-8"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3746"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       patternTransform="matrix(0.67643728,-0.81829155,2.4578314,1.8844554,-26.450606,18.294947)"
+       id="pattern5231"
+       xlink:href="#Strips1_1-4"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5224"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       inkscape:stockid="Stripes 1:1"
+       id="Strips1_1-4"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       height="1"
+       width="2"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <rect
+         id="rect4483-4"
+         height="2"
+         width="1"
+         y="-0.5"
+         x="0"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <inkscape:perspective
+       id="perspective5224-9"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,39.618381,8.9692804)"
+       id="pattern5231-4"
+       xlink:href="#Strips1_1-6"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5224-3"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       inkscape:stockid="Stripes 1:1"
+       id="Strips1_1-6"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       height="1"
+       width="2"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <rect
+         id="rect4483-0"
+         height="2"
+         width="1"
+         y="-0.5"
+         x="0"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <pattern
+       patternTransform="matrix(0.66513382,-1.0631299,2.4167603,2.4482973,-49.762569,2.9546807)"
+       id="pattern5296"
+       xlink:href="#pattern5231-3"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5288"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,-26.336284,10.887197)"
+       id="pattern5231-3"
+       xlink:href="#Strips1_1-4-3"
+       inkscape:collect="always" />
+    <pattern
+       inkscape:stockid="Stripes 1:1"
+       id="Strips1_1-4-3"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       height="1"
+       width="2"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <rect
+         id="rect4483-4-6"
+         height="2"
+         width="1"
+         y="-0.5"
+         x="0"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <pattern
+       patternTransform="matrix(0.42844886,-0.62155849,1.5567667,1.431396,27.948414,13.306456)"
+       id="pattern5330"
+       xlink:href="#Strips1_1-9"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5323"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       inkscape:stockid="Stripes 1:1"
+       id="Strips1_1-9"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       height="1"
+       width="2"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <rect
+         id="rect4483-3"
+         height="2"
+         width="1"
+         y="-0.5"
+         x="0"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <inkscape:perspective
+       id="perspective5361"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5383"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5411"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3681"
+       id="linearGradient3687"
+       x1="37.89756"
+       y1="41.087898"
+       x2="4.0605712"
+       y2="40.168594"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(127.27273,-51.272729)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3681"
+       id="linearGradient3695"
+       x1="37.894287"
+       y1="40.484772"
+       x2="59.811455"
+       y2="43.558987"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(127.27273,-51.272729)" />
+    <linearGradient
+       id="linearGradient3681-3">
+      <stop
+         id="stop3697-3"
+         offset="0"
+         style="stop-color:#fff110;stop-opacity:1;" />
+      <stop
+         style="stop-color:#cf7008;stop-opacity:1;"
+         offset="1"
+         id="stop3685-4" />
+    </linearGradient>
+    <linearGradient
+       y2="43.558987"
+       x2="59.811455"
+       y1="40.484772"
+       x1="37.894287"
+       gradientTransform="translate(-37.00068,-20.487365)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3608"
+       xlink:href="#linearGradient3681-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4513-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515-2" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517-4" />
+    </linearGradient>
+    <radialGradient
+       r="23.634638"
+       fy="7.9319997"
+       fx="32.151962"
+       cy="7.9319997"
+       cx="32.151962"
+       gradientTransform="matrix(1,0,0,1.1841158,-8.5173246,-3.4097568)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4538"
+       xlink:href="#linearGradient4513-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4513-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515-8" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517-6" />
+    </linearGradient>
+    <radialGradient
+       r="23.634638"
+       fy="7.9319997"
+       fx="32.151962"
+       cy="7.9319997"
+       cx="32.151962"
+       gradientTransform="matrix(1,0,0,1.1841158,-8.5173246,-3.4097568)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4538-6"
+       xlink:href="#linearGradient4513-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4513-1-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515-8-7" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517-6-5" />
+    </linearGradient>
+    <radialGradient
+       r="23.634638"
+       fy="35.869175"
+       fx="32.151962"
+       cy="35.869175"
+       cx="32.151962"
+       gradientTransform="matrix(0.39497909,0,0,1.1841158,-2.716491,-26.067007)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3069"
+       xlink:href="#linearGradient4513-1-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4513-1-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515-8-6" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517-6-6" />
+    </linearGradient>
+    <radialGradient
+       r="23.634638"
+       fy="35.869175"
+       fx="32.151962"
+       cy="35.869175"
+       cx="32.151962"
+       gradientTransform="matrix(0.39497909,0,0,1.1841158,-2.716491,-26.067007)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3102"
+       xlink:href="#linearGradient4513-1-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3862-0"
+       id="linearGradient3868-4"
+       x1="16.166359"
+       y1="5.12708"
+       x2="16.848885"
+       y2="12.905255"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3862-0">
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1"
+         offset="0"
+         id="stop3864-9" />
+      <stop
+         style="stop-color:#73d216;stop-opacity:1"
+         offset="1"
+         id="stop3866-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3862-5"
+       id="linearGradient3868-5"
+       x1="16.166359"
+       y1="5.12708"
+       x2="16.848885"
+       y2="12.905255"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3862-5">
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1"
+         offset="0"
+         id="stop3864-1" />
+      <stop
+         style="stop-color:#73d216;stop-opacity:1"
+         offset="1"
+         id="stop3866-7" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.5"
+     inkscape:cx="22.090909"
+     inkscape:cy="49.727273"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="872"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-nodes="false"
+     inkscape:snap-global="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3056"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2821">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+        <dc:title>CAM_Array</dc:title>
+        <dc:date>2016-01-19</dc:date>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/CAM/Gui/Resources/icons/CAM_Array.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect3083-0-3-8-0-5"
+       d="m 14.994846,38 -8.1914588,8 c -2.0478646,2 0,6 4.0957298,7 l 28.670104,5 c 4.09573,1 8.191459,-2 11.263256,-5 l 7.167526,-9"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect3083-0-3-8-0-1-27"
+       d="m 14.994845,37.803848 -8.1914598,8 c -2.047864,2 0,6 4.0957298,7 l 28.670104,5 c 4.09573,1 8.191459,-2 11.263256,-5 l 7.167526,-9"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#299a10;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;fill-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect3083-0-3-8-0-8"
+       d="m 14.994846,22 -8.1914585,8 c -2.0478646,2 0,6 4.0957295,7 l 28.670104,5 c 4.09573,1 8.191459,-2 11.263256,-5 l 7.167526,-9"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect3083-0-3-8-0-1-2"
+       d="m 14.994845,21.803848 -8.1914595,8 c -2.047864,2 0,6 4.0957295,7 l 28.670104,5 c 4.09573,1 8.191459,-2 11.263256,-5 l 7.167526,-9"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#e6cc18;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect3083-0-3-8-0"
+       d="m 14.994846,6 -8.1914585,8 c -2.0478646,2 0,6 4.0957295,7 l 28.670104,5 c 4.09573,1 8.191459,-2 11.263256,-5 l 7.167526,-9"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect3083-0-3-8-0-1"
+       d="M 14.994845,5.8038476 6.8033855,13.803848 c -2.047864,2 0,6 4.0957295,7 l 28.670104,5 c 4.09573,1 8.191459,-2 11.263256,-5 l 7.167526,-9"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#d21616;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  </g>
+</svg>

--- a/src/Mod/CAM/Path/Main/Gui/Simulator.py
+++ b/src/Mod/CAM/Path/Main/Gui/Simulator.py
@@ -151,9 +151,13 @@ class PathSimulation:
         self.ioperation = 0
         for i in range(form.listOperations.count()):
             if form.listOperations.item(i).checkState() == QtCore.Qt.CheckState.Checked:
+                if getattr(self.operations[i], "ArrayGroup", None):
+                    self.activeOps.extend(self.operations[i].ArrayGroup)
+                    self.numCommands += sum(op.Path.Size for op in self.operations[i].ArrayGroup)
+                else:
+                    self.activeOps.append(self.operations[i])
+                    self.numCommands += self.operations[i].Path.Size
                 self.firstDrill = True
-                self.activeOps.append(self.operations[i])
-                self.numCommands += len(self.operations[i].Path.Commands)
 
         self.stock = self.job.Stock.Shape
         if self.isVoxel:

--- a/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
+++ b/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
@@ -89,22 +89,14 @@ class CAMSimulation:
     def __init__(self):
         self.debug = False
         self.stdrot = FreeCAD.Rotation(Vector(0, 0, 1), 0)
-        self.iprogress = 0
-        self.numCommands = 0
-        self.simperiod = 20
         self.quality = 10
         self.resetSimulation = False
         self.jobs = []
-        self.initdone = False
         self.taskForm = None
-        self.disableAnim = False
-        self.firstDrill = True
         self.millSim = None
         self.job = None
         self.activeOps = []
-        self.ioperation = 0
         self.stock = None
-        self.busy = False
         self.operations = []
         self.baseShape = None
 
@@ -209,7 +201,6 @@ class CAMSimulation:
 
     def Activate(self):
         """Invoke the simulator task panel"""
-        self.initdone = False
         self.taskForm = CAMSimTaskUi(self)
         form = self.taskForm.form
         self.Connect(form.toolButtonPlay, self.SimPlay)
@@ -226,10 +217,7 @@ class CAMSimulation:
         self.onJobChange()
         form.listOperations.itemChanged.connect(self.onOperationItemChange)
         FreeCADGui.Control.showDialog(self.taskForm)
-        self.disableAnim = False
-        self.firstDrill = True
         self.millSim = CAMSimulator.PathSim()
-        self.initdone = True
         self.job = self.jobs[self.taskForm.form.comboJobs.currentIndex()]
         # self.SetupSimulation()
 
@@ -267,16 +255,14 @@ class CAMSimulation:
         """Prepare all selected job operations for simulation"""
         form = self.taskForm.form
         self.activeOps = []
-        self.numCommands = 0
-        self.ioperation = 0
         for i in range(form.listOperations.count()):
             if form.listOperations.item(i).checkState() == QtCore.Qt.CheckState.Checked:
-                self.firstDrill = True
-                self.activeOps.append(self.operations[i])
-                self.numCommands += len(self.operations[i].Path.Commands)
+                if getattr(self.operations[i], "ArrayGroup", None):
+                    self.activeOps.extend(self.operations[i].ArrayGroup)
+                else:
+                    self.activeOps.append(self.operations[i])
 
         self.stock = self.job.Stock.Shape
-        self.busy = False
 
     def onJobChange(self):
         """When a new job is selected from the drop-down, update job operation list"""

--- a/src/Mod/CAM/Path/Op/Gui/Array.py
+++ b/src/Mod/CAM/Path/Op/Gui/Array.py
@@ -19,18 +19,19 @@
 #                                                                              #
 ################################################################################
 
-import DraftVecUtils
 import FreeCAD
 import FreeCADGui
 import Path
 import PathScripts.PathUtils as PathUtils
-import Path.Base.Util as PathUtil
-from Path.Dressup.Utils import toolController
+from DraftVecUtils import rotate2D
+from Path.Base.Util import coolantModeForOp
+from Path.Base.Util import toolControllerForOp
 from Path.Op.Util import getCycleTimeEstimate
 import tsp_solver
 
 import random
 import math
+import time
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -66,7 +67,36 @@ class ObjectArray:
             "Path",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "The tool controller that will be used to calculate the toolpath\nShould be identical for all base operations",
+                "The tool controller that will be used to calculate the toolpath",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyLinkListHidden",
+            "ArrayGroup",
+            "Path",
+            QT_TRANSLATE_NOOP("App::Property", "List of child array objects"),
+        )
+        obj.addProperty(
+            "App::PropertyBool",
+            "Combine",
+            "Path",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "If operations with identical tool controller and without coolant:"
+                "\ncombine by copies"
+                "\n\nIf operations with different tool controllers or with coolant:"
+                "\ncombine operations with same tool controller and coolant mode, "
+                "\nbut only if operations placed one by one in tree",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyBool",
+            "ExpandArray",
+            "Path",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Split path by elements even all base operations without coolant"
+                " and with identical tool controller",
             ),
         )
 
@@ -197,13 +227,14 @@ class ObjectArray:
         obj.Active = True
         obj.Type = ("Linear1D", "Linear2D", "Points", "Polar")
         obj.PointsSorting = ("Automatic", "Manual")
-        obj.Copies = (0, 0, 99999, 1)
-        obj.CopiesX = (0, 0, 99999, 1)
-        obj.CopiesY = (0, 0, 99999, 1)
+        obj.Copies = (1, 1, 99999, 1)
+        obj.CopiesX = (1, 1, 99999, 1)
+        obj.CopiesY = (1, 1, 99999, 1)
         obj.JitterSeed = (0, 0, 2147483647, 1)
         obj.JitterMagnitude = FreeCAD.Vector(10, 10, 0)
         obj.JitterAngle = 10
 
+        self.group = []
         self.setEditorModes(obj)
         obj.Proxy = self
 
@@ -215,6 +246,7 @@ class ObjectArray:
 
     def setEditorModes(self, obj):
         obj.setEditorMode("ToolController", 2)  # hidden
+        obj.setEditorMode("ArrayGroup", 3)  # hidden and read-only
         obj.setEditorMode("CycleTime", 1)  # read-only
 
         angleMode = centreMode = copiesXMode = copiesYMode = swapDirectionMode = 2
@@ -245,12 +277,22 @@ class ObjectArray:
         obj.setEditorMode("JitterSeed", jitterMode)
         obj.setEditorMode("JitterAngle", jitterMode)
 
+        expandMode = 0 if self.isLegacy(obj) else 2
+        obj.setEditorMode("ExpandArray", expandMode)
+
+        combineMode = 0 if obj.ArrayGroup else 2
+        obj.setEditorMode("Combine", combineMode)
+
     def onChanged(self, obj, prop):
-        if prop in ("Type", "UseJitter") and not obj.Document.Restoring:
+        if prop in ("Path", "ExpandArray", "Type", "UseJitter") and not obj.Document.Restoring:
             self.setEditorModes(obj)
 
         if prop == "Active" and obj.ViewObject:
             obj.ViewObject.signalChangeIcon()
+
+        if prop == "Active":
+            for op in obj.ArrayGroup:
+                op.Active = obj.Active
 
     def onDocumentRestored(self, obj):
         """onDocumentRestored(obj) ... Called automatically when document is restored."""
@@ -279,6 +321,7 @@ class ObjectArray:
             obj.setGroupOfProperty("CopiesY", "Pattern")
             obj.setGroupOfProperty("Copies", "Pattern")
             obj.setGroupOfProperty("Offset", "Pattern")
+            obj.setGroupOfProperty("Angle", "Pattern")
             obj.setGroupOfProperty("Type", "Pattern")
 
         if not hasattr(obj, "CycleTime"):
@@ -288,8 +331,6 @@ class ObjectArray:
                 "Path",
                 QT_TRANSLATE_NOOP("App::Property", "Operations cycle time estimation"),
             )
-            obj.CycleTime = getCycleTimeEstimate(obj)
-
         if not hasattr(obj, "ReverseDirection"):
             obj.addProperty(
                 "App::PropertyBool",
@@ -338,22 +379,55 @@ class ObjectArray:
             )
             obj.PointsSorting = ("Automatic", "Manual")
 
+        if not hasattr(obj, "ArrayGroup"):
+            obj.addProperty(
+                "App::PropertyLinkListHidden",
+                "ArrayGroup",
+                "Path",
+                QT_TRANSLATE_NOOP("App::Property", "List of child array objects"),
+            )
+            expressions = dict(obj.ExpressionEngine)
+            for prop in ("Copies", "CopiesX", "CopiesY"):
+                if expr := expressions.get(prop):
+                    obj.setExpression(prop, f"{expr} + 1")
+                else:
+                    val = getattr(obj, prop, 0)
+                    setattr(obj, prop, val + 1)
+        if not hasattr(obj, "Combine"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "Combine",
+                "Path",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "If operations with identical tool controller and without coolant:"
+                    "\ncombine by copies"
+                    "\n\nIf operations with different tool controllers or with coolant:"
+                    "\ncombine operations with same tool controller and coolant mode, "
+                    "\nbut only if operations placed one by one in tree",
+                ),
+            )
+        if not hasattr(obj, "ExpandArray"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "ExpandArray",
+                "Path",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Split path by elements even all base operations without coolant and with identical tool controller",
+                ),
+            )
+            obj.ExpandArray = True
+
         self.setEditorModes(obj)
 
     def execute(self, obj):
-        # backwards compatibility for PathArrays created before support for multiple bases
-        if isinstance(obj.Base, list):
-            base = obj.Base
-        else:
-            base = [obj.Base]
-
-        # Do not generate paths and clear current Path data
-        # if operation not Active or no base operations or operations not compatible
-        if not obj.Active or len(base) == 0 or not self.isBaseCompatible(obj):
+        if not obj.Active or not self.isBaseCompatible(obj):
+            self.cleanArrayGroup(obj, 0)
             obj.Path = Path.Path()
             return
 
-        obj.ToolController = toolController(base[0])
+        obj.ToolController = toolControllerForOp(obj.Base[0])
 
         # Prepare random function
         jitterAngle = jitterMagnitude = None
@@ -364,57 +438,260 @@ class ObjectArray:
             if obj.JitterAngle:
                 jitterAngle = obj.JitterAngle
 
-        pa = PathArray(
-            obj.Base,
-            obj.Type,
-            obj.Copies,
-            obj.Offset,
-            obj.CopiesX,
-            obj.CopiesY,
-            obj.Angle.Value,
-            obj.Centre,
-            obj.SwapDirection,
-            obj.ReverseDirection,
-            jitterMagnitude,
-            jitterAngle,
-            obj.PointsSource,
-            obj.PointsOrigin,
-            obj.PointsSorting,
-        )
+        args = {
+            "base": obj.Base,
+            "arrayType": obj.Type,
+            "copies": obj.Copies - 1,
+            "offsetVector": obj.Offset,
+            "copiesX": obj.CopiesX - 1,
+            "copiesY": obj.CopiesY - 1,
+            "angle": obj.Angle.Value,
+            "centre": obj.Centre,
+            "swapDirection": obj.SwapDirection,
+            "reverse": obj.ReverseDirection,
+            "jitterMagnitude": jitterMagnitude,
+            "jitterAngle": jitterAngle,
+            "pointsSource": obj.PointsSource,
+            "pointsOrigin": obj.PointsOrigin,
+            "pointsSorting": obj.PointsSorting,
+        }
 
-        obj.Path = pa.getPath()
-        obj.CycleTime = getCycleTimeEstimate(obj)
+        pathArray = PathArray(**args).getPath()
+        if not pathArray:
+            self.cleanArrayGroup(obj, 0)
+            obj.Path = Path.Path()
+            obj.CycleTime = "0"
+            return
+
+        if self.isLegacy(obj) and not obj.ExpandArray:
+            # old type of array
+            self.cleanArrayGroup(obj, 0)
+            self.group = []
+            cmds = [cmd for op in pathArray for cmd in op["path"].Commands]
+            obj.Path = Path.Path(cmds)
+            obj.CycleTime = getCycleTimeEstimate(obj)
+        else:  # new type of array with separated copies
+            self.group = pathArray
+            if obj.Combine:
+                self.processGroupCompound(obj)
+            else:
+                self.processGroup(obj)
+            self.processGroupCycleTime(obj)
+            obj.Path = Path.Path()  # trigger to recompute elements in Group
 
     def isBaseCompatible(self, obj):
+        """Check compatibility of base operations
+        for array with multi tool controllers and coolant"""
         if not obj.Base:
             return False
-        tcs = []
-        cms = []
-        for sel in obj.Base:
-            if not sel.isDerivedFrom("Path::Feature"):
+
+        for base in obj.Base:
+            if not base.isDerivedFrom("Path::Feature"):
                 return False
-            tcs.append(toolController(sel))
-            cms.append(PathUtil.coolantModeForOp(sel))
 
-        if tcs == {None} or len(set(tcs)) > 1:
-            Path.Log.warning(
-                translate(
-                    "PathArray",
-                    "Arrays of toolpaths having different tool controllers or tool controller not selected.",
+            if not toolControllerForOp(base):
+                Path.Log.warning(
+                    translate("PathArray", "Tool controller not selected for operation %s")
+                    % base.Label
                 )
-            )
-            return False
+                return False
 
-        if set(cms) != {"None"}:
-            Path.Log.warning(
-                translate(
-                    "PathArray",
-                    "Arrays not compatible with coolant modes.",
-                )
-            )
+        return True
+
+    def isLegacy(self, obj):
+        """Check compatibility of base operations for old type of array,
+        identical tool controller and no coolant"""
+        tc0 = toolControllerForOp(obj.Base[0]) if obj.Base else None
+        if any(toolControllerForOp(b) != tc0 or coolantModeForOp(b) != "None" for b in obj.Base):
             return False
 
         return True
+
+    def cleanArrayGroup(self, obj, amount):
+        """Keep only needed amount of child elements in array"""
+        while len(obj.ArrayGroup) > amount:
+            op = obj.ArrayGroup[-1]
+            obj.ArrayGroup = obj.ArrayGroup[:-1]
+            op.Document.removeObject(op.Name)
+
+    def prepareArrayGroup(self, obj):
+        """Clean each child element in array"""
+        for op in obj.ArrayGroup:
+            op.Base = []
+            op.PathTemp = Path.Path()
+            op.Label = "empty"
+
+    def addNewArrayElement(self, obj):
+        """Create new Path Array object"""
+        new = obj.Document.addObject("Path::FeaturePython", "Array")
+        ObjectArrayChild(new)
+        ViewProviderArrayChild(new.ViewObject)
+        obj.ArrayGroup = obj.ArrayGroup + [new]
+
+        return new
+
+    def processGroup(self, obj):
+        """Create chield element for each repeat"""
+        if not self.group:
+            # no copies, remove all child elements
+            self.cleanArrayGroup(obj, 0)
+            return
+
+        self.prepareArrayGroup(obj)
+        counterCopies = 0
+        for i, op in enumerate(self.group):
+            if i >= len(obj.ArrayGroup):
+                self.addNewArrayElement(obj)
+
+            if op["opName"] == obj.Base[0].Name:
+                counterCopies += 1
+                prefix = f"Array_{counterCopies}_"
+
+            baseOp = obj.Document.getObject(op["opName"])
+            obj.ArrayGroup[i].Label = f"{prefix}{baseOp.Label}_{i:03d}"
+            obj.ArrayGroup[i].Base = [baseOp.Name]
+            obj.ArrayGroup[i].ToolController = toolControllerForOp(baseOp)
+            obj.ArrayGroup[i].CoolantMode = coolantModeForOp(baseOp)
+            obj.ArrayGroup[i].PathTemp = op["path"]
+
+            if obj.ArrayGroup[i].Active:
+                obj.ArrayGroup[i].Path = op["path"]
+            else:
+                obj.ArrayGroup[i].Path = Path.Path()
+
+        self.cleanArrayGroup(obj, len(self.group))
+
+    def processGroupCompound(self, obj):
+        """Combine elements with same tool controller and coolant mode which placed in sequence"""
+        if not self.group:
+            # no copies, remove all child elements
+            self.cleanArrayGroup(obj, 0)
+            return
+
+        self.prepareArrayGroup(obj)
+        prefix = ""
+        counterCopies = 0
+        i = 0
+        lastToolController = None
+        lastCoolant = None
+        for op in self.group:
+            baseOp = obj.Document.getObject(op["opName"])
+            toolController = toolControllerForOp(baseOp)
+            coolantMode = coolantModeForOp(baseOp)
+
+            if counterCopies:
+                if (
+                    op["opName"] == obj.Base[0].Name
+                    or lastToolController != toolController
+                    or lastCoolant != coolantMode
+                ):  # switch to next child element
+                    i += 1
+
+            if i > len(obj.ArrayGroup) - 1:
+                self.addNewArrayElement(obj)
+
+            cmName = f"_{coolantMode}" if coolantMode != "None" else ""
+            if op["opName"] == obj.Base[0].Name:
+                counterCopies += 1
+                prefix = f"Array_{counterCopies}"
+
+            obj.ArrayGroup[i].Label = f"{prefix}{cmName}_{toolController.Label}"
+            obj.ArrayGroup[i].ToolController = toolController
+            obj.ArrayGroup[i].CoolantMode = coolantMode
+
+            obj.ArrayGroup[i].Base += [op["opName"]]
+            obj.ArrayGroup[i].PathTemp.addCommands(op["path"].Commands)
+
+            if obj.ArrayGroup[i].Active:
+                obj.ArrayGroup[i].Path = obj.ArrayGroup[i].PathTemp
+            else:
+                obj.ArrayGroup[i].Path = Path.Path()
+
+            lastToolController = toolController
+            lastCoolant = coolantMode
+
+        self.cleanArrayGroup(obj, i + 1)
+
+    def processGroupCycleTime(self, obj):
+        """Get total cycle time for Array with child elements"""
+        seconds = 0
+        errorStr = ""
+        for op in obj.ArrayGroup:
+            result = getCycleTimeEstimate(op, formatted=False)
+            if isinstance(result, (int, float)):
+                seconds += result
+            else:
+                errorStr = f" ({op.Label}: {result})"
+        timeStr = time.strftime("%H:%M:%S", time.gmtime(seconds))
+        obj.CycleTime = f"{timeStr}{errorStr}"
+
+
+class ObjectArrayChild:
+    def __init__(self, obj):
+        obj.addProperty(
+            "App::PropertyBool",
+            "Active",
+            "Path",
+            "Make False, to prevent operation from generating code",
+        )
+        obj.addProperty(
+            "App::PropertyLink",
+            "ToolController",
+            "Path",
+            "The tool controller that will be used to calculate the toolpath",
+        )
+        obj.addProperty(
+            "App::PropertyString",
+            "CoolantMode",
+            "Path",
+            "Coolant mode for this operation",
+        )
+        obj.addProperty(
+            "Path::PropertyPath",
+            "PathTemp",
+            "Path",
+            "Temporary storage of the tool path if element not active",
+        )
+        obj.addProperty(
+            "App::PropertyString",
+            "CycleTime",
+            "Path",
+            "Operations cycle time estimation",
+        )
+        obj.addProperty(
+            "App::PropertyStringList",
+            "Base",
+            "Path",
+            "Name of the base operations",
+        )
+        obj.Active = True
+        obj.Proxy = self
+        obj.setEditorMode("ToolController", 1)  # read-only
+        obj.setEditorMode("CoolantMode", 1)  # read-only
+        obj.setEditorMode("CycleTime", 1)  # read-only
+        obj.setEditorMode("Base", 1)  # read-only
+
+    def dumps(self):
+        return None
+
+    def loads(self, state):
+        return None
+
+    def onChanged(self, obj, prop):
+        if prop == "Path":
+            obj.CycleTime = getCycleTimeEstimate(obj)
+
+        if prop == "Active" and obj.ViewObject:
+            obj.ViewObject.signalChangeIcon()
+
+    def onDocumentRestored(self, obj):
+        return
+
+    def execute(self, obj):
+        if obj.Active:
+            obj.Path = obj.PathTemp
+        else:
+            obj.Path = Path.Path()
 
 
 class PathArray:
@@ -459,26 +736,25 @@ class PathArray:
     def getPath(self):
         """getPath() ... Call this method on an instance of the class to generate and return
         path data for the requested path array."""
-
-        commands = []
+        pathGroup = []
 
         self.jitterCentre = FreeCAD.Vector()
         if self.jitterAngle:
             self.jitterCentre = self.getBasePathCenter(self.base)
 
-        if self.arrayType == "Polar":
-            self.getPolarArray(commands)
+        if self.arrayType == "Linear1D":
+            self.getLinear1DArray(pathGroup)
         elif self.arrayType == "Linear2D":
             if self.swapDirection:
-                self.getLinear2DXYArray(commands)
+                self.getLinear2DXYArray(pathGroup)
             else:
-                self.getLinear2DYXArray(commands)
+                self.getLinear2DYXArray(pathGroup)
+        elif self.arrayType == "Polar":
+            self.getPolarArray(pathGroup)
         elif self.arrayType == "Points":
-            self.getPointsArray(commands)
-        else:
-            self.getLinear1DArray(commands)
+            self.getPointsArray(pathGroup)
 
-        return Path.Path(commands)
+        return pathGroup
 
     def calculateJitter(self, pos):
         """calculateJitter(pos) ...
@@ -525,7 +801,7 @@ class PathArray:
 
         return FreeCAD.Vector()
 
-    def getLinear1DArray(self, commands):
+    def getLinear1DArray(self, pathGroup):
         """Array type Linear1D"""
         for i in reversed(range(self.copies)) if self.reverse else range(self.copies):
             pos = FreeCAD.Vector(
@@ -541,9 +817,15 @@ class PathArray:
                 pl.rotate(self.jitterCentre, FreeCAD.Vector(0, 0, 1), alpha)
                 path = PathUtils.getPathWithPlacement(b)
                 path = PathUtils.applyPlacementToPath(pl, path)
-                commands.extend(path.Commands)
 
-    def getLinear2DXYArray(self, commands):
+                pathGroup.append(
+                    {
+                        "path": Path.Path(path.Commands),
+                        "opName": b.Name,
+                    }
+                )
+
+    def getLinear2DXYArray(self, pathGroup):
         """Array type Linear2D with initial X direction"""
         rngX = list(reversed(range(self.copiesX + 1))) if self.reverse else range(self.copiesX + 1)
         rngY = reversed(range(self.copiesY + 1)) if self.reverse else range(self.copiesY + 1)
@@ -571,9 +853,15 @@ class PathArray:
                         pl.rotate(self.jitterCentre, FreeCAD.Vector(0, 0, 1), alpha)
                         path = PathUtils.getPathWithPlacement(b)
                         path = PathUtils.applyPlacementToPath(pl, path)
-                        commands.extend(path.Commands)
 
-    def getLinear2DYXArray(self, commands):
+                        pathGroup.append(
+                            {
+                                "path": Path.Path(path.Commands),
+                                "opName": b.Name,
+                            }
+                        )
+
+    def getLinear2DYXArray(self, pathGroup):
         """Array type Linear2D with initial Y direction"""
         rngX = reversed(range(self.copiesX + 1)) if self.reverse else range(self.copiesX + 1)
         rngY = list(reversed(range(self.copiesY + 1))) if self.reverse else range(self.copiesY + 1)
@@ -601,9 +889,15 @@ class PathArray:
                         pl.rotate(self.jitterCentre, FreeCAD.Vector(0, 0, 1), alpha)
                         path = PathUtils.getPathWithPlacement(b)
                         path = PathUtils.applyPlacementToPath(pl, path)
-                        commands.extend(path.Commands)
 
-    def getPolarArray(self, commands):
+                        pathGroup.append(
+                            {
+                                "path": Path.Path(path.Commands),
+                                "opName": b.Name,
+                            }
+                        )
+
+    def getPolarArray(self, pathGroup):
         """Array type Polar"""
         if not self.copies:
             return
@@ -627,9 +921,15 @@ class PathArray:
             for b in self.base:
                 path = PathUtils.getPathWithPlacement(b)
                 path = PathUtils.applyPlacementToPath(pl, path)
-                commands.extend(path.Commands)
 
-    def getPointsArray(self, commands):
+                pathGroup.append(
+                    {
+                        "path": Path.Path(path.Commands),
+                        "opName": b.Name,
+                    }
+                )
+
+    def getPointsArray(self, pathGroup):
         """Array type Points"""
         originPoint = FreeCAD.Vector()
         originAngle = 0
@@ -706,12 +1006,8 @@ class PathArray:
             routes = []
             for i, pos in enumerate(points):
                 origin = originPoint + pos["point"]
-                dirStartOffset = DraftVecUtils.rotate(
-                    dirStart, math.radians(pos["angle"]), FreeCAD.Vector(0, 0, 1)
-                )
-                dirEndOffset = DraftVecUtils.rotate(
-                    dirEnd, math.radians(pos["angle"]), FreeCAD.Vector(0, 0, 1)
-                )
+                dirStartOffset = rotate2D(dirStart, math.radians(pos["angle"]))
+                dirEndOffset = rotate2D(dirEnd, math.radians(pos["angle"]))
                 routes.append(
                     {
                         "startX": origin.x + dirStartOffset.x,
@@ -737,7 +1033,13 @@ class PathArray:
                 pl.rotate(originPoint, FreeCAD.Vector(0, 0, 1), pos["angle"])
                 path = PathUtils.getPathWithPlacement(b)
                 path = PathUtils.applyPlacementToPath(pl, path)
-                commands.extend(path.Commands)
+
+                pathGroup.append(
+                    {
+                        "path": Path.Path(path.Commands),
+                        "opName": b.Name,
+                    }
+                )
 
     def getPointsAngle(self, p1, p2=FreeCAD.Vector()):
         """return angle between vector (direction) and Y-axis"""
@@ -805,13 +1107,43 @@ class ViewProviderArray:
         return None
 
     def onChanged(self, vobj, prop):
-        return None
+        if prop == "Visibility" and not self.obj.Document.Restoring:
+            for op in self.obj.ArrayGroup:
+                op.Visibility = vobj.Visibility
 
     def claimChildren(self):
-        return []
+        return [base for base in self.obj.ArrayGroup]
 
     def onDelete(self, vobj, args):
-        return True
+        for op in self.obj.ArrayGroup:
+            op.Document.removeObject(op.Name)
+        self.obj.Document.removeObject(self.obj.Name)
+
+    def getIcon(self):
+        if self.obj.Active:
+            return ":/icons/CAM_ArrayMTC.svg"
+        else:
+            return ":/icons/CAM_OpActive.svg"
+
+
+class ViewProviderArrayChild:
+
+    def __init__(self, vobj):
+        self.attach(vobj)
+        vobj.Proxy = self
+
+    def attach(self, vobj):
+        self.vobj = vobj
+        self.obj = vobj.Object
+
+    def dumps(self):
+        return None
+
+    def loads(self, state):
+        return None
+
+    def onChanged(self, vobj, prop):
+        return
 
     def getIcon(self):
         if self.obj.Active:
@@ -823,34 +1155,30 @@ class ViewProviderArray:
 class CommandPathArray:
     def GetResources(self):
         return {
-            "Pixmap": "CAM_Array",
+            "Pixmap": "CAM_ArrayMTC",
             "MenuText": QT_TRANSLATE_NOOP("CAM_Array", "Array"),
-            "ToolTip": QT_TRANSLATE_NOOP("CAM_Array", "Creates an array from selected toolpaths"),
+            "ToolTip": QT_TRANSLATE_NOOP(
+                "CAM_Array",
+                "Creates an array with multiple tool controllers and coolant modes",
+            ),
         }
 
     def IsActive(self):
         selection = FreeCADGui.Selection.getSelection()
         if not selection:
             return False
-        tcs = []
+
         for sel in selection:
             if not sel.isDerivedFrom("Path::Feature"):
                 return False
-            tc = toolController(sel)
-            if tc:
-                # Active only for operations with identical tool controller
-                tcs.append(tc)
-                if len(set(tcs)) != 1:
-                    return False
-            else:
+
+            if not toolControllerForOp(sel):
+                # Active only for operations with tool controller
                 return False
-            if PathUtil.coolantModeForOp(sel) != "None":
-                # Active only for operations without cooling
-                return False
+
         return True
 
     def Activated(self):
-
         # check that the selection contains exactly what we want
         selection = FreeCADGui.Selection.getSelection()
 
@@ -862,8 +1190,7 @@ class CommandPathArray:
                 )
                 return
 
-        # if everything is ok, execute and register the transaction in the
-        # undo/redo stack
+        # if everything is ok, execute and register the transaction in the undo/redo stack
         FreeCAD.ActiveDocument.openTransaction("Create Array")
         FreeCADGui.addModule("Path.Op.Gui.Array")
         FreeCADGui.addModule("PathScripts.PathUtils")

--- a/src/Mod/CAM/Path/Op/Gui/Array.py
+++ b/src/Mod/CAM/Path/Op/Gui/Array.py
@@ -22,7 +22,7 @@
 import FreeCAD
 import FreeCADGui
 import Path
-import PathScripts.PathUtils as PathUtils
+from PathScripts import PathUtils
 from DraftVecUtils import rotate2D
 from Path.Base.Util import coolantModeForOp
 from Path.Base.Util import toolControllerForOp
@@ -501,11 +501,8 @@ class ObjectArray:
     def isLegacy(self, obj):
         """Check compatibility of base operations for old type of array,
         identical tool controller and no coolant"""
-        tc0 = toolControllerForOp(obj.Base[0]) if obj.Base else None
-        if any(toolControllerForOp(b) != tc0 or coolantModeForOp(b) != "None" for b in obj.Base):
-            return False
-
-        return True
+        tc = toolControllerForOp(obj.Base[0]) if obj.Base else None
+        return all(toolControllerForOp(b) == tc and coolantModeForOp(b) == "None" for b in obj.Base)
 
     def cleanArrayGroup(self, obj, amount):
         """Keep only needed amount of child elements in array"""
@@ -579,13 +576,12 @@ class ObjectArray:
             toolController = toolControllerForOp(baseOp)
             coolantMode = coolantModeForOp(baseOp)
 
-            if counterCopies:
-                if (
-                    op["opName"] == obj.Base[0].Name
-                    or lastToolController != toolController
-                    or lastCoolant != coolantMode
-                ):  # switch to next child element
-                    i += 1
+            if counterCopies and (
+                op["opName"] == obj.Base[0].Name
+                or lastToolController != toolController
+                or lastCoolant != coolantMode
+            ):  # switch to next child element
+                i += 1
 
             if i > len(obj.ArrayGroup) - 1:
                 self.addNewArrayElement(obj)
@@ -1041,7 +1037,7 @@ class PathArray:
                     }
                 )
 
-    def getPointsAngle(self, p1, p2=FreeCAD.Vector()):
+    def getPointsAngle(self, p1, p2):
         """return angle between vector (direction) and Y-axis"""
         direction = p1 - p2
         if Path.Geom.pointsCoincide(direction, FreeCAD.Vector()):

--- a/src/Mod/CAM/Path/Post/PostList.py
+++ b/src/Mod/CAM/Path/Post/PostList.py
@@ -383,7 +383,6 @@ def buildPostList(processor: Any) -> List[Tuple[str, List]]:
     Returns:
         List of tuples: [(section_name, [postable_items])]
     """
-
     orderby = processor._job.OrderOutputBy
     Path.Log.debug(f"Ordering by {orderby}")
 

--- a/src/Mod/CAM/Path/Post/PostList.py
+++ b/src/Mod/CAM/Path/Post/PostList.py
@@ -383,14 +383,18 @@ def buildPostList(processor: Any) -> List[Tuple[str, List]]:
     Returns:
         List of tuples: [(section_name, [postable_items])]
     """
+
     orderby = processor._job.OrderOutputBy
     Path.Log.debug(f"Ordering by {orderby}")
 
     if orderby == "Fixture":
+        extract_arrays(processor)
         postlist = build_postlist_by_fixture(processor)
     elif orderby == "Tool":
+        extract_arrays_by_tool(processor)
         postlist = build_postlist_by_tool(processor)
     elif orderby == "Operation":
+        extract_arrays(processor)
         postlist = build_postlist_by_operation(processor)
     else:
         raise ValueError(f"Unknown order: {orderby}")
@@ -414,6 +418,44 @@ def buildPostList(processor: Any) -> List[Tuple[str, List]]:
     if early_tool_prep:
         return apply_early_tool_prep(final_postlist)
     return final_postlist
+
+
+def extract_arrays(processor):
+    """Prepare operations list with arrays sub elements
+    Replace arrays by copies"""
+    for candidate in reversed(processor._operations):
+        if not getattr(candidate, "ArrayGroup", None) or not candidate.Active:
+            continue
+        i = processor._operations.index(candidate)
+        # replace Array object by all copies
+        processor._operations[i : i + 1] = [op for op in candidate.ArrayGroup]
+
+
+def extract_arrays_by_tool(processor):
+    """Prepare operations list with arrays sub elements
+    Place copies after base op to minimize tool changes"""
+    for candidate in reversed(processor._operations):
+        if not getattr(candidate, "ArrayGroup", None) or not candidate.Active:
+            continue
+        index = processor._operations.index(candidate)
+        # remove Array object from operations list
+        processor._operations.remove(candidate)
+        for opFromArray in reversed(candidate.ArrayGroup):
+            for i, op in enumerate(processor._operations):
+                if op.Name == opFromArray.Base[-1]:
+                    # insert copy after base op
+                    processor._operations.insert(i + 1, opFromArray)
+                    break
+                elif (
+                    isinstance(op.Proxy, Path.Op.Array.ObjectArrayChild)
+                    and op.Base[-1] == opFromArray.Base[-1]
+                ):
+                    # export without base operation, add before previous array child
+                    processor._operations.insert(i, opFromArray)
+                    break
+            else:
+                # export without base operation, add in the end
+                processor._operations.insert(index, opFromArray)
 
 
 def apply_early_tool_prep(postlist: List[Tuple[str, List]]) -> List[Tuple[str, List]]:

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -686,47 +686,6 @@ class PostProcessor:
                 getattr(self._job.Operations, "Group", []) if self._job is not None else []
             )
 
-        if self._operations:
-            self.processArrays()
-
-    # Prepare operations from arrays
-    def processArrays(self):
-        arrays = [
-            {"index": i, "array": op}
-            for i, op in enumerate(self._operations)
-            if getattr(op, "ArrayGroup", None) and op.Active
-        ]
-        if not arrays:
-            return
-
-        if self._job.OrderOutputBy == "Tool":
-            # place copies after base op to minimize tool changes
-            for array in reversed(arrays):
-                # remove Array object from operations list
-                del self._operations[array["index"]]
-                for opFromArray in reversed(array["array"].ArrayGroup):
-                    for i, op in enumerate(self._operations):
-                        if op.Name == opFromArray.Base[-1]:
-                            # insert copy after base op
-                            self._operations.insert(i + 1, opFromArray)
-                            break
-                        elif (
-                            isinstance(op.Proxy, Path.Op.Gui.Array.ObjectArrayChild)
-                            and op.Base[-1] == opFromArray.Base[-1]
-                        ):
-                            # export without base operation, add before previous array child
-                            self._operations.insert(i, opFromArray)
-                            break
-                    else:
-                        # export without base operation, add in the end
-                        self._operations.insert(array["index"], opFromArray)
-        else:
-            # replace array object by operation copies
-            for array in reversed(arrays):
-                i = array["index"]
-                # replace Array object by all copies
-                self._operations[i : i + 1] = [op for op in array["array"].ArrayGroup]
-
     @classmethod
     def exists(cls, processor):
         return processor in Path.Preferences.allAvailablePostProcessors()

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -677,6 +677,47 @@ class PostProcessor:
                 getattr(self._job.Operations, "Group", []) if self._job is not None else []
             )
 
+        if self._operations:
+            self.processArrays()
+
+    # Prepare operations from arrays
+    def processArrays(self):
+        arrays = [
+            {"index": i, "array": op}
+            for i, op in enumerate(self._operations)
+            if getattr(op, "ArrayGroup", None) and op.Active
+        ]
+        if not arrays:
+            return
+
+        if self._job.OrderOutputBy == "Tool":
+            # place copies after base op to minimize tool changes
+            for array in reversed(arrays):
+                # remove Array object from operations list
+                del self._operations[array["index"]]
+                for opFromArray in reversed(array["array"].ArrayGroup):
+                    for i, op in enumerate(self._operations):
+                        if op.Name == opFromArray.Base[-1]:
+                            # insert copy after base op
+                            self._operations.insert(i + 1, opFromArray)
+                            break
+                        elif (
+                            isinstance(op.Proxy, Path.Op.Gui.Array.ObjectArrayChild)
+                            and op.Base[-1] == opFromArray.Base[-1]
+                        ):
+                            # export without base operation, add before previous array child
+                            self._operations.insert(i, opFromArray)
+                            break
+                    else:
+                        # export without base operation, add in the end
+                        self._operations.insert(array["index"], opFromArray)
+        else:
+            # replace array object by operation copies
+            for array in reversed(arrays):
+                i = array["index"]
+                # replace Array object by all copies
+                self._operations[i : i + 1] = [op for op in array["array"].ArrayGroup]
+
     @classmethod
     def exists(cls, processor):
         return processor in Path.Preferences.allAvailablePostProcessors()

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -677,47 +677,6 @@ class PostProcessor:
                 getattr(self._job.Operations, "Group", []) if self._job is not None else []
             )
 
-        if self._operations:
-            self.processArrays()
-
-    # Prepare operations from arrays
-    def processArrays(self):
-        arrays = [
-            {"index": i, "array": op}
-            for i, op in enumerate(self._operations)
-            if getattr(op, "ArrayGroup", None) and op.Active
-        ]
-        if not arrays:
-            return
-
-        if self._job.OrderOutputBy == "Tool":
-            # place copies after base op to minimize tool changes
-            for array in reversed(arrays):
-                # remove Array object from operations list
-                del self._operations[array["index"]]
-                for opFromArray in reversed(array["array"].ArrayGroup):
-                    for i, op in enumerate(self._operations):
-                        if op.Name == opFromArray.Base[-1]:
-                            # insert copy after base op
-                            self._operations.insert(i + 1, opFromArray)
-                            break
-                        elif (
-                            isinstance(op.Proxy, Path.Op.Gui.Array.ObjectArrayChild)
-                            and op.Base[-1] == opFromArray.Base[-1]
-                        ):
-                            # export without base operation, add before previous array child
-                            self._operations.insert(i, opFromArray)
-                            break
-                    else:
-                        # export without base operation, add in the end
-                        self._operations.insert(array["index"], opFromArray)
-        else:
-            # replace array object by operation copies
-            for array in reversed(arrays):
-                i = array["index"]
-                # replace Array object by all copies
-                self._operations[i : i + 1] = [op for op in array["array"].ArrayGroup]
-
     @classmethod
     def exists(cls, processor):
         return processor in Path.Preferences.allAvailablePostProcessors()

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -686,6 +686,47 @@ class PostProcessor:
                 getattr(self._job.Operations, "Group", []) if self._job is not None else []
             )
 
+        if self._operations:
+            self.processArrays()
+
+    # Prepare operations from arrays
+    def processArrays(self):
+        arrays = [
+            {"index": i, "array": op}
+            for i, op in enumerate(self._operations)
+            if getattr(op, "ArrayGroup", None) and op.Active
+        ]
+        if not arrays:
+            return
+
+        if self._job.OrderOutputBy == "Tool":
+            # place copies after base op to minimize tool changes
+            for array in reversed(arrays):
+                # remove Array object from operations list
+                del self._operations[array["index"]]
+                for opFromArray in reversed(array["array"].ArrayGroup):
+                    for i, op in enumerate(self._operations):
+                        if op.Name == opFromArray.Base[-1]:
+                            # insert copy after base op
+                            self._operations.insert(i + 1, opFromArray)
+                            break
+                        elif (
+                            isinstance(op.Proxy, Path.Op.Gui.Array.ObjectArrayChild)
+                            and op.Base[-1] == opFromArray.Base[-1]
+                        ):
+                            # export without base operation, add before previous array child
+                            self._operations.insert(i, opFromArray)
+                            break
+                    else:
+                        # export without base operation, add in the end
+                        self._operations.insert(array["index"], opFromArray)
+        else:
+            # replace array object by operation copies
+            for array in reversed(arrays):
+                i = array["index"]
+                # replace Array object by all copies
+                self._operations[i : i + 1] = [op for op in array["array"].ArrayGroup]
+
     @classmethod
     def exists(cls, processor):
         return processor in Path.Preferences.allAvailablePostProcessors()


### PR DESCRIPTION
Fixes #21620
- #21620

---

### Changes:

- Set total amount of repeats instead of amount of copies
- Allows to process `Array` with multi tool controllers and coolant
- Allows to simulate repeats in legacy and GL simulator
- New icon to show ability to process several tool controllers
  Child objects uses old Array icon
   <img width="64" height="64" alt="1" src="https://github.com/user-attachments/assets/31daf8a0-8ce6-4e4c-84d1-d92162e7541a" />   <img width="64" height="64" alt="2" src="https://github.com/user-attachments/assets/5e658c8a-f18c-4fb0-86ca-61dd0d9a7af9" />

---

### Description:

`Array` creates and keeps links to independent `Path::FeaturePython` objects
Each of this object have specific tool controller and coolant mode
`Array` replaced by this objects inside `CAM/Path/Post/Processor.py` 

No any changes in post-processor scripts needed
All elements in array processing like all other operations in Job

<img width="1408" height="390" alt="Screenshot_20260616_120629_lossy" src="https://github.com/user-attachments/assets/86095672-b71b-478d-8325-a693aee2eb3a" />

---

> [!NOTE]
> Gui will be improved in next PR
> - #31497