### PR TITLE
Draft: Remove relative to WP option from Draft_Scale

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -130,11 +130,12 @@ class Scale(gui_base_original.Modifier):
                     ghosts.append(trackers.ghostTracker(shape))
         return ghosts
 
-    def scale_ghosts(self, x, y, z, rel):
+    def scale_ghosts(self, x, y, z, rel=False):
         """Scale the preview of the object."""
         delta = App.Vector(x, y, z)
-        if rel:
-            delta = self.wp.get_global_coords(delta)
+        # ScaleRelative option removed in v1.1 as it does not work properly:
+        # if rel:
+            # delta = self.wp.get_local_coords(delta)
         for ghost in self.ghosts:
             ghost.scale(delta)
         # calculate a correction factor depending on the scaling center
@@ -201,8 +202,9 @@ class Scale(gui_base_original.Modifier):
             return
 
         self.delta = App.Vector(sx, sy, sz)
-        if self.task.relative.isChecked():
-            self.delta = self.wp.get_global_coords(self.delta)
+        # ScaleRelative option removed in v1.1 as it does not work properly:
+        # if self.task.relative.isChecked():
+            # self.delta = self.wp.get_local_coords(self.delta)
         self.center = self.node[0]
         if self.task.isCopy.isChecked():
             cmd_name = translate("draft", "Copy")

--- a/src/Mod/Draft/drafttaskpanels/task_scale.py
+++ b/src/Mod/Draft/drafttaskpanels/task_scale.py
@@ -85,10 +85,11 @@ class ScaleTaskPanel:
         QtCore.QObject.connect(self.lock,QtCore.SIGNAL("toggled(bool)"),self.setLock)
 
         if self.__class__.__name__ != "ScaleTaskPanelEdit":
-            self.relative = QtWidgets.QCheckBox()
-            self.relative.setText(translate("Draft", "Working plane orientation"))
-            self.relative.setChecked(params.get_param("ScaleRelative"))
-            layout.addWidget(self.relative,4,0,1,2)
+            # ScaleRelative option removed in v1.1 as it does not work properly:
+            # self.relative = QtWidgets.QCheckBox()
+            # self.relative.setText(translate("Draft", "Working plane orientation"))
+            # self.relative.setChecked(params.get_param("ScaleRelative"))
+            # layout.addWidget(self.relative,4,0,1,2)
             self.isCopy = QtWidgets.QCheckBox()
             self.isCopy.setText(translate("Draft", "Copy"))
             self.isCopy.setChecked(params.get_param("ScaleCopy"))
@@ -105,7 +106,7 @@ class ScaleTaskPanel:
             self.pickrefButton.setText(translate("Draft", "Pick From/To Points"))
             layout.addWidget(self.pickrefButton,8,0,1,2)
 
-            QtCore.QObject.connect(self.relative,QtCore.SIGNAL("toggled(bool)"),self.setRelative)
+            # QtCore.QObject.connect(self.relative,QtCore.SIGNAL("toggled(bool)"),self.setRelative)
             QtCore.QObject.connect(self.isCopy,QtCore.SIGNAL("toggled(bool)"),self.setCopy)
             QtCore.QObject.connect(self.isSubelementMode,QtCore.SIGNAL("toggled(bool)"),self.setSubelementMode)
             QtCore.QObject.connect(self.isClone,QtCore.SIGNAL("toggled(bool)"),self.setClone)
@@ -122,7 +123,9 @@ class ScaleTaskPanel:
                 self.zValue.setValue(val)
         if self.sourceCmd:
             # self.sourceCmd is always None for ScaleTaskPanelEdit
-            self.sourceCmd.scale_ghosts(self.xValue.value(),self.yValue.value(),self.zValue.value(),self.relative.isChecked())
+            self.sourceCmd.scale_ghosts(
+                self.xValue.value(), self.yValue.value(), self.zValue.value()
+            )
 
     def setLock(self, state):
         """Set the uniform scaling."""
@@ -138,7 +141,9 @@ class ScaleTaskPanel:
         """Set the relative scaling."""
         params.set_param("ScaleRelative", state)
         if self.sourceCmd:
-            self.sourceCmd.scale_ghosts(self.xValue.value(),self.yValue.value(),self.zValue.value(),self.relative.isChecked())
+            self.sourceCmd.scale_ghosts(
+                self.xValue.value(), self.yValue.value(), self.zValue.value()
+            )
 
     def setCopy(self, state):
         """Set the copy option."""
@@ -153,7 +158,9 @@ class ScaleTaskPanel:
             self.isClone.setChecked(False)
         if self.sourceCmd:
             self.sourceCmd.set_ghosts()
-            self.sourceCmd.scale_ghosts(self.xValue.value(),self.yValue.value(),self.zValue.value(),self.relative.isChecked())
+            self.sourceCmd.scale_ghosts(
+                self.xValue.value(), self.yValue.value(), self.zValue.value()
+            )
 
     def setClone(self, state):
         """Set the clone option."""


### PR DESCRIPTION
Fixes  #19596

PR to remove the "Working plane orientation" checkbox from the 2nd task panel of the Draft_Scale command. This option does not work properly. There also does not seem to be a high demand for this feature as the current buggy implementation has gone unnoticed for several years.

See also:
https://github.com/FreeCAD/FreeCAD/issues/19596#issuecomment-3263689135