### PR TITLE
Sketcher: Fix is active.

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -224,13 +224,9 @@ void CmdSketcherIncreaseDegree::activated(int iMsg)
             const Part::Geometry* geo = Obj->getGeometry(GeoId);
 
             if (geo->is<Part::GeomBSplineCurve>()) {
-                Gui::cmdAppObjectArgs(Obj,
-                                      "increaseBSplineDegree(%d) ",
-                                      GeoId);
+                Gui::cmdAppObjectArgs(Obj, "increaseBSplineDegree(%d) ", GeoId);
                 // add new control points
-                Gui::cmdAppObjectArgs(Obj,
-                                      "exposeInternalGeometry(%d)",
-                                      GeoId);
+                Gui::cmdAppObjectArgs(Obj, "exposeInternalGeometry(%d)", GeoId);
             }
             else {
                 ignored = true;
@@ -365,7 +361,7 @@ bool isCommandNeedingBSplineKnotActive(Gui::Document* doc)
 
         bool applied = false;
         return isBsplineKnotOrEndPoint(Obj, geoId, posId)
-                          && findBSplineAndKnotIndex(Obj, geoId, posId, splineGeoId, knotIndexOCC);
+            && findBSplineAndKnotIndex(Obj, geoId, posId, splineGeoId, knotIndexOCC);
     }
     return false;
 }

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -176,7 +176,7 @@ void CmdSketcherConvertToNURBS::activated(int iMsg)
 
 bool CmdSketcherConvertToNURBS::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // Increase degree of the spline
@@ -211,7 +211,7 @@ void CmdSketcherIncreaseDegree::activated(int iMsg)
 
     // get the needed lists and objects
     const std::vector<std::string>& SubNames = selection[0].getSubNames();
-    Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
+    auto* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Increase B-spline degree"));
 
@@ -224,11 +224,11 @@ void CmdSketcherIncreaseDegree::activated(int iMsg)
             const Part::Geometry* geo = Obj->getGeometry(GeoId);
 
             if (geo->is<Part::GeomBSplineCurve>()) {
-                Gui::cmdAppObjectArgs(selection[0].getObject(),
+                Gui::cmdAppObjectArgs(Obj,
                                       "increaseBSplineDegree(%d) ",
                                       GeoId);
                 // add new control points
-                Gui::cmdAppObjectArgs(selection[0].getObject(),
+                Gui::cmdAppObjectArgs(Obj,
                                       "exposeInternalGeometry(%d)",
                                       GeoId);
             }
@@ -252,7 +252,7 @@ void CmdSketcherIncreaseDegree::activated(int iMsg)
 
 bool CmdSketcherIncreaseDegree::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandNeedingBSplineActive(getActiveGuiDocument());
 }
 
 
@@ -335,9 +335,40 @@ void CmdSketcherDecreaseDegree::activated(int iMsg)
 
 bool CmdSketcherDecreaseDegree::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandNeedingBSplineActive(getActiveGuiDocument());
 }
 
+bool isCommandNeedingBSplineKnotActive(Gui::Document* doc)
+{
+    if (!isCommandActive(doc)) {
+        return false;
+    }
+
+    std::vector<Gui::SelectionObject> sel =
+        Gui::Selection().getSelectionEx(doc->getDocument()->getName(),
+                                        Sketcher::SketchObject::getClassTypeId());
+    if (sel.size() == 1) {
+        const std::vector<std::string>& names = sel[0].getSubNames();
+        if (names.size() != 1) {
+            return false;
+        }
+
+        auto* Obj = static_cast<Sketcher::SketchObject*>(sel[0].getObject());
+        const std::string& name = names[0];
+
+        int geoId;
+        Sketcher::PointPos posId;
+        getIdsFromName(name, Obj, geoId, posId);
+
+        int splineGeoId;
+        int knotIndexOCC;
+
+        bool applied = false;
+        return isBsplineKnotOrEndPoint(Obj, geoId, posId)
+                          && findBSplineAndKnotIndex(Obj, geoId, posId, splineGeoId, knotIndexOCC);
+    }
+    return false;
+}
 
 DEF_STD_CMD_A(CmdSketcherIncreaseKnotMultiplicity)
 
@@ -483,7 +514,7 @@ void CmdSketcherIncreaseKnotMultiplicity::activated(int iMsg)
 
 bool CmdSketcherIncreaseKnotMultiplicity::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandNeedingBSplineKnotActive(getActiveGuiDocument());
 }
 
 DEF_STD_CMD_A(CmdSketcherDecreaseKnotMultiplicity)
@@ -618,7 +649,7 @@ void CmdSketcherDecreaseKnotMultiplicity::activated(int iMsg)
 
 bool CmdSketcherDecreaseKnotMultiplicity::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandNeedingBSplineKnotActive(getActiveGuiDocument());
 }
 
 
