### PR TITLE
Draft: update Group icons

### DIFF
--- a/src/Gui/Icons/Std_SelectGroupContents.svg
+++ b/src/Gui/Icons/Std_SelectGroupContents.svg
@@ -1,423 +1,111 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    id="svg3612"
-   height="64px"
-   width="64px">
+   height="64"
+   width="64"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs3614">
-    <marker
-       style="overflow:visible"
-       id="Arrow1Lstart"
-       refX="0.0"
-       refY="0.0"
-       orient="auto">
-      <path
-         transform="scale(0.8) translate(12.5,0)"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt;marker-start:none"
-         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
-         id="path3809" />
-    </marker>
+     id="defs1">
     <linearGradient
-       id="linearGradient3144-6">
+       id="linearGradient4680">
       <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
          offset="0"
+         id="stop4676" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="1"
+         id="stop4678" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="54.889133"
+       x2="56.859715"
+       y1="10"
+       x1="7.421875"
+       id="linearGradient3961"
+       xlink:href="#linearGradient4680" />
+    <linearGradient
+       xlink:href="#linearGradient3765"
+       id="linearGradient3771"
+       x1="35"
+       y1="51"
+       x2="31"
+       y2="18"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3765">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="0"
+         id="stop3767" />
+      <stop
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3146-9" />
-      <stop
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3148-2" />
+         id="stop3769" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3701">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3703" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3705" />
-    </linearGradient>
-    <radialGradient
-       r="34.345188"
-       fy="672.79736"
-       fx="225.26402"
-       cy="672.79736"
-       cx="225.26402"
-       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       xlink:href="#linearGradient3774"
+       id="linearGradient4274"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3688"
-       xlink:href="#linearGradient3144-6" />
+       gradientTransform="matrix(4.362888,0,0,4.698495,-3540.6062,-4138.7958)"
+       x1="820.69635"
+       y1="889.81598"
+       x2="817.02905"
+       y2="886.41058" />
     <linearGradient
-       id="linearGradient3708">
+       id="linearGradient3774">
       <stop
+         style="stop-color:#4e9a06;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3710" />
+         id="stop3776" />
       <stop
+         style="stop-color:#8ae234;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3712" />
+         id="stop3778" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3864-0-0">
-      <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
-         offset="0"
-         id="stop3866-5-7" />
-      <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
-         offset="1"
-         id="stop3868-7-6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3377">
-      <stop
-         style="stop-color:#ffaa00;stop-opacity:1;"
-         offset="0"
-         id="stop3379" />
-      <stop
-         style="stop-color:#faff2b;stop-opacity:1;"
-         offset="1"
-         id="stop3381" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3864-0">
-      <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
-         offset="0"
-         id="stop3866-5" />
-      <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
-         offset="1"
-         id="stop3868-7" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         offset="0"
-         style="stop-color:black;stop-opacity:0;" />
-      <stop
-         style="stop-color:black;stop-opacity:1;"
-         offset="0.5"
-         id="stop5056" />
-      <stop
-         id="stop5052"
-         offset="1"
-         style="stop-color:black;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3841-0-3">
-      <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
-         offset="0"
-         id="stop3843-1-3" />
-      <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
-         offset="1"
-         id="stop3845-0-8" />
-    </linearGradient>
-    <radialGradient
-       id="aigrd2"
-       cx="20.892099"
-       cy="114.5684"
-       r="5.256"
-       fx="20.892099"
-       fy="114.5684"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         offset="0"
-         style="stop-color:#F0F0F0"
-         id="stop15566" />
-      <stop
-         offset="1.0000000"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         id="stop15568" />
-    </radialGradient>
-    <radialGradient
-       id="aigrd3"
-       cx="20.892099"
-       cy="64.567902"
-       r="5.257"
-       fx="20.892099"
-       fy="64.567902"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         offset="0"
-         style="stop-color:#F0F0F0"
-         id="stop15573" />
-      <stop
-         offset="1.0000000"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         id="stop15575" />
-    </radialGradient>
-    <linearGradient
-       id="linearGradient15662">
-      <stop
-         id="stop15664"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop15666"
-         offset="1.0000000"
-         style="stop-color:#f8f8f8;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient259"
-       id="radialGradient4452"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.96049297,0,0,1.041132,-52.144249,-702.33158)"
-       cx="33.966679"
-       cy="35.736916"
-       fx="33.966679"
-       fy="35.736916"
-       r="86.70845" />
-    <linearGradient
-       id="linearGradient259">
-      <stop
-         id="stop260"
-         offset="0.0000000"
-         style="stop-color:#fafafa;stop-opacity:1.0000000;" />
-      <stop
-         id="stop261"
-         offset="1.0000000"
-         style="stop-color:#bbbbbb;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient269"
-       id="radialGradient4454"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.96827297,0,0,1.032767,-48.790699,-701.68513)"
-       cx="8.824419"
-       cy="3.7561285"
-       fx="8.824419"
-       fy="3.7561285"
-       r="37.751713" />
-    <linearGradient
-       id="linearGradient269">
-      <stop
-         id="stop270"
-         offset="0.0000000"
-         style="stop-color:#a3a3a3;stop-opacity:1.0000000;" />
-      <stop
-         id="stop271"
-         offset="1.0000000"
-         style="stop-color:#4c4c4c;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4095">
-      <stop
-         id="stop4097"
-         offset="0"
-         style="stop-color:#005bff;stop-opacity:1;" />
-      <stop
-         id="stop4099"
-         offset="1"
-         style="stop-color:#c1e3f7;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)"
-       gradientUnits="userSpaceOnUse"
-       y2="140.22731"
-       x2="434.73947"
-       y1="185.1304"
-       x1="394.15784"
-       id="linearGradient4253"
-       xlink:href="#linearGradient4247" />
-    <linearGradient
-       id="linearGradient4247">
-      <stop
-         id="stop4249"
-         offset="0"
-         style="stop-color:#2e8207;stop-opacity:1;" />
-      <stop
-         id="stop4251"
-         offset="1"
-         style="stop-color:#52ff00;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4247"
-       id="linearGradient5087"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)"
-       x1="394.15784"
-       y1="185.1304"
-       x2="434.73947"
-       y2="140.22731" />
   </defs>
   <g
-     id="layer1">
+     id="layer1"
+     style="display:inline">
     <path
