### PR TITLE
CAM: fix library import in snapmaker postprocessor

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/snapmaker_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/snapmaker_post.py
@@ -35,7 +35,7 @@ import Path.Base.Util as PathUtil
 import Path.Post.Processor
 import Path.Post.UtilsArguments
 import Path.Post.UtilsExport
-import Path.Post.Utils
+import Path.Post.Utils as PostUtils
 import Path.Post.UtilsParse
 import Path.Main.Job
 


### PR DESCRIPTION
There is a bug in the library import of the snapmaker postprocessor. Without it line 814 will fail (https://github.com/FreeCAD/FreeCAD/blob/817ffc5782097bbd6534118178bc4d52a8b3c123/src/Mod/CAM/Path/Post/scripts/snapmaker_post.py#L814)
