### PR TITLE
PartDesign: NewSketch: fix crash when no body

### DIFF
--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -504,7 +504,6 @@ public:
     SketchRequestSelection(Gui::Document* guidocument, PartDesign::Body* activeBody)
         : guidocument(guidocument)
         , activeBody(activeBody)
-        , planeFinder(guidocument->getDocument(), activeBody)
     {
     }
 
@@ -619,6 +618,7 @@ private:
     void findAndSelectPlane()
     {
         App::Document* appdocument = guidocument->getDocument();
+        PlaneFinder planeFinder {appdocument, activeBody};
 
         planeFinder.findBasePlanes();
         planeFinder.findDatumPlanes();
@@ -754,8 +754,6 @@ private:
 private:
     Gui::Document* guidocument;
     PartDesign::Body* activeBody;
-
-    PlaneFinder planeFinder;
 };
 
 }


### PR DESCRIPTION
The reason of the crash is because planeFinder [was moved](https://github.com/FreeCAD/FreeCAD/pull/23274) (for no visible reason) to be a member of the class and initialized it in the ctor.
But at this point the body is nullptr in the case where user creates a sketch without existing body. And so it crashes

Fix https://github.com/FreeCAD/FreeCAD/issues/23814
Fix https://github.com/FreeCAD/FreeCAD/issues/23827
Fix https://github.com/FreeCAD/FreeCAD/issues/23808