### PR TITLE
BIM: BIM Report command MVP

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -2022,11 +2022,11 @@ def makeReport(name=None):
     if not report_obj:
         return None
 
-    # Create and link the spreadsheet target
-    sheet = FreeCAD.ActiveDocument.addObject("Spreadsheet::Sheet", "ReportResult")
-    report_obj.Target = sheet
+    # Initialize spreadsheet if the proxy requests it (mirrors makeSchedule)
+    if hasattr(report_obj, 'Proxy') and hasattr(report_obj.Proxy, 'getSpreadSheet'):
+        # Let exceptions propagate here instead of masking them so failures are visible
+        report_obj.Proxy.getSpreadSheet(report_obj, force=True)
 
-    FreeCAD.ActiveDocument.recompute()
     return report_obj
 
 def selectObjects(query_string):

--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -2028,3 +2028,29 @@ def makeReport(name=None):
 
     FreeCAD.ActiveDocument.recompute()
     return report_obj
+
+def selectObjects(query_string):
+    """
+    Selects objects from the active document using a SQL-like query.
+
+    This provides a powerful, declarative way to select BIM objects
+    based on their properties.
+
+    Parameters
+    ----------
+    query_string : str
+        The SQL query to execute. For example:
+        'SELECT * FROM document WHERE IfcType = "Wall" AND Label LIKE "%exterior%"'
+
+    Returns
+    -------
+    list of App::DocumentObject
+        A list of the FreeCAD document objects that match the query.
+        Returns an empty list if the query is invalid or finds no objects.
+    """
+    # Use a local import to follow Arch.py conventions (lazy loading).
+    import ArchSql
+    if not FreeCAD.ActiveDocument:
+        FreeCAD.Console.PrintError("Arch.selectObjects() requires an active document.\n")
+        return []
+    return ArchSql.run_query_for_objects(query_string)