-       style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 8.999987,12.999996 0,32 14.000001,0"
-       id="path5098-3" />
+       id="rect15391"
+       d="M 19.578125,8 5.4042969,8.0058594 C 5.1706901,8.005955 4.9999125,8.2113736 5,8.4667969 V 55.617188 C 5.0003146,56.383475 5.677268,57.000287 6.5175781,57 L 57.5,56.982422 c 0.84031,-2.87e-4 1.517893,-0.618479 1.517578,-1.384766 L 59,16.382812 C 58.999685,15.616525 58.322732,14.999713 57.482422,15 H 25 Z"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;fill:url(#linearGradient3961);fill-opacity:1;fill-rule:nonzero;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
     <path
-       style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="M 23,29 8.999999,29"
-       id="path5100-6" />
+       id="rect15391-2"
+       d="M 18.578125,10 H 7.421875 C 7.1882682,10.000096 6.9999125,10.205514 7,10.460938 V 54 c 0,1 0,1 1,1 h 48 c 1,0 1,0 1,-1 V 18 c 0,-1 0,-1 -1,-1 H 24 Z"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  </g>
+  <g
+     id="g4259"
+     style="stroke-width:59.8044;stroke-dasharray:none">
     <path
-       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 8.999987,12.999996 0,32 14.000001,0"
-       id="path5098-1" />
+       id="rect4261"
+       style="opacity:1;fill:#8ae234;stroke:#172a04;stroke-width:2;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 21,23 H 43 V 45 H 21 Z" />
     <path
-       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="M 23,29 8.999999,29"
-       id="path5100-7" />
-    <rect
-       style="color:#000000;fill:#eeeeec;stroke:#2e3436;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect4258-1-7-4-4"
-       width="37.999989"
-       height="10"
-       x="3"
-       y="3"
-       rx="0"
-       ry="0" />
-    <rect
-       style="color:#000000;fill:#3465a4;stroke:#0b1521;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect4258-1-7-4-7"
-       width="28"
-       height="10"
-       x="23"
-       y="25"
-       rx="0"
-       ry="0" />
-    <rect
-       y="27"
-       x="24.806452"
-       height="5.9999914"
-       width="24.387096"
-       id="rect3852"
-       style="fill:#3465a4;fill-opacity:1;stroke:#729fcf;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <rect
-       y="5"
-       x="5"
-       height="6"
-       width="34"
-       id="rect3852-5-3"
-       style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <rect
-       style="color:#000000;fill:#3465a4;stroke:#0b1521;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect4258-1-7-4-7-0"
-       width="28"
-       height="10"
-       x="23"
-       y="41"
-       rx="0"
-       ry="0" />
-    <rect
-       y="43"
-       x="24.806452"
-       height="6"
-       width="24.387094"
-       id="rect3852-9"
-       style="fill:#3465a4;fill-opacity:1;stroke:#729fcf;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       id="path3953-1"
-       d="m 20.999999,19 4,0"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3957-5"
-       d="M 53.000001,19 C 57,19 57,19 57,19"
-       style="fill:none;stroke:#204a87;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1"
-       d="m 20.999999,19 4,0"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3957-5-8"
-       d="M 53.000001,19 C 57,19 57,19 57,19"
-       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-5"
-       d="m 37,19 4,0"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-7"
-       d="m 37,19 4,0"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-6"
-       d="m 19,57 4,0"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3957-5-1"
-       d="m 51.000002,57 c 3.999999,0 3.999999,0 3.999999,0"
-       style="fill:none;stroke:#204a87;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-8"
-       d="m 19,57 4,0"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3957-5-8-9"
-       d="m 51.000002,57 c 3.999999,0 3.999999,0 3.999999,0"
-       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-5-2"
-       d="m 35.000001,57 4,0"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-7-7"
-       d="m 35.000001,57 4,0"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-9"
-       d="M 17,26.999999 17,31"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-4"
-       d="M 17,26.999999 17,31"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-5-1"
-       d="M 17,43.000001 17,47"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-7-2"
-       d="M 17,43.000001 17,47"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-9-3"
-       d="M 57,28.999999 57,33"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-4-3"
-       d="M 57,28.999999 57,33"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-5-1-4"
-       d="M 57,45.000001 57,49"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-7-2-1"
-       d="M 57,45.000001 57,49"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+       id="rect4263"
+       style="opacity:1;fill:url(#linearGradient4274);stroke-width:59.8044;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 24,26 H 40 V 42 H 24 Z" />
   </g>
   <metadata
-     id="metadata5469">
+     id="metadata4251">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
         <cc:license
            rdf:resource="" />
-        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
-        <dc:creator>
-          <cc:Agent>
-            <dc:title>[wmayer]</dc:title>
-          </cc:Agent>
-        </dc:creator>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -428,23 +116,34 @@
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_SelectGroup.svg</dc:identifier>
+        <dc:identifier>FreeCAD/src/Gui/Std_SelectGroupContents.svg</dc:identifier>
         <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
-        <dc:contributor>
-          <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
-          </cc:Agent>
-        </dc:contributor>
         <dc:subject>
           <rdf:Bag>
-            <rdf:li>hierarchy</rdf:li>
-            <rdf:li>group</rdf:li>
-            <rdf:li>selection</rdf:li>
-            <rdf:li>tree</rdf:li>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>page</rdf:li>
+            <rdf:li>shapes</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:description>A hierarchical tree structure with two blue child elements of a white parent element, both of which are surrounded by the same dotted box</dc:description>
+        <dc:description>A cursor arrow pointing from left to right onto a folder with an square object on it</dc:description>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     transform="rotate(90,38.5,36.5)"
+     id="g4636"
+     style="display:inline">
+    <g
+       transform="matrix(0,0.54545355,0.54545355,0,31.90919,10.181783)"
+       id="g4147">
+      <path
+         id="path3761"
+         d="M 7,49 15,57 35,37 41,49 57,7 15,23 27,29 Z"
+         style="fill:url(#linearGradient3771);fill-opacity:1;stroke:#2e3436;stroke-width:3.66667;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3763"
+         d="M 10.962357,49 31.571972,28.196969 21.91667,23.314394 52.305932,11.59872 40.631925,42.093042 35.82706,32.778233 15.095348,53.132991 Z"
+         style="fill:none;stroke:#ffffff;stroke-width:1.83334;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/src/Mod/Draft/Resources/icons/Draft_AddConstruction.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_AddConstruction.svg
@@ -13,91 +13,53 @@
   <defs
      id="defs3613">
     <linearGradient
-       id="linearGradient3825">
-      <stop
-         style="stop-color:#34e0e2;stop-opacity:1;"
-         offset="0"
-         id="stop3827" />
-      <stop
-         style="stop-color:#34e0e2;stop-opacity:0;"
-         offset="1"
-         id="stop3829" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3817">
-      <stop
-         style="stop-color:#06989a;stop-opacity:1;"
-         offset="0"
-         id="stop3819" />
-      <stop
-         style="stop-color:#06989a;stop-opacity:0;"
-         offset="1"
-         id="stop3821" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3817"
-       id="linearGradient3823"
-       x1="17"
-       y1="37"
-       x2="15"
-       y2="32"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       xlink:href="#linearGradient3825"
-       id="linearGradient3831"
-       x1="40"
-       y1="21"
-       x2="47"
-       y2="38"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
+       xlink:href="#linearGradient32"
+       id="linearGradient43"
        gradientUnits="userSpaceOnUse"
-       y2="131.22015"
-       x2="154.4444"
-       y1="159.22015"
-       x1="162.4444"
-       id="linearGradient3850"
-       xlink:href="#linearGradient3836"
-       gradientTransform="translate(-141.44439,-128.22016)" />
+       x1="31"
+       y1="21.455433"
+       x2="39.287029"
+       y2="42.334869" />
     <linearGradient
-       id="linearGradient3836">
+       id="linearGradient32">
       <stop
-         id="stop3838"
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0"
-         style="stop-color:#06989a;stop-opacity:1;" />
+         id="stop33" />
       <stop
-         id="stop3840"
+         style="stop-color:#d3d7cf;stop-opacity:1;"
          offset="1"
-         style="stop-color:#34e0e2;stop-opacity:1;" />
+         id="stop32" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient32"
+       id="linearGradient44"
+       gradientUnits="userSpaceOnUse"
+       x1="10.672202"
+       y1="32.420074"
+       x2="12.841275"
+       y2="38.93948" />
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient55"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-17,4)"
+       x1="42"
+       y1="41"
+       x2="62"
+       y2="31.000002" />
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         id="stop3897"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop3899"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1;" />
     </linearGradient>
   </defs>
-  <g
-     transform="translate(0,6)"
-     id="layer1">
-    <path
-       style="fill:#06989a;fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 59.662253,17.123968 C 54.202538,10.619145 19,23 19,23 l 20,22 c 0,0 27.92132,-19.227416 20.662253,-27.876032 z"
-       id="path3498" />
-    <path
-       style="fill:url(#linearGradient3831);fill-opacity:1;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 58,18 C 54.434171,13.753987 22.586852,23.947813 22.586852,23.947813 L 39.287029,42.334868 C 39.287029,42.334868 63.5322,24.58747 58,18 Z"
-       id="path3498-3" />
-    <rect
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#16d0d2;fill-opacity:1;fill-rule:nonzero;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       id="rect3772"
-       width="3"
-       height="8"
-       x="30"
-       y="25" />
-    <path
-       style="fill:#34e0e2;fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 33,25 c -3,-1 -20,4 -24,6 -4,2 -6,5 -6,8 0,3 4,4 10,2 6,-2 20,-11 20,-16 z"
-       id="path3500" />
-    <path
-       style="fill:url(#linearGradient3823);fill-opacity:1;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 29.98637,26.883398 c -4.889547,0.05412 -16.07494,4.168831 -19.314168,5.536675 -3.2392271,1.367845 -5.7198849,4.18225 -5.7198849,6.234016 0,2.051766 3.2515281,1.923846 7.8889579,0.285389 4.637429,-1.638458 15.312301,-8.882481 17.145095,-12.05608 z"
-       id="path3500-6" />
-  </g>
   <metadata
      id="metadata3867">
     <rdf:RDF>
@@ -106,15 +68,9 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
         <cc:license
            rdf:resource="" />
         <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
-        <dc:creator>
-          <cc:Agent>
-            <dc:title>[vocx]</dc:title>
-          </cc:Agent>
-        </dc:creator>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -127,11 +83,6 @@
         </dc:publisher>
         <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_AddConstruction.svg</dc:identifier>
         <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
-        <dc:contributor>
-          <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson, [wmayer]</dc:title>
-          </cc:Agent>
-        </dc:contributor>
         <dc:subject>
           <rdf:Bag>
             <rdf:li>trowel</rdf:li>
@@ -139,20 +90,48 @@
             <rdf:li>plus sign</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:description>A trowel, and a plus sign</dc:description>
+        <dc:description>A trowel with an arrow on top of it.</dc:description>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="g1"
-     style="display:inline">
+     transform="matrix(-1,0,0,1,63.866291,16.00001)"
+     id="layer1-3-7-4-5">
     <path
-       id="rect3558"
-       d="M 13,3 V 13 H 3 v 8 h 10 v 10 h 8 V 21 H 31 V 13 H 21 V 3 Z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3850);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       style="fill:url(#linearGradient43);fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 59.662253,17.123968 C 54.202538,10.619145 19,23 19,23 l 20,22 c 0,0 27.92132,-19.227416 20.662253,-27.876032 z"
+       id="path3498-7-3-5" />
     <path
-       id="path3826"
-       d="M 5,15 H 15 V 5 h 4 v 10 h 10 v 4 H 19 V 29 H 15 V 19 H 5 Z"
-       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 58,18 C 54.434171,13.753987 22.586852,23.947813 22.586852,23.947813 L 39.287029,42.334868 C 39.287029,42.334868 63.5322,24.58747 58,18 Z"
+       id="path3498-3-1-0-4" />
+    <path
+       style="fill:url(#linearGradient44);fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 33,25 c -3,-1 -20,4 -24,6 -4,2 -6,5 -6,8 0,3 4,4 10,2 6,-2 20,-11 20,-16 z"
+       id="path3500-5-8-6" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 29.98637,26.883398 c -4.889547,0.05412 -16.07494,4.168831 -19.314168,5.536675 -3.2392271,1.367845 -5.7198849,4.18225 -5.7198849,6.234016 0,2.051766 3.2515281,1.923846 7.8889579,0.285389 4.637429,-1.638458 15.312301,-8.882481 17.145095,-12.05608 z"
+       id="path3500-6-9-6-5" />
+  </g>
+  <g
+     id="layer1-1-0-0"
+     transform="translate(-1.1786386,7.49669)">
+    <g
+       id="g28-29-9-3"
+       transform="translate(-11.821639,-17.496692)">
+      <g
+         transform="rotate(90,38,36)"
+         id="g4636-8-3-6-0">
+        <path
+           style="fill:url(#linearGradient55);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 38.000002,26.999894 v 7.999965 h -17 v 10 h 17 v 8 L 50.999983,39.999877 Z"
+           id="path3343-4-1-1-3-9" />
+      </g>
+      <path
+         style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 42.357223,37.999998 H 37.000141 V 21.000002 h -6 V 37.999998 H 25.64264 l 8.357501,8.472469 z"
+         id="path3343-2-06-3-9-8-2" />
+    </g>
   </g>
 </svg>

--- a/src/Mod/Draft/Resources/icons/Draft_AddConstruction.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_AddConstruction.svg
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="64px"
-   height="64px"
+   width="64"
+   height="64"
    id="svg3611"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3613">
     <linearGradient
@@ -35,83 +35,6 @@
          id="stop3821" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4292"
-       id="linearGradient4125"
-       gradientUnits="userSpaceOnUse"
-       x1="657.42859"
-       y1="92.117249"
-       x2="696.53217"
-       y2="92.117249" />
-    <linearGradient
-       id="linearGradient4292">
-      <stop
-         style="stop-color:#62d9c5;stop-opacity:1;"
-         offset="0"
-         id="stop4294" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="1"
-         id="stop4296" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4300"
-       id="linearGradient4127"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99534433,0.09638295,-0.09638295,0.99534433,12.979471,-62.75841)"
-       x1="651.69366"
-       y1="108.379"
-       x2="677.37708"
-       y2="108.379" />
-    <linearGradient
-       id="linearGradient4300">
-      <stop
-         style="stop-color:#dd4100;stop-opacity:1;"
-         offset="0"
-         id="stop4302" />
-      <stop
-         style="stop-color:#a80101;stop-opacity:1;"
-         offset="1"
-         id="stop4304" />
-    </linearGradient>
-    <linearGradient
-       y2="108.379"
-       x2="677.37708"
-       y1="108.379"
-       x1="651.69366"
-       gradientTransform="matrix(0.99534433,0.09638295,-0.09638295,0.99534433,12.979471,-62.75841)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3609"
-       xlink:href="#linearGradient4300" />
-    <linearGradient
-       xlink:href="#linearGradient4292-4"
-       id="linearGradient3001-0"
-       gradientUnits="userSpaceOnUse"
-       x1="657.42859"
-       y1="92.117249"
-       x2="696.53217"
-       y2="92.117249"
-       gradientTransform="matrix(0.93342445,0.4455918,-0.45023909,0.92378981,-552.52671,-364.08327)" />
-    <linearGradient
-       id="linearGradient4292-4">
-      <stop
-         style="stop-color:#62d9c5;stop-opacity:1;"
-         offset="0"
-         id="stop4294-4" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="1"
-         id="stop4296-4" />
-    </linearGradient>
-    <linearGradient
-       y2="92.117249"
-       x2="696.53217"
-       y1="92.117249"
-       x1="657.42859"
-       gradientTransform="matrix(0.93342445,0.4455918,-0.45023909,0.92378981,-527.86118,-368.62645)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3807"
-       xlink:href="#linearGradient4292-4" />
-    <linearGradient
        xlink:href="#linearGradient3817"
        id="linearGradient3823"
        x1="17"
@@ -127,6 +50,26 @@
        x2="47"
        y2="38"
        gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="131.22015"
+       x2="154.4444"
+       y1="159.22015"
+       x1="162.4444"
+       id="linearGradient3850"
+       xlink:href="#linearGradient3836"
+       gradientTransform="translate(-141.44439,-128.22016)" />
+    <linearGradient
+       id="linearGradient3836">
+      <stop
+         id="stop3838"
+         offset="0"
+         style="stop-color:#06989a;stop-opacity:1;" />
+      <stop
+         id="stop3840"
+         offset="1"
+         style="stop-color:#34e0e2;stop-opacity:1;" />
+    </linearGradient>
   </defs>
   <g
      transform="translate(0,6)"
@@ -163,7 +106,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
         <cc:license
            rdf:resource="" />
         <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
@@ -200,28 +143,16 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <path
-     style="fill:none;stroke:#042a2a;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 6.05697,18.049229 H 29.844572"
-     id="path853" />
-  <path
-     id="path851"
-     d="M 17.950771,6.1554283 V 29.94303"
-     style="fill:none;stroke:#042a2a;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="path847"
-     d="M 6.05697,18.049229 H 29.844572"
-     style="fill:none;stroke:#34e0e2;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     style="fill:none;stroke:#34e0e2;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 17.950771,6.1554283 V 29.94303"
-     id="path849" />
-  <path
-     id="path855"
-     d="M 17.950771,6.1554283 V 29.94303"
-     style="fill:none;stroke:#179a9b;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     style="fill:none;stroke:#0aa0a2;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 6.05697,18.049229 H 29.844572"
-     id="path857" />
+  <g
+     id="g1"
+     style="display:inline">
+    <path
+       id="rect3558"
+       d="M 13,3 V 13 H 3 v 8 h 10 v 10 h 8 V 21 H 31 V 13 H 21 V 3 Z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3850);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="path3826"
+       d="M 5,15 H 15 V 5 h 4 v 10 h 10 v 4 H 19 V 29 H 15 V 19 H 5 Z"
+       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
 </svg>

--- a/src/Mod/Draft/Resources/icons/Draft_AddNamedGroup.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_AddNamedGroup.svg
@@ -1,405 +1,60 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    id="svg3612"
-   height="64px"
-   width="64px"
-   sodipodi:docname="Draft_AddNamedGroup.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1003"
-     id="namedview70"
-     showgrid="false"
-     inkscape:zoom="3.6875"
-     inkscape:cx="-22.705694"
-     inkscape:cy="21.403241"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="g4670" />
+   height="64"
+   width="64"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3614">
     <linearGradient
-       id="linearGradient3144-6">
+       id="linearGradient4680">
       <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3146-9" />
+         id="stop4676" />
       <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3148-2" />
+         id="stop4678" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3701">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3703" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3705" />
-    </linearGradient>
-    <radialGradient
-       r="34.345188"
-       fy="672.79736"
-       fx="225.26402"
-       cy="672.79736"
-       cx="225.26402"
-       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3688"
-       xlink:href="#linearGradient3144-6" />
-    <linearGradient
-       id="linearGradient3708">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3710" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3712" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3864-0-0">
-      <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
-         offset="0"
-         id="stop3866-5-7" />
-      <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
-         offset="1"
-         id="stop3868-7-6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3377">
-      <stop
-         style="stop-color:#ffaa00;stop-opacity:1;"
-         offset="0"
-         id="stop3379" />
-      <stop
-         style="stop-color:#faff2b;stop-opacity:1;"
-         offset="1"
-         id="stop3381" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3864-0">
-      <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
-         offset="0"
-         id="stop3866-5" />
-      <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
-         offset="1"
-         id="stop3868-7" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         offset="0"
-         style="stop-color:black;stop-opacity:0;" />
-      <stop
-         style="stop-color:black;stop-opacity:1;"
-         offset="0.5"
-         id="stop5056" />
-      <stop
-         id="stop5052"
-         offset="1"
-         style="stop-color:black;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3841-0-3">
-      <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
-         offset="0"
-         id="stop3843-1-3" />
-      <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
-         offset="1"
-         id="stop3845-0-8" />
-    </linearGradient>
-    <radialGradient
-       id="aigrd2"
-       cx="20.892099"
-       cy="114.5684"
-       r="5.256"
-       fx="20.892099"
-       fy="114.5684"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         offset="0"
-         style="stop-color:#F0F0F0"
-         id="stop15566" />
-      <stop
-         offset="1.0000000"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         id="stop15568" />
-    </radialGradient>
-    <radialGradient
-       id="aigrd3"
-       cx="20.892099"
-       cy="64.567902"
-       r="5.257"
-       fx="20.892099"
-       fy="64.567902"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         offset="0"
-         style="stop-color:#F0F0F0"
-         id="stop15573" />
-      <stop
-         offset="1.0000000"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         id="stop15575" />
-    </radialGradient>
-    <linearGradient
-       id="linearGradient15662">
-      <stop
-         id="stop15664"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop15666"
-         offset="1.0000000"
-         style="stop-color:#f8f8f8;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient259"
-       id="radialGradient4452"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.96049297,0,0,1.041132,-52.144249,-702.33158)"
-       cx="33.966679"
-       cy="35.736916"
-       fx="33.966679"
-       fy="35.736916"
-       r="86.70845" />
-    <linearGradient
-       id="linearGradient259">
-      <stop
-         id="stop260"
-         offset="0.0000000"
-         style="stop-color:#fafafa;stop-opacity:1.0000000;" />
-      <stop
-         id="stop261"
-         offset="1.0000000"
-         style="stop-color:#bbbbbb;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient269"
-       id="radialGradient4454"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.96827297,0,0,1.032767,-48.790699,-701.68513)"
-       cx="8.824419"
-       cy="3.7561285"
-       fx="8.824419"
-       fy="3.7561285"
-       r="37.751713" />
-    <linearGradient
-       id="linearGradient269">
-      <stop
-         id="stop270"
-         offset="0.0000000"
-         style="stop-color:#a3a3a3;stop-opacity:1.0000000;" />
-      <stop
-         id="stop271"
-         offset="1.0000000"
-         style="stop-color:#4c4c4c;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4095">
-      <stop
-         id="stop4097"
-         offset="0"
-         style="stop-color:#005bff;stop-opacity:1;" />
-      <stop
-         id="stop4099"
-         offset="1"
-         style="stop-color:#c1e3f7;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)"
-       gradientUnits="userSpaceOnUse"
-       y2="140.22731"
-       x2="434.73947"
-       y1="185.1304"
-       x1="394.15784"
-       id="linearGradient4253"
-       xlink:href="#linearGradient4247" />
-    <linearGradient
-       id="linearGradient4247">
-      <stop
-         id="stop4249"
-         offset="0"
-         style="stop-color:#2e8207;stop-opacity:1;" />
-      <stop
-         id="stop4251"
-         offset="1"
-         style="stop-color:#52ff00;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4247"
-       id="linearGradient5087"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)"
-       x1="394.15784"
-       y1="185.1304"
-       x2="434.73947"
-       y2="140.22731" />
+       y2="54.889133"
+       x2="56.859715"
+       y1="10"
+       x1="7.421875"
+       id="linearGradient3961"
+       xlink:href="#linearGradient4680" />
   </defs>
   <g
