### PR TITLE
Spreadsheet: fix Split Cell name in context menu

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -207,7 +207,7 @@ SheetTableView::SheetTableView(QWidget* parent)
                                tr("Merge Cells"),
                                &SheetTableView::mergeCells);
     actionSplit = createAction(":/icons/SpreadsheetSplitCell.svg",
-                               tr("Split Cells"),
+                               tr("Split Cell"),
                                &SheetTableView::splitCell);
     contextMenu.addSeparator();
     actionCut = createAction(":/icons/edit-cut.svg", tr("Cut"), &SheetTableView::cutSelection);
@@ -665,7 +665,7 @@ bool SheetTableView::event(QEvent* event)
         actionRecompute->setText(tr("Recompute"));
         actionConf->setText(tr("Configuration Table…"));
         actionMerge->setText(tr("Merge Cells"));
-        actionSplit->setText(tr("Split Cells"));
+        actionSplit->setText(tr("Split Cell"));
         actionCopy->setText(tr("Copy"));
         actionPaste->setText(tr("Paste"));
         actionCut->setText(tr("Cut"));


### PR DESCRIPTION
In the main menu the name of the command is "Split Cell", which is correct because only a single merged cell can be selected for the command. In the context menu it was "Split Cells".