### PR TITLE
Gui: refactor gizmo attachment code

### DIFF
--- a/src/Gui/Inventor/Draggers/Gizmo.cpp
+++ b/src/Gui/Inventor/Draggers/Gizmo.cpp
@@ -40,6 +40,7 @@
 #include <Gui/Inventor/Draggers/GizmoStyleParameters.h>
 #include <Gui/Inventor/So3DAnnotation.h>
 #include <Gui/Inventor/SoToggleSwitch.h>
+#include <Gui/ViewProviderDragger.h>
 #include <Gui/QuantitySpinBox.h>
 #include <Gui/Utilities.h>
 #include <Gui/View3DInventorViewer.h>
@@ -653,6 +654,8 @@ GizmoContainer::~GizmoContainer()
     cameraPositionSensor.detach();
 
     uninitGizmos();
+
+    viewProvider->setGizmoContainer(nullptr);
 }
 
 void GizmoContainer::initGizmos()
@@ -693,6 +696,8 @@ void GizmoContainer::attachViewer(Gui::View3DInventorViewer* viewer, Base::Place
     if (!viewer) {
         return;
     }
+
+    setUpAutoScale(viewer->getSoRenderManager()->getCamera());
 
     auto mat = origin.toMatrix();
 
@@ -765,4 +770,18 @@ bool GizmoContainer::isEnabled()
         .GetGroup("BaseApp/Preferences/Mod/PartDesign");
 
     return hGrp->GetBool("EnableGizmos", true);
+}
+
+std::unique_ptr<GizmoContainer> GizmoContainer::create(
+    std::initializer_list<Gui::Gizmo*> gizmos,
+    ViewProviderDragger* vp
+)
+{
+    auto gizmoContainer = std::make_unique<GizmoContainer>();
+    gizmoContainer->addGizmos(gizmos);
+    gizmoContainer->viewProvider = vp;
+
+    vp->setGizmoContainer(gizmoContainer.get());
+
+    return gizmoContainer;
 }

--- a/src/Gui/Inventor/Draggers/Gizmo.h
+++ b/src/Gui/Inventor/Draggers/Gizmo.h
@@ -50,6 +50,7 @@ class SoLinearDraggerContainer;
 class SoRotationDragger;
 class SoRotationDraggerContainer;
 class View3DInventorViewer;