-     id="layer1">
-    <g
-       style="fill:none;stroke:#2e3436"
-       id="g4670"
-       transform="translate(-259.85207,-132.78349)">
-      <path
-         style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 270.85207,145.78349 0,42 12,0"
-         id="path5098-3" />
-      <path
-         style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 282.85207,155.78349 -12,0"
-         id="path5100-6" />
-      <path
-         style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 270.85207,205.78349 0,42 12,0"
-         id="path5098"
-         transform="translate(0,-60)" />
-      <path
-         style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 282.85207,155.78349 -12,0"
-         id="path5100" />
-      <rect
-         style="color:#000000;fill:#eeeeec;stroke:#2e3436;stroke-width:1.99999988000000006;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="rect4258-1-7-4"
-         width="37.999989"
-         height="10"
-         x="262.85208"
-         y="135.78349"
-         rx="0"
-         ry="0" />
-      <rect
-         style="color:#000000;fill:#eeeeec;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="rect4258-1-7-4-3"
-         width="37.999989"
-         height="9.9999943"
-         x="282.85208"
-         y="183.78349"
-         rx="0"
-         ry="0" />
-      <rect
-         style="color:#000000;fill:#eeeeec;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="rect4258-1-7-4-6"
-         width="37.999989"
-         height="10.000002"
-         x="282.85208"
-         y="151.78349"
-         rx="0"
-         ry="0" />
-      <rect
-         y="153.78349"
-         x="284.85208"
-         height="6"
-         width="34"
-         id="rect3852-5"
-         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <rect
-         y="137.78349"
-         x="264.85208"
-         height="6"
-         width="34"
-         id="rect3852-5-3"
-         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <rect
-         y="185.78349"
-         x="284.85208"
-         height="6"
-         width="34"
-         id="rect3852-5-5"
-         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#2e3436;stroke-width:5.74898672;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 283.06394,171.03772 H 272.04699"
-         id="path5100-6-7"
-         sodipodi:nodetypes="cc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#d3d7cf;stroke-width:2.14987254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 283.06394,171.03772 H 270.21649"
-         id="path5100-5"
-         sodipodi:nodetypes="cc" />
-      <rect
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#eeeeec;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="rect4258-1-7-4-6-3"
-         width="37.999989"
-         height="10.000002"
-         x="283.06396"
-         y="167.03772"
-         rx="0"
-         ry="0" />
-      <rect
-         y="169.03772"
-         x="285.06396"
-         height="6"
-         width="34"
-         id="rect3852-5-56"
-         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         style="fill:#2e3436;fill-opacity:1;stroke-width:0.9605186"
-         id="rect941"
-         width="1.5310026"
-         height="11.090331"
-         x="311.76453"
-         y="135.4756" />
-      <rect
-         style="fill:#2e3436;fill-opacity:1;stroke:#2e3436"
-         id="rect941-2"
-         width="1.4915212"
-         height="12.338985"
-         x="-141.80043"
-         y="306.5639"
-         ry="0"
-         transform="rotate(-90)" />
-    </g>
+     id="layer1"
+     style="display:inline">
+    <path
+       id="rect15391"
+       d="M 19.578125,8 5.4042969,8.0058594 C 5.1706901,8.005955 4.9823344,8.2113736 4.9824219,8.4667969 l 0.00391,7.9042971 c -2.596e-4,0.01067 -0.00391,0.02052 -0.00391,0.03125 L 5,55.617188 C 5.0003146,56.383475 5.677268,57.000287 6.5175781,57 L 57.5,56.982422 c 0.84031,-2.87e-4 1.517893,-0.618479 1.517578,-1.384766 L 59,16.382812 C 58.999685,15.616525 58.322732,14.999713 57.482422,15 H 25 L 20,8.4609375 C 19.999913,8.2055142 19.811732,7.9999044 19.578125,8 Z"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;fill:url(#linearGradient3961);fill-opacity:1;fill-rule:nonzero;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+    <path
+       id="rect15391-2"
+       d="M 18.578125,10 H 7.421875 C 7.1882682,10.000096 6.9999125,10.205514 7,10.460938 L 7.00391,15.96875 7,16 v 38 c 0,1 0,1 1,1 h 48 c 1,0 1,0 1,-1 V 18 c 0,-1 0,-1 -1,-1 H 24 L 19,10.460938 C 18.999913,10.205514 18.811732,9.9999044 18.578125,10 Z"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
   </g>
   <metadata
-     id="metadata3200">
+     id="metadata4251">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
         <cc:license
            rdf:resource="" />
-        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
-        <dc:creator>
-          <cc:Agent>
-            <dc:title>[wmayer]</dc:title>
-          </cc:Agent>
-        </dc:creator>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -410,23 +65,31 @@
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_AddToGroup.svg</dc:identifier>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_AddNamedGroup.svg</dc:identifier>
         <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
-        <dc:contributor>
-          <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
-          </cc:Agent>
-        </dc:contributor>
         <dc:subject>
           <rdf:Bag>
-            <rdf:li>tree</rdf:li>
-            <rdf:li>hierarchy</rdf:li>
-            <rdf:li>list</rdf:li>
-            <rdf:li>rectangle</rdf:li>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>page</rdf:li>
+            <rdf:li>shapes</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:description>A parent rectangle with two hierarchically subordinate rectangles with a single detached rectangle between the two children</dc:description>
+        <dc:description>A folder with a plus sign on its bottom right corner.</dc:description>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     id="g5"
+     style="display:inline;stroke:#2e3436">
+    <circle
+       style="fill:#eeeeec;stroke:#2e3436;stroke-width:2.00001;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       id="path2"
+       cx="46"
+       cy="46"
+       r="14.999995" />
+    <path
+       id="path1"
+       style="fill:#8ae234;stroke:#2e3436;stroke-width:1.99998;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="m 44,36 h 4 v 8 h 8 v 4 h -8 v 8 h -4 v -8 h -8 v -4 h 8 z" />
+  </g>
 </svg>

--- a/src/Mod/Draft/Resources/icons/Draft_AddToGroup.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_AddToGroup.svg
@@ -13,66 +13,55 @@
   <defs
      id="defs3614">
     <linearGradient
-       id="linearGradient4680">
+       id="linearGradient18">
       <stop
-         style="stop-color:#34e0e2;stop-opacity:1;"
+         id="stop17"
          offset="0"
-         id="stop4676" />
+         style="stop-color:#ffffff;stop-opacity:1;" />
       <stop
-         style="stop-color:#06989a;stop-opacity:1;"
+         id="stop18"
          offset="1"
-         id="stop4678" />
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="54.889133"
-       x2="56.859715"
-       y1="10"
-       x1="7.421875"
-       id="linearGradient3961"
-       xlink:href="#linearGradient4680" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="131.22015"
-       x2="154.4444"
-       y1="159.22015"
-       x1="162.4444"
-       id="linearGradient3850-2"
-       xlink:href="#linearGradient3836-7"
-       gradientTransform="translate(-141.44439,-128.22016)" />
-    <linearGradient
-       id="linearGradient3836-7">
+       id="linearGradient3895">
       <stop
-         id="stop3838-0"
+         id="stop3897"
          offset="0"
-         style="stop-color:#06989a;stop-opacity:1;" />
+         style="stop-color:#729fcf;stop-opacity:1;" />
       <stop
-         id="stop3840-9"
+         id="stop3899"
          offset="1"
-         style="stop-color:#34e0e2;stop-opacity:1;" />
+         style="stop-color:#204a87;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3836-7"
-       id="linearGradient1"
+       xlink:href="#linearGradient18"
+       id="linearGradient48"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-141.44439,-106.22016)"
-       x1="162.4444"
-       y1="159.22015"
-       x2="154.4444"
-       y2="131.22015" />
+       gradientTransform="translate(-200)"
+       x1="13.98611"
+       y1="22.999994"
+       x2="49.986111"
+       y2="55" />
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient41"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-17,4)"
+       x1="42"
+       y1="41"
+       x2="62"
+       y2="31.000002" />
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-17,4)"
+       x1="42"
+       y1="41"
+       x2="62"
+       y2="31.000002" />
   </defs>
-  <g
-     id="layer1"
-     style="display:inline">
-    <path
-       id="rect15391"
-       d="M 19.578125,8 5.4042969,8.0058594 C 5.1706901,8.005955 4.9823344,8.2113736 4.9824219,8.4667969 l 0.00391,7.9042971 c -2.596e-4,0.01067 -0.00391,0.02052 -0.00391,0.03125 L 5,55.617188 C 5.0003146,56.383475 5.677268,57.000287 6.5175781,57 L 57.5,56.982422 c 0.84031,-2.87e-4 1.517893,-0.618479 1.517578,-1.384766 L 59,16.382812 C 58.999685,15.616525 58.322732,14.999713 57.482422,15 H 25 L 20,8.4609375 C 19.999913,8.2055142 19.811732,7.9999044 19.578125,8 Z"
-       style="color:#000000;display:block;overflow:visible;visibility:visible;fill:url(#linearGradient3961);fill-opacity:1;fill-rule:nonzero;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-    <path
-       id="rect15391-2"
-       d="M 18.578125,10 H 7.421875 C 7.1882682,10.000096 6.9999125,10.205514 7,10.460938 L 7.00391,15.96875 7,16 v 38 c 0,1 0,1 1,1 h 48 c 1,0 1,0 1,-1 V 18 c 0,-1 0,-1 -1,-1 H 24 L 19,10.460938 C 18.999913,10.205514 18.811732,9.9999044 18.578125,10 Z"
-       style="color:#000000;display:block;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#34e0e2;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-  </g>
   <metadata
      id="metadata4251">
     <rdf:RDF>
