### PR TITLE
Gui: Make Report View properly claim Select All (Ctrl+A) shortcut

### DIFF
--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -555,7 +555,7 @@ bool ReportOutput::event(QEvent* event)
 {
     if (event && event->type() == QEvent::ShortcutOverride) {
         auto kevent = static_cast<QKeyEvent*>(event);
-        if (kevent == QKeySequence::Copy)
+        if (kevent == QKeySequence::Copy || kevent == QKeySequence::SelectAll)
             kevent->accept();
     }
     return QTextEdit::event(event);


### PR DESCRIPTION
Currently if user tries to use CTRL+A on Report View while having document opened, it rejects the action and nothing happens.

This happened during the introduction of Select All (CTRL+A) behavior in Sketcher. Basically, before Report View was not catching the event, but neither any widget, resulting in QTextEdit catching it at the end of the chain. Now, after enabling it for the whole document, Report View rejected it, but we have registered it throughout the document, so another widget was intercepting the event.

So, fix for that is simple - add a check for Select All shortcut on Report View level, so the event will get consumed instead of being rejected and propagated to further widgets.

Resolves: https://github.com/FreeCAD/FreeCAD/issues/23895