### PR TITLE
CMake: fix disable msvc warning on wrong target

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1534,7 +1534,7 @@ target_link_libraries(FreeCADGui PUBLIC ${FreeCADGui_LIBS})
 
 if (MSVC)
     target_compile_definitions(FreeCADGui PRIVATE WIN32_LEAN_AND_MEAN)
-    target_compile_options(FreeCADApp PRIVATE /wd4251 /wd4273 /wd4275)
+    target_compile_options(FreeCADGui PRIVATE /wd4251 /wd4273 /wd4275)
 endif()
 
 if (FREECAD_WARN_ERROR)


### PR DESCRIPTION
With my pull request #23855 I've accidentally disabled MSVC warnings on the wrong target - should have been FreeCADGui instead of FreeCADApp

This pull request fixes that.