### PR TITLE
Gui: set focus to the corresponding property when a gizmo is released

### DIFF
--- a/src/Gui/Inventor/Draggers/Gizmo.cpp
+++ b/src/Gui/Inventor/Draggers/Gizmo.cpp
@@ -252,6 +252,9 @@ void LinearGizmo::draggingFinished()
         property->blockSignals(false);
         property->valueChanged(property->value().getValue());
     }
+
+    property->setFocus();
+    property->selectAll();
 }
 
 void LinearGizmo::draggingContinued()
@@ -447,6 +450,9 @@ void RotationGizmo::draggingFinished()
         property->blockSignals(false);
         property->valueChanged(property->value().getValue());
     }
+
+    property->setFocus();
+    property->selectAll();
 }
 
 void RotationGizmo::draggingContinued()


### PR DESCRIPTION
This PR changes the focus to the property attached with a dragger while releasing the dragger.