### PR TITLE
Adding an AI clause to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,7 @@ The FreeCAD Contribution Process is expressed here with the following specific g
     2. all commits MUST have proper authorship, i.e. be authored by the original author and committed by the author of the PR;
     3. if changes to cherry-picked commits are necessary they SHOULD be done as follow-up commits. If it is not possible to do so, then the modified commits MUST contain a `Co-Authored-By` trailer in their commit message.
 14. A “Valid PR” is one which satisfies the above requirements.
+15. Human-quality contributions are expected. Contributors MUST be able to explain the code they submit, and should be able to offer reasonable guarantee their PR does not violate copyrighted work. In other words, AI-made contributions SHALL NOT be accepted.
 
 ## 6. Process
 


### PR DESCRIPTION
Proposing an AI-exclusion clause to the CONTRIBUTING rules. Basically:

AI-made contributions shall not be accepted. This doesn't say anything about you using AI-tools to help you code if you must, what we don't want is someone dropping AI slop. Because:

- FreeCAD is a human project with a lot of careful human work, and that's not a bug but a feature
- Once AI enters, there is no way to stop
- AI content is damaging the internet, we don't want the same to happen with our code
- Since contributors can attribute copyright of their PR to the FPA, this would turn the FPA liable to copyright violations
- We do want contributors to think and work and polish their code
- AI has huge environmental costs and we should try to lower the environmental cost of FreeCAD where possible, not raise it
- We want creativity, not average solutions