### PR TITLE
do not use precompiled header for setting global compiler definitions and to disable compiler warnings

### DIFF
--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -355,6 +355,12 @@ endif(FREECAD_USE_PCH)
 
 target_sources(FreeCADApp PRIVATE ${FreeCADApp_SRCS})
 target_link_libraries(FreeCADApp ${FreeCADApp_LIBS})
+
+if (MSVC)
+    target_compile_definitions(FreeCADApp PRIVATE WIN32_LEAN_AND_MEAN)
+    target_compile_options(FreeCADApp PRIVATE /wd4251 /wd4273 /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(FreeCADApp)
 endif()

--- a/src/App/PreCompiled.h
+++ b/src/App/PreCompiled.h
@@ -25,24 +25,6 @@
 
 #include <FCConfig.h>
 
-// point at which warnings of overly long specifiers disabled
-#ifdef _MSC_VER
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4273)
-#pragma warning(disable : 4275)
-#pragma warning(disable : 4482)  // nonstandard extension used: enum 'App::ObjectStatus' used in
-                                 // qualified name
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#endif
-
-#ifdef FC_OS_WIN32
-#define WIN32_LEAN_AND_MEAN
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -340,6 +340,11 @@ endif(FREECAD_USE_PCH)
 
 target_sources(FreeCADBase PRIVATE ${FreeCADBase_SRCS})
 target_link_libraries(FreeCADBase ${FreeCADBase_LIBS})
+
+if (MSVC)
+    target_compile_definitions(FreeCADBase PRIVATE WIN32_LEAN_AND_MEAN)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(FreeCADBase)
 endif()

--- a/src/Base/PreCompiled.h
+++ b/src/Base/PreCompiled.h
@@ -45,10 +45,6 @@
 
 #ifdef FC_OS_WIN32
 #include <direct.h>
-#define WIN32_LEAN_AND_MEAN
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 #include <crtdbg.h>
 #include <shellapi.h>

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1531,6 +1531,12 @@ endif ()
 
 target_sources(FreeCADGui PRIVATE ${FreeCADGui_SRCS})
 target_link_libraries(FreeCADGui PUBLIC ${FreeCADGui_LIBS})
+
+if (MSVC)
+    target_compile_definitions(FreeCADGui PRIVATE WIN32_LEAN_AND_MEAN)
+    target_compile_options(FreeCADApp PRIVATE /wd4251 /wd4273 /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(FreeCADGui)
 endif()

--- a/src/Gui/GLPainter.h
+++ b/src/Gui/GLPainter.h
@@ -25,9 +25,6 @@
 #define GUI_GLPAINTER_H
 
 #ifdef FC_OS_WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 #endif
 #ifdef FC_OS_MACOSX

--- a/src/Gui/PreCompiled.h
+++ b/src/Gui/PreCompiled.h
@@ -26,22 +26,6 @@
 
 #include <FCConfig.h>
 
-#ifdef FC_OS_WIN32
-#define WIN32_LEAN_AND_MEAN
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#endif
-
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-#pragma warning( disable : 4251 )
-#pragma warning( disable : 4273 )
-#pragma warning( disable : 4275 )
-#pragma warning( disable : 4503 )
-#pragma warning( disable : 4786 )  // specifier longer then 255 chars
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Gui/Selection/SoFCSelection.h
+++ b/src/Gui/Selection/SoFCSelection.h
@@ -27,9 +27,6 @@
 # include <OpenGL/gl.h>
 # else
 # ifdef FC_OS_WIN32
-#  ifndef NOMINMAX
-#  define NOMINMAX
-#  endif
 #  include <windows.h>
 # endif
 # include <GL/gl.h>

--- a/src/Mod/Assembly/App/PreCompiled.h
+++ b/src/Mod/Assembly/App/PreCompiled.h
@@ -26,10 +26,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 5208)
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/CAM/App/PreCompiled.h
+++ b/src/Mod/CAM/App/PreCompiled.h
@@ -36,10 +36,6 @@
 #define PartExport
 #endif
 