@@ -720,7 +751,7 @@ void CmdSketcherCompModifyKnotMultiplicity::updateAction(int /*mode*/)
 
 bool CmdSketcherCompModifyKnotMultiplicity::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandNeedingBSplineKnotActive(getActiveGuiDocument());
 }
 
 class DrawSketchHandlerBSplineInsertKnot: public DrawSketchHandler
@@ -943,7 +974,7 @@ void CmdSketcherInsertKnot::activated(int iMsg)
 
 bool CmdSketcherInsertKnot::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandNeedingBSplineActive(getActiveGuiDocument());
 }
 
 DEF_STD_CMD_A(CmdSketcherJoinCurves)
@@ -1099,7 +1130,7 @@ void CmdSketcherJoinCurves::activated(int iMsg)
 
 bool CmdSketcherJoinCurves::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+    return isCommandNeedingBSplineActive(getActiveGuiDocument());
 }
 
 void CreateSketcherCommandsBSpline()

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -352,14 +352,13 @@ bool isCommandNeedingBSplineKnotActive(Gui::Document* doc)
         auto* Obj = static_cast<Sketcher::SketchObject*>(sel[0].getObject());
         const std::string& name = names[0];
 
-        int geoId;
-        Sketcher::PointPos posId;
+        int geoId {GeoEnum::GeoUndef};
+        PointPos posId {PointPos::none};
         getIdsFromName(name, Obj, geoId, posId);
 
-        int splineGeoId;
-        int knotIndexOCC;
+        int splineGeoId {GeoEnum::GeoUndef};
+        int knotIndexOCC {-1};
 
-        bool applied = false;
         return isBsplineKnotOrEndPoint(Obj, geoId, posId)
             && findBSplineAndKnotIndex(Obj, geoId, posId, splineGeoId, knotIndexOCC);
     }

--- a/src/Mod/Sketcher/Gui/CommandSketcherOverlay.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherOverlay.cpp
@@ -82,7 +82,7 @@ void CmdSketcherBSplineDegree::activated(int iMsg)
 
 bool CmdSketcherBSplineDegree::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // Show/Hide B-spline polygon
@@ -111,7 +111,7 @@ void CmdSketcherBSplinePolygon::activated(int iMsg)
 
 bool CmdSketcherBSplinePolygon::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // Show/Hide B-spline comb
@@ -140,7 +140,7 @@ void CmdSketcherBSplineComb::activated(int iMsg)
 
 bool CmdSketcherBSplineComb::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 //
@@ -169,7 +169,7 @@ void CmdSketcherBSplineKnotMultiplicity::activated(int iMsg)
 
 bool CmdSketcherBSplineKnotMultiplicity::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 //
@@ -198,7 +198,7 @@ void CmdSketcherBSplinePoleWeight::activated(int iMsg)
 
 bool CmdSketcherBSplinePoleWeight::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // Composite drop down menu for show/hide BSpline information layer
