### PR TITLE
Don't inform Coin to use EGL for Coin 4.0.6+

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2389,7 +2389,7 @@ void Application::runApplication()
     int argc = App::Application::GetARGC();
     GUISingleApplication mainApp(argc, App::Application::GetARGV());
 
-#if defined(FC_OS_LINUX) || defined(FC_OS_BSD)
+#if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 406) && (defined(FC_OS_LINUX) || defined(FC_OS_BSD))
     // If QT is running with native Wayland then inform Coin to use EGL
     if (QGuiApplication::platformName() == QString::fromStdString("wayland")) {
         setenv("COIN_EGL", "1", 1);


### PR DESCRIPTION
The next version of Coin (4.0.6+) will be able to automatically detect GLX or EGL. So we don't need to explicitly inform Coin to use EGL anymore when on Wayland. https://github.com/coin3d/coin/pull/582. By automatically detecting GLX or EGL, Coin prevents accidentally mixing GLX and EGL which causes SIGSEGV like #23534 and #22695.

This basically reverts #21917. When using Coin 4.0.4 or 4.0.5 it is still needed to explicitly inform Coin to use EGL. 