### PR TITLE
Gui: hide the gizmos in case of any errors

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -399,11 +399,12 @@ void TaskChamferParameters::setGizmoPositions()
     }
 
     auto chamfer = getObject<PartDesign::Chamfer>();
-    if (!chamfer) {
+    if (!chamfer || chamfer->isError()) {
         gizmoContainer->visible = false;
         return;
     }
-    auto baseShape = chamfer->getBaseTopoShape();
+
+    PartDesign::TopoShape baseShape = chamfer->getBaseTopoShape(true);
     auto shapes = chamfer->getContinuousEdges(baseShape);
 
     if (shapes.size() == 0) {

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -1390,6 +1390,12 @@ void TaskExtrudeParameters::setGizmoPositions()
     }
 
     auto extrude = getObject<PartDesign::FeatureExtrude>();
+    if (!extrude || extrude->isError()) {
+        gizmoContainer->visible = false;
+        return;
+    }
+    gizmoContainer->visible = true;
+
     PartDesign::TopoShape shape = extrude->getProfileShape();
     Base::Vector3d center = getMidPointFromProfile(shape);
     std::string sideType = std::string(extrude->SideType.getValueAsString());

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -228,11 +228,11 @@ void TaskFilletParameters::setGizmoPositions()
     }
 
     auto fillet = getObject<PartDesign::Fillet>();
-    if (!fillet) {
+    if (!fillet || fillet->isError()) {
         gizmoContainer->visible = false;
         return;
     }
-    Part::TopoShape baseShape = fillet->getBaseTopoShape();
+    Part::TopoShape baseShape = fillet->getBaseTopoShape(true);
     std::vector<Part::TopoShape> shapes = fillet->getContinuousEdges(baseShape);
 
     if (shapes.size() == 0) {

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -740,6 +740,11 @@ void TaskHelixParameters::setGizmoPositions()
     }
 
     auto helix = getObject<PartDesign::Helix>();
+    if (!helix || helix->isError()) {
+        gizmoContainer->visible = false;
+        return;
+    }
+    gizmoContainer->visible = true;
     Part::TopoShape profileShape = helix->getProfileShape();
     double reversed = propReversed->getValue()? -1.0 : 1.0;
     auto profileCentre = getMidPointFromProfile(profileShape);

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -1233,6 +1233,10 @@ void TaskHoleParameters::setGizmoPositions()
     }
 
     auto hole = getObject<PartDesign::Hole>();
+    if (!hole || hole->isError()) {
+        gizmoContainer->visible = false;
+        return;
+    }
     Part::TopoShape profileShape = hole->getProfileShape(
         Part::ShapeOption::NeedSubElement |
         Part::ShapeOption::ResolveLink |

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -762,6 +762,10 @@ void TaskRevolutionParameters::setGizmoPositions()
 
     if (isGroove) {
         auto groove = getObject<PartDesign::Groove>();
+        if (!groove || groove->isError()) {
+            gizmoContainer->visible = false;
+            return;
+        }
         Part::TopoShape profile = groove->getProfileShape();
         
         profile.getCenterOfGravity(profileCog);
@@ -769,12 +773,17 @@ void TaskRevolutionParameters::setGizmoPositions()
         axisDir = groove->Axis.getValue();
     } else {
         auto revolution = getObject<PartDesign::Revolution>();
+        if (!revolution || revolution->isError()) {
+            gizmoContainer->visible = false;
+            return;
+        }
         Part::TopoShape profile = revolution->getProfileShape();
         
         profile.getCenterOfGravity(profileCog);
         basePos = revolution->Base.getValue();
         axisDir = revolution->Axis.getValue();
     }
+    gizmoContainer->visible = true;
 
     auto diff = profileCog - basePos;
     axisDir.Normalize();


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/23877
Fixes https://github.com/FreeCAD/FreeCAD/issues/23693

Improves the general error handling to the draggers so that they are hidden in case of any errors.