### PR TITLE
Gui: Check for every VP expiration in TaskAttacher

### DIFF
--- a/src/Gui/DocumentObserver.cpp
+++ b/src/Gui/DocumentObserver.cpp
@@ -345,6 +345,10 @@ ViewProviderWeakPtrT::ViewProviderWeakPtrT(ViewProviderDocumentObject* obj)
 {
 }
 
+ViewProviderWeakPtrT::ViewProviderWeakPtrT(ViewProviderWeakPtrT&&) = default;
+
+ViewProviderWeakPtrT& ViewProviderWeakPtrT::operator=(ViewProviderWeakPtrT&&) = default;
+
 ViewProviderWeakPtrT::~ViewProviderWeakPtrT() = default;
 
 ViewProviderDocumentObject* ViewProviderWeakPtrT::_get() const noexcept

--- a/src/Gui/DocumentObserver.h
+++ b/src/Gui/DocumentObserver.h
@@ -174,6 +174,12 @@ class GuiExport ViewProviderWeakPtrT
 {
 public:
     explicit ViewProviderWeakPtrT(ViewProviderDocumentObject*);
+
+    ViewProviderWeakPtrT(ViewProviderWeakPtrT &&);
+    ViewProviderWeakPtrT &operator=(ViewProviderWeakPtrT &&);
+
+    FC_DISABLE_COPY(ViewProviderWeakPtrT);
+
     ~ViewProviderWeakPtrT();
 
     /*!
@@ -221,12 +227,6 @@ public:
 private:
     ViewProviderDocumentObject* _get() const noexcept;
 
-public:
-    // disable
-    ViewProviderWeakPtrT(const ViewProviderWeakPtrT&) = delete;
-    ViewProviderWeakPtrT& operator=(const ViewProviderWeakPtrT&) = delete;
-
-private:
     class Private;
     std::unique_ptr<Private> d;
 };

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -230,7 +230,7 @@ TaskAttacher::TaskAttacher(Gui::ViewProviderDocumentObject* ViewProvider, QWidge
             continue;
         }
 
-        modifiedPlaneViewProviders.push_back(planeViewProvider);
+        modifiedPlaneViewProviders.emplace_back(planeViewProvider);
 
         planeViewProvider->setTemporaryScale(ViewParams::instance()->getDatumTemporaryScaleFactor());
         planeViewProvider->setLabelVisibility(true);
@@ -267,7 +267,16 @@ TaskAttacher::~TaskAttacher()
     connectDelObject.disconnect();
     connectDelDocument.disconnect();
 
-    for (auto planeViewProvider : modifiedPlaneViewProviders) {
+    for (auto& vp : modifiedPlaneViewProviders) {
+        if (vp.expired()) {
+            continue;
+        }
+
+        auto planeViewProvider = vp.get<Gui::ViewProviderPlane>();
+        if (!planeViewProvider) {
+            return;
+        }
+
         planeViewProvider->resetTemporarySize();
         planeViewProvider->setLabelVisibility(false);
     }

--- a/src/Mod/Part/Gui/TaskAttacher.h
+++ b/src/Mod/Part/Gui/TaskAttacher.h
@@ -26,6 +26,7 @@
 #define GUI_TASKVIEW_TaskAttacher_H
 
 #include <Gui/Selection/Selection.h>
+#include <Gui/DocumentObserver.h>
 #include <Gui/ViewProviderDocumentObject.h>
 #include <Gui/TaskView/TaskView.h>
 #include <Gui/TaskView/TaskDialog.h>
@@ -159,7 +160,7 @@ private:
     Connection connectDelObject;
     Connection connectDelDocument;
 
-    std::vector<Gui::ViewProviderPlane*> modifiedPlaneViewProviders;
+    std::vector<Gui::ViewProviderWeakPtrT> modifiedPlaneViewProviders;
 
     App::PropertyOverrideContext overrides;
 };


### PR DESCRIPTION
Task Attacher tries to restore plane sizes on in the destructor, which may fail if one of view providers was removed before TaskAttacherDialog is restored. To prevent that ViewProviderWeakPtrT is used which guards lifetime of the view provider.


<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
- Fixes https://github.com/FreeCAD/FreeCAD/issues/24077
- Fixes https://github.com/FreeCAD/FreeCAD/issues/23833
- Fixes https://github.com/FreeCAD/FreeCAD/issues/23886

<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
