### PR TITLE
BIM: fix material handling of equipment

### DIFF
--- a/src/Mod/BIM/ArchEquipment.py
+++ b/src/Mod/BIM/ArchEquipment.py
@@ -309,3 +309,5 @@ class _ViewProviderEquipment(ArchComponent.ViewProviderComponent):
                 self.coords.point.setValues([[p.x,p.y,p.z] for p in obj.SnapPoints])
             else:
                 self.coords.point.deleteValues(0)
+        else:
+            ArchComponent.ViewProviderComponent.updateData(self,obj,prop)


### PR DESCRIPTION
Fixes #23875.

I don't understand the use of `ArchComponent.ViewProviderComponent` instead of `super` but have followed that.