### PR TITLE
[CAM] add missing migration from intermediate version for lead in/out dressup

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -280,7 +280,12 @@ class ObjectDressup:
                 obj.AngleOut = 90 if styleOff == "Perpendicular" else 0
 
         toolRadius = PathDressup.toolController(obj.Base).Tool.Diameter.Value / 2
-        if hasattr(obj, "Length"):
+        if hasattr(obj, "Length") or hasattr(obj, "LengthIn"):
+            oldLength = obj.LengthIn if hasattr(obj, "LengthIn") else obj.Length
+            for prop in ["Length", "LengthIn"]:
+                if hasattr(obj, prop):
+                    obj.removeProperty(prop)
+
             # Replace Length by PercentageRadiusIn
             obj.addProperty(
                 "App::PropertyInteger",
@@ -288,8 +293,7 @@ class ObjectDressup:
                 "Path Lead-in",
                 QT_TRANSLATE_NOOP("App::Property", "Determine length of the Lead-In"),
             )
-            obj.PercentageRadiusIn = int(obj.Length / toolRadius * 100)
-            obj.removeProperty("Length")
+            obj.PercentageRadiusIn = int(oldLength / toolRadius * 100)
         if hasattr(obj, "LengthOut"):
             # Replace LengthOut by PercentageRadiusOut
             obj.addProperty(


### PR DESCRIPTION
Fixes bug reported by @jffmichi in the [comments of another PR](https://github.com/FreeCAD/FreeCAD/pull/22669#issuecomment-3262169292)

That PR change properties on the LeadInOut dressup and provided migrations from the properties of the last stable version, but accidentally dropped a migration path from a newer version. This PR adds that migration path.