### PR TITLE
Feature/sketcher hints comprehensive coverage 22282

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1232,6 +1232,10 @@ private:
             .selectionStep = 0,
             .hints = {{QObject::tr("%1 pick circle or arc"), {Gui::InputHint::UserInput::MouseLeft}}}},
 
+            {.commandName = "Sketcher_ConstrainRadiam",
+            .selectionStep = 0,
+            .hints = {{QObject::tr("%1 pick circle or arc"), {Gui::InputHint::UserInput::MouseLeft}}}},
+
             // Angle
             {.commandName = "Sketcher_ConstrainAngle",
             .selectionStep = 0,

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1151,6 +1151,72 @@ public:
         }
     }
 
+    // Special case for Sketcher_ConstrainPerpendicular to generate context-aware hints
+    if (commandName == "Sketcher_ConstrainPerpendicular") {
+        if (selectionStep == 0) {
+            return {{QObject::tr("%1 pick edge or first point"), {Gui::InputHint::UserInput::MouseLeft}}};
+        } else if (selectionStep == 1 && !selSeq.empty()) {
+            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+                // Point + Edge + Edge workflow
+                return {{QObject::tr("%1 pick first edge"), {Gui::InputHint::UserInput::MouseLeft}}};
+            } else {
+                // Edge + Edge workflow
+                return {{QObject::tr("%1 pick second edge"), {Gui::InputHint::UserInput::MouseLeft}}};
+            }
+        } else if (selectionStep == 2 && !selSeq.empty()) {
+            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+                // Point + Edge + Edge workflow
+                return {{QObject::tr("%1 pick second edge"), {Gui::InputHint::UserInput::MouseLeft}}};
+            }
+        }
+    }
+
+    // Special case for Sketcher_ConstrainTangent to generate context-aware hints
+    if (commandName == "Sketcher_ConstrainTangent") {
+        if (selectionStep == 0) {
+            return {{QObject::tr("%1 pick edge or first point"), {Gui::InputHint::UserInput::MouseLeft}}};
+        } else if (selectionStep == 1 && !selSeq.empty()) {
+            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+                // Point + Edge + Edge workflow
+                return {{QObject::tr("%1 pick first edge"), {Gui::InputHint::UserInput::MouseLeft}}};
+            } else {
+                // Could be Edge + Edge or Edge + Point + Edge workflow
+                return {{QObject::tr("%1 pick second edge or point"), {Gui::InputHint::UserInput::MouseLeft}}};
+            }
+        } else if (selectionStep == 2 && !selSeq.empty()) {
+            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+                // Point + Edge + Edge workflow
+                return {{QObject::tr("%1 pick second edge"), {Gui::InputHint::UserInput::MouseLeft}}};
+            } else if (isVertex(selSeq[1].GeoId, selSeq[1].PosId)) {
+                // Edge + Point + Edge workflow
+                return {{QObject::tr("%1 pick second edge"), {Gui::InputHint::UserInput::MouseLeft}}};
+            }
+        }
+    }
+
+    // Special case for Sketcher_ConstrainSymmetric to generate context-aware hints
+    if (commandName == "Sketcher_ConstrainSymmetric") {
+        if (selectionStep == 0) {
+            return {{QObject::tr("%1 pick edge or first point"), {Gui::InputHint::UserInput::MouseLeft}}};
+        } else if (selectionStep == 1 && !selSeq.empty()) {
+            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+                // Point + Edge + Point or Point + Point + Edge/Point workflow
+                return {{QObject::tr("%1 pick edge or second point"), {Gui::InputHint::UserInput::MouseLeft}}};
+            } else {
+                // Edge + Point workflow
+                return {{QObject::tr("%1 pick symmetry point"), {Gui::InputHint::UserInput::MouseLeft}}};
+            }
+        } else if (selectionStep == 2 && !selSeq.empty()) {
+            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId) && isVertex(selSeq[1].GeoId, selSeq[1].PosId)) {
+                // Point + Point + Edge/Point workflow
+                return {{QObject::tr("%1 pick symmetry line or point"), {Gui::InputHint::UserInput::MouseLeft}}};
+            } else if (isVertex(selSeq[0].GeoId, selSeq[0].PosId) && !isVertex(selSeq[1].GeoId, selSeq[1].PosId)) {
+                // Point + Edge + Point workflow
+                return {{QObject::tr("%1 pick symmetry point"), {Gui::InputHint::UserInput::MouseLeft}}};
+            }
+        }
+    }
+
     // For everything else, use the static table
     return lookupConstraintHints(commandName, selectionStep);
 }

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1127,6 +1127,30 @@ public:
         }
     }
 
+    // Special case for Sketcher_ConstrainAngle to generate context-aware hints
+    if (commandName == "Sketcher_ConstrainAngle") {
+        if (selectionStep == 0) {
+            return {{QObject::tr("%1 pick edge or first point"), {Gui::InputHint::UserInput::MouseLeft}}};
+        } else if (selectionStep == 1 && !selSeq.empty()) {
+            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+                // Point + Edge + Edge workflow
+                return {{QObject::tr("%1 pick first edge"), {Gui::InputHint::UserInput::MouseLeft}}};
+            } else {
+                // Could be Line + Line or Edge + Point + Edge workflow
+                // Tell user what they can actually pick next
+                return {{QObject::tr("%1 pick second line or point"), {Gui::InputHint::UserInput::MouseLeft}}};
+            }
+        } else if (selectionStep == 2 && !selSeq.empty()) {
+            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+                // Point + Edge + Edge workflow
+                return {{QObject::tr("%1 pick second edge"), {Gui::InputHint::UserInput::MouseLeft}}};
+            } else if (isVertex(selSeq[1].GeoId, selSeq[1].PosId)) {
+                // Edge + Point + Edge workflow
+                return {{QObject::tr("%1 pick second edge"), {Gui::InputHint::UserInput::MouseLeft}}};
+            }
+        }
+    }
+
     // For everything else, use the static table
     return lookupConstraintHints(commandName, selectionStep);
 }
