### PR TITLE
[RFC] CMake: Enable cheap STL checks on Debug builds

### DIFF
--- a/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
+++ b/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
@@ -34,6 +34,14 @@ macro(CompilerChecksAndSetups)
                  "C++23"
     )
 
+    # FREECAD_STL_ASSERTIONS:
+    #   AUTO (default) -> enable only in Debug config
+    #   ON             -> enable in all configs (including Release)
+    #   OFF            -> disabled
+    set(FREECAD_STL_ASSERTIONS "AUTO" CACHE STRING
+        "Enable inexpensive standard-library assertions (AUTO, ON, OFF). AUTO=Debug-only.")
+    set_property(CACHE FREECAD_STL_ASSERTIONS PROPERTY STRINGS AUTO ON OFF)
+
     if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.2)
         message(FATAL_ERROR "FreeCAD 1.1 and later requires C++20.  G++ must be 11.2 or later, the used version is ${CMAKE_CXX_COMPILER_VERSION}")
     elseif(CMAKE_COMPILER_IS_CLANGXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0)
@@ -66,6 +74,44 @@ macro(CompilerChecksAndSetups)
             set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-write-strings ${CMAKE_CXX_FLAGS}")
         endif()
         include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+        set(_FREECAD_STL_ASSERT_GENEX_DEBUG $<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CXX>>)
+        set(_FREECAD_STL_ASSERT_GENEX_ALL   $<COMPILE_LANGUAGE:CXX>)
+
+        if(FREECAD_STL_ASSERTIONS STREQUAL "ON")
+            set(_FREECAD_STL_ASSERT_GENEX ${_FREECAD_STL_ASSERT_GENEX_ALL})
+            set(_FREECAD_STL_ASSERT_SCOPE "all configs")
+        elseif(FREECAD_STL_ASSERTIONS STREQUAL "AUTO")
+            set(_FREECAD_STL_ASSERT_GENEX ${_FREECAD_STL_ASSERT_GENEX_DEBUG})
+            set(_FREECAD_STL_ASSERT_SCOPE "Debug only")
+        else()
+            set(_FREECAD_STL_ASSERT_GENEX "")  # OFF
+            set(_FREECAD_STL_ASSERT_SCOPE "disabled")
+        endif()
+
+        if(_FREECAD_STL_ASSERT_GENEX)
+            # Detect the STL implementation in use
+            include(CheckCXXSourceCompiles)
+            set(_FREECAD_PROBE_LIBSTDCXX "#include <vector>\nint main() {\n#ifdef __GLIBCXX__\n  return 0;\n#else\n# error not libstdc++\n#endif\n}")
+            check_cxx_source_compiles("${_FREECAD_PROBE_LIBSTDCXX}" _FREECAD_USE_LIBSTDCXX)
+
+            set(_FREECAD_PROBE_LIBCXX "#include <vector>\nint main() {\n#ifdef _LIBCPP_VERSION\n  return 0;\n#else\n# error not libc++\n#endif\n}")
+            check_cxx_source_compiles("${_FREECAD_PROBE_LIBCXX}" _FREECAD_USE_LIBCXX)
+
+            if(_FREECAD_USE_LIBSTDCXX)
+                add_compile_definitions($<${_FREECAD_STL_ASSERT_GENEX}:_GLIBCXX_ASSERTIONS>)
+                message(STATUS "STL assertions: libstdc++ _GLIBCXX_ASSERTIONS (${_FREECAD_STL_ASSERT_SCOPE})")
+            elseif(_FREECAD_USE_LIBCXX OR BUILD_USE_LIBCXX)
+                add_compile_definitions(
+                    $<${_FREECAD_STL_ASSERT_GENEX}:_LIBCPP_ENABLE_ASSERTIONS=1>
+                )
+                message(STATUS "STL assertions: libc++ assertions (${_FREECAD_STL_ASSERT_SCOPE})")
+            else()
+                message(STATUS "STL assertions: standard library not recognized (not libstdc++/libc++); not enabling.")
+            endif()
+        else()
+            message(STATUS "STL assertions: ${_FREECAD_STL_ASSERT_SCOPE}")
+        endif()
 
         # get linker errors as soon as possible and not at runtime e.g. for modules
         if(BUILD_DYNAMIC_LINK_PYTHON)


### PR DESCRIPTION
I have recently seen some crashes in FreeCAD where the underlying reason is an out-of-bounds access to an STL container like `std::vector` (e.g. #24064). Sometimes there is no crash, merely an out-of-bounds access, and the behavior likely depends on whatever happens to be in the memory (e.g. #23847).

Since many C++ standard libraries support cheap checks for container accesses, I suggest enabling those checks for Debug builds. A practical effect is getting assertions instead of crashes, or sometimes getting assertions instead of silently using wrong memory.

This PR adds a new CMake variable, `FREECAD_STL_ASSERTIONS`. It is tristate, ON/OFF/AUTO, defaulting to AUTO, which means enable on Debug builds.

On (GNU) libstdc++, enabling this defines `_GLIBCXX_ASSERTIONS`, which promises to be lightweight and ABI compatible. It catches many simple errors like out-of-bounds `std::vector` accesses.

On libc++, it defines `_LIBCPP_ENABLE_ASSERTIONS=1`, which supposedly is similar (but I have not tested it).

On Windows it changes nothing. Apparently the situation is a bit messy. There's `_ITERATOR_DEBUG_LEVEL`, but changing it is ABI breaking. This may be changing; there's some kind of "STL hardening" effort going on to solve this problem on the Microsoft side.

## Issues

I did not create an issue for this (seemed duplicative to create an issue saying the same things), but if desired for e.g. some kind of process reasons, I can do so. Or if you think it's better to take this up in the forum instead of discussing it in the PR, I can do so too.

## Notes

I admit I am not a CMake expert. It would help if someone who knows CMake looks at the implementation.

And, of course, I intend this as a discussion opener on whether this is in fact desirable.