### PR TITLE
TechDraw: Fix selections not clearing when subelements are also selected

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -199,15 +199,12 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
     }
 
     if (change == ItemSelectedHasChanged && scene()) {
-        bool thisViewIsSelected = value.toBool();
-        bool anyChildSelected = false;
-        if (!thisViewIsSelected) { // Only check children if this view is becoming unselected
-            anyChildSelected =
-                std::ranges::any_of(childItems(), [](QGraphicsItem* child) {
-                    return child->isSelected();
-                });
-        }
-        if(thisViewIsSelected || anyChildSelected || isSelected()) {
+        std::vector<Gui::SelectionObject> currentSelection = Gui::Selection().getSelectionEx();
+        bool isViewObjectSelected = Gui::Selection().isSelected(getViewObject());
+        bool hasSelectedSubElements =
+            !DrawGuiUtil::getSubsForSelectedObject(currentSelection, getViewObject()).empty();
+
+        if (isViewObjectSelected || hasSelectedSubElements) {
             m_colCurrent = getSelectColor();
             m_border->show();
             m_label->show();


### PR DESCRIPTION
 Fix selections not clearing when subelements are also selected.

## Issues
Fix #23998

## Demo of Fix

https://github.com/user-attachments/assets/70684c78-b565-4dcf-93ef-0e97eef0f5ae

