### PR TITLE
Added --tool-retraction option for linuxcnc_post

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -77,6 +77,7 @@ parser.add_argument(
     action="store_true",
     help="suppress tool length offset (G43) following tool changes",
 )
+parser.add_argument("--tool-retraction", action="store_true", help="Retract tool in Z-axis for every tool change")
 
 TOOLTIP_ARGS = parser.format_help()
 
@@ -108,7 +109,6 @@ PREAMBLE = """G17 G54 G40 G49 G80 G90
 # Postamble text will appear following the last operation.
 POSTAMBLE = """M05
 G17 G54 G90 G80 G40
-M2
 """
 
 # Pre operation text will be inserted before every operation
@@ -135,6 +135,7 @@ def processArguments(argstring):
     global MODAL
     global USE_TLO
     global OUTPUT_DOUBLES
+    global TOOL_CHANGE
 
     try:
         args = parser.parse_args(shlex.split(argstring))
@@ -157,12 +158,14 @@ def processArguments(argstring):
             UNIT_SPEED_FORMAT = "in/min"
             UNIT_FORMAT = "in"
             PRECISION = 4
+        if args.tool_retraction:
+            TOOL_CHANGE += "G30 Z0\n"
+            POSTAMBLE += "G30 Z0\n"            
         if args.modal:
             MODAL = True
         if args.no_tlo:
             USE_TLO = False
         if args.axis_modal:
-            print("here")
             OUTPUT_DOUBLES = False
 
     except Exception:
@@ -246,6 +249,7 @@ def export(objectslist, filename, argstring):
         gcode += "(begin postamble)\n"
     for line in POSTAMBLE.splitlines():
         gcode += linenumber() + line + "\n"
+    gcode += "M2\n"
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         final = gcode


### PR DESCRIPTION
For jobs requiring tool changes, it is often required for the tool to raise to it's maximum height so that the user has space to change the tool. 

The retraction is implemented by adding a new optional argument to linuxcnc_post. This change also required a slight mod to the way M2 is inserted in the gcode so that it's always the last line and so that postamble mods can more easily be made.

## Issues
A discussion of this topic can be found [here](https://forum.freecad.org/viewtopic.php?t=98925).


