### PR TITLE
BIM: fix material handling of component

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -1374,6 +1374,9 @@ class ViewProviderComponent:
                         c = tuple([float(f) for f in obj.Material.Material["DiffuseColor"].strip("()").strip("[]").split(",")])
                         if obj.ViewObject.ShapeColor != c:
                             obj.ViewObject.ShapeColor = c
+                        # Overwrite DiffuseColor (required if it does not match number of faces):
+                        if obj.ViewObject.DiffuseColor != [c]:
+                            obj.ViewObject.DiffuseColor = [c]
                     if "Transparency" in obj.Material.Material:
                         t = int(obj.Material.Material["Transparency"])
                         if obj.ViewObject.Transparency != t:


### PR DESCRIPTION
Fixes #23876

The problem was caused by the length of the ShapeAppearance and DiffuseColor properties. If their length does not match the number of faces of the shape the ShapeAppearance is not rendered. The solution is to also overwrite the DiffuseColor if required.

Note that this, and most other color functions still use the old color properties. They need to be updated to the new ShapeAppearance.