### PR TITLE
Sketcher: Bspline tool: prevent double click failure

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -1267,4 +1267,3 @@ void DSHBSplineController::addConstraints()
 
 
 #endif  // SKETCHERGUI_DrawSketchHandlerBSpline_H
-


### PR DESCRIPTION
Fix #13926