-#ifdef _MSC_VER
-#pragma warning(disable : 5208)
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/CAM/Gui/CMakeLists.txt
+++ b/src/Mod/CAM/Gui/CMakeLists.txt
@@ -78,6 +78,11 @@ target_include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(PathGui ${PathGui_LIBS})
+
+if (MSVC)
+    target_compile_options(PathGui PRIVATE /wd4273)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(PathGui)
 endif()

--- a/src/Mod/CAM/Gui/PreCompiled.h
+++ b/src/Mod/CAM/Gui/PreCompiled.h
@@ -38,10 +38,6 @@
 #define PathGuiExport
 #endif
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4273)
-#endif
-
 #ifdef _PreComp_
 
 // boost

--- a/src/Mod/Draft/App/CMakeLists.txt
+++ b/src/Mod/Draft/App/CMakeLists.txt
@@ -25,6 +25,11 @@ target_include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(DraftUtils ${DraftUtils_LIBS})
+
+if (MSVC)
+    target_compile_options(DraftUtils PRIVATE /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(DraftUtils)
 endif()

--- a/src/Mod/Draft/App/PreCompiled.h
+++ b/src/Mod/Draft/App/PreCompiled.h
@@ -25,8 +25,4 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-# pragma warning(disable : 4275)
-#endif
-
 #endif

--- a/src/Mod/Fem/App/CMakeLists.txt
+++ b/src/Mod/Fem/App/CMakeLists.txt
@@ -210,6 +210,11 @@ target_include_directories(
 
 target_link_directories(Fem PUBLIC ${SMESH_LIB_PATH})
 target_link_libraries(Fem ${Fem_LIBS} ${VTK_LIBRARIES})
+
+if (MSVC)
+    target_compile_options(Fem PRIVATE /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(Fem)
 endif()

--- a/src/Mod/Fem/App/PreCompiled.h
+++ b/src/Mod/Fem/App/PreCompiled.h
@@ -25,11 +25,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4290)
-#pragma warning(disable : 4275)
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/Fem/Gui/CMakeLists.txt
+++ b/src/Mod/Fem/Gui/CMakeLists.txt
@@ -404,6 +404,11 @@ target_include_directories(
 
 target_link_directories(FemGui PUBLIC ${SMESH_LIB_PATH})
 target_link_libraries(FemGui ${FemGui_LIBS} ${VTK_LIBRARIES})
+
+if (MSVC)
+    target_compile_definitions(FemGui PRIVATE WIN32_LEAN_AND_MEAN)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(FemGui)
 endif()

--- a/src/Mod/Fem/Gui/PreCompiled.h
+++ b/src/Mod/Fem/Gui/PreCompiled.h
@@ -25,11 +25,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4005)
-#pragma warning(disable : 4290)
-#endif
-
 #ifdef _PreComp_
 
 // standard
@@ -56,10 +51,6 @@
 #include <boost/lexical_cast.hpp>
 
 #ifdef FC_OS_WIN32
-#define WIN32_LEAN_AND_MEAN
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 #endif
 

--- a/src/Mod/Import/App/CMakeLists.txt
+++ b/src/Mod/Import/App/CMakeLists.txt
@@ -81,6 +81,11 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_link_libraries(Import ${Import_LIBS})
+
+if (MSVC)
+    target_compile_options(Import PRIVATE /wd4251 /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(Import)
 endif()

--- a/src/Mod/Import/App/PreCompiled.h
+++ b/src/Mod/Import/App/PreCompiled.h
@@ -26,16 +26,6 @@
 
 #include <FCConfig.h>
 
-
-/// point at which warnings of overly long specifiers disabled (needet for VC6)
-#ifdef _MSC_VER
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4275)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#endif
-
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/Import/Gui/CMakeLists.txt
+++ b/src/Mod/Import/Gui/CMakeLists.txt
@@ -32,6 +32,11 @@ target_include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(ImportGui ${ImportGui_LIBS})
+
+if (MSVC)
+    target_compile_options(ImportGui PRIVATE /wd4251)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(ImportGui)
 endif()

--- a/src/Mod/Import/Gui/PreCompiled.h
+++ b/src/Mod/Import/Gui/PreCompiled.h
@@ -26,15 +26,6 @@
 
 #include <FCConfig.h>
 
-
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-#pragma warning(disable : 4005)
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/Inspection/App/CMakeLists.txt
+++ b/src/Mod/Inspection/App/CMakeLists.txt
@@ -33,6 +33,11 @@ target_include_directories(
 )
 
 target_link_libraries(Inspection ${Inspection_LIBS})
+
+if (MSVC)
+    target_compile_options(Inspection PRIVATE /wd4251)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(Inspection)
 endif()

--- a/src/Mod/Inspection/App/PreCompiled.h
+++ b/src/Mod/Inspection/App/PreCompiled.h
@@ -25,13 +25,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4005)
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#endif
-
 #ifdef _PreComp_
 
 // STL

--- a/src/Mod/Inspection/Gui/CMakeLists.txt
+++ b/src/Mod/Inspection/Gui/CMakeLists.txt
@@ -57,6 +57,11 @@ target_include_directories(
 )
 
 target_link_libraries(InspectionGui ${InspectionGui_LIBS})
+
+if (MSVC)
+    target_compile_options(InspectionGui PRIVATE /wd4251)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(InspectionGui)
 endif()

--- a/src/Mod/Inspection/Gui/PreCompiled.h
+++ b/src/Mod/Inspection/Gui/PreCompiled.h
@@ -25,12 +25,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4005)
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#endif
 
 #ifdef _PreComp_
 

