### PR TITLE
CAM: Fix group dropdown showing individual letters by ensuring groups is a list

### DIFF
--- a/src/Mod/CAM/Path/Base/Gui/PropertyBag.py
+++ b/src/Mod/CAM/Path/Base/Gui/PropertyBag.py
@@ -128,7 +128,10 @@ class PropertyCreate(object):
         self.form = FreeCADGui.PySideUic.loadUi(":panels/PropertyCreate.ui")
 
         obj.Proxy.refreshCustomPropertyGroups()
-        for g in sorted(obj.CustomPropertyGroups):
+        groups = obj.CustomPropertyGroups
+        if not isinstance(groups, (list, tuple)):
+            groups = [groups]
+        for g in sorted(groups):
             self.form.propertyGroup.addItem(g)
         if grp:
             self.form.propertyGroup.setCurrentText(grp)


### PR DESCRIPTION
- Add type check in PropertyCreate to wrap CustomPropertyGroups as a list if not already
- Prevents dropdown from displaying each character of a string as a separate group option

This bug shows up when Adding a new property to the property bag.  Result of converting from CustomPropertyGroups from String to Enums

## Before and After Images
Before:
<img width="525" height="530" alt="Screenshot from 2025-09-22 12-52-17" src="https://github.com/user-attachments/assets/88f0e598-afaf-4cc6-ab83-e8d894dfe76e" />

After:
<img width="563" height="549" alt="Screenshot from 2025-09-22 12-50-18" src="https://github.com/user-attachments/assets/fea16e81-7ed6-416f-9424-20a432321f31" />

Fixes: #24142