@@ -81,7 +70,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
         <cc:license
            rdf:resource="" />
         <dc:rights>
@@ -103,29 +91,68 @@
             <rdf:li>shapes</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:description>An folder with a plus and a minus signs on top of it.</dc:description>
+        <dc:description>A folder with two arrows on top of it.</dc:description>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="g1"
-     style="display:inline"
-     transform="translate(15,8)">
+     id="g14-2-1"
+     transform="translate(-86,-17.999971)"
+     style="display:inline">
+    <g
+       id="layer1-31-6-9-0-7"
+       style="display:inline"
+       transform="translate(279.01389,4)">
+      <path
+         id="rect15391-4-2-3-6-7"
+         d="M -173.34739,20.999971 -188.01389,21 v 48.499973 c 3.1e-4,0.766246 0.65969,1.500273 1.5,1.499986 l 51,1.4e-5 c 0.84031,-2.87e-4 1.50031,-0.733713 1.5,-1.5 V 28.49997 c -3.2e-4,-0.766287 -0.65969,-1.500287 -1.5,-1.5 h -32.4995 z"
+         style="color:#000000;display:block;overflow:visible;visibility:visible;fill:url(#linearGradient48);fill-opacity:1;fill-rule:nonzero;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+    </g>
     <path
-       id="rect3558"
-       d="M 13,3 V 13 H 3 v 8 h 10 v 10 h 8 V 21 H 31 V 13 H 21 V 3 Z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3850-2);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <path
-       id="path3826"
-       d="M 5,15 H 15 V 5 h 4 v 10 h 10 v 4 H 19 V 29 H 15 V 19 H 5 Z"
-       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="rect3558-2"
-       d="m 3,35 v 8 h 28 v -8 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <path
-       id="path3826-2"
-       d="m 5,37 h 24 v 4 H 5 Z"
-       style="display:inline;fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       id="rect15391-4-2-3-8-1-1"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       d="M 92.999998,72.999973 H 143 V 32.99997 h -32.9995 l -5.325,-5.999975 H 92.999998 l 9e-5,45.999972 z" />
+  </g>
+  <g
+     id="layer1-1"
+     transform="translate(-1.178645,16.496699)"
+     style="display:inline">
+    <g
+       id="g28-29"
+       transform="translate(-11.821639,-17.496692)">
+      <g
+         transform="rotate(90,38,36)"
+         id="g4636-8-3">
+        <path
+           style="fill:url(#linearGradient2);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 38.000002,26.999894 v 7.999965 h -17 v 10 h 17 v 8 L 50.999983,39.999877 Z"
+           id="path3343-4-1-1" />
+      </g>
+      <path
+         style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 42.357223,37.999998 H 37.000141 V 21.000002 h -6 V 37.999998 H 25.64264 l 8.357501,8.472469 z"
+         id="path3343-2-06-3-9" />
+    </g>
+  </g>
+  <g
+     id="layer1-1-1"
+     transform="rotate(180,32.589094,24.751619)"
+     style="display:inline">
+    <g
+       id="g28-29-7"
+       transform="translate(-11.821639,-17.496692)">
+      <g
+         transform="rotate(90,38,36)"
+         id="g4636-8-3-2">
+        <path
+           style="fill:url(#linearGradient41);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 38.000002,26.999894 v 7.999965 h -17 v 10 h 17 v 8 L 50.999983,39.999877 Z"
+           id="path3343-4-1-1-7" />
+      </g>
+      <path
+         style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 42.357223,37.999998 H 37.000141 V 21.000002 h -6 V 37.999998 H 25.64264 l 8.357501,8.472469 z"
+         id="path3343-2-06-3-9-2" />
+    </g>
   </g>
 </svg>

--- a/src/Mod/Draft/Resources/icons/Draft_AddToGroup.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_AddToGroup.svg
@@ -1,353 +1,89 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    id="svg3612"
-   height="64px"
-   width="64px">
+   height="64"
+   width="64"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3614">
     <linearGradient
-       id="linearGradient3144-6">
+       id="linearGradient4680">
       <stop
+         style="stop-color:#34e0e2;stop-opacity:1;"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3146-9" />
+         id="stop4676" />
       <stop
+         style="stop-color:#06989a;stop-opacity:1;"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3148-2" />
+         id="stop4678" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3701">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3703" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3705" />
-    </linearGradient>
-    <radialGradient
-       r="34.345188"
-       fy="672.79736"
-       fx="225.26402"
-       cy="672.79736"
-       cx="225.26402"
-       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3688"
-       xlink:href="#linearGradient3144-6" />
+       y2="54.889133"
+       x2="56.859715"
+       y1="10"
+       x1="7.421875"
+       id="linearGradient3961"
+       xlink:href="#linearGradient4680" />
     <linearGradient
-       id="linearGradient3708">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3710" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3712" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3864-0-0">
-      <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
-         offset="0"
-         id="stop3866-5-7" />
-      <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
-         offset="1"
-         id="stop3868-7-6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3377">
-      <stop
-         style="stop-color:#ffaa00;stop-opacity:1;"
-         offset="0"
-         id="stop3379" />
-      <stop
-         style="stop-color:#faff2b;stop-opacity:1;"
-         offset="1"
-         id="stop3381" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3864-0">
-      <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
-         offset="0"
-         id="stop3866-5" />
-      <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
-         offset="1"
-         id="stop3868-7" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         offset="0"
-         style="stop-color:black;stop-opacity:0;" />
-      <stop
-         style="stop-color:black;stop-opacity:1;"
-         offset="0.5"
-         id="stop5056" />
-      <stop
-         id="stop5052"
-         offset="1"
-         style="stop-color:black;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3841-0-3">
-      <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
-         offset="0"
-         id="stop3843-1-3" />
-      <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
-         offset="1"
-         id="stop3845-0-8" />
-    </linearGradient>
-    <radialGradient
-       id="aigrd2"
-       cx="20.892099"
-       cy="114.5684"
-       r="5.256"
-       fx="20.892099"
-       fy="114.5684"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         offset="0"
-         style="stop-color:#F0F0F0"
-         id="stop15566" />
-      <stop
-         offset="1.0000000"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         id="stop15568" />
-    </radialGradient>
-    <radialGradient
-       id="aigrd3"
-       cx="20.892099"
-       cy="64.567902"
-       r="5.257"
-       fx="20.892099"
-       fy="64.567902"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         offset="0"
-         style="stop-color:#F0F0F0"
-         id="stop15573" />
-      <stop
-         offset="1.0000000"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         id="stop15575" />
-    </radialGradient>
-    <linearGradient
-       id="linearGradient15662">
-      <stop
-         id="stop15664"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop15666"
-         offset="1.0000000"
-         style="stop-color:#f8f8f8;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient259"
-       id="radialGradient4452"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.96049297,0,0,1.041132,-52.144249,-702.33158)"
-       cx="33.966679"
-       cy="35.736916"
-       fx="33.966679"
-       fy="35.736916"
-       r="86.70845" />
+       y2="131.22015"
+       x2="154.4444"
+       y1="159.22015"
+       x1="162.4444"
+       id="linearGradient3850-2"
+       xlink:href="#linearGradient3836-7"
+       gradientTransform="translate(-141.44439,-128.22016)" />
     <linearGradient
-       id="linearGradient259">
+       id="linearGradient3836-7">
       <stop
-         id="stop260"
-         offset="0.0000000"
-         style="stop-color:#fafafa;stop-opacity:1.0000000;" />
-      <stop
-         id="stop261"
-         offset="1.0000000"
-         style="stop-color:#bbbbbb;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient269"
-       id="radialGradient4454"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.96827297,0,0,1.032767,-48.790699,-701.68513)"
-       cx="8.824419"
-       cy="3.7561285"
-       fx="8.824419"
-       fy="3.7561285"
-       r="37.751713" />
-    <linearGradient
-       id="linearGradient269">
-      <stop
-         id="stop270"
-         offset="0.0000000"
-         style="stop-color:#a3a3a3;stop-opacity:1.0000000;" />
-      <stop
-         id="stop271"
-         offset="1.0000000"
-         style="stop-color:#4c4c4c;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4095">
-      <stop
-         id="stop4097"
+         id="stop3838-0"
          offset="0"
-         style="stop-color:#005bff;stop-opacity:1;" />
+         style="stop-color:#06989a;stop-opacity:1;" />
       <stop
-         id="stop4099"
+         id="stop3840-9"
          offset="1"
-         style="stop-color:#c1e3f7;stop-opacity:1;" />
+         style="stop-color:#34e0e2;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)"
+       xlink:href="#linearGradient3836-7"
+       id="linearGradient1"
        gradientUnits="userSpaceOnUse"
-       y2="140.22731"
-       x2="434.73947"
-       y1="185.1304"
-       x1="394.15784"
-       id="linearGradient4253"
-       xlink:href="#linearGradient4247" />
-    <linearGradient
-       id="linearGradient4247">
-      <stop
-         id="stop4249"
-         offset="0"
-         style="stop-color:#2e8207;stop-opacity:1;" />
-      <stop
-         id="stop4251"
-         offset="1"
-         style="stop-color:#52ff00;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4247"
-       id="linearGradient5087"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)"
-       x1="394.15784"
-       y1="185.1304"
-       x2="434.73947"
-       y2="140.22731" />
+       gradientTransform="translate(-141.44439,-106.22016)"
+       x1="162.4444"
+       y1="159.22015"
+       x2="154.4444"
+       y2="131.22015" />
   </defs>
   <g
-     id="layer1">
-    <g
-       style="fill:none;stroke:#2e3436"
-       id="g4670"
-       transform="translate(-259.85207,-132.78349)">
-      <path
-         style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 270.85207,145.78349 0,42 12,0"
-         id="path5098-3" />
-      <path
-         style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 282.85207,155.78349 -12,0"
-         id="path5100-6" />
-      <path
-         style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 270.85207,205.78349 0,42 12,0"
-         id="path5098"
-         transform="translate(0,-60)" />
-      <path
-         style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 282.85207,155.78349 -12,0"
-         id="path5100" />
-      <rect
-         style="color:#000000;fill:#eeeeec;stroke:#2e3436;stroke-width:1.99999988000000006;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="rect4258-1-7-4"
-         width="37.999989"
-         height="10"
-         x="262.85208"
-         y="135.78349"
-         rx="0"
-         ry="0" />
-      <rect
-         style="color:#000000;fill:#eeeeec;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="rect4258-1-7-4-3"
-         width="37.999989"
-         height="9.9999943"
-         x="282.85208"
-         y="183.78349"
-         rx="0"
-         ry="0" />
-      <rect
-         style="color:#000000;fill:#eeeeec;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="rect4258-1-7-4-6"
-         width="37.999989"
-         height="10.000002"
-         x="282.85208"
-         y="151.78349"
-         rx="0"
-         ry="0" />
-      <rect
-         style="color:#000000;fill:#3465a4;stroke:#0b1521;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="rect4258-1-7-4-7"
-         width="37.999989"
-         height="10"
-         x="276.85208"
-         y="167.78349"
-         rx="0"
-         ry="0" />
-      <rect
-         y="169.78349"
-         x="278.85208"
-         height="6"
-         width="34"
-         id="rect3852"
-         style="fill:#3465a4;fill-opacity:1;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <rect
-         y="153.78349"
-         x="284.85208"
-         height="6"
-         width="34"
-         id="rect3852-5"
-         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <rect
-         y="137.78349"
-         x="264.85208"
-         height="6"
-         width="34"
-         id="rect3852-5-3"
-         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <rect
-         y="185.78349"
-         x="284.85208"
-         height="6"
-         width="34"
-         id="rect3852-5-5"
-         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    </g>
+     id="layer1"
+     style="display:inline">
+    <path
+       id="rect15391"
+       d="M 19.578125,8 5.4042969,8.0058594 C 5.1706901,8.005955 4.9823344,8.2113736 4.9824219,8.4667969 l 0.00391,7.9042971 c -2.596e-4,0.01067 -0.00391,0.02052 -0.00391,0.03125 L 5,55.617188 C 5.0003146,56.383475 5.677268,57.000287 6.5175781,57 L 57.5,56.982422 c 0.84031,-2.87e-4 1.517893,-0.618479 1.517578,-1.384766 L 59,16.382812 C 58.999685,15.616525 58.322732,14.999713 57.482422,15 H 25 L 20,8.4609375 C 19.999913,8.2055142 19.811732,7.9999044 19.578125,8 Z"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;fill:url(#linearGradient3961);fill-opacity:1;fill-rule:nonzero;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+    <path
+       id="rect15391-2"
+       d="M 18.578125,10 H 7.421875 C 7.1882682,10.000096 6.9999125,10.205514 7,10.460938 L 7.00391,15.96875 7,16 v 38 c 0,1 0,1 1,1 h 48 c 1,0 1,0 1,-1 V 18 c 0,-1 0,-1 -1,-1 H 24 L 19,10.460938 C 18.999913,10.205514 18.811732,9.9999044 18.578125,10 Z"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#34e0e2;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
   </g>
   <metadata
-     id="metadata3200">
+     id="metadata4251">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
         <cc:license
            rdf:resource="" />
-        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
-        <dc:creator>
-          <cc:Agent>
-            <dc:title>[wmayer]</dc:title>
-          </cc:Agent>
-        </dc:creator>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -358,23 +94,38 @@
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_AddToGroup.svg</dc:identifier>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_AutoGroup_on.svg</dc:identifier>
         <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
-        <dc:contributor>
-          <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
-          </cc:Agent>
-        </dc:contributor>
         <dc:subject>
           <rdf:Bag>
-            <rdf:li>tree</rdf:li>
-            <rdf:li>hierarchy</rdf:li>
-            <rdf:li>list</rdf:li>
-            <rdf:li>rectangle</rdf:li>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>page</rdf:li>
+            <rdf:li>shapes</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:description>A parent rectangle with two hierarchically subordinate rectangles with a single detached rectangle between the two children</dc:description>
+        <dc:description>An folder with a plus and a minus signs on top of it.</dc:description>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     id="g1"
+     style="display:inline"
+     transform="translate(15,8)">
+    <path
+       id="rect3558"
+       d="M 13,3 V 13 H 3 v 8 h 10 v 10 h 8 V 21 H 31 V 13 H 21 V 3 Z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3850-2);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="path3826"
+       d="M 5,15 H 15 V 5 h 4 v 10 h 10 v 4 H 19 V 29 H 15 V 19 H 5 Z"
+       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="rect3558-2"
+       d="m 3,35 v 8 h 28 v -8 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="path3826-2"
+       d="m 5,37 h 24 v 4 H 5 Z"
+       style="display:inline;fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
 </svg>

--- a/src/Mod/Draft/Resources/icons/Draft_AddToLayer.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_AddToLayer.svg
@@ -15,45 +15,54 @@
   <defs
      id="defs2987">
     <linearGradient
-       id="linearGradient3815">
-      <stop
-         id="stop3817"
-         offset="0"
-         style="stop-color:#06989a;stop-opacity:1;" />
-      <stop
-         id="stop3819"
-         offset="1"
-         style="stop-color:#34e0e2;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3815"
-       id="linearGradient1"
+       xlink:href="#linearGradient14"
+       id="linearGradient13"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.66067504,0,0,0.63929414,18.06576,5.8678762)"
-       x1="28.741892"
-       y1="54.126049"
+       x1="27.753059"
+       y1="54.125957"
        x2="13.901636"
        y2="23.420826" />
     <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="131.22015"