--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -1991,3 +1991,40 @@ def _initializeArchObject(
         return None
 
     return obj
+
+def makeReport(name=None):
+    """
+    Creates a BIM Report object in the active document.
+
+    Parameters
+    ----------
+    name : str, optional
+        The name to assign to the created report object. Defaults to None.
+
+    Returns
+    -------
+    App::FeaturePython
+        The created report object.
+    """
+
+    # Use the helper to create the main object. Note that we pass the
+    # correct class and module names.
+    report_obj = _initializeArchObject(
+        objectType="App::FeaturePython",
+        baseClassName="Report",
+        internalName="ArchReport",
+        defaultLabel=name if name else translate("Arch", "Report"),
+        moduleName="ArchReport",
+        viewProviderName="ViewProviderReport"
+    )
+
+    # The helper returns None if there's no document, so we can exit early.
+    if not report_obj:
+        return None
+
+    # Create and link the spreadsheet target
+    sheet = FreeCAD.ActiveDocument.addObject("Spreadsheet::Sheet", "ReportResult")
+    report_obj.Target = sheet
+
+    FreeCAD.ActiveDocument.recompute()
+    return report_obj

--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -2027,7 +2027,8 @@ def makeReport(name=None):
     # Report object proxy needs its Statements list initialized before getSpreadSheet is called,
     # as getSpreadSheet calls execute() which now relies on obj.Statements.
     # Initialize with one default statement to provide a starting point for the user.
-    report_obj.Statements = [ArchReport.ReportStatement(description=translate("Arch", "New Statement"))]
+    default_stmt = ArchReport.ReportStatement(description=translate("Arch", "New Statement"))
+    report_obj.Statements = [default_stmt.dumps()]
 
     # Initialize a spreadsheet if the report requests one. The report is responsible for how the
     # association is stored (we use a non-dependent ``ReportName`` on the sheet and persist the

--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -2006,6 +2006,7 @@ def makeReport(name=None):
     App::FeaturePython
         The created report object.
     """
+    import ArchReport
 
     # Use the helper to create the main object. Note that we pass the
     # correct class and module names.
@@ -2021,6 +2022,12 @@ def makeReport(name=None):
     # The helper returns None if there's no document, so we can exit early.
     if not report_obj:
         return None
+
+    # Initialize the Statements property
+    # Report object proxy needs its Statements list initialized before getSpreadSheet is called,
+    # as getSpreadSheet calls execute() which now relies on obj.Statements.
+    # Initialize with one default statement to provide a starting point for the user.
+    report_obj.Statements = [ArchReport.ReportStatement(description=translate("Arch", "New Statement"))]
 
     # Initialize a spreadsheet if the report requests one. The report is responsible for how the
     # association is stored (we use a non-dependent ``ReportName`` on the sheet and persist the

--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -2022,10 +2022,11 @@ def makeReport(name=None):
     if not report_obj:
         return None
 
-    # Initialize spreadsheet if the proxy requests it (mirrors makeSchedule)
+    # Initialize a spreadsheet if the report requests one. The report is responsible for how the
+    # association is stored (we use a non-dependent ``ReportName`` on the sheet and persist the
+    # report's ``Target`` link when the report creates the sheet).
     if hasattr(report_obj, 'Proxy') and hasattr(report_obj.Proxy, 'getSpreadSheet'):
-        # Let exceptions propagate here instead of masking them so failures are visible
-        report_obj.Proxy.getSpreadSheet(report_obj, force=True)
+        sheet = report_obj.Proxy.getSpreadSheet(report_obj, force=True)
 
     return report_obj
 

--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -2036,6 +2036,10 @@ def makeReport(name=None):
     if hasattr(report_obj, 'Proxy') and hasattr(report_obj.Proxy, 'getSpreadSheet'):
         sheet = report_obj.Proxy.getSpreadSheet(report_obj, force=True)
 
+    if FreeCAD.GuiUp:
+        # Automatically open the task panel for the new report
+        FreeCADGui.ActiveDocument.setEdit(report_obj.Name, 0)
+
     return report_obj
 
 def selectObjects(query_string):

--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (c) 2025 The FreeCAD Project
+
+import FreeCAD
+import FreeCADGui
+from PySide import QtCore, QtWidgets
+import ArchSql
+
+class Report:
+    """The proxy class for the ArchReport FeaturePython object."""
+
+    def __init__(self, obj):
+        obj.Proxy = self
+        self.Type = "ArchReport"
+        self.set_properties(obj)
+
+    def set_properties(self, obj):
+        if not hasattr(obj, "Query"):
+            obj.addProperty("App::PropertyString", "Query", "Report", "The SQL query to execute")
+        if not hasattr(obj, "Target"):
+            obj.addProperty("App::PropertyLink", "Target", "Report", "The spreadsheet for the results")
+
+    def execute(self, fp):
+        """Called on document recompute."""
+        if not fp.Target or not fp.Query:
+            return
+
+        results = ArchSql.run_query_for_objects(fp.Query)
+
+        if results is None:
+            FreeCAD.Console.PrintError(f"Report '{fp.Label}': Error executing query.\n")
+            return
+
+        sheet = fp.Target
+        sheet.clearAll()
+        if results:
+            sheet.set("A1", "'Object Label'")
+            for i, res_obj in enumerate(results, 2):
+                sheet.set(f"A{i}", f"'{res_obj.Label}'")
+
+
+class ViewProviderReport:
+    """The ViewProvider for the ArchReport object."""
+
+    def __init__(self, vobj):
+        vobj.Proxy = self
+        self.vobj = vobj
+
+    def getIcon(self):
+        return ":/icons/Arch_Schedule.svg"
+
+    def doubleClicked(self, vobj):
+        # Delegate to setEdit, which is the primary and standard entry point.
+        return self.setEdit(vobj, 0)
+
+    def setEdit(self, vobj, mode):
+        # This is the primary entry point for all edit operations.
+        # Mode 0 is the default edit mode (double-click, F2, context menu).
+        if mode == 0:
+            if not hasattr(vobj.Object, "Query"):
+                return False
+            if FreeCAD.GuiUp:
+                panel = ReportTaskPanel(vobj.Object)
+                FreeCADGui.Control.showDialog(panel)
+            return True
+        return False
+
+    def dumps(self):
+        """Tells FreeCAD not to save any state for this view provider."""
+        return None
+
+    def loads(self, state):
+        """Tells FreeCAD not to restore any state for this view provider."""
+        return None
+
+class ReportTaskPanel:
+    """The Task Panel UI for editing an ArchReport object."""
+
+    def __init__(self, report_obj):
+        self.obj = report_obj
+        self.form = QtWidgets.QDialog()
+        self.form.setWindowTitle("BIM Report Editor")
+
+        self.query_edit = QtWidgets.QPlainTextEdit()
+        self.status_label = QtWidgets.QLabel("Ready")
+
+        self.status_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(QtWidgets.QLabel("Enter SQL Query:"))
+        layout.addWidget(self.query_edit)
+        layout.addWidget(self.status_label)
+
+        button_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel)
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.form.reject)
+        layout.addWidget(button_box)
+
+        self.form.setLayout(layout)
+
+        self.validation_timer = QtCore.QTimer()
+        self.validation_timer.setSingleShot(True)
+        self.validation_timer.timeout.connect(self.run_validation)
+
+        self.query_edit.textChanged.connect(self.on_query_changed)
+
+        self.query_edit.setPlainText(self.obj.Query)
+        self.run_validation()
+
+    def on_query_changed(self):
+        self.status_label.setText("<i>Typing...</i>")
+        self.status_label.setStyleSheet("color: gray;")
+        self.validation_timer.start(500)
+
+    def run_validation(self):
+        query = self.query_edit.toPlainText()
+        if not query.strip():
+            self.status_label.setText("Ready")
+            self.status_label.setStyleSheet("color: black;")
+            return
+
+        count, error = ArchSql.run_query_for_count(query)
+
+        try:
+            # Handle the "incomplete" case first and exit.
+            if error == "INCOMPLETE":
+                return  # Do nothing and wait for the user to finish typing.
+
+            # Handle any actual syntax errors and exit.
+            if error:
+                self.status_label.setText(f"❌ {error}")
+                self.status_label.setStyleSheet("color: red;")
+                return
+
+            # If we reach this point, the query is valid (error is None).
+            # We now only need to distinguish between zero and non-zero results.
+            if count == 0:
+                message = "⚠️ Query is valid, but found 0 objects."
+                color = "orange"
+            else:
+                message = f"✅ Found {count} objects."
+                color = "green"
+
+            self.status_label.setText(message)
+            self.status_label.setStyleSheet(f"color: {color};")
+
+        except Exception:
+            # If any other unexpected error happens, catch it and print the full traceback
+            import traceback
+            self.status_label.setText("❌ An unexpected error occurred. See Report View.")
+            self.status_label.setStyleSheet("color: red;")
+            FreeCAD.Console.PrintError("--- BIM Report Unexpected Error ---\n")
+            FreeCAD.Console.PrintError(traceback.format_exc())
+            FreeCAD.Console.PrintError("----------------------------------\n")
+
+    def accept(self):
+        self.obj.Query = self.query_edit.toPlainText()
+        FreeCAD.ActiveDocument.recompute()
+        self.form.accept()

--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -543,31 +543,25 @@ class ReportTaskPanel:
         self.editor_box = self.editor_widget
         self.editor_layout = QtWidgets.QVBoxLayout(self.editor_box)
 
-        # Description for edited statement (label and edit on same row)
-        self.description_label = QtWidgets.QLabel(translate("Arch", "Description:"))
+        # --- Form Layout for Aligned Inputs ---
+        self.form_layout = QtWidgets.QFormLayout()
+        self.form_layout.setContentsMargins(0, 0, 0, 0) # Use the main layout's margins
+
+        # Description Row
         self.description_edit = QtWidgets.QLineEdit()
-        desc_row = QtWidgets.QHBoxLayout()
-        desc_row.addWidget(self.description_label)
-        desc_row.addWidget(self.description_edit)
-        self.editor_layout.addLayout(desc_row)
+        self.form_layout.addRow(translate("Arch", "Description:"), self.description_edit)
 
-        # Use Description as Section Header checkbox
-        self.chk_use_description_as_header = QtWidgets.QCheckBox(translate("Arch", "Use Description as Section Header"))
-        self.chk_use_description_as_header.setToolTip(translate("Arch", "When checked, the statement's description will be written as a merged header row before its results."))
-        self.editor_layout.addWidget(self.chk_use_description_as_header)
-
-        # Preset controls for single queries
-        self.query_preset_layout = QtWidgets.QHBoxLayout()
+        # Preset Controls Row (widgets are placed in a QHBoxLayout for the second column)
+        self.preset_controls_layout = QtWidgets.QHBoxLayout()
         self.query_preset_dropdown = NoScrollHijackComboBox()
         self.query_preset_dropdown.setToolTip(translate("Arch", "Load a saved query preset into the editor."))
-        self.btn_save_query_preset = QtWidgets.QPushButton(translate("Arch", "Save as Preset..."))
+        self.btn_save_query_preset = QtWidgets.QPushButton(translate("Arch", "Save..."))
         self.btn_save_query_preset.setToolTip(translate("Arch", "Save the current query as a new preset."))
-        self.btn_save_query_preset.setIcon(FreeCADGui.getIcon(":/icons/document-save.svg"))
-        self.query_preset_layout.addWidget(self.query_preset_dropdown)
-        self.query_preset_layout.addWidget(self.btn_save_query_preset)
-        preset_label = QtWidgets.QLabel(translate("Arch", "Query Presets:"))
-        self.editor_layout.addWidget(preset_label)
-        self.editor_layout.addLayout(self.query_preset_layout)
+        self.preset_controls_layout.addWidget(self.query_preset_dropdown)
+        self.preset_controls_layout.addWidget(self.btn_save_query_preset)
+        self.form_layout.addRow(translate("Arch", "Query Presets:"), self.preset_controls_layout)
+
+        self.editor_layout.addLayout(self.form_layout)
 
         # SQL Query editor
         self.sql_label = QtWidgets.QLabel(translate("Arch", "SQL Query:"))

--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -326,6 +326,17 @@ class _ArchReport:
         self.spreadsheet = None
         self.docObserver = None
 
+    def _write_cell(self, spreadsheet, cell_address, value):
+        """Intelligently writes a value to a spreadsheet cell based on its type."""
+        if isinstance(value, (int, float)):
+            # Write numbers directly without quotes for calculations
+            spreadsheet.set(cell_address, str(value))
+        elif value is None:
+            spreadsheet.set(cell_address, "''") # Write an empty literal string
+        else:
+            # Write all other types as literal strings with a prepended quote
+            spreadsheet.set(cell_address, f"'{value}")
+
     def setSpreadsheetData(self, obj, headers, data_rows, start_row,
                            use_description_as_header=False, description_text="",
                            include_column_names=True,
@@ -340,29 +351,60 @@ class _ArchReport:
         # Determine the effective starting row for this block of data
         current_row = start_row
 
+        # --- Dynamic Header and Column Generation for Quantities ---
+        final_headers = []
+        quantity_columns = [] # Store indices of columns that contain Quantities
+
+        if data_rows:
+            # Pre-scan the first data row to identify Quantity columns
+            for i, cell_value in enumerate(data_rows[0]):
+                if isinstance(cell_value, FreeCAD.Units.Quantity):
+                    quantity_columns.append(i)
+                    final_headers.append(headers[i])
+                    final_headers.append(translate("Arch", "Unit"))
+                else:
+                    final_headers.append(headers[i])
+        else:
+            final_headers = headers # No data, use original headers
+
         # Add header for this statement if requested
         if use_description_as_header and description_text.strip():
             # Merging the header across columns (A to last data column)
-            last_col_char = chr(ord('A') + len(headers) - 1) if headers else 'A'
-            sp.set(f"A{current_row}", f"'{description_text}'")
+            last_col_char = chr(ord('A') + len(final_headers) - 1) if final_headers else 'A'
+            self._write_cell(sp, f"A{current_row}", description_text)
             sp.mergeCells(f"A{current_row}:{last_col_char}{current_row}")
             sp.setStyle(f"A{current_row}", 'bold', 'add')
             current_row += 1 # Advance row for data or column names
 
         # Write column names if requested
-        if include_column_names and headers:
-            for col_idx, header_text in enumerate(headers):
-                sp.set(f"{chr(ord('A') + col_idx)}{current_row}", f"'{header_text}'")
-            sp.setStyle(f'A{current_row}:{chr(ord("A") + len(headers) - 1)}{current_row}', 'bold', 'add')
+        if include_column_names and final_headers:
+            for col_idx, header_text in enumerate(final_headers):
+                self._write_cell(sp, f"{chr(ord('A') + col_idx)}{current_row}", header_text)
+            sp.setStyle(f'A{current_row}:{chr(ord("A") + len(final_headers) - 1)}{current_row}', 'bold', 'add')
             current_row += 1 # Advance row for data
 
         # Write data rows
         for row_data in data_rows:
+            col_idx = 0
             for col_idx, cell_value in enumerate(row_data):
-                cell_address = f"{chr(ord('A') + col_idx)}{current_row}"
-                sp.set(cell_address, f"'{cell_value}'")
-                if print_results_in_bold:
-                    sp.setStyle(cell_address, 'bold', 'add')
+                if i in quantity_columns and isinstance(cell_value, FreeCAD.Units.Quantity):
+                    # Split Quantity into two cells: Value and Unit
+                    val_cell = f"{chr(ord('A') + col_idx)}{current_row}"
+                    unit_cell = f"{chr(ord('A') + col_idx + 1)}{current_row}"
+                    self._write_cell(sp, val_cell, cell_value.Value)
+                    # Extract the unit symbol from the UserString representation
+                    user_string_parts = cell_value.UserString.split(' ', 1)
+                    unit_symbol = user_string_parts[1] if len(user_string_parts) > 1 else str(cell_value.Unit)
+                    self._write_cell(sp, unit_cell, unit_symbol)
+                    if print_results_in_bold:
+                        sp.setStyle(f"{val_cell}:{unit_cell}", 'bold', 'add')
+                    col_idx += 2
+                else:
+                    cell_address = f"{chr(ord('A') + col_idx)}{current_row}"
+                    self._write_cell(sp, cell_address, cell_value)
+                    if print_results_in_bold:
+                        sp.setStyle(cell_address, 'bold', 'add')
+                    col_idx += 1
             current_row += 1 # Advance row for next data row
 
         # Add empty row if specified

--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -20,14 +20,14 @@ else:
 import ArchSql
 
 if FreeCAD.GuiUp:
-    ICON_STATUS_OK = FreeCADGui.getIcon(":/icons/Task_Ok.svg")
-    ICON_STATUS_WARN = FreeCADGui.getIcon(":/icons/Task_Warning.svg")
-    ICON_STATUS_ERROR = FreeCADGui.getIcon(":/icons/Task_Error.svg")
-    ICON_STATUS_INCOMPLETE = FreeCADGui.getIcon(":/icons/Task_Incomplete.svg")
+    ICON_STATUS_OK = FreeCADGui.getIcon(":/icons/edit_OK.svg")
+    ICON_STATUS_WARN = FreeCADGui.getIcon(":/icons/Warning.svg")
+    ICON_STATUS_ERROR = FreeCADGui.getIcon(":/icons/delete.svg")
+    ICON_STATUS_INCOMPLETE = FreeCADGui.getIcon(":/icons/button_invalid.svg")
     ICON_EDIT = FreeCADGui.getIcon(":/icons/Draft_Edit.svg")
     ICON_ADD = FreeCADGui.getIcon(":/icons/list-add.svg")
     ICON_REMOVE = FreeCADGui.getIcon(":/icons/list-remove.svg")
-    ICON_DUPLICATE = FreeCADGui.getIcon(":/icons/copy.svg")
+    ICON_DUPLICATE = FreeCADGui.getIcon(":/icons/edit-copy.svg")
 
 
 def _get_preset_paths(preset_type):

--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -3,11 +3,12 @@
 # Copyright (c) 2025 The FreeCAD Project
 
 import FreeCAD
+import json # For ReportStatement serialization/deserialization
 
 from draftutils import params
 
 if FreeCAD.GuiUp:
-    from PySide import QtCore, QtWidgets
+    from PySide import QtCore, QtWidgets, QtGui
     from PySide.QtCore import QT_TRANSLATE_NOOP
     import FreeCADGui
     from draftutils.translate import translate
@@ -18,6 +19,87 @@ else:
         return txt
 
 import ArchSql
+
+# --- New: Icons for Status and Edit buttons ---
+ICON_STATUS_OK = FreeCADGui.getIcon(":/icons/Task_Ok.svg")
+ICON_STATUS_WARN = FreeCADGui.getIcon(":/icons/Task_Warning.svg")
+ICON_STATUS_ERROR = FreeCADGui.getIcon(":/icons/Task_Error.svg")
+ICON_STATUS_INCOMPLETE = FreeCADGui.getIcon(":/icons/Task_Incomplete.svg")
+ICON_EDIT = FreeCADGui.getIcon(":/icons/Draft_Edit.svg")
+ICON_ADD = FreeCADGui.getIcon(":/icons/list-add.svg")
+ICON_REMOVE = FreeCADGui.getIcon(":/icons/list-remove.svg")
+ICON_DUPLICATE = FreeCADGui.getIcon(":/icons/copy.svg")
+
+
+class ReportStatement:
+    """Encapsulates a single SQL query statement and its display options."""
+
+    def __init__(self, description="", query_string="",
+                 use_description_as_header=False, include_column_names=True,
+                 add_empty_row_after=False, print_results_in_bold=False):
+        self.description = description
+        self.query_string = query_string
+        self.use_description_as_header = use_description_as_header
+        self.include_column_names = include_column_names
+        self.add_empty_row_after = add_empty_row_after
+        self.print_results_in_bold = print_results_in_bold
+
+        # Internal validation state (transient, not serialized)
+        self._validation_status = "Ready" # e.g., "OK", "0_RESULTS", "ERROR", "INCOMPLETE"
+        self._validation_message = translate("Arch", "Ready") # e.g., "Found 5 objects.", "Syntax Error: ..."
+        self._validation_count = 0
+
+    def dumps(self):
+        """Returns the internal state for serialization."""
+        return {
+            'description': self.description,
+            'query_string': self.query_string,
+            'use_description_as_header': self.use_description_as_header,
+            'include_column_names': self.include_column_names,
+            'add_empty_row_after': self.add_empty_row_after,
+            'print_results_in_bold': self.print_results_in_bold,
+        }
+
+    def loads(self, state):
+        """Restores the internal state from serialized data."""
+        self.description = state.get('description', '')
+        self.query_string = state.get('query_string', '')
+        self.use_description_as_header = state.get('use_description_as_header', False)
+        self.include_column_names = state.get('include_column_names', True)
+        self.add_empty_row_after = state.get('add_empty_row_after', False)
+        self.print_results_in_bold = state.get('print_results_in_bold', False)
+
+        # Validation state is transient and re-calculated on UI load/edit
+        self._validation_status = "Ready"
+        self._validation_message = translate("Arch", "Ready")
+        self._validation_count = 0
+
+    def validate_and_update_status(self):
+        """Runs validation for this statement's query and updates its internal status."""
+        if not self.query_string.strip():
+            self._validation_status = "OK" # Empty query is valid, no error
+            self._validation_message = translate("Arch", "Ready")
+            self._validation_count = 0
+            return
+
+        count, error = ArchSql.run_query_for_count(self.query_string)
+
+        if error == "INCOMPLETE":
+            self._validation_status = "INCOMPLETE"
+            self._validation_message = translate("Arch", "Typing...")
+            self._validation_count = -1
+        elif error:
+            self._validation_status = "ERROR"
+            self._validation_message = error
+            self._validation_count = -1
+        elif count == 0:
+            self._validation_status = "0_RESULTS"
+            self._validation_message = translate("Arch", "Query is valid, but found 0 objects.")
+            self._validation_count = 0
+        else:
+            self._validation_status = "OK"
+            self._validation_message = f"{translate('Arch', 'Found')} {count} {translate('Arch', 'objects')}."
+            self._validation_count = count
 
 
 class _ArchReportDocObserver:
@@ -30,8 +112,6 @@ class _ArchReportDocObserver:
     def slotRecomputedDocument(self, doc):
         if doc != self.doc:
             return
-        # Execute the report when the document is recomputed. Let exceptions
-        # propagate so test failures and real errors are visible to the caller.
         self.report.Proxy.execute(self.report)
 
 
@@ -41,23 +121,37 @@ class _ArchReport:
         self.setProperties(obj)
         obj.Proxy = self
         self.Type = 'ArchReport'
-        # --- FIX: Initialize self.spreadsheet ---
         self.spreadsheet = None
-        self.docObserver = None # It will be re-attached by onChanged
+        self.docObserver = None
+        self.spreadsheet_current_row = 1 # Internal state for multi-statement reports
 
     def onDocumentRestored(self, obj):
-        self.setProperties(obj)
+        # This is called AFTER properties are set.
+        # Now we need to properly deserialize the Statements list.
+        # The temporary list from __setstate__ needs to be converted.
+        if hasattr(self, '_temp_statements_on_load') and self._temp_statements_on_load:
+            statements = []
+            for s_data in self._temp_statements_on_load:
+                statement = ReportStatement()
+                statement.loads(s_data)
+                statements.append(statement)
+            obj.Statements = statements
+            del self._temp_statements_on_load # Clean up temporary attribute
+
+        self.setProperties(obj) # This will ensure observer is re-attached
 
     def setProperties(self, obj):
-        if not 'Query' in obj.PropertiesList:
-            obj.addProperty('App::PropertyString', 'Query', 'Report', QT_TRANSLATE_NOOP('App::Property', 'The SQL query to execute'))
+        # Ensure the `Statements` property exists (list of ReportStatement objects)
+        if not 'Statements' in obj.PropertiesList:
+            obj.addProperty('App::PropertyPythonObject', 'Statements', 'Report', QT_TRANSLATE_NOOP('App::Property', 'The list of SQL statements to execute'), locked=True)
+            obj.Statements = [] # Initialize with an empty list
+
         if not 'Target' in obj.PropertiesList:
             obj.addProperty('App::PropertyLink', 'Target', 'Report', QT_TRANSLATE_NOOP('App::Property', 'The spreadsheet for the results'))
         if not 'AutoUpdate' in obj.PropertiesList:
             obj.addProperty('App::PropertyBool', 'AutoUpdate', 'Report', QT_TRANSLATE_NOOP('App::Property', 'If True, update report when document recomputes'))
             obj.AutoUpdate = True
 
-        # Attach observer state
         self.onChanged(obj, 'AutoUpdate')
 
     def setReportPropertySpreadsheet(self, sp, obj):
@@ -85,12 +179,10 @@ class _ArchReport:
         - obj: the report object
         - force: if True, create a new spreadsheet when none is found
         """
-        # Return cached sheet when it matches the report name
         sp = getattr(self, 'spreadsheet', None)
         if sp and getattr(sp, 'ReportName', None) == obj.Name:
             return sp
 
-        # Search document for a sheet whose ReportName matches the report
         for o in FreeCAD.ActiveDocument.Objects:
             if o.TypeId == 'Spreadsheet::Sheet' and getattr(o, 'ReportName', None) == obj.Name:
                 self.spreadsheet = o
@@ -115,88 +207,114 @@ class _ArchReport:
                     FreeCAD.removeDocumentObserver(self.docObserver)
                     self.docObserver = None
 
-    def setSpreadsheetData(self, obj, headers, data_rows, force=False):
-        """Write headers and rows into the report's spreadsheet.
+    def __getstate__(self):
+        """Returns the internal state of the _ArchReport object for serialization."""
+        state = {
+            'Type': self.Type,
+            # --- PHASE 1.5 FIX: Serialize Statements list ---
+            'Statements': [s.dumps() for s in getattr(self.obj, 'Statements', [])],
+            'spreadsheet_name': getattr(getattr(self, 'spreadsheet', None), 'Name', None),
+        }
+        return state
 
-        The method prefers an explicit ``obj.Target`` if present. If no valid
-        target exists, it will look up a spreadsheet by the sheet's
-        ``ReportName`` (matching ``obj.Name``) and, when ``force=True``, create
-        a new sheet and associate it.
+    def __setstate__(self, state):
+        """Restores the internal state of the _ArchReport object from serialized data."""
+        self.Type = state.get('Type', 'ArchReport')
+        # Store statements data temporarily as obj is not available yet
+        self._temp_statements_on_load = []
+        for s_data in state.get('Statements', []):
+            statement = ReportStatement()
+            statement.loads(s_data)
+            self._temp_statements_on_load.append(statement)
 
-        Parameters
-        - obj: report object
-        - headers: list of column header strings
-        - data_rows: list of row lists (each row is a list of cell values)
-        - force: if True, create the spreadsheet when none is found
-        """
-        # Prefer the explicit Target spreadsheet selected by the user.
-        # If no valid Target is provided, fall back to the named spreadsheet
-        # (ReportName) or create one when forced.
-        target = getattr(obj, 'Target', None)
-        sp = None
-        if target and getattr(target, 'TypeId', '') == 'Spreadsheet::Sheet':
-            sp = target
-        else:
-            if not (getattr(obj, 'Target', None) or force):
-                return
-            sp = self.getSpreadSheet(obj, force=force)
-        if not sp:
+        self.spreadsheet = None
+        self.docObserver = None
+
+    def setSpreadsheetData(self, obj, headers, data_rows, start_row,
+                           use_description_as_header=False, description_text="",
+                           include_column_names=True,
+                           add_empty_row_after=False, print_results_in_bold=False,
+                           force=False):
+        """Write headers and rows into the report's spreadsheet, starting from a specific row."""
+        sp = obj.Target # Always use obj.Target directly as it's the explicit link
+        if not sp: # ensure spreadsheet exists, this is an error condition
+            FreeCAD.Console.PrintError(f"Report '{getattr(obj, 'Label', '')}': No target spreadsheet found.\n")
+            return start_row # Return current row unchanged
+
+        # Determine the effective starting row for this block of data
+        current_row = start_row
+
+        # Add header for this statement if requested
+        if use_description_as_header and description_text.strip():
+            # Merging the header across columns (A to last data column)
+            last_col_char = chr(ord('A') + len(headers) - 1) if headers else 'A'
+            sp.set(f"A{current_row}", f"'{description_text}'")
+            sp.mergeCells(f"A{current_row}:{last_col_char}{current_row}")
+            sp.setStyle(f"A{current_row}", 'bold', 'add')
+            current_row += 1 # Advance row for data or column names
+
+        # Write column names if requested
+        if include_column_names and headers:
+            for col_idx, header_text in enumerate(headers):
+                sp.set(f"{chr(ord('A') + col_idx)}{current_row}", f"'{header_text}'")
+            sp.setStyle(f'A{current_row}:{chr(ord("A") + len(headers) - 1)}{current_row}', 'bold', 'add')
+            current_row += 1 # Advance row for data
+
+        # Write data rows
+        for row_data in data_rows:
+            for col_idx, cell_value in enumerate(row_data):
+                cell_address = f"{chr(ord('A') + col_idx)}{current_row}"
+                sp.set(cell_address, f"'{cell_value}'")
+                if print_results_in_bold:
+                    sp.setStyle(cell_address, 'bold', 'add')
+            current_row += 1 # Advance row for next data row
+
+        # Add empty row if specified
+        if add_empty_row_after:
+            current_row += 1 # Just increment row, leave it blank
+
+        return current_row # Return the next available row
+
+    def execute(self, obj):
+        # --- PHASE 1.5 FIX: Handle Statements list ---
+        if not hasattr(obj, 'Statements') or not obj.Statements:
             return
 
-        widths = [sp.getColumnWidth(col) for col in ('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H')]
-        sp.clearAll()
-        for i, width in enumerate(widths):
-            sp.setColumnWidth(chr(ord('A') + i), width)
+        sp = obj.Target # Ensure we use the explicitly linked Target
+        if not sp: # ensure spreadsheet exists, this is an error condition
+            FreeCAD.Console.PrintError(f"Report '{getattr(obj, 'Label', '')}': No target spreadsheet found.\n")
+            return
+        sp.clearAll() # Clear the spreadsheet for a new report
 
-        for col_idx, header_text in enumerate(headers):
-            sp.set(f"{chr(ord('A') + col_idx)}1", f"'{header_text}'")
-        sp.setStyle('A1:%s1' % chr(ord('A') + len(headers) - 1), 'bold', 'add')
+        self.spreadsheet_current_row = 1 # Reset row counter for a new report build
 
-        for row_idx, row_data in enumerate(data_rows, start=2):
-            for col_idx, cell_value in enumerate(row_data):
-                sp.set(f"{chr(ord('A') + col_idx)}{row_idx}", f"'{cell_value}'")
+        for statement in obj.Statements:
+            headers, results_data = ArchSql.run_query_for_objects(statement.query_string)
+
+            if results_data is None:
+                FreeCAD.Console.PrintError("Report '%s': Error executing query '%s'.\n" % (getattr(obj, 'Label', ''), statement.query_string))
+                # Add an error message to the spreadsheet
+                sp.set(f"A{self.spreadsheet_current_row}", f"❌ Error executing query: {statement.query_string}")
+                sp.setStyle(f"A{self.spreadsheet_current_row}", 'color:red', 'add')
+                self.spreadsheet_current_row += 1
+                continue # Skip to next statement
+
+            self.spreadsheet_current_row = self.setSpreadsheetData(
+                obj,
+                headers,
+                results_data,
+                self.spreadsheet_current_row,
+                use_description_as_header=statement.use_description_as_header,
+                description_text=statement.description,
+                include_column_names=statement.include_column_names,
+                add_empty_row_after=statement.add_empty_row_after,
+                print_results_in_bold=statement.print_results_in_bold,
+                force=False # Spreadsheet already exists
+            )
 
         sp.recompute()
         sp.purgeTouched()
 
-    def execute(self, obj):
-        if not getattr(obj, 'Query', None):
-            return
-
-        # --- FIX: run_query_for_objects now consistently returns (headers, data_rows) ---
-        headers, results_data = ArchSql.run_query_for_objects(obj.Query)
-
-        if results_data is None: # This should now be an empty list, not None, if no results
-            FreeCAD.Console.PrintError("Report '%s': Error executing query.\n" % getattr(obj, 'Label', ''))
-            return
-
-        # setSpreadsheetData expects (headers, list_of_lists_of_values)
-        self.setSpreadsheetData(obj, headers, results_data, force=True)
-
-    def onDelete(self, obj, subelements):
-        """
-        Clean up the associated spreadsheet on deletion
-        This method is called by FreeCAD when the Report object is about to be deleted.
-        It ensures the linked spreadsheet is also removed, preventing orphaned objects.
-        """
-        if obj.Target:
-            try:
-                # Remove the linked spreadsheet from the document.
-                FreeCAD.ActiveDocument.removeObject(obj.Target.Name)
-            except Exception as e:
-                FreeCAD.Console.PrintWarning(f"Failed to delete spreadsheet '{obj.Target.Label}' linked to Report '{obj.Label}': {e}\n")
-        return True # Return True to allow the Report object itself to be deleted.
-
-    def dumps(self):
-        # Explicitly *omits self.docObserver
-        # Only return 'self.Type', which is a simple string and serializable.
-        if hasattr(self,"Type"):
-            return self.Type
-
-    def loads(self,state):
-        if state:
-            self.Type = state
-        # The docObserver is NOT restored here; it's handled by onDocumentRestored -> setProperties -> onChanged.
 
 class Report(_ArchReport):
     """Public alias class so Arch._initializeArchObject can find 'Report'.
@@ -224,8 +342,6 @@ class ViewProviderReport:
 
     def setEdit(self, vobj, mode):
         if mode == 0:
-            if not hasattr(vobj.Object, "Query"):
-                return False
             if FreeCAD.GuiUp:
                 panel = ReportTaskPanel(vobj.Object)
                 try:
@@ -238,9 +354,8 @@ class ViewProviderReport:
         return False
 
     def attach(self, vobj):
-        # Called by the C++ loader when the view provider is rehydrated.
-        # Ensure we keep a reference to the view object for later callbacks.
-        self.vobj = vobj
+        """Called by the C++ loader when the view provider is rehydrated."""
+        self.vobj = vobj # Ensure self.vobj is set for consistent access
 
     def claimChildren(self):
         """
@@ -259,81 +374,352 @@ class ViewProviderReport:
 
 
 class ReportTaskPanel:
-    """The Task Panel UI for editing an ArchReport object."""
+    """Multi-statement task panel for editing a Report.
+
+    Exposes `self.form` as a QWidget so it works with FreeCADGui.Control.showDialog(panel).
+    Implements accept() and reject() to save or discard changes.
+    """
 
     def __init__(self, report_obj):
+        # Create two top-level widgets so FreeCAD will wrap each into a TaskBox.
+        # Box 1 (overview) contains the statements table and management buttons.
+        # Box 2 (editor) contains the query editor and options.
         self.obj = report_obj
-        self.form = QtWidgets.QDialog()
-        self.form.setWindowTitle("BIM Report Editor")
+        self.current_edited_statement_index = -1  # To track which statement is in editor
 
-        self.query_edit = QtWidgets.QPlainTextEdit()
-        self.status_label = QtWidgets.QLabel("Ready")
+        # Overview widget (TaskBox 1)
+        self.overview_widget = QtWidgets.QWidget()
+        self.overview_widget.setWindowTitle(translate("Arch", "Report Statements"))
+        self.statements_overview_widget = self.overview_widget  # preserve older name
+        self.statements_overview_layout = QtWidgets.QVBoxLayout(self.statements_overview_widget)
 
-        self.status_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+        # Table for statements
+        self.table_statements = QtWidgets.QTableWidget()
+        self.table_statements.setColumnCount(3)  # Description, Status, Edit
+        self.table_statements.setHorizontalHeaderLabels([
+            translate("Arch", "Description"),
+            translate("Arch", "Status"),
+            translate("Arch", "Edit"),
+        ])
+        self.table_statements.horizontalHeader().setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        self.table_statements.horizontalHeader().setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeToContents)
+        self.table_statements.horizontalHeader().setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeToContents)
+        self.table_statements.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
+        self.table_statements.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
+        self.table_statements.setDragDropMode(QtWidgets.QAbstractItemView.InternalMove)
+        self.statements_overview_layout.addWidget(self.table_statements)
 