--- a/src/Mod/JtReader/App/CMakeLists.txt
+++ b/src/Mod/JtReader/App/CMakeLists.txt
@@ -49,6 +49,11 @@ SOURCE_GROUP("Module" FILES ${JtReader_SRCS})
 
 add_library(JtReader SHARED ${JtReader_SRCS} ${JRJT_SRCS} ${JtReader_Scripts})
 target_link_libraries(JtReader ${JtReader_LIBS})
+
+if (MSVC)
+    target_compile_options(JtReader PRIVATE /wd4251 /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(JtReader)
 endif()

--- a/src/Mod/JtReader/App/PreCompiled.h
+++ b/src/Mod/JtReader/App/PreCompiled.h
@@ -20,15 +20,6 @@
 
 #ifdef _PreComp_
 
-/// point at which warnings of overly long specifiers disabled (needed for VC6)
-
-#ifdef _MSC_VER
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4275)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#endif
-
 // standard
 
 #include <cassert>

--- a/src/Mod/Material/App/CMakeLists.txt
+++ b/src/Mod/Material/App/CMakeLists.txt
@@ -166,6 +166,10 @@ endif(BUILD_MATERIAL_EXTERNAL)
 target_link_directories(Materials PUBLIC ${YAML_CPP_LIBRARY_DIR})
 target_link_libraries(Materials ${Materials_LIBS})
 
+if (MSVC)
+    target_compile_options(Materials PRIVATE /wd4251 /wd4273)
+endif()
+
 if(FREECAD_WARN_ERROR)
     target_compile_warn_error(Materials)
 endif()

--- a/src/Mod/Material/App/PreCompiled.h
+++ b/src/Mod/Material/App/PreCompiled.h
@@ -24,18 +24,7 @@
 
 #include <FCConfig.h>
 
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#pragma warning(disable : 4273)
-#endif
-
 #ifdef FC_OS_WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 #endif
 

--- a/src/Mod/Material/Gui/CMakeLists.txt
+++ b/src/Mod/Material/Gui/CMakeLists.txt
@@ -184,6 +184,11 @@ target_include_directories(
     ${QtConcurrent_INCLUDE_DIRS}
 )
 target_link_libraries(MatGui ${MatGui_LIBS})
+
+if (MSVC)
+    target_compile_options(MatGui PRIVATE /wd4251 /wd4273)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(MatGui)
 endif()

--- a/src/Mod/Material/Gui/PreCompiled.h
+++ b/src/Mod/Material/Gui/PreCompiled.h
@@ -24,18 +24,7 @@
 
 #include <FCConfig.h>
 
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#pragma warning(disable : 4273)
-#endif
-
 #ifdef FC_OS_WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 #endif
 

