### PR TITLE
Part: fix copy_visual_attributes in BOPFeatures.py

### DIFF
--- a/src/Mod/Part/BOPTools/BOPFeatures.py
+++ b/src/Mod/Part/BOPTools/BOPFeatures.py
@@ -103,8 +103,6 @@ class BOPFeatures:
 
     def copy_visual_attributes(self, target, source):
         if target.ViewObject:
-            if hasattr(target.ViewObject,"ShapeAppearance") and hasattr(source.ViewObject, "ShapeAppearance"):
-                target.ViewObject.ShapeAppearance = source.ViewObject.ShapeAppearance
             displayMode = source.ViewObject.DisplayMode
             src = source
             while displayMode == "Link":


### PR DESCRIPTION
Fixes #23900.

The ShapeAppearance related code should be removed. It is atypical that the result of a boolean operation has the same number of faces as one of its source objects, therefore simply applying its ShapeAppearance to the new object does not make sense in most cases.

The ShapeAppearance of Fusion objects gets overwritten by other code. For Cut objects this does not happen anymore (Used to happen in V0.21).