-        layout = QtWidgets.QVBoxLayout()
-        layout.addWidget(QtWidgets.QLabel("Enter SQL Query:"))
-        layout.addWidget(self.query_edit)
-        layout.addWidget(self.status_label)
+        # Statement Management Buttons
+        self.statement_buttons_layout = QtWidgets.QHBoxLayout()
+        self.btn_add_statement = QtWidgets.QPushButton(ICON_ADD, translate("Arch", "Add Statement"))
+        self.btn_remove_statement = QtWidgets.QPushButton(ICON_REMOVE, translate("Arch", "Remove Selected"))
+        self.btn_duplicate_statement = QtWidgets.QPushButton(ICON_DUPLICATE, translate("Arch", "Duplicate Selected"))
 
-        button_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel)
-        button_box.accepted.connect(self.accept)
-        button_box.rejected.connect(self.form.reject)
-        layout.addWidget(button_box)
+        self.statement_buttons_layout.addWidget(self.btn_add_statement)
+        self.statement_buttons_layout.addWidget(self.btn_remove_statement)
+        self.statement_buttons_layout.addWidget(self.btn_duplicate_statement)
+        self.statements_overview_layout.addLayout(self.statement_buttons_layout)
 
-        self.form.setLayout(layout)
+        # Editor widget (TaskBox 2) -- starts collapsed until a statement is selected
+        self.editor_widget = QtWidgets.QWidget()
+        self.editor_widget.setWindowTitle(translate("Arch", "Edit Statement: (None Selected)"))
+        # Keep compatibility name used elsewhere
+        self.editor_box = self.editor_widget
+        self.editor_layout = QtWidgets.QVBoxLayout(self.editor_box)
 