--- a/src/Mod/Measure/Gui/CMakeLists.txt
+++ b/src/Mod/Measure/Gui/CMakeLists.txt
@@ -78,6 +78,11 @@ target_include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(MeasureGui ${MeasureGui_LIBS})
+
+if (MSVC)
+    target_compile_options(MeasureGui PRIVATE /wd4251 /wd4273)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(MeasureGui)
 endif()

--- a/src/Mod/Measure/Gui/PreCompiled.h
+++ b/src/Mod/Measure/Gui/PreCompiled.h
@@ -26,18 +26,7 @@
 
 #include <Mod/Measure/MeasureGlobal.h>
 
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#pragma warning(disable : 4273)
-#endif
-
 #ifdef FC_OS_WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 #endif
 

--- a/src/Mod/Mesh/App/CMakeLists.txt
+++ b/src/Mod/Mesh/App/CMakeLists.txt
@@ -415,6 +415,11 @@ endif ()
 
 target_sources(Mesh PRIVATE ${Core_SRCS} ${WildMagic4_SRCS} ${Mesh_SRCS})
 target_link_libraries(Mesh ${Mesh_LIBS})
+
+if (MSVC)
+    target_compile_options(Mesh PRIVATE /wd4251 /wd4275 /wd4661)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(Mesh)
 endif()

--- a/src/Mod/Mesh/App/PreCompiled.h
+++ b/src/Mod/Mesh/App/PreCompiled.h
@@ -26,15 +26,6 @@
 
 #include <FCConfig.h>
 
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4275)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#pragma warning(disable : 4661)  // no suitable definition provided for explicit
-#endif                           // template instantiation request
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/Mesh/Gui/CMakeLists.txt
+++ b/src/Mod/Mesh/Gui/CMakeLists.txt
@@ -165,6 +165,11 @@ target_include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(MeshGui ${MeshGui_LIBS})
+
+if (MSVC)
+    target_compile_options(MeshGui PRIVATE /wd4251 /wd4273 /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(MeshGui)
 endif()

--- a/src/Mod/Mesh/Gui/PreCompiled.h
+++ b/src/Mod/Mesh/Gui/PreCompiled.h
@@ -25,16 +25,6 @@
 
 #include <FCConfig.h>
 
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-#pragma warning(disable : 4005)
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4275)
-#pragma warning(disable : 4273)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#endif
-
 #ifdef _PreComp_
 
 // standard
@@ -57,9 +47,6 @@
 #include <Gui/InventorAll.h>
 
 #elif defined(FC_OS_WIN32)
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <Windows.h>
 #endif  //_PreComp_
 

--- a/src/Mod/MeshPart/App/CMakeLists.txt
+++ b/src/Mod/MeshPart/App/CMakeLists.txt
@@ -85,6 +85,11 @@ endif()
 
 target_sources(MeshPart PRIVATE ${MeshPart_SRCS} ${MeshPart_Scripts})
 target_link_libraries(MeshPart ${MeshPart_LIBS})
