### PR TITLE
App: Fix GroupExtension finding wrong group for objects

### DIFF
--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -323,11 +323,15 @@ DocumentObject* GroupExtension::getGroupOfObject(const DocumentObject* obj)
     // object can be in only one group, and only one geofeaturegroup, however, it can be in both at
     // the same time)
     for (auto o : obj->getInList()) {
-        if (o->hasExtension(App::GroupExtension::getExtensionClassTypeId(), false)) {
-            return o;
+        Extension* ext = o->getExtension(GroupExtension::getExtensionClassTypeId(), false, true);
+        if (!ext) {
+            ext = o->getExtension(GroupExtensionPython::getExtensionClassTypeId(), false, true);
         }
-        if (o->hasExtension(App::GroupExtensionPython::getExtensionClassTypeId(), false)) {
-            return o;
+        if (ext) {
+            auto grp = static_cast<GroupExtension*>(ext)->Group.getValues();
+            if (std::find(grp.begin(), grp.end(), obj) != grp.end()) {
+                return o;
+            }
         }
     }
 
@@ -364,11 +368,14 @@ void GroupExtension::extensionOnChanged(const Property* p)
                 // an error. We need a custom check
                 auto list = obj->getInList();
                 for (auto in : list) {
-                    if (in->hasExtension(App::GroupExtension::getExtensionClassTypeId(), false)
-                        && in != getExtendedObject()) {
-                        error = true;
-                        corrected.erase(std::remove(corrected.begin(), corrected.end(), obj),
-                                        corrected.end());
+                    auto ext = in->getExtension(GroupExtension::getExtensionClassTypeId(), false, true);
+                    if (ext && (in != getExtendedObject())) {
+                        auto grp = static_cast<GroupExtension*>(ext)->Group.getValues();
+                        if (std::find(grp.begin(), grp.end(), obj) != grp.end()) {
+                            error = true;
+                            corrected.erase(std::remove(corrected.begin(), corrected.end(), obj),
+                                            corrected.end());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Currently, in certain cases, the extension fails to find the correct group for an object because it relies on `InList` to find the group membership.
A second group may be linked to the object, so using `InList` alone to determine membership may return an erroneous result.
To fix this bug, explicit checking for each group has been added.

Example:
```
g0 = App.ActiveDocument.addObject("App::DocumentObjectGroup")
g1 = App.ActiveDocument.addObject("App::DocumentObjectGroup")
obj = App.ActiveDocument.addObject("App::DocumentObject")

g0.addProperty("App::PropertyLink", "Test")
g0.Test = obj
g1.Group = [obj]    -> Error. Assumes  obj is in g0 group, but it isn't.
```
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