+        # Description for edited statement
+        self.description_label = QtWidgets.QLabel(translate("Arch", "Description:"))
+        self.description_edit = QtWidgets.QLineEdit()
+        self.editor_layout.addWidget(self.description_label)
+        self.editor_layout.addWidget(self.description_edit)
+
+        # Use Description as Section Header checkbox
+        self.chk_use_description_as_header = QtWidgets.QCheckBox(translate("Arch", "Use Description as Section Header"))
+        self.editor_layout.addWidget(self.chk_use_description_as_header)
+
+        # SQL Query editor
+        self.sql_label = QtWidgets.QLabel(translate("Arch", "SQL Query:"))
+        self.sql_query_edit = QtWidgets.QPlainTextEdit()
+        self.sql_query_status_label = QtWidgets.QLabel(translate("Arch", "Ready"))
+        self.sql_query_status_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+
+        self.editor_layout.addWidget(self.sql_label)
+        self.editor_layout.addWidget(self.sql_query_edit)
+        self.editor_layout.addWidget(self.sql_query_status_label)
+
+        # Display Options for edited statement
+        self.chk_include_column_names = QtWidgets.QCheckBox(translate("Arch", "Include Column Names"))
+        self.chk_add_empty_row_after = QtWidgets.QCheckBox(translate("Arch", "Add Empty Row After"))
+        self.chk_print_results_in_bold = QtWidgets.QCheckBox(translate("Arch", "Print Results in Bold"))
+
+        self.editor_layout.addWidget(self.chk_include_column_names)
+        self.editor_layout.addWidget(self.chk_add_empty_row_after)
+        self.editor_layout.addWidget(self.chk_print_results_in_bold)
+
+        # Expose form as a list of the two top-level widgets so FreeCAD creates
+        # two built-in TaskBox sections. The overview goes first, editor second.
+        self.form = [self.overview_widget, self.editor_widget]
+
+        # --- Connections ---
+        self.btn_add_statement.clicked.connect(self._add_statement)
+        self.btn_remove_statement.clicked.connect(self._remove_selected_statement)
+        self.btn_duplicate_statement.clicked.connect(self._duplicate_selected_statement)
+        self.table_statements.itemSelectionChanged.connect(self._on_table_selection_changed)
+        self.description_edit.textChanged.connect(self._on_editor_description_changed)
+        self.sql_query_edit.textChanged.connect(self._on_editor_sql_changed)
+        self.chk_use_description_as_header.stateChanged.connect(self._on_editor_checkbox_changed)
+        self.chk_include_column_names.stateChanged.connect(self._on_editor_checkbox_changed)
+        self.chk_add_empty_row_after.stateChanged.connect(self._on_editor_checkbox_changed)
+        self.chk_print_results_in_bold.stateChanged.connect(self._on_editor_checkbox_changed)
+
+        # Validation Timer for live SQL preview
+        # Timer doesn't need a specific QWidget parent here; use no parent.
         self.validation_timer = QtCore.QTimer()
         self.validation_timer.setSingleShot(True)
-        self.validation_timer.timeout.connect(self.run_validation)
+        self.validation_timer.timeout.connect(self._run_live_validation_for_editor)
 
-        self.query_edit.textChanged.connect(self.on_query_changed)
+        # Initial UI setup
+        self._populate_table_from_statements()
+        self._update_editor_visibility(False)  # Start with editor collapsed/hidden
+        # Do not auto-select the first statement; leave editor collapsed until user selects
 
-        self.query_edit.setPlainText(self.obj.Query)
-        self.run_validation()
 
-    def on_query_changed(self):
-        self.status_label.setText("<i>Typing...</i>")
-        self.status_label.setStyleSheet("color: gray;")
-        self.validation_timer.start(500)
 
-    def run_validation(self):
-        query = self.query_edit.toPlainText()
-        if not query.strip():
-            self.status_label.setText("Ready")
-            self.status_label.setStyleSheet("color: black;")
+    # --- Statement Management (Buttons and Table Interaction) ---
+    def _populate_table_from_statements(self):
+        self.table_statements.setRowCount(0) # Clear existing rows
+        statements = self.obj.Statements
+        for row_idx, statement in enumerate(statements):
+            self.table_statements.insertRow(row_idx)
+            self.table_statements.setItem(row_idx, 0, QtWidgets.QTableWidgetItem(statement.description))
+
+            # Status Item (Icon + Tooltip)
+            status_icon, status_tooltip = self._get_status_icon_and_tooltip(statement)
+            status_item = QtWidgets.QTableWidgetItem()
+            status_item.setIcon(status_icon)
+            status_item.setToolTip(status_tooltip)
+            status_item.setFlags(status_item.flags() & ~QtCore.Qt.ItemIsEditable) # Make read-only
+            self.table_statements.setItem(row_idx, 1, status_item)
+
+            # Edit Button Item
+            edit_button = QtWidgets.QToolButton()
+            edit_button.setIcon(ICON_EDIT)
+            edit_button.setToolTip(translate("Arch", "Edit statement details"))
+            edit_button.clicked.connect(lambda _, r=row_idx: self._select_statement_in_table(r)) # Use lambda to pass row_idx
+            self.table_statements.setCellWidget(row_idx, 2, edit_button)
+
+            # Make description editable directly in table
+            self.table_statements.item(row_idx, 0).setFlags(self.table_statements.item(row_idx, 0).flags() | QtCore.Qt.ItemIsEditable)
+
+            # Recalculate status for each statement (important on load)
+            statement.validate_and_update_status()
+
+    def _add_statement(self):
+        new_statement = ReportStatement(description=translate("Arch", f"New Statement {len(self.obj.Statements) + 1}"))
+        self.obj.Statements.append(new_statement)
+        self._populate_table_from_statements() # Refresh the table
+        new_statement.validate_and_update_status() # Validate immediately
+        self._select_statement_in_table(len(self.obj.Statements) - 1) # Select and open new statement
+
+    def _remove_selected_statement(self):
+        selected_rows = self.table_statements.selectionModel().selectedRows()
+        if not selected_rows:
             return
 
-        count, error = ArchSql.run_query_for_count(query)
+        row_to_remove = selected_rows[0].row()
+        description_to_remove = self.table_statements.item(row_to_remove, 0).text()
 
-        try:
-            if error == "INCOMPLETE":
-                return
+        if QtWidgets.QMessageBox.question(None, translate("Arch", "Remove Statement"),
+                                          translate("Arch", f"Are you sure you want to remove statement '{description_to_remove}'?"),
+                                          QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No) == QtWidgets.QMessageBox.Yes:
+            self.obj.Statements.pop(row_to_remove)
+            self._populate_table_from_statements()
+            self._select_first_statement_if_available()
 
-            if error:
-                self.status_label.setText(f"❌ {error}")
-                self.status_label.setStyleSheet("color: red;")
-                return
+    def _duplicate_selected_statement(self):
+        selected_rows = self.table_statements.selectionModel().selectedRows()
+        if not selected_rows:
+            return
 
-            if count == 0:
-                message = "⚠️ Query is valid, but found 0 objects."
-                color = "orange"
-            else:
-                message = f"✅ Found {count} objects."
-                color = "green"
+        row_to_duplicate = selected_rows[0].row()
+        original_statement = self.obj.Statements[row_to_duplicate]
 
-            self.status_label.setText(message)
-            self.status_label.setStyleSheet(f"color: {color};")
+        duplicated_statement = ReportStatement()
+        duplicated_statement.loads(original_statement.dumps()) # Use serialization to deep copy
+        duplicated_statement.description = translate("Arch", f"Copy of {original_statement.description}")
 
-        except Exception:
-            import traceback
-            self.status_label.setText("❌ An unexpected error occurred. See Report View.")
-            self.status_label.setStyleSheet("color: red;")
-            FreeCAD.Console.PrintError("--- BIM Report Unexpected Error ---\n")
-            FreeCAD.Console.PrintError(traceback.format_exc())
-            FreeCAD.Console.PrintError("----------------------------------\n")
+        self.obj.Statements.insert(row_to_duplicate + 1, duplicated_statement)
+        self._populate_table_from_statements()
+        duplicated_statement.validate_and_update_status()
+        self._select_statement_in_table(row_to_duplicate + 1)
 
