### PR TITLE
Gui: Indicator for collapsed groups in the property view

### DIFF
--- a/src/Gui/PropertyView.cpp
+++ b/src/Gui/PropertyView.cpp
@@ -86,12 +86,14 @@ PropertyView::PropertyView(QWidget *parent)
     propertyEditorView->setObjectName(QStringLiteral("propertyEditorView"));
     propertyEditorView->setAutomaticDocumentUpdate(_GetParam()->GetBool("AutoTransactionView", false));
     propertyEditorView->setAutomaticExpand(_GetParam()->GetBool("AutoExpandView", false));
+    propertyEditorView->setAutomaticCollapse(_GetParam()->GetBool("AutoCollapseView", false));
     tabs->addTab(propertyEditorView, tr("View"));
 
     propertyEditorData = new Gui::PropertyEditor::PropertyEditor();
     propertyEditorData->setObjectName(QStringLiteral("propertyEditorData"));
     propertyEditorData->setAutomaticDocumentUpdate(_GetParam()->GetBool("AutoTransactionData", true));
     propertyEditorData->setAutomaticExpand(_GetParam()->GetBool("AutoExpandData", false));
+    propertyEditorView->setAutomaticCollapse(_GetParam()->GetBool("AutoCollapseData", false));
     tabs->addTab(propertyEditorData, tr("Data"));
 
     int preferredTab = _GetParam()->GetInt("LastTabIndex", 1);

--- a/src/Gui/PropertyView.cpp
+++ b/src/Gui/PropertyView.cpp
@@ -85,15 +85,11 @@ PropertyView::PropertyView(QWidget *parent)
     propertyEditorView = new Gui::PropertyEditor::PropertyEditor();
     propertyEditorView->setObjectName(QStringLiteral("propertyEditorView"));
     propertyEditorView->setAutomaticDocumentUpdate(_GetParam()->GetBool("AutoTransactionView", false));
-    propertyEditorView->setAutomaticExpand(_GetParam()->GetBool("AutoExpandView", false));
-    propertyEditorView->setAutomaticCollapse(_GetParam()->GetBool("AutoCollapseView", false));
     tabs->addTab(propertyEditorView, tr("View"));
 
     propertyEditorData = new Gui::PropertyEditor::PropertyEditor();
     propertyEditorData->setObjectName(QStringLiteral("propertyEditorData"));
     propertyEditorData->setAutomaticDocumentUpdate(_GetParam()->GetBool("AutoTransactionData", true));
-    propertyEditorData->setAutomaticExpand(_GetParam()->GetBool("AutoExpandData", false));
-    propertyEditorView->setAutomaticCollapse(_GetParam()->GetBool("AutoCollapseData", false));
     tabs->addTab(propertyEditorData, tr("Data"));
 
     int preferredTab = _GetParam()->GetInt("LastTabIndex", 1);

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -76,7 +76,7 @@ PropertyEditor::PropertyEditor(QWidget* parent)
 
     setAlternatingRowColors(true);
     setRootIsDecorated(false);
-    setExpandsOnDoubleClick(true);
+    setExpandsOnDoubleClick(false);
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QStyleOptionViewItem opt = PropertyEditor::viewOptions();
@@ -411,6 +411,18 @@ void PropertyEditor::openEditor(const QModelIndex& index)
 
 void PropertyEditor::onItemActivated(const QModelIndex& index)
 {
+    if (!index.isValid()) {
+        return;
+    }
+    if (auto* prop = static_cast<PropertyItem*>(index.internalPointer());
+        prop && prop->isSeparator()) {
+
+        // setExpanded() only works on column 0
+        QModelIndex idxFirstColum = propertyModel->index(index.row(), 0, index.parent());
+        setExpanded(idxFirstColum, !isExpanded(idxFirstColum));
+        return;
+    }
+
     if (index.column() != 1) {
         return;
     }

--- a/src/Gui/propertyeditor/PropertyEditor.h
+++ b/src/Gui/propertyeditor/PropertyEditor.h
@@ -70,6 +70,12 @@ class GuiExport PropertyEditor: public QTreeView
     // clang-format on
 
 public:
+    enum class ExpansionMode {
+        DefaultExpand,
+        AutoExpand,
+        AutoCollapse
+    };
+
     PropertyEditor(QWidget* parent = nullptr);
     ~PropertyEditor() override;
 
@@ -79,10 +85,6 @@ public:
     void updateProperty(const App::Property&);
     void removeProperty(const App::Property&);
     void renameProperty(const App::Property&);
-    void setAutomaticCollapse(bool);
-    bool isAutomaticCollapse(bool) const;
-    void setAutomaticExpand(bool);
-    bool isAutomaticExpand(bool) const;
     void setAutomaticDocumentUpdate(bool);
     bool isAutomaticDocumentUpdate(bool) const;
     /*! Reset the internal state of the view. */
@@ -133,6 +135,10 @@ protected:
     void keyPressEvent(QKeyEvent* event) override;
 
 private:
+    void setFirstLevelExpanded(bool doExpand);
+    void expandToDefault();
+    QMenu* setupExpansionSubmenu(QWidget* parent);
+    void collapseAll();
     void setEditorMode(const QModelIndex& parent, int start, int end);
     void closeTransaction();
     void recomputeDocument(App::Document*);
@@ -150,8 +156,7 @@ private:
     QStringList selectedProperty;
     PropertyModel::PropertyList propList;
     std::unordered_set<const App::PropertyContainer*> propOwners;
-    bool autocollapse;
-    bool autoexpand;
+    ExpansionMode expansionMode;
     bool autoupdate;
     bool committing;
     bool delaybuild;

--- a/src/Gui/propertyeditor/PropertyEditor.h
+++ b/src/Gui/propertyeditor/PropertyEditor.h
@@ -79,6 +79,8 @@ public:
     void updateProperty(const App::Property&);
     void removeProperty(const App::Property&);
     void renameProperty(const App::Property&);
+    void setAutomaticCollapse(bool);
+    bool isAutomaticCollapse(bool) const;
     void setAutomaticExpand(bool);
     bool isAutomaticExpand(bool) const;
     void setAutomaticDocumentUpdate(bool);
@@ -148,6 +150,7 @@ private:
     QStringList selectedProperty;
     PropertyModel::PropertyList propList;
     std::unordered_set<const App::PropertyContainer*> propOwners;
+    bool autocollapse;
     bool autoexpand;
     bool autoupdate;
     bool committing;

--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -144,6 +144,16 @@ void PropertyItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         QItemDelegate::paint(painter, option, index);
     }
 
+    if (index.column() == 1 && property && property->isSeparator()) {
+        const auto* view = qobject_cast<const QTreeView*>(option.widget ? option.widget : parent());
+        QModelIndex indexFirstColumn = index.sibling(index.row(), 0);
+        const bool expanded = view ? view->isExpanded(indexFirstColumn) : false;
+
+        if (!expanded) {
+            // Add your indicator here
+        }
+    }
+
     QColor color = static_cast<QRgb>(QApplication::style()->styleHint(QStyle::SH_Table_GridLineColor, &opt, qobject_cast<QWidget*>(parent())));
     painter->setPen(QPen(color));
     if (index.column() == 1 || !(property && property->isSeparator())) {


### PR DESCRIPTION
This draft PR contains some logic and a comment of where to implement an indicator for collapsed groups. Drawing such an indicator is a bit beyond my expertise, so I hope someone else can pick up on this.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues

Closes https://github.com/FreeCAD/FreeCAD/issues/23967
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