+
+if (MSVC)
+    target_compile_options(MeshPart PRIVATE /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(MeshPart)
 endif()

--- a/src/Mod/MeshPart/App/PreCompiled.h
+++ b/src/Mod/MeshPart/App/PreCompiled.h
@@ -25,13 +25,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4244)
-#pragma warning(disable : 4275)
-#pragma warning(disable : 4290)
-#pragma warning(disable : 4522)
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/MeshPart/Gui/CMakeLists.txt
+++ b/src/Mod/MeshPart/Gui/CMakeLists.txt
@@ -76,6 +76,11 @@ target_include_directories(
 
 target_link_directories(MeshPartGui PUBLIC ${SMESH_LIB_PATH})
 target_link_libraries(MeshPartGui ${MeshPartGui_LIBS})
+
+if (MSVC)
+    target_compile_options(MeshPartGui PRIVATE /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(MeshPartGui)
 endif()

--- a/src/Mod/MeshPart/Gui/PreCompiled.h
+++ b/src/Mod/MeshPart/Gui/PreCompiled.h
@@ -25,12 +25,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4005)
-#pragma warning(disable : 4290)
-#pragma warning(disable : 4275)
-#endif
-
 #ifdef _PreComp_
 
 // STL

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -613,6 +613,12 @@ endif()
 
 target_sources(Part PRIVATE ${Part_SRCS} ${FCBRepAlgoAPI_SRCS})
 target_link_libraries(Part ${Part_LIBS})
+
+if (MSVC)
+    target_compile_definitions(Part PRIVATE WIN32_LEAN_AND_MEAN)
+    target_compile_options(Part PRIVATE /wd4251 /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(Part)
 endif()

--- a/src/Mod/Part/App/PreCompiled.h
+++ b/src/Mod/Part/App/PreCompiled.h
@@ -27,14 +27,6 @@
 
 #include <Mod/Part/PartGlobal.h>
 
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-#	pragma warning( disable : 4251 )
-#	pragma warning( disable : 4275 )
-#	pragma warning( disable : 4503 )
-#	pragma warning( disable : 4786 )  // specifier longer then 255 chars
-#endif
-
 #ifdef _PreComp_
 
 // standard
@@ -75,13 +67,9 @@
 #include "OpenCascadeAll.h"
 
 #elif defined(FC_OS_WIN32)
-#define WIN32_LEAN_AND_MEAN
-#ifndef NOMINMAX
-# define NOMINMAX
-#endif
 #include <Windows.h>
 #include <io.h>
-#endif //_PreComp_
+#endif
 
 #ifndef _Standard_Version_HeaderFile
 # include <Standard_Version.hxx>

--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -279,6 +279,11 @@ target_include_directories(
     ${QtConcurrent_INCLUDE_DIRS}
 )
 target_link_libraries(PartGui ${PartGui_LIBS})
+
+if (MSVC)
+    target_compile_options(PartGui PRIVATE /wd4251 /wd4273)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(PartGui)
 endif()

--- a/src/Mod/Part/Gui/PreCompiled.h
+++ b/src/Mod/Part/Gui/PreCompiled.h
@@ -27,18 +27,8 @@
 
 #include <Mod/Part/PartGlobal.h>
 
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-# pragma warning( disable : 4251 )
-# pragma warning( disable : 4503 )
-# pragma warning( disable : 4786 )  // specifier longer then 255 chars
-# pragma warning( disable : 4273 )
-#endif
 
 #ifdef FC_OS_WIN32
-# ifndef NOMINMAX
-#  define NOMINMAX
-# endif
 # include <windows.h>
 #endif
 

--- a/src/Mod/PartDesign/App/CMakeLists.txt
+++ b/src/Mod/PartDesign/App/CMakeLists.txt
@@ -144,6 +144,11 @@ target_include_directories(
 
 target_link_directories(PartDesign PUBLIC ${OCC_LIBRARY_DIR})
 target_link_libraries(PartDesign ${PartDesign_LIBS})
+
+if (MSVC)
+    target_compile_options(PartDesign PRIVATE /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(PartDesign)
 endif()

--- a/src/Mod/PartDesign/App/PreCompiled.h
+++ b/src/Mod/PartDesign/App/PreCompiled.h
@@ -25,13 +25,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-// disable warning triggered by use of Part::FaceMaker
-// see forum thread "Warning C4275 non-dll class used as base for dll class"
-// https://forum.freecad.org/viewtopic.php?f=10&t=17542
-#   pragma warning( disable : 4275)
-#endif
-
 #ifdef _PreComp_
 
 // stl

--- a/src/Mod/PartDesign/Gui/PreCompiled.h
+++ b/src/Mod/PartDesign/Gui/PreCompiled.h
@@ -25,16 +25,9 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#   pragma warning(disable : 4005)
-#endif
-
 #ifdef _PreComp_
 
 #ifdef FC_OS_WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 #endif
 

--- a/src/Mod/Points/App/PreCompiled.h
+++ b/src/Mod/Points/App/PreCompiled.h
@@ -25,13 +25,6 @@
 
 #include <FCConfig.h>
 
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-#pragma warning(disable : 4181)
-#pragma warning(disable : 4305)
-#pragma warning(disable : 4522)
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/ReverseEngineering/App/CMakeLists.txt
+++ b/src/Mod/ReverseEngineering/App/CMakeLists.txt
@@ -74,6 +74,11 @@ target_include_directories(
     ${FLANN_INCLUDE_DIRS}
 )
 target_link_libraries(ReverseEngineering ${Reen_LIBS})
+
+if (MSVC)
+    target_compile_options(ReverseEngineering PRIVATE /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(ReverseEngineering)
 endif()

--- a/src/Mod/ReverseEngineering/App/PreCompiled.h
+++ b/src/Mod/ReverseEngineering/App/PreCompiled.h
@@ -25,14 +25,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4181)
-#pragma warning(disable : 4267)
-#pragma warning(disable : 4275)
-#pragma warning(disable : 4305)
-#pragma warning(disable : 4522)
-#endif
-
 // pcl headers include <boost/bind.hpp> instead of <boost/bind/bind.hpp>
 #ifndef BOOST_BIND_GLOBAL_PLACEHOLDERS
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS

--- a/src/Mod/ReverseEngineering/Gui/CMakeLists.txt
+++ b/src/Mod/ReverseEngineering/Gui/CMakeLists.txt
@@ -69,6 +69,11 @@ target_include_directories(
 )
 
 target_link_libraries(ReverseEngineeringGui ${ReenGui_LIBS})
+
+if (MSVC)
+    target_compile_options(ReverseEngineeringGui PRIVATE /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(ReverseEngineeringGui)
 endif()

--- a/src/Mod/ReverseEngineering/Gui/PreCompiled.h
+++ b/src/Mod/ReverseEngineering/Gui/PreCompiled.h
@@ -25,14 +25,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4181)
-#pragma warning(disable : 4267)
-#pragma warning(disable : 4275)
-#pragma warning(disable : 4305)
-#pragma warning(disable : 4522)
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/Robot/Gui/CMakeLists.txt
+++ b/src/Mod/Robot/Gui/CMakeLists.txt
@@ -122,6 +122,11 @@ target_include_directories(
 )
 
 target_link_libraries(RobotGui ${RobotGui_LIBS})
+
+if (MSVC)
+    target_compile_options(RobotGui PRIVATE /wd4273)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(RobotGui)
 endif()

--- a/src/Mod/Robot/Gui/PreCompiled.h
+++ b/src/Mod/Robot/Gui/PreCompiled.h
@@ -38,11 +38,6 @@
 #define RobotGuiExport
 #endif
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4005)
-#pragma warning(disable : 4273)
-#endif
-
 #ifdef _PreComp_
 
 // STL

--- a/src/Mod/Sandbox/Gui/CMakeLists.txt
+++ b/src/Mod/Sandbox/Gui/CMakeLists.txt
@@ -57,6 +57,10 @@ set (SandboxGui_Scripts
 add_library(SandboxGui SHARED ${SandboxGui_SRCS} ${SandboxGui_Scripts})
 target_link_libraries(SandboxGui ${SandboxGui_LIBS})
 
+if (MSVC)
+    target_compile_definitions(SandboxGui PRIVATE WIN32_LEAN_AND_MEAN)
+endif()
+
 
 fc_target_copy_resource_flat(SandboxGui
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/Mod/Sandbox/Gui/Command.cpp
+++ b/src/Mod/Sandbox/Gui/Command.cpp
@@ -24,8 +24,6 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 # ifdef FC_OS_WIN32
-# define WIN32_LEAN_AND_MEAN
-# define NOMINMAX
 # include <windows.h>
 # endif
 # include <QApplication>

--- a/src/Mod/Sketcher/App/CMakeLists.txt
+++ b/src/Mod/Sketcher/App/CMakeLists.txt
@@ -149,6 +149,11 @@ SET(Sketcher_PCH_SRCS
 
 target_sources(Sketcher PRIVATE ${Sketcher_SRCS})
 target_link_libraries(Sketcher ${Sketcher_LIBS})
+
+if (MSVC)
+    target_compile_options(Sketcher PRIVATE /wd4251)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(Sketcher)
 endif()

--- a/src/Mod/Sketcher/App/PreCompiled.h
+++ b/src/Mod/Sketcher/App/PreCompiled.h
@@ -25,9 +25,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4251)
-#endif
 
 #ifdef _PreComp_
 
@@ -111,9 +108,6 @@
 #include <gp_Pnt.hxx>
 
 #elif defined(FC_OS_WIN32)
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 #endif  // _PreComp_
 

--- a/src/Mod/Sketcher/Gui/PreCompiled.h
+++ b/src/Mod/Sketcher/Gui/PreCompiled.h
@@ -25,10 +25,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4005)
-#endif
-
 #ifdef _PreComp_
 
 // standard
@@ -49,9 +45,6 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 
 #ifdef FC_OS_WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 #endif
 

--- a/src/Mod/Spreadsheet/App/CMakeLists.txt
+++ b/src/Mod/Spreadsheet/App/CMakeLists.txt
@@ -56,6 +56,11 @@ target_include_directories(
 )
 
 target_link_libraries(Spreadsheet ${Spreadsheet_LIBS})
+
+if (MSVC)
+    target_compile_options(Spreadsheet PRIVATE /wd4251 /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(Spreadsheet)
 endif()

--- a/src/Mod/Spreadsheet/App/PreCompiled.h
+++ b/src/Mod/Spreadsheet/App/PreCompiled.h
@@ -26,14 +26,6 @@
 
 #include <FCConfig.h>
 
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4275)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#endif
-
 #ifdef _PreComp_
 
 // STL

--- a/src/Mod/Spreadsheet/Gui/CMakeLists.txt
+++ b/src/Mod/Spreadsheet/Gui/CMakeLists.txt
@@ -113,6 +113,11 @@ target_include_directories(
 )
 
 target_link_libraries(SpreadsheetGui ${SpreadsheetGui_LIBS})
+
+if (MSVC)
+    target_compile_options(SpreadsheetGui PRIVATE /wd4251)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(SpreadsheetGui)
 endif()

--- a/src/Mod/Spreadsheet/Gui/PreCompiled.h
+++ b/src/Mod/Spreadsheet/Gui/PreCompiled.h
@@ -26,14 +26,6 @@
 
 #include <FCConfig.h>
 
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-#pragma warning(disable : 4005)
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/Start/App/PreCompiled.h
+++ b/src/Mod/Start/App/PreCompiled.h
@@ -26,10 +26,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 5208)
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/Start/Gui/PreCompiled.h
+++ b/src/Mod/Start/Gui/PreCompiled.h
@@ -26,10 +26,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 5208)
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/TechDraw/App/CMakeLists.txt
+++ b/src/Mod/TechDraw/App/CMakeLists.txt
@@ -289,6 +289,11 @@ target_include_directories(
 )
 
 target_link_libraries(TechDraw ${TechDrawLIBS} ${TechDraw})
+
+if (MSVC)
+    target_compile_options(TechDraw PRIVATE /wd4275)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(TechDraw)
 endif()

--- a/src/Mod/TechDraw/App/PreCompiled.h
+++ b/src/Mod/TechDraw/App/PreCompiled.h
@@ -25,10 +25,6 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-# pragma warning( disable : 4275 )
-#endif
-
 #ifdef _PreComp_
 
 // standard

--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -485,6 +485,11 @@ target_include_directories(
 )
 
 target_link_libraries(TechDrawGui ${TechDrawGui_LIBS})
+
+if (MSVC)
+    target_compile_definitions(TechDrawGui PRIVATE WIN32_LEAN_AND_MEAN)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(TechDrawGui)
 endif()

--- a/src/Mod/TechDraw/Gui/PreCompiled.h
+++ b/src/Mod/TechDraw/Gui/PreCompiled.h
@@ -25,14 +25,7 @@
 
 #include <FCConfig.h>
 
-#ifdef _MSC_VER
-# pragma warning(disable : 4005)
-#endif
-
 #ifdef FC_OS_WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #endif
 
 #ifdef _PreComp_
@@ -51,7 +44,6 @@
 #include <vector>
 
 #ifdef FC_OS_WIN32
-# define WIN32_LEAN_AND_MEAN
 # include <windows.h>
 # undef small
 #endif

--- a/src/Mod/Test/Gui/CMakeLists.txt
+++ b/src/Mod/Test/Gui/CMakeLists.txt
@@ -60,6 +60,11 @@ target_include_directories(
 
 target_link_libraries(QtUnitGui ${TestGui_LIBS})
 add_dependencies(QtUnitGui Test)
+
+if (MSVC)
+    target_compile_options(QtUnitGui PRIVATE /wd4251)
+endif()
+
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(QtUnitGui)
 endif()

--- a/src/Mod/Test/Gui/PreCompiled.h
+++ b/src/Mod/Test/Gui/PreCompiled.h
@@ -27,13 +27,6 @@
 
 #ifdef _PreComp_
 
-// point at which warnings of overly long specifiers disabled (needed for VC6)
-#ifdef _MSC_VER
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4503)
-#pragma warning(disable : 4786)  // specifier longer then 255 chars
-#endif
-
 // Qt Toolkit
 #include <QApplication>
 #include <QEventLoop>

--- a/src/Tools/embedded/Qt/cxx/CMakeLists.txt
+++ b/src/Tools/embedded/Qt/cxx/CMakeLists.txt
@@ -105,3 +105,7 @@ endif()
 
 add_library(FreeCADPlugin SHARED ${FreeCADPlugin_SRCS})
 target_link_libraries(FreeCADPlugin ${FreeCADPlugin_LIBS})
+
+if (MSVC)
+    target_compile_options(FreeCADPlugin PRIVATE /wd4251)
+endif()

--- a/src/Tools/embedded/Qt/cxx/PreCompiled.h
+++ b/src/Tools/embedded/Qt/cxx/PreCompiled.h
@@ -1,10 +1,6 @@
 #ifndef __PRECOMPILED__
 #define __PRECOMPILED__
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4251)
-#endif
-
 #ifdef FC_OS_WIN32
 // cmake generates this define
 #if defined(FreeCADPlugin_EXPORTS)

--- a/tests/src/Base/Reader.cpp
+++ b/tests/src/Base/Reader.cpp
@@ -4,6 +4,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4996)
+#pragma warning(disable : 4305)
 #endif
 
 #include "Base/Exception.h"


