### PR TITLE
Draft: fix issue with ContinueMode

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -394,8 +394,13 @@ class DraftToolBar:
         self.globalMode = params.get_param("GlobalMode")
         self.makeFaceMode = params.get_param("MakeFaceMode")
 
-        feature_name = getattr(FreeCAD.activeDraftCommand, "featureName", None)
-        self.continueMode = params.get_param(feature_name, "Mod/Draft/ContinueMode", silent=True)
+        if getattr(FreeCAD, "activeDraftCommand", None) \
+                and getattr(FreeCAD.activeDraftCommand, "featureName", None):
+            self.continueMode = params.get_param(
+                FreeCAD.activeDraftCommand.featureName,
+                "Mod/ContinueMode",
+                silent=True
+            )
 
         self.chainedMode = params.get_param("ChainedMode")
 


### PR DESCRIPTION
The handling of ContinueMode has been updated in the v1.1 dev cycle. This has resulted in an issue with the following scenario:

1. Prepare a file with a Draft Text.
2. Startup WB is PartDesign.
3. Restart FreeCAD, do not switch workbenches.
4. Open the file.
5. Double-click the text in the Tree View.
6. Result: error: module 'FreeCAD' has no attribute 'activeDraftCommand'.