### PR TITLE
TechDraw: fix TheoreticalExact frame color

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIDatumLabel.cpp
+++ b/src/Mod/TechDraw/Gui/QGIDatumLabel.cpp
@@ -551,7 +551,7 @@ void QGIDatumLabel::setPrettyNormal()
     m_tolTextOver->setPrettyNormal();
     m_tolTextUnder->setPrettyNormal();
     m_unitText->setPrettyNormal();
-    setFrameColor(PreferencesGui::normalQColor());
+    setFrameColor(m_colNormal);
     Q_EMIT setPretty(NORMAL);
 }
 


### PR DESCRIPTION
This PR implements a fix for issue #23450 where the system default color was being used instead of the current dimension color.

<img width="661" height="385" alt="TheoreticalExactFrameColour" src="https://github.com/user-attachments/assets/e0abe105-0c74-40b1-ad1a-3901c66c96d3" />
