### PR TITLE
CAM: Reorder the Clearance height and Safe Height spinners in task panel

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageHeightsEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageHeightsEdit.ui
@@ -19,36 +19,13 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Safe height</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="Gui::QuantitySpinBox" name="safeHeight">
-     <property name="toolTip">
-      <string>The height above which it is safe to move the tool bit with rapid movements. Below this height all lateral and downward movements are performed with feed rate speeds.</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="minimum">
-      <double>-999999999.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>999999999.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QLabel" name="label_9">
      <property name="text">
       <string>Clearance height</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="0" column="1">
     <widget class="Gui::QuantitySpinBox" name="clearanceHeight">
      <property name="toolTip">
       <string>The height where lateral movement of the toolbit is not obstructed by any fixtures or the part / stock material itself.</string>
@@ -64,7 +41,30 @@
      </property>
     </widget>
    </item>
-  <item row="2" column="0" colspan="2">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Safe height</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="Gui::QuantitySpinBox" name="safeHeight">
+     <property name="toolTip">
+      <string>The height above which it is safe to move the tool bit with rapid movements. Below this height all lateral and downward movements are performed with feed rate speeds.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="minimum">
+      <double>-999999999.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>999999999.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>


### PR DESCRIPTION
This PR reorders the Clearance height and Safe Height spinners in task panel

This is step 1 in clearing up some confusions in tool path heights. 
Clearance is a height that's above the Safe Height, but, in the task panel, Safe Height is first. 

Before:
<img width="443" height="323" alt="Screenshot from 2025-09-07 12-12-37" src="https://github.com/user-attachments/assets/63d565bc-2282-4113-8eb0-c3bb0117cb24" />

After:
<img width="443" height="323" alt="Screenshot from 2025-09-07 12-11-38" src="https://github.com/user-attachments/assets/9a214b66-b350-4060-8847-fd9d44a3af32" />