@@ -1239,11 +1263,15 @@ private:
             // Angle
             {.commandName = "Sketcher_ConstrainAngle",
             .selectionStep = 0,
-            .hints = {{QObject::tr("%1 pick line"), {Gui::InputHint::UserInput::MouseLeft}}}},
+            .hints = {{QObject::tr("%1 pick edge or first point"), {Gui::InputHint::UserInput::MouseLeft}}}},
 
             {.commandName = "Sketcher_ConstrainAngle",
             .selectionStep = 1,
-            .hints = {{QObject::tr("%1 pick second line"), {Gui::InputHint::UserInput::MouseLeft}}}},
+            .hints = {{QObject::tr("%1 pick second element"), {Gui::InputHint::UserInput::MouseLeft}}}},
+
+            {.commandName = "Sketcher_ConstrainAngle",
+            .selectionStep = 2,
+            .hints = {{QObject::tr("%1 pick second edge"), {Gui::InputHint::UserInput::MouseLeft}}}},
 
             // Symmetry
             {.commandName = "Sketcher_ConstrainSymmetric",


### PR DESCRIPTION
<!-- Add comprehensive context-aware hints for Sketcher constraint tools to address feedback about missing and incomplete hint coverage. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
Fixes #22282 "Sketcher: Input hints don't cover all workflows"

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

**Before:** Constraint tools showed generic or missing hints that didn't guide users through alternative workflows.

**After:** All constraint tools now provide context-aware hints that remember user selections and guide them through the correct workflow.

### Test Cases with Specific Hints

#### ConstrainRadiam
- **Test Case**: Create circle/arc → Select ConstrainRadiam → Shows "pick circle or arc"

#### ConstrainAngle
- **Test Case 1 (Line + Line)**: 
  - Step 0: "pick edge or first point"
  - Step 1: "pick second line or point"
- **Test Case 2 (Point + Edge + Edge)**: 
  - Step 0: "pick edge or first point"
  - Step 1: "pick first edge" (context-aware: knows you picked a point)
  - Step 2: "pick second edge"
- **Test Case 3 (Edge + Point + Edge)**: 
  - Step 0: "pick edge or first point"
  - Step 1: "pick second line or point" (context-aware: knows you picked a line)
  - Step 2: "pick second edge" (context-aware: knows you're in edge+point+edge workflow)

#### ConstrainPerpendicular
- **Test Case 1 (Edge + Edge)**: 
  - Step 0: "pick edge or first point"
  - Step 1: "pick second edge" (context-aware: knows you picked an edge)
- **Test Case 2 (Point + Edge + Edge)**: 
  - Step 0: "pick edge or first point"
  - Step 1: "pick first edge" (context-aware: knows you picked a point)
  - Step 2: "pick second edge"

#### ConstrainTangent
- **Test Case 1 (Edge + Edge)**: 
  - Step 0: "pick edge or first point"
  - Step 1: "pick second edge or point" (context-aware: knows you picked an edge)
- **Test Case 2 (Point + Edge + Edge)**: 
  - Step 0: "pick edge or first point"
  - Step 1: "pick first edge" (context-aware: knows you picked a point)
  - Step 2: "pick second edge"
- **Test Case 3 (Edge + Point + Edge)**: 
  - Step 0: "pick edge or first point"
  - Step 1: "pick second edge or point" (context-aware: knows you picked an edge)
  - Step 2: "pick second edge" (context-aware: knows you're in edge+point+edge workflow)

#### ConstrainSymmetric
- **Test Case 1 (Edge + Point)**: 
  - Step 0: "pick edge or first point"
  - Step 1: "pick symmetry point" (context-aware: knows you picked an edge)
- **Test Case 2 (Point + Edge + Point)**: 
  - Step 0: "pick edge or first point"
  - Step 1: "pick edge or second point" (context-aware: knows you picked a point)
  - Step 2: "pick symmetry point" (context-aware: knows you're in point+edge+point workflow)
- **Test Case 3 (Point + Point + Edge/Point)**: 
  - Step 0: "pick edge or first point"
  - Step 1: "pick edge or second point" (context-aware: knows you picked a point)
  - Step 2: "pick symmetry line or point" (context-aware: knows you're in point+point+edge/point workflow)

## Changes Made
- **ConstrainRadiam**: Added missing hints for auto radius/diameter tool
- **ConstrainAngle**: Added context-aware hints for all workflows (line+line, point+edge+edge, edge+point+edge)
- **ConstrainPerpendicular**: Added context-aware hints for all workflows (edge+edge, point+edge+edge)
- **ConstrainTangent**: Added context-aware hints for all workflows (edge+edge, point+edge+edge, edge+point+edge)
- **ConstrainSymmetric**: Added context-aware hints for all workflows (edge+point, point+edge+point, point+point+edge/point)

## Technical Details
- Hints now remember user selections to provide appropriate guidance for each workflow
- Uses special cases in `getToolHints()` method similar to existing `ConstrainPointOnObject`
- Covers all alternative workflows mentioned in the original feedback

