### PR TITLE
CAM: LeadInOut - Fix for rapid move in end

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -818,6 +818,8 @@ class ObjectDressup:
 
     # Get finish index of mill command for one profile
     def findLastCutMultiProfileIndex(self, source, startIndex):
+        if startIndex >= len(source):
+            return len(source) - 1
         for i in range(startIndex, len(source), +1):
             if not self.isCuttingMove(source[i]):
                 return i - 1


### PR DESCRIPTION
Get error If path without rapid move in the end

<img width="983" height="509" alt="Screenshot_20250915_224009_lossy" src="https://github.com/user-attachments/assets/aa58c2ff-2e27-4809-bcf0-be2b6b5ce097" />