+class ViewProviderDragger;
 
 struct GizmoPlacement
 {
@@ -235,20 +236,16 @@ public:
 
     // Checks if the gizmos are enabled in the preferences
     static bool isEnabled();
-    template <typename T>
-    static inline std::unique_ptr<GizmoContainer> createGizmo(std::initializer_list<Gui::Gizmo*> gizmos, T vp)
-    {
-        auto ptr = std::make_unique<GizmoContainer>();
-        ptr->addGizmos(gizmos);
-        vp->setGizmoContainer(ptr.get());
-
-        return ptr;
-    }
+    static std::unique_ptr<GizmoContainer> create(
+        std::initializer_list<Gui::Gizmo*> gizmos,
+        ViewProviderDragger* vp
+    );
 
 private:
     std::vector<Gizmo*> gizmos;
     SoFieldSensor cameraSensor;
     SoFieldSensor cameraPositionSensor;
+    ViewProviderDragger* viewProvider = nullptr;
 
     void addGizmo(Gizmo* gizmo);
 

--- a/src/Gui/ViewProviderDragger.cpp
+++ b/src/Gui/ViewProviderDragger.cpp
@@ -39,6 +39,7 @@
 #include "Control.h"
 #include "Document.h"
 #include "Inventor/Draggers/SoTransformDragger.h"
+#include "Inventor/Draggers/Gizmo.h"
 #include "Inventor/SoFCPlacementIndicatorKit.h"
 #include "SoFCUnifiedSelection.h"
 #include "TaskTransform.h"
@@ -92,6 +93,12 @@ void ViewProviderDragger::setTransformOrigin(const Base::Placement& placement)
 void ViewProviderDragger::resetTransformOrigin()
 {
     setTransformOrigin({});
+}
+
+
+void ViewProviderDragger::setGizmoContainer(Gui::GizmoContainer* gizmoContainer)
+{
+    this->gizmoContainer = gizmoContainer;
 }
 
 void ViewProviderDragger::onChanged(const App::Property* property)
@@ -221,7 +228,11 @@ void ViewProviderDragger::setEditViewer(Gui::View3DInventorViewer* viewer, int M
 {
     Q_UNUSED(ModNum);
 
-    if (transformDragger && viewer) {
+    if (!viewer) {
+        return;
+    }
+
+    if (transformDragger) {
         transformDragger->setUpAutoScale(viewer->getSoRenderManager()->getCamera());
 
         auto originPlacement = App::GeoFeature::getGlobalPlacement(getObject()) * getObjectPlacement().inverse();
@@ -229,6 +240,12 @@ void ViewProviderDragger::setEditViewer(Gui::View3DInventorViewer* viewer, int M
 
         viewer->getDocument()->setEditingTransform(mat);
         viewer->setupEditingRoot(transformDragger, &mat);
+    }
+
+    if (gizmoContainer) {
+        auto originPlacement = App::GeoFeature::getGlobalPlacement(getObject())
+            * getObjectPlacement().inverse();
+        gizmoContainer->attachViewer(viewer, originPlacement);
     }
 }
 

--- a/src/Gui/ViewProviderDragger.h
+++ b/src/Gui/ViewProviderDragger.h
@@ -40,6 +40,7 @@ namespace TaskView {
 
 class SoTransformDragger;
 class View3DInventorViewer;
+class GizmoContainer;
 
 /**
  * The base class for all view providers modifying the placement
@@ -70,6 +71,8 @@ public:
     void setTransformOrigin(const Base::Placement& placement);
     /// Resets transform origin to the object origin
     void resetTransformOrigin();
+
+    void setGizmoContainer(Gui::GizmoContainer* gizmoContainer);
 
 public:
     /** @name Edit methods */
@@ -147,6 +150,8 @@ private:
                                   Base::Vector3d y,
                                   Base::Vector3d z,
                                   ViewProviderDragger::DraggerComponents components = DraggerComponent::All);
+
+    GizmoContainer* gizmoContainer = nullptr;
 };
 
 } // namespace Gui

--- a/src/Mod/Part/Gui/TaskThickness.cpp
+++ b/src/Mod/Part/Gui/TaskThickness.cpp
@@ -326,7 +326,7 @@ void ThicknessWidget::setupGizmos()
         delete linearGizmo;
         return;
     }
-    gizmoContainer = Gui::GizmoContainer::createGizmo({linearGizmo}, vp);
+    gizmoContainer = Gui::GizmoContainer::create({linearGizmo}, vp);
 
     setGizmoPositions();
 }

--- a/src/Mod/Part/Gui/ViewProvider.cpp
+++ b/src/Mod/Part/Gui/ViewProvider.cpp
@@ -111,25 +111,6 @@ void ViewProviderPart::applyTransparency(float transparency, std::vector<App::Ma
     }
 }
 
-void ViewProviderPart::setEditViewer(Gui::View3DInventorViewer* viewer, int ModNum)
-{
-    ViewProviderPartExt::setEditViewer(viewer, ModNum);
-
-    if (gizmoContainer) {
-        gizmoContainer->setUpAutoScale(viewer->getSoRenderManager()->getCamera());
-
-        auto originPlacement = App::GeoFeature::getGlobalPlacement(getObject())
-            * getObjectPlacement().inverse();
-        gizmoContainer->attachViewer(viewer, originPlacement);
-    }
-}
-
-void ViewProviderPart::setGizmoContainer(Gui::GizmoContainer* gizmoContainer)
-{
-    assert(gizmoContainer);
-    this->gizmoContainer = gizmoContainer;
-}
-
 // ----------------------------------------------------------------------------
 
 void ViewProviderShapeBuilder::buildNodes(const App::Property* prop, std::vector<SoNode*>& nodes) const

--- a/src/Mod/Part/Gui/ViewProvider.h
+++ b/src/Mod/Part/Gui/ViewProvider.h
@@ -60,8 +60,6 @@ public:
     ~ViewProviderPart() override;
     bool doubleClicked() override;
 
