### PR TITLE
[TD]fix FileChooser mode in preferences

### DIFF
--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
@@ -43,6 +43,10 @@ DlgPrefsTechDrawGeneralImp::DlgPrefsTechDrawGeneralImp( QWidget* parent )
 
     ui->psb_GridSpacing->setUnit(Base::Unit::Length);
     ui->psb_GridSpacing->setMinimum(0);
+
+    ui->pfc_DefDir->setMode(Gui::FileChooser::Mode::Directory);
+    ui->pfc_Welding->setMode(Gui::FileChooser::Mode::Directory);
+    ui->fcSymbolDir->setMode(Gui::FileChooser::Mode::Directory);
 }
 
 DlgPrefsTechDrawGeneralImp::~DlgPrefsTechDrawGeneralImp()
@@ -96,7 +100,6 @@ void DlgPrefsTechDrawGeneralImp::loadSettings()
     ui->plsb_LabelSize->setValue(labelDefault);
     QFont prefFont(Preferences::labelFontQString());
     ui->pfb_LabelFont->setCurrentFont(prefFont);
-    //    ui->pfb_LabelFont->setCurrentText(Preferences::labelFontQString());   //only works in Qt5
 
     ui->pfb_LabelFont->onRestore();
     ui->plsb_LabelSize->onRestore();


### PR DESCRIPTION
Up to 4cae5bb8, certain file choosers in DlgPrefsTechDrawGeneral.ui used the "mode" property from Gui::FileChooser to specify whether to retrieve files or directories. 

Starting with the next commit (36f2aa61) the "mode" property is not present in the ui file and directory choosers have reverted to the default mode of file choosers.

This change explicitly sets the mode in the dlgPrefsTechDrawGeneral constructor for the relevant
choosers.