### PR DESCRIPTION
only 4 of these warnings are still relevant, CMake shall be used to disable them

**Compiler definitions:**

NOMINMAX:
- is already globally defined in SetGlobalCompilerAndLinkerSettings.cmake

WIN32_LEAN_AND_MEAN:
- use CMake target_compile_options on relevant targets

**Warnings that still occur:**

C4251, C4273, C4275: all related to dllimport / export
- use CMake target_compile_options on relevant targets

C4661: no suitable definition provied for explicit template instantiation request
- triggered in Mesh because of Vector3D in Base - not all functions are defined in header
- use CMake target_compile_options on relevant targets

**Warnings that are Currently not triggered (fix code if they appear again):**

C4005: macro redefinition

C4244: argument conversion, possible loss of data

C4267: conversion from size_t to type, possible loss of data

C4305: truncation from type1 to type2
- only occurrence disabled in Reader.cpp

C4522: multiple assignment operator specified

C5208: unnamed class in typedef name

**Obsolete Compiler warnings:**

C4181: not mentioned in Microsoft docs anymore

C4290: C++ exception specification ignored except to indicate a function is not __declspec(nothrow)
- throw(optional_type_list)  deprecated in C++17

C4482: nonstandard extension used: enum 'enumeration' used in qualified name
- not generated for compilers that support C++11

C4503: 'identifier': decorated name length exceeded, name was truncated
- obsolete since Visual Studio 2017

C4786: not mentioned in Microsoft docs anymore