-    void setGizmoContainer(Gui::GizmoContainer* gizmoContainer);
-
 protected:
     void applyColor(const Part::ShapeHistory& hist,
                     const std::vector<Base::Color>& colBase,
@@ -71,11 +69,6 @@ protected:
                        std::vector<App::Material>& colBool);
     void applyTransparency(float transparency, std::vector<Base::Color>& colors);
     void applyTransparency(float transparency, std::vector<App::Material>& colors);
-
-    void setEditViewer(Gui::View3DInventorViewer* viewer, int ModNum) override;
-
-private:
-    Gui::GizmoContainer* gizmoContainer = nullptr;
 };
 
 } // namespace PartGui

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -383,7 +383,7 @@ void TaskChamferParameters::setupGizmos(ViewProviderDressUp* vp)
         }
     });
 
-    gizmoContainer = GizmoContainer::createGizmo({
+    gizmoContainer = GizmoContainer::create({
         distanceGizmo, secondDistanceGizmo, angleGizmo
     }, vp);
 

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -1375,7 +1375,7 @@ void TaskExtrudeParameters::setupGizmos()
         setGizmoPositions();
     });
 
-    gizmoContainer = GizmoContainer::createGizmo({
+    gizmoContainer = GizmoContainer::create({
         lengthGizmo1, lengthGizmo2,
         taperAngleGizmo1, taperAngleGizmo2
     }, vp);

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -216,7 +216,7 @@ void TaskFilletParameters::setupGizmos(ViewProviderDressUp* vp)
     radiusGizmo = new Gui::LinearGizmo(ui->filletRadius);
     radiusGizmo2 = new Gui::LinearGizmo(ui->filletRadius);
 
-    gizmoContainer = GizmoContainer::createGizmo({radiusGizmo, radiusGizmo2}, vp);
+    gizmoContainer = GizmoContainer::create({radiusGizmo, radiusGizmo2}, vp);
 
     setGizmoPositions();
 }

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -726,7 +726,7 @@ void TaskHelixParameters::setupGizmos(ViewProviderHelix* vp)
         heightGizmo->setVisibility(!isPitchTurnsAngle);
     });
 
-    gizmoContainer = GizmoContainer::createGizmo({heightGizmo}, vp);
+    gizmoContainer = GizmoContainer::create({heightGizmo}, vp);
 
     setGizmoPositions();
 

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -1172,7 +1172,7 @@ void TaskHoleParameters::setupGizmos(ViewProviderHole* vp)
 
     holeDepthGizmo = new LinearGizmo(ui->Depth);
 
-    gizmoContainer = GizmoContainer::createGizmo({holeDepthGizmo}, vp);
+    gizmoContainer = GizmoContainer::create({holeDepthGizmo}, vp);
 
     setGizmoPositions();
 }

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -739,7 +739,7 @@ void TaskRevolutionParameters::setupGizmos(ViewProvider* vp)
     rotationGizmo = new Gui::RadialGizmo(ui->revolveAngle);
     rotationGizmo2 = new Gui::RadialGizmo(ui->revolveAngle2);
 
-    gizmoContainer = GizmoContainer::createGizmo({rotationGizmo, rotationGizmo2}, vp);
+    gizmoContainer = GizmoContainer::create({rotationGizmo, rotationGizmo2}, vp);
     rotationGizmo->flipArrow();
     rotationGizmo2->flipArrow();
 

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
@@ -278,7 +278,7 @@ void TaskThicknessParameters::setupGizmos(ViewProviderDressUp* vp)
 
     linearGizmo = new Gui::LinearGizmo(ui->Value);
 
-    gizmoContainer = GizmoContainer::createGizmo({linearGizmo}, vp);
+    gizmoContainer = GizmoContainer::create({linearGizmo}, vp);
 
     setGizmoPositions();
 }


### PR DESCRIPTION
I noticed that creating a pad, disabling the gizmos and then trying to edit the feature caused a segfault. The reason was quite clear that the view provider outlives the task dialog but we don't invalidate the gizmoContainer attached to the vp.
The solution was simple, store the vp and set gizmoContainer to null from the destructor. But I can't store a pointer to the ViewProviderPart without any hack because src/Gui can't access Part. To address this, I needed to store the gizmoContainer and attach it to the viewer from some Gui class. And what would be a better  choice than ViewProviderDragger because dragger<->gizmo :people_hugging: lol (well it was also already overriding the setEditViewer method).