### PR TITLE
[TD]fix uncommanded leader position change

### DIFF
--- a/src/Mod/TechDraw/Gui/QGILeaderLine.h
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.h
@@ -73,6 +73,9 @@ public:
     void drawBorder() override;
     void updateView(bool update = false) override;
 
+    // leaders are not draggable
+    void dragFinished() override { };
+
     virtual TechDraw::DrawLeaderLine* getLeaderFeature();
 
     void startPathEdit();

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -230,6 +230,10 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
 
     return QGraphicsItemGroup::itemChange(change, value);
 }
+
+//! The default behaviour here only applies to views whose (X, Y) describes a position on the page.
+//! Others, like QGILeaderLine whose (X, Y) describes a position within a view's boundary and is not
+//! draggable, should override this method.
 void QGIView::dragFinished()
 {
     if (!viewObj) {

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -178,7 +178,7 @@ protected:
     QGIView* getQGIVByName(std::string name) const;
 
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
-    void dragFinished();
+    virtual void dragFinished();
 
     // Preselection events:
     void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;


### PR DESCRIPTION
This PR implements a fix for a condition where a leader is displaced after an edit not involving position.

Current result of opening and closing the leader dialog:
<img width="896" height="678" alt="incorrectPosition" src="https://github.com/user-attachments/assets/3aa513ce-5c86-4508-8b43-800634982b8e" />

Fix result:
<img width="825" height="649" alt="correctPosition" src="https://github.com/user-attachments/assets/72b960b6-d308-4d13-ae36-15faf581af09" />
