### PR TITLE
Add system accent color support to theme settings

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsUI.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsUI.cpp
@@ -34,11 +34,29 @@
 #include "Dialogs/DlgThemeEditor.h"
 
 #include <Base/ServiceProvider.h>
+// Qt headers
+#include <QColor>
+#include <QApplication>
+// Base color packing helpers
+#include <Base/Color.h>
+// platform headers for system accent color
+#ifdef FC_OS_WIN32
+#  include <windows.h>
+#  include <dwmapi.h>
+#  pragma comment(lib, "dwmapi.lib")
+#endif
+#ifdef FC_OS_MACOSX
+#  include <CoreFoundation/CoreFoundation.h>
+#endif
 
 
 using namespace Gui::Dialog;
 
 /* TRANSLATOR Gui::Dialog::DlgSettingsUI */
+
+namespace {
+QColor getSystemAccentColor();
+}
 
 /**
  *  Constructs a DlgSettingsUI which is a child of 'parent', with the
@@ -50,9 +68,103 @@ DlgSettingsUI::DlgSettingsUI(QWidget* parent)
 {
     ui->setupUi(this);
 
-    connect(ui->themeEditorButton, &QPushButton::clicked, [this]() {
-        openThemeEditor();
-    });
+    connect(ui->themeEditorButton, &QPushButton::clicked, [this]() { openThemeEditor(); });
+
+    // helper: update preview color and enable/disable pickers
+    auto updateAccentUi = [this]() {
+        QColor accent;
+        bool useSystem = false;
+
+        if (ui->UseSystemAccentColors) {
+            useSystem = ui->UseSystemAccentColors->isChecked();
+        }
+
+        // If using system accent, prefer the stored ThemeAccentColor1 so the
+        // preview matches the persisted setting; fall back to runtime system
+        // accent if the parameter is not present.
+        if (useSystem) {
+            auto hGrpThemes = App::GetApplication().GetParameterGroupByPath(
+                "User parameter:BaseApp/Preferences/Themes");
+            unsigned long stored = hGrpThemes->GetUnsigned("ThemeAccentColor1", 0);
+            if (stored != 0) {
+                int a = (int)((stored >> 24) & 0xFF);
+                int r = (int)((stored >> 16) & 0xFF);
+                int g = (int)((stored >> 8) & 0xFF);
+                int b = (int)(stored & 0xFF);
+                if (a == 0) a = 255;
+                accent = QColor(r, g, b, a);
+            }
+            if (!accent.isValid()) {
+                accent = getSystemAccentColor();
+            }
+            // normalize alpha to opaque for consistent rendering
+            accent.setAlpha(255);
+            // ensure the pref button shows the same color even when disabled
+            if (ui->ThemeAccentColor1) {
+                ui->ThemeAccentColor1->setColor(accent);
+            }
+        } else {
+            accent = getSystemAccentColor();
+        }
+
+        // set preview background
+        if (ui->SystemAccentPreview) {
+            // ensure opaque preview
+            QColor previewColor = accent;
+            previewColor.setAlpha(255);
+            QString style = QStringLiteral("background-color: %1; border: 1px solid %2;")
+                .arg(previewColor.name(QColor::HexArgb))
+                .arg(previewColor.darker(250).name());
+            ui->SystemAccentPreview->setStyleSheet(style);
+        }
+
+        // enable/disable pickers based on checkbox state — only disable
+        // the primary accent picker. Secondary tones remain editable.
+        if (ui->UseSystemAccentColors) {
+            ui->ThemeAccentColor1->setEnabled(!useSystem);
+            // keep ThemeAccentColor2/3 editable so users can tweak variants
+            // even when following the OS accent for the primary tone.
+            ui->ThemeAccentColor2->setEnabled(true);
+            ui->ThemeAccentColor3->setEnabled(true);
+            // gray out preview when not using system accent
+            ui->SystemAccentPreview->setEnabled(useSystem);
+            ui->SystemAccentPreview->setWindowOpacity(useSystem ? 1.0 : 0.45);
+        }
+    };
+
+    if (ui->UseSystemAccentColors) {
+        connect(ui->UseSystemAccentColors, &Gui::PrefCheckBox::toggled, this, [this, updateAccentUi](bool on){
+            updateAccentUi();
+            if (on) {
+                // persist the system accent colors immediately into the Themes group
+                QColor accent = getSystemAccentColor();
+                auto hGrpThemes = App::GetApplication().GetParameterGroupByPath(
+                    "User parameter:BaseApp/Preferences/Themes");
+                // Use the same packed RGBA format as PrefColorButton
+                unsigned int icol = Base::Color::asPackedRGBA<QColor>(accent);
+                unsigned long val1 = static_cast<unsigned long>(icol);
+                unsigned long val2 = val1; // start from same base, will darken/lighen using QColor
+                unsigned long val3 = val1;
+                QColor c2 = accent.darker(115);
+                QColor c3 = accent.lighter(140);
+                val2 = ((unsigned long)c2.alpha() << 24) | ((unsigned long)c2.red() << 16) |
+                       ((unsigned long)c2.green() << 8) | (unsigned long)c2.blue();
+                val3 = ((unsigned long)c3.alpha() << 24) | ((unsigned long)c3.red() << 16) |
+                       ((unsigned long)c3.green() << 8) | (unsigned long)c3.blue();
+                // Persist only the primary accent color. Windows exposes
+                // multiple accent tones, but we only store ThemeAccentColor1
+                // here to keep behavior deterministic and avoid overwriting
+                // user-customized secondary tones.
+                hGrpThemes->SetUnsigned("ThemeAccentColor1", val1);
+                // Immediately restore the pref button from the parameter so
+                // the UI matches the persisted value (avoids transient
+                // mismatch between preview and button rendering).
+                if (ui->ThemeAccentColor1) {
+                    ui->ThemeAccentColor1->onRestore();
+                }
+            }
+        });
+    }
 }
 
 /**
@@ -66,8 +178,26 @@ void DlgSettingsUI::saveSettings()
     ui->ThemeAccentColor1->onSave();
     ui->ThemeAccentColor2->onSave();
     ui->ThemeAccentColor3->onSave();
+    ui->UseSystemAccentColors->onSave();
     ui->StyleSheets->onSave();
     ui->OverlayStyleSheets->onSave();
+
+    // If using system accent colors, persist the computed values into the Themes group
+    if (ui->UseSystemAccentColors && ui->UseSystemAccentColors->isChecked()) {
+        QColor accent = getSystemAccentColor();
+        auto hGrpThemes = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Themes");
+    unsigned int icol = Base::Color::asPackedRGBA<QColor>(accent);
+    unsigned long val1 = static_cast<unsigned long>(icol);
+        QColor c2 = accent.darker(115);
+        QColor c3 = accent.lighter(140);
+        unsigned long val2 = ((unsigned long)c2.alpha() << 24) | ((unsigned long)c2.red() << 16) |
+                            ((unsigned long)c2.green() << 8) | (unsigned long)c2.blue();
+        unsigned long val3 = ((unsigned long)c3.alpha() << 24) | ((unsigned long)c3.red() << 16) |
+                            ((unsigned long)c3.green() << 8) | (unsigned long)c3.blue();
+    // Persist only the primary accent color (ThemeAccentColor1).
+    hGrpThemes->SetUnsigned("ThemeAccentColor1", val1);
+    }
 
     // Tree View
     ui->iconSizeSpinBox->onSave();
@@ -97,6 +227,39 @@ void DlgSettingsUI::loadSettings()
     ui->ThemeAccentColor1->onRestore();
     ui->ThemeAccentColor2->onRestore();
     ui->ThemeAccentColor3->onRestore();
+    ui->UseSystemAccentColors->onRestore();
+
+    // If available, override the accent color widgets with the OS accent color
+    // so the UI matches the system look-and-feel. We compute two simple
+    // variants for accent2/3 (darker/lighter).
+    QColor systemAccent = getSystemAccentColor();
+
+    if (systemAccent.isValid()) {
+        // Only override if the stored theme accent is missing or still the
+        // default that comes with the preference pack. This avoids clobbering
+        // explicit user choices.
+        auto hGrpThemes = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Themes");
+        const unsigned long nonExistentColor = -1434171135;
+        const unsigned long defaultAccentColor = 1434171135;
+        unsigned long stored = hGrpThemes->GetUnsigned("ThemeAccentColor1", nonExistentColor);
+        if (stored == nonExistentColor || stored == defaultAccentColor) {
+            ui->ThemeAccentColor1->setColor(systemAccent);
+            ui->ThemeAccentColor2->setColor(systemAccent.darker(115));
+            ui->ThemeAccentColor3->setColor(systemAccent.lighter(140));
+        }
+    }
+
+    // Respect the use-system-accent checkbox: if enabled, disable manual pickers
+    bool useSystem = false;
+    if (ui->UseSystemAccentColors) {
+        // PrefCheckBox stores a boolean
+        useSystem = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Themes")->GetBool("UseSystemAccentColors", false);
+        ui->ThemeAccentColor1->setEnabled(!useSystem);
+        ui->ThemeAccentColor2->setEnabled(!useSystem);
+        ui->ThemeAccentColor3->setEnabled(!useSystem);
+    }
 
     // Tree View
     ui->iconSizeSpinBox->onRestore();
@@ -118,6 +281,25 @@ void DlgSettingsUI::loadSettings()
 
     // TaskWatcher
     ui->showTaskWatcherCheckBox->onRestore();
+
+    // update preview color and preview/picker enable state (initial)
+    QColor systemAccentColor = getSystemAccentColor();
+    if (ui->SystemAccentPreview) {
+        QString style = QStringLiteral("background-color: %1; border: 1px solid %2;")
+            .arg(systemAccentColor.name(QColor::HexArgb))
+            .arg(systemAccentColor.darker(250).name());
+        ui->SystemAccentPreview->setStyleSheet(style);
+    }
+
+    if (ui->UseSystemAccentColors) {
+        // useSystem was earlier read to enable/disable pickers; maintain preview state
+        bool useSystemPreview = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Themes")->GetBool("UseSystemAccentColors", false);
+        if (ui->SystemAccentPreview) {
+            ui->SystemAccentPreview->setEnabled(useSystemPreview);
+            ui->SystemAccentPreview->setWindowOpacity(useSystemPreview ? 1.0 : 0.45);
+        }
+    }
 
     loadStyleSheet();
 }
@@ -221,6 +403,63 @@ void applyStyleSheet(ParameterGrp *hGrp)
 }
 
 } // anonymous namespace
+
+// system accent helper (Windows DWM, macOS preferences, Qt fallback)
+namespace {
+QColor getSystemAccentColor()
+{
+#ifdef FC_OS_WIN32
+    DWORD color = 0;
+    BOOL opaque = FALSE;
+    if (SUCCEEDED(DwmGetColorizationColor(&color, &opaque))) {
+        int a = (int)((color >> 24) & 0xFF);
+        int r = (int)((color >> 16) & 0xFF);
+        int g = (int)((color >> 8) & 0xFF);
+        int b = (int)(color & 0xFF);
+        if (a == 0) a = 255;
+        return QColor(r, g, b, a);
+    }
+#endif
+#ifdef FC_OS_MACOSX
+    if (auto val = CFPreferencesCopyAppValue(CFSTR("AppleHighlightColor"), kCFPreferencesAnyApplication)) {
+        if (CFGetTypeID(val) == CFArrayGetTypeID()) {
+            CFIndex count = CFArrayGetCount((CFArrayRef)val);
+            if (count >= 3) {
+                double r = 0, g = 0, b = 0;
+                CFNumberRef num = (CFNumberRef)CFArrayGetValueAtIndex((CFArrayRef)val, 0);
+                CFNumberGetValue(num, kCFNumberDoubleType, &r);
+                num = (CFNumberRef)CFArrayGetValueAtIndex((CFArrayRef)val, 1);
+                CFNumberGetValue(num, kCFNumberDoubleType, &g);
+                num = (CFNumberRef)CFArrayGetValueAtIndex((CFArrayRef)val, 2);
+                CFNumberGetValue(num, kCFNumberDoubleType, &b);
+                CFRelease(val);
+                return QColor::fromRgbF((float)r, (float)g, (float)b);
+            }
+        }
+        CFRelease(val);
+    }
+    if (auto idxVal = CFPreferencesCopyAppValue(CFSTR("AppleAccentColor"), kCFPreferencesAnyApplication)) {
+        if (CFGetTypeID(idxVal) == CFNumberGetTypeID()) {
+            int idx = 0;
+            CFNumberGetValue((CFNumberRef)idxVal, kCFNumberIntType, &idx);
+            CFRelease(idxVal);
+            switch (idx) {
+                case 0: return QColor(128,128,128);
+                case 1: return QColor(255,59,48);
+                case 2: return QColor(255,149,0);
+                case 3: return QColor(255,204,0);
+                case 4: return QColor(52,199,89);
+                case 5: return QColor(0,122,255);
+                case 6: return QColor(88,86,214);
+                default: break;
+            }
+        }
+        CFRelease(idxVal);
+    }
+#endif
+    return qApp->palette().color(QPalette::Highlight);
+}
+} // helper namespace
 
 void DlgSettingsUI::attachObserver()
 {

--- a/src/Gui/PreferencePages/DlgSettingsUI.ui
+++ b/src/Gui/PreferencePages/DlgSettingsUI.ui
@@ -4,10 +4,10 @@
  <widget class="QWidget" name="Gui::Dialog::DlgSettingsUI">
   <property name="geometry">
    <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>405</width>
-    <height>1065</height>
+     <x>0</x>
+     <y>0</y>
+     <width>405</width>
+     <height>1065</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,181 +15,234 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Theme Customization</string>
+     <widget class="QGroupBox" name="groupBox">
+      <property name="title">
+       <string>Theme Customization</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Customize the current theme. The offered settings are optional for theme developers so they may or may not have an effect in the current theme.</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+        </widget>
+       </item>
+  <item>
+   <layout class="QHBoxLayout" name="systemAccentLayout">
+     <item>
+      <widget class="Gui::PrefCheckBox" name="UseSystemAccentColors">
+     <property name="text">
+      <string>Use system accent colors</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
+     <property name="toolTip">
+      <string>Automatically use the operating system accent color instead of manual accent colors.</string>
+     </property>
+     <property name="prefEntry" stdset="0">
+      <cstring>UseSystemAccentColors</cstring>
+     </property>
+     <property name="prefPath" stdset="0">
+      <cstring>Themes</cstring>
+     </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="SystemAccentPreview">
+     <property name="minimumSize">
+      <size>
+       <width>22</width>
+       <height>14</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>22</width>
+       <height>14</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="toolTip">
+      <string>Preview of the system accent color</string>
+     </property>
+      </widget>
+     </item>
+   </layout>
+  </item>
       <item>
-       <widget class="QLabel" name="label">
+      <layout class="QGridLayout" columnstretch="2,1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label1">
         <property name="text">
-         <string>Customize the current theme. The offered settings are optional for theme developers so they may or may not have an effect in the current theme.</string>
+         <string>Accent color 1</string>
         </property>
-        <property name="wordWrap">
-         <bool>true</bool>
+        <property name="buddy">
+         <cstring>ThemeAccentColor1</cstring>
         </property>
        </widget>
       </item>
-      <item>
-       <layout class="QGridLayout" columnstretch="2,1">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label1">
-          <property name="text">
-           <string>Accent color 1</string>
-          </property>
-          <property name="buddy">
-           <cstring>ThemeAccentColor1</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="Gui::PrefColorButton" name="ThemeAccentColor1">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>This color might be used by your theme to let you customize it.</string>
-          </property>
-          <property name="color" stdset="0">
-           <color>
-            <red>85</red>
-            <green>123</green>
-            <blue>182</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ThemeAccentColor1</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Themes</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label2">
-          <property name="text">
-           <string>Accent color 2</string>
-          </property>
-          <property name="buddy">
-           <cstring>ThemeAccentColor2</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label3">
-          <property name="text">
-           <string>Accent color 3</string>
-          </property>
-          <property name="buddy">
-           <cstring>ThemeAccentColor3</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="styleSheetLabel">
-          <property name="text">
-           <string>Style sheet (advanced)</string>
-          </property>
-          <property name="buddy">
-           <cstring>StyleSheets</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Overlay style sheet</string>
-          </property>
-          <property name="buddy">
-           <cstring>OverlayStyleSheets</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="Gui::PrefColorButton" name="ThemeAccentColor2">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>This color might be used by your theme to let you customize it.</string>
-          </property>
-          <property name="color" stdset="0">
-           <color>
-            <red>85</red>
-            <green>123</green>
-            <blue>182</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ThemeAccentColor2</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Themes</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="Gui::PrefColorButton" name="ThemeAccentColor3">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>This color might be used by your theme to let you customize it.</string>
-          </property>
-          <property name="color" stdset="0">
-           <color>
-            <red>85</red>
-            <green>123</green>
-            <blue>182</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ThemeAccentColor3</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Themes</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="Gui::PrefComboBox" name="StyleSheets">
-          <property name="toolTip">
-           <string>Style sheet how user interface will look like</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>StyleSheet</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>MainWindow</cstring>
-          </property>
-          <property name="prefType" stdset="0">
-           <cstring></cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="Gui::PrefComboBox" name="OverlayStyleSheets">
-          <property name="prefEntry" stdset="0">
-           <cstring>OverlayActiveStyleSheet</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>MainWindow</cstring>
-          </property>
-          <property name="prefType" stdset="0">
-           <cstring></cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="0" column="1">
+       <widget class="Gui::PrefColorButton" name="ThemeAccentColor1">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>This color might be used by your theme to let you customize it.</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>85</red>
+          <green>123</green>
+          <blue>182</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ThemeAccentColor1</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Themes</cstring>
+        </property>
+       </widget>
+      </item>
+      <!-- divider between primary accent and secondary accents -->
+      <item row="1" column="0" colspan="2">
+       <widget class="QFrame" name="accentDivider">
+        <property name="frameShape">
+         <enum>QFrame::HLine</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Sunken</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label2">
+        <property name="text">
+         <string>Accent color 2</string>
+        </property>
+        <property name="buddy">
+         <cstring>ThemeAccentColor2</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label3">
+        <property name="text">
+         <string>Accent color 3</string>
+        </property>
+        <property name="buddy">
+         <cstring>ThemeAccentColor3</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="styleSheetLabel">
+        <property name="text">
+         <string>Style sheet (advanced)</string>
+        </property>
+        <property name="buddy">
+         <cstring>StyleSheets</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Overlay style sheet</string>
+        </property>
+        <property name="buddy">
+         <cstring>OverlayStyleSheets</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefColorButton" name="ThemeAccentColor2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>This color might be used by your theme to let you customize it.</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>85</red>
+          <green>123</green>
+          <blue>182</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ThemeAccentColor2</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Themes</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefColorButton" name="ThemeAccentColor3">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>This color might be used by your theme to let you customize it.</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>85</red>
+          <green>123</green>
+          <blue>182</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ThemeAccentColor3</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Themes</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::PrefComboBox" name="StyleSheets">
+        <property name="toolTip">
+         <string>Style sheet how user interface will look like</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>StyleSheet</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>MainWindow</cstring>
+        </property>
+        <property name="prefType" stdset="0">
+         <cstring></cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="Gui::PrefComboBox" name="OverlayStyleSheets">
+        <property name="prefEntry" stdset="0">
+         <cstring>OverlayActiveStyleSheet</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>MainWindow</cstring>
+        </property>
+        <property name="prefType" stdset="0">
+         <cstring></cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
       </item>
       <item>
        <widget class="QPushButton" name="themeEditorButton">


### PR DESCRIPTION
Introduces a 'Use system accent colors' option in the theme customization UI, allowing users to automatically use the OS accent color for the primary accent. The implementation includes platform-specific accent color retrieval (Windows, macOS, Qt fallback), a preview widget, and logic to persist and update accent colors based on system settings, while keeping secondary accent colors editable.

<img width="1802" height="1800" alt="image" src="https://github.com/user-attachments/assets/9c34dd89-1cb8-4014-b56a-85b14e573be5" />

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