@@ -344,7 +344,7 @@ void CmdSketcherCompBSplineShowHideGeometryInformation::updateAction(int /*mode*
 
 bool CmdSketcherCompBSplineShowHideGeometryInformation::isActive()
 {
-    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 //

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -239,7 +239,7 @@ void CmdSketcherCopyClipboard::activated(int iMsg)
 
 bool CmdSketcherCopyClipboard::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -279,7 +279,7 @@ void CmdSketcherCut::activated(int iMsg)
 
 bool CmdSketcherCut::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -328,7 +328,7 @@ void CmdSketcherPaste::activated(int iMsg)
 
 bool CmdSketcherPaste::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -412,7 +412,7 @@ void CmdSketcherSelectConstraints::activated(int iMsg)
 
 bool CmdSketcherSelectConstraints::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -456,7 +456,7 @@ void CmdSketcherSelectOrigin::activated(int iMsg)
 
 bool CmdSketcherSelectOrigin::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -497,7 +497,7 @@ void CmdSketcherSelectVerticalAxis::activated(int iMsg)
 
 bool CmdSketcherSelectVerticalAxis::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -538,7 +538,7 @@ void CmdSketcherSelectHorizontalAxis::activated(int iMsg)
 
 bool CmdSketcherSelectHorizontalAxis::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -596,7 +596,7 @@ void CmdSketcherSelectRedundantConstraints::activated(int iMsg)
 
 bool CmdSketcherSelectRedundantConstraints::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -651,7 +651,7 @@ void CmdSketcherSelectMalformedConstraints::activated(int iMsg)
 
 bool CmdSketcherSelectMalformedConstraints::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -707,7 +707,7 @@ void CmdSketcherSelectPartiallyRedundantConstraints::activated(int iMsg)
 
 bool CmdSketcherSelectPartiallyRedundantConstraints::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -764,7 +764,7 @@ void CmdSketcherSelectConflictingConstraints::activated(int iMsg)
 
 bool CmdSketcherSelectConflictingConstraints::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -885,7 +885,7 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
 
 bool CmdSketcherSelectElementsAssociatedWithConstraints::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingConstraintActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -974,7 +974,7 @@ void CmdSketcherSelectElementsWithDoFs::activated(int iMsg)
 
 bool CmdSketcherSelectElementsWithDoFs::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -1089,7 +1089,7 @@ void CmdSketcherRestoreInternalAlignmentGeometry::activated(int iMsg)
 
 bool CmdSketcherRestoreInternalAlignmentGeometry::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -1124,7 +1124,7 @@ void CmdSketcherSymmetry::activated(int iMsg)
 
 bool CmdSketcherSymmetry::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -1502,7 +1502,7 @@ void CmdSketcherCopy::activate()
 
 bool CmdSketcherCopy::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -1552,7 +1552,7 @@ void CmdSketcherClone::activate()
 
 bool CmdSketcherClone::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 class CmdSketcherMove: public SketcherCopy
@@ -1599,7 +1599,7 @@ void CmdSketcherMove::activate()
 
 bool CmdSketcherMove::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -1710,7 +1710,7 @@ void CmdSketcherCompCopy::languageChange()
 
 bool CmdSketcherCompCopy::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -2059,7 +2059,7 @@ void CmdSketcherRectangularArray::activated(int iMsg)
 
 bool CmdSketcherRectangularArray::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -2124,7 +2124,7 @@ void CmdSketcherDeleteAllGeometry::activated(int iMsg)
 
 bool CmdSketcherDeleteAllGeometry::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -2190,7 +2190,7 @@ void CmdSketcherDeleteAllConstraints::activated(int iMsg)
 
 bool CmdSketcherDeleteAllConstraints::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), false);
+    return isCommandActive(getActiveGuiDocument());
 }
 
 // ================================================================================
@@ -2311,7 +2311,7 @@ void CmdSketcherRemoveAxesAlignment::activated(int iMsg)
 
 bool CmdSketcherRemoveAxesAlignment::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 
@@ -2394,7 +2394,7 @@ void CmdSketcherOffset::activated(int iMsg)
 
 bool CmdSketcherOffset::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // Rotate tool =====================================================================
@@ -2428,7 +2428,7 @@ void CmdSketcherRotate::activated(int iMsg)
 
 bool CmdSketcherRotate::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // Scale tool =====================================================================
@@ -2462,7 +2462,7 @@ void CmdSketcherScale::activated(int iMsg)
 
 bool CmdSketcherScale::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 // Translate / rectangular pattern tool =======================================================
@@ -2496,7 +2496,7 @@ void CmdSketcherTranslate::activated(int iMsg)
 
 bool CmdSketcherTranslate::isActive()
 {
-    return isCommandActive(getActiveGuiDocument(), true);
+    return isCommandNeedingGeometryActive(getActiveGuiDocument());
 }
 
 void CreateSketcherCommandsConstraintAccel()

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -497,7 +497,7 @@ bool SketcherGui::isSketchInEdit(Gui::Document* doc)
     return false;
 }
 
-bool SketcherGui::isCommandActive(Gui::Document* doc, bool actsOnSelection)
+bool SketcherGui::isCommandActive(Gui::Document* doc)
 {
     if (isSketchInEdit(doc)) {
         auto mode =
@@ -505,29 +505,79 @@ bool SketcherGui::isCommandActive(Gui::Document* doc, bool actsOnSelection)
 
         if (mode == ViewProviderSketch::STATUS_NONE
             || mode == ViewProviderSketch::STATUS_SKETCH_UseHandler) {
-
-            if (!actsOnSelection) {
-                return true;
-            }
-            return Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() > 0;
+            return true;
         }
     }
 
     return false;
 }
 
-bool SketcherGui::isSketcherBSplineActive(Gui::Document* doc, bool actsOnSelection)
+bool SketcherGui::isCommandNeedingConstraintActive(Gui::Document* doc)
 {
-    if (doc) {
-        // checks if a Sketch Viewprovider is in Edit and is in no special mode
-        if (doc->getInEdit()
-            && doc->getInEdit()->isDerivedFrom<SketcherGui::ViewProviderSketch>()) {
-            if (static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit())->getSketchMode()
-                == ViewProviderSketch::STATUS_NONE) {
-                if (!actsOnSelection) {
+    if (!isCommandActive(doc)) {
+        return false;
+    }
+
+    std::vector<Gui::SelectionObject> sel =
+        Gui::Selection().getSelectionEx(doc->getDocument()->getName(),
+                                        Sketcher::SketchObject::getClassTypeId());
+    if (sel.size() == 1) {
+        for (const std::string& name : sel[0].getSubNames()) {
+            if (name.rfind("Constraint", 0) == 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool SketcherGui::isCommandNeedingGeometryActive(Gui::Document* doc)
+{
+    if (!isCommandActive(doc)) {
+        return false;
+    }
+
+    std::vector<Gui::SelectionObject> sel =
+        Gui::Selection().getSelectionEx(doc->getDocument()->getName(),
+                                        Sketcher::SketchObject::getClassTypeId());
+    if (sel.size() == 1) {
+        auto* Obj = static_cast<Sketcher::SketchObject*>(sel[0].getObject());
+        for (const std::string& name : sel[0].getSubNames()) {
+            int geoId;
+            Sketcher::PointPos posId;
+            getIdsFromName(name, Obj, geoId, posId);
+
+            if (geoId != GeoEnum::GeoUndef) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool SketcherGui::isCommandNeedingBSplineActive(Gui::Document* doc)
+{
+    if (!isCommandActive(doc)) {
+        return false;
+    }
+
+    std::vector<Gui::SelectionObject> sel =
+        Gui::Selection().getSelectionEx(doc->getDocument()->getName(),
+                                        Sketcher::SketchObject::getClassTypeId());
+    if (sel.size() == 1) {
+        auto* Obj = static_cast<Sketcher::SketchObject*>(sel[0].getObject());
+        for (const std::string& name : sel[0].getSubNames()) {
+
+            int geoId;
+            Sketcher::PointPos posId;
+            getIdsFromName(name, Obj, geoId, posId);
+
+            if (geoId != GeoEnum::GeoUndef) {
+                const Part::Geometry* geo = Obj->getGeometry(geoId);
+
+                if (geo && geo->is<Part::GeomBSplineCurve>()) {
                     return true;
                 }
-                return Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() > 0;
             }
         }
     }

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -523,7 +523,7 @@ bool SketcherGui::isCommandNeedingConstraintActive(Gui::Document* doc)
                                         Sketcher::SketchObject::getClassTypeId());
     if (sel.size() == 1) {
         for (const std::string& name : sel[0].getSubNames()) {
-            if (name.rfind("Constraint", 0) == 0) {
+            if (name.starts_with("Constraint")) {
                 return true;
             }
         }
@@ -543,8 +543,8 @@ bool SketcherGui::isCommandNeedingGeometryActive(Gui::Document* doc)
     if (sel.size() == 1) {
         auto* Obj = static_cast<Sketcher::SketchObject*>(sel[0].getObject());
         for (const std::string& name : sel[0].getSubNames()) {
-            int geoId;
-            Sketcher::PointPos posId;
+            int geoId {GeoEnum::GeoUndef};
+            PointPos posId {PointPos::none};
             getIdsFromName(name, Obj, geoId, posId);
 
             if (geoId != GeoEnum::GeoUndef) {
@@ -568,8 +568,8 @@ bool SketcherGui::isCommandNeedingBSplineActive(Gui::Document* doc)
         auto* Obj = static_cast<Sketcher::SketchObject*>(sel[0].getObject());
         for (const std::string& name : sel[0].getSubNames()) {
 
-            int geoId;
-            Sketcher::PointPos posId;
+            int geoId {GeoEnum::GeoUndef};
+            PointPos posId {PointPos::none};
             getIdsFromName(name, Obj, geoId, posId);
 
             if (geoId != GeoEnum::GeoUndef) {

--- a/src/Mod/Sketcher/Gui/Utils.h
+++ b/src/Mod/Sketcher/Gui/Utils.h
@@ -196,9 +196,10 @@ bool isSketchInEdit(Gui::Document* doc);
 
 /// Returns whether an edit mode command should be activated or not. It is only activated if the
 /// sketcher is no special state or a sketchHandler is active.
-bool isCommandActive(Gui::Document* doc, bool actsOnSelection = false);
-
-bool isSketcherBSplineActive(Gui::Document* doc, bool actsOnSelection);
+bool isCommandActive(Gui::Document* doc);
+bool isCommandNeedingConstraintActive(Gui::Document* doc);
+bool isCommandNeedingGeometryActive(Gui::Document* doc);
+bool isCommandNeedingBSplineActive(Gui::Document* doc);
 
 SketcherGui::ViewProviderSketch* getInactiveHandlerEditModeSketchViewProvider(Gui::Document* doc);
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/19059

- Tools that need only constraint (select associate geometry)
- Tools that need only geometry (copy/cut/rotate/array...)
- Tools that need only bspline selection
- Tools that need only bspline knot selection (increase/decrease multiplicity).

Are now all active when they should