### PR TITLE
Gui: Render profile preview in proper coordinate space

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
@@ -38,6 +38,7 @@
 #include "StyleParameters.h"
 
 #include <Gui/Inventor/So3DAnnotation.h>
+#include <Mod/Part/App/BodyBase.h>
 
 
 using namespace PartDesignGui;
@@ -101,7 +102,12 @@ void ViewProviderSketchBased::updateProfileShape()
     }
 
     auto profileBased = getObject<PartDesign::ProfileBased>();
-    updatePreviewShape(profileBased->getTopoShapeVerifiedFace(true), pcProfileShape);
+    auto profileShape = profileBased->getTopoShapeVerifiedFace(true);
+
+    // set the correct coordinate space for the profile shape
+    profileShape.setPlacement(profileShape.getPlacement() * profileBased->Placement.getValue().inverse());
+
+    updatePreviewShape(profileShape, pcProfileShape);
 }
 
 void ViewProviderSketchBased::updateData(const App::Property* prop)


### PR DESCRIPTION
In some cases where placement of profile and feature was mismatched the profile was rendered in wrong orientation or place. This ensures that it is rendered in proper coordinate space.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
| Before | After |
|--------|--------|
| <img width="1228" height="968" alt="image" src="https://github.com/user-attachments/assets/dc46cb42-c02f-4d14-9258-0e2d265b86a3" /> | <img width="1109" height="1017" alt="image" src="https://github.com/user-attachments/assets/e2e87a26-7165-46c9-b0de-5241af42c489" /> | 


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