-       x2="154.4444"
-       y1="159.22015"
-       x1="162.4444"
-       id="linearGradient3850"
-       xlink:href="#linearGradient3836"
-       gradientTransform="translate(-141.44439,-128.22016)" />
-    <linearGradient
-       id="linearGradient3836">
+       id="linearGradient14">
       <stop
-         id="stop3838"
+         id="stop13"
          offset="0"
-         style="stop-color:#06989a;stop-opacity:1;" />
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
       <stop
-         id="stop3840"
+         id="stop14"
          offset="1"
-         style="stop-color:#34e0e2;stop-opacity:1;" />
+         style="stop-color:#ffffff;stop-opacity:1;" />
     </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient50"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-17,4)"
+       x1="42"
+       y1="41"
+       x2="62"
+       y2="31.000002" />
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         id="stop3897"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop3899"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-17,4)"
+       x1="42"
+       y1="41"
+       x2="62"
+       y2="31.000002" />
   </defs>
   <metadata
      id="metadata5826">
@@ -64,11 +73,6 @@
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title>Draft_AddToLayer</dc:title>
-        <dc:creator>
-          <cc:Agent>
-            <dc:title>[Yorik van Havre]</dc:title>
-          </cc:Agent>
-        </dc:creator>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -81,11 +85,6 @@
         </dc:publisher>
         <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_AddToLayer.svg</dc:identifier>
         <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
-        <dc:contributor>
-          <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
-          </cc:Agent>
-        </dc:contributor>
         <dc:subject>
           <rdf:Bag>
             <rdf:li>page</rdf:li>
@@ -94,7 +93,7 @@
             <rdf:li>stack</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:description>A layer with a plus sign on its top left corner.</dc:description>
+        <dc:description>A layer with two arrows on top of it.</dc:description>
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
       </cc:Work>
@@ -116,28 +115,56 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer2"
-     style="display:inline;stroke-width:0.653981"
-     transform="matrix(1.5298962,0,0,1.5282988,-16.690014,-6.8507747)">
+     id="layer2-0-1-9"
+     style="display:inline;stroke-width:0.653974"
+     transform="matrix(1.5298726,0,0,1.5283528,-16.689679,-5.8528404)">
     <path
-       d="M 27.250224,20.840975 50.127593,30.001487 37.05481,40.470644 14.177442,31.310132 Z"
-       style="display:inline;overflow:visible;fill:url(#linearGradient1);fill-rule:evenodd;stroke:#2e3436;stroke-width:1.30796;stroke-linejoin:round;stroke-dasharray:none;marker:none;enable-background:accumulate"
-       id="path1-2-9" />
+       d="M 27.250224,20.840975 49.474498,30.001516 36.401715,40.470673 14.177442,31.310132 Z"
+       style="display:inline;overflow:visible;fill:url(#linearGradient13);fill-rule:evenodd;stroke:#2e3436;stroke-width:1.30795;stroke-linejoin:round;stroke-dasharray:none;marker:none;enable-background:accumulate"
+       id="path1-2-9-6-49-3" />
     <path
-       id="path3-5"
-       style="display:inline;fill:none;stroke:#34e0e2;stroke-width:1.30796;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 16.744141,30.928014 c 6.697265,2.682292 13.394531,5.364583 20.091797,8.046875 3.574869,-2.863281 7.149739,-5.726563 10.724609,-8.589844 -6.697266,-2.682292 -13.394531,-5.364583 -20.091797,-8.046875 -3.57487,2.863281 -7.14974,5.726563 -10.724609,8.589844 z" />
+       id="path3-5-1-2-6"
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.30795;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.744141,30.928014 36.182843,38.974918 46.907452,30.385074 27.46875,22.33817 Z" />
   </g>
   <g
-     id="g1"
-     style="display:inline">
-    <path
-       id="rect3558"
-       d="M 13,3 V 13 H 3 v 8 h 10 v 10 h 8 V 21 H 31 V 13 H 21 V 3 Z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3850);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <path
-       id="path3826"
-       d="M 5,15 H 15 V 5 h 4 v 10 h 10 v 4 H 19 V 29 H 15 V 19 H 5 Z"
-       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     id="layer1-1-0"
+     transform="translate(-1.178643,7.4967296)">
+    <g
+       id="g28-29-9"
+       transform="translate(-11.821639,-17.496692)">
+      <g
+         transform="rotate(90,38,36)"
+         id="g4636-8-3-6">
+        <path
+           style="fill:url(#linearGradient2);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 38.000002,26.999894 v 7.999965 h -17 v 10 h 17 v 8 L 50.999983,39.999877 Z"
+           id="path3343-4-1-1-3" />
+      </g>
+      <path
+         style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 42.357223,37.999998 H 37.000141 V 21.000002 h -6 V 37.999998 H 25.64264 l 8.357501,8.472469 z"
+         id="path3343-2-06-3-9-8" />
+    </g>
+  </g>
+  <g
+     id="layer1-1-1-5"
+     transform="rotate(180,32.589095,20.251625)">
+    <g
+       id="g28-29-7-6"
+       transform="translate(-11.821639,-17.496692)">
+      <g
+         transform="rotate(90,38,36)"
+         id="g4636-8-3-2-1">
+        <path
+           style="fill:url(#linearGradient50);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 38.000002,26.999894 v 7.999965 h -17 v 10 h 17 v 8 L 50.999983,39.999877 Z"
+           id="path3343-4-1-1-7-1" />
+      </g>
+      <path
+         style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 42.357223,37.999998 H 37.000141 V 21.000002 h -6 V 37.999998 H 25.64264 l 8.357501,8.472469 z"
+         id="path3343-2-06-3-9-2-5" />
+    </g>
   </g>
 </svg>

--- a/src/Mod/Draft/Resources/icons/Draft_AddToLayer.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_AddToLayer.svg
@@ -2,119 +2,58 @@
 <svg
    version="1.1"
    id="svg2985"
-   height="64px"
-   width="64px"
-   sodipodi:docname="Draft_AddToLayer.svg"
-   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   height="64"
+   width="64"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview11517"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     inkscape:zoom="10.429825"
-     inkscape:cx="23.442388"
-     inkscape:cy="37.632463"
-     inkscape:window-width="1280"
-     inkscape:window-height="971"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2985" />
   <title
-     id="title853">Draft_Layer</title>
+     id="title853">Draft_AddToLayer</title>
   <defs
      id="defs2987">
-    <linearGradient
-       id="linearGradient1852">
-      <stop
-         id="stop1848"
-         offset="0"
-         style="stop-color:#06989a;stop-opacity:1;" />
-      <stop
-         id="stop1850"
-         offset="1"
-         style="stop-color:#34e0e2;stop-opacity:1;" />
-    </linearGradient>
     <linearGradient
        id="linearGradient3815">
       <stop
          id="stop3817"
          offset="0"
-         style="stop-color:#d3d7cf;stop-opacity:1;" />
+         style="stop-color:#06989a;stop-opacity:1;" />
       <stop
          id="stop3819"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:1" />
+         style="stop-color:#34e0e2;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
        xlink:href="#linearGradient3815"
-       id="linearGradient2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64426076,0,0,0.63928583,17.931015,13.729721)"
-       x1="53.257175"
-       y1="19.086002"
-       x2="25.928942"
-       y2="-1.3815211" />
-    <linearGradient
-       xlink:href="#linearGradient1852"
        id="linearGradient1"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.66067504,0,0,0.63929414,18.06576,5.8678762)"
-       x1="53.257175"
-       y1="19.086002"
-       x2="25.928942"
-       y2="-1.3815211" />
+       x1="28.741892"
+       y1="54.126049"
+       x2="13.901636"
+       y2="23.420826" />
     <linearGradient
-       xlink:href="#linearGradient3815"
-       id="linearGradient3"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66067504,0,0,0.63929414,18.06576,-1.9839915)"
-       x1="53.257175"
-       y1="19.086002"
-       x2="25.928942"
-       y2="-1.3815211" />
+       y2="131.22015"
+       x2="154.4444"
+       y1="159.22015"
+       x1="162.4444"
+       id="linearGradient3850"
+       xlink:href="#linearGradient3836"
+       gradientTransform="translate(-141.44439,-128.22016)" />
     <linearGradient
-       xlink:href="#linearGradient3057"
-       id="linearGradient3053"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.9455392,0,0,1.9455392,-47.998185,-58.673094)"
-       x1="41.511921"
-       y1="26.271811"
-       x2="42.984806"
-       y2="49.460072" />
-    <linearGradient
-       id="linearGradient3057">
+       id="linearGradient3836">
       <stop
-         style="stop-color:#8ae234;stop-opacity:1"
-         offset="0.0000000"
-         id="stop3059" />
+         id="stop3838"
+         offset="0"
+         style="stop-color:#06989a;stop-opacity:1;" />
       <stop
-         style="stop-color:#4e9a06;stop-opacity:1"
-         offset="1.0000000"
-         id="stop3061" />
+         id="stop3840"
+         offset="1"
+         style="stop-color:#34e0e2;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3057"
-       id="linearGradient3053-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.9455392,0,0,1.9455392,-47.998185,-58.673094)"
-       x1="41.511921"
-       y1="26.271811"
-       x2="42.984806"
-       y2="49.460072" />
   </defs>
   <metadata
      id="metadata5826">
@@ -124,8 +63,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>Draft_Layer</dc:title>
-        <dc:date>Tue Jun 10 10:21:01 2014 -0300</dc:date>
+        <dc:title>Draft_AddToLayer</dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[Yorik van Havre]</dc:title>
@@ -141,7 +79,7 @@
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Layer.svg</dc:identifier>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_AddToLayer.svg</dc:identifier>
         <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:contributor>
           <cc:Agent>
@@ -156,7 +94,7 @@
             <rdf:li>stack</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:description>Three pages or rectangles stacked on top of each other. Previously VisGroup.</dc:description>
+        <dc:description>A layer with a plus sign on its top left corner.</dc:description>
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
       </cc:Work>
@@ -180,7 +118,7 @@
   <g
      id="layer2"
      style="display:inline;stroke-width:0.653981"
-     transform="matrix(1.5298962,0,0,1.5282988,-17.190014,-6.6523599)">
+     transform="matrix(1.5298962,0,0,1.5282988,-16.690014,-6.8507747)">
     <path
        d="M 27.250224,20.840975 50.127593,30.001487 37.05481,40.470644 14.177442,31.310132 Z"
        style="display:inline;overflow:visible;fill:url(#linearGradient1);fill-rule:evenodd;stroke:#2e3436;stroke-width:1.30796;stroke-linejoin:round;stroke-dasharray:none;marker:none;enable-background:accumulate"