+    def _select_first_statement_if_available(self):
+        if self.obj.Statements:
+            self._select_statement_in_table(0)
+        else:
+            self._update_editor_visibility(False) # Hide editor if no statements
+
+    def _select_statement_in_table(self, row_idx):
+        # Select the row visually and trigger _on_table_selection_changed
+        self.table_statements.selectRow(row_idx)
+        # Ensure the editor is expanded if a statement is selected explicitly
+        self._update_editor_visibility(True)
+
+
+    # --- Editor (Box 2) Management ---
+    def _on_table_selection_changed(self):
+        selected_rows = self.table_statements.selectionModel().selectedRows()
+        if selected_rows:
+            new_index = selected_rows[0].row()
+            if new_index != self.current_edited_statement_index:
+                self._save_current_editor_state_to_statement() # Save old state
+                self.current_edited_statement_index = new_index
+                self._load_statement_to_editor(self.obj.Statements[new_index])
+                self._update_editor_title(self.obj.Statements[new_index].description)
+                self._run_live_validation_for_editor() # Validate the loaded query
+                self._update_editor_visibility(True) # Ensure editor is visible
+        else:
+            self._save_current_editor_state_to_statement() # Save last edited state
+            self.current_edited_statement_index = -1
+            self._update_editor_visibility(False) # Hide editor if nothing selected
+
+    def _load_statement_to_editor(self, statement: ReportStatement):
+        self.description_edit.setText(statement.description)
+        self.sql_query_edit.setPlainText(statement.query_string)
+        self.chk_use_description_as_header.setChecked(statement.use_description_as_header)
+        self.chk_include_column_names.setChecked(statement.include_column_names)
+        self.chk_add_empty_row_after.setChecked(statement.add_empty_row_after)
+        self.chk_print_results_in_bold.setChecked(statement.print_results_in_bold)
+        # Update validation status label for loaded query
+        self._update_editor_status_display(statement)
+
+    def _save_current_editor_state_to_statement(self):
+        if self.current_edited_statement_index != -1 and self.current_edited_statement_index < len(self.obj.Statements):
+            statement = self.obj.Statements[self.current_edited_statement_index]
+            statement.description = self.description_edit.text()
+            statement.query_string = self.sql_query_edit.toPlainText()
+            statement.use_description_as_header = self.chk_use_description_as_header.isChecked()
+            statement.include_column_names = self.chk_include_column_names.isChecked()
+            statement.add_empty_row_after = self.chk_add_empty_row_after.isChecked()
+            statement.print_results_in_bold = self.chk_print_results_in_bold.isChecked()
+            statement.validate_and_update_status() # Update status in the statement object
+            self._update_table_row_status(self.current_edited_statement_index, statement) # Refresh table status
+
+    def _on_editor_description_changed(self):
+        # Update table description live as user types in editor
+        if self.current_edited_statement_index != -1:
+            item = self.table_statements.item(self.current_edited_statement_index, 0)
+            if item:
+                item.setText(self.description_edit.text())
+            self._update_editor_title(self.description_edit.text())
+        # Re-trigger validation for other fields potentially (e.g. if query uses description)
+        self.validation_timer.start(500) # (Re)start timer for live validation
+
+    def _on_editor_sql_changed(self):
+        self.sql_query_status_label.setText(translate("Arch", "<i>Typing...</i>"))
+        self.sql_query_status_label.setStyleSheet("color: gray;")
+        self.validation_timer.start(500) # (Re)start timer for live validation
+
+    def _on_editor_checkbox_changed(self):
+        # Checkboxes are saved when editor state is saved, but ensure live validation for status icon
+        self.validation_timer.start(500) # (Re)start timer for live validation
+
+
+    def _run_live_validation_for_editor(self):
+        # Validate the query currently in the editor's text area
+        temp_statement = ReportStatement(query_string=self.sql_query_edit.toPlainText())
+        temp_statement.validate_and_update_status()
+        self._update_editor_status_display(temp_statement) # Update the status label in the editor UI
+
+        # Also update table if this is the currently edited statement
+        if self.current_edited_statement_index != -1:
+            statement_obj = self.obj.Statements[self.current_edited_statement_index]
+            statement_obj.query_string = temp_statement.query_string # Keep statement object's query updated for validation.
+            statement_obj.validate_and_update_status()
+            self._update_table_row_status(self.current_edited_statement_index, statement_obj)
+
+
+    def _update_editor_status_display(self, statement: ReportStatement):
+        # Update the status label (below SQL editor) in Box 2
+        if statement._validation_status == "INCOMPLETE":
+            self.sql_query_status_label.setText(translate("Arch", "<i>Typing...</i>"))
+            self.sql_query_status_label.setStyleSheet("color: gray;")
+        elif statement._validation_status == "ERROR":
+            self.sql_query_status_label.setText(f"❌ {statement._validation_message}")
+            self.sql_query_status_label.setStyleSheet("color: red;")
+        elif statement._validation_status == "0_RESULTS":
+            self.sql_query_status_label.setText(f"⚠️ {statement._validation_message}")
+            self.sql_query_status_label.setStyleSheet("color: orange;")
+        else: # OK or Ready
+            self.sql_query_status_label.setText(f"✅ {statement._validation_message}")
+            self.sql_query_status_label.setStyleSheet("color: green;")
+
+    def _update_table_row_status(self, row_idx, statement: ReportStatement):
+        # Update the status icon/tooltip in the QTableWidget (Box 1)
+        status_item = self.table_statements.item(row_idx, 1)
+        if status_item:
+            status_icon, status_tooltip = self._get_status_icon_and_tooltip(statement)
+            status_item.setIcon(status_icon)
+            status_item.setToolTip(status_tooltip)
+
+        # Update description in table in case it was changed via editor
+        desc_item = self.table_statements.item(row_idx, 0)
+        if desc_item:
+            desc_item.setText(statement.description)
+
+
+    def _get_status_icon_and_tooltip(self, statement: ReportStatement):
+        # Helper to get appropriate icon and tooltip for table status column
+        status = statement._validation_status
+        message = statement._validation_message
+        count = statement._validation_count
+
+        if status == "OK":
+            return ICON_STATUS_OK, message
+        elif status == "0_RESULTS":
+            return ICON_STATUS_WARN, message
+        elif status == "ERROR":
+            return ICON_STATUS_ERROR, message
+        elif status == "INCOMPLETE":
+            return ICON_STATUS_INCOMPLETE, translate("Arch", "Query incomplete or typing...")
+        return QtGui.QIcon(), translate("Arch", "Ready") # Default/initial state
+
+    def _update_editor_title(self, description):
+        # Updates the title of the collapsible editor box (Box 2)
+        if description.strip():
+            self.editor_box.setWindowTitle(translate("Arch", f"Edit Statement: {description}"))
+        else:
+            self.editor_box.setWindowTitle(translate("Arch", "Edit Statement: (No Description)"))
+
+    def _update_editor_visibility(self, visible: bool):
+        # Controls the visibility/collapsing of the editor box
+        self.editor_box.setVisible(visible)
+        # Change arrow indicator (Qt handles this if QGroupBox is collapsible,
+        # but we control visibility directly here.)
+
+
+    # --- Dialog Acceptance / Rejection ---
     def accept(self):
-        self.obj.Query = self.query_edit.toPlainText()
-        FreeCAD.ActiveDocument.recompute()
-        self.form.accept()
+        """Saves changes from UI to Report object and triggers recompute."""
+        # Ensure the currently edited statement's state is saved before final accept
+        self._save_current_editor_state_to_statement()
+        # Trigger a recompute to persist changes and refresh report
+        try:
+            FreeCAD.ActiveDocument.recompute()
+        except Exception:
+            # In headless/static checks FreeCAD.ActiveDocument may be unavailable
+            pass
+        # Close the task panel via FreeCADGui if available
+        try:
+            FreeCADGui.Control.closeDialog()
+        except Exception:
+            pass
+
+    def reject(self):
+        """Closes dialog without saving changes to the Report object."""
+        # Revert changes by not writing to self.obj.Statements
+        # Close the task panel without saving
+        try:
+            FreeCADGui.Control.closeDialog()
+        except Exception:
+            pass

--- a/src/Mod/BIM/ArchSql.py
+++ b/src/Mod/BIM/ArchSql.py
@@ -160,7 +160,14 @@ class SelectStatement:
                 value = None
                 if isinstance(extractor, AggregateFunction):
                     if extractor.function_name == 'count':
-                        value = len(object_list)
+                        # Distinguish between COUNT(*) and COUNT(property)
+                        if extractor.argument == '*':
+                            value = len(object_list)
+                        else:
+                            # Count only objects where the specified property is not None
+                            prop_name = extractor.argument.value
+                            count = sum(1 for obj in object_list if get_property(obj, prop_name) is not None)
+                            value = count
                     else:
                         # For other aggregates, extract the relevant property from all objects in the group
                         arg_extractor = extractor.argument
@@ -219,7 +226,13 @@ class SelectStatement:
                     value = extractor.get_value(None)
                 elif isinstance(extractor, AggregateFunction):
                     if extractor.function_name == 'count':
