### PR TITLE
TechDraw: Fix projection groups not recursively deleting

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -1211,3 +1211,25 @@ void DrawProjGroup::handleChangedPropertyType(Base::XMLReader& reader, const cha
         spacingY.setValue(spacingYProperty.getValue());
     }
 }
+
+void DrawProjGroup::unsetupObject()
+{
+    if (getDocument() && !getDocument()->isAnyRestoring()) {
+
+        std::vector<std::string> childNamesToDelete;
+        for (App::DocumentObject* child : Views.getValues()) {
+            if (child) {
+                const char* name = child->getNameInDocument();
+                if (name) {
+                    childNamesToDelete.push_back(name);
+                }
+            }
+        }
+
+        for (const std::string& childName : childNamesToDelete) {
+            getDocument()->removeObject(childName.c_str());
+        }
+    }
+
+    DrawViewCollection::unsetupObject();
+}

--- a/src/Mod/TechDraw/App/DrawProjGroup.h
+++ b/src/Mod/TechDraw/App/DrawProjGroup.h
@@ -152,6 +152,7 @@ public:
     void dumpTouchedProps();
 
 protected:
+    void unsetupObject() override;
     void onChanged(const App::Property* prop) override;
 
     /// Annoying helper - keep in sync with DrawProjGroupItem::TypeEnums


### PR DESCRIPTION
This PR fixes the deletion of projection groups. Previously, some or all child views would remain when deleting a page or projection group.

## Issues
Fixes #23905

## Demo Video

https://github.com/user-attachments/assets/a5a8438b-4fa3-4c52-b1a4-ea49d2426855