### PR TITLE
CMake: update Eigen3 version detection for Eigen 5.x compatibility

### DIFF
--- a/cMake/FindEigen3.cmake
+++ b/cMake/FindEigen3.cmake
@@ -23,7 +23,15 @@ if(NOT Eigen3_FIND_VERSION)
 endif(NOT Eigen3_FIND_VERSION)
 
 macro(_eigen3_check_version)
-  file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h" _eigen3_version_header)
+  file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/Version" _eigen3_version_header)
+
+  string(REGEX MATCH "define[ \t]+EIGEN_WORLD_VERSION[ \t]+([0-9]+)" _eigen3_world_version_match "${_eigen3_version_header}")
+
+  if(NOT _eigen3_world_version_match)
+
+    file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h" _eigen3_version_header)
+
+  endif()
 
   string(REGEX MATCH "define[ \t]+EIGEN_WORLD_VERSION[ \t]+([0-9]+)" _eigen3_world_version_match "${_eigen3_version_header}")
   set(EIGEN3_WORLD_VERSION "${CMAKE_MATCH_1}")


### PR DESCRIPTION
Update Eigen3 version detection in `cMake/FindEigen3.cmake` to support Eigen 5.x by prioritizing reading from `Eigen/Version` file, with a fallback to `Eigen/src/Core/util/Macros.h` for Eigen 3.x compatibility. This ensures the build system works with both older and newer Eigen library versions.
