### PR TITLE
[CAM] regression fix: re-enable adaptive profile mode

### DIFF
--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -545,8 +545,10 @@ def Execute(op, obj):
         # NOTE: Reminder that stock is formatted differently than inside/outside!
         stockPaths = {d: convertTo2d(op.stockPathArray[d]) for d in op.stockPathArray}
 
-        outsideOpType = area.AdaptiveOperationType.ClearingOutside
-        insideOpType = area.AdaptiveOperationType.ClearingInside
+        outsideClearing = area.AdaptiveOperationType.ClearingOutside
+        insideClearing = area.AdaptiveOperationType.ClearingInside
+        outsideProfiling = area.AdaptiveOperationType.ProfilingOutside
+        insideProfiling = area.AdaptiveOperationType.ProfilingInside
 
         # List every REGION separately- we can then calculate a toolpath based
         # on the region. One or more stepdowns may use that same toolpath by
@@ -563,7 +565,9 @@ def Execute(op, obj):
         for rdict in op.outsidePathArray:
             regionOps.append(
                 {
-                    "opType": outsideOpType,
+                    "opType": (
+                        outsideClearing if obj.OperationType == "Clearing" else outsideProfiling
+                    ),
                     "path2d": convertTo2d(rdict["edges"]),
                     "id": rdict["id"],
                     "children": rdict["children"],
@@ -578,7 +582,9 @@ def Execute(op, obj):
         for rdict in op.insidePathArray:
             regionOps.append(
                 {
-                    "opType": insideOpType,
+                    "opType": (
+                        insideClearing if obj.OperationType == "Clearing" else insideProfiling
+                    ),
                     "path2d": convertTo2d(rdict["edges"]),
                     "id": rdict["id"],
                     "children": rdict["children"],
@@ -599,7 +605,9 @@ def Execute(op, obj):
         outsideInputStateObject = {
             "tool": op.tool.Diameter.Value,
             "tolerance": obj.Tolerance,
-            "geometry": [k["path2d"] for k in regionOps if k["opType"] == outsideOpType],
+            "geometry": [
+                k["path2d"] for k in regionOps if k["opType"] in [outsideClearing, outsideProfiling]
+            ],
             "stockGeometry": stockPaths,
             "stepover": obj.StepOver,
             "effectiveHelixDiameter": helixDiameter,
@@ -616,7 +624,9 @@ def Execute(op, obj):
         insideInputStateObject = {
             "tool": op.tool.Diameter.Value,
             "tolerance": obj.Tolerance,
-            "geometry": [k["path2d"] for k in regionOps if k["opType"] == insideOpType],
+            "geometry": [
+                k["path2d"] for k in regionOps if k["opType"] in [insideClearing, insideProfiling]
+            ],
             "stockGeometry": stockPaths,
             "stepover": obj.StepOver,
             "effectiveHelixDiameter": helixDiameter,


### PR DESCRIPTION
@sliptonic regression fix for the release

Fixes #22074 

I think this fix is comparable to the one @RiccaDS proposed and @dbtayl rejected (I'm not certain because it's hard to read the diff on the Adaptive.py zip file; I'm not sure what version to compare against). I developed this change from scratch, reading @dbtayl's PR that introduced model awareness and broke the adaptive profile feature.

In any case, I think this fix should be accepted. @dbtayl objected to Ricca's fix with "Above proposal doesn't respect model geometry, so it's not a drop-in solution as presented." and a screenshot of undesirable behavior when the profile is applied to a sloped surface. That objection applies equally to this PR, but I think this is the wrong way to see this outcome. As I see it, adaptive profile mode worked as a 2D operation as of last release, and this PR restores that behavior. Adaptive never had desirable behavior in profile mode as a 3D operation. @dbtayl's PR added 3D/"model awareness" functionality for clearing mode and disabled profile mode. I think this PR should be seen as fixing that regression, restoring 2D functionality for profile mode while keeping @dbtayl's new 3D/"model awareness" functionality for clearing mode.

Hopefully a future PR in a later release will add 3D/model awareness functionality for profile mode.