-                        value = len(objects)
+                        if extractor.argument == '*':
+                            value = len(objects)
+                        else:
+                            # Count only objects where the specified property is not None
+                            prop_name = extractor.argument.value
+                            count = sum(1 for obj in objects if get_property(obj, prop_name) is not None)
+                            value = count
                     else:
                         # For other aggregates, they must have a property to act on.
                         if isinstance(extractor.argument, ReferenceExtractor):

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -267,6 +267,13 @@ add_custom_command(
 
 add_custom_target(ArchSqlParser ALL DEPENDS ${BIM_GENERATED_PARSER})
 
+# Copy ArchReport presets to the build directory to make them available for testing.
+# This is separate from the INSTALL command, which handles the final installation.
+file(COPY
+    ${CMAKE_CURRENT_SOURCE_DIR}/Presets/ArchReport/
+    DESTINATION ${CMAKE_BINARY_DIR}/Mod/BIM/Presets/ArchReport/
+)
+
 fc_target_copy_resource(BIM
     ${CMAKE_SOURCE_DIR}/src/Mod/BIM
     ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/BIM

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -89,6 +89,8 @@ SET(Arch_presets
     Presets/ifc_contexts_IFC2X3.json
     Presets/ifc_contexts_IFC4.json
     Presets/properties_conversion.csv
+	Presets/ArchReport/query_presets.json
+	Presets/ArchReport/report_templates.json
 )
 
 SET(bimcommands_SRCS

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -47,6 +47,8 @@ SET(Arch_SRCS
     BimStatus.py
     TestArch.py
     TestArchGui.py
+    ArchReport.py
+    ArchSql.py
 )
 
 SET(importers_SRCS
@@ -170,6 +172,7 @@ SET(bimcommands_SRCS
     bimcommands/BimWindow.py
     bimcommands/BimWindows.py
     bimcommands/BimWPCommands.py
+    bimcommands/BimReport.py
     bimcommands/__init__.py
 )
 
@@ -229,6 +232,7 @@ SET(bimtests_SRCS
     bimtests/TestArchTruss.py
     bimtests/TestWebGLExport.py
     bimtests/TestWebGLExportGui.py
+    bimtests/TestArchReport.py
 )
 
 SOURCE_GROUP("" FILES ${Arch_SRCS})
@@ -239,6 +243,32 @@ SET(BIMGuiIcon_SVG
 
 SET(ImportersSample_Files
     importers/samples/Sample.sh3d
+)
+
+SET(ArchSql_resources
+    Resources/ArchSql.lark
+    Resources/ArchSqlParserGenerator.py
+)
+
+find_package(PythonInterp REQUIRED)
+set(BIM_LARK_GRAMMAR ${CMAKE_CURRENT_SOURCE_DIR}/Resources/ArchSql.lark)
+set(BIM_PARSER_GENERATOR ${CMAKE_CURRENT_SOURCE_DIR}/Resources/ArchSqlParserGenerator.py)
+
+set(BIM_GENERATED_PARSER ${CMAKE_BINARY_DIR}/Mod/BIM/generated_sql_parser.py)
+
+add_custom_command(
+    OUTPUT ${BIM_GENERATED_PARSER}
+    COMMAND ${PYTHON_EXECUTABLE} ${BIM_PARSER_GENERATOR} ${BIM_LARK_GRAMMAR} ${BIM_GENERATED_PARSER}
+    DEPENDS ${BIM_LARK_GRAMMAR} ${BIM_PARSER_GENERATOR}
+    COMMENT "Generating Arch SQL parser..."
+)
+
+add_custom_target(ArchSqlParser ALL DEPENDS ${BIM_GENERATED_PARSER})
+
+fc_target_copy_resource(BIM
+    ${CMAKE_SOURCE_DIR}/src/Mod/BIM
+    ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/BIM
+    ${ArchSql_resources}
 )
 
 ADD_CUSTOM_TARGET(BIM ALL

--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -201,6 +201,7 @@ class BIMWorkbench(Workbench):
             "BIM_Layers",
             "BIM_Material",
             "Arch_Schedule",
+            "BIM_Report",
             "BIM_Preflight",
             "Draft_AnnotationStyleEditor",
         ]

--- a/src/Mod/BIM/Presets/ArchReport/query_presets.json
+++ b/src/Mod/BIM/Presets/ArchReport/query_presets.json
@@ -1,0 +1,14 @@
+{
+  "All Walls": {
+    "description": "Selects all Wall objects in the document.",
+    "query": "SELECT * FROM document WHERE IfcType = 'Wall'"
+  },
+  "All Spaces": {
+    "description": "Selects all Space objects in the document.",
+    "query": "SELECT * FROM document WHERE IfcRole = 'Space'"
+  },
+  "Count by IfcType": {
+    "description": "Counts all objects, grouped by their IfcType.",
+    "query": "SELECT IfcType, COUNT(*) FROM document GROUP BY IfcType"
+  }
+}

--- a/src/Mod/BIM/Presets/ArchReport/report_templates.json
+++ b/src/Mod/BIM/Presets/ArchReport/report_templates.json
@@ -1,0 +1,44 @@
+{
+  "Room and Area Schedule": {
+    "description": "A standard schedule listing all rooms and their areas, with a final total.",
+    "statements": [
+      {
+        "description": "Room List",
+        "query_string": "SELECT Label, Area FROM document WHERE IfcRole = 'Space'",
+        "use_description_as_header": true,
+        "include_column_names": true,
+        "add_empty_row_after": false,
+        "print_results_in_bold": false
+      },
+      {
+        "description": "Total Living Area",
+        "query_string": "SELECT 'Total', SUM(Area) FROM document WHERE IfcRole = 'Space'",
+        "use_description_as_header": false,
+        "include_column_names": false,
+        "add_empty_row_after": false,
+        "print_results_in_bold": true
+      }
+    ]
+  },
+  "Wall Quantities": {
+    "description": "A schedule that lists all walls and calculates their total length.",
+    "statements": [
+      {
+        "description": "Wall List",
+        "query_string": "SELECT Label, Length, Height, Width FROM document WHERE IfcType = 'Wall'",
+        "use_description_as_header": true,
+        "include_column_names": true,
+        "add_empty_row_after": true,
+        "print_results_in_bold": false
+      },
+      {
+        "description": "Total Wall Length",
+        "query_string": "SELECT 'Total Length', SUM(Length) FROM document WHERE IfcType = 'Wall'",
+        "use_description_as_header": false,
+        "include_column_names": false,
+        "add_empty_row_after": false,
+        "print_results_in_bold": true
+      }
+    ]
+  }
+}

--- a/src/Mod/BIM/Resources/Arch.qrc
+++ b/src/Mod/BIM/Resources/Arch.qrc
@@ -126,6 +126,7 @@
         <file>icons/BIM_ProjectManager.svg</file>
         <file>icons/BIM_Reextrude.svg</file>
         <file>icons/BIM_Reorder.svg</file>
+        <file>icons/BIM_Report.svg</file>
         <file>icons/BIM_ResetCloneColors.svg</file>
         <file>icons/BIM_Rewire.svg</file>
         <file>icons/BIM_Slab.svg</file>

--- a/src/Mod/BIM/Resources/ArchSql.lark
+++ b/src/Mod/BIM/Resources/ArchSql.lark
@@ -28,15 +28,16 @@
 
 // Main Rule
 start: statement
-statement: SELECT columns from_clause where_clause? ";"*
+statement: SELECT columns from_clause where_clause? group_by_clause? ";"*
 
 // Clauses
 from_clause: FROM reference
 where_clause: WHERE boolean_expression
+group_by_clause: GROUP BY reference ("," reference)*
 columns: (column ("," column)*)
 column: (asterisk | operand) as_clause?
 as_clause: AS literal
-operand: reference | literal | NUMBER | null
+operand: function | reference | literal | NUMBER | null
 
 // Boolean Logic
 boolean_expression: boolean_or
@@ -65,6 +66,9 @@ reference: CNAME
 literal: STRING
 null: NULL
 
+// Functions
+function: CNAME "(" (asterisk | reference) ")"
+
 // Terminal Definitions
 SELECT: "SELECT"i
 FROM:   "FROM"i
@@ -75,6 +79,8 @@ AND:    "AND"i
 IS:     "IS"i
 NOT:    "NOT"i
 LIKE:   "LIKE"i
+GROUP:  "GROUP"i
+BY:     "BY"i
 NULL:   "NULL"i
 STRING : /"[^"]*"|'[^']*'/
 CNAME: /[a-zA-Z0-9\._]+/

--- a/src/Mod/BIM/Resources/ArchSql.lark
+++ b/src/Mod/BIM/Resources/ArchSql.lark
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2019 Daniel Furtlehner (furti)
+// Copyright (c) 2025 The FreeCAD Project
+//
+// This file is a derivative work of the sql_grammar.peg file from the
+// FreeCAD-Reporting workbench (https://github.com/furti/FreeCAD-Reporting).
+// As per the terms of the original MIT license, this derivative work is also
+// licensed under the MIT license.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, to be subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Main Rule
+start: statement
+statement: SELECT columns from_clause where_clause? ";"*
+
+// Clauses
+from_clause: FROM reference
+where_clause: WHERE boolean_expression
+columns: (column ("," column)*)
+column: (asterisk | operand) as_clause?
+as_clause: AS literal
+operand: reference | literal | NUMBER | null
+
+// Boolean Logic
+boolean_expression: boolean_or
+boolean_or: boolean_or OR boolean_and -> boolean_expression_recursive
+          | boolean_and
+boolean_and: boolean_and AND boolean_term -> boolean_expression_recursive
+           | boolean_term
+boolean_term: boolean_comparison | "(" boolean_expression ")"
+boolean_comparison: operand comparison_operator operand
+
+// Comparison Operator
+comparison_operator: eq_op | neq_op | gt_op | lt_op | gte_op | lte_op | is_not_op | is_op | like_op
+eq_op: "="
+neq_op: "!="
+gt_op: ">"
+lt_op: "<"
+gte_op: ">="
+lte_op: "<="
+is_not_op: IS NOT
+is_op: IS
+like_op: LIKE
+
+// Basic Tokens
+asterisk: "*"
+reference: CNAME
+literal: STRING
+null: NULL
+
+// Terminal Definitions
+SELECT: "SELECT"i
+FROM:   "FROM"i
+WHERE:  "WHERE"i
+AS:     "AS"i
+OR:     "OR"i
+AND:    "AND"i
+IS:     "IS"i
+NOT:    "NOT"i
+LIKE:   "LIKE"i
+NULL:   "NULL"i
+STRING : /"[^"]*"|'[^']*'/
+CNAME: /[a-zA-Z0-9\._]+/
+NUMBER: /[0-9]+(\.[0-9]+)?/
+%import common.WS
+%ignore WS

--- a/src/Mod/BIM/Resources/ArchSql.lark
+++ b/src/Mod/BIM/Resources/ArchSql.lark
@@ -42,11 +42,12 @@ operand: function | reference | literal | NUMBER | null
 // Boolean Logic
 boolean_expression: boolean_or
 boolean_or: boolean_or OR boolean_and -> boolean_expression_recursive
-          | boolean_and
+            | boolean_and
 boolean_and: boolean_and AND boolean_term -> boolean_expression_recursive
-           | boolean_term
-boolean_term: boolean_comparison | "(" boolean_expression ")"
+            | boolean_term
+boolean_term: boolean_comparison | in_expression | "(" boolean_expression ")"
 boolean_comparison: operand comparison_operator operand
+in_expression: reference IN "(" literal ("," literal)* ")"
 
 // Comparison Operator
 comparison_operator: eq_op | neq_op | gt_op | lt_op | gte_op | lte_op | is_not_op | is_op | like_op
@@ -78,6 +79,7 @@ OR:     "OR"i
 AND:    "AND"i
 IS:     "IS"i
 NOT:    "NOT"i
+IN:     "IN"i
 LIKE:   "LIKE"i
 GROUP:  "GROUP"i
 BY:     "BY"i

--- a/src/Mod/BIM/Resources/ArchSqlParserGenerator.py
+++ b/src/Mod/BIM/Resources/ArchSqlParserGenerator.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (c) 2025 The FreeCAD Project
+
+"""This script generates a standalone Python parser from the ArchSql.lark grammar."""
+
+import sys
+import os
+
+try:
+    from lark import Lark
+    from lark.tools.standalone import gen_standalone
+except ImportError:
+    print("Error: The 'lark' Python package is required to generate the parser.")
+    print("Please install it using: pip install lark")
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python ArchSqlParserGenerator.py <input_grammar.lark> <output_parser.py>")
+        return 1
+
+    input_file = sys.argv[1]
+    output_file = sys.argv[2]
+
+    if not os.path.exists(input_file):
+        print(f"Error: Input grammar file not found at '{input_file}'")
+        return 1
+
+    print(f"Generating standalone parser from '{os.path.basename(input_file)}' to '{os.path.basename(output_file)}'...")
+
+    # 1. Read the grammar file content.
+    with open(input_file, 'r', encoding='utf8') as f:
+        grammar_text = f.read()
+
+    # 2. Create an instance of the Lark parser.
+    #    The 'lalr' parser is recommended for performance.
+    lark_instance = Lark(grammar_text, parser='lalr')
+
+    # 3. Open the output file and call the gen_standalone() API function.
+    with open(output_file, 'w', encoding='utf8') as f:
+        gen_standalone(lark_instance, out=f)
+
+    print("Parser generation complete.")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+

--- a/src/Mod/BIM/Resources/icons/BIM_Report.svg
+++ b/src/Mod/BIM/Resources/icons/BIM_Report.svg
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   id="svg249"
+   version="1.1"
+   sodipodi:docname="BIM_Report.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1850"
+     inkscape:window-height="1016"
+     id="namedview1618"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="12.890625"
+     inkscape:cx="32"
+     inkscape:cy="32"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg249">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1620" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient3815">
+      <stop
+         id="stop3817"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
+      <stop
+         id="stop3819"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3815"
+       id="linearGradient3771"
+       x1="98"
+       y1="1047.3622"
+       x2="81"
+       y2="993.36218"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-60,-988.36218)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3771-7">
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1"
+         offset="0"
+         id="stop3773" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop3775" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3771-7"
+       id="linearGradient1775"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0175439,0,0,1.0212766,-53.052635,-0.1914894)"
+       x1="35"
+       y1="55"
+       x2="27"
+       y2="11" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:title></dc:title>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     style="display:inline">
+    <path
+       style="display:inline;fill:url(#linearGradient3771);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="m 11,3 v 58.00002 h 42 v -48 L 43,3 Z"
+       id="path2991" />
+    <path
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 13,5 V 59.00002 H 51 V 13.81392 L 41.99741,5 Z"
+       id="path3763" />
+    <path
+       style="display:inline;fill:#2e3436;fill-opacity:0.392157;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="M 43,3 V 13.00002 H 53 Z"
+       id="path2993" />
+  </g>
+  <g
+     id="g1879">
+    <g
+       id="layer3-2"
+       style="display:inline;fill:#2b7ac4;fill-opacity:1;stroke:#0063a7;stroke-opacity:1"
+       transform="translate(-9.9997206,13.000001)">
+      <g
+         id="layer1-3-7"
+         transform="matrix(0.55823442,0,0,0.55994556,13.136501,14.655248)"
+         style="display:inline;fill:#2b7ac4;fill-opacity:1;stroke:#0063a7;stroke-width:3.57725;stroke-dasharray:none;stroke-opacity:1">
+        <path
+           style="fill:#2b7ac4;fill-opacity:1;stroke:#0063a7;stroke-width:3.57725;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+           d="M 21.252168,14.902792 39.166134,18.474567 51.705324,13.116903 33.791709,9.5451275 Z"
+           id="path2993-0-0" />
+        <path
+           style="fill:#2b7ac4;fill-opacity:1;stroke:#0063a7;stroke-width:3.57725;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+           d="m 51.705324,13.116903 v 19.64561 l -12.53919,5.357664 v -19.64561 z"
+           id="path2995-9" />
+        <path
+           id="path3825-3"
+           d="m 21.252168,14.902791 17.913966,3.571776 v 19.64561 L 21.252168,34.548401 Z"
+           style="display:inline;overflow:visible;visibility:visible;fill:#2b7ac4;fill-opacity:1;fill-rule:evenodd;stroke:#0063a7;stroke-width:3.57725;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      </g>
+    </g>
+    <g
+       id="layer3-0"
+       style="display:inline;fill:#319db6;fill-opacity:1;stroke:#00829a;stroke-opacity:1"
+       transform="translate(7.0002793,12)">
+      <g
+         id="layer1-3-6"
+         transform="matrix(0.55823442,0,0,0.55994556,13.136501,14.655248)"
+         style="display:inline;fill:#319db6;fill-opacity:1;stroke:#00829a;stroke-width:3.57725;stroke-dasharray:none;stroke-opacity:1">
+        <path
+           style="fill:#319db6;fill-opacity:1;stroke:#00829a;stroke-width:3.57725;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+           d="M 21.252168,14.902792 39.166134,18.474567 51.705324,13.116903 33.791709,9.5451275 Z"
+           id="path2993-0-2" />
+        <path
+           style="fill:#319db6;fill-opacity:1;stroke:#00829a;stroke-width:3.57725;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+           d="m 51.705324,13.116903 v 19.64561 l -12.53919,5.357664 v -19.64561 z"
+           id="path2995-6" />
+        <path
+           id="path3825-1"
+           d="m 21.252168,14.902791 17.913966,3.571776 v 19.64561 L 21.252168,34.548401 Z"
+           style="display:inline;overflow:visible;visibility:visible;fill:#319db6;fill-opacity:1;fill-rule:evenodd;stroke:#00829a;stroke-width:3.57725;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      </g>
+    </g>
+    <g
+       id="layer3"
+       style="display:inline;fill:#e5234b;fill-opacity:1;stroke:#c00017;stroke-opacity:1"
+       transform="translate(-2.9999132,-1.0004713)">
+      <g
+         id="layer1-3"
+         transform="matrix(0.55823442,0,0,0.55994556,13.136501,14.655248)"
+         style="display:inline;fill:#e5234b;fill-opacity:1;stroke:#c00017;stroke-width:3.57725;stroke-dasharray:none;stroke-opacity:1">
+        <path
+           style="fill:#e5234b;fill-opacity:1;stroke:#c00017;stroke-width:3.57725;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+           d="M 21.252168,14.902792 39.166134,18.474567 51.705324,13.116903 33.791709,9.5451275 Z"
+           id="path2993-0" />
+        <path
+           style="fill:#e5234b;fill-opacity:1;stroke:#c00017;stroke-width:3.57725;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+           d="m 51.705324,13.116903 v 19.64561 l -12.53919,5.357664 v -19.64561 z"
+           id="path2995" />
+        <path
+           id="path3825"
+           d="m 21.252168,14.902791 17.913966,3.571776 v 19.64561 L 21.252168,34.548401 Z"
+           style="display:inline;overflow:visible;visibility:visible;fill:#e5234b;fill-opacity:1;fill-rule:evenodd;stroke:#c00017;stroke-width:3.57725;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      </g>
+    </g>
+    <rect
+       style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient1775);fill-opacity:1;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000"
+       id="rect1698"
+       width="34"
+       height="34"
+       x="15"
+       y="19" />
+    <rect
+       style="font-variation-settings:normal;vector-effect:none;fill:none;fill-opacity:1;stroke:#fce94f;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000"
+       id="rect1725"
+       width="30"
+       height="30"
+       x="17"
+       y="21" />
+    <path
+       style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient1775);fill-opacity:1;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000;opacity:1;stop-opacity:1"
+       d="M 27,20 V 52"
+       id="path1748"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:url(#linearGradient1775);stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;font-variation-settings:normal;opacity:1;vector-effect:none;fill-opacity:1;stroke-dashoffset:0;marker:none;stop-color:#000000;stop-opacity:1"
+       d="M 16,28 H 48"
+       id="path1783" />
+    <path
+       style="fill:url(#linearGradient1775);stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;font-variation-settings:normal;opacity:1;vector-effect:none;fill-opacity:1;stroke-dashoffset:0;marker:none;stop-color:#000000;stop-opacity:1"
+       d="M 16,36 H 48"
+       id="path1785" />
+    <path
+       style="fill:url(#linearGradient1775);stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;font-variation-settings:normal;opacity:1;vector-effect:none;fill-opacity:1;stroke-dashoffset:0;marker:none;stop-color:#000000;stop-opacity:1"
+       d="M 16,44 H 48"
+       id="path1787" />
+  </g>
+</svg>

--- a/src/Mod/BIM/TestArch.py
+++ b/src/Mod/BIM/TestArch.py
@@ -48,3 +48,4 @@ from bimtests.TestArchSchedule import TestArchSchedule
 from bimtests.TestArchTruss import TestArchTruss
 from bimtests.TestArchComponent import TestArchComponent
 from bimtests.TestWebGLExport import TestWebGLExport
+from bimtests.TestArchReport import TestArchReport

--- a/src/Mod/BIM/bimcommands/BimReport.py
+++ b/src/Mod/BIM/bimcommands/BimReport.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (c) 2025 The FreeCAD Project
+
+import FreeCAD
+import FreeCADGui
+
+class BIM_Report:
+    """The command to create a new BIM Report object."""
+
+    def GetResources(self):
+        return {
+            "Pixmap": "Arch_Schedule",
+            "MenuText": "BIM Report",
+            "ToolTip": "Create a new BIM Report to query model data with SQL"
+        }
+
+    def Activated(self):
+        FreeCADGui.addModule("Arch")
+        FreeCADGui.doCommand("Arch.makeReport()")
+
+    def IsActive(self):
+        return FreeCAD.ActiveDocument is not None
+
+FreeCADGui.addCommand("BIM_Report", BIM_Report())

--- a/src/Mod/BIM/bimcommands/BimReport.py
+++ b/src/Mod/BIM/bimcommands/BimReport.py
@@ -10,7 +10,7 @@ class BIM_Report:
 
     def GetResources(self):
         return {
-            "Pixmap": "Arch_Schedule",
+            "Pixmap": "BIM_Report",
             "MenuText": "BIM Report",
             "ToolTip": "Create a new BIM Report to query model data with SQL"
         }

--- a/src/Mod/BIM/bimtests/TestArchReport.py
+++ b/src/Mod/BIM/bimtests/TestArchReport.py
@@ -150,8 +150,8 @@ class TestArchReport(TestArchBase.TestArchBase):
         self.assertEqual(len(results_data), 2)
 
         expected_rows = [
-            ["Exterior Wall", "Wall", self.wall_ext.Height.UserString],
-            ["Interior partition wall", "Wall", self.wall_int.Height.UserString],
+            ["Exterior Wall", "Wall", self.wall_ext.Height],
+            ["Interior partition wall", "Wall", self.wall_int.Height],
         ]
         self.assertCountEqual(results_data, expected_rows, "Specific column data mismatch.")
 

--- a/src/Mod/BIM/bimtests/TestArchReport.py
+++ b/src/Mod/BIM/bimtests/TestArchReport.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (c) 2025 The FreeCAD Project
+
+"""Unit tests for the ArchReport and ArchSql modules."""
+
+from unittest.mock import patch
+import FreeCAD
+import Arch
+import ArchReport
+from bimtests import TestArchBase
+import ArchSql
+
+class TestArchReport(TestArchBase.TestArchBase):
+
+    def setUp(self):
+        super().setUp()
+        self.doc = self.document
+        self.wall_ext = Arch.makeWall(length=1000, name="Exterior Wall")
+        self.wall_ext.IfcType = "Wall"
+        self.wall_int = Arch.makeWall(length=500, name="Interior partition wall")
+        self.wall_int.IfcType = "Wall"
+        self.column = Arch.makeStructure(length=300, width=300, height=2000, name="Main Column")
+        self.column.IfcType = "Column"
+        self.beam = Arch.makeStructure(length=2000, width=200, height=400, name="Main Beam")
+        self.beam.IfcType = "Beam"
+        self.window = Arch.makeWindow(name="Living Room Window")
+        self.window.IfcType = "Window"
+        self.part_box = self.doc.addObject("Part::Box", "Generic Box")
+        self.queryable_objects = [
+            self.wall_ext, self.wall_int, self.column, self.beam, self.window, self.part_box
+        ]
+        self.spreadsheet = self.doc.addObject("Spreadsheet::Sheet", "ReportTarget")
+        self.doc.recompute()
+
+    def _run_query_for_objects(self, query_string):
+        report = Arch.makeReport()
+        report.Target = self.spreadsheet
+        report.Query = query_string
+        self.doc.recompute()
+        statement, error = ArchSql._get_query_object(query_string)
+        self.assertIsNone(error, f"Query execution should not produce an error for: {query_string}")
+        return statement.execute()
+
+    def test_makeReport_default(self):
+        report = Arch.makeReport()
+        self.assertIsNotNone(report, "makeReport failed to create an object.")
+        self.assertEqual(report.Label, "Report", "Default report label is incorrect.")
+
+    def test_report_properties(self):
+        report = Arch.makeReport()
+        self.assertTrue(hasattr(report, "Query"), "Report object is missing 'Query' property.")
+        self.assertTrue(hasattr(report, "Target"), "Report object is missing 'Target' property.")
+
+    def test_select_all_from_document(self):
+        results = self._run_query_for_objects('SELECT * FROM document')
+        queryable_results = [o for o in results if o in self.queryable_objects]
+        self.assertCountEqual([o.Label for o in queryable_results],
+                              [o.Label for o in self.queryable_objects])
+
+    def test_where_equals_string(self):
+        results = self._run_query_for_objects('SELECT * FROM document WHERE IfcType = "Wall"')
+        self.assertEqual(len(results), 2)
+        self.assertCountEqual([o.Label for o in results], [self.wall_ext.Label, self.wall_int.Label])
+
+    def test_where_not_equals_string(self):
+        results = self._run_query_for_objects('SELECT * FROM document WHERE IfcType != "Wall"')
+        expected_labels = [self.column.Label, self.beam.Label, self.window.Label]
+        self.assertEqual(len(results), 3)
+        self.assertCountEqual([o.Label for o in results], expected_labels)
+
+    def test_where_is_null(self):
+        results = self._run_query_for_objects('SELECT * FROM document WHERE IfcType IS NULL')
+        self.assertIn(self.part_box, results, "The part_box should be found by 'IS NULL'.")
+        self.assertGreaterEqual(len(results), 1)
+
+    def test_where_is_not_null(self):
+        results = self._run_query_for_objects('SELECT * FROM document WHERE IfcType IS NOT NULL')
+        self.assertEqual(len(results), 5)
+        self.assertNotIn(self.part_box.Label, [o.Label for o in results])
+
+    def test_where_like_case_insensitive(self):
+        results = self._run_query_for_objects('SELECT * FROM document WHERE Label LIKE "exterior wall"')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].Label, self.wall_ext.Label)
+
+    def test_where_like_wildcard_middle(self):
+        results = self._run_query_for_objects('SELECT * FROM document WHERE Label LIKE "%wall%"')
+        self.assertEqual(len(results), 2)
+        self.assertCountEqual([o.Label for o in results], [self.wall_ext.Label, self.wall_int.Label])
+
+    def test_where_like_wildcard_end(self):
+        results = self._run_query_for_objects('SELECT * FROM document WHERE Label LIKE "Exterior%"')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].Label, self.wall_ext.Label)
+
+    def test_where_boolean_and(self):
+        query = 'SELECT * FROM document WHERE IfcType = "Wall" AND Label LIKE "%Exterior%"'
+        results = self._run_query_for_objects(query)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].Label, self.wall_ext.Label)
+
+    def test_where_boolean_or(self):
+        query = 'SELECT * FROM document WHERE IfcType = "Window" OR IfcType = "Column"'
+        results = self._run_query_for_objects(query)
+        self.assertEqual(len(results), 2)
+        self.assertCountEqual([o.Label for o in results], [self.window.Label, self.column.Label])
+
+    def test_query_no_results(self):
+        results = self._run_query_for_objects('SELECT * FROM document WHERE Label = "NonExistentObject"')
+        self.assertEqual(len(results), 0)
+
+    def test_query_invalid_syntax(self):
+        """
+        Test that invalid syntax is handled gracefully at both the internal
+        and public API levels.
+        """
+        # 1. Test the internal function (_get_query_object)
+        # It should return a raw exception object, not a string.
+        statement, error_obj = ArchSql._get_query_object('SELECT FROM document WHERE')
+        self.assertIsNone(statement, "Internal function should not return a statement on error.")
+        self.assertIsInstance(error_obj, Exception, "Internal function should return an exception object.")
+
+        # 2. Test the public function for the UI (run_query_for_count)
+        # It should catch the exception and return a user-friendly string.
+        count, error_str = ArchSql.run_query_for_count('SELECT FROM document WHERE')
+        self.assertEqual(count, -1, "Public function should return count of -1 on error.")
+        self.assertIsInstance(error_str, str, "Public function should return a string error message.")
+        self.assertTrue('Syntax Error' in error_str, "User-facing error message is incorrect.")
+
+    def test_incomplete_queries_are_handled_gracefully(self):
+        """Test that various incomplete queries return the 'INCOMPLETE' status."""
+        incomplete_queries = [
+            "SELECT",
+            "SELECT *",
+            "SELECT * FROM",
+            "SELECT * FROM document WHERE",
+            "SELECT * FROM document WHERE Label =",
+            "SELECT * FROM document WHERE Label LIKE",
+        ]
+
+        for query in incomplete_queries:
+            with self.subTest(query=query):
+                count, error = ArchSql.run_query_for_count(query)
+                self.assertEqual(error, "INCOMPLETE", f"Query '{query}' should be marked as INCOMPLETE.")
+
+    def test_invalid_partial_tokens_are_errors(self):
+        """
+        Test that queries with partial/mistyped keywords are correctly
+        identified as syntax errors, not as incomplete.
+        """
+        invalid_queries = {
+            "Partial keyword": "SELEC",
+            "Mistyped keyword": "SELECT * FRM document",
+        }
+
+        for name, query in invalid_queries.items():
+            with self.subTest(name=name, query=query):
+                count, error = ArchSql.run_query_for_count(query)
+                self.assertNotEqual(error, "INCOMPLETE", f"Query '{query}' should be a syntax error, not incomplete.")
+                self.assertIsNotNone(error, f"Query '{query}' should have returned an error.")
+
+    def test_report_no_target(self):
+        try:
+            report = Arch.makeReport()
+            report.Target = None
+            report.Query = 'SELECT * FROM document'
+            self.doc.recompute()
+        except Exception as e:
+            self.fail(f"Recomputing a report with no Target raised an unexpected exception: {e}")

