### PR TITLE
[TD]fix no dimension in DXF export

### DIFF
--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -730,7 +730,7 @@ private:
                         }
                         double grandParentX = 0.0;
                         double grandParentY = 0.0;
-                        if (dvp->isDerivedFrom<TechDraw::DrawProjGroupItem>()) {
+                        if (DrawView::isProjGroupItem(dvp)) {
                             TechDraw::DrawProjGroupItem* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(dvp);
                             TechDraw::DrawProjGroup* dpg = dpgi->getPGroup();
                             if (!dpg) {

--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -572,7 +572,7 @@ private:
         TopoDS_Shape shape = ShapeUtils::mirrorShape(gObj->getVisHard());
         double offX = 0.0;
         double offY = 0.0;
-        if (dvp->isDerivedFrom<TechDraw::DrawProjGroupItem>()) {
+        if (DrawView::isProjGroupItem(dvp)) {
             TechDraw::DrawProjGroupItem* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(dvp);
             TechDraw::DrawProjGroup*      dpg = dpgi->getPGroup();
             if (dpg) {

--- a/src/Mod/TechDraw/App/DrawPagePyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawPagePyImp.cpp
@@ -87,7 +87,8 @@ PyObject* DrawPagePy::getViews(PyObject* args)
 
     Py::List ret;
     for (auto v: allViews) {
-        if (v->isDerivedFrom<TechDraw::DrawProjGroupItem>()) {
+        auto dvp = freecad_cast<DrawViewPart*>(v);
+        if (dvp && DrawView::isProjGroupItem(dvp)) {
             TechDraw::DrawProjGroupItem* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(v);
             ret.append(Py::asObject(new TechDraw::DrawProjGroupItemPy(dpgi)));
         }
@@ -119,7 +120,8 @@ PyObject* DrawPagePy::getAllViews(PyObject* args)
 
     Py::List ret;
     for (auto v: allViews) {
-        if (v->isDerivedFrom<TechDraw::DrawProjGroupItem>()) {
+        auto dvp = freecad_cast<DrawViewPart*>(v);
+        if (dvp && DrawView::isProjGroupItem(dvp)) {
             TechDraw::DrawProjGroupItem* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(v);
             ret.append(Py::asObject(new TechDraw::DrawProjGroupItemPy(dpgi)));
         }

--- a/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
@@ -109,7 +109,8 @@ QVariant QGIProjGroup::itemChange(GraphicsItemChange change, const QVariant &val
          QGIView* gView = dynamic_cast<QGIView *>(childItem);
          if(gView) {
             TechDraw::DrawView *fView = gView->getViewObject();
-            if(fView->isDerivedFrom<TechDraw::DrawProjGroupItem>()) {
+            auto dvp = freecad_cast<TechDraw::DrawViewPart*>(fView);
+            if (dvp && TechDraw::DrawView::isProjGroupItem(dvp)) {
                 auto *projItemPtr = static_cast<TechDraw::DrawProjGroupItem *>(fView);
                 QString type = QString::fromLatin1(projItemPtr->Type.getValueAsString());
 

--- a/src/Mod/TechDraw/Gui/ViewProviderPageExtension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPageExtension.cpp
@@ -32,6 +32,7 @@
 
 
 using namespace TechDrawGui;
+using namespace TechDraw;
 
 EXTENSION_PROPERTY_SOURCE(TechDrawGui::ViewProviderPageExtension, Gui::ViewProviderExtension)
 
@@ -122,7 +123,8 @@ void ViewProviderPageExtension::extensionDropObject(App::DocumentObject* obj)
 //this code used to live in ViewProviderPage
 void ViewProviderPageExtension::dropObject(App::DocumentObject* obj)
 {
-    if (obj->isDerivedFrom<TechDraw::DrawProjGroupItem>()) {
+    auto dvp = freecad_cast<TechDraw::DrawViewPart*>(obj);
+    if (dvp && DrawView::isProjGroupItem(dvp)) {
         //DPGI can not be dropped onto the Page if it belongs to DPG
         auto* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(obj);
         if (dpgi->getPGroup()) {

--- a/src/Mod/TechDraw/Gui/ViewProviderViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewClip.cpp
@@ -35,6 +35,7 @@
 #include "QGIViewClip.h"
 
 using namespace TechDrawGui;
+using namespace TechDraw;
 
 PROPERTY_SOURCE(TechDrawGui::ViewProviderViewClip, TechDrawGui::ViewProviderDrawingView)
 
@@ -123,7 +124,8 @@ void ViewProviderViewClip::dragObject(App::DocumentObject* docObj)
 
 void ViewProviderViewClip::dropObject(App::DocumentObject* docObj)
 {
-    if (docObj->isDerivedFrom<TechDraw::DrawProjGroupItem>()) {
+    auto dvp = freecad_cast<DrawViewPart*>(docObj);
+    if (dvp && DrawView::isProjGroupItem(dvp)) {
         //DPGI can not be dropped onto the Page if it belongs to DPG
         auto* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(docObj);
         if (dpgi->getPGroup()) {


### PR DESCRIPTION
This PR implements a fix for #24052.

The PR also applies the isProjGroupItem() fix to the remaining uses of isDerivedFrom<DrawProjGroupItem>() which is no longer reliable after changes related to the "smart" view creation functions.