@@ -190,28 +128,16 @@
        style="display:inline;fill:none;stroke:#34e0e2;stroke-width:1.30796;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
        d="m 16.744141,30.928014 c 6.697265,2.682292 13.394531,5.364583 20.091797,8.046875 3.574869,-2.863281 7.149739,-5.726563 10.724609,-8.589844 -6.697266,-2.682292 -13.394531,-5.364583 -20.091797,-8.046875 -3.57487,2.863281 -7.14974,5.726563 -10.724609,8.589844 z" />
   </g>
-  <path
-     style="fill:none;stroke:#042a2a;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 6.05697,18.049229 H 29.844572"
-     id="path853" />
-  <path
-     id="path851"
-     d="M 17.950771,6.1554283 V 29.94303"
-     style="fill:none;stroke:#042a2a;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="path847"
-     d="M 6.05697,18.049229 H 29.844572"
-     style="fill:none;stroke:#34e0e2;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     style="fill:none;stroke:#34e0e2;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 17.950771,6.1554283 V 29.94303"
-     id="path849" />
-  <path
-     id="path855"
-     d="M 17.950771,6.1554283 V 29.94303"
-     style="fill:none;stroke:#179a9b;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     style="fill:none;stroke:#0aa0a2;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 6.05697,18.049229 H 29.844572"
-     id="path857" />
+  <g
+     id="g1"
+     style="display:inline">
+    <path
+       id="rect3558"
+       d="M 13,3 V 13 H 3 v 8 h 10 v 10 h 8 V 21 H 31 V 13 H 21 V 3 Z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3850);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="path3826"
+       d="M 5,15 H 15 V 5 h 4 v 10 h 10 v 4 H 19 V 29 H 15 V 19 H 5 Z"
+       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
 </svg>

--- a/src/Mod/Draft/Resources/icons/Draft_Construction.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_Construction.svg
@@ -1,159 +1,45 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    id="svg3611"
-   height="64px"
-   width="64px">
+   height="64"
+   width="64"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3613">
     <linearGradient
-       id="linearGradient3825">
+       xlink:href="#linearGradient32"
+       id="linearGradient43"
+       gradientUnits="userSpaceOnUse"
+       x1="31"
+       y1="21.455433"
+       x2="39.287029"
+       y2="42.334869" />
+    <linearGradient
+       id="linearGradient32">
       <stop
-         id="stop3827"
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0"
-         style="stop-color:#34e0e2;stop-opacity:1;" />
+         id="stop33" />
       <stop
-         id="stop3829"
+         style="stop-color:#d3d7cf;stop-opacity:1;"
          offset="1"
-         style="stop-color:#34e0e2;stop-opacity:0;" />
+         id="stop32" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3817">
-      <stop
-         id="stop3819"
-         offset="0"
-         style="stop-color:#06989a;stop-opacity:1;" />
-      <stop
-         id="stop3821"
-         offset="1"
-         style="stop-color:#06989a;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       y2="92.117249"
-       x2="696.53217"
-       y1="92.117249"
-       x1="657.42859"
+       xlink:href="#linearGradient32"
+       id="linearGradient44"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient4125"
-       xlink:href="#linearGradient4292" />
-    <linearGradient
-       id="linearGradient4292">
-      <stop
-         id="stop4294"
-         offset="0"
-         style="stop-color:#62d9c5;stop-opacity:1;" />
-      <stop
-         id="stop4296"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       y2="108.379"
-       x2="677.37708"
-       y1="108.379"
-       x1="651.69366"
-       gradientTransform="matrix(0.99534433,0.09638295,-0.09638295,0.99534433,12.979471,-62.75841)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4127"
-       xlink:href="#linearGradient4300" />
-    <linearGradient
-       id="linearGradient4300">
-      <stop
-         id="stop4302"
-         offset="0"
-         style="stop-color:#dd4100;stop-opacity:1;" />
-      <stop
-         id="stop4304"
-         offset="1"
-         style="stop-color:#a80101;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4300"
-       id="linearGradient3609"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99534433,0.09638295,-0.09638295,0.99534433,12.979471,-62.75841)"
-       x1="651.69366"
-       y1="108.379"
-       x2="677.37708"
-       y2="108.379" />
-    <linearGradient
-       gradientTransform="matrix(0.93342445,0.4455918,-0.45023909,0.92378981,-552.52671,-364.08327)"
-       y2="92.117249"
-       x2="696.53217"
-       y1="92.117249"
-       x1="657.42859"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3001-0"
-       xlink:href="#linearGradient4292-4" />
-    <linearGradient
-       id="linearGradient4292-4">
-      <stop
-         id="stop4294-4"
-         offset="0"
-         style="stop-color:#62d9c5;stop-opacity:1;" />
-      <stop
-         id="stop4296-4"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4292-4"
-       id="linearGradient3807"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.93342445,0.4455918,-0.45023909,0.92378981,-527.86118,-368.62645)"
-       x1="657.42859"
-       y1="92.117249"
-       x2="696.53217"
-       y2="92.117249" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="32"
-       x2="15"
-       y1="37"
-       x1="17"
-       id="linearGradient3823"
-       xlink:href="#linearGradient3817" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="38"
-       x2="47"
-       y1="21"
-       x1="40"
-       id="linearGradient3831"
-       xlink:href="#linearGradient3825" />
+       x1="10.672202"
+       y1="32.420074"
+       x2="12.841275"
+       y2="38.93948" />
   </defs>
-  <g
-     id="layer1">
-    <path
-       id="path3498"
-       d="M 59.662253,17.123968 C 54.202538,10.619145 19,23 19,23 l 20,22 c 0,0 27.92132,-19.227416 20.662253,-27.876032 z"
-       style="fill:#06989a;fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       id="path3498-3"
-       d="M 58,18 C 54.434171,13.753987 22.586852,23.947813 22.586852,23.947813 L 39.287029,42.334868 C 39.287029,42.334868 63.5322,24.58747 58,18 z"
-       style="fill:url(#linearGradient3831);stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;fill-opacity:1" />
-    <rect
-       y="25"
-       x="30"
-       height="8"
-       width="3"
-       id="rect3772"
-       style="color:#000000;fill:#16d0d2;fill-opacity:1;fill-rule:nonzero;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       id="path3500"
-       d="m 33,25 c -3,-1 -20,4 -24,6 -4,2 -6,5 -6,8 0,3 4,4 10,2 6,-2 20,-11 20,-16 z"
-       style="fill:#34e0e2;fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       id="path3500-6"
-       d="m 29.98637,26.883398 c -4.889547,0.05412 -16.07494,4.168831 -19.314168,5.536675 -3.2392271,1.367845 -5.7198849,4.18225 -5.7198849,6.234016 0,2.051766 3.2515281,1.923846 7.8889579,0.285389 4.637429,-1.638458 15.312301,-8.882481 17.145095,-12.05608 z"
-       style="fill:url(#linearGradient3823);stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;fill-opacity:1" />
-  </g>
   <metadata
      id="metadata3867">
     <rdf:RDF>
@@ -162,7 +48,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
         <cc:license
            rdf:resource="" />
         <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
@@ -198,4 +83,24 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     transform="matrix(-1,0,0,1,63.866291,1.7660435)"
+     id="layer1-3-7-4-5">
+    <path
+       style="fill:url(#linearGradient43);fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 59.662253,17.123968 C 54.202538,10.619145 19,23 19,23 l 20,22 c 0,0 27.92132,-19.227416 20.662253,-27.876032 z"
+       id="path3498-7-3-5" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 58,18 C 54.434171,13.753987 22.586852,23.947813 22.586852,23.947813 L 39.287029,42.334868 C 39.287029,42.334868 63.5322,24.58747 58,18 Z"
+       id="path3498-3-1-0-4" />
+    <path
+       style="fill:url(#linearGradient44);fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 33,25 c -3,-1 -20,4 -24,6 -4,2 -6,5 -6,8 0,3 4,4 10,2 6,-2 20,-11 20,-16 z"
+       id="path3500-5-8-6" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 29.98637,26.883398 c -4.889547,0.05412 -16.07494,4.168831 -19.314168,5.536675 -3.2392271,1.367845 -5.7198849,4.18225 -5.7198849,6.234016 0,2.051766 3.2515281,1.923846 7.8889579,0.285389 4.637429,-1.638458 15.312301,-8.882481 17.145095,-12.05608 z"
+       id="path3500-6-9-6-5" />
+  </g>
 </svg>

--- a/src/Mod/Draft/Resources/icons/Draft_NewLayer.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_NewLayer.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    id="svg2985"
-   height="64px"
-   width="64px">
+   height="64"
+   width="64"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title853">Draft_Layer</title>
+     id="title853">Draft_NewLayer</title>
   <defs
      id="defs2987">
     <linearGradient
@@ -26,647 +26,15 @@
          style="stop-color:#ffffff;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3807">
