### PR TITLE
BIM: Update shapefile import URL to latest version

### DIFF
--- a/src/Mod/BIM/importers/importSHP.py
+++ b/src/Mod/BIM/importers/importSHP.py
@@ -127,7 +127,8 @@ def checkShapeFileLibrary():
     try:
         import shapefile
     except Exception:
-        url = "https://raw.githubusercontent.com/GeospatialPython/pyshp/refs/heads/master/src/shapefile.py"
+        # pinning to pyshp upstream v2.4.1 since in 3.0.0 the path to shapefile.py changes
+        url = "https://raw.githubusercontent.com/GeospatialPython/pyshp/refs/tags/2.4.1/shapefile.py"
         if FreeCAD.GuiUp:
             import urllib.request
             import FreeCADGui

--- a/src/Mod/BIM/importers/importSHP.py
+++ b/src/Mod/BIM/importers/importSHP.py
@@ -127,7 +127,7 @@ def checkShapeFileLibrary():
     try:
         import shapefile
     except Exception:
-        url = "https://raw.githubusercontent.com/GeospatialPython/pyshp/master/shapefile.py"
+        url = "https://raw.githubusercontent.com/GeospatialPython/pyshp/refs/heads/master/src/shapefile.py"
         if FreeCAD.GuiUp:
             import urllib.request
             import FreeCADGui


### PR DESCRIPTION
Fixes #23911

We should probably consider a better long term solution than just pulling the raw file from upstream. This should be considered a temporary fix.

Probably OK to backport as well. 