### PR TITLE
TechDraw: Fix double drag in projection groups

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
@@ -74,8 +74,14 @@ bool QGIProjGroup::sceneEventFilter(QGraphicsItem* watched, QEvent *event)
             auto *mEvent = dynamic_cast<QGraphicsSceneMouseEvent*>(event);
 
             // Disable moves on the view to prevent double drag
-            bool initCanMove = qWatched->flags() & QGraphicsItem::ItemIsMovable;
-            qWatched->setFlag(QGraphicsItem::ItemIsMovable, false);
+            std::vector<QGraphicsItem*> modifiedChildren;
+            for (auto* child : childItems()) {
+                if (child->isSelected() && (child->flags() & QGraphicsItem::ItemIsMovable)) {
+                    child->setFlag(QGraphicsItem::ItemIsMovable, false);
+                    modifiedChildren.push_back(child);
+                }
+            }
+
             switch (event->type()) {
                 case QEvent::GraphicsSceneMousePress:
                     mousePressEvent(mEvent);
@@ -89,8 +95,9 @@ bool QGIProjGroup::sceneEventFilter(QGraphicsItem* watched, QEvent *event)
                 default:
                     break;
             }
-            // Restore flag
-            qWatched->setFlag(QGraphicsItem::ItemIsMovable, initCanMove);
+            for (auto* child : modifiedChildren) {
+                child->setFlag(QGraphicsItem::ItemIsMovable, true);
+            }
             return true;
         }
     }


### PR DESCRIPTION
This PR prevents double drag in Projection Groups in TechDraw. Each child view has its drag disabled then re-enabled after the drag.

## Issues
Fixes #23988

## The Money Shot

https://github.com/user-attachments/assets/b8dff744-87ee-43a9-9464-265a384e643d


