### PR TITLE
TechDraw: Fix spreadsheet incorrect render due to cell merges

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
@@ -259,12 +259,16 @@ std::string DrawViewSpreadsheet::getSheetImage()
          col != validColNames.end(); ++col) {
         // create a group for each column
         result << "  <g id=\"" << ViewName << "_col" << (*col) << "\">" << std::endl;
+        float naturalColumnWidth = 0.0;
         for (std::vector<int>::const_iterator row = validRowNumbers.begin();
              row != validRowNumbers.end(); ++row) {
             // get cell size
             std::stringstream srow;
             srow << (*row);
             App::CellAddress address((*col) + srow.str());
+            if (naturalColumnWidth == 0.0) {
+                naturalColumnWidth = sheet->getColumnWidth(address.col());
+            }
             cellwidth = sheet->getColumnWidth(address.col());
             cellheight = sheet->getRowHeight(address.row());
             celltext = "";
@@ -372,7 +376,7 @@ std::string DrawViewSpreadsheet::getSheetImage()
         }
         result << "  </g>" << std::endl;
         rowoffset = 0.0;
-        coloffset += cellwidth;
+        coloffset += naturalColumnWidth;
     }
 
     // close the containing group


### PR DESCRIPTION
Fix spreadsheet table rendering incorrectly when there are merged cells.
See linked issue for test file.

## Issues
#18828

## Before

<img width="805" height="164" alt="20250908_00h24m27s_grim" src="https://github.com/user-attachments/assets/070b258a-233c-42f0-b1b0-4f284f88ef79" />


## After

<img width="593" height="163" alt="20250908_00h22m25s_grim" src="https://github.com/user-attachments/assets/3d1541d5-56a4-48e0-a3bd-834cb3effc16" />