### PR TITLE
Core: Add beforeDelete python interface.

### DIFF
--- a/src/Gui/ViewProviderFeaturePython.cpp
+++ b/src/Gui/ViewProviderFeaturePython.cpp
@@ -759,6 +759,32 @@ void ViewProviderFeaturePythonImp::finishRestoring()
     }
 }
 
+void ViewProviderFeaturePythonImp::beforeDelete()
+{
+    _FC_PY_CALL_CHECK(beforeDelete, return);
+
+    Base::PyGILStateLocker lock;
+    try {
+        if (has__object__) {
+            Base::pyCall(py_beforeDelete.ptr());
+        }
+        else {
+            Py::Tuple args(1);
+            args.setItem(0, Py::Object(object->getPyObject(), true));
+            Base::pyCall(py_beforeDelete.ptr(), args.ptr());
+        }
+    }
+    catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+        }
+        else {
+            Base::PyException e;
+            e.reportException();
+        }
+    }
+}
+
 ViewProviderFeaturePythonImp::ValueT
 ViewProviderFeaturePythonImp::onDelete(const std::vector<std::string> & sub)
 {

--- a/src/Gui/ViewProviderFeaturePython.h
+++ b/src/Gui/ViewProviderFeaturePython.h
@@ -81,6 +81,7 @@ public:
     void onBeforeChange(const App::Property* prop);
     void startRestoring();
     void finishRestoring();
+    void beforeDelete();
     ValueT onDelete(const std::vector<std::string> & sub);
     ValueT canDelete(App::DocumentObject *obj) const;
     //@}
@@ -161,6 +162,7 @@ private:
     FC_PY_ELEMENT(onBeforeChange) \
     FC_PY_ELEMENT(startRestoring) \
     FC_PY_ELEMENT(finishRestoring) \
+    FC_PY_ELEMENT(beforeDelete) \
     FC_PY_ELEMENT(onDelete) \
     FC_PY_ELEMENT(canDelete) \
     FC_PY_ELEMENT(isShow) \
@@ -332,6 +334,10 @@ public:
     }
     void getTaskViewContent(std::vector<Gui::TaskView::TaskContent*>& c) const override {
         ViewProviderT::getTaskViewContent(c);
+    }
+    void beforeDelete() override {
+        imp->beforeDelete();
+        ViewProviderT::beforeDelete();
     }
     bool onDelete(const std::vector<std::string> & sub) override {
         switch(imp->onDelete(sub)) {


### PR DESCRIPTION
This PR adds the python interface for beforeDelete for featurepythons.

I thought I needed it, but beforeDelete is actually called too late to fix the issue I had.

But since I wrote the thing might as well get it in.