### PR TITLE
CAM: Tool asset - fix path text

### DIFF
--- a/src/Mod/CAM/Path/Tool/assets/ui/preferences.py
+++ b/src/Mod/CAM/Path/Tool/assets/ui/preferences.py
@@ -58,7 +58,7 @@ class AssetPreferencesPage:
             translate(
                 "CAM_PreferencesAssets",
                 "Note: Select the directory that will contain the "
-                "Bit/, Shape/, and Library/ subfolders.",
+                "Tool folder with Bit/, Shape/ and Library/ subfolders.",
             )
         )
         self.asset_path_note_label.setWordWrap(True)


### PR DESCRIPTION
In preferences we see:
<img width="496" height="80" alt="Screenshot_20250920_195008_lossy" src="https://github.com/user-attachments/assets/ed6f5a8a-3070-4bc9-88be-63eb3ada4837" />

But in real path is:
<img width="125" height="89" alt="Screenshot_20250920_194832_lossy" src="https://github.com/user-attachments/assets/6b9f4f51-7d69-435a-be59-79f7157d593b" />

No any word about folder `Tools` in text