### PR TITLE
Fix: Update tooltip for grouped commands

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -565,7 +565,7 @@ void ActionGroup::setCheckedAction(int index)
     this->setIcon(act->icon());
 
     if (!this->_isMode) {
-        this->setToolTip(act->toolTip(), act->text());
+        this->action()->setToolTip(act->toolTip());
     }
     this->setProperty("defaultAction", QVariant(index));
 }
@@ -594,7 +594,7 @@ void ActionGroup::onActivated (QAction* act)
 
         this->setIcon(act->icon());
         if (!this->_isMode) {
-            this->setToolTip(act->toolTip(), act->text());
+            this->action()->setToolTip(act->toolTip());
         }
         this->setProperty("defaultAction", QVariant(index));
         command()->invoke(index, Command::TriggerChildAction);


### PR DESCRIPTION
  ### Summary

  This PR fixes an issue where the tooltip for a grouped command in a toolbar would not display the shortcut of the active tool. This should address Issue https://github.com/FreeCAD/FreeCAD/issues/23009

###   The Problem

  When a command is part of a toolbar group (a fly-out menu), the tooltip for the main button of the group does not correctly display the shortcut of the
  currently active tool. This happens both for the default tool when FreeCAD starts and when a new tool is selected from the group. This can be confusing for
  users who rely on keyboard shortcuts.

###   The Solution

  The issue was traced to the ActionGroup class in src/Gui/Action.cpp. The methods responsible for updating the group's action (onActivated and
  setCheckedAction) were not correctly updating the tooltip with the child action's information.

  This PR fixes the issue by modifying these two methods to directly copy the tooltip from the child QAction to the group's QAction. The child action's
  tooltip is already correctly formatted with the shortcut, so this ensures that the group's button always displays the correct tooltip for the active tool.

###   How to Test

   1. Switch to the Sketcher workbench.
   2. Hover your mouse over a grouped toolbar icon (e.g., the "Conic" tools group which contains Circle, Ellipse, etc.).
   3. Verify that the tooltip for the default tool (e.g., Circle) shows the correct shortcut (e.g., G, C).
   4. Click the dropdown arrow for the group to expand it.
   5. Select a different tool from the group (e.g., Ellipse).
   6. Hover over the main button for the group again (it should now show the Ellipse icon).
   7. Verify that the tooltip now shows the correct shortcut for the Ellipse tool (e.g., G, E, E).

  This change should not introduce any new errors and has been tested to ensure it doesn't cause the build issues we previously encountered.