### PR TITLE
Gui: Fix string encoding for drag-and-drop

### DIFF
--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -104,9 +104,9 @@ void ViewProviderGroupExtension::extensionDropObject(App::DocumentObject* obj) {
     QString cmd;
     cmd = QStringLiteral("App.getDocument(\"%1\").getObject(\"%2\").addObject("
                         "App.getDocument(\"%1\").getObject(\"%3\"))")
-                        .arg(QString::fromLatin1(doc->getName()),
-                             QString::fromLatin1(grp->getNameInDocument()),
-                             QString::fromLatin1(obj->getNameInDocument()));
+                        .arg(QString::fromUtf8(doc->getName()),
+                             QString::fromUtf8(grp->getNameInDocument()),
+                             QString::fromUtf8(obj->getNameInDocument()));
 
     Gui::Command::doCommand(Gui::Command::App, cmd.toUtf8());
 }


### PR DESCRIPTION
Fixes #23986 (but *only* that one specific instance, and there are likely others). I didn't want to do a blanket replacement of all `QString::fromLatin1` uses because a few of them might be right, but I'd bet that most of the places it's being used, it's wrong. This particular fix needs to be tested on Linux and macOS before being merged.