### PR TITLE
[CAM] regression fix: migrate old tools to new system

### DIFF
--- a/src/Mod/CAM/Path/Tool/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Controller.py
@@ -148,6 +148,21 @@ class ToolController:
         return data
 
     def onDocumentRestored(self, obj):
+        self.ensureToolBit(obj)
+        if not obj.Tool.Proxy:
+            if hasattr(obj.Tool, "ShapeName") or hasattr(obj.Tool, "ShapeType"):
+                # Old tool file; perform migration
+                shape_name = (
+                    obj.Tool.ShapeType if hasattr(obj.Tool, "ShapeType") else obj.Tool.ShapeName
+                ).lower()
+                tool_data = {
+                    "name": obj.Tool.Label,
+                    "shape": shape_name,
+                    "shape-type": shape_name,
+                }
+                toolbit_instance = ToolBit.from_dict(tool_data)
+                toolbit_instance.onDocumentRestored(obj.Tool)
+
         obj.setEditorMode("Placement", 2)
 
     def onDelete(self, obj, arg2=None):


### PR DESCRIPTION
@sliptonic @Connor9220 fixes regression in loading old tools, for the release

Fixes #22464 (`'NoneType' object has no attribute 'get_spindle_direction'`)

Here's my current understanding of #22464 and how I address it:

Save files store tools as xml objects with a string reference to their python class. Old tools were `Path.Tool.Bit.ToolBit` python objects. For example (unzip the test file from the issue, look at Document.xml)

```
<Property name="Proxy" type="App::PropertyPythonObject">
        <Python value="bnVsbA==" encoded="yes" module="Path.Tool.Bit" class="ToolBit"/>
</Property>
```

Unfortunately, the file `src/Mod/CAM/)Path/Tool/Bit.py` no longer exists, as of
```
commit d749098dcb2093d3363c7325c2c4d2004c5dc3a4
Author: Samuel Abels <knipknap@gmail.com>
Date:   Mon May 19 20:25:00 2025 +0200

    CAM: Replace complete tool management (PR 21425)

diff --git a/src/Mod/CAM/Path/Tool/Bit.py b/src/Mod/CAM/Path/Tool/Bit.py
deleted file mode 100644
index b2b2905128..0000000000
--- a/src/Mod/CAM/Path/Tool/Bit.py
+++ /dev/null
```

I'm not sure where the relevant code is for deserializing python objects from xml, but evidently its behavior when the stored class no longer exists is that it silently does not create the object. This results in `tc.Tool.Proxy = None`, and later when we try to call `get_spindle_direction` on that object it produces an error.

The same commit added some migration pathways, but none of them seem to be invoked in this case. I decided to chain together pieces of two of them to migrate old tools:

1. ToolController invokes `from_dict` to create a `ToolBit` from data stored in a key/value system for job templates. I copied this usage to create a minimally initialized object of the appropriate subclass of `ToolBit`, using a minimal "template" dictionary constructed from stored object parameters.

2. `toolBit.onDocumentRestored` is expected to perform the migration to the new system, but it is only called if a `ToolBit` is restored from the save file. Since I am creating the new `ToolBit` object manually, I also invoke `onDocumentRestored` manually. I do this within the `ToolController`'s restore method

I'm not certain this is 100% the correct fix, but it seems to work and the logic makes sense to me. Hopefully it's at least close enough to the correct fix to close our outstanding bugs :)