### PR TITLE
Sketcher: Update Carbon Copy tool help text for macOS to show Cmd+Option

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
@@ -93,19 +93,21 @@ public:
                     this->notAllowedReason = QT_TR_NOOP("This object belongs to another part.");
                     break;
                 case Sketcher::SketchObject::rlNonParallel:
-                    this->notAllowedReason =
-                        QT_TR_NOOP("The selected sketch is not parallel to this sketch. Hold "
-                                   "Ctrl+Alt to allow non-parallel sketches.");
+                    this->notAllowedReason = QT_TR_NOOP(
+                        "The selected sketch is not parallel to this sketch. Hold "
+                        "Ctrl+Alt (Cmd+Option on macOS) to allow non-parallel sketches.");
                     break;
                 case Sketcher::SketchObject::rlAxesMisaligned:
                     this->notAllowedReason =
                         QT_TR_NOOP("The XY axes of the selected sketch do not have the same "
-                                   "direction as this sketch. Hold Ctrl+Alt to disregard it.");
+                                   "direction as this sketch. Hold Ctrl+Alt (Cmd+Option on macOS) "
+                                   "to disregard it.");
                     break;
                 case Sketcher::SketchObject::rlOriginsMisaligned:
                     this->notAllowedReason =
                         QT_TR_NOOP("The origin of the selected sketch is not aligned with the "
-                                   "origin of this sketch. Hold Ctrl+Alt to disregard it.");
+                                   "origin of this sketch. Hold Ctrl+Alt (Cmd+Option on macOS) to "
+                                   "disregard it.");
                     break;
                 default:
                     break;


### PR DESCRIPTION
## Description

This PR updates the help text for the Sketcher Carbon Copy tool to include platform-specific key combinations on macOS.

### Problem

The original tooltip text only mentioned "Ctrl+Alt", which is incorrect for macOS users where the equivalent key combination is "Cmd+Option". This was confusing for macOS users trying to enable non-parallel sketches, misaligned axes, or misaligned origins during carbon copying.

### Changes

Modified `src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h` to update three tooltip messages:

- __Non-parallel sketch__: "Hold Ctrl+Alt (Cmd+Option on macOS) to allow non-parallel sketches."
- __Axes misaligned__: "Hold Ctrl+Alt (Cmd+Option on macOS) to disregard it."
- __Origins misaligned__: "Hold Ctrl+Alt (Cmd+Option on macOS) to disregard it."

### Testing

Built and validated the changes on macOS - the tooltips now correctly display the macOS key combination without affecting functionality.

### Related Issues

Addresses #19935: "Sketcher: Carbon copying a non-parallel sketch has incorrect help text on macOS"

