### PR TITLE
Assembly: fix delete shortcut parameter mismatch

### DIFF
--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -1842,7 +1842,7 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
             delete_sequence = Gui.QtTools.deleteKeySequence()
         except AttributeError:
             # fallback to standard key if there is no sequence defined
-            delete_sequence = QtCore.Qt.Key_Delete
+            delete_sequence = QtGui.QKeySequence(QtCore.Qt.Key_Delete)
 
         self.deleteAction = QtGui.QAction("Remove", self.jForm)
         self.deleteAction.setShortcut(delete_sequence)


### PR DESCRIPTION
Fixes: https://github.com/FreeCAD/FreeCAD/issues/23792

- Qt5: https://doc.qt.io/archives/qtforpython-5/PySide2/QtWidgets/QAction.html#PySide2.QtWidgets.PySide2.QtWidgets.QAction.setShortcut
- Qt6: https://doc.qt.io/qtforpython-6/PySide6/QtGui/QAction.html#PySide6.QtGui.QAction.setShortcut

The fix should work for both Qt5 and Qt6.

The Ubuntu CI job runs on Qt5, so I'm puzzled as to why [this test](https://github.com/FreeCAD/FreeCAD/blob/8e7e9c4bbc226917c328f67f653e42769b36b03e/src/Mod/Assembly/AssemblyTests/TestCore.py#L100) did not trigger the issue. @PaddleStroke happy to extend the test either on this PR or on a follow up, but I'd welcome some guidance.