### PR TITLE
Py3.13: fix warnings

### DIFF
--- a/src/3rdParty/PyCXX/CXX/Python3/Config.hxx
+++ b/src/3rdParty/PyCXX/CXX/Python3/Config.hxx
@@ -133,6 +133,10 @@
 typedef long int Py_hash_t;
 #endif
 
+#if PY_VERSION_HEX >= 0x030d0000
+#define Py_UNICODE_DEPRECATED
+#endif
+
 #ifndef PYCXX_PYTHON_2TO3
 #define PYCXX_PYTHON_2TO3
 #endif

--- a/src/3rdParty/PyCXX/CXX/Python3/Objects.hxx
+++ b/src/3rdParty/PyCXX/CXX/Python3/Objects.hxx
@@ -1783,7 +1783,7 @@ namespace Py
     // Python strings return strings as individual elements.
     // I'll try having a class Char which is a String of length 1
     //
-#if !defined(Py_LIMITED_API)
+#if !defined(Py_LIMITED_API) && !defined(Py_UNICODE_DEPRECATED)
     typedef std::basic_string<Py_UNICODE> unicodestring;
     extern Py_UNICODE unicode_null_string[1];
 #endif
@@ -1979,7 +1979,7 @@ namespace Py
             validate();
         }
 
-#if !defined( Py_LIMITED_API )
+#if !defined( Py_LIMITED_API ) && !defined(Py_UNICODE_DEPRECATED)
         Char( Py_UNICODE v )
         : Object( PyUnicode_FromOrdinal( v ), true )
         {
@@ -1987,7 +1987,7 @@ namespace Py
         }
 #endif
 
-#if !defined( Py_LIMITED_API )
+#if !defined( Py_LIMITED_API ) && !defined(Py_UNICODE_DEPRECATED)
         Char( const unicodestring &v )
         : Object( PyUnicode_FromKindAndData( PyUnicode_4BYTE_KIND, const_cast<Py_UNICODE*>( v.data() ),1 ), true )
         {
@@ -2008,7 +2008,7 @@ namespace Py
             return *this;
         }
 
-#if !defined( Py_LIMITED_API )
+#if !defined( Py_LIMITED_API ) && !defined(Py_UNICODE_DEPRECATED)
         Char &operator=( const unicodestring &v )
         {
             set( PyUnicode_FromKindAndData( PyUnicode_4BYTE_KIND, const_cast<Py_UNICODE*>( v.data() ), 1 ), true );
@@ -2016,7 +2016,7 @@ namespace Py
         }
 #endif
 
-#if !defined( Py_LIMITED_API )
+#if !defined( Py_LIMITED_API ) && !defined(Py_UNICODE_DEPRECATED)
         Char &operator=( int v_ )
         {
             Py_UNICODE v( v_ );
@@ -2025,7 +2025,7 @@ namespace Py
         }
 #endif
 
-#if !defined( Py_LIMITED_API )
+#if !defined( Py_LIMITED_API ) && !defined(Py_UNICODE_DEPRECATED)
         Char &operator=( Py_UNICODE v )
         {
             set( PyUnicode_FromKindAndData( PyUnicode_4BYTE_KIND, &v, 1 ), true );
@@ -2164,7 +2164,7 @@ namespace Py
         }
 #endif
 
-#if !defined( Py_LIMITED_API )
+#if !defined( Py_LIMITED_API ) && !defined(Py_UNICODE_DEPRECATED)
         String( const Py_UNICODE *s, int length )
         : SeqBase<Char>( PyUnicode_FromKindAndData( PyUnicode_4BYTE_KIND, s, length ), true )
         {
@@ -2185,7 +2185,7 @@ namespace Py
             return *this;
         }
 
-#if !defined( Py_LIMITED_API )
+#if !defined( Py_LIMITED_API ) && !defined(Py_UNICODE_DEPRECATED)
         String &operator=( const unicodestring &v )
         {
             set( PyUnicode_FromKindAndData( PyUnicode_4BYTE_KIND, const_cast<Py_UNICODE *>( v.data() ), v.length() ), true );

--- a/src/3rdParty/PyCXX/CXX/Python3/cxxsupport.cxx
+++ b/src/3rdParty/PyCXX/CXX/Python3/cxxsupport.cxx
@@ -45,7 +45,7 @@ Py_ssize_t numeric_limits_max()
     return std::numeric_limits<Py_ssize_t>::max();
 }
 
-#if !defined(Py_LIMITED_API)
+#if !defined(Py_LIMITED_API) && !defined(Py_UNICODE_DEPRECATED)
 Py_UNICODE unicode_null_string[1] = { 0 };
 #endif
 char32_t ucs4_null_string[1] = { 0 };

--- a/src/App/FeaturePythonPyImp.h
+++ b/src/App/FeaturePythonPyImp.h
@@ -46,7 +46,9 @@
         virtual ~_class_(); \
     };
 
-#if PY_VERSION_HEX >= 0x030c0000
+#if PY_VERSION_HEX >= 0x030d0000
+#define PYTHON_TYPE_SLOTS 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#elif PY_VERSION_HEX >= 0x030c0000
 #define PYTHON_TYPE_SLOTS 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 #else
 #define PYTHON_TYPE_SLOTS 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0

--- a/src/App/FeaturePythonPyImp.inl
+++ b/src/App/FeaturePythonPyImp.inl
@@ -83,6 +83,9 @@ PyTypeObject FeaturePythonPyT<FeaturePyT>::Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     ,0                                                /*tp_watched */
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    ,0                                                /*tp_versions_used */
+#endif
 };
 
 template<class FeaturePyT>


### PR DESCRIPTION
Fixes (by @wwmayer):
```
In file included from src/3rdParty/PyCXX/CXX/cxxsupport.cxx:42:
src/3rdParty/PyCXX/CXX/Python3/cxxsupport.cxx:49:33: warning: ‘Py_UNICODE’ is deprecated [-Wdeprecated-declarations]
   49 | Py_UNICODE unicode_null_string[1] = { 0 };
      |                                 ^
In file included from /usr/include/python3.13/unicodeobject.h:1014,
                 from /usr/include/python3.13/Python.h:79,
                 from src/3rdParty/PyCXX/CXX/WrapPython.h:58,
                 from src/3rdParty/PyCXX/CXX/cxxsupport.cxx:37:
/usr/include/python3.13/cpython/unicodeobject.h:10:37: note: declared here
   10 | Py_DEPRECATED(3.13) typedef wchar_t Py_UNICODE;
      |                                     ^~~~~~~~~~
```
and:
```
In file included from src/Mod/Part/App/PrimitiveFeature.cpp:48:
src/App/FeaturePythonPyImp.h:67:5: warning: missing initializer for member ‘_typeobject::tp_versions_used’ [-Wmissing-field-initializers]
   67 |     }; \
      |     ^
src/Mod/Part/App/PrimitiveFeature.cpp:93:5: note: in expansion of macro ‘PYTHON_TYPE_IMP’
   93 |     PYTHON_TYPE_IMP(PrimitivePy, PartFeaturePy)
      |     ^~~~~~~~~~~~~~~
```

Fixes: #18545