### PR TITLE
PartDesign: Enable child reorder

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderBody.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.h
@@ -88,6 +88,8 @@ public:
     bool canDropObject(App::DocumentObject*) const override;
     /** Add an object to the view provider by drag and drop */
     void dropObject(App::DocumentObject*) override;
+    /* Check whether the object accept reordering of its children during drop.*/
+    bool acceptReorderingObjects() const override { return true; };
 
 protected:
     /// Copy over all visual properties to the child features
@@ -105,3 +107,4 @@ private:
 
 
 #endif // PARTGUI_ViewProviderHole_H
+


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/21162

After this PR you can reorder by drag and drop datums and sketches in the tree.