--- a/src/Mod/BIM/bimtests/TestArchReport.py
+++ b/src/Mod/BIM/bimtests/TestArchReport.py
@@ -58,7 +58,11 @@ class TestArchReport(TestArchBase.TestArchBase):
         """
         report = Arch.makeReport()
         report.Target = self.spreadsheet
-        report.Query = query_string
+        # Ensure the first statement holds the query string
+        if not hasattr(report, 'Statements') or not report.Statements:
+            report.Statements = [ArchReport.ReportStatement(description="Statement 1", query_string=query_string)]
+        else:
+            report.Statements[0].query_string = query_string
 
         self.doc.recompute()
 
@@ -99,7 +103,7 @@ class TestArchReport(TestArchBase.TestArchBase):
 
     def test_report_properties(self):
         report = Arch.makeReport()
-        self.assertTrue(hasattr(report, "Query"), "Report object is missing 'Query' property.")
+        self.assertTrue(hasattr(report, "Statements"), "Report object is missing 'Statements' property.")
         self.assertTrue(hasattr(report, "Target"), "Report object is missing 'Target' property.")
 
     # Category 2: Core SELECT Functionality
@@ -247,7 +251,11 @@ class TestArchReport(TestArchBase.TestArchBase):
             report = Arch.makeReport()
             # Creation initializes a target spreadsheet; verify it's set
             self.assertIsNotNone(report.Target, "Report Target should be set on creation.")
-            report.Query = 'SELECT * FROM document'
+            # Set the first statement's query string
+            if not hasattr(report, 'Statements') or not report.Statements:
+                report.Statements = [ArchReport.ReportStatement(description="Statement 1", query_string='SELECT * FROM document')]
+            else:
+                report.Statements[0].query_string = 'SELECT * FROM document'
             self.doc.recompute()
         except Exception as e:
             self.fail(f"Recomputing a report with no Target raised an unexpected exception: {e}")

--- a/src/Mod/BIM/bimtests/TestArchReport.py
+++ b/src/Mod/BIM/bimtests/TestArchReport.py
@@ -168,3 +168,21 @@ class TestArchReport(TestArchBase.TestArchBase):
             self.doc.recompute()
         except Exception as e:
             self.fail(f"Recomputing a report with no Target raised an unexpected exception: {e}")
+
+    def test_api_selectObjects(self):
+        """Test the public API function Arch.selectObjects()."""
+        # 1. Test a successful query
+        walls = Arch.selectObjects('SELECT * FROM document WHERE IfcType = "Wall"')
+        self.assertEqual(len(walls), 2)
+        self.assertCountEqual([o.Label for o in walls], [self.wall_ext.Label, self.wall_int.Label])
+
+        # 2. Test a query that should return no results
+        no_results = Arch.selectObjects('SELECT * FROM document WHERE Label = "NonExistentObject"')
+        self.assertEqual(len(no_results), 0)
+
+        # 3. Test that an invalid query does not crash and returns an empty list
+        with patch('FreeCAD.Console.PrintError') as mock_print_error:
+            invalid_results = Arch.selectObjects('SELECT FRM document')
+            self.assertEqual(len(invalid_results), 0)
+            # Verify that an error was printed to the console
+            mock_print_error.assert_called_once()

--- a/src/Mod/BIM/bimtests/TestArchReport.py
+++ b/src/Mod/BIM/bimtests/TestArchReport.py
@@ -133,16 +133,12 @@ class TestArchReport(TestArchBase.TestArchBase):
         # Note: A self-correction was made here from a previous version.
         # The path is relative to the *test file's* location.
         build_path = os.path.join(os.path.dirname(__file__), "..", "Presets", "ArchReport", filename)
-        print(f"\n[DIAGNOSTIC] Attempting to find template file in build directory: {build_path}")
         if os.path.exists(build_path):
-            print(f"\n[DIAGNOSTIC] Found template file in build directory: {build_path}")
             return build_path
 
         # Fallback to the final installed resource directory
         install_path = os.path.join(FreeCAD.getResourceDir(), "Mod", "BIM", "Presets", "ArchReport", filename)
-        print(f"\n[DIAGNOSTIC] Attempting to find template file in install directory: {install_path}")
         if os.path.exists(install_path):
-            print(f"\n[DIAGNOSTIC] Found template file in install directory: {install_path}")
             return install_path
 
         # If neither is found, the test will fail below.

--- a/src/Mod/BIM/bimtests/TestArchReport.py
+++ b/src/Mod/BIM/bimtests/TestArchReport.py
@@ -644,3 +644,23 @@ class TestArchReport(TestArchBase.TestArchBase):
                     self.assertIsInstance(headers, list)
                 except Exception as e:
                     self.fail(f"Query '{query}' from preset '{preset_name}' failed with an exception: {e}")
+
+    def test_where_in_clause(self):
+        """
+        Tests the SQL 'IN' clause for filtering against a list of values.
+        """
+        # This query should select only the two wall objects from the setup.
+        query = "SELECT * FROM document WHERE Label IN ('Exterior Wall', 'Interior partition wall')"
+
+        # This will fail at the parsing stage until the 'IN' keyword is implemented.
+        headers, results_data = ArchSql.run_query_for_objects(query)
+
+        # --- Assertions ---
+        # 1. The query should return exactly two rows.
+        self.assertEqual(len(results_data), 2, "The IN clause should have found exactly two matching objects.")
+
+        # 2. Verify the labels of the returned objects.
+        returned_labels = sorted([row[0] for row in results_data])
+        expected_labels = sorted([self.wall_ext.Label, self.wall_int.Label])
+        self.assertListEqual(returned_labels, expected_labels, "The objects returned by the IN clause are incorrect.")
+

--- a/src/Mod/BIM/bimtests/TestArchReport.py
+++ b/src/Mod/BIM/bimtests/TestArchReport.py
@@ -377,3 +377,19 @@ class TestArchReport(TestArchBase.TestArchBase):
 
         self.assertAlmostEqual(min_length, 500.0)
         self.assertAlmostEqual(max_length, 1000.0)
+
+    def test_invalid_group_by_raises_error(self):
+        """A SELECT column not in GROUP BY and not in an aggregate should fail validation."""
+        # 'Label' is not aggregated and not in the 'GROUP BY' clause, making this query invalid.
+        query = 'SELECT Label, COUNT(*) FROM document GROUP BY IfcType'
+
+        # We expect the validation step, which is part of _get_query_object, to catch this.
+        # It should return an error message, not a valid statement object.
+        statement, error = ArchSql._get_query_object(query)
+
+        self.assertIsNone(statement, "A statement object should not be created for an invalid query.")
+        self.assertIsNotNone(error, "An error message should have been returned.")
+
+        # Check for a specific, user-friendly error message.
+        self.assertIn("must appear in the GROUP BY clause", str(error),
+                      "The error message is not descriptive enough.")

--- a/src/Mod/BIM/bimtests/TestArchReport.py
+++ b/src/Mod/BIM/bimtests/TestArchReport.py
@@ -245,8 +245,15 @@ class TestArchReport(TestArchBase.TestArchBase):
     def test_report_no_target(self):
         try:
             report = Arch.makeReport()
-            report.Target = None
+            # Creation initializes a target spreadsheet; verify it's set
+            self.assertIsNotNone(report.Target, "Report Target should be set on creation.")
             report.Query = 'SELECT * FROM document'
             self.doc.recompute()
         except Exception as e:
             self.fail(f"Recomputing a report with no Target raised an unexpected exception: {e}")
+
+        # UX: when the report runs without a pre-set Target, it should create
+        # a spreadsheet, set the sheet.ReportName, and persist the Target link
+        # so subsequent runs are deterministic.
+        self.assertIsNotNone(report.Target, "Report Target should be set after running with no pre-existing Target.")
+        self.assertEqual(getattr(report.Target, 'ReportName', None), report.Name)


### PR DESCRIPTION
> [!CAUTION]
> While the basic command functionality is already present, this PR is still WIP and submitted as a draft for testing purposes at this time

---

This PR adds a new `BIM Report` command to the BIM workbench.

## Summary

The `BIM Report` command generates schedules from a model using an SQL-like query language. It is an alternative to the [ArchSchedule](https://wiki.freecad.org/Arch_Schedule) command, offering a different method to select, filter, and aggregate data.

The feature's architecture is a synthesis of two concepts:
*   It adapts the SQL parsing and execution engine from the third-party **Reporting Workbench**.
*   It uses the FreeCAD object lifecycle, document integration, and Task Panel patterns from the upstream **`ArchSchedule`** command.

## Features

**SQL engine:**

*   **Query Language:** Provides an SQL-like dialect for querying document objects.
*   **`SELECT` Clause:** Supports `SELECT *`, direct properties (`Label`), nested properties (`Placement.Base.x`), and computed shape properties (`Area`). Static/literal values are also supported.
*   **`WHERE` Clause:** Implements filtering with standard operators (`=`, `!=`, `LIKE`, `IS NULL`), logical `AND`/`OR`, and an `IN (...)` clause for list-based filtering.
*   **Aggregation and Grouping:** Supports `GROUP BY` and the aggregate functions `COUNT`, `SUM`, `MIN`, and `MAX`.

**User experience and workflow:**

*   **Multi-Statement Reports:** A single report object can execute a sequence of independent SQL queries to build a structured, multi-section document.
*   **Task Panel Editor:** All configuration is done in a dedicated Task Panel with:
    *   An overview of all statements in the report.
    *   A dedicated editor for the selected SQL statement.
    *   Live validation of SQL syntax, with syntax highlighting and a preview of the number of matching objects.
*   **Report Templates:**
    *   Users can load pre-configured, multi-statement report templates (e.g., "Room and Area Schedule") from a dropdown menu.
    *   The system includes a set of bundled default templates.
*   **Query Presets:**
    *   Users can save and load individual, commonly used SQL queries from a dropdown menu.
    *   Both templates and presets can be saved by the user, persisting in their user configuration directory.
*   **Immediate Feedback:** Upon completion via the Task Panel, the target spreadsheet is automatically opened to display the results.

## Issues

Fixes: https://github.com/FreeCAD/FreeCAD/issues/22616

## Before and After Images

[BimReport.webm](https://github.com/user-attachments/assets/59ed747c-f022-497e-85de-6ff881b87303)

