### PR TITLE
[CAM] Improve Adaptive operation to successfully generate for small stepover

### DIFF
--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -613,7 +613,10 @@ def Execute(op, obj):
             "orderCutsByRegion": obj.OrderCutsByRegion,
         }
 
+        import random
+
         insideInputStateObject = {
+            "TODO TESTING": random.random(),
             "tool": op.tool.Diameter.Value,
             "tolerance": obj.Tolerance,
             "geometry": [k["path2d"] for k in regionOps if k["opType"] == insideOpType],

--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -613,10 +613,7 @@ def Execute(op, obj):
             "orderCutsByRegion": obj.OrderCutsByRegion,
         }
 
-        import random
-
         insideInputStateObject = {
-            "TODO TESTING": random.random(),
             "tool": op.tool.Diameter.Value,
             "tolerance": obj.Tolerance,
             "geometry": [k["path2d"] for k in regionOps if k["opType"] == insideOpType],

--- a/src/Mod/CAM/libarea/Adaptive.cpp
+++ b/src/Mod/CAM/libarea/Adaptive.cpp
@@ -22,11 +22,13 @@
 
 #include "Adaptive.hpp"
 #include <iostream>
+#include <fstream>
 #include <cmath>
 #include <cstring>
 #include <ctime>
 #include <algorithm>
 #include <numbers>
+#include <optional>
 
 namespace ClipperLib
 {
@@ -1102,58 +1104,65 @@ public:
 
     void clear()
     {
-        angles.clear();
-        areas.clear();
+        m_min.reset();
+        m_max.reset();
+    }
+    bool bothSides()
+    {
+        return m_min && m_max && m_min->second < 0 && m_max->second >= 0;
     }
     // adds point keeping the incremental order of areas for interpolation to work correctly
     void addPoint(double area, double angle)
     {
-        std::size_t size = areas.size();
-        if (size == 0 || area > areas[size - 1] + NTOL) {  // first point or largest area point
-            areas.push_back(area);
-            angles.push_back(angle);
-            return;
+        if (!m_min) {
+            m_min = {angle, area};
         }
-
-        for (std::size_t i = 0; i < size; i++) {
-            if (area < areas[i] - NTOL && (i == 0 || area > areas[i - 1] + NTOL)) {
-                areas.insert(areas.begin() + i, area);
-                angles.insert(angles.begin() + i, angle);
+        else if (!m_max) {
+            m_max = {angle, area};
+            if (m_min->second > m_max->second) {
+                auto tmp = m_min;
+                m_min = m_max;
+                m_max = tmp;
             }
+        }
+        else if (bothSides()) {
+            if (area < 0) {
+                m_min = {angle, area};
+            }
+            else {
+                m_max = {angle, area};
+            }
+        }
+        else {
+            if (abs(m_min->second) > abs(m_max->second)) {
+                m_min.reset();
+            }
+            else {
+                m_max.reset();
+            }
+            addPoint(area, angle);
         }
     }
 
-    double interpolateAngle(double targetArea)
+    double interpolateAngle(ofstream& fout)
     {
-        std::size_t size = areas.size();
-        if (size < 2 || targetArea > areas[size - 1]) {
-            return MIN_ANGLE;  // max engage angle - convenient value to initially measure cut area
-        }
-        if (targetArea < areas[0]) {
-            return MAX_ANGLE;  // min engage angle
+        if (!m_min) {
+            return MIN_ANGLE;
         }
 
-        for (size_t i = 1; i < size; i++) {
-            // find 2 subsequent points where target area is between
-            if (areas[i - 1] <= targetArea && areas[i] > targetArea) {
-                // linear interpolation
-                double af = (targetArea - areas[i - 1]) / (areas[i] - areas[i - 1]);
-                double a = angles[i - 1] + af * (angles[i] - angles[i - 1]);
-                return a;
-            }
+        if (!m_max) {
+            return MAX_ANGLE;
         }
-        return MIN_ANGLE;
+
+        fout << "(" << m_min->first << ", " << m_min->second << ") ~ (" << m_max->first << ", "
+             << m_max->second << ") ";
+        double p = (0 - m_min->second) / (m_max->second - m_min->second);
+        return m_min->first * (1 - p) + m_max->first * p;
     }
 
     double clampAngle(double angle)
     {
-        if (angle < MIN_ANGLE) {
-            return MIN_ANGLE;
-        }
-        if (angle > MAX_ANGLE) {
-            return MAX_ANGLE;
-        }
-        return angle;
+        return max(min(angle, MAX_ANGLE), MIN_ANGLE);
     }
 
     double getRandomAngle()
@@ -1162,12 +1171,12 @@ public:
     }
     size_t getPointCount()
     {
-        return areas.size();
+        return (m_min ? 1 : 0) + (m_max ? 1 : 0);
     }
 
-private:
-    vector<double> angles;
-    vector<double> areas;
+public:
+    std::optional<std::pair<double, double>> m_min;
+    std::optional<std::pair<double, double>> m_max;
 };
 
 //***************************************
@@ -2704,6 +2713,9 @@ void Adaptive2d::AddPathToProgress(TPaths& progressPaths, const Path pth, Motion
 
 void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
 {
+    ofstream fout("adaptive_debug.txt");
+    fout << endl << endl << "----------------------" << endl;
+    fout << "Start ProcessPolyNode" << endl;
     Perf_ProcessPolyNode.Start();
     current_region++;
     cout << "** Processing region: " << current_region << endl;
@@ -2754,6 +2766,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             engageBounds.push_back(p);
         }
         outsideEntry = true;
+        fout << "Outside entry " << entryPoint << endl;
     }
     else {
         if (!FindEntryPoint(progressPaths,
@@ -2766,6 +2779,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             Perf_ProcessPolyNode.Stop();
             return;
         }
+        fout << "Helix entry " << entryPoint << endl;
     }
 
     EngagePoint engage(engageBounds);  // engage point stepping instance
@@ -2828,6 +2842,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
     // LOOP - PASSES
     //*******************************
     for (long pass = 0; pass < PASSES_LIMIT; pass++) {
+        fout << "New pass! " << pass << endl;
         if (stopProcessing) {
             break;
         }
@@ -2866,6 +2881,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
         // LOOP - POINTS
         //*******************************
         for (long point_index = 0; point_index < POINTS_PER_PASS_LIMIT; point_index++) {
+            fout << endl << "Point " << point_index << endl;
             if (stopProcessing) {
                 break;
             }
@@ -2908,12 +2924,14 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             if (stepScaled < RESOLUTION_FACTOR) {
                 stepScaled = long(RESOLUTION_FACTOR);
             }
+            fout << "\tstepScaled " << stepScaled << endl;
 
             //*****************************
             // ANGLE vs AREA ITERATIONS
             //*****************************
             double predictedAngle = averageDV(angleHistory);
             double maxError = AREA_ERROR_FACTOR * optimalCutAreaPD;
+            fout << "optimal area " << optimalCutAreaPD << " maxError " << maxError << endl;
             double area = 0;
             double areaPD = 0;
             interp.clear();
@@ -2923,32 +2941,49 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             double prev_error = __DBL_MAX__;
             for (iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
                 total_iterations++;
+                fout << "It " << iteration << " ";
                 if (iteration == 0) {
                     angle = predictedAngle;
+                    fout << "case predicted ";
                 }
                 else if (iteration == 1) {
                     angle = interp.MIN_ANGLE;  // max engage
+                    fout << "case minimum ";
                 }
-                else if (iteration == 3) {
-                    angle = interp.MAX_ANGLE;  // min engage
+                else if (iteration == 2) {
+                    if (interp.bothSides()) {
+                        angle = interp.interpolateAngle(fout);
+                        fout << "case interp ";
+                    }
+                    else {
+                        angle = interp.MAX_ANGLE;  // min engage
+                        fout << "case maximum ";
+                    }
                 }
                 else if (interp.getPointCount() < 2) {
                     angle = interp.getRandomAngle();
+                    fout << "case random ";
                 }
                 else {
-                    angle = interp.interpolateAngle(targetAreaPD);
+                    angle = interp.interpolateAngle(fout);
+                    fout << "case interp ";
                 }
+                fout << "raw " << angle << " ";
                 angle = interp.clampAngle(angle);
+                fout << "clamped " << angle << " ";
 
                 newToolDir = rotate(toolDir, angle);
                 newToolPos = IntPoint(long(toolPos.X + newToolDir.X * stepScaled),
                                       long(toolPos.Y + newToolDir.Y * stepScaled));
+                fout << "int pos " << newToolPos << " ";
 
                 area = CalcCutArea(clip, toolPos, newToolPos, cleared);
 
                 areaPD = area / double(stepScaled);  // area per distance
-                interp.addPoint(areaPD, angle);
+                fout << "addPoint " << areaPD << " " << angle << " ";
                 double error = areaPD - targetAreaPD;
+                interp.addPoint(error, angle);
+                fout << "areaPD " << areaPD << " error " << error << " ";
                 // cout << " iter:" << iteration << " angle:" << angle << " area:" << areaPD
                 //      << " target:" << targetAreaPD << " error:" << error << " max:" << maxError
                 //      << endl;
@@ -2957,14 +2992,18 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                     if (angleHistory.size() > ANGLE_HISTORY_POINTS) {
                         angleHistory.erase(angleHistory.begin());
                     }
+                    fout << "small enough" << endl;
                     break;
                 }
                 if (iteration > 5 && fabs(error - prev_error) < 0.001) {
+                    fout << "no change" << endl;
                     break;
                 }
                 if (iteration == MAX_ITERATIONS - 1) {
+                    fout << "too many iterations!" << endl;
                     total_exceeded++;
                 }
+                fout << endl;
                 prev_error = error;
             }
             Perf_PointIterations.Stop();
@@ -2982,6 +3021,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                 newToolPos = IntPoint(long(toolPos.X + newToolDir.X * stepScaled),
                                       long(toolPos.Y + newToolDir.Y * stepScaled));
                 recalcArea = true;
+                fout << "\tRewrote tooldir/toolpos for boundary approach" << endl;
             }
 
             //**********************************************
@@ -2995,6 +3035,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                 newToolDir = rotate(newToolDir, std::numbers::pi / 90);
                 newToolPos = IntPoint(long(toolPos.X + newToolDir.X * stepScaled),
                                       long(toolPos.Y + newToolDir.Y * stepScaled));
+                fout << "\tMoving tool back within boundary..." << endl;
             }
             if (rotateStep >= 180) {
 #ifdef DEV_MODE
@@ -3010,6 +3051,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             // safety condition
             if (area > stepScaled * optimalCutAreaPD && areaPD > 2 * optimalCutAreaPD) {
                 over_cut_count++;
+                fout << "\tCut area too big!!!" << endl;
                 break;
             }
 
@@ -3027,6 +3069,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
 
             if (area > 0.5 * MIN_CUT_AREA_FACTOR * optimalCutAreaPD
                     * RESOLUTION_FACTOR) {  // cut is ok - record it
+                fout << "\tFinal cut acceptance" << endl;
                 noCutDistance = 0;
                 if (toClearPath.empty()) {
                     toClearPath.push_back(toolPos);
@@ -3078,6 +3121,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                     break;
                 }
                 noCutDistance += stepScaled;
+                fout << "\tFailed to accept point??" << endl;
             }
         } /* end of points loop*/
 

--- a/src/Mod/CAM/libarea/Adaptive.cpp
+++ b/src/Mod/CAM/libarea/Adaptive.cpp
@@ -22,7 +22,6 @@
 
 #include "Adaptive.hpp"
 #include <iostream>
-#include <fstream>
 #include <cmath>
 #include <cstring>
 #include <ctime>
@@ -912,7 +911,6 @@ public:
     }
     inline void Start()
     {
-#define DEV_MODE
 #ifdef DEV_MODE
         start_ticks = clock();
         if (running) {
@@ -1174,17 +1172,13 @@ public:
         return max(min(angle, MAX_ANGLE), MIN_ANGLE);
     }
 
-    double getRandomAngle()
-    {
-        return MIN_ANGLE + (MAX_ANGLE - MIN_ANGLE) * double(rand()) / double(RAND_MAX);
-    }
     size_t getPointCount()
     {
         return (m_min ? 1 : 0) + (m_max ? 1 : 0);
     }
 
 public:
-    //{{angle, clipper point}, error}
+    // {{angle, clipper point}, error}
     std::optional<std::pair<std::pair<double, IntPoint>, double>> m_min;
     std::optional<std::pair<std::pair<double, IntPoint>, double>> m_max;
 };
@@ -2707,30 +2701,8 @@ void Adaptive2d::AddPathToProgress(TPaths& progressPaths, const Path pth, Motion
     }
 }
 
-struct nostream
-{
-    nostream(string a)
-    {}
-    nostream operator<<(string a)
-    {
-        return *this;
-    }
-    nostream operator<<(double a)
-    {
-        return *this;
-    }
-    nostream operator<<(IntPoint a)
-    {
-        return *this;
-    }
-};
-
 void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
 {
-    // ofstream fout("adaptive_debug.txt");
-    nostream fout("adaptive_debug.txt");
-    fout << "\n" << "\n" << "----------------------" << "\n";
-    fout << "Start ProcessPolyNode" << "\n";
     Perf_ProcessPolyNode.Start();
     current_region++;
     cout << "** Processing region: " << current_region << endl;
@@ -2781,7 +2753,6 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             engageBounds.push_back(p);
         }
         outsideEntry = true;
-        fout << "Outside entry " << entryPoint << "\n";
     }
     else {
         if (!FindEntryPoint(progressPaths,
@@ -2794,7 +2765,6 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             Perf_ProcessPolyNode.Stop();
             return;
         }
-        fout << "Helix entry " << entryPoint << "\n";
     }
 
     EngagePoint engage(engageBounds);  // engage point stepping instance
@@ -2852,13 +2822,11 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
 #endif
     ClearedArea clearedBeforePass(toolRadiusScaled);
     clearedBeforePass.SetClearedPaths(cleared.GetCleared());
-    fout << "Tool radius scaled: " << toolRadiusScaled << "\n";
 
     //*******************************
     // LOOP - PASSES
     //*******************************
     for (long pass = 0; pass < PASSES_LIMIT; pass++) {
-        fout << "New pass! " << pass << "\n";
         if (stopProcessing) {
             break;
         }
@@ -2897,7 +2865,6 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
         // LOOP - POINTS
         //*******************************
         for (long point_index = 0; point_index < POINTS_PER_PASS_LIMIT; point_index++) {
-            fout << "\n" << "Point " << point_index << "\n";
             if (stopProcessing) {
                 break;
             }
@@ -2940,14 +2907,12 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             if (stepScaled < MIN_STEP_CLIPPER) {
                 stepScaled = long(MIN_STEP_CLIPPER);
             }
-            fout << "\tstepScaled " << stepScaled << "\n";
 
             //*****************************
             // ANGLE vs AREA ITERATIONS
             //*****************************
             double predictedAngle = averageDV(angleHistory);
             double maxError = AREA_ERROR_FACTOR * optimalCutAreaPD;
-            fout << "optimal area " << optimalCutAreaPD << " maxError " << maxError << "\n";
             double area = 0;
             double areaPD = 0;
             interp.clear();
@@ -2958,48 +2923,33 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             bool pointNotInterp;
             for (iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
                 total_iterations++;
-                fout << "It " << iteration << " ";
                 if (iteration == 0) {
                     angle = predictedAngle;
                     pointNotInterp = true;
-                    fout << "case predicted ";
                 }
                 else if (iteration == 1) {
                     angle = interp.MIN_ANGLE;  // max engage
                     pointNotInterp = true;
-                    fout << "case minimum ";
                 }
                 else if (iteration == 2) {
                     if (interp.bothSides()) {
                         angle = interp.interpolateAngle();
-                        fout << "(" << interp.m_min->first.first << ", " << interp.m_min->second
-                             << ") ~ (" << interp.m_max->first.first << ", " << interp.m_max->second
-                             << ") ";
                         pointNotInterp = false;
-                        fout << "case interp ";
                     }
                     else {
                         angle = interp.MAX_ANGLE;  // min engage
-                        fout << "case maximum ";
                         pointNotInterp = true;
                     }
                 }
                 else {
                     angle = interp.interpolateAngle();
-                    fout << "(" << interp.m_min->first.first << ", " << interp.m_min->second
-                         << ") ~ (" << interp.m_max->first.first << ", " << interp.m_max->second
-                         << ") ";
                     pointNotInterp = false;
-                    fout << "case interp ";
                 }
-                fout << "raw " << angle << " ";
                 angle = interp.clampAngle(angle);
-                fout << "clamped " << angle << " ";
 
                 newToolDir = rotate(toolDir, angle);
                 newToolPos = IntPoint(long(toolPos.X + newToolDir.X * stepScaled),
                                       long(toolPos.Y + newToolDir.Y * stepScaled));
-                fout << "int pos " << newToolPos << " ";
 
                 // Skip iteration if this IntPoint has already been processed
                 if (interp.m_min && newToolPos == interp.m_min->first.second) {
@@ -3007,10 +2957,8 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                     if (interp.m_max
                         && abs(interp.m_min->first.second.X - interp.m_max->first.second.X) <= 1
                         && abs(interp.m_min->first.second.Y - interp.m_max->first.second.Y) <= 1) {
-                        fout << "hit integer floor" << "\n";
                         break;
                     }
-                    fout << "skip area calc " << "\n";
                     continue;
                 }
                 if (interp.m_max && newToolPos == interp.m_max->first.second) {
@@ -3018,20 +2966,16 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                     if (interp.m_min
                         && abs(interp.m_min->first.second.X - interp.m_max->first.second.X) <= 1
                         && abs(interp.m_min->first.second.Y - interp.m_max->first.second.Y) <= 1) {
-                        fout << "hit integer floor" << "\n";
                         break;
                     }
-                    fout << "skip area calc " << "\n";
                     continue;
                 }
 
                 area = CalcCutArea(clip, toolPos, newToolPos, cleared);
 
                 areaPD = area / double(stepScaled);  // area per distance
-                fout << "addPoint " << areaPD << " " << angle << " ";
                 double error = areaPD - targetAreaPD;
                 interp.addPoint(error, {angle, newToolPos}, pointNotInterp);
-                fout << "areaPD " << areaPD << " error " << error << " ";
                 // cout << " iter:" << iteration << " angle:" << angle << " area:" << areaPD
                 //      << " target:" << targetAreaPD << " error:" << error << " max:" << maxError
                 //      << endl;
@@ -3040,22 +2984,14 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                     if (angleHistory.size() > ANGLE_HISTORY_POINTS) {
                         angleHistory.erase(angleHistory.begin());
                     }
-                    fout << "small enough" << "\n";
-                    break;
-                }
-                if (iteration > 5 && fabs(error - prev_error) < 0.001) {
-                    fout << "no change" << "\n";
                     break;
                 }
                 if (iteration == MAX_ITERATIONS - 1) {
-                    fout << "too many iterations!" << "\n";
                     total_exceeded++;
                 }
-                fout << "\n";
                 prev_error = error;
             }
             Perf_PointIterations.Stop();
-            fout << "Iterations: " << iteration << "\n";
 
             recalcArea = false;
             // approach end boundary tangentially
@@ -3070,7 +3006,6 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                 newToolPos = IntPoint(long(toolPos.X + newToolDir.X * stepScaled),
                                       long(toolPos.Y + newToolDir.Y * stepScaled));
                 recalcArea = true;
-                fout << "\tRewrote tooldir/toolpos for boundary approach" << "\n";
             }
 
             //**********************************************
@@ -3084,7 +3019,6 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                 newToolDir = rotate(newToolDir, std::numbers::pi / 90);
                 newToolPos = IntPoint(long(toolPos.X + newToolDir.X * stepScaled),
                                       long(toolPos.Y + newToolDir.Y * stepScaled));
-                fout << "\tMoving tool back within boundary..." << "\n";
             }
             if (rotateStep >= 180) {
 #ifdef DEV_MODE
@@ -3100,7 +3034,6 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             // safety condition
             if (area > stepScaled * optimalCutAreaPD && areaPD > 2 * optimalCutAreaPD) {
                 over_cut_count++;
-                fout << "\tCut area too big!!!" << "\n";
                 break;
             }
 
@@ -3117,7 +3050,6 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             prevDistFromStart = distFromStart;
 
             if (area > 0.5 * MIN_CUT_AREA_FACTOR * optimalCutAreaPD) {  // cut is ok - record it
-                fout << "\tFinal cut acceptance" << "\n";
                 noCutDistance = 0;
                 if (toClearPath.empty()) {
                     toClearPath.push_back(toolPos);
@@ -3166,11 +3098,9 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
 #endif
                 // cout<<"Break: no cut @" << point_index << endl;
                 if (noCutDistance > stepOverScaled) {
-                    fout << "Points: " << point_index << "\n";
                     break;
                 }
                 noCutDistance += stepScaled;
-                fout << "\tFailed to accept point??" << "\n";
             }
         } /* end of points loop*/
 

--- a/src/Mod/CAM/libarea/Adaptive.cpp
+++ b/src/Mod/CAM/libarea/Adaptive.cpp
@@ -1566,7 +1566,7 @@ double Adaptive2d::CalcCutArea(Clipper& clip,
             maxFi += 2 * std::numbers::pi;
         }
 
-        if (preventConventional && interPathLen >= RESOLUTION_FACTOR) {
+        if (preventConventional && interPathLen >= MIN_STEP_CLIPPER) {
             // detect conventional mode cut - we want only climb mode
             IntPoint midPoint(long(c2.X + toolRadiusScaled * cos(0.5 * (maxFi + minFi))),
                               long(c2.Y + toolRadiusScaled * sin(0.5 * (maxFi + minFi))));
@@ -1582,7 +1582,7 @@ double Adaptive2d::CalcCutArea(Clipper& clip,
 
         double scanDistance = 2.5 * toolRadiusScaled;
         // stepping through path discretized to stepDistance
-        double stepDistance = min(double(RESOLUTION_FACTOR), interPathLen / 24) + 1;
+        double stepDistance = min(double(MIN_STEP_CLIPPER), interPathLen / 24) + 1;
         const IntPoint* prevPt = &interPath->front();
         double distance = 0;
         for (size_t j = 1; j < ipc2_size; j++) {
@@ -1733,29 +1733,16 @@ std::list<AdaptiveOutput> Adaptive2d::Execute(const DPaths& stockPaths,
     //**********************************
 
     // keep the tolerance in workable range
-    if (tolerance < 0.01) {
-        tolerance = 0.01;
-    }
-    if (tolerance > 0.2) {
-        tolerance = 0.2;
-    }
+    tolerance = max(tolerance, 0.01);
+    tolerance = min(tolerance, 1.0);
 
-    scaleFactor = RESOLUTION_FACTOR / tolerance;
-    long maxScaleFactor = toolDiameter < 1.0 ? 10000 : 1000;
-
-    if (stepOverFactor * toolDiameter < 1.0) {
-        scaleFactor *= 1.0 / (stepOverFactor * toolDiameter);
-    }
-
-
-    if (scaleFactor > maxScaleFactor) {
-        scaleFactor = maxScaleFactor;
-    }
-    // scaleFactor = round(scaleFactor);
+    // 1/"tolerance" = number of min-size adaptive steps per stepover
+    scaleFactor = MIN_STEP_CLIPPER / tolerance / (stepOverFactor * toolDiameter);
 
     current_region = 0;
     cout << "Tool Diameter: " << toolDiameter << endl;
-    cout << "Accuracy: " << round(10000.0 / scaleFactor) / 10 << " um" << endl;
+    cout << "Min step size: " << round(MIN_STEP_CLIPPER / scaleFactor * 1000 * 10) / 10 << " um"
+         << endl;
     cout << flush;
 
     toolRadiusScaled = long(toolDiameter * scaleFactor / 2);
@@ -1904,8 +1891,8 @@ std::list<AdaptiveOutput> Adaptive2d::Execute(const DPaths& stockPaths,
 
     if (opType == OperationType::otProfilingInside || opType == OperationType::otProfilingOutside) {
         double offset = opType == OperationType::otProfilingInside
-            ? -2 * (helixRampRadiusScaled + toolRadiusScaled) - RESOLUTION_FACTOR
-            : 2 * (helixRampRadiusScaled + toolRadiusScaled) + RESOLUTION_FACTOR;
+            ? -2 * (helixRampRadiusScaled + toolRadiusScaled) - MIN_STEP_CLIPPER
+            : 2 * (helixRampRadiusScaled + toolRadiusScaled) + MIN_STEP_CLIPPER;
         for (const auto& current : inputPaths) {
             int nesting = getPathNestingLevel(current, inputPaths);
             if (nesting % 2 != 0
@@ -1980,7 +1967,7 @@ bool Adaptive2d::FindEntryPoint(TPaths& progressPaths,
     for (int iter = 0; iter < 10; iter++) {
         clipof.Clear();
         clipof.AddPaths(checkPaths, JoinType::jtSquare, EndType::etClosedPolygon);
-        double step = RESOLUTION_FACTOR;
+        double step = MIN_STEP_CLIPPER;
         double currentDelta = -1;
         clipof.Execute(incOffset, currentDelta);
         while (!incOffset.empty()) {
@@ -2161,7 +2148,7 @@ bool Adaptive2d::IsAllowedToCutTrough(const IntPoint& p1,
     else {
         Clipper clip;
         double distance = sqrt(DistanceSqrd(p1, p2));
-        double stepSize = min(0.5 * stepOverScaled, 8 * RESOLUTION_FACTOR);
+        double stepSize = min(0.5 * stepOverScaled, 8 * MIN_STEP_CLIPPER);
         if (distance < stepSize / 2) {  // not significant cut
             Perf_IsAllowedToCutTrough.Stop();
             return true;
@@ -2207,7 +2194,7 @@ bool Adaptive2d::ResolveLinkPath(const IntPoint& startPoint,
     double directDistance = sqrt(DistanceSqrd(startPoint, endPoint));
     Paths linkPaths;
 
-    double scanStep = 2 * RESOLUTION_FACTOR;
+    double scanStep = 2 * MIN_STEP_CLIPPER;
     if (scanStep > scaleFactor * 0.1) {
         scanStep = scaleFactor * 0.1;
     }
@@ -2384,8 +2371,8 @@ bool Adaptive2d::MakeLeadPath(bool leadIn,
     double pathLen = 0;
     checkPath.push_back(nextPoint);
     for (int i = 0; i < 10000; i++) {
-        if (IsAllowedToCutTrough(IntPoint(currentPoint.X + RESOLUTION_FACTOR * nextDir.X,
-                                          currentPoint.Y + RESOLUTION_FACTOR * nextDir.Y),
+        if (IsAllowedToCutTrough(IntPoint(currentPoint.X + MIN_STEP_CLIPPER * nextDir.X,
+                                          currentPoint.Y + MIN_STEP_CLIPPER * nextDir.Y),
                                  nextPoint,
                                  clearedArea,
                                  toolBoundPaths)) {
@@ -2790,14 +2777,14 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             Perf_ProcessPolyNode.Stop();
             return;
         }
-        fout << "Helix entry " << entryPoint << endl;
+        fout << "Helix entry " << entryPoint << "\n";
     }
 
     EngagePoint engage(engageBounds);  // engage point stepping instance
 
     if (outsideEntry) {
-        engage.moveToClosestPoint(toolPos, 2 * RESOLUTION_FACTOR);
-        engage.moveForward(RESOLUTION_FACTOR);
+        engage.moveToClosestPoint(toolPos, 2 * MIN_STEP_CLIPPER);
+        engage.moveForward(MIN_STEP_CLIPPER);
         toolPos = engage.getCurrentPoint();
         toolDir = engage.getCurrentDir();
         entryPoint = toolPos;
@@ -2811,7 +2798,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
     output.HelixCenterPoint.first = double(entryPoint.X) / scaleFactor;
     output.HelixCenterPoint.second = double(entryPoint.Y) / scaleFactor;
 
-    long stepScaled = long(RESOLUTION_FACTOR);
+    long stepScaled = long(MIN_STEP_CLIPPER);
     IntPoint engagePoint;
 
     IntPoint newToolPos;

--- a/src/Mod/CAM/libarea/Adaptive.cpp
+++ b/src/Mod/CAM/libarea/Adaptive.cpp
@@ -1112,13 +1112,13 @@ public:
         return m_min && m_max && m_min->second < 0 && m_max->second >= 0;
     }
     // adds point keeping the incremental order of areas for interpolation to work correctly
-    void addPoint(double area, double angle)
+    void addPoint(double error, double angle, bool allowSkip = false)
     {
         if (!m_min) {
-            m_min = {angle, area};
+            m_min = {angle, error};
         }
         else if (!m_max) {
-            m_max = {angle, area};
+            m_max = {angle, error};
             if (m_min->second > m_max->second) {
                 auto tmp = m_min;
                 m_min = m_max;
@@ -1126,21 +1126,24 @@ public:
             }
         }
         else if (bothSides()) {
-            if (area < 0) {
-                m_min = {angle, area};
+            if (error < 0) {
+                m_min = {angle, error};
             }
             else {
-                m_max = {angle, area};
+                m_max = {angle, error};
             }
         }
         else {
+            if (allowSkip && abs(error) > abs(m_min->second) && abs(error) > abs(m_max->second)) {
+                return;
+            }
             if (abs(m_min->second) > abs(m_max->second)) {
                 m_min.reset();
             }
             else {
                 m_max.reset();
             }
-            addPoint(area, angle);
+            addPoint(error, angle);
         }
     }
 
@@ -1157,6 +1160,14 @@ public:
         fout << "(" << m_min->first << ", " << m_min->second << ") ~ (" << m_max->first << ", "
              << m_max->second << ") ";
         double p = (0 - m_min->second) / (m_max->second - m_min->second);
+
+        // Ensure search is sufficiently efficient -- this is a compromise
+        // between binary search (p = 0.5, guaranteed search completion in log
+        // time) and following linear interpolation completely (often faster
+        // since area cut is locally linear in movement angle)
+        const double minInterp = .2;
+        p = max(min(p, 1 - minInterp), minInterp);
+
         return m_min->first * (1 - p) + m_max->first * p;
     }
 
@@ -2837,6 +2848,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
 #endif
     ClearedArea clearedBeforePass(toolRadiusScaled);
     clearedBeforePass.SetClearedPaths(cleared.GetCleared());
+    fout << "Tool radius scaled: " << toolRadiusScaled << "\n";
 
     //*******************************
     // LOOP - PASSES
@@ -2939,33 +2951,40 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             Perf_PointIterations.Start();
             int iteration;
             double prev_error = __DBL_MAX__;
+            bool pointNotInterp;
             for (iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
                 total_iterations++;
                 fout << "It " << iteration << " ";
                 if (iteration == 0) {
                     angle = predictedAngle;
+                    pointNotInterp = true;
                     fout << "case predicted ";
                 }
                 else if (iteration == 1) {
                     angle = interp.MIN_ANGLE;  // max engage
+                    pointNotInterp = true;
                     fout << "case minimum ";
                 }
                 else if (iteration == 2) {
                     if (interp.bothSides()) {
                         angle = interp.interpolateAngle(fout);
+                        pointNotInterp = false;
                         fout << "case interp ";
                     }
                     else {
                         angle = interp.MAX_ANGLE;  // min engage
                         fout << "case maximum ";
+                        pointNotInterp = true;
                     }
                 }
-                else if (interp.getPointCount() < 2) {
+                else if (!interp.bothSides()) {
                     angle = interp.getRandomAngle();
                     fout << "case random ";
+                    pointNotInterp = true;
                 }
                 else {
                     angle = interp.interpolateAngle(fout);
+                    pointNotInterp = false;
                     fout << "case interp ";
                 }
                 fout << "raw " << angle << " ";
@@ -2982,7 +3001,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                 areaPD = area / double(stepScaled);  // area per distance
                 fout << "addPoint " << areaPD << " " << angle << " ";
                 double error = areaPD - targetAreaPD;
-                interp.addPoint(error, angle);
+                interp.addPoint(error, angle, pointNotInterp);
                 fout << "areaPD " << areaPD << " error " << error << " ";
                 // cout << " iter:" << iteration << " angle:" << angle << " area:" << areaPD
                 //      << " target:" << targetAreaPD << " error:" << error << " max:" << maxError
@@ -3006,6 +3025,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                 fout << endl;
                 prev_error = error;
             }
+            fout << "Iterations: " << iteration << endl;
             Perf_PointIterations.Stop();
 
             recalcArea = false;
@@ -3118,6 +3138,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
 #endif
                 // cout<<"Break: no cut @" << point_index << endl;
                 if (noCutDistance > stepOverScaled) {
+                    fout << "Points: " << point_index << "\n";
                     break;
                 }
                 noCutDistance += stepScaled;

--- a/src/Mod/CAM/libarea/Adaptive.cpp
+++ b/src/Mod/CAM/libarea/Adaptive.cpp
@@ -3087,8 +3087,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             prevDistTrend = distanceTrend;
             prevDistFromStart = distFromStart;
 
-            if (area > 0.5 * MIN_CUT_AREA_FACTOR * optimalCutAreaPD
-                    * RESOLUTION_FACTOR) {  // cut is ok - record it
+            if (area > 0.5 * MIN_CUT_AREA_FACTOR * optimalCutAreaPD) {  // cut is ok - record it
                 fout << "\tFinal cut acceptance" << endl;
                 noCutDistance = 0;
                 if (toClearPath.empty()) {
@@ -3150,7 +3149,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             cleared.ExpandCleared(toClearPath);
             toClearPath.clear();
         }
-        if (cumulativeCutArea > MIN_CUT_AREA_FACTOR * optimalCutAreaPD * RESOLUTION_FACTOR) {
+        if (cumulativeCutArea > MIN_CUT_AREA_FACTOR * optimalCutAreaPD) {
             Path cleaned;
             CleanPath(passToolPath, cleaned, CLEAN_PATH_TOLERANCE);
             total_output_points += long(cleaned.size());
@@ -3184,8 +3183,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             if (!engage.nextEngagePoint(this,
                                         cleared,
                                         moveDistance,
-                                        ENGAGE_AREA_THR_FACTOR * optimalCutAreaPD
-                                            * RESOLUTION_FACTOR,
+                                        ENGAGE_AREA_THR_FACTOR * optimalCutAreaPD,
                                         4 * referenceCutArea * stepOverFactor)) {
                 // check if there are any uncleared area left
                 Paths remaining;
@@ -3221,8 +3219,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                 if (!engage.nextEngagePoint(this,
                                             cleared,
                                             moveDistance,
-                                            ENGAGE_AREA_THR_FACTOR * optimalCutAreaPD
-                                                * RESOLUTION_FACTOR,
+                                            ENGAGE_AREA_THR_FACTOR * optimalCutAreaPD,
                                             4 * referenceCutArea * stepOverFactor)) {
                     break;
                 }

--- a/src/Mod/CAM/libarea/Adaptive.cpp
+++ b/src/Mod/CAM/libarea/Adaptive.cpp
@@ -912,6 +912,7 @@ public:
     }
     inline void Start()
     {
+#define DEV_MODE
 #ifdef DEV_MODE
         start_ticks = clock();
         if (running) {
@@ -1112,7 +1113,7 @@ public:
         return m_min && m_max && m_min->second < 0 && m_max->second >= 0;
     }
     // adds point keeping the incremental order of areas for interpolation to work correctly
-    void addPoint(double error, double angle, bool allowSkip = false)
+    void addPoint(double error, std::pair<double, IntPoint> angle, bool allowSkip = false)
     {
         if (!m_min) {
             m_min = {angle, error};
@@ -1147,7 +1148,7 @@ public:
         }
     }
 
-    double interpolateAngle(ofstream& fout)
+    double interpolateAngle()
     {
         if (!m_min) {
             return MIN_ANGLE;
@@ -1156,9 +1157,6 @@ public:
         if (!m_max) {
             return MAX_ANGLE;
         }
-
-        fout << "(" << m_min->first << ", " << m_min->second << ") ~ (" << m_max->first << ", "
-             << m_max->second << ") ";
         double p = (0 - m_min->second) / (m_max->second - m_min->second);
 
         // Ensure search is sufficiently efficient -- this is a compromise
@@ -1168,7 +1166,7 @@ public:
         const double minInterp = .2;
         p = max(min(p, 1 - minInterp), minInterp);
 
-        return m_min->first * (1 - p) + m_max->first * p;
+        return m_min->first.first * (1 - p) + m_max->first.first * p;
     }
 
     double clampAngle(double angle)
@@ -1186,8 +1184,9 @@ public:
     }
 
 public:
-    std::optional<std::pair<double, double>> m_min;
-    std::optional<std::pair<double, double>> m_max;
+    //{{angle, clipper point}, error}
+    std::optional<std::pair<std::pair<double, IntPoint>, double>> m_min;
+    std::optional<std::pair<std::pair<double, IntPoint>, double>> m_max;
 };
 
 //***************************************
@@ -2431,7 +2430,6 @@ void Adaptive2d::AppendToolPath(TPaths& progressPaths,
         IntPoint startPoint(long(lastTPoint.first * scaleFactor),
                             long(lastTPoint.second * scaleFactor));
 
-        ClipperOffset clipof;
         // first we try to cut through the linking move for short distances
         bool linkFound = false;
         double linkDistance = sqrt(DistanceSqrd(startPoint, endPoint));
@@ -2709,11 +2707,30 @@ void Adaptive2d::AddPathToProgress(TPaths& progressPaths, const Path pth, Motion
     }
 }
 
+struct nostream
+{
+    nostream(string a)
+    {}
+    nostream operator<<(string a)
+    {
+        return *this;
+    }
+    nostream operator<<(double a)
+    {
+        return *this;
+    }
+    nostream operator<<(IntPoint a)
+    {
+        return *this;
+    }
+};
+
 void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
 {
-    ofstream fout("adaptive_debug.txt");
-    fout << endl << endl << "----------------------" << endl;
-    fout << "Start ProcessPolyNode" << endl;
+    // ofstream fout("adaptive_debug.txt");
+    nostream fout("adaptive_debug.txt");
+    fout << "\n" << "\n" << "----------------------" << "\n";
+    fout << "Start ProcessPolyNode" << "\n";
     Perf_ProcessPolyNode.Start();
     current_region++;
     cout << "** Processing region: " << current_region << endl;
@@ -2764,7 +2781,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             engageBounds.push_back(p);
         }
         outsideEntry = true;
-        fout << "Outside entry " << entryPoint << endl;
+        fout << "Outside entry " << entryPoint << "\n";
     }
     else {
         if (!FindEntryPoint(progressPaths,
@@ -2841,7 +2858,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
     // LOOP - PASSES
     //*******************************
     for (long pass = 0; pass < PASSES_LIMIT; pass++) {
-        fout << "New pass! " << pass << endl;
+        fout << "New pass! " << pass << "\n";
         if (stopProcessing) {
             break;
         }
@@ -2880,7 +2897,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
         // LOOP - POINTS
         //*******************************
         for (long point_index = 0; point_index < POINTS_PER_PASS_LIMIT; point_index++) {
-            fout << endl << "Point " << point_index << endl;
+            fout << "\n" << "Point " << point_index << "\n";
             if (stopProcessing) {
                 break;
             }
@@ -2904,33 +2921,33 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
 
             double targetAreaPD = optimalCutAreaPD;
 
-            // set the step size
-            double slowDownDistance = max(double(toolRadiusScaled) / 4, RESOLUTION_FACTOR * 8);
+            // set the step size: 1x to 8x base size
+            double slowDownDistance = max(double(toolRadiusScaled) / 4, MIN_STEP_CLIPPER * 8);
             if (distanceToBoundary < slowDownDistance || distanceToEngage < slowDownDistance) {
-                stepScaled = long(RESOLUTION_FACTOR);
+                stepScaled = long(MIN_STEP_CLIPPER);
             }
             else if (fabs(angle) > NTOL) {
-                stepScaled = long(RESOLUTION_FACTOR / fabs(angle));
+                stepScaled = long(MIN_STEP_CLIPPER / fabs(angle));
             }
             else {
-                stepScaled = long(RESOLUTION_FACTOR * 4);
+                stepScaled = long(MIN_STEP_CLIPPER * 8);
             }
 
             // clamp the step size - for stability
-            if (stepScaled > min(long(toolRadiusScaled / 4), long(RESOLUTION_FACTOR * 8))) {
-                stepScaled = min(long(toolRadiusScaled / 4), long(RESOLUTION_FACTOR * 8));
+            if (stepScaled > min(long(toolRadiusScaled / 4), long(MIN_STEP_CLIPPER * 8))) {
+                stepScaled = min(long(toolRadiusScaled / 4), long(MIN_STEP_CLIPPER * 8));
             }
-            if (stepScaled < RESOLUTION_FACTOR) {
-                stepScaled = long(RESOLUTION_FACTOR);
+            if (stepScaled < MIN_STEP_CLIPPER) {
+                stepScaled = long(MIN_STEP_CLIPPER);
             }
-            fout << "\tstepScaled " << stepScaled << endl;
+            fout << "\tstepScaled " << stepScaled << "\n";
 
             //*****************************
             // ANGLE vs AREA ITERATIONS
             //*****************************
             double predictedAngle = averageDV(angleHistory);
             double maxError = AREA_ERROR_FACTOR * optimalCutAreaPD;
-            fout << "optimal area " << optimalCutAreaPD << " maxError " << maxError << endl;
+            fout << "optimal area " << optimalCutAreaPD << " maxError " << maxError << "\n";
             double area = 0;
             double areaPD = 0;
             interp.clear();
@@ -2954,7 +2971,10 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                 }
                 else if (iteration == 2) {
                     if (interp.bothSides()) {
-                        angle = interp.interpolateAngle(fout);
+                        angle = interp.interpolateAngle();
+                        fout << "(" << interp.m_min->first.first << ", " << interp.m_min->second
+                             << ") ~ (" << interp.m_max->first.first << ", " << interp.m_max->second
+                             << ") ";
                         pointNotInterp = false;
                         fout << "case interp ";
                     }
@@ -2964,13 +2984,11 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                         pointNotInterp = true;
                     }
                 }
-                else if (!interp.bothSides()) {
-                    angle = interp.getRandomAngle();
-                    fout << "case random ";
-                    pointNotInterp = true;
-                }
                 else {
-                    angle = interp.interpolateAngle(fout);
+                    angle = interp.interpolateAngle();
+                    fout << "(" << interp.m_min->first.first << ", " << interp.m_min->second
+                         << ") ~ (" << interp.m_max->first.first << ", " << interp.m_max->second
+                         << ") ";
                     pointNotInterp = false;
                     fout << "case interp ";
                 }
@@ -2983,12 +3001,36 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                                       long(toolPos.Y + newToolDir.Y * stepScaled));
                 fout << "int pos " << newToolPos << " ";
 
+                // Skip iteration if this IntPoint has already been processed
+                if (interp.m_min && newToolPos == interp.m_min->first.second) {
+                    interp.addPoint(interp.m_min->second, {angle, newToolPos});
+                    if (interp.m_max
+                        && abs(interp.m_min->first.second.X - interp.m_max->first.second.X) <= 1
+                        && abs(interp.m_min->first.second.Y - interp.m_max->first.second.Y) <= 1) {
+                        fout << "hit integer floor" << "\n";
+                        break;
+                    }
+                    fout << "skip area calc " << "\n";
+                    continue;
+                }
+                if (interp.m_max && newToolPos == interp.m_max->first.second) {
+                    interp.addPoint(interp.m_max->second, {angle, newToolPos});
+                    if (interp.m_min
+                        && abs(interp.m_min->first.second.X - interp.m_max->first.second.X) <= 1
+                        && abs(interp.m_min->first.second.Y - interp.m_max->first.second.Y) <= 1) {
+                        fout << "hit integer floor" << "\n";
+                        break;
+                    }
+                    fout << "skip area calc " << "\n";
+                    continue;
+                }
+
                 area = CalcCutArea(clip, toolPos, newToolPos, cleared);
 
                 areaPD = area / double(stepScaled);  // area per distance
                 fout << "addPoint " << areaPD << " " << angle << " ";
                 double error = areaPD - targetAreaPD;
-                interp.addPoint(error, angle, pointNotInterp);
+                interp.addPoint(error, {angle, newToolPos}, pointNotInterp);
                 fout << "areaPD " << areaPD << " error " << error << " ";
                 // cout << " iter:" << iteration << " angle:" << angle << " area:" << areaPD
                 //      << " target:" << targetAreaPD << " error:" << error << " max:" << maxError
@@ -2998,22 +3040,22 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                     if (angleHistory.size() > ANGLE_HISTORY_POINTS) {
                         angleHistory.erase(angleHistory.begin());
                     }
-                    fout << "small enough" << endl;
+                    fout << "small enough" << "\n";
                     break;
                 }
                 if (iteration > 5 && fabs(error - prev_error) < 0.001) {
-                    fout << "no change" << endl;
+                    fout << "no change" << "\n";
                     break;
                 }
                 if (iteration == MAX_ITERATIONS - 1) {
-                    fout << "too many iterations!" << endl;
+                    fout << "too many iterations!" << "\n";
                     total_exceeded++;
                 }
-                fout << endl;
+                fout << "\n";
                 prev_error = error;
             }
-            fout << "Iterations: " << iteration << endl;
             Perf_PointIterations.Stop();
+            fout << "Iterations: " << iteration << "\n";
 
             recalcArea = false;
             // approach end boundary tangentially
@@ -3028,7 +3070,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                 newToolPos = IntPoint(long(toolPos.X + newToolDir.X * stepScaled),
                                       long(toolPos.Y + newToolDir.Y * stepScaled));
                 recalcArea = true;
-                fout << "\tRewrote tooldir/toolpos for boundary approach" << endl;
+                fout << "\tRewrote tooldir/toolpos for boundary approach" << "\n";
             }
 
             //**********************************************
@@ -3042,7 +3084,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                 newToolDir = rotate(newToolDir, std::numbers::pi / 90);
                 newToolPos = IntPoint(long(toolPos.X + newToolDir.X * stepScaled),
                                       long(toolPos.Y + newToolDir.Y * stepScaled));
-                fout << "\tMoving tool back within boundary..." << endl;
+                fout << "\tMoving tool back within boundary..." << "\n";
             }
             if (rotateStep >= 180) {
 #ifdef DEV_MODE
@@ -3058,7 +3100,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             // safety condition
             if (area > stepScaled * optimalCutAreaPD && areaPD > 2 * optimalCutAreaPD) {
                 over_cut_count++;
-                fout << "\tCut area too big!!!" << endl;
+                fout << "\tCut area too big!!!" << "\n";
                 break;
             }
 
@@ -3075,7 +3117,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
             prevDistFromStart = distFromStart;
 
             if (area > 0.5 * MIN_CUT_AREA_FACTOR * optimalCutAreaPD) {  // cut is ok - record it
-                fout << "\tFinal cut acceptance" << endl;
+                fout << "\tFinal cut acceptance" << "\n";
                 noCutDistance = 0;
                 if (toClearPath.empty()) {
                     toClearPath.push_back(toolPos);
@@ -3128,7 +3170,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
                     break;
                 }
                 noCutDistance += stepScaled;
-                fout << "\tFailed to accept point??" << endl;
+                fout << "\tFailed to accept point??" << "\n";
             }
         } /* end of points loop*/
 

--- a/src/Mod/CAM/libarea/Adaptive.hpp
+++ b/src/Mod/CAM/libarea/Adaptive.hpp
@@ -181,7 +181,7 @@ private:
     void ApplyStockToLeave(Paths& inputPaths);
 
 private:  // constants for fine tuning
-    const double RESOLUTION_FACTOR = 16.0;
+    const double MIN_STEP_CLIPPER = 16.0;
     const int MAX_ITERATIONS = 10;
     const double AREA_ERROR_FACTOR =
         0.05; /* how precise to match the cut area to optimal, reasonable value: 0.05 = 5%*/

--- a/src/Mod/CAM/libarea/Adaptive.hpp
+++ b/src/Mod/CAM/libarea/Adaptive.hpp
@@ -189,9 +189,9 @@ private:  // constants for fine tuning
     const int DIRECTION_SMOOTHING_BUFLEN = 3;  // gyro points - used for angle smoothing
 
 
-    const double MIN_CUT_AREA_FACTOR =
-        0.1;  // used for filtering out of insignificant cuts (should be < ENGAGE_AREA_THR_FACTOR)
-    const double ENGAGE_AREA_THR_FACTOR = 0.5;       // influences minimal engage area
+    const double MIN_CUT_AREA_FACTOR = 0.1
+        * 16;  // used for filtering out of insignificant cuts (should be < ENGAGE_AREA_THR_FACTOR)
+    const double ENGAGE_AREA_THR_FACTOR = 0.5 * 16;  // influences minimal engage area
     const double ENGAGE_SCAN_DISTANCE_FACTOR = 0.2;  // influences the engage scan/stepping distance
 
     const double CLEAN_PATH_TOLERANCE = 1.41;            // should be >1


### PR DESCRIPTION
This PR address's sub project 1 of https://github.com/FreeCAD/FPA-grant-proposals/issues/61

Issue: TODO
Forum post: TODO

When you generate an Adaptive operation with a "small" stepover (~always at 1%, rarely at 6% in my experience), it fails to produce a path. This PR fixes this issue.

The fix primarily consists of a modification to the interpolation code. Adaptive paths are built incrementally in small steps. For each step, the algorithm considers a number of possible directions for the step and picks the one that cuts the appropriate amount of material (if it can find such a direction; otherwise it will abort the attempt and possibly fail to generate a path altogether).

In principle this is an optimization over a continuous variable -- the step direction -- but in reality since all geometric computation is done in Clipper's integer space, it is an optimization over a discrete variable: which clipper pixel to visit next. The existing interpolation code did not take this into account, and if its choice of the next step to explore landed within a previously explored Clipper pixel, it would simply redo the old work and likely get stuck rechecking the same pixel repeatedly until it gave up on the path.

I rewrote the interpolation code to simplify it, and additionally built a wrapper for it that understands the discrete nature of the search problem and handles it appropriately. This fixes path generation for small stepovers, and as a bonus, it also seems to find an acceptable next step for the path in fewer attempts on average, slightly decreasing the runtime of path generation.

TODO finish documenting: rename of RES, meaning of tolerance, potential for speedup in future work, plausibility of weird boundary stuff resulting from how we bump back into bounds