### PR TITLE
Gui: fix a lifetime issue with the draggers

### DIFF
--- a/src/Gui/Inventor/Draggers/Gizmo.cpp
+++ b/src/Gui/Inventor/Draggers/Gizmo.cpp
@@ -613,7 +613,7 @@ void GizmoContainer::initClass()
     SO_KIT_INIT_CLASS(GizmoContainer, SoBaseKit, "BaseKit");
 }
 
-GizmoContainer::GizmoContainer()
+GizmoContainer::GizmoContainer(): viewProvider(nullptr)
 {
     SO_KIT_CONSTRUCTOR(GizmoContainer);
 
@@ -655,7 +655,9 @@ GizmoContainer::~GizmoContainer()
 
     uninitGizmos();
 
-    viewProvider->setGizmoContainer(nullptr);
+    if (!viewProvider.expired()) {
+        viewProvider->setGizmoContainer(nullptr);
+    }
 }
 
 void GizmoContainer::initGizmos()

--- a/src/Gui/Inventor/Draggers/Gizmo.h
+++ b/src/Gui/Inventor/Draggers/Gizmo.h
@@ -35,6 +35,7 @@
 #include <QMetaObject>
 
 #include <Base/Placement.h>
+#include <Gui/DocumentObserver.h>
 
 #include <FCGlobal.h>
 
@@ -245,7 +246,7 @@ private:
     std::vector<Gizmo*> gizmos;
     SoFieldSensor cameraSensor;
     SoFieldSensor cameraPositionSensor;
-    ViewProviderDragger* viewProvider = nullptr;
+    WeakPtrT<ViewProviderDragger> viewProvider;
 
     void addGizmo(Gizmo* gizmo);
 


### PR DESCRIPTION
I wrongly assumed that the view-provider always out lives the task panel. This PR fixes that issue.