### PR TITLE
Core: GeoFeature::getPlacementFromProp prevent potential crash

### DIFF
--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -301,6 +301,10 @@ std::vector<Data::IndexedName> GeoFeature::getHigherElements(const char* element
 Base::Placement GeoFeature::getPlacementFromProp(App::DocumentObject* obj, const char* propName)
 {
     Base::Placement plc = Base::Placement();
+    if (!obj) {
+        return plc;
+    }
+
     auto* propPlacement = dynamic_cast<App::PropertyPlacement*>(obj->getPropertyByName(propName));
     if (propPlacement) {
         plc = propPlacement->getValue();
@@ -381,3 +385,4 @@ Base::Placement GeoFeature::getGlobalPlacement(const DocumentObject* obj)
 
     return placementProperty->getValue();
 }
+


### PR DESCRIPTION
No brainer here @chennes 

Part of the cause of this : https://github.com/FreeCAD/FreeCAD/issues/23948

Although this PR is not enough to fix the whole thing, this first immediate problem can be merged already.