### PR TITLE
BIM: fix linked document of BIM_Library task panel

### DIFF
--- a/src/Mod/BIM/bimcommands/BimLibrary.py
+++ b/src/Mod/BIM/bimcommands/BimLibrary.py
@@ -555,7 +555,7 @@ class BIM_Library_TaskPanel:
         if hasattr(self, "box") and self.box:
             self.box.off()
         FreeCADGui.Control.closeDialog()
-        if self.previewDocName in FreeCAD.listDocuments().keys():
+        if self.previewDocName in FreeCAD.listDocuments():
             FreeCAD.closeDocument(self.previewDocName)
         FreeCAD.ActiveDocument.recompute()
 

--- a/src/Mod/BIM/bimcommands/BimLibrary.py
+++ b/src/Mod/BIM/bimcommands/BimLibrary.py
@@ -105,8 +105,9 @@ class BIM_Library:
                 # save file paths with forward slashes even on windows
                 pr.SetString("destination", addondir.replace("\\", "/"))
                 libok = True
-        task = FreeCADGui.Control.showDialog(BIM_Library_TaskPanel(offlinemode=libok))
-        task.setDocumentName(FreeCAD.ActiveDocument.Name)
+        panel = BIM_Library_TaskPanel(offlinemode=libok)
+        task = FreeCADGui.Control.showDialog(panel)
+        task.setDocumentName(panel.mainDocName)
         task.setAutoCloseOnDeletedDocument(True)
 
 
@@ -554,6 +555,9 @@ class BIM_Library_TaskPanel:
         if hasattr(self, "box") and self.box:
             self.box.off()
         FreeCADGui.Control.closeDialog()
+        if self.previewDocName in FreeCAD.listDocuments().keys():
+            print(self.previewDocName)
+            FreeCAD.closeDocument(self.previewDocName)
         FreeCAD.ActiveDocument.recompute()
 
     def insert(self, index=None):
@@ -570,8 +574,6 @@ class BIM_Library_TaskPanel:
                 + "\n"
             )
             return
-        if self.previewDocName in FreeCAD.listDocuments().keys():
-            FreeCAD.closeDocument(self.previewDocName)
         if not index:
             index = self.form.tree.selectedIndexes()
             if not index:

--- a/src/Mod/BIM/bimcommands/BimLibrary.py
+++ b/src/Mod/BIM/bimcommands/BimLibrary.py
@@ -556,7 +556,6 @@ class BIM_Library_TaskPanel:
             self.box.off()
         FreeCADGui.Control.closeDialog()
         if self.previewDocName in FreeCAD.listDocuments().keys():
-            print(self.previewDocName)
             FreeCAD.closeDocument(self.previewDocName)
         FreeCAD.ActiveDocument.recompute()
 


### PR DESCRIPTION
Fixes #22437.

The task panel of the BIM_Library command would be linked to the active document, which would be the temporary Viewer document if that option was checked. Closing that document in the `insert` function would therefore also close the task panel resulting in errors for following code.

Additionally:
The code to close the temporary Viewer document was moved to the `reject` function. Otherwise that document would stay open if the task panel was closed without inserting.