-      <stop
-         id="stop3809"
-         offset="0"
-         style="stop-color:#d3d7cf;stop-opacity:1;" />
-      <stop
-         id="stop3811"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3799">
-      <stop
-         id="stop3801"
-         offset="0"
-         style="stop-color:#d3d7cf;stop-opacity:1;" />
-      <stop
-         id="stop3803"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(-0.02151317,-0.91811256)"
-       gradientUnits="userSpaceOnUse"
-       y2="-1.3815211"
-       x2="25.928942"
-       y1="19.086002"
-       x1="53.257175"
-       id="linearGradient3805"
-       xlink:href="#linearGradient3799" />
-    <linearGradient
-       gradientTransform="translate(0.75600263,0.0412295)"
-       gradientUnits="userSpaceOnUse"
-       y2="12.022611"
-       x2="36.843666"
-       y1="27.953379"
-       x1="61.719494"
-       id="linearGradient3813"
-       xlink:href="#linearGradient3807" />
-    <linearGradient
-       gradientTransform="translate(-0.18895427,-1.1237431)"
-       gradientUnits="userSpaceOnUse"
-       y2="23.542751"
-       x2="48.388607"
-       y1="43.419685"
-       x1="74.313408"
-       id="linearGradient3821"
-       xlink:href="#linearGradient3815" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient5031"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)" />
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient5029"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)" />
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient5027"
-       xlink:href="#linearGradient5048"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)" />
-    <radialGradient
-       cx="24.306795"
-       cy="42.07798"
-       r="15.821514"
-       fx="24.306795"
-       fy="42.07798"
-       id="radialGradient4548"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.284916,0,30.08928)" />
-    <linearGradient
-       id="linearGradient15662">
-      <stop
-         id="stop15664"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop15666"
-         style="stop-color:#f8f8f8;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="20.892099"
-       cy="64.567902"
-       r="5.257"
-       fx="20.892099"
-       fy="64.567902"
-       id="aigrd3"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop15573"
-         style="stop-color:#f0f0f0;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop15575"
-         style="stop-color:#9a9a9a;stop-opacity:1"
-         offset="1" />
-    </radialGradient>
-    <radialGradient
-       cx="20.892099"
-       cy="114.5684"
-       r="5.256"
-       fx="20.892099"
-       fy="114.5684"
-       id="aigrd2"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop15566"
-         style="stop-color:#f0f0f0;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop15568"
-         style="stop-color:#9a9a9a;stop-opacity:1"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       id="linearGradient269">
-      <stop
-         id="stop270"
-         style="stop-color:#a3a3a3;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop271"
-         style="stop-color:#4c4c4c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient259">
-      <stop
-         id="stop260"
-         style="stop-color:#fafafa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop261"
-         style="stop-color:#bbbbbb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient12512">
-      <stop
-         id="stop12513"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop12517"
-         style="stop-color:#fff520;stop-opacity:0.89108908"
-         offset="0.5" />
-      <stop
-         id="stop12514"
-         style="stop-color:#fff300;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="55"
-       cy="125"
-       r="14.375"
-       fx="55"
-       fy="125"
-       id="radialGradient278"
-       xlink:href="#linearGradient12512"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0434782,0,0,1.0434782,-9.2189114,-105.70069)" />
-    <radialGradient
-       cx="8.824419"
-       cy="3.7561285"
-       r="37.751713"
-       fx="8.824419"
-       fy="3.7561285"
-       id="radialGradient15656"
-       xlink:href="#linearGradient269"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.968273,0,0,1.032767,3.4281936,-47.492271)" />
-    <radialGradient
-       cx="33.966679"
-       cy="35.736916"
-       r="86.70845"
-       fx="33.966679"
-       fy="35.736916"
-       id="radialGradient15658"
-       xlink:href="#linearGradient259"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.960493,0,0,1.041132,0.07464063,-48.138718)" />
-    <radialGradient
-       cx="8.1435566"
-       cy="7.2678967"
-       r="38.158695"
-       fx="8.1435566"
-       fy="7.2678967"
-       id="radialGradient15668"
-       xlink:href="#linearGradient15662"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.968273,0,0,1.032767,3.4281936,-47.492271)" />
-    <radialGradient
-       cx="20.892099"
-       cy="114.5684"
-       r="5.256"
-       fx="20.892099"
-       fy="114.5684"
-       id="radialGradient2283"
-       xlink:href="#aigrd2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.229703,0,0,0.229703,4.613529,3.979808)" />
-    <radialGradient
-       cx="20.892099"
-       cy="64.567902"
-       r="5.257"
-       fx="20.892099"
-       fy="64.567902"
-       id="radialGradient2285"
-       xlink:href="#aigrd3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.229703,0,0,0.229703,4.613529,3.979808)" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient5029-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient5031-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
-       r="86.70845"
-       fy="35.736916"
-       fx="33.966679"
-       cy="35.736916"
-       cx="33.966679"
-       gradientTransform="matrix(0.93681254,0,0,1.0682567,-0.92539285,-48.545272)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient15658-2"
-       xlink:href="#linearGradient259" />
-    <radialGradient
-       r="37.751713"
-       fy="40.640011"
-       fx="4.4163604"
-       cy="40.640011"
-       cx="4.4163604"
-       gradientTransform="matrix(0.94440073,0,0,1.0596738,2.3454801,-47.881983)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient15656-3"
-       xlink:href="#linearGradient269" />
-    <radialGradient
-       r="38.158695"
-       fy="7.2678967"
-       fx="8.1435566"
-       cy="7.2678967"
-       cx="8.1435566"
-       gradientTransform="matrix(0.88587294,0,0,1.0079919,3.5841035,-46.659551)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient15668-2"
-       xlink:href="#linearGradient15662" />
-    <radialGradient
-       xlink:href="#aigrd2-9"
-       id="radialGradient2283-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.229703,0,0,0.229703,4.613529,3.979808)"
-       cx="20.892099"
-       cy="114.5684"
-       fx="20.892099"
-       fy="114.5684"
-       r="5.256" />
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       fy="114.5684"
-       fx="20.892099"
-       r="5.256"
-       cy="114.5684"
-       cx="20.892099"
-       id="aigrd2-9">
-      <stop
-         id="stop15566-2"
-         style="stop-color:#F0F0F0"
-         offset="0" />
-      <stop
-         id="stop15568-0"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         offset="1.0000000" />
-    </radialGradient>
-    <radialGradient
-       xlink:href="#aigrd3-3"
-       id="radialGradient2285-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.229703,0,0,0.229703,4.613529,3.979808)"
-       cx="20.892099"
-       cy="64.567902"
-       fx="20.892099"
-       fy="64.567902"
-       r="5.257" />
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       fy="64.567902"
-       fx="20.892099"
-       r="5.257"
-       cy="64.567902"
-       cx="20.892099"
-       id="aigrd3-3">
-      <stop
-         id="stop15573-7"
-         style="stop-color:#F0F0F0"
-         offset="0" />
-      <stop
-         id="stop15575-5"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         offset="1.0000000" />
-    </radialGradient>
-    <radialGradient
-       r="117.14286"
-       fy="486.64789"
-       fx="605.71429"
-       cy="486.64789"
-       cx="605.71429"
-       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3115"
-       xlink:href="#linearGradient5060" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient5029-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient5031-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
-       r="86.70845"
-       fy="35.736916"
-       fx="33.966679"
-       cy="35.736916"
-       cx="33.966679"
-       gradientTransform="matrix(0.93681254,0,0,1.0682567,0.57527068,-48.738688)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient15658-9"
-       xlink:href="#linearGradient259" />
-    <radialGradient
-       r="37.751713"
-       fy="40.640011"
-       fx="4.4163604"
-       cy="40.640011"
-       cx="4.4163604"
-       gradientTransform="matrix(0.94440073,0,0,1.0596738,3.8461434,-48.075399)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient15656-7"
-       xlink:href="#linearGradient269" />
-    <radialGradient
-       r="38.158695"
-       fy="7.2678967"
-       fx="8.1435566"
-       cy="7.2678967"
-       cx="8.1435566"
-       gradientTransform="matrix(0.88587294,0,0,1.0079919,5.084766,-46.852959)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient15668-0"
-       xlink:href="#linearGradient15662" />
-    <radialGradient
-       xlink:href="#aigrd2-6"
-       id="radialGradient2283-0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.229703,0,0,0.229703,4.613529,3.979808)"
-       cx="20.892099"
-       cy="114.5684"
-       fx="20.892099"
-       fy="114.5684"
-       r="5.256" />
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       fy="114.5684"
-       fx="20.892099"
-       r="5.256"
-       cy="114.5684"
-       cx="20.892099"
-       id="aigrd2-6">
-      <stop
-         id="stop15566-3"
-         style="stop-color:#F0F0F0"
-         offset="0" />
-      <stop
-         id="stop15568-2"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         offset="1.0000000" />
-    </radialGradient>
-    <radialGradient
-       xlink:href="#aigrd3-6"
-       id="radialGradient2285-0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.229703,0,0,0.229703,4.613529,3.979808)"
-       cx="20.892099"
-       cy="64.567902"
-       fx="20.892099"
-       fy="64.567902"
-       r="5.257" />
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       fy="64.567902"
-       fx="20.892099"
-       r="5.257"
-       cy="64.567902"
-       cx="20.892099"
-       id="aigrd3-6">
-      <stop
-         id="stop15573-1"
-         style="stop-color:#F0F0F0"
-         offset="0" />
-      <stop
-         id="stop15575-55"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         offset="1.0000000" />
-    </radialGradient>
-    <radialGradient
-       r="117.14286"
-       fy="486.64789"
-       fx="605.71429"
-       cy="486.64789"
-       cx="605.71429"
-       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3187"
-       xlink:href="#linearGradient5060" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient5029-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
-       r="117.14286"
-       fy="486.64789"
-       fx="605.71429"
-       cy="486.64789"
-       cx="605.71429"
-       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3255"
-       xlink:href="#linearGradient5060" />
-    <radialGradient
-       r="86.70845"
-       fy="35.736916"
-       fx="33.966679"
-       cy="35.736916"
-       cx="33.966679"
-       gradientTransform="matrix(1.3225497,0,0,1.4752117,-18.091662,-66.151727)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient15658-8"
-       xlink:href="#linearGradient259" />
-    <radialGradient
-       r="37.751713"
-       fy="37.388847"
-       fx="3.3431637"
-       cy="37.388847"
-       cx="3.3431637"
-       gradientTransform="matrix(1.3332625,0,0,1.4633592,-13.473991,-65.235756)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient15656-8"
-       xlink:href="#linearGradient269" />
-    <radialGradient
-       r="38.158695"
-       fy="7.2678967"
-       fx="8.1435566"
-       cy="7.2678967"
-       cx="8.1435566"
-       gradientTransform="matrix(1.3004371,0,0,1.4315028,-12.790081,-64.443402)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient15668-4"
-       xlink:href="#linearGradient15662" />
-    <radialGradient
-       xlink:href="#aigrd2-7"
-       id="radialGradient2283-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.229703,0,0,0.229703,4.613529,3.979808)"
-       cx="20.892099"
-       cy="114.5684"
-       fx="20.892099"
-       fy="114.5684"
-       r="5.256" />
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       fy="114.5684"
-       fx="20.892099"
-       r="5.256"
-       cy="114.5684"
-       cx="20.892099"
-       id="aigrd2-7">
-      <stop
-         id="stop15566-4"
-         style="stop-color:#F0F0F0"
-         offset="0" />
-      <stop
-         id="stop15568-27"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         offset="1.0000000" />
-    </radialGradient>
-    <radialGradient
-       xlink:href="#aigrd3-7"
-       id="radialGradient2285-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.229703,0,0,0.229703,4.613529,3.979808)"
-       cx="20.892099"
-       cy="64.567902"
-       fx="20.892099"
-       fy="64.567902"
-       r="5.257" />
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       fy="64.567902"
-       fx="20.892099"
-       r="5.257"
-       cy="64.567902"
-       cx="20.892099"
-       id="aigrd3-7">
-      <stop
-         id="stop15573-9"
-         style="stop-color:#F0F0F0"
-         offset="0" />
-      <stop
-         id="stop15575-3"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         offset="1.0000000" />
-    </radialGradient>
-    <radialGradient
-       r="117.14286"
-       fy="486.64789"
-       fx="605.71429"
-       cy="486.64789"
-       cx="605.71429"
-       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3172"
-       xlink:href="#linearGradient5060" />
-    <linearGradient
-       xlink:href="#linearGradient4200"
-       id="linearGradient4206"
-       x1="23.269085"
-       y1="34.403625"
-       x2="19.161451"
-       y2="22.080725"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4200">
-      <stop
-         style="stop-color:#888a85;stop-opacity:1"
-         offset="0"
-         id="stop4202" />
-      <stop
-         style="stop-color:#d3d7cf;stop-opacity:1"
-         offset="1"
-         id="stop4204" />
-    </linearGradient>
-    <linearGradient
        xlink:href="#linearGradient3815"
-       id="linearGradient3781"
-       x1="10"
-       y1="39.999996"
-       x2="53"
-       y2="25.999996"
+       id="linearGradient1"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-48.000004,-1.4697266e-8)" />
+       gradientTransform="matrix(0.66067504,0,0,0.63929414,18.06576,5.8678762)"
+       x1="53.257175"
+       y1="19.086002"
+       x2="25.928942"
+       y2="-1.3815211" />
   </defs>
-  <g
-     id="layer1">
-    <rect
-       transform="matrix(0.92408158,0.38219528,-0.75246174,0.65863596,0,0)"
-       y="6.2172832"
-       x="31.989382"
-       height="27.016869"
-       width="39.045357"
-       id="rect2993-0"
-       style="color:#000000;fill:url(#linearGradient3813);fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2.1126256;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       id="rect2993-0-9-3-6"
-       d="M 25.30824,18.773895 57.151731,31.961211 40.212355,46.74742 8.2994962,33.560104 z"
-       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  </g>
   <metadata
      id="metadata5826">
     <rdf:RDF>
@@ -675,10 +43,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>Draft_Layer</dc:title>
-        <cc:license
-           rdf:resource="" />
-        <dc:date>Tue Jun 10 10:21:01 2014 -0300</dc:date>
+        <dc:title>Draft_NewLayer</dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[Yorik van Havre]</dc:title>
@@ -694,7 +59,7 @@
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Layer.svg</dc:identifier>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_NewLayer.svg</dc:identifier>
         <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:contributor>
           <cc:Agent>
@@ -709,12 +74,52 @@
             <rdf:li>stack</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:description>Three pages or rectangles stacked on top of each other. Previously VisGroup.</dc:description>
+        <dc:description>A layer with a plus sign on its bottom right corner.</dc:description>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
       </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
     </rdf:RDF>
   </metadata>
-  <path
-     d="m 63.172393,24.734089 a 15,15 0 0 1 -30,0 15,15 0 1 1 30,0 z"
-     id="path12511"
-     style="color:#000000;display:block;visibility:visible;fill:url(#radialGradient278);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.25;marker:none" />
+  <g
+     id="layer2"
+     style="display:inline;stroke-width:0.653981"
+     transform="matrix(1.5298962,0,0,1.5282988,-16.690014,-13.850775)">
+    <path
+       d="M 27.250224,20.840975 50.127593,30.001487 37.05481,40.470644 14.177442,31.310132 Z"
+       style="display:inline;overflow:visible;fill:url(#linearGradient1);fill-rule:evenodd;stroke:#2e3436;stroke-width:1.30796;stroke-linejoin:round;stroke-dasharray:none;marker:none;enable-background:accumulate"
+       id="path1-2-9" />
+    <path
+       id="path3-5"
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.30796;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 16.744141,30.928014 c 6.697265,2.682292 13.394531,5.364583 20.091797,8.046875 3.574869,-2.863281 7.149739,-5.726563 10.724609,-8.589844 -6.697266,-2.682292 -13.394531,-5.364583 -20.091797,-8.046875 -3.57487,2.863281 -7.14974,5.726563 -10.724609,8.589844 z" />
+  </g>
+  <g
+     id="g5"
+     style="stroke:#2e3436">
+    <circle
+       style="fill:#eeeeec;stroke:#2e3436;stroke-width:2.00001;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       id="path2"
+       cx="46"
+       cy="46"
+       r="14.999995" />
+    <path
+       id="path1"
+       style="fill:#8ae234;stroke:#2e3436;stroke-width:1.99998;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="m 44,36 h 4 v 8 h 8 v 4 h -8 v 8 h -4 v -8 h -8 v -4 h 8 z" />
+  </g>
 </svg>

--- a/src/Mod/Draft/Resources/icons/Draft_SelectGroup.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_SelectGroup.svg
@@ -1,423 +1,111 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    id="svg3612"
-   height="64px"
-   width="64px">
+   height="64"
+   width="64"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs3614">
-    <marker
-       style="overflow:visible"
-       id="Arrow1Lstart"
-       refX="0.0"
-       refY="0.0"
-       orient="auto">
-      <path
-         transform="scale(0.8) translate(12.5,0)"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt;marker-start:none"
-         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
-         id="path3809" />
-    </marker>
+     id="defs1">
     <linearGradient
-       id="linearGradient3144-6">
+       id="linearGradient4680">
       <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
          offset="0"
