### PR TITLE
App: Sanitize all paths for null characters

### DIFF
--- a/src/App/ApplicationDirectories.cpp
+++ b/src/App/ApplicationDirectories.cpp
@@ -286,7 +286,7 @@ std::filesystem::path ApplicationDirectories::sanitizePath(const std::string& pa
 void ApplicationDirectories::configureResourceDirectory(const std::map<std::string,std::string>& mConfig) {
 #ifdef RESOURCEDIR
     // #6892: Conda may inject null characters
-    fs::path path = sanitizePath (RESOURCEDIR);
+    fs::path path = sanitizePath(RESOURCEDIR);
     if (path.is_absolute()) {
         _resource = path;
     } else {
@@ -300,7 +300,7 @@ void ApplicationDirectories::configureResourceDirectory(const std::map<std::stri
 void ApplicationDirectories::configureLibraryDirectory(const std::map<std::string,std::string>& mConfig) {
 #ifdef LIBRARYDIR
     // #6892: Conda may inject null characters
-    fs::path path = sanitizePath (LIBRARYDIR);
+    fs::path path = sanitizePath(LIBRARYDIR);
     if (path.is_absolute()) {
         _library = path;
     } else {
@@ -316,7 +316,7 @@ void ApplicationDirectories::configureHelpDirectory(const std::map<std::string,s
 {
 #ifdef DOCDIR
     // #6892: Conda may inject null characters
-    fs::path path = sanitizePath (DOCDIR);
+    fs::path path = sanitizePath(DOCDIR);
     if (path.is_absolute()) {
         _help = path;
     } else {

--- a/src/App/ApplicationDirectories.cpp
+++ b/src/App/ApplicationDirectories.cpp
@@ -274,11 +274,19 @@ bool ApplicationDirectories::startSafeMode(std::map<std::string,std::string>& mC
     return false;
 }
 
+std::filesystem::path ApplicationDirectories::sanitizePath(const std::string& pathAsString)
+{
+    size_t positionOfFirstNull = pathAsString.find('\0');
+    if (positionOfFirstNull != std::string::npos) {
+        return {pathAsString.substr(0, positionOfFirstNull)};
+    }
+    return {pathAsString};
+}
 
 void ApplicationDirectories::configureResourceDirectory(const std::map<std::string,std::string>& mConfig) {
 #ifdef RESOURCEDIR
-    // #6892: Conda may inject null characters => remove them using c_str()
-    fs::path path {std::string(RESOURCEDIR).c_str()};
+    // #6892: Conda may inject null characters
+    fs::path path = sanitizePath (RESOURCEDIR);
     if (path.is_absolute()) {
         _resource = path;
     } else {
@@ -291,8 +299,8 @@ void ApplicationDirectories::configureResourceDirectory(const std::map<std::stri
 
 void ApplicationDirectories::configureLibraryDirectory(const std::map<std::string,std::string>& mConfig) {
 #ifdef LIBRARYDIR
-    // #6892: Conda may inject null characters => remove them using c_str()
-    fs::path path {std::string(LIBRARYDIR).c_str()};
+    // #6892: Conda may inject null characters
+    fs::path path = sanitizePath (LIBRARYDIR);
     if (path.is_absolute()) {
         _library = path;
     } else {
@@ -307,8 +315,8 @@ void ApplicationDirectories::configureLibraryDirectory(const std::map<std::strin
 void ApplicationDirectories::configureHelpDirectory(const std::map<std::string,std::string>& mConfig)
 {
 #ifdef DOCDIR
-    // #6892: Conda may inject null characters => remove them using c_str()
-    fs::path path {std::string(DOCDIR).c_str()};
+    // #6892: Conda may inject null characters
+    fs::path path = sanitizePath (DOCDIR);
     if (path.is_absolute()) {
         _help = path;
     } else {
@@ -333,7 +341,8 @@ fs::path ApplicationDirectories::getUserHome()
     if (!result || error != 0) {
         throw Base::RuntimeError("Getting HOME path from system failed!");
     }
-    path = Base::FileInfo::stringToPath(result->pw_dir);
+    std::string sanitizedPath = sanitizePath(pwd.pw_dir);
+    path = Base::FileInfo::stringToPath(sanitizedPath);
 #else
     path = Base::FileInfo::stringToPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation).toStdString());
 #endif

--- a/src/App/ApplicationDirectories.h
+++ b/src/App/ApplicationDirectories.h
@@ -228,6 +228,12 @@ namespace App {
         /// \return The version tuple.
         static std::tuple<int, int> extractVersionFromConfigMap(const std::map<std::string,std::string> &config);
 
+        /// A utility method to remove any stray null characters from a path (Conda sometimes
+        /// injects these for unknown reasons -- see #6892 in the bug tracker).
+        /// \param pathAsString The std::string path to sanitize
+        /// \returns A path with any stray nulls removed
+        static std::filesystem::path sanitizePath(const std::string& pathAsString);
+
     private:
         std::tuple<int, int> _currentVersion;
         std::filesystem::path _home;

--- a/tests/src/App/ApplicationDirectories.cpp
+++ b/tests/src/App/ApplicationDirectories.cpp
@@ -751,7 +751,8 @@ TEST_F(ApplicationDirectoriesTest, extractVersionNegativeNumbersPassThrough)
 }
 
 
-TEST_F(ApplicationDirectoriesTest, sanitizeRemovesNullCharacterAtEnd) {
+TEST_F(ApplicationDirectoriesTest, sanitizeRemovesNullCharacterAtEnd)
+{
     std::string input = std::string("valid_path") + '\0' + "junk_after";
     std::filesystem::path result = ApplicationDirectoriesTestClass::wrapSanitizePath(input);
 
@@ -759,7 +760,8 @@ TEST_F(ApplicationDirectoriesTest, sanitizeRemovesNullCharacterAtEnd) {
     EXPECT_EQ(result.string().find('\0'), std::string::npos);
 }
 
-TEST_F(ApplicationDirectoriesTest, sanitizeReturnsUnchangedIfNoNullCharacter) {
+TEST_F(ApplicationDirectoriesTest, sanitizeReturnsUnchangedIfNoNullCharacter)
+{
     std::string input = "clean_path/without_nulls";
     std::filesystem::path result = ApplicationDirectoriesTestClass::wrapSanitizePath(input);
 

--- a/tests/src/App/ApplicationDirectories.cpp
+++ b/tests/src/App/ApplicationDirectories.cpp
@@ -52,6 +52,11 @@ public:
     {
         return extractVersionFromConfigMap(config);
     }
+
+    static std::filesystem::path wrapSanitizePath(const std::string& pathAsString)
+    {
+        return sanitizePath(pathAsString);
+    }
 };
 
 class ApplicationDirectoriesTest: public ::testing::Test
@@ -743,6 +748,23 @@ TEST_F(ApplicationDirectoriesTest, extractVersionNegativeNumbersPassThrough)
     auto [maj, min] = appDirs->wrapExtractVersionFromConfigMap(m);
     EXPECT_EQ(maj, -2);
     EXPECT_EQ(min, -7);
+}
+
+
+TEST_F(ApplicationDirectoriesTest, sanitizeRemovesNullCharacterAtEnd) {
+    std::string input = std::string("valid_path") + '\0' + "junk_after";
+    std::filesystem::path result = ApplicationDirectoriesTestClass::wrapSanitizePath(input);
+
+    EXPECT_EQ(result.string(), "valid_path");
+    EXPECT_EQ(result.string().find('\0'), std::string::npos);
+}
+
+TEST_F(ApplicationDirectoriesTest, sanitizeReturnsUnchangedIfNoNullCharacter) {
+    std::string input = "clean_path/without_nulls";
+    std::filesystem::path result = ApplicationDirectoriesTestClass::wrapSanitizePath(input);
+
+    EXPECT_EQ(result.string(), input);
+    EXPECT_EQ(result.string().find('\0'), std::string::npos);
 }
 
 /* NOLINTEND(


### PR DESCRIPTION
Conda sometimes appends `\0` characters to paths: this explicitly looks for those nulls and truncates the string at them. This eliminates the somewhat mysterious-looking pass-through-c-string mechanism that was previously used in favor of a clearer (but probably slower) mechanism.