### PR TITLE
Sketcher: fix some prefs texts

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
@@ -486,7 +486,7 @@
       <item row="9" column="0">
        <widget class="QLabel" name="label_20">
         <property name="text">
-         <string>External reference geometry</string>
+         <string>External construction geometry</string>
         </property>
        </widget>
       </item>
@@ -499,7 +499,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string>Color of external geometry in edit mode</string>
+         <string>Color of external construction geometry in edit mode</string>
         </property>
         <property name="color" stdset="0">
          <color>
@@ -519,7 +519,7 @@
       <item row="9" column="3">
        <widget class="QComboBox" name="ExternalPattern">
         <property name="toolTip">
-         <string>Line pattern of external reference edges</string>
+         <string>Line pattern of external construction edges</string>
         </property>
         <property name="currentIndex">
          <number>-1</number>
@@ -529,7 +529,7 @@
       <item row="9" column="4">
        <widget class="Gui::PrefSpinBox" name="ExternalWidth">
         <property name="toolTip">
-         <string>Width of external edges</string>
+         <string>Width of external construction edges</string>
         </property>
         <property name="unit" stdset="0">
          <string notr="true">px</string>

--- a/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
@@ -125,7 +125,7 @@
   <item row="10" column="0">
        <widget class="Gui::PrefCheckBox" name="checkBoxShowDimensionalName">
         <property name="toolTip">
-         <string>Displays names of dimensional constraints, if they exist</string>
+         <string>Shows names of dimensional constraints, if they exist</string>
         </property>
         <property name="text">
          <string>Show dimensional constraint name with format</string>
@@ -274,10 +274,10 @@ Supports all unit systems except 'US customary' and 'Building US/Euro'.</string>
   <item row="8" column="0">
        <widget class="Gui::PrefCheckBox" name="checkBoxShowCursorCoords">
         <property name="toolTip">
-         <string>Displays cursor position coordinates next to the cursor while editing a sketch</string>
+         <string>Shows cursor position coordinates next to the cursor while editing a sketch</string>
         </property>
         <property name="text">
-         <string>Displays coordinates next to the cursor while editing</string>
+         <string>Show coordinates next to the cursor while editing</string>
         </property>
         <property name="checked">
          <bool>true</bool>


### PR DESCRIPTION
* Change checkbox "Displays coordinates next to the cursor while editing" to "Show coordinates next to the cursor while editing".
* Use "Shows" instead of "Displays" in tootips for consistence.
* Change "External reference geometry" to "External construction geometry".
* Also update/complete the related tootips.