+         id="stop4676" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="1"
+         id="stop4678" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="54.889133"
+       x2="56.859715"
+       y1="10"
+       x1="7.421875"
+       id="linearGradient3961"
+       xlink:href="#linearGradient4680" />
+    <linearGradient
+       xlink:href="#linearGradient3765"
+       id="linearGradient3771"
+       x1="35"
+       y1="51"
+       x2="31"
+       y2="18"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3765">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="0"
+         id="stop3767" />
+      <stop
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3146-9" />
-      <stop
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3148-2" />
+         id="stop3769" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3701">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3703" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3705" />
-    </linearGradient>
-    <radialGradient
-       r="34.345188"
-       fy="672.79736"
-       fx="225.26402"
-       cy="672.79736"
-       cx="225.26402"
-       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       xlink:href="#linearGradient3774"
+       id="linearGradient4274"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3688"
-       xlink:href="#linearGradient3144-6" />
+       gradientTransform="matrix(4.362888,0,0,4.698495,-3540.6062,-4138.7958)"
+       x1="820.69635"
+       y1="889.81598"
+       x2="817.02905"
+       y2="886.41058" />
     <linearGradient
-       id="linearGradient3708">
+       id="linearGradient3774">
       <stop
+         style="stop-color:#4e9a06;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3710" />
+         id="stop3776" />
       <stop
+         style="stop-color:#8ae234;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3712" />
+         id="stop3778" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3864-0-0">
-      <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
-         offset="0"
-         id="stop3866-5-7" />
-      <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
-         offset="1"
-         id="stop3868-7-6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3377">
-      <stop
-         style="stop-color:#ffaa00;stop-opacity:1;"
-         offset="0"
-         id="stop3379" />
-      <stop
-         style="stop-color:#faff2b;stop-opacity:1;"
-         offset="1"
-         id="stop3381" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3864-0">
-      <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
-         offset="0"
-         id="stop3866-5" />
-      <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
-         offset="1"
-         id="stop3868-7" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         offset="0"
-         style="stop-color:black;stop-opacity:0;" />
-      <stop
-         style="stop-color:black;stop-opacity:1;"
-         offset="0.5"
-         id="stop5056" />
-      <stop
-         id="stop5052"
-         offset="1"
-         style="stop-color:black;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3841-0-3">
-      <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
-         offset="0"
-         id="stop3843-1-3" />
-      <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
-         offset="1"
-         id="stop3845-0-8" />
-    </linearGradient>
-    <radialGradient
-       id="aigrd2"
-       cx="20.892099"
-       cy="114.5684"
-       r="5.256"
-       fx="20.892099"
-       fy="114.5684"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         offset="0"
-         style="stop-color:#F0F0F0"
-         id="stop15566" />
-      <stop
-         offset="1.0000000"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         id="stop15568" />
-    </radialGradient>
-    <radialGradient
-       id="aigrd3"
-       cx="20.892099"
-       cy="64.567902"
-       r="5.257"
-       fx="20.892099"
-       fy="64.567902"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         offset="0"
-         style="stop-color:#F0F0F0"
-         id="stop15573" />
-      <stop
-         offset="1.0000000"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         id="stop15575" />
-    </radialGradient>
-    <linearGradient
-       id="linearGradient15662">
-      <stop
-         id="stop15664"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop15666"
-         offset="1.0000000"
-         style="stop-color:#f8f8f8;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient259"
-       id="radialGradient4452"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.96049297,0,0,1.041132,-52.144249,-702.33158)"
-       cx="33.966679"
-       cy="35.736916"
-       fx="33.966679"
-       fy="35.736916"
-       r="86.70845" />
-    <linearGradient
-       id="linearGradient259">
-      <stop
-         id="stop260"
-         offset="0.0000000"
-         style="stop-color:#fafafa;stop-opacity:1.0000000;" />
-      <stop
-         id="stop261"
-         offset="1.0000000"
-         style="stop-color:#bbbbbb;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient269"
-       id="radialGradient4454"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.96827297,0,0,1.032767,-48.790699,-701.68513)"
-       cx="8.824419"
-       cy="3.7561285"
-       fx="8.824419"
-       fy="3.7561285"
-       r="37.751713" />
-    <linearGradient
-       id="linearGradient269">
-      <stop
-         id="stop270"
-         offset="0.0000000"
-         style="stop-color:#a3a3a3;stop-opacity:1.0000000;" />
-      <stop
-         id="stop271"
-         offset="1.0000000"
-         style="stop-color:#4c4c4c;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4095">
-      <stop
-         id="stop4097"
-         offset="0"
-         style="stop-color:#005bff;stop-opacity:1;" />
-      <stop
-         id="stop4099"
-         offset="1"
-         style="stop-color:#c1e3f7;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)"
-       gradientUnits="userSpaceOnUse"
-       y2="140.22731"
-       x2="434.73947"
-       y1="185.1304"
-       x1="394.15784"
-       id="linearGradient4253"
-       xlink:href="#linearGradient4247" />
-    <linearGradient
-       id="linearGradient4247">
-      <stop
-         id="stop4249"
-         offset="0"
-         style="stop-color:#2e8207;stop-opacity:1;" />
-      <stop
-         id="stop4251"
-         offset="1"
-         style="stop-color:#52ff00;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4247"
-       id="linearGradient5087"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)"
-       x1="394.15784"
-       y1="185.1304"
-       x2="434.73947"
-       y2="140.22731" />
   </defs>
   <g
-     id="layer1">
+     id="layer1"
+     style="display:inline">
     <path
-       style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 8.999987,12.999996 0,32 14.000001,0"
-       id="path5098-3" />
+       id="rect15391"
+       d="M 19.578125,8 5.4042969,8.0058594 C 5.1706901,8.005955 4.9999125,8.2113736 5,8.4667969 V 55.617188 C 5.0003146,56.383475 5.677268,57.000287 6.5175781,57 L 57.5,56.982422 c 0.84031,-2.87e-4 1.517893,-0.618479 1.517578,-1.384766 L 59,16.382812 C 58.999685,15.616525 58.322732,14.999713 57.482422,15 H 25 Z"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;fill:url(#linearGradient3961);fill-opacity:1;fill-rule:nonzero;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
     <path
-       style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="M 23,29 8.999999,29"
-       id="path5100-6" />
+       id="rect15391-2"
+       d="M 18.578125,10 H 7.421875 C 7.1882682,10.000096 6.9999125,10.205514 7,10.460938 V 54 c 0,1 0,1 1,1 h 48 c 1,0 1,0 1,-1 V 18 c 0,-1 0,-1 -1,-1 H 24 Z"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  </g>
+  <g
+     id="g4259"
+     style="stroke-width:59.8044;stroke-dasharray:none">
     <path
-       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 8.999987,12.999996 0,32 14.000001,0"
-       id="path5098-1" />
+       id="rect4261"
+       style="opacity:1;fill:#8ae234;stroke:#172a04;stroke-width:2;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 21,23 H 43 V 45 H 21 Z" />
     <path
-       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="M 23,29 8.999999,29"
-       id="path5100-7" />
-    <rect
-       style="color:#000000;fill:#eeeeec;stroke:#2e3436;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect4258-1-7-4-4"
-       width="37.999989"
-       height="10"
-       x="3"
-       y="3"
-       rx="0"
-       ry="0" />
-    <rect
-       style="color:#000000;fill:#3465a4;stroke:#0b1521;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect4258-1-7-4-7"
-       width="28"
-       height="10"
-       x="23"
-       y="25"
-       rx="0"
-       ry="0" />
-    <rect
-       y="27"
-       x="24.806452"
-       height="5.9999914"
-       width="24.387096"
-       id="rect3852"
-       style="fill:#3465a4;fill-opacity:1;stroke:#729fcf;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <rect
-       y="5"
-       x="5"
-       height="6"
-       width="34"
-       id="rect3852-5-3"
-       style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <rect
-       style="color:#000000;fill:#3465a4;stroke:#0b1521;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect4258-1-7-4-7-0"
-       width="28"
-       height="10"
-       x="23"
-       y="41"
-       rx="0"
-       ry="0" />
-    <rect
-       y="43"
-       x="24.806452"
-       height="6"
-       width="24.387094"
-       id="rect3852-9"
-       style="fill:#3465a4;fill-opacity:1;stroke:#729fcf;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       id="path3953-1"
-       d="m 20.999999,19 4,0"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3957-5"
-       d="M 53.000001,19 C 57,19 57,19 57,19"
-       style="fill:none;stroke:#204a87;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1"
-       d="m 20.999999,19 4,0"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3957-5-8"
-       d="M 53.000001,19 C 57,19 57,19 57,19"
-       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-5"
-       d="m 37,19 4,0"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-7"
-       d="m 37,19 4,0"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-6"
-       d="m 19,57 4,0"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3957-5-1"
-       d="m 51.000002,57 c 3.999999,0 3.999999,0 3.999999,0"
-       style="fill:none;stroke:#204a87;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-8"
-       d="m 19,57 4,0"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3957-5-8-9"
-       d="m 51.000002,57 c 3.999999,0 3.999999,0 3.999999,0"
-       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-5-2"
-       d="m 35.000001,57 4,0"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-7-7"
-       d="m 35.000001,57 4,0"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-9"
-       d="M 17,26.999999 17,31"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-4"
-       d="M 17,26.999999 17,31"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-5-1"
-       d="M 17,43.000001 17,47"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-7-2"
-       d="M 17,43.000001 17,47"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-9-3"
-       d="M 57,28.999999 57,33"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-4-3"
-       d="M 57,28.999999 57,33"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-5-1-4"
-       d="M 57,45.000001 57,49"
-       style="fill:none;stroke:#204a87;stroke-width:5.99999952000000030;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path3953-1-1-7-2-1"
-       d="M 57,45.000001 57,49"
-       style="fill:none;stroke:#729fcf;stroke-width:1.99999988000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+       id="rect4263"
+       style="opacity:1;fill:url(#linearGradient4274);stroke-width:59.8044;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 24,26 H 40 V 42 H 24 Z" />
   </g>
   <metadata
-     id="metadata5469">
+     id="metadata4251">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
         <cc:license
            rdf:resource="" />
-        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
-        <dc:creator>
-          <cc:Agent>
-            <dc:title>[wmayer]</dc:title>
-          </cc:Agent>
-        </dc:creator>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -430,21 +118,32 @@
         </dc:publisher>
         <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_SelectGroup.svg</dc:identifier>
         <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
-        <dc:contributor>
-          <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
-          </cc:Agent>
-        </dc:contributor>
         <dc:subject>
           <rdf:Bag>
-            <rdf:li>hierarchy</rdf:li>
-            <rdf:li>group</rdf:li>
-            <rdf:li>selection</rdf:li>
-            <rdf:li>tree</rdf:li>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>page</rdf:li>
+            <rdf:li>shapes</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:description>A hierarchical tree structure with two blue child elements of a white parent element, both of which are surrounded by the same dotted box</dc:description>
+        <dc:description>A cursor arrow pointing from left to right onto a folder with an square object on it</dc:description>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     transform="rotate(90,38.5,36.5)"
+     id="g4636"
+     style="display:inline">
+    <g
+       transform="matrix(0,0.54545355,0.54545355,0,31.90919,10.181783)"
+       id="g4147">
+      <path
+         id="path3761"
+         d="M 7,49 15,57 35,37 41,49 57,7 15,23 27,29 Z"
+         style="fill:url(#linearGradient3771);fill-opacity:1;stroke:#2e3436;stroke-width:3.66667;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3763"
+         d="M 10.962357,49 31.571972,28.196969 21.91667,23.314394 52.305932,11.59872 40.631925,42.093042 35.82706,32.778233 15.095348,53.132991 Z"
+         style="fill:none;stroke:#ffffff;stroke-width:1.83334;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
 </svg>


### PR DESCRIPTION
### Issues
Part of [Draft/BIM - Icon updates task ](https://github.com/FreeCAD/FreeCAD/issues/13895) and [Draft: implement Draft_AddToLayer](https://github.com/FreeCAD/FreeCAD/pull/19427).

Icons used for the Draft Group and Layers are updated and simplified:
- `Draft_AddNamedGroup` is updated to use the similar Folder element as other Group icons.
- `Draft_SelectGroup` is updated to use the same element, with a cursor arrow and a green element like Box selection.
- `Draft_AddToGroup` is updated to use the same element, with plus and minus signs as this Tool can do both.
- `Draft_AddConstruction` and `Draft_AddToLayer` are slightly updated to be closer to the above.
- `Draft_NewLayer` is updated to use a similar plus sign as the New Document, New Techdraw Page and the updated `Draft_AddNamedGroup`.

The corresponding GUI `Std_SelectGroupContents` icon is updated for consistency as well.

### Before (Left) and After (Right) Images

![draft](https://github.com/user-attachments/assets/0c521d52-5bd9-451f-aac0-a276f2b63460)

> [!NOTE]  
> Documentation update is done via the unofficial [Documentation Project repo](https://github.com/Reqrefusion/FreeCAD-Documentation-Project).