### PR TITLE
Correct tooltip for Datum size preference

### DIFF
--- a/src/Gui/PreferencePages/DlgSettings3DView.ui
+++ b/src/Gui/PreferencePages/DlgSettings3DView.ui
@@ -512,9 +512,7 @@ bounding box size of the 3D object that is currently displayed.</string>
            </size>
           </property>
           <property name="toolTip">
-           <string>Eye-to-eye distance used for stereo projections.
-The specified value is a factor that will be multiplied with the
-bounding box size of the 3D object that is currently displayed.</string>
+           <string>Size of core datum objects</string>
           </property>
           <property name="suffix">
            <string>%</string>


### PR DESCRIPTION
Currently, the Datum size preference has the same tooltip as eye-to-eye distance by a mistake.