### PR TITLE
[CAM] bugfix: replace python uses of QSignalBlocker

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -705,7 +705,8 @@ class StockFromExistingEdit(StockEdit):
         # dropdown list. This is important because the `currentIndexChanged` signal
         # will in the end result in the stock object being recreated in `getFields`
         # method, discarding any changes made (like position in respect to origin).
-        with QtCore.QSignalBlocker(self.form.stockExisting):
+        try:
+            self.form.stockExisting.blockSignals(True)
             self.form.stockExisting.clear()
             stockName = obj.Stock.Label if obj.Stock else None
             index = -1
@@ -716,6 +717,8 @@ class StockFromExistingEdit(StockEdit):
                     index = i
 
             self.form.stockExisting.setCurrentIndex(index if index != -1 else 0)
+        finally:
+            self.form.stockExisting.blockSignals(False)
 
         if not self.IsStock(obj):
             self.getFields(obj)

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -371,24 +371,26 @@ class TaskPanelPage(object):
     def selectInComboBox(self, name, combo):
         """selectInComboBox(name, combo) ...
         helper function to select a specific value in a combo box."""
-        blocker = QtCore.QSignalBlocker(combo)
-        index = combo.currentIndex()  # Save initial index
+        try:
+            combo.blockSignals(True)
+            index = combo.currentIndex()  # Save initial index
 
-        # Search using currentData and return if found
-        newindex = combo.findData(name)
-        if newindex >= 0:
-            combo.setCurrentIndex(newindex)
-            return
+            # Search using currentData and return if found
+            newindex = combo.findData(name)
+            if newindex >= 0:
+                combo.setCurrentIndex(newindex)
+                return
 
-        # if not found, search using current text
-        newindex = combo.findText(name, QtCore.Qt.MatchFixedString)
-        if newindex >= 0:
-            combo.setCurrentIndex(newindex)
-            return
+            # if not found, search using current text
+            newindex = combo.findText(name, QtCore.Qt.MatchFixedString)
+            if newindex >= 0:
+                combo.setCurrentIndex(newindex)
+                return
 
-        # not found, return unchanged
-        combo.setCurrentIndex(index)
-        return
+            # not found, return unchanged
+            combo.setCurrentIndex(index)
+        finally:
+            combo.blockSignals(False)
 
     def populateCombobox(self, form, enumTups, comboBoxesPropertyMap):
         """populateCombobox(form, enumTups, comboBoxesPropertyMap) ... proxy for PathGuiUtil.populateCombobox()"""

--- a/src/Mod/CAM/Path/Tool/Gui/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Gui/Controller.py
@@ -230,7 +230,8 @@ class ToolControllerEditor(object):
     def selectInComboBox(self, name, combo):
         """selectInComboBox(name, combo) ...
         helper function to select a specific value in a combo box."""
-        with QtCore.QSignalBlocker(combo):
+        try:
+            combo.blockSignals(True)
             index = combo.currentIndex()  # Save initial index
 
             # Search using currentData and return if found
@@ -247,21 +248,26 @@ class ToolControllerEditor(object):
 
             # not found, return unchanged
             combo.setCurrentIndex(index)
-        return
+        finally:
+            combo.blockSignals(False)
 
     def updateUi(self):
         tc = self.obj
 
-        with (
-            QtCore.QSignalBlocker(self.controller.tcName),
-            QtCore.QSignalBlocker(self.controller.tcNumber),
-            QtCore.QSignalBlocker(self.horizFeed.widget),
-            QtCore.QSignalBlocker(self.horizRapid.widget),
-            QtCore.QSignalBlocker(self.vertFeed.widget),
-            QtCore.QSignalBlocker(self.vertRapid.widget),
-            QtCore.QSignalBlocker(self.controller.spindleSpeed),
-            QtCore.QSignalBlocker(self.controller.spindleDirection),
-        ):
+        blockObjects = [
+            self.controller.tcName,
+            self.controller.tcNumber,
+            self.horizFeed.widget,
+            self.horizRapid.widget,
+            self.vertFeed.widget,
+            self.vertRapid.widget,
+            self.controller.spindleSpeed,
+            self.controller.spindleDirection,
+        ]
+        try:
+            for obj in blockObjects:
+                obj.blockSignals(True)
+
             self.controller.tcName.setText(tc.Label)
             self.controller.tcNumber.setValue(tc.ToolNumber)
             self.horizFeed.updateWidget()
@@ -274,6 +280,9 @@ class ToolControllerEditor(object):
 
             if self.editor:
                 self.editor.updateUI()
+        finally:
+            for obj in blockObjects:
+                obj.blockSignals(False)
 
     def updateToolController(self):
         tc = self.obj


### PR DESCRIPTION
Fix for #23723, for the release @sliptonic 

@Dimitris75 could you test this? This fix should work, but I have pyside6/qt6, so the bug was a non-issue for me in the first place

The bug is that QSignalBlocker in pyside2/qt5 was a bad python class. It is meant to be used in C++ as an object you can create to block signals so long as it is in scope (automatically unblocking when it goes out of scope), but python doesn't support this type of memory management. Qt's C++-oriented documentation does not make this clear. The pythonic way to do this (`with QSignalBlocker(...):`) was implemented in pysid6/qt6, but this syntax is unsupported in qt5, and produces the error from the issue.

I have removed uses of QSignalBlocker from CAM and replaced them with
```
try:
    qobject.blockSignal(True)
    ...
finally:
    qobject.blockSignal(False)
```

I have done this in the tool controller edit UI I just introduced and also in Job.py. Additionally, I applied this fix to an incorrect usage of QSignalBlocker in Base.py (which constructed the object but never actually used it -- correct for C++, but not correct in python), so now that blocker will actually do something.