### PR TITLE
Sketcher: Remove redundant title case from task panel option of the Mirror tool

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
@@ -274,7 +274,7 @@ void DSHSymmetryController::configureToolWidget()
                                                              "Delete original geometries (U)"));
         toolWidget->setCheckboxLabel(WCheckbox::SecondBox,
                                      QApplication::translate("TaskSketcherTool_c2_symmetry",
-                                                             "Create Symmetry Constraints (J)"));
+                                                             "Create symmetry constraints (J)"));
     }
 }
 
@@ -302,3 +302,4 @@ void DSHSymmetryController::adaptDrawingToCheckboxChange(int checkboxindex, bool
 
 
 #endif  // SKETCHERGUI_DrawSketchHandlerSymmetry_H
+

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
@@ -302,4 +302,3 @@ void DSHSymmetryController::adaptDrawingToCheckboxChange(int checkboxindex, bool
 
 
 #endif  // SKETCHERGUI_DrawSketchHandlerSymmetry_H
-


### PR DESCRIPTION
Removes unnecessary title case from here:

<img width="397" height="105" alt="mirror title case" src="https://github.com/user-attachments/assets/f24a60b5-9861-41ad-8a40-f220b11e58de" />
