### PR TITLE
Sketcher: Change "By control points" and "By knots" texts

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -907,8 +907,8 @@ void DSHBSplineController::configureToolWidget()
         toolWidget->setNoticeText(
             QApplication::translate("TaskSketcherTool_c1_bspline", "Press F to undo last point."));
 
-        QStringList names = {QApplication::translate("Sketcher_CreateBSpline", "By control points"),
-                             QApplication::translate("Sketcher_CreateBSpline", "By knots")};
+        QStringList names = {QApplication::translate("Sketcher_CreateBSpline", "From control points"),
+                             QApplication::translate("Sketcher_CreateBSpline", "From knots")};
         toolWidget->setComboboxElements(WCombobox::FirstCombo, names);
 
         toolWidget->setCheckboxLabel(


### PR DESCRIPTION
Elsewhere in the Sketcher GUI texts, "By" has been replaced by "From". For example "Arc From Center". It makes sense to also do that for the B-spline modes "By control points" and "By knots".