### PR TITLE
Gui: Request 24-bit color depth if available

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2384,11 +2384,30 @@ void Application::runApplication()
 {
     StartupProcess::setupApplication();
 
-    QSurfaceFormat fmt;
-    fmt.setRenderableType(QSurfaceFormat::OpenGL);
-    fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
-    fmt.setOption(QSurfaceFormat::DeprecatedFunctions, true);
-    QSurfaceFormat::setDefaultFormat(fmt);
+    {
+        QSurfaceFormat defaultFormat;
+        defaultFormat.setRenderableType(QSurfaceFormat::OpenGL);
+        defaultFormat.setProfile(QSurfaceFormat::CompatibilityProfile);
+        defaultFormat.setOption(QSurfaceFormat::DeprecatedFunctions, true);
+#if defined(FC_OS_LINUX) || defined(FC_OS_BSD)
+        // QGuiApplication::platformName() doesn't yet work at this point, so we use the env var
+        if (getenv("WAYLAND_DISPLAY")) {
+            // In some settings (at least EGL on Wayland) we get RGB565 by default.
+            // Request something better.
+            defaultFormat.setRedBufferSize(8);
+            defaultFormat.setGreenBufferSize(8);
+            defaultFormat.setBlueBufferSize(8);
+            // Qt's behavior with format requests seems opaque, underdocumented and,
+            // unfortunately, inconsistent between platforms. Requesting an alpha
+            // channel tends to steer it away from weird legacy choices like RGB565.
+            defaultFormat.setAlphaBufferSize(8);
+            // And a depth/stencil buffer is generally useful if we can have it.
+            defaultFormat.setDepthBufferSize(24);
+            defaultFormat.setStencilBufferSize(8);
+        }
+#endif
+        QSurfaceFormat::setDefaultFormat(defaultFormat);
+    }
 
     // A new QApplication
     Base::Console().log("Init: Creating Gui::Application and QApplication\n");


### PR DESCRIPTION
In some configurations, Qt apparently defaults to giving the "first acceptable" buffer format. This often ends up being RGB565, which gives us little color resolution.

Request 8-bit RGB samples to fix this.

This tends to happen easiest with
`QT_WAYLAND_DISABLE_WINDOWDECORATION=1` and `QT_QPA_PLATFORM=wayland`.

## Issues

Fixes: #23830 

## Before and After Images

No GUI changes, only color depth.

**Before:**

<img width="1920" height="1063" alt="image" src="https://github.com/user-attachments/assets/3a1d21cc-bbb0-4a2a-bb2a-823caf9b04ae" />

**After:**

<img width="1923" height="1066" alt="image" src="https://github.com/user-attachments/assets/49b367eb-0d03-4b27-b680-43a465f27d37" />

---

**NOTE:**

After considering things, I made this run only for Wayland. I think this is a tricky question: This could in principle happen on other systems, but I also think it has potential to break setups. I believe it would likely break systems that don't support RGB888 color—although I'd expect that to mean software rendering plus maybe 90s graphics cards.

I think it might also hypothetically do things like make some systems downgrade from 10-bit samples color to 8-bit samples, although I suspect Qt doesn't even support 10-bit samples.

Unfortunately, Qt's behavior here is apparently notoriously tricky and even system dependent.

I think that in principle the best fix would be to write code that does this:

1. Ask Qt for which backend it is using for 3D
2. if it's GLX or EGL, use the routines provided by those (two different code paths) to enumerate available surface formats
3. Choose the one that looks the most reasonable.

This is doable but probably an overkill, and would also require care to make sure to only use GLX if linked to and EGL if linked to, which sounds annoying to implement.

Having said that, I welcome suggestions other than to guard it on the system being Wayland! Actually, I think a good start would be to log the surface format used (wherever that happens; it doesn't happen in the place this PR touches).